### PR TITLE
refactor(apiserver): decouple restore status checks from worker (#1291)

### DIFF
--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -31,8 +31,11 @@ import (
 	"github.com/denisvmedia/inventario/services"
 )
 
-// RestoreWorkerInterface defines the interface for the restore worker
-type RestoreWorkerInterface interface {
+// RestoreStatusQuerier reports the aggregate status of restore operations
+// without requiring a running worker goroutine. It lets the HTTP API enforce
+// the "one active restore at a time" invariant in deployments where the
+// RestoreWorker runs in a separate process.
+type RestoreStatusQuerier interface {
 	HasRunningRestores(ctx context.Context) (bool, error) // Returns true if any restore is running or pending
 }
 
@@ -190,7 +193,7 @@ func (p *Params) Validate() error {
 	return validation.ValidateStruct(p, fields...)
 }
 
-func APIServer(params Params, restoreWorker RestoreWorkerInterface) http.Handler {
+func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 	render.Decode = JSONAPIAwareDecoder
 
 	r := chi.NewRouter()
@@ -346,7 +349,7 @@ func APIServer(params Params, restoreWorker RestoreWorkerInterface) http.Handler
 			r.Route("/areas", Areas())
 			r.Route("/commodities", Commodities(params))
 			r.Route("/files", Files(params))
-			r.Route("/exports", Exports(params, restoreWorker))
+			r.Route("/exports", Exports(params, restoreStatus))
 			r.Route("/settings", Settings())
 			r.Route("/commodities/values", Values())
 			r.Route("/upload-slots", UploadSlots(params.FactorySet))

--- a/go/apiserver/areas_test.go
+++ b/go/apiserver/areas_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/denisvmedia/inventario/models"
 )
 
-// mockRestoreWorker is a mock implementation of RestoreWorkerInterface for testing
+// mockRestoreWorker is a mock implementation of RestoreStatusQuerier for testing
 type mockRestoreWorker struct {
 	hasRunningRestores bool
 }

--- a/go/apiserver/export_restores.go
+++ b/go/apiserver/export_restores.go
@@ -12,7 +12,7 @@ import (
 )
 
 type exportRestoresAPI struct {
-	restoreWorker RestoreWorkerInterface
+	restoreStatus RestoreStatusQuerier
 }
 
 // listExportRestores lists all restore operations for an export.
@@ -184,7 +184,7 @@ func (api *exportRestoresAPI) createExportRestore(w http.ResponseWriter, r *http
 	}
 
 	// Check if there are any running restore operations
-	hasRunning, err := api.restoreWorker.HasRunningRestores(r.Context())
+	hasRunning, err := api.restoreStatus.HasRunningRestores(r.Context())
 	if err != nil {
 		internalServerError(w, r, err)
 		return
@@ -284,9 +284,9 @@ func (api *exportRestoresAPI) deleteExportRestore(w http.ResponseWriter, r *http
 }
 
 // ExportRestores sets up the export restore API routes.
-func ExportRestores(restoreWorker RestoreWorkerInterface) func(r chi.Router) {
+func ExportRestores(restoreStatus RestoreStatusQuerier) func(r chi.Router) {
 	api := &exportRestoresAPI{
-		restoreWorker: restoreWorker,
+		restoreStatus: restoreStatus,
 	}
 
 	return func(r chi.Router) {

--- a/go/apiserver/exports.go
+++ b/go/apiserver/exports.go
@@ -400,7 +400,7 @@ func exportCtx() func(next http.Handler) http.Handler {
 }
 
 // Exports sets up the exports API routes.
-func Exports(params Params, restoreWorker RestoreWorkerInterface) func(r chi.Router) {
+func Exports(params Params, restoreStatus RestoreStatusQuerier) func(r chi.Router) {
 	api := &exportsAPI{
 		uploadLocation: params.UploadLocation,
 		entityService:  params.EntityService,
@@ -416,7 +416,7 @@ func Exports(params Params, restoreWorker RestoreWorkerInterface) func(r chi.Rou
 			r.Get("/", api.apiGetExport)
 			r.Delete("/", api.deleteExport)
 			r.Get("/download", api.downloadExport)
-			r.Route("/restores", ExportRestores(restoreWorker))
+			r.Route("/restores", ExportRestores(restoreStatus))
 		})
 	}
 }

--- a/go/backup/restore/status_querier.go
+++ b/go/backup/restore/status_querier.go
@@ -1,0 +1,46 @@
+package restore
+
+import (
+	"context"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// StatusQuerier reports aggregate status of restore operations without
+// requiring a background worker goroutine to be running. It is intended for
+// components that need to check whether a restore is currently in progress
+// but do not themselves process restore work (e.g. an API-only process).
+type StatusQuerier interface {
+	// HasRunningRestores returns true if any restore operation is currently
+	// running or pending.
+	HasRunningRestores(ctx context.Context) (bool, error)
+}
+
+// RegistryStatusQuerier is a StatusQuerier backed solely by the restore
+// operation registry. It performs no background processing and is safe to
+// use in processes that do not run the RestoreWorker.
+type RegistryStatusQuerier struct {
+	registrySet *registry.Set
+}
+
+// NewRegistryStatusQuerier returns a RegistryStatusQuerier that reads restore
+// operation state from the provided registry set.
+func NewRegistryStatusQuerier(registrySet *registry.Set) *RegistryStatusQuerier {
+	return &RegistryStatusQuerier{registrySet: registrySet}
+}
+
+// HasRunningRestores returns true if any restore operation in the registry is
+// currently running or pending.
+func (q *RegistryStatusQuerier) HasRunningRestores(ctx context.Context) (bool, error) {
+	restoreOperations, err := q.registrySet.RestoreOperationRegistry.List(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, op := range restoreOperations {
+		if op.Status == models.RestoreStatusRunning || op.Status == models.RestoreStatusPending {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/go/backup/restore/status_querier_test.go
+++ b/go/backup/restore/status_querier_test.go
@@ -1,0 +1,120 @@
+package restore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/backup/restore"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+// seedUserRegistrySet provisions a memory-backed registry set with a single
+// tenant and user context suitable for restore-operation CRUD in tests.
+func seedUserRegistrySet(c *qt.C) (*registry.Set, context.Context) {
+	c.Helper()
+
+	factorySet := memory.NewFactorySet()
+
+	tenant := models.Tenant{
+		EntityID: models.EntityID{ID: "test-tenant-id"},
+		Name:     "Test Tenant",
+	}
+	must.Must(factorySet.TenantRegistry.Create(c.Context(), tenant))
+
+	user := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: "test-tenant-id",
+			EntityID: models.EntityID{ID: "test-user-id"},
+		},
+		Name:  "Test User",
+		Email: "querier@example.com",
+	}
+	createdUser, err := factorySet.UserRegistry.Create(c.Context(), user)
+	c.Assert(err, qt.IsNil)
+
+	ctx := appctx.WithUser(c.Context(), createdUser)
+	registrySet := must.Must(factorySet.CreateUserRegistrySet(ctx))
+	return registrySet, ctx
+}
+
+func seedRestoreOps(c *qt.C, registrySet *registry.Set, ctx context.Context, statuses ...models.RestoreStatus) {
+	c.Helper()
+	for _, status := range statuses {
+		op := models.RestoreOperation{
+			ExportID:    "test-export-id",
+			Description: "seeded " + string(status),
+			Status:      status,
+			Options: models.RestoreOptions{
+				Strategy:        "merge_update",
+				IncludeFileData: false,
+				DryRun:          false,
+			},
+			CreatedDate: models.PNow(),
+		}
+		_, err := registrySet.RestoreOperationRegistry.Create(ctx, op)
+		c.Assert(err, qt.IsNil)
+	}
+}
+
+func TestRegistryStatusQuerier_HasRunningRestores_HappyPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		seed     []models.RestoreStatus
+		expected bool
+	}{
+		{name: "empty registry reports false", seed: nil, expected: false},
+		{name: "only completed reports false", seed: []models.RestoreStatus{models.RestoreStatusCompleted}, expected: false},
+		{name: "only failed reports false", seed: []models.RestoreStatus{models.RestoreStatusFailed}, expected: false},
+		{name: "mixed terminal reports false", seed: []models.RestoreStatus{models.RestoreStatusCompleted, models.RestoreStatusFailed}, expected: false},
+		{name: "single pending reports true", seed: []models.RestoreStatus{models.RestoreStatusPending}, expected: true},
+		{name: "single running reports true", seed: []models.RestoreStatus{models.RestoreStatusRunning}, expected: true},
+		{name: "pending with completed reports true", seed: []models.RestoreStatus{models.RestoreStatusCompleted, models.RestoreStatusPending}, expected: true},
+		{name: "running with failed reports true", seed: []models.RestoreStatus{models.RestoreStatusFailed, models.RestoreStatusRunning}, expected: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			registrySet, ctx := seedUserRegistrySet(c)
+			seedRestoreOps(c, registrySet, ctx, tc.seed...)
+
+			querier := restore.NewRegistryStatusQuerier(registrySet)
+			got, err := querier.HasRunningRestores(ctx)
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, tc.expected)
+		})
+	}
+}
+
+// failingRestoreOperationRegistry is a minimal stub used to verify that
+// registry errors from List are propagated by RegistryStatusQuerier.
+type failingRestoreOperationRegistry struct {
+	registry.RestoreOperationRegistry
+	listErr error
+}
+
+func (f *failingRestoreOperationRegistry) List(context.Context) ([]*models.RestoreOperation, error) {
+	return nil, f.listErr
+}
+
+func TestRegistryStatusQuerier_HasRunningRestores_PropagatesRegistryError(t *testing.T) {
+	c := qt.New(t)
+
+	sentinel := errors.New("registry unavailable")
+	registrySet := &registry.Set{
+		RestoreOperationRegistry: &failingRestoreOperationRegistry{listErr: sentinel},
+	}
+
+	querier := restore.NewRegistryStatusQuerier(registrySet)
+	got, err := querier.HasRunningRestores(context.Background())
+	c.Assert(err, qt.ErrorIs, sentinel)
+	c.Assert(got, qt.IsFalse)
+}

--- a/go/backup/restore/worker.go
+++ b/go/backup/restore/worker.go
@@ -146,18 +146,10 @@ func (w *RestoreWorker) processRestore(ctx context.Context, restoreOperationID s
 	slog.Info("Successfully processed restore operation", "restore_operation_id", restoreOperationID)
 }
 
-// HasRunningRestores checks if there are any restore operations currently running or pending
+// HasRunningRestores checks if there are any restore operations currently
+// running or pending. It delegates to RegistryStatusQuerier so that query-only
+// callers (for example the HTTP API in an API-only deployment) can reuse the
+// same implementation without a running worker.
 func (w *RestoreWorker) HasRunningRestores(ctx context.Context) (bool, error) {
-	restoreOperations, err := w.registrySet.RestoreOperationRegistry.List(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	for _, restoreOp := range restoreOperations {
-		if restoreOp.Status == models.RestoreStatusRunning || restoreOp.Status == models.RestoreStatusPending {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return NewRegistryStatusQuerier(w.registrySet).HasRunningRestores(ctx)
 }


### PR DESCRIPTION
Closes #1291. Part of #1214.

## What

Extract a query-only `RestoreStatusQuerier` interface (renamed from `RestoreWorkerInterface`) and introduce `restore.RegistryStatusQuerier` that reads restore-operation state directly from the registry — no worker goroutine required.

## Why

The HTTP API needs to check whether a restore is currently running/pending before accepting `POST /exports/{id}/restores`. Today this check is served by `RestoreWorker`, which forces every apiserver process to also instantiate the worker. That blocks splitting `inventario run` into independent `apiserver` and `workers` roles (the broader goal in #1214).

Since the check is a pure registry lookup, it does not actually need worker state. Extracting it into a dedicated querier lets an API-only process satisfy the concurrency guard without starting any background goroutines.

## How

- New `restore.StatusQuerier` interface and `restore.RegistryStatusQuerier` implementation in `go/backup/restore/status_querier.go`. Reads `RestoreOperationRegistry.List` and reports `true` if any operation is `pending` or `running`.
- `RestoreWorker.HasRunningRestores` now delegates to `RegistryStatusQuerier`, so query-only and worker-backed callers share a single implementation.
- `apiserver.RestoreWorkerInterface` renamed to `apiserver.RestoreStatusQuerier`; parameters and the `exportRestoresAPI` field renamed from `restoreWorker` to `restoreStatus` to reflect the narrowed contract.
- Existing tests keep working unchanged — `mockRestoreWorker` satisfies the renamed interface structurally. Only the doc comment in `areas_test.go` is updated to point at the new name.

## Tests

- New `go/backup/restore/status_querier_test.go` with table-driven happy-path cases (empty registry, only completed/failed, single pending, single running, mixed) and a separate test verifying registry error propagation via a minimal stub registry.
- Existing `TestHasRunningRestores` / `TestHasRunningRestores_PendingAlsoBlocks` continue to pass unchanged (they exercise the worker's delegating method).
- `make test-go` and `make lint-go` clean locally.

## No behavior change

`run.go` still passes the concrete `*RestoreWorker` to `apiserver.APIServer`; the combined-mode process keeps the exact same wiring. The apiserver-only wiring will land in #1293 / #1294.