### PR TITLE
refactor(workers): consolidate worker families into operational groups (#1311)

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -72,7 +72,7 @@ jobs:
           --set setupJob.initData.adminPassword=demo-secret
           > /tmp/inventario-demo-render.yaml
 
-      - name: Render chart in split mode (apiserver + all workers)
+      - name: Render chart in split mode (apiserver + all worker groups)
         run: >-
           helm template inventario helm/inventario
           --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require'
@@ -81,12 +81,10 @@ jobs:
           --set setupJob.initData.adminPassword=test
           --set run.all.enabled=false
           --set run.apiserver.enabled=true
-          --set run.workers.thumbnails.enabled=true
-          --set run.workers.exports.enabled=true
-          --set run.workers.imports.enabled=true
-          --set run.workers.restores.enabled=true
+          --set run.workers.archive.enabled=true
           --set run.workers.emails.enabled=true
-          --set run.workers.tokenCleanup.enabled=true
+          --set run.workers.housekeeping.enabled=true
+          --set run.workers.media.enabled=true
           > /tmp/inventario-split-all-render.yaml
 
       - name: Render chart in split mode (apiserver only)
@@ -100,7 +98,7 @@ jobs:
           --set run.apiserver.enabled=true
           > /tmp/inventario-split-apiserver-render.yaml
 
-      - name: Render chart in split mode (workers subset + HPA stubs)
+      - name: Render chart in split mode (worker-groups subset + HPA stubs)
         run: >-
           helm template inventario helm/inventario
           --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require'
@@ -110,9 +108,9 @@ jobs:
           --set run.all.enabled=false
           --set run.apiserver.enabled=true
           --set run.apiserver.autoscaling.enabled=true
-          --set run.workers.thumbnails.enabled=true
-          --set run.workers.thumbnails.autoscaling.enabled=true
-          --set run.workers.exports.enabled=true
+          --set run.workers.media.enabled=true
+          --set run.workers.media.autoscaling.enabled=true
+          --set run.workers.archive.enabled=true
           > /tmp/inventario-split-workers-subset-render.yaml
 
       - name: Verify missing DSN is rejected

--- a/go/cmd/inventario/run/workers/selector.go
+++ b/go/cmd/inventario/run/workers/selector.go
@@ -189,7 +189,7 @@ func parseIDList(raw, flag string) ([]WorkerID, []DeprecatedAlias, error) {
 		}
 		id := WorkerID(token)
 		if !isKnownID(id) {
-			return nil, nil, fmt.Errorf("%s: unknown worker %q (valid: %s)", flag, token, strings.Join(idStrings(), ", "))
+			return nil, nil, fmt.Errorf("%s: unknown worker group %q (valid: %s)", flag, token, strings.Join(idStrings(), ", "))
 		}
 		out = append(out, id)
 	}

--- a/go/cmd/inventario/run/workers/selector.go
+++ b/go/cmd/inventario/run/workers/selector.go
@@ -7,63 +7,90 @@ import (
 	"strings"
 )
 
-// WorkerID identifies a single background worker family. The string values are
-// the canonical identifiers accepted by --workers-only / --workers-exclude on
-// `run workers` and are intended to double as the source of truth for logs,
-// metrics labels and any future Helm values keyed off worker type.
+// WorkerID identifies a single operational group of background workers. The
+// string values are the canonical identifiers accepted by --workers-only /
+// --workers-exclude on `run workers` and are intended to double as the source
+// of truth for logs, metrics labels, and Helm values keyed off worker group.
+//
+// Each group bundles one or more individual worker families that share an
+// operational profile (lifecycle, scaling signal, resource footprint). See
+// the groups slice in workers.go for the composition of each group.
 type WorkerID string
 
-// Canonical worker identifiers. Keep alphabetically ordered; tests and
+// Canonical worker group identifiers. Keep alphabetically ordered; tests and
 // AllWorkerIDs rely on this being the authoritative list.
 const (
-	WorkerEmails       WorkerID = "emails"
-	WorkerExports      WorkerID = "exports"
-	WorkerImports      WorkerID = "imports"
-	WorkerRestores     WorkerID = "restores"
-	WorkerThumbnails   WorkerID = "thumbnails"
-	WorkerTokenCleanup WorkerID = "token-cleanup"
+	// WorkerArchive bundles exports, imports, and restores. They share the
+	// archive-format code path, are long-running, and have matching I/O + DB
+	// characteristics, so they scale on a single queue-depth signal.
+	WorkerArchive WorkerID = "archive"
+	// WorkerEmails owns the email delivery lifecycle. Kept as its own group
+	// because SMTP / provider rate limits are a distinct scaling story.
+	WorkerEmails WorkerID = "emails"
+	// WorkerHousekeeping groups periodic maintenance tasks (refresh token
+	// cleanup today; pending-deletion group purge and expired-invite GC in
+	// follow-ups). replicaCount is expected to stay at 1.
+	WorkerHousekeeping WorkerID = "housekeeping"
+	// WorkerMedia bundles CPU/RAM-heavy media processing (thumbnails today,
+	// future image resize / OCR). Scales on the media-queue depth signal.
+	WorkerMedia WorkerID = "media"
 )
 
 var allWorkerIDs = []WorkerID{
+	WorkerArchive,
 	WorkerEmails,
-	WorkerExports,
-	WorkerImports,
-	WorkerRestores,
-	WorkerThumbnails,
-	WorkerTokenCleanup,
+	WorkerHousekeeping,
+	WorkerMedia,
 }
 
 var knownWorkerIDs = map[WorkerID]struct{}{
+	WorkerArchive:      {},
 	WorkerEmails:       {},
-	WorkerExports:      {},
-	WorkerImports:      {},
-	WorkerRestores:     {},
-	WorkerThumbnails:   {},
-	WorkerTokenCleanup: {},
+	WorkerHousekeeping: {},
+	WorkerMedia:        {},
 }
 
 var allWorkerIDStrings = []string{
+	string(WorkerArchive),
 	string(WorkerEmails),
-	string(WorkerExports),
-	string(WorkerImports),
-	string(WorkerRestores),
-	string(WorkerThumbnails),
-	string(WorkerTokenCleanup),
+	string(WorkerHousekeeping),
+	string(WorkerMedia),
 }
 
-// selectorAll is the explicit synonym for "every worker", accepted as a value
+// deprecatedAliases maps the pre-#1311 worker-family names to the operational
+// group that now owns them. Accepted on --workers-only / --workers-exclude for
+// one release, with a structured deprecation warning surfaced by ParseSelector
+// so operators can migrate their systemd units and CI pipelines.
+var deprecatedAliases = map[string]WorkerID{
+	"exports":       WorkerArchive,
+	"imports":       WorkerArchive,
+	"restores":      WorkerArchive,
+	"thumbnails":    WorkerMedia,
+	"token-cleanup": WorkerHousekeeping,
+}
+
+// selectorAll is the explicit synonym for "every group", accepted as a value
 // of --workers-only so operators can make the intent explicit in systemd units
 // and CI pipelines without relying on the empty string.
 const selectorAll = "all"
 
