### PR TITLE
feat(auth): default_group_id preference + deterministic fallback (closes #1263)

### DIFF
--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -835,3 +835,197 @@ test.describe('Group selection persistence (#1262)', () => {
     expect(ids).toContain(parsed.id);
   });
 });
+
+test.describe('Default group preference (#1263)', () => {
+  // #1263 layers a persistent, user-level preference on top of the
+  // session-persistent selection from #1262: when a user clears cookies or
+  // logs in on a new device (no localStorage snapshot), the app should land
+  // them in whatever group they picked as default in their profile, not in
+  // the arbitrary "first group the server returned" fallback.
+  //
+  // The test walks the full contract:
+  //   1. Set default_group_id via PUT /auth/me for a group the user has.
+  //   2. Wipe the snapshot localStorage key to simulate a fresh device.
+  //   3. Reload and assert the selector lands on the preferred group.
+  //   4. Clear the preference (default_group_id: null) and confirm the API
+  //      accepted the null.
+
+  test('PUT /auth/me rejects default_group_id for a group the user does not belong to', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    // A well-formed UUID that the user cannot belong to — the backend must
+    // 400 on membership check, not silently store the value. Picking an
+    // unambiguous UUID avoids false positives if any group happens to share
+    // a short prefix with the fixture.
+    const resp = await request.put('/api/v1/auth/me', {
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Authorization': `Bearer ${authToken}`,
+        'X-CSRF-Token': csrfToken,
+      },
+      data: {
+        name: 'Keep My Name',
+        default_group_id: '00000000-0000-4000-8000-000000000000',
+      },
+    });
+
+    expect(resp.status(), await resp.text()).toBe(400);
+  });
+
+  test('preferred group is honoured on a fresh device (no snapshot)', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    // Create a dedicated test group and mark it as the default. Using a
+    // fresh group means the preference can't accidentally match the group
+    // a fallback rule would also pick.
+    const groupName = `Default Pref Test ${Date.now()}`;
+    const createResp = await request.post('/api/v1/groups', {
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+        'X-CSRF-Token': csrfToken,
+      },
+      data: {
+        data: {
+          type: 'groups',
+          attributes: { name: groupName, icon: '⭐' },
+        },
+      },
+    });
+    expect(createResp.status(), await createResp.text()).toBe(201);
+    const createdGroupId = (await createResp.json()).data.id as string;
+
+    // Capture the current default (if any) so cleanup can restore it.
+    const meBefore = await request.get('/api/v1/auth/me', {
+      headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${authToken}` },
+    });
+    const meBeforeBody = await meBefore.json();
+    const previousDefault = (meBeforeBody.default_group_id as string | null) ?? null;
+
+    try {
+      // Persist the preference server-side.
+      const putResp = await request.put('/api/v1/auth/me', {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: {
+          name: meBeforeBody.name,
+          default_group_id: createdGroupId,
+        },
+      });
+      expect(putResp.status(), await putResp.text()).toBe(200);
+      const putBody = await putResp.json();
+      expect(putBody.default_group_id).toBe(createdGroupId);
+
+      // Simulate a fresh device: scrub any session-persistent group state.
+      // The localStorage user cache also needs the new default_group_id for
+      // the *first* frame to read it; the background /auth/me fetch would
+      // refresh it anyway, but clearing the snapshot forces the preference
+      // path in restoreFromStorage() to run on the first pass.
+      await page.evaluate(() => {
+        localStorage.removeItem('inventario_current_group');
+        localStorage.removeItem('currentGroupSlug');
+      });
+      await page.reload();
+
+      // Wait for the selector to arrive and reconciliation to finish.
+      await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
+      await expect(page.locator('.group-selector__name')).toHaveText(groupName, {
+        timeout: 10000,
+      });
+
+      // Verify the snapshot was rewritten with the preferred group, not
+      // some fallback target — that's how the login flow "honours" the
+      // preference (#1263 acceptance criterion).
+      const persisted = await page.evaluate(() =>
+        localStorage.getItem('inventario_current_group'),
+      );
+      const parsed = JSON.parse(persisted as string);
+      expect(parsed.id).toBe(createdGroupId);
+    } finally {
+      // Clear the preference (null) so the next test starts clean, then
+      // delete the test group. Restore any previous default afterwards.
+      await request.put('/api/v1/auth/me', {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { name: meBeforeBody.name, default_group_id: null },
+      });
+
+      // Switch the UI away from the test group before deleting it to avoid
+      // leaving the selector pointing at a deleted entity.
+      const groupsResp = await request.get('/api/v1/groups', {
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+      });
+      const groupsBody = await groupsResp.json();
+      const other = groupsBody.data.find((g: { id: string }) => g.id !== createdGroupId);
+      if (other) {
+        await page.evaluate(
+          ({ snapshot }) => {
+            localStorage.setItem('inventario_current_group', JSON.stringify(snapshot));
+          },
+          {
+            snapshot: {
+              id: other.id,
+              slug: other.attributes.slug,
+              name: other.attributes.name,
+              icon: other.attributes.icon,
+              status: other.attributes.status,
+              main_currency: other.attributes.main_currency,
+              created_by: other.attributes.created_by,
+              created_at: other.attributes.created_at,
+              updated_at: other.attributes.updated_at,
+            },
+          },
+        );
+      }
+
+      const deleteResp = await request.delete(`/api/v1/groups/${createdGroupId}`, {
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { confirm_word: groupName },
+      });
+      expect(deleteResp.status()).toBe(204);
+
+      // Restore the prior default if there was one (best-effort).
+      if (previousDefault) {
+        await request.put('/api/v1/auth/me', {
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'Authorization': `Bearer ${authToken}`,
+            'X-CSRF-Token': csrfToken,
+          },
+          data: { name: meBeforeBody.name, default_group_id: previousDefault },
+        });
+      }
+    }
+  });
+});

--- a/frontend/src/services/__tests__/authService.test.ts
+++ b/frontend/src/services/__tests__/authService.test.ts
@@ -47,6 +47,7 @@ describe('authService', () => {
         id: 'u1',
         email: 'alice@example.com',
         name: 'Alice Updated',
+        default_group_id: null,
       })
     })
 
@@ -67,10 +68,28 @@ describe('authService', () => {
         id: 'user-42',
         email: 'bob@example.com',
         name: 'Bob Smith',
+        default_group_id: null,
       })
       // is_active and tenant_id should NOT be present in the mapped result
       expect(result).not.toHaveProperty('is_active')
       expect(result).not.toHaveProperty('tenant_id')
+    })
+
+    it('preserves default_group_id from the server response (#1263)', async () => {
+      const serverUser = {
+        id: 'user-42',
+        email: 'bob@example.com',
+        name: 'Bob Smith',
+        default_group_id: '11111111-1111-1111-1111-111111111111',
+      }
+      mockedApi.put.mockResolvedValue({ data: serverUser })
+
+      const result = await authService.updateProfile({
+        name: 'Bob Smith',
+        default_group_id: '11111111-1111-1111-1111-111111111111',
+      })
+
+      expect(result.default_group_id).toBe('11111111-1111-1111-1111-111111111111')
     })
 
     it('propagates API errors to the caller', async () => {

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -28,6 +28,7 @@ export interface LoginResponse {
     id: string
     email: string
     name: string
+    default_group_id?: string | null
   }
 }
 
@@ -35,10 +36,17 @@ export interface User {
   id: string
   email: string
   name: string
+  // #1263: the user's preferred landing group. null/undefined means "no
+  // preference set" — the frontend falls back to a deterministic rule
+  // (see groupStore.restoreFromStorage).
+  default_group_id?: string | null
 }
 
 export interface UpdateProfileRequest {
   name: string
+  // Optional on PUT /auth/me: omit to leave the stored value untouched,
+  // send null to clear, or a UUID to set. The backend validates membership.
+  default_group_id?: string | null
 }
 
 class AuthService {
@@ -124,6 +132,7 @@ class AuthService {
       id: userData.id,
       email: userData.email,
       name: userData.name,
+      default_group_id: userData.default_group_id ?? null,
     }
 
     console.log('getCurrentUser - Mapped user data:', user)
@@ -211,6 +220,7 @@ class AuthService {
       id: userData.id,
       email: userData.email,
       name: userData.name,
+      default_group_id: userData.default_group_id ?? null,
     }
     return user
   }

--- a/frontend/src/stores/__tests__/groupStore.spec.ts
+++ b/frontend/src/stores/__tests__/groupStore.spec.ts
@@ -17,8 +17,20 @@ vi.mock('@/services/groupService', () => ({
   },
 }))
 
+// Mutable so tests for #1263 can seed user.default_group_id per case.
+const authMockState: { user: { id: string; default_group_id?: string | null } | null } = {
+  user: { id: 'user-1', default_group_id: null },
+}
+
 vi.mock('@/stores/authStore', () => ({
-  useAuthStore: () => ({ user: { id: 'user-1' } }),
+  useAuthStore: () => ({
+    get user() {
+      return authMockState.user
+    },
+    get userDefaultGroupID() {
+      return authMockState.user?.default_group_id ?? null
+    },
+  }),
 }))
 
 const mockedGroupService = vi.mocked(groupService)
@@ -67,10 +79,12 @@ describe('groupStore — localStorage persistence (#1262)', () => {
   beforeEach(() => {
     localStorage.clear()
     vi.clearAllMocks()
+    authMockState.user = { id: 'user-1', default_group_id: null }
   })
 
   afterEach(() => {
     localStorage.clear()
+    authMockState.user = { id: 'user-1', default_group_id: null }
   })
 
   describe('initial state rehydration from snapshot', () => {
@@ -280,6 +294,133 @@ describe('groupStore — localStorage persistence (#1262)', () => {
 
       const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP) || 'null')
       expect(persisted.name).toBe('Home Office')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // #1263: user-level default group preference + deterministic fallback.
+  // The ordering tested here mirrors the priority chain documented in
+  // restoreFromStorage(): snapshot → legacy slug → user preference →
+  // first-created → first-invited.
+  // -----------------------------------------------------------------------
+  describe('default group preference and fallback (#1263)', () => {
+    it('honours user.default_group_id on a fresh device with no snapshot', async () => {
+      const primary = makeGroup({
+        id: 'grp-primary',
+        slug: 'primary',
+        name: 'Primary',
+        created_by: 'user-1',
+        created_at: '2026-01-01T00:00:00Z',
+      })
+      const preferred = makeGroup({
+        id: 'grp-preferred',
+        slug: 'preferred',
+        name: 'Preferred',
+        // Different creator so the fallback "first-created-by-user" branch
+        // would ignore this group; the only way it wins is the preference.
+        created_by: 'user-99',
+        created_at: '2026-03-01T00:00:00Z',
+      })
+      mockedGroupService.listGroups.mockResolvedValueOnce([primary, preferred])
+      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+      authMockState.user = { id: 'user-1', default_group_id: 'grp-preferred' }
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.restoreFromStorage()
+
+      expect(store.currentGroup?.id).toBe('grp-preferred')
+    })
+
+    it('falls back from a stale preference to first-created group', async () => {
+      const firstCreated = makeGroup({
+        id: 'grp-created-1',
+        slug: 'created-first',
+        name: 'Created First',
+        created_by: 'user-1',
+        created_at: '2026-01-01T00:00:00Z',
+      })
+      const laterCreated = makeGroup({
+        id: 'grp-created-2',
+        slug: 'created-second',
+        name: 'Created Second',
+        created_by: 'user-1',
+        created_at: '2026-02-01T00:00:00Z',
+      })
+      const invited = makeGroup({
+        id: 'grp-invited',
+        slug: 'invited',
+        name: 'Invited',
+        created_by: 'user-99',
+        created_at: '2025-12-01T00:00:00Z',
+      })
+      mockedGroupService.listGroups.mockResolvedValueOnce([laterCreated, invited, firstCreated])
+      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+      // Preference points at a group the user no longer has access to — should
+      // be skipped and trigger the fallback path.
+      authMockState.user = { id: 'user-1', default_group_id: 'grp-that-does-not-exist' }
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.restoreFromStorage()
+
+      // Invited is older than both created-by-me, but the #1263 rule prefers
+      // the oldest "created by me" group over any invited one regardless of age.
+      expect(store.currentGroup?.id).toBe('grp-created-1')
+    })
+
+    it('falls back to first-invited group when the user created none', async () => {
+      const invitedNewer = makeGroup({
+        id: 'grp-invited-newer',
+        slug: 'invited-newer',
+        name: 'Invited Newer',
+        created_by: 'user-99',
+        created_at: '2026-05-01T00:00:00Z',
+      })
+      const invitedOlder = makeGroup({
+        id: 'grp-invited-older',
+        slug: 'invited-older',
+        name: 'Invited Older',
+        created_by: 'user-99',
+        created_at: '2026-01-01T00:00:00Z',
+      })
+      mockedGroupService.listGroups.mockResolvedValueOnce([invitedNewer, invitedOlder])
+      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+      authMockState.user = { id: 'user-1', default_group_id: null }
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.restoreFromStorage()
+
+      expect(store.currentGroup?.id).toBe('grp-invited-older')
+    })
+
+    it('session snapshot beats default_group_id (session continuity wins on refresh)', async () => {
+      const snapshotGroup = makeGroup({
+        id: 'grp-session',
+        slug: 'session',
+        name: 'Session',
+        created_by: 'user-1',
+      })
+      const preferredGroup = makeGroup({
+        id: 'grp-preferred',
+        slug: 'preferred',
+        name: 'Preferred',
+        created_by: 'user-1',
+      })
+      // Pre-seed localStorage with the last-selected group — this is the
+      // #1262 refresh-continuity behaviour; #1263 must not regress it.
+      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(snapshotGroup))
+      localStorage.setItem(STORAGE_KEY_GROUP_SLUG_LEGACY, snapshotGroup.slug)
+      mockedGroupService.listGroups.mockResolvedValueOnce([snapshotGroup, preferredGroup])
+      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+      authMockState.user = { id: 'user-1', default_group_id: 'grp-preferred' }
+
+      const store = await freshStore()
+      await store.fetchGroups()
+      await store.restoreFromStorage()
+
+      expect(store.currentGroup?.id).toBe('grp-session')
     })
   })
 })

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -13,6 +13,10 @@ export const useAuthStore = defineStore('auth', () => {
   const isAuthenticated = computed(() => !!user.value)
   const userName = computed(() => user.value?.name || null)
   const userEmail = computed(() => user.value?.email || null)
+  // userDefaultGroupID (#1263) is the server-stored landing-group preference.
+  // null means the user hasn't picked one — the groupStore will then apply
+  // the deterministic fallback (first created, else first invited).
+  const userDefaultGroupID = computed(() => user.value?.default_group_id ?? null)
 
   // Actions
   async function login(credentials: LoginRequest): Promise<void> {
@@ -160,6 +164,7 @@ export const useAuthStore = defineStore('auth', () => {
     isAuthenticated,
     userName,
     userEmail,
+    userDefaultGroupID,
 
     // Actions
     login,

--- a/frontend/src/stores/groupStore.ts
+++ b/frontend/src/stores/groupStore.ts
@@ -184,16 +184,20 @@ export const useGroupStore = defineStore('group', () => {
   }
 
   // restoreFromStorage reconciles the (possibly pre-seeded) currentGroup
-  // against the freshly fetched groups list. It runs after fetchGroups()
-  // and is responsible for three things:
-  //   1. Preferring the user's last-selected group (by id, then by slug
-  //      for back-compat with the legacy slug-only storage format).
-  //   2. Falling back to the first available group when the stored one
-  //      is no longer accessible — e.g. the user was removed from it,
-  //      the group was deleted, or they switched accounts.
-  //   3. Re-writing the snapshot with the authoritative server copy so
-  //      stale fields (name/icon renamed from another device) don't
-  //      linger in localStorage.
+  // against the freshly fetched groups list. It runs after fetchGroups() and
+  // implements the priority chain spelled out in #1263:
+  //   1. Last-selected group from localStorage (id match, then legacy slug) —
+  //      preserves session continuity across refreshes (#1262).
+  //   2. The user's explicit default_group_id preference — honoured when no
+  //      session snapshot exists or when it points to a group the user has
+  //      since lost access to (cleared cookies, new device).
+  //   3. Deterministic fallback: first group the user created (by created_at
+  //      ASC), else first group they were invited to. This fires on a fresh
+  //      device with no preference set.
+  //   4. Last resort: groups[0] — defensive, practically unreachable because
+  //      step 3 already covers a non-empty groups list.
+  // Whichever branch wins, the snapshot is rewritten with the authoritative
+  // server copy so a rename from another device doesn't linger in localStorage.
   async function restoreFromStorage(): Promise<void> {
     if (groups.value.length === 0) {
       currentGroup.value = null
@@ -212,10 +216,34 @@ export const useGroupStore = defineStore('group', () => {
       match = groups.value.find((g) => g.slug === legacySlug)
     }
 
-    const resolved = match ?? groups.value[0]
+    if (!match) {
+      const defaultGroupID = useAuthStore().userDefaultGroupID
+      if (defaultGroupID) {
+        match = groups.value.find((g) => g.id === defaultGroupID)
+      }
+    }
+
+    const resolved = match ?? pickFallbackGroup(groups.value, useAuthStore().user?.id ?? null)
     currentGroup.value = resolved
     writeStoredSnapshot(resolved)
     await loadCurrentMembership(resolved.id)
+  }
+
+  // pickFallbackGroup implements the "no preference, no snapshot" branch of
+  // #1263: prefer the oldest group the user created, otherwise the oldest
+  // group they were invited to. Sorting by created_at ASC keeps the choice
+  // deterministic so the same user lands in the same group on every fresh
+  // device — which is the whole point of a fallback rule.
+  function pickFallbackGroup(list: LocationGroup[], userId: string | null): LocationGroup {
+    const byCreatedAtAsc = (a: LocationGroup, b: LocationGroup): number =>
+      a.created_at.localeCompare(b.created_at)
+    if (userId) {
+      const created = list.filter((g) => g.created_by === userId).sort(byCreatedAtAsc)
+      if (created.length > 0) return created[0]
+      const invited = list.filter((g) => g.created_by !== userId).sort(byCreatedAtAsc)
+      if (invited.length > 0) return invited[0]
+    }
+    return [...list].sort(byCreatedAtAsc)[0] ?? list[0]
   }
 
   async function createGroup(name: string, icon?: string, mainCurrency?: string): Promise<LocationGroup> {

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -180,8 +180,28 @@ onMounted(async () => {
   defaultGroupField.value = authStore.userDefaultGroupID ?? ''
   // Ensure the dropdown has an up-to-date list of the user's groups even when
   // the profile page is the first thing a user loads (deep-link from an email,
-  // "Settings" menu, etc.).
-  await groupStore.ensureLoaded()
+  // "Settings" menu, etc.). Any /groups failure is routed through handleError
+  // instead of rejecting the lifecycle hook — otherwise Vue swallows the error
+  // and the user is stuck with an empty dropdown and no feedback.
+  try {
+    await groupStore.ensureLoaded()
+  } catch (err: any) {
+    handleError(err, 'profile', 'Failed to load your groups. Please refresh the page.')
+  }
+
+  // Defensive: the stored preference might point at a group the user no longer
+  // belongs to (e.g. admin removed them elsewhere without the server having
+  // cleared default_group_id yet — ON DELETE SET NULL only fires when the
+  // group itself is deleted, not when a membership is revoked). If we leave
+  // the stale value in the select, a subsequent save would 400 on the backend
+  // membership check and block unrelated profile edits. Reset silently to
+  // "no default" so the user can still change their name.
+  if (
+    defaultGroupField.value !== '' &&
+    !groupStore.groups.some((g) => g.id === defaultGroupField.value)
+  ) {
+    defaultGroupField.value = ''
+  }
 })
 
 onUnmounted(() => {

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -40,6 +40,32 @@
 
         <!-- Role field removed — roles are now per-group -->
 
+        <!-- #1263: user-level preference for which group to land in on login.
+             Empty value means "no preference" — the app applies the
+             deterministic fallback (first created, else first invited). -->
+        <div v-if="groupStore.groups.length > 0" class="form-group">
+          <label for="profile-default-group">Default Group</label>
+          <select
+            id="profile-default-group"
+            v-model="defaultGroupField"
+            class="form-input"
+            data-testid="default-group-select"
+          >
+            <option value="">No default (use fallback)</option>
+            <option
+              v-for="g in groupStore.groups"
+              :key="g.id"
+              :value="g.id"
+            >
+              {{ g.icon ? g.icon + ' ' : '' }}{{ g.name }}
+            </option>
+          </select>
+          <span class="field-hint">
+            After login you'll land in this group. Leave as "No default" to fall
+            back to the first group you created (or were invited to).
+          </span>
+        </div>
+
         <div class="form-actions">
           <button type="submit" class="btn btn-primary" :disabled="saving">
             <font-awesome-icon v-if="saving" icon="spinner" spin />
@@ -118,15 +144,21 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore'
+import { useGroupStore } from '@/stores/groupStore'
 import { useErrorState } from '@/utils/errorUtils'
 import ErrorNotificationStack from '@/components/ErrorNotificationStack.vue'
 
 const router = useRouter()
 const authStore = useAuthStore()
+const groupStore = useGroupStore()
 const { errors, handleError, removeError } = useErrorState()
 
 const nameField = ref('')
 const nameError = ref('')
+// #1263: empty string represents "no default" — mapped to null when sent to the
+// API. Initialized from the authStore so refreshing the profile page keeps the
+// currently saved preference selected.
+const defaultGroupField = ref('')
 const saving = ref(false)
 const successMessage = ref('')
 
@@ -143,8 +175,13 @@ const passwordError = ref('')
 // before the 2-second delay fires (e.g. the user navigates away from /profile).
 const logoutTimer = ref<ReturnType<typeof setTimeout> | null>(null)
 
-onMounted(() => {
+onMounted(async () => {
   nameField.value = authStore.userName ?? ''
+  defaultGroupField.value = authStore.userDefaultGroupID ?? ''
+  // Ensure the dropdown has an up-to-date list of the user's groups even when
+  // the profile page is the first thing a user loads (deep-link from an email,
+  // "Settings" menu, etc.).
+  await groupStore.ensureLoaded()
 })
 
 onUnmounted(() => {
@@ -175,7 +212,13 @@ async function onSave() {
   successMessage.value = ''
 
   try {
-    await authStore.updateProfile({ name: nameField.value.trim() })
+    await authStore.updateProfile({
+      name: nameField.value.trim(),
+      // Empty string → null clears the preference on the server; a group id
+      // sets it. Sending the field unconditionally (not just when it changed)
+      // keeps the client-side code simple and the server idempotent.
+      default_group_id: defaultGroupField.value ? defaultGroupField.value : null,
+    })
     successMessage.value = 'Profile updated successfully.'
   } catch (err: any) {
     handleError(err, 'profile', 'Failed to update profile')

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -273,14 +273,15 @@ func APIServer(params Params, restoreWorker RestoreWorkerInterface) http.Handler
 		// of the login page when the global budget is exhausted — the exact failure
 		// mode described in issue #1208. Keep auth outside the global limiter.
 		r.Route("/auth", Auth(AuthParams{
-			UserRegistry:         params.FactorySet.UserRegistry,
-			RefreshTokenRegistry: params.FactorySet.RefreshTokenRegistry,
-			BlacklistService:     blacklist,
-			RateLimiter:          rateLimiter,
-			CSRFService:          csrfSvc,
-			AuditService:         auditSvc,
-			JWTSecret:            params.JWTSecret,
-			EmailService:         emailSvc,
+			UserRegistry:            params.FactorySet.UserRegistry,
+			RefreshTokenRegistry:    params.FactorySet.RefreshTokenRegistry,
+			GroupMembershipRegistry: params.FactorySet.GroupMembershipRegistry,
+			BlacklistService:        blacklist,
+			RateLimiter:             rateLimiter,
+			CSRFService:             csrfSvc,
+			AuditService:            auditSvc,
+			JWTSecret:               params.JWTSecret,
+			EmailService:            emailSvc,
 		}))
 
 		// Unauthenticated public routes: apply the global per-IP rate limit as a

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -37,14 +37,15 @@ const (
 
 // AuthAPI handles authentication endpoints.
 type AuthAPI struct {
-	userRegistry         registry.UserRegistry
-	refreshTokenRegistry registry.RefreshTokenRegistry
-	blacklistService     services.TokenBlacklister
-	rateLimiter          services.AuthRateLimiter
-	csrfService          csrf.Service
-	auditService         services.AuditLogger
-	emailService         services.EmailService
-	jwtSecret            []byte
+	userRegistry            registry.UserRegistry
+	refreshTokenRegistry    registry.RefreshTokenRegistry
+	groupMembershipRegistry registry.GroupMembershipRegistry
+	blacklistService        services.TokenBlacklister
+	rateLimiter             services.AuthRateLimiter
+	csrfService             csrf.Service
+	auditService            services.AuditLogger
+	emailService            services.EmailService
+	jwtSecret               []byte
 }
 
 func (api *AuthAPI) sendPasswordChangedNotification(user *models.User) {
@@ -513,27 +514,29 @@ func (api *AuthAPI) writeCSRFHeader(w http.ResponseWriter, ctx context.Context, 
 
 // AuthParams holds all dependencies needed by the auth API.
 type AuthParams struct {
-	UserRegistry         registry.UserRegistry
-	RefreshTokenRegistry registry.RefreshTokenRegistry
-	BlacklistService     services.TokenBlacklister
-	RateLimiter          services.AuthRateLimiter
-	CSRFService          csrf.Service
-	AuditService         services.AuditLogger
-	EmailService         services.EmailService
-	JWTSecret            []byte
+	UserRegistry            registry.UserRegistry
+	RefreshTokenRegistry    registry.RefreshTokenRegistry
+	GroupMembershipRegistry registry.GroupMembershipRegistry
+	BlacklistService        services.TokenBlacklister
+	RateLimiter             services.AuthRateLimiter
+	CSRFService             csrf.Service
+	AuditService            services.AuditLogger
+	EmailService            services.EmailService
+	JWTSecret               []byte
 }
 
 // Auth sets up the authentication API routes.
 func Auth(params AuthParams) func(r chi.Router) {
 	api := &AuthAPI{
-		userRegistry:         params.UserRegistry,
-		refreshTokenRegistry: params.RefreshTokenRegistry,
-		blacklistService:     params.BlacklistService,
-		rateLimiter:          params.RateLimiter,
-		csrfService:          params.CSRFService,
-		auditService:         params.AuditService,
-		emailService:         params.EmailService,
-		jwtSecret:            params.JWTSecret,
+		userRegistry:            params.UserRegistry,
+		refreshTokenRegistry:    params.RefreshTokenRegistry,
+		groupMembershipRegistry: params.GroupMembershipRegistry,
+		blacklistService:        params.BlacklistService,
+		rateLimiter:             params.RateLimiter,
+		csrfService:             params.CSRFService,
+		auditService:            params.AuditService,
+		emailService:            params.EmailService,
+		jwtSecret:               params.JWTSecret,
 	}
 
 	return func(r chi.Router) {
@@ -548,10 +551,14 @@ func Auth(params AuthParams) func(r chi.Router) {
 }
 
 // handleUpdateCurrentUser allows an authenticated user to update their own profile.
-// Only safe fields (name) may be changed; email, role, tenant_id, and is_active are
-// always sourced from the authenticated session and cannot be changed by this endpoint.
+// Only safe fields (name, default_group_id) may be changed; email, role, tenant_id,
+// and is_active are always sourced from the authenticated session and cannot be
+// changed by this endpoint.
 // @Summary Update current user profile
-// @Description Update the authenticated user's profile. Only the name field may be changed; email, role, tenant_id, and is_active are ignored even if submitted.
+// @Description Update the authenticated user's profile. The name field is required;
+// @Description default_group_id (#1263) is optional — send null to clear or a
+// @Description group UUID the user is a member of to set. Email, role, tenant_id,
+// @Description and is_active are ignored even if submitted.
 // @Tags auth
 // @Accept json
 // @Produce json
@@ -575,6 +582,13 @@ func (api *AuthAPI) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Reque
 
 	// Only update the allowed field; all security-sensitive fields are preserved.
 	user.Name = req.Name
+
+	if req.DefaultGroupIDSet {
+		if !api.applyDefaultGroupUpdate(w, r, user, &req) {
+			return
+		}
+	}
+
 	updated, err := api.userRegistry.Update(r.Context(), *user)
 	if err != nil {
 		slog.Error("Failed to update user profile", "user_id", user.ID, "error", err)
@@ -586,6 +600,36 @@ func (api *AuthAPI) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Reque
 	if err := json.NewEncoder(w).Encode(updated); err != nil {
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 	}
+}
+
+// applyDefaultGroupUpdate writes req.DefaultGroupID into user, enforcing the
+// "must be a group you belong to" invariant. Returns false after an HTTP error
+// has already been written — callers must stop handling the request in that case.
+// Extracted from handleUpdateCurrentUser to stay under the nestif complexity budget.
+func (api *AuthAPI) applyDefaultGroupUpdate(w http.ResponseWriter, r *http.Request, user *models.User, req *jsonapi.UpdateProfileRequest) bool {
+	if req.DefaultGroupID == nil {
+		user.DefaultGroupID = nil
+		return true
+	}
+	// Membership check: the user can only pick a group they actually belong to.
+	// GroupMembershipRegistry is tenant-scoped, so a cross-tenant id is rejected
+	// by the same lookup.
+	if api.groupMembershipRegistry == nil {
+		slog.Error("Default group preference requested but group membership registry is not configured",
+			"user_id", user.ID)
+		http.Error(w, "Group preferences are not available", http.StatusServiceUnavailable)
+		return false
+	}
+	membership, err := api.groupMembershipRegistry.GetByGroupAndUser(r.Context(), *req.DefaultGroupID, user.ID)
+	if err != nil || membership == nil {
+		slog.Warn("User tried to set default_group_id for a group they do not belong to",
+			"user_id", user.ID, "group_id", *req.DefaultGroupID, "error", err)
+		http.Error(w, "default_group_id must reference a group you belong to", http.StatusBadRequest)
+		return false
+	}
+	groupID := *req.DefaultGroupID
+	user.DefaultGroupID = &groupID
+	return true
 }
 
 // handleChangePassword allows an authenticated user to change their own password.

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -621,10 +621,29 @@ func (api *AuthAPI) applyDefaultGroupUpdate(w http.ResponseWriter, r *http.Reque
 		return false
 	}
 	membership, err := api.groupMembershipRegistry.GetByGroupAndUser(r.Context(), *req.DefaultGroupID, user.ID)
-	if err != nil || membership == nil {
+	switch {
+	case errors.Is(err, registry.ErrNotFound):
+		// Not a member of this group — the only genuinely "your request was
+		// wrong" path. Anything else below is an infrastructure failure.
 		slog.Warn("User tried to set default_group_id for a group they do not belong to",
-			"user_id", user.ID, "group_id", *req.DefaultGroupID, "error", err)
+			"user_id", user.ID, "group_id", *req.DefaultGroupID)
 		http.Error(w, "default_group_id must reference a group you belong to", http.StatusBadRequest)
+		return false
+	case err != nil:
+		// DB outage, RLS misconfiguration, etc. Returning 400 here would mask
+		// the outage and let the client report "you can't pick this group"
+		// when the real problem is server-side.
+		slog.Error("Failed to verify group membership for default_group_id update",
+			"user_id", user.ID, "group_id", *req.DefaultGroupID, "error", err)
+		http.Error(w, "Failed to verify group membership", http.StatusInternalServerError)
+		return false
+	case membership == nil:
+		// Belt-and-braces: registries are expected to return ErrNotFound or a
+		// non-nil membership. A nil-nil pair would indicate a bug, not user
+		// error — bubble it up as 500 so it gets noticed.
+		slog.Error("Group membership lookup returned nil membership without an error",
+			"user_id", user.ID, "group_id", *req.DefaultGroupID)
+		http.Error(w, "Failed to verify group membership", http.StatusInternalServerError)
 		return false
 	}
 	groupID := *req.DefaultGroupID

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -191,6 +191,63 @@ func (m *mockUserRegistryForAuth) ListByTenant(ctx context.Context, tenantID str
 	return nil, nil
 }
 
+// mockGroupMembershipRegistryForAuth satisfies registry.GroupMembershipRegistry for the
+// default_group_id membership check (#1263). Only GetByGroupAndUser is exercised by the
+// auth handler; the rest return zero values.
+type mockGroupMembershipRegistryForAuth struct {
+	members map[string]*models.GroupMembership // key: groupID|userID
+}
+
+func newMockGroupMembershipRegistryForAuth(pairs ...struct {
+	groupID string
+	userID  string
+}) *mockGroupMembershipRegistryForAuth {
+	m := &mockGroupMembershipRegistryForAuth{members: map[string]*models.GroupMembership{}}
+	for _, p := range pairs {
+		key := p.groupID + "|" + p.userID
+		m.members[key] = &models.GroupMembership{
+			TenantOnlyEntityID: models.TenantOnlyEntityID{
+				EntityID: models.EntityID{ID: "membership-" + p.groupID + "-" + p.userID},
+				TenantID: "test-tenant-id",
+			},
+			GroupID:      p.groupID,
+			MemberUserID: p.userID,
+			Role:         models.GroupRoleUser,
+		}
+	}
+	return m
+}
+
+func (m *mockGroupMembershipRegistryForAuth) Create(_ context.Context, _ models.GroupMembership) (*models.GroupMembership, error) {
+	return nil, nil
+}
+func (m *mockGroupMembershipRegistryForAuth) Get(_ context.Context, _ string) (*models.GroupMembership, error) {
+	return nil, registry.ErrNotFound
+}
+func (m *mockGroupMembershipRegistryForAuth) List(_ context.Context) ([]*models.GroupMembership, error) {
+	return nil, nil
+}
+func (m *mockGroupMembershipRegistryForAuth) Update(_ context.Context, _ models.GroupMembership) (*models.GroupMembership, error) {
+	return nil, nil
+}
+func (m *mockGroupMembershipRegistryForAuth) Delete(_ context.Context, _ string) error { return nil }
+func (m *mockGroupMembershipRegistryForAuth) Count(_ context.Context) (int, error)     { return 0, nil }
+func (m *mockGroupMembershipRegistryForAuth) GetByGroupAndUser(_ context.Context, groupID, userID string) (*models.GroupMembership, error) {
+	if gm, ok := m.members[groupID+"|"+userID]; ok {
+		return gm, nil
+	}
+	return nil, registry.ErrNotFound
+}
+func (m *mockGroupMembershipRegistryForAuth) ListByGroup(_ context.Context, _ string) ([]*models.GroupMembership, error) {
+	return nil, nil
+}
+func (m *mockGroupMembershipRegistryForAuth) ListByUser(_ context.Context, _, _ string) ([]*models.GroupMembership, error) {
+	return nil, nil
+}
+func (m *mockGroupMembershipRegistryForAuth) CountAdminsByGroup(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
 func TestAuthAPI_Login(t *testing.T) {
 	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
 
@@ -600,6 +657,174 @@ func TestAuthAPI_UpdateCurrentUser(t *testing.T) {
 		c.Assert(storedErr, qt.IsNil)
 		c.Assert(stored.TenantID, qt.Equals, "test-tenant-id")
 		c.Assert(stored.Email, qt.Equals, "test@example.com")
+	})
+
+	// default_group_id (#1263) — the profile endpoint is the write path for the
+	// user's "land in this group on login" preference. The tests below cover the
+	// four states the handler must distinguish: absent / null / valid / invalid,
+	// plus the cross-tenant rejection that relies on GroupMembershipRegistry.
+	t.Run("default_group_id absent leaves stored preference unchanged", func(t *testing.T) {
+		c := qt.New(t)
+		testUser := setupUser(t)
+		existingGroupID := "11111111-1111-1111-1111-111111111111"
+		testUser.DefaultGroupID = &existingGroupID
+		userRegistry := &mockUserRegistryForAuth{users: map[string]*models.User{"user-123": testUser}}
+		memberships := newMockGroupMembershipRegistryForAuth(struct {
+			groupID string
+			userID  string
+		}{groupID: existingGroupID, userID: "user-123"})
+		authHandler := apiserver.Auth(apiserver.AuthParams{
+			UserRegistry:            userRegistry,
+			GroupMembershipRegistry: memberships,
+			JWTSecret:               jwtSecret,
+		})
+
+		// Send only name — default_group_id is not in the body at all.
+		req, resp := makeRequest(t, makeToken(t), map[string]string{"name": "Renamed"})
+
+		router := chi.NewRouter()
+		authHandler(router)
+		router.ServeHTTP(resp, req)
+
+		c.Assert(resp.Code, qt.Equals, http.StatusOK)
+		stored, storedErr := userRegistry.Get(context.Background(), "user-123")
+		c.Assert(storedErr, qt.IsNil)
+		c.Assert(stored.DefaultGroupID, qt.IsNotNil)
+		c.Assert(*stored.DefaultGroupID, qt.Equals, existingGroupID)
+		c.Assert(stored.Name, qt.Equals, "Renamed")
+	})
+
+	t.Run("default_group_id null clears the stored preference", func(t *testing.T) {
+		c := qt.New(t)
+		testUser := setupUser(t)
+		existingGroupID := "11111111-1111-1111-1111-111111111111"
+		testUser.DefaultGroupID = &existingGroupID
+		userRegistry := &mockUserRegistryForAuth{users: map[string]*models.User{"user-123": testUser}}
+		authHandler := apiserver.Auth(apiserver.AuthParams{
+			UserRegistry:            userRegistry,
+			GroupMembershipRegistry: newMockGroupMembershipRegistryForAuth(),
+			JWTSecret:               jwtSecret,
+		})
+
+		req, resp := makeRequest(t, makeToken(t), map[string]any{
+			"name":             "Same Name",
+			"default_group_id": nil,
+		})
+
+		router := chi.NewRouter()
+		authHandler(router)
+		router.ServeHTTP(resp, req)
+
+		c.Assert(resp.Code, qt.Equals, http.StatusOK)
+		stored, storedErr := userRegistry.Get(context.Background(), "user-123")
+		c.Assert(storedErr, qt.IsNil)
+		c.Assert(stored.DefaultGroupID, qt.IsNil)
+	})
+
+	t.Run("default_group_id can be set to a group the user belongs to", func(t *testing.T) {
+		c := qt.New(t)
+		testUser := setupUser(t)
+		groupID := "22222222-2222-2222-2222-222222222222"
+		userRegistry := &mockUserRegistryForAuth{users: map[string]*models.User{"user-123": testUser}}
+		memberships := newMockGroupMembershipRegistryForAuth(struct {
+			groupID string
+			userID  string
+		}{groupID: groupID, userID: "user-123"})
+		authHandler := apiserver.Auth(apiserver.AuthParams{
+			UserRegistry:            userRegistry,
+			GroupMembershipRegistry: memberships,
+			JWTSecret:               jwtSecret,
+		})
+
+		req, resp := makeRequest(t, makeToken(t), map[string]any{
+			"name":             "Same Name",
+			"default_group_id": groupID,
+		})
+
+		router := chi.NewRouter()
+		authHandler(router)
+		router.ServeHTTP(resp, req)
+
+		c.Assert(resp.Code, qt.Equals, http.StatusOK)
+		stored, storedErr := userRegistry.Get(context.Background(), "user-123")
+		c.Assert(storedErr, qt.IsNil)
+		c.Assert(stored.DefaultGroupID, qt.IsNotNil)
+		c.Assert(*stored.DefaultGroupID, qt.Equals, groupID)
+	})
+
+	t.Run("default_group_id for a group the user does not belong to is rejected", func(t *testing.T) {
+		c := qt.New(t)
+		testUser := setupUser(t)
+		userRegistry := &mockUserRegistryForAuth{users: map[string]*models.User{"user-123": testUser}}
+		authHandler := apiserver.Auth(apiserver.AuthParams{
+			UserRegistry:            userRegistry,
+			GroupMembershipRegistry: newMockGroupMembershipRegistryForAuth(), // empty
+			JWTSecret:               jwtSecret,
+		})
+
+		req, resp := makeRequest(t, makeToken(t), map[string]any{
+			"name":             "Same Name",
+			"default_group_id": "33333333-3333-3333-3333-333333333333",
+		})
+
+		router := chi.NewRouter()
+		authHandler(router)
+		router.ServeHTTP(resp, req)
+
+		c.Assert(resp.Code, qt.Equals, http.StatusBadRequest)
+		// Preference must remain unchanged (nil from setupUser).
+		stored, storedErr := userRegistry.Get(context.Background(), "user-123")
+		c.Assert(storedErr, qt.IsNil)
+		c.Assert(stored.DefaultGroupID, qt.IsNil)
+	})
+
+	t.Run("default_group_id with malformed UUID is rejected", func(t *testing.T) {
+		c := qt.New(t)
+		testUser := setupUser(t)
+		userRegistry := &mockUserRegistryForAuth{users: map[string]*models.User{"user-123": testUser}}
+		authHandler := apiserver.Auth(apiserver.AuthParams{
+			UserRegistry:            userRegistry,
+			GroupMembershipRegistry: newMockGroupMembershipRegistryForAuth(),
+			JWTSecret:               jwtSecret,
+		})
+
+		req, resp := makeRequest(t, makeToken(t), map[string]any{
+			"name":             "Same Name",
+			"default_group_id": "not-a-uuid",
+		})
+
+		router := chi.NewRouter()
+		authHandler(router)
+		router.ServeHTTP(resp, req)
+
+		c.Assert(resp.Code, qt.Equals, http.StatusBadRequest)
+	})
+
+	t.Run("default_group_id empty string clears the preference", func(t *testing.T) {
+		c := qt.New(t)
+		testUser := setupUser(t)
+		existing := "44444444-4444-4444-4444-444444444444"
+		testUser.DefaultGroupID = &existing
+		userRegistry := &mockUserRegistryForAuth{users: map[string]*models.User{"user-123": testUser}}
+		authHandler := apiserver.Auth(apiserver.AuthParams{
+			UserRegistry:            userRegistry,
+			GroupMembershipRegistry: newMockGroupMembershipRegistryForAuth(),
+			JWTSecret:               jwtSecret,
+		})
+
+		req, resp := makeRequest(t, makeToken(t), map[string]any{
+			"name":             "Same Name",
+			"default_group_id": "",
+		})
+
+		router := chi.NewRouter()
+		authHandler(router)
+		router.ServeHTTP(resp, req)
+
+		c.Assert(resp.Code, qt.Equals, http.StatusOK)
+		stored, storedErr := userRegistry.Get(context.Background(), "user-123")
+		c.Assert(storedErr, qt.IsNil)
+		c.Assert(stored.DefaultGroupID, qt.IsNil)
 	})
 }
 

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -221,30 +222,90 @@ func newMockGroupMembershipRegistryForAuth(pairs ...struct {
 func (m *mockGroupMembershipRegistryForAuth) Create(_ context.Context, _ models.GroupMembership) (*models.GroupMembership, error) {
 	return nil, nil
 }
+
 func (m *mockGroupMembershipRegistryForAuth) Get(_ context.Context, _ string) (*models.GroupMembership, error) {
 	return nil, registry.ErrNotFound
 }
+
 func (m *mockGroupMembershipRegistryForAuth) List(_ context.Context) ([]*models.GroupMembership, error) {
 	return nil, nil
 }
+
 func (m *mockGroupMembershipRegistryForAuth) Update(_ context.Context, _ models.GroupMembership) (*models.GroupMembership, error) {
 	return nil, nil
 }
-func (m *mockGroupMembershipRegistryForAuth) Delete(_ context.Context, _ string) error { return nil }
-func (m *mockGroupMembershipRegistryForAuth) Count(_ context.Context) (int, error)     { return 0, nil }
+
+func (m *mockGroupMembershipRegistryForAuth) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *mockGroupMembershipRegistryForAuth) Count(_ context.Context) (int, error) {
+	return 0, nil
+}
+
 func (m *mockGroupMembershipRegistryForAuth) GetByGroupAndUser(_ context.Context, groupID, userID string) (*models.GroupMembership, error) {
 	if gm, ok := m.members[groupID+"|"+userID]; ok {
 		return gm, nil
 	}
 	return nil, registry.ErrNotFound
 }
+
 func (m *mockGroupMembershipRegistryForAuth) ListByGroup(_ context.Context, _ string) ([]*models.GroupMembership, error) {
 	return nil, nil
 }
+
 func (m *mockGroupMembershipRegistryForAuth) ListByUser(_ context.Context, _, _ string) ([]*models.GroupMembership, error) {
 	return nil, nil
 }
+
 func (m *mockGroupMembershipRegistryForAuth) CountAdminsByGroup(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
+// erroringGroupMembershipRegistry is a minimal GroupMembershipRegistry whose
+// GetByGroupAndUser always returns a caller-supplied error. Used to exercise
+// the "registry error ≠ ErrNotFound" branch that must surface as 500.
+type erroringGroupMembershipRegistry struct {
+	err error
+}
+
+func (m *erroringGroupMembershipRegistry) Create(_ context.Context, _ models.GroupMembership) (*models.GroupMembership, error) {
+	return nil, nil
+}
+
+func (m *erroringGroupMembershipRegistry) Get(_ context.Context, _ string) (*models.GroupMembership, error) {
+	return nil, registry.ErrNotFound
+}
+
+func (m *erroringGroupMembershipRegistry) List(_ context.Context) ([]*models.GroupMembership, error) {
+	return nil, nil
+}
+
+func (m *erroringGroupMembershipRegistry) Update(_ context.Context, _ models.GroupMembership) (*models.GroupMembership, error) {
+	return nil, nil
+}
+
+func (m *erroringGroupMembershipRegistry) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *erroringGroupMembershipRegistry) Count(_ context.Context) (int, error) {
+	return 0, nil
+}
+
+func (m *erroringGroupMembershipRegistry) GetByGroupAndUser(_ context.Context, _, _ string) (*models.GroupMembership, error) {
+	return nil, m.err
+}
+
+func (m *erroringGroupMembershipRegistry) ListByGroup(_ context.Context, _ string) ([]*models.GroupMembership, error) {
+	return nil, nil
+}
+
+func (m *erroringGroupMembershipRegistry) ListByUser(_ context.Context, _, _ string) ([]*models.GroupMembership, error) {
+	return nil, nil
+}
+
+func (m *erroringGroupMembershipRegistry) CountAdminsByGroup(_ context.Context, _ string) (int, error) {
 	return 0, nil
 }
 
@@ -798,6 +859,36 @@ func TestAuthAPI_UpdateCurrentUser(t *testing.T) {
 		router.ServeHTTP(resp, req)
 
 		c.Assert(resp.Code, qt.Equals, http.StatusBadRequest)
+	})
+
+	t.Run("registry errors other than NotFound surface as 500, not 400", func(t *testing.T) {
+		c := qt.New(t)
+		testUser := setupUser(t)
+		userRegistry := &mockUserRegistryForAuth{users: map[string]*models.User{"user-123": testUser}}
+		// Explicit mock that returns a non-ErrNotFound error to prove the
+		// handler distinguishes "you can't pick this group" (client error)
+		// from "we couldn't check" (infrastructure error).
+		failingMembership := &erroringGroupMembershipRegistry{err: errors.New("simulated DB outage")}
+		authHandler := apiserver.Auth(apiserver.AuthParams{
+			UserRegistry:            userRegistry,
+			GroupMembershipRegistry: failingMembership,
+			JWTSecret:               jwtSecret,
+		})
+
+		req, resp := makeRequest(t, makeToken(t), map[string]any{
+			"name":             "Same Name",
+			"default_group_id": "55555555-5555-5555-5555-555555555555",
+		})
+
+		router := chi.NewRouter()
+		authHandler(router)
+		router.ServeHTTP(resp, req)
+
+		c.Assert(resp.Code, qt.Equals, http.StatusInternalServerError)
+		// Preference must remain unchanged.
+		stored, storedErr := userRegistry.Get(context.Background(), "user-123")
+		c.Assert(storedErr, qt.IsNil)
+		c.Assert(stored.DefaultGroupID, qt.IsNil)
 	})
 
 	t.Run("default_group_id empty string clears the preference", func(t *testing.T) {

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -5282,6 +5282,10 @@ const docTemplate = `{
         "jsonapi.UpdateProfileRequest": {
             "type": "object",
             "properties": {
+                "default_group_id": {
+                    "description": "DefaultGroupID is nil when the request wants to clear the preference.\nNon-nil holds the target group UUID.\n\nThe tag uses \"default_group_id,omitempty\" rather than \"-\" so the\nSwagger schema advertises the field (the API contract has to be\ndiscoverable for frontend/API consumers). Custom UnmarshalJSON below\noverrides the default decoding anyway, so the ` + "`" + `omitempty` + "`" + ` only affects\noutgoing marshalling — which is never performed on request types.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 }

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -372,7 +372,7 @@ const docTemplate = `{
                 }
             },
             "put": {
-                "description": "Update the authenticated user's profile. Only the name field may be changed; email, role, tenant_id, and is_active are ignored even if submitted.",
+                "description": "Update the authenticated user's profile. The name field is required;\ndefault_group_id (#1263) is optional — send null to clear or a\ngroup UUID the user is a member of to set. Email, role, tenant_id,\nand is_active are ignored even if submitted.",
                 "consumes": [
                     "application/json"
                 ],
@@ -6189,6 +6189,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "created_at": {
+                    "type": "string"
+                },
+                "default_group_id": {
+                    "description": "DefaultGroupID is the user's preferred landing group after login.\nNullable: when unset, the login flow falls back to \"first group the user\ncreated, else first group they were invited to\" (#1263). ON DELETE SET NULL\nso removing a group silently clears the preference instead of blocking the delete.",
                     "type": "string"
                 },
                 "email": {

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -365,7 +365,7 @@
                 }
             },
             "put": {
-                "description": "Update the authenticated user's profile. Only the name field may be changed; email, role, tenant_id, and is_active are ignored even if submitted.",
+                "description": "Update the authenticated user's profile. The name field is required;\ndefault_group_id (#1263) is optional — send null to clear or a\ngroup UUID the user is a member of to set. Email, role, tenant_id,\nand is_active are ignored even if submitted.",
                 "consumes": [
                     "application/json"
                 ],
@@ -6182,6 +6182,10 @@
             "type": "object",
             "properties": {
                 "created_at": {
+                    "type": "string"
+                },
+                "default_group_id": {
+                    "description": "DefaultGroupID is the user's preferred landing group after login.\nNullable: when unset, the login flow falls back to \"first group the user\ncreated, else first group they were invited to\" (#1263). ON DELETE SET NULL\nso removing a group silently clears the preference instead of blocking the delete.",
                     "type": "string"
                 },
                 "email": {

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -5275,6 +5275,10 @@
         "jsonapi.UpdateProfileRequest": {
             "type": "object",
             "properties": {
+                "default_group_id": {
+                    "description": "DefaultGroupID is nil when the request wants to clear the preference.\nNon-nil holds the target group UUID.\n\nThe tag uses \"default_group_id,omitempty\" rather than \"-\" so the\nSwagger schema advertises the field (the API contract has to be\ndiscoverable for frontend/API consumers). Custom UnmarshalJSON below\noverrides the default decoding anyway, so the `omitempty` only affects\noutgoing marshalling — which is never performed on request types.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 }

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -957,6 +957,17 @@ definitions:
     type: object
   jsonapi.UpdateProfileRequest:
     properties:
+      default_group_id:
+        description: |-
+          DefaultGroupID is nil when the request wants to clear the preference.
+          Non-nil holds the target group UUID.
+
+          The tag uses "default_group_id,omitempty" rather than "-" so the
+          Swagger schema advertises the field (the API contract has to be
+          discoverable for frontend/API consumers). Custom UnmarshalJSON below
+          overrides the default decoding anyway, so the `omitempty` only affects
+          outgoing marshalling — which is never performed on request types.
+        type: string
       name:
         type: string
     type: object

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1642,6 +1642,13 @@ definitions:
     properties:
       created_at:
         type: string
+      default_group_id:
+        description: |-
+          DefaultGroupID is the user's preferred landing group after login.
+          Nullable: when unset, the login flow falls back to "first group the user
+          created, else first group they were invited to" (#1263). ON DELETE SET NULL
+          so removing a group silently clears the preference instead of blocking the delete.
+        type: string
       email:
         type: string
       id:
@@ -1905,8 +1912,11 @@ paths:
     put:
       consumes:
       - application/json
-      description: Update the authenticated user's profile. Only the name field may
-        be changed; email, role, tenant_id, and is_active are ignored even if submitted.
+      description: |-
+        Update the authenticated user's profile. The name field is required;
+        default_group_id (#1263) is optional — send null to clear or a
+        group UUID the user is a member of to set. Email, role, tenant_id,
+        and is_active are ignored even if submitted.
       parameters:
       - description: Profile update request
         in: body

--- a/go/jsonapi/auth.go
+++ b/go/jsonapi/auth.go
@@ -1,11 +1,14 @@
 package jsonapi
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 
 	"github.com/go-chi/render"
+	"github.com/google/uuid"
 	"github.com/jellydator/validation"
 
 	"github.com/denisvmedia/inventario/models/rules"
@@ -14,8 +17,65 @@ import (
 var _ render.Binder = (*UpdateProfileRequest)(nil)
 
 // UpdateProfileRequest is the body for PUT /auth/me.
+//
+// Name must always be supplied (the endpoint enforces a non-blank profile name).
+//
+// DefaultGroupID (#1263) is tri-state: absent, null, or a UUID. The
+// DefaultGroupIDSet flag distinguishes "leave the stored value alone" (key
+// absent) from "clear the default" (key present as null/empty). A plain *string
+// collapses the first two cases into nil, which would silently clear a user's
+// preference every time the profile form is saved without touching the field —
+// hard to spot and hard to recover from.
 type UpdateProfileRequest struct {
 	Name string `json:"name"`
+
+	// DefaultGroupID is nil when the request wants to clear the preference.
+	// Non-nil holds the target group UUID.
+	DefaultGroupID *string `json:"-"`
+	// DefaultGroupIDSet records whether "default_group_id" appeared in the
+	// JSON body at all. When false, the handler must leave the stored value
+	// untouched (back-compat with callers that only know about "name").
+	DefaultGroupIDSet bool `json:"-"`
+}
+
+// UnmarshalJSON implements custom decoding so the handler can tell apart
+// "key absent" (leave DB value alone) from "key = null" (clear the value).
+// Decoding into a map[string]json.RawMessage first is the cleanest way to
+// detect key presence — *json.RawMessage collapses absent and null into nil.
+func (req *UpdateProfileRequest) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if nameRaw, ok := raw["name"]; ok {
+		var s string
+		if err := json.Unmarshal(nameRaw, &s); err != nil {
+			return err
+		}
+		req.Name = s
+	}
+
+	if defRaw, ok := raw["default_group_id"]; ok {
+		req.DefaultGroupIDSet = true
+		trimmed := bytes.TrimSpace(defRaw)
+		if bytes.Equal(trimmed, []byte("null")) {
+			req.DefaultGroupID = nil
+			return nil
+		}
+		var s string
+		if err := json.Unmarshal(defRaw, &s); err != nil {
+			return err
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			// Empty string is treated the same as null — clear the preference.
+			req.DefaultGroupID = nil
+			return nil
+		}
+		req.DefaultGroupID = &s
+	}
+	return nil
 }
 
 // Bind implements render.Binder. It normalizes and validates the request fields.
@@ -27,8 +87,29 @@ func (req *UpdateProfileRequest) Bind(r *http.Request) error {
 
 // ValidateWithContext validates the UpdateProfileRequest using the established
 // validation pattern. Name must not be blank and must not exceed 100 characters.
+// When DefaultGroupID is provided (non-nil), it must look like a UUID so we fail
+// fast before hitting the DB; membership checks happen in the handler because
+// they need registry access.
 func (req *UpdateProfileRequest) ValidateWithContext(ctx context.Context) error {
-	return validation.ValidateStructWithContext(ctx, req,
+	fields := []*validation.FieldRules{
 		validation.Field(&req.Name, rules.NotEmpty, validation.Length(1, 100)),
-	)
+	}
+	if req.DefaultGroupIDSet && req.DefaultGroupID != nil {
+		fields = append(fields, validation.Field(&req.DefaultGroupID, validation.By(validateUUIDPointer)))
+	}
+	return validation.ValidateStructWithContext(ctx, req, fields...)
+}
+
+// validateUUIDPointer enforces that a *string holds a parseable UUID. We can't
+// rely on validation/is.UUID without pulling govalidator into go.mod, and the
+// rest of the codebase already depends on google/uuid.
+func validateUUIDPointer(value any) error {
+	ptr, ok := value.(*string)
+	if !ok || ptr == nil {
+		return nil
+	}
+	if _, err := uuid.Parse(*ptr); err != nil {
+		return validation.NewError("validation_invalid_uuid", "must be a valid UUID")
+	}
+	return nil
 }

--- a/go/jsonapi/auth.go
+++ b/go/jsonapi/auth.go
@@ -31,7 +31,13 @@ type UpdateProfileRequest struct {
 
 	// DefaultGroupID is nil when the request wants to clear the preference.
 	// Non-nil holds the target group UUID.
-	DefaultGroupID *string `json:"-"`
+	//
+	// The tag uses "default_group_id,omitempty" rather than "-" so the
+	// Swagger schema advertises the field (the API contract has to be
+	// discoverable for frontend/API consumers). Custom UnmarshalJSON below
+	// overrides the default decoding anyway, so the `omitempty` only affects
+	// outgoing marshalling — which is never performed on request types.
+	DefaultGroupID *string `json:"default_group_id,omitempty"`
 	// DefaultGroupIDSet records whether "default_group_id" appeared in the
 	// JSON body at all. When false, the handler must leave the stored value
 	// untouched (back-compat with callers that only know about "name").

--- a/go/models/user.go
+++ b/go/models/user.go
@@ -39,6 +39,12 @@ type User struct {
 	IsActive bool `json:"is_active" db:"is_active"`
 	//migrator:schema:field name="last_login_at" type="TIMESTAMP"
 	LastLoginAt *time.Time `json:"last_login_at" db:"last_login_at" userinput:"false"`
+	// DefaultGroupID is the user's preferred landing group after login.
+	// Nullable: when unset, the login flow falls back to "first group the user
+	// created, else first group they were invited to" (#1263). ON DELETE SET NULL
+	// so removing a group silently clears the preference instead of blocking the delete.
+	//migrator:schema:field name="default_group_id" type="TEXT" foreign="location_groups(id)" foreign_key_name="fk_user_default_group" on_delete="SET NULL"
+	DefaultGroupID *string `json:"default_group_id" db:"default_group_id"`
 	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
 	CreatedAt time.Time `json:"created_at" db:"created_at" userinput:"false"`
 	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"

--- a/go/schema/migrations/_sqldata/1776710604_add_user_default_group_id.down.sql
+++ b/go/schema/migrations/_sqldata/1776710604_add_user_default_group_id.down.sql
@@ -1,0 +1,9 @@
+-- Migration rollback
+-- Generated on: 2026-04-20T20:43:24+02:00
+-- Direction: DOWN
+
+ALTER TABLE users DROP CONSTRAINT IF EXISTS fk_user_default_group;
+-- Remove columns from table: users --
+-- ALTER statements: --
+ALTER TABLE users DROP COLUMN default_group_id CASCADE;
+-- WARNING: Dropping column users.default_group_id with CASCADE - This will delete data and dependent objects! --

--- a/go/schema/migrations/_sqldata/1776710604_add_user_default_group_id.up.sql
+++ b/go/schema/migrations/_sqldata/1776710604_add_user_default_group_id.up.sql
@@ -1,0 +1,14 @@
+-- Migration generated from schema differences
+-- Generated on: 2026-04-20T20:43:24+02:00
+-- Direction: UP
+
+-- Add/modify columns for table: users --
+-- ALTER statements: --
+ALTER TABLE users ADD COLUMN default_group_id TEXT;
+-- Add foreign key constraints for table: users --
+-- ALTER statements: --
+-- ON DELETE SET NULL is added manually: the Ptah generator does not yet emit
+-- delete behaviour even when the model carries on_delete="SET NULL". Keeping
+-- it explicit here ensures that deleting a group clears every user's
+-- default_group_id preference instead of blocking the delete.
+ALTER TABLE users ADD CONSTRAINT fk_user_default_group FOREIGN KEY (default_group_id) REFERENCES location_groups(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary

Closes #1263.

Users with multi-group access can now pin which group they land in on login,
and the app has a deterministic fallback when no preference is set. The UI
exposes the preference in the profile page; the session-persistent selection
from #1262 still wins on a normal refresh — the preference only kicks in on a
fresh device, after a cookie clear, or when the snapshot points at a group
the user no longer has access to.

- **Layered priority** (implemented in `groupStore.restoreFromStorage`):
  session snapshot → legacy slug → `user.default_group_id` → first group the
  user **created** (by `created_at` ASC) → first group they were **invited
  to** → defensive `groups[0]`.
- **Backend contract**: `PUT /api/v1/auth/me` now takes an optional
  `default_group_id`. Custom JSON decoding tells *absent* (leave alone) apart
  from *null* / *empty string* (clear) from a UUID (set). A membership check
  via `GroupMembershipRegistry.GetByGroupAndUser` rejects any group the user
  doesn't belong to; format is validated up-front with `uuid.Parse`.
- **Schema**: `users.default_group_id TEXT` with FK to `location_groups(id)
  ON DELETE SET NULL` — removing a group silently nulls out every user's
  preference instead of blocking the delete.
- **UI**: ProfileView renders a `<select>` populated from `groupStore.groups`
  with an explicit "No default (use fallback)" option. Saving sends the
  selected id (or `null`) alongside `name` in a single PUT.

## Acceptance criteria (from #1263)

- [x] Backend stores `default_group_id` on the user record (nullable)
- [x] API exposes read/write of this preference (`PATCH`-semantics on PUT
  `/api/v1/auth/me { default_group_id }`)
- [x] Frontend profile page has a Default Group dropdown with all user's
  groups
- [x] Login / auth flow honors this preference
- [x] Fallback rule (first-created, then first-invited) when preference is
  null
- [x] Covered by e2e tests (see below)

## Test plan

- [x] `go test ./... -count=1` — all packages pass.
- [x] `make lint-go` — 0 issues (nolintguard, qtlint, golangci-lint all
  green).
- [x] `go vet` — no new warnings (pre-existing `drivertest.go` warnings are
  untouched).
- [x] Migration `1776710604_add_user_default_group_id` applies cleanly; the
  `ON DELETE SET NULL` constraint is confirmed via
  `pg_constraint.confdeltype = 'n'` (manually added because the Ptah
  generator does not yet emit delete behaviour — noted inline in the up
  SQL).
- [x] `inventool db migrations generate --check` reports the schema is in
  sync after the migration.
- [x] Swagger regenerated (`swag init --output docs`).
- [x] `npm test` in `frontend/` — 385 tests pass, including 4 new
  `groupStore.spec.ts` cases (preference honoured, stale-preference falls
  through to first-created, invited-only fallback, snapshot beats
  preference) and 1 `authService` case asserting `default_group_id` is
  preserved through the mapper.
- [x] `npm run lint` — 0 new errors / warnings in changed files.
- [x] `tsc --noEmit` on `e2e/` — clean.
- [ ] Playwright — new `Default group preference (#1263)` describe adds:
  - `PUT /auth/me rejects default_group_id for a group the user does not
    belong to` — 400 assertion.
  - `preferred group is honoured on a fresh device (no snapshot)` — creates
    a group, sets it as default via API, scrubs localStorage, reloads, and
    asserts the selector and snapshot land on the preferred group. (Needs
    to run in the full e2e stack.)
