### PR TITLE
feat(locations): add View button to location list (#1212)

### DIFF
--- a/e2e/tests/location-file-uploads.spec.ts
+++ b/e2e/tests/location-file-uploads.spec.ts
@@ -5,23 +5,13 @@ import { createLocation, deleteLocation } from './includes/locations.js';
 import { navigateTo, TO_LOCATIONS } from './includes/navigate.js';
 import { deleteFile, downloadFile, fileinfo, uploadFile } from './includes/uploads.js';
 
-// Helper: navigate to location detail page by clicking Edit, extracting the ID, then going to /locations/{id}
+// Helper: navigate to location detail page by clicking the View button
 async function navigateToLocationDetail(page: any, recorder: any, locationName: string) {
   const locationCard = page.locator(`.location-card:has-text("${locationName}")`).first();
   await locationCard.waitFor({ state: 'visible', timeout: 10000 });
 
-  // Click Edit button to land on /locations/{id}/edit, from which we extract the ID
-  await locationCard.locator('button[title="Edit"]').click();
-  await page.waitForURL(/\/locations\/[^/]+\/edit/, { timeout: 10000 });
-
-  const url = page.url();
-  const locationId = url.match(/\/locations\/([^/]+)\/edit/)?.[1];
-  if (!locationId) {
-    throw new Error(`Could not extract location ID from URL: ${url}`);
-  }
-
-  recorder.log(`Navigating to location detail page: /locations/${locationId}`);
-  await page.goto(`/locations/${locationId}`);
+  // Click the View button to navigate directly to /locations/{id}
+  await locationCard.locator('button[title="View"]').click();
   await page.waitForURL(/\/locations\/[^/]+$/, { timeout: 10000 });
   await page.waitForSelector('.location-images', { timeout: 10000 });
   await recorder.takeScreenshot('location-detail-page');

--- a/frontend/src/views/locations/LocationListView.vue
+++ b/frontend/src/views/locations/LocationListView.vue
@@ -54,6 +54,9 @@
             </div>
           </div>
           <div class="location-actions">
+            <button class="btn btn-info btn-sm" title="View" @click.stop="viewLocation(location.id)">
+              <font-awesome-icon icon="eye" />
+            </button>
             <button class="btn btn-secondary btn-sm" title="Edit" @click.stop="editLocation(location.id)">
               <font-awesome-icon icon="edit" />
             </button>
@@ -399,6 +402,10 @@ const handleAreaCreated = async (_newArea: any) => {
 }
 
 // Location actions
+const viewLocation = (id: string) => {
+  router.push(`/locations/${id}`)
+}
+
 const editLocation = (id: string) => {
   router.push(`/locations/${id}/edit`)
 }


### PR DESCRIPTION
## Summary

Closes #1212

Now that location media attachments are implemented (#1215/#1216), the location detail page has real content — but there was no way to reach it from the list without going through Edit. This PR adds a **View button** (eye icon) to each location row, matching the same UX pattern as commodities.

## Changes

### `frontend/src/views/locations/LocationListView.vue`
- Added a View button (`btn-info` + `eye` icon) before Edit in the `location-actions` div per location row
- Added `viewLocation(id)` function that pushes to `/locations/:id`

### `e2e/tests/location-file-uploads.spec.ts`
- Simplified `navigateToLocationDetail()`: now clicks `button[title="View"]` directly instead of the previous workaround (clicking Edit → extracting ID from URL → navigating manually to the detail page)

## Acceptance criteria

- [x] Location list has a View button (eye icon) per row that navigates to `/locations/:id`
- [x] Location detail page is reachable from the list without going through edit
- [x] After save in edit mode, redirect to the detail page (existing behaviour — unchanged)
- [x] E2e test updated to use the View button navigation path