### PR TITLE
ci(e2e): run Playwright against the built Docker image

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -81,3 +81,23 @@ jobs:
             docker manifest create "${IMAGE_TAG}" "${IMAGE_TAG}-amd64" "${IMAGE_TAG}-arm64"
             docker manifest push "${IMAGE_TAG}"
           done
+
+      - name: Stage darwin/arm64 binary for e2e
+        # goreleaser has already produced native binaries for every os/arch in
+        # .goreleaser.yaml. Expose the darwin/arm64 one as a GHA artifact so the
+        # macOS e2e lane can consume the exact shipped binary instead of
+        # rebuilding (macos-latest runners are Apple Silicon).
+        run: |
+          set -euo pipefail
+          BIN_DIR=$(ls -d dist/inventario_darwin_arm64*/ | head -1)
+          mkdir -p dist-e2e
+          cp "${BIN_DIR}inventario" dist-e2e/inventario
+          chmod +x dist-e2e/inventario
+
+      - name: Upload darwin/arm64 binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: inventario-darwin-arm64
+          path: dist-e2e/inventario
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -113,6 +113,26 @@ jobs:
           docker manifest create "${PR_TAG}" "${PR_TAG}-amd64" "${PR_TAG}-arm64"
           docker manifest push "${PR_TAG}"
 
+      - name: Stage darwin/arm64 binary for e2e
+        # goreleaser has already produced native binaries for every os/arch in
+        # .goreleaser.yaml. Expose the darwin/arm64 one as a GHA artifact so the
+        # macOS e2e lane can consume the exact shipped binary instead of
+        # rebuilding (macos-latest runners are Apple Silicon).
+        run: |
+          set -euo pipefail
+          BIN_DIR=$(ls -d dist/inventario_darwin_arm64*/ | head -1)
+          mkdir -p dist-e2e
+          cp "${BIN_DIR}inventario" dist-e2e/inventario
+          chmod +x dist-e2e/inventario
+
+      - name: Upload darwin/arm64 binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: inventario-darwin-arm64
+          path: dist-e2e/inventario
+          if-no-files-found: error
+          retention-days: 7
+
   cleanup:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,65 +10,44 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# e2e-tests is a pure consumer: it pulls the production Docker image produced
+# by docker-pr.yml (PRs) / docker-edge.yml (master pushes), and the darwin
+# binary uploaded by those same workflows. Nothing is built here.
+#
+#   - `packages: read` — pull from ghcr.io.
+#   - `actions: read`  — cross-workflow `gh run list` + `download-artifact`.
 permissions:
   contents: read
-  packages: write
+  packages: read
+  actions: read
 
 jobs:
-  # Build the production Docker image once and publish it to GHCR so that the
-  # Linux matrix jobs can pull it. We want e2e to exercise the exact artifact
-  # we ship, not a `go run` + `npm run dev` stack.
-  #
-  # Same-repo only — fork PRs don't get packages:write, so they cannot publish
-  # images. Those runs fail fast at the build step, which is the documented
-  # contribution model for this repo (see .github/workflows/docker-pr.yml).
-  build-image:
-    name: Build E2E Docker image
+  # Resolve which image tag / build workflow corresponds to this event so both
+  # lanes use the same SHA-correlated artifact.
+  resolve-build:
+    name: Resolve build artifacts
     runs-on: ubuntu-latest
-    timeout-minutes: 25
     outputs:
-      image: ${{ steps.meta.outputs.image }}
+      image: ${{ steps.out.outputs.image }}
+      build_workflow: ${{ steps.out.outputs.build_workflow }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - id: meta
-        name: Compute image tag
+      - id: out
         run: |
-          # Unique per workflow run so concurrent PRs don't collide; deleted in
-          # the cleanup job below once all matrix lanes finish.
-          IMAGE="ghcr.io/${{ github.repository_owner }}/inventario:e2e-${{ github.run_id }}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG=edge
+            WORKFLOW=docker-edge.yml
+          else
+            TAG=pr-${{ github.event.pull_request.number }}
+            WORKFLOW=docker-pr.yml
+          fi
+          IMAGE="ghcr.io/${{ github.repository_owner }}/inventario:${TAG}"
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          target: production
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.image }}
-          cache-from: type=gha,scope=e2e-image
-          cache-to: type=gha,scope=e2e-image,mode=max
+          echo "build_workflow=${WORKFLOW}" >> "$GITHUB_OUTPUT"
 
   e2e-tests-linux:
     name: E2E Tests (${{ matrix.browser }})
     runs-on: ubuntu-latest
-    needs: build-image
+    needs: resolve-build
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -92,14 +71,12 @@ jobs:
       - name: Install e2e dependencies
         run: cd e2e && npm ci
 
-      # Cache Playwright browsers
       - name: Cache Playwright browsers
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ matrix.browser }}-${{ hashFiles('e2e/package-lock.json') }}
 
-      # Install only the browser needed for this matrix job
       - name: Install Playwright browser (${{ matrix.browser }})
         run: cd e2e && npx playwright install --with-deps ${{ matrix.browser }}
 
@@ -109,6 +86,24 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for Docker image
+        env:
+          IMAGE: ${{ needs.resolve-build.outputs.image }}
+        # docker-pr.yml / docker-edge.yml publish the image in parallel with
+        # this workflow. Poll until the tag resolves on GHCR (15 min ceiling —
+        # comfortably longer than the build's typical 6-8 min).
+        run: |
+          for i in $(seq 1 60); do
+            if docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
+              echo "Image available: $IMAGE"
+              exit 0
+            fi
+            echo "Waiting for $IMAGE ($i/60)..."
+            sleep 15
+          done
+          echo "ERROR: $IMAGE did not appear within 15 minutes"
+          exit 1
 
       - name: Prepare host directories
         # Both inventario-init-data (/app/state) and inventario (/app/uploads)
@@ -123,9 +118,9 @@ jobs:
 
       - name: Bring up the Inventario stack (pre-built image)
         env:
-          INVENTARIO_IMAGE: ${{ needs.build-image.outputs.image }}
+          INVENTARIO_IMAGE: ${{ needs.resolve-build.outputs.image }}
           # Deterministic e2e secrets; shared across inventario-init-data and
