### PR TITLE
feat(run): expose worker limits and poll intervals as CLI flags (closes #1292)

### DIFF
--- a/go/backup/export/worker.go
+++ b/go/backup/export/worker.go
@@ -30,12 +30,35 @@ type ExportWorker struct {
 	semaphore     *semaphore.Weighted
 }
 
+// WorkerOption customizes an ExportWorker constructed via NewExportWorker.
+type WorkerOption func(*exportWorkerOptions)
+
+type exportWorkerOptions struct {
+	pollInterval time.Duration
+}
+
+// WithPollInterval overrides the default interval between export queue polls.
+// Non-positive values are ignored.
+func WithPollInterval(d time.Duration) WorkerOption {
+	return func(o *exportWorkerOptions) {
+		if d > 0 {
+			o.pollInterval = d
+		}
+	}
+}
+
 // NewExportWorker creates a new export worker
-func NewExportWorker(exportService *ExportService, factorySet *registry.FactorySet, maxConcurrentExports int) *ExportWorker {
+func NewExportWorker(exportService *ExportService, factorySet *registry.FactorySet, maxConcurrentExports int, opts ...WorkerOption) *ExportWorker {
+	options := exportWorkerOptions{
+		pollInterval: defaultPollInterval,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
 	return &ExportWorker{
 		exportService: exportService,
 		factorySet:    factorySet,
-		pollInterval:  defaultPollInterval, // Check for new exports every 10 seconds
+		pollInterval:  options.pollInterval,
 		stopCh:        make(chan struct{}),
 		semaphore:     semaphore.NewWeighted(int64(maxConcurrentExports)),
 	}

--- a/go/backup/import/worker.go
+++ b/go/backup/import/worker.go
@@ -29,23 +29,35 @@ type ImportWorker struct {
 	semaphore     *semaphore.Weighted
 }
 
-// NewImportWorker creates a new import worker
-func NewImportWorker(importService *ImportService, factorySet *registry.FactorySet, maxConcurrentImports int) *ImportWorker {
-	return &ImportWorker{
-		importService: importService,
-		factorySet:    factorySet,
-		pollInterval:  defaultPollInterval, // Check for new imports every 10 seconds
-		stopCh:        make(chan struct{}),
-		semaphore:     semaphore.NewWeighted(int64(maxConcurrentImports)),
+// WorkerOption customizes an ImportWorker constructed via NewImportWorker.
+type WorkerOption func(*importWorkerOptions)
+
+type importWorkerOptions struct {
+	pollInterval time.Duration
+}
+
+// WithPollInterval overrides the default interval between import queue polls.
+// Non-positive values are ignored.
+func WithPollInterval(d time.Duration) WorkerOption {
+	return func(o *importWorkerOptions) {
+		if d > 0 {
+			o.pollInterval = d
+		}
 	}
 }
 
-// NewImportWorkerWithPollInterval creates a new import worker with custom poll interval
-func NewImportWorkerWithPollInterval(importService *ImportService, factorySet *registry.FactorySet, maxConcurrentImports int, pollInterval time.Duration) *ImportWorker {
+// NewImportWorker creates a new import worker
+func NewImportWorker(importService *ImportService, factorySet *registry.FactorySet, maxConcurrentImports int, opts ...WorkerOption) *ImportWorker {
+	options := importWorkerOptions{
+		pollInterval: defaultPollInterval,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
 	return &ImportWorker{
 		importService: importService,
 		factorySet:    factorySet,
-		pollInterval:  pollInterval,
+		pollInterval:  options.pollInterval,
 		stopCh:        make(chan struct{}),
 		semaphore:     semaphore.NewWeighted(int64(maxConcurrentImports)),
 	}

--- a/go/backup/restore/worker.go
+++ b/go/backup/restore/worker.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	defaultPollInterval = 10 * time.Second
+	defaultPollInterval          = 10 * time.Second
+	defaultMaxConcurrentRestores = 1
 )
 
 // RestoreWorker processes restore requests in the background
@@ -30,16 +31,50 @@ type RestoreWorker struct {
 	semaphore      *semaphore.Weighted
 }
 
+// WorkerOption customizes a RestoreWorker constructed via NewRestoreWorker.
+type WorkerOption func(*restoreWorkerOptions)
+
+type restoreWorkerOptions struct {
+	pollInterval  time.Duration
+	maxConcurrent int
+}
+
+// WithPollInterval overrides the default interval between restore queue polls.
+// Non-positive values are ignored.
+func WithPollInterval(d time.Duration) WorkerOption {
+	return func(o *restoreWorkerOptions) {
+		if d > 0 {
+			o.pollInterval = d
+		}
+	}
+}
+
+// WithMaxConcurrent overrides the default number of restores processed in parallel.
+// Non-positive values are ignored.
+func WithMaxConcurrent(n int) WorkerOption {
+	return func(o *restoreWorkerOptions) {
+		if n > 0 {
+			o.maxConcurrent = n
+		}
+	}
+}
+
 // NewRestoreWorker creates a new restore worker
-func NewRestoreWorker(restoreService *RestoreService, registrySet *registry.Set, uploadLocation string) *RestoreWorker {
-	const maxConcurrentRestores = 1
+func NewRestoreWorker(restoreService *RestoreService, registrySet *registry.Set, uploadLocation string, opts ...WorkerOption) *RestoreWorker {
+	options := restoreWorkerOptions{
+		pollInterval:  defaultPollInterval,
+		maxConcurrent: defaultMaxConcurrentRestores,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
 	return &RestoreWorker{
 		restoreService: restoreService,
 		registrySet:    registrySet,
 		uploadLocation: uploadLocation,
-		pollInterval:   defaultPollInterval, // Check for new restores every 10 seconds
+		pollInterval:   options.pollInterval,
 		stopCh:         make(chan struct{}),
-		semaphore:      semaphore.NewWeighted(int64(maxConcurrentRestores)),
+		semaphore:      semaphore.NewWeighted(int64(options.maxConcurrent)),
 	}
 }
 

--- a/go/cmd/inventario/initconfig/data/config.yaml.tmpl
+++ b/go/cmd/inventario/initconfig/data/config.yaml.tmpl
@@ -43,6 +43,26 @@ run:
   # Higher values allow more imports to run simultaneously but use more resources
   max-concurrent-imports: {{.Workers.MaxConcurrentImports}}
 
+  # Maximum number of concurrent restore processes
+  # Higher values allow more restores to run simultaneously but use more resources
+  max-concurrent-restores: {{.Workers.MaxConcurrentRestores}}
+
+  # Export worker poll interval (e.g., "10s", "30s")
+  # How often the export worker checks for new export jobs
+  export-poll-interval: "{{.Workers.ExportPollInterval}}"
+
+  # Import worker poll interval (e.g., "10s", "30s")
+  # How often the import worker checks for new import jobs
+  import-poll-interval: "{{.Workers.ImportPollInterval}}"
+
+  # Restore worker poll interval (e.g., "10s", "30s")
+  # How often the restore worker checks for new restore jobs
+  restore-poll-interval: "{{.Workers.RestorePollInterval}}"
+
+  # Interval between refresh token cleanup runs (e.g., "1h", "30m")
+  # The worker periodically deletes expired refresh tokens from the database
+  refresh-token-cleanup-interval: "{{.Workers.RefreshTokenCleanupInterval}}"
+
   # Thumbnail generation limits per user
   # Maximum number of simultaneous thumbnail generation jobs per user
   thumbnail-max-concurrent-per-user: {{.ThumbnailGeneration.MaxConcurrentPerUser}}
@@ -52,6 +72,30 @@ run:
 
   # Duration for which a concurrency slot is held (e.g., "30m", "1h")
   thumbnail-slot-duration: "{{.ThumbnailGeneration.SlotDuration}}"
+
+  # Maximum thumbnail jobs processed per batch
+  # Higher values increase throughput but hold worker slots longer
+  thumbnail-batch-size: {{.ThumbnailGeneration.BatchSize}}
+
+  # Thumbnail worker poll interval (e.g., "5s", "10s")
+  # How often the thumbnail worker checks for new generation jobs
+  thumbnail-poll-interval: "{{.ThumbnailGeneration.PollInterval}}"
+
+  # Interval between thumbnail job cleanup runs (e.g., "5m", "10m")
+  # How often completed/failed jobs older than the retention period are removed
+  thumbnail-cleanup-interval: "{{.ThumbnailGeneration.CleanupInterval}}"
+
+  # How long completed thumbnail jobs are retained (e.g., "24h", "72h")
+  # Jobs older than this are removed by the cleanup routine
+  thumbnail-job-retention-period: "{{.ThumbnailGeneration.JobRetentionPeriod}}"
+
+  # Maximum wait for an in-flight thumbnail batch before polling again (e.g., "30s")
+  # Bounds how long the worker waits on a single batch before yielding to the poll loop
+  thumbnail-job-batch-timeout: "{{.ThumbnailGeneration.JobBatchTimeout}}"
+
+  # Per-job timeout for detached thumbnail generation (e.g., "2m", "5m")
+  # Bounds how long a single thumbnail generation job may run in detached mode
+  detached-thumbnail-job-timeout: "{{.ThumbnailGeneration.DetachedJobTimeout}}"
 
   # JWT secret for user authentication
   # IMPORTANT: This should be a secure random string of at least 32 characters

--- a/go/cmd/inventario/run/config.go
+++ b/go/cmd/inventario/run/config.go
@@ -9,12 +9,23 @@ type Config struct {
 	UploadLocation                string `yaml:"upload_location" env:"UPLOAD_LOCATION" env-default:""`
 	MaxConcurrentExports          int    `yaml:"max_concurrent_exports" env:"MAX_CONCURRENT_EXPORTS" env-default:"0"`
 	MaxConcurrentImports          int    `yaml:"max_concurrent_imports" env:"MAX_CONCURRENT_IMPORTS" env-default:"0"`
+	MaxConcurrentRestores         int    `yaml:"max_concurrent_restores" env:"MAX_CONCURRENT_RESTORES" env-default:"0"`
+	ExportPollInterval            string `yaml:"export_poll_interval" env:"EXPORT_POLL_INTERVAL" env-default:""`
+	ImportPollInterval            string `yaml:"import_poll_interval" env:"IMPORT_POLL_INTERVAL" env-default:""`
+	RestorePollInterval           string `yaml:"restore_poll_interval" env:"RESTORE_POLL_INTERVAL" env-default:""`
+	RefreshTokenCleanupInterval   string `yaml:"refresh_token_cleanup_interval" env:"REFRESH_TOKEN_CLEANUP_INTERVAL" env-default:""`
 	JWTSecret                     string `yaml:"jwt_secret" env:"JWT_SECRET" env-default:""`
 	FileSigningKey                string `yaml:"file_signing_key" env:"FILE_SIGNING_KEY" env-default:""`
 	FileURLExpiration             string `yaml:"file_url_expiration" env:"FILE_URL_EXPIRATION" env-default:"15m"`
 	ThumbnailMaxConcurrentPerUser int    `yaml:"thumbnail_max_concurrent_per_user" env:"THUMBNAIL_MAX_CONCURRENT_PER_USER" env-default:"0"`
 	ThumbnailRateLimitPerMinute   int    `yaml:"thumbnail_rate_limit_per_minute" env:"THUMBNAIL_RATE_LIMIT_PER_MINUTE" env-default:"0"`
 	ThumbnailSlotDuration         string `yaml:"thumbnail_slot_duration" env:"THUMBNAIL_SLOT_DURATION" env-default:"30m"`
+	ThumbnailBatchSize            int    `yaml:"thumbnail_batch_size" env:"THUMBNAIL_BATCH_SIZE" env-default:"0"`
+	ThumbnailPollInterval         string `yaml:"thumbnail_poll_interval" env:"THUMBNAIL_POLL_INTERVAL" env-default:""`
+	ThumbnailCleanupInterval      string `yaml:"thumbnail_cleanup_interval" env:"THUMBNAIL_CLEANUP_INTERVAL" env-default:""`
+	ThumbnailJobRetentionPeriod   string `yaml:"thumbnail_job_retention_period" env:"THUMBNAIL_JOB_RETENTION_PERIOD" env-default:""`
+	ThumbnailJobBatchTimeout      string `yaml:"thumbnail_job_batch_timeout" env:"THUMBNAIL_JOB_BATCH_TIMEOUT" env-default:""`
+	DetachedThumbnailJobTimeout   string `yaml:"detached_thumbnail_job_timeout" env:"DETACHED_THUMBNAIL_JOB_TIMEOUT" env-default:""`
 	TokenBlacklistRedisURL        string `yaml:"token_blacklist_redis_url" env:"TOKEN_BLACKLIST_REDIS_URL" env-default:""`
 	AuthRateLimitRedisURL         string `yaml:"auth_rate_limit_redis_url" env:"AUTH_RATE_LIMIT_REDIS_URL" env-default:""`
 	AuthRateLimitDisabled         bool   `yaml:"auth_rate_limit_disabled" env:"AUTH_RATE_LIMIT_DISABLED" env-default:"false"`
@@ -55,24 +66,11 @@ func (c *Config) setDefaults() {
 	if c.UploadLocation == "" {
 		c.UploadLocation = defaults.GetUploadLocation()
 	}
-	if c.MaxConcurrentExports == 0 {
-		c.MaxConcurrentExports = defaults.GetMaxConcurrentExports()
-	}
-	if c.MaxConcurrentImports == 0 {
-		c.MaxConcurrentImports = defaults.GetMaxConcurrentImports()
-	}
 	if c.JWTSecret == "" {
 		c.JWTSecret = defaults.GetJWTSecret()
 	}
-	if c.ThumbnailMaxConcurrentPerUser == 0 {
-		c.ThumbnailMaxConcurrentPerUser = defaults.GetThumbnailMaxConcurrentPerUser()
-	}
-	if c.ThumbnailRateLimitPerMinute == 0 {
-		c.ThumbnailRateLimitPerMinute = defaults.GetThumbnailRateLimitPerMinute()
-	}
-	if c.ThumbnailSlotDuration == "" {
-		c.ThumbnailSlotDuration = defaults.GetThumbnailSlotDuration()
-	}
+	c.setWorkerDefaults()
+	c.setThumbnailDefaults()
 	if !c.GlobalRateLimitDisabled && c.GlobalRateLimit <= 0 {
 		c.GlobalRateLimit = 1000
 	}
@@ -87,5 +85,63 @@ func (c *Config) setDefaults() {
 	}
 	if c.SMTPPort == 0 {
 		c.SMTPPort = 587
+	}
+}
+
+// setWorkerDefaults applies defaults to background worker tunables (concurrency
+// limits and poll intervals for export, import, restore, and refresh-token workers).
+func (c *Config) setWorkerDefaults() {
+	if c.MaxConcurrentExports == 0 {
+		c.MaxConcurrentExports = defaults.GetMaxConcurrentExports()
+	}
+	if c.MaxConcurrentImports == 0 {
+		c.MaxConcurrentImports = defaults.GetMaxConcurrentImports()
+	}
+	if c.MaxConcurrentRestores == 0 {
+		c.MaxConcurrentRestores = defaults.GetMaxConcurrentRestores()
+	}
+	if c.ExportPollInterval == "" {
+		c.ExportPollInterval = defaults.GetExportPollInterval()
+	}
+	if c.ImportPollInterval == "" {
+		c.ImportPollInterval = defaults.GetImportPollInterval()
+	}
+	if c.RestorePollInterval == "" {
+		c.RestorePollInterval = defaults.GetRestorePollInterval()
+	}
+	if c.RefreshTokenCleanupInterval == "" {
+		c.RefreshTokenCleanupInterval = defaults.GetRefreshTokenCleanupInterval()
+	}
+}
+
+// setThumbnailDefaults applies defaults to thumbnail generation worker tunables
+// (per-user limits, batch size, and the various interval/timeout knobs).
+func (c *Config) setThumbnailDefaults() {
+	if c.ThumbnailMaxConcurrentPerUser == 0 {
+		c.ThumbnailMaxConcurrentPerUser = defaults.GetThumbnailMaxConcurrentPerUser()
+	}
+	if c.ThumbnailRateLimitPerMinute == 0 {
+		c.ThumbnailRateLimitPerMinute = defaults.GetThumbnailRateLimitPerMinute()
+	}
+	if c.ThumbnailSlotDuration == "" {
+		c.ThumbnailSlotDuration = defaults.GetThumbnailSlotDuration()
+	}
+	if c.ThumbnailBatchSize == 0 {
+		c.ThumbnailBatchSize = defaults.GetThumbnailBatchSize()
+	}
+	if c.ThumbnailPollInterval == "" {
+		c.ThumbnailPollInterval = defaults.GetThumbnailPollInterval()
+	}
+	if c.ThumbnailCleanupInterval == "" {
+		c.ThumbnailCleanupInterval = defaults.GetThumbnailCleanupInterval()
+	}
+	if c.ThumbnailJobRetentionPeriod == "" {
+		c.ThumbnailJobRetentionPeriod = defaults.GetThumbnailJobRetentionPeriod()
+	}
+	if c.ThumbnailJobBatchTimeout == "" {
+		c.ThumbnailJobBatchTimeout = defaults.GetThumbnailJobBatchTimeout()
+	}
+	if c.DetachedThumbnailJobTimeout == "" {
+		c.DetachedThumbnailJobTimeout = defaults.GetDetachedThumbnailJobTimeout()
 	}
 }

--- a/go/cmd/inventario/run/config_test.go
+++ b/go/cmd/inventario/run/config_test.go
@@ -92,6 +92,64 @@ func TestConfigSetDefaults_GlobalRateLimitDisabledPreservesZero(t *testing.T) {
 	c.Assert(cfg.GlobalRateWindow, qt.Equals, "1h")
 }
 
+func TestConfigSetDefaults_WorkerTunablesAppliedFromDefaults(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := Config{}
+
+	cfg.setDefaults()
+
+	c.Assert(cfg.MaxConcurrentExports, qt.Equals, 3)
+	c.Assert(cfg.MaxConcurrentImports, qt.Equals, 1)
+	c.Assert(cfg.MaxConcurrentRestores, qt.Equals, 1)
+	c.Assert(cfg.ExportPollInterval, qt.Equals, "10s")
+	c.Assert(cfg.ImportPollInterval, qt.Equals, "10s")
+	c.Assert(cfg.RestorePollInterval, qt.Equals, "10s")
+	c.Assert(cfg.RefreshTokenCleanupInterval, qt.Equals, "1h")
+	c.Assert(cfg.ThumbnailBatchSize, qt.Equals, 10)
+	c.Assert(cfg.ThumbnailPollInterval, qt.Equals, "5s")
+	c.Assert(cfg.ThumbnailCleanupInterval, qt.Equals, "5m")
+	c.Assert(cfg.ThumbnailJobRetentionPeriod, qt.Equals, "24h")
+	c.Assert(cfg.ThumbnailJobBatchTimeout, qt.Equals, "30s")
+	c.Assert(cfg.DetachedThumbnailJobTimeout, qt.Equals, "2m")
+}
+
+func TestConfigSetDefaults_WorkerTunablesPreserveExplicitValues(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := Config{
+		MaxConcurrentExports:        7,
+		MaxConcurrentImports:        4,
+		MaxConcurrentRestores:       2,
+		ExportPollInterval:          "20s",
+		ImportPollInterval:          "25s",
+		RestorePollInterval:         "30s",
+		RefreshTokenCleanupInterval: "15m",
+		ThumbnailBatchSize:          25,
+		ThumbnailPollInterval:       "2s",
+		ThumbnailCleanupInterval:    "10m",
+		ThumbnailJobRetentionPeriod: "48h",
+		ThumbnailJobBatchTimeout:    "45s",
+		DetachedThumbnailJobTimeout: "4m",
+	}
+
+	cfg.setDefaults()
+
+	c.Assert(cfg.MaxConcurrentExports, qt.Equals, 7)
+	c.Assert(cfg.MaxConcurrentImports, qt.Equals, 4)
+	c.Assert(cfg.MaxConcurrentRestores, qt.Equals, 2)
+	c.Assert(cfg.ExportPollInterval, qt.Equals, "20s")
+	c.Assert(cfg.ImportPollInterval, qt.Equals, "25s")
+	c.Assert(cfg.RestorePollInterval, qt.Equals, "30s")
+	c.Assert(cfg.RefreshTokenCleanupInterval, qt.Equals, "15m")
+	c.Assert(cfg.ThumbnailBatchSize, qt.Equals, 25)
+	c.Assert(cfg.ThumbnailPollInterval, qt.Equals, "2s")
+	c.Assert(cfg.ThumbnailCleanupInterval, qt.Equals, "10m")
+	c.Assert(cfg.ThumbnailJobRetentionPeriod, qt.Equals, "48h")
+	c.Assert(cfg.ThumbnailJobBatchTimeout, qt.Equals, "45s")
+	c.Assert(cfg.DetachedThumbnailJobTimeout, qt.Equals, "4m")
+}
+
 func TestValidatePublicURLForTransactionalEmails_Invalid(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/cmd/inventario/run/config_test.go
+++ b/go/cmd/inventario/run/config_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -221,6 +222,130 @@ func TestValidateEmailPublicURLConfig_Invalid(t *testing.T) {
 			err := validateEmailPublicURLConfig(tc.provider, tc.publicURL)
 			c.Assert(err, qt.IsNotNil)
 			c.Assert(err.Error(), qt.Contains, tc.wantErrContains)
+		})
+	}
+}
+
+func TestParseWorkerDuration_Valid(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{"seconds", "5s", 5 * time.Second},
+		{"minutes", "2m", 2 * time.Minute},
+		{"hours", "1h", time.Hour},
+		{"compound", "1h30m", 90 * time.Minute},
+		{"milliseconds", "250ms", 250 * time.Millisecond},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got, err := parseWorkerDuration("some-flag", tc.value)
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestParseWorkerDuration_Errors(t *testing.T) {
+	cases := []struct {
+		name            string
+		value           string
+		wantErrContains string
+	}{
+		{"empty", "", "invalid --some-flag"},
+		{"garbage", "not-a-duration", "invalid --some-flag"},
+		{"bare number", "10", "invalid --some-flag"},
+		{"zero", "0s", "must be positive"},
+		{"negative", "-5s", "must be positive"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got, err := parseWorkerDuration("some-flag", tc.value)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, tc.wantErrContains)
+			c.Assert(err.Error(), qt.Contains, "some-flag")
+			c.Assert(got, qt.Equals, time.Duration(0))
+		})
+	}
+}
+
+func TestParseWorkerDurations_Valid(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := Config{
+		ExportPollInterval:          "11s",
+		ImportPollInterval:          "12s",
+		RestorePollInterval:         "13s",
+		RefreshTokenCleanupInterval: "2h",
+		ThumbnailPollInterval:       "7s",
+		ThumbnailCleanupInterval:    "6m",
+		ThumbnailJobRetentionPeriod: "48h",
+		ThumbnailJobBatchTimeout:    "45s",
+		DetachedThumbnailJobTimeout: "3m",
+	}
+	cmd := &Command{config: cfg}
+
+	got, err := cmd.parseWorkerDurations()
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.exportPollInterval, qt.Equals, 11*time.Second)
+	c.Assert(got.importPollInterval, qt.Equals, 12*time.Second)
+	c.Assert(got.restorePollInterval, qt.Equals, 13*time.Second)
+	c.Assert(got.refreshTokenCleanupInterval, qt.Equals, 2*time.Hour)
+	c.Assert(got.thumbnailPollInterval, qt.Equals, 7*time.Second)
+	c.Assert(got.thumbnailCleanupInterval, qt.Equals, 6*time.Minute)
+	c.Assert(got.thumbnailJobRetentionPeriod, qt.Equals, 48*time.Hour)
+	c.Assert(got.thumbnailJobBatchTimeout, qt.Equals, 45*time.Second)
+	c.Assert(got.detachedThumbnailJobTimeout, qt.Equals, 3*time.Minute)
+}
+
+func TestParseWorkerDurations_FailsOnInvalidFlag(t *testing.T) {
+	cases := []struct {
+		name        string
+		mutate      func(*Config)
+		wantFlag    string
+		wantMessage string
+	}{
+		{
+			name:        "invalid export poll interval",
+			mutate:      func(c *Config) { c.ExportPollInterval = "nope" },
+			wantFlag:    "export-poll-interval",
+			wantMessage: "invalid",
+		},
+		{
+			name:        "non-positive import poll interval",
+			mutate:      func(c *Config) { c.ImportPollInterval = "0s" },
+			wantFlag:    "import-poll-interval",
+			wantMessage: "must be positive",
+		},
+		{
+			name:        "non-positive thumbnail retention",
+			mutate:      func(c *Config) { c.ThumbnailJobRetentionPeriod = "-1h" },
+			wantFlag:    "thumbnail-job-retention-period",
+			wantMessage: "must be positive",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			cfg := Config{}
+			cfg.setDefaults()
+			tc.mutate(&cfg)
+			cmd := &Command{config: cfg}
+
+			got, err := cmd.parseWorkerDurations()
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, tc.wantFlag)
+			c.Assert(err.Error(), qt.Contains, tc.wantMessage)
+			c.Assert(got, qt.Equals, workerDurations{})
 		})
 	}
 }

--- a/go/cmd/inventario/run/run.go
+++ b/go/cmd/inventario/run/run.go
@@ -116,6 +116,17 @@ func (c *Command) registerFlags() {
 	shared.RegisterLocalDatabaseFlags(c.Cmd(), &c.dbConfig)
 	flags.IntVar(&c.config.MaxConcurrentExports, "max-concurrent-exports", c.config.MaxConcurrentExports, "Maximum number of concurrent export processes")
 	flags.IntVar(&c.config.MaxConcurrentImports, "max-concurrent-imports", c.config.MaxConcurrentImports, "Maximum number of concurrent import processes")
+	flags.IntVar(&c.config.MaxConcurrentRestores, "max-concurrent-restores", c.config.MaxConcurrentRestores, "Maximum number of concurrent restore processes")
+	flags.StringVar(&c.config.ExportPollInterval, "export-poll-interval", c.config.ExportPollInterval, "Export worker poll interval (e.g., 10s, 30s)")
+	flags.StringVar(&c.config.ImportPollInterval, "import-poll-interval", c.config.ImportPollInterval, "Import worker poll interval (e.g., 10s, 30s)")
+	flags.StringVar(&c.config.RestorePollInterval, "restore-poll-interval", c.config.RestorePollInterval, "Restore worker poll interval (e.g., 10s, 30s)")
+	flags.StringVar(&c.config.RefreshTokenCleanupInterval, "refresh-token-cleanup-interval", c.config.RefreshTokenCleanupInterval, "Interval between refresh token cleanup runs (e.g., 1h, 30m)")
+	flags.IntVar(&c.config.ThumbnailBatchSize, "thumbnail-batch-size", c.config.ThumbnailBatchSize, "Maximum thumbnail jobs processed per batch")
+	flags.StringVar(&c.config.ThumbnailPollInterval, "thumbnail-poll-interval", c.config.ThumbnailPollInterval, "Thumbnail worker poll interval (e.g., 5s, 10s)")
+	flags.StringVar(&c.config.ThumbnailCleanupInterval, "thumbnail-cleanup-interval", c.config.ThumbnailCleanupInterval, "Interval between thumbnail job cleanup runs (e.g., 5m)")
+	flags.StringVar(&c.config.ThumbnailJobRetentionPeriod, "thumbnail-job-retention-period", c.config.ThumbnailJobRetentionPeriod, "How long completed thumbnail jobs are retained (e.g., 24h)")
+	flags.StringVar(&c.config.ThumbnailJobBatchTimeout, "thumbnail-job-batch-timeout", c.config.ThumbnailJobBatchTimeout, "How long the thumbnail worker waits for an in-flight batch before polling again (e.g., 30s)")
+	flags.StringVar(&c.config.DetachedThumbnailJobTimeout, "detached-thumbnail-job-timeout", c.config.DetachedThumbnailJobTimeout, "Per-job timeout for detached thumbnail generation (e.g., 2m)")
 	flags.StringVar(&c.config.JWTSecret, "jwt-secret", c.config.JWTSecret, "JWT secret for authentication (minimum 32 characters, auto-generated if not provided)")
 	flags.StringVar(&c.config.FileSigningKey, "file-signing-key", c.config.FileSigningKey, "File signing key for secure file URLs (minimum 32 characters, auto-generated if not provided)")
 	flags.StringVar(&c.config.FileURLExpiration, "file-url-expiration", c.config.FileURLExpiration, "File URL expiration duration (e.g., 15m, 1h, 30s)")
@@ -216,10 +227,17 @@ func (c *Command) runCommand() error {
 	emailLifecycle.start(ctx)
 	defer emailLifecycle.stop()
 
+	workerDurations, err := c.parseWorkerDurations()
+	if err != nil {
+		return err
+	}
+
 	// Start export worker
-	maxConcurrentExports := c.config.MaxConcurrentExports
 	exportService := export.NewExportService(factorySet, params.UploadLocation)
-	exportWorker := export.NewExportWorker(exportService, factorySet, maxConcurrentExports)
+	exportWorker := export.NewExportWorker(
+		exportService, factorySet, c.config.MaxConcurrentExports,
+		export.WithPollInterval(workerDurations.exportPollInterval),
+	)
 	exportWorker.Start(ctx)
 	defer exportWorker.Stop()
 
@@ -227,24 +245,41 @@ func (c *Command) runCommand() error {
 	restoreService := restore.NewRestoreService(factorySet, params.EntityService, params.UploadLocation)
 	// Create a service registry set for the restore worker
 	serviceRegistrySet := factorySet.CreateServiceRegistrySet()
-	restoreWorker := restore.NewRestoreWorker(restoreService, serviceRegistrySet, params.UploadLocation)
+	restoreWorker := restore.NewRestoreWorker(
+		restoreService, serviceRegistrySet, params.UploadLocation,
+		restore.WithPollInterval(workerDurations.restorePollInterval),
+		restore.WithMaxConcurrent(c.config.MaxConcurrentRestores),
+	)
 	restoreWorker.Start(ctx)
 	defer restoreWorker.Stop()
 
 	// Start import worker
-	maxConcurrentImports := c.config.MaxConcurrentImports
 	importService := importpkg.NewImportService(factorySet, params.UploadLocation)
-	importWorker := importpkg.NewImportWorker(importService, factorySet, maxConcurrentImports)
+	importWorker := importpkg.NewImportWorker(
+		importService, factorySet, c.config.MaxConcurrentImports,
+		importpkg.WithPollInterval(workerDurations.importPollInterval),
+	)
 	importWorker.Start(ctx)
 	defer importWorker.Stop()
 
 	// Start thumbnail generation worker
-	thumbnailWorker := services.NewThumbnailGenerationWorker(factorySet, params.UploadLocation, params.ThumbnailConfig)
+	thumbnailWorker := services.NewThumbnailGenerationWorker(
+		factorySet, params.UploadLocation, params.ThumbnailConfig,
+		services.WithThumbnailPollInterval(workerDurations.thumbnailPollInterval),
+		services.WithThumbnailBatchSize(c.config.ThumbnailBatchSize),
+		services.WithThumbnailCleanupInterval(workerDurations.thumbnailCleanupInterval),
+		services.WithThumbnailJobRetentionPeriod(workerDurations.thumbnailJobRetentionPeriod),
+		services.WithThumbnailJobBatchTimeout(workerDurations.thumbnailJobBatchTimeout),
+		services.WithDetachedThumbnailJobTimeout(workerDurations.detachedThumbnailJobTimeout),
+	)
 	thumbnailWorker.Start(ctx)
 	defer thumbnailWorker.Stop()
 
-	// Start refresh token cleanup worker (deletes expired tokens every hour)
-	refreshTokenCleanupWorker := services.NewRefreshTokenCleanupWorker(factorySet.RefreshTokenRegistry)
+	// Start refresh token cleanup worker (deletes expired tokens on the configured interval)
+	refreshTokenCleanupWorker := services.NewRefreshTokenCleanupWorker(
+		factorySet.RefreshTokenRegistry,
+		services.WithRefreshTokenCleanupInterval(workerDurations.refreshTokenCleanupInterval),
+	)
 	refreshTokenCleanupWorker.Start(ctx)
 	defer refreshTokenCleanupWorker.Stop()
 
@@ -273,6 +308,57 @@ type serverSetup struct {
 	params                    apiserver.Params
 	emailLifecycle            emailServiceLifecycle
 	closeReadinessRedisPinger func()
+}
+
+type workerDurations struct {
+	exportPollInterval          time.Duration
+	importPollInterval          time.Duration
+	restorePollInterval         time.Duration
+	refreshTokenCleanupInterval time.Duration
+	thumbnailPollInterval       time.Duration
+	thumbnailCleanupInterval    time.Duration
+	thumbnailJobRetentionPeriod time.Duration
+	thumbnailJobBatchTimeout    time.Duration
+	detachedThumbnailJobTimeout time.Duration
+}
+
+func parseWorkerDuration(flagName, value string) (time.Duration, error) {
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --%s %q: %w", flagName, value, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid --%s %q: must be positive", flagName, value)
+	}
+	return d, nil
+}
+
+func (c *Command) parseWorkerDurations() (workerDurations, error) {
+	var out workerDurations
+	specs := []struct {
+		flag  string
+		value string
+		dst   *time.Duration
+	}{
+		{"export-poll-interval", c.config.ExportPollInterval, &out.exportPollInterval},
+		{"import-poll-interval", c.config.ImportPollInterval, &out.importPollInterval},
+		{"restore-poll-interval", c.config.RestorePollInterval, &out.restorePollInterval},
+		{"refresh-token-cleanup-interval", c.config.RefreshTokenCleanupInterval, &out.refreshTokenCleanupInterval},
+		{"thumbnail-poll-interval", c.config.ThumbnailPollInterval, &out.thumbnailPollInterval},
+		{"thumbnail-cleanup-interval", c.config.ThumbnailCleanupInterval, &out.thumbnailCleanupInterval},
+		{"thumbnail-job-retention-period", c.config.ThumbnailJobRetentionPeriod, &out.thumbnailJobRetentionPeriod},
+		{"thumbnail-job-batch-timeout", c.config.ThumbnailJobBatchTimeout, &out.thumbnailJobBatchTimeout},
+		{"detached-thumbnail-job-timeout", c.config.DetachedThumbnailJobTimeout, &out.detachedThumbnailJobTimeout},
+	}
+	for _, spec := range specs {
+		d, err := parseWorkerDuration(spec.flag, spec.value)
+		if err != nil {
+			slog.Error("Failed to parse worker duration", "flag", spec.flag, "error", err)
+			return workerDurations{}, err
+		}
+		*spec.dst = d
+	}
+	return out, nil
 }
 
 func (c *Command) buildServerParams(factorySet *registry.FactorySet, dsn string) (serverSetup, error) {

--- a/go/cmd/inventario/run/run.go
+++ b/go/cmd/inventario/run/run.go
@@ -224,13 +224,16 @@ func (c *Command) runCommand() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	emailLifecycle.start(ctx)
-	defer emailLifecycle.stop()
-
+	// Validate all duration-valued worker flags up front so misconfiguration
+	// fails fast without starting any background goroutines or external
+	// connections (email queue, workers, HTTP listener).
 	workerDurations, err := c.parseWorkerDurations()
 	if err != nil {
 		return err
 	}
+
+	emailLifecycle.start(ctx)
+	defer emailLifecycle.stop()
 
 	// Start export worker
 	exportService := export.NewExportService(factorySet, params.UploadLocation)

--- a/go/internal/defaults/defaults.go
+++ b/go/internal/defaults/defaults.go
@@ -22,8 +22,13 @@ type Database struct {
 
 // Workers contains default values for worker configuration
 type Workers struct {
-	MaxConcurrentExports int
-	MaxConcurrentImports int
+	MaxConcurrentExports        int
+	MaxConcurrentImports        int
+	MaxConcurrentRestores       int
+	ExportPollInterval          string // Export worker poll interval (e.g., "10s")
+	ImportPollInterval          string // Import worker poll interval (e.g., "10s")
+	RestorePollInterval         string // Restore worker poll interval (e.g., "10s")
+	RefreshTokenCleanupInterval string // Refresh token cleanup interval (e.g., "1h")
 }
 
 // ThumbnailGeneration contains default values for thumbnail generation configuration
@@ -31,6 +36,12 @@ type ThumbnailGeneration struct {
 	MaxConcurrentPerUser int    // Maximum simultaneous thumbnail generation jobs per user
 	RateLimitPerMinute   int    // Maximum thumbnail generation requests per minute per user
 	SlotDuration         string // Duration for which a concurrency slot is held (e.g., "30m")
+	BatchSize            int    // Maximum thumbnail jobs processed per batch
+	PollInterval         string // Thumbnail worker poll interval (e.g., "5s")
+	CleanupInterval      string // Interval between completed-job cleanups (e.g., "5m")
+	JobRetentionPeriod   string // How long completed thumbnail jobs are retained (e.g., "24h")
+	JobBatchTimeout      string // Max wait for an in-flight batch before polling again (e.g., "30s")
+	DetachedJobTimeout   string // Per-job timeout for detached thumbnail generation (e.g., "2m")
 }
 
 // Config contains all default configuration values
@@ -70,13 +81,24 @@ func New() Config {
 			DSN: "memory://",
 		},
 		Workers: Workers{
-			MaxConcurrentExports: 3,
-			MaxConcurrentImports: 1,
+			MaxConcurrentExports:        3,
+			MaxConcurrentImports:        1,
+			MaxConcurrentRestores:       1,
+			ExportPollInterval:          "10s",
+			ImportPollInterval:          "10s",
+			RestorePollInterval:         "10s",
+			RefreshTokenCleanupInterval: "1h",
 		},
 		ThumbnailGeneration: ThumbnailGeneration{
 			MaxConcurrentPerUser: 5,     // Maximum 5 simultaneous thumbnail generation jobs per user
 			RateLimitPerMinute:   50,    // Maximum 50 thumbnail generation requests per minute per user
 			SlotDuration:         "30m", // Hold concurrency slots for 30 minutes
+			BatchSize:            10,    // Process up to 10 thumbnail jobs per batch
+			PollInterval:         "5s",  // Check for new thumbnail jobs every 5 seconds
+			CleanupInterval:      "5m",  // Cleanup completed jobs every 5 minutes
+			JobRetentionPeriod:   "24h", // Keep completed jobs for 24 hours
+			JobBatchTimeout:      "30s", // Wait up to 30 seconds for a batch before polling again
+			DetachedJobTimeout:   "2m",  // Bound each detached thumbnail job
 		},
 	}
 }
@@ -126,4 +148,59 @@ func GetThumbnailRateLimitPerMinute() int {
 // GetThumbnailSlotDuration returns the default thumbnail generation slot duration
 func GetThumbnailSlotDuration() string {
 	return defaultConfig.ThumbnailGeneration.SlotDuration
+}
+
+// GetMaxConcurrentRestores returns the default max concurrent restores
+func GetMaxConcurrentRestores() int {
+	return defaultConfig.Workers.MaxConcurrentRestores
+}
+
+// GetExportPollInterval returns the default export worker poll interval
+func GetExportPollInterval() string {
+	return defaultConfig.Workers.ExportPollInterval
+}
+
+// GetImportPollInterval returns the default import worker poll interval
+func GetImportPollInterval() string {
+	return defaultConfig.Workers.ImportPollInterval
+}
+
+// GetRestorePollInterval returns the default restore worker poll interval
+func GetRestorePollInterval() string {
+	return defaultConfig.Workers.RestorePollInterval
+}
+
+// GetRefreshTokenCleanupInterval returns the default refresh token cleanup interval
+func GetRefreshTokenCleanupInterval() string {
+	return defaultConfig.Workers.RefreshTokenCleanupInterval
+}
+
+// GetThumbnailBatchSize returns the default thumbnail worker batch size
+func GetThumbnailBatchSize() int {
+	return defaultConfig.ThumbnailGeneration.BatchSize
+}
+
+// GetThumbnailPollInterval returns the default thumbnail worker poll interval
+func GetThumbnailPollInterval() string {
+	return defaultConfig.ThumbnailGeneration.PollInterval
+}
+
+// GetThumbnailCleanupInterval returns the default interval between completed-job cleanups
+func GetThumbnailCleanupInterval() string {
+	return defaultConfig.ThumbnailGeneration.CleanupInterval
+}
+
+// GetThumbnailJobRetentionPeriod returns the default retention period for completed thumbnail jobs
+func GetThumbnailJobRetentionPeriod() string {
+	return defaultConfig.ThumbnailGeneration.JobRetentionPeriod
+}
+
+// GetThumbnailJobBatchTimeout returns the default batch timeout for the thumbnail worker
+func GetThumbnailJobBatchTimeout() string {
+	return defaultConfig.ThumbnailGeneration.JobBatchTimeout
+}
+
+// GetDetachedThumbnailJobTimeout returns the default per-job timeout for detached thumbnail generation
+func GetDetachedThumbnailJobTimeout() string {
+	return defaultConfig.ThumbnailGeneration.DetachedJobTimeout
 }

--- a/go/internal/defaults/defaults_test.go
+++ b/go/internal/defaults/defaults_test.go
@@ -26,11 +26,22 @@ func TestDefaults(t *testing.T) {
 	// Test worker defaults
 	c.Assert(cfg.Workers.MaxConcurrentExports, qt.Equals, 3)
 	c.Assert(cfg.Workers.MaxConcurrentImports, qt.Equals, 1)
+	c.Assert(cfg.Workers.MaxConcurrentRestores, qt.Equals, 1)
+	c.Assert(cfg.Workers.ExportPollInterval, qt.Equals, "10s")
+	c.Assert(cfg.Workers.ImportPollInterval, qt.Equals, "10s")
+	c.Assert(cfg.Workers.RestorePollInterval, qt.Equals, "10s")
+	c.Assert(cfg.Workers.RefreshTokenCleanupInterval, qt.Equals, "1h")
 
 	// Test thumbnail generation defaults
 	c.Assert(cfg.ThumbnailGeneration.MaxConcurrentPerUser, qt.Equals, 5)
 	c.Assert(cfg.ThumbnailGeneration.RateLimitPerMinute, qt.Equals, 50)
 	c.Assert(cfg.ThumbnailGeneration.SlotDuration, qt.Equals, "30m")
+	c.Assert(cfg.ThumbnailGeneration.BatchSize, qt.Equals, 10)
+	c.Assert(cfg.ThumbnailGeneration.PollInterval, qt.Equals, "5s")
+	c.Assert(cfg.ThumbnailGeneration.CleanupInterval, qt.Equals, "5m")
+	c.Assert(cfg.ThumbnailGeneration.JobRetentionPeriod, qt.Equals, "24h")
+	c.Assert(cfg.ThumbnailGeneration.JobBatchTimeout, qt.Equals, "30s")
+	c.Assert(cfg.ThumbnailGeneration.DetachedJobTimeout, qt.Equals, "2m")
 }
 
 func TestDefaultGetters(t *testing.T) {
@@ -41,6 +52,17 @@ func TestDefaultGetters(t *testing.T) {
 	c.Assert(defaults.GetDatabaseDSN(), qt.Equals, "memory://")
 	c.Assert(defaults.GetMaxConcurrentExports(), qt.Equals, 3)
 	c.Assert(defaults.GetMaxConcurrentImports(), qt.Equals, 1)
+	c.Assert(defaults.GetMaxConcurrentRestores(), qt.Equals, 1)
+	c.Assert(defaults.GetExportPollInterval(), qt.Equals, "10s")
+	c.Assert(defaults.GetImportPollInterval(), qt.Equals, "10s")
+	c.Assert(defaults.GetRestorePollInterval(), qt.Equals, "10s")
+	c.Assert(defaults.GetRefreshTokenCleanupInterval(), qt.Equals, "1h")
+	c.Assert(defaults.GetThumbnailBatchSize(), qt.Equals, 10)
+	c.Assert(defaults.GetThumbnailPollInterval(), qt.Equals, "5s")
+	c.Assert(defaults.GetThumbnailCleanupInterval(), qt.Equals, "5m")
+	c.Assert(defaults.GetThumbnailJobRetentionPeriod(), qt.Equals, "24h")
+	c.Assert(defaults.GetThumbnailJobBatchTimeout(), qt.Equals, "30s")
+	c.Assert(defaults.GetDetachedThumbnailJobTimeout(), qt.Equals, "2m")
 	c.Assert(defaults.GetJWTSecret(), qt.Equals, "") // Empty by default
 
 	// Test upload location getter

--- a/go/services/refresh_token_cleanup_worker.go
+++ b/go/services/refresh_token_cleanup_worker.go
@@ -22,11 +22,35 @@ type RefreshTokenCleanupWorker struct {
 	wg              sync.WaitGroup
 }
 
-// NewRefreshTokenCleanupWorker creates a cleanup worker with a default interval of 1 hour.
-func NewRefreshTokenCleanupWorker(r registry.RefreshTokenRegistry) *RefreshTokenCleanupWorker {
+// RefreshTokenCleanupOption customizes a RefreshTokenCleanupWorker created by NewRefreshTokenCleanupWorker.
+type RefreshTokenCleanupOption func(*refreshTokenCleanupOptions)
+
+type refreshTokenCleanupOptions struct {
+	cleanupInterval time.Duration
+}
+
+// WithRefreshTokenCleanupInterval overrides the default cleanup interval.
+// Non-positive values are ignored.
+func WithRefreshTokenCleanupInterval(d time.Duration) RefreshTokenCleanupOption {
+	return func(o *refreshTokenCleanupOptions) {
+		if d > 0 {
+			o.cleanupInterval = d
+		}
+	}
+}
+
+// NewRefreshTokenCleanupWorker creates a cleanup worker with the default one-hour interval,
+// overridable via RefreshTokenCleanupOption values (e.g., WithRefreshTokenCleanupInterval).
+func NewRefreshTokenCleanupWorker(r registry.RefreshTokenRegistry, opts ...RefreshTokenCleanupOption) *RefreshTokenCleanupWorker {
+	options := refreshTokenCleanupOptions{
+		cleanupInterval: defaultRefreshTokenCleanupInterval,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
 	return &RefreshTokenCleanupWorker{
 		registry:        r,
-		cleanupInterval: defaultRefreshTokenCleanupInterval,
+		cleanupInterval: options.cleanupInterval,
 		stopCh:          make(chan struct{}),
 	}
 }

--- a/go/services/thumbnail_generation_worker.go
+++ b/go/services/thumbnail_generation_worker.go
@@ -20,31 +20,119 @@ const (
 
 // ThumbnailGenerationWorker processes thumbnail generation requests in the background
 type ThumbnailGenerationWorker struct {
-	thumbnailService *ThumbnailGenerationService
-	factorySet       *registry.FactorySet
-	pollInterval     time.Duration
-	jobBatchSize     int
-	cleanupInterval  time.Duration
-	retentionPeriod  time.Duration
-	stopCh           chan struct{}
-	wg               sync.WaitGroup
-	isRunning        bool
-	mu               sync.RWMutex
-	stopped          bool
+	thumbnailService   *ThumbnailGenerationService
+	factorySet         *registry.FactorySet
+	pollInterval       time.Duration
+	jobBatchSize       int
+	cleanupInterval    time.Duration
+	retentionPeriod    time.Duration
+	jobBatchTimeout    time.Duration
+	detachedJobTimeout time.Duration
+	stopCh             chan struct{}
+	wg                 sync.WaitGroup
+	isRunning          bool
+	mu                 sync.RWMutex
+	stopped            bool
+}
+
+// ThumbnailWorkerOption customizes a ThumbnailGenerationWorker constructed via NewThumbnailGenerationWorker.
+type ThumbnailWorkerOption func(*thumbnailWorkerOptions)
+
+type thumbnailWorkerOptions struct {
+	pollInterval       time.Duration
+	jobBatchSize       int
+	cleanupInterval    time.Duration
+	retentionPeriod    time.Duration
+	jobBatchTimeout    time.Duration
+	detachedJobTimeout time.Duration
+}
+
+// WithThumbnailPollInterval overrides the default interval between job queue polls.
+// Non-positive values are ignored.
+func WithThumbnailPollInterval(d time.Duration) ThumbnailWorkerOption {
+	return func(o *thumbnailWorkerOptions) {
+		if d > 0 {
+			o.pollInterval = d
+		}
+	}
+}
+
+// WithThumbnailBatchSize overrides the maximum number of jobs processed per batch.
+// Non-positive values are ignored.
+func WithThumbnailBatchSize(n int) ThumbnailWorkerOption {
+	return func(o *thumbnailWorkerOptions) {
+		if n > 0 {
+			o.jobBatchSize = n
+		}
+	}
+}
+
+// WithThumbnailCleanupInterval overrides the default interval between completed-job cleanups.
+// Non-positive values are ignored.
+func WithThumbnailCleanupInterval(d time.Duration) ThumbnailWorkerOption {
+	return func(o *thumbnailWorkerOptions) {
+		if d > 0 {
+			o.cleanupInterval = d
+		}
+	}
+}
+
+// WithThumbnailJobRetentionPeriod overrides the default retention period for completed jobs.
+// Non-positive values are ignored.
+func WithThumbnailJobRetentionPeriod(d time.Duration) ThumbnailWorkerOption {
+	return func(o *thumbnailWorkerOptions) {
+		if d > 0 {
+			o.retentionPeriod = d
+		}
+	}
+}
+
+// WithThumbnailJobBatchTimeout overrides how long the worker waits for an in-flight batch
+// before polling again. Non-positive values are ignored.
+func WithThumbnailJobBatchTimeout(d time.Duration) ThumbnailWorkerOption {
+	return func(o *thumbnailWorkerOptions) {
+		if d > 0 {
+			o.jobBatchTimeout = d
+		}
+	}
+}
+
+// WithDetachedThumbnailJobTimeout overrides the per-job timeout applied to each detached
+// thumbnail generation goroutine. Non-positive values are ignored.
+func WithDetachedThumbnailJobTimeout(d time.Duration) ThumbnailWorkerOption {
+	return func(o *thumbnailWorkerOptions) {
+		if d > 0 {
+			o.detachedJobTimeout = d
+		}
+	}
 }
 
 // NewThumbnailGenerationWorker creates a new thumbnail generation worker
-func NewThumbnailGenerationWorker(factorySet *registry.FactorySet, uploadLocation string, config ThumbnailGenerationConfig) *ThumbnailGenerationWorker {
+func NewThumbnailGenerationWorker(factorySet *registry.FactorySet, uploadLocation string, config ThumbnailGenerationConfig, opts ...ThumbnailWorkerOption) *ThumbnailGenerationWorker {
 	thumbnailService := NewThumbnailGenerationService(factorySet, uploadLocation, config)
 
+	options := thumbnailWorkerOptions{
+		pollInterval:       defaultThumbnailPollInterval,
+		jobBatchSize:       defaultJobBatchSize,
+		cleanupInterval:    defaultCleanupInterval,
+		retentionPeriod:    defaultJobRetentionPeriod,
+		jobBatchTimeout:    defaultThumbnailJobBatchTimeout,
+		detachedJobTimeout: defaultDetachedThumbnailTimeout,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	return &ThumbnailGenerationWorker{
-		thumbnailService: thumbnailService,
-		factorySet:       factorySet,
-		pollInterval:     defaultThumbnailPollInterval,
-		jobBatchSize:     defaultJobBatchSize,
-		cleanupInterval:  defaultCleanupInterval,
-		retentionPeriod:  defaultJobRetentionPeriod,
-		stopCh:           make(chan struct{}),
+		thumbnailService:   thumbnailService,
+		factorySet:         factorySet,
+		pollInterval:       options.pollInterval,
+		jobBatchSize:       options.jobBatchSize,
+		cleanupInterval:    options.cleanupInterval,
+		retentionPeriod:    options.retentionPeriod,
+		jobBatchTimeout:    options.jobBatchTimeout,
+		detachedJobTimeout: options.detachedJobTimeout,
+		stopCh:             make(chan struct{}),
 	}
 }
 
@@ -158,7 +246,7 @@ func (w *ThumbnailGenerationWorker) processPendingJobs(ctx context.Context) {
 	var wg sync.WaitGroup
 	for _, job := range jobs {
 		wg.Add(1)
-		jobCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), defaultDetachedThumbnailTimeout)
+		jobCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), w.detachedJobTimeout)
 		go func(jobID string, jobCtx context.Context, cancel context.CancelFunc) {
 			defer wg.Done()
 			defer cancel()
@@ -183,7 +271,7 @@ func (w *ThumbnailGenerationWorker) processPendingJobs(ctx context.Context) {
 	case <-ctx.Done():
 		// Context cancelled, but let jobs continue in background
 		slog.Info("Context cancelled during job processing, jobs will continue in background")
-	case <-time.After(defaultThumbnailJobBatchTimeout):
+	case <-time.After(w.jobBatchTimeout):
 		// Timeout, but let jobs continue in background
 		slog.Warn("Job processing batch timed out, jobs will continue in background")
 	}


### PR DESCRIPTION
Part of #1214. Closes #1292.

## Summary

Parameterize hardcoded concurrency limits, poll intervals, batch sizes, timeouts, and retention periods for all background workers so operators can tune them without recompiling. All new knobs are available via CLI flags, environment variables, and YAML configuration.

## Scope

Preparatory work for #1294 (hierarchical `run` command). CLI structure stays flat for now — flags live on the existing `run` command. They will move to the appropriate subcommand (`run apiserver` vs `run workers`) in #1294 without renaming.

## Changes

### `go/internal/defaults/defaults.go`
Added constants, defaults, and getters for:
- `MaxConcurrentRestores` (default: 1)
- `ExportPollInterval`, `ImportPollInterval`, `RestorePollInterval` (default: `10s`)
- `RefreshTokenCleanupInterval` (default: `1h`)
- `ThumbnailBatchSize` (default: 10)
- `ThumbnailPollInterval` (default: `5s`)
- `ThumbnailCleanupInterval` (default: `5m`)
- `ThumbnailJobRetentionPeriod` (default: `24h`)
- `ThumbnailJobBatchTimeout` (default: `30s`)
- `DetachedThumbnailJobTimeout` (default: `2m`)

### Worker constructors
Introduced functional options on export/import/restore workers:

```go
restore.NewRestoreWorker(svc, regs, uploadLoc,
    restore.WithPollInterval(15*time.Second),
    restore.WithMaxConcurrent(3),
)
```

- Dropped the single-use `NewImportWorkerWithPollInterval` in favor of the generic options API.
- `RefreshTokenCleanupWorker` now accepts a custom interval.
- `ThumbnailGenerationWorker` accepts batch size, poll/cleanup intervals, retention period, and two timeout knobs.

### `go/cmd/inventario/run`
- 13 new flags registered with matching `yaml` and `env` tags:
  ```
  --max-concurrent-exports / --max-concurrent-imports / --max-concurrent-restores
  --export-poll-interval / --import-poll-interval / --restore-poll-interval
  --refresh-token-cleanup-interval
  --thumbnail-batch-size / --thumbnail-poll-interval / --thumbnail-cleanup-interval
  --thumbnail-job-retention-period / --thumbnail-job-batch-timeout
  --detached-thumbnail-job-timeout
  ```
- Centralized duration parsing via `parseWorkerDurations` — all string durations validated once at startup with clear error messages.
- Split `setDefaults` into `setWorkerDefaults` + `setThumbnailDefaults` to satisfy `gocyclo` (complexity was 26, threshold 20).

### `go/cmd/inventario/initconfig/data/config.yaml.tmpl`
Added new keys under `run:` with defaults mirroring the flag definitions.

## Verification

- `make lint-go` — 0 issues
- `make test-go` — all affected packages green
- `inventario run --help` shows all 13 new flags with defaults
- `inventario init-config` generates a template containing every new key

## Tests

- `go/internal/defaults/defaults_test.go` — coverage for all new getters
- `go/cmd/inventario/run/config_test.go` — defaulting behavior for worker/thumbnail knobs

## Follow-ups

- #1293: decompose run bootstrap into composable per-subsystem functions (no behavior change).
- #1294: split flags between `run apiserver` and `run workers` (pure CLI reshuffle; flag names kept stable).