### PR TITLE
feat(groups): colocate group selector + role indicator in header (closes #1258)

### DIFF
--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -1251,3 +1251,174 @@ test.describe('Default group preference (#1263)', () => {
     }
   });
 });
+
+test.describe('Group + role cluster in header (#1258)', () => {
+  // Before #1258 the current-group selector and the user's role lived in
+  // separate parts of the UI — the role wasn't surfaced in the header at
+  // all. The fix colocates the two in a flex cluster so the pair reads as
+  // one "my identity in this context" display, with shared visual tokens
+  // (padding, font-size, radius) so they look like one unit.
+
+  test('role badge sits next to the group selector with matching height and text from API', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    await page.goto('/');
+
+    const cluster = page.locator('.group-role-cluster');
+    await expect(cluster).toBeVisible({ timeout: 10000 });
+
+    // Adjacency: both controls live inside the same flex cluster. Asserting
+    // the nesting (rather than just "both visible somewhere") is what
+    // catches a regression that accidentally moves the role back into the
+    // user menu or the settings page.
+    const selector = cluster.locator('.group-selector__trigger');
+    const role = cluster.locator('[data-testid="current-role"]');
+    await expect(selector).toBeVisible();
+    await expect(role).toBeVisible();
+
+    // Derive the expected role from the API rather than hard-coding 'admin' —
+    // that way the test still passes if the seed ever starts the user off as
+    // a member of their active group instead of an admin.
+    const snapshot = await page.evaluate(() =>
+      JSON.parse(localStorage.getItem('inventario_current_group') || 'null'),
+    );
+    expect(snapshot?.id, 'current group must be resolved before role assertion').toBeTruthy();
+
+    const meResp = await request.get('/api/v1/auth/me', {
+      headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${authToken}` },
+    });
+    const me = await meResp.json();
+
+    const membersResp = await request.get(`/api/v1/groups/${snapshot.id}/members`, {
+      headers: { 'Accept': 'application/vnd.api+json', 'Authorization': `Bearer ${authToken}` },
+    });
+    const membersBody = await membersResp.json();
+    const myMembership = membersBody.data.find(
+      (m: { attributes: { member_user_id: string } }) => m.attributes.member_user_id === me.id,
+    );
+    expect(myMembership, 'caller must be a member of their active group').toBeDefined();
+    const expectedRole = myMembership.attributes.role as 'admin' | 'user';
+
+    await expect(role).toHaveText(expectedRole);
+    await expect(role).toHaveClass(new RegExp(`role-indicator--${expectedRole}`));
+
+    // Shared visual tokens in SCSS should produce matching box metrics. A
+    // bounding-box check is end-to-end — it would catch a regression that
+    // passes unit tests (SCSS vars still defined) but visually breaks
+    // because a global override bumped line-height or padding for one side.
+    // <2px tolerance accounts for subpixel rounding at non-integer zooms.
+    const selectorBox = await selector.boundingBox();
+    const roleBox = await role.boundingBox();
+    expect(selectorBox, 'selector trigger must render a box').not.toBeNull();
+    expect(roleBox, 'role badge must render a box').not.toBeNull();
+    expect(Math.abs(selectorBox!.height - roleBox!.height)).toBeLessThan(2);
+    // Same Y baseline — the pair is arranged in a row, not stacked.
+    expect(Math.abs(selectorBox!.y - roleBox!.y)).toBeLessThan(2);
+    // Role badge sits to the right of the selector trigger ("immediately
+    // next to", per the issue), with a small gap — not overlapping, not
+    // pushed to the far side of the header.
+    const gap = roleBox!.x - (selectorBox!.x + selectorBox!.width);
+    expect(gap).toBeGreaterThan(0);
+    expect(gap).toBeLessThan(24);
+  });
+
+  test('role badge refreshes when switching to a different group', async ({ page, request }) => {
+    // Group switching exercises the wiring end-to-end: setCurrentGroup
+    // triggers loadCurrentMembership, which populates currentMembership,
+    // which drives currentRole, which renders the badge. The acceptance
+    // criterion "role indicator updates when group changes" hinges on
+    // this chain. Cross-role switching (admin → member) needs a second
+    // authenticated user context and is covered by the unit tests that
+    // mock the store directly; this e2e nails the dataflow.
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    const groupName = `Role Cluster Switch ${Date.now()}`;
+    const createResp = await request.post('/api/v1/groups', {
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+        'X-CSRF-Token': csrfToken,
+      },
+      data: { data: { type: 'groups', attributes: { name: groupName, icon: '🏷️' } } },
+    });
+    expect(createResp.status(), await createResp.text()).toBe(201);
+    const newGroupId = (await createResp.json()).data.id as string;
+
+    try {
+      await page.goto('/');
+      await page.waitForSelector('.group-role-cluster', { state: 'visible', timeout: 10000 });
+
+      await page.click('.group-selector__trigger');
+      const targetItem = page.locator('.group-selector__item', { hasText: groupName });
+      await expect(targetItem).toBeVisible({ timeout: 5000 });
+
+      // GroupSelector triggers window.location.reload() after setCurrentGroup —
+      // same pattern the #1262 persistence test relies on. Wait for the
+      // *next* load event, not the current one (a bare waitForLoadState
+      // would resolve against the already-loaded page and race the reload).
+      const nextLoad = page.waitForEvent('load');
+      await targetItem.click();
+      await nextLoad;
+      await page.waitForLoadState('networkidle', { timeout: 15000 });
+
+      await expect(page.locator('.group-selector__name')).toHaveText(groupName);
+      // The new group's only member is the caller and they're the admin
+      // (invariant enforced by the create endpoint), so the refreshed
+      // badge must read "admin". If the reactive chain ever breaks, this
+      // would flip to empty or stale text.
+      const role = page.locator('[data-testid="current-role"]');
+      await expect(role).toHaveText('admin');
+      await expect(role).toHaveClass(/role-indicator--admin/);
+    } finally {
+      // Point the UI snapshot at a different group before deleting the test
+      // group — same cleanup pattern as the #1262 persistence test. Without
+      // this, the selector would end up on a deleted entity.
+      const groupsResp = await request.get('/api/v1/groups', {
+        headers: { 'Accept': 'application/vnd.api+json', 'Authorization': `Bearer ${authToken}` },
+      });
+      const groupsBody = await groupsResp.json();
+      const other = groupsBody.data.find((g: { id: string }) => g.id !== newGroupId);
+      if (other) {
+        await page.evaluate(
+          ({ snapshot }) => {
+            localStorage.setItem('inventario_current_group', JSON.stringify(snapshot));
+          },
+          {
+            snapshot: {
+              id: other.id,
+              slug: other.attributes.slug,
+              name: other.attributes.name,
+              icon: other.attributes.icon,
+              status: other.attributes.status,
+              main_currency: other.attributes.main_currency,
+              created_by: other.attributes.created_by,
+              created_at: other.attributes.created_at,
+              updated_at: other.attributes.updated_at,
+            },
+          },
+        );
+      }
+
+      const deleteResp = await request.delete(`/api/v1/groups/${newGroupId}`, {
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { confirm_word: groupName },
+      });
+      expect(deleteResp.status()).toBe(204);
+    }
+  });
+});

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -19,7 +19,27 @@
           <router-link to="/exports" :class="{ 'custom-active': isExportsActive }">Exports</router-link> |
           <router-link to="/system" :class="{ 'custom-active': isSystemActive }">System</router-link>
         </nav>
-        <GroupSelector v-if="authStore.isAuthenticated && groupStore.hasGroups" />
+        <!-- Group selector + current role badge are two facets of the same
+             "my identity in this context" display (#1258). They live in a
+             flex cluster so the pair reads as one unit and stays together
+             when the header wraps on narrow viewports. -->
+        <div
+          v-if="authStore.isAuthenticated && groupStore.hasGroups"
+          class="group-role-cluster"
+        >
+          <GroupSelector />
+          <span
+            v-if="groupStore.currentRole"
+            class="role-indicator"
+            :class="`role-indicator--${groupStore.currentRole}`"
+            data-testid="current-role"
+            :title="groupStore.currentRole === 'admin'
+              ? 'You are an admin of the current group'
+              : 'You are a member of the current group'"
+          >
+            {{ groupStore.currentRole }}
+          </span>
+        </div>
         <div v-if="authStore.isAuthenticated" ref="userMenuRef" class="user-info">
           <button
             class="user-menu-trigger"
@@ -175,12 +195,46 @@ onUnmounted(() => {
 </script>
 
 <style lang="scss">
-// @use './assets/main.scss' as *;
+@use './assets/variables' as *;
 
 .print-container {
   max-width: 100%;
   margin: 0;
   padding: 0;
+}
+
+.group-role-cluster {
+  display: inline-flex;
+  align-items: center;
+  gap: $header-control-gap;
+}
+
+// Role indicator sits next to the GroupSelector trigger and mirrors its
+// visual language (border, padding, font-size, radius) so the pair reads
+// as one unit. It's intentionally non-interactive — selecting a different
+// role isn't a thing; the role follows the active group.
+.role-indicator {
+  display: inline-flex;
+  align-items: center;
+  padding: $header-control-padding-y $header-control-padding-x;
+  border: 1px solid $header-control-border-color;
+  border-radius: $header-control-radius;
+  font-size: $header-control-font-size;
+  line-height: 1.2;
+  color: inherit;
+  background: none;
+  text-transform: capitalize;
+  letter-spacing: 0.02em;
+
+  &--admin {
+    border-color: rgb(76 175 80 / 70%);
+    background: rgb(76 175 80 / 15%);
+  }
+
+  &--user {
+    border-color: rgb(108 117 125 / 70%);
+    background: rgb(108 117 125 / 18%);
+  }
 }
 
 .header-content {

--- a/frontend/src/assets/_variables.scss
+++ b/frontend/src/assets/_variables.scss
@@ -25,3 +25,16 @@ $default-radius: 4px;
 
 // Effect variables
 $mask-background-transition: 0.2s;
+
+// Header pill controls — shared tokens for the group selector trigger,
+// the role indicator beside it, and any future sibling (#1258). Keeps them
+// visually identical so the cluster reads as one "my identity" unit rather
+// than two disjoint widgets.
+$header-control-font-size: 0.9em;
+$header-control-padding-y: 0.3em;
+$header-control-padding-x: 0.7em;
+$header-control-radius: 6px;
+$header-control-border-color: #ccc;
+$header-control-border-color-hover: #999;
+$header-control-hover-bg: rgb(0 0 0 / 3%);
+$header-control-gap: 0.5rem;

--- a/frontend/src/components/GroupSelector.vue
+++ b/frontend/src/components/GroupSelector.vue
@@ -90,6 +90,8 @@ onUnmounted(() => {
 </script>
 
 <style scoped lang="scss">
+@use '@/assets/variables' as *;
+
 .group-selector {
   position: relative;
   display: inline-block;
@@ -99,16 +101,22 @@ onUnmounted(() => {
     align-items: center;
     gap: 0.4em;
     background: none;
-    border: 1px solid #ccc;
-    border-radius: 6px;
-    padding: 0.3em 0.7em;
+    border: 1px solid $header-control-border-color;
+    border-radius: $header-control-radius;
+    padding: $header-control-padding-y $header-control-padding-x;
     cursor: pointer;
-    font-size: 0.9em;
+    font-size: $header-control-font-size;
+    line-height: 1.2;
     color: inherit;
 
     &:hover {
-      border-color: #999;
-      background: rgb(0 0 0 / 3%);
+      border-color: $header-control-border-color-hover;
+      background: $header-control-hover-bg;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $header-control-border-color-hover;
+      outline-offset: 1px;
     }
   }
 

--- a/frontend/src/components/__tests__/App.spec.ts
+++ b/frontend/src/components/__tests__/App.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createRouter, createWebHistory } from 'vue-router'
 import App from '@/App.vue'
@@ -26,13 +26,18 @@ vi.mock('@/stores/authStore', () => ({
 const mockGroupStore = {
   groups: [],
   currentGroup: null,
+  currentMembership: null,
   hasGroups: false,
   currentGroupSlug: null,
   currentGroupName: null,
   currentGroupIcon: null,
+  currentRole: null as 'admin' | 'user' | null,
   isGroupAdmin: false,
+  isGroupUser: false,
   fetchGroups: vi.fn().mockResolvedValue(undefined),
+  ensureLoaded: vi.fn().mockResolvedValue(undefined),
   restoreFromStorage: vi.fn().mockResolvedValue(undefined),
+  clearAll: vi.fn(),
 }
 
 vi.mock('@/stores/groupStore', () => ({
@@ -226,5 +231,100 @@ describe('App.vue Navigation', () => {
     expect(locationsLink.classes()).not.toContain('custom-active')
     expect(exportsLink.classes()).not.toContain('custom-active')
     expect(systemLink.classes()).not.toContain('custom-active')
+  })
+})
+
+describe('App.vue header — group role indicator (#1258)', () => {
+  // Locks in the acceptance criteria from issue #1258:
+  //   * Role indicator lives in the header cluster next to the group
+  //     selector, not in a separate or missing part of the UI.
+  //   * The badge reflects groupStore.currentRole reactively, so switching
+  //     groups (which triggers loadCurrentMembership -> updates role) flows
+  //     through to what the user sees.
+  //   * When membership is unknown (null), nothing is rendered rather than
+  //     showing a misleading "admin" placeholder.
+
+  const buildRouter = () =>
+    createRouter({
+      history: createWebHistory(),
+      routes: [{ path: '/', component: { template: '<div>Home</div>' } }],
+    })
+
+  const mountApp = async () => {
+    const router = buildRouter()
+    await router.push('/')
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router],
+        // Stubbing GroupSelector keeps the test focused on the role badge
+        // wiring — the selector is covered independently and pulling it in
+        // would drag along its own store/router expectations.
+        stubs: { GroupSelector: true },
+      },
+    })
+    await wrapper.vm.$nextTick()
+    return wrapper
+  }
+
+  beforeEach(() => {
+    mockAuthStore.isAuthenticated = true
+    mockGroupStore.hasGroups = true
+  })
+
+  afterEach(() => {
+    mockAuthStore.isAuthenticated = false
+    mockGroupStore.hasGroups = false
+    mockGroupStore.currentRole = null
+  })
+
+  it('renders the role indicator next to GroupSelector when role is admin', async () => {
+    mockGroupStore.currentRole = 'admin'
+    const wrapper = await mountApp()
+
+    const cluster = wrapper.find('.group-role-cluster')
+    expect(cluster.exists()).toBe(true)
+
+    const badge = cluster.find('[data-testid="current-role"]')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('admin')
+    expect(badge.classes()).toContain('role-indicator')
+    expect(badge.classes()).toContain('role-indicator--admin')
+  })
+
+  it('renders the role indicator with the user modifier when role is user', async () => {
+    mockGroupStore.currentRole = 'user'
+    const wrapper = await mountApp()
+
+    const badge = wrapper.find('[data-testid="current-role"]')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('user')
+    expect(badge.classes()).toContain('role-indicator--user')
+  })
+
+  it('omits the role indicator when currentRole is null (membership not loaded)', async () => {
+    mockGroupStore.currentRole = null
+    const wrapper = await mountApp()
+
+    // Cluster itself still renders (group selector lives there), but the
+    // role badge must stay out of the DOM until we actually know the role.
+    expect(wrapper.find('.group-role-cluster').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="current-role"]').exists()).toBe(false)
+  })
+
+  it('omits the cluster entirely when the user has no groups', async () => {
+    mockGroupStore.hasGroups = false
+    mockGroupStore.currentRole = 'admin'
+    const wrapper = await mountApp()
+
+    expect(wrapper.find('.group-role-cluster').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="current-role"]').exists()).toBe(false)
+  })
+
+  it('omits the cluster when the user is not authenticated', async () => {
+    mockAuthStore.isAuthenticated = false
+    mockGroupStore.currentRole = 'admin'
+    const wrapper = await mountApp()
+
+    expect(wrapper.find('.group-role-cluster').exists()).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- Colocate the current-group selector and role indicator in a `.group-role-cluster` flex row in the header, so the "Group X as admin/member" pair reads as one unit (#1258).
- Extract shared `$header-control-*` SCSS tokens so the selector trigger and the new role badge have identical padding, font-size, border-radius, and hover/focus language by definition — not by accident.
- Drive the role badge off `groupStore.currentRole`, which is already reactive to `setCurrentGroup → loadCurrentMembership`, so switching groups refreshes the role automatically.

## Behaviour

- When the user is authenticated and belongs to ≥1 group, the header renders `[Group ▾]  [admin|user]` as adjacent pills. The badge is non-interactive; the role follows the active group.
- When membership is still being loaded (`currentRole === null`), the badge is omitted rather than rendered with a misleading placeholder.
- When the user has no groups or isn't authenticated, the whole cluster stays out of the DOM.

## Test plan

- [x] `npm run test` — 402/402 unit tests green (5 new in `App.spec.ts` covering admin/user/null/no-groups/unauthenticated paths).
- [x] `npm run lint` — 0 errors (pre-existing `no-explicit-any` warnings untouched).
- [x] `npm run build` — clean SCSS compilation with the new tokens.
- [x] `npx tsc --noEmit` in `e2e/` — clean.
- [ ] CI: e2e "Group + role cluster in header (#1258)" block (2 tests) — adjacency + bounding-box parity + role text from API, and role refresh after switching groups.