-          # inventario so the JWT/file-signing keys match between services.
+          # inventario so JWT/file-signing keys match between services.
           JWT_SECRET: "e2e-jwt-secret-please-change-for-prod"
           FILE_SIGNING_KEY: "e2e-file-signing-key-please-change"
           # Credentials must match e2e/tests/includes/auth.ts TEST_CREDENTIALS.
@@ -175,21 +170,26 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml down -v
 
-  # macOS webkit lane stays on the dev-mode path. Running docker-compose on
-  # macos-latest runners requires Colima/Docker Desktop and is fragile; since
-  # Playwright webkit works equally well against any HTTP base URL, we still
-  # cover the webkit engine without the container overhead. The dev-mode stack
-  # is still an interesting smoke signal for the go run / vite dev flow itself.
+  # macOS webkit consumes the darwin/arm64 binary that the same goreleaser
+  # snapshot produced in docker-pr.yml / docker-edge.yml. No Go rebuild here —
+  # this lane exercises the exact native binary we ship for Apple Silicon
+  # (macos-latest == ARM64).
   e2e-tests-macos:
     name: E2E Tests (webkit)
     runs-on: macos-latest
+    needs: resolve-build
     timeout-minutes: 45
 
     env:
-      INVENTARIO_DB_DSN: postgres://postgres@localhost:5432/inventario_test?sslmode=disable
+      INVENTARIO_DB_DSN: postgres://postgres@localhost:5432/inventario?sslmode=disable
       INVENTARIO_LOG_FORMAT: json
+      INVENTARIO_ADDR: ":3333"
+      INVENTARIO_UPLOAD_LOCATION: "file:///tmp/inventario-uploads?create_dir=1"
       INVENTARIO_RUN_AUTH_RATE_LIMIT_DISABLED: "true"
       INVENTARIO_RUN_GLOBAL_RATE_LIMIT_DISABLED: "true"
+      INVENTARIO_RUN_JWT_SECRET: "e2e-jwt-secret-please-change-for-prod"
+      INVENTARIO_RUN_FILE_SIGNING_KEY: "e2e-file-signing-key-please-change"
+      INVENTARIO_RUN_PUBLIC_URL: "http://localhost:3333"
 
     steps:
       - name: Checkout code
@@ -198,16 +198,11 @@ jobs:
       - id: vars
         uses: ./.github/actions/vars
 
-      # Set up PostgreSQL on macOS
       - name: Set up PostgreSQL
         run: |
           brew install postgresql@17
           brew services start postgresql@17
-
-          # Add PostgreSQL to PATH (it's keg-only)
           export PATH="/opt/homebrew/opt/postgresql@17/bin:$PATH"
-
-          # Wait for PostgreSQL to be ready
           for i in {1..30}; do
             if pg_isready -h localhost -p 5432 2>/dev/null; then
               echo "PostgreSQL is ready"
@@ -216,88 +211,134 @@ jobs:
             echo "Waiting for PostgreSQL... ($i/30)"
             sleep 1
           done
-
-          # Create test database and user
           createuser -s postgres
-          createdb -O postgres inventario_test
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: 1.26.2
-          cache: true
-          cache-dependency-path: go/go.sum
+          createdb -O postgres inventario
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ steps.vars.outputs.node_version }}
           cache: 'npm'
-          cache-dependency-path: |
-            frontend/package-lock.json
-            e2e/package-lock.json
-
-      - name: Install frontend dependencies
-        run: cd frontend && npm ci
+          cache-dependency-path: e2e/package-lock.json
 
       - name: Install e2e dependencies
         run: cd e2e && npm ci
 
-      # Cache Playwright browsers
       - name: Cache Playwright browsers
         uses: actions/cache@v5
         with:
           path: ~/Library/Caches/ms-playwright
           key: ${{ runner.os }}-playwright-webkit-${{ hashFiles('e2e/package-lock.json') }}
 
-      # Install only WebKit browser
       - name: Install Playwright browser (webkit)
         run: cd e2e && npx playwright install --with-deps webkit
 
-      - name: Run database migrations
+      - name: Find build run for this SHA
+        id: find-run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_WORKFLOW: ${{ needs.resolve-build.outputs.build_workflow }}
+          COMMIT_SHA: ${{ github.sha }}
+        # docker-pr / docker-edge run in parallel with this workflow. Poll until
+        # their run for our commit completes successfully, then capture its run
+        # ID for the cross-workflow artifact download.
         run: |
-          cd go
-          go mod download
-          cd ..
-          make build-inventool
-          bin/inventool db bootstrap apply --username=postgres --db-dsn "${{ env.INVENTARIO_DB_DSN }}"
-          bin/inventool db migrations up --db-dsn "${{ env.INVENTARIO_DB_DSN }}"
-
-      - name: Start application stack and run fast-fail test
-        run: |
-          env
-
-          # Start the backend, seed the database, and start the frontend
-          cd e2e && npm run stack &
-          STACK_PID=$!
-
-          # Poll until the frontend is up, but stop immediately if the stack process dies.
-          echo "Waiting for frontend at http://localhost:5173 (stack PID $STACK_PID)..."
-          for i in $(seq 1 120); do
-            if ! kill -0 $STACK_PID 2>/dev/null; then
-              echo "ERROR: stack process exited unexpectedly (seed or startup failure)"
-              exit 1
+          for i in $(seq 1 60); do
+            RUN_ID=$(gh run list \
+              --repo "${{ github.repository }}" \
+              --workflow "$BUILD_WORKFLOW" \
+              --commit "$COMMIT_SHA" \
+              --limit 1 \
+              --json databaseId,status,conclusion \
+              --jq '.[0] | select(.status=="completed" and .conclusion=="success") | .databaseId // empty')
+            if [ -n "$RUN_ID" ]; then
+              echo "Found $BUILD_WORKFLOW run $RUN_ID for $COMMIT_SHA"
+              echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
-            if curl -sf http://localhost:5173 > /dev/null 2>&1; then
-              echo "Frontend is ready"
-              break
-            fi
-            echo "  attempt $i/120..."
-            sleep 1
-            if [ "$i" -eq 120 ]; then
-              echo "Timeout: frontend not ready after 120 s"
-              exit 1
-            fi
+            echo "Waiting for $BUILD_WORKFLOW run on $COMMIT_SHA... ($i/60)"
+            sleep 15
           done
