### PR TITLE
Fix extension check in filekit test

### DIFF
--- a/go/internal/filekit/filekit_test.go
+++ b/go/internal/filekit/filekit_test.go
@@ -67,7 +67,5 @@ func TestUploadFileNameWithCurrentTime(t *testing.T) {
 
 	// Verify that the file extension is preserved
 	ext := filepath.Ext(fileName)
-	c.Assert(ext, qt.Satisfies, func(s string) bool {
-		return strings.HasSuffix(fileName, s)
-	})
+	c.Assert(strings.HasSuffix(result, ext), qt.IsTrue)
 }

--- a/go/internal/filekit/filekit_test.go
+++ b/go/internal/filekit/filekit_test.go
@@ -67,5 +67,5 @@ func TestUploadFileNameWithCurrentTime(t *testing.T) {
 
 	// Verify that the file extension is preserved
 	ext := filepath.Ext(fileName)
-	c.Assert(strings.HasSuffix(result, ext), qt.IsTrue)
+	c.Assert(filepath.Ext(result), qt.Equals, ext)
 }

--- a/go/internal/filekit/filekit_test.go
+++ b/go/internal/filekit/filekit_test.go
@@ -65,7 +65,7 @@ func TestUploadFileNameWithCurrentTime(t *testing.T) {
 	now := time.Now().Unix()
 	c.Assert(result, qt.Contains, fmt.Sprintf("%v", now))
 
-	// Verify that the file extension is preserved
+	// Verify that the generated file name preserves the original extension
 	ext := filepath.Ext(fileName)
 	c.Assert(filepath.Ext(result), qt.Equals, ext)
 }


### PR DESCRIPTION
## Summary
- ensure TestUploadFileNameWithCurrentTime validates the generated file name keeps the original extension

## Testing
- `make test-go`

------
https://chatgpt.com/codex/tasks/task_e_683f4ebcb5848333b1731ae1bef648ed