### PR TITLE
Pricing improvement

### DIFF
--- a/frontend/src/views/areas/AreaDetailView.vue
+++ b/frontend/src/views/areas/AreaDetailView.vue
@@ -38,9 +38,9 @@
                 <span class="count" v-if="(commodity.attributes.count || 1) > 1">×{{ commodity.attributes.count }}</span>
               </div>
               <div class="commodity-price" v-if="commodity.attributes.current_price">
-                <span class="price">{{ commodity.attributes.current_price }} {{ commodity.attributes.original_price_currency }}</span>
+                <span class="price">{{ commodity.attributes.current_price }} {{ mainCurrency }}</span>
                 <span class="price-per-unit" v-if="(commodity.attributes.count || 1) > 1">
-                  {{ calculatePricePerUnit(commodity) }} {{ commodity.attributes.original_price_currency }} per unit
+                  {{ calculatePricePerUnit(commodity) }} {{ mainCurrency }} per unit
                 </span>
               </div>
               <div class="commodity-status" v-if="commodity.attributes.status">
@@ -72,6 +72,7 @@ import { useRouter, useRoute } from 'vue-router'
 import areaService from '@/services/areaService'
 import locationService from '@/services/locationService'
 import commodityService from '@/services/commodityService'
+import settingsService from '@/services/settingsService'
 import { COMMODITY_TYPES } from '@/constants/commodityTypes'
 import { COMMODITY_STATUSES } from '@/constants/commodityStatuses'
 
@@ -84,6 +85,7 @@ const loading = ref<boolean>(true)
 const error = ref<string | null>(null)
 const locationName = ref<string | null>(null)
 const locationAddress = ref<string | null>(null)
+const mainCurrency = ref<string>('USD') // Default to USD if not set
 
 // Highlight commodity if specified in the URL
 const highlightCommodityId = ref(route.query.highlightCommodityId as string || '')
