### PR TITLE
feat(groups): persist current group selection across refresh (closes #1262)

### DIFF
--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -792,11 +792,18 @@ test.describe('Group selection persistence (#1262)', () => {
     await page.reload();
     await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
 
+    // The Ghost snapshot is rehydrated synchronously on first paint, so the
+    // selector initially shows "Ghost Group" and then swaps to a real group
+    // once fetchGroups() + restoreFromStorage() reconcile. Poll until the
+    // swap has happened rather than asserting on the first frame — otherwise
+    // the test races the bootstrap and flakes.
+    await expect(page.locator('.group-selector__name')).not.toHaveText('Ghost Group', {
+      timeout: 10000,
+    });
+
     // Fallback kicked in: the selector shows *some* real group the user
-    // actually has, never the planted Ghost Group and never the empty
-    // "Select Group" placeholder.
+    // actually has, never the "Select Group" placeholder.
     const displayedName = await page.locator('.group-selector__name').textContent();
-    expect(displayedName).not.toBe('Ghost Group');
     expect(displayedName).not.toBe('Select Group');
     expect(displayedName?.trim().length ?? 0).toBeGreaterThan(0);
 

--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -637,3 +637,187 @@ test.describe('Leave Group UI — last admin protection (#1259)', () => {
     }
   });
 });
