### PR TITLE
test(e2e): cover mailpit email delivery pipeline (closes #1282)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,6 +111,14 @@ jobs:
           docker pull "$INVENTARIO_IMAGE"
           # --wait blocks until the inventario healthcheck (curl /readyz) passes
           # and the one-shot bootstrap/migrate/init-data containers exit 0.
+          #
+          # Mailpit is NOT named here but still comes up — the inventario
+          # service's `depends_on` in docker-compose.yaml includes `mailpit`
+          # and `mailpit-sidecar`, and --wait follows the dependency chain,
+          # blocking on mailpit-sidecar's HTTP healthcheck against Mailpit's
+          # /api/v1/info. This is what makes e2e/tests/mailpit-email.spec.ts
+          # (issue #1282) see a reachable Mailpit at http://localhost:8025
+          # — the host port is mapped by the base compose file.
           docker compose \
             -f docker-compose.yaml \
             -f docker-compose.e2e.yaml \
@@ -198,6 +206,11 @@ jobs:
   # the binary runs natively. The embedded frontend bundle is built with the
   # same Node version Dockerfile pins (frontend/package.json volta.node), so
   # both lanes exercise equivalent JS.
+  #
+  # No Mailpit is started here: the webkit lane runs inventario directly as
+  # a host binary without docker-compose, so EMAIL_PROVIDER defaults to
+  # "stub" and mailpit-email.spec.ts (issue #1282) self-skips via its
+  # beforeAll reachability probe against http://localhost:8025.
   e2e-tests-macos:
     name: E2E Tests (webkit)
     runs-on: macos-latest

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -160,3 +160,59 @@ npm run clean:artifacts
 - `recorder-example.spec.ts` - Examples of using the TestRecorder helper
 - `fixture-recorder.spec.ts` - Examples of using the recorder fixture
 - `conditional-screenshots.spec.ts` - Examples of taking screenshots based on conditions
+
+## Email delivery tests (Mailpit)
+
+`tests/mailpit-email.spec.ts` (issue #1282) asserts the full transactional
+email pipeline — verification, password reset, welcome, password-changed —
+by fetching delivered mail out of Mailpit via its HTTP API. The helper lives
+at `tests/includes/mailpit.ts` and wraps Mailpit's `/api/v1/messages` and
+`/api/v1/message/{id}` endpoints.
+
+**Mailpit is not started by this suite.** It piggybacks on whatever stack is
+already up. The tests probe `MAILPIT_URL` (default `http://localhost:8025`)
+once in `beforeAll`; if it's unreachable, all tests in the spec `test.skip()`
+cleanly.
+
+Where Mailpit comes from in each run mode:
+
+| Mode                              | Mailpit source                                               | mailpit-email.spec.ts |
+| --------------------------------- | ------------------------------------------------------------ | --------------------- |
+| CI Linux (`chromium`, `firefox`)  | Transitive dep of `inventario` in `docker-compose.yaml`      | Runs                  |
+| CI macOS (`webkit`)               | Not present — binary runs without docker                     | Skips                 |
+| Local `docker compose up`         | Same transitive dep (plus host port `8025:8025`)             | Runs                  |
+| Local `npm run stack` (dev mode)  | Not started; `go run` backend uses the stub email provider   | Skips                 |
+
+The Linux CI lane doesn't explicitly name Mailpit in the `docker compose up`
+command — `inventario`'s `depends_on` list includes `mailpit` and
+`mailpit-sidecar` (a busybox sidecar whose healthcheck probes Mailpit's
+`/api/v1/info`), so `--wait` blocks until Mailpit is reachable before any
+test starts. The host port mapping `8025:8025` is defined in the base
+`docker-compose.yaml`, which is how the Playwright runner sees it at
+`http://localhost:8025`.
+
+### Running the email tests locally
+
+The fast path is the same compose stack CI uses:
+
+```bash
+# From the project root
+INVENTARIO_IMAGE=inventario-inventario:latest \
+  docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml \
+  up -d --wait --no-build inventario
+
+# From e2e/
+USE_PREBUILT=true npx playwright test mailpit-email.spec.ts
+```
+
+The `docker-compose.e2e.yaml` override disables the auth + global rate
+limits; without it, the suite's parallel `POST /register` calls trip
+`429 Too Many Requests` after the first few. If you run without it and see
+rate-limit failures, bring the stack up again using both compose files.
+
+Override `MAILPIT_URL` to point at a different Mailpit instance if needed:
+
+```bash
+MAILPIT_URL=http://mailpit.internal:8025 USE_PREBUILT=true \
+  npx playwright test mailpit-email.spec.ts
+```

--- a/e2e/tests/includes/mailpit.ts
+++ b/e2e/tests/includes/mailpit.ts
@@ -62,10 +62,12 @@ export async function isMailpitReachable(request: APIRequestContext): Promise<bo
 }
 
 /**
- * Delete every message in the Mailpit inbox. Tests call this in beforeEach
- * so `waitForEmailTo` never trips on leftovers from a previous test. The
- * compose `mailpit` service uses in-memory storage (MP_MAX_MESSAGES=500) so
- * the delete is cheap.
+ * Delete every message in the Mailpit inbox. Because Mailpit is typically a
+ * shared service during e2e runs, clearing it is only safe in isolated or
+ * serial test setups; parallel tests should avoid using this helper because
+ * deleting the shared inbox can race with other workers. The compose
+ * `mailpit` service uses in-memory storage (MP_MAX_MESSAGES=500), so when it
+ * is safe to do so the delete is cheap.
  */
 export async function clearInbox(request: APIRequestContext): Promise<void> {
   const res = await request.delete(`${MAILPIT_URL}/api/v1/messages`);

--- a/e2e/tests/includes/mailpit.ts
+++ b/e2e/tests/includes/mailpit.ts
@@ -1,0 +1,163 @@
+/**
+ * Helpers for asserting against Mailpit, the local SMTP catch-all the
+ * docker-compose stack wires into the app (EMAIL_PROVIDER=smtp,
+ * SMTP_HOST=mailpit:1025). The transactional email flows (verification,
+ * password reset, password-changed, welcome) all deliver here during e2e
+ * runs that bring up the full compose stack.
+ *
+ * These helpers never touch browser state: they hit Mailpit's HTTP API via
+ * Playwright's APIRequestContext so tests can assert on delivered mail
+ * directly. When Mailpit isn't reachable (e.g. dev-mode `npm run stack`
+ * starts a host-local `go run` backend that defaults to the stub provider,
+ * or the webkit macOS lane which runs the binary without SMTP), the spec
+ * that uses them probes reachability once in beforeAll and skips all tests.
+ *
+ * Mailpit API reference: https://mailpit.axllent.org/docs/api-v1/
+ */
+import { APIRequestContext, expect } from '@playwright/test';
+
+/**
+ * Base URL for Mailpit's HTTP API. In docker-compose, the Mailpit UI is
+ * published on host port 8025 (see docker-compose.yaml `mailpit` service);
+ * override MAILPIT_URL if a different topology is in use.
+ */
+export const MAILPIT_URL = process.env.MAILPIT_URL ?? 'http://localhost:8025';
+
+/**
+ * Envelope summary returned by GET /api/v1/messages. Many fields Mailpit
+ * emits are unused here; only the pieces each test actually asserts on are
+ * typed.
+ */
+export interface MailpitSummary {
+  ID: string;
+  From: { Name: string; Address: string };
+  To: { Name: string; Address: string }[];
+  Subject: string;
+  Created: string;
+}
+
+/**
+ * Full message body returned by GET /api/v1/message/{id}. Includes both
+ * text and HTML parts plus the raw header map — enough to assert multipart
+ * structure, subject, and From/Reply-To headers.
+ */
+export interface MailpitMessage extends MailpitSummary {
+  Text: string;
+  HTML: string;
+  Headers: Record<string, string[]>;
+}
+
+/**
+ * Probe Mailpit's info endpoint. Returns true when Mailpit responds within
+ * the timeout, false otherwise (network error, non-2xx, timeout). Used by
+ * specs to decide whether to run or skip the email-delivery tests.
+ */
+export async function isMailpitReachable(request: APIRequestContext): Promise<boolean> {
+  try {
+    const res = await request.get(`${MAILPIT_URL}/api/v1/info`, { timeout: 3000 });
+    return res.ok();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Delete every message in the Mailpit inbox. Tests call this in beforeEach
+ * so `waitForEmailTo` never trips on leftovers from a previous test. The
+ * compose `mailpit` service uses in-memory storage (MP_MAX_MESSAGES=500) so
+ * the delete is cheap.
+ */
+export async function clearInbox(request: APIRequestContext): Promise<void> {
+  const res = await request.delete(`${MAILPIT_URL}/api/v1/messages`);
+  expect(res.ok(), `clearInbox expected 2xx, got ${res.status()}: ${await res.text()}`).toBe(true);
+}
+
+/**
+ * Poll Mailpit until a message arrives that matches every provided filter.
+ * Filters are AND-ed: `to` is required, `subject` is matched as a RegExp
+ * when supplied. Polls every 250ms up to `timeoutMs` (default 10s, aligned
+ * with the ~seconds delivery latency of the in-memory email queue).
+ *
+ * Returns the full message (with Text/HTML/Headers) — not just the summary
+ * — so callers can extract links, inspect headers, and assert on bodies
+ * without a second fetch.
+ */
+export async function waitForEmailTo(
+  request: APIRequestContext,
+  to: string,
+  opts: { subject?: RegExp; timeoutMs?: number } = {},
+): Promise<MailpitMessage> {
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const deadline = Date.now() + timeoutMs;
+  const targetAddress = to.toLowerCase();
+
+  let lastError = '';
+  while (Date.now() < deadline) {
+    const summaries = await listMessages(request);
+    const match = summaries.find((msg) => {
+      const toHit = msg.To.some((recipient) => recipient.Address.toLowerCase() === targetAddress);
+      if (!toHit) return false;
+      if (opts.subject && !opts.subject.test(msg.Subject)) return false;
+      return true;
+    });
+    if (match) {
+      return await fetchMessage(request, match.ID);
+    }
+    lastError = `no match for to=${to} subject=${opts.subject?.source ?? '<any>'} among ${summaries.length} messages`;
+    await sleep(250);
+  }
+  throw new Error(`waitForEmailTo timed out after ${timeoutMs}ms: ${lastError}`);
+}
+
+/**
+ * List all messages currently in Mailpit. Exposed so tests can assert
+ * "no second email was sent" without waiting for a timeout — e.g. after
+ * a duplicate-registration silent-drop.
+ */
+export async function listMessages(request: APIRequestContext): Promise<MailpitSummary[]> {
+  const res = await request.get(`${MAILPIT_URL}/api/v1/messages`);
+  expect(res.ok(), `listMessages expected 2xx, got ${res.status()}: ${await res.text()}`).toBe(true);
+  const body = (await res.json()) as { messages?: MailpitSummary[] };
+  return body.messages ?? [];
+}
+
+/**
+ * Fetch a single message by Mailpit ID.
+ */
+export async function fetchMessage(request: APIRequestContext, id: string): Promise<MailpitMessage> {
+  const res = await request.get(`${MAILPIT_URL}/api/v1/message/${id}`);
+  expect(res.ok(), `fetchMessage expected 2xx, got ${res.status()}: ${await res.text()}`).toBe(true);
+  return (await res.json()) as MailpitMessage;
+}
+
+/**
+ * Extract the first URL from the text body that matches `pattern`. The
+ * rendered text templates (go/services/email_templates/*.txt.tmpl) put
+ * each actionable link on its own line, so the matcher just needs to find
+ * a contiguous non-whitespace span matching the URL pattern.
+ */
+export function extractLink(text: string, pattern: RegExp): string {
+  const match = text.match(pattern);
+  if (!match) {
+    throw new Error(`link matching ${pattern.source} not found in body: ${text.slice(0, 400)}`);
+  }
+  return match[0];
+}
+
+/**
+ * Extract the `token` query parameter from a URL — used by tests that
+ * want to hit the API verify/reset endpoints directly instead of driving
+ * the browser.
+ */
+export function tokenFromURL(url: string): string {
+  const parsed = new URL(url);
+  const token = parsed.searchParams.get('token');
+  if (!token) {
+    throw new Error(`url has no token query parameter: ${url}`);
+  }
+  return token;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/e2e/tests/invite-flow.spec.ts
+++ b/e2e/tests/invite-flow.spec.ts
@@ -53,12 +53,12 @@ test.describe('Invite Flow', () => {
     // Navigate to the invite page
     await page.goto(`/invite/${token}`);
 
-    // Wait for the invite card to load
-    await page.waitForSelector('.invite-card', { state: 'visible', timeout: 10000 });
-
-    // Should show the group name
-    const pageContent = await page.textContent('.invite-card');
-    expect(pageContent).toContain(groupName);
+    // The .invite-card div is always present — its content switches from
+    // "Loading invite..." to either the error branch or the group header
+    // once groupService.getInviteInfo resolves. Polling via toContainText
+    // waits for that transition instead of racing a textContent read
+    // against an in-flight fetch.
+    await expect(page.locator('.invite-card')).toContainText(groupName, { timeout: 10000 });
 
     // Clean up — revoke the invite. Assert 204 so cleanup failures (e.g. 403/422)
     // do not silently leave state behind while reporting a green test.
@@ -76,11 +76,11 @@ test.describe('Invite Flow', () => {
   test('invite page handles invalid token gracefully', async ({ page }) => {
     await page.goto('/invite/this-is-not-a-valid-token');
 
-    // Wait for the page to load
-    await page.waitForSelector('.invite-card', { state: 'visible', timeout: 10000 });
-
-    // Should show an error message
-    const pageContent = await page.textContent('.invite-card');
-    expect(pageContent).toContain('not valid');
+    // .invite-card renders "Loading invite..." first, then flips to the
+    // error branch ("This invite link is not valid.") once the service
+    // call rejects. Wait for that terminal text via the auto-retrying
+    // expect() rather than a one-shot textContent, which races the
+    // in-flight fetch and intermittently reads the loading state.
+    await expect(page.locator('.invite-card')).toContainText('not valid', { timeout: 10000 });
   });
 });

--- a/e2e/tests/mailpit-email.spec.ts
+++ b/e2e/tests/mailpit-email.spec.ts
@@ -282,11 +282,17 @@ test.describe('Mailpit — email delivery', () => {
     // user and sends no new email; it returns the same success message.
     await registerUser(request, email, password, name);
 
-    // Give the worker pool a short grace window to demonstrate
-    // "nothing else is coming" — ~1s is enough given the in-memory
-    // queue typically flushes in hundreds of ms.
-    await new Promise((r) => setTimeout(r, 1500));
+    // Observe the mailbox for longer than the email worker queue pop
+    // timeout so a delayed, buggy second send cannot slip past this
+    // assertion under load.
+    const noSecondEmailWindowMs = 2500;
+    const pollIntervalMs = 250;
+    const deadline = Date.now() + noSecondEmailWindowMs;
 
+    while (Date.now() < deadline) {
+      expect(await messagesTo(request, email)).toBe(1);
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+    }
     expect(await messagesTo(request, email)).toBe(1);
   });
 

--- a/e2e/tests/mailpit-email.spec.ts
+++ b/e2e/tests/mailpit-email.spec.ts
@@ -1,0 +1,306 @@
+/**
+ * E2E coverage for the transactional email pipeline that delivers into
+ * Mailpit (issue #1282). The docker-compose stack wires the app to
+ * Mailpit as its SMTP catch-all (EMAIL_PROVIDER=smtp, SMTP_HOST=mailpit),
+ * but no spec previously read an email out of it — verification URLs,
+ * reset links, welcome + password-changed notifications, and the
+ * multipart sanity of outgoing mail were all un-asserted at the wire
+ * level. The SMTP sender unit test stubs the protocol with a hand-rolled
+ * listener; registration.spec.ts only clicks the UI with fake tokens.
+ *
+ * This suite closes that gap by driving the real flows — register /
+ * verify-email, forgot-password / reset-password — through the public
+ * API, fetching the resulting emails from Mailpit, and asserting both
+ * the delivered URLs activate accounts / change passwords and the
+ * rendered messages carry the expected From/Subject/multipart shape.
+ *
+ * When Mailpit isn't reachable (dev-mode `npm run stack` starts a host
+ * `go run` with the stub provider; the webkit macOS CI lane runs the
+ * binary with no SMTP config either), a beforeAll probe flips a module
+ * flag and every test skips. In CI this suite runs only on the Linux
+ * lane that brings up docker-compose. See MAILPIT_URL override in
+ * e2e/tests/includes/mailpit.ts.
+ */
+import { test, expect, APIRequestContext } from '@playwright/test';
+import { BACKEND_URL } from '../setup/urls.js';
+import {
+  MAILPIT_URL,
+  extractLink,
+  fetchMessage,
+  isMailpitReachable,
+  listMessages,
+  tokenFromURL,
+  waitForEmailTo,
+} from './includes/mailpit.js';
+
+// Module-scoped because tests run in parallel and each worker gets its
+// own fresh APIRequestContext; the reachability probe only needs to
+// happen once per worker, not per test.
+let mailpitReachable = false;
+
+test.beforeAll(async ({ request }) => {
+  mailpitReachable = await isMailpitReachable(request);
+  if (!mailpitReachable) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Mailpit not reachable at ${MAILPIT_URL}; mailpit-email.spec.ts will skip. ` +
+        `Expected when running without docker-compose (e.g. the webkit macOS lane or dev-mode stub).`,
+    );
+  }
+});
+
+test.beforeEach(async () => {
+  test.skip(
+    !mailpitReachable,
+    `Mailpit not reachable at ${MAILPIT_URL}; skipping email-delivery tests.`,
+  );
+});
+
+/**
+ * Build a fresh unique recipient address per test. Mailpit's inbox is a
+ * single global mailbox shared across all parallel workers; scoping each
+ * test to its own `To` address means we never call DELETE on the shared
+ * inbox (which would race sibling workers and drop their mail) and
+ * listMessages+filter-by-To always gives us this test's slice.
+ */
+function freshEmail(label: string): string {
+  return `e2e-mailpit-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+}
+
+/**
+ * Return only the summaries Mailpit has for a specific recipient. Used by
+ * the duplicate-register assertion where we need "no further message
+ * arrived after the first" — which must not be corrupted by other
+ * workers delivering to different addresses in parallel.
+ */
+async function messagesTo(request: APIRequestContext, email: string): Promise<number> {
+  const all = await listMessages(request);
+  const target = email.toLowerCase();
+  return all.filter((m) => m.To.some((t) => t.Address.toLowerCase() === target)).length;
+}
+
+async function registerUser(
+  request: APIRequestContext,
+  email: string,
+  password: string,
+  name: string,
+): Promise<void> {
+  const res = await request.post(`${BACKEND_URL}/api/v1/register`, {
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    data: { email, password, name },
+  });
+  // Registration always responds 200 even for duplicates (anti-enumeration),
+  // so a non-200 here is a real server/shape failure worth surfacing.
+  expect(res.status(), await res.text()).toBe(200);
+}
+
+async function activateUser(request: APIRequestContext, email: string): Promise<void> {
+  const msg = await waitForEmailTo(request, email, {
+    subject: /verify your inventario account/i,
+  });
+  const verifyURL = extractLink(msg.Text, /https?:\/\/\S+\/verify-email\?token=\S+/);
+  const token = tokenFromURL(verifyURL);
+  const verifyRes = await request.get(
+    `${BACKEND_URL}/api/v1/verify-email?token=${encodeURIComponent(token)}`,
+  );
+  expect(verifyRes.status(), await verifyRes.text()).toBe(200);
+}
+
+async function login(
+  request: APIRequestContext,
+  email: string,
+  password: string,
+): Promise<{ status: number; body: string }> {
+  const res = await request.post(`${BACKEND_URL}/api/v1/auth/login`, {
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    data: { email, password },
+  });
+  return { status: res.status(), body: await res.text() };
+}
+
+test.describe('Mailpit — email delivery', () => {
+  test('register → activates user via the emailed verification link', async ({ request, page }) => {
+    const email = freshEmail('verify');
+    const password = 'Password123!';
+    const name = 'Mailpit Verify';
+
+    await registerUser(request, email, password, name);
+
+    const msg = await waitForEmailTo(request, email, {
+      subject: /verify your inventario account/i,
+    });
+
+    // Links are emitted into the text body one per line by
+    // verification.txt.tmpl. The HTML body also contains the link but
+    // parsing text is simpler and less brittle across whitespace.
+    const verifyURL = extractLink(msg.Text, /https?:\/\/\S+\/verify-email\?token=\S+/);
+    expect(verifyURL).toContain('/verify-email?token=');
+
+    // Before verification: login must fail (IsActive=false). The auth
+    // endpoint returns 401/403 for inactive accounts; the precise code
+    // isn't the thing under test here, only that login is denied.
+    const beforeLogin = await login(request, email, password);
+    expect(beforeLogin.status).not.toBe(200);
+
+    // Drive the real user flow: navigate the browser to the verification
+    // URL. The SPA's /verify-email route reads ?token=X and posts to the
+    // API; the page should render the success state.
+    await page.goto(verifyURL);
+    await expect(page.locator('.status-message.success')).toBeVisible({ timeout: 10_000 });
+
+    // After verification: login must succeed.
+    const afterLogin = await login(request, email, password);
+    expect(afterLogin.status, afterLogin.body).toBe(200);
+  });
+
+  test('verification flow also delivers a welcome email', async ({ request }) => {
+    const email = freshEmail('welcome');
+    const password = 'Password123!';
+    const name = 'Mailpit Welcome';
+
+    await registerUser(request, email, password, name);
+    // Activate via the API directly (no browser needed) so this test
+    // stays focused on "welcome email gets sent post-activation".
+    await activateUser(request, email);
+
+    const welcome = await waitForEmailTo(request, email, {
+      subject: /welcome to inventario/i,
+    });
+    // Text template renders {{.Name}} verbatim; confirm the substitution
+    // made it through the queue + renderer + SMTP hop unchanged.
+    expect(welcome.Text).toContain(name);
+    expect(welcome.HTML).not.toBe('');
+  });
+
+  test('forgot-password → reset-password rotates the password and notifies the user', async ({ request }) => {
+    const email = freshEmail('reset');
+    const oldPassword = 'Password123!';
+    const newPassword = 'BrandNewPassword456!';
+    const name = 'Mailpit Reset';
+
+    await registerUser(request, email, oldPassword, name);
+    await activateUser(request, email);
+
+    // The verification + welcome mails are already in the shared inbox;
+    // we don't delete them (that would race parallel workers). Instead,
+    // waitForEmailTo's subject filter picks out the specific reset /
+    // password-changed messages by rendered Subject below.
+    const forgotRes = await request.post(`${BACKEND_URL}/api/v1/forgot-password`, {
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      data: { email },
+    });
+    expect(forgotRes.status(), await forgotRes.text()).toBe(200);
+
+    const resetMsg = await waitForEmailTo(request, email, {
+      subject: /reset your inventario password/i,
+    });
+    const resetURL = extractLink(resetMsg.Text, /https?:\/\/\S+\/reset-password\?token=\S+/);
+    const resetToken = tokenFromURL(resetURL);
+
+    const resetRes = await request.post(`${BACKEND_URL}/api/v1/reset-password`, {
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      data: { token: resetToken, new_password: newPassword },
+    });
+    expect(resetRes.status(), await resetRes.text()).toBe(200);
+
+    // Old password no longer works.
+    const oldAttempt = await login(request, email, oldPassword);
+    expect(oldAttempt.status).not.toBe(200);
+
+    // New password works.
+    const newAttempt = await login(request, email, newPassword);
+    expect(newAttempt.status, newAttempt.body).toBe(200);
+
+    // Password-changed notification arrives. The reset email is already
+    // delivered; this is a separate message with a different subject.
+    const changed = await waitForEmailTo(request, email, {
+      subject: /inventario password was changed/i,
+    });
+    // The changed-at timestamp is rendered as RFC1123 UTC; just assert
+    // the template substitution produced a non-empty body containing
+    // the user's name.
+    expect(changed.Text).toContain(name);
+  });
+
+  test('outgoing mail carries the configured From and both text + HTML parts', async ({ request }) => {
+    const email = freshEmail('headers');
+    const password = 'Password123!';
+    const name = 'Mailpit Headers';
+
+    await registerUser(request, email, password, name);
+
+    const msg = await waitForEmailTo(request, email, {
+      subject: /verify your inventario account/i,
+    });
+
+    // Subject is rendered from the template's subjectByTemplateType table,
+    // so a non-empty match proves the renderer ran. The exact string is
+    // already asserted by the subject regex in waitForEmailTo above; the
+    // redundant non-empty check guards against Mailpit returning an
+    // empty Subject on malformed messages.
+    expect(msg.Subject.trim().length).toBeGreaterThan(0);
+
+    // Default FROM when docker-compose env leaves EMAIL_FROM unset is
+    // inventario@localhost (see docker-compose.yaml). If deployments
+    // override it, the test still passes as long as the From address is
+    // non-empty and looks like an address — which is the load-bearing
+    // invariant: DKIM/SPF regressions that blank or mangle From would
+    // trip this.
+    expect(msg.From.Address).toMatch(/^\S+@\S+$/);
+
+    // Both multipart sections must be non-empty. The async renderer
+    // produces HTML + Text pairs from embedded templates; a regression
+    // that drops one variant would only show up at the wire level and
+    // would be invisible to the unit tests (which assert the renderer
+    // return value directly, not the transport).
+    expect(msg.Text.trim().length).toBeGreaterThan(0);
+    expect(msg.HTML.trim().length).toBeGreaterThan(0);
+    expect(msg.HTML).toMatch(/<html[\s>]/i);
+  });
+
+  test('duplicate registration is silently dropped and only the first message is sent', async ({ request }) => {
+    // Exercises the anti-enumeration path: POST /register twice with the
+    // same email should return 200 both times (visible) but only send a
+    // single verification email (server-internal). Covers the branch
+    // handleRegister takes when GetByEmail returns an existing user.
+    //
+    // Scoped to this test's unique email so the assertion is independent
+    // of what parallel workers are delivering for other addresses.
+    const email = freshEmail('dup');
+    const password = 'Password123!';
+    const name = 'Mailpit Duplicate';
+
+    await registerUser(request, email, password, name);
+
+    // Wait for the first email so the comparison below isn't racing the
+    // first send.
+    await waitForEmailTo(request, email, {
+      subject: /verify your inventario account/i,
+    });
+
+    // Second register for the same email. The server creates no new
+    // user and sends no new email; it returns the same success message.
+    await registerUser(request, email, password, name);
+
+    // Give the worker pool a short grace window to demonstrate
+    // "nothing else is coming" — ~1s is enough given the in-memory
+    // queue typically flushes in hundreds of ms.
+    await new Promise((r) => setTimeout(r, 1500));
+
+    expect(await messagesTo(request, email)).toBe(1);
+  });
+
+  test('fetchMessage round-trips a delivered email by its Mailpit ID', async ({ request }) => {
+    // Smoke test for the fetchMessage helper: after registration we can
+    // round-trip a message ID through GET /api/v1/message/{id} and get
+    // the same envelope back. Catches regressions in the helper without
+    // relying on a full auth flow.
+    const email = freshEmail('smoke');
+    await registerUser(request, email, 'Password123!', 'Mailpit Smoke');
+    const msg = await waitForEmailTo(request, email);
+
+    const round = await fetchMessage(request, msg.ID);
+    expect(round.ID).toBe(msg.ID);
+    expect(round.To.some((t) => t.Address.toLowerCase() === email.toLowerCase())).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- New e2e spec `mailpit-email.spec.ts` closes the coverage gap called out in #1282: no existing test ever read an email out of Mailpit. The six tests drive register → browser-verify, register+verify → welcome, forgot→reset→password-changed, multipart+From sanity, duplicate-register silent-drop, and a fetch-by-id round-trip.
- New helper `tests/includes/mailpit.ts` wraps Mailpit's HTTP API (list, fetch, poll-by-recipient, link extraction). The spec probes `MAILPIT_URL` once in `beforeAll` and skips every test when Mailpit isn't reachable — expected on the webkit macOS CI lane and local dev-mode `npm run stack` (stub provider).
- Side fix in `tests/invite-flow.spec.ts`: `waitForSelector('.invite-card')` resolved on the always-present card while its content was still "Loading invite…", so a subsequent `textContent` read intermittently hit the loading state instead of the terminal group-name/error text. Swapped to `expect(locator).toContainText(..., { timeout })` which auto-retries past the loading state. Reproduced the flake 1/3 runs before the fix; 5/5 green after.

### Design notes
- **Parallelism**: each test scopes to a unique recipient (`Date.now()+random`). No test calls `DELETE /api/v1/messages`, which would race the shared Mailpit inbox across workers.
- **CI**: Mailpit is brought up by `docker-compose.yaml` on the Linux lane, so chromium + firefox run the suite. The webkit macOS lane boots only `./bin/inventario run` with the stub provider — the reachability probe returns false there and the tests skip cleanly.
- **Override**: `MAILPIT_URL` env var (default `http://localhost:8025`) lets non-default topologies point at a different Mailpit instance.

## Test plan
- [x] `USE_PREBUILT=true npx playwright test mailpit-email.spec.ts` → 18/18 green on chromium + firefox + webkit, 5/5 consecutive runs
- [x] `USE_PREBUILT=true npx playwright test invite-flow.spec.ts` → 5/5 consecutive green runs (flake reproduced 1/3 before the fix)
- [x] Full chromium suite: 110/110 green
- [x] Skip path: `MAILPIT_URL=http://127.0.0.1:59999 npx playwright test mailpit-email.spec.ts` → 6 skipped, 0 failed
