### PR TITLE
Fix test logic in `errkit_test.go` 

### DIFF
--- a/go/internal/errkit/errkit_test.go
+++ b/go/internal/errkit/errkit_test.go
@@ -48,7 +48,15 @@ func TestError_WithFields(t *testing.T) {
 	newErr := e.WithFields(fields)
 
 	c.Assert(newErr.Error(), qt.Matches, `wrapped error: some error \(\s*(key1=value1, key2=2|key2=2, key1=value1)\s*\)`)
-	c.Assert(newErr.WithField("key3", true).Error(), qt.Matches, `wrapped error: some error \((?:.*key1=value1.*key2=2.*key3=true.*|.*key2=2.*key1=value1.*key3=true.*|.*key3=true.*key1=value1.*key2=2.*|.*key3=true.*key2=2.*key1=value1.*)\)`)
+
+	// Test with three fields - use a more robust pattern that matches any order
+	threeFieldErr := newErr.WithField("key3", true)
+	threeFieldStr := threeFieldErr.Error()
+	c.Assert(threeFieldStr, qt.Matches, `wrapped error: some error \(.*\)`)
+	c.Assert(threeFieldStr, qt.Contains, "key1=value1")
+	c.Assert(threeFieldStr, qt.Contains, "key2=2")
+	c.Assert(threeFieldStr, qt.Contains, "key3=true")
+
 	c.Assert(newErr.WithField("key1", "updated").Error(), qt.Matches, `wrapped error: some error \(\s*(key1=updated, key2=2|key2=2, key1=updated)\s*\)`)
 
 	data, err := json.Marshal(newErr)


### PR DESCRIPTION
This pull request updates the test logic in `errkit_test.go` to improve the robustness of error field validation. Specifically, it simplifies the pattern matching for error messages with multiple fields and ensures individual field values are explicitly checked.

Enhancements to error field validation:

* [`go/internal/errkit/errkit_test.go`](diffhunk://#diff-a20951f4e4ac48e1581ef9ed3b6324db7423ca0461ef5de1ecbc7fc4c9e69dccL51-R59): Updated the test for error messages with three fields to use a simpler and more robust pattern that matches any order. Added explicit checks to ensure each field value (`key1=value1`, `key2=2`, `key3=true`) is present in the error message.