### PR TITLE
fix: cleanup in-memory global limiter lifecycle in tests (#1023)

### DIFF
--- a/go/apiserver/global_rate_limit_middleware_test.go
+++ b/go/apiserver/global_rate_limit_middleware_test.go
@@ -28,6 +28,7 @@ func TestGlobalRateLimitMiddleware_BlocksAndSetsHeaders(t *testing.T) {
 	c := qt.New(t)
 
 	limiter := services.NewInMemoryGlobalRateLimiter(2, time.Hour)
+	t.Cleanup(limiter.Stop)
 	handler := apiserver.GlobalRateLimitMiddleware(limiter, nil)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -82,6 +83,7 @@ func TestGlobalRateLimitMiddleware_UsesXForwardedForOnlyForTrustedProxies(t *tes
 	t.Run("trusted proxy honors X-Forwarded-For", func(t *testing.T) {
 		c := qt.New(t)
 		limiter := services.NewInMemoryGlobalRateLimiter(1, time.Hour)
+		t.Cleanup(limiter.Stop)
 		handler := apiserver.GlobalRateLimitMiddleware(limiter, trustedNets)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -104,6 +106,7 @@ func TestGlobalRateLimitMiddleware_UsesXForwardedForOnlyForTrustedProxies(t *tes
 	t.Run("untrusted proxy ignores X-Forwarded-For", func(t *testing.T) {
 		c := qt.New(t)
 		limiter := services.NewInMemoryGlobalRateLimiter(1, time.Hour)
+		t.Cleanup(limiter.Stop)
 		handler := apiserver.GlobalRateLimitMiddleware(limiter, trustedNets)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))

--- a/go/services/global_rate_limiter.go
+++ b/go/services/global_rate_limiter.go
@@ -137,12 +137,13 @@ func (l *RedisGlobalRateLimiter) RateLimitHits() uint64 {
 type InMemoryGlobalRateLimiter struct {
 	now func() time.Time
 
-	limit   int
-	window  time.Duration
-	mu      sync.Mutex
-	windows map[string][]time.Time
-	hits    atomic.Uint64
-	stopCh  chan struct{}
+	limit    int
+	window   time.Duration
+	mu       sync.Mutex
+	windows  map[string][]time.Time
+	hits     atomic.Uint64
+	stopCh   chan struct{}
+	stopOnce sync.Once
 }
 
 func NewInMemoryGlobalRateLimiter(limit int, window time.Duration) *InMemoryGlobalRateLimiter {
@@ -221,10 +222,13 @@ func (l *InMemoryGlobalRateLimiter) startCleanup() {
 	}()
 }
 
-// Stop stops the background cleanup goroutine. It must be called exactly once
-// when the limiter is no longer needed to avoid goroutine leaks.
+// Stop stops the background cleanup goroutine. It is safe to call multiple
+// times and should be called when the limiter is no longer needed to avoid
+// goroutine leaks.
 func (l *InMemoryGlobalRateLimiter) Stop() {
-	close(l.stopCh)
+	l.stopOnce.Do(func() {
+		close(l.stopCh)
+	})
 }
 
 func (l *InMemoryGlobalRateLimiter) cleanup() {

--- a/go/services/global_rate_limiter_test.go
+++ b/go/services/global_rate_limiter_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -58,4 +59,23 @@ func TestNewGlobalRateLimiter_DisablesWhenLimitOrWindowInvalid(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(res.Allowed, qt.IsTrue)
 	c.Assert(lim.RateLimitHits(), qt.Equals, uint64(0))
+}
+
+func TestInMemoryGlobalRateLimiter_StopIsIdempotent(t *testing.T) {
+	lim := NewInMemoryGlobalRateLimiter(1, time.Minute)
+	t.Cleanup(lim.Stop)
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			lim.Stop()
+		}()
+	}
+
+	wg.Wait()
+	lim.Stop()
 }


### PR DESCRIPTION
## Summary
- make `InMemoryGlobalRateLimiter.Stop()` idempotent via `sync.Once`
- register `t.Cleanup(limiter.Stop)` in global rate-limit middleware tests
- add `TestInMemoryGlobalRateLimiter_StopIsIdempotent` for concurrent/repeated shutdown

## Validation
- `go test ./services ./apiserver`
- `go test -race ./services -run TestInMemoryGlobalRateLimiter_StopIsIdempotent`
- `go test -race ./apiserver -run TestGlobalRateLimitMiddleware`

Closes #1023