### PR TITLE
fix(rate-limit): exempt auth & authenticated routes from global rate limit (#1208)

### DIFF
--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -224,11 +224,14 @@ func APIServer(params Params, restoreWorker RestoreWorkerInterface) http.Handler
 	}
 
 	r.Route("/api/v1", func(r chi.Router) {
-		r.Use(GlobalRateLimitMiddleware(globalRateLimiter, params.GlobalRateTrustedProxyNets))
 		// Resolve tenant from request host and place it in context for all handlers,
 		// including public ones (login, registration, password reset).
 		r.Use(PublicTenantMiddleware(tenantResolver, params.FactorySet.TenantRegistry))
-		// Public routes (no authentication required)
+
+		// Auth routes have dedicated per-endpoint rate limiters (login, registration,
+		// password-reset); applying the global per-IP limit here would lock users out
+		// of the login page when the global budget is exhausted — the exact failure
+		// mode described in issue #1208. Keep auth outside the global limiter.
 		r.Route("/auth", Auth(AuthParams{
 			UserRegistry:         params.FactorySet.UserRegistry,
 			RefreshTokenRegistry: params.FactorySet.RefreshTokenRegistry,
@@ -239,37 +242,46 @@ func APIServer(params Params, restoreWorker RestoreWorkerInterface) http.Handler
 			JWTSecret:            params.JWTSecret,
 			EmailService:         emailSvc,
 		}))
-		r.Group(Registration(RegistrationParams{
-			UserRegistry:         params.FactorySet.UserRegistry,
-			VerificationRegistry: params.FactorySet.EmailVerificationRegistry,
-			EmailService:         emailSvc,
-			AuditService:         auditSvc,
-			RateLimiter:          rateLimiter,
-			RegistrationMode:     params.RegistrationMode,
-			PublicBaseURL:        params.PublicURL,
-		}))
-		r.Group(PasswordReset(PasswordResetParams{
-			UserRegistry:          params.FactorySet.UserRegistry,
-			PasswordResetRegistry: params.FactorySet.PasswordResetRegistry,
-			RefreshTokenRegistry:  params.FactorySet.RefreshTokenRegistry,
-			BlacklistService:      blacklist,
-			EmailService:          emailSvc,
-			AuditService:          auditSvc,
-			RateLimiter:           rateLimiter,
-			PublicBaseURL:         params.PublicURL,
-		}))
-		r.Route("/currencies", Currencies())
-		// Seed endpoint is public for e2e testing and development
-		// Seed uses a service registry set since it's a privileged operation in dev/test
-		r.With(defaultAPIMiddlewares...).Route("/seed", Seed(params.FactorySet))
+
+		// Unauthenticated public routes: apply the global per-IP rate limit as a
+		// defence-in-depth layer on top of their dedicated rate limiters.
+		r.Group(func(r chi.Router) {
+			r.Use(GlobalRateLimitMiddleware(globalRateLimiter, params.GlobalRateTrustedProxyNets))
+			r.Group(Registration(RegistrationParams{
+				UserRegistry:         params.FactorySet.UserRegistry,
+				VerificationRegistry: params.FactorySet.EmailVerificationRegistry,
+				EmailService:         emailSvc,
+				AuditService:         auditSvc,
+				RateLimiter:          rateLimiter,
+				RegistrationMode:     params.RegistrationMode,
+				PublicBaseURL:        params.PublicURL,
+			}))
+			r.Group(PasswordReset(PasswordResetParams{
+				UserRegistry:          params.FactorySet.UserRegistry,
+				PasswordResetRegistry: params.FactorySet.PasswordResetRegistry,
+				RefreshTokenRegistry:  params.FactorySet.RefreshTokenRegistry,
+				BlacklistService:      blacklist,
+				EmailService:          emailSvc,
+				AuditService:          auditSvc,
+				RateLimiter:           rateLimiter,
+				PublicBaseURL:         params.PublicURL,
+			}))
+			r.Route("/currencies", Currencies())
+			// Seed endpoint is public for e2e testing and development.
+			// Seed uses a service registry set since it's a privileged operation in dev/test.
+			r.With(defaultAPIMiddlewares...).Route("/seed", Seed(params.FactorySet))
+		})
 
 		// Create user aware middlewares for protected routes
 		userMiddlewares := createUserAwareMiddlewares(params.JWTSecret, params.FactorySet, blacklist, csrfSvc)
 		userUploadMiddlewares := createUserAwareMiddlewaresForUploads(params.JWTSecret, params.FactorySet.UserRegistry, params.FactorySet, blacklist, csrfSvc)
 
-		// Protected routes (authentication required)
-		// Note: RegistrySetMiddleware creates user-aware registries and adds them to context
-		// System requires a settings registry
+		// Protected routes (authentication required).
+		// Authenticated users are not subject to the global per-IP rate limit; a
+		// valid JWT already proves legitimacy and the SPA issues several API calls
+		// per page navigation, making the global budget easy to exhaust legitimately.
+		// Note: RegistrySetMiddleware creates user-aware registries and adds them to context.
+		// System requires a settings registry.
 		r.With(userMiddlewares...).Route("/system", System(params.DebugInfo, params.StartTime))
 		r.With(userMiddlewares...).Route("/locations", Locations())
 		r.With(userMiddlewares...).Route("/areas", Areas())

--- a/go/apiserver/global_rate_limit_middleware_test.go
+++ b/go/apiserver/global_rate_limit_middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -125,4 +126,49 @@ func TestGlobalRateLimitMiddleware_UsesXForwardedForOnlyForTrustedProxies(t *tes
 		handler.ServeHTTP(res2, req2)
 		c.Assert(res2.Code, qt.Equals, http.StatusTooManyRequests)
 	})
+}
+
+// TestAPIServer_GlobalRateLimitExemptions verifies the route-tier exemptions introduced
+// in issue #1208: the /auth/* subrouter must remain accessible when the global per-IP
+// rate-limit budget has been exhausted by requests to other public endpoints.
+func TestAPIServer_GlobalRateLimitExemptions(t *testing.T) {
+	c := qt.New(t)
+
+	params, _ := newParamsAreaRegistryOnly()
+
+	// Limit of 1 request per hour means a single hit to a globally-limited public
+	// endpoint exhausts the entire budget for that IP.
+	limiter := services.NewInMemoryGlobalRateLimiter(1, time.Hour)
+	t.Cleanup(limiter.Stop)
+	params.GlobalRateLimiter = limiter
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	const clientIP = "203.0.113.42:1234"
+
+	makeReq := func(method, path, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(method, path, strings.NewReader(body))
+		req.RemoteAddr = clientIP
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w
+	}
+
+	// First request to a globally-rate-limited public endpoint (/register):
+	// budget = 1, so this request is allowed (response is some non-429 status).
+	first := makeReq(http.MethodPost, "/api/v1/register",
+		`{"email":"a@example.com","password":"pass1234","name":"Alice"}`)
+	c.Assert(first.Code, qt.Not(qt.Equals), http.StatusTooManyRequests)
+
+	// Second request to the same endpoint: budget exhausted — must return 429.
+	second := makeReq(http.MethodPost, "/api/v1/register",
+		`{"email":"b@example.com","password":"pass1234","name":"Bob"}`)
+	c.Assert(second.Code, qt.Equals, http.StatusTooManyRequests)
+
+	// /auth/login is exempt from the global limiter and must still be reachable.
+	// Wrong credentials yield 401; anything other than 429 proves the route is accessible.
+	login := makeReq(http.MethodPost, "/api/v1/auth/login",
+		`{"email":"nobody@example.com","password":"wrongpassword"}`)
+	c.Assert(login.Code, qt.Not(qt.Equals), http.StatusTooManyRequests)
 }

