### PR TITLE
ci: add auto-merge workflow for dependency updates

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,85 @@
+name: Dependabot & Renovate Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    name: Auto-merge Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on major updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "$PR_URL" --body "⚠️ This is a **major version update**. Please review the changelog before merging."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  renovate:
+    name: Auto-merge Renovate PRs
+    runs-on: ubuntu-latest
+    if: github.actor == 'renovate[bot]'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Get PR labels
+        id: pr-labels
+        run: |
+          labels=$(gh pr view "$PR_URL" --json labels --jq '.labels[].name' | tr '\n' ',')
+          echo "labels=$labels" >> $GITHUB_OUTPUT
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if major update
+        id: check-major
+        run: |
+          title="${{ github.event.pull_request.title }}"
+          body="${{ github.event.pull_request.body }}"
+
+          # Check if this is a major update based on title or labels
+          if echo "$title" | grep -qiE '\bmajor\b'; then
+            echo "is_major=true" >> $GITHUB_OUTPUT
+          elif echo "${{ steps.pr-labels.outputs.labels }}" | grep -qi 'major'; then
+            echo "is_major=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_major=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.check-major.outputs.is_major != 'true'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on major updates
+        if: steps.check-major.outputs.is_major == 'true'
+        run: |
+          gh pr comment "$PR_URL" --body "⚠️ This is a **major version update**. Please review the changelog before merging."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,13 @@
   "schedule": ["before 6am on monday"],
   "packageRules": [
     {
+      "description": "Auto-merge patch and minor updates",
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
       "description": "Group Cloud SDKs updates",
       "groupName": "cloud-sdks",
       "matchPackageNames": [


### PR DESCRIPTION
This PR adds automatic merging for dependency updates from Dependabot and Renovate to reduce manual maintenance overhead.

## Changes

- Added `.github/workflows/dependabot-automerge.yml` workflow that:
  - Automatically merges patch and minor dependency updates
  - Comments on major version updates for manual review
  - Supports both Dependabot and Renovate PRs
  - Uses squash merge strategy

- Updated `renovate.json` to enable automerge:
  - Configured automerge for patch and minor updates
  - Uses GitHub's native PR automerge feature
  - Maintains squash strategy for consistency

## Behavior

**Patch/Minor Updates**: Automatically merged once CI passes
**Major Updates**: Flagged with warning comment for manual review

This approach mirrors the setup used in other repositories and should significantly reduce the manual work required for keeping dependencies up to date.