@@ -93,6 +95,17 @@ onMounted(async () => {
   const id = route.params.id as string
 
   try {
+    // Fetch main currency from settings
+    try {
+      const currency = await settingsService.getMainCurrency()
+      if (currency) {
+        mainCurrency.value = currency
+      }
+    } catch (settingsErr) {
+      console.error('Failed to load main currency from settings:', settingsErr)
+      // Continue with default currency
+    }
+
     // Load area, locations, and commodities in parallel
     const [areaResponse, locationsResponse, commoditiesResponse] = await Promise.all([
       areaService.getArea(id),

--- a/frontend/src/views/commodities/CommodityDetailView.vue
+++ b/frontend/src/views/commodities/CommodityDetailView.vue
@@ -60,15 +60,15 @@
           </div>
           <div class="info-row">
             <span class="label">Converted Original Price:</span>
-            <span>{{ commodity.attributes.converted_original_price }}</span>
+            <span>{{ commodity.attributes.converted_original_price }} {{ mainCurrency }}</span>
           </div>
           <div class="info-row">
             <span class="label">Current Price:</span>
-            <span>{{ commodity.attributes.current_price }} {{ commodity.attributes.original_price_currency }}</span>
+            <span>{{ commodity.attributes.current_price }} {{ mainCurrency }}</span>
           </div>
           <div class="info-row" v-if="(commodity.attributes.count || 1) > 1">
             <span class="label">Price Per Unit:</span>
-            <span>{{ calculatePricePerUnit() }} {{ commodity.attributes.original_price_currency }}</span>
+            <span>{{ calculatePricePerUnit() }} {{ mainCurrency }}</span>
           </div>
         </div>
 
@@ -212,6 +212,7 @@
 import { ref, onMounted, computed } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import commodityService from '@/services/commodityService'
+import settingsService from '@/services/settingsService'
 import { COMMODITY_TYPES } from '@/constants/commodityTypes'
 import { COMMODITY_STATUSES } from '@/constants/commodityStatuses'
 import FileUploader from '@/components/FileUploader.vue'
@@ -224,6 +225,7 @@ const route = useRoute()
 const commodity = ref<any>(null)
 const loading = ref<boolean>(true)
 const error = ref<string | null>(null)
+const mainCurrency = ref<string>('USD') // Default to USD if not set
 
 // Navigation source tracking
 const sourceIsArea = computed(() => route.query.source === 'area')
@@ -248,6 +250,17 @@ onMounted(async () => {
   const id = route.params.id as string
 
   try {
+    // Fetch main currency from settings
+    try {
+      const currency = await settingsService.getMainCurrency()
+      if (currency) {
+        mainCurrency.value = currency
+      }
+    } catch (settingsErr) {
+      console.error('Failed to load main currency from settings:', settingsErr)
+      // Continue with default currency
+    }
+
     const response = await commodityService.getCommodity(id)
     commodity.value = response.data.data
     loading.value = false

--- a/frontend/src/views/commodities/CommodityDetailView.vue
+++ b/frontend/src/views/commodities/CommodityDetailView.vue
@@ -58,7 +58,7 @@
             <span class="label">Original Price:</span>
             <span>{{ commodity.attributes.original_price }} {{ commodity.attributes.original_price_currency }}</span>
           </div>
-          <div class="info-row">
+          <div class="info-row" v-if="commodity.attributes.converted_original_price !== '0' && commodity.attributes.converted_original_price !== 0">
             <span class="label">Converted Original Price:</span>
             <span>{{ commodity.attributes.converted_original_price }} {{ mainCurrency }}</span>
           </div>

--- a/frontend/src/views/commodities/CommodityListView.vue
+++ b/frontend/src/views/commodities/CommodityListView.vue
@@ -27,9 +27,9 @@
             <span class="count" v-if="(commodity.attributes.count || 1) > 1">×{{ commodity.attributes.count }}</span>
           </div>
           <div class="commodity-price">
-            <span class="price">{{ commodity.attributes.current_price }} {{ commodity.attributes.original_price_currency }}</span>
+            <span class="price">{{ commodity.attributes.current_price }} {{ mainCurrency }}</span>
             <span class="price-per-unit" v-if="(commodity.attributes.count || 1) > 1">
-              {{ calculatePricePerUnit(commodity) }} {{ commodity.attributes.original_price_currency }} per unit
+              {{ calculatePricePerUnit(commodity) }} {{ mainCurrency }} per unit
             </span>
           </div>
           <div class="commodity-status">
@@ -55,6 +55,7 @@ import { useRouter, useRoute } from 'vue-router'
 import commodityService from '@/services/commodityService'
 import areaService from '@/services/areaService'
 import locationService from '@/services/locationService'
+import settingsService from '@/services/settingsService'
 import { COMMODITY_TYPES } from '@/constants/commodityTypes'
 import { COMMODITY_STATUSES } from '@/constants/commodityStatuses'
 
@@ -65,6 +66,7 @@ const areas = ref<any[]>([])
 const locations = ref<any[]>([])
 const loading = ref<boolean>(true)
 const error = ref<string | null>(null)
+const mainCurrency = ref<string>('USD') // Default to USD if not set
 
 // Highlight commodity if specified in the URL
 const highlightCommodityId = ref(route.query.highlightCommodityId as string || '')
@@ -127,6 +129,17 @@ const calculatePricePerUnit = (commodity: any) => {
 
 onMounted(async () => {
   try {
+    // Fetch main currency from settings
+    try {
+      const currency = await settingsService.getMainCurrency()
+      if (currency) {
+        mainCurrency.value = currency
+      }
+    } catch (settingsErr) {
+      console.error('Failed to load main currency from settings:', settingsErr)
+      // Continue with default currency
+    }
+
     // Load commodities, areas, and locations in parallel
     const [commoditiesResponse, areasResponse, locationsResponse] = await Promise.all([
       commodityService.getCommodities(),

--- a/frontend/src/views/commodities/CommodityPrintView.vue
+++ b/frontend/src/views/commodities/CommodityPrintView.vue
@@ -115,7 +115,7 @@
               <span class="label">Original Price:</span>
               <span>{{ commodity.attributes.original_price }} {{ commodity.attributes.original_price_currency }}</span>
             </div>
-            <div class="info-row">
+            <div class="info-row" v-if="commodity.attributes.converted_original_price !== '0' && commodity.attributes.converted_original_price !== 0">
               <span class="label">Converted Original Price:</span>
               <span>{{ commodity.attributes.converted_original_price }}</span>
             </div>


### PR DESCRIPTION
This pull request introduces a feature to dynamically fetch and use the main currency from the settings service across multiple views in the application. It also updates the display logic to consistently use the fetched currency instead of the original price currency. Below are the key changes grouped by theme:

### Currency Fetching and Initialization:
* Added a `mainCurrency` reactive variable with a default value of `'USD'` in `AreaDetailView.vue`, `CommodityDetailView.vue`, and `CommodityListView.vue`. This variable is updated by fetching the main currency from the `settingsService` during the `onMounted` lifecycle hook. If the fetch fails, the default currency is retained. [[1]](diffhunk://#diff-0f597a7543a741d2ccfd7f1a20fb69f7af9f06827fef8e6bd7425a8e4a25c892R88) [[2]](diffhunk://#diff-0f597a7543a741d2ccfd7f1a20fb69f7af9f06827fef8e6bd7425a8e4a25c892R98-R108) [[3]](diffhunk://#diff-0a2911811c854081b9df07f0efeb5197577fe76db6d222e9ca361b38897aa4c7R228) [[4]](diffhunk://#diff-0a2911811c854081b9df07f0efeb5197577fe76db6d222e9ca361b38897aa4c7R253-R263) [[5]](diffhunk://#diff-634a616c38c6e93777bc51f33b69d339054ecd2544c63d6571b31df57dc8d70fR69) [[6]](diffhunk://#diff-634a616c38c6e93777bc51f33b69d339054ecd2544c63d6571b31df57dc8d70fR132-R142)

### Display Updates for Currency:
* Replaced instances of `commodity.attributes.original_price_currency` with the `mainCurrency` variable in price displays and calculations across `AreaDetailView.vue`, `CommodityDetailView.vue`, and `CommodityListView.vue`. This ensures the application consistently uses the main currency for all price-related information. [[1]](diffhunk://#diff-0f597a7543a741d2ccfd7f1a20fb69f7af9f06827fef8e6bd7425a8e4a25c892L41-R43) [[2]](diffhunk://#diff-0a2911811c854081b9df07f0efeb5197577fe76db6d222e9ca361b38897aa4c7L61-R71) [[3]](diffhunk://#diff-634a616c38c6e93777bc51f33b69d339054ecd2544c63d6571b31df57dc8d70fL30-R32)

### Conditional Rendering:
* Updated the "Converted Original Price" row in `CommodityDetailView.vue` and `CommodityPrintView.vue` to only render if the `converted_original_price` is not zero. [[1]](diffhunk://#diff-0a2911811c854081b9df07f0efeb5197577fe76db6d222e9ca361b38897aa4c7L61-R71) [[2]](diffhunk://#diff-c95bc3d00f7698342ddde014261febca4f1445d78d4635d4d509b138c1e4c1c1L118-R118)

### Dependency Management:
* Imported `settingsService` into `AreaDetailView.vue`, `CommodityDetailView.vue`, and `CommodityListView.vue` to enable fetching the main currency. [[1]](diffhunk://#diff-0f597a7543a741d2ccfd7f1a20fb69f7af9f06827fef8e6bd7425a8e4a25c892R75) [[2]](diffhunk://#diff-0a2911811c854081b9df07f0efeb5197577fe76db6d222e9ca361b38897aa4c7R215) [[3]](diffhunk://#diff-634a616c38c6e93777bc51f33b69d339054ecd2544c63d6571b31df57dc8d70fR58)