--- a/helm/inventario/templates/configmap.yaml
+++ b/helm/inventario/templates/configmap.yaml
@@ -19,6 +19,7 @@ data:
   INVENTARIO_RUN_ALLOWED_ORIGINS: {{ .Values.app.allowedOrigins | quote }}
   INVENTARIO_RUN_GLOBAL_RATE_LIMIT: {{ .Values.app.globalRateLimit | quote }}
   INVENTARIO_RUN_GLOBAL_RATE_WINDOW: {{ .Values.app.globalRateWindow | quote }}
+  INVENTARIO_RUN_GLOBAL_RATE_LIMIT_DISABLED: {{ .Values.app.globalRateLimitDisabled | quote }}
   INVENTARIO_RUN_GLOBAL_RATE_TRUSTED_PROXIES: {{ .Values.app.globalRateTrustedProxies | quote }}
   INVENTARIO_RUN_EMAIL_PROVIDER: {{ .Values.email.provider | quote }}
   INVENTARIO_RUN_EMAIL_FROM: {{ .Values.email.from | quote }}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -113,13 +113,21 @@ app:
   # Env: INVENTARIO_RUN_ALLOWED_ORIGINS
   allowedOrigins: ""
 
-  # Global per-IP API rate limit (requests per window)
+  # Global per-IP API rate limit (requests per window).
+  # Only applies to unauthenticated public routes (registration, password-reset,
+  # currencies, seed). Auth and protected routes are exempt.
   # Env: INVENTARIO_RUN_GLOBAL_RATE_LIMIT
