### PR TITLE
Fix file upload date

### DIFF
--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -132,11 +133,14 @@ func (api *filesAPI) createFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	now := time.Now()
 	fileEntity := models.FileEntity{
 		Title:       input.Data.Attributes.Title,
 		Description: input.Data.Attributes.Description,
 		Type:        models.FileTypeOther, // Default type, should be updated when file is uploaded
 		Tags:        input.Data.Attributes.Tags,
+		CreatedAt:   now,
+		UpdatedAt:   now,
 		File: &models.File{
 			Path:         input.Data.Attributes.Path,
 			OriginalPath: input.Data.Attributes.Path,
@@ -221,6 +225,7 @@ func (api *filesAPI) updateFile(w http.ResponseWriter, r *http.Request) {
 	file.Description = input.Data.Attributes.Description
 	file.Tags = input.Data.Attributes.Tags
 	file.Path = textutils.CleanFilename(input.Data.Attributes.Path)
+	file.UpdatedAt = time.Now() // Set updated timestamp
 
 	// Auto-detect file type from MIME type if available
 	if file.File != nil && file.MIMEType != "" {

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -223,11 +224,14 @@ func (api *uploadsAPI) handleFilesUpload(w http.ResponseWriter, r *http.Request)
 		}
 
 		// Create file entity with auto-generated title from filename
+		now := time.Now()
 		fileEntity := models.FileEntity{
 			Title:       pathWithoutExt, // Use filename as default title
 			Description: "",             // Empty description
 			Type:        fileType,
 			Tags:        []string{}, // Empty tags
+			CreatedAt:   now,
+			UpdatedAt:   now,
 			File: &models.File{
 				Path:         pathWithoutExt,
 				OriginalPath: originalPath,


### PR DESCRIPTION
This pull request introduces timestamp management for file entities by adding explicit `CreatedAt` and `UpdatedAt` fields in various parts of the codebase. It also refactors SQL queries to use these fields instead of relying on database-generated timestamps. Below are the most important changes grouped by theme:

### Timestamp Management for File Entities:

* **Initialization of Timestamps in Handlers:**
  - Added `CreatedAt` and `UpdatedAt` fields initialized with `time.Now()` in the `createFile` and `updateFile` methods of `filesAPI` (`go/apiserver/files.go`) to ensure consistent timestamp handling. [[1]](diffhunk://#diff-6f1381f76ae985db227d3d8b9728586b19a3570f735cfec0ce67da402cdb55d3R136-R143) [[2]](diffhunk://#diff-6f1381f76ae985db227d3d8b9728586b19a3570f735cfec0ce67da402cdb55d3R228)
  - Added similar timestamp initialization in the `handleFilesUpload` method of `uploadsAPI` (`go/apiserver/uploads.go`).

* **SQL Query Updates:**
  - Updated the `Create` method in `FileRegistry` (`go/registry/commonsql/files.go`) to use explicitly passed `CreatedAt` and `UpdatedAt` values instead of relying on `NOW()` in the SQL query.
  - Refactored the `Update` method in `FileRegistry` to accept `UpdatedAt` as a parameter and handle cases where no rows are affected, returning a `registry.ErrNotFound` error if applicable.

### Dependency Updates:

* **Imports:**
  - Added the `time` package to `files.go` and `uploads.go` to support timestamp generation. [[1]](diffhunk://#diff-6f1381f76ae985db227d3d8b9728586b19a3570f735cfec0ce67da402cdb55d3R9) [[2]](diffhunk://#diff-14e32a970e6e911ad46933cff947d2c813a102fcb8560adf0056e65aa5d6c494R10)