### PR TITLE
Group Vitest packages in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,10 +34,20 @@ updates:
     directory: "/frontend" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/e2e" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Configure Dependabot to group vitest and @vitest/* packages together in both frontend and e2e directories. This ensures related Vitest updates come in a single PR.