### PR TITLE
feat(groups): prevent removing the last admin via UI (#1257)

### DIFF
--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -397,6 +397,166 @@ test.describe('Main Currency dropdown (#1256)', () => {
   });
 });
 
+test.describe('Remove Member — last admin protection (#1257)', () => {
+  // Parallel to the "leave group" protection (#1259), an admin removing
+  // another user via DELETE /api/v1/groups/{id}/members/{userId} must also
+  // refuse to strip the group's last admin. Coverage here is split: an
+  // API-level assertion nails down the 422, and a UI assertion confirms the
+  // Remove button is pre-emptively disabled so no doomed request is ever
+  // submitted.
+
+  test('API refuses DELETE /members/{id} for the sole admin with 422', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    // Create a fresh group so the caller is the only admin and only member.
+    const groupName = `Last Admin Remove API Test ${Date.now()}`;
+    const createResp = await request.post('/api/v1/groups', {
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+        'X-CSRF-Token': csrfToken,
+      },
+      data: {
+        data: {
+          type: 'groups',
+          attributes: { name: groupName, icon: '🛡️' },
+        },
+      },
+    });
+    expect(createResp.status(), await createResp.text()).toBe(201);
+    const groupId = (await createResp.json()).data.id;
+
+    try {
+      // Discover the admin's member_user_id from the membership listing
+      // rather than decoding the JWT — the API is the contract surface the
+      // UI relies on, and this keeps the test independent of token format.
+      const membersResp = await request.get(`/api/v1/groups/${groupId}/members`, {
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+      });
+      expect(membersResp.status()).toBe(200);
+      const membersBody = await membersResp.json();
+      const admin = membersBody.data.find((m: { attributes: { role: string } }) => m.attributes.role === 'admin');
+      expect(admin, 'fresh group must have an admin').toBeDefined();
+      const adminUserId = admin.attributes.member_user_id;
+
+      // Remove-the-last-admin must map to 422 ErrLastAdmin, not a generic
+      // failure mode. Asserting the exact status guards against auth or CSRF
+      // misconfiguration silently passing the test with e.g. 401/403.
+      const removeResp = await request.delete(
+        `/api/v1/groups/${groupId}/members/${adminUserId}`,
+        {
+          headers: {
+            'Content-Type': 'application/vnd.api+json',
+            'Accept': 'application/vnd.api+json',
+            'Authorization': `Bearer ${authToken}`,
+            'X-CSRF-Token': csrfToken,
+          },
+        },
+      );
+      expect(removeResp.status()).toBe(422);
+
+      // The member must still be in the group — the endpoint is supposed to
+      // reject atomically, not partially strip state before failing.
+      const afterResp = await request.get(`/api/v1/groups/${groupId}/members`, {
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+      });
+      const afterBody = await afterResp.json();
+      expect(afterBody.data.some((m: { attributes: { member_user_id: string } }) => m.attributes.member_user_id === adminUserId)).toBe(true);
+    } finally {
+      const deleteResp = await request.delete(`/api/v1/groups/${groupId}`, {
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { confirm_word: groupName },
+      });
+      expect(deleteResp.status()).toBe(204);
+    }
+  });
+
+  test('Remove button on the sole admin is disabled with tooltip', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    // Fresh group so the caller is the only admin — makes the
+    // "last admin" state deterministic independent of the seed.
+    const groupName = `Last Admin Remove UI Test ${Date.now()}`;
+    const createResp = await request.post('/api/v1/groups', {
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+        'X-CSRF-Token': csrfToken,
+      },
+      data: {
+        data: {
+          type: 'groups',
+          attributes: { name: groupName, icon: '🛡️' },
+        },
+      },
+    });
+    expect(createResp.status(), await createResp.text()).toBe(201);
+    const groupId = (await createResp.json()).data.id;
+
+    try {
+      const membersResp = await request.get(`/api/v1/groups/${groupId}/members`, {
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+      });
+      const membersBody = await membersResp.json();
+      const admin = membersBody.data.find((m: { attributes: { role: string } }) => m.attributes.role === 'admin');
+      const adminUserId = admin.attributes.member_user_id;
+
+      await page.goto(`/groups/${groupId}/settings`);
+
+      const removeBtn = page.locator(`[data-testid="remove-member-btn-${adminUserId}"]`);
+      await expect(removeBtn).toBeVisible({ timeout: 10000 });
+
+      // Native disabled + aria-disabled + title: mouse, keyboard, and
+      // screen-reader users all learn the Remove action is blocked and why.
+      await expect(removeBtn).toBeDisabled();
+      await expect(removeBtn).toHaveAttribute('aria-disabled', 'true');
+      await expect(removeBtn).toHaveAttribute(
+        'title',
+        'Cannot remove the last admin — promote another member first or delete the group.',
+      );
+    } finally {
+      const deleteResp = await request.delete(`/api/v1/groups/${groupId}`, {
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { confirm_word: groupName },
+      });
+      expect(deleteResp.status()).toBe(204);
+    }
+  });
+});
+
 test.describe('Leave Group UI — last admin protection (#1259)', () => {
   // These tests cover the frontend half of the contract: the backend already
   // rejects "last admin leaves" with 422 (see the API test above). The UI

--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -527,6 +527,7 @@ test.describe('Remove Member — last admin protection (#1257)', () => {
       });
       const membersBody = await membersResp.json();
       const admin = membersBody.data.find((m: { attributes: { role: string } }) => m.attributes.role === 'admin');
+      expect(admin, 'fresh group must have an admin').toBeDefined();
       const adminUserId = admin.attributes.member_user_id;
 
       await page.goto(`/groups/${groupId}/settings`);

--- a/frontend/src/views/groups/GroupSettingsView.vue
+++ b/frontend/src/views/groups/GroupSettingsView.vue
@@ -79,7 +79,11 @@
             </div>
           </div>
         </div>
-        <span id="remove-last-admin-desc" class="sr-only">{{ REMOVE_LAST_ADMIN_TOOLTIP }}</span>
+        <!-- Rendered only when a disabled Remove button references it, so the
+             description doesn't leak into the accessibility tree on pages
+             where no such button exists (multiple admins, or non-admin
+             viewers who don't see the actions block at all). -->
+        <span v-if="isAdmin && adminCount === 1" id="remove-last-admin-desc" class="sr-only">{{ REMOVE_LAST_ADMIN_TOOLTIP }}</span>
       </section>
 
       <!-- Invites -->

--- a/frontend/src/views/groups/GroupSettingsView.vue
+++ b/frontend/src/views/groups/GroupSettingsView.vue
@@ -57,10 +57,29 @@
                 <option value="admin">Admin</option>
                 <option value="user">User</option>
               </select>
-              <button class="btn btn-danger btn-small" @click="removeMember(member.member_user_id)">Remove</button>
+              <button
+                v-if="isLastAdminMember(member)"
+                class="btn btn-danger btn-small"
+                disabled
+                aria-disabled="true"
+                aria-describedby="remove-last-admin-desc"
+                :title="REMOVE_LAST_ADMIN_TOOLTIP"
+                :data-testid="`remove-member-btn-${member.member_user_id}`"
+              >
+                Remove
+              </button>
+              <button
+                v-else
+                class="btn btn-danger btn-small"
+                :data-testid="`remove-member-btn-${member.member_user_id}`"
+                @click="removeMember(member.member_user_id)"
+              >
+                Remove
+              </button>
             </div>
           </div>
         </div>
+        <span id="remove-last-admin-desc" class="sr-only">{{ REMOVE_LAST_ADMIN_TOOLTIP }}</span>
       </section>
 
       <!-- Invites -->
@@ -190,6 +209,18 @@ const isLastAdmin = computed(() => isAdmin.value && adminCount.value === 1)
 const hasPromotableMembers = computed(() => members.value.some((m) => m.role === 'user'))
 
 const LAST_ADMIN_TOOLTIP = 'You are the last admin. Promote another member first, or delete the group.'
+
+// Mirror of the backend ≥1-admin invariant for the member list: if the target
+// is an admin AND there is only one admin, removing them would leave the
+// group unmanageable. The backend rejects such requests with 422
+// ErrLastAdmin — this predicate is the UI-side gate so the Remove button is
+// disabled up-front instead of only after a failed round-trip.
+function isLastAdminMember(member: GroupMembership): boolean {
+  return member.role === 'admin' && adminCount.value === 1
+}
+
+const REMOVE_LAST_ADMIN_TOOLTIP =
+  'Cannot remove the last admin — promote another member first or delete the group.'
 
 async function loadData() {
   loading.value = true

--- a/frontend/src/views/groups/__tests__/GroupSettingsView.spec.ts
+++ b/frontend/src/views/groups/__tests__/GroupSettingsView.spec.ts
@@ -231,25 +231,6 @@ describe('GroupSettingsView — Remove Member action', () => {
     )
   })
 
-  it('disables Remove for the sole admin even when they are not the viewer', async () => {
-    // Two admins total would allow removing either; here user-2 is the
-    // single admin but user-1 (viewer) is a demoted admin. Even though the
-    // viewer can't currently be in this state via the UI (they'd fail the
-    // isAdmin guard around the section), the predicate itself must be
-    // correct: "last admin" is a property of the target, not the viewer.
-    // We assert the viewer-is-admin path below; this case is kept as a
-    // guard in case the component is ever reused in a different access path.
-    mockAuthStore.user = { id: 'user-1', name: 'Alice', email: 'alice@example.com' }
-    const wrapper = await mountView([
-      makeMembership('user-1', 'admin'),
-      makeMembership('user-2', 'user'),
-      makeMembership('user-3', 'user'),
-    ])
-
-    const soleAdminBtn = wrapper.get('[data-testid="remove-member-btn-user-1"]')
-    expect(soleAdminBtn.attributes('disabled')).toBeDefined()
-  })
-
   it('enables Remove for non-admin members even when only one admin exists', async () => {
     const wrapper = await mountView([
       makeMembership('user-1', 'admin'),

--- a/frontend/src/views/groups/__tests__/GroupSettingsView.spec.ts
+++ b/frontend/src/views/groups/__tests__/GroupSettingsView.spec.ts
@@ -207,3 +207,84 @@ describe('GroupSettingsView — Leave Group action', () => {
     })
   })
 })
+
+describe('GroupSettingsView — Remove Member action', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    // The viewer is user-1, an admin, so the member-actions block renders
+    // for every row. The protection being tested here is about the *target*
+    // of the Remove action — orthogonal to who is clicking.
+    mockAuthStore.user = { id: 'user-1', name: 'Alice', email: 'alice@example.com' }
+  })
+
+  it('disables Remove for the sole admin (same user as the viewer)', async () => {
+    const wrapper = await mountView([
+      makeMembership('user-1', 'admin'),
+      makeMembership('user-2', 'user'),
+    ])
+
+    const btn = wrapper.get('[data-testid="remove-member-btn-user-1"]')
+    expect(btn.attributes('disabled')).toBeDefined()
+    expect(btn.attributes('aria-disabled')).toBe('true')
+    expect(btn.attributes('title')).toBe(
+      'Cannot remove the last admin — promote another member first or delete the group.',
+    )
+  })
+
+  it('disables Remove for the sole admin even when they are not the viewer', async () => {
+    // Two admins total would allow removing either; here user-2 is the
+    // single admin but user-1 (viewer) is a demoted admin. Even though the
+    // viewer can't currently be in this state via the UI (they'd fail the
+    // isAdmin guard around the section), the predicate itself must be
+    // correct: "last admin" is a property of the target, not the viewer.
+    // We assert the viewer-is-admin path below; this case is kept as a
+    // guard in case the component is ever reused in a different access path.
+    mockAuthStore.user = { id: 'user-1', name: 'Alice', email: 'alice@example.com' }
+    const wrapper = await mountView([
+      makeMembership('user-1', 'admin'),
+      makeMembership('user-2', 'user'),
+      makeMembership('user-3', 'user'),
+    ])
+
+    const soleAdminBtn = wrapper.get('[data-testid="remove-member-btn-user-1"]')
+    expect(soleAdminBtn.attributes('disabled')).toBeDefined()
+  })
+
+  it('enables Remove for non-admin members even when only one admin exists', async () => {
+    const wrapper = await mountView([
+      makeMembership('user-1', 'admin'),
+      makeMembership('user-2', 'user'),
+    ])
+
+    const btn = wrapper.get('[data-testid="remove-member-btn-user-2"]')
+    expect(btn.attributes('disabled')).toBeUndefined()
+    expect(btn.attributes('aria-disabled')).toBeUndefined()
+  })
+
+  it('enables Remove for admins once a second admin exists', async () => {
+    // Both admins are removable — dropping either keeps the admin count ≥ 1.
+    const wrapper = await mountView([
+      makeMembership('user-1', 'admin'),
+      makeMembership('user-2', 'admin'),
+    ])
+
+    const btn1 = wrapper.get('[data-testid="remove-member-btn-user-1"]')
+    const btn2 = wrapper.get('[data-testid="remove-member-btn-user-2"]')
+    expect(btn1.attributes('disabled')).toBeUndefined()
+    expect(btn2.attributes('disabled')).toBeUndefined()
+  })
+
+  it('does not call removeMember when the disabled Remove button is clicked', async () => {
+    const wrapper = await mountView([
+      makeMembership('user-1', 'admin'),
+      makeMembership('user-2', 'user'),
+    ])
+
+    // Regression guard: if a future a11y refactor drops the native `disabled`
+    // attribute in favor of class-only styling, the click handler would fire
+    // and issue a doomed request that the backend rejects with 422. This
+    // assertion locks the UI gate in place.
+    await wrapper.get('[data-testid="remove-member-btn-user-1"]').trigger('click')
+    expect(mockedGroupService.removeMember).not.toHaveBeenCalled()
+  })
+})

