### PR TITLE
Disallow changing main currency

### DIFF
--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -35,9 +35,17 @@ export const useSettingsStore = defineStore('settings', () => {
     try {
       await settingsService.updateMainCurrency(currency)
       mainCurrency.value = currency
-    } catch (err) {
+    } catch (err: any) {
       console.error('Failed to update main currency:', err)
-      error.value = 'Failed to update main currency'
+
+      // Check if this is the specific error about main currency already being set
+      if (err.response && err.response.status === 422 &&
+          err.response.data && err.response.data.includes('main currency already set')) {
+        error.value = 'Main currency has already been set and cannot be changed'
+      } else {
+        error.value = 'Failed to update main currency'
+      }
+
       throw err
     } finally {
       isLoading.value = false

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -60,6 +60,8 @@ func toJSONAPIError(err error) jsonapi.Error {
 		return NewUnprocessableEntityError(err)
 	case errors.Is(err, registry.ErrNotFound):
 		return NewNotFoundError(err)
+	case errors.Is(err, registry.ErrMainCurrencyAlreadySet):
+		return NewUnprocessableEntityError(err)
 	default:
 		log.WithError(err).Error("internal server error")
 		return NewInternalServerError(err)

--- a/go/apiserver/settings.go
+++ b/go/apiserver/settings.go
@@ -57,6 +57,21 @@ func (api *settingsAPI) updateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check if main currency is being changed
+	if settings.MainCurrency != nil {
+		currentSettings, err := api.registry.Get()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// If main currency is already set and the new value is different, return an error
+		if currentSettings.MainCurrency != nil && *currentSettings.MainCurrency != "" && *settings.MainCurrency != *currentSettings.MainCurrency {
+			http.Error(w, registry.ErrMainCurrencyAlreadySet.Error(), http.StatusUnprocessableEntity)
+			return
+		}
+	}
+
 	// Save the settings
 	if err := api.registry.Save(settings); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -96,6 +111,21 @@ func (api *settingsAPI) patchSetting(w http.ResponseWriter, r *http.Request) {
 	if field == "" {
 		http.Error(w, "Field path is required", http.StatusBadRequest)
 		return
+	}
+
+	// Check if trying to update main currency
+	if field == "system.main_currency" {
+		currentSettings, err := api.registry.Get()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// If main currency is already set, prevent changing it
+		if currentSettings.MainCurrency != nil && *currentSettings.MainCurrency != "" {
+			http.Error(w, registry.ErrMainCurrencyAlreadySet.Error(), http.StatusUnprocessableEntity)
+			return
+		}
 	}
 
 	// Decode the request body into a value

--- a/go/registry/errors.go
+++ b/go/registry/errors.go
@@ -12,5 +12,6 @@ var (
 	ErrAlreadyExists    = errors.New("already exists")
 	ErrBadDataStructure = errors.New("bad data structure")
 
-	ErrMainCurrencyNotSet = errors.New("main currency not set")
+	ErrMainCurrencyNotSet      = errors.New("main currency not set")
+	ErrMainCurrencyAlreadySet = errors.New("main currency already set and cannot be changed")
 )


### PR DESCRIPTION
This pull request introduces functionality to enforce that the "main currency" setting cannot be changed once it has been set. The changes span both the frontend and backend, ensuring consistent behavior and error handling across the application. Key updates include UI adjustments, backend validation, error handling, and test coverage.

### Frontend Changes:

* **Error Handling and Messaging:**
  - Updated `useSettingsStore` in `settingsStore.ts` to handle specific errors related to the main currency being already set, displaying a user-friendly error message.

* **UI Updates:**
  - Disabled the currency dropdown in `SettingDetailView.vue` if the main currency is already set, and added a lock icon with a message indicating that the currency is locked. [[1]](diffhunk://#diff-f846719eb3843657c982c4da043b26c3729cf5e9b4bfd7d6aaa27a10f94b11b9R111-R123) [[2]](diffhunk://#diff-f846719eb3843657c982c4da043b26c3729cf5e9b4bfd7d6aaa27a10f94b11b9R616-R626)
  - Prevented saving changes to the main currency in `SettingDetailView.vue` if it is already set, with appropriate error messages. [[1]](diffhunk://#diff-f846719eb3843657c982c4da043b26c3729cf5e9b4bfd7d6aaa27a10f94b11b9R431-R442) [[2]](diffhunk://#diff-f846719eb3843657c982c4da043b26c3729cf5e9b4bfd7d6aaa27a10f94b11b9R456-R465)

* **State Management:**
  - Introduced `isMainCurrencySet` and `originalMainCurrency` in `SettingDetailView.vue` to track the status and original value of the main currency. [[1]](diffhunk://#diff-f846719eb3843657c982c4da043b26c3729cf5e9b4bfd7d6aaa27a10f94b11b9R223-R226) [[2]](diffhunk://#diff-f846719eb3843657c982c4da043b26c3729cf5e9b4bfd7d6aaa27a10f94b11b9R323-R330)

### Backend Changes:

* **Validation Logic:**
  - Added checks in `settings.go` to prevent updates to the main currency if it is already set, returning a 422 error in such cases. [[1]](diffhunk://#diff-44f9557e777635423fd5192927f5f9cd2df9ae353831a56b3d7dfd8bf9ba24dfR60-R74) [[2]](diffhunk://#diff-44f9557e777635423fd5192927f5f9cd2df9ae353831a56b3d7dfd8bf9ba24dfR116-R130)

* **Error Handling:**
  - Added a new error type `ErrMainCurrencyAlreadySet` in `errors.go` and mapped it to a 422 Unprocessable Entity response. [[1]](diffhunk://#diff-0fe95e9de9ff7b0a72ace7ebb921300ef21b8460473681332bef34f0939039acR16) [[2]](diffhunk://#diff-43ecf03bd73a0573e47aa71c0fc879a8482adb0b6c2ae900f4515e9b5852c0efR63-R64)

### Tests:

* **Backend Tests:**
  - Added a comprehensive test case in `settings_test.go` to verify that attempts to change the main currency after it has been set are correctly blocked for both PUT and PATCH requests.