+
+test.describe('Group selection persistence (#1262)', () => {
+  // The header's current-group selector used to reset to "Select Group"
+  // on every browser refresh because the chosen group wasn't persisted
+  // client-side. These tests lock in the acceptance criteria from #1262:
+  //   1. Selection survives a full page reload.
+  //   2. If the stored group is no longer accessible (deleted, user
+  //      removed), the UI falls back to an available group instead of
+  //      getting stuck on an empty selector.
+
+  test('selected group is preserved across a browser refresh', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    // Create a second group so the test exercises an explicit user choice
+    // rather than the default-group fallback (which would pass even without
+    // any persistence — a false-positive trap).
+    const groupName = `Persistence Test ${Date.now()}`;
+    const createResp = await request.post('/api/v1/groups', {
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+        'X-CSRF-Token': csrfToken,
+      },
+      data: {
+        data: {
+          type: 'groups',
+          attributes: { name: groupName, icon: '🧷' },
+        },
+      },
+    });
+    expect(createResp.status(), await createResp.text()).toBe(201);
+    const createdGroupId = (await createResp.json()).data.id as string;
+
+    try {
+      // The GroupSelector consumes store state; make sure the store has
+      // fetched the just-created group before we try to click it.
+      await page.goto('/');
+      await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
+
+      // Open the dropdown and switch to the new group. selectGroup() in
+      // GroupSelector.vue triggers window.location.reload() to refetch
+      // group-scoped data — wait for the reload to settle before asserting.
+      await page.click('.group-selector__trigger');
+      const targetItem = page.locator('.group-selector__item', { hasText: groupName });
+      await expect(targetItem).toBeVisible({ timeout: 5000 });
+
+      const reloadAfterSwitch = page.waitForLoadState('load');
+      await targetItem.click();
+      await reloadAfterSwitch;
+
+      await expect(page.locator('.group-selector__name')).toHaveText(groupName, { timeout: 10000 });
+
+      // The core of the bug: force a fresh browser load (not an SPA
+      // navigation) and assert the selection survived. If persistence
+      // regresses, the selector reverts to the default group or to the
+      // "Select Group" placeholder.
+      await page.reload();
+      await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
+      await expect(page.locator('.group-selector__name')).toHaveText(groupName);
+
+      // And the persisted value must actually be in localStorage — guards
+      // against a future change that relies on an in-memory-only cache and
+      // happens to pass the UI assertion because the page hasn't fully
+      // unmounted the store between reload() calls.
+      const persisted = await page.evaluate(() =>
+        localStorage.getItem('inventario_current_group'),
+      );
+      expect(persisted, 'currentGroup snapshot must live in localStorage').not.toBeNull();
+      const parsed = JSON.parse(persisted as string);
+      expect(parsed.id).toBe(createdGroupId);
+      expect(parsed.name).toBe(groupName);
+    } finally {
+      // Switch the store away from the test group before deleting it so
+      // that cleanup doesn't leave the UI on a now-nonexistent group.
+      const groupsResp = await request.get('/api/v1/groups', {
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+      });
+      const groupsBody = await groupsResp.json();
+      const other = groupsBody.data.find((g: { id: string }) => g.id !== createdGroupId);
+      if (other) {
+        await page.evaluate(
+          ({ snapshot }) => {
+            localStorage.setItem('inventario_current_group', JSON.stringify(snapshot));
+          },
+          {
+            snapshot: {
+              id: other.id,
+              slug: other.attributes.slug,
+              name: other.attributes.name,
+              icon: other.attributes.icon,
+              status: other.attributes.status,
+              main_currency: other.attributes.main_currency,
+              created_by: other.attributes.created_by,
+              created_at: other.attributes.created_at,
+              updated_at: other.attributes.updated_at,
+            },
+          },
+        );
+      }
+
+      const deleteResp = await request.delete(`/api/v1/groups/${createdGroupId}`, {
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { confirm_word: groupName },
+      });
+      expect(deleteResp.status()).toBe(204);
+    }
+  });
+
+  test('falls back to an available group when the stored selection is no longer accessible', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    // Plant a snapshot that references a group the user is not a member of
+    // (random id + slug). On bootstrap, restoreFromStorage() must recognize
+    // the mismatch and swap in the first available group instead of leaving
+    // the selector showing "Select Group".
+    await page.evaluate(() => {
+      localStorage.setItem(
+        'inventario_current_group',
+        JSON.stringify({
+          id: 'grp-nonexistent-0000000000000000',
+          slug: 'nonexistent-slug-aaaaaaaaaaaaaa',
+          name: 'Ghost Group',
+          icon: '👻',
+          status: 'active',
+          main_currency: 'USD',
+          created_by: 'user-x',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        }),
+      );
+    });
+
+    await page.reload();
+    await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
+
+    // Fallback kicked in: the selector shows *some* real group the user
+    // actually has, never the planted Ghost Group and never the empty
+    // "Select Group" placeholder.
+    const displayedName = await page.locator('.group-selector__name').textContent();
+    expect(displayedName).not.toBe('Ghost Group');
+    expect(displayedName).not.toBe('Select Group');
+    expect(displayedName?.trim().length ?? 0).toBeGreaterThan(0);
+
+    // The stale snapshot must be overwritten so a subsequent refresh
+    // doesn't replay the mismatch path every time.
+    const persisted = await page.evaluate(() =>
+      localStorage.getItem('inventario_current_group'),
+    );
+    const parsed = JSON.parse(persisted as string);
+    expect(parsed.id).not.toBe('grp-nonexistent-0000000000000000');
+
+    // Cross-check with the API: the resolved group really belongs to the
+    // user. Guards against a bug where fallback picks a bogus placeholder.
+    const groupsResp = await request.get('/api/v1/groups', {
+      headers: {
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+      },
+    });
+    const groupsBody = await groupsResp.json();
+    const ids = groupsBody.data.map((g: { id: string }) => g.id);
+    expect(ids).toContain(parsed.id);
+  });
+});

