### PR TITLE
feat(helm): split apiserver and workers into per-role Deployments

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -72,6 +72,49 @@ jobs:
           --set setupJob.initData.adminPassword=demo-secret
           > /tmp/inventario-demo-render.yaml
 
+      - name: Render chart in split mode (apiserver + all workers)
+        run: >-
+          helm template inventario helm/inventario
+          --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require'
+          --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest'
+          --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest'
+          --set setupJob.initData.adminPassword=test
+          --set run.all.enabled=false
+          --set run.apiserver.enabled=true
+          --set run.workers.thumbnails.enabled=true
+          --set run.workers.exports.enabled=true
+          --set run.workers.imports.enabled=true
+          --set run.workers.restores.enabled=true
+          --set run.workers.emails.enabled=true
+          --set run.workers.tokenCleanup.enabled=true
+          > /tmp/inventario-split-all-render.yaml
+
+      - name: Render chart in split mode (apiserver only)
+        run: >-
+          helm template inventario helm/inventario
+          --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require'
+          --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest'
+          --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest'
+          --set setupJob.initData.adminPassword=test
+          --set run.all.enabled=false
+          --set run.apiserver.enabled=true
+          > /tmp/inventario-split-apiserver-render.yaml
+
+      - name: Render chart in split mode (workers subset + HPA stubs)
+        run: >-
+          helm template inventario helm/inventario
+          --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require'
+          --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest'
+          --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest'
+          --set setupJob.initData.adminPassword=test
+          --set run.all.enabled=false
+          --set run.apiserver.enabled=true
+          --set run.apiserver.autoscaling.enabled=true
+          --set run.workers.thumbnails.enabled=true
+          --set run.workers.thumbnails.autoscaling.enabled=true
+          --set run.workers.exports.enabled=true
+          > /tmp/inventario-split-workers-subset-render.yaml
+
       - name: Verify missing DSN is rejected
         run: |
           set -euo pipefail
@@ -85,3 +128,41 @@ jobs:
 
           cat /tmp/inventario-missing-dsn-error.log
           grep -Eq 'dbDsn|existingSecret|DSN' /tmp/inventario-missing-dsn-error.log
+
+      - name: Verify run.all + run.apiserver mutual exclusion is rejected
+        run: |
+          set -euo pipefail
+
+          if helm template inventario helm/inventario \
+            --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
+            --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+            --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+            --set setupJob.initData.adminPassword=test \
+            --set run.apiserver.enabled=true \
+            > /tmp/inventario-mutex-render.yaml \
+            2> /tmp/inventario-mutex-error.log; then
+            echo "Expected helm template to fail when run.all and run.apiserver are both enabled." >&2
+            exit 1
+          fi
+
+          cat /tmp/inventario-mutex-error.log
+          grep -Eq 'mutually exclusive' /tmp/inventario-mutex-error.log
+
+      - name: Verify no-topology configuration is rejected
+        run: |
+          set -euo pipefail
+
+          if helm template inventario helm/inventario \
+            --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
+            --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+            --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+            --set setupJob.initData.adminPassword=test \
+            --set run.all.enabled=false \
+            > /tmp/inventario-no-topology-render.yaml \
+            2> /tmp/inventario-no-topology-error.log; then
+            echo "Expected helm template to fail when neither run.all nor a split role is enabled." >&2
+            exit 1
+          fi
+
+          cat /tmp/inventario-no-topology-error.log
+          grep -Eq 'No run topology' /tmp/inventario-no-topology-error.log

--- a/helm/inventario/Chart.yaml
+++ b/helm/inventario/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inventario
 description: Personal inventory management system
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "latest" # overridden by CI with the actual image tag
 keywords:
   - inventory

--- a/helm/inventario/README.md
+++ b/helm/inventario/README.md
@@ -5,6 +5,11 @@ This chart lives at `helm/inventario/` and deploys Inventario in two supported m
 - **Production-style**: connect the app to external PostgreSQL, Redis, and object storage.
 - **Demo mode**: optionally run in-cluster PostgreSQL, Redis, and MinIO for evaluation.
 
