### PR TITLE
Price validation

### DIFF
--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -55,29 +55,31 @@ func newAreaRegistry(locationRegistry registry.LocationRegistry) registry.AreaRe
 	return areaRegistry
 }
 
-func newCommodityRegistry(areaRegistry registry.AreaRegistry, settingsRegistry registry.SettingsRegistry) registry.CommodityRegistry {
-	commodityRegistry := memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
+func newCommodityRegistry(areaRegistry registry.AreaRegistry) registry.CommodityRegistry {
+	commodityRegistry := memory.NewCommodityRegistry(areaRegistry)
 
 	areas := must.Must(areaRegistry.List())
 
 	must.Must(commodityRegistry.Create(models.Commodity{
-		Name:          "Commodity 1",
-		ShortName:     "C1",
-		AreaID:        areas[0].ID,
-		Type:          models.CommodityTypeFurniture,
-		Status:        models.CommodityStatusInUse,
-		Count:         10,
-		OriginalPrice: must.Must(decimal.NewFromString("2000.00")),
+		Name:                  "Commodity 1",
+		ShortName:             "C1",
+		AreaID:                areas[0].ID,
+		Type:                  models.CommodityTypeFurniture,
+		Status:                models.CommodityStatusInUse,
+		Count:                 10,
+		OriginalPrice:         must.Must(decimal.NewFromString("2000.00")),
+		OriginalPriceCurrency: models.Currency("USD"),
 	}))
 
 	must.Must(commodityRegistry.Create(models.Commodity{
-		Name:          "Commodity 2",
-		ShortName:     "C2",
-		AreaID:        areas[0].ID,
-		Status:        models.CommodityStatusInUse,
-		Type:          models.CommodityTypeElectronics,
-		Count:         5,
-		OriginalPrice: must.Must(decimal.NewFromString("1500.00")),
+		Name:                  "Commodity 2",
+		ShortName:             "C2",
+		AreaID:                areas[0].ID,
+		Status:                models.CommodityStatusInUse,
+		Type:                  models.CommodityTypeElectronics,
+		Count:                 5,
+		OriginalPrice:         must.Must(decimal.NewFromString("1500.00")),
+		OriginalPriceCurrency: models.Currency("USD"),
 	}))
 
 	return commodityRegistry
@@ -223,7 +225,7 @@ func newParams() apiserver.Params {
 	params.RegistrySet.LocationRegistry = newLocationRegistry()
 	params.RegistrySet.AreaRegistry = newAreaRegistry(params.RegistrySet.LocationRegistry)
 	params.RegistrySet.SettingsRegistry = newSettingsRegistry()
-	params.RegistrySet.CommodityRegistry = newCommodityRegistry(params.RegistrySet.AreaRegistry, params.RegistrySet.SettingsRegistry)
+	params.RegistrySet.CommodityRegistry = newCommodityRegistry(params.RegistrySet.AreaRegistry)
 	params.RegistrySet.ImageRegistry = newImageRegistry(params.RegistrySet.CommodityRegistry)
 	params.RegistrySet.InvoiceRegistry = newInvoiceRegistry(params.RegistrySet.CommodityRegistry)
 	params.RegistrySet.ManualRegistry = newManualRegistry(params.RegistrySet.CommodityRegistry)

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -55,9 +55,8 @@ func newAreaRegistry(locationRegistry registry.LocationRegistry) registry.AreaRe
 	return areaRegistry
 }
 
-func newCommodityRegistry(areaRegistry registry.AreaRegistry) registry.CommodityRegistry {
-	settingsRegistry := memory.NewSettingsRegistry()
-	var commodityRegistry = memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
+func newCommodityRegistry(areaRegistry registry.AreaRegistry, settingsRegistry registry.SettingsRegistry) registry.CommodityRegistry {
+	commodityRegistry := memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
 
 	areas := must.Must(areaRegistry.List())
 
@@ -210,12 +209,21 @@ func newManualRegistry(commodityRegistry registry.CommodityRegistry) registry.Ma
 	return manualRegistry
 }
 
+func newSettingsRegistry() registry.SettingsRegistry {
+	var settingsRegistry = memory.NewSettingsRegistry()
+
+	must.Assert(settingsRegistry.Patch("system.main_currency", "USD"))
+
+	return settingsRegistry
+}
+
 func newParams() apiserver.Params {
 	var params apiserver.Params
 	params.RegistrySet = &registry.Set{}
 	params.RegistrySet.LocationRegistry = newLocationRegistry()
 	params.RegistrySet.AreaRegistry = newAreaRegistry(params.RegistrySet.LocationRegistry)
-	params.RegistrySet.CommodityRegistry = newCommodityRegistry(params.RegistrySet.AreaRegistry)
+	params.RegistrySet.SettingsRegistry = newSettingsRegistry()
+	params.RegistrySet.CommodityRegistry = newCommodityRegistry(params.RegistrySet.AreaRegistry, params.RegistrySet.SettingsRegistry)
 	params.RegistrySet.ImageRegistry = newImageRegistry(params.RegistrySet.CommodityRegistry)
 	params.RegistrySet.InvoiceRegistry = newInvoiceRegistry(params.RegistrySet.CommodityRegistry)
 	params.RegistrySet.ManualRegistry = newManualRegistry(params.RegistrySet.CommodityRegistry)

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -56,7 +56,8 @@ func newAreaRegistry(locationRegistry registry.LocationRegistry) registry.AreaRe
 }
 
 func newCommodityRegistry(areaRegistry registry.AreaRegistry) registry.CommodityRegistry {
-	var commodityRegistry = memory.NewCommodityRegistry(areaRegistry)
+	settingsRegistry := memory.NewSettingsRegistry()
+	var commodityRegistry = memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
 
 	areas := must.Must(areaRegistry.List())
 

--- a/apiserver/commodities_test.go
+++ b/apiserver/commodities_test.go
@@ -128,7 +128,7 @@ func TestCommodityCreate(t *testing.T) {
 				Type:                   models.CommodityTypeElectronics,
 				OriginalPrice:          must.Must(decimal.NewFromString("1000.00")),
 				OriginalPriceCurrency:  models.Currency("USD"),
-				ConvertedOriginalPrice: must.Must(decimal.NewFromString("1200.00")),
+				ConvertedOriginalPrice: must.Must(decimal.NewFromString("0")), // to pass the validation
 				CurrentPrice:           must.Must(decimal.NewFromString("800.00")),
 				SerialNumber:           "SN123456",
 				ExtraSerialNumbers:     []string{"SN654321"},
@@ -156,8 +156,8 @@ func TestCommodityCreate(t *testing.T) {
 	handler := apiserver.APIServer(params)
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusCreated)
 	body := rr.Body.Bytes()
+	c.Assert(rr.Code, qt.Equals, http.StatusCreated, qt.Commentf("Body: %s", body))
 
 	c.Check(body, checkers.JSONPathEquals("$.data.type"), "commodities")
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.name"), "New Commodity in Area 2")
@@ -168,7 +168,7 @@ func TestCommodityCreate(t *testing.T) {
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.count"), float64(1))
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.original_price"), "1000")
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.original_price_currency"), "USD")
-	c.Check(body, checkers.JSONPathEquals("$.data.attributes.converted_original_price"), "1200")
+	c.Check(body, checkers.JSONPathEquals("$.data.attributes.converted_original_price"), "0")
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.current_price"), "800")
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.serial_number"), "SN123456")
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.extra_serial_numbers"), []any{"SN654321"})
@@ -201,7 +201,7 @@ func TestCommodityUpdate(t *testing.T) {
 				Count:                  10,
 				OriginalPrice:          must.Must(decimal.NewFromString("2000.00")),
 				OriginalPriceCurrency:  models.Currency("USD"),
-				ConvertedOriginalPrice: must.Must(decimal.NewFromString("2400.00")),
+				ConvertedOriginalPrice: must.Must(decimal.NewFromString("0")), // to pass the validation
 				CurrentPrice:           must.Must(decimal.NewFromString("1800.00")),
 				SerialNumber:           "SN654321",
 				ExtraSerialNumbers:     []string{"SN123456"},
@@ -227,8 +227,8 @@ func TestCommodityUpdate(t *testing.T) {
 	handler := apiserver.APIServer(params)
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	body := rr.Body.Bytes()
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 
 	expectedImages := sliceToSliceOfAny(getCommodityMeta(c, params).Images)
 	expectedInvoices := sliceToSliceOfAny(getCommodityMeta(c, params).Invoices)
@@ -244,7 +244,7 @@ func TestCommodityUpdate(t *testing.T) {
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.count"), float64(commodity.Count))
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.original_price"), "2000")
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.original_price_currency"), "USD")
-	c.Check(body, checkers.JSONPathEquals("$.data.attributes.converted_original_price"), "2400")
+	c.Check(body, checkers.JSONPathEquals("$.data.attributes.converted_original_price"), "0")
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.current_price"), "1800")
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.serial_number"), "SN654321")
 	c.Check(body, checkers.JSONPathEquals("$.data.attributes.extra_serial_numbers"), []any{"SN123456"})

--- a/apiserver/locations_test.go
+++ b/apiserver/locations_test.go
@@ -266,8 +266,8 @@ func TestLocationsUpdate_PartialData(t *testing.T) {
 	handler := apiserver.APIServer(params)
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 	body := rr.Body.Bytes()
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("Body: %s", body))
 	c.Assert(body, checkers.JSONPathEquals("$.errors[0].error.error.data.attributes.address"), "cannot be blank")
 }
 

--- a/internal/seeddata/seeddata.go
+++ b/internal/seeddata/seeddata.go
@@ -9,7 +9,7 @@ import (
 )
 
 // SeedData seeds the database with example data.
-func SeedData(registrySet *registry.Set) error { //nolint:funlen,gocyclo // it's a seed function
+func SeedData(registrySet *registry.Set) error { //nolint:funlen,gocyclo,gocognit // it's a seed function
 	// Create default system configuration with CZK as main currency
 	systemConfig := models.SettingsObject{
 		MainCurrency: ptr.To("CZK"),

--- a/internal/seeddata/seeddata.go
+++ b/internal/seeddata/seeddata.go
@@ -328,7 +328,7 @@ func SeedData(registrySet *registry.Set) error { //nolint:funlen,gocyclo,gocogni
 		RegisteredDate:        ptr.To(models.Date("2023-01-16")),
 		Tags:                  []string{"appliance", "kitchen"},
 		Comments:              "Espresso machine with milk frother",
-		Draft:                 true, // Draft status
+		Draft:                 true, // Value status
 	})
 	if err != nil {
 		return err

--- a/internal/validationctx/errors.go
+++ b/internal/validationctx/errors.go
@@ -1,0 +1,9 @@
+package validationctx
+
+import (
+	"errors"
+)
+
+var (
+	ErrMainCurrencyNotSet = errors.New("main currency not set in context")
+)

--- a/internal/validationctx/validationctx.go
+++ b/internal/validationctx/validationctx.go
@@ -1,0 +1,21 @@
+package validationctx
+
+import (
+	"context"
+)
+
+type ctxValueKey string
+
+const mainCurrencyCtxKey ctxValueKey = "mainCurrency"
+
+func MainCurrencyFromContext(ctx context.Context) (string, error) {
+	mainCurrency, ok := ctx.Value(mainCurrencyCtxKey).(string)
+	if !ok {
+		return "", ErrMainCurrencyNotSet
+	}
+	return mainCurrency, nil
+}
+
+func WithMainCurrency(ctx context.Context, mainCurrency string) context.Context {
+	return context.WithValue(ctx, mainCurrencyCtxKey, mainCurrency)
+}

--- a/internal/valuation/valuation_test.go
+++ b/internal/valuation/valuation_test.go
@@ -14,6 +14,14 @@ import (
 
 // setupTestRegistry creates a test registry with test data
 func setupTestRegistry(c *qt.C, mainCurrency string) *registry.Set {
+	c.Helper()
+
+	nonMainCurrency := "USD"
+
+	if mainCurrency == "USD" {
+		nonMainCurrency = "EUR"
+	}
+
 	// Create a memory registry for testing
 	registrySet, err := memory.NewRegistrySet("")
 	c.Assert(err, qt.IsNil)
@@ -56,15 +64,17 @@ func setupTestRegistry(c *qt.C, mainCurrency string) *registry.Set {
 
 	// Create commodities
 	_, err = registrySet.CommodityRegistry.Create(models.Commodity{
-		Name:         "Commodity 1",
-		ShortName:    "C1",
-		AreaID:       area1.ID,
-		Count:        2,
-		CurrentPrice: decimal.NewFromFloat(100.00),
-		Status:       models.CommodityStatusInUse,
-		Draft:        false,
-		Type:         models.CommodityTypeElectronics,
-		PurchaseDate: models.ToPDate("2023-01-01"),
+		Name:                  "Commodity 1",
+		ShortName:             "C1",
+		AreaID:                area1.ID,
+		Count:                 2,
+		OriginalPrice:         decimal.NewFromFloat(100.00),
+		OriginalPriceCurrency: models.Currency(mainCurrency),
+		CurrentPrice:          decimal.NewFromFloat(100.00), // 100
+		Status:                models.CommodityStatusInUse,
+		Draft:                 false,
+		Type:                  models.CommodityTypeElectronics,
+		PurchaseDate:          models.ToPDate("2023-01-01"),
 	})
 	c.Assert(err, qt.IsNil)
 
@@ -73,12 +83,13 @@ func setupTestRegistry(c *qt.C, mainCurrency string) *registry.Set {
 		ShortName:             "C2",
 		AreaID:                area1.ID,
 		Count:                 1,
-		OriginalPrice:         decimal.NewFromFloat(200.00),
-		OriginalPriceCurrency: "USD",
-		Status:                models.CommodityStatusInUse,
-		Draft:                 false,
-		Type:                  models.CommodityTypeElectronics,
-		PurchaseDate:          models.ToPDate("2023-01-01"),
+		OriginalPrice:         decimal.NewFromFloat(200.00), // 0: invalid
+		OriginalPriceCurrency: models.Currency(nonMainCurrency),
+		// no converted price and no current price, so it should not be counted
+		Status:       models.CommodityStatusInUse,
+		Draft:        false,
+		Type:         models.CommodityTypeElectronics,
+		PurchaseDate: models.ToPDate("2023-01-01"),
 	})
 	c.Assert(err, qt.IsNil)
 
@@ -87,9 +98,9 @@ func setupTestRegistry(c *qt.C, mainCurrency string) *registry.Set {
 		ShortName:              "C3",
 		AreaID:                 area2.ID,
 		Count:                  3,
-		OriginalPrice:          decimal.NewFromFloat(300.00),
-		OriginalPriceCurrency:  "EUR",
-		ConvertedOriginalPrice: decimal.NewFromFloat(330.00),
+		OriginalPrice:          decimal.NewFromFloat(300.00), // 300
+		OriginalPriceCurrency:  models.Currency(mainCurrency),
+		ConvertedOriginalPrice: decimal.NewFromFloat(0),
 		Status:                 models.CommodityStatusInUse,
 		Draft:                  false,
 		Type:                   models.CommodityTypeElectronics,
@@ -97,13 +108,13 @@ func setupTestRegistry(c *qt.C, mainCurrency string) *registry.Set {
 	})
 	c.Assert(err, qt.IsNil)
 
-	_, err = registrySet.CommodityRegistry.Create(models.Commodity{
+	_, err = registrySet.CommodityRegistry.Create(models.Commodity{ // 400
 		Name:                  "Commodity 4",
 		ShortName:             "C4",
 		AreaID:                area2.ID,
 		Count:                 1,
 		OriginalPrice:         decimal.NewFromFloat(400.00),
-		OriginalPriceCurrency: "EUR",
+		OriginalPriceCurrency: models.Currency(mainCurrency),
 		Status:                models.CommodityStatusInUse,
 		Draft:                 false,
 		Type:                  models.CommodityTypeElectronics,
@@ -111,29 +122,33 @@ func setupTestRegistry(c *qt.C, mainCurrency string) *registry.Set {
 	})
 	c.Assert(err, qt.IsNil)
 
-	_, err = registrySet.CommodityRegistry.Create(models.Commodity{
-		Name:         "Commodity 5",
-		ShortName:    "C5",
-		AreaID:       area3.ID,
-		Count:        1,
-		CurrentPrice: decimal.NewFromFloat(500.00),
-		Status:       models.CommodityStatusSold, // Not in use
-		Draft:        false,
-		Type:         models.CommodityTypeElectronics,
-		PurchaseDate: models.ToPDate("2023-01-01"),
+	_, err = registrySet.CommodityRegistry.Create(models.Commodity{ // 0: sold
+		Name:                  "Commodity 5",
+		ShortName:             "C5",
+		AreaID:                area3.ID,
+		Count:                 1,
+		OriginalPrice:         decimal.NewFromFloat(500.00),
+		OriginalPriceCurrency: models.Currency(nonMainCurrency),
+		CurrentPrice:          decimal.NewFromFloat(500.00),
+		Status:                models.CommodityStatusSold, // Not in use
+		Draft:                 false,
+		Type:                  models.CommodityTypeElectronics,
+		PurchaseDate:          models.ToPDate("2023-01-01"),
 	})
 	c.Assert(err, qt.IsNil)
 
-	_, err = registrySet.CommodityRegistry.Create(models.Commodity{
-		Name:         "Commodity 6",
-		ShortName:    "C6",
-		AreaID:       area3.ID,
-		Count:        1,
-		CurrentPrice: decimal.NewFromFloat(600.00),
-		Status:       models.CommodityStatusInUse,
-		Draft:        true, // Draft
-		Type:         models.CommodityTypeElectronics,
-		PurchaseDate: models.ToPDate("2023-01-01"),
+	_, err = registrySet.CommodityRegistry.Create(models.Commodity{ // 0: draft
+		Name:                  "Commodity 6",
+		ShortName:             "C6",
+		AreaID:                area3.ID,
+		Count:                 1,
+		OriginalPrice:         decimal.NewFromFloat(600.00),
+		OriginalPriceCurrency: models.Currency(nonMainCurrency),
+		CurrentPrice:          decimal.NewFromFloat(600.00),
+		Status:                models.CommodityStatusInUse,
+		Draft:                 true, // Draft
+		Type:                  models.CommodityTypeElectronics,
+		PurchaseDate:          models.ToPDate("2023-01-01"),
 	})
 	c.Assert(err, qt.IsNil)
 
@@ -153,8 +168,8 @@ func TestValuator_CalculateGlobalTotalValue(t *testing.T) {
 		total, err := valuator.CalculateGlobalTotalValue()
 		c.Assert(err, qt.IsNil)
 
-		// Expected total: 100 + 200 + 330 = 630 (prices already represent total value for all items)
-		expectedTotal := decimal.NewFromFloat(630.00)
+		// Expected total: 100 + 300 + 400 = 800 (prices already represent total value for all items)
+		expectedTotal := decimal.NewFromFloat(800.00)
 		c.Assert(total.Equal(expectedTotal), qt.IsTrue, qt.Commentf("Expected total to be %s, got %s", expectedTotal, total))
 	})
 
@@ -201,8 +216,8 @@ func TestValuator_CalculateTotalValueByLocation(t *testing.T) {
 		// Location 1: 100 + 200 = 300
 		// Location 2: 330 + 0 = 330 (Commodity 4 has no valid price in USD)
 		expectedTotals := map[string]decimal.Decimal{
-			"Location 1": decimal.NewFromFloat(300.00),
-			"Location 2": decimal.NewFromFloat(330.00),
+			"Location 1": decimal.NewFromFloat(100.00),
+			"Location 2": decimal.NewFromFloat(700.00),
 		}
 
 		// Check that we have the expected number of totals
@@ -253,8 +268,8 @@ func TestValuator_CalculateTotalValueByArea(t *testing.T) {
 		// Area 2: 330 = 330
 		// Area 3: (0) = 0 (No valid commodities in Area 3 with USD as main currency)
 		expectedTotals := map[string]decimal.Decimal{
-			area1ID: decimal.NewFromFloat(300.00),
-			area2ID: decimal.NewFromFloat(330.00),
+			area1ID: decimal.NewFromFloat(100.00),
+			area2ID: decimal.NewFromFloat(700.00),
 		}
 
 		// Check that we have the expected number of totals

--- a/internal/valuation/valuation_test.go
+++ b/internal/valuation/valuation_test.go
@@ -146,7 +146,7 @@ func setupTestRegistry(c *qt.C, mainCurrency string) *registry.Set {
 		OriginalPriceCurrency: models.Currency(nonMainCurrency),
 		CurrentPrice:          decimal.NewFromFloat(600.00),
 		Status:                models.CommodityStatusInUse,
-		Draft:                 true, // Draft
+		Draft:                 true, // Value
 		Type:                  models.CommodityTypeElectronics,
 		PurchaseDate:          models.ToPDate("2023-01-01"),
 	})

--- a/jsonapi/commodities.go
+++ b/jsonapi/commodities.go
@@ -2,6 +2,7 @@
 package jsonapi
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -120,20 +121,20 @@ type CommodityData struct {
 	Attributes *models.Commodity `json:"attributes"`
 }
 
-func (cd *CommodityData) Validate() error {
+func (cd *CommodityData) ValidateWithContext(ctx context.Context) error {
 	fields := make([]*validation.FieldRules, 0)
 	fields = append(fields,
 		validation.Field(&cd.Type, validation.Required, validation.In("commodities")),
 		validation.Field(&cd.Attributes, validation.Required),
 	)
-	return validation.ValidateStruct(cd, fields...)
+	return validation.ValidateStructWithContext(ctx, cd, fields...)
 }
 
 var _ render.Binder = (*CommodityRequest)(nil)
 
 // Bind binds the commodity data from the request to the CommodityRequest object.
-func (cr *CommodityRequest) Bind(_r *http.Request) error {
-	err := cr.Validate()
+func (cr *CommodityRequest) Bind(r *http.Request) error {
+	err := cr.ValidateWithContext(r.Context())
 	if err != nil {
 		return err
 	}
@@ -141,11 +142,11 @@ func (cr *CommodityRequest) Bind(_r *http.Request) error {
 	return nil
 }
 
-// Validate validates the commodity request data.
-func (cr *CommodityRequest) Validate() error {
+// ValidateWithContext validates the commodity request data.
+func (cr *CommodityRequest) ValidateWithContext(ctx context.Context) error {
 	fields := make([]*validation.FieldRules, 0)
 	fields = append(fields,
 		validation.Field(&cr.Data, validation.Required),
 	)
-	return validation.ValidateStruct(cr, fields...)
+	return validation.ValidateStructWithContext(ctx, cr, fields...)
 }

--- a/jsonapi/locations.go
+++ b/jsonapi/locations.go
@@ -1,6 +1,7 @@
 package jsonapi
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-chi/render"
@@ -95,17 +96,17 @@ type LocationData struct {
 	Attributes *models.Location `json:"attributes"`
 }
 
-func (ld *LocationData) Validate() error {
+func (ld *LocationData) ValidateWithContext(ctx context.Context) error {
 	fields := make([]*validation.FieldRules, 0)
 	fields = append(fields,
 		validation.Field(&ld.Type, validation.Required, validation.In("locations")),
 		validation.Field(&ld.Attributes, validation.Required),
 	)
-	return validation.ValidateStruct(ld, fields...)
+	return validation.ValidateStructWithContext(ctx, ld, fields...)
 }
 
-func (lr *LocationRequest) Bind(_r *http.Request) error {
-	err := lr.Validate()
+func (lr *LocationRequest) Bind(r *http.Request) error {
+	err := lr.ValidateWithContext(r.Context())
 	if err != nil {
 		return err
 	}
@@ -115,10 +116,8 @@ func (lr *LocationRequest) Bind(_r *http.Request) error {
 	return nil
 }
 
-func (lr *LocationRequest) Validate() error {
+func (lr *LocationRequest) ValidateWithContext(ctx context.Context) error {
 	fields := make([]*validation.FieldRules, 0)
-	fields = append(fields,
-		validation.Field(&lr.Data, validation.Required),
-	)
-	return validation.ValidateStruct(lr, fields...)
+	fields = append(fields, validation.Field(&lr.Data, validation.Required))
+	return validation.ValidateStructWithContext(ctx, lr, fields...)
 }

--- a/models/commodity.go
+++ b/models/commodity.go
@@ -114,7 +114,7 @@ type Commodity struct {
 	Draft                  bool            `json:"draft"`
 }
 
-func (a *Commodity) Validate() error {
+func (*Commodity) Validate() error {
 	return validation.NewError("must_use_validate_with_context", "must use validate with context")
 }
 
@@ -148,6 +148,11 @@ func (a *Commodity) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&a.URLs),
 		// Add validation for converted original price
 		validation.Field(&a.ConvertedOriginalPrice, priceRule),
+		validation.Field(&a.OriginalPrice, validation.Required, validation.By(func(any) error {
+			v, _ := a.OriginalPrice.Float64()
+			return validation.Min(0.00).Exclusive().Validate(v)
+		})),
+		validation.Field(&a.OriginalPriceCurrency, rules.NotEmpty),
 	)
 
 	return validation.ValidateStruct(a, fields...)

--- a/models/commodity.go
+++ b/models/commodity.go
@@ -130,11 +130,12 @@ func (a *Commodity) ValidateWithContext(ctx context.Context) error {
 	fields := make([]*validation.FieldRules, 0)
 
 	// Create a validation rule for price consistency
-	// When original price is in the main currency, converted original price must be zero
-	priceRule := rules.NewConvertedPriceRule(
+	priceRule := rules.NewPriceRule(
 		string(mainCurrency),
 		string(a.OriginalPriceCurrency),
+		a.OriginalPrice,
 		a.ConvertedOriginalPrice,
+		a.CurrentPrice,
 	)
 
 	fields = append(fields,
@@ -146,11 +147,18 @@ func (a *Commodity) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&a.PurchaseDate, rules.NotEmpty),
 		validation.Field(&a.Count, validation.Required, validation.Min(1)),
 		validation.Field(&a.URLs),
-		// Add validation for converted original price
 		validation.Field(&a.ConvertedOriginalPrice, priceRule),
 		validation.Field(&a.OriginalPrice, validation.Required, validation.By(func(any) error {
 			v, _ := a.OriginalPrice.Float64()
-			return validation.Min(0.00).Exclusive().Validate(v)
+			return validation.Min(0.00).Validate(v)
+		})),
+		validation.Field(&a.ConvertedOriginalPrice, validation.Required, validation.By(func(any) error {
+			v, _ := a.OriginalPrice.Float64()
+			return validation.Min(0.00).Validate(v)
+		})),
+		validation.Field(&a.CurrentPrice, validation.Required, validation.By(func(any) error {
+			v, _ := a.OriginalPrice.Float64()
+			return validation.Min(0.00).Validate(v)
 		})),
 		validation.Field(&a.OriginalPriceCurrency, rules.NotEmpty),
 	)

--- a/models/errors.go
+++ b/models/errors.go
@@ -1,0 +1,11 @@
+package models
+
+import (
+	"errors"
+)
+
+var (
+	// ErrConvertedPriceNotZero is the error that returns when the original price is in the main currency
+	// but the converted original price is not zero.
+	ErrConvertedPriceNotZero = errors.New("converted original price must be zero when original price is in the main currency")
+)

--- a/models/rules/price_validation.go
+++ b/models/rules/price_validation.go
@@ -1,0 +1,41 @@
+package rules
+
+import (
+	"github.com/jellydator/validation"
+	"github.com/shopspring/decimal"
+)
+
+var (
+	// ErrConvertedPriceNotZero is the error that returns when the original price is in the main currency
+	// but the converted original price is not zero.
+	ErrConvertedPriceNotZero = validation.NewError(
+		"validation_converted_price_not_zero",
+		"converted original price must be zero when original price is in the main currency",
+	)
+)
+
+// ConvertedPriceRule validates that when the original price is in the main currency,
+// the converted original price must be zero.
+type ConvertedPriceRule struct {
+	MainCurrency      string
+	OriginalCurrency  string
+	ConvertedPrice    decimal.Decimal
+}
+
+// NewConvertedPriceRule creates a new ConvertedPriceRule.
+func NewConvertedPriceRule(mainCurrency, originalCurrency string, convertedPrice decimal.Decimal) ConvertedPriceRule {
+	return ConvertedPriceRule{
+		MainCurrency:     mainCurrency,
+		OriginalCurrency: originalCurrency,
+		ConvertedPrice:   convertedPrice,
+	}
+}
+
+// Validate implements the validation.Rule interface.
+func (r ConvertedPriceRule) Validate(_ any) error {
+	// If original currency is the main currency and converted price is not zero, return error
+	if r.OriginalCurrency == r.MainCurrency && !r.ConvertedPrice.IsZero() {
+		return ErrConvertedPriceNotZero
+	}
+	return nil
+}

--- a/models/rules/price_validation.go
+++ b/models/rules/price_validation.go
@@ -12,6 +12,19 @@ var (
 		"validation_converted_price_not_zero",
 		"converted original price must be zero when original price is in the main currency",
 	)
+
+	// ErrAllPricesZero is the error that returns when all prices are zero.
+	ErrAllPricesZero = validation.NewError(
+		"validation_all_prices_zero",
+		"at least one of current price, original price, or converted original price must be set",
+	)
+
+	// ErrNoPriceInMainCurrency is the error that returns when the original price is not in the main currency
+	// and neither the converted original price nor the current price is set.
+	ErrNoPriceInMainCurrency = validation.NewError(
+		"validation_no_price_in_main_currency",
+		"if original price is not in the main currency, converted original price or current price must be set",
+	)
 )
 
 // ConvertedPriceRule validates that when the original price is in the main currency,
@@ -19,15 +32,19 @@ var (
 type ConvertedPriceRule struct {
 	MainCurrency     string
 	OriginalCurrency string
+	OriginalPrice    decimal.Decimal
 	ConvertedPrice   decimal.Decimal
+	CurrentPrice     decimal.Decimal
 }
 
-// NewConvertedPriceRule creates a new ConvertedPriceRule.
-func NewConvertedPriceRule(mainCurrency, originalCurrency string, convertedPrice decimal.Decimal) ConvertedPriceRule {
+// NewPriceRule creates a new ConvertedPriceRule.
+func NewPriceRule(mainCurrency, originalCurrency string, originalPrice, convertedPrice, currentPrice decimal.Decimal) ConvertedPriceRule {
 	return ConvertedPriceRule{
 		MainCurrency:     mainCurrency,
 		OriginalCurrency: originalCurrency,
 		ConvertedPrice:   convertedPrice,
+		OriginalPrice:    originalPrice,
+		CurrentPrice:     currentPrice,
 	}
 }
 
@@ -37,5 +54,14 @@ func (r ConvertedPriceRule) Validate(_ any) error {
 	if r.OriginalCurrency == r.MainCurrency && !r.ConvertedPrice.IsZero() {
 		return ErrConvertedPriceNotZero
 	}
+
+	if r.CurrentPrice.IsZero() && r.OriginalPrice.IsZero() && r.ConvertedPrice.IsZero() {
+		return ErrAllPricesZero
+	}
+
+	if r.OriginalCurrency != r.MainCurrency && r.ConvertedPrice.IsZero() && r.CurrentPrice.IsZero() {
+		return ErrNoPriceInMainCurrency
+	}
+
 	return nil
 }

--- a/models/rules/price_validation.go
+++ b/models/rules/price_validation.go
@@ -17,9 +17,9 @@ var (
 // ConvertedPriceRule validates that when the original price is in the main currency,
 // the converted original price must be zero.
 type ConvertedPriceRule struct {
-	MainCurrency      string
-	OriginalCurrency  string
-	ConvertedPrice    decimal.Decimal
+	MainCurrency     string
+	OriginalCurrency string
+	ConvertedPrice   decimal.Decimal
 }
 
 // NewConvertedPriceRule creates a new ConvertedPriceRule.

--- a/models/rules/price_validation.go
+++ b/models/rules/price_validation.go
@@ -49,16 +49,22 @@ func NewPriceRule(mainCurrency, originalCurrency string, originalPrice, converte
 }
 
 // Validate implements the validation.Rule interface.
+// It checks the following conditions:
+// 1. If the original price is in the main currency, the converted original price must be zero.
+// 2. At least one of the prices (current, original, or converted original) must be set.
+// 3. If the original price is not in the main currency, either the converted original price or the current price must be set.
 func (r ConvertedPriceRule) Validate(_ any) error {
 	// If original currency is the main currency and converted price is not zero, return error
 	if r.OriginalCurrency == r.MainCurrency && !r.ConvertedPrice.IsZero() {
 		return ErrConvertedPriceNotZero
 	}
 
+	// If all prices are zero, return error
 	if r.CurrentPrice.IsZero() && r.OriginalPrice.IsZero() && r.ConvertedPrice.IsZero() {
 		return ErrAllPricesZero
 	}
 
+	// If original currency is not the main currency and neither converted price nor current price is set, return error
 	if r.OriginalCurrency != r.MainCurrency && r.ConvertedPrice.IsZero() && r.CurrentPrice.IsZero() {
 		return ErrNoPriceInMainCurrency
 	}

--- a/models/rules/whennotdraft.go
+++ b/models/rules/whennotdraft.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"errors"
+
+	"github.com/jellydator/validation"
+)
+
+type WhenTrueRule struct {
+	Value bool
+	Rules []validation.Rule
+}
+
+var (
+	_ validation.Rule = (*WhenTrueRule)(nil)
+)
+
+// WhenTrue returns a new WhenTrueRule.
+// It applies the given rules when the Value flag is true.
+func WhenTrue(draft bool, rules ...validation.Rule) WhenTrueRule {
+	return WhenTrueRule{
+		Value: draft,
+		Rules: rules,
+	}
+}
+
+// WithRules returns a new WhenTrueRule with the given rules added.
+func (r WhenTrueRule) WithRules(rules ...validation.Rule) WhenTrueRule {
+	ret := r
+	copy(ret.Rules, r.Rules)
+	ret.Rules = append(ret.Rules, rules...)
+	return ret
+}
+
+// Validate implements the validation.Rule interface.
+// It checks the following conditions:
+// 1. If the Value flag is true, it applies the given rules.
+// 2. If the Value flag is false, it does not apply any rules.
+func (r WhenTrueRule) Validate(value any) error {
+	if !r.Value {
+		return nil
+	}
+
+	var errs []error
+	for _, rule := range r.Rules {
+		errs = append(errs, rule.Validate(value))
+	}
+
+	return errors.Join(errs...)
+}

--- a/registry/boltdb/boltdb.go
+++ b/registry/boltdb/boltdb.go
@@ -34,11 +34,11 @@ func NewRegistrySet(c registry.Config) (*registry.Set, error) {
 	s := &registry.Set{}
 	s.LocationRegistry = NewLocationRegistry(db)
 	s.AreaRegistry = NewAreaRegistry(db, s.LocationRegistry)
-	s.CommodityRegistry = NewCommodityRegistry(db, s.AreaRegistry)
+	s.SettingsRegistry = NewSettingsRegistry(db)
+	s.CommodityRegistry = NewCommodityRegistry(db, s.AreaRegistry, s.SettingsRegistry)
 	s.ImageRegistry = NewImageRegistry(db, s.CommodityRegistry)
 	s.InvoiceRegistry = NewInvoiceRegistry(db, s.CommodityRegistry)
 	s.ManualRegistry = NewManualRegistry(db, s.CommodityRegistry)
-	s.SettingsRegistry = NewSettingsRegistry(db)
 
 	return s, nil
 }

--- a/registry/boltdb/boltdb.go
+++ b/registry/boltdb/boltdb.go
@@ -35,7 +35,7 @@ func NewRegistrySet(c registry.Config) (*registry.Set, error) {
 	s.LocationRegistry = NewLocationRegistry(db)
 	s.AreaRegistry = NewAreaRegistry(db, s.LocationRegistry)
 	s.SettingsRegistry = NewSettingsRegistry(db)
-	s.CommodityRegistry = NewCommodityRegistry(db, s.AreaRegistry, s.SettingsRegistry)
+	s.CommodityRegistry = NewCommodityRegistry(db, s.AreaRegistry)
 	s.ImageRegistry = NewImageRegistry(db, s.CommodityRegistry)
 	s.InvoiceRegistry = NewInvoiceRegistry(db, s.CommodityRegistry)
 	s.ManualRegistry = NewManualRegistry(db, s.CommodityRegistry)

--- a/registry/boltdb/commodities_test.go
+++ b/registry/boltdb/commodities_test.go
@@ -30,13 +30,8 @@ func setupTestCommodityRegistry(t *testing.T) (*boltdb.CommodityRegistry, *boltd
 	// Create an area registry
 	areaRegistry := boltdb.NewAreaRegistry(db, locationRegistry)
 
-	// Create a settings registry
-	settingsRegistry := boltdb.NewSettingsRegistry(db)
-	err = settingsRegistry.Patch("system.main_currency", "USD")
-	c.Assert(err, qt.IsNil)
-
 	// Create a commodity registry
-	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry, settingsRegistry)
+	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry)
 
 	// Return the registries and a cleanup function
 	cleanup := func() {

--- a/registry/boltdb/images_test.go
+++ b/registry/boltdb/images_test.go
@@ -14,6 +14,7 @@ import (
 
 func setupTestImageRegistry(t *testing.T) (*boltdb.ImageRegistry, *boltdb.CommodityRegistry, *boltdb.AreaRegistry, *boltdb.LocationRegistry, func()) {
 	c := qt.New(t)
+	c.Helper()
 
 	// Create a temporary directory for the test database
 	tempDir, err := os.MkdirTemp("", "boltdb-test-*")
@@ -29,8 +30,13 @@ func setupTestImageRegistry(t *testing.T) (*boltdb.ImageRegistry, *boltdb.Commod
 	// Create an area registry
 	areaRegistry := boltdb.NewAreaRegistry(db, locationRegistry)
 
+	// Create a settings registry
+	settingsRegistry := boltdb.NewSettingsRegistry(db)
+	err = settingsRegistry.Patch("system.main_currency", "USD")
+	c.Assert(err, qt.IsNil)
+
 	// Create a commodity registry
-	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry)
+	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry, settingsRegistry)
 
 	// Create an image registry
 	imageRegistry := boltdb.NewImageRegistry(db, commodityRegistry)

--- a/registry/boltdb/images_test.go
+++ b/registry/boltdb/images_test.go
@@ -30,13 +30,8 @@ func setupTestImageRegistry(t *testing.T) (*boltdb.ImageRegistry, *boltdb.Commod
 	// Create an area registry
 	areaRegistry := boltdb.NewAreaRegistry(db, locationRegistry)
 
-	// Create a settings registry
-	settingsRegistry := boltdb.NewSettingsRegistry(db)
-	err = settingsRegistry.Patch("system.main_currency", "USD")
-	c.Assert(err, qt.IsNil)
-
 	// Create a commodity registry
-	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry, settingsRegistry)
+	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry)
 
 	// Create an image registry
 	imageRegistry := boltdb.NewImageRegistry(db, commodityRegistry)

--- a/registry/boltdb/invoices_test.go
+++ b/registry/boltdb/invoices_test.go
@@ -29,13 +29,8 @@ func setupTestInvoiceRegistry(t *testing.T) (*boltdb.InvoiceRegistry, *boltdb.Co
 	// Create an area registry
 	areaRegistry := boltdb.NewAreaRegistry(db, locationRegistry)
 
-	// Create a settings registry
-	settingsRegistry := boltdb.NewSettingsRegistry(db)
-	err = settingsRegistry.Patch("system.main_currency", "USD")
-	c.Assert(err, qt.IsNil)
-
 	// Create a commodity registry
-	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry, settingsRegistry)
+	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry)
 
 	// Create an invoice registry
 	invoiceRegistry := boltdb.NewInvoiceRegistry(db, commodityRegistry)

--- a/registry/boltdb/invoices_test.go
+++ b/registry/boltdb/invoices_test.go
@@ -29,8 +29,13 @@ func setupTestInvoiceRegistry(t *testing.T) (*boltdb.InvoiceRegistry, *boltdb.Co
 	// Create an area registry
 	areaRegistry := boltdb.NewAreaRegistry(db, locationRegistry)
 
+	// Create a settings registry
+	settingsRegistry := boltdb.NewSettingsRegistry(db)
+	err = settingsRegistry.Patch("system.main_currency", "USD")
+	c.Assert(err, qt.IsNil)
+
 	// Create a commodity registry
-	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry)
+	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry, settingsRegistry)
 
 	// Create an invoice registry
 	invoiceRegistry := boltdb.NewInvoiceRegistry(db, commodityRegistry)
@@ -46,6 +51,7 @@ func setupTestInvoiceRegistry(t *testing.T) (*boltdb.InvoiceRegistry, *boltdb.Co
 
 func getInvoiceTestSetup(t *testing.T) (registry.InvoiceRegistry, *models.Commodity, func()) {
 	c := qt.New(t)
+	c.Helper()
 
 	invoiceRegistry, commodityRegistry, areaRegistry, locationRegistry, cleanup := setupTestInvoiceRegistry(t)
 

--- a/registry/boltdb/manuals_test.go
+++ b/registry/boltdb/manuals_test.go
@@ -29,13 +29,8 @@ func setupTestManualRegistry(t *testing.T) (*boltdb.ManualRegistry, *boltdb.Comm
 	// Create an area registry
 	areaRegistry := boltdb.NewAreaRegistry(db, locationRegistry)
 
-	// Create a settings registry
-	settingsRegistry := boltdb.NewSettingsRegistry(db)
-	err = settingsRegistry.Patch("system.main_currency", "USD")
-	c.Assert(err, qt.IsNil)
-
 	// Create a commodity registry
-	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry, settingsRegistry)
+	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry)
 
 	// Create a manual registry
 	manualRegistry := boltdb.NewManualRegistry(db, commodityRegistry)

--- a/registry/boltdb/manuals_test.go
+++ b/registry/boltdb/manuals_test.go
@@ -29,8 +29,13 @@ func setupTestManualRegistry(t *testing.T) (*boltdb.ManualRegistry, *boltdb.Comm
 	// Create an area registry
 	areaRegistry := boltdb.NewAreaRegistry(db, locationRegistry)
 
+	// Create a settings registry
+	settingsRegistry := boltdb.NewSettingsRegistry(db)
+	err = settingsRegistry.Patch("system.main_currency", "USD")
+	c.Assert(err, qt.IsNil)
+
 	// Create a commodity registry
-	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry)
+	commodityRegistry := boltdb.NewCommodityRegistry(db, areaRegistry, settingsRegistry)
 
 	// Create a manual registry
 	manualRegistry := boltdb.NewManualRegistry(db, commodityRegistry)

--- a/registry/errors.go
+++ b/registry/errors.go
@@ -11,4 +11,6 @@ var (
 	ErrFieldRequired    = errors.New("field required")
 	ErrAlreadyExists    = errors.New("already exists")
 	ErrBadDataStructure = errors.New("bad data structure")
+
+	ErrMainCurrencyNotSet = errors.New("main currency not set")
 )

--- a/registry/memory/commodities_price_test.go
+++ b/registry/memory/commodities_price_test.go
@@ -16,14 +16,9 @@ func TestCommodityRegistry_Create_PriceValidation(t *testing.T) {
 	// Create registries
 	locationRegistry := memory.NewLocationRegistry()
 	areaRegistry := memory.NewAreaRegistry(locationRegistry)
-	settingsRegistry := memory.NewSettingsRegistry()
-
-	// Set main currency to USD
-	err := settingsRegistry.Patch("system.main_currency", "USD")
-	c.Assert(err, qt.IsNil)
 
 	// Create commodity registry
-	commodityRegistry := memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
+	commodityRegistry := memory.NewCommodityRegistry(areaRegistry)
 
 	// Create a location
 	location, err := locationRegistry.Create(models.Location{
@@ -71,8 +66,7 @@ func TestCommodityRegistry_Create_PriceValidation(t *testing.T) {
 	}
 
 	_, err = commodityRegistry.Create(commodity2)
-	c.Assert(err, qt.Not(qt.IsNil), qt.Commentf("Should not allow creation when original price is in main currency and converted price is not zero"))
-	c.Assert(err.Error(), qt.Contains, "converted original price must be zero when original price is in the main currency")
+	c.Assert(err, qt.IsNil, qt.Commentf("Should allow creation even when original price is in main currency and converted price is not zero (validation is only done in the API)"))
 
 	// Test case 3: Original price in different currency (EUR) and converted original price is not zero - should pass
 	commodity3 := models.Commodity{
@@ -98,14 +92,9 @@ func TestCommodityRegistry_Update_PriceValidation(t *testing.T) {
 	// Create registries
 	locationRegistry := memory.NewLocationRegistry()
 	areaRegistry := memory.NewAreaRegistry(locationRegistry)
-	settingsRegistry := memory.NewSettingsRegistry()
-
-	// Set main currency to USD
-	err := settingsRegistry.Patch("system.main_currency", "USD")
-	c.Assert(err, qt.IsNil)
 
 	// Create commodity registry
-	commodityRegistry := memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
+	commodityRegistry := memory.NewCommodityRegistry(areaRegistry)
 
 	// Create a location
 	location, err := locationRegistry.Create(models.Location{
@@ -152,6 +141,5 @@ func TestCommodityRegistry_Update_PriceValidation(t *testing.T) {
 	updatedCommodity2.ConvertedOriginalPrice = decimal.NewFromFloat(110.00) // Non-zero value
 
 	_, err = commodityRegistry.Update(updatedCommodity2)
-	c.Assert(err, qt.Not(qt.IsNil), qt.Commentf("Should not allow update when original price is in main currency and converted price is not zero"))
-	c.Assert(err.Error(), qt.Contains, "converted original price must be zero when original price is in the main currency")
+	c.Assert(err, qt.IsNil, qt.Commentf("Should allow update even when original price is in main currency and converted price is not zero (validation should be done in the API)"))
 }

--- a/registry/memory/commodities_price_test.go
+++ b/registry/memory/commodities_price_test.go
@@ -1,0 +1,157 @@
+package memory_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+func TestCommodityRegistry_Create_PriceValidation(t *testing.T) {
+	c := qt.New(t)
+
+	// Create registries
+	locationRegistry := memory.NewLocationRegistry()
+	areaRegistry := memory.NewAreaRegistry(locationRegistry)
+	settingsRegistry := memory.NewSettingsRegistry()
+
+	// Set main currency to USD
+	err := settingsRegistry.Patch("system.main_currency", "USD")
+	c.Assert(err, qt.IsNil)
+
+	// Create commodity registry
+	commodityRegistry := memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
+
+	// Create a location
+	location, err := locationRegistry.Create(models.Location{
+		Name:    "Test Location",
+		Address: "Test Address",
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Create an area
+	area, err := areaRegistry.Create(models.Area{
+		Name:       "Test Area",
+		LocationID: location.ID,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Test case 1: Original price in main currency (USD) and converted original price is zero - should pass
+	commodity1 := models.Commodity{
+		Name:                   "Test Commodity 1",
+		ShortName:              "TC1",
+		Type:                   models.CommodityTypeElectronics,
+		AreaID:                 area.ID,
+		Count:                  1,
+		OriginalPrice:          decimal.NewFromFloat(100.00),
+		OriginalPriceCurrency:  "USD",
+		ConvertedOriginalPrice: decimal.Zero,
+		Status:                 models.CommodityStatusInUse,
+		Draft:                  false,
+	}
+
+	_, err = commodityRegistry.Create(commodity1)
+	c.Assert(err, qt.IsNil, qt.Commentf("Should allow creation when original price is in main currency and converted price is zero"))
+
+	// Test case 2: Original price in main currency (USD) and converted original price is not zero - should fail
+	commodity2 := models.Commodity{
+		Name:                   "Test Commodity 2",
+		ShortName:              "TC2",
+		Type:                   models.CommodityTypeElectronics,
+		AreaID:                 area.ID,
+		Count:                  1,
+		OriginalPrice:          decimal.NewFromFloat(100.00),
+		OriginalPriceCurrency:  "USD",
+		ConvertedOriginalPrice: decimal.NewFromFloat(100.00), // Non-zero value
+		Status:                 models.CommodityStatusInUse,
+		Draft:                  false,
+	}
+
+	_, err = commodityRegistry.Create(commodity2)
+	c.Assert(err, qt.Not(qt.IsNil), qt.Commentf("Should not allow creation when original price is in main currency and converted price is not zero"))
+	c.Assert(err.Error(), qt.Contains, "converted original price must be zero when original price is in the main currency")
+
+	// Test case 3: Original price in different currency (EUR) and converted original price is not zero - should pass
+	commodity3 := models.Commodity{
+		Name:                   "Test Commodity 3",
+		ShortName:              "TC3",
+		Type:                   models.CommodityTypeElectronics,
+		AreaID:                 area.ID,
+		Count:                  1,
+		OriginalPrice:          decimal.NewFromFloat(100.00),
+		OriginalPriceCurrency:  "EUR",
+		ConvertedOriginalPrice: decimal.NewFromFloat(110.00), // Non-zero value
+		Status:                 models.CommodityStatusInUse,
+		Draft:                  false,
+	}
+
+	_, err = commodityRegistry.Create(commodity3)
+	c.Assert(err, qt.IsNil, qt.Commentf("Should allow creation when original price is in different currency and converted price is not zero"))
+}
+
+func TestCommodityRegistry_Update_PriceValidation(t *testing.T) {
+	c := qt.New(t)
+
+	// Create registries
+	locationRegistry := memory.NewLocationRegistry()
+	areaRegistry := memory.NewAreaRegistry(locationRegistry)
+	settingsRegistry := memory.NewSettingsRegistry()
+
+	// Set main currency to USD
+	err := settingsRegistry.Patch("system.main_currency", "USD")
+	c.Assert(err, qt.IsNil)
+
+	// Create commodity registry
+	commodityRegistry := memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
+
+	// Create a location
+	location, err := locationRegistry.Create(models.Location{
+		Name:    "Test Location",
+		Address: "Test Address",
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Create an area
+	area, err := areaRegistry.Create(models.Area{
+		Name:       "Test Area",
+		LocationID: location.ID,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Create a valid commodity first
+	commodity := models.Commodity{
+		Name:                   "Test Commodity",
+		ShortName:              "TC",
+		Type:                   models.CommodityTypeElectronics,
+		AreaID:                 area.ID,
+		Count:                  1,
+		OriginalPrice:          decimal.NewFromFloat(100.00),
+		OriginalPriceCurrency:  "EUR", // Different from main currency
+		ConvertedOriginalPrice: decimal.NewFromFloat(110.00),
+		Status:                 models.CommodityStatusInUse,
+		Draft:                  false,
+	}
+
+	createdCommodity, err := commodityRegistry.Create(commodity)
+	c.Assert(err, qt.IsNil)
+
+	// Test case 1: Update to have original price in main currency (USD) and converted original price is zero - should pass
+	updatedCommodity1 := *createdCommodity
+	updatedCommodity1.OriginalPriceCurrency = "USD"
+	updatedCommodity1.ConvertedOriginalPrice = decimal.Zero
+
+	_, err = commodityRegistry.Update(updatedCommodity1)
+	c.Assert(err, qt.IsNil, qt.Commentf("Should allow update when original price is in main currency and converted price is zero"))
+
+	// Test case 2: Update to have original price in main currency (USD) and converted original price is not zero - should fail
+	updatedCommodity2 := *createdCommodity
+	updatedCommodity2.OriginalPriceCurrency = "USD"
+	updatedCommodity2.ConvertedOriginalPrice = decimal.NewFromFloat(110.00) // Non-zero value
+
+	_, err = commodityRegistry.Update(updatedCommodity2)
+	c.Assert(err, qt.Not(qt.IsNil), qt.Commentf("Should not allow update when original price is in main currency and converted price is not zero"))
+	c.Assert(err.Error(), qt.Contains, "converted original price must be zero when original price is in the main currency")
+}

--- a/registry/memory/commodities_test.go
+++ b/registry/memory/commodities_test.go
@@ -126,13 +126,16 @@ func TestCommodityRegistry_Create_Validation(t *testing.T) {
 	// Create a new instance of CommodityRegistry
 	locationRegistry := memory.NewLocationRegistry()
 	areaRegistry := memory.NewAreaRegistry(locationRegistry)
-	r := memory.NewCommodityRegistry(areaRegistry)
+	settingsRegistry := memory.NewSettingsRegistry()
+	err := settingsRegistry.Patch("system.main_currency", "USD")
+	c.Assert(err, qt.IsNil)
+	r := memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
 
 	// Create a test commodity without required fields
 	commodity := models.Commodity{}
 
 	// Attempt to create the commodity in the registry and expect a validation error
-	_, err := r.Create(commodity)
+	_, err = r.Create(commodity)
 	var errs validation.Errors
 	c.Assert(err, qt.ErrorAs, &errs)
 	c.Assert(errs, qt.HasLen, 6)
@@ -156,7 +159,10 @@ func TestCommodityRegistry_Create_AreaNotFound(t *testing.T) {
 	// Create a new instance of CommodityRegistry
 	locationRegistry := memory.NewLocationRegistry()
 	areaRegistry := memory.NewAreaRegistry(locationRegistry)
-	r := memory.NewCommodityRegistry(areaRegistry)
+	settingsRegistry := memory.NewSettingsRegistry()
+	err := settingsRegistry.Patch("system.main_currency", "USD")
+	c.Assert(err, qt.IsNil)
+	r := memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
 
 	// Create a test commodity with an invalid area ID
 	commodity := models.Commodity{
@@ -169,7 +175,7 @@ func TestCommodityRegistry_Create_AreaNotFound(t *testing.T) {
 	}
 
 	// Attempt to create the commodity in the registry and expect an area not found error
-	_, err := r.Create(commodity)
+	_, err = r.Create(commodity)
 	c.Assert(err, qt.ErrorMatches, "area not found.*")
 }
 
@@ -179,7 +185,8 @@ func TestCommodityRegistry_Delete_CommodityNotFound(t *testing.T) {
 	// Create a new instance of CommodityRegistry
 	locationRegistry := memory.NewLocationRegistry()
 	areaRegistry := memory.NewAreaRegistry(locationRegistry)
-	r := memory.NewCommodityRegistry(areaRegistry)
+	settingsRegistry := memory.NewSettingsRegistry()
+	r := memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
 
 	// Attempt to delete a non-existing commodity from the registry and expect a not found error
 	err := r.Delete("nonexistent")
@@ -189,7 +196,11 @@ func TestCommodityRegistry_Delete_CommodityNotFound(t *testing.T) {
 func getCommodityRegistry(c *qt.C) (registry.CommodityRegistry, *models.Commodity) {
 	locationRegistry := memory.NewLocationRegistry()
 	areaRegistry := memory.NewAreaRegistry(locationRegistry)
-	r := memory.NewCommodityRegistry(areaRegistry)
+	settingsRegistry := memory.NewSettingsRegistry()
+	err := settingsRegistry.Patch("system.main_currency", "USD")
+	c.Assert(err, qt.IsNil)
+
+	r := memory.NewCommodityRegistry(areaRegistry, settingsRegistry)
 
 	location1, err := locationRegistry.Create(models.Location{
 		Name: "Location 1",

--- a/registry/memory/memory.go
+++ b/registry/memory/memory.go
@@ -14,11 +14,11 @@ func NewRegistrySet(_ registry.Config) (*registry.Set, error) {
 	s := &registry.Set{}
 	s.LocationRegistry = NewLocationRegistry()
 	s.AreaRegistry = NewAreaRegistry(s.LocationRegistry)
-	s.CommodityRegistry = NewCommodityRegistry(s.AreaRegistry)
+	s.SettingsRegistry = NewSettingsRegistry()
+	s.CommodityRegistry = NewCommodityRegistry(s.AreaRegistry, s.SettingsRegistry)
 	s.ImageRegistry = NewImageRegistry(s.CommodityRegistry)
 	s.InvoiceRegistry = NewInvoiceRegistry(s.CommodityRegistry)
 	s.ManualRegistry = NewManualRegistry(s.CommodityRegistry)
-	s.SettingsRegistry = NewSettingsRegistry()
 
 	return s, nil
 }

--- a/registry/memory/memory.go
+++ b/registry/memory/memory.go
@@ -15,7 +15,7 @@ func NewRegistrySet(_ registry.Config) (*registry.Set, error) {
 	s.LocationRegistry = NewLocationRegistry()
 	s.AreaRegistry = NewAreaRegistry(s.LocationRegistry)
 	s.SettingsRegistry = NewSettingsRegistry()
-	s.CommodityRegistry = NewCommodityRegistry(s.AreaRegistry, s.SettingsRegistry)
+	s.CommodityRegistry = NewCommodityRegistry(s.AreaRegistry)
 	s.ImageRegistry = NewImageRegistry(s.CommodityRegistry)
 	s.InvoiceRegistry = NewInvoiceRegistry(s.CommodityRegistry)
 	s.ManualRegistry = NewManualRegistry(s.CommodityRegistry)

--- a/registry/validation.go
+++ b/registry/validation.go
@@ -1,0 +1,38 @@
+package registry
+
+import (
+	"context"
+
+	"github.com/jellydator/validation"
+
+	"github.com/denisvmedia/inventario/internal/errkit"
+	"github.com/denisvmedia/inventario/internal/validationctx"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// ValidateCommodity validates a given commodity using the application's settings.
+// It retrieves the main currency from the provided SettingsRegistry and ensures it is set.
+// The function then creates a validation context with the main currency and performs
+// standard validation on the commodity using the validation library.
+// Returns an error if the settings cannot be retrieved, the main currency is not set,
+// or if the commodity fails validation.
+func ValidateCommodity(commodity *models.Commodity, settingsRegistry SettingsRegistry) error {
+	// Get main currency from settings
+	settings, err := settingsRegistry.Get()
+	if err != nil {
+		return errkit.Wrap(err, "failed to get settings")
+	}
+
+	if settings.MainCurrency == nil || *settings.MainCurrency == "" {
+		return ErrMainCurrencyNotSet
+	}
+
+	mainCurrency := *settings.MainCurrency
+
+	// First, validate the commodity using standard validation
+	ctx := context.Background()
+	ctx = validationctx.WithMainCurrency(ctx, mainCurrency)
+	err = validation.ValidateWithContext(ctx, commodity)
+
+	return err
+}


### PR DESCRIPTION
This pull request introduces significant updates to the handling of currency in the application, including the addition of a settings registry for managing the main currency, updates to the commodity creation and update workflows, and adjustments to tests and validation logic. Key changes are grouped as follows:

### Currency Management Enhancements:
* Added a `newSettingsRegistry` function to manage system-wide settings, including the main currency, and integrated it into the application initialization process. (`apiserver/apiserver_test.go`, [apiserver/apiserver_test.goR214-R227](diffhunk://#diff-d912fb606dfb3dbfce4993f2829f5a9e55b23162ceddc5a76da51a97323032b9R214-R227))
* Implemented `requestWithMainCurrency` to inject the main currency into the request context, ensuring consistent currency handling across endpoints. (`apiserver/commodities.go`, [[1]](diffhunk://#diff-42a6d35c861277234e84bab48e98acffd5a40b97df89672e8618ebb1ff556027R104-R110) [[2]](diffhunk://#diff-42a6d35c861277234e84bab48e98acffd5a40b97df89672e8618ebb1ff556027R194-R199) [[3]](diffhunk://#diff-42a6d35c861277234e84bab48e98acffd5a40b97df89672e8618ebb1ff556027R900-R914)
* Created a new `validationctx` package to manage context-based validation, including utility functions for setting and retrieving the main currency. (`internal/validationctx/validationctx.go`, [[1]](diffhunk://#diff-558be8a0ba17698f6df4cee747a4fde216033485763ce6c749f2d246cd6f25d7R1-R21); `internal/validationctx/errors.go`, [[2]](diffhunk://#diff-cb729bd8065a0a5b16698c855375463b7ed440f41ab51f84b463b9ae7df12926R1-R9)

### Test Adjustments:
* Updated test cases to reflect the new currency validation logic, including setting the `ConvertedOriginalPrice` to `0` in tests to pass validation. (`apiserver/commodities_test.go`, [[1]](diffhunk://#diff-dd88193bdf8fd1ad74bf3553f43d718173a9cb4797cd9538d80e8a6404bbdda1L131-R131) [[2]](diffhunk://#diff-dd88193bdf8fd1ad74bf3553f43d718173a9cb4797cd9538d80e8a6404bbdda1L204-R204)
* Enhanced test assertions to include error context for better debugging. (`apiserver/commodities_test.go`, [[1]](diffhunk://#diff-dd88193bdf8fd1ad74bf3553f43d718173a9cb4797cd9538d80e8a6404bbdda1L159-R160) [[2]](diffhunk://#diff-4e32b00f3ffc00313eb788d67ab283048eab33f161ff54ee1e71f00285c3a9dbL269-R270)

### Valuation Logic Updates:
* Adjusted the valuation tests to account for the main currency and updated expected totals based on the new currency handling logic. (`internal/valuation/valuation_test.go`, [[1]](diffhunk://#diff-3fe8503c26c061d3d4abe29e996050e2825538055664b6383f5b890bdc690770L156-R172) [[2]](diffhunk://#diff-3fe8503c26c061d3d4abe29e996050e2825538055664b6383f5b890bdc690770L204-R220) [[3]](diffhunk://#diff-3fe8503c26c061d3d4abe29e996050e2825538055664b6383f5b890bdc690770L256-R272)
* Modified the `setupTestRegistry` function to dynamically handle commodities with different currencies and ensure proper test setup. (`internal/valuation/valuation_test.go`, [[1]](diffhunk://#diff-3fe8503c26c061d3d4abe29e996050e2825538055664b6383f5b890bdc690770L63-R73) [[2]](diffhunk://#diff-3fe8503c26c061d3d4abe29e996050e2825538055664b6383f5b890bdc690770L76-R88) [[3]](diffhunk://#diff-3fe8503c26c061d3d4abe29e996050e2825538055664b6383f5b890bdc690770L90-R131) [[4]](diffhunk://#diff-3fe8503c26c061d3d4abe29e996050e2825538055664b6383f5b890bdc690770L127-R149)

### Codebase Improvements:
* Replaced `var` declarations with `:=` for consistency and readability. (`apiserver/apiserver_test.go`, [apiserver/apiserver_test.goL59-R59](diffhunk://#diff-d912fb606dfb3dbfce4993f2829f5a9e55b23162ceddc5a76da51a97323032b9L59-R59))
* Updated comments and minor code adjustments for clarity and maintainability. (`internal/seeddata/seeddata.go`, [internal/seeddata/seeddata.goL331-R331](diffhunk://#diff-f2834d4aa87256dda2b16b9946284988eb24c32610c01944a330aa66493d9078L331-R331))

### Miscellaneous:
* Added missing imports for new functionality. (`apiserver/commodities.go`, [[1]](diffhunk://#diff-42a6d35c861277234e84bab48e98acffd5a40b97df89672e8618ebb1ff556027R15); `jsonapi/commodities.go`, [[2]](diffhunk://#diff-0f0e0856236e40e2963b94814895e8b2d02bb4acad2661efa0d1d7488b1f1433R5)