--- a/frontend/src/stores/__tests__/groupStore.spec.ts
+++ b/frontend/src/stores/__tests__/groupStore.spec.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import groupService from '@/services/groupService'
+import type { GroupMembership, LocationGroup } from '@/types/group'
+
+// The store talks to groupService for API data and to authStore for the
+// current user id (used by loadCurrentMembership). Mocking both keeps the
+// tests focused on the persistence + reconciliation logic introduced for
+// #1262 — "Current group selection lost on page refresh".
+
+vi.mock('@/services/groupService', () => ({
+  default: {
+    listGroups: vi.fn(),
+    listMembers: vi.fn(),
+    createGroup: vi.fn(),
+    updateGroup: vi.fn(),
+  },
+}))
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({ user: { id: 'user-1' } }),
+}))
+
+const mockedGroupService = vi.mocked(groupService)
+
+const STORAGE_KEY_CURRENT_GROUP = 'inventario_current_group'
+const STORAGE_KEY_GROUP_SLUG_LEGACY = 'currentGroupSlug'
+
+function makeGroup(overrides: Partial<LocationGroup> = {}): LocationGroup {
+  return {
+    id: 'grp-1',
+    slug: 'home',
+    name: 'Home',
+    icon: '🏠',
+    status: 'active',
+    main_currency: 'USD',
+    created_by: 'user-1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeMembership(userId: string, role: 'admin' | 'user' = 'admin'): GroupMembership {
+  return {
+    id: `mem-${userId}`,
+    group_id: 'grp-1',
+    member_user_id: userId,
+    role,
+    joined_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+// The groupStore reads localStorage synchronously at state-initialization
+// time (to pre-seed currentGroup before the first render). That means the
+// localStorage value set inside a test is only picked up if the module is
+// re-imported fresh — hence resetModules() + dynamic import in each test
+// that depends on the initial snapshot behavior.
+async function freshStore(): Promise<ReturnType<typeof import('@/stores/groupStore').useGroupStore>> {
+  vi.resetModules()
+  const { useGroupStore } = await import('@/stores/groupStore')
+  setActivePinia(createPinia())
+  return useGroupStore()
+}
+
+describe('groupStore — localStorage persistence (#1262)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('initial state rehydration from snapshot', () => {
+    it('seeds currentGroup from a stored snapshot before any API call', async () => {
+      // Simulates a page refresh for a user who previously selected a group.
+      // The header's GroupSelector must render the group name immediately on
+      // mount — not wait for /api/v1/groups to resolve — otherwise the user
+      // sees a "Select Group" flash (the symptom reported in #1262).
+      const stored = makeGroup({ id: 'grp-7', slug: 'office', name: 'Office', icon: '🏢' })
+      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(stored))
+
+      const store = await freshStore()
+
+      expect(store.currentGroup).toEqual(stored)
+      expect(store.currentGroupId).toBe('grp-7')
+      expect(store.currentGroupSlug).toBe('office')
+      expect(store.currentGroupName).toBe('Office')
+      expect(store.currentGroupIcon).toBe('🏢')
+      // The full groups list hasn't loaded yet, so the selector's dropdown is
+      // still hidden (gated by hasGroups). Reconciliation happens in
+      // restoreFromStorage() once fetchGroups() resolves.
+      expect(store.hasGroups).toBe(false)
+    })
+
+    it('starts with null currentGroup when no snapshot exists', async () => {
+      const store = await freshStore()
+      expect(store.currentGroup).toBeNull()
+    })
+
+    it('ignores a malformed snapshot instead of crashing', async () => {
+      // A corrupted or partial JSON blob must not prevent the app from
+      // booting — return null and fall through to the normal fetch flow.
+      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, 'not-valid-json')
+      const store = await freshStore()
+      expect(store.currentGroup).toBeNull()
+    })
+
+    it('ignores a snapshot missing required fields', async () => {
+      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify({ foo: 'bar' }))
+      const store = await freshStore()
+      expect(store.currentGroup).toBeNull()
+    })
+  })
+
+  describe('restoreFromStorage reconciliation', () => {
+    it('keeps the stored group when it is still in the fresh list', async () => {
+      const a = makeGroup({ id: 'grp-a', slug: 'a', name: 'Alpha' })
+      const b = makeGroup({ id: 'grp-b', slug: 'b', name: 'Beta' })
+      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(b))
+
+      mockedGroupService.listGroups.mockResolvedValueOnce([a, b])
+      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.restoreFromStorage()
+
+      expect(store.currentGroupId).toBe('grp-b')
+      expect(store.currentGroupName).toBe('Beta')
+    })
+
+    it('refreshes the snapshot with server-authoritative data after reconcile', async () => {
+      // User renamed the group on another device — the local snapshot has a
+      // stale name/icon. After reconciliation, the server copy wins and the
+      // localStorage snapshot must be rewritten; otherwise a future refresh
+      // flashes the stale name before reconciliation runs.
+      const stale = makeGroup({ id: 'grp-1', slug: 'home', name: 'Home', icon: '🏠' })
+      const fresh = makeGroup({ id: 'grp-1', slug: 'home', name: 'Home Sweet Home', icon: '🏡' })
+      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(stale))
+
+      mockedGroupService.listGroups.mockResolvedValueOnce([fresh])
+      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.restoreFromStorage()
+
+      expect(store.currentGroupName).toBe('Home Sweet Home')
+      expect(store.currentGroupIcon).toBe('🏡')
+      const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP) || 'null')
+      expect(persisted).toEqual(fresh)
+    })
+
+    it('falls back to the first group when the stored group is no longer accessible', async () => {
+      // Covers the acceptance criterion "Graceful fallback when the saved
+      // group is no longer accessible" — e.g. user was removed, or logged
+      // in as someone else with a different group set.
+      const stale = makeGroup({ id: 'grp-gone', slug: 'gone', name: 'Gone' })
+      const first = makeGroup({ id: 'grp-new', slug: 'new', name: 'New' })
+      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(stale))
+
+      mockedGroupService.listGroups.mockResolvedValueOnce([first])
+      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.restoreFromStorage()
+
+      expect(store.currentGroupId).toBe('grp-new')
+      const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP) || 'null')
+      expect(persisted.id).toBe('grp-new')
+    })
+
+    it('falls back to the legacy slug key when the snapshot key is absent', async () => {
+      // Users upgrading from the pre-#1262 deployment only have the slug
+      // stored. Reconciliation must still honor their prior selection; a
+      // silent revert to "first group" would flip their active group on
+      // the first refresh after the update.
+      const first = makeGroup({ id: 'grp-a', slug: 'alpha', name: 'Alpha' })
+      const second = makeGroup({ id: 'grp-b', slug: 'beta', name: 'Beta' })
+      localStorage.setItem(STORAGE_KEY_GROUP_SLUG_LEGACY, 'beta')
+
+      mockedGroupService.listGroups.mockResolvedValueOnce([first, second])
+      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.restoreFromStorage()
+
+      expect(store.currentGroupId).toBe('grp-b')
+    })
+
+    it('clears currentGroup when the fresh groups list is empty', async () => {
+      // A user who was removed from every group should not retain a stale
+      // currentGroup — the app needs to send them to /no-group instead.
+      const stale = makeGroup()
+      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(stale))
+
+      mockedGroupService.listGroups.mockResolvedValueOnce([])
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.restoreFromStorage()
+
+      expect(store.currentGroup).toBeNull()
+      expect(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP)).toBeNull()
+    })
+  })
+
+  describe('setters persist to localStorage', () => {
+    it('setCurrentGroup writes the full snapshot', async () => {
+      const a = makeGroup({ id: 'grp-a', slug: 'a', name: 'A' })
+      const b = makeGroup({ id: 'grp-b', slug: 'b', name: 'B' })
+      mockedGroupService.listGroups.mockResolvedValueOnce([a, b])
+      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.setCurrentGroup('b')
+
+      const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP) || 'null')
+      expect(persisted).toEqual(b)
+    })
+
+    it('clearAll removes both the snapshot and the legacy slug', async () => {
+      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(makeGroup()))
+      localStorage.setItem(STORAGE_KEY_GROUP_SLUG_LEGACY, 'home')
+
+      const store = await freshStore()
+      store.clearAll()
+
+      expect(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP)).toBeNull()
+      expect(localStorage.getItem(STORAGE_KEY_GROUP_SLUG_LEGACY)).toBeNull()
+    })
+
+    it('updateGroupById refreshes the snapshot when editing the current group', async () => {
+      const original = makeGroup({ id: 'grp-1', name: 'Home' })
+      const renamed = makeGroup({ id: 'grp-1', name: 'Home Office' })
+      mockedGroupService.listGroups.mockResolvedValueOnce([original])
+      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+      mockedGroupService.updateGroup.mockResolvedValueOnce(renamed)
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.setCurrentGroup('home')
+      await store.updateGroupById('grp-1', 'Home Office')
+
+      const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP) || 'null')
+      expect(persisted.name).toBe('Home Office')
+    })
+  })
+})

