### PR TITLE
Fix: Helm chart command mismatch & Dockerfile updates (#1200)

### DIFF
--- a/.github/workflows/kind-smoke-test.yml
+++ b/.github/workflows/kind-smoke-test.yml
@@ -113,10 +113,10 @@ jobs:
         if: matrix.build-method == 'goreleaser'
         run: |
           set -euo pipefail
-          SNAPSHOT_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -E '^ghcr.io/denisvmedia/inventario:SNAPSHOT-.*-amd64$' | head -n 1)
-          if [ -z "$SNAPSHOT_IMAGE" ]; then
+          SNAPSHOT_IMAGE=$(jq -r '.[] | select(.type=="Docker Image" and .goarch=="amd64") | .name' dist/artifacts.json | head -n 1)
+          if [ -z "$SNAPSHOT_IMAGE" ] || [ "$SNAPSHOT_IMAGE" = "null" ]; then
             echo "Failed to find GoReleaser snapshot image"
-            docker images
+            cat dist/artifacts.json || true
             exit 1
           fi
           docker tag "$SNAPSHOT_IMAGE" "$APP_IMAGE"

--- a/.github/workflows/kind-smoke-test.yml
+++ b/.github/workflows/kind-smoke-test.yml
@@ -87,13 +87,6 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
-      - name: Build frontend (GoReleaser)
-        if: matrix.build-method == 'goreleaser'
-        run: |
-          npm ci
-          npm run build
-        working-directory: frontend
-
       - name: Install Go dependencies (GoReleaser)
         if: matrix.build-method == 'goreleaser'
         run: go mod download
@@ -142,7 +135,7 @@ jobs:
           set -euo pipefail
           manifests_dir="$(mktemp -d)"
           cp -R k8s/dev/. "$manifests_dir/"
-          perl -0pi -e 's#ghcr.io/denisvmedia/inventario:latest#inventario:kind-ci#g' \
+          perl -0pi -e "s#ghcr.io/denisvmedia/inventario:latest#$APP_IMAGE#g" \
             "$manifests_dir/inventario/job-setup.yaml" \
             "$manifests_dir/inventario/deployment.yaml"
           echo "CI_MANIFESTS_DIR=$manifests_dir" >> "$GITHUB_ENV"

--- a/.github/workflows/kind-smoke-test.yml
+++ b/.github/workflows/kind-smoke-test.yml
@@ -30,14 +30,18 @@ concurrency:
 
 jobs:
   kind-smoke-test:
