### PR TITLE
feat(groups): prevent last admin from leaving via UI (#1259)

### DIFF
--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -293,3 +293,83 @@ test.describe('Group Members API', () => {
     expect(leaveResponse.status()).toBe(422);
   });
 });
+
+test.describe('Leave Group UI — last admin protection (#1259)', () => {
+  // These tests cover the frontend half of the contract: the backend already
+  // rejects "last admin leaves" with 422 (see the API test above). The UI
+  // must prevent the user from ever submitting that doomed request by
+  // disabling the button and explaining why. A fresh group per test (rather
+  // than reusing the default group) makes the member-count state
+  // deterministic — otherwise a seed change adding a second admin would
+  // silently flip this from "disabled" to "enabled" without a failure.
+
+  test('Leave Group button is disabled and a notice is shown when user is the sole admin', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    // Create a fresh group so the authenticated user is the only admin.
+    const groupName = `Last Admin UI Test ${Date.now()}`;
+    const createResp = await request.post('/api/v1/groups', {
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+        'X-CSRF-Token': csrfToken,
+      },
+      data: {
+        data: {
+          type: 'groups',
+          attributes: { name: groupName, icon: '🔒' },
+        },
+      },
+    });
+    expect(createResp.status(), await createResp.text()).toBe(201);
+    const groupId = (await createResp.json()).data.id;
+
+    try {
+      await page.goto(`/groups/${groupId}/settings`);
+
+      // Wait for the Leave Group section to render — loadData() is async and
+      // the last-admin branch only appears once the membership list arrives.
+      const leaveBtn = page.locator('[data-testid="leave-group-btn"]');
+      await expect(leaveBtn).toBeVisible({ timeout: 10000 });
+
+      // The button must be disabled AND advertise the reason via title/aria
+      // so mouse and screen-reader users both get the explanation.
+      await expect(leaveBtn).toBeDisabled();
+      await expect(leaveBtn).toHaveAttribute('aria-disabled', 'true');
+      await expect(leaveBtn).toHaveAttribute(
+        'title',
+        'You are the last admin. Promote another member first, or delete the group.',
+      );
+
+      // Inline notice explains the situation and points at the remediation.
+      const notice = page.locator('[data-testid="last-admin-notice"]');
+      await expect(notice).toBeVisible();
+      await expect(notice).toContainText('You are the last admin of this group');
+      // Sole admin + sole member -> deletion-only branch (no promote advice).
+      await expect(notice).toContainText('delete the group below');
+
+      // Danger Zone (with Delete Group) must be reachable — the notice
+      // tells the user to use it, so it must actually be rendered.
+      await expect(page.locator('button:has-text("Delete Group")')).toBeVisible();
+    } finally {
+      // Clean up the test group so repeat runs don't accumulate state.
+      const deleteResp = await request.delete(`/api/v1/groups/${groupId}`, {
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { confirm_word: groupName },
+      });
+      expect(deleteResp.status()).toBe(204);
+    }
+  });
+});

--- a/frontend/src/views/groups/GroupSettingsView.vue
+++ b/frontend/src/views/groups/GroupSettingsView.vue
@@ -88,8 +88,28 @@
       <!-- Leave Group -->
       <section class="settings-section">
         <h2>Leave Group</h2>
-        <p>You will lose access to all data in this group.</p>
-        <button class="btn btn-warning" @click="handleLeave">Leave Group</button>
+        <template v-if="isLastAdmin">
+          <p class="leave-warning" data-testid="last-admin-notice">
+            You are the last admin of this group.
+            <template v-if="hasPromotableMembers">Promote another member to admin before leaving, or delete the group below.</template>
+            <template v-else>To remove your access, delete the group below.</template>
+          </p>
+          <button
+            class="btn btn-warning"
+            disabled
+            aria-disabled="true"
+            aria-describedby="last-admin-notice-desc"
+            :title="LAST_ADMIN_TOOLTIP"
+            data-testid="leave-group-btn"
+          >
+            Leave Group
+          </button>
+          <span id="last-admin-notice-desc" class="sr-only">{{ LAST_ADMIN_TOOLTIP }}</span>
+        </template>
+        <template v-else>
+          <p>You will lose access to all data in this group.</p>
+          <button class="btn btn-warning" data-testid="leave-group-btn" @click="handleLeave">Leave Group</button>
+        </template>
       </section>
 
       <!-- Danger Zone -->
@@ -153,6 +173,23 @@ const isAdmin = computed(() => {
   if (!userId) return false
   return members.value.some((m) => m.member_user_id === userId && m.role === 'admin')
 })
