### PR TITLE
fix(helm): allow mc to write config by providing emptyDir and MC_CONFIG_DIR

### DIFF
--- a/helm/inventario/templates/demo/minio-job.yaml
+++ b/helm/inventario/templates/demo/minio-job.yaml
@@ -25,9 +25,15 @@ spec:
         - name: mc
           image: quay.io/minio/mc:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: MC_CONFIG_DIR
+              value: /tmp/.mc
           envFrom:
             - secretRef:
                 name: {{ include "inventario.demoMinioSecretName" . }}
+          volumeMounts:
+            - name: mc-config
+              mountPath: /tmp/.mc
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -42,4 +48,7 @@ spec:
                 sleep 2
               done
               mc mb --ignore-existing demo/"$MINIO_BUCKET_NAME"
+      volumes:
+        - name: mc-config
+          emptyDir: {}
 {{- end }}

--- a/k8s/dev/minio/job.yaml
+++ b/k8s/dev/minio/job.yaml
@@ -25,9 +25,15 @@ spec:
         - name: mc
           image: quay.io/minio/mc:latest
           imagePullPolicy: IfNotPresent
+          env:
+            - name: MC_CONFIG_DIR
+              value: /tmp/.mc
           envFrom:
             - secretRef:
                 name: minio-credentials
+          volumeMounts:
+            - name: mc-config
+              mountPath: /tmp/.mc
           command:
             - /bin/sh
             - -c
@@ -38,3 +44,6 @@ spec:
                 sleep 2
               done
               mc mb --ignore-existing dev/"$MINIO_BUCKET_NAME"
+      volumes:
+        - name: mc-config
+          emptyDir: {}


### PR DESCRIPTION
Fixes #1202

Added emptyDir volume `mc-config` and `MC_CONFIG_DIR` env variable to make sure `mc` can write configs.