--- a/frontend/src/stores/__tests__/groupStore.spec.ts
+++ b/frontend/src/stores/__tests__/groupStore.spec.ts
@@ -113,6 +113,18 @@ describe('groupStore — localStorage persistence (#1262)', () => {
       const store = await freshStore()
       expect(store.currentGroup).toBeNull()
     })
+
+    it('rejects a partial snapshot that has only id and slug', async () => {
+      // A corrupted or truncated snapshot would otherwise pre-seed currentGroup
+      // with undefined name/icon, so the header briefly renders placeholders
+      // until reconciliation arrives. Full-shape validation is the cheaper fix.
+      localStorage.setItem(
+        STORAGE_KEY_CURRENT_GROUP,
+        JSON.stringify({ id: 'grp-1', slug: 'home' }),
+      )
+      const store = await freshStore()
+      expect(store.currentGroup).toBeNull()
+    })
   })
 
   describe('restoreFromStorage reconciliation', () => {
@@ -223,6 +235,24 @@ describe('groupStore — localStorage persistence (#1262)', () => {
 
       const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP) || 'null')
       expect(persisted).toEqual(b)
+    })
+
+    it('setCurrentGroup mirrors the slug for the api.ts interceptor', async () => {
+      // services/api.ts reads STORAGE_KEY_GROUP_SLUG_LEGACY on every request
+      // to rewrite /api/v1/<resource> into /api/v1/g/{slug}/<resource>. If the
+      // snapshot writer drops this mirror, every group-scoped fetch silently
+      // stops rewriting — the CI-breaking bug that surfaced after the first
+      // pass at #1262 and was flagged by review.
+      const a = makeGroup({ id: 'grp-a', slug: 'a', name: 'A' })
+      const b = makeGroup({ id: 'grp-b', slug: 'beta-slug', name: 'B' })
+      mockedGroupService.listGroups.mockResolvedValueOnce([a, b])
+      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.setCurrentGroup('beta-slug')
+
+      expect(localStorage.getItem(STORAGE_KEY_GROUP_SLUG_LEGACY)).toBe('beta-slug')
     })
 
     it('clearAll removes both the snapshot and the legacy slug', async () => {

--- a/frontend/src/stores/groupStore.ts
+++ b/frontend/src/stores/groupStore.ts
@@ -4,12 +4,51 @@ import groupService from '../services/groupService'
 import { useAuthStore } from './authStore'
 import type { LocationGroup, GroupMembership, GroupRole } from '../types/group'
 
-const STORAGE_KEY_GROUP_SLUG = 'currentGroupSlug'
+// Primary key: full LocationGroup JSON snapshot. Stored so the header's
+// GroupSelector can render the current group name/icon synchronously on
+// page load, before fetchGroups() resolves — otherwise there's a visible
+// "Select Group" flash between mount and the first API response (#1262).
+const STORAGE_KEY_CURRENT_GROUP = 'inventario_current_group'
+// Legacy slug-only key from the first persistence attempt. Read on load
+// for back-compat with users whose localStorage predates the snapshot;
+// cleared alongside the snapshot on logout. No longer written.
+const STORAGE_KEY_GROUP_SLUG_LEGACY = 'currentGroupSlug'
+
+function readStoredSnapshot(): LocationGroup | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_CURRENT_GROUP)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed.id === 'string' && typeof parsed.slug === 'string') {
+      return parsed as LocationGroup
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function readLegacyStoredSlug(): string | null {
+  return localStorage.getItem(STORAGE_KEY_GROUP_SLUG_LEGACY)
+}
+
+function writeStoredSnapshot(group: LocationGroup | null): void {
+  if (group) {
+    localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(group))
+  } else {
+    localStorage.removeItem(STORAGE_KEY_CURRENT_GROUP)
+    localStorage.removeItem(STORAGE_KEY_GROUP_SLUG_LEGACY)
+  }
+}
 
 export const useGroupStore = defineStore('group', () => {
   // State
   const groups = ref<LocationGroup[]>([])
-  const currentGroup = ref<LocationGroup | null>(null)
+  // Seed currentGroup from localStorage synchronously so the selector
+  // shows the active group's name immediately on page refresh. The
+  // snapshot is later reconciled against the fresh /api/v1/groups
+  // response in restoreFromStorage().
+  const currentGroup = ref<LocationGroup | null>(readStoredSnapshot())
   const currentMembership = ref<GroupMembership | null>(null)
   const isLoading = ref(false)
   const error = ref<string | null>(null)
@@ -59,7 +98,7 @@ export const useGroupStore = defineStore('group', () => {
     const group = groups.value.find((g) => g.slug === slug)
     if (group) {
       currentGroup.value = group
-      localStorage.setItem(STORAGE_KEY_GROUP_SLUG, slug)
+      writeStoredSnapshot(group)
       // Load membership info for the current user
       await loadCurrentMembership(group.id)
     }
@@ -69,7 +108,7 @@ export const useGroupStore = defineStore('group', () => {
     const group = groups.value.find((g) => g.id === groupId)
     if (group) {
       currentGroup.value = group
-      localStorage.setItem(STORAGE_KEY_GROUP_SLUG, group.slug)
+      writeStoredSnapshot(group)
     }
   }
 
@@ -91,25 +130,39 @@ export const useGroupStore = defineStore('group', () => {
     currentMembership.value = membership
   }
 
+  // restoreFromStorage reconciles the (possibly pre-seeded) currentGroup
+  // against the freshly fetched groups list. It runs after fetchGroups()
+  // and is responsible for three things:
+  //   1. Preferring the user's last-selected group (by id, then by slug
+  //      for back-compat with the legacy slug-only storage format).
+  //   2. Falling back to the first available group when the stored one
+  //      is no longer accessible — e.g. the user was removed from it,
+  //      the group was deleted, or they switched accounts.
+  //   3. Re-writing the snapshot with the authoritative server copy so
+  //      stale fields (name/icon renamed from another device) don't
+  //      linger in localStorage.
   async function restoreFromStorage(): Promise<void> {
-    const storedSlug = localStorage.getItem(STORAGE_KEY_GROUP_SLUG)
-    if (storedSlug && groups.value.length > 0) {
-      const group = groups.value.find((g) => g.slug === storedSlug)
-      if (group) {
-        currentGroup.value = group
-        // Refresh the user's membership for this group so currentRole /
-        // isGroupAdmin / isGroupUser getters aren't stale after a reload.
-        await loadCurrentMembership(group.id)
-        return
-      }
+    if (groups.value.length === 0) {
+      currentGroup.value = null
+      writeStoredSnapshot(null)
+      return
     }
-    // If stored slug not found, select the first group
-    if (groups.value.length > 0) {
-      const group = groups.value[0]
-      currentGroup.value = group
-      localStorage.setItem(STORAGE_KEY_GROUP_SLUG, group.slug)
-      await loadCurrentMembership(group.id)
+
+    const snapshot = readStoredSnapshot()
+    const legacySlug = readLegacyStoredSlug()
+
+    let match: LocationGroup | undefined
+    if (snapshot) {
+      match = groups.value.find((g) => g.id === snapshot.id)
     }
+    if (!match && legacySlug) {
+      match = groups.value.find((g) => g.slug === legacySlug)
+    }
+
+    const resolved = match ?? groups.value[0]
+    currentGroup.value = resolved
+    writeStoredSnapshot(resolved)
+    await loadCurrentMembership(resolved.id)
   }
 
   async function createGroup(name: string, icon?: string, mainCurrency?: string): Promise<LocationGroup> {
@@ -134,6 +187,7 @@ export const useGroupStore = defineStore('group', () => {
     const updated = await groupService.updateGroup(groupId, { name, icon })
     if (currentGroup.value && currentGroup.value.id === updated.id) {
       currentGroup.value = updated
+      writeStoredSnapshot(updated)
     }
     const idx = groups.value.findIndex((g) => g.id === updated.id)
     if (idx >= 0) {
@@ -150,6 +204,7 @@ export const useGroupStore = defineStore('group', () => {
   function syncGroup(group: LocationGroup): void {
     if (currentGroup.value && currentGroup.value.id === group.id) {
       currentGroup.value = group
+      writeStoredSnapshot(group)
     }
     const idx = groups.value.findIndex((g) => g.id === group.id)
     if (idx >= 0) {
@@ -160,14 +215,14 @@ export const useGroupStore = defineStore('group', () => {
   function clearCurrentGroup(): void {
     currentGroup.value = null
     currentMembership.value = null
-    localStorage.removeItem(STORAGE_KEY_GROUP_SLUG)
+    writeStoredSnapshot(null)
   }
 
   function clearAll(): void {
     groups.value = []
     currentGroup.value = null
     currentMembership.value = null
-    localStorage.removeItem(STORAGE_KEY_GROUP_SLUG)
+    writeStoredSnapshot(null)
   }
 
   return {

--- a/frontend/src/stores/groupStore.ts
+++ b/frontend/src/stores/groupStore.ts
@@ -9,20 +9,41 @@ import type { LocationGroup, GroupMembership, GroupRole } from '../types/group'
 // page load, before fetchGroups() resolves — otherwise there's a visible
 // "Select Group" flash between mount and the first API response (#1262).
 const STORAGE_KEY_CURRENT_GROUP = 'inventario_current_group'
-// Legacy slug-only key from the first persistence attempt. Read on load
-// for back-compat with users whose localStorage predates the snapshot;
-// cleared alongside the snapshot on logout. No longer written.
+// Slug mirror of the snapshot. Kept in sync with STORAGE_KEY_CURRENT_GROUP
+// because the axios request interceptor in services/api.ts reads this key
+// on every request to rewrite /api/v1/<resource>/... into the group-scoped
+// /api/v1/g/{slug}/... form. Dropping this key silently breaks every
+// group-scoped fetch (locations, commodities, ...) the moment a group is
+// selected. Also serves as a back-compat read path for users whose
+// localStorage predates the snapshot format.
 const STORAGE_KEY_GROUP_SLUG_LEGACY = 'currentGroupSlug'
+
+// isStoredLocationGroupSnapshot validates the full LocationGroup shape
+// before we trust a localStorage blob enough to seed currentGroup. Accepting
+// a partial object (id + slug only) would let a corrupted snapshot render
+// the header with missing name/icon until reconciliation catches up.
+function isStoredLocationGroupSnapshot(value: unknown): value is LocationGroup {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Record<string, unknown>
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.slug === 'string' &&
+    typeof candidate.name === 'string' &&
+    typeof candidate.icon === 'string' &&
+    typeof candidate.status === 'string' &&
+    typeof candidate.main_currency === 'string' &&
+    typeof candidate.created_by === 'string' &&
+    typeof candidate.created_at === 'string' &&
+    typeof candidate.updated_at === 'string'
+  )
+}
 
 function readStoredSnapshot(): LocationGroup | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY_CURRENT_GROUP)
     if (!raw) return null
     const parsed = JSON.parse(raw)
-    if (parsed && typeof parsed.id === 'string' && typeof parsed.slug === 'string') {
-      return parsed as LocationGroup
-    }
-    return null
+    return isStoredLocationGroupSnapshot(parsed) ? parsed : null
   } catch {
     return null
   }
@@ -35,6 +56,9 @@ function readLegacyStoredSlug(): string | null {
 function writeStoredSnapshot(group: LocationGroup | null): void {
   if (group) {
     localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(group))
+    // Mirror the slug for the api.ts interceptor — see
+    // STORAGE_KEY_GROUP_SLUG_LEGACY comment.
+    localStorage.setItem(STORAGE_KEY_GROUP_SLUG_LEGACY, group.slug)
   } else {
     localStorage.removeItem(STORAGE_KEY_CURRENT_GROUP)
     localStorage.removeItem(STORAGE_KEY_GROUP_SLUG_LEGACY)


### PR DESCRIPTION
## Summary

Closes #1262.

Group selection used to reset on every browser refresh — the header's GroupSelector flashed "Select Group" and then, once a prior slug-only persistence attempt landed, still flashed briefly before the server list arrived. This PR makes the selection survive a refresh visibly (no flash) and resiliently (graceful fallback when the stored group is gone).

- **Persist a full LocationGroup snapshot** in localStorage under `inventario_current_group` and seed `currentGroup` from it *synchronously* in the Pinia state initializer, so the header renders the active group's name/icon on the first frame after refresh.
- **Reconcile** the snapshot against the freshly fetched `/api/v1/groups` list in `restoreFromStorage()` — prefer id match, fall back to the legacy slug key for back-compat, then fall back to the first available group if neither matches. Rewrite the snapshot with server-authoritative data so a rename from another device doesn't re-flash on the next refresh.
- **Cleanup paths** (`clearCurrentGroup`, `clearAll`) remove both the new snapshot key and the legacy slug key on logout.
- **Robustness**: malformed / partial JSON in storage is ignored instead of crashing the boot path; mutations that touch the current group (`setCurrentGroup`, `setCurrentGroupById`, `updateGroupById`, `syncGroup`) all rewrite the snapshot.

## Acceptance criteria (from #1262)

- [x] Group selection persists across page refreshes (localStorage)
- [x] Group selector always shows the currently active group name
- [x] Graceful fallback when the saved group is no longer accessible
- [x] Covered by e2e tests: select group A, refresh, verify group A is still selected

## Test plan

- [x] `npm test` in `frontend/` — 378 tests pass, including 12 new `groupStore.spec.ts` cases covering synchronous rehydration, id-match reconcile, stale-field refresh, fallback-on-gone, legacy-slug fallback, empty-list clear, setter persistence, and `clearAll` cleanup.
- [x] `npm run lint` — 0 new errors/warnings in changed files.
- [x] `tsc --noEmit` on `e2e/` — clean.
- [ ] Playwright: new `Group selection persistence (#1262)` describe block adds
  - `selected group is preserved across a browser refresh` — creates a second group via API, switches to it in the UI, reloads the page, asserts the selector still shows the created group, and verifies the localStorage snapshot contains the matching id/name.
  - `falls back to an available group when the stored selection is no longer accessible` — plants a "ghost" snapshot for a group the user doesn't belong to, reloads, and asserts the UI lands on a real group (not "Ghost Group", not "Select Group") and that the stale snapshot is overwritten. (Needs to run in the full e2e stack.)