### PR TITLE
feat(locations): add image and file attachment support

### DIFF
--- a/e2e/tests/location-file-uploads.spec.ts
+++ b/e2e/tests/location-file-uploads.spec.ts
@@ -1,0 +1,101 @@
+import { expect } from '@playwright/test';
+import { test } from '../fixtures/app-fixture.js';
+import path from 'path';
+import { createLocation, deleteLocation } from './includes/locations.js';
+import { navigateTo, TO_LOCATIONS } from './includes/navigate.js';
+import { deleteFile, downloadFile, fileinfo, uploadFile } from './includes/uploads.js';
+
+// Helper: navigate to location detail page by clicking Edit, extracting the ID, then going to /locations/{id}
+async function navigateToLocationDetail(page: any, recorder: any, locationName: string) {
+  const locationCard = page.locator(`.location-card:has-text("${locationName}")`).first();
+  await locationCard.waitFor({ state: 'visible', timeout: 10000 });
+
+  // Click Edit button to land on /locations/{id}/edit, from which we extract the ID
+  await locationCard.locator('button[title="Edit"]').click();
+  await page.waitForURL(/\/locations\/[^/]+\/edit/, { timeout: 10000 });
+
+  const url = page.url();
+  const locationId = url.match(/\/locations\/([^/]+)\/edit/)?.[1];
+  if (!locationId) {
+    throw new Error(`Could not extract location ID from URL: ${url}`);
+  }
+
+  recorder.log(`Navigating to location detail page: /locations/${locationId}`);
+  await page.goto(`/locations/${locationId}`);
+  await page.waitForURL(/\/locations\/[^/]+$/, { timeout: 10000 });
+  await page.waitForSelector('.location-images', { timeout: 10000 });
+  await recorder.takeScreenshot('location-detail-page');
+}
+
+test.describe('Location File Uploads Tests', () => {
+  const timestamp = Date.now();
+  const testLocation = {
+    name: `Test Location for File Uploads ${timestamp}`,
+    address: '42 Upload Test Street, Test City'
+  };
+
+  const testImagePath = path.join('fixtures', 'files', 'image.jpg');
+  const testFilePath = path.join('fixtures', 'files', 'manual.pdf');
+
+  test('should upload, view info, download and delete image and file on a location', async ({ page, recorder }) => {
+    let step = 1;
+
+    // STEP 1: Navigate to Locations and create a location
+    recorder.log(`Step ${step++}: Creating a new location`);
+    await navigateTo(page, recorder, TO_LOCATIONS);
+    await createLocation(page, recorder, testLocation);
+
+    // STEP 2: Navigate to the location detail page
+    recorder.log(`Step ${step++}: Navigating to location detail page`);
+    await navigateToLocationDetail(page, recorder, testLocation.name);
+
+    // STEP 3: Upload an image
+    recorder.log(`Step ${step++}: Uploading an image to the location`);
+    await uploadFile(page, recorder, '.location-images', testImagePath);
+
+    // STEP 4: Upload a generic file (PDF)
+    recorder.log(`Step ${step++}: Uploading a file to the location`);
+    await uploadFile(page, recorder, '.location-files', testFilePath);
+
+    // STEP 5: Verify both sections show the uploaded files
+    recorder.log(`Step ${step++}: Verifying uploaded files are visible`);
+    await expect(page.locator('.location-images .file-item')).toBeVisible();
+    await expect(page.locator('.location-files .file-item')).toBeVisible();
+    await recorder.takeScreenshot('location-files-uploaded');
+
+    // STEP 6: Check file properties (info dialog) for both sections
+    recorder.log(`Step ${step++}: Testing file info dialog`);
+    for (const { selector, fileType } of [
+      { selector: '.location-images', fileType: 'image' },
+      { selector: '.location-files', fileType: 'file' }
+    ]) {
+      recorder.log(`Checking file info for ${fileType}`);
+      await fileinfo(page, recorder, selector, fileType);
+    }
+
+    // STEP 7: Download both files via signed URL
+    recorder.log(`Step ${step++}: Testing file downloads`);
+    for (const { selector, fileType } of [
+      { selector: '.location-images', fileType: 'image' },
+      { selector: '.location-files', fileType: 'file' }
+    ]) {
+      recorder.log(`Downloading ${fileType}`);
+      await downloadFile(page, recorder, selector, fileType);
+    }
+
+    // STEP 8: Delete both files
+    recorder.log(`Step ${step++}: Deleting uploaded files`);
+    for (const { selector, fileType } of [
+      { selector: '.location-images', fileType: 'image' },
+      { selector: '.location-files', fileType: 'file' }
+    ]) {
+      recorder.log(`Deleting ${fileType}`);
+      await deleteFile(page, recorder, selector, fileType);
+    }
+
+    // STEP 9: Cleanup — delete the location
+    recorder.log(`Step ${step++}: Cleaning up — deleting the location`);
+    await navigateTo(page, recorder, TO_LOCATIONS);
+    await deleteLocation(page, recorder, testLocation.name);
+  });
+});