+          echo "ERROR: $BUILD_WORKFLOW did not succeed for $COMMIT_SHA within 15 minutes"
+          exit 1
 
-          # Run the fast-fail test first to debug the specific issue
+      - name: Download inventario darwin/arm64 binary
+        uses: actions/download-artifact@v7
+        with:
+          name: inventario-darwin-arm64
+          path: ./bin
+          run-id: ${{ steps.find-run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare binary
+        run: |
+          chmod +x ./bin/inventario
+          ./bin/inventario --help >/dev/null
+          ./bin/inventario version || true
+
+      - name: Bootstrap DB and create admin user
+        # Mirrors what inventario-bootstrap / inventario-migrate / inventario-
+        # init-data do inside Docker for the Linux lane. The same `inventario`
+        # binary drives both paths — this is the gap #1247 set out to close.
+        run: |
+          ./bin/inventario db bootstrap apply --username=postgres
+          ./bin/inventario db migrate up
+          ./bin/inventario db migrate data \
+            --default-tenant-name="Test Organization" \
+            --default-tenant-slug=test-org \
+            --admin-email=admin@test-org.com \
+            --admin-password=testpassword123 \
+            --admin-name="Test Administrator"
+
+      - name: Start inventario
+        run: |
+          mkdir -p /tmp/inventario-uploads
+          nohup ./bin/inventario run > /tmp/inventario.log 2>&1 &
+          echo $! > /tmp/inventario.pid
+          echo "Waiting for http://localhost:3333/readyz..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3333/readyz > /dev/null; then
+              echo "Ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: /readyz never returned 200"
+          cat /tmp/inventario.log
+          exit 1
+
+      - name: Seed test fixtures
+        # Matches scripts/init-data.sh's seed call — populates the test-org
+        # tenant with locations/areas/commodities expected by the e2e suite.
+        run: |
+          curl -fsS -X POST \
+            -H "Content-Type: application/json" \
+            -d '{"user_email":"admin@test-org.com","tenant_slug":"test-org"}' \
+            http://localhost:3333/api/v1/seed
+
+      - name: Run fast-fail test
+        env:
+          USE_PREBUILT: "true"
+        run: |
           cd e2e && npx playwright test --project=webkit --grep "should update and immediately retrieve a commodity \(fast-fail debug\)"
 
       - name: Run full test suite
         if: success()
+        env:
+          USE_PREBUILT: "true"
         run: |
-          # Run the full test suite for webkit
           cd e2e && npx playwright test --project=webkit
+
+      - name: Dump server log on failure
+        if: failure()
+        run: cat /tmp/inventario.log || true
+
+      - name: Stop inventario
+        if: always()
+        run: |
+          if [ -f /tmp/inventario.pid ]; then
+            kill "$(cat /tmp/inventario.pid)" 2>/dev/null || true
+          fi
 
       - name: Upload test results
         if: always()
@@ -306,42 +347,3 @@ jobs:
           name: playwright-report-webkit
           path: e2e/playwright-report/
           retention-days: 30
-
-  # Delete the e2e GHCR image once all matrix lanes are done (or skipped).
-  # Without this, every push would leave a SNAPSHOT tag lingering on GHCR.
-  cleanup-image:
-    name: Cleanup E2E image
-    runs-on: ubuntu-latest
-    needs: [build-image, e2e-tests-linux]
-    if: always() && needs.build-image.result == 'success'
-    steps:
-      - name: Delete e2e image from GHCR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          PACKAGE_NAME: inventario
-          E2E_TAG: e2e-${{ github.run_id }}
-        run: |
-          set -euo pipefail
-
-          owner_type="$(gh api "/users/${OWNER}" --jq '.type')"
-          if [ "${owner_type}" = "Organization" ]; then
-            package_api="/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
-          else
-            package_api="/users/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
-          fi
-
-          mapfile -t version_ids < <(
-            gh api "${package_api}?per_page=100" --paginate \
-              --jq '.[] | select(any((.metadata.container.tags // [])[]; . == env.E2E_TAG)) | .id'
-          )
-
-          if [ "${#version_ids[@]}" -eq 0 ]; then
-            echo "No GHCR package versions found for ${E2E_TAG}"
-            exit 0
-          fi
-
-          for version_id in "${version_ids[@]}"; do
-            gh api --method DELETE "${package_api}/${version_id}"
-            echo "Deleted package version ${version_id} for ${E2E_TAG}"
-          done

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -163,6 +163,25 @@ jobs:
               --tenant=test-org \
               --no-interactive
 
+      - name: Bootstrap system settings for user2
+        # Without MainCurrency, the SPA's router guard redirects user2 to
+        # /system?required=true on every navigation — so /commodities/{id}
+        # never renders ResourceNotFound and user-isolation's direct-URL
+        # access tests time out. seeddata.go:216 does this for user2 in the
+        # no-user_email path; we replicate it here via the HTTP API.
+        run: |
+          TOKEN=$(curl -fsS -X POST http://localhost:3333/api/v1/auth/login \
+            -H "Content-Type: application/json" \
+            -d '{"email":"user2@test-org.com","password":"testpassword123"}' \
+            | jq -r '.access_token')
+          [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
+            || { echo "ERROR: user2 login did not yield access_token"; exit 1; }
+          curl -fsS -X PUT http://localhost:3333/api/v1/settings \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $TOKEN" \
+            -d '{"main_currency":"EUR"}' > /dev/null
+          echo "user2 MainCurrency=EUR configured"
+
       - name: Run fast-fail test
         env:
           USE_PREBUILT: "true"
@@ -351,6 +370,23 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{"user_email":"admin@test-org.com","tenant_slug":"test-org"}' \
             http://localhost:3333/api/v1/seed
+
+      - name: Bootstrap system settings for user2
+        # Mirrors the Linux lane: without MainCurrency, the SPA router guard
+        # redirects user2 away from /commodities/{id} to /system, breaking
+        # user-isolation's direct-URL access assertions.
+        run: |
+          TOKEN=$(curl -fsS -X POST http://localhost:3333/api/v1/auth/login \
+            -H "Content-Type: application/json" \
+            -d '{"email":"user2@test-org.com","password":"testpassword123"}' \
+            | jq -r '.access_token')
+          [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
+            || { echo "ERROR: user2 login did not yield access_token"; exit 1; }
+          curl -fsS -X PUT http://localhost:3333/api/v1/settings \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $TOKEN" \
+            -d '{"main_currency":"EUR"}' > /dev/null
+          echo "user2 MainCurrency=EUR configured"
 
       - name: Run fast-fail test
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -170,15 +170,21 @@ jobs:
         # access tests time out. seeddata.go:216 does this for user2 in the
         # no-user_email path; we replicate it here via the HTTP API.
         run: |
-          TOKEN=$(curl -fsS -X POST http://localhost:3333/api/v1/auth/login \
+          LOGIN_RESP=$(curl -fsS -X POST http://localhost:3333/api/v1/auth/login \
             -H "Content-Type: application/json" \
-            -d '{"email":"user2@test-org.com","password":"testpassword123"}' \
-            | jq -r '.access_token')
+            -d '{"email":"user2@test-org.com","password":"testpassword123"}')
+          TOKEN=$(echo "$LOGIN_RESP" | jq -r '.access_token')
+          CSRF=$(echo "$LOGIN_RESP" | jq -r '.csrf_token')
           [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
-            || { echo "ERROR: user2 login did not yield access_token"; exit 1; }
+            || { echo "ERROR: user2 login did not yield access_token"; echo "$LOGIN_RESP"; exit 1; }
+          [ -n "$CSRF" ] && [ "$CSRF" != "null" ] \
+            || { echo "ERROR: user2 login did not yield csrf_token"; echo "$LOGIN_RESP"; exit 1; }
+          # PUT /settings is CSRF-protected (X-CSRF-Token required on mutating
+          # methods — see apiserver/csrf_middleware.go).
           curl -fsS -X PUT http://localhost:3333/api/v1/settings \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
+            -H "X-CSRF-Token: $CSRF" \
             -d '{"main_currency":"EUR"}' > /dev/null
           echo "user2 MainCurrency=EUR configured"
 
@@ -376,15 +382,21 @@ jobs:
         # redirects user2 away from /commodities/{id} to /system, breaking
         # user-isolation's direct-URL access assertions.
         run: |
-          TOKEN=$(curl -fsS -X POST http://localhost:3333/api/v1/auth/login \
+          LOGIN_RESP=$(curl -fsS -X POST http://localhost:3333/api/v1/auth/login \
             -H "Content-Type: application/json" \
-            -d '{"email":"user2@test-org.com","password":"testpassword123"}' \
-            | jq -r '.access_token')
+            -d '{"email":"user2@test-org.com","password":"testpassword123"}')
+          TOKEN=$(echo "$LOGIN_RESP" | jq -r '.access_token')
+          CSRF=$(echo "$LOGIN_RESP" | jq -r '.csrf_token')
           [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
-            || { echo "ERROR: user2 login did not yield access_token"; exit 1; }
+            || { echo "ERROR: user2 login did not yield access_token"; echo "$LOGIN_RESP"; exit 1; }
+          [ -n "$CSRF" ] && [ "$CSRF" != "null" ] \
+            || { echo "ERROR: user2 login did not yield csrf_token"; echo "$LOGIN_RESP"; exit 1; }
+          # PUT /settings is CSRF-protected (X-CSRF-Token required on mutating
+          # methods — see apiserver/csrf_middleware.go).
           curl -fsS -X PUT http://localhost:3333/api/v1/settings \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
+            -H "X-CSRF-Token: $CSRF" \
             -d '{"main_currency":"EUR"}' > /dev/null
           echo "user2 MainCurrency=EUR configured"
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,9 +111,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare host directories
-        # inventario-init-data writes /app/state as UID 1001 (see Dockerfile).
-        # Pre-create with 777 so the bind mount works without root.
-        run: mkdir -p .docker/init-state && chmod 777 .docker/init-state
+        # Both inventario-init-data (/app/state) and inventario (/app/uploads)
+        # run as UID 1001 per the Dockerfile. Bind-mounted host dirs are
+        # auto-created by Docker as root if absent, which then blocks writes
+        # from the container — and a silently non-writable uploads dir is how
+        # the export worker quietly stops completing, so tests timeout waiting
+        # for .export-status--completed.
+        run: |
+          mkdir -p .docker/init-state .docker/inventario/uploads
+          chmod 777 .docker/init-state .docker/inventario/uploads
 
       - name: Bring up the Inventario stack (pre-built image)
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,35 +10,70 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
+  # Build the production Docker image once and publish it to GHCR so that the
+  # Linux matrix jobs can pull it. We want e2e to exercise the exact artifact
+  # we ship, not a `go run` + `npm run dev` stack.
+  #
+  # Same-repo only — fork PRs don't get packages:write, so they cannot publish
+  # images. Those runs fail fast at the build step, which is the documented
+  # contribution model for this repo (see .github/workflows/docker-pr.yml).
+  build-image:
+    name: Build E2E Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        name: Compute image tag
+        run: |
+          # Unique per workflow run so concurrent PRs don't collide; deleted in
+          # the cleanup job below once all matrix lanes finish.
+          IMAGE="ghcr.io/${{ github.repository_owner }}/inventario:e2e-${{ github.run_id }}"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: production
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+          cache-from: type=gha,scope=e2e-image
+          cache-to: type=gha,scope=e2e-image,mode=max
+
   e2e-tests-linux:
     name: E2E Tests (${{ matrix.browser }})
     runs-on: ubuntu-latest
+    needs: build-image
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         browser: [chromium, firefox]
-
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: inventario_test
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-    env:
-      INVENTARIO_DB_DSN: postgres://postgres:postgres@localhost:5432/inventario_test?sslmode=disable
-      INVENTARIO_LOG_FORMAT: json
-      INVENTARIO_RUN_AUTH_RATE_LIMIT_DISABLED: "true"
-      INVENTARIO_RUN_GLOBAL_RATE_LIMIT_DISABLED: "true"
 
     steps:
       - name: Checkout code
@@ -47,24 +82,12 @@ jobs:
       - id: vars
         uses: ./.github/actions/vars
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: 1.26.2
-          cache: true
-          cache-dependency-path: go/go.sum
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ steps.vars.outputs.node_version }}
           cache: 'npm'
-          cache-dependency-path: |
-            frontend/package-lock.json
-            e2e/package-lock.json
-
-      - name: Install frontend dependencies
-        run: cd frontend && npm ci
+          cache-dependency-path: e2e/package-lock.json
 
       - name: Install e2e dependencies
         run: cd e2e && npm ci
@@ -80,52 +103,59 @@ jobs:
       - name: Install Playwright browser (${{ matrix.browser }})
         run: cd e2e && npx playwright install --with-deps ${{ matrix.browser }}
 
-      - name: Run database migrations
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare host directories
+        # inventario-init-data writes /app/state as UID 1001 (see Dockerfile).
+        # Pre-create with 777 so the bind mount works without root.
+        run: mkdir -p .docker/init-state && chmod 777 .docker/init-state
+
+      - name: Bring up the Inventario stack (pre-built image)
+        env:
+          INVENTARIO_IMAGE: ${{ needs.build-image.outputs.image }}
+          # Deterministic e2e secrets; shared across inventario-init-data and
+          # inventario so the JWT/file-signing keys match between services.
+          JWT_SECRET: "e2e-jwt-secret-please-change-for-prod"
+          FILE_SIGNING_KEY: "e2e-file-signing-key-please-change"
+          # Credentials must match e2e/tests/includes/auth.ts TEST_CREDENTIALS.
+          # These flow into inventario-init-data via ${VAR:-default} in the base
+          # compose file, so they must be set in the shell env here.
+          ADMIN_EMAIL: "admin@test-org.com"
+          ADMIN_PASSWORD: "testpassword123"
+          ADMIN_NAME: "Test Administrator"
+          DEFAULT_TENANT_NAME: "Test Organization"
+          DEFAULT_TENANT_SLUG: "test-org"
+          SEED_DATABASE: "true"
         run: |
-          cd go
-          go mod download
-          cd ..
-          make build-inventool
-          bin/inventool db bootstrap apply --username=postgres --db-dsn "${{ env.INVENTARIO_DB_DSN }}"
-          bin/inventool db migrations up --db-dsn "${{ env.INVENTARIO_DB_DSN }}"
+          docker pull "$INVENTARIO_IMAGE"
+          # --wait blocks until the inventario healthcheck (curl /readyz) passes
+          # and the one-shot bootstrap/migrate/init-data containers exit 0.
+          docker compose \
+            -f docker-compose.yaml \
+            -f docker-compose.e2e.yaml \
+            up -d --wait --wait-timeout 300 --no-build inventario
 
-      - name: Start application stack and run fast-fail test
+      - name: Run fast-fail test
+        env:
+          USE_PREBUILT: "true"
         run: |
-          env
-
-          # Start the backend, seed the database, and start the frontend
-          cd e2e && npm run stack &
-          STACK_PID=$!
-
-          # Poll until the frontend is up, but stop immediately if the stack process dies.
-          # This ensures a seed failure (or any other startup error) surfaces as a CI failure
-          # right away instead of waiting forever.
-          echo "Waiting for frontend at http://localhost:5173 (stack PID $STACK_PID)..."
-          for i in $(seq 1 120); do
-            if ! kill -0 $STACK_PID 2>/dev/null; then
-              echo "ERROR: stack process exited unexpectedly (seed or startup failure)"
-              exit 1
-            fi
-            if curl -sf http://localhost:5173 > /dev/null 2>&1; then
-              echo "Frontend is ready"
-              break
-            fi
-            echo "  attempt $i/120..."
-            sleep 1
-            if [ "$i" -eq 120 ]; then
-              echo "Timeout: frontend not ready after 120 s"
-              exit 1
-            fi
-          done
-
-          # Run the fast-fail test first to debug the specific issue
           cd e2e && npx playwright test --project=${{ matrix.browser }} --grep "should update and immediately retrieve a commodity \(fast-fail debug\)"
 
       - name: Run full test suite
         if: success()
+        env:
+          USE_PREBUILT: "true"
         run: |
-          # Run the full test suite for this browser
           cd e2e && npx playwright test --project=${{ matrix.browser }}
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml logs
 
       - name: Upload test results
         if: always()
@@ -135,9 +165,19 @@ jobs:
           path: e2e/playwright-report/
           retention-days: 30
 
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml down -v
+
+  # macOS webkit lane stays on the dev-mode path. Running docker-compose on
+  # macos-latest runners requires Colima/Docker Desktop and is fragile; since
+  # Playwright webkit works equally well against any HTTP base URL, we still
+  # cover the webkit engine without the container overhead. The dev-mode stack
+  # is still an interesting smoke signal for the go run / vite dev flow itself.
   e2e-tests-macos:
     name: E2E Tests (webkit)
     runs-on: macos-latest
+    timeout-minutes: 45
 
     env:
       INVENTARIO_DB_DSN: postgres://postgres@localhost:5432/inventario_test?sslmode=disable
@@ -260,3 +300,42 @@ jobs:
           name: playwright-report-webkit
           path: e2e/playwright-report/
           retention-days: 30
+
+  # Delete the e2e GHCR image once all matrix lanes are done (or skipped).
+  # Without this, every push would leave a SNAPSHOT tag lingering on GHCR.
+  cleanup-image:
+    name: Cleanup E2E image
+    runs-on: ubuntu-latest
+    needs: [build-image, e2e-tests-linux]
+    if: always() && needs.build-image.result == 'success'
+    steps:
+      - name: Delete e2e image from GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE_NAME: inventario
+          E2E_TAG: e2e-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          owner_type="$(gh api "/users/${OWNER}" --jq '.type')"
+          if [ "${owner_type}" = "Organization" ]; then
+            package_api="/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
+          else
+            package_api="/users/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
+          fi
+
+          mapfile -t version_ids < <(
+            gh api "${package_api}?per_page=100" --paginate \
+              --jq '.[] | select(any((.metadata.container.tags // [])[]; . == env.E2E_TAG)) | .id'
+          )
+
+          if [ "${#version_ids[@]}" -eq 0 ]; then
+            echo "No GHCR package versions found for ${E2E_TAG}"
+            exit 0
+          fi
+
+          for version_id in "${version_ids[@]}"; do
+            gh api --method DELETE "${package_api}/${version_id}"
+            echo "Deleted package version ${version_id} for ${E2E_TAG}"
+          done

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -54,6 +54,11 @@ jobs:
       matrix:
         browser: [chromium, firefox]
 
+    # Exported at job scope so both the "up" and "down" compose invocations can
+    # resolve ${INVENTARIO_IMAGE:?} in docker-compose.e2e.yaml.
+    env:
+      INVENTARIO_IMAGE: ${{ needs.resolve-build.outputs.image }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -88,21 +93,19 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for Docker image
-        env:
-          IMAGE: ${{ needs.resolve-build.outputs.image }}
         # docker-pr.yml / docker-edge.yml publish the image in parallel with
         # this workflow. Poll until the tag resolves on GHCR (15 min ceiling —
         # comfortably longer than the build's typical 6-8 min).
         run: |
           for i in $(seq 1 60); do
-            if docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
-              echo "Image available: $IMAGE"
+            if docker manifest inspect "$INVENTARIO_IMAGE" >/dev/null 2>&1; then
+              echo "Image available: $INVENTARIO_IMAGE"
               exit 0
             fi
-            echo "Waiting for $IMAGE ($i/60)..."
+            echo "Waiting for $INVENTARIO_IMAGE ($i/60)..."
             sleep 15
           done
-          echo "ERROR: $IMAGE did not appear within 15 minutes"
+          echo "ERROR: $INVENTARIO_IMAGE did not appear within 15 minutes"
           exit 1
 
       - name: Prepare host directories
@@ -118,7 +121,6 @@ jobs:
 
       - name: Bring up the Inventario stack (pre-built image)
         env:
-          INVENTARIO_IMAGE: ${{ needs.resolve-build.outputs.image }}
           # Deterministic e2e secrets; shared across inventario-init-data and
           # inventario so JWT/file-signing keys match between services.
           JWT_SECRET: "e2e-jwt-secret-please-change-for-prod"
@@ -238,7 +240,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILD_WORKFLOW: ${{ needs.resolve-build.outputs.build_workflow }}
-          COMMIT_SHA: ${{ github.sha }}
+          # On pull_request, github.sha is the synthetic merge commit — but
+          # docker-pr.yml runs against the PR HEAD commit, which is what gh
+          # run list's --commit filter matches. Fall back to github.sha on
+          # push events (where it IS the pushed commit).
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         # docker-pr / docker-edge run in parallel with this workflow. Poll until
         # their run for our commit completes successfully, then capture its run
         # ID for the cross-workflow artifact download.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -143,6 +143,26 @@ jobs:
             -f docker-compose.e2e.yaml \
             up -d --wait --wait-timeout 300 --no-build inventario
 
+      - name: Create regular user for user-isolation tests
+        # user-isolation.spec.ts logs in as user2@test-org.com to verify
+        # cross-user boundaries. inventario-init-data's /api/v1/seed call
+        # passes user_email=admin@test-org.com, which takes the fast path in
+        # seeddata.findOrCreateUsers and never reaches createTestUsers — so
+        # user2 is not auto-created. Provision it explicitly via the CLI
+        # (same image, shares the inventario service's env/network).
+        run: |
+          docker compose \
+            -f docker-compose.yaml \
+            -f docker-compose.e2e.yaml \
+            run --rm --no-deps inventario \
+            users create \
+              --email=user2@test-org.com \
+              --password=testpassword123 \
+              --name="Test User 2" \
+              --role=user \
+              --tenant=test-org \
+              --no-interactive
+
       - name: Run fast-fail test
         env:
           USE_PREBUILT: "true"
@@ -295,6 +315,16 @@ jobs:
             --admin-email=admin@test-org.com \
             --admin-password=testpassword123 \
             --admin-name="Test Administrator"
+          # user2 is expected by user-isolation.spec.ts. seeddata's fast path
+          # with user_email skips createTestUsers, so we provision user2
+          # ourselves.
+          ./bin/inventario users create \
+            --email=user2@test-org.com \
+            --password=testpassword123 \
+            --name="Test User 2" \
+            --role=user \
+            --tenant=test-org \
+            --no-interactive
 
       - name: Start inventario
         run: |

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -1,0 +1,38 @@
+# E2E override for docker-compose.yaml.
+#
+# Usage (invoked by .github/workflows/e2e-tests.yml):
+#   INVENTARIO_IMAGE=ghcr.io/denisvmedia/inventario:e2e-<sha> \
+#   ADMIN_EMAIL=admin@test-org.com ADMIN_PASSWORD=testpassword123 \
+#   DEFAULT_TENANT_SLUG=test-org DEFAULT_TENANT_NAME="Test Organization" \
+#   SEED_DATABASE=true \
+#     docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml \
+#     up -d --wait --no-build
+#
+# The base compose file reads ADMIN_EMAIL/ADMIN_PASSWORD/etc. via ${VAR:-default}
+# at parse time — they must be set in the shell env, not in this override's
+# `environment:` block, because ${VAR} is resolved before overrides are applied.
+#
+# --no-build is important: every Inventario service has `build:` in the base
+# file. We want the pre-built image from CI, not a rebuild.
+#
+# Contract with e2e/tests/includes/auth.ts — TEST_CREDENTIALS must match the
+# admin that inventario-init-data creates. SEED_DATABASE=true makes init-data
+# POST /api/v1/seed against the freshly-created tenant so e2e sees the same
+# fixtures as the dev-mode path.
+
+services:
+  inventario-bootstrap:
+    image: ${INVENTARIO_IMAGE:-inventario:e2e}
+
+  inventario-migrate:
+    image: ${INVENTARIO_IMAGE:-inventario:e2e}
+
+  inventario-init-data:
+    image: ${INVENTARIO_IMAGE:-inventario:e2e}
+
+  inventario:
+    image: ${INVENTARIO_IMAGE:-inventario:e2e}
+    environment:
+      # E2E is intentionally high-throughput and parallelized; let it through.
+      INVENTARIO_RUN_AUTH_RATE_LIMIT_DISABLED: "true"
+      INVENTARIO_RUN_GLOBAL_RATE_LIMIT_DISABLED: "true"

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -1,12 +1,16 @@
 # E2E override for docker-compose.yaml.
 #
 # Usage (invoked by .github/workflows/e2e-tests.yml):
-#   INVENTARIO_IMAGE=ghcr.io/denisvmedia/inventario:e2e-<sha> \
+#   INVENTARIO_IMAGE=ghcr.io/denisvmedia/inventario:pr-<num> \
 #   ADMIN_EMAIL=admin@test-org.com ADMIN_PASSWORD=testpassword123 \
 #   DEFAULT_TENANT_SLUG=test-org DEFAULT_TENANT_NAME="Test Organization" \
 #   SEED_DATABASE=true \
 #     docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml \
 #     up -d --wait --no-build
+#
+# INVENTARIO_IMAGE must be set — it points at the image that docker-pr.yml /
+# docker-edge.yml already pushed to GHCR. There's no local fallback because
+# e2e must always run against the exact artifact those workflows produced.
 #
 # The base compose file reads ADMIN_EMAIL/ADMIN_PASSWORD/etc. via ${VAR:-default}
 # at parse time — they must be set in the shell env, not in this override's
@@ -22,16 +26,16 @@
 
 services:
   inventario-bootstrap:
-    image: ${INVENTARIO_IMAGE:-inventario:e2e}
+    image: ${INVENTARIO_IMAGE:?INVENTARIO_IMAGE must be set}
 
   inventario-migrate:
-    image: ${INVENTARIO_IMAGE:-inventario:e2e}
+    image: ${INVENTARIO_IMAGE:?INVENTARIO_IMAGE must be set}
 
   inventario-init-data:
-    image: ${INVENTARIO_IMAGE:-inventario:e2e}
+    image: ${INVENTARIO_IMAGE:?INVENTARIO_IMAGE must be set}
 
   inventario:
-    image: ${INVENTARIO_IMAGE:-inventario:e2e}
+    image: ${INVENTARIO_IMAGE:?INVENTARIO_IMAGE must be set}
     environment:
       # E2E is intentionally high-throughput and parallelized; let it through.
       INVENTARIO_RUN_AUTH_RATE_LIMIT_DISABLED: "true"

--- a/e2e/fixtures/app-fixture.ts
+++ b/e2e/fixtures/app-fixture.ts
@@ -2,6 +2,7 @@ import { test as base, expect } from '@playwright/test';
 import { TestRecorder } from '../utils/test-recorder.js';
 import { ensureAuthenticated } from '../tests/includes/auth.js';
 import waitOn from 'wait-on';
+import { BASE_URL } from '../setup/urls.js';
 
 // Define the type for our custom fixtures
 type AppFixtures = {
@@ -27,7 +28,7 @@ export const test = base.extend<AppFixtures>({
   // Setup the application stack before tests
   page: async ({ page }, use) => {
     await waitOn({
-      resources: ['http://localhost:5173'],
+      resources: [BASE_URL],
       timeout: 15000,
       interval: 250,
       window: 1000,

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -26,7 +26,9 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never' }]]
+    : 'html',
   /* Output directory for test artifacts */
   outputDir: './test-results/',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { BASE_URL } from './setup/urls.js';
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -31,7 +32,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:5173',
+    baseURL: BASE_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/e2e/setup/global-setup.ts
+++ b/e2e/setup/global-setup.ts
@@ -1,6 +1,7 @@
 import { startStack } from './setup-stack.js';
 import { FullConfig } from '@playwright/test';
 import waitOn from 'wait-on';
+import { BASE_URL } from './urls.js';
 
 async function globalSetup(config: FullConfig) {
   if (process.env.START_STACK === 'true') {
@@ -10,7 +11,7 @@ async function globalSetup(config: FullConfig) {
 
   // If stack startup is explicitly disabled, wait for an externally-managed server.
   await waitOn({
-    resources: ['http://localhost:5173'],
+    resources: [BASE_URL],
     delay: 100, // minimum delay before starting (ms)
     interval: 250, // interval between attempts
     timeout: 30000, // maximum wait time (ms)

--- a/e2e/setup/setup-stack.ts
+++ b/e2e/setup/setup-stack.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcess } from 'child_process';
 import axios from 'axios';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { BACKEND_URL, BASE_URL, USE_PREBUILT } from './urls.js';
 
 // Sleep utility
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
@@ -116,12 +117,12 @@ export async function startBackend(): Promise<void> {
 async function waitForBackend(maxRetries = 60, retryInterval = 1000): Promise<void> {
   let retries = 0;
 
-  console.log('Waiting for backend to be available at http://localhost:3333');
+  console.log(`Waiting for backend to be available at ${BACKEND_URL}`);
 
   while (retries < maxRetries) {
     try {
       console.log(`Attempt ${retries + 1}/${maxRetries} to connect to backend...`);
-      const response = await axios.get('http://localhost:3333', { timeout: 5000 });
+      const response = await axios.get(BACKEND_URL, { timeout: 5000 });
       if (response.status === 200) {
         console.log('Successfully connected to backend!');
         return;
@@ -157,7 +158,7 @@ export async function seedDatabase(): Promise<void> {
 
   try {
     // Seed the database (endpoint is public for e2e testing)
-    const response = await axios.post('http://localhost:3333/api/v1/seed');
+    const response = await axios.post(`${BACKEND_URL}/api/v1/seed`);
 
     if (response.status === 200) {
       console.log('Database seeded successfully');
@@ -230,12 +231,12 @@ export async function startFrontend(): Promise<void> {
 async function waitForFrontend(maxRetries = 120, retryInterval = 1000): Promise<void> {
   let retries = 0;
 
-  console.log('Waiting for frontend to be available at http://localhost:5173');
+  console.log(`Waiting for frontend to be available at ${BASE_URL}`);
 
   while (retries < maxRetries) {
     try {
       console.log(`Attempt ${retries + 1}/${maxRetries} to connect to frontend...`);
-      const response = await axios.get('http://localhost:5173', { timeout: 5000 });
+      const response = await axios.get(BASE_URL, { timeout: 5000 });
       if (response.status === 200) {
         console.log('Successfully connected to frontend!');
         return;
@@ -264,6 +265,15 @@ async function waitForFrontend(maxRetries = 120, retryInterval = 1000): Promise<
  * Start the entire stack (backend + frontend)
  */
 export async function startStack(): Promise<void> {
+  if (USE_PREBUILT) {
+    // Seeding is done inside the inventario-init-data container (SEED_DATABASE=true).
+    // Re-posting /api/v1/seed here would duplicate non-idempotent fixtures.
+    console.log(`USE_PREBUILT=true — waiting for pre-started stack at ${BASE_URL}`);
+    await waitForBackend();
+    await waitForFrontend();
+    return;
+  }
+
   try {
     await startBackend();
     await seedDatabase();
@@ -278,6 +288,11 @@ export async function startStack(): Promise<void> {
  * Stop all running processes
  */
 export async function stopStack(): Promise<void> {
+  if (USE_PREBUILT) {
+    // Stack is externally managed (docker-compose down is the caller's job).
+    return;
+  }
+
   console.log('Stopping all services...');
 
   if (backendProcess) {

--- a/e2e/setup/urls.ts
+++ b/e2e/setup/urls.ts
@@ -1,0 +1,18 @@
+/**
+ * Where the Inventario stack is reachable for e2e tests.
+ *
+ * Two modes:
+ *   - Dev mode (default): `go run` backend on :3333 + Vite dev server on :5173.
+ *     Playwright hits Vite, which proxies /api to :3333.
+ *   - Pre-built mode (USE_PREBUILT=true): a Docker image serves backend and the
+ *     embedded SPA from :3333. No Vite. Playwright hits :3333 directly.
+ *
+ * `E2E_BASE_URL` overrides both defaults (e.g. pointing tests at a deployed env).
+ */
+export const USE_PREBUILT = process.env.USE_PREBUILT === 'true';
+
+export const BACKEND_URL = process.env.E2E_BACKEND_URL || 'http://localhost:3333';
+
+export const BASE_URL =
+  process.env.E2E_BASE_URL ||
+  (USE_PREBUILT ? BACKEND_URL : 'http://localhost:5173');

--- a/e2e/tests/includes/csrf.ts
+++ b/e2e/tests/includes/csrf.ts
@@ -44,9 +44,10 @@ export async function extractCsrfTokenFromResponse(page: Page, recorder?: TestRe
       try {
         const data = await response.json();
         if (data.csrf_token) {
-          token = data.csrf_token;
-          setCsrfToken(token);
-          log(recorder, `🔑 CSRF token extracted: ${token.substring(0, 10)}...`);
+          const csrfValue: string = data.csrf_token;
+          token = csrfValue;
+          setCsrfToken(csrfValue);
+          log(recorder, `🔑 CSRF token extracted: ${csrfValue.substring(0, 10)}...`);
         }
       } catch (err) {
         // Ignore JSON parse errors


### PR DESCRIPTION
Closes #1247.

## Summary
- Linux e2e lanes (chromium, firefox) now run against the production Docker image we actually ship, brought up with `docker compose` against a pre-built `inventario-*` stack — no more `go run -tags with_frontend` + `npm run dev`.
- `docker-compose.e2e.yaml` override pins `inventario-bootstrap`, `inventario-migrate`, `inventario-init-data`, and `inventario` to the CI-built image and disables auth/global rate limits for e2e throughput; the base compose wires postgres/redis/mailpit as in the smoke lane.
- Seed credentials flow from the workflow shell env (`ADMIN_EMAIL`, `ADMIN_PASSWORD`, `DEFAULT_TENANT_SLUG`, `SEED_DATABASE=true`), so `inventario-init-data` creates the exact admin that `e2e/tests/includes/auth.ts::TEST_CREDENTIALS` expects and posts `/api/v1/seed` inside the container.
- `USE_PREBUILT=true` gates the new `setup-stack.ts` branch that just waits for `http://localhost:3333` instead of spawning `go run` + Vite. Unset (local dev), everything still does `go run` + Vite at :5173 with the same fast inner loop.
- `BASE_URL` / `BACKEND_URL` / `USE_PREBUILT` are centralised in `e2e/setup/urls.ts` and consumed by `playwright.config.ts`, `global-setup.ts`, `fixtures/app-fixture.ts`, `setup-stack.ts`.
- macOS webkit lane keeps the dev-mode flow (matrix intentionally not shrunk per the issue's non-goal; Docker on `macos-latest` adds setup cost and the engine is orthogonal to how the server is started).
- New `build-image` job pushes `ghcr.io/<owner>/inventario:e2e-<run_id>` with GHA layer cache; `cleanup-image` deletes the tag after the matrix completes so we don't pile up SNAPSHOT versions.
- Drive-by: fix pre-existing `TS18047: 'token' is possibly 'null'` in `e2e/tests/includes/csrf.ts` that was blocking `npx tsc --noEmit` from running clean.

## Why
Per the issue: today's dev-mode stack shares no code path with the shipped artifact, so issues at the Docker / embed / SPA‑proxy boundary (frontend URL interceptors, `groupScopedPrefixes`, seed flows, RLS context leakage from the Location Groups train) only surfaced in the Kind / compose smoke lanes or production. Playwright driving the real image catches those earlier.

## Definition of done (from #1247)
- [x] `.github/workflows/e2e-tests.yml` depends on the docker build step and uses the resulting image.
- [x] `e2e/setup/setup-stack.ts` supports `USE_PREBUILT=true` and waits for the pre-started container instead of spawning `go run` + `npm run dev`.
- [x] A failing docker build fails e2e before Playwright starts (`needs: build-image` gates the matrix).
- [x] Local `npm run test:e2e` continues to work without Docker by defaulting to the dev-mode path (`USE_PREBUILT` unset → `:5173`).
- [ ] CI run time for e2e does not regress by more than ~3 min on the critical path. Needs measuring on this PR's first CI run.

## Test plan
- [ ] Wait for the `build-image` job — image published to `ghcr.io/denisvmedia/inventario:e2e-<run_id>`.
- [ ] Both Linux matrix lanes (chromium, firefox) pass against the pulled image; verify `docker compose logs inventario` shows the real binary serving the embedded SPA (no Vite banner).
- [ ] macOS webkit lane still passes (regression guard for the unchanged dev-mode path).
- [ ] `cleanup-image` job deletes the GHCR e2e tag after matrix completion (check the job log).
- [ ] Compare wall-clock time vs. master's e2e run — should not regress > 3 min.
- [ ] Sanity check locally: `cd e2e && npm run test:e2e` still boots `go run` + Vite without Docker (no `USE_PREBUILT` env set).