### PR TITLE
Add fast MIME validation

### DIFF
--- a/apiserver/testdata/invalid.txt
+++ b/apiserver/testdata/invalid.txt
@@ -1,0 +1,15 @@
+The sun dipped below the horizon, casting a fiery glow across the sky. As twilight settled in, a gentle breeze rustled through the trees, causing the leaves to whisper secrets to one another. The world seemed to hold its breath, anticipating the magic that was about to unfold.
+
+In the distance, the sound of waves crashing against the shore created a soothing rhythm. The ocean, vast and mysterious, stretched out as far as the eye could see. Its depths were home to an array of creatures, from the smallest vibrant fish to the majestic whales that roamed the deep.
+
+On the beach, a group of friends gathered around a crackling bonfire. Laughter filled the air as they shared stories and toasted marshmallows. The flames danced and flickered, casting playful shadows on their faces. It was a night of camaraderie and warmth, a moment frozen in time.
+
+Above them, the stars began to emerge, one by one, painting the velvet canvas of the night sky. Each twinkling light held a story of its own, a tale of distant galaxies and ancient civilizations. The vastness of the universe became apparent, igniting a sense of wonder within those who dared to gaze upon it.
+
+As the night wore on, the moon rose high, casting a soft silver glow on the world below. Its ethereal beauty captivated all who beheld it, casting a spell of serenity and tranquility. Time seemed to stand still as the night embraced the earth in its gentle embrace.
+
+In this moment, surrounded by nature's symphony, the worries and troubles of the day faded away. It was a reminder that in the grand tapestry of life, we are but small specks in an infinite universe. And yet, in our connections and shared experiences, we find meaning and purpose.
+
+As the night drew to a close, the friends bid their farewell, carrying with them memories that would last a lifetime. They walked away, hearts full, knowing that the beauty they had witnessed would forever be etched in their souls.
+
+And so, the night unfolded its secrets, leaving behind a sense of awe and reverence. It was a reminder that in the darkness, there is always light, and in the vastness of the unknown, there is always room for exploration and discovery.

--- a/internal/mimekit/errors.go
+++ b/internal/mimekit/errors.go
@@ -1,0 +1,9 @@
+package mimekit
+
+import (
+	"errors"
+)
+
+var (
+	ErrInvalidContentType = errors.New("invalid content type")
+)

--- a/internal/mimekit/mimekit.go
+++ b/internal/mimekit/mimekit.go
@@ -1,4 +1,4 @@
-package mimetypes
+package mimekit
 
 var imageContentTypes = []string{
 	"image/gif",

--- a/internal/mimekit/mimereader.go
+++ b/internal/mimekit/mimereader.go
@@ -1,0 +1,92 @@
+package mimekit
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"mime"
+	"net/http"
+
+	"golang.org/x/exp/slices"
+
+	"github.com/denisvmedia/inventario/internal/errkit"
+)
+
+// The sniff algorithm uses at most sniffLen bytes to make its decision.
+const sniffLen = 512
+
+// MIMEReader represents a reader that performs MIME type detection and validation on data read from an underlying io.Reader.
+type MIMEReader struct {
+	r                   io.Reader
+	read                int64
+	buf                 bytes.Buffer
+	allowedContentTypes []string
+	mimeDetected        bool
+	err                 error
+}
+
+// NewMIMEReader creates a new MIMEReader instance with the provided io.Reader and a list of allowed content types.
+//
+// The MIMEReader is designed to read data from the underlying reader while performing MIME type detection and validation.
+// It allows developers to ensure that the content being read conforms to the expected MIME types.
+// The provided allowedContentTypes is a list of MIME types that are considered valid.
+//
+// It will stop reading from the underlying reader as soon it detects disallowed content type.
+func NewMIMEReader(r io.Reader, allowedContentTypes []string) *MIMEReader {
+	return &MIMEReader{
+		r:                   r,
+		allowedContentTypes: allowedContentTypes,
+	}
+}
+
+// Read reads data from the underlying reader into the provided byte slice,
+// performs MIME type detection and validation, and returns the number of bytes read and an error (if any).
+//
+//   - If the MIME type has already been detected, the method reads data until the end of the underlying reader.
+//   - If the MIME type has not been detected, the method continues reading and buffering data until the detection criteria are met.
+//   - Once the detection criteria are met, the buffered data is used to detect the MIME type using http.DetectContentType,
+//     and the detected MIME type is compared against the list of allowed content types.
+//   - If the detected MIME type is not in the allowed list, an error is returned.
+//
+// The method implements the io.Reader interface.
+func (mr *MIMEReader) Read(p []byte) (n int, err error) {
+	if mr.err != nil {
+		// Previous calls failed, return the error again.
+		return 0, mr.err
+	}
+
+	if mr.mimeDetected {
+		// Read from the underlying reader till the end
+		n, err = mr.r.Read(p)
+		mr.read += int64(n)
+		return n, err
+	}
+
+	// Read from the underlying reader
+	n, err = mr.r.Read(p)
+	mr.read += int64(n)
+
+	mr.buf.Write(p[0:n])
+
+	switch {
+	case err == io.EOF || (mr.read >= sniffLen && mr.buf.Len() > 0):
+		defer mr.buf.Reset()
+		ct := http.DetectContentType(mr.buf.Bytes())
+		mt, _, _ := mime.ParseMediaType(ct)
+		if !slices.Contains(mr.allowedContentTypes, mt) {
+			mr.err = errkit.WithFields(ErrInvalidContentType, errkit.Fields{
+				"expected": mr.allowedContentTypes,
+				"detected": ct,
+				"parsed":   mt,
+			})
+			log.Printf("=================== Invalid MIME: %s", mr.err.Error())
+			return n, mr.err
+		}
+		mr.mimeDetected = true
+	case err != nil:
+		mr.buf.Reset() // if we had an error, and it wasn't io.EOF, we should reset the buffer
+		mr.err = err
+	}
+
+	return n, err
+}

