### PR TITLE
fix(groups): restore ISO 4217 currency dropdown for main currency (closes #1256)

### DIFF
--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -294,6 +294,109 @@ test.describe('Group Members API', () => {
   });
 });
 
+test.describe('Main Currency dropdown (#1256)', () => {
+  // The "main currency" field regressed to a free-text input after the
+  // location-groups rework, which let callers submit typos like "USDD" and
+  // triggered confusing downstream errors. These tests lock in that the UI
+  // only exposes valid ISO 4217 codes, and that the API still rejects an
+  // invalid code for any caller bypassing the dropdown.
+
+  test('group-create form exposes a searchable currency dropdown, not a free-text input', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    await page.goto('/groups/new');
+
+    // The regression was a plain <input type="text" id="main-currency">.
+    // The fix wraps PrimeVue's <Select> around the same id, which renders
+    // as a div.p-select and explicitly not an <input type="text">. Assert
+    // both to prevent silently re-regressing by changing only the markup.
+    const dropdown = page.locator('.p-select#main-currency');
+    await expect(dropdown).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('input[type="text"]#main-currency')).toHaveCount(0);
+
+    // Open the dropdown and confirm a well-known ISO code is offered.
+    // Using EUR (not USD) because USD is the default placeholder — picking
+    // it wouldn't prove the list was actually populated.
+    await dropdown.click();
+    const eurOption = page.locator('.p-select-option-label', { hasText: /^EUR\b/ });
+    await expect(eurOption.first()).toBeVisible({ timeout: 5000 });
+    await eurOption.first().click();
+
+    const groupName = `Currency Dropdown Test ${Date.now()}`;
+    await page.fill('#name', groupName);
+    await page.click('button[type="submit"]:has-text("Create Group")');
+
+    // Successful create navigates away from /groups/new. Wait for that.
+    await page.waitForURL((url) => !url.pathname.endsWith('/groups/new'), { timeout: 10000 });
+
+    // Verify the group was created with EUR via the API (the UI read path
+    // goes through a read-only label on the settings page, so hitting the
+    // API here keeps the assertion narrow and avoids a second navigation).
+    const groupsResp = await request.get('/api/v1/groups', {
+      headers: {
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+      },
+    });
+    const groupsBody = await groupsResp.json();
+    const created = groupsBody.data.find((g: { attributes: { name: string } }) => g.attributes.name === groupName);
+    expect(created, `created group "${groupName}" not found in /api/v1/groups`).toBeDefined();
+    expect(created.attributes.main_currency).toBe('EUR');
+
+    // Clean up so re-runs in a persistent env don't accumulate groups.
+    const deleteResp = await request.delete(`/api/v1/groups/${created.id}`, {
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+        'X-CSRF-Token': csrfToken,
+      },
+      data: { confirm_word: groupName },
+    });
+    expect(deleteResp.status()).toBe(204);
+  });
+
+  test('API rejects an invalid main_currency with 400 (defense in depth behind the dropdown)', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    const resp = await request.post('/api/v1/groups', {
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+        'X-CSRF-Token': csrfToken,
+      },
+      data: {
+        data: {
+          type: 'groups',
+          attributes: {
+            name: `Invalid Currency ${Date.now()}`,
+            main_currency: 'NOPE',
+          },
+        },
+      },
+    });
+
+    // 400 comes from apiserver/groups.go: MainCurrency.IsValid() is false, so
+    // the handler returns badRequest before the group is written. The UI's
+    // dropdown prevents this path for normal users, but the backend check
+    // still guards against a stale client or hand-crafted request.
+    expect(resp.status()).toBe(400);
+  });
+});
+
 test.describe('Leave Group UI — last admin protection (#1259)', () => {
   // These tests cover the frontend half of the contract: the backend already
   // rejects "last admin leaves" with 422 (see the API test above). The UI

--- a/frontend/src/components/CurrencySelect.vue
+++ b/frontend/src/components/CurrencySelect.vue
@@ -1,0 +1,90 @@
+<template>
+  <Select
+    :model-value="modelValue"
+    :options="currencies"
+    option-label="label"
+    option-value="code"
+    :placeholder="loading ? 'Loading currencies…' : 'Select a currency'"
+    :disabled="loading"
+    :filter="true"
+    filter-placeholder="Type to search (e.g. USD, Euro)"
+    :auto-filter-focus="true"
+    class="currency-select w-100"
+    @update:model-value="onUpdate"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import Select from 'primevue/select'
+import settingsService from '@/services/settingsService'
+
+interface CurrencyOption {
+  code: string
+  label: string
+}
+
+const props = withDefaults(defineProps<{
+  modelValue: string
+  defaultCurrency?: string
+}>(), {
+  defaultCurrency: 'USD',
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const currencies = ref<CurrencyOption[]>([])
+const loading = ref(true)
+
+function onUpdate(value: string) {
+  emit('update:modelValue', value)
+}
+
+onMounted(async () => {
+  try {
+    const response = await settingsService.getCurrencies()
+    const codes: string[] = response.data || []
+    // Intl.DisplayNames gives the localized currency name (e.g. "US Dollar").
+    // Failing gracefully per-code is important: bojanz/currency includes a
+    // handful of historical/obscure ISO codes that Intl may not recognize —
+    // we keep them in the list with just the code as the label rather than
+    // dropping them entirely.
+    const names = new Intl.DisplayNames(['en'], { type: 'currency' })
+    currencies.value = codes
+      .map((code) => {
+        let label = code
+        try {
+          const name = names.of(code)
+          if (name && name !== code) {
+            label = `${code} — ${name}`
+          }
+        } catch { /* fall through: use bare code */ }
+        return { code, label }
+      })
+      .sort((a, b) => a.code.localeCompare(b.code))
+
+    // Seed the default so the caller never submits an empty main_currency
+    // when the user accepts the form as-is. Only apply when the caller hasn't
+    // already set a value (e.g. editing an existing group in the future).
+    if (!props.modelValue) {
+      emit('update:modelValue', props.defaultCurrency)
+    }
+  } catch (err) {
+    // A failed fetch leaves the dropdown empty; the caller sees a disabled
+    // control and can retry. We don't want to silently fall back to a
+    // hardcoded list here — that would re-introduce the very regression this
+    // component exists to fix.
+    console.error('Failed to load currencies', err)
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped lang="scss">
+.currency-select {
+  width: 100%;
+}
+</style>

--- a/frontend/src/components/CurrencySelect.vue
+++ b/frontend/src/components/CurrencySelect.vue
@@ -9,6 +9,8 @@
     :filter="true"
     filter-placeholder="Type to search (e.g. USD, Euro)"
     :auto-filter-focus="true"
+    :show-clear="false"
+    aria-label="Currency"
     class="currency-select w-100"
     @update:model-value="onUpdate"
   />
@@ -42,27 +44,48 @@ function onUpdate(value: string) {
   emit('update:modelValue', value)
 }
 
+function formatLabel(code: string, names: Intl.DisplayNames): string {
+  let name: string | undefined
+  try {
+    name = names.of(code)
+  } catch { /* leave name undefined */ }
+
+  let symbol: string | undefined
+  try {
+    const parts = new Intl.NumberFormat('en', {
+      style: 'currency',
+      currency: code,
+      currencyDisplay: 'narrowSymbol',
+    }).formatToParts(0)
+    const part = parts.find((p) => p.type === 'currency')
+    if (part && part.value && part.value !== code) {
+      symbol = part.value
+    }
+  } catch { /* leave symbol undefined */ }
+
+  if (!name || name === code) {
+    // Intl couldn't localize — fall back to the bare code so the entry
+    // stays useful instead of appearing as a duplicate in the list.
+    return code
+  }
+  return symbol ? `${code} — ${name} (${symbol})` : `${code} — ${name}`
+}
+
 onMounted(async () => {
   try {
     const response = await settingsService.getCurrencies()
     const codes: string[] = response.data || []
-    // Intl.DisplayNames gives the localized currency name (e.g. "US Dollar").
-    // Failing gracefully per-code is important: bojanz/currency includes a
-    // handful of historical/obscure ISO codes that Intl may not recognize —
-    // we keep them in the list with just the code as the label rather than
-    // dropping them entirely.
+    // Labels follow the format spelled out in issue #1256's acceptance
+    // criteria: `CODE — Name (symbol)`, e.g. `EUR — Euro (€)`. The symbol
+    // falls out of Intl.NumberFormat's parts; when it matches the code
+    // verbatim (common for minor / historical currencies) we omit the
+    // parenthesised segment rather than print `USD — US Dollar (USD)`.
+    // Each lookup is guarded because bojanz/currency lists a handful of
+    // codes Intl doesn't recognise — we keep them in the dropdown with
+    // a bare-code label so they remain selectable.
     const names = new Intl.DisplayNames(['en'], { type: 'currency' })
     currencies.value = codes
-      .map((code) => {
-        let label = code
-        try {
-          const name = names.of(code)
-          if (name && name !== code) {
-            label = `${code} — ${name}`
-          }
-        } catch { /* fall through: use bare code */ }
-        return { code, label }
-      })
+      .map((code) => ({ code, label: formatLabel(code, names) }))
       .sort((a, b) => a.code.localeCompare(b.code))
 
     // Seed the default so the caller never submits an empty main_currency

--- a/frontend/src/views/groups/GroupCreateView.vue
+++ b/frontend/src/views/groups/GroupCreateView.vue
@@ -13,15 +13,11 @@
       </div>
       <div class="form-group">
         <label for="main-currency">Main Currency</label>
-        <input
+        <CurrencySelect
           id="main-currency"
           v-model="mainCurrency"
-          type="text"
-          class="form-input"
-          placeholder="USD"
-          maxlength="3"
         />
-        <small>ISO 4217 code (e.g. USD, EUR, CZK). Defaults to USD. Immutable after creation — see <a href="https://github.com/denisvmedia/inventario/issues/202" target="_blank" rel="noopener">#202</a>.</small>
+        <small>Defaults to USD. Immutable after creation — see <a href="https://github.com/denisvmedia/inventario/issues/202" target="_blank" rel="noopener">#202</a>.</small>
       </div>
       <div class="form-actions">
         <button type="button" class="btn btn-secondary" @click="router.back()">Cancel</button>
@@ -38,6 +34,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useGroupStore } from '@/stores/groupStore'
+import CurrencySelect from '@/components/CurrencySelect.vue'
 
 const router = useRouter()
 const groupStore = useGroupStore()

--- a/frontend/src/views/groups/NoGroupView.vue
+++ b/frontend/src/views/groups/NoGroupView.vue
@@ -36,16 +36,12 @@
         </div>
         <div class="form-group">
           <label for="group-currency">Main Currency</label>
-          <input
+          <CurrencySelect
             id="group-currency"
             v-model="groupCurrency"
-            type="text"
-            class="form-input"
-            placeholder="USD"
-            maxlength="3"
           />
           <small class="no-group__hint">
-            ISO 4217 code (USD, EUR, CZK, …). Defaults to USD. Immutable after creation — see
+            Defaults to USD. Immutable after creation — see
             <a href="https://github.com/denisvmedia/inventario/issues/202" target="_blank" rel="noopener">#202</a>.
           </small>
         </div>
@@ -65,6 +61,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useGroupStore } from '@/stores/groupStore'
+import CurrencySelect from '@/components/CurrencySelect.vue'
 
 const groupStore = useGroupStore()
 const router = useRouter()


### PR DESCRIPTION
## Summary

- Replace the free-text main-currency input in the location-group create flow with a searchable PrimeVue `Select` backed by `/api/v1/currencies`. Labels are produced by `Intl.DisplayNames` (e.g. `EUR — Euro`); default is `USD` to match the backend default.
- Shared `CurrencySelect` component reused by both `GroupCreateView` and `NoGroupView`, so both entry points get the fix.
- E2E coverage in `groups.spec.ts`: asserts the dropdown is rendered (and the old `input[type="text"]#main-currency` is not), selects EUR end-to-end and verifies the stored `main_currency`, and keeps an API-level check that an invalid code (`NOPE`) still returns 400.

## Why

Before the location-groups rework the main currency was a dropdown; it regressed to free text, which allowed typos (`USDD`, `EURO`, …) and surfaced as a generic "cannot create group" error downstream. Closes #1256.

## Test plan

- [x] `npm run lint:js` — no new errors
- [x] `npm run lint:styles` — clean for the touched files
- [x] `npm run build`
- [x] `npm run test` (vitest, 362 passing)
- [x] `tsc --noEmit` in `e2e/`
- [ ] Playwright run against the live stack (not executed locally — CI will cover it)
- [ ] Manual check: `/groups/new` and the "no groups yet" landing page both show the dropdown and let the user pick a currency