-// AllWorkerIDs returns the canonical, stable-ordered list of every worker ID.
-// The returned slice is a fresh copy and safe for callers to mutate.
+// DeprecatedAlias records a legacy identifier that was accepted during
+// selector parsing. Callers surface it as a deprecation warning so operators
+// see one line per legacy token rather than a single bag of mappings.
+type DeprecatedAlias struct {
+	Alias     string
+	Canonical WorkerID
+}
+
+// AllWorkerIDs returns the canonical, stable-ordered list of every worker
+// group. The returned slice is a fresh copy and safe for callers to mutate.
 func AllWorkerIDs() []WorkerID {
 	return slices.Clone(allWorkerIDs)
 }
 
-// Set is the resolved set of workers that should run in the current process.
-// It is produced by ParseSelector and consumed by the run logic in workers.go.
+// Set is the resolved set of worker groups that should run in the current
+// process. It is produced by ParseSelector and consumed by run logic in
+// workers.go.
 type Set map[WorkerID]struct{}
 
 // Has reports whether id is enabled in the set.
@@ -72,7 +99,7 @@ func (s Set) Has(id WorkerID) bool {
 	return ok
 }
 
-// Sorted returns the enabled worker IDs in canonical (alphabetical) order,
+// Sorted returns the enabled group IDs in canonical (alphabetical) order,
 // suitable for logging or diffing.
 func (s Set) Sorted() []WorkerID {
 	out := make([]WorkerID, 0, len(s))
@@ -83,53 +110,56 @@ func (s Set) Sorted() []WorkerID {
 	return out
 }
 
-// ParseSelector resolves the effective worker set from the raw --workers-only /
-// --workers-exclude flag values. Both arguments are comma-separated lists of
-// worker identifiers (case-insensitive, surrounding whitespace tolerated).
+// ParseSelector resolves the effective worker-group set from the raw
+// --workers-only / --workers-exclude flag values. Both arguments are
+// comma-separated lists of identifiers (case-insensitive, surrounding
+// whitespace tolerated). Legacy per-family names (exports, imports, restores,
+// thumbnails, token-cleanup) are accepted and mapped to their owning group;
+// each such mapping is returned in the second result so the caller can log it.
 //
 // Rules:
 //   - --workers-only and --workers-exclude are mutually exclusive; supplying
 //     both is an error.
-//   - --workers-only="" or --workers-only="all" selects every worker.
-//   - --workers-only="a,b" selects exactly those workers.
-//   - --workers-exclude="a,b" selects every worker except those listed.
-//   - Unknown identifiers produce an error that lists the valid values.
-func ParseSelector(only, exclude string) (Set, error) {
+//   - --workers-only="" or --workers-only="all" selects every group.
+//   - --workers-only="a,b" selects exactly those groups.
+//   - --workers-exclude="a,b" selects every group except those listed.
+//   - Unknown identifiers produce an error that lists the valid groups.
+func ParseSelector(only, exclude string) (Set, []DeprecatedAlias, error) {
 	only = strings.TrimSpace(only)
 	exclude = strings.TrimSpace(exclude)
 
 	if only != "" && exclude != "" {
-		return nil, errors.New("--workers-only and --workers-exclude are mutually exclusive")
+		return nil, nil, errors.New("--workers-only and --workers-exclude are mutually exclusive")
 	}
 
 	if only != "" {
 		if strings.EqualFold(only, selectorAll) {
-			return allSet(), nil
+			return allSet(), nil, nil
 		}
-		ids, err := parseIDList(only, "--workers-only")
+		ids, aliases, err := parseIDList(only, "--workers-only")
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return idsToSet(ids), nil
+		return idsToSet(ids), aliases, nil
 	}
 
 	if exclude != "" {
-		ids, err := parseIDList(exclude, "--workers-exclude")
+		ids, aliases, err := parseIDList(exclude, "--workers-exclude")
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		set := allSet()
 		for _, id := range ids {
 			delete(set, id)
 		}
-		return set, nil
+		return set, aliases, nil
 	}
 
-	return allSet(), nil
+	return allSet(), nil, nil
 }
 
-// allSet returns a fresh Set containing every canonical worker. The returned
-// map is owned by the caller and safe to mutate.
+// allSet returns a fresh Set containing every canonical worker group. The
+// returned map is owned by the caller and safe to mutate.
 func allSet() Set {
 	set := make(Set, len(allWorkerIDs))
 	for _, id := range allWorkerIDs {
@@ -139,23 +169,31 @@ func allSet() Set {
 }
 
 // parseIDList splits raw on commas, trims and lowercases each element,
-// validates it against the canonical list, and returns the parsed IDs. flag is
-// the human-readable flag name used in error messages.
-func parseIDList(raw, flag string) ([]WorkerID, error) {
+// resolves deprecated aliases to their owning group, validates the result
+// against the canonical list, and returns the parsed IDs together with the
+// list of deprecated identifiers that were encountered. flag is the
+// human-readable flag name used in error messages.
+func parseIDList(raw, flag string) ([]WorkerID, []DeprecatedAlias, error) {
 	parts := strings.Split(raw, ",")
 	out := make([]WorkerID, 0, len(parts))
+	var aliases []DeprecatedAlias
 	for _, p := range parts {
 		token := strings.ToLower(strings.TrimSpace(p))
 		if token == "" {
-			return nil, fmt.Errorf("%s: empty identifier in list %q", flag, raw)
+			return nil, nil, fmt.Errorf("%s: empty identifier in list %q", flag, raw)
+		}
+		if canonical, ok := deprecatedAliases[token]; ok {
+			aliases = append(aliases, DeprecatedAlias{Alias: token, Canonical: canonical})
+			out = append(out, canonical)
+			continue
 		}
 		id := WorkerID(token)
 		if !isKnownID(id) {
-			return nil, fmt.Errorf("%s: unknown worker %q (valid: %s)", flag, token, strings.Join(idStrings(), ", "))
+			return nil, nil, fmt.Errorf("%s: unknown worker %q (valid: %s)", flag, token, strings.Join(idStrings(), ", "))
 		}
 		out = append(out, id)
 	}
-	return out, nil
+	return out, aliases, nil
 }
 
 func isKnownID(id WorkerID) bool {

--- a/go/cmd/inventario/run/workers/selector_test.go
+++ b/go/cmd/inventario/run/workers/selector_test.go
@@ -12,9 +12,10 @@ import (
 func TestParseSelector_DefaultsToAll(t *testing.T) {
 	c := qt.New(t)
 
-	set, err := workers.ParseSelector("", "")
+	set, deprecated, err := workers.ParseSelector("", "")
 
 	c.Assert(err, qt.IsNil)
+	c.Assert(deprecated, qt.HasLen, 0)
 	c.Assert(set.Sorted(), qt.DeepEquals, workers.AllWorkerIDs())
 }
 
@@ -32,9 +33,10 @@ func TestParseSelector_ExplicitAllKeyword(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			set, err := workers.ParseSelector(tc.input, "")
+			set, deprecated, err := workers.ParseSelector(tc.input, "")
 
 			c.Assert(err, qt.IsNil)
+			c.Assert(deprecated, qt.HasLen, 0)
 			c.Assert(set.Sorted(), qt.DeepEquals, workers.AllWorkerIDs())
 		})
 	}
@@ -43,44 +45,45 @@ func TestParseSelector_ExplicitAllKeyword(t *testing.T) {
 func TestParseSelector_OnlySelectsSubset(t *testing.T) {
 	c := qt.New(t)
 
-	set, err := workers.ParseSelector("thumbnails,exports", "")
+	set, deprecated, err := workers.ParseSelector("media,archive", "")
 
 	c.Assert(err, qt.IsNil)
+	c.Assert(deprecated, qt.HasLen, 0)
 	c.Assert(set.Sorted(), qt.DeepEquals, []workers.WorkerID{
-		workers.WorkerExports,
-		workers.WorkerThumbnails,
+		workers.WorkerArchive,
+		workers.WorkerMedia,
 	})
 }
 
 func TestParseSelector_OnlyNormalizesCaseAndWhitespace(t *testing.T) {
 	c := qt.New(t)
 
-	set, err := workers.ParseSelector("  THUMBNAILS , Exports ", "")
+	set, deprecated, err := workers.ParseSelector("  MEDIA , Archive ", "")
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(set.Has(workers.WorkerExports), qt.IsTrue)
-	c.Assert(set.Has(workers.WorkerThumbnails), qt.IsTrue)
+	c.Assert(deprecated, qt.HasLen, 0)
+	c.Assert(set.Has(workers.WorkerArchive), qt.IsTrue)
+	c.Assert(set.Has(workers.WorkerMedia), qt.IsTrue)
 	c.Assert(set.Has(workers.WorkerEmails), qt.IsFalse)
 }
 
 func TestParseSelector_ExcludeDropsIDs(t *testing.T) {
 	c := qt.New(t)
 
-	set, err := workers.ParseSelector("", "emails,token-cleanup")
+	set, deprecated, err := workers.ParseSelector("", "emails,housekeeping")
 
 	c.Assert(err, qt.IsNil)
+	c.Assert(deprecated, qt.HasLen, 0)
 	c.Assert(set.Has(workers.WorkerEmails), qt.IsFalse)
-	c.Assert(set.Has(workers.WorkerTokenCleanup), qt.IsFalse)
-	c.Assert(set.Has(workers.WorkerExports), qt.IsTrue)
-	c.Assert(set.Has(workers.WorkerImports), qt.IsTrue)
-	c.Assert(set.Has(workers.WorkerRestores), qt.IsTrue)
-	c.Assert(set.Has(workers.WorkerThumbnails), qt.IsTrue)
+	c.Assert(set.Has(workers.WorkerHousekeeping), qt.IsFalse)
+	c.Assert(set.Has(workers.WorkerArchive), qt.IsTrue)
+	c.Assert(set.Has(workers.WorkerMedia), qt.IsTrue)
 }
 
 func TestParseSelector_MutuallyExclusive(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := workers.ParseSelector("thumbnails", "emails")
+	_, _, err := workers.ParseSelector("media", "emails")
 
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "mutually exclusive")
@@ -93,7 +96,7 @@ func TestParseSelector_UnknownIdentifier(t *testing.T) {
 		excl string
 		flag string
 	}{
-		{name: "unknown in --workers-only", only: "thumbnails,bogus", excl: "", flag: "--workers-only"},
+		{name: "unknown in --workers-only", only: "media,bogus", excl: "", flag: "--workers-only"},
 		{name: "unknown in --workers-exclude", only: "", excl: "bogus", flag: "--workers-exclude"},
 	}
 
@@ -101,7 +104,7 @@ func TestParseSelector_UnknownIdentifier(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			_, err := workers.ParseSelector(tc.only, tc.excl)
+			_, _, err := workers.ParseSelector(tc.only, tc.excl)
 
 			c.Assert(err, qt.IsNotNil)
 			c.Assert(err.Error(), qt.Contains, tc.flag)
@@ -113,7 +116,7 @@ func TestParseSelector_UnknownIdentifier(t *testing.T) {
 func TestParseSelector_EmptyIdentifierInList(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := workers.ParseSelector("thumbnails,,exports", "")
+	_, _, err := workers.ParseSelector("media,,archive", "")
 
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "empty identifier")
@@ -128,21 +131,74 @@ func TestParseSelector_ExcludingEveryIDProducesEmptySet(t *testing.T) {
 		excludeParts[i] = string(id)
 	}
 
-	set, err := workers.ParseSelector("", strings.Join(excludeParts, ","))
+	set, deprecated, err := workers.ParseSelector("", strings.Join(excludeParts, ","))
 
 	c.Assert(err, qt.IsNil)
+	c.Assert(deprecated, qt.HasLen, 0)
 	c.Assert(set, qt.HasLen, 0)
+}
+
+func TestParseSelector_LegacyAliasesMapToGroups(t *testing.T) {
+	cases := []struct {
+		name      string
+		only      string
+		wantGroup workers.WorkerID
+	}{
+		{name: "exports -> archive", only: "exports", wantGroup: workers.WorkerArchive},
+		{name: "imports -> archive", only: "imports", wantGroup: workers.WorkerArchive},
+		{name: "restores -> archive", only: "restores", wantGroup: workers.WorkerArchive},
+		{name: "thumbnails -> media", only: "thumbnails", wantGroup: workers.WorkerMedia},
+		{name: "token-cleanup -> housekeeping", only: "token-cleanup", wantGroup: workers.WorkerHousekeeping},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			set, deprecated, err := workers.ParseSelector(tc.only, "")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(set.Sorted(), qt.DeepEquals, []workers.WorkerID{tc.wantGroup})
+			c.Assert(deprecated, qt.HasLen, 1)
+			c.Assert(deprecated[0].Alias, qt.Equals, tc.only)
+			c.Assert(deprecated[0].Canonical, qt.Equals, tc.wantGroup)
+		})
+	}
+}
+
+func TestParseSelector_LegacyAliasesCollapseToSingleGroup(t *testing.T) {
+	c := qt.New(t)
+
+	set, deprecated, err := workers.ParseSelector("exports,imports,restores", "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(set.Sorted(), qt.DeepEquals, []workers.WorkerID{workers.WorkerArchive})
+	c.Assert(deprecated, qt.HasLen, 3)
+	for _, d := range deprecated {
+		c.Assert(d.Canonical, qt.Equals, workers.WorkerArchive)
+	}
+}
+
+func TestParseSelector_LegacyAliasesInExcludeAreReported(t *testing.T) {
+	c := qt.New(t)
+
+	set, deprecated, err := workers.ParseSelector("", "thumbnails,token-cleanup")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(set.Has(workers.WorkerMedia), qt.IsFalse)
+	c.Assert(set.Has(workers.WorkerHousekeeping), qt.IsFalse)
+	c.Assert(set.Has(workers.WorkerArchive), qt.IsTrue)
+	c.Assert(set.Has(workers.WorkerEmails), qt.IsTrue)
+	c.Assert(deprecated, qt.HasLen, 2)
 }
 
 func TestAllWorkerIDs_StableOrder(t *testing.T) {
 	c := qt.New(t)
 
 	c.Assert(workers.AllWorkerIDs(), qt.DeepEquals, []workers.WorkerID{
+		workers.WorkerArchive,
 		workers.WorkerEmails,
-		workers.WorkerExports,
-		workers.WorkerImports,
-		workers.WorkerRestores,
-		workers.WorkerThumbnails,
-		workers.WorkerTokenCleanup,
+		workers.WorkerHousekeeping,
+		workers.WorkerMedia,
 	})
 }

--- a/go/cmd/inventario/run/workers/workers.go
+++ b/go/cmd/inventario/run/workers/workers.go
@@ -36,23 +36,30 @@ func New(cfg *bootstrap.Config, dbConfig *shared.DatabaseConfig) *Command {
 		Use:     "workers",
 		Aliases: []string{"worker"},
 		Short:   "Start every background worker with an observability-only HTTP listener",
-		Long: `Start every background worker (export, import, restore, thumbnail generation,
-refresh token cleanup) together with the email delivery lifecycle, without
-opening the application HTTP listener.
+		Long: `Start every background worker group (archive, media, emails, housekeeping)
+without opening the application HTTP listener.
 
 This mode is intended for split deployments where the API server runs as a
 separate "inventario run apiserver" process. Email delivery workers only run
 here, so the API server can safely enqueue messages without producing
 duplicate deliveries.
 
+Groups bundle worker families that share an operational profile:
+  * archive       - exports, imports, restores (long-running, I/O + DB heavy)
+  * emails        - SMTP / provider-rate-limited delivery lifecycle
+  * housekeeping  - periodic maintenance (refresh token GC, and follow-ups)
+  * media         - CPU/RAM-heavy media processing (thumbnails)
+
 A minimal observability listener is started on --probe-addr exposing /healthz,
 /readyz and /metrics so Kubernetes liveness/readiness probes and Prometheus
 scrapes work uniformly across "run apiserver" and "run workers" deployments.
 
-Use --workers-only or --workers-exclude to isolate a subset of workers onto a
-dedicated pod/host. Valid worker identifiers: exports, imports, restores,
-thumbnails, emails, token-cleanup. "--workers-only=all" is an explicit synonym
-for the default (every worker). The two flags are mutually exclusive.`,
+Use --workers-only or --workers-exclude to isolate a subset of groups onto a
+dedicated pod/host. Valid group identifiers: archive, emails, housekeeping,
+media. Legacy per-family names (exports, imports, restores, thumbnails,
+token-cleanup) are accepted for one release and mapped to their owning group
+with a deprecation warning. "--workers-only=all" is an explicit synonym for
+the default (every group). The two flags are mutually exclusive.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return c.run()
 		},
@@ -66,23 +73,46 @@ for the default (every worker). The two flags are mutually exclusive.`,
 func (c *Command) registerFlags() {
 	flags := c.Cmd().Flags()
 	flags.StringVar(&c.cfg.WorkersOnly, "workers-only", c.cfg.WorkersOnly,
-		"Comma-separated list of worker identifiers to run exclusively (e.g., thumbnails,exports). "+
-			"Use \"all\" or leave empty to run every worker. Mutually exclusive with --workers-exclude.")
+		"Comma-separated list of worker-group identifiers to run exclusively "+
+			"(e.g., media,archive). Valid groups: archive, emails, housekeeping, media. "+
+			"Legacy family names (exports, imports, restores, thumbnails, token-cleanup) "+
+			"are accepted with a deprecation warning. Use \"all\" or leave empty to run "+
+			"every group. Mutually exclusive with --workers-exclude.")
 	flags.StringVar(&c.cfg.WorkersExclude, "workers-exclude", c.cfg.WorkersExclude,
-		"Comma-separated list of worker identifiers to skip (e.g., emails). "+
+		"Comma-separated list of worker-group identifiers to skip (e.g., emails). "+
 			"Mutually exclusive with --workers-only.")
 	flags.StringVar(&c.cfg.ProbeAddr, "probe-addr", c.cfg.ProbeAddr,
 		"Bind address for the workers' probe listener that serves /healthz, /readyz and /metrics.")
 }
 
-// run starts the subset of background workers selected by --workers-only /
-// --workers-exclude (all six by default) without opening the HTTP listener. It
-// blocks until the process receives SIGINT or SIGTERM.
+// starter is the shared shape every bootstrap.Start* helper reduces to after
+// wrapping. It returns a stop function that the run loop pushes onto a LIFO
+// shutdown stack.
+type starter func(context.Context, *bootstrap.RuntimeSetup, *bootstrap.Config) func()
+
+// group bundles one or more starters under a single operational group id.
+// Members of a group share a process, a DB/Redis connection pool, and a
+// Deployment when running in split mode; see the Long description on the
+// workers subcommand for the operational profile each group targets.
+type group struct {
+	id       WorkerID
+	starters []starter
+}
+
+// run starts the worker groups selected by --workers-only / --workers-exclude
+// (all four by default) without opening the HTTP listener. It blocks until
+// the process receives SIGINT or SIGTERM.
 func (c *Command) run() error {
-	selected, err := ParseSelector(c.cfg.WorkersOnly, c.cfg.WorkersExclude)
+	selected, deprecated, err := ParseSelector(c.cfg.WorkersOnly, c.cfg.WorkersExclude)
 	if err != nil {
 		slog.Error("Invalid worker selector", "error", err)
 		return err
+	}
+	for _, d := range deprecated {
+		slog.Warn("Worker identifier is deprecated; update --workers-only/--workers-exclude to the group name",
+			"alias", d.Alias,
+			"canonical", string(d.Canonical),
+		)
 	}
 	if len(selected) == 0 {
 		return errors.New("worker selector resolved to an empty set; nothing to run")
@@ -97,35 +127,36 @@ func (c *Command) run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Worker start order matches the historical `run all` / `run workers`
-	// sequence so LIFO shutdown is unchanged for the default (all-workers) case.
-	starters := []struct {
-		id    WorkerID
-		start func(context.Context, *bootstrap.RuntimeSetup, *bootstrap.Config) func()
-	}{
-		{WorkerEmails, bootstrap.StartEmailLifecycle},
-		{WorkerExports, bootstrap.StartExportWorker},
-		{WorkerRestores, func(ctx context.Context, rs *bootstrap.RuntimeSetup, cfg *bootstrap.Config) func() {
-			_, stop := bootstrap.StartRestoreWorker(ctx, rs, cfg)
-			return stop
+	// Group and starter order matches the historical `run all` / `run workers`
+	// sequence so LIFO shutdown is unchanged for the default (all-groups) case.
+	groups := []group{
+		{WorkerEmails, []starter{bootstrap.StartEmailLifecycle}},
+		{WorkerArchive, []starter{
+			bootstrap.StartExportWorker,
+			func(ctx context.Context, rs *bootstrap.RuntimeSetup, cfg *bootstrap.Config) func() {
+				_, stop := bootstrap.StartRestoreWorker(ctx, rs, cfg)
+				return stop
+			},
+			bootstrap.StartImportWorker,
 		}},
-		{WorkerImports, bootstrap.StartImportWorker},
-		{WorkerThumbnails, bootstrap.StartThumbnailWorker},
-		{WorkerTokenCleanup, bootstrap.StartRefreshTokenCleanupWorker},
+		{WorkerMedia, []starter{bootstrap.StartThumbnailWorker}},
+		{WorkerHousekeeping, []starter{bootstrap.StartRefreshTokenCleanupWorker}},
 	}
 
-	stops := make([]func(), 0, len(starters))
+	stops := make([]func(), 0, 8)
 	defer func() {
 		// LIFO shutdown to mirror the deferred-stop ordering of `run all`.
 		for i := len(stops) - 1; i >= 0; i-- {
 			stops[i]()
 		}
 	}()
-	for _, s := range starters {
-		if !selected.Has(s.id) {
+	for _, g := range groups {
+		if !selected.Has(g.id) {
 			continue
 		}
-		stops = append(stops, s.start(ctx, rs, c.cfg))
+		for _, start := range g.starters {
+			stops = append(stops, start(ctx, rs, c.cfg))
+		}
 	}
 
 	active := selected.Sorted()

--- a/helm/inventario/README.md
+++ b/helm/inventario/README.md
@@ -75,7 +75,16 @@ Demo notes:
 
 ## Split deployment mode
 
-Split mode renders one Deployment per role so the API server and each background worker can scale, schedule, and auto-scale independently. Enable it by turning off the combined Deployment and turning on the roles you need:
+Split mode renders one Deployment per worker group so the API server and each group can scale, schedule, and auto-scale independently. Worker groups consolidate individual families that share an operational profile:
+
+| Group | Members | Scales on |
+| --- | --- | --- |
+| `archive` | exports, imports, restores | archive-queue depth |
+| `emails` | email delivery lifecycle | SMTP / provider rate |
+| `housekeeping` | refresh-token GC (and future periodic cleanup loops) | n/a — periodic |
+| `media` | thumbnails (future resize / OCR) | media-queue depth / CPU |
+
+Enable split mode by turning off the combined Deployment and turning on the groups you need:
 
 ```yaml
 run:
@@ -84,35 +93,31 @@ run:
   apiserver:
     enabled: true
   workers:
-    thumbnails:
-      enabled: true
-    exports:
-      enabled: true
-    imports:
-      enabled: true
-    restores:
+    archive:
       enabled: true
     emails:
       enabled: true
-    tokenCleanup:
+    housekeeping:
+      enabled: true
+    media:
       enabled: true
 ```
 
-Each enabled worker role renders:
+Each enabled worker group renders:
 
-- a `Deployment` named `<release>-<chart>-worker-<cli-id>` running `run workers --workers-only=<cli-id> --probe-addr=:<probePort>`;
+- a `Deployment` named `<release>-<chart>-worker-<group>` running `run workers --workers-only=<group> --probe-addr=:<probePort>`;
 - a headless `Service` on the probe port so Prometheus (or a `ServiceMonitor`) can discover the pods and scrape `/metrics`.
 
 `run.all.enabled` and any split role are **mutually exclusive**. The chart fails the render with a clear error if both are enabled, or if neither is.
 
-Per-role values deep-merge over `run.workers.common`. Typical overrides are `replicaCount`, `resources`, `nodeSelector`, `tolerations`, and `autoscaling`.
+Per-group values deep-merge over `run.workers.common`. Typical overrides are `replicaCount`, `resources`, `nodeSelector`, `tolerations`, and `autoscaling`.
 
 Split mode notes:
 
 - **Shared uploads**: when `app.uploadLocation` stays on `file://` and `persistence.enabled=true`, every role pod mounts the same uploads PVC. This requires an `accessMode` that allows multi-pod use (for example `ReadWriteMany`). For single-node clusters, ReadWriteOnce works only if every pod is scheduled on the same node. Object storage (`s3://`, `azblob://`, `gs://`) avoids the multi-pod PVC constraint entirely.
-- **Restores scaling**: each `run.workers.restores` replica enforces its own `app.maxConcurrentRestores` limit, so cluster-wide concurrency equals `replicaCount × maxConcurrentRestores`. Database-level job locking prevents duplicate work, but keep `replicaCount=1` unless your DB can sustain the multiplied load.
-- **CLI identifiers**: the Helm key `tokenCleanup` maps to the CLI flag value `token-cleanup`. All other role keys match the CLI flag value as-is.
-- **Autoscaling**: set `<role>.autoscaling.enabled=true` to render a `HorizontalPodAutoscaler` targeting the matching Deployment. CPU utilization is the default metric; extend via `<role>.autoscaling.metrics` and `<role>.autoscaling.behavior`.
+- **Archive scaling**: each `run.workers.archive` replica enforces its own `app.maxConcurrentRestores` (and export/import) limits, so cluster-wide concurrency equals `replicaCount × maxConcurrent` per family. Database-level job locking prevents duplicate work, but keep `replicaCount=1` unless your DB can sustain the multiplied load.
+- **CLI identifiers**: group keys match the `--workers-only` flag value exactly. Legacy per-family names (`exports`, `imports`, `restores`, `thumbnails`, `token-cleanup`) remain accepted on the CLI for one release with a deprecation warning; the Helm values surface only the group keys.
+- **Autoscaling**: set `<group>.autoscaling.enabled=true` to render a `HorizontalPodAutoscaler` targeting the matching Deployment. CPU utilization is the default metric; extend via `<group>.autoscaling.metrics` and `<group>.autoscaling.behavior`.
 
 Example split install using external services:
 
@@ -125,12 +130,10 @@ helm upgrade --install inventario ./helm/inventario \
   --set-string setupJob.initData.adminPassword='replace-me' \
   --set run.all.enabled=false \
   --set run.apiserver.enabled=true \
-  --set run.workers.thumbnails.enabled=true \
-  --set run.workers.exports.enabled=true \
-  --set run.workers.imports.enabled=true \
-  --set run.workers.restores.enabled=true \
+  --set run.workers.archive.enabled=true \
   --set run.workers.emails.enabled=true \
-  --set run.workers.tokenCleanup.enabled=true
+  --set run.workers.housekeeping.enabled=true \
+  --set run.workers.media.enabled=true
 ```
 
 ## Secret handling
@@ -179,10 +182,10 @@ For the complete default surface, see `helm/inventario/values.yaml`.
 | `run.apiserver.enabled` | `false` | Enable to render the standalone API-server Deployment in split mode. |
 | `run.apiserver.replicaCount` | `1` | Scale the API tier independently of workers. |
 | `run.apiserver.autoscaling.enabled` | `false` | Enable to emit an HPA for the API-server Deployment. |
-| `run.workers.common.*` | see `values.yaml` | Shared defaults deep-merged into each per-role worker block. |
-| `run.workers.<role>.enabled` | `false` | Turn on a worker Deployment for the given role (`thumbnails`, `exports`, `imports`, `restores`, `emails`, `tokenCleanup`). |
-| `run.workers.<role>.replicaCount` | `1` | Scale the worker pool for the given role. Review caveats for `restores`. |
-| `run.workers.<role>.autoscaling.enabled` | `false` | Enable to emit an HPA for the given worker role. |
+| `run.workers.common.*` | see `values.yaml` | Shared defaults deep-merged into each per-group worker block. |
+| `run.workers.<group>.enabled` | `false` | Turn on a worker Deployment for the given group (`archive`, `emails`, `housekeeping`, `media`). |
+| `run.workers.<group>.replicaCount` | `1` | Scale the worker pool for the given group. Review caveats for `archive`. |
+| `run.workers.<group>.autoscaling.enabled` | `false` | Enable to emit an HPA for the given worker group. |
 | `service.type` | `ClusterIP` | Change for NodePort/LoadBalancer exposure. |
 | `ingress.enabled` | `false` | Enable public ingress routing. |
 | `ingress.hosts` / `ingress.tls` | example host / empty | Set your real hostname and TLS secret(s). |
@@ -212,6 +215,13 @@ For the complete default surface, see `helm/inventario/values.yaml`.
 - The setup hook re-runs on upgrades to keep bootstrap/migrations safe and idempotent.
 - Demo bucket creation is a `post-install,post-upgrade` hook.
 - Demo database seeding is skipped on upgrades even if `setupJob.initData.seedDatabase=true`.
+- **Worker roles consolidated (breaking values change)**: `run.workers.{thumbnails,exports,imports,restores,emails,tokenCleanup}` have been replaced by the four groups `run.workers.{archive,emails,housekeeping,media}`. Rename values before upgrading:
+  - `run.workers.thumbnails` → `run.workers.media`
+  - `run.workers.{exports,imports,restores}` → single `run.workers.archive`
+  - `run.workers.tokenCleanup` → `run.workers.housekeeping`
+  - `run.workers.emails` unchanged
+
+  The CLI `--workers-only` / `--workers-exclude` flags still accept the old family names (`exports`, `imports`, `restores`, `thumbnails`, `token-cleanup`) for one release and log a deprecation warning; Helm values surface only the group keys.
 
 ## Validation
 
@@ -236,7 +246,7 @@ helm template inventario helm/inventario/ \
   --set demo.minio.enabled=true \
   --set setupJob.initData.adminPassword=demo-secret
 
-# Split mode render (apiserver + all workers).
+# Split mode render (apiserver + all worker groups).
 helm template inventario helm/inventario/ \
   --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
   --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
@@ -244,12 +254,10 @@ helm template inventario helm/inventario/ \
   --set setupJob.initData.adminPassword=test \
   --set run.all.enabled=false \
   --set run.apiserver.enabled=true \
-  --set run.workers.thumbnails.enabled=true \
-  --set run.workers.exports.enabled=true \
-  --set run.workers.imports.enabled=true \
-  --set run.workers.restores.enabled=true \
+  --set run.workers.archive.enabled=true \
   --set run.workers.emails.enabled=true \
-  --set run.workers.tokenCleanup.enabled=true
+  --set run.workers.housekeeping.enabled=true \
+  --set run.workers.media.enabled=true
 
 # Mutual exclusion guard (expected to fail).
 if helm template inventario helm/inventario/ \

--- a/helm/inventario/README.md
+++ b/helm/inventario/README.md
@@ -8,7 +8,7 @@ This chart lives at `helm/inventario/` and deploys Inventario in two supported m
 Each mode additionally supports two **run topologies**:
 
 - **Combined** (default): one Deployment runs `inventario run all`, serving both the HTTP API and every background worker (`run.all.enabled=true`).
-- **Split**: one Deployment per role (`run.apiserver` + zero or more `run.workers.<role>`) so each subsystem can be sized and scaled independently. See [Split deployment mode](#split-deployment-mode).
+- **Split**: one Deployment per worker group (`run.apiserver` + zero or more `run.workers.<group>`) so each subsystem can be sized and scaled independently. See [Split deployment mode](#split-deployment-mode).
 
 The chart source of truth is `helm/inventario/values.yaml` plus the templates in `helm/inventario/templates/`. `values.yaml` contains the complete default surface with inline comments; this README focuses on the install paths and the values you normally need to change.
 

--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -31,26 +31,25 @@ app.kubernetes.io/component: web
 {{- end -}}
 
 {{/*
-Canonical, stable-ordered list of worker role keys. Each entry must
-match both a run.workers.<key> values block and exactly one worker
-identifier accepted by `run workers --workers-only=<cli-id>`.
+Canonical, stable-ordered list of worker group keys. Each entry must
+match both a run.workers.<key> values block and exactly one worker-group
+identifier accepted by `run workers --workers-only=<cli-id>`. Groups
+consolidate individual worker families sharing an operational profile;
+see go/cmd/inventario/run/workers/selector.go for composition.
 */}}
 {{- define "inventario.workerRoles" -}}
-thumbnails exports imports restores emails tokenCleanup
+archive emails housekeeping media
 {{- end -}}
 
 {{/*
 Translate a role key (as it appears in values.run.workers.*) to the
-CLI identifier accepted by `--workers-only`. The only irregular case
-today is tokenCleanup -> token-cleanup.
-Usage: include "inventario.workerCliId" "tokenCleanup"
+CLI identifier accepted by `--workers-only`. Group ids are already
+CLI-shaped, so this is an identity mapping kept as a helper in case
+future aliases are needed.
+Usage: include "inventario.workerCliId" "housekeeping"
 */}}
 {{- define "inventario.workerCliId" -}}
-{{- if eq . "tokenCleanup" -}}
-token-cleanup
-{{- else -}}
 {{ . }}
-{{- end -}}
 {{- end -}}
 
 {{/*
@@ -90,7 +89,7 @@ Resource name suffix for the API-server split Deployment.
 
 {{/*
 Resource name suffix for a per-role worker Deployment.
-Usage: include "inventario.workerName" (dict "root" . "role" "thumbnails")
+Usage: include "inventario.workerName" (dict "root" . "role" "media")
 */}}
 {{- define "inventario.workerName" -}}
 {{- $cli := include "inventario.workerCliId" .role -}}
@@ -115,7 +114,7 @@ app.kubernetes.io/component: apiserver
 
 {{/*
 Component selector labels for a worker Deployment.
-Usage: include "inventario.workerSelectorLabels" (dict "root" . "role" "thumbnails")
+Usage: include "inventario.workerSelectorLabels" (dict "root" . "role" "media")
 */}}
 {{- define "inventario.workerSelectorLabels" -}}
 {{- $cli := include "inventario.workerCliId" .role -}}
@@ -127,7 +126,7 @@ app.kubernetes.io/component: {{ printf "worker-%s" $cli }}
 Deep-merge the role-specific worker values block over run.workers.common.
 Returns the merged dict. The caller is expected to deepCopy the result
 before mutating.
-Usage: $cfg := include "inventario.workerConfig" (dict "root" . "role" "thumbnails") | fromYaml
+Usage: $cfg := include "inventario.workerConfig" (dict "root" . "role" "media") | fromYaml
 (or use a with-$ pattern when only selected fields are read).
 */}}
 {{- define "inventario.workerConfig" -}}

--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -42,10 +42,10 @@ archive emails housekeeping media
 {{- end -}}
 
 {{/*
-Translate a role key (as it appears in values.run.workers.*) to the
-CLI identifier accepted by `--workers-only`. Group ids are already
-CLI-shaped, so this is an identity mapping kept as a helper in case
-future aliases are needed.
+Translate a worker-group key (as it appears in values.run.workers.*)
+to the CLI identifier accepted by `--workers-only`. Group ids are
+already CLI-shaped, so this is an identity mapping kept as a helper
+in case future aliases are needed.
 Usage: include "inventario.workerCliId" "housekeeping"
 */}}
 {{- define "inventario.workerCliId" -}}
@@ -73,10 +73,10 @@ neither mode is active.
 {{- $all := .Values.run.all.enabled -}}
 {{- $split := eq (include "inventario.splitEnabled" .) "true" -}}
 {{- if and $all $split -}}
-{{- fail "run.all.enabled and split roles (run.apiserver or run.workers.<role>) are mutually exclusive. Set run.all.enabled=false when using split Deployments." -}}
+{{- fail "run.all.enabled and split roles (run.apiserver or run.workers.<group>) are mutually exclusive. Set run.all.enabled=false when using split Deployments." -}}
 {{- end -}}
 {{- if not (or $all $split) -}}
-{{- fail "No run topology is active. Enable run.all (combined) or run.apiserver together with at least one run.workers.<role>.enabled=true (split)." -}}
+{{- fail "No run topology is active. Enable run.all (combined) or run.apiserver together with at least one run.workers.<group>.enabled=true (split)." -}}
 {{- end -}}
 {{- end -}}
 
@@ -88,7 +88,7 @@ Resource name suffix for the API-server split Deployment.
 {{- end -}}
 
 {{/*
-Resource name suffix for a per-role worker Deployment.
+Resource name suffix for a per-worker-group Deployment.
 Usage: include "inventario.workerName" (dict "root" . "role" "media")
 */}}
 {{- define "inventario.workerName" -}}

--- a/helm/inventario/templates/hpa.yaml
+++ b/helm/inventario/templates/hpa.yaml
@@ -1,8 +1,8 @@
 {{/*
-HorizontalPodAutoscaler stubs. One HPA per enabled role with
-autoscaling.enabled=true. Default metric is CPU; callers may
-extend via <role>.autoscaling.metrics (external or resource) and
-<role>.autoscaling.behavior.
+HorizontalPodAutoscaler stubs. One HPA per enabled worker group
+(or apiserver) with autoscaling.enabled=true. Default metric is
+CPU; callers may extend via <group>.autoscaling.metrics (external
+or resource) and <group>.autoscaling.behavior.
 */}}
 {{- $root := . -}}
 

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -17,15 +17,16 @@ image:
 # Run topology
 # ============================================================
 # Controls whether Inventario runs as one combined Deployment
-# (`inventario run all`, the default) or as per-role Deployments
-# (`run apiserver` + one or more `run workers --workers-only=<id>`).
+# (`inventario run all`, the default) or as per-worker-group
+# Deployments (`run apiserver` + one or more
+# `run workers --workers-only=<group>`).
 #
 # Exactly ONE of the following must be active:
 #   * run.all.enabled=true                (single Deployment)
 #   * run.apiserver.enabled=true AND at least one
-#     run.workers.<role>.enabled=true     (split Deployments)
+#     run.workers.<group>.enabled=true    (split Deployments)
 #
-# Enabling run.all together with any split role is rejected at
+# Enabling run.all together with any split group is rejected at
 # template time.
 #
 # Per-role blocks (apiserver + each worker) deep-merge over the
@@ -100,7 +101,7 @@ run:
 
   # ----------------------------------------------------------
   # API-server-only mode (run apiserver). Pair with at least one
-  # run.workers.<role>.enabled=true to get a working split
+  # run.workers.<group>.enabled=true to get a working split
   # deployment.
   # ----------------------------------------------------------
   apiserver:
@@ -162,7 +163,7 @@ run:
   # for one release with a deprecation warning.
   # ----------------------------------------------------------
   workers:
-    # Shared defaults. Each per-role block deep-merges over these.
+    # Shared defaults. Each per-group block deep-merges over these.
     common:
       # Probe/metrics listener port inside the worker container.
       # Passed to workers as --probe-addr=:<probePort>.

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -91,7 +91,7 @@ run:
       #         name: inventario_jobs_pending
       #         selector:
       #           matchLabels:
-      #             worker: thumbnails
+      #             worker: media
       #       target:
       #         type: AverageValue
       #         averageValue: "5"
@@ -147,11 +147,19 @@ run:
       behavior: {}
 
   # ----------------------------------------------------------
-  # Per-worker Deployments. Each worker role renders its own
+  # Per-worker-group Deployments. Each group renders its own
   # Deployment + headless Service (probe/metrics) when enabled.
+  # Groups consolidate individual worker families sharing an
+  # operational profile:
+  #   archive       - exports, imports, restores
+  #   emails        - SMTP delivery lifecycle
+  #   housekeeping  - periodic maintenance (refresh-token GC, …)
+  #   media         - thumbnails (CPU/RAM-heavy)
   #
-  # CLI identifiers (passed to `run workers --workers-only=<id>`):
-  #   thumbnails, exports, imports, restores, emails, token-cleanup
+  # CLI identifiers (passed to `run workers --workers-only=<id>`)
+  # match the keys below. Legacy per-family names (exports, imports,
+  # restores, thumbnails, token-cleanup) are still accepted on the CLI
+  # for one release with a deprecation warning.
   # ----------------------------------------------------------
   workers:
     # Shared defaults. Each per-role block deep-merges over these.
@@ -199,11 +207,34 @@ run:
         metrics: []
         behavior: {}
 
-    # Per-role overrides. Each block may override any key from
+    # Per-group overrides. Each block may override any key from
     # run.workers.common. Enable the Deployment with `enabled: true`.
-    thumbnails:
+    archive:
+      # Bundles exports, imports, and restores. They share the archive
+      # code path and a single queue-depth scaling signal.
+      # NOTE: Each replica enforces its own app.maxConcurrentRestores
+      # (and export/import) limit. Cluster-wide concurrency =
+      # replicaCount * maxConcurrent per family. DB-level job locking
+      # prevents duplicate work, but keep replicaCount=1 unless your DB
+      # sizing supports the multiplied concurrency.
       enabled: false
-      # Thumbnail generation is CPU/memory-heavy — bump defaults.
+    emails:
+      enabled: false
+    housekeeping:
+      # Periodic maintenance (refresh-token GC, and follow-up cleanup
+      # loops). Replica count should stay at 1; the group is tiny.
+      enabled: false
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 200m
+          memory: 128Mi
+    media:
+      # Thumbnail generation (and future resize/OCR) is CPU/memory-heavy
+      # — bump defaults over run.workers.common.
+      enabled: false
       resources:
         requests:
           cpu: 250m
@@ -211,21 +242,6 @@ run:
         limits:
           cpu: 1000m
           memory: 1Gi
-    exports:
-      enabled: false
-    imports:
-      enabled: false
-    restores:
-      # NOTE: Each replica enforces its own app.maxConcurrentRestores
-      # limit. Cluster-wide concurrency = replicaCount * maxConcurrent.
-      # DB-level job locking prevents duplicate work, but keep
-      # replicaCount=1 unless your DB sizing supports the multiplied
-      # concurrency.
-      enabled: false
-    emails:
-      enabled: false
-    tokenCleanup:
-      enabled: false
 
 # ============================================================
 # Service (targets the apiserver endpoint — run.all or run.apiserver).


### PR DESCRIPTION
Closes #1311.

Replaces the six per-family workers (`thumbnails`, `exports`, `imports`, `restores`, `emails`, `token-cleanup`) with four operational groups consolidating workers that share an operational profile:

| Group | Members | Scales on |
|---|---|---|
| `archive` | exports, imports, restores | archive-queue depth |
| `emails` | SMTP delivery lifecycle | provider rate |
| `housekeeping` | refresh-token GC (+ future periodic cleanups, incl. #1309) | n/a — periodic |
| `media` | thumbnails (+ future resize / OCR) | media-queue depth / CPU |

## Changes

### Go (`go/cmd/inventario/run/workers/`)
- `selector.go`: new canonical `WorkerID` constants (`archive`, `emails`, `housekeeping`, `media`), `resolveAliases` layer mapping legacy names to the new groups with `slog.Warn` deprecation notices, updated `AllWorkerIDs` / help strings.
- `workers.go`: starters grouped per canonical id — one group can start multiple independent worker loops (e.g., `archive` brings up export/import/restore together). CLI long description and flag help rewritten.
- `selector_test.go`: rewritten for the new group ids, new coverage for alias deprecation paths.

### Helm (`helm/inventario/`)
- `templates/_helpers.tpl`: `inventario.workerRoles` → `archive emails housekeeping media`; legacy `tokenCleanup → token-cleanup` special case dropped (group ids are already CLI-shaped, `workerCliId` is now identity).
- `values.yaml`: six per-family blocks replaced by four group blocks. `housekeeping` gets light defaults (50m/64Mi requests), `media` keeps heavy defaults (250m/256Mi requests, 1000m/1Gi limits), `archive` carries the former restores concurrency caveat.
- `README.md`: new group table, updated split-mode examples and config table, breaking-change upgrade note with explicit `old → new` mapping.

### CI
- `.github/workflows/helm-lint.yml`: split-mode render steps switched to group names (`archive`, `emails`, `housekeeping`, `media`).

## Backwards compatibility

Legacy CLI names (`--workers-only=thumbnails|exports|imports|restores|token-cleanup`) still resolve for **one release** with a `slog.Warn` deprecation notice. Helm values surface only the group keys — `run.workers.{thumbnails,exports,imports,restores,tokenCleanup}` are gone.

### Upgrade mapping for operators

```yaml
# before
run.workers.thumbnails          → run.workers.media
run.workers.{exports,imports,restores}  → run.workers.archive  (single Deployment)
run.workers.tokenCleanup        → run.workers.housekeeping
run.workers.emails              → run.workers.emails            (unchanged key)
```

Also documented in `helm/inventario/README.md` under *Upgrade notes*.

## Verification

- `go build ./...` — clean.
- `go test ./cmd/inventario/run/...` — green.
- `golangci-lint run ./cmd/inventario/run/...` — 0 issues.
- `helm lint helm/inventario ...` — green.
- `helm template ... --set run.apiserver.enabled=true --set run.workers.{archive,emails,housekeeping,media}.enabled=true` renders exactly 4 worker `Deployment`s + 4 `Service`s, each with `args: [workers, --workers-only=<group>, --probe-addr=:3334]`.

## Unblocks

- #1309 — purge loop for `pending_deletion` location groups now lands inside `housekeeping` (no new CLI id, no new Helm role).