--- a/go/services/group_service_test.go
+++ b/go/services/group_service_test.go
@@ -145,17 +145,27 @@ func TestGroupService_RemoveMember_LastAdminProtection(t *testing.T) {
 	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
 	c.Assert(err, qt.IsNil)
 
-	// Cannot remove the last admin
+	// The sole admin cannot be removed — would leave the group without an
+	// admin. ErrorIs guards against the check being skipped in favor of a
+	// generic failure (e.g. NotFound), which would still satisfy IsNotNil but
+	// not the ≥1-admin invariant the endpoint is supposed to defend.
 	err = svc.RemoveMember(ctx, group.ID, "user-1")
-	c.Assert(err, qt.IsNotNil)
+	c.Assert(err, qt.ErrorIs, services.ErrLastAdmin)
+	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-1"), qt.IsTrue)
 
-	// Add a second admin
-	_, err = svc.AddMember(ctx, "tenant-1", group.ID, "user-2", models.GroupRoleAdmin)
+	// A non-admin member can still be removed even when there's only one
+	// admin: the admin count stays at 1, so the invariant is preserved.
+	_, err = svc.AddMember(ctx, "tenant-1", group.ID, "user-2", models.GroupRoleUser)
+	c.Assert(err, qt.IsNil)
+	err = svc.RemoveMember(ctx, group.ID, "user-2")
 	c.Assert(err, qt.IsNil)
 
-	// Now we can remove the first admin
+	// Once a second admin exists the original admin can be removed.
+	_, err = svc.AddMember(ctx, "tenant-1", group.ID, "user-3", models.GroupRoleAdmin)
+	c.Assert(err, qt.IsNil)
 	err = svc.RemoveMember(ctx, group.ID, "user-1")
 	c.Assert(err, qt.IsNil)
+	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-1"), qt.IsFalse)
 }
 
 func TestGroupService_UpdateMemberRole(t *testing.T) {


### PR DESCRIPTION
Closes #1257.

## Summary

Parallel to #1259/#1270, which gated the "leave group" path, this closes the same gap for the admin-facing **Remove member** path. The backend already rejects the request with `422 ErrLastAdmin` (`GroupService.RemoveMember`); this PR prevents the doomed request from ever being submitted and explains *why* to mouse, keyboard, and screen-reader users.

## Backend

- `TestGroupService_RemoveMember_LastAdminProtection` upgraded from `qt.IsNotNil` to `qt.ErrorIs(err, services.ErrLastAdmin)` — the invariant must be enforced by the specific sentinel, not just "any error." Also extends coverage to:
  - Non-admin member removal when only one admin exists (invariant not at risk)
  - Admin removal unblocked once a second admin exists

  Mirrors the structure of `TestGroupService_LeaveGroup_LastAdminProtection`.

## Frontend

- New `isLastAdminMember(member)` predicate on `GroupSettingsView.vue`, scoped by the *target's* role plus the group's admin count — **not** by the viewer — so the gate is correct regardless of who is performing the action.
- Remove button renders disabled with `aria-disabled="true"`, a `title` tooltip, and an `aria-describedby`-linked `sr-only` sibling (matches the Leave Group pattern from #1270). The sr-only description is itself gated on `isAdmin && adminCount === 1` so it never sits in the a11y tree when no disabled button references it.
- `data-testid="remove-member-btn-{user_id}"` on each button for deterministic selection from tests.

## Testing

- **Go service test** (`go/services/group_service_test.go`): upgraded & extended as above.
- **Frontend vitest** (`GroupSettingsView.spec.ts`, +4 cases in a new `describe`): disabled on sole admin with tooltip text, enabled on non-admin members, enabled on both admins once two exist, regression guard that clicks on the disabled button don't invoke `removeMember`.
- **Playwright e2e** (`e2e/tests/groups.spec.ts`, +2 tests):
  - API-level: `DELETE /api/v1/groups/{id}/members/{userId}` on the sole admin returns 422 and membership is preserved (atomic rejection).
  - UI-level: fresh group → settings page → Remove button for the sole admin has `disabled`, `aria-disabled="true"`, and the expected `title`.

## Acceptance criteria

- [x] Backend refuses the operation with descriptive error (pre-existing, now directly covered by `ErrorIs`)
- [x] Frontend disables the Remove action on the last admin
- [x] Error surfaced clearly in UI (tooltip + sr-only description; inline error still rendered for any backend-only edge case via existing `error` ref)
- [x] Covered by e2e tests (API + UI)

## Test plan

- [ ] `cd go && go test ./services/...`
- [ ] `cd frontend && npx vitest run`
- [ ] `cd frontend && npm run build`
- [ ] `cd frontend && npx stylelint src/views/groups/GroupSettingsView.vue`
- [ ] `cd e2e && npx tsc --noEmit`
- [ ] Playwright: `cd e2e && npm run test -- groups.spec.ts` with the stack running