--- a/frontend/src/components/FileList.vue
+++ b/frontend/src/components/FileList.vue
@@ -69,7 +69,7 @@ const props = defineProps({
   fileType: {
     type: String,
     required: true,
-    validator: (value: string) => ['images', 'manuals', 'invoices'].includes(value)
+    validator: (value: string) => ['images', 'manuals', 'invoices', 'files'].includes(value)
   },
   commodityId: {
     type: String,

--- a/frontend/src/components/FileViewer.vue
+++ b/frontend/src/components/FileViewer.vue
@@ -166,7 +166,7 @@ const props = defineProps({
   fileType: {
     type: String,
     required: true,
-    validator: (value: string) => ['images', 'manuals', 'invoices'].includes(value)
+    validator: (value: string) => ['images', 'manuals', 'invoices', 'files'].includes(value)
   },
   allowDelete: {
     type: Boolean,

--- a/frontend/src/services/locationService.ts
+++ b/frontend/src/services/locationService.ts
@@ -29,21 +29,33 @@ const locationService = {
     return api.get(`${API_URL}/locations/${id}/images`)
   },
 
-  uploadImages(id: string, files: File[]) {
+  uploadImage(id: string, file: File) {
     const formData = new FormData()
-    files.forEach(file => {
-      formData.append('files', file)
-    })
-
-    return api.post(`/api/v1/uploads/locations/${id}/images`, formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data'
-      }
+    formData.append('file', file)
+    return api.post(`${API_URL}/uploads/locations/${id}/image`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
     })
   },
 
   deleteImage(locationId: string, imageId: string) {
     return api.delete(`${API_URL}/locations/${locationId}/images/${imageId}`)
+  },
+
+  // File handling methods
+  getFiles(id: string) {
+    return api.get(`${API_URL}/locations/${id}/files`)
+  },
+
+  uploadFile(id: string, file: File) {
+    const formData = new FormData()
+    formData.append('file', file)
+    return api.post(`${API_URL}/uploads/locations/${id}/file`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+  },
+
+  deleteFile(locationId: string, fileId: string) {
+    return api.delete(`${API_URL}/locations/${locationId}/files/${fileId}`)
   }
 }
 

--- a/frontend/src/views/locations/LocationDetailView.vue
+++ b/frontend/src/views/locations/LocationDetailView.vue
@@ -68,6 +68,84 @@
         </div>
       </div>
 
+      <!-- Images Section -->
+      <div class="info-card full-width location-images">
+        <div class="section-header">
+          <h2>Images</h2>
+          <button
+            class="btn btn-sm"
+            :class="showImageUploader ? 'btn-secondary-alt' : 'btn-primary'"
+            @click="showImageUploader = !showImageUploader"
+          >
+            {{ showImageUploader ? 'Cancel' : 'Add Images' }}
+          </button>
+        </div>
+
+        <Transition name="file-uploader" mode="out-in">
+          <FileUploader
+            v-if="showImageUploader"
+            ref="imageUploaderRef"
+            :multiple="true"
+            accept=".gif,.jpg,.jpeg,.png,.webp,image/gif,image/jpeg,image/png,image/webp"
+            upload-prompt="Drag and drop images here"
+            upload-hint="Supports image formats (GIF, JPG, PNG, WebP)"
+            @upload="uploadImages"
+          />
+        </Transition>
+
+        <div v-if="loadingImages" class="loading">Loading images...</div>
+        <FileViewer
+          v-else
+          :files="images"
+          :signed-urls="imagesSignedUrls"
+          file-type="images"
+          :entity-id="location.id"
+          entity-type="locations"
+          @delete="deleteImage"
+          @update="updateLocationFile"
+          @download="downloadLocationFile"
+        />
+      </div>
+
+      <!-- Files Section -->
+      <div class="info-card full-width location-files">
+        <div class="section-header">
+          <h2>Files</h2>
+          <button
+            class="btn btn-sm"
+            :class="showFileUploader ? 'btn-secondary-alt' : 'btn-primary'"
+            @click="showFileUploader = !showFileUploader"
+          >
+            {{ showFileUploader ? 'Cancel' : 'Add Files' }}
+          </button>
+        </div>
+
+        <Transition name="file-uploader" mode="out-in">
+          <FileUploader
+            v-if="showFileUploader"
+            ref="fileUploaderRef"
+            :multiple="true"
+            accept="*"
+            upload-prompt="Drag and drop files here"
+            upload-hint="Supports any file type"
+            @upload="uploadFiles"
+          />
+        </Transition>
+
+        <div v-if="loadingFiles" class="loading">Loading files...</div>
+        <FileViewer
+          v-else
+          :files="locationFiles"
+          :signed-urls="filesSignedUrls"
+          file-type="files"
+          :entity-id="location.id"
+          entity-type="locations"
+          @delete="deleteLocationFileEntry"
+          @update="updateLocationFile"
+          @download="downloadLocationFile"
+        />
+      </div>
+
       <!-- Location Delete Confirmation Dialog -->
       <Confirmation
         v-model:visible="showDeleteDialog"
@@ -101,8 +179,11 @@
 import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import locationService from '@/services/locationService'
+import fileService from '@/services/fileService'
 import areaService from '@/services/areaService'
 import AreaForm from '@/components/AreaForm.vue'
+import FileViewer from '@/components/FileViewer.vue'
+import FileUploader from '@/components/FileUploader.vue'
 import Confirmation from "@/components/Confirmation.vue"
 import ErrorNotificationStack from '@/components/ErrorNotificationStack.vue'
 import ResourceNotFound from '@/components/ResourceNotFound.vue'
@@ -123,6 +204,20 @@ const is404Error = computed(() => lastError.value && checkIs404Error(lastError.v
 
 // State for inline forms
 const showAreaForm = ref(false)
+
+// Images state
+const images = ref<any[]>([])
+const imagesSignedUrls = ref<Record<string, any>>({})
+const loadingImages = ref(false)
+const showImageUploader = ref(false)
+const imageUploaderRef = ref<any>(null)
+
+// Files state
+const locationFiles = ref<any[]>([])
+const filesSignedUrls = ref<Record<string, any>>({})
+const loadingFiles = ref(false)
+const showFileUploader = ref(false)
+const fileUploaderRef = ref<any>(null)
 
 onMounted(() => {
   loadLocation()
@@ -148,6 +243,10 @@ const loadLocation = async () => {
     )
 
     loading.value = false
+
+    // Load images and files after location is loaded
+    loadImages(id)
+    loadLocationFiles(id)
   } catch (err: any) {
     lastError.value = err
     if (checkIs404Error(err)) {
@@ -159,8 +258,116 @@ const loadLocation = async () => {
   }
 }
 
+const loadImages = async (id: string) => {
+  loadingImages.value = true
+  try {
+    const response = await locationService.getImages(id)
+    images.value = response.data?.data || []
+    imagesSignedUrls.value = response.data?.meta?.signed_urls || {}
+  } catch (err: any) {
+    console.error('Failed to load location images:', err)
+  } finally {
+    loadingImages.value = false
+  }
+}
+
+const loadLocationFiles = async (id: string) => {
+  loadingFiles.value = true
+  try {
+    const response = await locationService.getFiles(id)
+    locationFiles.value = response.data?.data || []
+    filesSignedUrls.value = response.data?.meta?.signed_urls || {}
+  } catch (err: any) {
+    console.error('Failed to load location files:', err)
+  } finally {
+    loadingFiles.value = false
+  }
+}
+
 const goBackToList = () => {
   router.push('/locations')
+}
+
+// Image upload/delete/update handlers
+const uploadImages = async (files: File[]) => {
+  if (!location.value || files.length === 0) return
+  try {
+    for (const file of files) {
+      await locationService.uploadImage(location.value.id, file)
+    }
+    imageUploaderRef.value?.markUploadCompleted()
+    showImageUploader.value = false
+    await loadImages(location.value.id)
+  } catch (err: any) {
+    handleError(err, 'location', 'Failed to upload image')
+    imageUploaderRef.value?.markUploadFailed()
+  }
+}
+
+const deleteImage = async (image: any) => {
+  if (!location.value) return
+  try {
+    await locationService.deleteImage(location.value.id, image.id)
+    images.value = images.value.filter((img: any) => img.id !== image.id)
+  } catch (err: any) {
+    handleError(err, 'location', 'Failed to delete image')
+  }
+}
+
+// File upload/delete handlers
+const uploadFiles = async (files: File[]) => {
+  if (!location.value || files.length === 0) return
+  try {
+    for (const file of files) {
+      await locationService.uploadFile(location.value.id, file)
+    }
+    fileUploaderRef.value?.markUploadCompleted()
+    showFileUploader.value = false
+    await loadLocationFiles(location.value.id)
+  } catch (err: any) {
+    handleError(err, 'location', 'Failed to upload file')
+    fileUploaderRef.value?.markUploadFailed()
+  }
+}
+
+const deleteLocationFileEntry = async (file: any) => {
+  if (!location.value) return
+  try {
+    await locationService.deleteFile(location.value.id, file.id)
+    locationFiles.value = locationFiles.value.filter((f: any) => f.id !== file.id)
+  } catch (err: any) {
+    handleError(err, 'location', 'Failed to delete file')
+  }
+}
+
+// Shared update handler for both images and files (updates filename/path via generic files API)
+const updateLocationFile = async (data: any) => {
+  try {
+    await fileService.updateFile(data.id, { path: data.path, title: data.path, description: '', tags: [] })
+    // Update in images list
+    const imgIdx = images.value.findIndex((f: any) => f.id === data.id)
+    if (imgIdx !== -1) images.value[imgIdx].path = data.path
+    // Update in files list
+    const fileIdx = locationFiles.value.findIndex((f: any) => f.id === data.id)
+    if (fileIdx !== -1) locationFiles.value[fileIdx].path = data.path
+  } catch (err: any) {
+    handleError(err, 'location', 'Failed to update file')
+  }
+}
+
+// Download handler - uses direct download URL
+const downloadLocationFile = (file: any) => {
+  if (!location.value) return
+  const ext = file.attributes?.ext || file.ext || ''
+  const path = file.attributes?.path || file.path || file.id
+  const link = document.createElement('a')
+  // Use the appropriate endpoint based on the linked entity meta
+  const meta = file.attributes?.linked_entity_meta || file.linked_entity_meta || 'files'
+  link.href = `/api/v1/locations/${location.value.id}/${meta}/${file.id}${ext}`
+  link.download = path + ext
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
 }
 
 
@@ -385,5 +592,26 @@ pre {
   &:hover {
     background-color: #138496;
   }
+}
+
+.btn-secondary-alt {
+  background-color: $secondary-color;
+  color: white;
+  border: none;
+
+  &:hover {
+    opacity: 0.85;
+  }
+}
+
+.file-uploader-enter-active,
+.file-uploader-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.file-uploader-enter-from,
+.file-uploader-leave-to {
+  opacity: 0;
+  transform: translateY(-8px);
 }
 </style>

--- a/frontend/src/views/locations/LocationDetailView.vue
+++ b/frontend/src/views/locations/LocationDetailView.vue
@@ -125,7 +125,6 @@
             v-if="showFileUploader"
             ref="fileUploaderRef"
             :multiple="true"
-            accept="*"
             upload-prompt="Drag and drop files here"
             upload-hint="Supports any file type"
             @upload="uploadFiles"
@@ -342,14 +341,28 @@ const deleteLocationFileEntry = async (file: any) => {
 
 // Shared update handler for both images and files (updates filename/path via generic files API)
 const updateLocationFile = async (data: any) => {
+  if (!location.value) return
+  // Find the existing file record to preserve its current title, description, tags and linkage.
+  const existing =
+    images.value.find((f: any) => f.id === data.id) ||
+    locationFiles.value.find((f: any) => f.id === data.id)
+  const attrs = existing?.attributes ?? existing ?? {}
   try {
-    await fileService.updateFile(data.id, { path: data.path, title: data.path, description: '', tags: [] })
+    await fileService.updateFile(data.id, {
+      path: data.path,
+      title: data.title ?? attrs.title ?? data.path,
+      description: data.description ?? attrs.description ?? '',
+      tags: data.tags ?? attrs.tags ?? [],
+      linked_entity_type: attrs.linked_entity_type ?? 'location',
+      linked_entity_id: attrs.linked_entity_id ?? location.value.id,
+      linked_entity_meta: attrs.linked_entity_meta,
+    })
     // Update in images list
     const imgIdx = images.value.findIndex((f: any) => f.id === data.id)
-    if (imgIdx !== -1) images.value[imgIdx].path = data.path
+    if (imgIdx !== -1) images.value[imgIdx].attributes = { ...attrs, path: data.path }
     // Update in files list
     const fileIdx = locationFiles.value.findIndex((f: any) => f.id === data.id)
-    if (fileIdx !== -1) locationFiles.value[fileIdx].path = data.path
+    if (fileIdx !== -1) locationFiles.value[fileIdx].attributes = { ...attrs, path: data.path }
   } catch (err: any) {
     handleError(err, 'location', 'Failed to update file')
   }

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -283,7 +283,7 @@ func APIServer(params Params, restoreWorker RestoreWorkerInterface) http.Handler
 		// Note: RegistrySetMiddleware creates user-aware registries and adds them to context.
 		// System requires a settings registry.
 		r.With(userMiddlewares...).Route("/system", System(params.DebugInfo, params.StartTime))
-		r.With(userMiddlewares...).Route("/locations", Locations())
+		r.With(userMiddlewares...).Route("/locations", Locations(params))
 		r.With(userMiddlewares...).Route("/areas", Areas())
 		r.With(userMiddlewares...).Route("/commodities", Commodities(params))
 		r.With(userMiddlewares...).Route("/settings", Settings())

--- a/go/apiserver/apiserver_test.go
+++ b/go/apiserver/apiserver_test.go
@@ -469,6 +469,58 @@ func CreateFormFileMIME(fieldname, filename, contentType string) textproto.MIMEH
 	return h
 }
 
+// populateLocationFileTestData creates location-linked FileEntity records and the corresponding
+// blobs in the bucket. It returns the location used and the created file entities.
+func populateLocationFileTestData(ctx context.Context, fileRegistry registry.FileRegistry, locationRegistry registry.LocationRegistry) (location *models.Location, imageFile *models.FileEntity, genericFile *models.FileEntity) {
+	locations := must.Must(locationRegistry.List(ctx))
+	location = locations[0]
+
+	b := must.Must(blob.OpenBucket(context.Background(), uploadLocation))
+	defer b.Close()
+	must.Assert(b.WriteAll(context.Background(), "loc-image1.jpg", []byte("location-image-content"), nil))
+	must.Assert(b.WriteAll(context.Background(), "loc-file1.pdf", []byte("location-file-content"), nil))
+
+	now := time.Now()
+
+	imageFile = must.Must(fileRegistry.Create(ctx, models.FileEntity{
+		Title:            "loc-image1",
+		Description:      "Location test image",
+		Type:             models.FileTypeImage,
+		Tags:             []string{},
+		LinkedEntityType: "location",
+		LinkedEntityID:   location.ID,
+		LinkedEntityMeta: "images",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		File: &models.File{
+			Path:         "loc-image1",
+			OriginalPath: "loc-image1.jpg",
+			Ext:          ".jpg",
+			MIMEType:     "image/jpeg",
+		},
+	}))
+
+	genericFile = must.Must(fileRegistry.Create(ctx, models.FileEntity{
+		Title:            "loc-file1",
+		Description:      "Location test file",
+		Type:             models.FileTypeDocument,
+		Tags:             []string{},
+		LinkedEntityType: "location",
+		LinkedEntityID:   location.ID,
+		LinkedEntityMeta: "files",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		File: &models.File{
+			Path:         "loc-file1",
+			OriginalPath: "loc-file1.pdf",
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}))
+
+	return location, imageFile, genericFile
+}
+
 func sliceToSliceOfAny[T any](v []T) (result []any) {
 	for _, item := range v {
 		result = append(result, item)

--- a/go/apiserver/locations.go
+++ b/go/apiserver/locations.go
@@ -523,10 +523,10 @@ func Locations(params Params) func(r chi.Router) {
 			r.Put("/", api.updateLocation)    // PUT /locations/123
 			r.Delete("/", api.deleteLocation) // DELETE /locations/123
 
-			r.Get("/images", api.listLocationImages)                    // GET /locations/123/images
-			r.Get("/files", api.listLocationFiles)                      // GET /locations/123/files
-			r.Delete("/images/{imageID}", api.deleteLocationImage)      // DELETE /locations/123/images/456
-			r.Delete("/files/{fileID}", api.deleteLocationFile)         // DELETE /locations/123/files/456
+			r.Get("/images", api.listLocationImages)                                       // GET /locations/123/images
+			r.Get("/files", api.listLocationFiles)                                         // GET /locations/123/files
+			r.Delete("/images/{imageID}", api.deleteLocationImage)                         // DELETE /locations/123/images/456
+			r.Delete("/files/{fileID}", api.deleteLocationFile)                            // DELETE /locations/123/files/456
 			r.Get("/images/{imageID}{imageExt:[.][a-zA-Z0-9]+}", api.getLocationImageData) // GET /locations/123/images/456.png
 			r.Get("/files/{fileID}{fileExt:[.][a-zA-Z0-9]+}", api.getLocationFileData)     // GET /locations/123/files/456.pdf
 		})

--- a/go/apiserver/locations.go
+++ b/go/apiserver/locations.go
@@ -524,10 +524,10 @@ func Locations(params Params) func(r chi.Router) {
 			r.Put("/", api.updateLocation)    // PUT /locations/123
 			r.Delete("/", api.deleteLocation) // DELETE /locations/123
 
-			r.Get("/images", api.listLocationImages)                                       // GET /locations/123/images
-			r.Get("/files", api.listLocationFiles)                                         // GET /locations/123/files
-			r.Delete("/images/{imageID}", api.deleteLocationImage)                         // DELETE /locations/123/images/456
-			r.Delete("/files/{fileID}", api.deleteLocationFile)                            // DELETE /locations/123/files/456
+			r.Get("/images", api.listLocationImages)                        // GET /locations/123/images
+			r.Get("/files", api.listLocationFiles)                          // GET /locations/123/files
+			r.Delete("/images/{imageID}", api.deleteLocationImage)          // DELETE /locations/123/images/456
+			r.Delete("/files/{fileID}", api.deleteLocationFile)             // DELETE /locations/123/files/456
 			r.Get("/images/{imageID}.{imageExt}", api.getLocationImageData) // GET /locations/123/images/456.png
 			r.Get("/files/{fileID}.{fileExt}", api.getLocationFileData)     // GET /locations/123/files/456.pdf
 		})

--- a/go/apiserver/locations.go
+++ b/go/apiserver/locations.go
@@ -475,15 +475,16 @@ func (api *locationsAPI) getLocationFileData(w http.ResponseWriter, r *http.Requ
 
 // streamFile streams the content of a FileEntity to the response.
 func (api *locationsAPI) streamFile(w http.ResponseWriter, r *http.Request, file *models.FileEntity) {
-	originalPath := file.Path + file.Ext
+	// Use OriginalPath for blob storage lookup; Path+Ext is only the user-visible download filename.
+	storagePath := file.OriginalPath
 
-	attrs, err := downloadutils.GetFileAttributes(r.Context(), api.uploadLocation, originalPath)
+	attrs, err := downloadutils.GetFileAttributes(r.Context(), api.uploadLocation, storagePath)
 	if err != nil {
 		internalServerError(w, r, err)
 		return
 	}
 
-	reader, err := api.getDownloadFile(r.Context(), originalPath)
+	reader, err := api.getDownloadFile(r.Context(), storagePath)
 	if err != nil {
 		internalServerError(w, r, err)
 		return

--- a/go/apiserver/locations.go
+++ b/go/apiserver/locations.go
@@ -1,16 +1,48 @@
 package apiserver
 
 import (
+	"context"
+	"errors"
+	"mime"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
+	"gocloud.dev/blob"
 
+	"github.com/denisvmedia/inventario/apiserver/internal/downloadutils"
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/jsonapi"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/services"
 )
 
 type locationsAPI struct {
+	uploadLocation     string
+	fileService        *services.FileService
+	fileSigningService *services.FileSigningService
+}
+
+// generateSignedURLsForFiles generates signed URLs for a list of files.
+func (api *locationsAPI) generateSignedURLsForFiles(ctx context.Context, files []*models.FileEntity) map[string]jsonapi.URLData {
+	signedUrls := make(map[string]jsonapi.URLData)
+	user := appctx.UserFromContext(ctx)
+	if user == nil {
+		return signedUrls
+	}
+
+	for _, file := range files {
+		originalURL, thumbnails, err := api.fileSigningService.GenerateSignedURLsWithThumbnails(file, user.ID)
+		if err != nil {
+			continue
+		}
+		signedUrls[file.ID] = jsonapi.URLData{
+			URL:        originalURL,
+			Thumbnails: thumbnails,
+		}
+	}
+
+	return signedUrls
 }
 
 // listLocations lists all locations with pagination.
@@ -261,8 +293,228 @@ func (api *locationsAPI) updateLocation(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-func Locations() func(r chi.Router) {
-	api := &locationsAPI{}
+// listLocationImages returns all images linked to the given location.
+func (api *locationsAPI) listLocationImages(w http.ResponseWriter, r *http.Request) {
+	registrySet := RegistrySetFromContext(r.Context())
+	if registrySet == nil {
+		internalServerError(w, r, errors.New("registry set not found in context"))
+		return
+	}
+
+	location := locationFromContext(r.Context())
+	if location == nil {
+		unprocessableEntityError(w, r, nil)
+		return
+	}
+
+	files, err := registrySet.FileRegistry.ListByLinkedEntityAndMeta(r.Context(), "location", location.ID, "images")
+	if err != nil {
+		internalServerError(w, r, err)
+		return
+	}
+
+	signedUrls := api.generateSignedURLsForFiles(r.Context(), files)
+	resp := jsonapi.NewFilesResponseWithSignedUrls(files, len(files), signedUrls)
+	if err := render.Render(w, r, resp); err != nil {
+		internalServerError(w, r, err)
+	}
+}
+
+// listLocationFiles returns all files linked to the given location.
+func (api *locationsAPI) listLocationFiles(w http.ResponseWriter, r *http.Request) {
+	registrySet := RegistrySetFromContext(r.Context())
+	if registrySet == nil {
+		internalServerError(w, r, errors.New("registry set not found in context"))
+		return
+	}
+
+	location := locationFromContext(r.Context())
+	if location == nil {
+		unprocessableEntityError(w, r, nil)
+		return
+	}
+
+	files, err := registrySet.FileRegistry.ListByLinkedEntityAndMeta(r.Context(), "location", location.ID, "files")
+	if err != nil {
+		internalServerError(w, r, err)
+		return
+	}
+
+	signedUrls := api.generateSignedURLsForFiles(r.Context(), files)
+	resp := jsonapi.NewFilesResponseWithSignedUrls(files, len(files), signedUrls)
+	if err := render.Render(w, r, resp); err != nil {
+		internalServerError(w, r, err)
+	}
+}
+
+// deleteLocationImage deletes an image associated with the given location.
+func (api *locationsAPI) deleteLocationImage(w http.ResponseWriter, r *http.Request) {
+	registrySet := RegistrySetFromContext(r.Context())
+	if registrySet == nil {
+		internalServerError(w, r, errors.New("registry set not found in context"))
+		return
+	}
+
+	location := locationFromContext(r.Context())
+	if location == nil {
+		unprocessableEntityError(w, r, nil)
+		return
+	}
+
+	imageID := chi.URLParam(r, "imageID")
+	file, err := registrySet.FileRegistry.Get(r.Context(), imageID)
+	if err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
+
+	if file.LinkedEntityID != location.ID || file.LinkedEntityType != "location" || file.LinkedEntityMeta != "images" {
+		notFound(w, r)
+		return
+	}
+
+	if err := api.fileService.DeleteFileWithPhysical(r.Context(), file.ID); err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
+
+	render.NoContent(w, r)
+}
+
+// deleteLocationFile deletes a file associated with the given location.
+func (api *locationsAPI) deleteLocationFile(w http.ResponseWriter, r *http.Request) {
+	registrySet := RegistrySetFromContext(r.Context())
+	if registrySet == nil {
+		internalServerError(w, r, errors.New("registry set not found in context"))
+		return
+	}
+
+	location := locationFromContext(r.Context())
+	if location == nil {
+		unprocessableEntityError(w, r, nil)
+		return
+	}
+
+	fileID := chi.URLParam(r, "fileID")
+	file, err := registrySet.FileRegistry.Get(r.Context(), fileID)
+	if err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
+
+	if file.LinkedEntityID != location.ID || file.LinkedEntityType != "location" || file.LinkedEntityMeta != "files" {
+		notFound(w, r)
+		return
+	}
+
+	if err := api.fileService.DeleteFileWithPhysical(r.Context(), file.ID); err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
+
+	render.NoContent(w, r)
+}
+
+// getLocationImageData downloads the raw image data for the given location.
+func (api *locationsAPI) getLocationImageData(w http.ResponseWriter, r *http.Request) {
+	registrySet := RegistrySetFromContext(r.Context())
+	if registrySet == nil {
+		internalServerError(w, r, errors.New("registry set not found in context"))
+		return
+	}
+
+	location := locationFromContext(r.Context())
+	if location == nil {
+		unprocessableEntityError(w, r, nil)
+		return
+	}
+
+	imageID := chi.URLParam(r, "imageID")
+	file, err := registrySet.FileRegistry.Get(r.Context(), imageID)
+	if err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
+
+	if file.LinkedEntityID != location.ID || file.LinkedEntityType != "location" || file.LinkedEntityMeta != "images" {
+		notFound(w, r)
+		return
+	}
+
+	api.streamFile(w, r, file)
+}
+
+// getLocationFileData downloads the raw file data for the given location.
+func (api *locationsAPI) getLocationFileData(w http.ResponseWriter, r *http.Request) {
+	registrySet := RegistrySetFromContext(r.Context())
+	if registrySet == nil {
+		internalServerError(w, r, errors.New("registry set not found in context"))
+		return
+	}
+
+	location := locationFromContext(r.Context())
+	if location == nil {
+		unprocessableEntityError(w, r, nil)
+		return
+	}
+
+	fileID := chi.URLParam(r, "fileID")
+	file, err := registrySet.FileRegistry.Get(r.Context(), fileID)
+	if err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
+
+	if file.LinkedEntityID != location.ID || file.LinkedEntityType != "location" || file.LinkedEntityMeta != "files" {
+		notFound(w, r)
+		return
+	}
+
+	api.streamFile(w, r, file)
+}
+
+// streamFile streams the content of a FileEntity to the response.
+func (api *locationsAPI) streamFile(w http.ResponseWriter, r *http.Request, file *models.FileEntity) {
+	originalPath := file.Path + file.Ext
+
+	attrs, err := downloadutils.GetFileAttributes(r.Context(), api.uploadLocation, originalPath)
+	if err != nil {
+		internalServerError(w, r, err)
+		return
+	}
+
+	reader, err := api.getDownloadFile(r.Context(), originalPath)
+	if err != nil {
+		internalServerError(w, r, err)
+		return
+	}
+	defer reader.Close()
+
+	contentType := mime.TypeByExtension(file.Ext)
+	downloadutils.SetStreamingHeaders(w, contentType, attrs.Size, file.Path+file.Ext)
+	if err := downloadutils.CopyFileInChunks(w, reader); err != nil {
+		internalServerError(w, r, err)
+	}
+}
+
+// getDownloadFile opens and returns a reader for the file stored at originalPath.
+func (api *locationsAPI) getDownloadFile(ctx context.Context, originalPath string) (*blob.Reader, error) {
+	b, err := blob.OpenBucket(ctx, api.uploadLocation)
+	if err != nil {
+		return nil, err
+	}
+	defer b.Close()
+
+	return b.NewReader(context.Background(), originalPath, nil)
+}
+
+// Locations returns a Chi router function that registers all location-related routes.
+func Locations(params Params) func(r chi.Router) {
+	api := &locationsAPI{
+		uploadLocation:     params.UploadLocation,
+		fileService:        services.NewFileService(params.FactorySet, params.UploadLocation),
+		fileSigningService: services.NewFileSigningService(params.FileSigningKey, params.FileURLExpiration),
+	}
 	return func(r chi.Router) {
 		r.With(paginate).Get("/", api.listLocations) // GET /locations
 		r.Route("/{locationID}", func(r chi.Router) {
@@ -270,6 +522,13 @@ func Locations() func(r chi.Router) {
 			r.Get("/", api.getLocation)       // GET /locations/123
 			r.Put("/", api.updateLocation)    // PUT /locations/123
 			r.Delete("/", api.deleteLocation) // DELETE /locations/123
+
+			r.Get("/images", api.listLocationImages)                    // GET /locations/123/images
+			r.Get("/files", api.listLocationFiles)                      // GET /locations/123/files
+			r.Delete("/images/{imageID}", api.deleteLocationImage)      // DELETE /locations/123/images/456
+			r.Delete("/files/{fileID}", api.deleteLocationFile)         // DELETE /locations/123/files/456
+			r.Get("/images/{imageID}{imageExt:[.][a-zA-Z0-9]+}", api.getLocationImageData) // GET /locations/123/images/456.png
+			r.Get("/files/{fileID}{fileExt:[.][a-zA-Z0-9]+}", api.getLocationFileData)     // GET /locations/123/files/456.pdf
 		})
 		r.Post("/", api.createLocation) // POST /locations
 	}

--- a/go/apiserver/locations.go
+++ b/go/apiserver/locations.go
@@ -528,8 +528,8 @@ func Locations(params Params) func(r chi.Router) {
 			r.Get("/files", api.listLocationFiles)                                         // GET /locations/123/files
 			r.Delete("/images/{imageID}", api.deleteLocationImage)                         // DELETE /locations/123/images/456
 			r.Delete("/files/{fileID}", api.deleteLocationFile)                            // DELETE /locations/123/files/456
-			r.Get("/images/{imageID}{imageExt:[.][a-zA-Z0-9]+}", api.getLocationImageData) // GET /locations/123/images/456.png
-			r.Get("/files/{fileID}{fileExt:[.][a-zA-Z0-9]+}", api.getLocationFileData)     // GET /locations/123/files/456.pdf
+			r.Get("/images/{imageID}.{imageExt}", api.getLocationImageData) // GET /locations/123/images/456.png
+			r.Get("/files/{fileID}.{fileExt}", api.getLocationFileData)     // GET /locations/123/files/456.pdf
 		})
 		r.Post("/", api.createLocation) // POST /locations
 	}

--- a/go/apiserver/locations_test.go
+++ b/go/apiserver/locations_test.go
@@ -239,7 +239,6 @@ func TestLocationFiles_Download(t *testing.T) {
 // Original location CRUD tests
 // ---------------------------------------------------------------------------
 
-
 func TestLocationsDelete(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/apiserver/locations_test.go
+++ b/go/apiserver/locations_test.go
@@ -18,6 +18,228 @@ import (
 	"github.com/denisvmedia/inventario/models"
 )
 
+// ---------------------------------------------------------------------------
+// Location images endpoint tests
+// ---------------------------------------------------------------------------
+
+func TestLocationImages_List(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser := newParams()
+	ctx := createTestUserContext(testUser.ID, testUser.TenantID)
+	registrySet := getRegistrySetFromParams(params, testUser)
+	location, imageFile, _ := populateLocationFileTestData(ctx, registrySet.FileRegistry, registrySet.LocationRegistry)
+
+	req, err := http.NewRequest("GET", "/api/v1/locations/"+location.ID+"/images", nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	body := rr.Body.Bytes()
+	c.Assert(body, checkers.JSONPathMatches("$.data", qt.HasLen), 1)
+	c.Assert(body, checkers.JSONPathEquals("$.data[0].id"), imageFile.ID)
+	c.Assert(body, checkers.JSONPathEquals("$.data[0].linked_entity_meta"), "images")
+}
+
+func TestLocationImages_List_Empty(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	locations := must.Must(registrySet.LocationRegistry.List(c.Context()))
+
+	req, err := http.NewRequest("GET", "/api/v1/locations/"+locations[1].ID+"/images", nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data"), make([]any, 0))
+}
+
+func TestLocationImages_Delete(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser := newParams()
+	ctx := createTestUserContext(testUser.ID, testUser.TenantID)
+	registrySet := getRegistrySetFromParams(params, testUser)
+	location, imageFile, _ := populateLocationFileTestData(ctx, registrySet.FileRegistry, registrySet.LocationRegistry)
+
+	req, err := http.NewRequest("DELETE", "/api/v1/locations/"+location.ID+"/images/"+imageFile.ID, nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusNoContent)
+}
+
+func TestLocationImages_Delete_WrongLocation(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser := newParams()
+	ctx := createTestUserContext(testUser.ID, testUser.TenantID)
+	registrySet := getRegistrySetFromParams(params, testUser)
+	location, imageFile, _ := populateLocationFileTestData(ctx, registrySet.FileRegistry, registrySet.LocationRegistry)
+
+	// Use a different location ID to attempt cross-access
+	locations := must.Must(registrySet.LocationRegistry.List(c.Context()))
+	otherLocation := locations[1]
+	c.Assert(otherLocation.ID, qt.Not(qt.Equals), location.ID)
+
+	req, err := http.NewRequest("DELETE", "/api/v1/locations/"+otherLocation.ID+"/images/"+imageFile.ID, nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+func TestLocationImages_Download(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser := newParams()
+	ctx := createTestUserContext(testUser.ID, testUser.TenantID)
+	registrySet := getRegistrySetFromParams(params, testUser)
+	location, imageFile, _ := populateLocationFileTestData(ctx, registrySet.FileRegistry, registrySet.LocationRegistry)
+
+	req, err := http.NewRequest("GET", "/api/v1/locations/"+location.ID+"/images/"+imageFile.ID+imageFile.Ext, nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.String(), qt.Equals, "location-image-content")
+}
+
+// ---------------------------------------------------------------------------
+// Location files endpoint tests
+// ---------------------------------------------------------------------------
+
+func TestLocationFiles_List(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser := newParams()
+	ctx := createTestUserContext(testUser.ID, testUser.TenantID)
+	registrySet := getRegistrySetFromParams(params, testUser)
+	location, _, genericFile := populateLocationFileTestData(ctx, registrySet.FileRegistry, registrySet.LocationRegistry)
+
+	req, err := http.NewRequest("GET", "/api/v1/locations/"+location.ID+"/files", nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	body := rr.Body.Bytes()
+	c.Assert(body, checkers.JSONPathMatches("$.data", qt.HasLen), 1)
+	c.Assert(body, checkers.JSONPathEquals("$.data[0].id"), genericFile.ID)
+	c.Assert(body, checkers.JSONPathEquals("$.data[0].linked_entity_meta"), "files")
+}
+
+func TestLocationFiles_List_Empty(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	locations := must.Must(registrySet.LocationRegistry.List(c.Context()))
+
+	req, err := http.NewRequest("GET", "/api/v1/locations/"+locations[1].ID+"/files", nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data"), make([]any, 0))
+}
+
+func TestLocationFiles_Delete(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser := newParams()
+	ctx := createTestUserContext(testUser.ID, testUser.TenantID)
+	registrySet := getRegistrySetFromParams(params, testUser)
+	location, _, genericFile := populateLocationFileTestData(ctx, registrySet.FileRegistry, registrySet.LocationRegistry)
+
+	req, err := http.NewRequest("DELETE", "/api/v1/locations/"+location.ID+"/files/"+genericFile.ID, nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusNoContent)
+}
+
+func TestLocationFiles_Delete_WrongLocation(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser := newParams()
+	ctx := createTestUserContext(testUser.ID, testUser.TenantID)
+	registrySet := getRegistrySetFromParams(params, testUser)
+	location, _, genericFile := populateLocationFileTestData(ctx, registrySet.FileRegistry, registrySet.LocationRegistry)
+
+	locations := must.Must(registrySet.LocationRegistry.List(c.Context()))
+	otherLocation := locations[1]
+	c.Assert(otherLocation.ID, qt.Not(qt.Equals), location.ID)
+
+	req, err := http.NewRequest("DELETE", "/api/v1/locations/"+otherLocation.ID+"/files/"+genericFile.ID, nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+func TestLocationFiles_Download(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser := newParams()
+	ctx := createTestUserContext(testUser.ID, testUser.TenantID)
+	registrySet := getRegistrySetFromParams(params, testUser)
+	location, _, genericFile := populateLocationFileTestData(ctx, registrySet.FileRegistry, registrySet.LocationRegistry)
+
+	req, err := http.NewRequest("GET", "/api/v1/locations/"+location.ID+"/files/"+genericFile.ID+genericFile.Ext, nil)
+	c.Assert(err, qt.IsNil)
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.String(), qt.Equals, "location-file-content")
+}
+
+// ---------------------------------------------------------------------------
+// Original location CRUD tests
+// ---------------------------------------------------------------------------
+
+
 func TestLocationsDelete(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/apiserver/middlewares.go
+++ b/go/apiserver/middlewares.go
@@ -90,6 +90,7 @@ func locationCtx(locationRegistry registry.LocationRegistry) func(http.Handler) 
 				return
 			}
 			ctx := context.WithValue(r.Context(), locationCtxKey, location)
+			ctx = context.WithValue(ctx, entityIDKey, locationID)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/go/apiserver/security_test.go
+++ b/go/apiserver/security_test.go
@@ -156,7 +156,7 @@ func TestSecurityIDRejection(t *testing.T) {
 			// Add authentication middleware and routes
 			r.With(apiserver.RequireAuth(testJWTSecret, factorySet.UserRegistry, nil)).With(apiserver.RegistrySetMiddleware(factorySet)).Route("/commodities", apiserver.Commodities(params))
 			r.With(apiserver.RequireAuth(testJWTSecret, factorySet.UserRegistry, nil)).With(apiserver.RegistrySetMiddleware(factorySet)).Route("/areas", apiserver.Areas())
-			r.With(apiserver.RequireAuth(testJWTSecret, factorySet.UserRegistry, nil)).With(apiserver.RegistrySetMiddleware(factorySet)).Route("/locations", apiserver.Locations())
+			r.With(apiserver.RequireAuth(testJWTSecret, factorySet.UserRegistry, nil)).With(apiserver.RegistrySetMiddleware(factorySet)).Route("/locations", apiserver.Locations(params))
 			r.With(apiserver.RequireAuth(testJWTSecret, factorySet.UserRegistry, nil)).With(apiserver.RegistrySetMiddleware(factorySet)).Route("/files", apiserver.Files(params))
 
 			// Serialize request body
@@ -308,7 +308,7 @@ func TestSecurityServerGeneratedIDs(t *testing.T) {
 			// Add authentication middleware and routes
 			r.With(apiserver.RequireAuth(testJWTSecret, factorySet.UserRegistry, nil)).With(apiserver.RegistrySetMiddleware(factorySet)).Route("/commodities", apiserver.Commodities(params))
 			r.With(apiserver.RequireAuth(testJWTSecret, factorySet.UserRegistry, nil)).With(apiserver.RegistrySetMiddleware(factorySet)).Route("/areas", apiserver.Areas())
-			r.With(apiserver.RequireAuth(testJWTSecret, factorySet.UserRegistry, nil)).With(apiserver.RegistrySetMiddleware(factorySet)).Route("/locations", apiserver.Locations())
+			r.With(apiserver.RequireAuth(testJWTSecret, factorySet.UserRegistry, nil)).With(apiserver.RegistrySetMiddleware(factorySet)).Route("/locations", apiserver.Locations(params))
 			r.With(apiserver.RequireAuth(testJWTSecret, factorySet.UserRegistry, nil)).With(apiserver.RegistrySetMiddleware(factorySet)).Route("/files", apiserver.Files(params))
 
 			// Serialize request body

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -514,6 +514,195 @@ func (api *uploadsAPI) handleFileUpload(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
+// handleLocationImageUpload handles image file upload for a location.
+// @Summary Upload location image
+// @Description Upload a single image file and associate it with the specified location.
+// @Tags uploads
+// @Accept multipart/form-data
+// @Produce json-api
+// @Param locationID path string true "Location ID"
+// @Param file formData file true "Image file to upload"
+// @Success 201 {object} jsonapi.FileResponse "Created"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /uploads/locations/{locationID}/image [post]
+func (api *uploadsAPI) handleLocationImageUpload(w http.ResponseWriter, r *http.Request) {
+	registrySet := RegistrySetFromContext(r.Context())
+	if registrySet == nil {
+		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+		return
+	}
+
+	uploadedFiles := uploadedFilesFromContext(r.Context())
+	if len(uploadedFiles) != 1 {
+		unprocessableEntityError(w, r, ErrNoFilesUploaded)
+		return
+	}
+
+	entityID := entityIDFromContext(r.Context())
+	if entityID == "" {
+		unprocessableEntityError(w, r, ErrEntityNotFound)
+		return
+	}
+
+	user := GetUserFromRequest(r)
+	if user == nil {
+		http.Error(w, "User context required", http.StatusInternalServerError)
+		return
+	}
+
+	fileReg := registrySet.FileRegistry
+	f := uploadedFiles[0]
+
+	ext := mimekit.ExtensionByMime(f.MIMEType)
+	originalPath := f.FilePath
+	pathWithoutExt := strings.TrimSuffix(originalPath, filepath.Ext(originalPath))
+
+	now := time.Now()
+	fileEntity := models.FileEntity{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: user.TenantID,
+			UserID:   user.ID,
+		},
+		Title:            pathWithoutExt,
+		Description:      "",
+		Type:             models.FileTypeImage,
+		Tags:             []string{},
+		LinkedEntityType: "location",
+		LinkedEntityID:   entityID,
+		LinkedEntityMeta: "images",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		File: &models.File{
+			Path:         pathWithoutExt,
+			OriginalPath: originalPath,
+			Ext:          ext,
+			MIMEType:     f.MIMEType,
+		},
+	}
+
+	createdFile, err := fileReg.Create(r.Context(), fileEntity)
+	if err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
+
+	api.generateThumbnailInline(r.Context(), createdFile, user.ID)
+
+	originalURL, thumbnails, err := api.fileSigningService.GenerateSignedURLsWithThumbnails(createdFile, user.ID)
+	if err != nil {
+		slog.Error("Failed to generate signed URLs after upload", "error", err.Error(), "file_id", createdFile.ID)
+		resp := jsonapi.NewFileResponse(createdFile).WithStatusCode(http.StatusCreated)
+		if err := render.Render(w, r, resp); err != nil {
+			internalServerError(w, r, err)
+		}
+		return
+	}
+
+	signedUrls := map[string]jsonapi.URLData{
+		createdFile.ID: {URL: originalURL, Thumbnails: thumbnails},
+	}
+	resp := jsonapi.NewFileResponseWithSignedUrls(createdFile, signedUrls).WithStatusCode(http.StatusCreated)
+	if err := render.Render(w, r, resp); err != nil {
+		internalServerError(w, r, err)
+	}
+}
+
+// handleLocationFileUpload handles generic file upload for a location.
+// @Summary Upload location file
+// @Description Upload a single file of any type and associate it with the specified location.
+// @Tags uploads
+// @Accept multipart/form-data
+// @Produce json-api
+// @Param locationID path string true "Location ID"
+// @Param file formData file true "File to upload"
+// @Success 201 {object} jsonapi.FileResponse "Created"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /uploads/locations/{locationID}/file [post]
+func (api *uploadsAPI) handleLocationFileUpload(w http.ResponseWriter, r *http.Request) {
+	registrySet := RegistrySetFromContext(r.Context())
+	if registrySet == nil {
+		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+		return
+	}
+
+	uploadedFiles := uploadedFilesFromContext(r.Context())
+	if len(uploadedFiles) != 1 {
+		unprocessableEntityError(w, r, ErrNoFilesUploaded)
+		return
+	}
+
+	entityID := entityIDFromContext(r.Context())
+	if entityID == "" {
+		unprocessableEntityError(w, r, ErrEntityNotFound)
+		return
+	}
+
+	user := GetUserFromRequest(r)
+	if user == nil {
+		http.Error(w, "User context required", http.StatusInternalServerError)
+		return
+	}
+
+	fileReg := registrySet.FileRegistry
+	f := uploadedFiles[0]
+
+	ext := mimekit.ExtensionByMime(f.MIMEType)
+	originalPath := f.FilePath
+	pathWithoutExt := strings.TrimSuffix(originalPath, filepath.Ext(originalPath))
+	fileType := detectFileType(f.MIMEType)
+
+	now := time.Now()
+	fileEntity := models.FileEntity{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: user.TenantID,
+			UserID:   user.ID,
+		},
+		Title:            pathWithoutExt,
+		Description:      "",
+		Type:             fileType,
+		Tags:             []string{},
+		LinkedEntityType: "location",
+		LinkedEntityID:   entityID,
+		LinkedEntityMeta: "files",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		File: &models.File{
+			Path:         pathWithoutExt,
+			OriginalPath: originalPath,
+			Ext:          ext,
+			MIMEType:     f.MIMEType,
+		},
+	}
+
+	createdFile, err := fileReg.Create(r.Context(), fileEntity)
+	if err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
+
+	api.generateThumbnailInline(r.Context(), createdFile, user.ID)
+
+	originalURL, thumbnails, err := api.fileSigningService.GenerateSignedURLsWithThumbnails(createdFile, user.ID)
+	if err != nil {
+		slog.Error("Failed to generate signed URLs after upload", "error", err.Error(), "file_id", createdFile.ID)
+		resp := jsonapi.NewFileResponse(createdFile).WithStatusCode(http.StatusCreated)
+		if err := render.Render(w, r, resp); err != nil {
+			internalServerError(w, r, err)
+		}
+		return
+	}
+
+	signedUrls := map[string]jsonapi.URLData{
+		createdFile.ID: {URL: originalURL, Thumbnails: thumbnails},
+	}
+	resp := jsonapi.NewFileResponseWithSignedUrls(createdFile, signedUrls).WithStatusCode(http.StatusCreated)
+	if err := render.Render(w, r, resp); err != nil {
+		internalServerError(w, r, err)
+	}
+}
+
 // handleRestoreUpload handles XML backup file upload for restore operations.
 // @Summary Upload restore file
 // @Description Upload an XML backup file to be used for a restore operation.
@@ -672,6 +861,25 @@ func Uploads(params Params) func(r chi.Router) {
 					api.uploadFiles(mimekit.DocContentTypes()...),
 				}
 				r.With(invoiceMiddlewares...).Post("/invoice", api.handleInvoiceUpload)
+			})
+
+		r.With(locationCtx(nil)).
+			Route("/locations/{locationID}", func(r chi.Router) {
+				// Single image upload for location
+				locationImageMiddlewares := []func(http.Handler) http.Handler{
+					middleware.SetUploadOperation("image_upload"),
+					uploadLimiter,
+					api.uploadFiles(mimekit.ImageContentTypes()...),
+				}
+				r.With(locationImageMiddlewares...).Post("/image", api.handleLocationImageUpload)
+
+				// Single file upload for location (any type)
+				locationFileMiddlewares := []func(http.Handler) http.Handler{
+					middleware.SetUploadOperation("file_upload"),
+					uploadLimiter,
+					api.uploadFiles(mimekit.AllContentTypes()...),
+				}
+				r.With(locationFileMiddlewares...).Post("/file", api.handleLocationFileUpload)
 			})
 
 		// Single file upload - allow all content types with concurrent upload limiting

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -3035,6 +3035,108 @@ const docTemplate = `{
                 }
             }
         },
+        "/uploads/locations/{locationID}/file": {
+            "post": {
+                "description": "Upload a single file of any type and associate it with the specified location.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "uploads"
+                ],
+                "summary": "Upload location file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Location ID",
+                        "name": "locationID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "File to upload",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/uploads/locations/{locationID}/image": {
+            "post": {
+                "description": "Upload a single image file and associate it with the specified location.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "uploads"
+                ],
+                "summary": "Upload location image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Location ID",
+                        "name": "locationID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "Image file to upload",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/uploads/restores": {
             "post": {
                 "description": "Upload an XML backup file to be used for a restore operation.",

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -3028,6 +3028,108 @@
                 }
             }
         },
+        "/uploads/locations/{locationID}/file": {
+            "post": {
+                "description": "Upload a single file of any type and associate it with the specified location.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "uploads"
+                ],
+                "summary": "Upload location file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Location ID",
+                        "name": "locationID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "File to upload",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/uploads/locations/{locationID}/image": {
+            "post": {
+                "description": "Upload a single image file and associate it with the specified location.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "uploads"
+                ],
+                "summary": "Upload location image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Location ID",
+                        "name": "locationID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "Image file to upload",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/uploads/restores": {
             "post": {
                 "description": "Upload an XML backup file to be used for a restore operation.",

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -3440,6 +3440,76 @@ paths:
       summary: Upload a file
       tags:
       - uploads
+  /uploads/locations/{locationID}/file:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Upload a single file of any type and associate it with the specified
+        location.
+      parameters:
+      - description: Location ID
+        in: path
+        name: locationID
+        required: true
+        type: string
+      - description: File to upload
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/jsonapi.FileResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Upload location file
+      tags:
+      - uploads
+  /uploads/locations/{locationID}/image:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Upload a single image file and associate it with the specified
+        location.
+      parameters:
+      - description: Location ID
+        in: path
+        name: locationID
+        required: true
+        type: string
+      - description: Image file to upload
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/jsonapi.FileResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Upload location image
+      tags:
+      - uploads
   /uploads/restores:
     post:
       consumes:

--- a/go/jsonapi/files.go
+++ b/go/jsonapi/files.go
@@ -285,7 +285,7 @@ func (fur *FileUpdateRequestFileData) ValidateWithContext(ctx context.Context) e
 		validation.Field(&fur.Description, validation.Length(0, 1000)),
 		validation.Field(&fur.Path, validation.Required),
 		validation.Field(&fur.Tags, validation.Length(0, 100)),                            // Allow up to 100 tags
-		validation.Field(&fur.LinkedEntityType, validation.In("", "commodity", "export")), // Allow export for existing files
+		validation.Field(&fur.LinkedEntityType, validation.In("", "commodity", "export", "location")), // Allow export/location for existing files
 		validation.Field(&fur.LinkedEntityID, validation.Length(0, 255)),
 		validation.Field(&fur.LinkedEntityMeta, validation.Length(0, 255)),
 	)
@@ -301,6 +301,11 @@ func (fur *FileUpdateRequestFileData) ValidateWithContext(ctx context.Context) e
 		fields = append(fields,
 			validation.Field(&fur.LinkedEntityID, validation.Required),
 			validation.Field(&fur.LinkedEntityMeta, validation.Required, validation.In("xml-1.0")),
+		)
+	case "location":
+		fields = append(fields,
+			validation.Field(&fur.LinkedEntityID, validation.Required),
+			validation.Field(&fur.LinkedEntityMeta, validation.Required, validation.In("images", "files")),
 		)
 	}
 

--- a/go/jsonapi/files.go
+++ b/go/jsonapi/files.go
@@ -284,7 +284,7 @@ func (fur *FileUpdateRequestFileData) ValidateWithContext(ctx context.Context) e
 		validation.Field(&fur.Title, validation.Length(0, 255)), // Title is now optional
 		validation.Field(&fur.Description, validation.Length(0, 1000)),
 		validation.Field(&fur.Path, validation.Required),
-		validation.Field(&fur.Tags, validation.Length(0, 100)),                            // Allow up to 100 tags
+		validation.Field(&fur.Tags, validation.Length(0, 100)),                                        // Allow up to 100 tags
 		validation.Field(&fur.LinkedEntityType, validation.In("", "commodity", "export", "location")), // Allow export/location for existing files
 		validation.Field(&fur.LinkedEntityID, validation.Length(0, 255)),
 		validation.Field(&fur.LinkedEntityMeta, validation.Length(0, 255)),

--- a/go/models/models.go
+++ b/go/models/models.go
@@ -266,7 +266,7 @@ func (fe *FileEntity) ValidateWithContext(ctx context.Context) error {
 			FileTypeImage, FileTypeDocument, FileTypeVideo,
 			FileTypeAudio, FileTypeArchive, FileTypeOther,
 		)),
-		validation.Field(&fe.LinkedEntityType, validation.In("", "commodity", "export")),
+		validation.Field(&fe.LinkedEntityType, validation.In("", "commodity", "export", "location")),
 		validation.Field(&fe.File, validation.Required),
 	)
 
@@ -286,6 +286,10 @@ func (fe *FileEntity) ValidateWithContext(ctx context.Context) error {
 		case "export":
 			fields = append(fields,
 				validation.Field(&fe.LinkedEntityMeta, validation.In("xml-1.0")),
+			)
+		case "location":
+			fields = append(fields,
+				validation.Field(&fe.LinkedEntityMeta, validation.In("images", "files")),
 			)
 		}
 	}


### PR DESCRIPTION
## Summary

Implements [#1215](https://github.com/denisvmedia/inventario/issues/1215) — adds image and file attachment support to Locations, mirroring the existing commodity media attachment system.

Users can now upload, view, download, and delete **images** and **generic files** from the Location detail page.

---

## Backend changes

### `go/models/models.go`
- Added `"location"` to the `LinkedEntityType` validation allowlist
- Added `"images"` and `"files"` as valid `LinkedEntityMeta` values for the `location` type

### `go/apiserver/middlewares.go`
- `locationCtx` now also propagates `entityIDKey` into the request context (needed by upload handlers)

### `go/apiserver/locations.go`
- Converted `locationsAPI` to a struct carrying `uploadLocation`, `fileService`, and `fileSigningService`
- New handlers: `listLocationImages`, `listLocationFiles`, `deleteLocationImage`, `deleteLocationFile`, `getLocationImageData`, `getLocationFileData`
- New routes registered under `/{locationID}`:
  - `GET /images` · `GET /files`
  - `DELETE /images/{imageID}` · `DELETE /files/{fileID}`
  - `GET /images/{imageID}{ext}` · `GET /files/{fileID}{ext}` (raw download)
- `Locations()` now accepts `Params` to wire up the required services

### `go/apiserver/uploads.go`
- New handlers: `handleLocationImageUpload`, `handleLocationFileUpload`
- New upload routes under `/uploads/locations/{locationID}`:
  - `POST /image` — single image upload
  - `POST /file` — single file upload (any MIME type)

### `go/apiserver/apiserver.go`
- Updated `Locations()` call to `Locations(params)`

### `go/apiserver/security_test.go`
- Updated two `Locations()` call sites to `Locations(params)`

---

## Frontend changes

### `frontend/src/services/locationService.ts`
- Added `uploadImage(id, file)`, `getFiles(id)`, `uploadFile(id, file)`, `deleteFile(locationId, fileId)` methods
- Fixed upload endpoint to match single-file pattern used by the backend (`/image`, `/file`)

### `frontend/src/components/FileList.vue` & `FileViewer.vue`
- Added `'files'` to the `fileType` prop validator (was restricted to `images`, `manuals`, `invoices`)

### `frontend/src/views/locations/LocationDetailView.vue`
- Added **Images** section with `FileUploader` + `FileViewer`
- Added **Files** section with `FileUploader` + `FileViewer`
- Upload, delete, download, and update handlers for both sections
- CSS for `btn-secondary-alt` and `file-uploader` transition animations

---

## E2E tests

### `e2e/tests/location-file-uploads.spec.ts` _(new file)_
Full lifecycle test:
1. Create a location
2. Navigate to the location detail page
3. Upload an image → upload a PDF file
4. Verify info dialog for both files
5. Download both files via signed URL
6. Delete both files
7. Delete the location (cleanup)

Reuses existing helpers from `e2e/tests/includes/uploads.ts`.

---

## Testing

```powershell
# Go unit tests
make test-go

# E2E (requires running server)
make test-e2e
# or just the new spec:
cd e2e; npx playwright test location-file-uploads.spec.ts
```