### PR TITLE
fix(helm): narrow Service selector to app pod only via appSelectorLabels

### DIFF
--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -25,6 +25,11 @@ app.kubernetes.io/name: {{ include "inventario.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
+{{- define "inventario.appSelectorLabels" -}}
+{{- include "inventario.selectorLabels" . }}
+app.kubernetes.io/component: web
+{{- end -}}
+
 {{- define "inventario.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "inventario.fullname" .) .Values.serviceAccount.name -}}

--- a/helm/inventario/templates/deployment.yaml
+++ b/helm/inventario/templates/deployment.yaml
@@ -19,12 +19,11 @@ spec:
       maxSurge: 1
   selector:
     matchLabels:
-      {{- include "inventario.selectorLabels" . | nindent 6 }}
+      {{- include "inventario.appSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "inventario.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: web
+        {{- include "inventario.appSelectorLabels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/helm/inventario/templates/service.yaml
+++ b/helm/inventario/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   selector:
-    {{- include "inventario.selectorLabels" . | nindent 4 }}
+    {{- include "inventario.appSelectorLabels" . | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.service.port }}


### PR DESCRIPTION
## Problem

The Service selector only used `app.kubernetes.io/name` + `app.kubernetes.io/instance`, which matched **all** pods in the release — including demo-postgresql, demo-redis, demo-minio, and the setup Job pod. None of those pods listen on port 3333, so Traefik round-robined requests across all endpoints and ~75% hit a `connection refused` → HTTP 502.

Closes #1204

## Solution

Add an `inventario.appSelectorLabels` helper to `_helpers.tpl` that extends `inventario.selectorLabels` with `app.kubernetes.io/component: web`:

```yaml
{{- define "inventario.appSelectorLabels" -}}
{{- include "inventario.selectorLabels" . }}
app.kubernetes.io/component: web
{{- end -}}
```

Use it in:
- **`deployment.yaml`** — `spec.selector.matchLabels` and pod template labels (removes the now-redundant explicit `component: web` line)
- **`service.yaml`** — `spec.selector` (removes the now-redundant explicit `component: web` line)

The base `inventario.selectorLabels` is left unchanged so demo Deployment selectors (which already add their own `component: demo-*`) are unaffected.