+Each mode additionally supports two **run topologies**:
+
+- **Combined** (default): one Deployment runs `inventario run all`, serving both the HTTP API and every background worker (`run.all.enabled=true`).
+- **Split**: one Deployment per role (`run.apiserver` + zero or more `run.workers.<role>`) so each subsystem can be sized and scaled independently. See [Split deployment mode](#split-deployment-mode).
+
 The chart source of truth is `helm/inventario/values.yaml` plus the templates in `helm/inventario/templates/`. `values.yaml` contains the complete default surface with inline comments; this README focuses on the install paths and the values you normally need to change.
 
 ## Prerequisites
@@ -68,6 +73,66 @@ Demo notes:
 - Demo Redis wires all Redis-backed features to a single demo Redis instance.
 - `setupJob.initData.seedDatabase=true` is available for a seeded demo install and is skipped automatically on upgrades to avoid duplicate demo data.
 
+## Split deployment mode
+
+Split mode renders one Deployment per role so the API server and each background worker can scale, schedule, and auto-scale independently. Enable it by turning off the combined Deployment and turning on the roles you need:
+
+```yaml
+run:
+  all:
+    enabled: false
+  apiserver:
+    enabled: true
+  workers:
+    thumbnails:
+      enabled: true
+    exports:
+      enabled: true
+    imports:
+      enabled: true
+    restores:
+      enabled: true
+    emails:
+      enabled: true
+    tokenCleanup:
+      enabled: true
+```
+
+Each enabled worker role renders:
+
+- a `Deployment` named `<release>-<chart>-worker-<cli-id>` running `run workers --workers-only=<cli-id> --probe-addr=:<probePort>`;
+- a headless `Service` on the probe port so Prometheus (or a `ServiceMonitor`) can discover the pods and scrape `/metrics`.
+
+`run.all.enabled` and any split role are **mutually exclusive**. The chart fails the render with a clear error if both are enabled, or if neither is.
+
+Per-role values deep-merge over `run.workers.common`. Typical overrides are `replicaCount`, `resources`, `nodeSelector`, `tolerations`, and `autoscaling`.
+
+Split mode notes:
+
+- **Shared uploads**: when `app.uploadLocation` stays on `file://` and `persistence.enabled=true`, every role pod mounts the same uploads PVC. This requires an `accessMode` that allows multi-pod use (for example `ReadWriteMany`). For single-node clusters, ReadWriteOnce works only if every pod is scheduled on the same node. Object storage (`s3://`, `azblob://`, `gs://`) avoids the multi-pod PVC constraint entirely.
+- **Restores scaling**: each `run.workers.restores` replica enforces its own `app.maxConcurrentRestores` limit, so cluster-wide concurrency equals `replicaCount × maxConcurrentRestores`. Database-level job locking prevents duplicate work, but keep `replicaCount=1` unless your DB can sustain the multiplied load.
+- **CLI identifiers**: the Helm key `tokenCleanup` maps to the CLI flag value `token-cleanup`. All other role keys match the CLI flag value as-is.
+- **Autoscaling**: set `<role>.autoscaling.enabled=true` to render a `HorizontalPodAutoscaler` targeting the matching Deployment. CPU utilization is the default metric; extend via `<role>.autoscaling.metrics` and `<role>.autoscaling.behavior`.
+
+Example split install using external services:
+
+```bash
+helm upgrade --install inventario ./helm/inventario \
+  --namespace inventario --create-namespace \
+  --set-string secrets.dbDsn='postgres://inventario:password@postgres.example:5432/inventario?sslmode=require' \
+  --set-string secrets.jwtSecret='replace-with-at-least-32-characters' \
+  --set-string secrets.fileSigningKey='replace-with-at-least-32-characters' \
+  --set-string setupJob.initData.adminPassword='replace-me' \
+  --set run.all.enabled=false \
+  --set run.apiserver.enabled=true \
+  --set run.workers.thumbnails.enabled=true \
+  --set run.workers.exports.enabled=true \
+  --set run.workers.imports.enabled=true \
+  --set run.workers.restores.enabled=true \
+  --set run.workers.emails.enabled=true \
+  --set run.workers.tokenCleanup.enabled=true
+```
+
 ## Secret handling
 
 By default the chart renders its own Secret (`templates/secret.yaml`) from `values.yaml` and `--set-string` values.
@@ -108,7 +173,16 @@ For the complete default surface, see `helm/inventario/values.yaml`.
 | --- | --- | --- |
 | `image.repository` | `ghcr.io/denisvmedia/inventario` | Use your own registry/image mirror. |
 | `image.tag` | `""` | Pin a specific app version instead of `Chart.appVersion`. |
-| `replicaCount` | `1` | Increase only with shared object storage; do not scale `file://` uploads. |
+| `run.all.enabled` | `true` | Disable to switch from the combined Deployment to split mode. Mutually exclusive with `run.apiserver`/`run.workers.*`. |
+| `run.all.replicaCount` | `1` | Increase only with shared object storage; do not scale `file://` uploads. |
+| `run.all.autoscaling.enabled` | `false` | Enable to emit an HPA for the combined Deployment. |
+| `run.apiserver.enabled` | `false` | Enable to render the standalone API-server Deployment in split mode. |
+| `run.apiserver.replicaCount` | `1` | Scale the API tier independently of workers. |
+| `run.apiserver.autoscaling.enabled` | `false` | Enable to emit an HPA for the API-server Deployment. |
+| `run.workers.common.*` | see `values.yaml` | Shared defaults deep-merged into each per-role worker block. |
+| `run.workers.<role>.enabled` | `false` | Turn on a worker Deployment for the given role (`thumbnails`, `exports`, `imports`, `restores`, `emails`, `tokenCleanup`). |
+| `run.workers.<role>.replicaCount` | `1` | Scale the worker pool for the given role. Review caveats for `restores`. |
+| `run.workers.<role>.autoscaling.enabled` | `false` | Enable to emit an HPA for the given worker role. |
 | `service.type` | `ClusterIP` | Change for NodePort/LoadBalancer exposure. |
 | `ingress.enabled` | `false` | Enable public ingress routing. |
 | `ingress.hosts` / `ingress.tls` | example host / empty | Set your real hostname and TLS secret(s). |
@@ -141,47 +215,56 @@ For the complete default surface, see `helm/inventario/values.yaml`.
 
 ## Validation
 
-Validated in this workspace on 2026-03-11 with the following commands:
+The chart is covered by the `helm-lint.yml` CI workflow across combined, split, demo, and misconfiguration scenarios. The commands below reproduce those scenarios locally:
 
 ```bash
-helm lint helm/inventario/ \
-  --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
-  --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
-  --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
-  --set setupJob.initData.adminPassword=test
-
+# Combined (run.all) render with explicit secrets.
 helm template inventario helm/inventario/ \
   --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
   --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
   --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
   --set setupJob.initData.adminPassword=test
 
+# Combined render with an existing Secret.
 helm template inventario helm/inventario/ \
   --set-string secrets.existingSecret='inventario-runtime'
 
-helm lint helm/inventario/ \
-  --set demo.postgresql.enabled=true \
-  --set demo.redis.enabled=true \
-  --set demo.minio.enabled=true \
-  --set setupJob.initData.adminPassword=demo-secret
-
+# Demo render.
 helm template inventario helm/inventario/ \
   --set demo.postgresql.enabled=true \
   --set demo.redis.enabled=true \
   --set demo.minio.enabled=true \
   --set setupJob.initData.adminPassword=demo-secret
 
+# Split mode render (apiserver + all workers).
+helm template inventario helm/inventario/ \
+  --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
+  --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+  --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+  --set setupJob.initData.adminPassword=test \
+  --set run.all.enabled=false \
+  --set run.apiserver.enabled=true \
+  --set run.workers.thumbnails.enabled=true \
+  --set run.workers.exports.enabled=true \
+  --set run.workers.imports.enabled=true \
+  --set run.workers.restores.enabled=true \
+  --set run.workers.emails.enabled=true \
+  --set run.workers.tokenCleanup.enabled=true
+
+# Mutual exclusion guard (expected to fail).
+if helm template inventario helm/inventario/ \
+  --set-string secrets.dbDsn='postgres://u:p@h/d' \
+  --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+  --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+  --set setupJob.initData.adminPassword=test \
+  --set run.apiserver.enabled=true; then
+  echo "expected combined+split render to fail" >&2
+  exit 1
+fi
+
+# Missing-DSN guard (expected to fail).
 if helm template inventario helm/inventario/; then
   echo "expected missing-DSN render to fail" >&2
   exit 1
 fi
 ```
-
-Observed results:
-
-- Production-style `helm lint` passed.
-- Production-style render passed and rendered only the app resources (`ServiceAccount`, app `Secret`, `ConfigMap`, uploads `PVC`, `Service`, `Deployment`, setup `Job`).
-- Existing-secret render passed and omitted `templates/secret.yaml` as expected.
-- Demo `helm lint` passed.
-- Demo render passed and rendered the app plus demo PostgreSQL, Redis, MinIO, and the MinIO bucket Job.
-- Missing-DSN render failed fast with `secrets.dbDsn must be set when demo.postgresql.enabled=false and secrets.existingSecret is empty`.

--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -30,6 +30,135 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: web
 {{- end -}}
 
+{{/*
+Canonical, stable-ordered list of worker role keys. Each entry must
+match both a run.workers.<key> values block and exactly one worker
+identifier accepted by `run workers --workers-only=<cli-id>`.
+*/}}
+{{- define "inventario.workerRoles" -}}
+thumbnails exports imports restores emails tokenCleanup
+{{- end -}}
+
+{{/*
+Translate a role key (as it appears in values.run.workers.*) to the
+CLI identifier accepted by `--workers-only`. The only irregular case
+today is tokenCleanup -> token-cleanup.
+Usage: include "inventario.workerCliId" "tokenCleanup"
+*/}}
+{{- define "inventario.workerCliId" -}}
+{{- if eq . "tokenCleanup" -}}
+token-cleanup
+{{- else -}}
+{{ . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compute whether any split role is enabled. Emits "true" or empty.
+*/}}
+{{- define "inventario.splitEnabled" -}}
+{{- $split := .Values.run.apiserver.enabled -}}
+{{- range $role := splitList " " (include "inventario.workerRoles" .) -}}
+  {{- $cfg := index $.Values.run.workers $role -}}
+  {{- if and $cfg $cfg.enabled -}}{{- $split = true -}}{{- end -}}
+{{- end -}}
+{{- if $split -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Validate the run topology. Fails the render when run.all and any
+split role (apiserver or any worker) are both enabled, or when
+neither mode is active.
+*/}}
+{{- define "inventario.validateRunMode" -}}
+{{- $all := .Values.run.all.enabled -}}
+{{- $split := eq (include "inventario.splitEnabled" .) "true" -}}
+{{- if and $all $split -}}
+{{- fail "run.all.enabled and split roles (run.apiserver or run.workers.<role>) are mutually exclusive. Set run.all.enabled=false when using split Deployments." -}}
+{{- end -}}
+{{- if not (or $all $split) -}}
+{{- fail "No run topology is active. Enable run.all (combined) or run.apiserver together with at least one run.workers.<role>.enabled=true (split)." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resource name suffix for the API-server split Deployment.
+*/}}
+{{- define "inventario.apiserverName" -}}
+{{- printf "%s-apiserver" (include "inventario.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Resource name suffix for a per-role worker Deployment.
+Usage: include "inventario.workerName" (dict "root" . "role" "thumbnails")
+*/}}
+{{- define "inventario.workerName" -}}
+{{- $cli := include "inventario.workerCliId" .role -}}
+{{- printf "%s-worker-%s" (include "inventario.fullname" .root) $cli | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Component selector labels for the combined (run.all) Deployment.
+Alias of appSelectorLabels kept for explicitness.
+*/}}
+{{- define "inventario.allSelectorLabels" -}}
+{{ include "inventario.appSelectorLabels" . }}
+{{- end -}}
+
+{{/*
+Component selector labels for the split API-server Deployment.
+*/}}
+{{- define "inventario.apiserverSelectorLabels" -}}
+{{- include "inventario.selectorLabels" . }}
+app.kubernetes.io/component: apiserver
+{{- end -}}
+
+{{/*
+Component selector labels for a worker Deployment.
+Usage: include "inventario.workerSelectorLabels" (dict "root" . "role" "thumbnails")
+*/}}
+{{- define "inventario.workerSelectorLabels" -}}
+{{- $cli := include "inventario.workerCliId" .role -}}
+{{ include "inventario.selectorLabels" .root }}
+app.kubernetes.io/component: {{ printf "worker-%s" $cli }}
+{{- end -}}
+
+{{/*
+Deep-merge the role-specific worker values block over run.workers.common.
+Returns the merged dict. The caller is expected to deepCopy the result
+before mutating.
+Usage: $cfg := include "inventario.workerConfig" (dict "root" . "role" "thumbnails") | fromYaml
+(or use a with-$ pattern when only selected fields are read).
+*/}}
+{{- define "inventario.workerConfig" -}}
+{{- $common := deepCopy .root.Values.run.workers.common -}}
+{{- $role := index .root.Values.run.workers .role -}}
+{{- $override := deepCopy (default (dict) $role) -}}
+{{- $merged := mustMergeOverwrite $common $override -}}
+{{- toYaml $merged -}}
+{{- end -}}
+
+{{/*
+True when the apiserver endpoint is served by an internally-rendered
+Deployment (either run.all or run.apiserver). Used by Service and
+Ingress to decide whether to emit.
+*/}}
+{{- define "inventario.apiserverRendered" -}}
+{{- if or .Values.run.all.enabled .Values.run.apiserver.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Selector labels used by the apiserver Service/Ingress. Matches
+whichever Deployment (all or apiserver) is currently enabled.
+*/}}
+{{- define "inventario.apiserverServiceSelectorLabels" -}}
+{{- if .Values.run.all.enabled -}}
+{{ include "inventario.allSelectorLabels" . }}
+{{- else -}}
+{{ include "inventario.apiserverSelectorLabels" . }}
+{{- end -}}
+{{- end -}}
+
 {{- define "inventario.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "inventario.fullname" .) .Values.serviceAccount.name -}}

--- a/helm/inventario/templates/deployment-apiserver.yaml
+++ b/helm/inventario/templates/deployment-apiserver.yaml
@@ -1,18 +1,18 @@
-{{- include "inventario.validateRunMode" . -}}
-{{- if .Values.run.all.enabled -}}
+{{- if .Values.run.apiserver.enabled -}}
 {{- $fullName := include "inventario.fullname" . -}}
+{{- $name := include "inventario.apiserverName" . -}}
 {{- $secretName := include "inventario.secretName" . -}}
 {{- $imageTag := default .Chart.AppVersion .Values.image.tag -}}
 {{- $redisUrl := include "inventario.redisUrl" . -}}
 {{- $usePersistentUploads := and .Values.persistence.enabled (hasPrefix "file://" (include "inventario.uploadLocation" .)) -}}
-{{- $cfg := .Values.run.all -}}
+{{- $cfg := .Values.run.apiserver -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $fullName }}
+  name: {{ $name }}
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: apiserver
 spec:
   {{- if not $cfg.autoscaling.enabled }}
   replicas: {{ $cfg.replicaCount }}
@@ -24,11 +24,11 @@ spec:
       maxSurge: 1
   selector:
     matchLabels:
-      {{- include "inventario.allSelectorLabels" . | nindent 6 }}
+      {{- include "inventario.apiserverSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "inventario.allSelectorLabels" . | nindent 8 }}
+        {{- include "inventario.apiserverSelectorLabels" . | nindent 8 }}
         {{- with $cfg.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -56,7 +56,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - run
-            - all
+            - apiserver
             {{- with $cfg.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/inventario/templates/deployment-workers.yaml
+++ b/helm/inventario/templates/deployment-workers.yaml
@@ -1,21 +1,28 @@
-{{- include "inventario.validateRunMode" . -}}
-{{- if .Values.run.all.enabled -}}
+{{- $root := . -}}
 {{- $fullName := include "inventario.fullname" . -}}
 {{- $secretName := include "inventario.secretName" . -}}
 {{- $imageTag := default .Chart.AppVersion .Values.image.tag -}}
 {{- $redisUrl := include "inventario.redisUrl" . -}}
 {{- $usePersistentUploads := and .Values.persistence.enabled (hasPrefix "file://" (include "inventario.uploadLocation" .)) -}}
-{{- $cfg := .Values.run.all -}}
+{{- range $role := splitList " " (include "inventario.workerRoles" .) -}}
+{{- $roleCfg := index $root.Values.run.workers $role -}}
+{{- if and $roleCfg $roleCfg.enabled -}}
+{{- $cfg := include "inventario.workerConfig" (dict "root" $root "role" $role) | fromYaml -}}
+{{- $cli := include "inventario.workerCliId" $role -}}
+{{- $probePort := int $cfg.probePort -}}
+{{- $probeAddr := printf ":%d" $probePort -}}
+{{- $name := include "inventario.workerName" (dict "root" $root "role" $role) -}}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $fullName }}
+  name: {{ $name }}
   labels:
-    {{- include "inventario.labels" . | nindent 4 }}
-    app.kubernetes.io/component: web
+    {{- include "inventario.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ printf "worker-%s" $cli }}
 spec:
   {{- if not $cfg.autoscaling.enabled }}
-  replicas: {{ $cfg.replicaCount }}
+  replicas: {{ $cfg.replicaCount | default 1 }}
   {{- end }}
   strategy:
     type: RollingUpdate
@@ -24,11 +31,11 @@ spec:
       maxSurge: 1
   selector:
     matchLabels:
-      {{- include "inventario.allSelectorLabels" . | nindent 6 }}
+      {{- include "inventario.workerSelectorLabels" (dict "root" $root "role" $role) | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "inventario.allSelectorLabels" . | nindent 8 }}
+        {{- include "inventario.workerSelectorLabels" (dict "root" $root "role" $role) | nindent 8 }}
         {{- with $cfg.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -37,45 +44,47 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with .Values.image.pullSecrets }}
+      {{- with $root.Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "inventario.serviceAccountName" . }}
+      serviceAccountName: {{ include "inventario.serviceAccountName" $root }}
       terminationGracePeriodSeconds: 30
       {{- with $cfg.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
-      {{- with .Values.podSecurityContext }}
+      {{- with $root.Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: inventario
-          image: {{ printf "%s:%s" .Values.image.repository $imageTag | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ printf "%s:%s" $root.Values.image.repository $imageTag | quote }}
+          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
           args:
             - run
-            - all
+            - workers
+            - {{ printf "--workers-only=%s" $cli | quote }}
+            - {{ printf "--probe-addr=%s" $probeAddr | quote }}
             {{- with $cfg.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            - name: http
-              containerPort: 3333
+            - name: probe
+              containerPort: {{ $probePort }}
               protocol: TCP
           envFrom:
             - configMapRef:
                 name: {{ $fullName }}-config
             - secretRef:
                 name: {{ $secretName }}
-          {{- if or .Values.demo.postgresql.enabled .Values.demo.redis.enabled .Values.demo.minio.enabled }}
+          {{- if or $root.Values.demo.postgresql.enabled $root.Values.demo.redis.enabled $root.Values.demo.minio.enabled }}
           env:
-            {{- if .Values.demo.postgresql.enabled }}
+            {{- if $root.Values.demo.postgresql.enabled }}
             - name: INVENTARIO_DB_DSN
-              value: {{ include "inventario.dbDsn" . | quote }}
+              value: {{ include "inventario.dbDsn" $root | quote }}
             {{- end }}
-            {{- if .Values.demo.redis.enabled }}
+            {{- if $root.Values.demo.redis.enabled }}
             - name: INVENTARIO_RUN_TOKEN_BLACKLIST_REDIS_URL
               value: {{ $redisUrl | quote }}
             - name: INVENTARIO_RUN_AUTH_RATE_LIMIT_REDIS_URL
@@ -87,11 +96,11 @@ spec:
             - name: INVENTARIO_RUN_EMAIL_QUEUE_REDIS_URL
               value: {{ $redisUrl | quote }}
             {{- end }}
-            {{- if .Values.demo.minio.enabled }}
+            {{- if $root.Values.demo.minio.enabled }}
             - name: AWS_ACCESS_KEY_ID
-              value: {{ .Values.demo.minio.rootUser | quote }}
+              value: {{ $root.Values.demo.minio.rootUser | quote }}
             - name: AWS_SECRET_ACCESS_KEY
-              value: {{ .Values.demo.minio.rootPassword | quote }}
+              value: {{ $root.Values.demo.minio.rootPassword | quote }}
             {{- end }}
           {{- end }}
           volumeMounts:
@@ -105,7 +114,7 @@ spec:
             {{- toYaml $cfg.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml $cfg.resources | nindent 12 }}
-          {{- with .Values.containerSecurityContext }}
+          {{- with $root.Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -131,4 +140,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end }}
+{{ end }}
+{{ end }}

--- a/helm/inventario/templates/hpa.yaml
+++ b/helm/inventario/templates/hpa.yaml
@@ -1,0 +1,147 @@
+{{/*
+HorizontalPodAutoscaler stubs. One HPA per enabled role with
+autoscaling.enabled=true. Default metric is CPU; callers may
+extend via <role>.autoscaling.metrics (external or resource) and
+<role>.autoscaling.behavior.
+*/}}
+{{- $root := . -}}
+
+{{/* run.all HPA */}}
+{{- if and .Values.run.all.enabled .Values.run.all.autoscaling.enabled }}
+{{- $cfg := .Values.run.all.autoscaling }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "inventario.fullname" . }}
+  labels:
+    {{- include "inventario.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "inventario.fullname" . }}
+  minReplicas: {{ $cfg.minReplicas }}
+  maxReplicas: {{ $cfg.maxReplicas }}
+  metrics:
+    {{- if $cfg.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $cfg.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $cfg.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $cfg.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- with $cfg.metrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $cfg.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+{{/* run.apiserver HPA */}}
+{{- if and .Values.run.apiserver.enabled .Values.run.apiserver.autoscaling.enabled }}
+{{- $cfg := .Values.run.apiserver.autoscaling }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "inventario.apiserverName" . }}
+  labels:
+    {{- include "inventario.labels" . | nindent 4 }}
+    app.kubernetes.io/component: apiserver
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "inventario.apiserverName" . }}
+  minReplicas: {{ $cfg.minReplicas }}
+  maxReplicas: {{ $cfg.maxReplicas }}
+  metrics:
+    {{- if $cfg.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $cfg.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $cfg.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $cfg.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- with $cfg.metrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $cfg.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+{{/* Per-worker-role HPAs */}}
+{{- range $role := splitList " " (include "inventario.workerRoles" .) }}
+{{- $roleCfg := index $root.Values.run.workers $role }}
+{{- if and $roleCfg $roleCfg.enabled }}
+{{- $cfg := include "inventario.workerConfig" (dict "root" $root "role" $role) | fromYaml }}
+{{- if and $cfg.autoscaling $cfg.autoscaling.enabled }}
+{{- $cli := include "inventario.workerCliId" $role }}
+{{- $name := include "inventario.workerName" (dict "root" $root "role" $role) }}
+{{- $acfg := $cfg.autoscaling }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "inventario.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ printf "worker-%s" $cli }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $name }}
+  minReplicas: {{ $acfg.minReplicas }}
+  maxReplicas: {{ $acfg.maxReplicas }}
+  metrics:
+    {{- if $acfg.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $acfg.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $acfg.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $acfg.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- with $acfg.metrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $acfg.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{ end }}
+{{ end }}
+{{ end }}

--- a/helm/inventario/templates/service-workers.yaml
+++ b/helm/inventario/templates/service-workers.yaml
@@ -1,0 +1,28 @@
+{{- $root := . -}}
+{{- range $role := splitList " " (include "inventario.workerRoles" .) }}
+{{- $roleCfg := index $root.Values.run.workers $role }}
+{{- if and $roleCfg $roleCfg.enabled }}
+{{- $cfg := include "inventario.workerConfig" (dict "root" $root "role" $role) | fromYaml }}
+{{- $cli := include "inventario.workerCliId" $role }}
+{{- $probePort := int $cfg.probePort }}
+{{- $name := include "inventario.workerName" (dict "root" $root "role" $role) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "inventario.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ printf "worker-%s" $cli }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    {{- include "inventario.workerSelectorLabels" (dict "root" $root "role" $role) | nindent 4 }}
+  ports:
+    - name: probe
+      port: {{ $probePort }}
+      targetPort: probe
+      protocol: TCP
+{{ end }}
+{{ end }}

--- a/helm/inventario/templates/service.yaml
+++ b/helm/inventario/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "inventario.apiserverRendered" .) "true" -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,9 +9,10 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   selector:
-    {{- include "inventario.appSelectorLabels" . | nindent 4 }}
+    {{- include "inventario.apiserverServiceSelectorLabels" . | nindent 4 }}
   ports:
     - name: http
       port: {{ .Values.service.port }}
       targetPort: 3333
       protocol: TCP
+{{- end }}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -13,13 +13,222 @@ image:
   # Optional list of image pull secrets
   pullSecrets: []
 
-# -- Number of application replicas
-# NOTE: More than 1 replica requires shared file storage (S3/MinIO/GCS/Azure).
-# Local file:// storage does NOT work with replicaCount > 1.
-replicaCount: 1
+# ============================================================
+# Run topology
+# ============================================================
+# Controls whether Inventario runs as one combined Deployment
+# (`inventario run all`, the default) or as per-role Deployments
+# (`run apiserver` + one or more `run workers --workers-only=<id>`).
+#
+# Exactly ONE of the following must be active:
+#   * run.all.enabled=true                (single Deployment)
+#   * run.apiserver.enabled=true AND at least one
+#     run.workers.<role>.enabled=true     (split Deployments)
+#
+# Enabling run.all together with any split role is rejected at
+# template time.
+#
+# Per-role blocks (apiserver + each worker) deep-merge over the
+# role's defaults from run.workers.common for workers, and over
+# their own block for apiserver/all. Leave a field empty to use
+# the default.
+run:
+  # ----------------------------------------------------------
+  # Combined mode (run all): one Deployment, API + every worker.
+  # ----------------------------------------------------------
+  all:
+    enabled: true
+    # NOTE: More than 1 replica requires shared file storage
+    # (S3/MinIO/GCS/Azure). Local file:// storage does NOT work
+    # with replicaCount > 1.
+    replicaCount: 1
+    podAnnotations: {}
+    podLabels: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    priorityClassName: ""
+    # Extra args appended after "run all".
+    extraArgs: []
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 3333
+      initialDelaySeconds: 10
+      periodSeconds: 15
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: 3333
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 70
+      # Leave null to disable; set to an int percent to enable.
+      targetMemoryUtilizationPercentage: null
+      # Additional metrics entries (autoscaling/v2 MetricSpec), for
+      # example an external metric exposed by the app's /metrics
+      # endpoint via a metrics adapter. Inventario does not ship
+      # custom metrics yet; this list stays empty by default.
+      # metrics:
+      #   - type: External
+      #     external:
+      #       metric:
+      #         name: inventario_jobs_pending
+      #         selector:
+      #           matchLabels:
+      #             worker: thumbnails
+      #       target:
+      #         type: AverageValue
+      #         averageValue: "5"
+      metrics: []
+      behavior: {}
+
+  # ----------------------------------------------------------
+  # API-server-only mode (run apiserver). Pair with at least one
+  # run.workers.<role>.enabled=true to get a working split
+  # deployment.
+  # ----------------------------------------------------------
+  apiserver:
+    enabled: false
+    replicaCount: 1
+    podAnnotations: {}
+    podLabels: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    priorityClassName: ""
+    # Extra args appended after "run apiserver".
+    extraArgs: []
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 3333
+      initialDelaySeconds: 10
+      periodSeconds: 15
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: 3333
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: null
+      metrics: []
+      behavior: {}
+
+  # ----------------------------------------------------------
+  # Per-worker Deployments. Each worker role renders its own
+  # Deployment + headless Service (probe/metrics) when enabled.
+  #
+  # CLI identifiers (passed to `run workers --workers-only=<id>`):
+  #   thumbnails, exports, imports, restores, emails, token-cleanup
+  # ----------------------------------------------------------
+  workers:
+    # Shared defaults. Each per-role block deep-merges over these.
+    common:
+      # Probe/metrics listener port inside the worker container.
+      # Passed to workers as --probe-addr=:<probePort>.
+      probePort: 3334
+      podAnnotations: {}
+      podLabels: {}
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+      priorityClassName: ""
+      # Extra args appended after "run workers --workers-only=<id>".
+      extraArgs: []
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: probe
+        initialDelaySeconds: 10
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        httpGet:
+          path: /readyz
+          port: probe
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+      autoscaling:
+        enabled: false
+        minReplicas: 1
+        maxReplicas: 5
+        targetCPUUtilizationPercentage: 70
+        targetMemoryUtilizationPercentage: null
+        metrics: []
+        behavior: {}
+
+    # Per-role overrides. Each block may override any key from
+    # run.workers.common. Enable the Deployment with `enabled: true`.
+    thumbnails:
+      enabled: false
+      # Thumbnail generation is CPU/memory-heavy — bump defaults.
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          cpu: 1000m
+          memory: 1Gi
+    exports:
+      enabled: false
+    imports:
+      enabled: false
+    restores:
+      # NOTE: Each replica enforces its own app.maxConcurrentRestores
+      # limit. Cluster-wide concurrency = replicaCount * maxConcurrent.
+      # DB-level job locking prevents duplicate work, but keep
+      # replicaCount=1 unless your DB sizing supports the multiplied
+      # concurrency.
+      enabled: false
+    emails:
+      enabled: false
+    tokenCleanup:
+      enabled: false
 
 # ============================================================
-# Service
+# Service (targets the apiserver endpoint — run.all or run.apiserver).
 # ============================================================
 service:
   # Service type: ClusterIP | NodePort | LoadBalancer
@@ -342,48 +551,6 @@ containerSecurityContext:
   capabilities:
     drop:
       - ALL
-
-# ============================================================
-# Resource requests and limits for the main app container
-# ============================================================
-resources:
-  requests:
-    cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 500m
-    memory: 512Mi
-
-# ============================================================
-# Liveness and readiness probes
-# Liveness uses GET /healthz and readiness uses GET /readyz on port 3333.
-# Configure these if you customize the backend health endpoints.
-# ============================================================
-livenessProbe:
-  httpGet:
-    path: /healthz
-    port: 3333
-  initialDelaySeconds: 10
-  periodSeconds: 15
-  timeoutSeconds: 5
-  failureThreshold: 3
-
-readinessProbe:
-  httpGet:
-    path: /readyz
-    port: 3333
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 3
-
-# ============================================================
-# Pod scheduling
-# ============================================================
-podAnnotations: {}
-nodeSelector: {}
-tolerations: []
-affinity: {}
 
 # ============================================================
 # DEMO — in-cluster dependencies for evaluation / CI


### PR DESCRIPTION
Closes #1297
Refs #1214

## Summary

Reshape the Helm chart so the API server and each background worker can be deployed independently. The combined `run all` Deployment remains the default, but users can now flip to per-role Deployments for independent scaling, scheduling, and autoscaling.

## What changed

### Values schema (`values.yaml`)

New hierarchy rooted under `run:`:

- `run.all.*` — combined Deployment settings (previous top-level `replicaCount`, `resources`, `livenessProbe`, `readinessProbe`, `podAnnotations`, `nodeSelector`, `tolerations`, `affinity`, `priorityClassName` moved here). Default `run.all.enabled=true`.
- `run.apiserver.*` — standalone API-server Deployment (`run apiserver`). Same surface as `run.all` plus `autoscaling`. Default `enabled=false`.
- `run.workers.common` — shared defaults for every worker role (probes, resources, scheduling, `autoscaling`, `probePort: 3334`).
- `run.workers.{thumbnails,exports,imports,restores,emails,tokenCleanup}` — per-role blocks that deep-merge over `common`. Each defaults to `enabled: false`.

`Chart.yaml` bumps to **0.3.0** because the schema is reshaped.

### Templates

- `templates/deployment.yaml` — gated on `run.all.enabled`; adds explicit `args: [run, all]`. Otherwise unchanged (see diff below).
- `templates/deployment-apiserver.yaml` (**new**) — renders `<release>-<chart>-apiserver` on :3333 with `args: [run, apiserver]`.
- `templates/deployment-workers.yaml` (**new**) — loops over enabled worker roles and emits `<release>-<chart>-worker-<cli-id>` Deployments with `args: [run, workers, --workers-only=<cli-id>, --probe-addr=:<port>]`.
- `templates/service.yaml` — now emits only when the API endpoint is rendered (combined **or** apiserver) and targets the correct Deployment via role-aware selectors.
- `templates/service-workers.yaml` (**new**) — headless ClusterIP Service per enabled worker role exposing the probe/metrics port for Prometheus/ServiceMonitor discovery.
- `templates/hpa.yaml` (**new**) — renders a HorizontalPodAutoscaler for every role whose `autoscaling.enabled=true` (CPU-based by default, extensible via `autoscaling.metrics` and `autoscaling.behavior`).
- `templates/_helpers.tpl` — adds `workerRoles`, `workerCliId`, `splitEnabled`, `validateRunMode`, `apiserverName`, `workerName`, `apiserverSelectorLabels`, `workerSelectorLabels`, `workerConfig` (deep-merge), `apiserverRendered`, `apiserverServiceSelectorLabels`. The `validateRunMode` helper fails the render when:
  - `run.all.enabled=true` and any split role is enabled (mutual exclusion), or
  - no topology is active.

### CI (`helm-lint.yml`)

Adds five new render/verification steps:

- **split-all-roles** (apiserver + every worker)
- **split-apiserver-only**
- **split-workers-subset** with HPA stubs on apiserver and one worker
- **mutex rejection** (`run.all` + `run.apiserver` together)
- **no-topology rejection** (`run.all.enabled=false` with no split role)

### Docs (`README.md`)

New *Split deployment mode* section, updated values-reference table covering `run.*`, refreshed validation commands that match the CI scenarios, explicit notes on:

- RWX requirement when `app.uploadLocation` stays on `file://` in split mode;
- `restores` worker concurrency (`replicaCount × maxConcurrentRestores`).

## Backward compatibility

- Default render (`helm template` with no overrides) differs from 0.2.0 only by the chart version label and an explicit `args: [run, all]` — behaviorally equivalent because the Dockerfile's `CMD ["run"]` already delegated to `run all` via #1294.
- Users upgrading existing installs can keep the previous Deployment topology without any values changes.
- Users moving to split mode must flip `run.all.enabled=false` and opt into the roles they need.

## Validation

```
helm lint helm/inventario ...              # passes
helm template (defaults)                    # 7 resources, matches master modulo chart version
helm template (existingSecret)              # secret omitted as before
helm template (demo)                        # demo postgres/redis/minio rendered
helm template (split, all roles)            # 7 Deployments (1 apiserver + 6 workers), 7 Services
helm template (split, apiserver only)       # 1 Deployment + 1 Service
helm template (split, workers subset + HPA) # 1 apiserver + 1 worker, 2 HPAs
helm template (run.all + run.apiserver)     # fails: mutually exclusive
helm template (run.all=false, no workers)   # fails: No run topology is active
```

All runs locally green with Helm 3.x and covered in CI.

## Prerequisites (already merged)

- #1304 — `run all` / `run apiserver` / `run workers` subcommands
- #1302 — `run workers --workers-only` / `--workers-exclude`
- #1305 — `/healthz`, `/readyz`, `/metrics` on workers via `--probe-addr`