-    name: Kind smoke test
+    strategy:
+      fail-fast: false
+      matrix:
+        build-method: [docker, goreleaser]
+    name: Kind smoke test (${{ matrix.build-method }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     env:
-      KIND_CLUSTER_NAME: inventario-ci
+      KIND_CLUSTER_NAME: inventario-ci-${{ matrix.build-method }}
       K8S_NAMESPACE: inventario-dev
-      APP_IMAGE: inventario:kind-ci
+      APP_IMAGE: inventario:kind-ci-${{ matrix.build-method }}
       ARTIFACTS_DIR: artifacts
       PORT_FORWARD_LOG: artifacts/inventario-port-forward.log
       PORT_FORWARD_PID_FILE: artifacts/inventario-port-forward.pid
@@ -63,8 +67,66 @@ jobs:
       - name: Prepare artifacts directory
         run: mkdir -p "$ARTIFACTS_DIR"
 
-      - name: Build app image
+      - name: Build app image (Docker)
+        if: matrix.build-method == 'docker'
         run: docker build --target production -t "$APP_IMAGE" .
+
+      - name: Set up Go (GoReleaser)
+        if: matrix.build-method == 'goreleaser'
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.2
+          cache: true
+          cache-dependency-path: go/go.sum
+
+      - name: Set up Node.js (GoReleaser)
+        if: matrix.build-method == 'goreleaser'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend (GoReleaser)
+        if: matrix.build-method == 'goreleaser'
+        run: |
+          npm ci
+          npm run build
+        working-directory: frontend
+
+      - name: Install Go dependencies (GoReleaser)
+        if: matrix.build-method == 'goreleaser'
+        run: go mod download
+        working-directory: go
+
+      - name: Set up QEMU (GoReleaser)
+        if: matrix.build-method == 'goreleaser'
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx (GoReleaser)
+        if: matrix.build-method == 'goreleaser'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Run GoReleaser (GoReleaser)
+        if: matrix.build-method == 'goreleaser'
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: latest
+          args: release --snapshot --clean --skip=publish,sbom,sign
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag GoReleaser image
+        if: matrix.build-method == 'goreleaser'
+        run: |
+          set -euo pipefail
+          SNAPSHOT_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -E '^ghcr.io/denisvmedia/inventario:SNAPSHOT-.*-amd64$' | head -n 1)
+          if [ -z "$SNAPSHOT_IMAGE" ]; then
+            echo "Failed to find GoReleaser snapshot image"
+            docker images
+            exit 1
+          fi
+          docker tag "$SNAPSHOT_IMAGE" "$APP_IMAGE"
 
       - name: Create kind cluster
         run: |
@@ -213,7 +275,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: kind-smoke-diagnostics
+          name: kind-smoke-diagnostics-${{ matrix.build-method }}
           path: artifacts/
           retention-days: 14
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,7 @@ before:
 
 builds:
   - binary: inventario
-    main: .
+    main: ./cmd/inventario
     dir: go
     flags:
       # Use build tags to include frontend assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,10 +106,7 @@ RUN mkdir -p /app/uploads /app/data && \
 WORKDIR /app
 
 # Copy binary from builder stage
-COPY --from=backend-builder /app/go/cmd/inventario/inventario /usr/local/bin/inventario
-
-# Change ownership
-RUN chown inventario:inventario /usr/local/bin/inventario
+COPY --chown=inventario:inventario --from=backend-builder /app/go/cmd/inventario/inventario /usr/local/bin/inventario
 
 # Switch to non-root user
 USER inventario

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,10 +106,10 @@ RUN mkdir -p /app/uploads /app/data && \
 WORKDIR /app
 
 # Copy binary from builder stage
-COPY --from=backend-builder /app/go/cmd/inventario/inventario .
+COPY --from=backend-builder /app/go/cmd/inventario/inventario /usr/local/bin/inventario
 
 # Change ownership
-RUN chown inventario:inventario inventario
+RUN chown inventario:inventario /usr/local/bin/inventario
 
 # Switch to non-root user
 USER inventario
@@ -122,4 +122,5 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:3333/api/v1/settings || exit 1
 
 # Default command
-CMD ["./inventario", "run"]
+ENTRYPOINT ["/usr/local/bin/inventario"]
+CMD ["run"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -2,15 +2,24 @@ FROM alpine:3.23
 
 RUN apk add --no-cache ca-certificates tzdata curl
 
+# Create non-root user
+RUN addgroup -g 1001 -S inventario && \
+    adduser -u 1001 -S inventario -G inventario
+
+# Create directories
+RUN mkdir -p /app/uploads /app/data && \
+    chown -R inventario:inventario /app
+
 WORKDIR /app
 
-COPY inventario /usr/local/bin/inventario
-
-# Non-root user
-RUN addgroup -S inventario && adduser -S inventario -G inventario
+COPY --chown=inventario:inventario inventario /usr/local/bin/inventario
 USER inventario
 
 EXPOSE 3333
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:3333/api/v1/settings || exit 1
 
 ENTRYPOINT ["/usr/local/bin/inventario"]
 CMD ["run"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -93,6 +93,7 @@ services:
       - inventario-network
     volumes:
       - ./scripts/bootstrap.sh:/app/bootstrap.sh:ro
+    entrypoint: [""]
     command: ["sh", "/app/bootstrap.sh"]
 
   # Database Migration Service (runs on every startup)
@@ -111,6 +112,7 @@ services:
       - inventario-network
     volumes:
       - ./scripts/migrate.sh:/app/migrate.sh:ro
+    entrypoint: [""]
     command: ["sh", "/app/migrate.sh"]
 
   # Initial Data Setup Service (runs only once using external state tracking)
@@ -144,6 +146,7 @@ services:
       - ./scripts/init-data.sh:/app/init-data.sh:ro
     networks:
       - inventario-network
+    entrypoint: [""]
     command: ["sh", "/app/init-data.sh"]
 
   # Inventario Application (Production)

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -70,6 +70,7 @@ services:
       - inventario-internal
     volumes:
       - ./scripts/bootstrap.sh:/app/bootstrap.sh:ro
+    entrypoint: [""]
     command: ["sh", "/app/bootstrap.sh"]
 
   # Database Migration Service (runs on every startup)
@@ -92,6 +93,7 @@ services:
       - inventario-internal
     volumes:
       - ./scripts/migrate.sh:/app/migrate.sh:ro
+    entrypoint: [""]
     command: ["sh", "/app/migrate.sh"]
 
   # Initial Data Setup Service (runs only once using external state tracking)
@@ -121,6 +123,7 @@ services:
       - ./scripts/init-data.sh:/app/init-data.sh:ro
     networks:
       - inventario-internal
+    entrypoint: [""]
     command: ["sh", "/app/init-data.sh"]
 
   # Main Inventario Application

--- a/example/scripts/bootstrap.sh
+++ b/example/scripts/bootstrap.sh
@@ -16,7 +16,7 @@ for i in $(seq 1 30); do
   echo "=== Attempt $i ==="
 
   # Try to run bootstrap directly - it will handle connection and user creation
-  if ./inventario db bootstrap apply \
+  if inventario db bootstrap apply \
     --username="$INVENTARIO_BOOTSTRAP_USERNAME" \
     --username-for-migrations="$INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS" 2>&1; then
     echo "✅ Bootstrap migrations completed successfully!"

--- a/example/scripts/init-data.sh
+++ b/example/scripts/init-data.sh
@@ -8,7 +8,7 @@ if [ ! -f /app/state/data-initialized ]; then
   # Wait for database to be ready with retry mechanism
   echo "Waiting for database to be ready for initial data setup..."
   for i in $(seq 1 15); do
-    if ./inventario db migrate data \
+    if inventario db migrate data \
       --default-tenant-name="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_NAME" \
       --default-tenant-slug="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_SLUG" \
       --admin-email="$INVENTARIO_MIGRATE_DATA_ADMIN_EMAIL" \

--- a/example/scripts/migrate.sh
+++ b/example/scripts/migrate.sh
@@ -7,7 +7,7 @@ echo "Database DSN: $INVENTARIO_DATABASE_DB_DSN"
 # Wait for database to be ready with retry mechanism
 echo "Waiting for database to be ready for migrations..."
 for i in $(seq 1 15); do
-  if ./inventario db migrate up; then
+  if inventario db migrate up; then
     echo "Schema migrations completed successfully"
     exit 0
   else

--- a/helm/inventario/Chart.yaml
+++ b/helm/inventario/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inventario
 description: Personal inventory management system
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "latest" # overridden by CI with the actual image tag
 keywords:
   - inventory

--- a/helm/inventario/templates/deployment.yaml
+++ b/helm/inventario/templates/deployment.yaml
@@ -44,7 +44,6 @@ spec:
         - name: inventario
           image: {{ printf "%s:%s" .Values.image.repository $imageTag | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["./inventario", "run"]
           ports:
             - name: http
               containerPort: 3333

--- a/helm/inventario/templates/job-setup.yaml
+++ b/helm/inventario/templates/job-setup.yaml
@@ -49,7 +49,7 @@ spec:
               fi
               i=1
               while [ "$i" -le 30 ]; do
-                if ./inventario db bootstrap apply \
+                if inventario db bootstrap apply \
                   --username="$INVENTARIO_BOOTSTRAP_USERNAME" \
                   --username-for-migrations="$INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS"; then
                   echo "Bootstrap migrations completed successfully"
@@ -105,7 +105,7 @@ spec:
               export INVENTARIO_DB_DSN="${MIGRATOR_DB_DSN:-$APP_DB_DSN}"
               i=1
               while [ "$i" -le 15 ]; do
-                if ./inventario db migrate up; then
+                if inventario db migrate up; then
                   echo "Schema migrations completed successfully"
                   exit 0
                 fi
@@ -152,7 +152,7 @@ spec:
               export INVENTARIO_DB_DSN="${MIGRATOR_DB_DSN:-$APP_DB_DSN}"
               i=1
               while [ "$i" -le 15 ]; do
-                if ./inventario db migrate data \
+                if inventario db migrate data \
                   --default-tenant-name="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_NAME" \
                   --default-tenant-slug="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_SLUG" \
                   --admin-email="$INVENTARIO_MIGRATE_DATA_ADMIN_EMAIL" \
@@ -197,7 +197,7 @@ spec:
                   ;;
               esac
 
-              ./inventario run &
+              inventario run &
               server_pid=$!
               trap 'kill "$server_pid" 2>/dev/null || true; wait "$server_pid" 2>/dev/null || true' EXIT
 

--- a/k8s/dev/inventario/deployment.yaml
+++ b/k8s/dev/inventario/deployment.yaml
@@ -111,7 +111,7 @@ spec:
               set -eu
               i=1
               while [ "$i" -le 30 ]; do
-                if ./inventario db bootstrap apply \
+                if inventario db bootstrap apply \
                   --username="$INVENTARIO_BOOTSTRAP_USERNAME" \
                   --username-for-migrations="$INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS"; then
                   echo "Bootstrap migrations completed successfully"
@@ -150,7 +150,7 @@ spec:
               set -eu
               i=1
               while [ "$i" -le 15 ]; do
-                if ./inventario db migrate up; then
+                if inventario db migrate up; then
                   echo "Schema migrations completed successfully"
                   exit 0
                 fi
@@ -187,7 +187,7 @@ spec:
               set -eu
               i=1
               while [ "$i" -le 15 ]; do
-                if ./inventario db migrate data \
+                if inventario db migrate data \
                   --default-tenant-name="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_NAME" \
                   --default-tenant-slug="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_SLUG" \
                   --admin-email="$INVENTARIO_MIGRATE_DATA_ADMIN_EMAIL" \
@@ -210,7 +210,7 @@ spec:
               fi
 
               export INVENTARIO_DB_DSN="$INVENTARIO_SEED_DB_DSN"
-              ./inventario run &
+              inventario run &
               server_pid=$!
               trap 'kill "$server_pid" 2>/dev/null || true; wait "$server_pid" 2>/dev/null || true' EXIT
 
@@ -267,7 +267,6 @@ spec:
         - name: inventario
           image: ghcr.io/denisvmedia/inventario:latest
           imagePullPolicy: IfNotPresent
-          command: ["./inventario", "run"]
           ports:
             - name: http
               containerPort: 3333

--- a/k8s/prod/deployment.yaml
+++ b/k8s/prod/deployment.yaml
@@ -70,7 +70,7 @@ spec:
               set -eu
               i=1
               while [ "$i" -le 15 ]; do
-                if ./inventario db migrate up; then
+                if inventario db migrate up; then
                   mkdir -p /data/setup-state
                   touch /data/setup-state/migrate-complete
                   exit 0
@@ -123,7 +123,6 @@ spec:
         - name: inventario
           image: ghcr.io/denisvmedia/inventario:latest
           imagePullPolicy: Always
-          command: ["./inventario", "run"]
           ports:
             - name: http
               containerPort: 3333

--- a/k8s/prod/job-setup.yaml
+++ b/k8s/prod/job-setup.yaml
@@ -39,7 +39,7 @@ spec:
               set -eu
               i=1
               while [ "$i" -le 30 ]; do
-                if ./inventario db bootstrap apply \
+                if inventario db bootstrap apply \
                   --username="$INVENTARIO_BOOTSTRAP_USERNAME" \
                   --username-for-migrations="$INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS"; then
                   mkdir -p /data/setup-state
@@ -101,7 +101,7 @@ spec:
               success=0
               i=1
               while [ "$i" -le 15 ]; do
-                if ./inventario db migrate data \
+                if inventario db migrate data \
                   --default-tenant-name="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_NAME" \
                   --default-tenant-slug="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_SLUG" \
                   --admin-email="$INVENTARIO_MIGRATE_DATA_ADMIN_EMAIL" \
@@ -121,7 +121,7 @@ spec:
 
               if [ "${SEED_DATABASE:-false}" = "true" ]; then
                 export INVENTARIO_DB_DSN="$INVENTARIO_SEED_DB_DSN"
-                ./inventario run &
+                inventario run &
                 SERVER_PID=$!
                 trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -16,7 +16,7 @@ for i in $(seq 1 30); do
   echo "=== Attempt $i ==="
 
   # Try to run bootstrap directly - it will handle connection and user creation
-  if ./inventario db bootstrap apply \
+  if inventario db bootstrap apply \
     --username="$INVENTARIO_BOOTSTRAP_USERNAME" \
     --username-for-migrations="$INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS" 2>&1; then
     echo "✅ Bootstrap migrations completed successfully!"

--- a/scripts/init-data.sh
+++ b/scripts/init-data.sh
@@ -8,7 +8,7 @@ if [ ! -f /app/state/data-initialized ]; then
   # Wait for database to be ready with retry mechanism
   echo "Waiting for database to be ready for initial data setup..."
   for i in $(seq 1 15); do
-    if ./inventario db migrate data \
+    if inventario db migrate data \
       --default-tenant-name="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_NAME" \
       --default-tenant-slug="$INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_SLUG" \
       --admin-email="$INVENTARIO_MIGRATE_DATA_ADMIN_EMAIL" \
@@ -27,7 +27,7 @@ if [ ! -f /app/state/data-initialized ]; then
         echo "Using DSN: $INVENTARIO_DB_DSN (for seeding)"
 
         # Start server in background
-        ./inventario run &
+        inventario run &
         SERVER_PID=$!
 
         # Wait for server to be ready

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -7,7 +7,7 @@ echo "Database DSN: $INVENTARIO_DB_DSN"
 # Wait for database to be ready with retry mechanism
 echo "Waiting for database to be ready for migrations..."
 for i in $(seq 1 15); do
-  if ./inventario db migrate up; then
+  if inventario db migrate up; then
     echo "Schema migrations completed successfully"
     exit 0
   else


### PR DESCRIPTION
This PR implements the solutions proposed in #1200:

1. **Option B for Dockerfile**: Modifies the `Dockerfile` to match `Dockerfile.release` by placing the compiled binary globally in `/usr/local/bin/inventario` and setting the appropriate `ENTRYPOINT` and `CMD`.
2. **Option A for Helm Chart & K8s Manifests**: Removes the hardcoded `command: ["./inventario", "run"]` configurations from the Helm Chart (`deployment.yaml`) and the static kubernetes manifests. For `job-setup.yaml`, updates script commands from `if ./inventario ...` to `if inventario ...` to utilize the global binary.
3. **Smoke Tests Updates**: Updates `.github/workflows/kind-smoke-test.yml` to use a test matrix testing both the Dockerfile build process and a GoReleaser-built snapshot.

**Note on compatibility**: This tightens the coupling between the Helm chart and the image version. Since the chart no longer provides the `command:` override, it strictly relies on the updated Dockerfile's `ENTRYPOINT`. Running the new chart with an older image tag that expects `command:` to be overridden will cause failures.

Resolves #1200