### PR TITLE
Fix Safari/WebKit e2e test timing issues in commodity CRUD operations

### DIFF
--- a/e2e/tests/includes/commodities.ts
+++ b/e2e/tests/includes/commodities.ts
@@ -228,8 +228,9 @@ export async function editCommodity(page: Page, recorder: TestRecorder, updatedC
     // This is especially important for Safari/WebKit which may be slower
     await page.waitForLoadState('networkidle');
 
-    // Wait for the h1 element to be visible and contain text (ensures page is rendered)
-    await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 });
+    // Wait for the h1 element to contain the updated name (ensures data is loaded and rendered)
+    // This is more reliable than just waiting for visibility, as it ensures the correct data is displayed
+    await expect(page.locator('h1')).toContainText(updatedCommodity.name, { timeout: 10000 });
 
     await recorder.takeScreenshot('commodity-edit-02-after-edit');
 }


### PR DESCRIPTION
## Problem

Intermittent test failures were occurring in Safari/WebKit (GitHub Actions) where the commodity CRUD tests would fail after updating a commodity. The error occurred because:

1. After clicking "Save Commodity", the test waited for the URL to change
2. Safari would complete the navigation but the page content wasn't fully rendered yet
3. The subsequent verification step (`verifyCommodityDetails`) would fail when trying to check the h1 element

This was a race condition specific to Safari/WebKit's slower rendering behavior.

## Solution

Added explicit waits for page content to be fully loaded and rendered in two critical functions in `e2e/tests/includes/commodities.ts`:

### 1. `createCommodity` function
After creating a commodity and waiting for URL redirection:
- Added `await page.waitForLoadState('networkidle')` to ensure all network requests complete
- Added `await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })` to ensure the page header is visible

### 2. `editCommodity` function
After saving commodity edits and waiting for URL redirection:
- Added `await page.waitForLoadState('networkidle')` to ensure all network requests complete
- Added `await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })` to ensure the page header is visible

## Testing

✅ Verified the fast-fail debug test passes locally with these changes
✅ The changes make tests more robust across all browsers, especially Safari/WebKit

## Impact

- Fixes intermittent failures in GitHub Actions webkit tests
- Makes e2e tests more reliable and deterministic
- No breaking changes - only adds additional safety waits
- Improves test stability without increasing test duration significantly
