### PR TITLE
feat(groups): close remaining #1219 gaps (closes #1289)

### DIFF
--- a/e2e/tests/delete-group-dialog.spec.ts
+++ b/e2e/tests/delete-group-dialog.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * E2E coverage for the group-deletion Danger Zone dialog (issue #1289 Gap A,
+ * spec #1219 §12). The backend contract — "typing the group name AND the
+ * current password are both required, wrong password is distinguishable from
+ * wrong confirm-word" — is covered at the handler level in
+ * go/apiserver/groups_test.go. These tests drive the dialog end-to-end to
+ * guard the UX pieces: password input is present, the inline error surfaces
+ * specifically on the password field for wrong passwords, and the whole
+ * flow actually transitions the group to pending_deletion on the happy path.
+ */
+import { expect, APIRequestContext, Page } from '@playwright/test';
+import { test } from '../fixtures/app-fixture.js';
+
+const ADMIN_PASSWORD = 'testpassword123';
+
+async function createThrowawayGroup(
+  request: APIRequestContext,
+  adminAuth: { accessToken: string; csrfToken: string },
+  label: string,
+): Promise<{ id: string; name: string; slug: string }> {
+  const name = `${label} ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const resp = await request.post('/api/v1/groups', {
+    headers: {
+      'Content-Type': 'application/vnd.api+json',
+      'Accept': 'application/vnd.api+json',
+      'Authorization': `Bearer ${adminAuth.accessToken}`,
+      'X-CSRF-Token': adminAuth.csrfToken,
+    },
+    data: {
+      data: {
+        type: 'groups',
+        attributes: { name, icon: '🧪' },
+      },
+    },
+  });
+  expect(resp.status(), await resp.text()).toBe(201);
+  const body = await resp.json();
+  return {
+    id: body.data.id as string,
+    name,
+    slug: body.data.attributes.slug as string,
+  };
+}
+
+async function hardDelete(
+  request: APIRequestContext,
+  adminAuth: { accessToken: string; csrfToken: string },
+  group: { id: string; name: string },
+) {
+  // Teardown uses the same protocol under test, so it must supply both
+  // fields — otherwise the group leaks when a test path short-circuits
+  // before calling the UI.
+  await request.delete(`/api/v1/groups/${group.id}`, {
+    headers: {
+      'Content-Type': 'application/vnd.api+json',
+      'Accept': 'application/vnd.api+json',
+      'Authorization': `Bearer ${adminAuth.accessToken}`,
+      'X-CSRF-Token': adminAuth.csrfToken,
+    },
+    data: { confirm_word: group.name, password: ADMIN_PASSWORD },
+  });
+}
+
+async function openDangerZone(page: Page, group: { id: string; slug: string }) {
+  // The settings page sits under /groups/:groupId/settings — not the
+  // group-scoped data routes, so no /g/<slug>/ prefix needed.
+  await page.goto(`/groups/${group.id}/settings`);
+  await page.waitForSelector('[data-testid="delete-group-open"]', { timeout: 10000 });
+  await page.click('[data-testid="delete-group-open"]');
+  await page.waitForSelector('[data-testid="delete-confirm-word"]', { state: 'visible', timeout: 5000 });
+}
+
+test.describe('Delete-group dialog (#1289 Gap A)', () => {
+  test('wrong password surfaces inline error on the password field only', async ({ page, request }) => {
+    const adminToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const adminCsrf = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+    const adminAuth = { accessToken: adminToken, csrfToken: adminCsrf };
+
+    const group = await createThrowawayGroup(request, adminAuth, 'Delete Dialog Wrong Password');
+
+    try {
+      await openDangerZone(page, group);
+
+      await page.fill('[data-testid="delete-confirm-word"]', group.name);
+      await page.fill('[data-testid="delete-password"]', 'definitely-not-the-real-password');
+
+      const delResp = page.waitForResponse(
+        (r) => r.url().includes(`/api/v1/groups/${group.id}`) && r.request().method() === 'DELETE',
+      );
+      await page.click('[data-testid="delete-group-submit"]');
+      const resp = await delResp;
+      expect(resp.status()).toBe(422);
+
+      // Password error visible; confirm-word error not.
+      await expect(page.locator('[data-testid="delete-password-error"]')).toBeVisible();
+      await expect(page.locator('[data-testid="delete-confirm-error"]')).toHaveCount(0);
+
+      // Group still active — nothing was mutated.
+      const groupResp = await request.get(`/api/v1/groups/${group.id}`, {
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${adminAuth.accessToken}`,
+        },
+      });
+      expect(groupResp.status()).toBe(200);
+      const body = await groupResp.json();
+      expect(body.data.attributes.status).toBe('active');
+    } finally {
+      await hardDelete(request, adminAuth, group);
+    }
+  });
+
+  test('correct confirm-word + password transitions the group to pending_deletion', async ({ page, request }) => {
+    const adminToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const adminCsrf = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+    const adminAuth = { accessToken: adminToken, csrfToken: adminCsrf };
+
+    const group = await createThrowawayGroup(request, adminAuth, 'Delete Dialog Happy Path');
+
+    try {
+      await openDangerZone(page, group);
+
+      await page.fill('[data-testid="delete-confirm-word"]', group.name);
+      await page.fill('[data-testid="delete-password"]', ADMIN_PASSWORD);
+
+      const delResp = page.waitForResponse(
+        (r) => r.url().includes(`/api/v1/groups/${group.id}`) && r.request().method() === 'DELETE',
+      );
+      await page.click('[data-testid="delete-group-submit"]');
+      const resp = await delResp;
+      expect(resp.status()).toBe(204);
+
+      // Group is now pending_deletion — the slug resolver returns 410 Gone
+      // on its data routes, but the ID-based GET (not slug-resolved) still
+      // returns the record so admins can see the deletion state. Use that.
+      const groupResp = await request.get(`/api/v1/groups/${group.id}`, {
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${adminAuth.accessToken}`,
+        },
+      });
+      expect(groupResp.status()).toBe(200);
+      const body = await groupResp.json();
+      expect(body.data.attributes.status).toBe('pending_deletion');
+    } finally {
+      // Teardown no-op: the group is already in pending_deletion. Trying to
+      // delete again returns 410 Gone. Swallow the error — the background
+      // worker (once #1214 lands) will eventually purge it.
+    }
+  });
+});

--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -88,7 +88,7 @@ test.describe('Group Management API', () => {
         'Authorization': `Bearer ${authToken}`,
         'X-CSRF-Token': csrfToken,
       },
-      data: { confirm_word: groupName },
+      data: { confirm_word: groupName, password: 'testpassword123' },
     });
     expect(deleteResponse.status()).toBe(204);
   });
@@ -357,7 +357,7 @@ test.describe('Main Currency dropdown (#1256)', () => {
         'Authorization': `Bearer ${authToken}`,
         'X-CSRF-Token': csrfToken,
       },
-      data: { confirm_word: groupName },
+      data: { confirm_word: groupName, password: 'testpassword123' },
     });
     expect(deleteResp.status()).toBe(204);
   });
@@ -483,7 +483,7 @@ test.describe('Remove Member — last admin protection (#1257)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName },
+        data: { confirm_word: groupName, password: 'testpassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }
@@ -551,7 +551,7 @@ test.describe('Remove Member — last admin protection (#1257)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName },
+        data: { confirm_word: groupName, password: 'testpassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }
@@ -631,7 +631,7 @@ test.describe('Leave Group UI — last admin protection (#1259)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName },
+        data: { confirm_word: groupName, password: 'testpassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }
@@ -761,7 +761,7 @@ test.describe('Group selection persistence (#1262)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName },
+        data: { confirm_word: groupName, password: 'testpassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }
@@ -911,7 +911,7 @@ test.describe('Group icon picker (#1255)', () => {
         'Authorization': `Bearer ${authToken}`,
         'X-CSRF-Token': csrfToken,
       },
-      data: { confirm_word: groupName },
+      data: { confirm_word: groupName, password: 'testpassword123' },
     });
     expect(deleteResp.status()).toBe(204);
   });
@@ -974,7 +974,7 @@ test.describe('Group icon picker (#1255)', () => {
         'Authorization': `Bearer ${authToken}`,
         'X-CSRF-Token': csrfToken,
       },
-      data: { confirm_word: groupName },
+      data: { confirm_word: groupName, password: 'testpassword123' },
     });
     expect(deleteResp.status()).toBe(204);
   });
@@ -1051,7 +1051,7 @@ test.describe('Group icon picker (#1255)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName },
+        data: { confirm_word: groupName, password: 'testpassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }
@@ -1232,7 +1232,7 @@ test.describe('Default group preference (#1263)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName },
+        data: { confirm_word: groupName, password: 'testpassword123' },
       });
       expect(deleteResp.status()).toBe(204);
 
@@ -1416,7 +1416,7 @@ test.describe('Group + role cluster in header (#1258)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName },
+        data: { confirm_word: groupName, password: 'testpassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }

--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -683,22 +683,21 @@ test.describe('Group selection persistence (#1262)', () => {
       await page.goto('/');
       await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
 
-      // Open the dropdown and switch to the new group. selectGroup() in
-      // GroupSelector.vue triggers window.location.reload() to refetch
-      // group-scoped data — wait for the reload to settle before asserting.
+      // Open the dropdown and switch to the new group. After #1289 Gap C,
+      // GroupSelector navigates to /g/<new-slug>/... via router.push
+      // instead of triggering a full window.location.reload() — the URL
+      // is now the source of truth, so a plain SPA navigation is enough
+      // to flip every API call and the selector's name binding.
       await page.click('.group-selector__trigger');
       const targetItem = page.locator('.group-selector__item', { hasText: groupName });
       await expect(targetItem).toBeVisible({ timeout: 5000 });
 
-      // `waitForLoadState('load')` resolves against the *current* page's load
-      // state — if the page is already loaded it returns immediately and
-      // doesn't actually block on the JS-triggered reload. `waitForEvent('load')`
-      // waits for the *next* load event, which is what we want here. Then let
-      // the network settle so the subsequent page.reload() doesn't race with
-      // the in-flight reload (that race surfaced as ERR_ABORTED in CI).
-      const nextLoad = page.waitForEvent('load');
       await targetItem.click();
-      await nextLoad;
+      // Wait for the URL to carry the new group slug before asserting
+      // anything that depends on the switch. This replaces the previous
+      // waitForEvent('load') + networkidle dance used when the selector
+      // did a full reload.
+      await page.waitForURL(/\/g\/[^/]+/, { timeout: 10000 });
       await page.waitForLoadState('networkidle', { timeout: 15000 });
 
       await expect(page.locator('.group-selector__name')).toHaveText(groupName, { timeout: 10000 });
@@ -1362,13 +1361,11 @@ test.describe('Group + role cluster in header (#1258)', () => {
       const targetItem = page.locator('.group-selector__item', { hasText: groupName });
       await expect(targetItem).toBeVisible({ timeout: 5000 });
 
-      // GroupSelector triggers window.location.reload() after setCurrentGroup —
-      // same pattern the #1262 persistence test relies on. Wait for the
-      // *next* load event, not the current one (a bare waitForLoadState
-      // would resolve against the already-loaded page and race the reload).
-      const nextLoad = page.waitForEvent('load');
+      // After #1289 Gap C, GroupSelector navigates to /g/<new-slug>/... via
+      // router.push (no full reload). Wait for the URL to reflect the new
+      // group before asserting any reactive state that depends on the switch.
       await targetItem.click();
-      await nextLoad;
+      await page.waitForURL(/\/g\/[^/]+/, { timeout: 10000 });
       await page.waitForLoadState('networkidle', { timeout: 15000 });
 
       await expect(page.locator('.group-selector__name')).toHaveText(groupName);

--- a/e2e/tests/includes/commodities.ts
+++ b/e2e/tests/includes/commodities.ts
@@ -253,9 +253,11 @@ export async function deleteCommodity(page: Page, recorder: TestRecorder, commod
     // Wait for the confirmation modal to disappear
     await page.locator('.confirmation-modal').waitFor({ state: 'hidden', timeout: 5000 });
 
-    // Verify we're redirected back to the correct page
+    // Verify we're redirected back to the correct page. After issue
+    // #1289 Gap C every data route lives under /g/:groupSlug/..., so
+    // match the suffix rather than the exact path.
     if (backTo === 'commodities') {
-        await expect(page).toHaveURL('/commodities', { timeout: 10000 });
+        await expect(page).toHaveURL(/\/commodities(?:\?.*)?$/, { timeout: 10000 });
         await recorder.takeScreenshot('commodity-delete-02-after-delete');
     } else if (backTo === 'areas') {
         await expect(page).toHaveURL(/\/areas\/[a-zA-Z0-9-]+/, { timeout: 10000 });

--- a/e2e/tests/invite-accept.spec.ts
+++ b/e2e/tests/invite-accept.spec.ts
@@ -151,7 +151,7 @@ async function deleteGroup(
       'Authorization': `Bearer ${adminAuth.accessToken}`,
       'X-CSRF-Token': adminAuth.csrfToken,
     },
-    data: { confirm_word: group.name },
+    data: { confirm_word: group.name, password: 'testpassword123' },
   });
   expect(resp.status()).toBe(204);
 }

--- a/e2e/tests/register-via-invite.spec.ts
+++ b/e2e/tests/register-via-invite.spec.ts
@@ -90,7 +90,7 @@ async function deleteGroup(
       'Authorization': `Bearer ${adminAuth.accessToken}`,
       'X-CSRF-Token': adminAuth.csrfToken,
     },
-    data: { confirm_word: group.name },
+    data: { confirm_word: group.name, password: 'testpassword123' },
   });
   // Asserting the status guards against silent leaks into the shared
   // seeded environment — a stuck pending_deletion group is invisible but

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,11 +13,11 @@
         </div>
         <nav>
           <router-link to="/" :class="{ 'custom-active': isHomeActive }">Home</router-link> |
-          <router-link to="/locations" :class="{ 'custom-active': isLocationsActive }">Locations</router-link> |
-          <router-link to="/commodities" :class="{ 'custom-active': isCommoditiesActive }">Commodities</router-link> |
-          <router-link to="/files" :class="{ 'custom-active': isFilesActive }">Files</router-link> |
-          <router-link to="/exports" :class="{ 'custom-active': isExportsActive }">Exports</router-link> |
-          <router-link to="/system" :class="{ 'custom-active': isSystemActive }">System</router-link>
+          <router-link :to="groupPath('/locations')" :class="{ 'custom-active': isLocationsActive }">Locations</router-link> |
+          <router-link :to="groupPath('/commodities')" :class="{ 'custom-active': isCommoditiesActive }">Commodities</router-link> |
+          <router-link :to="groupPath('/files')" :class="{ 'custom-active': isFilesActive }">Files</router-link> |
+          <router-link :to="groupPath('/exports')" :class="{ 'custom-active': isExportsActive }">Exports</router-link> |
+          <router-link :to="groupPath('/system')" :class="{ 'custom-active': isSystemActive }">System</router-link>
         </nav>
         <!-- Group selector + current role badge are two facets of the same
              "my identity in this context" display (#1258). They live in a
@@ -114,30 +114,35 @@ const isPrintRoute = computed(() => {
   return route.path.includes('/print')
 })
 
+// groupPath builds an absolute data-route URL under the current group's
+// /g/<slug>/ prefix. It returns the flat legacy form when the user has no
+// current group (the router guard will then bounce the click to /no-group).
+// Introduced for issue #1289 Gap C so the nav renders bookmarkable URLs
+// and supports two tabs holding two different groups simultaneously.
+function groupPath(subpath: string): string {
+  const slug = groupStore.currentGroupSlug
+  if (!slug) return subpath
+  return `/g/${encodeURIComponent(slug)}${subpath}`
+}
+
+// Each nav link highlights when the URL (stripped of the optional
+// /g/<slug> prefix) starts with its section root. Matching against the
+// group-prefixed and flat forms keeps the highlight correct for both the
+// new canonical URLs and any legacy bookmarks still in the wild.
+function sectionPathMatches(...prefixes: string[]): boolean {
+  const raw = route.path
+  const slug = typeof route.params.groupSlug === 'string' ? route.params.groupSlug : ''
+  const stripped = slug ? raw.replace(`/g/${encodeURIComponent(slug)}`, '') : raw
+  return prefixes.some((p) => stripped.startsWith(p))
+}
+
 // Computed properties to determine active navigation sections
-const isHomeActive = computed(() => {
-  return route.path === '/'
-})
-
-const isLocationsActive = computed(() => {
-  return route.path.startsWith('/locations') || route.path.startsWith('/areas')
-})
-
-const isCommoditiesActive = computed(() => {
-  return route.path.startsWith('/commodities')
-})
-
-const isFilesActive = computed(() => {
-  return route.path.startsWith('/files')
-})
-
-const isExportsActive = computed(() => {
-  return route.path.startsWith('/exports')
-})
-
-const isSystemActive = computed(() => {
-  return route.path.startsWith('/system')
-})
+const isHomeActive = computed(() => route.path === '/')
+const isLocationsActive = computed(() => sectionPathMatches('/locations', '/areas'))
+const isCommoditiesActive = computed(() => sectionPathMatches('/commodities'))
+const isFilesActive = computed(() => sectionPathMatches('/files'))
+const isExportsActive = computed(() => sectionPathMatches('/exports'))
+const isSystemActive = computed(() => sectionPathMatches('/system'))
 
 // Admin active state removed — user management is now per-group
 

--- a/frontend/src/components/GroupSelector.vue
+++ b/frontend/src/components/GroupSelector.vue
@@ -75,6 +75,12 @@ async function selectGroup(group: LocationGroup) {
       subpath = route.path.slice(marker.length)
     }
   }
+  // Persist the choice before navigating so the cold-start redirect after a
+  // later login lands on the group the user last picked. The route guard
+  // only updates in-memory state on URL-driven syncs (see router/index.ts)
+  // precisely so it doesn't stomp on this localStorage write from a
+  // different tab — this call is the user's explicit "remember this".
+  await groupStore.setCurrentGroup(group.slug, { persist: true })
   const targetPath = `/g/${encodeURIComponent(group.slug)}${subpath || '/'}`
   await router.push(targetPath)
 }

--- a/frontend/src/components/GroupSelector.vue
+++ b/frontend/src/components/GroupSelector.vue
@@ -43,23 +43,40 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useGroupStore } from '@/stores/groupStore'
 import type { LocationGroup } from '@/types/group'
 
 const groupStore = useGroupStore()
 const router = useRouter()
+const route = useRoute()
 const isOpen = ref(false)
 const selectorRef = ref<HTMLElement | null>(null)
 
+// Switch to another group by navigating to its /g/<slug>/... URL, rebuilding
+// the current subpath under the new slug so the user stays on the same kind
+// of screen (commodities → commodities, exports → exports…). Writing the
+// slug into the URL instead of mutating localStorage is what makes two tabs
+// with two different groups independent (issue #1289 Gap C).
 async function selectGroup(group: LocationGroup) {
-  const previousSlug = groupStore.currentGroupSlug
-  await groupStore.setCurrentGroup(group.slug)
   isOpen.value = false
-  // Full reload ensures all data-dependent views re-fetch for the new group
-  if (previousSlug !== group.slug) {
-    window.location.reload()
+  if (groupStore.currentGroupSlug === group.slug) {
+    return
   }
+
+  // Preserve the current subpath after the /g/<slug> prefix when possible,
+  // so the user stays on the same view kind. Fall back to the group's root
+  // path when the current route isn't group-scoped (profile, no-group, …).
+  const currentSlug = typeof route.params.groupSlug === 'string' ? route.params.groupSlug : ''
+  let subpath = ''
+  if (currentSlug) {
+    const marker = `/g/${encodeURIComponent(currentSlug)}`
+    if (route.path.startsWith(marker)) {
+      subpath = route.path.slice(marker.length)
+    }
+  }
+  const targetPath = `/g/${encodeURIComponent(group.slug)}${subpath || '/'}`
+  await router.push(targetPath)
 }
 
 function openCreateDialog() {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -30,22 +30,13 @@ const GROUP_EXEMPT_ROUTE_NAMES = new Set([
   'home',
 ])
 
-// DATA_ROUTE_SLUGS maps the legacy flat subpath → its canonical
-// /g/:groupSlug/... counterpart. When a user (or a test) navigates to a
-// flat data path we redirect them to the group-scoped form so the slug is
-// explicit in the URL (spec #1219 §8, issue #1289 Gap C). Having the slug
-// on the URL is what makes two tabs with two different groups actually
-// independent — the legacy localStorage-only scheme made tab 1 silently
-// start hitting tab 2's group on the next navigation.
-const DATA_ROUTE_PREFIXES = [
-  '/locations',
-  '/areas',
-  '/commodities',
-  '/files',
-  '/exports',
-  '/system',
-  '/search',
-]
+// Legacy flat data paths (/locations, /commodities, …) are redirected to
+// their /g/:groupSlug/... counterpart by the router guard (spec #1219 §8,
+// issue #1289 Gap C) using the `legacyFlatDataRoute` meta on each stub
+// route declared below. Having the slug on the URL is what makes two tabs
+// with two different groups actually independent — the legacy
+// localStorage-only scheme let tab 1 silently start hitting tab 2's group
+// on the next navigation.
 
 // Define routes without using RouteRecordRaw type
 const routes = [

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -27,7 +27,6 @@ const GROUP_EXEMPT_ROUTE_NAMES = new Set([
   'no-group',
   'group-create',
   'profile',
-  'home',
 ])
 
 // Legacy flat data paths (/locations, /commodities, …) are redirected to

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -27,7 +27,25 @@ const GROUP_EXEMPT_ROUTE_NAMES = new Set([
   'no-group',
   'group-create',
   'profile',
+  'home',
 ])
+
+// DATA_ROUTE_SLUGS maps the legacy flat subpath → its canonical
+// /g/:groupSlug/... counterpart. When a user (or a test) navigates to a
+// flat data path we redirect them to the group-scoped form so the slug is
+// explicit in the URL (spec #1219 §8, issue #1289 Gap C). Having the slug
+// on the URL is what makes two tabs with two different groups actually
+// independent — the legacy localStorage-only scheme made tab 1 silently
+// start hitting tab 2's group on the next navigation.
+const DATA_ROUTE_PREFIXES = [
+  '/locations',
+  '/areas',
+  '/commodities',
+  '/files',
+  '/exports',
+  '/system',
+  '/search',
+]
 
 // Define routes without using RouteRecordRaw type
 const routes = [
@@ -69,122 +87,53 @@ const routes = [
     component: HomeView,
     meta: { requiresAuth: true }
   },
-  // Locations (now includes areas)
+  // Group-scoped data routes: /g/:groupSlug/... — see issue #1289 Gap C.
+  // Keeping the slug in the URL (not in localStorage) is what makes two
+  // browser tabs with two different groups actually independent. Flat
+  // equivalents are preserved below as legacy redirects.
   {
-    path: '/locations',
-    name: 'locations',
-    component: () => import('../views/locations/LocationListView.vue')
+    path: '/g/:groupSlug',
+    meta: { requiresAuth: true, groupScoped: true },
+    children: [
+      { path: 'locations',           name: 'locations',            component: () => import('../views/locations/LocationListView.vue') },
+      { path: 'locations/:id',       name: 'location-detail',      component: () => import('../views/locations/LocationDetailView.vue') },
+      { path: 'locations/:id/edit', name: 'location-edit',        component: () => import('../views/locations/LocationEditView.vue') },
+      { path: 'areas/:id',           name: 'area-detail',          component: () => import('../views/areas/AreaDetailView.vue') },
+      { path: 'areas/:id/edit',      name: 'area-edit',            component: () => import('../views/areas/AreaEditView.vue') },
+      { path: 'commodities',         name: 'commodities',          component: () => import('../views/commodities/CommodityListView.vue') },
+      { path: 'commodities/new',     name: 'commodity-create',     component: () => import('../views/commodities/CommodityCreateView.vue') },
+      { path: 'commodities/:id',     name: 'commodity-detail',     component: () => import('../views/commodities/CommodityDetailView.vue') },
+      { path: 'commodities/:id/edit',  name: 'commodity-edit',     component: () => import('../views/commodities/CommodityEditView.vue') },
+      { path: 'commodities/:id/print', name: 'commodity-print',    component: () => import('../views/commodities/CommodityPrintView.vue') },
+      { path: 'exports',             name: 'exports',              component: () => import('../views/exports/ExportListView.vue') },
+      { path: 'exports/new',         name: 'export-create',        component: () => import('../views/exports/ExportCreateView.vue') },
+      { path: 'exports/import',      name: 'export-import',        component: () => import('../views/exports/ExportImportView.vue') },
+      { path: 'exports/:id',         name: 'export-detail',        component: () => import('../views/exports/ExportDetailView.vue') },
+      { path: 'exports/:id/restore', name: 'export-restore',       component: () => import('../views/exports/restore/RestoreCreateView.vue') },
+      { path: 'files',               name: 'files',                component: () => import('../views/files/FileListView.vue') },
+      { path: 'files/create',        name: 'file-create',          component: () => import('../views/files/FileCreateView.vue') },
+      { path: 'files/:id',           name: 'file-detail',          component: () => import('../views/files/FileDetailView.vue') },
+      { path: 'files/:id/edit',      name: 'file-edit',            component: () => import('../views/files/FileEditView.vue') },
+      { path: 'system',              name: 'system',               component: () => import('../views/system/SystemView.vue') },
+      { path: 'system/settings/:id', name: 'system-setting-detail', component: () => import('../views/system/SystemSettingDetailView.vue') },
+    ]
   },
-  {
-    path: '/locations/:id',
-    name: 'location-detail',
-    component: () => import('../views/locations/LocationDetailView.vue')
-  },
-  {
-    path: '/locations/:id/edit',
-    name: 'location-edit',
-    component: () => import('../views/locations/LocationEditView.vue')
-  },
-  {
-    path: '/areas/:id',
-    name: 'area-detail',
-    component: () => import('../views/areas/AreaDetailView.vue')
-  },
-  {
-    path: '/areas/:id/edit',
-    name: 'area-edit',
-    component: () => import('../views/areas/AreaEditView.vue')
-  },
-  // Commodities
-  {
-    path: '/commodities',
-    name: 'commodities',
-    component: () => import('../views/commodities/CommodityListView.vue')
-  },
-  {
-    path: '/commodities/new',
-    name: 'commodity-create',
-    component: () => import('../views/commodities/CommodityCreateView.vue')
-  },
-  {
-    path: '/commodities/:id',
-    name: 'commodity-detail',
-    component: () => import('../views/commodities/CommodityDetailView.vue')
-  },
-  {
-    path: '/commodities/:id/edit',
-    name: 'commodity-edit',
-    component: () => import('../views/commodities/CommodityEditView.vue')
-  },
-  {
-    path: '/commodities/:id/print',
-    name: 'commodity-print',
-    component: () => import('../views/commodities/CommodityPrintView.vue')
-  },
-  // Exports
-  {
-    path: '/exports',
-    name: 'exports',
-    component: () => import('../views/exports/ExportListView.vue')
-  },
-  {
-    path: '/exports/new',
-    name: 'export-create',
-    component: () => import('../views/exports/ExportCreateView.vue')
-  },
-  {
-    path: '/exports/import',
-    name: 'export-import',
-    component: () => import('../views/exports/ExportImportView.vue')
-  },
-  {
-    path: '/exports/:id',
-    name: 'export-detail',
-    component: () => import('../views/exports/ExportDetailView.vue')
-  },
-  {
-    path: '/exports/:id/restore',
-    name: 'export-restore',
-    component: () => import('../views/exports/restore/RestoreCreateView.vue')
-  },
-  // Files
-  {
-    path: '/files',
-    name: 'files',
-    component: () => import('../views/files/FileListView.vue')
-  },
-  {
-    path: '/files/create',
-    name: 'file-create',
-    component: () => import('../views/files/FileCreateView.vue')
-  },
-  {
-    path: '/files/:id',
-    name: 'file-detail',
-    component: () => import('../views/files/FileDetailView.vue')
-  },
-  {
-    path: '/files/:id/edit',
-    name: 'file-edit',
-    component: () => import('../views/files/FileEditView.vue')
-  },
-  // Profile (authenticated users)
+  // Legacy flat routes — kept as redirect stubs so any stray
+  // `router.push('/locations')` or bookmarked pre-#1289 URL still works.
+  // The router-level beforeEach guard rewrites them to /g/<current-slug>/...
+  // using groupStore.currentGroup.
+  { path: '/locations/:pathMatch(.*)*',    meta: { legacyFlatDataRoute: '/locations' },   component: () => import('../views/locations/LocationListView.vue') },
+  { path: '/areas/:pathMatch(.*)*',        meta: { legacyFlatDataRoute: '/areas' },       component: () => import('../views/areas/AreaDetailView.vue') },
+  { path: '/commodities/:pathMatch(.*)*',  meta: { legacyFlatDataRoute: '/commodities' }, component: () => import('../views/commodities/CommodityListView.vue') },
+  { path: '/files/:pathMatch(.*)*',        meta: { legacyFlatDataRoute: '/files' },       component: () => import('../views/files/FileListView.vue') },
+  { path: '/exports/:pathMatch(.*)*',      meta: { legacyFlatDataRoute: '/exports' },     component: () => import('../views/exports/ExportListView.vue') },
+  { path: '/system/:pathMatch(.*)*',       meta: { legacyFlatDataRoute: '/system' },      component: () => import('../views/system/SystemView.vue') },
+  // Profile (authenticated users, not group-scoped)
   {
     path: '/profile',
     name: 'profile',
     component: () => import('../views/ProfileView.vue'),
     meta: { requiresAuth: true }
-  },
-  // System (formerly Settings)
-  {
-    path: '/system',
-    name: 'system',
-    component: () => import('../views/system/SystemView.vue')
-  },
-  {
-    path: '/system/settings/:id',
-    name: 'system-setting-detail',
-    component: () => import('../views/system/SystemSettingDetailView.vue')
   },
   // Group management
   {
@@ -305,6 +254,43 @@ router.beforeEach(async (to, from) => {
       if (!groupStore.hasGroups) {
         console.log('No groups — redirecting to /no-group')
         return { path: '/no-group' }
+      }
+
+      // Legacy flat data-route handling (issue #1289 Gap C): rewrite
+      // /locations, /commodities, etc. to /g/<current-slug>/... so the
+      // active group is explicit in the URL and independent per-tab.
+      const legacyPrefix = (to.meta as { legacyFlatDataRoute?: string })?.legacyFlatDataRoute
+      if (legacyPrefix && groupStore.currentGroup) {
+        const slug = groupStore.currentGroup.slug
+        // Preserve any subpath after the matched prefix (e.g. /commodities/:id/edit).
+        const suffix = to.path.startsWith(legacyPrefix)
+          ? to.path.slice(legacyPrefix.length)
+          : ''
+        const targetPath = `/g/${encodeURIComponent(slug)}${legacyPrefix}${suffix}`
+        return { path: targetPath, query: to.query, hash: to.hash, replace: true }
+      }
+
+      // When navigating into a /g/:groupSlug/... route, sync the store to
+      // whatever slug is on the URL. Two tabs can now hold two different
+      // currentGroup values because each tab derives its state from its
+      // own URL rather than a shared localStorage key.
+      const slugParam = typeof to.params.groupSlug === 'string' ? to.params.groupSlug : ''
+      if (slugParam) {
+        const match = groupStore.groups.find((g) => g.slug === slugParam)
+        if (!match) {
+          // Unknown slug for this user (wrong group, revoked membership,
+          // or stale URL). Redirect to the user's current group so they
+          // land somewhere safe instead of on a 404.
+          if (groupStore.currentGroup) {
+            return { path: `/g/${encodeURIComponent(groupStore.currentGroup.slug)}/` }
+          }
+          return { path: '/no-group' }
+        }
+        if (groupStore.currentGroup?.slug !== slugParam) {
+          // Route-driven switch: update the store but don't write to
+          // localStorage — per-tab isolation is the whole point.
+          await groupStore.setCurrentGroup(slugParam)
+        }
       }
     }
   }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -85,6 +85,16 @@ const routes = [
     path: '/g/:groupSlug',
     meta: { requiresAuth: true, groupScoped: true },
     children: [
+      // Empty-child index: bare /g/<slug>/ or /g/<slug> lands on the
+      // group's commodities list, which is the most common day-to-day
+      // view. Without this redirect Vue Router can't resolve the parent
+      // route alone (it has no component) and the navigation 404s — this
+      // was the silent failure that broke GroupSelector switches from
+      // the tenant-wide home page in PR #1290.
+      { path: '', redirect: (to: { params: Record<string, string | string[]> }) => {
+        const slug = typeof to.params.groupSlug === 'string' ? to.params.groupSlug : String(to.params.groupSlug)
+        return { path: `/g/${encodeURIComponent(slug)}/commodities` }
+      } },
       { path: 'locations',           name: 'locations',            component: () => import('../views/locations/LocationListView.vue') },
       { path: 'locations/:id',       name: 'location-detail',      component: () => import('../views/locations/LocationDetailView.vue') },
       { path: 'locations/:id/edit', name: 'location-edit',        component: () => import('../views/locations/LocationEditView.vue') },
@@ -277,9 +287,12 @@ router.beforeEach(async (to, from) => {
           return { path: '/no-group' }
         }
         if (groupStore.currentGroup?.slug !== slugParam) {
-          // Route-driven switch: update the store but don't write to
-          // localStorage — per-tab isolation is the whole point.
-          await groupStore.setCurrentGroup(slugParam)
+          // Route-driven sync: update only in-memory state. Persisting
+          // here would let tab A's /g/<A>/ refresh overwrite the
+          // localStorage snapshot that tab B's /g/<B>/ relied on for
+          // its cold-start redirect — i.e. re-introduce cross-tab
+          // coupling after #1289 Gap C explicitly decoupled them.
+          await groupStore.setCurrentGroup(slugParam, { persist: false })
         }
       }
     }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -71,6 +71,38 @@ function getAuthToken(): string | null {
   return localStorage.getItem('inventario_token')
 }
 
+// resolveCurrentGroupSlug returns the group slug for the API request URL
+// rewrite. It prefers the slug that the router has resolved on the current
+// navigation — that's the per-tab, URL-derived source of truth introduced
+// by issue #1289 Gap C so two tabs can hold two different groups.
+// localStorage is only consulted as a cold-start fallback during the
+// narrow window between app boot and the first navigation.
+function resolveCurrentGroupSlug(): string | null {
+  // The router module is dynamically imported in a side-effect up top to
+  // avoid a circular dependency with this file; mirror the same pattern
+  // here to avoid reintroducing one.
+  const routerModule = getRouterModule()
+  if (routerModule) {
+    const routeSlug = routerModule.currentRoute.value.params.groupSlug
+    if (typeof routeSlug === 'string' && routeSlug) {
+      return routeSlug
+    }
+  }
+  return localStorage.getItem('currentGroupSlug')
+}
+
+// Router reference populated once the dynamic import above resolves.
+// Exposed through a getter so the interceptor stays synchronous.
+let routerModuleRef: (typeof import('../router'))['default'] | null = null
+function getRouterModule(): (typeof import('../router'))['default'] | null {
+  return routerModuleRef
+}
+if (typeof window !== 'undefined') {
+  import('../router').then(({ default: router }) => {
+    routerModuleRef = router
+  }).catch(() => { /* silence — getAuthToken path still works */ })
+}
+
 // State-changing methods that require a CSRF token.
 const mutatingMethods = new Set(['post', 'put', 'patch', 'delete'])
 
@@ -92,14 +124,25 @@ api.interceptors.request.use(
     // This transparently routes requests through /api/v1/g/{slug}/... without
     // requiring changes to individual service files.
     //
-    // `encodeURIComponent` is intentional: today slugs are base64url (safe
-    // for URLs without encoding), but the slug is routed through user storage
-    // and a schema change could introduce reserved characters. Encoding here
-    // is cheap insurance against that class of bug — it's also what the rest
-    // of the codebase that builds `/api/v1/g/{slug}/...` URLs does (e.g. the
-    // raw `fetch()` in ExportImportView).
+    // Group-scoped API URL rewriting (issue #1289 Gap C).
+    //
+    // The source of truth for the current group is the URL path — the
+    // router's /g/:groupSlug/ parent route determines which group this
+    // tab is looking at. Reading the slug from the live route instead of
+    // localStorage is what makes two tabs with two different groups
+    // actually independent; the previous localStorage-only scheme made
+    // a group switch in tab 1 silently flip tab 2's next API call to
+    // the new group.
+    //
+    // localStorage remains as a cold-start fallback for the narrow
+    // window between app boot and the first navigation, but the moment
+    // the router has resolved a route, route params win.
+    //
+    // `encodeURIComponent` is cheap insurance: slugs are base64url today
+    // (URL-safe without encoding), but a schema change could introduce
+    // reserved characters.
     if (config.url) {
-      const groupSlug = localStorage.getItem('currentGroupSlug')
+      const groupSlug = resolveCurrentGroupSlug()
       if (groupSlug) {
         const groupScopedPrefixes = [
           '/api/v1/locations',

--- a/frontend/src/stores/groupStore.ts
+++ b/frontend/src/stores/groupStore.ts
@@ -147,11 +147,19 @@ export const useGroupStore = defineStore('group', () => {
     return loadingPromise
   }
 
-  async function setCurrentGroup(slug: string): Promise<void> {
+  async function setCurrentGroup(slug: string, options: { persist?: boolean } = {}): Promise<void> {
+    // persist defaults to true: user-initiated switches (GroupSelector click)
+    // should remember the selection for the next cold start. Router-driven
+    // syncs (issue #1289 Gap C — slug from the URL) pass `persist: false`
+    // so two tabs with two different /g/<slug>/... URLs don't
+    // ping-pong each other's localStorage entries.
+    const persist = options.persist !== false
     const group = groups.value.find((g) => g.slug === slug)
     if (group) {
       currentGroup.value = group
-      writeStoredSnapshot(group)
+      if (persist) {
+        writeStoredSnapshot(group)
+      }
       // Load membership info for the current user
       await loadCurrentMembership(group.id)
     }

--- a/frontend/src/types/group.ts
+++ b/frontend/src/types/group.ts
@@ -60,6 +60,7 @@ export interface GroupUpdateRequest {
 
 export interface GroupDeleteRequest {
   confirm_word: string
+  password: string
 }
 
 export interface MemberRoleUpdateRequest {

--- a/frontend/src/views/groups/GroupSettingsView.vue
+++ b/frontend/src/views/groups/GroupSettingsView.vue
@@ -145,15 +145,45 @@
       <section v-if="isAdmin" class="settings-section danger-zone">
         <h2>Danger Zone</h2>
         <p>Deleting this group will permanently remove all locations, items, files, and exports. This action cannot be undone.</p>
-        <button class="btn btn-danger" @click="showDeleteConfirm = true">Delete Group</button>
+        <button class="btn btn-danger" data-testid="delete-group-open" @click="openDeleteDialog">Delete Group</button>
         <div v-if="showDeleteConfirm" class="delete-confirm">
-          <p>To confirm, type the group name: <strong>{{ group.name }}</strong></p>
-          <input v-model="deleteConfirmWord" type="text" class="form-input" :placeholder="group.name" />
+          <p>
+            To confirm, type the group name
+            <strong>{{ group.name }}</strong>
+            and enter your current password. Both are required — the name
+            guards against accidental clicks, the password against a hijacked
+            session.
+          </p>
+          <label class="form-label">Group name</label>
+          <input
+            v-model="deleteConfirmWord"
+            type="text"
+            class="form-input"
+            data-testid="delete-confirm-word"
+            :placeholder="group.name"
+            autocomplete="off"
+          />
+          <label class="form-label">Your password</label>
+          <input
+            v-model="deletePassword"
+            type="password"
+            class="form-input"
+            data-testid="delete-password"
+            placeholder="Current password"
+            autocomplete="current-password"
+          />
+          <p v-if="deleteWrongPassword" class="field-error" data-testid="delete-password-error">
+            The password you entered is incorrect.
+          </p>
+          <p v-if="deleteWrongConfirmWord" class="field-error" data-testid="delete-confirm-error">
+            The group name doesn't match.
+          </p>
           <div class="delete-confirm-actions">
-            <button class="btn btn-secondary" @click="showDeleteConfirm = false">Cancel</button>
+            <button class="btn btn-secondary" @click="cancelDeleteDialog">Cancel</button>
             <button
               class="btn btn-danger"
-              :disabled="deleteConfirmWord !== group.name || isDeleting"
+              data-testid="delete-group-submit"
+              :disabled="!canSubmitDelete"
               @click="handleDelete"
             >
               {{ isDeleting ? 'Deleting...' : 'Delete Permanently' }}
@@ -196,7 +226,32 @@ const isCreatingInvite = ref(false)
 
 const showDeleteConfirm = ref(false)
 const deleteConfirmWord = ref('')
+const deletePassword = ref('')
+const deleteWrongPassword = ref(false)
+const deleteWrongConfirmWord = ref(false)
 const isDeleting = ref(false)
+
+const canSubmitDelete = computed(() =>
+  !isDeleting.value &&
+  deleteConfirmWord.value.trim() !== '' &&
+  deletePassword.value !== '',
+)
+
+function openDeleteDialog() {
+  showDeleteConfirm.value = true
+  deleteConfirmWord.value = ''
+  deletePassword.value = ''
+  deleteWrongPassword.value = false
+  deleteWrongConfirmWord.value = false
+}
+
+function cancelDeleteDialog() {
+  showDeleteConfirm.value = false
+  deleteConfirmWord.value = ''
+  deletePassword.value = ''
+  deleteWrongPassword.value = false
+  deleteWrongConfirmWord.value = false
+}
 
 const isAdmin = computed(() => {
   const userId = authStore.user?.id
@@ -340,8 +395,13 @@ async function handleLeave() {
 async function handleDelete() {
   if (!group.value) return
   isDeleting.value = true
+  deleteWrongPassword.value = false
+  deleteWrongConfirmWord.value = false
   try {
-    await groupService.deleteGroup(group.value.id, { confirm_word: deleteConfirmWord.value })
+    await groupService.deleteGroup(group.value.id, {
+      confirm_word: deleteConfirmWord.value.trim(),
+      password: deletePassword.value,
+    })
     groupStore.clearCurrentGroup()
     await groupStore.fetchGroups()
     if (groupStore.hasGroups) {
@@ -351,7 +411,19 @@ async function handleDelete() {
       router.push({ name: 'no-group' })
     }
   } catch (err: any) {
-    error.value = err.response?.data?.errors?.[0]?.detail || 'Failed to delete group'
+    const detail: string = err?.response?.data?.errors?.[0]?.detail || ''
+    const lower = detail.toLowerCase()
+    // The backend emits distinct sentinels (ErrInvalidPassword vs.
+    // ErrInvalidConfirmation) with specific substrings — key off them to
+    // flag the offending field inline instead of a generic error banner.
+    if (lower.includes('password')) {
+      deleteWrongPassword.value = true
+      deletePassword.value = ''
+    } else if (lower.includes('confirmation')) {
+      deleteWrongConfirmWord.value = true
+    } else {
+      error.value = detail || 'Failed to delete group'
+    }
   } finally {
     isDeleting.value = false
   }
@@ -521,20 +593,34 @@ onMounted(loadData)
     background: #fff0f0;
     border-radius: 6px;
 
+    .form-label {
+      display: block;
+      margin-top: 0.6em;
+      font-size: 0.85em;
+      font-weight: 600;
+      color: #444;
+    }
+
     .form-input {
-      margin: 0.5em 0;
+      margin: 0.3em 0 0.2em;
       width: 100%;
       max-width: 300px;
       padding: 0.5em;
       border: 1px solid #ccc;
       border-radius: 6px;
     }
+
+    .field-error {
+      color: #c62828;
+      font-size: 0.85em;
+      margin: 0.2em 0 0;
+    }
   }
 
   .delete-confirm-actions {
     display: flex;
     gap: 0.5em;
-    margin-top: 0.5em;
+    margin-top: 0.8em;
   }
 }
 

--- a/frontend/src/views/groups/GroupSettingsView.vue
+++ b/frontend/src/views/groups/GroupSettingsView.vue
@@ -411,18 +411,27 @@ async function handleDelete() {
       router.push({ name: 'no-group' })
     }
   } catch (err: any) {
-    const detail: string = err?.response?.data?.errors?.[0]?.detail || ''
-    const lower = detail.toLowerCase()
-    // The backend emits distinct sentinels (ErrInvalidPassword vs.
-    // ErrInvalidConfirmation) with specific substrings — key off them to
-    // flag the offending field inline instead of a generic error banner.
-    if (lower.includes('password')) {
+    // The server returns one of two distinct sentinels for this endpoint:
+    // services.ErrInvalidPassword ("invalid password") and
+    // services.ErrInvalidConfirmation ("invalid deletion confirmation").
+    // Both come back as 422 with the marshaled errx error nested several
+    // levels deep — `errors[0].error.error.msg` for the Go sentinel shape,
+    // but the exact path differs by error type. Key off the raw response
+    // body rather than hunting for a specific nested field so the branch
+    // stays correct whether the shape is nested `{error: {msg: "..."}}`
+    // or a plain `detail` string.
+    const body = err?.response?.data
+    const lower = JSON.stringify(body ?? '').toLowerCase()
+    if (lower.includes('invalid password')) {
       deleteWrongPassword.value = true
       deletePassword.value = ''
-    } else if (lower.includes('confirmation')) {
+    } else if (lower.includes('invalid deletion confirmation') || lower.includes('confirm_word')) {
       deleteWrongConfirmWord.value = true
     } else {
-      error.value = detail || 'Failed to delete group'
+      error.value =
+        (typeof body === 'string' && body) ||
+        body?.errors?.[0]?.detail ||
+        'Failed to delete group'
     }
   } finally {
     isDeleting.value = false

--- a/frontend/src/views/groups/GroupSettingsView.vue
+++ b/frontend/src/views/groups/GroupSettingsView.vue
@@ -411,27 +411,29 @@ async function handleDelete() {
       router.push({ name: 'no-group' })
     }
   } catch (err: any) {
-    // The server returns one of two distinct sentinels for this endpoint:
-    // services.ErrInvalidPassword ("invalid password") and
-    // services.ErrInvalidConfirmation ("invalid deletion confirmation").
-    // Both come back as 422 with the marshaled errx error nested several
-    // levels deep — `errors[0].error.error.msg` for the Go sentinel shape,
-    // but the exact path differs by error type. Key off the raw response
-    // body rather than hunting for a specific nested field so the branch
-    // stays correct whether the shape is nested `{error: {msg: "..."}}`
-    // or a plain `detail` string.
-    const body = err?.response?.data
-    const lower = JSON.stringify(body ?? '').toLowerCase()
-    if (lower.includes('invalid password')) {
+    // Two distinct sentinels come back here:
+    //   services.ErrInvalidPassword    → "invalid password"
+    //   services.ErrInvalidConfirmation → "invalid deletion confirmation"
+    // Both are marshaled by errormarshal as:
+    //   errors[0] = { status: "Unprocessable Entity", error: { error: { message, sentinels: [...] }, type: "*errx.sentinel" } }
+    // Read the sentinels array first (authoritative), fall back to the
+    // message string, and only then to errors[0].detail for defensive
+    // compatibility with other error shapes in the rest of the API.
+    const apiError = err?.response?.data?.errors?.[0]
+    const inner = apiError?.error?.error
+    const sentinels: string[] = Array.isArray(inner?.sentinels) ? inner.sentinels : []
+    const message: string = typeof inner?.message === 'string' ? inner.message : ''
+    const detail: string = typeof apiError?.detail === 'string' ? apiError.detail : ''
+    const probes = [...sentinels, message, detail].map((s) => s.toLowerCase())
+
+    const matches = (needle: string) => probes.some((p) => p.includes(needle))
+    if (matches('invalid password')) {
       deleteWrongPassword.value = true
       deletePassword.value = ''
-    } else if (lower.includes('invalid deletion confirmation') || lower.includes('confirm_word')) {
+    } else if (matches('invalid deletion confirmation')) {
       deleteWrongConfirmWord.value = true
     } else {
-      error.value =
-        (typeof body === 'string' && body) ||
-        body?.errors?.[0]?.detail ||
-        'Failed to delete group'
+      error.value = message || detail || 'Failed to delete group'
     }
   } finally {
     isDeleting.value = false

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -330,7 +330,7 @@ func APIServer(params Params, restoreWorker RestoreWorkerInterface) http.Handler
 		// tenant-level `users.role` column. Per-group user management lives
 		// under /groups/{id}/members; a tenant-wide admin surface will be
 		// re-introduced only when group-based admin authorization is designed.
-		r.With(userMiddlewares...).Route("/groups", Groups(params, groupService))
+		r.With(userMiddlewares...).Route("/groups", Groups(params, groupService, auditSvc))
 		// Invites are mounted WITHOUT userMiddlewares so that GET /invites/{token}
 		// remains public (the invitee is typically unauthenticated at first).
 		// POST /invites/{token}/accept is wrapped with the userMiddlewares chain

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -798,7 +798,7 @@ func (api *AuthAPI) issueRefreshTokenCookie(w http.ResponseWriter, r *http.Reque
 	}
 
 	rt := models.RefreshToken{
-		TenantAwareEntityID: models.TenantAwareEntityID{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
 			TenantID: user.TenantID,
 			UserID:   user.ID,
 		},

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -115,7 +115,8 @@ func toJSONAPIError(err error) jsonapi.Error {
 		return NewMaskedNotFoundError(err)
 	case errors.Is(err, services.ErrLastAdmin):
 		return NewUnprocessableEntityError(err)
-	case errors.Is(err, services.ErrInvalidConfirmation):
+	case errors.Is(err, services.ErrInvalidConfirmation),
+		errors.Is(err, services.ErrInvalidPassword):
 		return NewUnprocessableEntityError(err)
 	case errors.Is(err, services.ErrInviteExpired),
 		errors.Is(err, services.ErrInviteAlreadyUsed),

--- a/go/apiserver/groups.go
+++ b/go/apiserver/groups.go
@@ -21,6 +21,7 @@ const groupCtxKey ctxValueKey = "group"
 
 type groupsAPI struct {
 	groupService *services.GroupService
+	auditService services.AuditLogger
 }
 
 func groupFromContext(ctx context.Context) *models.LocationGroup {
@@ -180,9 +181,10 @@ func requireGroupAdmin(groupService *services.GroupService) func(http.Handler) h
 }
 
 // Groups returns the route handler for group management endpoints.
-func Groups(params Params, groupService *services.GroupService) func(r chi.Router) {
+func Groups(params Params, groupService *services.GroupService, auditService services.AuditLogger) func(r chi.Router) {
 	api := &groupsAPI{
 		groupService: groupService,
+		auditService: auditService,
 	}
 	return func(r chi.Router) {
 		r.Get("/", api.listGroups)
@@ -380,21 +382,26 @@ func (api *groupsAPI) updateGroup(w http.ResponseWriter, r *http.Request) {
 
 // deleteGroup initiates async group deletion.
 // @Summary Delete group
-// @Description Initiates async deletion of a location group. Requires typing the group name as confirmation. Requires group admin role.
+// @Description Initiates async deletion of a location group. Requires typing the group name AND the caller's current password. Requires group admin role. Failed attempts are audit-logged.
 // @Tags groups
 // @Accept json
 // @Produce json-api
 // @Param groupID path string true "Group ID"
-// @Param data body jsonapi.GroupDeleteRequest true "Deletion confirmation"
+// @Param data body jsonapi.GroupDeleteRequest true "Deletion confirmation (confirm_word + password)"
 // @Success 204 "No Content"
 // @Failure 403 {string} string "Forbidden - not a group admin"
 // @Failure 404 {object} jsonapi.Errors "Group not found"
-// @Failure 422 {object} jsonapi.Errors "Invalid confirmation"
+// @Failure 422 {object} jsonapi.Errors "Invalid confirmation word or password"
 // @Router /groups/{groupID} [delete].
 func (api *groupsAPI) deleteGroup(w http.ResponseWriter, r *http.Request) {
 	group := groupFromContext(r.Context())
 	if group == nil {
 		unprocessableEntityError(w, r, nil)
+		return
+	}
+	user := GetUserFromRequest(r)
+	if user == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
 		return
 	}
 
@@ -404,13 +411,46 @@ func (api *groupsAPI) deleteGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := api.groupService.InitiateGroupDeletion(r.Context(), group.ID, input.ConfirmWord, group.Name)
-	if err != nil {
+	// Verify the caller's password before touching the group. Distinct
+	// from the confirm-word check so the frontend can show a specific
+	// "wrong password" error (see spec #1219 §12). Every attempt is
+	// audit-logged — a failed delete-group is worth tracing because it
+	// signals either fumbled input or a hijacked session.
+	if !user.CheckPassword(input.Password) {
+		api.logGroupDeletion(r, user, group, false, "invalid_password")
+		renderEntityError(w, r, services.ErrInvalidPassword)
+		return
+	}
+
+	if err := api.groupService.InitiateGroupDeletion(r.Context(), group.ID, input.ConfirmWord, group.Name); err != nil {
+		reason := "service_error"
+		if errors.Is(err, services.ErrInvalidConfirmation) {
+			reason = "invalid_confirmation"
+		}
+		api.logGroupDeletion(r, user, group, false, reason)
 		renderEntityError(w, r, err)
 		return
 	}
 
+	api.logGroupDeletion(r, user, group, true, "")
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// logGroupDeletion is a nil-safe audit log helper for group deletion
+// attempts. Action name "group_delete" is used consistently across success
+// and failure so an oncall can grep one string to find every attempt on a
+// given group.
+func (api *groupsAPI) logGroupDeletion(r *http.Request, user *models.User, group *models.LocationGroup, success bool, errReason string) {
+	if api.auditService == nil {
+		return
+	}
+	var errPtr *string
+	if errReason != "" {
+		msg := errReason + " on group " + group.ID
+		errPtr = &msg
+	}
+	tenantID := user.TenantID
+	api.auditService.LogAuth(r.Context(), "group_delete", &user.ID, &tenantID, success, r, errPtr)
 }
 
 // listMembers lists all members of a group.

--- a/go/apiserver/groups.go
+++ b/go/apiserver/groups.go
@@ -401,7 +401,7 @@ func (api *groupsAPI) deleteGroup(w http.ResponseWriter, r *http.Request) {
 	}
 	user := GetUserFromRequest(r)
 	if user == nil {
-		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		unauthorizedError(w, r, nil)
 		return
 	}
 

--- a/go/apiserver/groups_test.go
+++ b/go/apiserver/groups_test.go
@@ -100,7 +100,7 @@ func newGroupTestEnv(t *testing.T, groupCurrency models.Currency) groupTestEnv {
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 	r.Use(stampCtx)
 	r.Use(apiserver.RegistrySetMiddleware(factorySet))
-	r.Route("/groups", apiserver.Groups(apiserver.Params{FactorySet: factorySet}, groupService))
+	r.Route("/groups", apiserver.Groups(apiserver.Params{FactorySet: factorySet}, groupService, nil))
 
 	return groupTestEnv{
 		router:     r,
@@ -301,4 +301,88 @@ func TestGroupsAPI_UpdateGroup_RejectsIconOutsideCuratedSet(t *testing.T) {
 
 	current := must.Must(env.factorySet.LocationGroupRegistry.Get(context.Background(), env.group.ID))
 	c.Assert(current.Icon, qt.Equals, "")
+}
+
+// deleteGroup — spec #1219 §12: admin must type the group name AND their
+// current password. Both checks are distinguishable (different error
+// surfaces) so the frontend can render specific copy for each failure.
+
+func deleteGroup(t *testing.T, env groupTestEnv, payload map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal delete body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodDelete, "/groups/"+env.group.ID, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	return w
+}
+
+func TestGroupsAPI_DeleteGroup_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, models.Currency("USD"))
+
+	resp := deleteGroup(t, env, map[string]any{
+		"confirm_word": env.group.Name,
+		"password":     "testpassword123",
+	})
+	c.Assert(resp.Code, qt.Equals, http.StatusNoContent, qt.Commentf("body: %s", resp.Body.String()))
+
+	current := must.Must(env.factorySet.LocationGroupRegistry.Get(context.Background(), env.group.ID))
+	c.Assert(current.Status, qt.Equals, models.LocationGroupStatusPendingDeletion)
+}
+
+func TestGroupsAPI_DeleteGroup_WrongPasswordReturns422(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, models.Currency("USD"))
+
+	resp := deleteGroup(t, env, map[string]any{
+		"confirm_word": env.group.Name,
+		"password":     "not-the-real-password",
+	})
+	c.Assert(resp.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body: %s", resp.Body.String()))
+
+	// Distinguishable error — body carries the password-specific message,
+	// not the confirm-word one. This is what the frontend keys off to
+	// render inline per-field feedback.
+	c.Assert(resp.Body.String(), qt.Contains, "password")
+
+	// Group must not have been touched.
+	current := must.Must(env.factorySet.LocationGroupRegistry.Get(context.Background(), env.group.ID))
+	c.Assert(current.Status, qt.Equals, models.LocationGroupStatusActive)
+}
+
+func TestGroupsAPI_DeleteGroup_WrongConfirmWordReturns422(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, models.Currency("USD"))
+
+	resp := deleteGroup(t, env, map[string]any{
+		"confirm_word": "not-the-group-name",
+		"password":     "testpassword123",
+	})
+	c.Assert(resp.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body: %s", resp.Body.String()))
+	c.Assert(resp.Body.String(), qt.Contains, "confirmation")
+
+	current := must.Must(env.factorySet.LocationGroupRegistry.Get(context.Background(), env.group.ID))
+	c.Assert(current.Status, qt.Equals, models.LocationGroupStatusActive)
+}
+
+func TestGroupsAPI_DeleteGroup_MissingPasswordRejectedAtBind(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, models.Currency("USD"))
+
+	resp := deleteGroup(t, env, map[string]any{
+		"confirm_word": env.group.Name,
+	})
+	c.Assert(resp.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body: %s", resp.Body.String()))
+
+	current := must.Must(env.factorySet.LocationGroupRegistry.Get(context.Background(), env.group.ID))
+	c.Assert(current.Status, qt.Equals, models.LocationGroupStatusActive)
 }

--- a/go/apiserver/signed_url_middleware_test.go
+++ b/go/apiserver/signed_url_middleware_test.go
@@ -84,7 +84,6 @@ func TestSignedURLMiddleware(t *testing.T) {
 		TenantAwareEntityID: models.TenantAwareEntityID{
 			EntityID: models.EntityID{ID: "test-user-123"},
 			TenantID: "test-tenant-123",
-			UserID:   "test-user-123",
 		},
 		Email:    "test@example.com",
 		Name:     "Test User",
@@ -226,7 +225,6 @@ func TestSignedURLMiddleware(t *testing.T) {
 			TenantAwareEntityID: models.TenantAwareEntityID{
 				EntityID: models.EntityID{ID: "inactive-user-123"},
 				TenantID: "test-tenant-123",
-				UserID:   "inactive-user-123",
 			},
 			Email:    "inactive@example.com",
 			Name:     "Inactive User",
@@ -317,7 +315,6 @@ func TestSignedURLMiddleware_SecurityScenarios(t *testing.T) {
 		TenantAwareEntityID: models.TenantAwareEntityID{
 			EntityID: models.EntityID{ID: "user-1"},
 			TenantID: "test-tenant-123",
-			UserID:   "user-1",
 		},
 		Email:    "user1@example.com",
 		Name:     "User 1",
@@ -327,7 +324,6 @@ func TestSignedURLMiddleware_SecurityScenarios(t *testing.T) {
 		TenantAwareEntityID: models.TenantAwareEntityID{
 			EntityID: models.EntityID{ID: "user-2"},
 			TenantID: "test-tenant-123",
-			UserID:   "user-2",
 		},
 		Email:    "user2@example.com",
 		Name:     "User 2",

--- a/go/cmd/inventario/db/setup/setup.go
+++ b/go/cmd/inventario/db/setup/setup.go
@@ -263,9 +263,11 @@ func (m *DataSetupManager) createOrUpdateAdminUser(ctx context.Context, tx *sql.
 		return existingUserID, nil
 	}
 
+	// users.user_id column was dropped by issue #1289 Gap B — the row's id
+	// is authoritative, so we only need to keep tenant_id in sync here.
 	_, err = tx.ExecContext(ctx, `
-		UPDATE users 
-		SET tenant_id = $1, user_id = COALESCE(NULLIF(user_id, ''), id), updated_at = $2
+		UPDATE users
+		SET tenant_id = $1, updated_at = $2
 		WHERE id = $3`,
 		opts.DefaultTenantID, time.Now(), existingUserID)
 	if err != nil {
@@ -289,10 +291,11 @@ func (m *DataSetupManager) assignUsersToDefaultTenant(ctx context.Context, tx *s
 		return nil
 	}
 
-	// Update users without tenant_id
+	// Update users without tenant_id. users.user_id was dropped by issue
+	// #1289 Gap B — the row's own id column is authoritative.
 	res, err := tx.ExecContext(ctx, `
 		UPDATE users
-		SET tenant_id = $1, user_id = COALESCE(NULLIF(user_id, ''), id), updated_at = $2
+		SET tenant_id = $1, updated_at = $2
 		WHERE tenant_id IS NULL OR tenant_id = ''`,
 		opts.DefaultTenantID, time.Now())
 	if err != nil {
@@ -375,23 +378,11 @@ func (m *DataSetupManager) assignUserIDToTable(ctx context.Context, tx *sql.Tx, 
 	return nil
 }
 
-// validateDataIntegrity validates that users have proper user_id assignments
-// and data tables have proper created_by_user_id assignments.
+// validateDataIntegrity validates that data tables have proper
+// created_by_user_id assignments. users.user_id used to be validated here
+// too but the column was dropped by issue #1289 Gap B — the row's own id
+// column is authoritative now.
 func (m *DataSetupManager) validateDataIntegrity(ctx context.Context, tx *sql.Tx, result *SetupResult) error {
-	// Validate users table (uses user_id, not created_by_user_id)
-	m.printf("  Checking user user_id assignments...\n")
-	var userMissingCount int
-	err := tx.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM users WHERE user_id IS NULL OR user_id = ''").Scan(&userMissingCount)
-	switch {
-	case err != nil:
-		result.Errors = append(result.Errors, fmt.Sprintf("Failed to validate users: %v", err))
-	case userMissingCount > 0:
-		result.Errors = append(result.Errors, fmt.Sprintf("%d users have missing user_id", userMissingCount))
-	default:
-		m.printf("    ✅ All users have user_id assigned\n")
-	}
-
 	// Validate data tables (use created_by_user_id)
 	dataValidations := []struct {
 		table       string
@@ -435,8 +426,7 @@ func (m *DataSetupManager) validateDataIntegrity(ctx context.Context, tx *sql.Tx
 	}{
 		{"users", "users with invalid tenant references",
 			"SELECT COUNT(*) FROM users u LEFT JOIN tenants t ON u.tenant_id = t.id WHERE t.id IS NULL"},
-		{"users", "users with invalid user_id self-references",
-			"SELECT COUNT(*) FROM users u1 LEFT JOIN users u2 ON u1.user_id = u2.id WHERE u2.id IS NULL"},
+		// users.user_id self-FK was dropped in #1289 Gap B — nothing to validate here.
 		{"locations", "locations with invalid created_by_user references",
 			"SELECT COUNT(*) FROM locations l LEFT JOIN users u ON l.created_by_user_id = u.id WHERE u.id IS NULL"},
 		{"areas", "areas with invalid created_by_user references",

--- a/go/cmd/inventario/db/setup/setup.go
+++ b/go/cmd/inventario/db/setup/setup.go
@@ -221,12 +221,13 @@ func (m *DataSetupManager) createOrUpdateAdminUser(ctx context.Context, tx *sql.
 			return adminUserID, nil
 		}
 
-		// Create user with hashed password
+		// Create user with hashed password. users.user_id was a
+		// self-referencing legacy column dropped by the TenantAwareEntityID
+		// refactor (issue #1289 Gap B) — no need to populate it here.
 		user := models.User{
 			TenantAwareEntityID: models.TenantAwareEntityID{
 				EntityID: models.EntityID{ID: adminUserID},
 				TenantID: opts.DefaultTenantID,
-				UserID:   adminUserID, // Self-reference
 			},
 			Email:    opts.AdminEmail,
 			Name:     opts.AdminName,
@@ -240,10 +241,10 @@ func (m *DataSetupManager) createOrUpdateAdminUser(ctx context.Context, tx *sql.
 
 		now := time.Now()
 		_, err = tx.ExecContext(ctx, `
-			INSERT INTO users (id, email, password_hash, name, is_active, tenant_id, user_id, created_at, updated_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+			INSERT INTO users (id, email, password_hash, name, is_active, tenant_id, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 			adminUserID, user.Email, user.PasswordHash, user.Name, user.IsActive,
-			user.TenantID, user.UserID, now, now)
+			user.TenantID, now, now)
 		if err != nil {
 			return "", fmt.Errorf("failed to create admin user: %w", err)
 		}

--- a/go/debug/seeddata/seeddata_test.go
+++ b/go/debug/seeddata/seeddata_test.go
@@ -37,10 +37,12 @@ func TestSeedData(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(users, qt.HasLen, 2)
 
-	// Check that both users have the correct tenant ID
+	// Check that both users have the correct tenant ID. The legacy
+	// users.user_id self-FK was dropped by issue #1289 Gap B — the row's
+	// own id is authoritative, so there is nothing left to assert on a
+	// separate user_id field.
 	for _, user := range users {
 		c.Assert(user.TenantID, qt.Equals, tenant.ID)
-		c.Assert(user.UserID, qt.Equals, user.ID) // Self-referencing user ID
 	}
 
 	// Check specific user details

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -2273,7 +2273,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Initiates async deletion of a location group. Requires typing the group name as confirmation. Requires group admin role.",
+                "description": "Initiates async deletion of a location group. Requires typing the group name AND the caller's current password. Requires group admin role. Failed attempts are audit-logged.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2293,7 +2293,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "Deletion confirmation",
+                        "description": "Deletion confirmation (confirm_word + password)",
                         "name": "data",
                         "in": "body",
                         "required": true,
@@ -2319,7 +2319,7 @@ const docTemplate = `{
                         }
                     },
                     "422": {
-                        "description": "Invalid confirmation",
+                        "description": "Invalid confirmation word or password",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -4599,6 +4599,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "confirm_word": {
+                    "type": "string"
+                },
+                "password": {
                     "type": "string"
                 }
             }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -2266,7 +2266,7 @@
                 }
             },
             "delete": {
-                "description": "Initiates async deletion of a location group. Requires typing the group name as confirmation. Requires group admin role.",
+                "description": "Initiates async deletion of a location group. Requires typing the group name AND the caller's current password. Requires group admin role. Failed attempts are audit-logged.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2286,7 +2286,7 @@
                         "required": true
                     },
                     {
-                        "description": "Deletion confirmation",
+                        "description": "Deletion confirmation (confirm_word + password)",
                         "name": "data",
                         "in": "body",
                         "required": true,
@@ -2312,7 +2312,7 @@
                         }
                     },
                     "422": {
-                        "description": "Invalid confirmation",
+                        "description": "Invalid confirmation word or password",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -4592,6 +4592,9 @@
             "type": "object",
             "properties": {
                 "confirm_word": {
+                    "type": "string"
+                },
+                "password": {
                     "type": "string"
                 }
             }

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -503,6 +503,8 @@ definitions:
     properties:
       confirm_word:
         type: string
+      password:
+        type: string
     type: object
   jsonapi.GroupInviteData:
     properties:
@@ -3180,14 +3182,15 @@ paths:
       consumes:
       - application/json
       description: Initiates async deletion of a location group. Requires typing the
-        group name as confirmation. Requires group admin role.
+        group name AND the caller's current password. Requires group admin role. Failed
+        attempts are audit-logged.
       parameters:
       - description: Group ID
         in: path
         name: groupID
         required: true
         type: string
-      - description: Deletion confirmation
+      - description: Deletion confirmation (confirm_word + password)
         in: body
         name: data
         required: true
@@ -3207,7 +3210,7 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "422":
-          description: Invalid confirmation
+          description: Invalid confirmation word or password
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: Delete group

--- a/go/integration/thumbnail_generation_integration_test.go
+++ b/go/integration/thumbnail_generation_integration_test.go
@@ -42,7 +42,6 @@ func TestThumbnailGenerationIntegration(t *testing.T) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	testUser.UserID = testUser.ID
 	ctx := appctx.WithUser(context.Background(), testUser)
 
 	// Create factory set and services

--- a/go/jsonapi/groups.go
+++ b/go/jsonapi/groups.go
@@ -373,13 +373,21 @@ func (*InviteInfoResponse) Render(_ http.ResponseWriter, r *http.Request) error 
 
 var _ render.Binder = (*GroupDeleteRequest)(nil)
 
+// GroupDeleteRequest carries both the confirmation word (the group's name)
+// and the caller's current password. Spec #1219 §12 requires both — the
+// confirm word guards against accidental clicks, the password prevents an
+// attacker with a hijacked-but-unauthenticated session from nuking a group.
 type GroupDeleteRequest struct {
 	ConfirmWord string `json:"confirm_word"`
+	Password    string `json:"password"`
 }
 
 func (r *GroupDeleteRequest) Bind(_ *http.Request) error {
 	if r.ConfirmWord == "" {
 		return validation.NewError("validation_required", "confirm_word is required")
+	}
+	if r.Password == "" {
+		return validation.NewError("validation_required", "password is required")
 	}
 	return nil
 }

--- a/go/models/models.go
+++ b/go/models/models.go
@@ -325,7 +325,7 @@ var (
 	_ IDable                 = (*EntityID)(nil)
 	_ UUIDable               = (*EntityID)(nil)
 	_ TenantAwareIDable      = (*TenantAwareEntityID)(nil)
-	_ TenantUserAwareIDable  = (*TenantAwareEntityID)(nil)
+	_ TenantUserAwareIDable  = (*TenantUserAwareEntityID)(nil)
 	_ TenantGroupAwareIDable = (*TenantGroupAwareEntityID)(nil)
 	_ validation.Validatable = (*FileEntity)(nil)
 )
@@ -365,13 +365,19 @@ func WithID[T IDable](id string, i T) T {
 	return i
 }
 
+// TenantAwareEntityID is the base struct for entities scoped to a tenant
+// only, with no further isolation (per spec #1219 §1). Used by users,
+// settings-like tenant-wide singletons, group metadata tables
+// (location_groups, group_memberships, group_invites), and other auth
+// infrastructure that doesn't need per-user or per-group isolation on the
+// base struct itself. Tables that want user-level isolation embed
+// TenantUserAwareEntityID instead; group-isolated data tables embed
+// TenantGroupAwareEntityID.
 type TenantAwareEntityID struct {
 	//migrator:embedded mode="inline"
 	EntityID
 	//migrator:schema:field name="tenant_id" type="TEXT" not_null="true" foreign="tenants(id)" foreign_key_name="fk_entity_tenant"
 	TenantID string `json:"-" db:"tenant_id" userinput:"false"`
-	//migrator:schema:field name="user_id" type="TEXT" not_null="true" foreign="users(id)" foreign_key_name="fk_entity_user"
-	UserID string `json:"-" db:"user_id" userinput:"false"`
 }
 
 func (i *TenantAwareEntityID) GetTenantID() string {
@@ -382,25 +388,36 @@ func (i *TenantAwareEntityID) SetTenantID(tenantID string) {
 	i.TenantID = tenantID
 }
 
-func (i *TenantAwareEntityID) GetUserID() string {
-	return i.UserID
-}
-
-func (i *TenantAwareEntityID) SetUserID(userID string) {
-	i.UserID = userID
-}
-
 func WithTenantID[T TenantAware](tenantID string, i T) T {
 	i.SetTenantID(tenantID)
 	return i
 }
+
+// TenantUserAwareEntityID is the base struct for tenant-scoped entities
+// owned by a specific user (e.g. refresh tokens, settings, operation
+// slots). It carries the (tenant_id, user_id) pair used by user-scoped
+// RLS policies. Keep distinct from TenantAwareEntityID so that schemas
+// that don't need a user_id column don't accidentally grow one.
+type TenantUserAwareEntityID struct {
+	//migrator:embedded mode="inline"
+	EntityID
+	//migrator:schema:field name="tenant_id" type="TEXT" not_null="true" foreign="tenants(id)" foreign_key_name="fk_entity_tenant"
+	TenantID string `json:"-" db:"tenant_id" userinput:"false"`
+	//migrator:schema:field name="user_id" type="TEXT" not_null="true" foreign="users(id)" foreign_key_name="fk_entity_user"
+	UserID string `json:"-" db:"user_id" userinput:"false"`
+}
+
+func (i *TenantUserAwareEntityID) GetTenantID() string         { return i.TenantID }
+func (i *TenantUserAwareEntityID) SetTenantID(tenantID string) { i.TenantID = tenantID }
+func (i *TenantUserAwareEntityID) GetUserID() string           { return i.UserID }
+func (i *TenantUserAwareEntityID) SetUserID(userID string)     { i.UserID = userID }
 
 func WithUserID[T UserAware](userID string, i T) T {
 	i.SetUserID(userID)
 	return i
 }
 
-// WithTenantAwareEntityID creates a TenantAwareEntityID with the given ID and tenant ID
+// WithTenantAwareEntityID creates a TenantAwareEntityID with the given ID and tenant ID.
 func WithTenantAwareEntityID(id, tenantID string) TenantAwareEntityID {
 	return TenantAwareEntityID{
 		EntityID: EntityID{ID: id},
@@ -408,9 +425,9 @@ func WithTenantAwareEntityID(id, tenantID string) TenantAwareEntityID {
 	}
 }
 
-// WithTenantUserAwareEntityID creates a TenantAwareEntityID with the given ID, tenant ID, and user ID
-func WithTenantUserAwareEntityID(id, tenantID, userID string) TenantAwareEntityID {
-	return TenantAwareEntityID{
+// WithTenantUserAwareEntityID creates a TenantUserAwareEntityID with the given ID, tenant ID, and user ID.
+func WithTenantUserAwareEntityID(id, tenantID, userID string) TenantUserAwareEntityID {
+	return TenantUserAwareEntityID{
 		EntityID: EntityID{ID: id},
 		TenantID: tenantID,
 		UserID:   userID,

--- a/go/models/multitenant_test.go
+++ b/go/models/multitenant_test.go
@@ -324,8 +324,9 @@ func TestUserAwareInterface_Compliance(t *testing.T) {
 		var _ models.CreatedByUserAware = &models.RestoreOperation{}
 		var _ models.CreatedByUserAware = &models.RestoreStep{}
 
-		// User still implements UserAware
-		var _ models.UserAware = &models.User{}
+		// User no longer implements UserAware — users.user_id was a
+		// legacy self-FK dropped by issue #1289 Gap B. The row's own ID is
+		// authoritative, and access control lives in group_memberships.
 
 		// Data models implement TenantGroupAware
 		var _ models.TenantGroupAware = &models.Location{}
@@ -339,8 +340,8 @@ func TestUserAwareInterface_Compliance(t *testing.T) {
 		var _ models.TenantGroupAware = &models.RestoreOperation{}
 		var _ models.TenantGroupAware = &models.RestoreStep{}
 
-		// User still implements TenantUserAware
-		var _ models.TenantUserAware = &models.User{}
+		// User no longer implements TenantUserAware — see comment on
+		// UserAware above.
 
 		// Data models implement TenantGroupAwareIDable
 		var _ models.TenantGroupAwareIDable = &models.Location{}
@@ -354,8 +355,9 @@ func TestUserAwareInterface_Compliance(t *testing.T) {
 		var _ models.TenantGroupAwareIDable = &models.RestoreOperation{}
 		var _ models.TenantGroupAwareIDable = &models.RestoreStep{}
 
-		// User still implements TenantUserAwareIDable
-		var _ models.TenantUserAwareIDable = &models.User{}
+		// User implements TenantAwareIDable (not TenantUserAwareIDable —
+		// users.user_id was dropped in #1289 Gap B).
+		var _ models.TenantAwareIDable = &models.User{}
 
 		c.Assert(true, qt.IsTrue) // If we get here, all interfaces are implemented correctly
 	})

--- a/go/models/operation_slot.go
+++ b/go/models/operation_slot.go
@@ -12,7 +12,7 @@ import (
 //migrator:schema:table name="operation_slots"
 type OperationSlot struct {
 	//migrator:embedded mode="inline"
-	TenantAwareEntityID
+	TenantUserAwareEntityID
 
 	// SlotID is the numeric identifier for this slot within the user/operation scope
 	//migrator:schema:field name="slot_id" type="INTEGER" not_null="true"

--- a/go/models/refresh_token.go
+++ b/go/models/refresh_token.go
@@ -15,7 +15,7 @@ import (
 //migrator:schema:table name="refresh_tokens"
 type RefreshToken struct {
 	//migrator:embedded mode="inline"
-	TenantAwareEntityID
+	TenantUserAwareEntityID
 	//migrator:schema:field name="token_hash" type="VARCHAR(128)" not_null="true"
 	TokenHash string `json:"-" db:"token_hash"`
 	//migrator:schema:field name="expires_at" type="TIMESTAMP" not_null="true"

--- a/go/models/settings.go
+++ b/go/models/settings.go
@@ -14,7 +14,7 @@ import (
 //migrator:schema:table name="settings"
 type Setting struct {
 	//migrator:embedded mode="inline"
-	TenantAwareEntityID
+	TenantUserAwareEntityID
 	//migrator:schema:field name="name" type="TEXT" not_null="true"
 	Name string `db:"name"`
 	//migrator:schema:field name="value" type="JSONB" not_null="true"

--- a/go/models/thumbnail_generation.go
+++ b/go/models/thumbnail_generation.go
@@ -30,7 +30,7 @@ func (s ThumbnailGenerationStatus) String() string {
 //migrator:schema:table name="thumbnail_generation_jobs"
 type ThumbnailGenerationJob struct {
 	//migrator:embedded mode="inline"
-	TenantAwareEntityID
+	TenantUserAwareEntityID
 
 	// FileID is the ID of the file for which thumbnails need to be generated
 	//migrator:schema:field name="file_id" type="TEXT" not_null="true" foreign="files(id)" foreign_key_name="fk_thumbnail_job_file"
@@ -140,7 +140,7 @@ func (s SlotStatus) String() string {
 //migrator:schema:table name="user_concurrency_slots"
 type UserConcurrencySlot struct {
 	//migrator:embedded mode="inline"
-	TenantAwareEntityID
+	TenantUserAwareEntityID
 
 	// JobID is the ID of the thumbnail generation job currently using this slot
 	//migrator:schema:field name="job_id" type="TEXT" not_null="true" foreign="thumbnail_generation_jobs(id)" foreign_key_name="fk_concurrency_slot_job"

--- a/go/registry/memory/race_condition_test.go
+++ b/go/registry/memory/race_condition_test.go
@@ -232,7 +232,6 @@ func TestE2EScenarioSimulation(t *testing.T) {
 		TenantAwareEntityID: models.TenantAwareEntityID{
 			EntityID: models.EntityID{ID: testUserID},
 			TenantID: "tenant-1",
-			UserID:   testUserID, // Self-reference
 		},
 		Email: "admin@test-org.com",
 		Name:  "Admin User",

--- a/go/registry/memory/user_concurrency_slots.go
+++ b/go/registry/memory/user_concurrency_slots.go
@@ -121,7 +121,7 @@ func (r *UserConcurrencySlotRegistry) AcquireSlot(ctx context.Context, userID, j
 	// Create new slot
 	now = time.Now()
 	slot := models.UserConcurrencySlot{
-		TenantAwareEntityID: models.TenantAwareEntityID{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
 			UserID:   userID,
 			TenantID: tenantID,
 		},

--- a/go/registry/memory/users.go
+++ b/go/registry/memory/users.go
@@ -54,10 +54,8 @@ func (r *UserRegistry) Create(ctx context.Context, user models.User) (*models.Us
 		user.UUID = uuid.New().String()
 	}
 
-	// Set UserID to self-reference if not already set
-	if user.UserID == "" {
-		user.UserID = generatedID
-	}
+	// The legacy users.user_id self-FK was removed by issue #1289 Gap B — the
+	// row's own id column is authoritative, so nothing else to populate here.
 
 	r.lock.Lock()
 	r.items.Set(user.ID, &user)

--- a/go/registry/postgres/user_concurrency_slots.go
+++ b/go/registry/postgres/user_concurrency_slots.go
@@ -184,7 +184,7 @@ func (r *UserConcurrencySlotRegistry) AcquireSlot(ctx context.Context, userID, j
 
 		// Create the slot with proper tenant/user context
 		slot := models.UserConcurrencySlot{
-			TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantUserAwareEntityID: models.TenantUserAwareEntityID{
 				UserID:   userID,
 				TenantID: tenantID,
 			},

--- a/go/registry/postgres/users.go
+++ b/go/registry/postgres/users.go
@@ -69,10 +69,8 @@ func (r *UserRegistry) Create(ctx context.Context, user models.User) (*models.Us
 		user.UUID = uuid.New().String()
 	}
 
-	// Set UserID to self-reference if not already set
-	if user.UserID == "" {
-		user.UserID = generatedID
-	}
+	// The legacy users.user_id self-FK was removed by issue #1289 Gap B —
+	// the row's own id column is authoritative, so nothing else to populate.
 
 	// Check if a user with the same email already exists (within the same tenant)
 	var existingUser models.User

--- a/go/schema/migrations/_sqldata/1776789750_drop_users_user_id.down.sql
+++ b/go/schema/migrations/_sqldata/1776789750_drop_users_user_id.down.sql
@@ -1,0 +1,8 @@
+-- Restore the legacy users.user_id self-FK column. Best-effort: the
+-- original values (each user's id) can be reconstructed from users.id
+-- because the column was always a self-reference.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS user_id TEXT;
+UPDATE users SET user_id = id WHERE user_id IS NULL;
+ALTER TABLE users ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE users ADD CONSTRAINT fk_entity_user FOREIGN KEY (user_id) REFERENCES users(id);

--- a/go/schema/migrations/_sqldata/1776789750_drop_users_user_id.up.sql
+++ b/go/schema/migrations/_sqldata/1776789750_drop_users_user_id.up.sql
@@ -1,0 +1,14 @@
+-- Drop the legacy self-referencing users.user_id column (issue #1289 Gap B).
+--
+-- users.user_id was introduced by the original multi-tenant migration when
+-- TenantAwareEntityID had a `user_id` field embedded on every model. For the
+-- users table that field ended up pointing at the user's own id — a self-FK
+-- that never carried any semantic value. Spec #1219 §1 requires
+-- TenantAwareEntityID to be {id, uuid, tenant_id} only; the refactor in the
+-- same PR as this migration moves user_id declarations out of the shared
+-- base struct and into the concrete types that actually need them
+-- (refresh_tokens, settings, operation_slots, thumbnail_generation_jobs,
+-- user_concurrency_slots). Users no longer has a user_id column.
+
+ALTER TABLE users DROP CONSTRAINT IF EXISTS fk_entity_user;
+ALTER TABLE users DROP COLUMN IF EXISTS user_id;

--- a/go/services/entity_service_test.go
+++ b/go/services/entity_service_test.go
@@ -27,9 +27,6 @@ func newTestContext(factorySet *registry.FactorySet) context.Context {
 		Email: "test@example.com",
 		Name:  "Test User",
 	}
-	// Set UserID to self-reference
-	testUser.UserID = testUser.ID
-
 	// Register the user in the system
 	userReg := factorySet.CreateServiceRegistrySet().UserRegistry
 	u := must.Must(userReg.Create(context.Background(), testUser))

--- a/go/services/file_service_test.go
+++ b/go/services/file_service_test.go
@@ -29,9 +29,6 @@ func newTestContext() context.Context {
 			TenantID: "test-tenant-id",
 		},
 	}
-	// Set UserID to self-reference
-	testUser.UserID = testUser.ID
-
 	return appctx.WithUser(context.Background(), testUser)
 }
 

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -21,7 +21,11 @@ var (
 	ErrNotGroupMember      = errx.NewSentinel("user is not a member of this group")
 	ErrNotGroupAdmin       = errx.NewSentinel("user is not an admin of this group")
 	ErrInvalidConfirmation = errx.NewSentinel("invalid deletion confirmation")
-	ErrInviteNotInGroup    = errx.NewSentinel("invite does not belong to this group")
+	// ErrInvalidPassword is distinct from ErrInvalidConfirmation so the
+	// frontend can render different copy ("wrong group name" vs. "wrong
+	// password"). See spec #1219 §12.
+	ErrInvalidPassword  = errx.NewSentinel("invalid password")
+	ErrInviteNotInGroup = errx.NewSentinel("invite does not belong to this group")
 )
 
 // GroupService handles business logic for location groups, memberships, and invites.

--- a/go/services/thumbnail_generation_service.go
+++ b/go/services/thumbnail_generation_service.go
@@ -89,7 +89,7 @@ func (s *ThumbnailGenerationService) RequestThumbnailGeneration(ctx context.Cont
 	// Create new job owned by the requesting user.
 	now := time.Now()
 	job := models.ThumbnailGenerationJob{
-		TenantAwareEntityID: models.TenantAwareEntityID{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
 			TenantID: file.TenantID,
 			UserID:   requestingUser.ID,
 		},


### PR DESCRIPTION
## Summary

Closes #1289 by addressing the three unblocked acceptance-criteria gaps from the #1219 audit (the async-deletion worker stays out of scope — it's blocked on #1214).

- **Gap A (HIGH)**: group deletion requires both confirmation word **and** the caller's current password, with distinguishable errors so the UI can render per-field feedback. Every attempt is audit-logged.
- **Gap B (MEDIUM)**: `TenantAwareEntityID` is now `{id, uuid, tenant_id}` only as spec §1 required. Introduced `TenantUserAwareEntityID` for (tenant, user)-scoped tables. Dropped the `users.user_id` self-FK column via a hand-written migration.
- **Gap C (HIGH)**: frontend data routes now live under `/g/:groupSlug/…` so two tabs can hold two different groups independently and URLs become bookmarkable. Axios reads the slug from the live route; localStorage is a cold-start fallback only.

## Files changed (highlights)

### Gap A
- `go/jsonapi/groups.go` — `GroupDeleteRequest.Password` field + Bind validation.
- `go/services/group_service.go` — new `ErrInvalidPassword` sentinel.
- `go/apiserver/groups.go` — handler verifies password before calling the service; `logGroupDeletion` helper audit-logs success/failure with distinguishable reasons.
- `go/apiserver/errors.go` — maps `ErrInvalidPassword` to 422.
- `frontend/src/views/groups/GroupSettingsView.vue` — password input, per-field error surface, `openDeleteDialog` / `cancelDeleteDialog` reset lifecycle.
- `frontend/src/types/group.ts` — `GroupDeleteRequest.password`.
- `go/apiserver/groups_test.go` — happy path + wrong password + wrong confirm word + missing password cases.
- `e2e/tests/delete-group-dialog.spec.ts` — UI flow for wrong password and full happy path.
- `e2e/tests/*.spec.ts` — existing delete calls updated to include the password field.

### Gap B
- `go/models/models.go` — `TenantAwareEntityID` slimmed; new `TenantUserAwareEntityID` added.
- `go/models/{refresh_token,operation_slot,settings,thumbnail_generation}.go` — embed `TenantUserAwareEntityID`.
- `go/models/user.go` (no change) — User embeds the slimmed `TenantAwareEntityID`.
- `go/apiserver/auth.go`, `go/services/thumbnail_generation_service.go`, `go/registry/memory/user_concurrency_slots.go`, `go/registry/postgres/user_concurrency_slots.go` — struct literals updated.
- `go/cmd/inventario/db/setup/setup.go`, `go/registry/{memory,postgres}/users.go` — drop self-referencing user_id writes.
- `go/schema/migrations/_sqldata/1776789750_drop_users_user_id.{up,down}.sql` — hand-written migration.
- `go/models/multitenant_test.go`, `go/debug/seeddata/seeddata_test.go` etc. — interface assertions and self-reference assertions updated.

### Gap C
- `frontend/src/router/index.ts` — data routes nested under `/g/:groupSlug`, legacy flat routes kept as redirect stubs, guard syncs `groupStore.currentGroup` to the URL slug on every navigation and bounces unknown slugs.
- `frontend/src/services/api.ts` — `resolveCurrentGroupSlug()` reads `router.currentRoute.value.params.groupSlug`, falls back to localStorage.
- `frontend/src/components/GroupSelector.vue` — switches via `router.push` to `/g/<new-slug>/<current-subpath>`.
- `frontend/src/App.vue` — nav links compute the `/g/<slug>/…` path from the current group; active-highlight helpers strip the prefix before comparing.
- `e2e/tests/includes/commodities.ts` — loosen a URL assertion to tolerate the new prefix.

## Test plan

- [x] `go test ./...` — green (including new Gap A handler tests).
- [x] `make lint-go` — 0 issues.
- [x] `npx vitest run` in `frontend/` — 413 / 413 green.
- [x] `npx vite build` — green.
- [ ] Playwright E2E — runs via CI on push.
- [ ] Manual smoke:
  - [ ] Delete group: wrong password surfaces the field error; right password completes the delete.
  - [ ] Open `/g/<slug-A>/commodities` and `/g/<slug-B>/locations` in two tabs — each stays on its own group.
  - [ ] Fresh clone, run `inventario db setup` — users table no longer has `user_id`.

## Out of scope

Async deletion background worker (spec #1219 §12) — still blocked on #1214 ("Separate background workers from the API server"). `InitiateGroupDeletion` already flips status to `pending_deletion` and the slug resolver returns 410 Gone for such groups; the actual data+blob purge worker lands with #1214.
