### PR TITLE
feat(groups): redirect zero-group users to onboarding flow (closes #1261)

### DIFF
--- a/e2e/tests/no-group-redirect.spec.ts
+++ b/e2e/tests/no-group-redirect.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * E2E tests for issue #1261 — authenticated users with zero groups must be
+ * redirected to the `/no-group` onboarding view from every protected route
+ * so they never see broken / 403 pages that assume a selected group.
+ *
+ * We simulate the zero-group state by intercepting GET /api/v1/groups and
+ * returning an empty collection. Actually leaving the seeded admin's only
+ * group is not an option: admin is the sole admin, so the leave endpoint
+ * rejects the request, and deleting the group would wipe the default seed
+ * data that the rest of the E2E suite depends on.
+ */
+import { expect } from '@playwright/test';
+import { test } from '../fixtures/app-fixture.js';
+
+const GROUPS_URL_GLOB = '**/api/v1/groups';
+
+async function mockEmptyGroups(page: Parameters<Parameters<typeof test>[2]>[0]['page']) {
+  await page.route(GROUPS_URL_GLOB, (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/vnd.api+json',
+        body: JSON.stringify({ data: [] }),
+      });
+    }
+    return route.continue();
+  });
+}
+
+test.describe('No-group redirects (#1261)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockEmptyGroups(page);
+
+    // Drop any cached group snapshot so the header selector doesn't briefly
+    // render the previous session's group before restoreFromStorage reconciles
+    // against the (mocked) empty list.
+    await page.evaluate(() => {
+      localStorage.removeItem('inventario_current_group');
+      localStorage.removeItem('currentGroupSlug');
+    });
+
+    // Reload so the pinia store forgets the real admin group and re-runs
+    // ensureLoaded() against the mocked endpoint.
+    await page.reload();
+    // Wait for the post-reload auth + groups bootstrap to finish before the
+    // test-specific navigation, otherwise assertions can race the redirect.
+    await page.waitForLoadState('networkidle');
+  });
+
+  for (const target of ['/', '/locations', '/commodities', '/files', '/exports', '/system']) {
+    test(`zero-group user visiting ${target} is redirected to /no-group`, async ({ page }) => {
+      await page.goto(target);
+      await expect(page).toHaveURL(/\/no-group$/, { timeout: 10000 });
+      await expect(page.locator('[data-testid="no-group-view"]')).toBeVisible();
+    });
+  }
+
+  test('zero-group user can still reach /profile (exempt route)', async ({ page }) => {
+    await page.goto('/profile');
+    await expect(page).toHaveURL(/\/profile$/);
+    // The guard must not have bounced us to /no-group.
+    await expect(page.locator('[data-testid="no-group-view"]')).toHaveCount(0);
+  });
+
+  test('zero-group user can still reach /groups/new (exempt route)', async ({ page }) => {
+    await page.goto('/groups/new');
+    await expect(page).toHaveURL(/\/groups\/new$/);
+    await expect(page.locator('[data-testid="no-group-view"]')).toHaveCount(0);
+  });
+
+  test('invite-accept route is reachable with zero groups (exempt route)', async ({ page }) => {
+    // The invite URL itself is public; with zero groups the guard must not
+    // intercept it, or a user accepting their first invite could never get in.
+    await page.goto('/invite/definitely-not-a-real-token');
+    await expect(page).toHaveURL(/\/invite\//);
+    await expect(page.locator('[data-testid="no-group-view"]')).toHaveCount(0);
+  });
+
+  test('NoGroupView renders guided onboarding copy', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/no-group$/);
+    await expect(page.locator('h1')).toContainText('Welcome to Inventario');
+    await expect(page.locator('[data-testid="no-group-create-button"]')).toBeVisible();
+  });
+
+  test('NoGroupView drives group creation and returns the user to /', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/no-group$/);
+
+    // Swap the mock so POST /api/v1/groups "succeeds" and the subsequent GET
+    // returns the newly-created group. After that the router guard sees
+    // hasGroups=true and lets the user through to /.
+    const createdGroup = {
+      id: 'mock-grp-1261',
+      type: 'groups',
+      attributes: {
+        slug: 'mock-slug-1261',
+        name: 'Onboarding Test Group',
+        icon: '📦',
+        status: 'active',
+        main_currency: 'USD',
+        created_by: 'mock-user',
+        created_at: '2026-04-20T00:00:00Z',
+        updated_at: '2026-04-20T00:00:00Z',
+      },
+    };
+    let createSucceeded = false;
+    await page.unroute(GROUPS_URL_GLOB);
+    await page.route(GROUPS_URL_GLOB, (route) => {
+      const method = route.request().method();
+      if (method === 'POST') {
+        createSucceeded = true;
+        return route.fulfill({
+          status: 201,
+          contentType: 'application/vnd.api+json',
+          body: JSON.stringify({ data: createdGroup }),
+        });
+      }
+      if (method === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/vnd.api+json',
+          body: JSON.stringify({ data: createSucceeded ? [createdGroup] : [] }),
+        });
+      }
+      return route.continue();
+    });
+    // setCurrentGroup loads members for the active group — stub it to avoid
+    // hitting the real backend with a mock group id it's never heard of.
+    await page.route(`**/api/v1/groups/${createdGroup.id}/members`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/vnd.api+json',
+        body: JSON.stringify({ data: [] }),
+      }),
+    );
+
+    await page.locator('[data-testid="no-group-create-button"]').click();
+    await page.locator('[data-testid="no-group-name-input"]').fill('Onboarding Test Group');
+    await page.locator('[data-testid="no-group-submit"]').click();
+
+    await expect(page).toHaveURL(/\/$/, { timeout: 10000 });
+    await expect(page.locator('[data-testid="no-group-view"]')).toHaveCount(0);
+  });
+});

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -123,23 +123,16 @@ const isSystemActive = computed(() => {
 
 // bootstrapForAuthenticatedUser loads the data the SPA needs the moment the
 // user becomes authenticated: main currency shim (no-op now, kept for back-
-// compat) and the group list. If the user has zero groups AND is sitting
-// on the home page, it pushes them to /no-group where they can create or
-// accept an invite — gating on route.path === '/' matters because a test
-// or deep link may have already navigated elsewhere in parallel, and an
-// unconditional redirect would cancel that in-flight navigation
-// (user-isolation tests tripped on exactly that race — Webkit won it,
-// Firefox / Chromium lost).
+// compat) and the group list. ensureLoaded is single-flight — the router
+// guard also calls it on the first navigation, but only one /api/v1/groups
+// request actually hits the wire. The zero-group redirect lives in the
+// router guard (#1261) so every protected route is covered, not just '/'.
 async function bootstrapForAuthenticatedUser(): Promise<void> {
   await settingsStore.fetchMainCurrency()
   try {
-    await groupStore.fetchGroups()
-    await groupStore.restoreFromStorage()
+    await groupStore.ensureLoaded()
   } catch (err) {
     console.warn('Failed to initialize groups:', err)
-  }
-  if (!groupStore.hasGroups && route.path === '/') {
-    await router.push('/no-group')
   }
 }
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -7,6 +7,27 @@ import ResetPasswordView from '../views/ResetPasswordView.vue'
 import RegisterView from '../views/RegisterView.vue'
 import VerifyEmailView from '../views/VerifyEmailView.vue'
 import { useAuthStore } from '../stores/authStore'
+import { useGroupStore } from '../stores/groupStore'
+
+// GROUP_EXEMPT_ROUTE_NAMES lists routes that an authenticated user with zero
+// groups is allowed to reach without being bounced to /no-group. Everything
+// else is gated because the UI assumes a selected group (locations,
+// commodities, files, exports, system…) and would otherwise render empty /
+// 403 states with no guidance for the user.
+// NOTE: 'login' / 'register' / etc. are also listed so a logged-in no-group
+// user who explicitly types /login gets the usual "already authenticated"
+// redirect to '/' instead of being clobbered into /no-group twice.
+const GROUP_EXEMPT_ROUTE_NAMES = new Set([
+  'login',
+  'register',
+  'forgot-password',
+  'reset-password',
+  'verify-email',
+  'invite-accept',
+  'no-group',
+  'group-create',
+  'profile',
+])
 
 // Define routes without using RouteRecordRaw type
 const routes = [
@@ -261,6 +282,31 @@ router.beforeEach(async (to, from) => {
   if (to.path === '/login' && authStore.isAuthenticated) {
     console.log('Already authenticated, redirecting to home')
     return { path: '/' }
+  }
+
+  // Group-membership gate (#1261): an authenticated user with zero groups
+  // has nothing to see on /commodities, /locations, /files, etc. — those
+  // views assume a selected group and hit /api/v1/g/{slug}/... endpoints
+  // that 404 without one. Bounce them to /no-group (the guided first-run
+  // view) unless the destination is one of the onboarding-friendly routes.
+  if (authStore.isAuthenticated) {
+    const routeName = typeof to.name === 'string' ? to.name : ''
+    if (!GROUP_EXEMPT_ROUTE_NAMES.has(routeName)) {
+      const groupStore = useGroupStore()
+      try {
+        await groupStore.ensureLoaded()
+      } catch (err) {
+        // If the groups endpoint errors we don't know the count — let
+        // navigation through so the user sees the page's own error handling
+        // rather than being stuck in a redirect loop.
+        console.warn('Router guard: ensureLoaded failed, allowing navigation', err)
+        return true
+      }
+      if (!groupStore.hasGroups) {
+        console.log('No groups — redirecting to /no-group')
+        return { path: '/no-group' }
+      }
+    }
   }
 
   // The former "check that admin's system.main_currency is set, otherwise

--- a/frontend/src/stores/groupStore.ts
+++ b/frontend/src/stores/groupStore.ts
@@ -279,14 +279,6 @@ export const useGroupStore = defineStore('group', () => {
     writeStoredSnapshot(null)
   }
 
-  // invalidate drops the "we've loaded" flag so the next ensureLoaded call
-  // refetches. Used after mutations that change the user's group set (create,
-  // join via invite, leave) so the router guard sees the new count on the
-  // very next navigation instead of waiting for the next full-page reload.
-  function invalidate(): void {
-    isInitialized.value = false
-  }
-
   return {
     // State
     groups,
@@ -321,6 +313,5 @@ export const useGroupStore = defineStore('group', () => {
     syncGroup,
     clearCurrentGroup,
     clearAll,
-    invalidate,
   }
 })

--- a/frontend/src/stores/groupStore.ts
+++ b/frontend/src/stores/groupStore.ts
@@ -76,6 +76,16 @@ export const useGroupStore = defineStore('group', () => {
   const currentMembership = ref<GroupMembership | null>(null)
   const isLoading = ref(false)
   const error = ref<string | null>(null)
+  // isInitialized flips true once the first fetchGroups + restoreFromStorage
+  // completes after login. The router guard consults this flag (via
+  // ensureLoaded) before deciding whether to redirect a zero-group user to
+  // /no-group — otherwise a deep-link on a fresh page load would land on the
+  // target route before hasGroups has any real data to check against.
+  const isInitialized = ref(false)
+  // Single-flight promise for ensureLoaded — two concurrent callers (e.g.
+  // App.vue's onMounted + the router guard firing on the initial navigation)
+  // must share one in-flight /api/v1/groups request instead of racing.
+  let loadingPromise: Promise<void> | null = null
 
   // Getters
   const hasGroups = computed(() => groups.value.length > 0)
@@ -116,6 +126,25 @@ export const useGroupStore = defineStore('group', () => {
     } finally {
       isLoading.value = false
     }
+  }
+
+  // ensureLoaded runs fetchGroups + restoreFromStorage once per session and
+  // then returns synchronously. Callers (router guard, App.vue bootstrap) can
+  // await it on every invocation and trust that the store reflects the
+  // server's current group set before they branch on hasGroups.
+  async function ensureLoaded(): Promise<void> {
+    if (isInitialized.value) return
+    if (loadingPromise) return loadingPromise
+    loadingPromise = (async () => {
+      try {
+        await fetchGroups()
+        await restoreFromStorage()
+        isInitialized.value = true
+      } finally {
+        loadingPromise = null
+      }
+    })()
+    return loadingPromise
   }
 
   async function setCurrentGroup(slug: string): Promise<void> {
@@ -246,7 +275,16 @@ export const useGroupStore = defineStore('group', () => {
     groups.value = []
     currentGroup.value = null
     currentMembership.value = null
+    isInitialized.value = false
     writeStoredSnapshot(null)
+  }
+
+  // invalidate drops the "we've loaded" flag so the next ensureLoaded call
+  // refetches. Used after mutations that change the user's group set (create,
+  // join via invite, leave) so the router guard sees the new count on the
+  // very next navigation instead of waiting for the next full-page reload.
+  function invalidate(): void {
+    isInitialized.value = false
   }
 
   return {
@@ -256,6 +294,7 @@ export const useGroupStore = defineStore('group', () => {
     currentMembership,
     isLoading,
     error,
+    isInitialized,
 
     // Getters
     hasGroups,
@@ -271,6 +310,7 @@ export const useGroupStore = defineStore('group', () => {
 
     // Actions
     fetchGroups,
+    ensureLoaded,
     setCurrentGroup,
     setCurrentGroupById,
     setCurrentMembership,
@@ -281,5 +321,6 @@ export const useGroupStore = defineStore('group', () => {
     syncGroup,
     clearCurrentGroup,
     clearAll,
+    invalidate,
   }
 })

--- a/frontend/src/views/groups/NoGroupView.vue
+++ b/frontend/src/views/groups/NoGroupView.vue
@@ -1,13 +1,24 @@
 <template>
-  <div class="no-group">
+  <div class="no-group" data-testid="no-group-view">
     <div class="no-group__card">
+      <div class="no-group__hero">🎉</div>
       <h1>Welcome to Inventario</h1>
+      <p class="no-group__lead">
+        A group is your inventory space — an organization, household, or project.
+        Every location, commodity, and file lives inside one.
+      </p>
       <p class="no-group__message">
-        You don't have any groups yet. Create one to get started, or accept an invite link from someone who already has a group.
+        To get started, create your first group. Already invited by someone?
+        Open the invite link they sent you instead.
       </p>
       <div class="no-group__actions">
-        <button v-if="!showCreateForm" class="btn btn-primary" @click="showCreateForm = true">
-          Create a Group
+        <button
+          v-if="!showCreateForm"
+          class="btn btn-primary"
+          data-testid="no-group-create-button"
+          @click="showCreateForm = true"
+        >
+          Create your first group
         </button>
       </div>
       <div v-if="showCreateForm" class="no-group__form">
@@ -20,6 +31,7 @@
             class="form-input"
             placeholder="e.g. My Inventory"
             maxlength="100"
+            data-testid="no-group-name-input"
             @keyup.enter="createGroup"
           />
         </div>
@@ -47,8 +59,13 @@
         </div>
         <div class="no-group__form-actions">
           <button class="btn btn-secondary" @click="showCreateForm = false">Cancel</button>
-          <button class="btn btn-primary" :disabled="!groupName.trim() || isCreating" @click="createGroup">
-            {{ isCreating ? 'Creating...' : 'Create' }}
+          <button
+            class="btn btn-primary"
+            :disabled="!groupName.trim() || isCreating"
+            data-testid="no-group-submit"
+            @click="createGroup"
+          >
+            {{ isCreating ? 'Creating...' : 'Create Group' }}
           </button>
         </div>
         <p v-if="error" class="no-group__error">{{ error }}</p>
@@ -104,16 +121,28 @@ async function createGroup() {
 
   &__card {
     text-align: center;
-    max-width: 480px;
-    padding: 2em;
+    max-width: 520px;
+    padding: 2.5em 2em;
     background: white;
     border-radius: 12px;
     box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
   }
 
+  &__hero {
+    font-size: 3em;
+    line-height: 1;
+    margin-bottom: 0.3em;
+  }
+
+  &__lead {
+    color: #444;
+    margin: 1em 0 0.5em;
+    line-height: 1.5;
+  }
+
   &__message {
     color: #666;
-    margin: 1em 0 1.5em;
+    margin: 0 0 1.5em;
     line-height: 1.5;
   }
 

--- a/frontend/src/views/groups/NoGroupView.vue
+++ b/frontend/src/views/groups/NoGroupView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="no-group" data-testid="no-group-view">
     <div class="no-group__card">
-      <div class="no-group__hero">🎉</div>
+      <div class="no-group__hero" aria-hidden="true">🎉</div>
       <h1>Welcome to Inventario</h1>
       <p class="no-group__lead">
         A group is your inventory space — an organization, household, or project.


### PR DESCRIPTION
## Summary

- Closes #1261.
- Adds a group-membership check to the Vue router's `beforeEach` guard. Authenticated users with zero groups are now redirected to `/no-group` from every protected route (`/commodities`, `/locations`, `/files`, `/exports`, `/system`, `/`), not just `/` as before.
- Keeps an onboarding-friendly allow-list reachable: `/profile`, `/groups/new`, `/no-group`, `/invite/:token`, and the public auth routes.
- `groupStore` gains a single-flight `ensureLoaded()` action (`fetchGroups` + `restoreFromStorage`, idempotent via `isInitialized`). The router guard and `App.vue`'s `onMounted` bootstrap both call it — only one `/api/v1/groups` request actually goes out per session.
- `NoGroupView` picks up a first-run hero, clearer guided-onboarding copy, and `data-testid` hooks for the e2e suite.

## Why the guard, not the backend

A backend middleware that 403s zero-group users was rejected: group-aware handlers already return empty collections safely, and a 403 doesn't help the UI render a guided welcome. The router guard keeps the "you need a group" UX in one file and makes it trivial to extend the allow-list when new onboarding routes land.

## Edge cases

- `/invite/:token` is exempt — a user accepting their first invite must be able to open the invite link even though they have zero groups at the moment.
- If `ensureLoaded()` errors (backend 5xx on `/api/v1/groups`), the guard lets navigation through instead of redirect-looping; the page's own error handling takes over.
- `groupStore.clearAll()` now also resets `isInitialized` so the next login reloads groups from scratch.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm run lint:js` — no new errors (254 pre-existing `any` warnings unchanged).
- [x] `npm run lint:styles` — clean.
- [x] `npm test` — 380/380 pass.
- [x] `e2e/tests/no-group-redirect.spec.ts` on chromium / firefox / webkit — 11 × 3 = 33 passed.
- [x] `e2e/tests/{home,navigation,invite-flow}.spec.ts` on chromium — no regressions.