+
+const adminCount = computed(() => members.value.filter((m) => m.role === 'admin').length)
+
+// isLastAdmin guards the "Leave Group" button: a sole admin leaving would
+// leave the group without any admin, violating the backend's ≥1-admin
+// invariant. The backend also rejects the request (422 ErrLastAdmin) — this
+// check is strictly about UX. Frame it in the caller's role first (isAdmin):
+// a non-admin can always leave, even if they're the only non-admin member,
+// so the admin-count check must not kick in for them.
+const isLastAdmin = computed(() => isAdmin.value && adminCount.value === 1)
+
+// Whether there is a non-admin member the last admin could promote as a
+// prerequisite to leaving. When false, "delete the group" is the only
+// sensible suggestion — avoid telling the user to promote nobody.
+const hasPromotableMembers = computed(() => members.value.some((m) => m.role === 'user'))
+
+const LAST_ADMIN_TOOLTIP = 'You are the last admin. Promote another member first, or delete the group.'
 
 async function loadData() {
   loading.value = true
@@ -461,6 +498,30 @@ onMounted(loadData)
 
 // .btn and its -primary/-secondary/-warning/-danger/-small modifiers come
 // from shared _components.scss.
+
+.leave-warning {
+  color: #8a5a00;
+  background: #fff8e1;
+  padding: 0.6em 0.8em;
+  border-left: 3px solid #f5a623;
+  border-radius: 4px;
+  margin-bottom: 0.8em;
+}
+
+// Visually hidden, still available to screen readers. Local copy — the app
+// doesn't expose a global .sr-only utility. Uses clip-path (not the
+// deprecated clip) per current a11y guidance.
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
 
 .error-message {
   color: #c00;

--- a/frontend/src/views/groups/__tests__/GroupSettingsView.spec.ts
+++ b/frontend/src/views/groups/__tests__/GroupSettingsView.spec.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
+import { createRouter, createWebHistory, type Router } from 'vue-router'
+import GroupSettingsView from '../GroupSettingsView.vue'
+import groupService from '@/services/groupService'
+import type { GroupMembership, LocationGroup } from '@/types/group'
+
+// The component talks to groupService directly for data, to groupStore for
+// side-effects after mutations, and to authStore for "who am I". All three
+// are mocked so the tests can drive membership shape deterministically and
+// exercise only the UI logic (isAdmin / isLastAdmin / hasPromotableMembers).
+
+vi.mock('@/services/groupService', () => ({
+  default: {
+    getGroup: vi.fn(),
+    listMembers: vi.fn(),
+    listInvites: vi.fn(),
+    leaveGroup: vi.fn(),
+    deleteGroup: vi.fn(),
+    updateMemberRole: vi.fn(),
+    removeMember: vi.fn(),
+    createInvite: vi.fn(),
+    revokeInvite: vi.fn(),
+  },
+}))
+
+const mockAuthStore = {
+  user: { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
+}
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => mockAuthStore,
+}))
+
+const mockGroupStore = {
+  currentGroup: null,
+  hasGroups: false,
+  updateGroupById: vi.fn(),
+  clearCurrentGroup: vi.fn(),
+  fetchGroups: vi.fn().mockResolvedValue(undefined),
+  restoreFromStorage: vi.fn().mockResolvedValue(undefined),
+}
+
+vi.mock('@/stores/groupStore', () => ({
+  useGroupStore: () => mockGroupStore,
+}))
+
+const mockedGroupService = vi.mocked(groupService)
+
+function makeGroup(overrides: Partial<LocationGroup> = {}): LocationGroup {
+  return {
+    id: 'grp-1',
+    slug: 'test-group',
+    name: 'Test Group',
+    icon: '📦',
+    status: 'active',
+    main_currency: 'USD',
+    created_by: 'user-1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeMembership(
+  userId: string,
+  role: 'admin' | 'user',
+  id = `mem-${userId}`,
+): GroupMembership {
+  return {
+    id,
+    group_id: 'grp-1',
+    member_user_id: userId,
+    role,
+    joined_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+function createTestRouter(): Router {
+  return createRouter({
+    history: createWebHistory(),
+    routes: [
+      { path: '/', component: { template: '<div>home</div>' } },
+      { path: '/no-group', name: 'no-group', component: { template: '<div>no-group</div>' } },
+      {
+        path: '/groups/:groupId/settings',
+        name: 'group-settings',
+        component: GroupSettingsView,
+      },
+    ],
+  })
+}
+
+async function mountView(members: GroupMembership[]): Promise<VueWrapper> {
+  mockedGroupService.getGroup.mockResolvedValueOnce(makeGroup())
+  mockedGroupService.listMembers.mockResolvedValueOnce(members)
+  // listInvites is only called for admins — return empty to keep tests focused.
+  mockedGroupService.listInvites.mockResolvedValueOnce([])
+
+  const router = createTestRouter()
+  await router.push('/groups/grp-1/settings')
+  await router.isReady()
+
+  const wrapper = mount(GroupSettingsView, {
+    global: { plugins: [router] },
+  })
+
+  // loadData() is async; wait for both getGroup and listMembers to settle
+  // before assertions so computed props reflect the loaded membership.
+  await flushPromises()
+  return wrapper
+}
+
+describe('GroupSettingsView — Leave Group action', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockAuthStore.user = { id: 'user-1', name: 'Alice', email: 'alice@example.com' }
+  })
+
+  describe('when the current user is the sole admin (last admin)', () => {
+    it('disables the Leave Group button', async () => {
+      const wrapper = await mountView([
+        makeMembership('user-1', 'admin'),
+        makeMembership('user-2', 'user'),
+      ])
+
+      const leaveBtn = wrapper.get('[data-testid="leave-group-btn"]')
+      expect(leaveBtn.attributes('disabled')).toBeDefined()
+      expect(leaveBtn.attributes('aria-disabled')).toBe('true')
+    })
+
+    it('exposes the tooltip via the title attribute', async () => {
+      const wrapper = await mountView([
+        makeMembership('user-1', 'admin'),
+        makeMembership('user-2', 'user'),
+      ])
+
+      const leaveBtn = wrapper.get('[data-testid="leave-group-btn"]')
+      expect(leaveBtn.attributes('title')).toBe(
+        'You are the last admin. Promote another member first, or delete the group.',
+      )
+    })
+
+    it('suggests promoting a member when one is available', async () => {
+      const wrapper = await mountView([
+        makeMembership('user-1', 'admin'),
+        makeMembership('user-2', 'user'),
+      ])
+
+      const notice = wrapper.get('[data-testid="last-admin-notice"]')
+      expect(notice.text()).toContain('You are the last admin of this group')
+      expect(notice.text()).toContain('Promote another member to admin before leaving')
+      expect(notice.text()).toContain('delete the group below')
+    })
+
+    it('suggests only deletion when no promotable members exist', async () => {
+      // Sole member is also sole admin — nobody to promote.
+      const wrapper = await mountView([makeMembership('user-1', 'admin')])
+
+      const notice = wrapper.get('[data-testid="last-admin-notice"]')
+      expect(notice.text()).not.toContain('Promote another member')
+      expect(notice.text()).toContain('To remove your access, delete the group below')
+    })
+
+    it('does not call leaveGroup when the disabled button is clicked', async () => {
+      const wrapper = await mountView([
+        makeMembership('user-1', 'admin'),
+        makeMembership('user-2', 'user'),
+      ])
+
+      // A native disabled button swallows click events, but we assert the
+      // service call explicitly — if someone later replaces the disabled
+      // attribute with a :class/:aria-disabled-only pattern (common mistake
+      // in a11y-focused rewrites), this test will flag the regression.
+      await wrapper.get('[data-testid="leave-group-btn"]').trigger('click')
+      expect(mockedGroupService.leaveGroup).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when another admin exists', () => {
+    it('keeps the Leave Group button enabled and shows no warning', async () => {
+      const wrapper = await mountView([
+        makeMembership('user-1', 'admin'),
+        makeMembership('user-2', 'admin'),
+      ])
+
+      const leaveBtn = wrapper.get('[data-testid="leave-group-btn"]')
+      expect(leaveBtn.attributes('disabled')).toBeUndefined()
+      expect(leaveBtn.attributes('aria-disabled')).toBeUndefined()
+      expect(wrapper.find('[data-testid="last-admin-notice"]').exists()).toBe(false)
+    })
+  })
+
+  describe('when the current user is not an admin', () => {
+    it('keeps the Leave Group button enabled even if there is only one admin total', async () => {
+      // user-1 is a regular member; user-2 is the sole admin. The last-admin
+      // check must be scoped by role — a non-admin leaving never endangers
+      // the ≥1-admin invariant.
+      const wrapper = await mountView([
+        makeMembership('user-1', 'user'),
+        makeMembership('user-2', 'admin'),
+      ])
+
+      const leaveBtn = wrapper.get('[data-testid="leave-group-btn"]')
+      expect(leaveBtn.attributes('disabled')).toBeUndefined()
+      expect(wrapper.find('[data-testid="last-admin-notice"]').exists()).toBe(false)
+    })
+  })
+})

--- a/go/services/group_service_test.go
+++ b/go/services/group_service_test.go
@@ -211,6 +211,37 @@ func TestGroupService_LeaveGroup(t *testing.T) {
 	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-1"), qt.IsFalse)
 }
 
+func TestGroupService_LeaveGroup_LastAdminProtection(t *testing.T) {
+	c := qt.New(t)
+	svc := newTestGroupService()
+	ctx := context.Background()
+
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	c.Assert(err, qt.IsNil)
+
+	// The sole admin cannot leave — would leave the group without an admin.
+	// ErrorIs guards against the check being skipped in favor of a generic
+	// failure (e.g. NotFound), which would still satisfy IsNotNil but not
+	// the ≥1-admin invariant the endpoint is supposed to defend.
+	err = svc.LeaveGroup(ctx, group.ID, "user-1")
+	c.Assert(err, qt.ErrorIs, services.ErrLastAdmin)
+	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-1"), qt.IsTrue)
+
+	// A non-admin member can still leave even when there's only one admin:
+	// the admin count stays at 1, so the invariant is preserved.
+	_, err = svc.AddMember(ctx, "tenant-1", group.ID, "user-2", models.GroupRoleUser)
+	c.Assert(err, qt.IsNil)
+	err = svc.LeaveGroup(ctx, group.ID, "user-2")
+	c.Assert(err, qt.IsNil)
+
+	// Promoting a second admin unblocks the original admin's leave.
+	_, err = svc.AddMember(ctx, "tenant-1", group.ID, "user-3", models.GroupRoleAdmin)
+	c.Assert(err, qt.IsNil)
+	err = svc.LeaveGroup(ctx, group.ID, "user-1")
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-1"), qt.IsFalse)
+}
+
 func TestGroupService_InviteFlow(t *testing.T) {
 	c := qt.New(t)
 	svc := newTestGroupService()


### PR DESCRIPTION
Closes #1259.

## Summary

- Backend already rejects "last admin leaves" with `422 ErrLastAdmin` (via `GroupService.LeaveGroup` → `RemoveMember`). This PR closes the UX gap where the UI still submitted the doomed request and only surfaced the error after the round-trip.
- When the current user is the sole admin, the **Leave Group** button is now disabled with `aria-disabled`, a `title` tooltip, and an `aria-describedby`-linked sr-only sibling — so mouse, keyboard, and screen-reader users all see the reason.
- Inline notice explains the situation and branches on whether a promotable (non-admin) member exists: with promotable members it recommends promote-then-leave OR delete; without, it recommends delete only (avoids "promote nobody" wording).
- Existing admin Danger Zone (Delete Group) is the recommended remediation path — the notice points straight at it.

## Testing

- **Go service test** (`group_service_test.go`): `TestGroupService_LeaveGroup_LastAdminProtection` asserts via `ErrorIs` that the sole admin is blocked with `ErrLastAdmin`, that a non-admin can still leave (invariant not at risk), and that promoting a second admin unblocks the original.
- **Frontend vitest** (`GroupSettingsView.spec.ts`, new, 7 cases): disabled/enabled branches, tooltip contents, promote-vs-delete message branching, non-admin case, and a regression guard that a click on the disabled button does not invoke `leaveGroup` (catches a11y refactors that drop native `disabled` in favor of class-only states).
- **Playwright UI test** (`groups.spec.ts`): creates a fresh group (caller is sole admin), navigates to `/groups/{id}/settings`, asserts disabled state, `title`/`aria-disabled`, notice text, and Delete Group fallback presence. Existing API-only "cannot remove the last admin" test keeps guarding the bypass path (422).

## Acceptance criteria

- [x] Backend refuses "leave group" when user is the last admin (pre-existing + now directly covered by unit test)
- [x] Frontend disables the action with clear messaging
- [x] Offers a sensible alternative (delete group, or promote-then-leave flow referenced by the notice)
- [x] Covered by e2e tests

## Test plan

- [ ] `cd go && go test ./services/...`
- [ ] `cd frontend && npx vitest run`
- [ ] `cd frontend && npm run build`
- [ ] `cd frontend && npx stylelint src/views/groups/GroupSettingsView.vue`
- [ ] Playwright: `cd e2e && npm run test -- groups.spec.ts` with the stack running

🤖 Generated with [Claude Code](https://claude.com/claude-code)