### PR TITLE
Fix broken files when no files

### DIFF
--- a/go/internal/defaults/defaults.go
+++ b/go/internal/defaults/defaults.go
@@ -57,7 +57,7 @@ func New() Config {
 		},
 		Workers: Workers{
 			MaxConcurrentExports: 3,
-			MaxConcurrentImports: 3,
+			MaxConcurrentImports: 1,
 		},
 	}
 }

--- a/go/internal/defaults/defaults_test.go
+++ b/go/internal/defaults/defaults_test.go
@@ -24,7 +24,7 @@ func TestDefaults(t *testing.T) {
 
 	// Test worker defaults
 	c.Assert(cfg.Workers.MaxConcurrentExports, qt.Equals, 3)
-	c.Assert(cfg.Workers.MaxConcurrentImports, qt.Equals, 3)
+	c.Assert(cfg.Workers.MaxConcurrentImports, qt.Equals, 1)
 }
 
 func TestDefaultGetters(t *testing.T) {
@@ -34,7 +34,7 @@ func TestDefaultGetters(t *testing.T) {
 	c.Assert(defaults.GetServerAddr(), qt.Equals, ":3333")
 	c.Assert(defaults.GetDatabaseDSN(), qt.Equals, "memory://")
 	c.Assert(defaults.GetMaxConcurrentExports(), qt.Equals, 3)
-	c.Assert(defaults.GetMaxConcurrentImports(), qt.Equals, 3)
+	c.Assert(defaults.GetMaxConcurrentImports(), qt.Equals, 1)
 
 	// Test upload location getter
 	uploadLocation := defaults.GetUploadLocation()

--- a/go/jsonapi/consistency_test.go
+++ b/go/jsonapi/consistency_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestResponseConsistency_EmptySlicesNotNull(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		response any

--- a/go/jsonapi/consistency_test.go
+++ b/go/jsonapi/consistency_test.go
@@ -1,0 +1,101 @@
+package jsonapi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/jsonapi"
+	"github.com/denisvmedia/inventario/models"
+)
+
+func TestResponseConsistency_EmptySlicesNotNull(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		response any
+		jsonPath string
+	}{
+		{
+			name:     "FilesResponse with nil slice",
+			response: jsonapi.NewFilesResponse(nil, 0),
+			jsonPath: "data",
+		},
+		{
+			name:     "FilesResponse with empty slice",
+			response: jsonapi.NewFilesResponse([]*models.FileEntity{}, 0),
+			jsonPath: "data",
+		},
+		{
+			name:     "ImagesResponse with nil slice",
+			response: jsonapi.NewImagesResponse(nil, 0),
+			jsonPath: "data",
+		},
+		{
+			name:     "ImagesResponse with empty slice",
+			response: jsonapi.NewImagesResponse([]*models.Image{}, 0),
+			jsonPath: "data",
+		},
+		{
+			name:     "InvoicesResponse with nil slice",
+			response: jsonapi.NewInvoicesResponse(nil, 0),
+			jsonPath: "data",
+		},
+		{
+			name:     "InvoicesResponse with empty slice",
+			response: jsonapi.NewInvoicesResponse([]*models.Invoice{}, 0),
+			jsonPath: "data",
+		},
+		{
+			name:     "ManualsResponse with nil slice",
+			response: jsonapi.NewManualsResponse(nil, 0),
+			jsonPath: "data",
+		},
+		{
+			name:     "ManualsResponse with empty slice",
+			response: jsonapi.NewManualsResponse([]*models.Manual{}, 0),
+			jsonPath: "data",
+		},
+		{
+			name:     "ExportsResponse with nil slice",
+			response: jsonapi.NewExportsResponse(nil, 0),
+			jsonPath: "data",
+		},
+		{
+			name:     "ExportsResponse with empty slice",
+			response: jsonapi.NewExportsResponse([]*models.Export{}, 0),
+			jsonPath: "data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			// Marshal to JSON
+			jsonBytes, err := json.Marshal(tt.response)
+			c.Assert(err, qt.IsNil)
+
+			// Parse back to verify structure
+			var result map[string]any
+			err = json.Unmarshal(jsonBytes, &result)
+			c.Assert(err, qt.IsNil)
+
+			// Check that data field exists and is an array, not null
+			data, exists := result[tt.jsonPath]
+			c.Assert(exists, qt.IsTrue, qt.Commentf("Field %s should exist", tt.jsonPath))
+			c.Assert(data, qt.Not(qt.IsNil), qt.Commentf("Field %s should not be null", tt.jsonPath))
+
+			// Verify it's an array
+			dataArray, ok := data.([]any)
+			c.Assert(ok, qt.IsTrue, qt.Commentf("Field %s should be an array", tt.jsonPath))
+			c.Assert(len(dataArray), qt.Equals, 0, qt.Commentf("Field %s should be an empty array", tt.jsonPath))
+
+			// Verify the JSON contains [] not null for the data field
+			jsonStr := string(jsonBytes)
+			c.Assert(jsonStr, qt.Contains, `"`+tt.jsonPath+`":[]`, qt.Commentf("JSON should contain empty array for %s", tt.jsonPath))
+			c.Assert(jsonStr, qt.Not(qt.Contains), `"`+tt.jsonPath+`":null`, qt.Commentf("JSON should not contain null for %s", tt.jsonPath))
+		})
+	}
+}

