### PR TITLE
Styles for different statuses + draft

### DIFF
--- a/frontend/src/views/areas/AreaDetailView.vue
+++ b/frontend/src/views/areas/AreaDetailView.vue
@@ -30,7 +30,14 @@
           <router-link :to="`/commodities/new?area=${area.id}`" class="btn btn-primary btn-sm"><font-awesome-icon icon="plus" /> New</router-link>
         </div>
         <div class="commodities-grid">
-          <div v-for="commodity in commodities" :key="commodity.id" class="commodity-card" :class="{ 'highlighted': commodity.id === highlightCommodityId, 'draft': commodity.attributes.draft }">
+          <div v-for="commodity in commodities" :key="commodity.id" class="commodity-card" :class="{
+            'highlighted': commodity.id === highlightCommodityId,
+            'draft': commodity.attributes.draft,
+            'sold': !commodity.attributes.draft && commodity.attributes.status === 'sold',
+            'lost': !commodity.attributes.draft && commodity.attributes.status === 'lost',
+            'disposed': !commodity.attributes.draft && commodity.attributes.status === 'disposed',
+            'written-off': !commodity.attributes.draft && commodity.attributes.status === 'written_off'
+          }">
             <div class="commodity-content" @click="viewCommodity(commodity.id)">
               <h3>{{ commodity.attributes.name }}</h3>
               <div class="commodity-meta">
@@ -491,6 +498,103 @@ const deleteCommodity = async (id: string) => {
     .status {
       background-color: #e2e3e5 !important;
       color: #383d41 !important;
+    }
+  }
+
+  &.sold {
+    position: relative;
+    filter: grayscale(0.8);
+
+    &::before {
+      content: 'SOLD';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) rotate(-45deg);
+      font-size: 2.5rem;
+      font-weight: bold;
+      color: rgba(204, 229, 255, 0.8);
+      border: 3px solid rgba(0, 64, 133, 0.5);
+      padding: 0.5rem 1rem;
+      border-radius: $default-radius;
+      z-index: 1;
+      pointer-events: none;
+    }
+  }
+
+  &.lost {
+    position: relative;
+    filter: saturate(0.7);
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(255, 243, 205, 0.3);
+      z-index: 1;
+      pointer-events: none;
+    }
+
+    &::after {
+      content: '⚠️';
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      font-size: 1.5rem;
+      z-index: 2;
+      pointer-events: none;
+    }
+  }
+
+  &.disposed {
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(248, 215, 218, 0.3);
+      background-image: linear-gradient(45deg, transparent, transparent 48%, rgba(114, 28, 36, 0.2) 49%, rgba(114, 28, 36, 0.2) 51%, transparent 52%, transparent);
+      background-size: 20px 20px;
+      z-index: 1;
+      pointer-events: none;
+    }
+
+    &::after {
+      content: '🗑️';
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      font-size: 1.5rem;
+      z-index: 2;
+      pointer-events: none;
+    }
+  }
+
+  &.written-off {
+    position: relative;
+    filter: contrast(0.8);
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(226, 227, 229, 0.3);
+      background-image:
+        linear-gradient(45deg, transparent, transparent 45%, rgba(56, 61, 65, 0.3) 46%, rgba(56, 61, 65, 0.3) 54%, transparent 55%, transparent),
+        linear-gradient(135deg, transparent, transparent 45%, rgba(56, 61, 65, 0.3) 46%, rgba(56, 61, 65, 0.3) 54%, transparent 55%, transparent);
+      background-size: 30px 30px;
+      z-index: 1;
+      pointer-events: none;
     }
   }
 }

--- a/frontend/src/views/areas/AreaDetailView.vue
+++ b/frontend/src/views/areas/AreaDetailView.vue
@@ -30,7 +30,7 @@
           <router-link :to="`/commodities/new?area=${area.id}`" class="btn btn-primary btn-sm"><font-awesome-icon icon="plus" /> New</router-link>
         </div>
         <div class="commodities-grid">
-          <div v-for="commodity in commodities" :key="commodity.id" class="commodity-card" :class="{ 'highlighted': commodity.id === highlightCommodityId }">
+          <div v-for="commodity in commodities" :key="commodity.id" class="commodity-card" :class="{ 'highlighted': commodity.id === highlightCommodityId, 'draft': commodity.attributes.draft }">
             <div class="commodity-content" @click="viewCommodity(commodity.id)">
               <h3>{{ commodity.attributes.name }}</h3>
               <div class="commodity-meta">