--- a/internal/mimekit/mimereader_test.go
+++ b/internal/mimekit/mimereader_test.go
@@ -1,0 +1,174 @@
+package mimekit_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/internal/mimekit"
+)
+
+func TestMIMEReader_Read(t *testing.T) {
+	t.Run("Expected content type", func(t *testing.T) {
+		c := qt.New(t)
+
+		contentTypes := []string{"text/plain", "application/json"}
+
+		r := bytes.NewReader([]byte("Hello, World!"))
+		mr := mimekit.NewMIMEReader(r, contentTypes)
+
+		buf := make([]byte, 10)
+		n, err := mr.Read(buf)
+		c.Assert(err, qt.IsNil)
+		c.Assert(n, qt.Equals, 10)
+
+		// Make sure the bytes read match the input
+		c.Assert(buf[:n], qt.DeepEquals, []byte("Hello, Wor"))
+
+		// the content should not be detected yet (we have not read enough bytes, and we have not reached the end of the stream)
+		n, err = mr.Read(buf)
+		c.Assert(err, qt.IsNil)
+		c.Assert(n, qt.Equals, 3)
+
+		// Make sure the bytes read match the input
+		c.Assert(buf[:n], qt.DeepEquals, []byte("ld!"))
+
+		// Now it shouldn't read anything else, since the content type has been detected and the stream has ended.
+		n, err = mr.Read(buf)
+		c.Assert(err, qt.Equals, io.EOF)
+		c.Assert(n, qt.Equals, 0)
+
+		// Sequential reads should now return EOF
+		n, err = mr.Read(buf)
+		c.Assert(err, qt.Equals, io.EOF)
+		c.Assert(n, qt.Equals, 0)
+	})
+
+	t.Run("Unexpected content type", func(t *testing.T) {
+		c := qt.New(t)
+
+		contentTypes := []string{"application/json"}
+
+		r := bytes.NewReader([]byte("Hello, World!"))
+		mr := mimekit.NewMIMEReader(r, contentTypes)
+
+		buf := make([]byte, 10)
+		n, err := mr.Read(buf)
+		c.Assert(err, qt.IsNil)
+		c.Assert(n, qt.Equals, 10)
+
+		// Make sure the bytes read match the input
+		c.Assert(buf[:n], qt.DeepEquals, []byte("Hello, Wor"))
+
+		// the content should not be detected yet (we have not read enough bytes and we have not reached the end of the stream)
+		n, err = mr.Read(buf)
+		c.Assert(err, qt.IsNil)
+		c.Assert(n, qt.Equals, 3)
+
+		// Make sure the bytes read match the input
+		c.Assert(buf[:n], qt.DeepEquals, []byte("ld!"))
+
+		// Now it shouldn't read anything else, since the content type has been detected and the stream has ended.
+		n, err = mr.Read(buf)
+		c.Assert(err, qt.ErrorIs, mimekit.ErrInvalidContentType)
+		c.Assert(n, qt.Equals, 0)
+
+		// Sequential reads should now return the same error
+		n, err = mr.Read(buf)
+		c.Assert(err, qt.ErrorIs, mimekit.ErrInvalidContentType)
+		c.Assert(n, qt.Equals, 0)
+	})
+
+	t.Run("Expected content type with more bytes", func(t *testing.T) {
+		contentTypes := []string{"text/plain"}
+
+		c := qt.New(t)
+
+		data := []byte(strings.Repeat("Hello, World!", 1000)) // 13000 bytes
+
+		r := bytes.NewReader(data)
+		mr := mimekit.NewMIMEReader(r, contentTypes)
+
+		read, err := io.ReadAll(mr)
+		c.Assert(err, qt.IsNil)
+		c.Assert(read, qt.DeepEquals, data)
+
+		buf := make([]byte, 256)
+		n, err := mr.Read(buf)
+		c.Assert(err, qt.ErrorIs, io.EOF)
+		c.Assert(n, qt.Equals, 0)
+	})
+
+	t.Run("Unexpected content type with more bytes", func(t *testing.T) {
+		contentTypes := []string{"application/json"}
+
+		c := qt.New(t)
+
+		data := []byte(strings.Repeat("Hello, World!", 1000)) // 13000 bytes
+
+		r := bytes.NewReader(data)
+		mr := mimekit.NewMIMEReader(r, contentTypes)
+
+		buf := make([]byte, 256) // half of sniffLen
+		n, err := mr.Read(buf)
+		c.Assert(err, qt.IsNil)
+
+		// Make sure the bytes read match the input
+		c.Assert(buf[:n], qt.DeepEquals, data[:n])
+
+		// we have read enough bytes and the content should be invalid
+		n, err = mr.Read(buf)
+		c.Assert(err, qt.ErrorIs, mimekit.ErrInvalidContentType)
+		c.Assert(n, qt.Equals, 256)
+
+		// sequential calls should return the same error
+		n, err = mr.Read(buf)
+		c.Assert(err, qt.ErrorIs, mimekit.ErrInvalidContentType)
+		c.Assert(n, qt.Equals, 0)
+	})
+
+	t.Run("Unexpected content type with more bytes with io.ReadAll", func(t *testing.T) {
+		contentTypes := []string{"application/json"}
+
+		c := qt.New(t)
+
+		data := []byte(strings.Repeat("Hello, World!", 1000)) // 13000 bytes
+
+		r := bytes.NewReader(data)
+		mr := mimekit.NewMIMEReader(r, contentTypes)
+
+		_, err := io.ReadAll(mr)
+		c.Assert(err, qt.ErrorIs, mimekit.ErrInvalidContentType)
+	})
+
+	t.Run("Reader returned an error", func(t *testing.T) {
+		contentTypes := []string{"application/json"}
+
+		c := qt.New(t)
+
+		expectedError := errors.New("some error")
+		r := &errorReader{err: expectedError}
+		mr := mimekit.NewMIMEReader(r, contentTypes)
+
+		read, err := io.ReadAll(mr)
+		c.Assert(err, qt.ErrorIs, expectedError)
+		c.Assert(read, qt.DeepEquals, []byte("Hello, Wor"))
+
+		read, err = io.ReadAll(mr)
+		c.Assert(err, qt.ErrorIs, expectedError)
+		c.Assert(read, qt.DeepEquals, []byte(""))
+	})
+}
+
+type errorReader struct {
+	err error
+}
+
+func (e *errorReader) Read(p []byte) (n int, err error) {
+	copy(p[0:10], "Hello, Wor")
+	return 10, e.err
+}


### PR DESCRIPTION
Content type for the uploaded files is now validated on the fly and if it doesn't match the expected (and allowed) ones, it will abort the upload stream.