--- a/go/jsonapi/files.go
+++ b/go/jsonapi/files.go
@@ -56,6 +56,10 @@ type FilesResponse struct {
 
 // NewFilesResponse creates a new FilesResponse instance.
 func NewFilesResponse(files []*models.FileEntity, total int) *FilesResponse {
+	// Ensure Data is never nil to maintain consistent JSON output
+	if files == nil {
+		files = []*models.FileEntity{}
+	}
 	return &FilesResponse{
 		Data: files,
 		Meta: FilesMeta{Files: len(files), Total: total},

--- a/go/jsonapi/images.go
+++ b/go/jsonapi/images.go
@@ -54,6 +54,10 @@ type ImagesResponse struct {
 
 // NewImagesResponse creates a new ImagesResponse instance.
 func NewImagesResponse(images []*models.Image, total int) *ImagesResponse {
+	// Ensure Data is never nil to maintain consistent JSON output
+	if images == nil {
+		images = []*models.Image{}
+	}
 	return &ImagesResponse{
 		Data: images,
 		Meta: ImagesMeta{Images: total},

--- a/go/jsonapi/invoices.go
+++ b/go/jsonapi/invoices.go
@@ -54,6 +54,10 @@ type InvoicesResponse struct {
 
 // NewInvoicesResponse creates a new InvoicesResponse instance.
 func NewInvoicesResponse(invoices []*models.Invoice, total int) *InvoicesResponse {
+	// Ensure Data is never nil to maintain consistent JSON output
+	if invoices == nil {
+		invoices = []*models.Invoice{}
+	}
 	return &InvoicesResponse{
 		Data: invoices,
 		Meta: InvoicesMeta{Invoices: total},

--- a/go/jsonapi/manuals.go
+++ b/go/jsonapi/manuals.go
@@ -54,6 +54,10 @@ type ManualsResponse struct {
 
 // NewManualsResponse creates a new ManualsResponse instance.
 func NewManualsResponse(manuals []*models.Manual, total int) *ManualsResponse {
+	// Ensure Data is never nil to maintain consistent JSON output
+	if manuals == nil {
+		manuals = []*models.Manual{}
+	}
 	return &ManualsResponse{
 		Data: manuals,
 		Meta: ManualsMeta{Manuals: total},


### PR DESCRIPTION
This pull request introduces changes to improve JSON consistency in API responses and adjusts default configuration values. The main updates ensure that empty slices in API responses are serialized as empty arrays (`[]`) instead of `null`, and reduce the maximum number of concurrent imports in the default configuration.

### Improvements to JSON consistency:

* [`go/jsonapi/files.go`](diffhunk://#diff-23b7e04aa69d6085441a157f64532b578f3f7f9d4700ccfe5893df857d8e1c40R59-R62): Modified `NewFilesResponse` to ensure `Data` is never `nil`, maintaining consistent JSON output by using an empty slice when no files are provided.
* [`go/jsonapi/images.go`](diffhunk://#diff-ed345c98676d20d5ec768421117e8767a7ed3de9369ef76721593ae61671ac1bR57-R60): Updated `NewImagesResponse` to prevent `Data` from being `nil`, ensuring consistent JSON serialization with an empty slice for images.
* [`go/jsonapi/invoices.go`](diffhunk://#diff-6d351241811c473789e1ddb8074ee25b3a0111b539f151f961104594d7aeed13R57-R60): Adjusted `NewInvoicesResponse` to replace `nil` with an empty slice for `Data`, maintaining JSON consistency for invoices.
* [`go/jsonapi/manuals.go`](diffhunk://#diff-e5770b910eb469c2ca376a087d7741f62ac82a3e9fc919e8e972172ef890b50dR57-R60): Enhanced `NewManualsResponse` to use an empty slice instead of `nil` for `Data`, ensuring uniform JSON output for manuals.
* [`go/jsonapi/consistency_test.go`](diffhunk://#diff-02691b4ba12e424b7597409267e0ee8cb538cf12ad5bc645bb28108f0364d992R1-R101): Added comprehensive tests to verify that API responses serialize empty slices as `[]` and not `null`, covering various response types.

### Configuration updates:

* [`go/internal/defaults/defaults.go`](diffhunk://#diff-7b4bab67106b569f4f44350fc085a66138ce2b58c3d424db92d2ad5135642db8L60-R60): Reduced `MaxConcurrentImports` from 3 to 1 in the default configuration to limit simultaneous import operations.