### PR TITLE
Fix vite config

### DIFF
--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -2,7 +2,6 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
   resolve: {
@@ -11,16 +10,11 @@ export default defineConfig({
     }
   },
   server: {
-    port: 3000,
-    open: true,
     proxy: {
       '/api': {
         target: 'http://localhost:3333',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, '')
+        changeOrigin: true
       }
     }
-  },
-  // Ensure the base path is correctly set
-  base: '/'
+  }
 })


### PR DESCRIPTION
This pull request involves a migration of the Vite configuration file from TypeScript (`vite.config.ts`) to JavaScript (`vite.config.mjs`) and includes updates to the configuration itself. The most notable changes include simplifying the server proxy settings and removing unused configuration options.

### Migration and Configuration Updates:

* **File Migration**: Renamed `frontend/vite.config.ts` to `frontend/vite.config.mjs` to switch from TypeScript to JavaScript for the Vite configuration.

* **Server Configuration Simplification**:
  - Removed `port` and `open` options from the `server` configuration, likely to rely on default behavior.
  - Simplified the `/api` proxy settings by removing the `rewrite` function.

* **Base Path Removal**: Removed the `base` configuration option, which previously set the base path to `'/'`.