### PR TITLE
fix(e2e): stabilize commodity CRUD delete + un-skip user isolation tests

### DIFF
--- a/e2e/tests/commodity-simple-crud.spec.ts
+++ b/e2e/tests/commodity-simple-crud.spec.ts
@@ -91,7 +91,11 @@ test.describe('Commodity Simple CRUD Operations', () => {
     // STEP 1: CREATE LOCATION - First create a location
     recorder.log('Step 1: Creating a new location');
     await navigateTo(page, recorder, TO_LOCATIONS);
-    await createLocation(page, recorder, testLocation);
+    // Capture the ID up front so the cleanup step targets *this* test's
+    // location, not an orphan with the same name left by the CI warmup
+    // invocation or by the sibling fast-fail-debug test (same describe →
+    // same testLocation.name).
+    const locationId = await createLocation(page, recorder, testLocation);
 
     // STEP 2: CREATE AREA - Create a new area in-place in the location list view
     recorder.log('Step 2: Creating a new area');
@@ -130,7 +134,7 @@ test.describe('Commodity Simple CRUD Operations', () => {
     // Delete the area
     await deleteArea(page, recorder, testArea.name);
 
-    // Delete the location
-    await deleteLocation(page, recorder, testLocation.name);
+    // Delete the location (pass the ID so we delete *this* test's clone)
+    await deleteLocation(page, recorder, testLocation.name, locationId);
   });
 });

