### PR TITLE
fix(embed): use all:dist to include underscore-prefixed Vite chunks

### DIFF
--- a/.github/workflows/frontend-embed-smoke-test.yml
+++ b/.github/workflows/frontend-embed-smoke-test.yml
@@ -1,0 +1,66 @@
+name: Frontend Embed Smoke Test
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'frontend/**'
+      - 'go/apiserver/frontend_embed_test.go'
+      - '.github/workflows/frontend-embed-smoke-test.yml'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - 'go/apiserver/frontend_embed_test.go'
+      - '.github/workflows/frontend-embed-smoke-test.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  embed-smoke-test:
+    name: embed smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - id: vars
+        uses: ./.github/actions/vars
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.vars.outputs.node_version }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.2
+          cache: true
+          cache-dependency-path: go/go.sum
+
+      - name: Build frontend
+        run: npm ci && npm run build
+        working-directory: frontend
+
+      - name: Install Go dependencies
+        run: go mod download
+        working-directory: go
+
+      - name: Run embed smoke test
+        # Requires -tags with_frontend so that frontend.GetDist() is compiled in.
+        # The test walks the embedded dist/assets directory and fails if no
+        # underscore-prefixed Vite chunks are found — which would indicate that
+        # the //go:embed directive is missing the "all:" prefix.
+        run: go test -v -tags with_frontend -run TestFrontendEmbed_UnderscorePrefixedFilesArePresent ./apiserver/...
+        working-directory: go

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -7,7 +7,14 @@ import (
 	"io/fs"
 )
 
-//go:embed dist
+// The "all:" prefix is required so that Go's embed includes files whose names
+// begin with "_" or ".". Without it those files are silently skipped, which
+// breaks the SPA: Vite's code-splitter emits chunks with underscore-prefixed
+// names (e.g. _plugin-vue_export-helper-*.js), and missing chunks cause
+// FrontendHandler to fall back to serving index.html with Content-Type
+// text/html instead of the actual JavaScript, resulting in browser errors.
+//
+//go:embed all:dist
 var dist embed.FS
 
 func GetDist() fs.ReadFileFS {

--- a/go/apiserver/frontend_embed_test.go
+++ b/go/apiserver/frontend_embed_test.go
@@ -1,0 +1,49 @@
+//go:build with_frontend
+
+package apiserver_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/frontend"
+)
+
+// TestFrontendEmbed_UnderscorePrefixedFilesArePresent verifies that Vite chunks
+// with underscore-prefixed names (e.g. _plugin-vue_export-helper-*.js) are
+// included in the embedded filesystem returned by frontend.GetDist().
+//
+// Go's //go:embed silently skips any file whose name begins with "_" or "."
+// unless the directive uses the "all:" prefix. Without it the chunks are absent
+// from the binary, FrontendHandler falls back to serving index.html for those
+// paths, and the browser receives Content-Type: text/html instead of
+// application/javascript — breaking the SPA entirely.
+//
+// This test requires the frontend to be built first (npm run build in frontend/).
+// It is executed in CI by the frontend-embed-smoke-test workflow.
+func TestFrontendEmbed_UnderscorePrefixedFilesArePresent(t *testing.T) {
+	c := qt.New(t)
+
+	dist := frontend.GetDist()
+
+	var found []string
+	err := fs.WalkDir(dist, "dist/assets", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasPrefix(filepath.Base(path), "_") {
+			found = append(found, path)
+		}
+		return nil
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(found) > 0, qt.IsTrue,
+		qt.Commentf("no underscore-prefixed Vite chunks found in embedded dist/assets — "+
+			"ensure the //go:embed directive in frontend/frontend.go uses 'all:dist'"))
+
+	t.Logf("found %d underscore-prefixed chunk(s): %v", len(found), found)
+}


### PR DESCRIPTION
## Problem

`//go:embed dist` in `frontend/frontend.go` silently skips any file whose name begins with `_` or `.`. Vite's code-splitter emits chunks with underscore-prefixed names (e.g. `_plugin-vue_export-helper-*.js`). Those files were absent from the binary, so `FrontendHandler` fell back to serving `index.html` for every request to such a path — returning `Content-Type: text/html` instead of `application/javascript` and breaking the SPA.

Closes #1205

## Solution

Change the embed directive to use the `all:` prefix:

```go
//go:embed all:dist
var dist embed.FS
```

A comment in the source explains the reason so the directive is never silently reverted.

## Verification

- **`go/apiserver/frontend_embed_test.go`** (`//go:build with_frontend`) — walks the embedded `dist/assets/` and fails if no underscore-prefixed chunks are found.
- **`.github/workflows/frontend-embed-smoke-test.yml`** — CI workflow that builds the frontend with `npm run build` and then runs the test with `-tags with_frontend`. Triggers on changes to `frontend/**`.