### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -66,7 +66,7 @@
       "schedule": ["before 6am on monday"]
     },
     {
-      "description": "Disallow major versions update for databases"
+      "description": "Disallow major versions update for databases",
       "matchDatasources": ["docker", "github-actions"],
       "matchPackageNames": ["postgres", "mysql", "mariadb"],
       "matchUpdateTypes": ["major"],

--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,11 @@
       "matchFileNames": ["frontend/package.json", "e2e/package.json"],
       "rangeStrategy": "pin",
       "schedule": ["before 6am on monday"]
+    },
+    {
+      "matchPackageNames": ["mysql", "postgres", "mariadb"],
+      "updateType": "major",
+      "enabled": false
     }
   ],
   "postUpdateOptions": ["gomodTidy", "npmDedupe"],

--- a/renovate.json
+++ b/renovate.json
@@ -66,8 +66,10 @@
       "schedule": ["before 6am on monday"]
     },
     {
-      "matchPackageNames": ["mysql", "postgres", "mariadb"],
-      "updateType": "major",
+      "description": "Disallow major versions update for databases"
+      "matchDatasources": ["docker", "github-actions"],
+      "matchPackageNames": ["postgres", "mysql", "mariadb"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration file to refine dependency management strategies. The most notable change involves adding a new rule to handle major updates for specific database packages.

Dependency management updates:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R67-R71): Added a configuration block to match package names `mysql`, `postgres`, and `mariadb`, specifying that major updates for these packages should be disabled (`enabled: false`).