--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -690,9 +690,16 @@ test.describe('Group selection persistence (#1262)', () => {
       const targetItem = page.locator('.group-selector__item', { hasText: groupName });
       await expect(targetItem).toBeVisible({ timeout: 5000 });
 
-      const reloadAfterSwitch = page.waitForLoadState('load');
+      // `waitForLoadState('load')` resolves against the *current* page's load
+      // state — if the page is already loaded it returns immediately and
+      // doesn't actually block on the JS-triggered reload. `waitForEvent('load')`
+      // waits for the *next* load event, which is what we want here. Then let
+      // the network settle so the subsequent page.reload() doesn't race with
+      // the in-flight reload (that race surfaced as ERR_ABORTED in CI).
+      const nextLoad = page.waitForEvent('load');
       await targetItem.click();
-      await reloadAfterSwitch;
+      await nextLoad;
+      await page.waitForLoadState('networkidle', { timeout: 15000 });
 
       await expect(page.locator('.group-selector__name')).toHaveText(groupName, { timeout: 10000 });
 

--- a/e2e/tests/includes/locations.ts
+++ b/e2e/tests/includes/locations.ts
@@ -29,6 +29,14 @@ export async function deleteLocation(page: Page, recorder: TestRecorder, locatio
     const locationCard = page.locator(`.location-card:has-text("${locationName}")`).first();
     await locationCard.waitFor({ state: 'visible', timeout: 10000 });
 
+    // Capture the specific location's ID so the DELETE waitForResponse can match
+    // that single call — prevents false positives from unrelated 204 DELETEs on
+    // /locations/<uuid> (parallel cleanup, list refetches, etc.).
+    const locationId = await locationCard.getAttribute('data-location-id');
+    if (!locationId) {
+        throw new Error(`deleteLocation: could not read data-location-id from card "${locationName}"`);
+    }
+
     // Click the delete button
     await locationCard.locator('button[title="Delete"]').click();
     await recorder.takeScreenshot('location-delete-01-confirm');
@@ -39,13 +47,14 @@ export async function deleteLocation(page: Page, recorder: TestRecorder, locatio
     // Click the delete button in the confirmation modal and wait for the API response.
     // Data API calls go through /api/v1/g/{groupSlug}/locations/... after the
     // Location Groups refactor (the axios interceptor rewrites the url), so match
-    // on /locations/<uuid> rather than the pre-rewrite prefix.
+    // on /locations/<id> rather than the pre-rewrite prefix. Timeout is 30s
+    // because cascaded deletes (areas + commodities) can exceed 10s under CI load.
     await Promise.all([
         page.waitForResponse(response =>
-            /\/locations\/[0-9a-f-]+$/.test(new URL(response.url()).pathname) &&
+            new URL(response.url()).pathname.endsWith(`/locations/${locationId}`) &&
             response.request().method() === 'DELETE' &&
             response.status() === 204,
-            { timeout: 10000 }
+            { timeout: 30000 }
         ),
         page.click('.confirmation-modal button:has-text("Delete")')
     ]);

--- a/e2e/tests/includes/locations.ts
+++ b/e2e/tests/includes/locations.ts
@@ -1,7 +1,7 @@
 import {expect, Page} from "@playwright/test";
 import {TestRecorder} from "../../utils/test-recorder.js";
 
-export async function createLocation(page: Page, recorder: TestRecorder, testLocation: any) {
+export async function createLocation(page: Page, recorder: TestRecorder, testLocation: any): Promise<string> {
     await recorder.takeScreenshot('locations-create-01-before-create');
 
     // Click the New button to show the location form
@@ -19,21 +19,33 @@ export async function createLocation(page: Page, recorder: TestRecorder, testLoc
     await page.waitForSelector(`.location-card:has-text("${testLocation.name}")`);
     await recorder.takeScreenshot('location-create-03-created');
 
-    // Click on the location card to expand it
-    // await page.click(`.location-card:has-text("${testLocation.name}")`);
+    // Capture the newly-created location's ID so the caller can delete the
+    // exact same card later. Using `.last()` picks the just-created entry when
+    // earlier runs (e.g. the CI warmup invocation) left another location with
+    // the same name behind — without an ID the subsequent deleteLocation would
+    // hit the orphan and get a 422 "contains areas".
+    const createdCard = page.locator(`.location-card:has-text("${testLocation.name}")`).last();
+    const locationId = await createdCard.getAttribute('data-location-id');
+    if (!locationId) {
+        throw new Error(`createLocation: could not read data-location-id after creating "${testLocation.name}"`);
+    }
+    return locationId;
 }
 
-export async function deleteLocation(page: Page, recorder: TestRecorder, locationName: string) {
-    // First, ensure the location card is visible
-    // Use .first() to handle cases where multiple locations might have similar names
-    const locationCard = page.locator(`.location-card:has-text("${locationName}")`).first();
+export async function deleteLocation(page: Page, recorder: TestRecorder, locationName: string, locationId?: string) {
+    // Prefer the ID when the caller has one — name-based lookup is ambiguous
+    // if previous test invocations (the CI warmup, a prior retry, a sibling
+    // test sharing the same describe-level testLocation) left a same-named
+    // orphan card behind.
+    const locationCard = locationId
+        ? page.locator(`.location-card[data-location-id="${locationId}"]`)
+        : page.locator(`.location-card:has-text("${locationName}")`).last();
     await locationCard.waitFor({ state: 'visible', timeout: 10000 });
 
-    // Capture the specific location's ID so the DELETE waitForResponse can match
-    // that single call — prevents false positives from unrelated 204 DELETEs on
-    // /locations/<uuid> (parallel cleanup, list refetches, etc.).
-    const locationId = await locationCard.getAttribute('data-location-id');
-    if (!locationId) {
+    // Without an explicit ID we still need one for the DELETE waitForResponse
+    // predicate and the post-delete toHaveCount check.
+    const targetId = locationId ?? await locationCard.getAttribute('data-location-id');
+    if (!targetId) {
         throw new Error(`deleteLocation: could not read data-location-id from card "${locationName}"`);
     }
 
@@ -51,7 +63,7 @@ export async function deleteLocation(page: Page, recorder: TestRecorder, locatio
     // because cascaded deletes (areas + commodities) can exceed 10s under CI load.
     await Promise.all([
         page.waitForResponse(response =>
-            new URL(response.url()).pathname.endsWith(`/locations/${locationId}`) &&
+            new URL(response.url()).pathname.endsWith(`/locations/${targetId}`) &&
             response.request().method() === 'DELETE' &&
             response.status() === 204,
             { timeout: 30000 }
@@ -66,7 +78,7 @@ export async function deleteLocation(page: Page, recorder: TestRecorder, locatio
     // substring is unreliable: a previous retry can leave a sibling card with
     // the same base name behind, which makes the :has-text match non-unique
     // even though the deletion itself succeeded. Match on the stable ID.
-    await expect(page.locator(`.location-card[data-location-id="${locationId}"]`)).toHaveCount(0, { timeout: 15000 });
+    await expect(page.locator(`.location-card[data-location-id="${targetId}"]`)).toHaveCount(0, { timeout: 15000 });
 
     await recorder.takeScreenshot('location-delete-02-deleted');
 

--- a/e2e/tests/includes/locations.ts
+++ b/e2e/tests/includes/locations.ts
@@ -62,9 +62,11 @@ export async function deleteLocation(page: Page, recorder: TestRecorder, locatio
     // Wait for the confirmation modal to disappear
     await page.locator('.confirmation-modal').waitFor({ state: 'hidden', timeout: 5000 });
 
-    // Wait for the specific location card to be removed from the DOM
-    // Re-query the locator to ensure we're checking the current DOM state
-    await expect(page.locator(`.location-card:has-text("${locationName}")`)).toHaveCount(0, { timeout: 15000 });
+    // Assert the *specific* location we deleted is gone. Checking by name
+    // substring is unreliable: a previous retry can leave a sibling card with
+    // the same base name behind, which makes the :has-text match non-unique
+    // even though the deletion itself succeeded. Match on the stable ID.
+    await expect(page.locator(`.location-card[data-location-id="${locationId}"]`)).toHaveCount(0, { timeout: 15000 });
 
     await recorder.takeScreenshot('location-delete-02-deleted');
 

--- a/e2e/tests/includes/locations.ts
+++ b/e2e/tests/includes/locations.ts
@@ -12,23 +12,30 @@ export async function createLocation(page: Page, recorder: TestRecorder, testLoc
     await page.fill('#address', testLocation.address);
     await recorder.takeScreenshot('location-create-02-form-filled');
 
-    // Submit the form
-    await page.click('button:has-text("Create Location")');
+    // Submit the form and capture the create response so we can extract the
+    // new id unambiguously. DOM-based lookup (`.first()`/`.last()` on the name
+    // filter) is unreliable — the list endpoint sorts locations DESC by
+    // created_at, so the just-created card's position flips depending on how
+    // many same-named orphans exist from warmup/sibling tests.
+    const [createResponse] = await Promise.all([
+        page.waitForResponse(response =>
+            new URL(response.url()).pathname.endsWith('/locations') &&
+            response.request().method() === 'POST' &&
+            response.status() === 201,
+            { timeout: 30000 }
+        ),
+        page.click('button:has-text("Create Location")')
+    ]);
+    const createBody = await createResponse.json();
+    const locationId = createBody?.data?.id;
+    if (!locationId) {
+        throw new Error(`createLocation: POST response missing data.id (body: ${JSON.stringify(createBody)})`);
+    }
 
     // Wait for the location to be created and displayed
     await page.waitForSelector(`.location-card:has-text("${testLocation.name}")`);
     await recorder.takeScreenshot('location-create-03-created');
 
-    // Capture the newly-created location's ID so the caller can delete the
-    // exact same card later. Using `.last()` picks the just-created entry when
-    // earlier runs (e.g. the CI warmup invocation) left another location with
-    // the same name behind — without an ID the subsequent deleteLocation would
-    // hit the orphan and get a 422 "contains areas".
-    const createdCard = page.locator(`.location-card:has-text("${testLocation.name}")`).last();
-    const locationId = await createdCard.getAttribute('data-location-id');
-    if (!locationId) {
-        throw new Error(`createLocation: could not read data-location-id after creating "${testLocation.name}"`);
-    }
     return locationId;
 }
 

--- a/e2e/tests/user-isolation.spec.ts
+++ b/e2e/tests/user-isolation.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
 import {
   getTestUsers,
   setupUserContexts,
@@ -115,7 +117,7 @@ test.describe('User Isolation', () => {
     }
   });
 
-  test('Export functionality is isolated between users', async ({ browser, page }) => {
+  test('Export functionality is isolated between users', async ({ browser }) => {
     // Get pre-seeded test users
     const users = await getTestUsers('export-test', 2);
     const userContexts = await setupUserContexts(browser, users);
@@ -126,40 +128,38 @@ test.describe('User Isolation', () => {
 
       const [user1, user2] = userContexts;
 
-      // User 1 creates an export (if export functionality exists)
-      await user1.page!.goto('/exports');
+      // Unique description so the assertion can't collide with exports that
+      // other tests / prior runs may have left behind on shared fixtures.
+      const exportDescription = `User1 Private Export ${Date.now()}`;
 
-      // Check if export functionality exists, if not skip this test
-      const hasExportButton = await user1.page!.locator('a.new-export-button').isVisible({ timeout: 2000 });
-      if (!hasExportButton) {
-        test.skip();
-        return;
-      }
+      // User 1 creates a full-database export through the real form. No
+      // conditional skip: if the feature is missing or the form selectors
+      // regress, the test fails loudly — that's the point.
+      await user1.page!.goto('/exports/new');
+      await user1.page!.waitForSelector('h1:has-text("Create New Export")', { timeout: 10000 });
+      await user1.page!.fill('#description', exportDescription);
+      await user1.page!.click('.p-select[id="type"]');
+      await user1.page!.click('.p-select-option-label:has-text("Full Database")');
+      await user1.page!.click('button[type="submit"]:has-text("Create Export")');
+      // Landing on the detail page proves the backend accepted the export.
+      await user1.page!.waitForURL(/\/exports\/[0-9a-fA-F-]{36}/, { timeout: 30000 });
 
-      await user1.page!.click('a.new-export-button');
-
-      // Fill export form (using generic selectors)
-      const nameField = user1.page!.locator('input[name="name"], #name, input[placeholder*="name" i]').first();
-      if (await nameField.isVisible()) {
-        await nameField.fill('User1 Private Export');
-      }
-
-      await user1.page!.click('button:has-text("Create"), button:has-text("Save")');
-
-      // User 2 checks exports - should not see User1's export
+      // User 2 must not see User 1's export on the shared exports list.
       await user2.page!.goto('/exports');
-      await verifyUserCannotSeeContent(user2, 'User1 Private Export');
+      await user2.page!.waitForLoadState('networkidle', { timeout: 10000 });
+      await expect(user2.page!.locator(`text=${exportDescription}`)).toHaveCount(0);
 
-      // User 1 can see their own export
+      // Sanity check: User 1 can still see their own export.
       await user1.page!.goto('/exports');
-      await verifyUserCanSeeContent(user1, 'User1 Private Export');
+      await user1.page!.waitForLoadState('networkidle', { timeout: 10000 });
+      await expect(user1.page!.locator(`text=${exportDescription}`).first()).toBeVisible();
 
     } finally {
       await cleanupUserContexts(userContexts);
     }
   });
 
-  test('File uploads are isolated between users', async ({ browser, page }) => {
+  test('File uploads are isolated between users', async ({ browser }) => {
     // Get pre-seeded test users
     const users = await getTestUsers('file-test', 2);
     const userContexts = await setupUserContexts(browser, users);
@@ -170,25 +170,34 @@ test.describe('User Isolation', () => {
 
       const [user1, user2] = userContexts;
 
-      // Navigate to files section for both users
-      await user1.page!.goto('/files');
+      // Upload the shared fixture under a unique name so the assertion has a
+      // stable identifier that can't collide with anything else in the DB.
+      const uniqueFileName = `user1-isolation-${Date.now()}.jpg`;
+      const fixturePath = path.join('fixtures', 'files', 'image.jpg');
 
-      // Check if files functionality exists
-      const hasFilesSection = await user1.page!.locator('h1:has-text("Files"), h2:has-text("Files")').isVisible({ timeout: 2000 });
-      if (!hasFilesSection) {
-        test.skip();
-        return;
-      }
+      // User 1 uploads a file via the real uploader. No conditional skip:
+      // upload is the precondition this test needs, so if it can't happen the
+      // test must fail, not silently pass.
+      await user1.page!.goto('/files/create');
+      await user1.page!.waitForSelector('h1:has-text("Upload Files")', { timeout: 10000 });
+      await user1.page!.setInputFiles('input.file-input', {
+        name: uniqueFileName,
+        mimeType: 'image/jpeg',
+        buffer: fs.readFileSync(fixturePath)
+      });
+      await user1.page!.click('.upload-actions button:has-text("Upload File")');
+      // Landing on the file detail page proves the upload + entity create succeeded.
+      await user1.page!.waitForURL(/\/files\/[0-9a-fA-F-]{36}/, { timeout: 30000 });
 
+      // User 2 must not see User 1's file on the shared files list.
       await user2.page!.goto('/files');
+      await user2.page!.waitForLoadState('networkidle', { timeout: 10000 });
+      await expect(user2.page!.locator(`text=${uniqueFileName}`)).toHaveCount(0);
 
-      // User2 should not see any files initially
-      // Check for empty state or no files message
-      const hasFiles = await user2.page!.locator('text=No files found, .file-item, .file-card').isVisible({ timeout: 2000 });
-
-      // This test assumes file upload functionality exists
-      // In a real implementation, you would upload a file as user1
-      // and verify user2 cannot see it
+      // Sanity check: User 1 can still see their own file.
+      await user1.page!.goto('/files');
+      await user1.page!.waitForLoadState('networkidle', { timeout: 10000 });
+      await expect(user1.page!.locator(`text=${uniqueFileName}`).first()).toBeVisible();
 
     } finally {
       await cleanupUserContexts(userContexts);

--- a/e2e/tests/user-isolation.spec.ts
+++ b/e2e/tests/user-isolation.spec.ts
@@ -185,9 +185,17 @@ test.describe('User Isolation', () => {
         mimeType: 'image/jpeg',
         buffer: fs.readFileSync(fixturePath)
       });
-      await user1.page!.click('.upload-actions button:has-text("Upload File")');
-      // Landing on the file detail page proves the upload + entity create succeeded.
-      await user1.page!.waitForURL(/\/files\/[0-9a-fA-F-]{36}/, { timeout: 30000 });
+      // Wait on the upload API response, not a specific post-upload URL —
+      // the FileCreateView's router.push branch depends on response shape and
+      // may land on /files or /files/<id>; the 201 is what we actually need.
+      const [uploadResponse] = await Promise.all([
+        user1.page!.waitForResponse(
+          resp => resp.url().includes('/uploads/file') && resp.request().method() === 'POST',
+          { timeout: 30000 }
+        ),
+        user1.page!.click('.upload-actions button:has-text("Upload File")')
+      ]);
+      expect(uploadResponse.status()).toBe(201);
 
       // User 2 must not see User 1's file on the shared files list.
       await user2.page!.goto('/files');

--- a/e2e/tests/user-isolation.spec.ts
+++ b/e2e/tests/user-isolation.spec.ts
@@ -172,7 +172,10 @@ test.describe('User Isolation', () => {
 
       // Upload the shared fixture under a unique name so the assertion has a
       // stable identifier that can't collide with anything else in the DB.
-      const uniqueFileName = `user1-isolation-${Date.now()}.jpg`;
+      // The backend rewrites the title to `<uniqueBase>-<unix-seconds>` (no
+      // .jpg), so match on the unique prefix rather than the full filename.
+      const uniqueBase = `user1-isolation-${Date.now()}`;
+      const uniqueFileName = `${uniqueBase}.jpg`;
       const fixturePath = path.join('fixtures', 'files', 'image.jpg');
 
       // User 1 uploads a file via the real uploader. No conditional skip:
@@ -200,12 +203,12 @@ test.describe('User Isolation', () => {
       // User 2 must not see User 1's file on the shared files list.
       await user2.page!.goto('/files');
       await user2.page!.waitForLoadState('networkidle', { timeout: 10000 });
-      await expect(user2.page!.locator(`text=${uniqueFileName}`)).toHaveCount(0);
+      await expect(user2.page!.locator(`text=${uniqueBase}`)).toHaveCount(0);
 
       // Sanity check: User 1 can still see their own file.
       await user1.page!.goto('/files');
       await user1.page!.waitForLoadState('networkidle', { timeout: 10000 });
-      await expect(user1.page!.locator(`text=${uniqueFileName}`).first()).toBeVisible();
+      await expect(user1.page!.locator(`text=${uniqueBase}`).first()).toBeVisible();
 
     } finally {
       await cleanupUserContexts(userContexts);

--- a/frontend/src/views/locations/LocationListView.vue
+++ b/frontend/src/views/locations/LocationListView.vue
@@ -40,7 +40,7 @@
 
     <div v-else class="locations-list">
       <div v-for="location in locations" :key="location.id" class="location-container">
-        <div class="location-card" @click="toggleLocationExpanded(location.id)">
+        <div class="location-card" :data-location-id="location.id" @click="toggleLocationExpanded(location.id)">
           <div class="location-content">
             <div class="location-header">
               <h3>{{ location.attributes.name }}</h3>


### PR DESCRIPTION
Closes #1253.

## Summary

- **Flaky CRUD DELETE** (`e2e/tests/includes/locations.ts`): The `waitForResponse` predicate now matches the **specific** location ID instead of any `/locations/<uuid>` DELETE with 204, and the timeout is bumped from 10s to 30s because cascaded deletes (areas + commodities) can exceed 10s under CI load. The location ID is read from a new `data-location-id` attribute on `.location-card`.
- **Silent-skip isolation tests** (`e2e/tests/user-isolation.spec.ts`): Both the Export and File isolation tests have had their `test.skip()` bailouts removed. They now seed their own preconditions — user1 creates a full-database export via the real form (`#description`, PrimeVue `.p-select[id="type"]`), and user1 uploads a uniquely-named file via the real uploader — then assert user2 cannot see them on the shared list. The `nameField` / `button:has-text("Create"), button:has-text("Save")` disjoint selectors that never matched on webkit are gone.

## Why

- A passing run after retry hides a real intermittent backend issue; tightening the predicate removes cross-talk as a possible cause and the longer timeout absorbs legitimate backend variance.
- Silently-skipped isolation tests looked green but verified nothing: a real cross-user data leak would have passed CI. Removing the skips makes the signal real again.

## Test plan

- [ ] Run `commodity-simple-crud.spec.ts` on chromium / firefox / webkit lanes and confirm 5 consecutive green runs with no retry needed.
- [ ] Run `user-isolation.spec.ts` on all three browser lanes; expect Export + File tests to execute (not skip) and pass.
- [ ] CI report shows `0 flaky / 0 skipped` for these specs.