### PR TITLE
fix(helm): replace `disableSSL=true` with `http://` endpoint prefix for MinIO

### DIFF
--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -114,7 +114,7 @@ app.kubernetes.io/component: web
 
 {{- define "inventario.uploadLocation" -}}
 {{- if .Values.demo.minio.enabled -}}
-{{- printf "s3://%s?prefix=%s&region=us-east-1&endpoint=%s&disableSSL=true&s3ForcePathStyle=true" .Values.demo.minio.bucket .Values.demo.minio.prefix (include "inventario.minioEndpoint" .) -}}
+{{- printf "s3://%s?prefix=%s&region=us-east-1&endpoint=%s&s3ForcePathStyle=true" .Values.demo.minio.bucket .Values.demo.minio.prefix (include "inventario.minioEndpointUrl" .) -}}
 {{- else -}}
 {{- .Values.app.uploadLocation -}}
 {{- end -}}


### PR DESCRIPTION
## Problem

Closes #1209

All file uploads fail with HTTP 500 when using demo MinIO mode:

```
error="unable to save file: failed to open bucket:
  open bucket s3://inventario?disableSSL=true&endpoint=...:9000&region=us-east-1&s3ForcePathStyle=true:
  unknown query parameter \"disableSSL\""
```

Go CDK's `s3blob` URL opener does not support `disableSSL` as a query parameter.

## Fix

In `helm/inventario/templates/_helpers.tpl`, the `inventario.uploadLocation` helper was using `inventario.minioEndpoint` (which returns just `host:port`) and appending `&disableSSL=true`. The template already had an `inventario.minioEndpointUrl` helper that produces `http://host:port`.

**Change:** Switch from `inventario.minioEndpoint` + `&disableSSL=true` → `inventario.minioEndpointUrl` (no `disableSSL` param).

Before:
```
s3://inventario?prefix=uploads/&region=us-east-1&endpoint=inventario-inventario-demo-minio:9000&disableSSL=true&s3ForcePathStyle=true
```

After:
```
s3://inventario?prefix=uploads/&region=us-east-1&endpoint=http://inventario-inventario-demo-minio:9000&s3ForcePathStyle=true
```

The AWS SDK underneath Go CDK infers plain HTTP from the `http://` scheme in the endpoint URL — same intent as `disableSSL=true`, but using the supported mechanism.