### PR TITLE
refactor(groups): drop group-state localStorage, persist via default_group_id (closes #1300)

### DIFF
--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -638,16 +638,17 @@ test.describe('Leave Group UI — last admin protection (#1259)', () => {
   });
 });
 
-test.describe('Group selection persistence (#1262)', () => {
-  // The header's current-group selector used to reset to "Select Group"
-  // on every browser refresh because the chosen group wasn't persisted
-  // client-side. These tests lock in the acceptance criteria from #1262:
-  //   1. Selection survives a full page reload.
-  //   2. If the stored group is no longer accessible (deleted, user
-  //      removed), the UI falls back to an available group instead of
-  //      getting stuck on an empty selector.
+test.describe('Group selection persistence (#1262 / #1300)', () => {
+  // After #1300, the active group lives in two authoritative places:
+  //   1. The URL (/g/:groupSlug/...) — per-tab, survives a browser refresh
+  //      because the URL is reloaded as-is.
+  //   2. user.default_group_id on the server — the cross-device preference
+  //      that decides which group to land on when no URL slug is available
+  //      (cold start on '/', '/profile', etc.).
+  // localStorage is no longer consulted for group selection; only the
+  // legacy-migration shim touches it to wipe old keys.
 
-  test('selected group is preserved across a browser refresh', async ({ page, request }) => {
+  test('user-initiated group switch writes PUT /auth/me default_group_id and survives a reload', async ({ page, request }) => {
     const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
     const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
 
@@ -677,53 +678,87 @@ test.describe('Group selection persistence (#1262)', () => {
     expect(createResp.status(), await createResp.text()).toBe(201);
     const createdGroupId = (await createResp.json()).data.id as string;
 
+    // Capture the existing default so cleanup can restore it after the test.
+    const meBefore = await request.get('/api/v1/auth/me', {
+      headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${authToken}` },
+    });
+    const meBeforeBody = await meBefore.json();
+    const previousDefault = (meBeforeBody.default_group_id as string | null) ?? null;
+
     try {
-      // The GroupSelector consumes store state; make sure the store has
-      // fetched the just-created group before we try to click it.
       await page.goto('/');
       await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
 
-      // Open the dropdown and switch to the new group. After #1289 Gap C,
-      // GroupSelector navigates to /g/<new-slug>/... via router.push
-      // instead of triggering a full window.location.reload() — the URL
-      // is now the source of truth, so a plain SPA navigation is enough
-      // to flip every API call and the selector's name binding.
+      // Watch for the PUT /auth/me the selector fires after switching. The
+      // call is debounced (~400ms), so we use waitForRequest which polls
+      // the network rather than snapshot-checking. Filtering on the
+      // exact default_group_id makes the assertion tight.
+      const putPromise = page.waitForRequest(
+        (req) =>
+          req.url().includes('/api/v1/auth/me') &&
+          req.method() === 'PUT' &&
+          (req.postData() || '').includes(createdGroupId),
+        { timeout: 15000 },
+      );
+
       await page.click('.group-selector__trigger');
       const targetItem = page.locator('.group-selector__item', { hasText: groupName });
       await expect(targetItem).toBeVisible({ timeout: 5000 });
 
       await targetItem.click();
-      // Wait for the URL to carry the new group slug before asserting
-      // anything that depends on the switch. This replaces the previous
-      // waitForEvent('load') + networkidle dance used when the selector
-      // did a full reload.
+      // GroupSelector navigates to /g/<new-slug>/... via router.push. The
+      // URL is the immediate source of truth; default_group_id catches up
+      // asynchronously via the debounced PUT.
       await page.waitForURL(/\/g\/[^/]+/, { timeout: 10000 });
       await page.waitForLoadState('networkidle', { timeout: 15000 });
 
       await expect(page.locator('.group-selector__name')).toHaveText(groupName, { timeout: 10000 });
 
-      // The core of the bug: force a fresh browser load (not an SPA
-      // navigation) and assert the selection survived. If persistence
-      // regresses, the selector reverts to the default group or to the
-      // "Select Group" placeholder.
+      const putRequest = await putPromise;
+      const putBody = JSON.parse(putRequest.postData() ?? '{}');
+      expect(putBody.default_group_id).toBe(createdGroupId);
+
+      // Server-side round-trip: the preference survives a cold re-read of
+      // /auth/me (not just an in-flight request). Guards against a bug
+      // where the PUT is made but the server silently ignored the field.
+      const meAfter = await request.get('/api/v1/auth/me', {
+        headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${authToken}` },
+      });
+      const meAfterBody = await meAfter.json();
+      expect(meAfterBody.default_group_id).toBe(createdGroupId);
+
+      // URL-driven refresh: the browser reloads /g/<slug>/... verbatim,
+      // so the selector still shows the same group — no localStorage
+      // needed. This is what replaces the pre-#1300 snapshot behaviour.
       await page.reload();
       await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
       await expect(page.locator('.group-selector__name')).toHaveText(groupName);
 
-      // And the persisted value must actually be in localStorage — guards
-      // against a future change that relies on an in-memory-only cache and
-      // happens to pass the UI assertion because the page hasn't fully
-      // unmounted the store between reload() calls.
-      const persisted = await page.evaluate(() =>
-        localStorage.getItem('inventario_current_group'),
-      );
-      expect(persisted, 'currentGroup snapshot must live in localStorage').not.toBeNull();
-      const parsed = JSON.parse(persisted as string);
-      expect(parsed.id).toBe(createdGroupId);
-      expect(parsed.name).toBe(groupName);
+      // And #1300's headline invariant: the legacy localStorage keys
+      // must stay absent. If they came back the cross-tab coupling
+      // that the issue set out to remove would be back too.
+      const legacyKeys = await page.evaluate(() => ({
+        snapshot: localStorage.getItem('inventario_current_group'),
+        slug: localStorage.getItem('currentGroupSlug'),
+      }));
+      expect(legacyKeys.snapshot, 'inventario_current_group must not be written anymore').toBeNull();
+      expect(legacyKeys.slug, 'currentGroupSlug must not be written anymore').toBeNull();
     } finally {
-      // Switch the store away from the test group before deleting it so
-      // that cleanup doesn't leave the UI on a now-nonexistent group.
+      // Restore the preference before deleting the test group so we don't
+      // leave a stale default_group_id pointing at the deleted entity.
+      await request.put('/api/v1/auth/me', {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { name: meBeforeBody.name, default_group_id: previousDefault },
+      });
+
+      // Navigate away from the /g/<new-slug>/... URL before deletion so
+      // the UI isn't stranded on a now-nonexistent group when the delete
+      // returns 204.
       const groupsResp = await request.get('/api/v1/groups', {
         headers: {
           'Accept': 'application/vnd.api+json',
@@ -733,24 +768,10 @@ test.describe('Group selection persistence (#1262)', () => {
       const groupsBody = await groupsResp.json();
       const other = groupsBody.data.find((g: { id: string }) => g.id !== createdGroupId);
       if (other) {
-        await page.evaluate(
-          ({ snapshot }) => {
-            localStorage.setItem('inventario_current_group', JSON.stringify(snapshot));
-          },
-          {
-            snapshot: {
-              id: other.id,
-              slug: other.attributes.slug,
-              name: other.attributes.name,
-              icon: other.attributes.icon,
-              status: other.attributes.status,
-              main_currency: other.attributes.main_currency,
-              created_by: other.attributes.created_by,
-              created_at: other.attributes.created_at,
-              updated_at: other.attributes.updated_at,
-            },
-          },
-        );
+        await page.goto(`/g/${other.attributes.slug}/`);
+        await page.waitForLoadState('networkidle', { timeout: 10000 });
+      } else {
+        await page.goto('/');
       }
 
       const deleteResp = await request.delete(`/api/v1/groups/${createdGroupId}`, {
@@ -766,72 +787,159 @@ test.describe('Group selection persistence (#1262)', () => {
     }
   });
 
-  test('falls back to an available group when the stored selection is no longer accessible', async ({ page, request }) => {
+  test('cold start on / with no preference falls back to an available group', async ({ page, request }) => {
     const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
 
     if (!authToken) {
       test.skip();
       return;
     }
 
-    // Plant a snapshot that references a group the user is not a member of
-    // (random id + slug). On bootstrap, restoreFromStorage() must recognize
-    // the mismatch and swap in the first available group instead of leaving
-    // the selector showing "Select Group".
-    await page.evaluate(() => {
-      localStorage.setItem(
-        'inventario_current_group',
-        JSON.stringify({
-          id: 'grp-nonexistent-0000000000000000',
-          slug: 'nonexistent-slug-aaaaaaaaaaaaaa',
-          name: 'Ghost Group',
-          icon: '👻',
-          status: 'active',
-          main_currency: 'USD',
-          created_by: 'user-x',
-          created_at: '2026-01-01T00:00:00Z',
-          updated_at: '2026-01-01T00:00:00Z',
-        }),
-      );
+    // Remember the existing default so we can restore it after the test.
+    const meBefore = await request.get('/api/v1/auth/me', {
+      headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${authToken}` },
     });
+    const meBeforeBody = await meBefore.json();
+    const previousDefault = (meBeforeBody.default_group_id as string | null) ?? null;
 
-    await page.reload();
-    await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
+    try {
+      // Clear the preference. Without a default_group_id and without a
+      // /g/:groupSlug/ URL, the groupStore must fall back deterministically
+      // to the first-created (or first-invited) group rather than leaving
+      // the selector on "Select Group".
+      const putResp = await request.put('/api/v1/auth/me', {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { name: meBeforeBody.name, default_group_id: null },
+      });
+      expect(putResp.status(), await putResp.text()).toBe(200);
 
-    // The Ghost snapshot is rehydrated synchronously on first paint, so the
-    // selector initially shows "Ghost Group" and then swaps to a real group
-    // once fetchGroups() + restoreFromStorage() reconcile. Poll until the
-    // swap has happened rather than asserting on the first frame — otherwise
-    // the test races the bootstrap and flakes.
-    await expect(page.locator('.group-selector__name')).not.toHaveText('Ghost Group', {
-      timeout: 10000,
-    });
+      await page.goto('/');
+      await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
 
-    // Fallback kicked in: the selector shows *some* real group the user
-    // actually has, never the "Select Group" placeholder.
-    const displayedName = await page.locator('.group-selector__name').textContent();
-    expect(displayedName).not.toBe('Select Group');
-    expect(displayedName?.trim().length ?? 0).toBeGreaterThan(0);
+      const displayedName = await page.locator('.group-selector__name').textContent();
+      expect(displayedName).not.toBe('Select Group');
+      expect(displayedName?.trim().length ?? 0).toBeGreaterThan(0);
 
-    // The stale snapshot must be overwritten so a subsequent refresh
-    // doesn't replay the mismatch path every time.
-    const persisted = await page.evaluate(() =>
-      localStorage.getItem('inventario_current_group'),
-    );
-    const parsed = JSON.parse(persisted as string);
-    expect(parsed.id).not.toBe('grp-nonexistent-0000000000000000');
+      // Cross-check with the API: the resolved group really belongs to
+      // the user. Guards against a bug where fallback picks a bogus
+      // placeholder.
+      const groupsResp = await request.get('/api/v1/groups', {
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+      });
+      const groupsBody = await groupsResp.json();
+      const names = groupsBody.data.map((g: { attributes: { name: string } }) => g.attributes.name);
+      expect(names).toContain(displayedName);
+    } finally {
+      if (previousDefault) {
+        await request.put('/api/v1/auth/me', {
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'Authorization': `Bearer ${authToken}`,
+            'X-CSRF-Token': csrfToken,
+          },
+          data: { name: meBeforeBody.name, default_group_id: previousDefault },
+        });
+      }
+    }
+  });
 
-    // Cross-check with the API: the resolved group really belongs to the
-    // user. Guards against a bug where fallback picks a bogus placeholder.
-    const groupsResp = await request.get('/api/v1/groups', {
-      headers: {
-        'Accept': 'application/vnd.api+json',
-        'Authorization': `Bearer ${authToken}`,
-      },
-    });
-    const groupsBody = await groupsResp.json();
-    const ids = groupsBody.data.map((g: { id: string }) => g.id);
-    expect(ids).toContain(parsed.id);
+  test('two tabs on different /g/<slug>/ URLs stay independent across reload', async ({ browser }) => {
+    // The core behavioural guarantee that #1300 locks in: the URL is the
+    // per-tab source of truth for the active group, so two tabs that sit
+    // on two different /g/<slug>/... URLs must survive a refresh without
+    // leaking each other's group state through a shared localStorage key.
+    const context = await browser.newContext();
+    const pageA = await context.newPage();
+    const pageB = await context.newPage();
+
+    try {
+      // Log in via pageA — the auth cookie + access token land in the
+      // context so pageB inherits them on the next navigation.
+      await pageA.goto('/login');
+      await pageA.fill('[data-testid="email"]', 'admin@example.com');
+      await pageA.fill('[data-testid="password"]', 'admin123');
+      await pageA.click('[data-testid="login-button"]');
+      await pageA.waitForURL((u) => !u.pathname.startsWith('/login'), { timeout: 15000 });
+
+      // Ensure at least two groups exist so both tabs can hold a
+      // distinct /g/<slug>/ URL. Re-use an existing second group if the
+      // seed has one; otherwise create a second via the API wrapper.
+      const authToken = await pageA.evaluate(() => localStorage.getItem('inventario_token') || '');
+      const csrfToken = await pageA.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+      const groupsResp = await pageA.request.get('/api/v1/groups', {
+        headers: { 'Accept': 'application/vnd.api+json', 'Authorization': `Bearer ${authToken}` },
+      });
+      const groupsBody = await groupsResp.json();
+      let groupA = groupsBody.data[0];
+      let groupB = groupsBody.data.find((g: { id: string }) => g.id !== groupA.id);
+      let createdGroupId: string | null = null;
+      const secondGroupName = `Second Tab Test ${Date.now()}`;
+      if (!groupB) {
+        const createResp = await pageA.request.post('/api/v1/groups', {
+          headers: {
+            'Content-Type': 'application/vnd.api+json',
+            'Accept': 'application/vnd.api+json',
+            'Authorization': `Bearer ${authToken}`,
+            'X-CSRF-Token': csrfToken,
+          },
+          data: { data: { type: 'groups', attributes: { name: secondGroupName, icon: '🧩' } } },
+        });
+        expect(createResp.status(), await createResp.text()).toBe(201);
+        const created = (await createResp.json()).data;
+        createdGroupId = created.id;
+        groupB = created;
+      }
+
+      const slugA = groupA.attributes.slug as string;
+      const slugB = groupB.attributes.slug as string;
+      expect(slugA).not.toBe(slugB);
+
+      try {
+        await pageA.goto(`/g/${slugA}/commodities`);
+        await pageB.goto(`/g/${slugB}/commodities`);
+        await pageA.waitForLoadState('networkidle', { timeout: 15000 });
+        await pageB.waitForLoadState('networkidle', { timeout: 15000 });
+
+        await expect(pageA.locator('.group-selector__name')).toHaveText(groupA.attributes.name, { timeout: 10000 });
+        await expect(pageB.locator('.group-selector__name')).toHaveText(groupB.attributes.name, { timeout: 10000 });
+
+        // Reload both tabs — each must re-read its own URL, not a shared
+        // localStorage key.
+        await pageA.reload();
+        await pageB.reload();
+        await pageA.waitForLoadState('networkidle', { timeout: 15000 });
+        await pageB.waitForLoadState('networkidle', { timeout: 15000 });
+
+        await expect(pageA.locator('.group-selector__name')).toHaveText(groupA.attributes.name);
+        await expect(pageB.locator('.group-selector__name')).toHaveText(groupB.attributes.name);
+      } finally {
+        if (createdGroupId) {
+          // Move pageA off the about-to-be-deleted group before deleting.
+          await pageA.goto(`/g/${slugA}/`);
+          await pageA.request.delete(`/api/v1/groups/${createdGroupId}`, {
+            headers: {
+              'Content-Type': 'application/vnd.api+json',
+              'Accept': 'application/vnd.api+json',
+              'Authorization': `Bearer ${authToken}`,
+              'X-CSRF-Token': csrfToken,
+            },
+            data: { confirm_word: secondGroupName, password: 'admin123' },
+          });
+        }
+      }
+    } finally {
+      await context.close();
+    }
   });
 });
 
@@ -1155,31 +1263,20 @@ test.describe('Default group preference (#1263)', () => {
       const putBody = await putResp.json();
       expect(putBody.default_group_id).toBe(createdGroupId);
 
-      // Simulate a fresh device: scrub any session-persistent group state.
-      // The localStorage user cache also needs the new default_group_id for
-      // the *first* frame to read it; the background /auth/me fetch would
-      // refresh it anyway, but clearing the snapshot forces the preference
-      // path in restoreFromStorage() to run on the first pass.
-      await page.evaluate(() => {
-        localStorage.removeItem('inventario_current_group');
-        localStorage.removeItem('currentGroupSlug');
-      });
+      // Navigate to a non-group URL so the router has no /g/:groupSlug/
+      // param to seed the store from — that forces restoreFromPreference()
+      // to run the #1263 priority chain (default_group_id → fallback).
+      // After #1300 there's no snapshot key to clear; the store never
+      // wrote one in the first place.
+      await page.goto('/profile');
       await page.reload();
+      await page.goto('/');
 
       // Wait for the selector to arrive and reconciliation to finish.
       await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
       await expect(page.locator('.group-selector__name')).toHaveText(groupName, {
         timeout: 10000,
       });
-
-      // Verify the snapshot was rewritten with the preferred group, not
-      // some fallback target — that's how the login flow "honours" the
-      // preference (#1263 acceptance criterion).
-      const persisted = await page.evaluate(() =>
-        localStorage.getItem('inventario_current_group'),
-      );
-      const parsed = JSON.parse(persisted as string);
-      expect(parsed.id).toBe(createdGroupId);
     } finally {
       // Clear the preference (null) so the next test starts clean, then
       // delete the test group. Restore any previous default afterwards.
@@ -1193,8 +1290,8 @@ test.describe('Default group preference (#1263)', () => {
         data: { name: meBeforeBody.name, default_group_id: null },
       });
 
-      // Switch the UI away from the test group before deleting it to avoid
-      // leaving the selector pointing at a deleted entity.
+      // Navigate the UI away from the test group before deleting so the
+      // selector doesn't briefly point at a deleted entity.
       const groupsResp = await request.get('/api/v1/groups', {
         headers: {
           'Accept': 'application/vnd.api+json',
@@ -1204,24 +1301,10 @@ test.describe('Default group preference (#1263)', () => {
       const groupsBody = await groupsResp.json();
       const other = groupsBody.data.find((g: { id: string }) => g.id !== createdGroupId);
       if (other) {
-        await page.evaluate(
-          ({ snapshot }) => {
-            localStorage.setItem('inventario_current_group', JSON.stringify(snapshot));
-          },
-          {
-            snapshot: {
-              id: other.id,
-              slug: other.attributes.slug,
-              name: other.attributes.name,
-              icon: other.attributes.icon,
-              status: other.attributes.status,
-              main_currency: other.attributes.main_currency,
-              created_by: other.attributes.created_by,
-              created_at: other.attributes.created_at,
-              updated_at: other.attributes.updated_at,
-            },
-          },
-        );
+        await page.goto(`/g/${other.attributes.slug}/`);
+        await page.waitForLoadState('networkidle', { timeout: 10000 });
+      } else {
+        await page.goto('/');
       }
 
       const deleteResp = await request.delete(`/api/v1/groups/${createdGroupId}`, {
@@ -1281,18 +1364,28 @@ test.describe('Group + role cluster in header (#1258)', () => {
 
     // Derive the expected role from the API rather than hard-coding 'admin' —
     // that way the test still passes if the seed ever starts the user off as
-    // a member of their active group instead of an admin.
-    const snapshot = await page.evaluate(() =>
-      JSON.parse(localStorage.getItem('inventario_current_group') || 'null'),
-    );
-    expect(snapshot?.id, 'current group must be resolved before role assertion').toBeTruthy();
+    // a member of their active group instead of an admin. After #1300 the
+    // current-group id is no longer kept in localStorage; wait for the
+    // router to land on /g/:groupSlug/... and read the slug from the URL.
+    await page.waitForURL(/\/g\/[^/]+/, { timeout: 10000 });
+    const activeSlug = new URL(page.url()).pathname.split('/')[2];
+    expect(activeSlug, 'router must resolve a /g/:groupSlug/... URL').toBeTruthy();
 
     const meResp = await request.get('/api/v1/auth/me', {
       headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${authToken}` },
     });
     const me = await meResp.json();
 
-    const membersResp = await request.get(`/api/v1/groups/${snapshot.id}/members`, {
+    const allGroupsResp = await request.get('/api/v1/groups', {
+      headers: { 'Accept': 'application/vnd.api+json', 'Authorization': `Bearer ${authToken}` },
+    });
+    const allGroupsBody = await allGroupsResp.json();
+    const activeGroup = allGroupsBody.data.find(
+      (g: { attributes: { slug: string } }) => g.attributes.slug === activeSlug,
+    );
+    expect(activeGroup, 'active /g/:groupSlug/ must resolve to a real group').toBeDefined();
+
+    const membersResp = await request.get(`/api/v1/groups/${activeGroup.id}/members`, {
       headers: { 'Accept': 'application/vnd.api+json', 'Authorization': `Bearer ${authToken}` },
     });
     const membersBody = await membersResp.json();
@@ -1377,33 +1470,18 @@ test.describe('Group + role cluster in header (#1258)', () => {
       await expect(role).toHaveText('admin');
       await expect(role).toHaveClass(/role-indicator--admin/);
     } finally {
-      // Point the UI snapshot at a different group before deleting the test
-      // group — same cleanup pattern as the #1262 persistence test. Without
-      // this, the selector would end up on a deleted entity.
+      // Navigate the UI away from the about-to-be-deleted group before
+      // deleting it — same cleanup pattern as the #1262 persistence test.
       const groupsResp = await request.get('/api/v1/groups', {
         headers: { 'Accept': 'application/vnd.api+json', 'Authorization': `Bearer ${authToken}` },
       });
       const groupsBody = await groupsResp.json();
       const other = groupsBody.data.find((g: { id: string }) => g.id !== newGroupId);
       if (other) {
-        await page.evaluate(
-          ({ snapshot }) => {
-            localStorage.setItem('inventario_current_group', JSON.stringify(snapshot));
-          },
-          {
-            snapshot: {
-              id: other.id,
-              slug: other.attributes.slug,
-              name: other.attributes.name,
-              icon: other.attributes.icon,
-              status: other.attributes.status,
-              main_currency: other.attributes.main_currency,
-              created_by: other.attributes.created_by,
-              created_at: other.attributes.created_at,
-              updated_at: other.attributes.updated_at,
-            },
-          },
-        );
+        await page.goto(`/g/${other.attributes.slug}/`);
+        await page.waitForLoadState('networkidle', { timeout: 10000 });
+      } else {
+        await page.goto('/');
       }
 
       const deleteResp = await request.delete(`/api/v1/groups/${newGroupId}`, {

--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -1361,12 +1361,12 @@ test.describe('Group + role cluster in header (#1258)', () => {
 
     // Derive the expected role from the API rather than hard-coding 'admin' —
     // that way the test still passes if the seed ever starts the user off as
-    // a member of their active group instead of an admin. After #1300 the
-    // current-group id is no longer kept in localStorage; wait for the
-    // router to land on /g/:groupSlug/... and read the slug from the URL.
-    await page.waitForURL(/\/g\/[^/]+/, { timeout: 10000 });
-    const activeSlug = new URL(page.url()).pathname.split('/')[2];
-    expect(activeSlug, 'router must resolve a /g/:groupSlug/... URL').toBeTruthy();
+    // a member of their active group instead of an admin. Post-#1300 the
+    // current-group id is no longer in localStorage and the Home view at /
+    // doesn't redirect to /g/:groupSlug/... — so derive the active group
+    // from the selector's visible name and cross-reference /api/v1/groups.
+    const displayedName = (await page.locator('.group-selector__name').textContent())?.trim();
+    expect(displayedName, 'group selector must display the active group name').toBeTruthy();
 
     const meResp = await request.get('/api/v1/auth/me', {
       headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${authToken}` },
@@ -1378,9 +1378,9 @@ test.describe('Group + role cluster in header (#1258)', () => {
     });
     const allGroupsBody = await allGroupsResp.json();
     const activeGroup = allGroupsBody.data.find(
-      (g: { attributes: { slug: string } }) => g.attributes.slug === activeSlug,
+      (g: { attributes: { name: string } }) => g.attributes.name === displayedName,
     );
-    expect(activeGroup, 'active /g/:groupSlug/ must resolve to a real group').toBeDefined();
+    expect(activeGroup, 'group selector name must resolve to a real group').toBeDefined();
 
     const membersResp = await request.get(`/api/v1/groups/${activeGroup.id}/members`, {
       headers: { 'Accept': 'application/vnd.api+json', 'Authorization': `Bearer ${authToken}` },

--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -853,92 +853,89 @@ test.describe('Group selection persistence (#1262 / #1300)', () => {
     }
   });
 
-  test('two tabs on different /g/<slug>/ URLs stay independent across reload', async ({ browser }) => {
+  test('two tabs on different /g/<slug>/ URLs stay independent across reload', async ({ page, request }) => {
     // The core behavioural guarantee that #1300 locks in: the URL is the
     // per-tab source of truth for the active group, so two tabs that sit
     // on two different /g/<slug>/... URLs must survive a refresh without
     // leaking each other's group state through a shared localStorage key.
-    const context = await browser.newContext();
-    const pageA = await context.newPage();
-    const pageB = await context.newPage();
+    //
+    // Re-use the fixture-authenticated `page` as tab A and spawn tab B in
+    // the same browser context (so it inherits cookies, localStorage, and
+    // sessionStorage) instead of logging in from scratch.
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    // Ensure at least two groups exist so both tabs can hold a distinct
+    // /g/<slug>/ URL. Re-use any pre-existing second group the seed
+    // provides; otherwise create one and delete it at the end.
+    const groupsResp = await request.get('/api/v1/groups', {
+      headers: { 'Accept': 'application/vnd.api+json', 'Authorization': `Bearer ${authToken}` },
+    });
+    const groupsBody = await groupsResp.json();
+    const groupA = groupsBody.data[0];
+    let groupB = groupsBody.data.find((g: { id: string }) => g.id !== groupA.id);
+    let createdGroupId: string | null = null;
+    const secondGroupName = `Second Tab Test ${Date.now()}`;
+    if (!groupB) {
+      const createResp = await request.post('/api/v1/groups', {
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { data: { type: 'groups', attributes: { name: secondGroupName, icon: '🧩' } } },
+      });
+      expect(createResp.status(), await createResp.text()).toBe(201);
+      const created = (await createResp.json()).data;
+      createdGroupId = created.id;
+      groupB = created;
+    }
+
+    const slugA = groupA.attributes.slug as string;
+    const slugB = groupB.attributes.slug as string;
+    expect(slugA).not.toBe(slugB);
+
+    const pageA = page;
+    const pageB = await page.context().newPage();
 
     try {
-      // Log in via pageA — the auth cookie + access token land in the
-      // context so pageB inherits them on the next navigation.
-      await pageA.goto('/login');
-      await pageA.fill('[data-testid="email"]', 'admin@example.com');
-      await pageA.fill('[data-testid="password"]', 'admin123');
-      await pageA.click('[data-testid="login-button"]');
-      await pageA.waitForURL((u) => !u.pathname.startsWith('/login'), { timeout: 15000 });
+      await pageA.goto(`/g/${slugA}/commodities`);
+      await pageB.goto(`/g/${slugB}/commodities`);
+      await pageA.waitForLoadState('networkidle', { timeout: 15000 });
+      await pageB.waitForLoadState('networkidle', { timeout: 15000 });
 
-      // Ensure at least two groups exist so both tabs can hold a
-      // distinct /g/<slug>/ URL. Re-use an existing second group if the
-      // seed has one; otherwise create a second via the API wrapper.
-      const authToken = await pageA.evaluate(() => localStorage.getItem('inventario_token') || '');
-      const csrfToken = await pageA.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
-      const groupsResp = await pageA.request.get('/api/v1/groups', {
-        headers: { 'Accept': 'application/vnd.api+json', 'Authorization': `Bearer ${authToken}` },
-      });
-      const groupsBody = await groupsResp.json();
-      let groupA = groupsBody.data[0];
-      let groupB = groupsBody.data.find((g: { id: string }) => g.id !== groupA.id);
-      let createdGroupId: string | null = null;
-      const secondGroupName = `Second Tab Test ${Date.now()}`;
-      if (!groupB) {
-        const createResp = await pageA.request.post('/api/v1/groups', {
+      await expect(pageA.locator('.group-selector__name')).toHaveText(groupA.attributes.name, { timeout: 10000 });
+      await expect(pageB.locator('.group-selector__name')).toHaveText(groupB.attributes.name, { timeout: 10000 });
+
+      // Reload both tabs — each must re-read its own URL, not a shared
+      // localStorage key.
+      await pageA.reload();
+      await pageB.reload();
+      await pageA.waitForLoadState('networkidle', { timeout: 15000 });
+      await pageB.waitForLoadState('networkidle', { timeout: 15000 });
+
+      await expect(pageA.locator('.group-selector__name')).toHaveText(groupA.attributes.name);
+      await expect(pageB.locator('.group-selector__name')).toHaveText(groupB.attributes.name);
+    } finally {
+      await pageB.close();
+      if (createdGroupId) {
+        // Move pageA off the about-to-be-deleted group before deleting.
+        await pageA.goto(`/g/${slugA}/`);
+        await request.delete(`/api/v1/groups/${createdGroupId}`, {
           headers: {
             'Content-Type': 'application/vnd.api+json',
             'Accept': 'application/vnd.api+json',
             'Authorization': `Bearer ${authToken}`,
             'X-CSRF-Token': csrfToken,
           },
-          data: { data: { type: 'groups', attributes: { name: secondGroupName, icon: '🧩' } } },
+          data: { confirm_word: secondGroupName, password: 'testpassword123' },
         });
-        expect(createResp.status(), await createResp.text()).toBe(201);
-        const created = (await createResp.json()).data;
-        createdGroupId = created.id;
-        groupB = created;
       }
-
-      const slugA = groupA.attributes.slug as string;
-      const slugB = groupB.attributes.slug as string;
-      expect(slugA).not.toBe(slugB);
-
-      try {
-        await pageA.goto(`/g/${slugA}/commodities`);
-        await pageB.goto(`/g/${slugB}/commodities`);
-        await pageA.waitForLoadState('networkidle', { timeout: 15000 });
-        await pageB.waitForLoadState('networkidle', { timeout: 15000 });
-
-        await expect(pageA.locator('.group-selector__name')).toHaveText(groupA.attributes.name, { timeout: 10000 });
-        await expect(pageB.locator('.group-selector__name')).toHaveText(groupB.attributes.name, { timeout: 10000 });
-
-        // Reload both tabs — each must re-read its own URL, not a shared
-        // localStorage key.
-        await pageA.reload();
-        await pageB.reload();
-        await pageA.waitForLoadState('networkidle', { timeout: 15000 });
-        await pageB.waitForLoadState('networkidle', { timeout: 15000 });
-
-        await expect(pageA.locator('.group-selector__name')).toHaveText(groupA.attributes.name);
-        await expect(pageB.locator('.group-selector__name')).toHaveText(groupB.attributes.name);
-      } finally {
-        if (createdGroupId) {
-          // Move pageA off the about-to-be-deleted group before deleting.
-          await pageA.goto(`/g/${slugA}/`);
-          await pageA.request.delete(`/api/v1/groups/${createdGroupId}`, {
-            headers: {
-              'Content-Type': 'application/vnd.api+json',
-              'Accept': 'application/vnd.api+json',
-              'Authorization': `Bearer ${authToken}`,
-              'X-CSRF-Token': csrfToken,
-            },
-            data: { confirm_word: secondGroupName, password: 'admin123' },
-          });
-        }
-      }
-    } finally {
-      await context.close();
     }
   });
 });

--- a/e2e/tests/includes/group-url.ts
+++ b/e2e/tests/includes/group-url.ts
@@ -7,16 +7,20 @@ import { Page } from '@playwright/test';
  * that drive the raw `page.request` / `request` fixtures bypass that axios
  * instance, so they have to prepend it themselves.
  *
- * Reads the same `currentGroupSlug` localStorage key the axios interceptor
- * uses (set by the groupStore on setCurrentGroup / restoreFromStorage).
- * Throws if no slug is present — tests that need group-scoped URLs must
- * have a group selected, and silently producing an unprefixed URL would
- * only re-introduce the 404 failure mode this helper exists to avoid.
+ * After #1300 the active group lives on the URL itself
+ * (/g/:groupSlug/...), not in localStorage. Parse the current URL to pull
+ * the slug out. Throws if the page isn't on a /g/<slug>/... route — tests
+ * that need group-scoped URLs must have navigated into a group first, and
+ * silently producing an unprefixed URL would only re-introduce the 404
+ * failure mode this helper exists to avoid.
  */
 export async function groupApiBase(page: Page): Promise<string> {
-  const slug = await page.evaluate(() => localStorage.getItem('currentGroupSlug'));
-  if (!slug) {
-    throw new Error('groupApiBase: currentGroupSlug is not set in localStorage — tests using group-scoped endpoints must have an active group selected');
+  const pathname = new URL(page.url()).pathname;
+  const match = pathname.match(/^\/g\/([^/]+)(?:\/|$)/);
+  if (!match) {
+    throw new Error(
+      `groupApiBase: page URL ${page.url()} is not /g/<slug>/... — tests using group-scoped endpoints must navigate into a group first`,
+    );
   }
-  return `/api/v1/g/${slug}`;
+  return `/api/v1/g/${decodeURIComponent(match[1])}`;
 }

--- a/e2e/tests/no-group-redirect.spec.ts
+++ b/e2e/tests/no-group-redirect.spec.ts
@@ -31,16 +31,9 @@ test.describe('No-group redirects (#1261)', () => {
   test.beforeEach(async ({ page }) => {
     await mockEmptyGroups(page);
 
-    // Drop any cached group snapshot so the header selector doesn't briefly
-    // render the previous session's group before restoreFromStorage reconciles
-    // against the (mocked) empty list.
-    await page.evaluate(() => {
-      localStorage.removeItem('inventario_current_group');
-      localStorage.removeItem('currentGroupSlug');
-    });
-
-    // Reload so the pinia store forgets the real admin group and re-runs
-    // ensureLoaded() against the mocked endpoint.
+    // After #1300 the groupStore doesn't keep a localStorage snapshot, so
+    // there's nothing to scrub — a reload is enough to force ensureLoaded()
+    // to re-run against the (mocked) empty /api/v1/groups response.
     await page.reload();
     // Wait for the post-reload auth + groups bootstrap to finish before the
     // test-specific navigation, otherwise assertions can race the redirect.

--- a/frontend/src/components/GroupSelector.vue
+++ b/frontend/src/components/GroupSelector.vue
@@ -140,6 +140,14 @@ onMounted(() => {
 
 onUnmounted(() => {
   document.removeEventListener('click', handleClickOutside)
+  // A still-pending debounced PUT /auth/me would otherwise fire after the
+  // component (and likely the whole route) is gone — the user-visible
+  // error state couldn't be surfaced anymore and the write may race a
+  // logout that's about to invalidate the token.
+  if (preferenceTimer) {
+    clearTimeout(preferenceTimer)
+    preferenceTimer = null
+  }
 })
 </script>
 

--- a/frontend/src/components/GroupSelector.vue
+++ b/frontend/src/components/GroupSelector.vue
@@ -38,6 +38,9 @@
         Group settings
       </button>
     </div>
+    <p v-if="preferenceError" class="group-selector__error" role="alert" data-testid="group-selector-error">
+      {{ preferenceError }}
+    </p>
   </div>
 </template>
 
@@ -45,19 +48,29 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useGroupStore } from '@/stores/groupStore'
+import { useAuthStore } from '@/stores/authStore'
 import type { LocationGroup } from '@/types/group'
 
 const groupStore = useGroupStore()
+const authStore = useAuthStore()
 const router = useRouter()
 const route = useRoute()
 const isOpen = ref(false)
 const selectorRef = ref<HTMLElement | null>(null)
+const preferenceError = ref<string | null>(null)
+
+// Debounce the PUT /auth/me that persists the user's "remember this group"
+// preference. Rapid clicks through the dropdown collapse into one round
+// trip, and the final click is always the one that wins.
+let preferenceTimer: ReturnType<typeof setTimeout> | null = null
+const PREFERENCE_DEBOUNCE_MS = 400
 
 // Switch to another group by navigating to its /g/<slug>/... URL, rebuilding
 // the current subpath under the new slug so the user stays on the same kind
 // of screen (commodities → commodities, exports → exports…). Writing the
-// slug into the URL instead of mutating localStorage is what makes two tabs
-// with two different groups independent (issue #1289 Gap C).
+// slug into the URL makes two tabs with two different groups independent
+// (#1289 Gap C), and the "remember this group for next time" follows the
+// user across devices via user.default_group_id (#1300).
 async function selectGroup(group: LocationGroup) {
   isOpen.value = false
   if (groupStore.currentGroupSlug === group.slug) {
@@ -75,14 +88,32 @@ async function selectGroup(group: LocationGroup) {
       subpath = route.path.slice(marker.length)
     }
   }
-  // Persist the choice before navigating so the cold-start redirect after a
-  // later login lands on the group the user last picked. The route guard
-  // only updates in-memory state on URL-driven syncs (see router/index.ts)
-  // precisely so it doesn't stomp on this localStorage write from a
-  // different tab — this call is the user's explicit "remember this".
-  await groupStore.setCurrentGroup(group.slug, { persist: true })
+  preferenceError.value = null
   const targetPath = `/g/${encodeURIComponent(group.slug)}${subpath || '/'}`
   await router.push(targetPath)
+  schedulePreferenceUpdate(group.id)
+}
+
+function schedulePreferenceUpdate(groupId: string): void {
+  if (preferenceTimer) {
+    clearTimeout(preferenceTimer)
+  }
+  preferenceTimer = setTimeout(() => {
+    preferenceTimer = null
+    void persistPreference(groupId)
+  }, PREFERENCE_DEBOUNCE_MS)
+}
+
+async function persistPreference(groupId: string): Promise<void> {
+  const name = authStore.user?.name
+  if (!name) return
+  try {
+    await authStore.updateProfile({ name, default_group_id: groupId })
+  } catch (err: unknown) {
+    const e = err as { response?: { status?: number; data?: { errors?: Array<{ detail?: string }> } } }
+    const detail = e.response?.data?.errors?.[0]?.detail
+    preferenceError.value = detail ?? 'Could not save group preference. Your selection is active for this session only.'
+  }
 }
 
 function openCreateDialog() {
@@ -217,6 +248,13 @@ onUnmounted(() => {
     height: 1px;
     background: #eee;
     margin: 4px 0;
+  }
+
+  &__error {
+    margin: 0.3em 0 0;
+    font-size: 0.8em;
+    color: #c62828;
+    max-width: 250px;
   }
 }
 </style>

--- a/frontend/src/components/__tests__/App.spec.ts
+++ b/frontend/src/components/__tests__/App.spec.ts
@@ -36,7 +36,7 @@ const mockGroupStore = {
   isGroupUser: false,
   fetchGroups: vi.fn().mockResolvedValue(undefined),
   ensureLoaded: vi.fn().mockResolvedValue(undefined),
-  restoreFromStorage: vi.fn().mockResolvedValue(undefined),
+  restoreFromPreference: vi.fn().mockResolvedValue(undefined),
   clearAll: vi.fn(),
 }
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -287,12 +287,11 @@ router.beforeEach(async (to, from) => {
           return { path: '/no-group' }
         }
         if (groupStore.currentGroup?.slug !== slugParam) {
-          // Route-driven sync: update only in-memory state. Persisting
-          // here would let tab A's /g/<A>/ refresh overwrite the
-          // localStorage snapshot that tab B's /g/<B>/ relied on for
-          // its cold-start redirect — i.e. re-introduce cross-tab
-          // coupling after #1289 Gap C explicitly decoupled them.
-          await groupStore.setCurrentGroup(slugParam, { persist: false })
+          // Route-driven sync: the URL is the source of truth, so this
+          // just updates in-memory state to match. Server-side "remember
+          // my default group" persistence lives in GroupSelector (#1300);
+          // the router guard stays purely reactive.
+          await groupStore.setCurrentGroup(slugParam)
         }
       }
     }

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -1,10 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest'
-import api, { setCsrfToken, getCsrfToken, clearCsrfToken } from '../api'
+import api, {
+  setCsrfToken,
+  getCsrfToken,
+  clearCsrfToken,
+  __setRouterForTesting,
+} from '../api'
 
 // The key used by api.ts to persist the CSRF token in sessionStorage.
 const CSRF_SESSION_KEY = 'inventario_csrf_token'
-// The key used by api.ts to persist the currently-selected group slug.
-const GROUP_SLUG_KEY = 'currentGroupSlug'
+
+// Synchronous stub for the router module's currentRoute. api.ts reads
+// `router.currentRoute.value.params.groupSlug` and decides whether to
+// rewrite group-scoped request URLs; injecting a stub directly via
+// __setRouterForTesting sidesteps the timing of api.ts's dynamic
+// import('../router') — otherwise the cached ref could still be null
+// when the first test runs.
+const mockCurrentRoute = {
+  value: { params: {} as Record<string, string | undefined> },
+}
 
 describe('CSRF token management', () => {
   beforeEach(() => {
@@ -94,14 +107,15 @@ describe('CSRF token management', () => {
 // -----------------------------------------------------------------------
 // Group-scoped URL rewrite in the axios request interceptor.
 //
-// The interceptor reads currentGroupSlug from localStorage and rewrites
-// /api/v1/<prefix>/... to /api/v1/g/{slug}/<prefix>/... for data endpoints.
-// We drive this by replacing the axios adapter with a vi.fn(); the adapter
-// is the last stop before the HTTP call and receives the post-interceptor
-// config, so its captured `url` reflects exactly what the interceptor
-// produced. We restore the original adapter after each test.
+// Post-#1300 the interceptor reads the group slug exclusively from the
+// router's /g/:groupSlug/ route param — localStorage is no longer a
+// fallback. These tests drive the interceptor by setting the mocked
+// router's current-route params directly.
+//
+// Axios requests are captured by replacing the default adapter with a spy
+// so the post-interceptor `config.url` is observable without a network hit.
 // -----------------------------------------------------------------------
-describe('group-scoped URL rewrite interceptor', () => {
+describe('group-scoped URL rewrite interceptor (#1300)', () => {
   const originalAdapter = api.defaults.adapter
   let captured: string | undefined
 
@@ -119,26 +133,26 @@ describe('group-scoped URL rewrite interceptor', () => {
   beforeEach(() => {
     captured = undefined
     fakeAdapter.mockClear()
-    localStorage.removeItem(GROUP_SLUG_KEY)
+    mockCurrentRoute.value = { params: {} }
+    // __setRouterForTesting injects our stub directly into the module's
+    // private routerModuleRef; the interceptor then reads currentRoute
+    // off the stub on every call.
+    __setRouterForTesting({ currentRoute: mockCurrentRoute })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     api.defaults.adapter = fakeAdapter as any
   })
 
-  // Restore the real adapter after each test so a thrown assertion, a
-  // filtered run, or a reorder can't leak the fake into unrelated tests.
   afterEach(() => {
     api.defaults.adapter = originalAdapter
-    localStorage.removeItem(GROUP_SLUG_KEY)
+    mockCurrentRoute.value = { params: {} }
+    __setRouterForTesting(null)
   })
 
-  // Defense in depth: if something in the module scope ever left the fake
-  // adapter set (e.g. beforeEach throws before afterEach exists), make sure
-  // the final state of the file is the original adapter.
   afterAll(() => {
     api.defaults.adapter = originalAdapter
   })
 
-  it('leaves URLs untouched when no group slug is set', async () => {
+  it('leaves URLs untouched when the current route has no group slug', async () => {
     await api.get('/api/v1/locations')
 
     expect(captured).toBe('/api/v1/locations')
@@ -154,8 +168,8 @@ describe('group-scoped URL rewrite interceptor', () => {
     ['/api/v1/uploads', '/api/v1/g/my-slug/uploads'],
     ['/api/v1/settings', '/api/v1/g/my-slug/settings'],
     ['/api/v1/search', '/api/v1/g/my-slug/search'],
-  ])('rewrites group-scoped endpoint %s to %s', async (input, expected) => {
-    localStorage.setItem(GROUP_SLUG_KEY, 'my-slug')
+  ])('rewrites %s to %s when the route carries /g/my-slug', async (input, expected) => {
+    mockCurrentRoute.value = { params: { groupSlug: 'my-slug' } }
 
     await api.get(input)
 
@@ -163,7 +177,7 @@ describe('group-scoped URL rewrite interceptor', () => {
   })
 
   it('preserves path segments and query strings when rewriting', async () => {
-    localStorage.setItem(GROUP_SLUG_KEY, 'my-slug')
+    mockCurrentRoute.value = { params: { groupSlug: 'my-slug' } }
 
     await api.get('/api/v1/commodities/abc-123?include=images')
 
@@ -171,7 +185,7 @@ describe('group-scoped URL rewrite interceptor', () => {
   })
 
   it('does NOT rewrite endpoints outside the group-scoped prefix list', async () => {
-    localStorage.setItem(GROUP_SLUG_KEY, 'my-slug')
+    mockCurrentRoute.value = { params: { groupSlug: 'my-slug' } }
 
     await api.get('/api/v1/groups')
     expect(captured).toBe('/api/v1/groups')
@@ -181,5 +195,19 @@ describe('group-scoped URL rewrite interceptor', () => {
 
     await api.get('/api/v1/invites/some-token')
     expect(captured).toBe('/api/v1/invites/some-token')
+  })
+
+  it('ignores a lingering legacy currentGroupSlug in localStorage', async () => {
+    // Regression guard for #1300: pre-migration localStorage values must
+    // never leak into the interceptor. With no groupSlug on the route,
+    // the request goes out unrewritten — the backend decides.
+    localStorage.setItem('currentGroupSlug', 'stale-slug')
+    try {
+      await api.get('/api/v1/locations')
+
+      expect(captured).toBe('/api/v1/locations')
+    } finally {
+      localStorage.removeItem('currentGroupSlug')
+    }
   })
 })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -72,11 +72,10 @@ function getAuthToken(): string | null {
 }
 
 // resolveCurrentGroupSlug returns the group slug for the API request URL
-// rewrite. It prefers the slug that the router has resolved on the current
-// navigation — that's the per-tab, URL-derived source of truth introduced
-// by issue #1289 Gap C so two tabs can hold two different groups.
-// localStorage is only consulted as a cold-start fallback during the
-// narrow window between app boot and the first navigation.
+// rewrite. The router's /g/:groupSlug/ param is the per-tab, URL-derived
+// source of truth (#1289 Gap C). When the current route has no groupSlug
+// (e.g. /profile, /, /no-group) the interceptor declines to rewrite — the
+// request goes to /api/v1/<resource> and the backend decides.
 function resolveCurrentGroupSlug(): string | null {
   // The router module is dynamically imported in a side-effect up top to
   // avoid a circular dependency with this file; mirror the same pattern
@@ -88,19 +87,28 @@ function resolveCurrentGroupSlug(): string | null {
       return routeSlug
     }
   }
-  return localStorage.getItem('currentGroupSlug')
+  return null
 }
 
 // Router reference populated once the dynamic import above resolves.
 // Exposed through a getter so the interceptor stays synchronous.
-let routerModuleRef: (typeof import('../router'))['default'] | null = null
-function getRouterModule(): (typeof import('../router'))['default'] | null {
+type RouterRef = {
+  currentRoute: { value: { params: Record<string, string | string[] | undefined> } }
+}
+let routerModuleRef: RouterRef | null = null
+function getRouterModule(): RouterRef | null {
   return routerModuleRef
 }
 if (typeof window !== 'undefined') {
   import('../router').then(({ default: router }) => {
-    routerModuleRef = router
+    routerModuleRef = router as unknown as RouterRef
   }).catch(() => { /* silence — getAuthToken path still works */ })
+}
+
+// __setRouterForTesting lets tests inject a router stub synchronously,
+// sidestepping the dynamic import timing above. Not used in production.
+export function __setRouterForTesting(router: RouterRef | null): void {
+  routerModuleRef = router
 }
 
 // State-changing methods that require a CSRF token.
@@ -120,45 +128,54 @@ api.interceptors.request.use(
       console.log('❌ No token available for request')
     }
 
-    // Rewrite data API URLs to include the group slug when a group is active.
-    // This transparently routes requests through /api/v1/g/{slug}/... without
-    // requiring changes to individual service files.
+    // Group-scoped API URL rewriting (issue #1289 Gap C, #1300).
     //
-    // Group-scoped API URL rewriting (issue #1289 Gap C).
-    //
-    // The source of truth for the current group is the URL path — the
-    // router's /g/:groupSlug/ parent route determines which group this
-    // tab is looking at. Reading the slug from the live route instead of
-    // localStorage is what makes two tabs with two different groups
-    // actually independent; the previous localStorage-only scheme made
-    // a group switch in tab 1 silently flip tab 2's next API call to
-    // the new group.
-    //
-    // localStorage remains as a cold-start fallback for the narrow
-    // window between app boot and the first navigation, but the moment
-    // the router has resolved a route, route params win.
+    // The router's /g/:groupSlug/ parent route is the single source of
+    // truth for which group this tab is looking at. When the current
+    // route carries a groupSlug, rewrite /api/v1/<resource> into
+    // /api/v1/g/{slug}/<resource> for the known group-scoped resource
+    // prefixes. When it does not, the interceptor declines to rewrite —
+    // the request goes to /api/v1/<resource> and the backend responds
+    // (usually with 404 for group-scoped endpoints, which is the correct
+    // signal that the caller should not have issued the request from a
+    // non-group route in the first place).
     //
     // `encodeURIComponent` is cheap insurance: slugs are base64url today
     // (URL-safe without encoding), but a schema change could introduce
     // reserved characters.
     if (config.url) {
       const groupSlug = resolveCurrentGroupSlug()
+      const GROUP_SCOPED_PREFIXES = [
+        '/api/v1/locations',
+        '/api/v1/areas',
+        '/api/v1/commodities',
+        '/api/v1/files',
+        '/api/v1/exports',
+        '/api/v1/upload-slots',
+        '/api/v1/uploads',
+        '/api/v1/settings',
+        '/api/v1/search',
+      ]
       if (groupSlug) {
-        const groupScopedPrefixes = [
-          '/api/v1/locations',
-          '/api/v1/areas',
-          '/api/v1/commodities',
-          '/api/v1/files',
-          '/api/v1/exports',
-          '/api/v1/upload-slots',
-          '/api/v1/uploads',
-          '/api/v1/settings',
-          '/api/v1/search',
-        ]
-        for (const prefix of groupScopedPrefixes) {
+        for (const prefix of GROUP_SCOPED_PREFIXES) {
           if (config.url.startsWith(prefix)) {
             const suffix = config.url.slice('/api/v1'.length)
             config.url = `/api/v1/g/${encodeURIComponent(groupSlug)}${suffix}`
+            break
+          }
+        }
+      } else if (import.meta.env.DEV) {
+        // Surface the regression early: a group-scoped call issued from a
+        // non-group route is almost certainly a bug (a view mounted outside
+        // /g/:groupSlug/ or a service call that forgot to wait for the
+        // router). In production we let the backend answer; in dev we log
+        // so the developer sees the mismatch the moment it happens.
+        for (const prefix of GROUP_SCOPED_PREFIXES) {
+          if (config.url.startsWith(prefix)) {
+            console.warn(
+              `[api] group-scoped request ${config.url} issued from a non-group route — ` +
+                'the router has no /g/:groupSlug/ param so the URL will not be rewritten.',
+            )
             break
           }
         }

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -43,7 +43,7 @@ export interface User {
   name: string
   // #1263: the user's preferred landing group. null/undefined means "no
   // preference set" — the frontend falls back to a deterministic rule
-  // (see groupStore.restoreFromStorage).
+  // (see groupStore.restoreFromPreference).
   default_group_id?: string | null
 }
 

--- a/frontend/src/stores/__tests__/groupStore.spec.ts
+++ b/frontend/src/stores/__tests__/groupStore.spec.ts
@@ -4,9 +4,9 @@ import groupService from '@/services/groupService'
 import type { GroupMembership, LocationGroup } from '@/types/group'
 
 // The store talks to groupService for API data and to authStore for the
-// current user id (used by loadCurrentMembership). Mocking both keeps the
-// tests focused on the persistence + reconciliation logic introduced for
-// #1262 — "Current group selection lost on page refresh".
+// current user id and default_group_id preference. Mocking both keeps the
+// tests focused on the priority chain in restoreFromPreference() and the
+// legacy-localStorage migration path (#1300 cleanup of #1262).
 
 vi.mock('@/services/groupService', () => ({
   default: {
@@ -17,9 +17,12 @@ vi.mock('@/services/groupService', () => ({
   },
 }))
 
-// Mutable so tests for #1263 can seed user.default_group_id per case.
-const authMockState: { user: { id: string; default_group_id?: string | null } | null } = {
-  user: { id: 'user-1', default_group_id: null },
+// authStore is both queried (user / userDefaultGroupID getters) and mutated
+// (updateProfile called by the legacy-storage migration). Expose updateProfile
+// as a spy so individual tests can assert it was called with the right id.
+const authUpdateProfile = vi.fn().mockResolvedValue(undefined)
+const authMockState: { user: { id: string; name?: string; default_group_id?: string | null } | null } = {
+  user: { id: 'user-1', name: 'Alice', default_group_id: null },
 }
 
 vi.mock('@/stores/authStore', () => ({
@@ -30,13 +33,16 @@ vi.mock('@/stores/authStore', () => ({
     get userDefaultGroupID() {
       return authMockState.user?.default_group_id ?? null
     },
+    updateProfile: authUpdateProfile,
   }),
 }))
 
 const mockedGroupService = vi.mocked(groupService)
 
-const STORAGE_KEY_CURRENT_GROUP = 'inventario_current_group'
-const STORAGE_KEY_GROUP_SLUG_LEGACY = 'currentGroupSlug'
+// Legacy keys that the one-shot migration looks for on boot. Tests seed
+// these to exercise the migration path and assert it wipes them afterwards.
+const LEGACY_STORAGE_KEY_CURRENT_GROUP = 'inventario_current_group'
+const LEGACY_STORAGE_KEY_GROUP_SLUG = 'currentGroupSlug'
 
 function makeGroup(overrides: Partial<LocationGroup> = {}): LocationGroup {
   return {
@@ -63,11 +69,6 @@ function makeMembership(userId: string, role: 'admin' | 'user' = 'admin'): Group
   }
 }
 
-// The groupStore reads localStorage synchronously at state-initialization
-// time (to pre-seed currentGroup before the first render). That means the
-// localStorage value set inside a test is only picked up if the module is
-// re-imported fresh — hence resetModules() + dynamic import in each test
-// that depends on the initial snapshot behavior.
 async function freshStore(): Promise<ReturnType<typeof import('@/stores/groupStore').useGroupStore>> {
   vi.resetModules()
   const { useGroupStore } = await import('@/stores/groupStore')
@@ -75,352 +76,307 @@ async function freshStore(): Promise<ReturnType<typeof import('@/stores/groupSto
   return useGroupStore()
 }
 
-describe('groupStore — localStorage persistence (#1262)', () => {
+describe('groupStore — initial state (#1300)', () => {
   beforeEach(() => {
     localStorage.clear()
     vi.clearAllMocks()
-    authMockState.user = { id: 'user-1', default_group_id: null }
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
   })
 
   afterEach(() => {
     localStorage.clear()
-    authMockState.user = { id: 'user-1', default_group_id: null }
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
   })
 
-  describe('initial state rehydration from snapshot', () => {
-    it('seeds currentGroup from a stored snapshot before any API call', async () => {
-      // Simulates a page refresh for a user who previously selected a group.
-      // The header's GroupSelector must render the group name immediately on
-      // mount — not wait for /api/v1/groups to resolve — otherwise the user
-      // sees a "Select Group" flash (the symptom reported in #1262).
-      const stored = makeGroup({ id: 'grp-7', slug: 'office', name: 'Office', icon: '🏢' })
-      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(stored))
+  it('starts with null currentGroup regardless of localStorage state', async () => {
+    // Legacy snapshots must not pre-seed currentGroup synchronously anymore —
+    // the router's /g/:groupSlug/ param is the authoritative source of truth
+    // and reading localStorage at construction time would re-introduce the
+    // cross-tab coupling that #1289 Gap C and #1300 removed.
+    const legacy = makeGroup({ id: 'grp-7', slug: 'office', name: 'Office' })
+    localStorage.setItem(LEGACY_STORAGE_KEY_CURRENT_GROUP, JSON.stringify(legacy))
 
-      const store = await freshStore()
+    const store = await freshStore()
 
-      expect(store.currentGroup).toEqual(stored)
-      expect(store.currentGroupId).toBe('grp-7')
-      expect(store.currentGroupSlug).toBe('office')
-      expect(store.currentGroupName).toBe('Office')
-      expect(store.currentGroupIcon).toBe('🏢')
-      // The full groups list hasn't loaded yet, so the selector's dropdown is
-      // still hidden (gated by hasGroups). Reconciliation happens in
-      // restoreFromStorage() once fetchGroups() resolves.
-      expect(store.hasGroups).toBe(false)
-    })
-
-    it('starts with null currentGroup when no snapshot exists', async () => {
-      const store = await freshStore()
-      expect(store.currentGroup).toBeNull()
-    })
-
-    it('ignores a malformed snapshot instead of crashing', async () => {
-      // A corrupted or partial JSON blob must not prevent the app from
-      // booting — return null and fall through to the normal fetch flow.
-      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, 'not-valid-json')
-      const store = await freshStore()
-      expect(store.currentGroup).toBeNull()
-    })
-
-    it('ignores a snapshot missing required fields', async () => {
-      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify({ foo: 'bar' }))
-      const store = await freshStore()
-      expect(store.currentGroup).toBeNull()
-    })
-
-    it('rejects a partial snapshot that has only id and slug', async () => {
-      // A corrupted or truncated snapshot would otherwise pre-seed currentGroup
-      // with undefined name/icon, so the header briefly renders placeholders
-      // until reconciliation arrives. Full-shape validation is the cheaper fix.
-      localStorage.setItem(
-        STORAGE_KEY_CURRENT_GROUP,
-        JSON.stringify({ id: 'grp-1', slug: 'home' }),
-      )
-      const store = await freshStore()
-      expect(store.currentGroup).toBeNull()
-    })
+    expect(store.currentGroup).toBeNull()
+    expect(store.currentGroupId).toBeNull()
+    expect(store.currentGroupSlug).toBeNull()
+    expect(store.hasGroups).toBe(false)
   })
 
-  describe('restoreFromStorage reconciliation', () => {
-    it('keeps the stored group when it is still in the fresh list', async () => {
-      const a = makeGroup({ id: 'grp-a', slug: 'a', name: 'Alpha' })
-      const b = makeGroup({ id: 'grp-b', slug: 'b', name: 'Beta' })
-      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(b))
+  it('starts with null currentGroup when nothing is stored', async () => {
+    const store = await freshStore()
+    expect(store.currentGroup).toBeNull()
+  })
+})
 
-      mockedGroupService.listGroups.mockResolvedValueOnce([a, b])
-      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+describe('groupStore — restoreFromPreference (#1263 / #1300)', () => {
+  // After #1300, the priority chain for seeding currentGroup on a cold start
+  // (i.e. a route with no /g/:groupSlug/ param) is:
+  //   1. user.default_group_id (#1263).
+  //   2. pickFallbackGroup: oldest group the user created, else oldest they
+  //      were invited to.
+  //   3. groups[0] — defensive last resort.
+  // localStorage is no longer part of the chain.
 
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.restoreFromStorage()
-
-      expect(store.currentGroupId).toBe('grp-b')
-      expect(store.currentGroupName).toBe('Beta')
-    })
-
-    it('refreshes the snapshot with server-authoritative data after reconcile', async () => {
-      // User renamed the group on another device — the local snapshot has a
-      // stale name/icon. After reconciliation, the server copy wins and the
-      // localStorage snapshot must be rewritten; otherwise a future refresh
-      // flashes the stale name before reconciliation runs.
-      const stale = makeGroup({ id: 'grp-1', slug: 'home', name: 'Home', icon: '🏠' })
-      const fresh = makeGroup({ id: 'grp-1', slug: 'home', name: 'Home Sweet Home', icon: '🏡' })
-      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(stale))
-
-      mockedGroupService.listGroups.mockResolvedValueOnce([fresh])
-      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.restoreFromStorage()
-
-      expect(store.currentGroupName).toBe('Home Sweet Home')
-      expect(store.currentGroupIcon).toBe('🏡')
-      const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP) || 'null')
-      expect(persisted).toEqual(fresh)
-    })
-
-    it('falls back to the first group when the stored group is no longer accessible', async () => {
-      // Covers the acceptance criterion "Graceful fallback when the saved
-      // group is no longer accessible" — e.g. user was removed, or logged
-      // in as someone else with a different group set.
-      const stale = makeGroup({ id: 'grp-gone', slug: 'gone', name: 'Gone' })
-      const first = makeGroup({ id: 'grp-new', slug: 'new', name: 'New' })
-      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(stale))
-
-      mockedGroupService.listGroups.mockResolvedValueOnce([first])
-      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.restoreFromStorage()
-
-      expect(store.currentGroupId).toBe('grp-new')
-      const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP) || 'null')
-      expect(persisted.id).toBe('grp-new')
-    })
-
-    it('falls back to the legacy slug key when the snapshot key is absent', async () => {
-      // Users upgrading from the pre-#1262 deployment only have the slug
-      // stored. Reconciliation must still honor their prior selection; a
-      // silent revert to "first group" would flip their active group on
-      // the first refresh after the update.
-      const first = makeGroup({ id: 'grp-a', slug: 'alpha', name: 'Alpha' })
-      const second = makeGroup({ id: 'grp-b', slug: 'beta', name: 'Beta' })
-      localStorage.setItem(STORAGE_KEY_GROUP_SLUG_LEGACY, 'beta')
-
-      mockedGroupService.listGroups.mockResolvedValueOnce([first, second])
-      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.restoreFromStorage()
-
-      expect(store.currentGroupId).toBe('grp-b')
-    })
-
-    it('clears currentGroup when the fresh groups list is empty', async () => {
-      // A user who was removed from every group should not retain a stale
-      // currentGroup — the app needs to send them to /no-group instead.
-      const stale = makeGroup()
-      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(stale))
-
-      mockedGroupService.listGroups.mockResolvedValueOnce([])
-
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.restoreFromStorage()
-
-      expect(store.currentGroup).toBeNull()
-      expect(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP)).toBeNull()
-    })
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
   })
 
-  describe('setters persist to localStorage', () => {
-    it('setCurrentGroup writes the full snapshot', async () => {
-      const a = makeGroup({ id: 'grp-a', slug: 'a', name: 'A' })
-      const b = makeGroup({ id: 'grp-b', slug: 'b', name: 'B' })
-      mockedGroupService.listGroups.mockResolvedValueOnce([a, b])
-      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.setCurrentGroup('b')
-
-      const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP) || 'null')
-      expect(persisted).toEqual(b)
-    })
-
-    it('setCurrentGroup mirrors the slug for the api.ts interceptor', async () => {
-      // services/api.ts reads STORAGE_KEY_GROUP_SLUG_LEGACY on every request
-      // to rewrite /api/v1/<resource> into /api/v1/g/{slug}/<resource>. If the
-      // snapshot writer drops this mirror, every group-scoped fetch silently
-      // stops rewriting — the CI-breaking bug that surfaced after the first
-      // pass at #1262 and was flagged by review.
-      const a = makeGroup({ id: 'grp-a', slug: 'a', name: 'A' })
-      const b = makeGroup({ id: 'grp-b', slug: 'beta-slug', name: 'B' })
-      mockedGroupService.listGroups.mockResolvedValueOnce([a, b])
-      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.setCurrentGroup('beta-slug')
-
-      expect(localStorage.getItem(STORAGE_KEY_GROUP_SLUG_LEGACY)).toBe('beta-slug')
-    })
-
-    it('clearAll removes both the snapshot and the legacy slug', async () => {
-      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(makeGroup()))
-      localStorage.setItem(STORAGE_KEY_GROUP_SLUG_LEGACY, 'home')
-
-      const store = await freshStore()
-      store.clearAll()
-
-      expect(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP)).toBeNull()
-      expect(localStorage.getItem(STORAGE_KEY_GROUP_SLUG_LEGACY)).toBeNull()
-    })
-
-    it('updateGroupById refreshes the snapshot when editing the current group', async () => {
-      const original = makeGroup({ id: 'grp-1', name: 'Home' })
-      const renamed = makeGroup({ id: 'grp-1', name: 'Home Office' })
-      mockedGroupService.listGroups.mockResolvedValueOnce([original])
-      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-      mockedGroupService.updateGroup.mockResolvedValueOnce(renamed)
-
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.setCurrentGroup('home')
-      await store.updateGroupById('grp-1', 'Home Office')
-
-      const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY_CURRENT_GROUP) || 'null')
-      expect(persisted.name).toBe('Home Office')
-    })
+  afterEach(() => {
+    localStorage.clear()
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
   })
 
-  // -----------------------------------------------------------------------
-  // #1263: user-level default group preference + deterministic fallback.
-  // The ordering tested here mirrors the priority chain documented in
-  // restoreFromStorage(): snapshot → legacy slug → user preference →
-  // first-created → first-invited.
-  // -----------------------------------------------------------------------
-  describe('default group preference and fallback (#1263)', () => {
-    it('honours user.default_group_id on a fresh device with no snapshot', async () => {
-      const primary = makeGroup({
-        id: 'grp-primary',
-        slug: 'primary',
-        name: 'Primary',
-        created_by: 'user-1',
-        created_at: '2026-01-01T00:00:00Z',
-      })
-      const preferred = makeGroup({
-        id: 'grp-preferred',
-        slug: 'preferred',
-        name: 'Preferred',
-        // Different creator so the fallback "first-created-by-user" branch
-        // would ignore this group; the only way it wins is the preference.
-        created_by: 'user-99',
-        created_at: '2026-03-01T00:00:00Z',
-      })
-      mockedGroupService.listGroups.mockResolvedValueOnce([primary, preferred])
-      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-      authMockState.user = { id: 'user-1', default_group_id: 'grp-preferred' }
-
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.restoreFromStorage()
-
-      expect(store.currentGroup?.id).toBe('grp-preferred')
+  it('honours user.default_group_id when set', async () => {
+    const primary = makeGroup({
+      id: 'grp-primary',
+      slug: 'primary',
+      name: 'Primary',
+      created_by: 'user-1',
+      created_at: '2026-01-01T00:00:00Z',
     })
-
-    it('falls back from a stale preference to first-created group', async () => {
-      const firstCreated = makeGroup({
-        id: 'grp-created-1',
-        slug: 'created-first',
-        name: 'Created First',
-        created_by: 'user-1',
-        created_at: '2026-01-01T00:00:00Z',
-      })
-      const laterCreated = makeGroup({
-        id: 'grp-created-2',
-        slug: 'created-second',
-        name: 'Created Second',
-        created_by: 'user-1',
-        created_at: '2026-02-01T00:00:00Z',
-      })
-      const invited = makeGroup({
-        id: 'grp-invited',
-        slug: 'invited',
-        name: 'Invited',
-        created_by: 'user-99',
-        created_at: '2025-12-01T00:00:00Z',
-      })
-      mockedGroupService.listGroups.mockResolvedValueOnce([laterCreated, invited, firstCreated])
-      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-      // Preference points at a group the user no longer has access to — should
-      // be skipped and trigger the fallback path.
-      authMockState.user = { id: 'user-1', default_group_id: 'grp-that-does-not-exist' }
-
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.restoreFromStorage()
-
-      // Invited is older than both created-by-me, but the #1263 rule prefers
-      // the oldest "created by me" group over any invited one regardless of age.
-      expect(store.currentGroup?.id).toBe('grp-created-1')
+    const preferred = makeGroup({
+      id: 'grp-preferred',
+      slug: 'preferred',
+      name: 'Preferred',
+      // Different creator so the fallback "first-created-by-user" branch
+      // would ignore this group; only the preference can make it win.
+      created_by: 'user-99',
+      created_at: '2026-03-01T00:00:00Z',
     })
+    mockedGroupService.listGroups.mockResolvedValueOnce([primary, preferred])
+    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: 'grp-preferred' }
 
-    it('falls back to first-invited group when the user created none', async () => {
-      const invitedNewer = makeGroup({
-        id: 'grp-invited-newer',
-        slug: 'invited-newer',
-        name: 'Invited Newer',
-        created_by: 'user-99',
-        created_at: '2026-05-01T00:00:00Z',
-      })
-      const invitedOlder = makeGroup({
-        id: 'grp-invited-older',
-        slug: 'invited-older',
-        name: 'Invited Older',
-        created_by: 'user-99',
-        created_at: '2026-01-01T00:00:00Z',
-      })
-      mockedGroupService.listGroups.mockResolvedValueOnce([invitedNewer, invitedOlder])
-      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-      authMockState.user = { id: 'user-1', default_group_id: null }
+    const store = await freshStore()
+    await store.fetchGroups()
+    await store.restoreFromPreference()
 
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.restoreFromStorage()
+    expect(store.currentGroup?.id).toBe('grp-preferred')
+  })
 
-      expect(store.currentGroup?.id).toBe('grp-invited-older')
+  it('falls back from a stale preference to first-created group', async () => {
+    const firstCreated = makeGroup({
+      id: 'grp-created-1',
+      slug: 'created-first',
+      name: 'Created First',
+      created_by: 'user-1',
+      created_at: '2026-01-01T00:00:00Z',
     })
-
-    it('session snapshot beats default_group_id (session continuity wins on refresh)', async () => {
-      const snapshotGroup = makeGroup({
-        id: 'grp-session',
-        slug: 'session',
-        name: 'Session',
-        created_by: 'user-1',
-      })
-      const preferredGroup = makeGroup({
-        id: 'grp-preferred',
-        slug: 'preferred',
-        name: 'Preferred',
-        created_by: 'user-1',
-      })
-      // Pre-seed localStorage with the last-selected group — this is the
-      // #1262 refresh-continuity behaviour; #1263 must not regress it.
-      localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(snapshotGroup))
-      localStorage.setItem(STORAGE_KEY_GROUP_SLUG_LEGACY, snapshotGroup.slug)
-      mockedGroupService.listGroups.mockResolvedValueOnce([snapshotGroup, preferredGroup])
-      mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-      authMockState.user = { id: 'user-1', default_group_id: 'grp-preferred' }
-
-      const store = await freshStore()
-      await store.fetchGroups()
-      await store.restoreFromStorage()
-
-      expect(store.currentGroup?.id).toBe('grp-session')
+    const laterCreated = makeGroup({
+      id: 'grp-created-2',
+      slug: 'created-second',
+      name: 'Created Second',
+      created_by: 'user-1',
+      created_at: '2026-02-01T00:00:00Z',
     })
+    const invited = makeGroup({
+      id: 'grp-invited',
+      slug: 'invited',
+      name: 'Invited',
+      created_by: 'user-99',
+      created_at: '2025-12-01T00:00:00Z',
+    })
+    mockedGroupService.listGroups.mockResolvedValueOnce([laterCreated, invited, firstCreated])
+    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+    // Preference points at a group the user no longer has access to — should
+    // be skipped and trigger the fallback path.
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: 'grp-that-does-not-exist' }
+
+    const store = await freshStore()
+    await store.fetchGroups()
+    await store.restoreFromPreference()
+
+    // Oldest "created by me" wins over any invited group, regardless of age.
+    expect(store.currentGroup?.id).toBe('grp-created-1')
+  })
+
+  it('falls back to first-invited group when the user created none', async () => {
+    const invitedNewer = makeGroup({
+      id: 'grp-invited-newer',
+      slug: 'invited-newer',
+      name: 'Invited Newer',
+      created_by: 'user-99',
+      created_at: '2026-05-01T00:00:00Z',
+    })
+    const invitedOlder = makeGroup({
+      id: 'grp-invited-older',
+      slug: 'invited-older',
+      name: 'Invited Older',
+      created_by: 'user-99',
+      created_at: '2026-01-01T00:00:00Z',
+    })
+    mockedGroupService.listGroups.mockResolvedValueOnce([invitedNewer, invitedOlder])
+    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
+
+    const store = await freshStore()
+    await store.fetchGroups()
+    await store.restoreFromPreference()
+
+    expect(store.currentGroup?.id).toBe('grp-invited-older')
+  })
+
+  it('clears currentGroup when the fresh groups list is empty', async () => {
+    mockedGroupService.listGroups.mockResolvedValueOnce([])
+
+    const store = await freshStore()
+    await store.fetchGroups()
+    await store.restoreFromPreference()
+
+    expect(store.currentGroup).toBeNull()
+  })
+})
+
+describe('groupStore — setters do not touch localStorage (#1300)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
+  })
+
+  it('setCurrentGroup only mutates in-memory state', async () => {
+    const a = makeGroup({ id: 'grp-a', slug: 'a', name: 'A' })
+    const b = makeGroup({ id: 'grp-b', slug: 'b', name: 'B' })
+    mockedGroupService.listGroups.mockResolvedValueOnce([a, b])
+    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+
+    const store = await freshStore()
+    await store.fetchGroups()
+    await store.setCurrentGroup('b')
+
+    expect(store.currentGroupId).toBe('grp-b')
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY_GROUP_SLUG)).toBeNull()
+  })
+
+  it('clearAll leaves localStorage keys alone (migration wipes them once)', async () => {
+    // clearAll is called on logout; it zeroes in-memory state. The legacy
+    // keys are gone by the time logout fires (migration runs on bootstrap),
+    // so clearAll has no business poking at them anymore.
+    const store = await freshStore()
+    store.clearAll()
+
+    expect(store.groups).toEqual([])
+    expect(store.currentGroup).toBeNull()
+    expect(store.isInitialized).toBe(false)
+  })
+
+  it('updateGroupById refreshes in-memory state only', async () => {
+    const original = makeGroup({ id: 'grp-1', name: 'Home' })
+    const renamed = makeGroup({ id: 'grp-1', name: 'Home Office' })
+    mockedGroupService.listGroups.mockResolvedValueOnce([original])
+    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+    mockedGroupService.updateGroup.mockResolvedValueOnce(renamed)
+
+    const store = await freshStore()
+    await store.fetchGroups()
+    await store.setCurrentGroup('home')
+    await store.updateGroupById('grp-1', 'Home Office')
+
+    expect(store.currentGroupName).toBe('Home Office')
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
+  })
+})
+
+describe('groupStore — legacy localStorage migration (#1300)', () => {
+  // One-shot cleanup on app boot: if localStorage has the pre-#1300 keys,
+  // read them once, call PUT /auth/me with the matching default_group_id,
+  // then removeItem. Runs inside ensureLoaded() after fetchGroups().
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
+  })
+
+  it('promotes a legacy snapshot to default_group_id when no preference is set', async () => {
+    const other = makeGroup({ id: 'grp-other', slug: 'other', created_by: 'user-1', created_at: '2026-02-01T00:00:00Z' })
+    const legacy = makeGroup({ id: 'grp-legacy', slug: 'legacy', name: 'Legacy', created_by: 'user-1', created_at: '2026-01-01T00:00:00Z' })
+    localStorage.setItem(LEGACY_STORAGE_KEY_CURRENT_GROUP, JSON.stringify(legacy))
+    mockedGroupService.listGroups.mockResolvedValueOnce([other, legacy])
+    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+
+    const store = await freshStore()
+    await store.ensureLoaded()
+
+    expect(authUpdateProfile).toHaveBeenCalledWith({ name: 'Alice', default_group_id: 'grp-legacy' })
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY_GROUP_SLUG)).toBeNull()
+  })
+
+  it('promotes the legacy slug key when the snapshot is absent', async () => {
+    const beta = makeGroup({ id: 'grp-beta', slug: 'beta', name: 'Beta', created_by: 'user-1' })
+    const alpha = makeGroup({ id: 'grp-alpha', slug: 'alpha', name: 'Alpha', created_by: 'user-1', created_at: '2025-12-01T00:00:00Z' })
+    localStorage.setItem(LEGACY_STORAGE_KEY_GROUP_SLUG, 'beta')
+    mockedGroupService.listGroups.mockResolvedValueOnce([alpha, beta])
+    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+
+    const store = await freshStore()
+    await store.ensureLoaded()
+
+    expect(authUpdateProfile).toHaveBeenCalledWith({ name: 'Alice', default_group_id: 'grp-beta' })
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY_GROUP_SLUG)).toBeNull()
+  })
+
+  it('does not overwrite an existing default_group_id preference', async () => {
+    const legacy = makeGroup({ id: 'grp-legacy', slug: 'legacy', created_by: 'user-1' })
+    const preferred = makeGroup({ id: 'grp-preferred', slug: 'preferred', created_by: 'user-1' })
+    localStorage.setItem(LEGACY_STORAGE_KEY_CURRENT_GROUP, JSON.stringify(legacy))
+    mockedGroupService.listGroups.mockResolvedValueOnce([legacy, preferred])
+    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: 'grp-preferred' }
+
+    const store = await freshStore()
+    await store.ensureLoaded()
+
+    expect(authUpdateProfile).not.toHaveBeenCalled()
+    // Legacy keys are still dropped — the preference is the future source of
+    // truth, and the old keys are dead weight either way.
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
+  })
+
+  it('drops unresolvable legacy keys without calling PUT /auth/me', async () => {
+    // Legacy snapshot points at a group the user no longer has access to.
+    // The migration must not call updateProfile with a value the server
+    // would reject — just wipe the key and move on.
+    const stale = makeGroup({ id: 'grp-gone', slug: 'gone' })
+    const available = makeGroup({ id: 'grp-available', slug: 'available', created_by: 'user-1' })
+    localStorage.setItem(LEGACY_STORAGE_KEY_CURRENT_GROUP, JSON.stringify(stale))
+    mockedGroupService.listGroups.mockResolvedValueOnce([available])
+    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+
+    const store = await freshStore()
+    await store.ensureLoaded()
+
+    expect(authUpdateProfile).not.toHaveBeenCalled()
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
+  })
+
+  it('does not crash on a malformed legacy snapshot', async () => {
+    localStorage.setItem(LEGACY_STORAGE_KEY_CURRENT_GROUP, 'not-valid-json')
+    const available = makeGroup({ id: 'grp-available', slug: 'available', created_by: 'user-1' })
+    mockedGroupService.listGroups.mockResolvedValueOnce([available])
+    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
+
+    const store = await freshStore()
+    await store.ensureLoaded()
+
+    expect(authUpdateProfile).not.toHaveBeenCalled()
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
+    expect(store.isInitialized).toBe(true)
   })
 })

--- a/frontend/src/stores/groupStore.ts
+++ b/frontend/src/stores/groupStore.ts
@@ -4,79 +4,26 @@ import groupService from '../services/groupService'
 import { useAuthStore } from './authStore'
 import type { LocationGroup, GroupMembership, GroupRole } from '../types/group'
 
-// Primary key: full LocationGroup JSON snapshot. Stored so the header's
-// GroupSelector can render the current group name/icon synchronously on
-// page load, before fetchGroups() resolves — otherwise there's a visible
-// "Select Group" flash between mount and the first API response (#1262).
-const STORAGE_KEY_CURRENT_GROUP = 'inventario_current_group'
-// Slug mirror of the snapshot. Kept in sync with STORAGE_KEY_CURRENT_GROUP
-// because the axios request interceptor in services/api.ts reads this key
-// on every request to rewrite /api/v1/<resource>/... into the group-scoped
-// /api/v1/g/{slug}/... form. Dropping this key silently breaks every
-// group-scoped fetch (locations, commodities, ...) the moment a group is
-// selected. Also serves as a back-compat read path for users whose
-// localStorage predates the snapshot format.
-const STORAGE_KEY_GROUP_SLUG_LEGACY = 'currentGroupSlug'
-
-// isStoredLocationGroupSnapshot validates the full LocationGroup shape
-// before we trust a localStorage blob enough to seed currentGroup. Accepting
-// a partial object (id + slug only) would let a corrupted snapshot render
-// the header with missing name/icon until reconciliation catches up.
-function isStoredLocationGroupSnapshot(value: unknown): value is LocationGroup {
-  if (!value || typeof value !== 'object') return false
-  const candidate = value as Record<string, unknown>
-  return (
-    typeof candidate.id === 'string' &&
-    typeof candidate.slug === 'string' &&
-    typeof candidate.name === 'string' &&
-    typeof candidate.icon === 'string' &&
-    typeof candidate.status === 'string' &&
-    typeof candidate.main_currency === 'string' &&
-    typeof candidate.created_by === 'string' &&
-    typeof candidate.created_at === 'string' &&
-    typeof candidate.updated_at === 'string'
-  )
-}
-
-function readStoredSnapshot(): LocationGroup | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY_CURRENT_GROUP)
-    if (!raw) return null
-    const parsed = JSON.parse(raw)
-    return isStoredLocationGroupSnapshot(parsed) ? parsed : null
-  } catch {
-    return null
-  }
-}
-
-function readLegacyStoredSlug(): string | null {
-  return localStorage.getItem(STORAGE_KEY_GROUP_SLUG_LEGACY)
-}
-
-function writeStoredSnapshot(group: LocationGroup | null): void {
-  if (group) {
-    localStorage.setItem(STORAGE_KEY_CURRENT_GROUP, JSON.stringify(group))
-    // Mirror the slug for the api.ts interceptor — see
-    // STORAGE_KEY_GROUP_SLUG_LEGACY comment.
-    localStorage.setItem(STORAGE_KEY_GROUP_SLUG_LEGACY, group.slug)
-  } else {
-    localStorage.removeItem(STORAGE_KEY_CURRENT_GROUP)
-    localStorage.removeItem(STORAGE_KEY_GROUP_SLUG_LEGACY)
-  }
-}
+// Legacy localStorage keys — kept here only so the one-shot migration in
+// migrateLegacyStorageToPreference() below can recognise and drop them.
+// Active group selection is now driven by the URL (per-tab) and persisted
+// across devices via user.default_group_id (#1263). Delete these keys in a
+// future release once the migration has had time to run on all clients.
+const LEGACY_STORAGE_KEY_CURRENT_GROUP = 'inventario_current_group'
+const LEGACY_STORAGE_KEY_GROUP_SLUG = 'currentGroupSlug'
 
 export const useGroupStore = defineStore('group', () => {
   // State
   const groups = ref<LocationGroup[]>([])
-  // Seed currentGroup from localStorage synchronously so the selector
-  // shows the active group's name immediately on page refresh. The
-  // snapshot is later reconciled against the fresh /api/v1/groups
-  // response in restoreFromStorage().
-  const currentGroup = ref<LocationGroup | null>(readStoredSnapshot())
+  // currentGroup starts null: the router's /g/:groupSlug/ param is the
+  // authoritative source of truth for the active group once routing
+  // resolves, and restoreFromPreference() seeds the store for non-group
+  // routes using the user's default_group_id preference.
+  const currentGroup = ref<LocationGroup | null>(null)
   const currentMembership = ref<GroupMembership | null>(null)
   const isLoading = ref(false)
   const error = ref<string | null>(null)
-  // isInitialized flips true once the first fetchGroups + restoreFromStorage
+  // isInitialized flips true once the first fetchGroups + restoreFromPreference
   // completes after login. The router guard consults this flag (via
   // ensureLoaded) before deciding whether to redirect a zero-group user to
   // /no-group — otherwise a deep-link on a fresh page load would land on the
@@ -98,10 +45,6 @@ export const useGroupStore = defineStore('group', () => {
   const isGroupAdmin = computed(() => currentMembership.value?.role === 'admin')
   const isGroupUser = computed(() => currentMembership.value?.role === 'user')
 
-  // currentGroupMainCurrency is the valuation currency of the active group.
-  // Moved here (from the user-scoped settingsStore) in #1248 — valuation is a
-  // group-level property so a user who toggles between a CZK group and a USD
-  // group sees the right currency on each.
   const currentGroupMainCurrency = computed(() => currentGroup.value?.main_currency || '')
 
   /**
@@ -128,7 +71,7 @@ export const useGroupStore = defineStore('group', () => {
     }
   }
 
-  // ensureLoaded runs fetchGroups + restoreFromStorage once per session and
+  // ensureLoaded runs fetchGroups + restoreFromPreference once per session and
   // then returns synchronously. Callers (router guard, App.vue bootstrap) can
   // await it on every invocation and trust that the store reflects the
   // server's current group set before they branch on hasGroups.
@@ -138,7 +81,8 @@ export const useGroupStore = defineStore('group', () => {
     loadingPromise = (async () => {
       try {
         await fetchGroups()
-        await restoreFromStorage()
+        await migrateLegacyStorageToPreference()
+        await restoreFromPreference()
         isInitialized.value = true
       } finally {
         loadingPromise = null
@@ -147,20 +91,10 @@ export const useGroupStore = defineStore('group', () => {
     return loadingPromise
   }
 
-  async function setCurrentGroup(slug: string, options: { persist?: boolean } = {}): Promise<void> {
-    // persist defaults to true: user-initiated switches (GroupSelector click)
-    // should remember the selection for the next cold start. Router-driven
-    // syncs (issue #1289 Gap C — slug from the URL) pass `persist: false`
-    // so two tabs with two different /g/<slug>/... URLs don't
-    // ping-pong each other's localStorage entries.
-    const persist = options.persist !== false
+  async function setCurrentGroup(slug: string): Promise<void> {
     const group = groups.value.find((g) => g.slug === slug)
     if (group) {
       currentGroup.value = group
-      if (persist) {
-        writeStoredSnapshot(group)
-      }
-      // Load membership info for the current user
       await loadCurrentMembership(group.id)
     }
   }
@@ -169,7 +103,6 @@ export const useGroupStore = defineStore('group', () => {
     const group = groups.value.find((g) => g.id === groupId)
     if (group) {
       currentGroup.value = group
-      writeStoredSnapshot(group)
     }
   }
 
@@ -191,55 +124,81 @@ export const useGroupStore = defineStore('group', () => {
     currentMembership.value = membership
   }
 
-  // restoreFromStorage reconciles the (possibly pre-seeded) currentGroup
-  // against the freshly fetched groups list. It runs after fetchGroups() and
-  // implements the priority chain spelled out in #1263:
-  //   1. Last-selected group from localStorage (id match, then legacy slug) —
-  //      preserves session continuity across refreshes (#1262).
-  //   2. The user's explicit default_group_id preference — honoured when no
-  //      session snapshot exists or when it points to a group the user has
-  //      since lost access to (cleared cookies, new device).
-  //   3. Deterministic fallback: first group the user created (by created_at
-  //      ASC), else first group they were invited to. This fires on a fresh
-  //      device with no preference set.
-  //   4. Last resort: groups[0] — defensive, practically unreachable because
-  //      step 3 already covers a non-empty groups list.
-  // Whichever branch wins, the snapshot is rewritten with the authoritative
-  // server copy so a rename from another device doesn't linger in localStorage.
-  async function restoreFromStorage(): Promise<void> {
+  // restoreFromPreference seeds currentGroup on a cold start when the URL
+  // has no group slug (e.g. / or /profile). The priority chain is:
+  //   1. user.default_group_id (#1263) — the cross-device preference.
+  //   2. pickFallbackGroup — the oldest group the user created, else the
+  //      oldest group they were invited to.
+  //   3. groups[0] — defensive, practically unreachable when step 2 is live.
+  // When the URL *does* carry a group slug, the router guard is responsible
+  // for calling setCurrentGroup(slugFromURL) instead; this function doesn't
+  // need to know about the URL.
+  async function restoreFromPreference(): Promise<void> {
     if (groups.value.length === 0) {
       currentGroup.value = null
-      writeStoredSnapshot(null)
       return
     }
 
-    const snapshot = readStoredSnapshot()
-    const legacySlug = readLegacyStoredSlug()
-
     let match: LocationGroup | undefined
-    if (snapshot) {
-      match = groups.value.find((g) => g.id === snapshot.id)
-    }
-    if (!match && legacySlug) {
-      match = groups.value.find((g) => g.slug === legacySlug)
-    }
-
-    if (!match) {
-      const defaultGroupID = useAuthStore().userDefaultGroupID
-      if (defaultGroupID) {
-        match = groups.value.find((g) => g.id === defaultGroupID)
-      }
+    const defaultGroupID = useAuthStore().userDefaultGroupID
+    if (defaultGroupID) {
+      match = groups.value.find((g) => g.id === defaultGroupID)
     }
 
     const resolved = match ?? pickFallbackGroup(groups.value, useAuthStore().user?.id ?? null)
     currentGroup.value = resolved
-    writeStoredSnapshot(resolved)
     await loadCurrentMembership(resolved.id)
   }
 
-  // pickFallbackGroup implements the "no preference, no snapshot" branch of
-  // #1263: prefer the oldest group the user created, otherwise the oldest
-  // group they were invited to. Sorting by created_at ASC keeps the choice
+  // migrateLegacyStorageToPreference is a one-shot cleanup for clients that
+  // still carry the pre-#1300 localStorage keys. If the legacy snapshot /
+  // slug points at a group this user belongs to AND they have no
+  // default_group_id yet, promote it to the server-side preference so the
+  // device-scoped "remember my last group" behaviour survives the switch.
+  // The keys are removed unconditionally — even an unresolvable legacy
+  // value is dead weight now. Drop the whole function after one release.
+  async function migrateLegacyStorageToPreference(): Promise<void> {
+    const rawSnapshot = safeLocalStorageGet(LEGACY_STORAGE_KEY_CURRENT_GROUP)
+    const legacySlug = safeLocalStorageGet(LEGACY_STORAGE_KEY_GROUP_SLUG)
+    if (!rawSnapshot && !legacySlug) return
+
+    let candidate: LocationGroup | undefined
+    if (rawSnapshot) {
+      try {
+        const parsed = JSON.parse(rawSnapshot) as { id?: unknown }
+        if (parsed && typeof parsed.id === 'string') {
+          candidate = groups.value.find((g) => g.id === parsed.id)
+        }
+      } catch {
+        // Ignore malformed legacy snapshot — we only care that it existed.
+      }
+    }
+    if (!candidate && legacySlug) {
+      candidate = groups.value.find((g) => g.slug === legacySlug)
+    }
+
+    // Only promote to default_group_id if the user has no preference yet;
+    // an existing preference was picked deliberately and the legacy
+    // per-device hint shouldn't override it.
+    const authStore = useAuthStore()
+    if (candidate && !authStore.userDefaultGroupID) {
+      try {
+        await authStore.updateProfile({
+          name: authStore.user?.name ?? '',
+          default_group_id: candidate.id,
+        })
+      } catch (err) {
+        console.warn('Legacy group preference migration failed:', err)
+      }
+    }
+
+    safeLocalStorageRemove(LEGACY_STORAGE_KEY_CURRENT_GROUP)
+    safeLocalStorageRemove(LEGACY_STORAGE_KEY_GROUP_SLUG)
+  }
+
+  // pickFallbackGroup implements the "no preference" branch of #1263:
+  // prefer the oldest group the user created, otherwise the oldest group
+  // they were invited to. Sorting by created_at ASC keeps the choice
   // deterministic so the same user lands in the same group on every fresh
   // device — which is the whole point of a fallback rule.
   function pickFallbackGroup(list: LocationGroup[], userId: string | null): LocationGroup {
@@ -276,7 +235,6 @@ export const useGroupStore = defineStore('group', () => {
     const updated = await groupService.updateGroup(groupId, { name, icon })
     if (currentGroup.value && currentGroup.value.id === updated.id) {
       currentGroup.value = updated
-      writeStoredSnapshot(updated)
     }
     const idx = groups.value.findIndex((g) => g.id === updated.id)
     if (idx >= 0) {
@@ -293,7 +251,6 @@ export const useGroupStore = defineStore('group', () => {
   function syncGroup(group: LocationGroup): void {
     if (currentGroup.value && currentGroup.value.id === group.id) {
       currentGroup.value = group
-      writeStoredSnapshot(group)
     }
     const idx = groups.value.findIndex((g) => g.id === group.id)
     if (idx >= 0) {
@@ -304,7 +261,6 @@ export const useGroupStore = defineStore('group', () => {
   function clearCurrentGroup(): void {
     currentGroup.value = null
     currentMembership.value = null
-    writeStoredSnapshot(null)
   }
 
   function clearAll(): void {
@@ -312,7 +268,6 @@ export const useGroupStore = defineStore('group', () => {
     currentGroup.value = null
     currentMembership.value = null
     isInitialized.value = false
-    writeStoredSnapshot(null)
   }
 
   return {
@@ -342,7 +297,7 @@ export const useGroupStore = defineStore('group', () => {
     setCurrentGroup,
     setCurrentGroupById,
     setCurrentMembership,
-    restoreFromStorage,
+    restoreFromPreference,
     createGroup,
     updateCurrentGroup,
     updateGroupById,
@@ -351,3 +306,20 @@ export const useGroupStore = defineStore('group', () => {
     clearAll,
   }
 })
+
+function safeLocalStorageGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function safeLocalStorageRemove(key: string): void {
+  try {
+    localStorage.removeItem(key)
+  } catch {
+    // localStorage may be unavailable (private mode, SSR, …) — ignore.
+  }
+}
+

--- a/frontend/src/stores/groupStore.ts
+++ b/frontend/src/stores/groupStore.ts
@@ -188,7 +188,19 @@ export const useGroupStore = defineStore('group', () => {
           default_group_id: candidate.id,
         })
       } catch (err) {
-        console.warn('Legacy group preference migration failed:', err)
+        // Don't log the full error object: Axios attaches the request
+        // config (including the Bearer token) to the error, which would
+        // land the token in the browser console.
+        const message = err instanceof Error ? err.message : 'unknown error'
+        const status =
+          typeof err === 'object' &&
+          err !== null &&
+          'response' in err &&
+          typeof (err as { response?: { status?: unknown } }).response === 'object' &&
+          (err as { response?: { status?: unknown } }).response !== null
+            ? (err as { response: { status?: unknown } }).response.status
+            : undefined
+        console.warn('Legacy group preference migration failed:', { message, status })
       }
     }
 

--- a/frontend/src/views/groups/GroupSettingsView.vue
+++ b/frontend/src/views/groups/GroupSettingsView.vue
@@ -382,7 +382,7 @@ async function handleLeave() {
     groupStore.clearCurrentGroup()
     await groupStore.fetchGroups()
     if (groupStore.hasGroups) {
-      await groupStore.restoreFromStorage()
+      await groupStore.restoreFromPreference()
       router.push('/')
     } else {
       router.push({ name: 'no-group' })
@@ -405,7 +405,7 @@ async function handleDelete() {
     groupStore.clearCurrentGroup()
     await groupStore.fetchGroups()
     if (groupStore.hasGroups) {
-      await groupStore.restoreFromStorage()
+      await groupStore.restoreFromPreference()
       router.push('/')
     } else {
       router.push({ name: 'no-group' })

--- a/frontend/src/views/groups/__tests__/GroupSettingsView.spec.ts
+++ b/frontend/src/views/groups/__tests__/GroupSettingsView.spec.ts
@@ -38,7 +38,7 @@ const mockGroupStore = {
   updateGroupById: vi.fn(),
   clearCurrentGroup: vi.fn(),
   fetchGroups: vi.fn().mockResolvedValue(undefined),
-  restoreFromStorage: vi.fn().mockResolvedValue(undefined),
+  restoreFromPreference: vi.fn().mockResolvedValue(undefined),
 }
 
 vi.mock('@/stores/groupStore', () => ({


### PR DESCRIPTION
## Summary

- Drops the `inventario_current_group` / `currentGroupSlug` localStorage keys; the URL (`/g/:groupSlug/`) is now the only per-tab source of truth for the active group, and the "remember my group across devices" bit lives on `user.default_group_id` server-side.
- `GroupSelector` fires a debounced `PUT /auth/me` on user-initiated switches, so the preference follows the user across devices instead of being trapped in one browser profile. Failures surface inline.
- `api.ts` interceptor no longer consults localStorage — when the current route carries no `groupSlug`, the request goes out unrewritten (with a dev-mode warning to flag accidental group-scoped calls from non-group routes).
- `restoreFromStorage` → `restoreFromPreference`; the priority chain is now `default_group_id` → first-created → first-invited → `groups[0]`.
- One-shot boot-time migration promotes legacy localStorage values to `default_group_id` (only when no preference is set yet) and then wipes the keys. Safe to drop the shim after a release.

## Test plan

- [x] `npx vitest run` — 410/410 green (includes new `#1300` suites for the migration shim, priority chain, and router-driven interceptor).
- [x] `npm run lint` — 0 errors.
- [x] `npm run build` — clean.
- [ ] Full Playwright suite — rewritten `#1262` / `#1258` / `#1263` specs now assert URL + `PUT /auth/me` round-trips instead of localStorage snapshots; added a cross-tab independence test.
- [ ] Manual smoke: sign in → select a different group in the header → confirm `PUT /auth/me` in devtools with `default_group_id` → reload → selector still shows the picked group.
- [ ] Upgrade smoke: seed legacy `inventario_current_group` in localStorage, load the app, confirm `PUT /auth/me` fires once and the key is gone afterwards.

Closes #1300.
