### PR TITLE
Minor code clean up and fixes

### DIFF
--- a/frontend/src/components/FileDetails.vue
+++ b/frontend/src/components/FileDetails.vue
@@ -93,11 +93,11 @@ const fileUrl = computed(() => {
   if (!props.file) return ''
 
   if (props.fileType === 'images') {
-    return `/api/v1/commodities/${props.commodityId}/images/${props.file.id}.${props.file.ext}`
+    return `/api/v1/commodities/${props.commodityId}/images/${props.file.id}${props.file.ext}`
   } else if (props.fileType === 'manuals') {
-    return `/api/v1/commodities/${props.commodityId}/manuals/${props.file.id}.${props.file.ext}`
+    return `/api/v1/commodities/${props.commodityId}/manuals/${props.file.id}${props.file.ext}`
   } else if (props.fileType === 'invoices') {
-    return `/api/v1/commodities/${props.commodityId}/invoices/${props.file.id}.${props.file.ext}`
+    return `/api/v1/commodities/${props.commodityId}/invoices/${props.file.id}${props.file.ext}`
   }
   return ''
 })

--- a/frontend/src/components/FileList.vue
+++ b/frontend/src/components/FileList.vue
@@ -81,11 +81,11 @@ const emit = defineEmits(['delete', 'download', 'update', 'view-details', 'open-
 
 const getFileUrl = (file: any) => {
   if (props.fileType === 'images') {
-    return `/api/v1/commodities/${props.commodityId}/images/${file.id}.${file.ext}`
+    return `/api/v1/commodities/${props.commodityId}/images/${file.id}${file.ext}`
   } else if (props.fileType === 'manuals') {
-    return `/api/v1/commodities/${props.commodityId}/manuals/${file.id}.${file.ext}`
+    return `/api/v1/commodities/${props.commodityId}/manuals/${file.id}${file.ext}`
   } else if (props.fileType === 'invoices') {
-    return `/api/v1/commodities/${props.commodityId}/invoices/${file.id}.${file.ext}`
+    return `/api/v1/commodities/${props.commodityId}/invoices/${file.id}${file.ext}`
   }
   return ''
 }

--- a/frontend/src/views/commodities/CommodityDetailView.vue
+++ b/frontend/src/views/commodities/CommodityDetailView.vue
@@ -369,7 +369,7 @@ const downloadImage = (image: any) => {
 
   // Create a link and trigger download
   const link = document.createElement('a')
-  const imageUrl = `/api/v1/commodities/${commodity.value.id}/images/${image.id}.${image.ext}`
+  const imageUrl = `/api/v1/commodities/${commodity.value.id}/images/${image.id}${image.ext}`
   link.href = imageUrl
   link.download = image.path + image.ext
   document.body.appendChild(link)
@@ -382,7 +382,7 @@ const downloadManual = (manual: any) => {
 
   // Create a link and trigger download
   const link = document.createElement('a')
-  const manualUrl = `/api/v1/commodities/${commodity.value.id}/manuals/${manual.id}.${manual.ext}`
+  const manualUrl = `/api/v1/commodities/${commodity.value.id}/manuals/${manual.id}${manual.ext}`
   link.href = manualUrl
   link.download = manual.path + manual.ext
   document.body.appendChild(link)
@@ -395,7 +395,7 @@ const downloadInvoice = (invoice: any) => {
 
   // Create a link and trigger download
   const link = document.createElement('a')
-  const invoiceUrl = `/api/v1/commodities/${commodity.value.id}/invoices/${invoice.id}.${invoice.ext}`
+  const invoiceUrl = `/api/v1/commodities/${commodity.value.id}/invoices/${invoice.id}${invoice.ext}`
   link.href = invoiceUrl
   link.download = invoice.path + invoice.ext
   document.body.appendChild(link)

--- a/frontend/src/views/commodities/CommodityPrintView.vue
+++ b/frontend/src/views/commodities/CommodityPrintView.vue
@@ -300,7 +300,7 @@ const formatDate = (dateString: string) => {
 }
 
 const getImageUrl = (image: any) => {
-  return `/api/v1/commodities/${commodity.value.id}/images/${image.id}.${image.ext}`
+  return `/api/v1/commodities/${commodity.value.id}/images/${image.id}${image.ext}`
 }
 
 const getImageName = (image: any) => {
@@ -345,6 +345,12 @@ const goBack = () => {
 .toolbar-section {
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
+}
+
+.toolbar-section:last-child {
+  display: flex;
+  flex-direction: row;
   gap: 0.5rem;
 }
 


### PR DESCRIPTION
This pull request standardizes the URL structure for file downloads and adds a minor UI improvement to the `CommodityPrintView` component. Below is a summary of the most important changes:

### Standardization of file download URLs:
* Updated file URLs in `FileDetails.vue` to remove the dot (`.`) separator between the file ID and extension for images, manuals, and invoices.
* Updated file URLs in `FileList.vue` to follow the same format without the dot separator for images, manuals, and invoices.
* Adjusted download URLs in `CommodityDetailView.vue` for images [[1]](diffhunk://#diff-0a2911811c854081b9df07f0efeb5197577fe76db6d222e9ca361b38897aa4c7L372-R372) manuals [[2]](diffhunk://#diff-0a2911811c854081b9df07f0efeb5197577fe76db6d222e9ca361b38897aa4c7L385-R385) and invoices [[3]](diffhunk://#diff-0a2911811c854081b9df07f0efeb5197577fe76db6d222e9ca361b38897aa4c7L398-R398) to align with the new URL structure.
* Modified the `getImageUrl` function in `CommodityPrintView.vue` to reflect the updated URL format for images.

### UI improvement:
* Added a new toolbar section with a flex layout in `CommodityPrintView.vue` to improve the arrangement of toolbar items.