### PR TITLE
chore(ci): manage swag via Go 1.24+ tool directive

### DIFF
--- a/.github/actions/vars/action.yml
+++ b/.github/actions/vars/action.yml
@@ -4,9 +4,6 @@ outputs:
   node_version:
     description: "Node.js version"
     value: ${{ steps.node.outputs.NODE_VERSION }}
-  swag_version:
-    description: "swag version"
-    value: ${{ steps.swag_version.outputs.SWAG_VERSION }}
 runs:
   using: "composite"
   steps:
@@ -15,15 +12,4 @@ runs:
       run: |
         echo "NODE_VERSION=$(jq -r .volta.node package.json)" >> $GITHUB_OUTPUT
       working-directory: frontend
-      shell: bash
-
-    - name: Extract swag version from go.mod
-      id: swag_version
-      run: |
-        SWAG_VERSION=$(awk '/require \(/,/\)/ { if ($1 == "github.com/swaggo/swag") print $2 } /^github.com\/swaggo\/swag / { print $2 }' go/go.mod | head -n1)
-        if [ -z "$SWAG_VERSION" ]; then
-          echo "github.com/swaggo/swag is not in go.mod" >&2
-          exit 1
-        fi
-        printf "SWAG_VERSION=%s\n" "$SWAG_VERSION" | tee -a "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,9 +62,7 @@ associated metadata. Please follow these guidelines when contributing:
 ### API Documentation
 - When changing Go API entities, regenerate Swagger docs:
   ```bash
-  SWAG_VERSION=$(go list -m -f '{{.Version}}' github.com/swaggo/swag)
-  go install github.com/swaggo/swag/cmd/swag@${SWAG_VERSION}
-  swag init --output docs
+  go tool swag init --output docs
   ```
 
 ### Database Support

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -74,10 +74,7 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${{ steps.vars.outputs.golangci_lint_version }}
         working-directory: go
 
-      - name: Install swag for Swagger documentation
-        run: |
-          # Install swag for Swagger documentation (version from go.mod)
-          go install github.com/swaggo/swag/cmd/swag@${{ steps.vars.outputs.swag_version }}
+      # swag is available via `go tool swag` (declared in go/go.mod's tool block).
 
       # Install frontend dependencies
       - name: Install frontend dependencies

--- a/.github/workflows/go-swagger-docs.yml
+++ b/.github/workflows/go-swagger-docs.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - id: vars
-        uses: ./.github/actions/vars
-
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -36,19 +33,14 @@ jobs:
         run: go mod download
         working-directory: go
 
-      - name: Install swag CLI
-        run: |
-          go install github.com/swaggo/swag/cmd/swag@${{ steps.vars.outputs.swag_version }}
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
       - name: Regenerate Swagger docs
-        run: swag init --output docs
+        run: go tool swag init --output docs
         working-directory: go
 
       - name: Check for uncommitted changes in docs/
         run: |
           if ! git diff --exit-code -- docs/; then
-            echo "Swagger docs are out of sync. Please run 'swag init --output docs' and commit the changes." >&2
+            echo "Swagger docs are out of sync. Please run 'go tool swag init --output docs' and commit the changes." >&2
             exit 1
           fi
         working-directory: go

--- a/go/go.mod
+++ b/go/go.mod
@@ -2,6 +2,8 @@ module github.com/denisvmedia/inventario
 
 go 1.26.0
 
+tool github.com/swaggo/swag/cmd/swag
+
 require github.com/denisvmedia/inventario/frontend v0.0.0
 
 replace github.com/denisvmedia/inventario/frontend => ../frontend
@@ -95,6 +97,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.3 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
@@ -129,9 +132,11 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/swaggo/files/v2 v2.0.2 // indirect
+	github.com/urfave/cli/v2 v2.3.0 // indirect
 	github.com/yuin/gopher-lua v1.1.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
@@ -155,6 +160,8 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -151,7 +151,9 @@ github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -402,6 +404,7 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -447,6 +450,8 @@ github.com/swaggo/http-swagger/v2 v2.0.2/go.mod h1:r7/GBkAWIfK6E/OLnE8fXnviHiDeA
 github.com/swaggo/swag v1.16.6 h1:qBNcx53ZaX+M5dxVyTrgQ0PJ/ACK+NzhwcbieTt+9yI=
 github.com/swaggo/swag v1.16.6/go.mod h1:ngP2etMK5a0P3QBizic5MEwpRmluJZPHjXcMoj4Xesg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
@@ -667,7 +672,9 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
@@ -679,3 +686,5 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 h1:slmdOY3vp8a7KQbHkL+FLbvbkgMqmXojpFUO/jENuqQ=
 olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3/go.mod h1:oVgVk4OWVDi43qWBEyGhXgYxt7+ED4iYNpTngSLX2Iw=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=


### PR DESCRIPTION
Closes #1252.

## Summary
- Add `tool github.com/swaggo/swag/cmd/swag` to `go/go.mod` so swag is pinned alongside the rest of the module's deps and runs via `go tool swag` — no more `go install` round-trip, no more custom version extraction.
- Both CI workflows (`go-swagger-docs.yml`, `copilot-setup-steps.yml`) drop the install step; swagger regen becomes `go tool swag init --output docs`.
- Drop the now-unused `swag_version` output and awk step from `.github/actions/vars/action.yml`.
- Update the regen snippet in `.github/copilot-instructions.md` to match.

Module benefits from the layer-baked `/go/pkg/mod` cache (#1250), so `go tool swag` runs without a cold Go-install compile on each CI job.

## Test plan
- [x] `go mod tidy` clean (adds swag CLI's transitive indirects: md2man, blackfriday, urfave/cli, yaml.v2, sigs.k8s.io/yaml).
- [x] `go build ./...` passes.
- [x] `go tool swag init --output docs` produces byte-identical output to the committed `go/docs/` — `git status` clean after regen.
- [ ] CI: `Swagger Docs Sync` workflow passes on this PR (sanity-checks the new `go tool swag` path end-to-end).