-  globalRateLimit: 100
+  globalRateLimit: 1000
 
   # Global rate limit window duration
   # Env: INVENTARIO_RUN_GLOBAL_RATE_WINDOW
   globalRateWindow: "1h"
+
+  # Disable the global per-IP API rate limit entirely.
+  # Set to true for private/internal deployments where rate limiting is handled
+  # by an external proxy, or for testing purposes.
+  # Env: INVENTARIO_RUN_GLOBAL_RATE_LIMIT_DISABLED
+  globalRateLimitDisabled: false
 
   # Comma-separated trusted proxy CIDRs for real-IP resolution
   # Env: INVENTARIO_RUN_GLOBAL_RATE_TRUSTED_PROXIES


### PR DESCRIPTION
Fixes #1208

## Problem

Three separate issues caused users to be locked out of their own instance after ~20–30 page navigations:

1. **Helm chart default was 100 req/hour** — mismatched the Go backend default of 1000. The SPA makes 3–5 API calls per route change, so a user could exhaust the budget in under a minute of normal browsing.

2. **Login endpoint was blocked by the global rate limit** — when the budget was exhausted, `/api/v1/auth/login` returned 429, making it impossible to re-authenticate for up to an hour. This happened even though the auth subrouter already has dedicated per-endpoint rate limiters (`AuthLoginRateLimitMiddleware`, `RegistrationRateLimitMiddleware`, `PasswordResetRateLimitMiddleware`).

3. **Authenticated (SPA) requests counted against the global budget** — every page navigation by a logged-in user consumed quota, making the limit easy to hit in normal usage.

4. **`INVENTARIO_RUN_GLOBAL_RATE_LIMIT_DISABLED` was not exposed in the Helm chart** — operators on private/internal deployments had to inject the env var manually.

## Changes

### `helm/inventario/values.yaml`
- Raised `globalRateLimit` from `100` → `1000` (matches Go backend default)
- Added `globalRateLimitDisabled: false` to expose the opt-out flag

### `helm/inventario/templates/configmap.yaml`
- Added `INVENTARIO_RUN_GLOBAL_RATE_LIMIT_DISABLED` to render the new `globalRateLimitDisabled` value

### `go/apiserver/apiserver.go`
Restructured the `/api/v1` router into three tiers:

| Routes | Global rate limit | Reason |
|---|---|---|
| `/api/v1/auth/*` | ❌ Exempt | Has dedicated per-endpoint limiters; applying global limit here caused the login lockout |
| `/register`, `/forgot-password`, `/reset-password`, `/currencies`, `/seed` | ✅ Applied | Unauthenticated public routes — global limiter adds defence-in-depth on top of dedicated limiters |
| All JWT-protected routes (`/system`, `/locations`, `/commodities`, etc.) | ❌ Exempt | Valid JWT already proves legitimacy; SPA makes many calls per page navigation |