@@ -46,7 +46,7 @@
                   {{ formatPrice(calculatePricePerUnit(commodity)) }} per unit
                 </span>
               </div>
-              <div class="commodity-status" v-if="commodity.attributes.status">
+              <div class="commodity-status" v-if="commodity.attributes.status" :class="{ 'with-draft': commodity.attributes.draft }">
                 <span class="status" :class="commodity.attributes.status">{{ getStatusName(commodity.attributes.status) }}</span>
               </div>
             </div>
@@ -479,6 +479,20 @@ const deleteCommodity = async (id: string) => {
     box-shadow: 0 2px 10px rgba($primary-color, 0.3);
     background-color: lighten($primary-color, 45%);
   }
+
+  &.draft {
+    background: repeating-linear-gradient(45deg, #ffffff, #ffffff 5px, #eeeeee4d 5px, #eeeeee4d 7px);
+    position: relative;
+
+    h3, .commodity-meta, .commodity-price, .price-per-unit {
+      color: $text-secondary-color;
+    }
+
+    .status {
+      background-color: #e2e3e5 !important;
+      color: #383d41 !important;
+    }
+  }
 }
 
 .commodity-content {
@@ -526,6 +540,24 @@ const deleteCommodity = async (id: string) => {
 
 .commodity-status {
   margin-top: 0.5rem;
+
+  &.with-draft {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &::after {
+      content: 'Draft';
+      font-size: 0.8rem;
+      font-weight: 500;
+      color: $text-secondary-color;
+      font-style: italic;
+      transform: rotate(-45deg);
+      position: absolute;
+      bottom: 0.5rem;
+      right: 0.5rem;
+    }
+  }
 }
 
 .status {

--- a/frontend/src/views/areas/AreaDetailView.vue
+++ b/frontend/src/views/areas/AreaDetailView.vue
@@ -541,7 +541,7 @@ const deleteCommodity = async (id: string) => {
     &::after {
       content: '⚠️';
       position: absolute;
-      top: 1rem;
+      bottom: 1rem;
       right: 1rem;
       font-size: 1.5rem;
       z-index: 2;
@@ -569,7 +569,7 @@ const deleteCommodity = async (id: string) => {
     &::after {
       content: '🗑️';
       position: absolute;
-      top: 1rem;
+      bottom: 1rem;
       right: 1rem;
       font-size: 1.5rem;
       z-index: 2;
@@ -588,10 +588,10 @@ const deleteCommodity = async (id: string) => {
       left: 0;
       right: 0;
       bottom: 0;
-      background-color: rgba(226, 227, 229, 0.3);
+      background-color: rgba(226, 227, 229, 0.15);
       background-image:
-        linear-gradient(45deg, transparent, transparent 45%, rgba(56, 61, 65, 0.3) 46%, rgba(56, 61, 65, 0.3) 54%, transparent 55%, transparent),
-        linear-gradient(135deg, transparent, transparent 45%, rgba(56, 61, 65, 0.3) 46%, rgba(56, 61, 65, 0.3) 54%, transparent 55%, transparent);
+        linear-gradient(45deg, transparent, transparent 45%, rgba(56, 61, 65, 0.15) 46%, rgba(56, 61, 65, 0.15) 54%, transparent 55%, transparent),
+        linear-gradient(135deg, transparent, transparent 45%, rgba(56, 61, 65, 0.15) 46%, rgba(56, 61, 65, 0.15) 54%, transparent 55%, transparent);
       background-size: 30px 30px;
       z-index: 1;
       pointer-events: none;

--- a/frontend/src/views/areas/AreaDetailView.vue
+++ b/frontend/src/views/areas/AreaDetailView.vue
@@ -490,6 +490,7 @@ const deleteCommodity = async (id: string) => {
   &.draft {
     background: repeating-linear-gradient(45deg, #ffffff, #ffffff 5px, #eeeeee4d 5px, #eeeeee4d 7px);
     position: relative;
+    filter: grayscale(0.8);
 
     h3, .commodity-meta, .commodity-price, .price-per-unit {
       color: $text-secondary-color;
@@ -579,7 +580,7 @@ const deleteCommodity = async (id: string) => {
 
   &.written-off {
     position: relative;
-    filter: contrast(0.8);
+    filter: contrast(0.95);
 
     &::before {
       content: '';
@@ -588,10 +589,10 @@ const deleteCommodity = async (id: string) => {
       left: 0;
       right: 0;
       bottom: 0;
-      background-color: rgba(226, 227, 229, 0.15);
+      background-color: rgba(226, 227, 229, 0.0375);
       background-image:
-        linear-gradient(45deg, transparent, transparent 45%, rgba(56, 61, 65, 0.15) 46%, rgba(56, 61, 65, 0.15) 54%, transparent 55%, transparent),
-        linear-gradient(135deg, transparent, transparent 45%, rgba(56, 61, 65, 0.15) 46%, rgba(56, 61, 65, 0.15) 54%, transparent 55%, transparent);
+        linear-gradient(45deg, transparent, transparent 45%, rgba(56, 61, 65, 0.0375) 46%, rgba(56, 61, 65, 0.0375) 54%, transparent 55%, transparent),
+        linear-gradient(135deg, transparent, transparent 45%, rgba(56, 61, 65, 0.0375) 46%, rgba(56, 61, 65, 0.0375) 54%, transparent 55%, transparent);
       background-size: 30px 30px;
       z-index: 1;
       pointer-events: none;

--- a/frontend/src/views/commodities/CommodityListView.vue
+++ b/frontend/src/views/commodities/CommodityListView.vue
@@ -425,7 +425,7 @@ const deleteCommodity = async (id: string) => {
     &::after {
       content: '⚠️';
       position: absolute;
-      top: 1rem;
+      bottom: 1rem;
       right: 1rem;
       font-size: 1.5rem;
       z-index: 2;
@@ -453,7 +453,7 @@ const deleteCommodity = async (id: string) => {
     &::after {
       content: '🗑️';
       position: absolute;
-      top: 1rem;
+      bottom: 1rem;
       right: 1rem;
       font-size: 1.5rem;
       z-index: 2;
@@ -472,10 +472,10 @@ const deleteCommodity = async (id: string) => {
       left: 0;
       right: 0;
       bottom: 0;
-      background-color: rgba(226, 227, 229, 0.3);
+      background-color: rgba(226, 227, 229, 0.15);
       background-image:
-        linear-gradient(45deg, transparent, transparent 45%, rgba(56, 61, 65, 0.3) 46%, rgba(56, 61, 65, 0.3) 54%, transparent 55%, transparent),
-        linear-gradient(135deg, transparent, transparent 45%, rgba(56, 61, 65, 0.3) 46%, rgba(56, 61, 65, 0.3) 54%, transparent 55%, transparent);
+        linear-gradient(45deg, transparent, transparent 45%, rgba(56, 61, 65, 0.15) 46%, rgba(56, 61, 65, 0.15) 54%, transparent 55%, transparent),
+        linear-gradient(135deg, transparent, transparent 45%, rgba(56, 61, 65, 0.15) 46%, rgba(56, 61, 65, 0.15) 54%, transparent 55%, transparent);
       background-size: 30px 30px;
       z-index: 1;
       pointer-events: none;

--- a/frontend/src/views/commodities/CommodityListView.vue
+++ b/frontend/src/views/commodities/CommodityListView.vue
@@ -36,7 +36,7 @@
     </div>
 
     <div v-else class="commodities-grid">
-      <div v-for="commodity in commodities" :key="commodity.id" class="commodity-card" :class="{ 'highlighted': commodity.id === highlightCommodityId }" @click="viewCommodity(commodity.id)">
+      <div v-for="commodity in commodities" :key="commodity.id" class="commodity-card" :class="{ 'highlighted': commodity.id === highlightCommodityId, 'draft': commodity.attributes.draft }" @click="viewCommodity(commodity.id)">
         <div class="commodity-content">
           <h3>{{ commodity.attributes.name }}</h3>
           <div class="commodity-location" v-if="commodity.attributes.area_id">
@@ -58,7 +58,7 @@
               {{ formatPrice(calculatePricePerUnit(commodity)) }} per unit
             </span>
           </div>
-          <div class="commodity-status">
+          <div class="commodity-status" :class="{ 'with-draft': commodity.attributes.draft }">
             <span class="status" :class="commodity.attributes.status">{{ getStatusName(commodity.attributes.status) }}</span>
           </div>
         </div>
@@ -363,6 +363,20 @@ const deleteCommodity = async (id: string) => {
     box-shadow: 0 2px 10px rgba($primary-color, 0.3);
     background-color: #f9fff9;
   }
+
+  &.draft {
+    background: repeating-linear-gradient(45deg, #ffffff, #ffffff 5px, #eeeeee4d 5px, #eeeeee4d 7px);
+    position: relative;
+
+    h3, .commodity-location, .commodity-meta, .commodity-price, .price-per-unit {
+      color: $text-secondary-color;
+    }
+
+    .status {
+      background-color: #e2e3e5 !important;
+      color: #383d41 !important;
+    }
+  }
 }
 
 .commodity-content {
@@ -426,6 +440,24 @@ const deleteCommodity = async (id: string) => {
 
 .commodity-status {
   margin-top: 0.5rem;
+
+  &.with-draft {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &::after {
+      content: 'Draft';
+      font-size: 0.8rem;
+      font-weight: 500;
+      color: $text-secondary-color;
+      font-style: italic;
+      transform: rotate(-45deg);
+      position: absolute;
+      bottom: 0.5rem;
+      right: 0.5rem;
+    }
+  }
 }
 
 .status {

--- a/frontend/src/views/commodities/CommodityListView.vue
+++ b/frontend/src/views/commodities/CommodityListView.vue
@@ -36,7 +36,14 @@
     </div>
 
     <div v-else class="commodities-grid">
-      <div v-for="commodity in commodities" :key="commodity.id" class="commodity-card" :class="{ 'highlighted': commodity.id === highlightCommodityId, 'draft': commodity.attributes.draft }" @click="viewCommodity(commodity.id)">
+      <div v-for="commodity in commodities" :key="commodity.id" class="commodity-card" :class="{
+        'highlighted': commodity.id === highlightCommodityId,
+        'draft': commodity.attributes.draft,
+        'sold': !commodity.attributes.draft && commodity.attributes.status === 'sold',
+        'lost': !commodity.attributes.draft && commodity.attributes.status === 'lost',
+        'disposed': !commodity.attributes.draft && commodity.attributes.status === 'disposed',
+        'written-off': !commodity.attributes.draft && commodity.attributes.status === 'written_off'
+      }" @click="viewCommodity(commodity.id)">
         <div class="commodity-content">
           <h3>{{ commodity.attributes.name }}</h3>
           <div class="commodity-location" v-if="commodity.attributes.area_id">
@@ -375,6 +382,103 @@ const deleteCommodity = async (id: string) => {
     .status {
       background-color: #e2e3e5 !important;
       color: #383d41 !important;
+    }
+  }
+
+  &.sold {
+    position: relative;
+    filter: grayscale(0.8);
+
+    &::before {
+      content: 'SOLD';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) rotate(-45deg);
+      font-size: 2.5rem;
+      font-weight: bold;
+      color: rgba(204, 229, 255, 0.8);
+      border: 3px solid rgba(0, 64, 133, 0.5);
+      padding: 0.5rem 1rem;
+      border-radius: $default-radius;
+      z-index: 1;
+      pointer-events: none;
+    }
+  }
+
+  &.lost {
+    position: relative;
+    filter: saturate(0.7);
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(255, 243, 205, 0.3);
+      z-index: 1;
+      pointer-events: none;
+    }
+
+    &::after {
+      content: '⚠️';
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      font-size: 1.5rem;
+      z-index: 2;
+      pointer-events: none;
+    }
+  }
+
+  &.disposed {
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(248, 215, 218, 0.3);
+      background-image: linear-gradient(45deg, transparent, transparent 48%, rgba(114, 28, 36, 0.2) 49%, rgba(114, 28, 36, 0.2) 51%, transparent 52%, transparent);
+      background-size: 20px 20px;
+      z-index: 1;
+      pointer-events: none;
+    }
+
+    &::after {
+      content: '🗑️';
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      font-size: 1.5rem;
+      z-index: 2;
+      pointer-events: none;
+    }
+  }
+
+  &.written-off {
+    position: relative;
+    filter: contrast(0.8);
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(226, 227, 229, 0.3);
+      background-image:
+        linear-gradient(45deg, transparent, transparent 45%, rgba(56, 61, 65, 0.3) 46%, rgba(56, 61, 65, 0.3) 54%, transparent 55%, transparent),
+        linear-gradient(135deg, transparent, transparent 45%, rgba(56, 61, 65, 0.3) 46%, rgba(56, 61, 65, 0.3) 54%, transparent 55%, transparent);
+      background-size: 30px 30px;
+      z-index: 1;
+      pointer-events: none;
     }
   }
 }

--- a/frontend/src/views/commodities/CommodityListView.vue
+++ b/frontend/src/views/commodities/CommodityListView.vue
@@ -374,6 +374,7 @@ const deleteCommodity = async (id: string) => {
   &.draft {
     background: repeating-linear-gradient(45deg, #ffffff, #ffffff 5px, #eeeeee4d 5px, #eeeeee4d 7px);
     position: relative;
+    filter: grayscale(0.8);
 
     h3, .commodity-location, .commodity-meta, .commodity-price, .price-per-unit {
       color: $text-secondary-color;
@@ -463,7 +464,7 @@ const deleteCommodity = async (id: string) => {
 
   &.written-off {
     position: relative;
-    filter: contrast(0.8);
+    filter: contrast(0.95);
 
     &::before {
       content: '';
@@ -472,10 +473,10 @@ const deleteCommodity = async (id: string) => {
       left: 0;
       right: 0;
       bottom: 0;
-      background-color: rgba(226, 227, 229, 0.15);
+      background-color: rgba(226, 227, 229, 0.0375);
       background-image:
-        linear-gradient(45deg, transparent, transparent 45%, rgba(56, 61, 65, 0.15) 46%, rgba(56, 61, 65, 0.15) 54%, transparent 55%, transparent),
-        linear-gradient(135deg, transparent, transparent 45%, rgba(56, 61, 65, 0.15) 46%, rgba(56, 61, 65, 0.15) 54%, transparent 55%, transparent);
+        linear-gradient(45deg, transparent, transparent 45%, rgba(56, 61, 65, 0.0375) 46%, rgba(56, 61, 65, 0.0375) 54%, transparent 55%, transparent),
+        linear-gradient(135deg, transparent, transparent 45%, rgba(56, 61, 65, 0.0375) 46%, rgba(56, 61, 65, 0.0375) 54%, transparent 55%, transparent);
       background-size: 30px 30px;
       z-index: 1;
       pointer-events: none;


### PR DESCRIPTION
This pull request introduces enhanced visual differentiation for commodities based on their status in the `AreaDetailView` and `CommodityListView` components. It adds new CSS classes and logic to handle various statuses like "draft," "sold," "lost," "disposed," and "written-off," improving the user interface and making commodity statuses more visually distinct.

### Changes to Status-Based Styling:

* **Added CSS classes for commodity statuses**: New classes (`draft`, `sold`, `lost`, `disposed`, `written-off`) have been introduced to visually distinguish commodities based on their status. Each class applies unique styles, such as background patterns, filters, and status indicators. [[1]](diffhunk://#diff-0f597a7543a741d2ccfd7f1a20fb69f7af9f06827fef8e6bd7425a8e4a25c892R489-R600) [[2]](diffhunk://#diff-634a616c38c6e93777bc51f33b69d339054ecd2544c63d6571b31df57dc8d70fR373-R484)

* **Enhanced status display for "draft" commodities**: The `commodity-status` element now includes a `with-draft` class when the commodity is in draft status, displaying a "Draft" label with specific styles. [[1]](diffhunk://#diff-0f597a7543a741d2ccfd7f1a20fb69f7af9f06827fef8e6bd7425a8e4a25c892R648-R665) [[2]](diffhunk://#diff-634a616c38c6e93777bc51f33b69d339054ecd2544c63d6571b31df57dc8d70fR548-R565)

### Updates to Component Logic:

* **Dynamic class binding for commodity cards**: The `v-for` loops in both `AreaDetailView.vue` and `CommodityListView.vue` now dynamically apply the new status-based classes to commodity cards. This ensures that the visual styles reflect the current status of each commodity. [[1]](diffhunk://#diff-0f597a7543a741d2ccfd7f1a20fb69f7af9f06827fef8e6bd7425a8e4a25c892L33-R40) [[2]](diffhunk://#diff-634a616c38c6e93777bc51f33b69d339054ecd2544c63d6571b31df57dc8d70fL39-R46)

* **Updated status element logic**: The logic for displaying the `commodity-status` element has been updated to include the new `with-draft` class conditionally, ensuring that the draft label is shown appropriately. [[1]](diffhunk://#diff-0f597a7543a741d2ccfd7f1a20fb69f7af9f06827fef8e6bd7425a8e4a25c892L49-R56) [[2]](diffhunk://#diff-634a616c38c6e93777bc51f33b69d339054ecd2544c63d6571b31df57dc8d70fL61-R68)