### PR TITLE
feat(groups): add group purge housekeeping worker (#1309)

### DIFF
--- a/.augment/rules/inventario-base.md
+++ b/.augment/rules/inventario-base.md
@@ -25,5 +25,9 @@ type: "always_apply"
 - Maintain consistency in coding style, naming conventions, and architectural patterns throughout the codebase.
 - For any newly written Go code, proactively suggest writing corresponding unit tests when it makes logical sense (skip trivial getters/setters or simple data structures).
 
+# Git Operations
+- Always use the MCP git tools (`git_status`, `git_add`, `git_commit`, `git_push`, `git_pull`, `git_diff`, `git_diff_staged`, `git_diff_unstaged`, `git_log`, `git_show`, `git_checkout`, `git_create_branch`, `git_apply_patch_string`, etc.) for repository operations. Do NOT run `git` through `launch-process` for these.
+- Only fall back to `launch-process` with raw `git` when the operation cannot be expressed via the MCP tools (e.g., `git stash`, `git fetch`, interactive rebase, complex pipelines), and call out the fallback explicitly.
+
 # Additional information
 Refer to .github/copilot-instructions.md and CLAUDE.md for additional instructions

--- a/go/cmd/inventario/run/all/all.go
+++ b/go/cmd/inventario/run/all/all.go
@@ -79,6 +79,9 @@ func (c *Command) run() error {
 	stopRefreshTokenCleanup := bootstrap.StartRefreshTokenCleanupWorker(ctx, rs, c.cfg)
 	defer stopRefreshTokenCleanup()
 
+	stopGroupPurge := bootstrap.StartGroupPurgeWorker(ctx, rs, c.cfg)
+	defer stopGroupPurge()
+
 	srv, errCh := bootstrap.StartAPIServer(c.cfg, rs, restoreWorker)
 	return bootstrap.WaitForShutdown(srv, errCh)
 }

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	ImportPollInterval            string `yaml:"import_poll_interval" env:"IMPORT_POLL_INTERVAL" env-default:""`
 	RestorePollInterval           string `yaml:"restore_poll_interval" env:"RESTORE_POLL_INTERVAL" env-default:""`
 	RefreshTokenCleanupInterval   string `yaml:"refresh_token_cleanup_interval" env:"REFRESH_TOKEN_CLEANUP_INTERVAL" env-default:""`
+	GroupPurgeInterval            string `yaml:"group_purge_interval" env:"GROUP_PURGE_INTERVAL" env-default:""`
 	JWTSecret                     string `yaml:"jwt_secret" env:"JWT_SECRET" env-default:""`
 	FileSigningKey                string `yaml:"file_signing_key" env:"FILE_SIGNING_KEY" env-default:""`
 	FileURLExpiration             string `yaml:"file_url_expiration" env:"FILE_URL_EXPIRATION" env-default:"15m"`
@@ -140,6 +141,9 @@ func (c *Config) setWorkerDefaults() {
 	}
 	if c.RefreshTokenCleanupInterval == "" {
 		c.RefreshTokenCleanupInterval = defaults.GetRefreshTokenCleanupInterval()
+	}
+	if c.GroupPurgeInterval == "" {
+		c.GroupPurgeInterval = defaults.GetGroupPurgeInterval()
 	}
 }
 

--- a/go/cmd/inventario/run/bootstrap/durations.go
+++ b/go/cmd/inventario/run/bootstrap/durations.go
@@ -15,6 +15,7 @@ type WorkerDurations struct {
 	ImportPollInterval          time.Duration
 	RestorePollInterval         time.Duration
 	RefreshTokenCleanupInterval time.Duration
+	GroupPurgeInterval          time.Duration
 	ThumbnailPollInterval       time.Duration
 	ThumbnailCleanupInterval    time.Duration
 	ThumbnailJobRetentionPeriod time.Duration
@@ -50,6 +51,7 @@ func ParseWorkerDurations(cfg *Config) (WorkerDurations, error) {
 		{"import-poll-interval", cfg.ImportPollInterval, &out.ImportPollInterval},
 		{"restore-poll-interval", cfg.RestorePollInterval, &out.RestorePollInterval},
 		{"refresh-token-cleanup-interval", cfg.RefreshTokenCleanupInterval, &out.RefreshTokenCleanupInterval},
+		{"group-purge-interval", cfg.GroupPurgeInterval, &out.GroupPurgeInterval},
 		{"thumbnail-poll-interval", cfg.ThumbnailPollInterval, &out.ThumbnailPollInterval},
 		{"thumbnail-cleanup-interval", cfg.ThumbnailCleanupInterval, &out.ThumbnailCleanupInterval},
 		{"thumbnail-job-retention-period", cfg.ThumbnailJobRetentionPeriod, &out.ThumbnailJobRetentionPeriod},

--- a/go/cmd/inventario/run/bootstrap/durations_test.go
+++ b/go/cmd/inventario/run/bootstrap/durations_test.go
@@ -17,6 +17,7 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 		ImportPollInterval:          "12s",
 		RestorePollInterval:         "13s",
 		RefreshTokenCleanupInterval: "2h",
+		GroupPurgeInterval:          "7m",
 		ThumbnailPollInterval:       "7s",
 		ThumbnailCleanupInterval:    "6m",
 		ThumbnailJobRetentionPeriod: "48h",
@@ -30,6 +31,7 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 	c.Assert(got.ImportPollInterval, qt.Equals, 12*time.Second)
 	c.Assert(got.RestorePollInterval, qt.Equals, 13*time.Second)
 	c.Assert(got.RefreshTokenCleanupInterval, qt.Equals, 2*time.Hour)
+	c.Assert(got.GroupPurgeInterval, qt.Equals, 7*time.Minute)
 	c.Assert(got.ThumbnailPollInterval, qt.Equals, 7*time.Second)
 	c.Assert(got.ThumbnailCleanupInterval, qt.Equals, 6*time.Minute)
 	c.Assert(got.ThumbnailJobRetentionPeriod, qt.Equals, 48*time.Hour)

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -26,6 +26,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags.StringVar(&cfg.ImportPollInterval, "import-poll-interval", cfg.ImportPollInterval, "Import worker poll interval (e.g., 10s, 30s)")
 	flags.StringVar(&cfg.RestorePollInterval, "restore-poll-interval", cfg.RestorePollInterval, "Restore worker poll interval (e.g., 10s, 30s)")
 	flags.StringVar(&cfg.RefreshTokenCleanupInterval, "refresh-token-cleanup-interval", cfg.RefreshTokenCleanupInterval, "Interval between refresh token cleanup runs (e.g., 1h, 30m)")
+	flags.StringVar(&cfg.GroupPurgeInterval, "group-purge-interval", cfg.GroupPurgeInterval, "Interval between group purge sweeps (hard-deletes pending_deletion groups and expired unused invites; e.g., 5m, 15m)")
 	flags.IntVar(&cfg.ThumbnailBatchSize, "thumbnail-batch-size", cfg.ThumbnailBatchSize, "Maximum thumbnail jobs processed per batch")
 	flags.StringVar(&cfg.ThumbnailPollInterval, "thumbnail-poll-interval", cfg.ThumbnailPollInterval, "Thumbnail worker poll interval (e.g., 5s, 10s)")
 	flags.StringVar(&cfg.ThumbnailCleanupInterval, "thumbnail-cleanup-interval", cfg.ThumbnailCleanupInterval, "Interval between thumbnail job cleanup runs (e.g., 5m)")

--- a/go/cmd/inventario/run/bootstrap/workers.go
+++ b/go/cmd/inventario/run/bootstrap/workers.go
@@ -82,3 +82,17 @@ func StartRefreshTokenCleanupWorker(ctx context.Context, rs *RuntimeSetup, _ *Co
 	worker.Start(ctx)
 	return worker.Stop
 }
+
+// StartGroupPurgeWorker wires and starts the group purge worker (which hard-
+// deletes LocationGroups marked pending_deletion and cleans up expired unused
+// invites on the configured interval) and returns its stop function.
+func StartGroupPurgeWorker(ctx context.Context, rs *RuntimeSetup, _ *Config) func() {
+	fileService := services.NewFileService(rs.FactorySet, rs.Params.UploadLocation)
+	service := services.NewGroupPurgeService(rs.FactorySet, fileService)
+	worker := services.NewGroupPurgeWorker(
+		service,
+		services.WithGroupPurgeInterval(rs.WorkerDurations.GroupPurgeInterval),
+	)
+	worker.Start(ctx)
+	return worker.Stop
+}

--- a/go/cmd/inventario/run/workers/workers.go
+++ b/go/cmd/inventario/run/workers/workers.go
@@ -140,7 +140,10 @@ func (c *Command) run() error {
 			bootstrap.StartImportWorker,
 		}},
 		{WorkerMedia, []starter{bootstrap.StartThumbnailWorker}},
-		{WorkerHousekeeping, []starter{bootstrap.StartRefreshTokenCleanupWorker}},
+		{WorkerHousekeeping, []starter{
+			bootstrap.StartRefreshTokenCleanupWorker,
+			bootstrap.StartGroupPurgeWorker,
+		}},
 	}
 
 	stops := make([]func(), 0, 8)

--- a/go/internal/defaults/defaults.go
+++ b/go/internal/defaults/defaults.go
@@ -29,6 +29,7 @@ type Workers struct {
 	ImportPollInterval          string // Import worker poll interval (e.g., "10s")
 	RestorePollInterval         string // Restore worker poll interval (e.g., "10s")
 	RefreshTokenCleanupInterval string // Refresh token cleanup interval (e.g., "1h")
+	GroupPurgeInterval          string // Group purge worker interval (e.g., "5m")
 }
 
 // ThumbnailGeneration contains default values for thumbnail generation configuration
@@ -88,6 +89,7 @@ func New() Config {
 			ImportPollInterval:          "10s",
 			RestorePollInterval:         "10s",
 			RefreshTokenCleanupInterval: "1h",
+			GroupPurgeInterval:          "5m",
 		},
 		ThumbnailGeneration: ThumbnailGeneration{
 			MaxConcurrentPerUser: 5,     // Maximum 5 simultaneous thumbnail generation jobs per user
@@ -173,6 +175,11 @@ func GetRestorePollInterval() string {
 // GetRefreshTokenCleanupInterval returns the default refresh token cleanup interval
 func GetRefreshTokenCleanupInterval() string {
 	return defaultConfig.Workers.RefreshTokenCleanupInterval
+}
+
+// GetGroupPurgeInterval returns the default interval between group purge sweeps.
+func GetGroupPurgeInterval() string {
+	return defaultConfig.Workers.GroupPurgeInterval
 }
 
 // GetThumbnailBatchSize returns the default thumbnail worker batch size

--- a/go/internal/defaults/defaults_test.go
+++ b/go/internal/defaults/defaults_test.go
@@ -31,6 +31,7 @@ func TestDefaults(t *testing.T) {
 	c.Assert(cfg.Workers.ImportPollInterval, qt.Equals, "10s")
 	c.Assert(cfg.Workers.RestorePollInterval, qt.Equals, "10s")
 	c.Assert(cfg.Workers.RefreshTokenCleanupInterval, qt.Equals, "1h")
+	c.Assert(cfg.Workers.GroupPurgeInterval, qt.Equals, "5m")
 
 	// Test thumbnail generation defaults
 	c.Assert(cfg.ThumbnailGeneration.MaxConcurrentPerUser, qt.Equals, 5)
@@ -57,6 +58,7 @@ func TestDefaultGetters(t *testing.T) {
 	c.Assert(defaults.GetImportPollInterval(), qt.Equals, "10s")
 	c.Assert(defaults.GetRestorePollInterval(), qt.Equals, "10s")
 	c.Assert(defaults.GetRefreshTokenCleanupInterval(), qt.Equals, "1h")
+	c.Assert(defaults.GetGroupPurgeInterval(), qt.Equals, "5m")
 	c.Assert(defaults.GetThumbnailBatchSize(), qt.Equals, 10)
 	c.Assert(defaults.GetThumbnailPollInterval(), qt.Equals, "5s")
 	c.Assert(defaults.GetThumbnailCleanupInterval(), qt.Equals, "5m")

--- a/go/models/group_invite_audit.go
+++ b/go/models/group_invite_audit.go
@@ -94,6 +94,13 @@ type GroupInviteAuditIndexes struct {
 	//migrator:schema:index name="idx_group_invites_audit_uuid" fields="uuid" unique="true" table="group_invites_audit"
 	_ int
 
+	// Unique per (tenant_id, original_invite_id) so retries of the purge
+	// orchestration cannot produce duplicate snapshots for the same source
+	// invite. The Postgres audit registry relies on this to make Create
+	// idempotent; the memory registry performs the same check in Go.
+	//migrator:schema:index name="idx_group_invites_audit_tenant_invite" fields="tenant_id,original_invite_id" unique="true" table="group_invites_audit"
+	_ int
+
 	//migrator:schema:index name="idx_group_invites_audit_tenant_id" fields="tenant_id" table="group_invites_audit"
 	_ int
 

--- a/go/models/group_invite_audit.go
+++ b/go/models/group_invite_audit.go
@@ -1,0 +1,159 @@
+package models
+
+import (
+	"context"
+	"time"
+
+	"github.com/jellydator/validation"
+
+	"github.com/denisvmedia/inventario/models/rules"
+)
+
+var (
+	_ validation.Validatable            = (*GroupInviteAudit)(nil)
+	_ validation.ValidatableWithContext = (*GroupInviteAudit)(nil)
+	_ TenantAwareIDable                 = (*GroupInviteAudit)(nil)
+)
+
+// Enable RLS for multi-tenant isolation (tenant-only). The audit table keeps
+// a persistent snapshot of used invites after the parent group is hard-
+// deleted by the purge worker, so it intentionally has no group_id FK.
+//
+//migrator:schema:rls:enable table="group_invites_audit" comment="Enable RLS for multi-tenant group invite audit isolation"
+//migrator:schema:rls:policy name="group_invite_audit_tenant_isolation" table="group_invites_audit" for="ALL" to="inventario_app" using="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != ''" with_check="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != ''" comment="Ensures group invite audit records are isolated by tenant"
+//migrator:schema:rls:policy name="group_invite_audit_background_worker_access" table="group_invites_audit" for="ALL" to="inventario_background_worker" using="true" with_check="true" comment="Allows background workers to insert audit rows during group purge"
+
+//migrator:schema:table name="group_invites_audit"
+type GroupInviteAudit struct {
+	//migrator:embedded mode="inline"
+	TenantOnlyEntityID
+
+	// OriginalInviteID preserves the primary key of the source GroupInvite
+	// row. No FK — the source row is hard-deleted during purge.
+	//migrator:schema:field name="original_invite_id" type="TEXT" not_null="true"
+	OriginalInviteID string `json:"original_invite_id" db:"original_invite_id" userinput:"false"`
+
+	// OriginalInviteUUID preserves the immutable UUID of the source invite
+	// for cross-export/restore correlation.
+	//migrator:schema:field name="original_invite_uuid" type="TEXT" not_null="true"
+	OriginalInviteUUID string `json:"original_invite_uuid" db:"original_invite_uuid" userinput:"false"`
+
+	// OriginalGroupID preserves the ID of the purged group. Plain TEXT (no
+	// FK): the group row is deleted before/after this audit row is written.
+	//migrator:schema:field name="original_group_id" type="TEXT" not_null="true"
+	OriginalGroupID string `json:"original_group_id" db:"original_group_id" userinput:"false"`
+
+	// OriginalGroupSlug is the purged group's slug, captured for human
+	// readability in audit queries after the group is gone.
+	//migrator:schema:field name="original_group_slug" type="TEXT" not_null="true"
+	OriginalGroupSlug string `json:"original_group_slug" db:"original_group_slug" userinput:"false"`
+
+	// OriginalGroupName is the purged group's human-readable display name.
+	//migrator:schema:field name="original_group_name" type="TEXT" not_null="true"
+	OriginalGroupName string `json:"original_group_name" db:"original_group_name" userinput:"false"`
+
+	// Token is the original invite token. Kept for audit queries that cross-
+	// reference login records; not unique in the audit table because
+	// long-lived snapshots from different lifecycles may collide in theory.
+	//migrator:schema:field name="token" type="TEXT" not_null="true"
+	Token string `json:"token" db:"token" userinput:"false"`
+
+	// CreatedBy is the admin user who generated the original invite. Kept as
+	// a FK: the user row survives group purge. If the user is later deleted,
+	// that concern is handled by the users table's own delete path.
+	//migrator:schema:field name="created_by" type="TEXT" not_null="true" foreign="users(id)" foreign_key_name="fk_invite_audit_created_by"
+	CreatedBy string `json:"created_by" db:"created_by" userinput:"false"`
+
+	// UsedBy is the user who accepted the invite. NOT NULL on the audit
+	// table — we only snapshot used invites (unused ones are purged outright
+	// by the expiry sweep).
+	//migrator:schema:field name="used_by" type="TEXT" not_null="true" foreign="users(id)" foreign_key_name="fk_invite_audit_used_by"
+	UsedBy string `json:"used_by" db:"used_by" userinput:"false"`
+
+	// OriginalCreatedAt is when the invite was originally generated.
+	//migrator:schema:field name="original_created_at" type="TIMESTAMP" not_null="true"
+	OriginalCreatedAt time.Time `json:"original_created_at" db:"original_created_at" userinput:"false"`
+
+	// OriginalExpiresAt is the original expiry timestamp of the invite.
+	//migrator:schema:field name="original_expires_at" type="TIMESTAMP" not_null="true"
+	OriginalExpiresAt time.Time `json:"original_expires_at" db:"original_expires_at" userinput:"false"`
+
+	// UsedAt is when the invite was accepted by UsedBy.
+	//migrator:schema:field name="used_at" type="TIMESTAMP" not_null="true"
+	UsedAt time.Time `json:"used_at" db:"used_at" userinput:"false"`
+
+	// ArchivedAt is when the audit row was written (i.e. when the parent
+	// group was purged). Defaults to now at insert time.
+	//migrator:schema:field name="archived_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	ArchivedAt time.Time `json:"archived_at" db:"archived_at" userinput:"false"`
+}
+
+// GroupInviteAuditIndexes defines PostgreSQL indexes for the
+// group_invites_audit table.
+type GroupInviteAuditIndexes struct {
+	//migrator:schema:index name="idx_group_invites_audit_uuid" fields="uuid" unique="true" table="group_invites_audit"
+	_ int
+
+	//migrator:schema:index name="idx_group_invites_audit_tenant_id" fields="tenant_id" table="group_invites_audit"
+	_ int
+
+	//migrator:schema:index name="idx_group_invites_audit_original_group_id" fields="original_group_id" table="group_invites_audit"
+	_ int
+
+	//migrator:schema:index name="idx_group_invites_audit_used_by" fields="used_by" table="group_invites_audit"
+	_ int
+
+	//migrator:schema:index name="idx_group_invites_audit_archived_at" fields="archived_at" table="group_invites_audit"
+	_ int
+}
+
+func (*GroupInviteAudit) Validate() error {
+	return ErrMustUseValidateWithContext
+}
+
+func (gia *GroupInviteAudit) ValidateWithContext(ctx context.Context) error {
+	fields := []*validation.FieldRules{
+		validation.Field(&gia.TenantID, rules.NotEmpty),
+		validation.Field(&gia.OriginalInviteID, rules.NotEmpty),
+		validation.Field(&gia.OriginalInviteUUID, rules.NotEmpty),
+		validation.Field(&gia.OriginalGroupID, rules.NotEmpty),
+		validation.Field(&gia.OriginalGroupSlug, rules.NotEmpty),
+		validation.Field(&gia.OriginalGroupName, rules.NotEmpty),
+		validation.Field(&gia.Token, rules.NotEmpty),
+		validation.Field(&gia.CreatedBy, rules.NotEmpty),
+		validation.Field(&gia.UsedBy, rules.NotEmpty),
+		validation.Field(&gia.OriginalCreatedAt, validation.Required),
+		validation.Field(&gia.OriginalExpiresAt, validation.Required),
+		validation.Field(&gia.UsedAt, validation.Required),
+	}
+
+	return validation.ValidateStructWithContext(ctx, gia, fields...)
+}
+
+// NewGroupInviteAuditFromInvite builds an audit snapshot from a used invite
+// and the parent group about to be purged. The caller is responsible for
+// providing a GroupInvite whose UsedBy/UsedAt fields are populated (unused
+// invites are discarded by the expiry sweep, not archived).
+func NewGroupInviteAuditFromInvite(invite *GroupInvite, group *LocationGroup) *GroupInviteAudit {
+	audit := &GroupInviteAudit{
+		TenantOnlyEntityID: TenantOnlyEntityID{
+			TenantID: invite.TenantID,
+		},
+		OriginalInviteID:   invite.ID,
+		OriginalInviteUUID: invite.UUID,
+		OriginalGroupID:    group.ID,
+		OriginalGroupSlug:  group.Slug,
+		OriginalGroupName:  group.Name,
+		Token:              invite.Token,
+		CreatedBy:          invite.CreatedBy,
+		OriginalCreatedAt:  invite.CreatedAt,
+		OriginalExpiresAt:  invite.ExpiresAt,
+	}
+	if invite.UsedBy != nil {
+		audit.UsedBy = *invite.UsedBy
+	}
+	if invite.UsedAt != nil {
+		audit.UsedAt = *invite.UsedAt
+	}
+	return audit
+}

--- a/go/registry/factories.go
+++ b/go/registry/factories.go
@@ -120,6 +120,8 @@ type FactorySet struct {
 	LocationGroupRegistry                 LocationGroupRegistry       // LocationGroupRegistry is tenant-scoped, not user-aware
 	GroupMembershipRegistry               GroupMembershipRegistry     // GroupMembershipRegistry is tenant-scoped, not user-aware
 	GroupInviteRegistry                   GroupInviteRegistry         // GroupInviteRegistry is tenant-scoped, not user-aware
+	GroupInviteAuditRegistry              GroupInviteAuditRegistry    // GroupInviteAuditRegistry is tenant-scoped, not user-aware
+	GroupPurger                           GroupPurger                 // GroupPurger hard-deletes group-scoped data during purge ticks
 }
 
 // Ping checks readiness of the backing registry dependency (e.g. database).
@@ -227,6 +229,8 @@ func (fs *FactorySet) CreateUserRegistrySet(ctx context.Context) (*Set, error) {
 		LocationGroupRegistry:          fs.LocationGroupRegistry,
 		GroupMembershipRegistry:        fs.GroupMembershipRegistry,
 		GroupInviteRegistry:            fs.GroupInviteRegistry,
+		GroupInviteAuditRegistry:       fs.GroupInviteAuditRegistry,
+		GroupPurger:                    fs.GroupPurger,
 	}, nil
 }
 
@@ -256,5 +260,7 @@ func (fs *FactorySet) CreateServiceRegistrySet() *Set {
 		LocationGroupRegistry:          fs.LocationGroupRegistry,
 		GroupMembershipRegistry:        fs.GroupMembershipRegistry,
 		GroupInviteRegistry:            fs.GroupInviteRegistry,
+		GroupInviteAuditRegistry:       fs.GroupInviteAuditRegistry,
+		GroupPurger:                    fs.GroupPurger,
 	}
 }

--- a/go/registry/memory/files.go
+++ b/go/registry/memory/files.go
@@ -189,6 +189,24 @@ func (r *FileRegistry) ListByLinkedEntity(ctx context.Context, entityType, entit
 	return filtered, nil
 }
 
+// ListByGroup returns every file belonging to the given (tenant_id, group_id)
+// tuple, bypassing the registry's user/group filtering. Mirrors the postgres
+// counterpart used by GroupPurgeService to avoid a full file-table scan.
+func (r *FileRegistry) ListByGroup(_ context.Context, tenantID, groupID string) ([]*models.FileEntity, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	var filtered []*models.FileEntity
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		file := pair.Value
+		if file.TenantID == tenantID && file.GroupID == groupID {
+			v := *file
+			filtered = append(filtered, &v)
+		}
+	}
+	return filtered, nil
+}
+
 // ListByLinkedEntityAndMeta returns files linked to a specific entity with specific metadata
 func (r *FileRegistry) ListByLinkedEntityAndMeta(ctx context.Context, entityType, entityID, entityMeta string) ([]*models.FileEntity, error) {
 	allFiles, err := r.List(ctx)

--- a/go/registry/memory/group_invites.go
+++ b/go/registry/memory/group_invites.go
@@ -74,3 +74,41 @@ func (r *GroupInviteRegistry) MarkUsed(_ context.Context, inviteID, userID strin
 	r.items.Set(inviteID, invite)
 	return true, nil
 }
+
+// DeleteByGroup removes every invite belonging to the given group and
+// returns the count of removed rows.
+func (r *GroupInviteRegistry) DeleteByGroup(_ context.Context, groupID string) (int, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	var victims []string
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		if pair.Value.GroupID == groupID {
+			victims = append(victims, pair.Key)
+		}
+	}
+	for _, id := range victims {
+		r.items.Delete(id)
+	}
+	return len(victims), nil
+}
+
+// DeleteExpiredUnused removes unused invites whose ExpiresAt is strictly
+// before cutoff. Used invites are never touched here — they are either
+// snapshotted into the audit table by the purge worker or retained as-is.
+func (r *GroupInviteRegistry) DeleteExpiredUnused(_ context.Context, cutoff time.Time) (int, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	var victims []string
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		invite := pair.Value
+		if invite.UsedBy == nil && invite.ExpiresAt.Before(cutoff) {
+			victims = append(victims, pair.Key)
+		}
+	}
+	for _, id := range victims {
+		r.items.Delete(id)
+	}
+	return len(victims), nil
+}

--- a/go/registry/memory/group_invites.go
+++ b/go/registry/memory/group_invites.go
@@ -55,6 +55,24 @@ func (r *GroupInviteRegistry) ListActiveByGroup(_ context.Context, groupID strin
 	return invites, nil
 }
 
+// ListUsedByGroup returns every accepted (used) invite for a group. Mirrors
+// the service-mode postgres counterpart used by GroupPurgeService to build
+// the audit snapshot without scanning the whole table.
+func (r *GroupInviteRegistry) ListUsedByGroup(_ context.Context, groupID string) ([]*models.GroupInvite, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	var invites []*models.GroupInvite
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		invite := pair.Value
+		if invite.GroupID == groupID && invite.UsedBy != nil {
+			v := *invite
+			invites = append(invites, &v)
+		}
+	}
+	return invites, nil
+}
+
 // MarkUsed atomically flips an invite from unused to used-by-userID.
 // The underlying Registry lock serializes the read-modify-write so two
 // concurrent callers cannot both observe UsedBy == nil and both succeed.

--- a/go/registry/memory/group_invites_audit.go
+++ b/go/registry/memory/group_invites_audit.go
@@ -1,0 +1,58 @@
+package memory
+
+import (
+	"context"
+	"sort"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+var _ registry.GroupInviteAuditRegistry = (*GroupInviteAuditRegistry)(nil)
+
+type baseGroupInviteAuditRegistry = Registry[models.GroupInviteAudit, *models.GroupInviteAudit]
+
+type GroupInviteAuditRegistry struct {
+	*baseGroupInviteAuditRegistry
+}
+
+func NewGroupInviteAuditRegistry() *GroupInviteAuditRegistry {
+	return &GroupInviteAuditRegistry{
+		baseGroupInviteAuditRegistry: NewRegistry[models.GroupInviteAudit, *models.GroupInviteAudit](),
+	}
+}
+
+func (r *GroupInviteAuditRegistry) ListByOriginalGroup(_ context.Context, originalGroupID string) ([]*models.GroupInviteAudit, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	var audits []*models.GroupInviteAudit
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		audit := pair.Value
+		if audit.OriginalGroupID == originalGroupID {
+			v := *audit
+			audits = append(audits, &v)
+		}
+	}
+	return audits, nil
+}
+
+func (r *GroupInviteAuditRegistry) ListByTenant(_ context.Context, tenantID string) ([]*models.GroupInviteAudit, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	var audits []*models.GroupInviteAudit
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		audit := pair.Value
+		if audit.TenantID == tenantID {
+			v := *audit
+			audits = append(audits, &v)
+		}
+	}
+
+	// Most recent first — the postgres counterpart matches this ordering.
+	sort.SliceStable(audits, func(i, j int) bool {
+		return audits[i].ArchivedAt.After(audits[j].ArchivedAt)
+	})
+	return audits, nil
+}

--- a/go/registry/memory/group_invites_audit.go
+++ b/go/registry/memory/group_invites_audit.go
@@ -22,6 +22,27 @@ func NewGroupInviteAuditRegistry() *GroupInviteAuditRegistry {
 	}
 }
 
+// Create is idempotent per (tenant_id, original_invite_id), mirroring the
+// Postgres counterpart and the idx_group_invites_audit_tenant_invite unique
+// constraint: if a snapshot already exists for the same source invite, the
+// existing row is returned unchanged so GroupPurgeService retries after a
+// partial failure produce no duplicate audit records.
+func (r *GroupInviteAuditRegistry) Create(ctx context.Context, audit models.GroupInviteAudit) (*models.GroupInviteAudit, error) {
+	if audit.TenantID != "" && audit.OriginalInviteID != "" {
+		r.lock.RLock()
+		for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+			existing := pair.Value
+			if existing.TenantID == audit.TenantID && existing.OriginalInviteID == audit.OriginalInviteID {
+				v := *existing
+				r.lock.RUnlock()
+				return &v, nil
+			}
+		}
+		r.lock.RUnlock()
+	}
+	return r.baseGroupInviteAuditRegistry.Create(ctx, audit)
+}
+
 func (r *GroupInviteAuditRegistry) ListByOriginalGroup(_ context.Context, originalGroupID string) ([]*models.GroupInviteAudit, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()

--- a/go/registry/memory/group_purger.go
+++ b/go/registry/memory/group_purger.go
@@ -1,0 +1,130 @@
+package memory
+
+import (
+	"context"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+
+	"github.com/denisvmedia/inventario/registry"
+)
+
+var _ registry.GroupPurger = (*GroupPurger)(nil)
+
+// GroupPurger is the in-memory counterpart to postgres.GroupPurger. It
+// deletes every group-scoped row whose (tenant_id, group_id) matches the
+// request via each registry's service-mode view, in FK-safe order.
+//
+// It does NOT touch location_groups, group_invites, or group_invites_audit —
+// the orchestration layer (services.GroupPurgeService) owns those.
+type GroupPurger struct {
+	locations         registry.LocationRegistryFactory
+	areas             registry.AreaRegistryFactory
+	commodities       registry.CommodityRegistryFactory
+	images            registry.ImageRegistryFactory
+	invoices          registry.InvoiceRegistryFactory
+	manuals           registry.ManualRegistryFactory
+	exports           registry.ExportRegistryFactory
+	restoreOperations registry.RestoreOperationRegistryFactory
+	restoreSteps      registry.RestoreStepRegistryFactory
+	files             registry.FileRegistryFactory
+	memberships       registry.GroupMembershipRegistry
+}
+
+// NewGroupPurger wires a GroupPurger to the registry factories that own the
+// shared in-memory data maps. All parameters are required.
+func NewGroupPurger(
+	locations registry.LocationRegistryFactory,
+	areas registry.AreaRegistryFactory,
+	commodities registry.CommodityRegistryFactory,
+	images registry.ImageRegistryFactory,
+	invoices registry.InvoiceRegistryFactory,
+	manuals registry.ManualRegistryFactory,
+	exports registry.ExportRegistryFactory,
+	restoreOperations registry.RestoreOperationRegistryFactory,
+	restoreSteps registry.RestoreStepRegistryFactory,
+	files registry.FileRegistryFactory,
+	memberships registry.GroupMembershipRegistry,
+) *GroupPurger {
+	return &GroupPurger{
+		locations:         locations,
+		areas:             areas,
+		commodities:       commodities,
+		images:            images,
+		invoices:          invoices,
+		manuals:           manuals,
+		exports:           exports,
+		restoreOperations: restoreOperations,
+		restoreSteps:      restoreSteps,
+		files:             files,
+		memberships:       memberships,
+	}
+}
+
+// PurgeGroupDependents walks each group-scoped registry in FK-safe order and
+// deletes every row whose (TenantID, GroupID) matches. Unlike the postgres
+// variant, these deletes are not in a single transaction — memory mode is
+// only used for tests where partial failure is acceptable.
+func (r *GroupPurger) PurgeGroupDependents(ctx context.Context, tenantID, groupID string) error {
+	if tenantID == "" {
+		return errxtrace.Wrap("tenantID required", registry.ErrFieldRequired)
+	}
+	if groupID == "" {
+		return errxtrace.Wrap("groupID required", registry.ErrFieldRequired)
+	}
+
+	type step struct {
+		name string
+		run  func() error
+	}
+	steps := []step{
+		{"restore_steps", func() error {
+			reg := r.restoreSteps.CreateServiceRegistry()
+			return purgeByTenantGroup(ctx, tenantID, groupID, reg.List, reg.Delete)
+		}},
+		{"restore_operations", func() error {
+			reg := r.restoreOperations.CreateServiceRegistry()
+			return purgeByTenantGroup(ctx, tenantID, groupID, reg.List, reg.Delete)
+		}},
+		{"exports", func() error {
+			reg := r.exports.CreateServiceRegistry()
+			return purgeByTenantGroup(ctx, tenantID, groupID, reg.List, reg.Delete)
+		}},
+		{"manuals", func() error {
+			reg := r.manuals.CreateServiceRegistry()
+			return purgeByTenantGroup(ctx, tenantID, groupID, reg.List, reg.Delete)
+		}},
+		{"invoices", func() error {
+			reg := r.invoices.CreateServiceRegistry()
+			return purgeByTenantGroup(ctx, tenantID, groupID, reg.List, reg.Delete)
+		}},
+		{"images", func() error {
+			reg := r.images.CreateServiceRegistry()
+			return purgeByTenantGroup(ctx, tenantID, groupID, reg.List, reg.Delete)
+		}},
+		{"files", func() error {
+			reg := r.files.CreateServiceRegistry()
+			return purgeByTenantGroup(ctx, tenantID, groupID, reg.List, reg.Delete)
+		}},
+		{"commodities", func() error {
+			reg := r.commodities.CreateServiceRegistry()
+			return purgeByTenantGroup(ctx, tenantID, groupID, reg.List, reg.Delete)
+		}},
+		{"areas", func() error {
+			reg := r.areas.CreateServiceRegistry()
+			return purgeByTenantGroup(ctx, tenantID, groupID, reg.List, reg.Delete)
+		}},
+		{"locations", func() error {
+			reg := r.locations.CreateServiceRegistry()
+			return purgeByTenantGroup(ctx, tenantID, groupID, reg.List, reg.Delete)
+		}},
+		{"group_memberships", func() error {
+			return purgeMembershipsByTenantGroup(ctx, r.memberships, tenantID, groupID)
+		}},
+	}
+	for _, s := range steps {
+		if err := s.run(); err != nil {
+			return errxtrace.Wrap("failed to purge "+s.name, err)
+		}
+	}
+	return nil
+}

--- a/go/registry/memory/group_purger_helpers.go
+++ b/go/registry/memory/group_purger_helpers.go
@@ -1,0 +1,60 @@
+package memory
+
+import (
+	"context"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// purgeByTenantGroup lists everything from a service-mode registry view,
+// keeps only rows matching (tenantID, groupID), and deletes each. The
+// service-mode List returns all rows (user/group filtering disabled), so
+// filtering happens here using the entity's TenantGroupAware interface.
+func purgeByTenantGroup[T any](
+	ctx context.Context,
+	tenantID, groupID string,
+	list func(context.Context) ([]*T, error),
+	del func(context.Context, string) error,
+) error {
+	items, err := list(ctx)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		ga, ok := any(item).(models.TenantGroupAware)
+		if !ok {
+			continue
+		}
+		if ga.GetTenantID() != tenantID || ga.GetGroupID() != groupID {
+			continue
+		}
+		idable, ok := any(item).(models.IDable)
+		if !ok {
+			continue
+		}
+		if err := del(ctx, idable.GetID()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// purgeMembershipsByTenantGroup removes group_membership rows for the given
+// (tenant, group). GroupMembership is TenantOnly (not TenantGroupAware), so
+// it needs its own filter path.
+func purgeMembershipsByTenantGroup(ctx context.Context, reg registry.GroupMembershipRegistry, tenantID, groupID string) error {
+	items, err := reg.ListByGroup(ctx, groupID)
+	if err != nil {
+		return err
+	}
+	for _, m := range items {
+		if m.TenantID != tenantID {
+			continue
+		}
+		if err := reg.Delete(ctx, m.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/registry/memory/memory.go
+++ b/go/registry/memory/memory.go
@@ -55,6 +55,20 @@ func NewFactorySet() *registry.FactorySet {
 	fs.LocationGroupRegistry = NewLocationGroupRegistry()
 	fs.GroupMembershipRegistry = NewGroupMembershipRegistry()
 	fs.GroupInviteRegistry = NewGroupInviteRegistry()
+	fs.GroupInviteAuditRegistry = NewGroupInviteAuditRegistry()
+	fs.GroupPurger = NewGroupPurger(
+		locationFactory,
+		areaFactory,
+		commodityFactory,
+		imageFactory,
+		invoiceFactory,
+		manualFactory,
+		exportFactory,
+		restoreOperationFactory,
+		restoreStepFactory,
+		fileFactory,
+		fs.GroupMembershipRegistry,
+	)
 	fs.PingFn = func(context.Context) error { return nil }
 
 	return fs

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"github.com/go-extras/go-kit/must"
 	"github.com/jmoiron/sqlx"
@@ -201,6 +202,54 @@ func (r *FileRegistry) ListByLinkedEntity(ctx context.Context, entityType, entit
 		return nil, errxtrace.Wrap("failed to list files by linked entity", err)
 	}
 
+	return files, nil
+}
+
+// ListByGroup returns every file belonging to the given (tenant_id, group_id)
+// tuple. Used by GroupPurgeService to find physical blobs to delete before
+// the dependent-row purge wipes the file table. Runs as a single indexed
+// query so purge cost scales with per-group files rather than with the full
+// tenant-wide file count (review comment on #1316).
+//
+// Called from the purge worker, which has no tenant context; must therefore
+// be invoked on a service-mode registry. For user-mode callers the RLS
+// policies already scope List() to a single tenant/group combination.
+func (r *FileRegistry) ListByGroup(ctx context.Context, tenantID, groupID string) ([]*models.FileEntity, error) {
+	if tenantID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if groupID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+	}
+
+	var files []*models.FileEntity
+
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(`
+			SELECT * FROM %s
+			WHERE tenant_id = $1 AND group_id = $2
+			ORDER BY created_at DESC`, r.tableNames.Files())
+
+		rows, err := tx.QueryxContext(ctx, query, tenantID, groupID)
+		if err != nil {
+			return errxtrace.Wrap("failed to list files by group", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var file models.FileEntity
+			if scanErr := rows.StructScan(&file); scanErr != nil {
+				return errxtrace.Wrap("failed to scan file", scanErr)
+			}
+			files = append(files, &file)
+		}
+
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list files by group", err)
+	}
 	return files, nil
 }
 

--- a/go/registry/postgres/group_invites.go
+++ b/go/registry/postgres/group_invites.go
@@ -215,6 +215,63 @@ func (r *GroupInviteRegistry) MarkUsed(ctx context.Context, inviteID, userID str
 	return rowsAffected == 1, nil
 }
 
+// DeleteByGroup removes every invite (used or unused) belonging to the given
+// group. Runs inside the service-mode tx so the background-worker role
+// bypasses the tenant-isolation RLS policy; callers (the group purge worker)
+// are expected to snapshot used invites into group_invites_audit before
+// invoking this.
+func (r *GroupInviteRegistry) DeleteByGroup(ctx context.Context, groupID string) (int, error) {
+	if groupID == "" {
+		return 0, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+	}
+
+	tableName := r.tableNames.GroupInvites()
+	query := fmt.Sprintf("DELETE FROM %s WHERE group_id = $1", tableName)
+	var rowsAffected int64
+	err := r.newSQLRegistry().Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		res, execErr := tx.ExecContext(ctx, query, groupID)
+		if execErr != nil {
+			return errxtrace.Wrap("failed to delete invites by group", execErr)
+		}
+		n, raErr := res.RowsAffected()
+		if raErr != nil {
+			return errxtrace.Wrap("failed to read rows affected for DeleteByGroup", raErr)
+		}
+		rowsAffected = n
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return int(rowsAffected), nil
+}
+
+// DeleteExpiredUnused removes invites whose ExpiresAt is strictly before
+// cutoff and that have not been accepted (used_by IS NULL). Used invites
+// are preserved because they may still be needed for audit snapshotting at
+// group-purge time.
+func (r *GroupInviteRegistry) DeleteExpiredUnused(ctx context.Context, cutoff time.Time) (int, error) {
+	tableName := r.tableNames.GroupInvites()
+	query := fmt.Sprintf("DELETE FROM %s WHERE used_by IS NULL AND expires_at < $1", tableName)
+	var rowsAffected int64
+	err := r.newSQLRegistry().Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		res, execErr := tx.ExecContext(ctx, query, cutoff)
+		if execErr != nil {
+			return errxtrace.Wrap("failed to delete expired unused invites", execErr)
+		}
+		n, raErr := res.RowsAffected()
+		if raErr != nil {
+			return errxtrace.Wrap("failed to read rows affected for DeleteExpiredUnused", raErr)
+		}
+		rowsAffected = n
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return int(rowsAffected), nil
+}
+
 func (r *GroupInviteRegistry) ListActiveByGroup(ctx context.Context, groupID string) ([]*models.GroupInvite, error) {
 	if groupID == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))

--- a/go/registry/postgres/group_invites.go
+++ b/go/registry/postgres/group_invites.go
@@ -272,6 +272,41 @@ func (r *GroupInviteRegistry) DeleteExpiredUnused(ctx context.Context, cutoff ti
 	return int(rowsAffected), nil
 }
 
+// ListUsedByGroup returns every accepted (used_by IS NOT NULL) invite for a
+// group in one indexed query. Runs in service mode (background-worker role
+// bypass policy) because the caller is the group purge worker, which has no
+// tenant context. Scoped by group_id so we never page through unrelated
+// tenants the way a full List() would.
+func (r *GroupInviteRegistry) ListUsedByGroup(ctx context.Context, groupID string) ([]*models.GroupInvite, error) {
+	if groupID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+	}
+
+	var invites []*models.GroupInvite
+	tableName := r.tableNames.GroupInvites()
+	query := fmt.Sprintf("SELECT * FROM %s WHERE group_id = $1 AND used_by IS NOT NULL", tableName)
+	err := r.newSQLRegistry().Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		rows, execErr := tx.QueryxContext(ctx, query, groupID)
+		if execErr != nil {
+			return errxtrace.Wrap("failed to list used invites by group", execErr)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var invite models.GroupInvite
+			if scanErr := rows.StructScan(&invite); scanErr != nil {
+				return errxtrace.Wrap("failed to scan group invite", scanErr)
+			}
+			invites = append(invites, &invite)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return invites, nil
+}
+
 func (r *GroupInviteRegistry) ListActiveByGroup(ctx context.Context, groupID string) ([]*models.GroupInvite, error) {
 	if groupID == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))

--- a/go/registry/postgres/group_invites_audit.go
+++ b/go/registry/postgres/group_invites_audit.go
@@ -76,6 +76,12 @@ func (r *GroupInviteAuditRegistry) Count(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+// Create is idempotent per (tenant_id, original_invite_id): if a snapshot
+// already exists for the same source invite, the existing row is returned
+// unchanged. This lets GroupPurgeService safely re-snapshot after a partial
+// failure (e.g. blob delete failed between audit commit and dependent
+// delete) without producing duplicate audit entries, matching the uniqueness
+// contract declared by idx_group_invites_audit_tenant_invite.
 func (r *GroupInviteAuditRegistry) Create(ctx context.Context, audit models.GroupInviteAudit) (*models.GroupInviteAudit, error) {
 	if audit.TenantID == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
@@ -93,11 +99,50 @@ func (r *GroupInviteAuditRegistry) Create(ctx context.Context, audit models.Grou
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "UsedAt"))
 	}
 
+	existing, err := r.getByTenantAndOriginalInvite(ctx, audit.TenantID, audit.OriginalInviteID)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to check existing group invite audit", err)
+	}
+	if existing != nil {
+		return existing, nil
+	}
+
 	created, err := r.newSQLRegistry().Create(ctx, audit, nil)
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to create group invite audit", err)
 	}
 	return &created, nil
+}
+
+// getByTenantAndOriginalInvite returns a previously-snapshotted audit row
+// for the given source invite, or nil if none exists. Scoped to service mode
+// (background-worker role) so the lookup bypasses tenant RLS just like the
+// subsequent insert.
+func (r *GroupInviteAuditRegistry) getByTenantAndOriginalInvite(ctx context.Context, tenantID, originalInviteID string) (*models.GroupInviteAudit, error) {
+	var audit models.GroupInviteAudit
+	found := false
+	err := r.newSQLRegistry().Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		txreg := store.NewTxRegistry[models.GroupInviteAudit](tx, r.tableNames.GroupInvitesAudit())
+		scanErr := txreg.ScanOneByFields(ctx, []store.FieldValue{
+			store.Pair("tenant_id", tenantID),
+			store.Pair("original_invite_id", originalInviteID),
+		}, &audit)
+		if scanErr != nil {
+			if errors.Is(scanErr, store.ErrNotFound) {
+				return nil
+			}
+			return scanErr
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	return &audit, nil
 }
 
 // Update is provided for Registry-interface completeness. Audit rows are

--- a/go/registry/postgres/group_invites_audit.go
+++ b/go/registry/postgres/group_invites_audit.go
@@ -1,0 +1,163 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/go-extras/errx"
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+var _ registry.GroupInviteAuditRegistry = (*GroupInviteAuditRegistry)(nil)
+
+// GroupInviteAuditRegistry persists audit snapshots of used invites after
+// the parent LocationGroup is hard-deleted by the purge worker. Like
+// RefreshTokenRegistry and GroupInviteRegistry, it runs in service mode so
+// inserts during the purge transaction are not blocked by tenant RLS
+// (background-worker role has a bypass policy).
+type GroupInviteAuditRegistry struct {
+	dbx        *sqlx.DB
+	tableNames store.TableNames
+}
+
+func NewGroupInviteAuditRegistry(dbx *sqlx.DB) *GroupInviteAuditRegistry {
+	return &GroupInviteAuditRegistry{
+		dbx:        dbx,
+		tableNames: store.DefaultTableNames,
+	}
+}
+
+func (r *GroupInviteAuditRegistry) newSQLRegistry() *store.RLSRepository[models.GroupInviteAudit, *models.GroupInviteAudit] {
+	return store.NewServiceSQLRegistry[models.GroupInviteAudit, *models.GroupInviteAudit](r.dbx, r.tableNames.GroupInvitesAudit())
+}
+
+func (r *GroupInviteAuditRegistry) Get(ctx context.Context, id string) (*models.GroupInviteAudit, error) {
+	if id == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+
+	var audit models.GroupInviteAudit
+	err := r.newSQLRegistry().ScanOneByField(ctx, store.Pair("id", id), &audit)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
+				"entity_type", "GroupInviteAudit",
+				"entity_id", id,
+			))
+		}
+		return nil, errxtrace.Wrap("failed to get group invite audit", err)
+	}
+
+	return &audit, nil
+}
+
+func (r *GroupInviteAuditRegistry) List(ctx context.Context) ([]*models.GroupInviteAudit, error) {
+	var audits []*models.GroupInviteAudit
+	for audit, err := range r.newSQLRegistry().Scan(ctx) {
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to list group invite audits", err)
+		}
+		audits = append(audits, &audit)
+	}
+	return audits, nil
+}
+
+func (r *GroupInviteAuditRegistry) Count(ctx context.Context) (int, error) {
+	count, err := r.newSQLRegistry().Count(ctx)
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to count group invite audits", err)
+	}
+	return count, nil
+}
+
+func (r *GroupInviteAuditRegistry) Create(ctx context.Context, audit models.GroupInviteAudit) (*models.GroupInviteAudit, error) {
+	if audit.TenantID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if audit.OriginalInviteID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "OriginalInviteID"))
+	}
+	if audit.OriginalGroupID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "OriginalGroupID"))
+	}
+	if audit.UsedBy == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "UsedBy"))
+	}
+	if audit.UsedAt.IsZero() {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "UsedAt"))
+	}
+
+	created, err := r.newSQLRegistry().Create(ctx, audit, nil)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to create group invite audit", err)
+	}
+	return &created, nil
+}
+
+// Update is provided for Registry-interface completeness. Audit rows are
+// intentionally immutable in normal operation — no caller in the codebase
+// invokes this method outside of tests/maintenance.
+func (r *GroupInviteAuditRegistry) Update(ctx context.Context, audit models.GroupInviteAudit) (*models.GroupInviteAudit, error) {
+	if audit.GetID() == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+
+	err := r.newSQLRegistry().Update(ctx, audit, nil)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to update group invite audit", err)
+	}
+	return &audit, nil
+}
+
+func (r *GroupInviteAuditRegistry) Delete(ctx context.Context, id string) error {
+	if id == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+
+	err := r.newSQLRegistry().Delete(ctx, id, nil)
+	if err != nil {
+		return errxtrace.Wrap("failed to delete group invite audit", err)
+	}
+	return nil
+}
+
+func (r *GroupInviteAuditRegistry) ListByOriginalGroup(ctx context.Context, originalGroupID string) ([]*models.GroupInviteAudit, error) {
+	if originalGroupID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "OriginalGroupID"))
+	}
+
+	var audits []*models.GroupInviteAudit
+	for audit, err := range r.newSQLRegistry().ScanByField(ctx, store.Pair("original_group_id", originalGroupID)) {
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to list group invite audits by original group", err)
+		}
+		audits = append(audits, &audit)
+	}
+	return audits, nil
+}
+
+func (r *GroupInviteAuditRegistry) ListByTenant(ctx context.Context, tenantID string) ([]*models.GroupInviteAudit, error) {
+	if tenantID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+
+	var audits []*models.GroupInviteAudit
+	for audit, err := range r.newSQLRegistry().ScanByField(ctx, store.Pair("tenant_id", tenantID)) {
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to list group invite audits by tenant", err)
+		}
+		audits = append(audits, &audit)
+	}
+
+	// Match memory behavior: most recent first.
+	sort.SliceStable(audits, func(i, j int) bool {
+		return audits[i].ArchivedAt.After(audits[j].ArchivedAt)
+	})
+	return audits, nil
+}

--- a/go/registry/postgres/group_purger.go
+++ b/go/registry/postgres/group_purger.go
@@ -1,0 +1,98 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-extras/errx"
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+var _ registry.GroupPurger = (*GroupPurger)(nil)
+
+// GroupPurger bulk-deletes all data rows belonging to a single LocationGroup
+// in one background-worker transaction, honoring FK order so the DELETEs
+// succeed without needing ON DELETE CASCADE on every child table.
+//
+// It does NOT touch location_groups, group_invites or group_invites_audit —
+// the orchestration layer (services.GroupPurgeService) snapshots used invites,
+// deletes invites, then drops the group row itself.
+type GroupPurger struct {
+	dbx        *sqlx.DB
+	tableNames store.TableNames
+}
+
+// NewGroupPurger returns a GroupPurger bound to the default table names.
+func NewGroupPurger(dbx *sqlx.DB) *GroupPurger {
+	return NewGroupPurgerWithTableNames(dbx, store.DefaultTableNames)
+}
+
+// NewGroupPurgerWithTableNames returns a GroupPurger using a custom TableNames
+// (used by tests that want to sandbox against renamed tables).
+func NewGroupPurgerWithTableNames(dbx *sqlx.DB, tableNames store.TableNames) *GroupPurger {
+	return &GroupPurger{dbx: dbx, tableNames: tableNames}
+}
+
+// purgeOrder is the FK-safe DELETE sequence. Each entry is a fmt template
+// with two %s placeholders: the fully-qualified table name, then the
+// WHERE clause column. The transaction is scoped by (tenant_id, group_id)
+// so the background-worker role can't accidentally wipe the wrong tenant.
+var purgeOrder = []func(t store.TableNames) string{
+	// Restore pipeline (deepest children first).
+	func(t store.TableNames) string { return string(t.RestoreSteps()) },
+	func(t store.TableNames) string { return string(t.RestoreOperations()) },
+	func(t store.TableNames) string { return string(t.Exports()) },
+
+	// Commodity-owned attachments.
+	func(t store.TableNames) string { return string(t.Manuals()) },
+	func(t store.TableNames) string { return string(t.Invoices()) },
+	func(t store.TableNames) string { return string(t.Images()) },
+
+	// Generic group-scoped files (linked by polymorphic entity_type/id, no FK chain).
+	func(t store.TableNames) string { return string(t.Files()) },
+
+	// Inventory hierarchy.
+	func(t store.TableNames) string { return string(t.Commodities()) },
+	func(t store.TableNames) string { return string(t.Areas()) },
+	func(t store.TableNames) string { return string(t.Locations()) },
+
+	// Memberships last — they don't block child deletes but are cheapest to
+	// drop after everything else is already gone.
+	func(t store.TableNames) string { return string(t.GroupMemberships()) },
+}
+
+// PurgeGroupDependents issues a DELETE ... WHERE tenant_id = $1 AND
+// group_id = $2 against each dependent table in FK-safe order, inside a
+// single background-worker transaction. All deletes succeed or none do —
+// that's the whole reason this isn't per-registry: partial progress would
+// leave orphaned rows that RLS hides from inventario_app entirely.
+//
+// Idempotent: a second call after a clean purge is a no-op (every DELETE
+// affects zero rows).
+func (r *GroupPurger) PurgeGroupDependents(ctx context.Context, tenantID, groupID string) error {
+	if tenantID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if groupID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+	}
+
+	return store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		for _, nameFn := range purgeOrder {
+			table := nameFn(r.tableNames)
+			query := fmt.Sprintf("DELETE FROM %s WHERE tenant_id = $1 AND group_id = $2", table)
+			if _, err := tx.ExecContext(ctx, query, tenantID, groupID); err != nil {
+				return errxtrace.Wrap(
+					"failed to purge group dependents",
+					err,
+					errx.Attrs("table", table, "tenant_id", tenantID, "group_id", groupID),
+				)
+			}
+		}
+		return nil
+	})
+}

--- a/go/registry/postgres/group_purger.go
+++ b/go/registry/postgres/group_purger.go
@@ -37,10 +37,11 @@ func NewGroupPurgerWithTableNames(dbx *sqlx.DB, tableNames store.TableNames) *Gr
 	return &GroupPurger{dbx: dbx, tableNames: tableNames}
 }
 
-// purgeOrder is the FK-safe DELETE sequence. Each entry is a fmt template
-// with two %s placeholders: the fully-qualified table name, then the
-// WHERE clause column. The transaction is scoped by (tenant_id, group_id)
-// so the background-worker role can't accidentally wipe the wrong tenant.
+// purgeOrder is the FK-safe DELETE sequence. Each entry resolves to the
+// fully-qualified name of a dependent table; PurgeGroupDependents then
+// issues `DELETE FROM <table> WHERE tenant_id = $1 AND group_id = $2`
+// against each one inside a single background-worker transaction, so the
+// worker role can't accidentally wipe the wrong tenant.
 var purgeOrder = []func(t store.TableNames) string{
 	// Restore pipeline (deepest children first).
 	func(t store.TableNames) string { return string(t.RestoreSteps()) },

--- a/go/registry/postgres/group_purger_test.go
+++ b/go/registry/postgres/group_purger_test.go
@@ -1,0 +1,283 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+
+	_ "github.com/denisvmedia/inventario/internal/fileblob" // register file:// driver
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres"
+	"github.com/denisvmedia/inventario/schema/migrations/migrator"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// setupCleanPostgresFactorySet migrates the schema and returns a raw factory
+// set with no seeded tenants/users/groups. Used by multi-tenant purge tests
+// that need to manage their own fixtures.
+func setupCleanPostgresFactorySet(t *testing.T) *registry.FactorySet {
+	t.Helper()
+
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+
+	// Drop and recreate the schema so fixtures from prior tests don't bleed in.
+	migr := migrator.NewWithFallback(dsn, "../../models")
+	ctx := context.Background()
+	c.Assert(migrateUp(t, ctx, migr, dsn), qt.IsNil)
+
+	sqlxDB := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	return postgres.NewFactorySet(sqlxDB)
+}
+
+// newPostgresFileUploadLocation returns a file:// DSN for a temp dir so the
+// FileService can open its bucket during purge (a no-op when no files are
+// seeded, but the code path must not error out).
+func newPostgresFileUploadLocation(c *qt.C) string {
+	tempDir := c.TempDir()
+	if runtime.GOOS == "windows" {
+		return "file:///" + tempDir + "?create_dir=1"
+	}
+	return "file://" + tempDir + "?create_dir=1"
+}
+
+// seedTenantWithPendingGroup creates a tenant + admin user + pending_deletion
+// location group + one used invite inside that tenant. Returns the tenant ID,
+// user ID, group ID, and the invite's token (useful for audit assertions).
+func seedTenantWithPendingGroup(c *qt.C, ctx context.Context, fs *registry.FactorySet, slug, email string) (tenantID, userID, groupID, inviteToken string) {
+	c.Helper()
+
+	tenant, err := fs.TenantRegistry.Create(ctx, models.Tenant{
+		Name:   "Tenant " + slug,
+		Slug:   slug,
+		Status: models.TenantStatusActive,
+	})
+	c.Assert(err, qt.IsNil)
+
+	user := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenant.ID},
+		Email:               email,
+		Name:                "Admin " + slug,
+		IsActive:            true,
+	}
+	c.Assert(user.SetPassword("password123"), qt.IsNil)
+	createdUser, err := fs.UserRegistry.Create(ctx, user)
+	c.Assert(err, qt.IsNil)
+
+	groupSlug, err := models.GenerateGroupSlug()
+	c.Assert(err, qt.IsNil)
+	group, err := fs.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: tenant.ID},
+		Name:               "Pending " + slug,
+		Slug:               groupSlug,
+		Status:             models.LocationGroupStatusPendingDeletion,
+		CreatedBy:          createdUser.ID,
+		MainCurrency:       models.Currency("USD"),
+	})
+	c.Assert(err, qt.IsNil)
+
+	token, err := models.GenerateInviteToken()
+	c.Assert(err, qt.IsNil)
+	usedAt := time.Now().Add(-1 * time.Hour)
+	usedByPtr := createdUser.ID
+	_, err = fs.GroupInviteRegistry.Create(ctx, models.GroupInvite{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: tenant.ID},
+		GroupID:            group.ID,
+		Token:              token,
+		CreatedBy:          createdUser.ID,
+		ExpiresAt:          time.Now().Add(24 * time.Hour),
+		UsedBy:             &usedByPtr,
+		UsedAt:             &usedAt,
+	})
+	c.Assert(err, qt.IsNil)
+
+	return tenant.ID, createdUser.ID, group.ID, token
+}
+
+// TestGroupPurgeService_Postgres_CrossTenantRLSBypass verifies that the
+// purge worker can see and delete pending_deletion LocationGroups belonging
+// to multiple tenants in a single sweep, AND that the resulting audit rows
+// are written across tenant boundaries. Under the inventario_app role the
+// tenant-isolation RLS policies on location_groups, group_invites, and
+// group_invites_audit would hide rows from foreign tenants; the
+// inventario_background_worker role has a bypass policy on each of those
+// tables and that is what makes cross-tenant maintenance work. This test
+// asserts the bypass end-to-end against a real PostgreSQL schema.
+func TestGroupPurgeService_Postgres_CrossTenantRLSBypass(t *testing.T) {
+	fs := setupCleanPostgresFactorySet(t)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tenantA, _, groupA, _ := seedTenantWithPendingGroup(c, ctx, fs, "tenant-a", "admin@a.example")
+	tenantB, _, groupB, _ := seedTenantWithPendingGroup(c, ctx, fs, "tenant-b", "admin@b.example")
+
+	fileSvc := services.NewFileService(fs, newPostgresFileUploadLocation(c))
+	svc := services.NewGroupPurgeService(fs, fileSvc)
+
+	purged, failed, err := svc.PurgeOnce(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(purged, qt.Equals, 2)
+	c.Assert(failed, qt.Equals, 0)
+
+	// Both pending groups are gone — the service-mode registry ran as the
+	// background worker role, which has a USING(true) bypass policy on
+	// location_groups, and was therefore able to DELETE rows belonging to
+	// foreign tenants in a single transaction sequence.
+	_, err = fs.LocationGroupRegistry.Get(ctx, groupA)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue, qt.Commentf("group A should be purged"))
+	_, err = fs.LocationGroupRegistry.Get(ctx, groupB)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue, qt.Commentf("group B should be purged"))
+
+	// Audit rows were INSERTed for both tenants — group_invites_audit's
+	// bypass policy on inventario_background_worker is what permits a
+	// single transaction to write rows tagged with different tenant_ids.
+	auditA, err := fs.GroupInviteAuditRegistry.ListByTenant(ctx, tenantA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(auditA, qt.HasLen, 1)
+	c.Assert(auditA[0].OriginalGroupID, qt.Equals, groupA)
+
+	auditB, err := fs.GroupInviteAuditRegistry.ListByTenant(ctx, tenantB)
+	c.Assert(err, qt.IsNil)
+	c.Assert(auditB, qt.HasLen, 1)
+	c.Assert(auditB[0].OriginalGroupID, qt.Equals, groupB)
+
+	// ListByOriginalGroup scoped to tenant A's original group must not leak
+	// tenant B's audit row (even though the worker role can see both, the
+	// field filter is by original_group_id).
+	auditByGroupA, err := fs.GroupInviteAuditRegistry.ListByOriginalGroup(ctx, groupA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(auditByGroupA, qt.HasLen, 1)
+	c.Assert(auditByGroupA[0].TenantID, qt.Equals, tenantA)
+
+	// Invites for both purged groups must be gone (DeleteByGroup ran in
+	// service mode, so it reached across both tenants in the same sweep).
+	invitesA, err := fs.GroupInviteRegistry.ListActiveByGroup(ctx, groupA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(invitesA, qt.HasLen, 0)
+	invitesB, err := fs.GroupInviteRegistry.ListActiveByGroup(ctx, groupB)
+	c.Assert(err, qt.IsNil)
+	c.Assert(invitesB, qt.HasLen, 0)
+}
+
+// TestGroupPurgeService_Postgres_CleanExpiredInvitesCrossTenant verifies
+// the Option 2i sweep reaches across tenants: unused expired invites owned
+// by different tenants are all removed in one service-mode DELETE, while
+// used invites (which are the domain of the per-group purge audit path)
+// and unused non-expired invites are preserved regardless of tenant.
+func TestGroupPurgeService_Postgres_CleanExpiredInvitesCrossTenant(t *testing.T) {
+	fs := setupCleanPostgresFactorySet(t)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	// Two separate tenants, each with an ACTIVE group (so the per-group
+	// purge path will not touch them) and a mix of invites.
+	tenantA := mustCreateTenant(c, ctx, fs, "tenant-a")
+	userA := mustCreateUser(c, ctx, fs, tenantA, "admin@a.example")
+	groupA := mustCreateActiveGroup(c, ctx, fs, tenantA, userA.ID)
+
+	tenantB := mustCreateTenant(c, ctx, fs, "tenant-b")
+	userB := mustCreateUser(c, ctx, fs, tenantB, "admin@b.example")
+	groupB := mustCreateActiveGroup(c, ctx, fs, tenantB, userB.ID)
+
+	// Invites to sweep (unused, expired) — one per tenant.
+	expiredA := mustCreateInvite(c, ctx, fs, tenantA, groupA, userA.ID, time.Now().Add(-time.Hour), nil, nil)
+	expiredB := mustCreateInvite(c, ctx, fs, tenantB, groupB, userB.ID, time.Now().Add(-30*time.Minute), nil, nil)
+
+	// Invite that must survive: unused, non-expired.
+	activeInvite := mustCreateInvite(c, ctx, fs, tenantA, groupA, userA.ID, time.Now().Add(24*time.Hour), nil, nil)
+
+	// Invite that must survive: used, expired (audit domain, not sweep).
+	usedAt := time.Now().Add(-2 * time.Hour)
+	usedBy := userB.ID
+	usedInvite := mustCreateInvite(c, ctx, fs, tenantB, groupB, userB.ID, time.Now().Add(-1*time.Hour), &usedBy, &usedAt)
+
+	fileSvc := services.NewFileService(fs, newPostgresFileUploadLocation(c))
+	svc := services.NewGroupPurgeService(fs, fileSvc)
+
+	deleted, err := svc.CleanExpiredInvites(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(deleted, qt.Equals, 2)
+
+	_, err = fs.GroupInviteRegistry.Get(ctx, expiredA)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue, qt.Commentf("tenant A expired unused invite should be gone"))
+	_, err = fs.GroupInviteRegistry.Get(ctx, expiredB)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue, qt.Commentf("tenant B expired unused invite should be gone"))
+
+	// Survivors.
+	_, err = fs.GroupInviteRegistry.Get(ctx, activeInvite)
+	c.Assert(err, qt.IsNil)
+	_, err = fs.GroupInviteRegistry.Get(ctx, usedInvite)
+	c.Assert(err, qt.IsNil)
+}
+
+// -- small, test-local fixture helpers -------------------------------------
+
+func mustCreateTenant(c *qt.C, ctx context.Context, fs *registry.FactorySet, slug string) string {
+	c.Helper()
+	t, err := fs.TenantRegistry.Create(ctx, models.Tenant{
+		Name:   "Tenant " + slug,
+		Slug:   slug,
+		Status: models.TenantStatusActive,
+	})
+	c.Assert(err, qt.IsNil)
+	return t.ID
+}
+
+func mustCreateUser(c *qt.C, ctx context.Context, fs *registry.FactorySet, tenantID, email string) *models.User {
+	c.Helper()
+	u := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Email:               email,
+		Name:                "User " + email,
+		IsActive:            true,
+	}
+	c.Assert(u.SetPassword("password123"), qt.IsNil)
+	created, err := fs.UserRegistry.Create(ctx, u)
+	c.Assert(err, qt.IsNil)
+	return created
+}
+
+func mustCreateActiveGroup(c *qt.C, ctx context.Context, fs *registry.FactorySet, tenantID, userID string) string {
+	c.Helper()
+	slug, err := models.GenerateGroupSlug()
+	c.Assert(err, qt.IsNil)
+	g, err := fs.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: tenantID},
+		Name:               "Active " + slug,
+		Slug:               slug,
+		Status:             models.LocationGroupStatusActive,
+		CreatedBy:          userID,
+		MainCurrency:       models.Currency("USD"),
+	})
+	c.Assert(err, qt.IsNil)
+	return g.ID
+}
+
+func mustCreateInvite(c *qt.C, ctx context.Context, fs *registry.FactorySet, tenantID, groupID, createdBy string, expiresAt time.Time, usedBy *string, usedAt *time.Time) string {
+	c.Helper()
+	token, err := models.GenerateInviteToken()
+	c.Assert(err, qt.IsNil)
+	inv, err := fs.GroupInviteRegistry.Create(ctx, models.GroupInvite{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: tenantID},
+		GroupID:            groupID,
+		Token:              token,
+		CreatedBy:          createdBy,
+		ExpiresAt:          expiresAt,
+		UsedBy:             usedBy,
+		UsedAt:             usedAt,
+	})
+	c.Assert(err, qt.IsNil)
+	return inv.ID
+}

--- a/go/registry/postgres/postgres.go
+++ b/go/registry/postgres/postgres.go
@@ -51,6 +51,8 @@ func NewFactorySet(dbx *sqlx.DB) *registry.FactorySet {
 	fs.LocationGroupRegistry = NewLocationGroupRegistry(dbx)
 	fs.GroupMembershipRegistry = NewGroupMembershipRegistry(dbx)
 	fs.GroupInviteRegistry = NewGroupInviteRegistry(dbx)
+	fs.GroupInviteAuditRegistry = NewGroupInviteAuditRegistry(dbx)
+	fs.GroupPurger = NewGroupPurger(dbx)
 	fs.PingFn = dbx.PingContext
 
 	return fs

--- a/go/registry/postgres/store/tablenames.go
+++ b/go/registry/postgres/store/tablenames.go
@@ -26,6 +26,7 @@ type TableNames struct {
 	LocationGroups          func() TableName
 	GroupMemberships        func() TableName
 	GroupInvites            func() TableName
+	GroupInvitesAudit       func() TableName
 }
 
 var DefaultTableNames = TableNames{
@@ -52,6 +53,7 @@ var DefaultTableNames = TableNames{
 	LocationGroups:          func() TableName { return "location_groups" },
 	GroupMemberships:        func() TableName { return "group_memberships" },
 	GroupInvites:            func() TableName { return "group_invites" },
+	GroupInvitesAudit:       func() TableName { return "group_invites_audit" },
 }
 
 // NewTableNames returns the default table names

--- a/go/registry/postgres/store/utils.go
+++ b/go/registry/postgres/store/utils.go
@@ -154,3 +154,26 @@ func beginTxWithTenantAndGroup(ctx context.Context, dbx *sqlx.DB, tenantID, grou
 func generateID() string {
 	return uuid.New().String()
 }
+
+// DoAsBackgroundWorker runs fn inside a transaction that has SET LOCAL ROLE
+// to inventario_background_worker, committing on nil return and rolling back
+// otherwise. It is the public entry point for cross-table maintenance that
+// legitimately needs to bypass the tenant-scoped RLS policies on
+// inventario_app (group purge, housekeeping sweeps, etc.). New callers
+// should be rare; prefer per-registry methods where possible.
+func DoAsBackgroundWorker(ctx context.Context, dbx *sqlx.DB, fn func(context.Context, *sqlx.Tx) error) (err error) {
+	tx, err := beginServiceTx(ctx, dbx)
+	if err != nil {
+		return errxtrace.Wrap("failed to begin background-worker transaction", err)
+	}
+	defer func() {
+		if rbErr := RollbackOrCommit(tx, err); rbErr != nil && err == nil {
+			err = errxtrace.Wrap("failed to finish background-worker transaction", rbErr)
+		}
+	}()
+
+	if err = fn(ctx, tx); err != nil {
+		return errxtrace.Wrap("background-worker operation failed", err)
+	}
+	return nil
+}

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -333,6 +333,32 @@ type GroupInviteRegistry interface {
 	// one concurrent caller succeeds per invite — postgres uses a conditional
 	// UPDATE, memory uses a mutex.
 	MarkUsed(ctx context.Context, inviteID, userID string, usedAt time.Time) (bool, error)
+
+	// DeleteByGroup removes all invite rows (used or unused) belonging to the
+	// given group. Called by the group purge worker right after it snapshots
+	// used invites into the audit table. Returns the number of deleted rows.
+	DeleteByGroup(ctx context.Context, groupID string) (int, error)
+
+	// DeleteExpiredUnused removes every invite whose ExpiresAt is before the
+	// provided cutoff and that has not been accepted (used_by IS NULL).
+	// Returns the number of deleted rows. Used by the housekeeping expiry
+	// sweep (spec #1309 Option 2i).
+	DeleteExpiredUnused(ctx context.Context, cutoff time.Time) (int, error)
+}
+
+// GroupInviteAuditRegistry manages persistent audit rows for used invites
+// that outlive their parent LocationGroup. Rows are inserted only by the
+// group purge worker and are tenant-scoped (no group FK — the source group
+// is hard-deleted as part of the purge).
+type GroupInviteAuditRegistry interface {
+	Registry[models.GroupInviteAudit]
+
+	// ListByOriginalGroup returns all audit records for a previously-purged
+	// group, identified by its original (pre-purge) group ID.
+	ListByOriginalGroup(ctx context.Context, originalGroupID string) ([]*models.GroupInviteAudit, error)
+
+	// ListByTenant returns all audit records for a tenant, most recent first.
+	ListByTenant(ctx context.Context, tenantID string) ([]*models.GroupInviteAudit, error)
 }
 
 type UserRegistry interface {
@@ -361,6 +387,27 @@ type RefreshTokenRegistry interface {
 	DeleteExpired(ctx context.Context) error
 }
 
+// GroupPurger hard-deletes every row whose group_id references the given
+// LocationGroup, in a FK-safe order: restore_steps, restore_operations,
+// exports, manuals, invoices, images, commodities, files, areas, locations
+// and finally group_memberships. It is intentionally a separate abstraction
+// from per-registry CRUD because the purge flow must run under the
+// background-worker RLS role and cross many entity boundaries in a single
+// transaction.
+//
+// The LocationGroup row itself and any group_invites / group_invites_audit
+// rows are NOT touched here — the caller (GroupPurgeService) handles invite
+// snapshotting and the final location_groups DELETE separately so blob
+// cleanup, audit-writing and group removal remain explicit at the
+// orchestration layer.
+type GroupPurger interface {
+	// PurgeGroupDependents deletes all dependent entities for the given
+	// tenant/group pair. Implementations must be idempotent — a second call
+	// on the same group after a partial failure must succeed and leave the
+	// database in the same state.
+	PurgeGroupDependents(ctx context.Context, tenantID, groupID string) error
+}
+
 // Set contains ready-to-use registries that have been created with proper user or service context.
 // This is the result of calling CreateUserRegistrySet() or CreateServiceRegistrySet() on a FactorySet.
 type Set struct {
@@ -387,6 +434,8 @@ type Set struct {
 	LocationGroupRegistry          LocationGroupRegistry     // LocationGroupRegistry is tenant-scoped, not user-aware
 	GroupMembershipRegistry        GroupMembershipRegistry   // GroupMembershipRegistry is tenant-scoped, not user-aware
 	GroupInviteRegistry            GroupInviteRegistry       // GroupInviteRegistry is tenant-scoped, not user-aware
+	GroupInviteAuditRegistry       GroupInviteAuditRegistry  // GroupInviteAuditRegistry is tenant-scoped, not user-aware; written only by the group purge worker
+	GroupPurger                    GroupPurger               // GroupPurger bulk-removes group-scoped entities during the purge worker's tick
 }
 
 // Search-related types and functions

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -138,6 +138,14 @@ type FileRegistry interface {
 	// ListByLinkedEntityAndMeta returns files linked to a specific entity with specific metadata
 	ListByLinkedEntityAndMeta(ctx context.Context, entityType, entityID, meta string) ([]*models.FileEntity, error)
 
+	// ListByGroup returns every file belonging to the given (tenant_id,
+	// group_id) tuple. Used by the group purge worker to find physical blobs
+	// to delete before the row-level purge wipes the file table — avoids the
+	// O(tenant × total_files) scan that List() would perform. Only makes
+	// sense for service-mode callers: group-scoped user registries already
+	// see exactly the right slice via RLS.
+	ListByGroup(ctx context.Context, tenantID, groupID string) ([]*models.FileEntity, error)
+
 	// Search returns files matching the search criteria
 	Search(ctx context.Context, query string, fileType *models.FileType, tags []string) ([]*models.FileEntity, error)
 
@@ -325,6 +333,13 @@ type GroupInviteRegistry interface {
 
 	// ListActiveByGroup returns all non-expired, unused invites for a group.
 	ListActiveByGroup(ctx context.Context, groupID string) ([]*models.GroupInvite, error)
+
+	// ListUsedByGroup returns every invite belonging to the given group that
+	// has already been accepted (used_by IS NOT NULL). Called by the group
+	// purge worker to build the audit snapshot without having to page through
+	// the whole invite table. Implementations run in service mode and ignore
+	// tenant RLS; callers must supply a group ID they are authorised to purge.
+	ListUsedByGroup(ctx context.Context, groupID string) ([]*models.GroupInvite, error)
 
 	// MarkUsed atomically marks an invite as used by the given user.
 	// It returns (true, nil) iff this call was the winner of the compare-and-swap

--- a/go/schema/migrations/_sqldata/1776973984_phase8_add_group_invites_audit.down.sql
+++ b/go/schema/migrations/_sqldata/1776973984_phase8_add_group_invites_audit.down.sql
@@ -1,0 +1,16 @@
+-- Migration rollback
+-- Generated on: 2026-04-23T21:53:04+02:00
+-- Direction: DOWN
+
+DROP INDEX IF EXISTS idx_group_invites_audit_archived_at;
+DROP INDEX IF EXISTS idx_group_invites_audit_original_group_id;
+DROP INDEX IF EXISTS idx_group_invites_audit_tenant_id;
+DROP INDEX IF EXISTS idx_group_invites_audit_used_by;
+DROP INDEX IF EXISTS idx_group_invites_audit_uuid;
+-- Drop RLS policy group_invite_audit_background_worker_access from table group_invites_audit
+DROP POLICY IF EXISTS group_invite_audit_background_worker_access ON group_invites_audit;
+-- Drop RLS policy group_invite_audit_tenant_isolation from table group_invites_audit
+DROP POLICY IF EXISTS group_invite_audit_tenant_isolation ON group_invites_audit;
+-- NOTE: RLS policies were removed from table group_invites_audit - verify if RLS should be disabled --
+-- WARNING: This will delete all data!
+DROP TABLE IF EXISTS group_invites_audit CASCADE;

--- a/go/schema/migrations/_sqldata/1776973984_phase8_add_group_invites_audit.down.sql
+++ b/go/schema/migrations/_sqldata/1776973984_phase8_add_group_invites_audit.down.sql
@@ -5,6 +5,7 @@
 DROP INDEX IF EXISTS idx_group_invites_audit_archived_at;
 DROP INDEX IF EXISTS idx_group_invites_audit_original_group_id;
 DROP INDEX IF EXISTS idx_group_invites_audit_tenant_id;
+DROP INDEX IF EXISTS idx_group_invites_audit_tenant_invite;
 DROP INDEX IF EXISTS idx_group_invites_audit_used_by;
 DROP INDEX IF EXISTS idx_group_invites_audit_uuid;
 -- Drop RLS policy group_invite_audit_background_worker_access from table group_invites_audit

--- a/go/schema/migrations/_sqldata/1776973984_phase8_add_group_invites_audit.up.sql
+++ b/go/schema/migrations/_sqldata/1776973984_phase8_add_group_invites_audit.up.sql
@@ -1,0 +1,45 @@
+-- Migration generated from schema differences
+-- Generated on: 2026-04-23T21:53:04+02:00
+-- Direction: UP
+
+-- POSTGRES TABLE: group_invites_audit --
+CREATE TABLE group_invites_audit (
+  original_invite_id TEXT NOT NULL,
+  original_invite_uuid TEXT NOT NULL,
+  original_group_id TEXT NOT NULL,
+  original_group_slug TEXT NOT NULL,
+  original_group_name TEXT NOT NULL,
+  token TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  used_by TEXT NOT NULL,
+  original_created_at TIMESTAMP NOT NULL,
+  original_expires_at TIMESTAMP NOT NULL,
+  used_at TIMESTAMP NOT NULL,
+  archived_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  tenant_id TEXT NOT NULL,
+  id TEXT PRIMARY KEY NOT NULL,
+  uuid TEXT NOT NULL DEFAULT (gen_random_uuid())::text
+);
+-- ALTER statements: --
+ALTER TABLE group_invites_audit ADD CONSTRAINT fk_invite_audit_created_by FOREIGN KEY (created_by) REFERENCES users(id);
+-- ALTER statements: --
+ALTER TABLE group_invites_audit ADD CONSTRAINT fk_invite_audit_used_by FOREIGN KEY (used_by) REFERENCES users(id);
+-- ALTER statements: --
+ALTER TABLE group_invites_audit ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+-- Enable RLS for group_invites_audit table
+ALTER TABLE group_invites_audit ENABLE ROW LEVEL SECURITY;
+-- Allows background workers to insert audit rows during group purge
+DROP POLICY IF EXISTS group_invite_audit_background_worker_access ON group_invites_audit;
+CREATE POLICY group_invite_audit_background_worker_access ON group_invites_audit FOR ALL TO inventario_background_worker
+    USING (true)
+    WITH CHECK (true);
+-- Ensures group invite audit records are isolated by tenant
+DROP POLICY IF EXISTS group_invite_audit_tenant_isolation ON group_invites_audit;
+CREATE POLICY group_invite_audit_tenant_isolation ON group_invites_audit FOR ALL TO inventario_app
+    USING (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '')
+    WITH CHECK (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '');
+CREATE INDEX IF NOT EXISTS idx_group_invites_audit_archived_at ON group_invites_audit (archived_at);
+CREATE INDEX IF NOT EXISTS idx_group_invites_audit_original_group_id ON group_invites_audit (original_group_id);
+CREATE INDEX IF NOT EXISTS idx_group_invites_audit_tenant_id ON group_invites_audit (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_group_invites_audit_used_by ON group_invites_audit (used_by);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_group_invites_audit_uuid ON group_invites_audit (uuid);

--- a/go/schema/migrations/_sqldata/1776973984_phase8_add_group_invites_audit.up.sql
+++ b/go/schema/migrations/_sqldata/1776973984_phase8_add_group_invites_audit.up.sql
@@ -41,5 +41,6 @@ CREATE POLICY group_invite_audit_tenant_isolation ON group_invites_audit FOR ALL
 CREATE INDEX IF NOT EXISTS idx_group_invites_audit_archived_at ON group_invites_audit (archived_at);
 CREATE INDEX IF NOT EXISTS idx_group_invites_audit_original_group_id ON group_invites_audit (original_group_id);
 CREATE INDEX IF NOT EXISTS idx_group_invites_audit_tenant_id ON group_invites_audit (tenant_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_group_invites_audit_tenant_invite ON group_invites_audit (tenant_id, original_invite_id);
 CREATE INDEX IF NOT EXISTS idx_group_invites_audit_used_by ON group_invites_audit (used_by);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_group_invites_audit_uuid ON group_invites_audit (uuid);

--- a/go/services/file_service.go
+++ b/go/services/file_service.go
@@ -154,6 +154,44 @@ func (s *FileService) DeletePhysicalFile(ctx context.Context, filePath string) e
 	return s.deletePhysicalFile(ctx, filePath)
 }
 
+// DeletePhysicalFilesForGroup deletes every physical blob (and its thumbnails)
+// that belongs to the given (tenant, group) pair. It is intended for the
+// group-purge background worker and therefore uses a service-mode file
+// registry to bypass tenant/group RLS. Database rows are NOT touched here —
+// that is the responsibility of the GroupPurger. Callers must ensure the
+// group is in pending_deletion state before invoking this method.
+//
+// The method is fail-fast: the first blob that fails to delete aborts the
+// entire sweep so the orchestration layer can leave the group in
+// pending_deletion and retry on the next tick.
+func (s *FileService) DeletePhysicalFilesForGroup(ctx context.Context, tenantID, groupID string) error {
+	if tenantID == "" || groupID == "" {
+		return errxtrace.Wrap("tenantID and groupID are required", registry.ErrFieldRequired)
+	}
+
+	fileReg := s.factorySet.FileRegistryFactory.CreateServiceRegistry()
+	files, err := fileReg.List(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to list files in service mode", err)
+	}
+
+	for _, file := range files {
+		if file == nil {
+			continue
+		}
+		if file.TenantID != tenantID || file.GroupID != groupID {
+			continue
+		}
+		if file.File == nil || file.File.OriginalPath == "" {
+			continue
+		}
+		if err := s.deletePhysicalFileAndThumbnails(ctx, file.ID, file.File.OriginalPath, file.File.MIMEType); err != nil {
+			return errxtrace.Wrap(fmt.Sprintf("failed to delete physical blobs for file %s", file.ID), err)
+		}
+	}
+	return nil
+}
+
 // deletePhysicalFileAndThumbnails deletes the physical file and all its thumbnails
 func (s *FileService) deletePhysicalFileAndThumbnails(ctx context.Context, fileID, filePath, mimeType string) error {
 	// Delete the original file

--- a/go/services/file_service.go
+++ b/go/services/file_service.go
@@ -170,16 +170,13 @@ func (s *FileService) DeletePhysicalFilesForGroup(ctx context.Context, tenantID,
 	}
 
 	fileReg := s.factorySet.FileRegistryFactory.CreateServiceRegistry()
-	files, err := fileReg.List(ctx)
+	files, err := fileReg.ListByGroup(ctx, tenantID, groupID)
 	if err != nil {
-		return errxtrace.Wrap("failed to list files in service mode", err)
+		return errxtrace.Wrap("failed to list files by group", err)
 	}
 
 	for _, file := range files {
 		if file == nil {
-			continue
-		}
-		if file.TenantID != tenantID || file.GroupID != groupID {
 			continue
 		}
 		if file.File == nil || file.File.OriginalPath == "" {

--- a/go/services/group_purge_service.go
+++ b/go/services/group_purge_service.go
@@ -112,19 +112,21 @@ func (s *GroupPurgeService) purgeGroup(ctx context.Context, g *models.LocationGr
 	return nil
 }
 
-// snapshotUsedInvites lists every invite belonging to the group and copies
-// the used ones into group_invites_audit. Unused invites are ignored — they
-// are purged outright in step (4).
+// snapshotUsedInvites copies every accepted invite for the group into
+// group_invites_audit. Uses the group-scoped ListUsedByGroup query so cost
+// scales with per-group invites rather than the full invite table. The audit
+// Create is idempotent (unique index on tenant_id + original_invite_id), so
+// retries after a mid-purge failure never produce duplicate rows.
 func (s *GroupPurgeService) snapshotUsedInvites(ctx context.Context, g *models.LocationGroup) error {
-	all, err := s.factorySet.GroupInviteRegistry.List(ctx)
+	used, err := s.factorySet.GroupInviteRegistry.ListUsedByGroup(ctx, g.ID)
 	if err != nil {
-		return errxtrace.Wrap("failed to list invites", err)
+		return errxtrace.Wrap("failed to list used invites", err)
 	}
-	for _, inv := range all {
+	for _, inv := range used {
 		if inv == nil {
 			continue
 		}
-		if inv.GroupID != g.ID || inv.TenantID != g.TenantID {
+		if inv.TenantID != g.TenantID {
 			continue
 		}
 		if inv.UsedBy == nil || *inv.UsedBy == "" {

--- a/go/services/group_purge_service.go
+++ b/go/services/group_purge_service.go
@@ -1,0 +1,139 @@
+package services
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// GroupPurgeService orchestrates hard-deletion of LocationGroups that were
+// previously marked pending_deletion. A single PurgeOnce tick:
+//
+//  1. lists every LocationGroup in pending_deletion state (across tenants via
+//     the service-mode registry, which runs as inventario_background_worker);
+//  2. for each group, snapshots its used invites into group_invites_audit,
+//     deletes physical blobs (fail-fast), bulk-deletes group-scoped rows via
+//     GroupPurger, removes remaining invites, and finally deletes the
+//     location_groups row itself.
+//
+// Per-group failures are logged and the tick continues with the next group —
+// a failed group stays pending_deletion and will be retried on the next tick.
+// That idempotency is what makes fail-fast blob deletion safe.
+type GroupPurgeService struct {
+	factorySet  *registry.FactorySet
+	fileService *FileService
+}
+
+// NewGroupPurgeService constructs the orchestrator. Both dependencies are
+// required.
+func NewGroupPurgeService(factorySet *registry.FactorySet, fileService *FileService) *GroupPurgeService {
+	return &GroupPurgeService{factorySet: factorySet, fileService: fileService}
+}
+
+// PurgeOnce runs one full sweep across every pending_deletion LocationGroup
+// and returns the number of successfully purged groups alongside the number
+// that failed. Errors for individual groups are logged but do not abort the
+// sweep — a non-nil error is only returned when the initial listing itself
+// fails.
+func (s *GroupPurgeService) PurgeOnce(ctx context.Context) (purged, failed int, err error) {
+	if s.factorySet == nil || s.factorySet.LocationGroupRegistry == nil {
+		return 0, 0, errxtrace.Wrap("factorySet.LocationGroupRegistry is not configured", registry.ErrFieldRequired)
+	}
+	all, err := s.factorySet.LocationGroupRegistry.List(ctx)
+	if err != nil {
+		return 0, 0, errxtrace.Wrap("failed to list location_groups", err)
+	}
+
+	for _, g := range all {
+		if g == nil || g.Status != models.LocationGroupStatusPendingDeletion {
+			continue
+		}
+		if err := s.purgeGroup(ctx, g); err != nil {
+			failed++
+			slog.Error("group purge failed",
+				"group_id", g.ID,
+				"tenant_id", g.TenantID,
+				"error", err)
+			continue
+		}
+		purged++
+		slog.Info("group purged",
+			"group_id", g.ID,
+			"tenant_id", g.TenantID,
+			"slug", g.Slug)
+	}
+	return purged, failed, nil
+}
+
+// CleanExpiredInvites deletes every unused invite whose ExpiresAt is in the
+// past (spec #1309 Option 2i). Used invites are never touched here — they
+// are snapshotted into group_invites_audit during per-group purge.
+func (s *GroupPurgeService) CleanExpiredInvites(ctx context.Context) (int, error) {
+	if s.factorySet == nil || s.factorySet.GroupInviteRegistry == nil {
+		return 0, errxtrace.Wrap("factorySet.GroupInviteRegistry is not configured", registry.ErrFieldRequired)
+	}
+	n, err := s.factorySet.GroupInviteRegistry.DeleteExpiredUnused(ctx, time.Now())
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to delete expired unused invites", err)
+	}
+	return n, nil
+}
+
+// purgeGroup executes the full purge sequence for a single group. Order
+// matters — see doc on GroupPurgeService.
+func (s *GroupPurgeService) purgeGroup(ctx context.Context, g *models.LocationGroup) error {
+	// 1) snapshot used invites into the audit table BEFORE deleting them.
+	if err := s.snapshotUsedInvites(ctx, g); err != nil {
+		return errxtrace.Wrap("failed to snapshot used invites", err)
+	}
+	// 2) physical blobs first — if object storage is unavailable we abort
+	// without mutating the database, and the next tick retries.
+	if err := s.fileService.DeletePhysicalFilesForGroup(ctx, g.TenantID, g.ID); err != nil {
+		return errxtrace.Wrap("failed to delete physical blobs", err)
+	}
+	// 3) bulk-delete every group-scoped row in FK-safe order.
+	if err := s.factorySet.GroupPurger.PurgeGroupDependents(ctx, g.TenantID, g.ID); err != nil {
+		return errxtrace.Wrap("failed to purge group dependents", err)
+	}
+	// 4) delete any remaining invites (used rows are already audited).
+	if _, err := s.factorySet.GroupInviteRegistry.DeleteByGroup(ctx, g.ID); err != nil {
+		return errxtrace.Wrap("failed to delete group invites", err)
+	}
+	// 5) finally, delete the location_groups row itself. Once this succeeds
+	// the purge is durable — the row won't reappear on the next tick.
+	if err := s.factorySet.LocationGroupRegistry.Delete(ctx, g.ID); err != nil {
+		return errxtrace.Wrap("failed to delete location_groups row", err)
+	}
+	return nil
+}
+
+// snapshotUsedInvites lists every invite belonging to the group and copies
+// the used ones into group_invites_audit. Unused invites are ignored — they
+// are purged outright in step (4).
+func (s *GroupPurgeService) snapshotUsedInvites(ctx context.Context, g *models.LocationGroup) error {
+	all, err := s.factorySet.GroupInviteRegistry.List(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to list invites", err)
+	}
+	for _, inv := range all {
+		if inv == nil {
+			continue
+		}
+		if inv.GroupID != g.ID || inv.TenantID != g.TenantID {
+			continue
+		}
+		if inv.UsedBy == nil || *inv.UsedBy == "" {
+			continue
+		}
+		audit := models.NewGroupInviteAuditFromInvite(inv, g)
+		if _, err := s.factorySet.GroupInviteAuditRegistry.Create(ctx, *audit); err != nil {
+			return errxtrace.Wrap("failed to write invite audit row", err)
+		}
+	}
+	return nil
+}

--- a/go/services/group_purge_service_test.go
+++ b/go/services/group_purge_service_test.go
@@ -333,3 +333,62 @@ func TestGroupPurgeService_PurgeOnce_Reentrancy(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(audits, qt.HasLen, 1)
 }
+
+// TestGroupPurgeService_PurgeOnce_PartialFailure_NoDuplicateAudit drives the
+// re-entrancy contract on a hard case: the first sweep writes the invite
+// audit snapshot and then crashes during blob deletion, leaving the group
+// pending_deletion. A second sweep must snapshot the same used invite again
+// and succeed, but the unique (tenant_id, original_invite_id) index on
+// group_invites_audit must collapse the retry into a no-op so we end up with
+// exactly one audit row.
+func TestGroupPurgeService_PurgeOnce_PartialFailure_NoDuplicateAudit(t *testing.T) {
+	c := qt.New(t)
+	ctx, fs, _, uploadLocation, pendingID, _, blobPath := newPurgeFixture(c)
+
+	// First attempt: bad upload location so blob.OpenBucket fails inside
+	// DeletePhysicalFilesForGroup, which is invoked AFTER snapshotUsedInvites.
+	brokenFileSvc := services.NewFileService(fs, "unknownscheme://invalid")
+	brokenSvc := services.NewGroupPurgeService(fs, brokenFileSvc)
+	purged, failed, err := brokenSvc.PurgeOnce(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(purged, qt.Equals, 0)
+	c.Assert(failed, qt.Equals, 1)
+
+	// Audit row was written by the failed first attempt.
+	audits, err := fs.GroupInviteAuditRegistry.ListByOriginalGroup(ctx, pendingID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(audits, qt.HasLen, 1)
+	firstAuditID := audits[0].ID
+
+	// Group is still pending_deletion — nothing downstream of the failed
+	// blob delete ran.
+	pending, err := fs.LocationGroupRegistry.Get(ctx, pendingID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(pending.Status, qt.Equals, models.LocationGroupStatusPendingDeletion)
+
+	// Second attempt: healthy file service finishes the purge.
+	workingSvc := services.NewGroupPurgeService(fs, services.NewFileService(fs, uploadLocation))
+	purged, failed, err = workingSvc.PurgeOnce(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(purged, qt.Equals, 1)
+	c.Assert(failed, qt.Equals, 0)
+
+	// Exactly one audit row survives — the retry's snapshotUsedInvites
+	// re-ran but the idempotent Create dropped the duplicate. The original
+	// audit ID from attempt #1 is still the one present.
+	audits, err = fs.GroupInviteAuditRegistry.ListByOriginalGroup(ctx, pendingID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(audits, qt.HasLen, 1)
+	c.Assert(audits[0].ID, qt.Equals, firstAuditID)
+
+	// Group and blob are gone.
+	_, err = fs.LocationGroupRegistry.Get(ctx, pendingID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+	b, err := blob.OpenBucket(ctx, uploadLocation)
+	c.Assert(err, qt.IsNil)
+	defer b.Close()
+	exists, err := b.Exists(ctx, blobPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsFalse)
+}

--- a/go/services/group_purge_service_test.go
+++ b/go/services/group_purge_service_test.go
@@ -1,0 +1,335 @@
+package services_test
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"gocloud.dev/blob"
+
+	_ "github.com/denisvmedia/inventario/internal/fileblob" // register file:// driver
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// newFileUploadLocation returns a file:// DSN for a temp directory, cross-
+// platform. Mirrors the helper pattern in file_service_test.go.
+func newFileUploadLocation(c *qt.C) string {
+	tempDir := c.TempDir()
+	if runtime.GOOS == "windows" {
+		return "file:///" + tempDir + "?create_dir=1"
+	}
+	return "file://" + tempDir + "?create_dir=1"
+}
+
+// seedPurgeFixtures inserts one pending-deletion group with a file (and
+// physical blob), one used invite, one unused-expired invite, and one active
+// group with its own file that must survive the sweep. Returns the two group
+// IDs so tests can assert on them.
+func seedPurgeFixtures(c *qt.C, ctx context.Context, fs *registry.FactorySet, uploadLocation string) (pendingID, activeID, blobPath string) {
+	c.Helper()
+
+	// Pending-deletion group.
+	pending, err := fs.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: "tenant-a"},
+		Slug:               "pending-group-slug-0000000000",
+		Name:               "Pending Group",
+		Status:             models.LocationGroupStatusPendingDeletion,
+		CreatedBy:          "user-admin",
+		MainCurrency:       "USD",
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Active group — must be left untouched by the sweep.
+	active, err := fs.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: "tenant-a"},
+		Slug:               "active-group-slug-00000000000",
+		Name:               "Active Group",
+		Status:             models.LocationGroupStatusActive,
+		CreatedBy:          "user-admin",
+		MainCurrency:       "USD",
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Seed a physical blob referenced by a FileEntity in the pending group.
+	blobPath = "pending/file.txt"
+	b, err := blob.OpenBucket(ctx, uploadLocation)
+	c.Assert(err, qt.IsNil)
+	c.Assert(b.WriteAll(ctx, blobPath, []byte("payload"), nil), qt.IsNil)
+	c.Assert(b.Close(), qt.IsNil)
+
+	fileReg := fs.FileRegistryFactory.CreateServiceRegistry()
+	_, err = fileReg.Create(ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        "tenant-a",
+			GroupID:         pending.ID,
+			CreatedByUserID: "user-admin",
+		},
+		Title: "pending-file",
+		Type:  models.FileTypeDocument,
+		File: &models.File{
+			Path:         "pending/file",
+			OriginalPath: blobPath,
+			Ext:          ".txt",
+			MIMEType:     "text/plain",
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Survivor file in the active group.
+	_, err = fileReg.Create(ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        "tenant-a",
+			GroupID:         active.ID,
+			CreatedByUserID: "user-admin",
+		},
+		Title: "active-file",
+		Type:  models.FileTypeDocument,
+		File: &models.File{
+			Path:         "active/file",
+			OriginalPath: "active/file.txt",
+			Ext:          ".txt",
+			MIMEType:     "text/plain",
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Used invite for the pending group — must be snapshotted to audit.
+	usedAt := time.Now().Add(-2 * time.Hour)
+	usedBy := "user-member"
+	_, err = fs.GroupInviteRegistry.Create(ctx, models.GroupInvite{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: "tenant-a"},
+		GroupID:            pending.ID,
+		Token:              "used-token",
+		CreatedBy:          "user-admin",
+		ExpiresAt:          time.Now().Add(-1 * time.Hour),
+		UsedBy:             &usedBy,
+		UsedAt:             &usedAt,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Unused expired invite for the active group — removed by
+	// CleanExpiredInvites, NOT by the per-group purge path.
+	_, err = fs.GroupInviteRegistry.Create(ctx, models.GroupInvite{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: "tenant-a"},
+		GroupID:            active.ID,
+		Token:              "expired-unused-token",
+		CreatedBy:          "user-admin",
+		ExpiresAt:          time.Now().Add(-30 * time.Minute),
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Unused active invite for the active group — must survive.
+	_, err = fs.GroupInviteRegistry.Create(ctx, models.GroupInvite{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: "tenant-a"},
+		GroupID:            active.ID,
+		Token:              "active-unused-token",
+		CreatedBy:          "user-admin",
+		ExpiresAt:          time.Now().Add(24 * time.Hour),
+	})
+	c.Assert(err, qt.IsNil)
+
+	return pending.ID, active.ID, blobPath
+}
+
+func newPurgeFixture(c *qt.C) (
+	ctx context.Context,
+	fs *registry.FactorySet,
+	svc *services.GroupPurgeService,
+	uploadLocation, pendingID, activeID, blobPath string,
+) {
+	ctx = context.Background()
+	uploadLocation = newFileUploadLocation(c)
+	fs = memory.NewFactorySet()
+	fileSvc := services.NewFileService(fs, uploadLocation)
+	svc = services.NewGroupPurgeService(fs, fileSvc)
+	pendingID, activeID, blobPath = seedPurgeFixtures(c, ctx, fs, uploadLocation)
+	return ctx, fs, svc, uploadLocation, pendingID, activeID, blobPath
+}
+
+// TestGroupPurgeService_PurgeOnce_HappyPath verifies the full purge sweep:
+// pending group and its dependents are hard-deleted, the used invite is
+// snapshotted into the audit table, the physical blob is removed, and the
+// active group is untouched.
+func TestGroupPurgeService_PurgeOnce_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	ctx, fs, svc, uploadLocation, pendingID, activeID, blobPath := newPurgeFixture(c)
+
+	purged, failed, err := svc.PurgeOnce(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(purged, qt.Equals, 1)
+	c.Assert(failed, qt.Equals, 0)
+
+	// Pending group row is gone.
+	_, err = fs.LocationGroupRegistry.Get(ctx, pendingID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+	// Active group survives.
+	survivor, err := fs.LocationGroupRegistry.Get(ctx, activeID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(survivor.Status, qt.Equals, models.LocationGroupStatusActive)
+
+	// Pending group's file is gone (service-mode view).
+	fileReg := fs.FileRegistryFactory.CreateServiceRegistry()
+	files, err := fileReg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	for _, f := range files {
+		c.Assert(f.GroupID, qt.Not(qt.Equals), pendingID)
+	}
+
+	// Physical blob removed.
+	b, err := blob.OpenBucket(ctx, uploadLocation)
+	c.Assert(err, qt.IsNil)
+	defer b.Close()
+	exists, err := b.Exists(ctx, blobPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsFalse)
+
+	// Used invite was archived.
+	audits, err := fs.GroupInviteAuditRegistry.ListByOriginalGroup(ctx, pendingID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(audits, qt.HasLen, 1)
+	c.Assert(audits[0].TenantID, qt.Equals, "tenant-a")
+	c.Assert(audits[0].OriginalGroupID, qt.Equals, pendingID)
+	c.Assert(audits[0].OriginalGroupSlug, qt.Equals, "pending-group-slug-0000000000")
+	c.Assert(audits[0].Token, qt.Equals, "used-token")
+	c.Assert(audits[0].UsedBy, qt.Equals, "user-member")
+
+	// All invites belonging to the pending group are gone.
+	allInvites, err := fs.GroupInviteRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+	for _, inv := range allInvites {
+		c.Assert(inv.GroupID, qt.Not(qt.Equals), pendingID)
+	}
+}
+
+// TestGroupPurgeService_PurgeOnce_SkipsActive verifies that a factory set
+// with only active groups yields a no-op sweep.
+func TestGroupPurgeService_PurgeOnce_SkipsActive(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	fs := memory.NewFactorySet()
+	fileSvc := services.NewFileService(fs, newFileUploadLocation(c))
+	svc := services.NewGroupPurgeService(fs, fileSvc)
+
+	created, err := fs.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: "tenant-a"},
+		Slug:               "active-only-slug-000000000000",
+		Name:               "Active Only",
+		Status:             models.LocationGroupStatusActive,
+		CreatedBy:          "user-admin",
+		MainCurrency:       "USD",
+	})
+	c.Assert(err, qt.IsNil)
+
+	purged, failed, err := svc.PurgeOnce(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(purged, qt.Equals, 0)
+	c.Assert(failed, qt.Equals, 0)
+
+	// Group row is still there.
+	_, err = fs.LocationGroupRegistry.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+}
+
+// TestGroupPurgeService_CleanExpiredInvites verifies the expiry sweep
+// (spec #1309 Option 2i): unused expired invites are removed, used invites
+// and unused non-expired invites are preserved.
+func TestGroupPurgeService_CleanExpiredInvites(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	fs := memory.NewFactorySet()
+	fileSvc := services.NewFileService(fs, newFileUploadLocation(c))
+	svc := services.NewGroupPurgeService(fs, fileSvc)
+
+	// Parent group (active).
+	group, err := fs.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: "tenant-a"},
+		Slug:               "expiry-group-slug-0000000000",
+		Name:               "Expiry Group",
+		Status:             models.LocationGroupStatusActive,
+		CreatedBy:          "user-admin",
+		MainCurrency:       "USD",
+	})
+	c.Assert(err, qt.IsNil)
+
+	usedAt := time.Now().Add(-90 * time.Minute)
+	usedBy := "user-member"
+	// Used expired invite — NOT touched by CleanExpiredInvites.
+	usedExpired, err := fs.GroupInviteRegistry.Create(ctx, models.GroupInvite{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: "tenant-a"},
+		GroupID:            group.ID,
+		Token:              "used-expired",
+		CreatedBy:          "user-admin",
+		ExpiresAt:          time.Now().Add(-1 * time.Hour),
+		UsedBy:             &usedBy,
+		UsedAt:             &usedAt,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Unused expired invite — must be removed.
+	unusedExpired, err := fs.GroupInviteRegistry.Create(ctx, models.GroupInvite{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: "tenant-a"},
+		GroupID:            group.ID,
+		Token:              "unused-expired",
+		CreatedBy:          "user-admin",
+		ExpiresAt:          time.Now().Add(-5 * time.Minute),
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Unused active invite — must survive.
+	unusedActive, err := fs.GroupInviteRegistry.Create(ctx, models.GroupInvite{
+		TenantOnlyEntityID: models.TenantOnlyEntityID{TenantID: "tenant-a"},
+		GroupID:            group.ID,
+		Token:              "unused-active",
+		CreatedBy:          "user-admin",
+		ExpiresAt:          time.Now().Add(24 * time.Hour),
+	})
+	c.Assert(err, qt.IsNil)
+
+	deleted, err := svc.CleanExpiredInvites(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(deleted, qt.Equals, 1)
+
+	// Used expired invite stays.
+	_, err = fs.GroupInviteRegistry.Get(ctx, usedExpired.ID)
+	c.Assert(err, qt.IsNil)
+
+	// Unused expired invite is gone.
+	_, err = fs.GroupInviteRegistry.Get(ctx, unusedExpired.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+
+	// Unused active invite stays.
+	_, err = fs.GroupInviteRegistry.Get(ctx, unusedActive.ID)
+	c.Assert(err, qt.IsNil)
+}
+
+// TestGroupPurgeService_PurgeOnce_Reentrancy verifies that a second sweep
+// over an already-purged factory set is a no-op: the previously-purged group
+// row is gone, so nothing is reprocessed and no duplicate audit rows are
+// written.
+func TestGroupPurgeService_PurgeOnce_Reentrancy(t *testing.T) {
+	c := qt.New(t)
+	ctx, fs, svc, _, pendingID, _, _ := newPurgeFixture(c)
+
+	// First sweep does the real work.
+	purged, failed, err := svc.PurgeOnce(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(purged, qt.Equals, 1)
+	c.Assert(failed, qt.Equals, 0)
+
+	// Second sweep has nothing to do — the pending row is gone.
+	purged, failed, err = svc.PurgeOnce(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(purged, qt.Equals, 0)
+	c.Assert(failed, qt.Equals, 0)
+
+	// Exactly one audit row for the purged group, not two.
+	audits, err := fs.GroupInviteAuditRegistry.ListByOriginalGroup(ctx, pendingID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(audits, qt.HasLen, 1)
+}

--- a/go/services/group_purge_worker.go
+++ b/go/services/group_purge_worker.go
@@ -1,0 +1,143 @@
+package services
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const defaultGroupPurgeInterval = 5 * time.Minute
+
+// Prometheus counters for the group purge worker. Registered lazily at
+// package init via promauto against the default registry. Scraped through
+// /metrics alongside the rest of the app's instrumentation.
+var (
+	groupsPurgedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "inventario_groups_purged_total",
+		Help: "Number of location_groups successfully hard-deleted by the purge worker.",
+	})
+	groupsPurgeFailuresTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "inventario_groups_purge_failures_total",
+		Help: "Number of location_groups whose per-group purge raised an error (will be retried next tick).",
+	})
+	groupInvitesExpiredPurgedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "inventario_group_invites_expired_purged_total",
+		Help: "Number of unused, expired group invites removed by the housekeeping sweep.",
+	})
+)
+
+// GroupPurgeWorker periodically runs the GroupPurgeService sweep: it purges
+// any LocationGroups in pending_deletion state and deletes expired unused
+// group invites. It mirrors the RefreshTokenCleanupWorker pattern — a single
+// goroutine driven by a ticker, with a best-effort graceful stop.
+type GroupPurgeWorker struct {
+	service       *GroupPurgeService
+	purgeInterval time.Duration
+	stopCh        chan struct{}
+	stopOnce      sync.Once
+	wg            sync.WaitGroup
+}
+
+// GroupPurgeOption customizes a GroupPurgeWorker created by
+// NewGroupPurgeWorker.
+type GroupPurgeOption func(*groupPurgeOptions)
+
+type groupPurgeOptions struct {
+	purgeInterval time.Duration
+}
+
+// WithGroupPurgeInterval overrides the default purge interval. Non-positive
+// values are ignored.
+func WithGroupPurgeInterval(d time.Duration) GroupPurgeOption {
+	return func(o *groupPurgeOptions) {
+		if d > 0 {
+			o.purgeInterval = d
+		}
+	}
+}
+
+// NewGroupPurgeWorker creates a worker with the default five-minute interval,
+// overridable via GroupPurgeOption values (e.g. WithGroupPurgeInterval).
+func NewGroupPurgeWorker(service *GroupPurgeService, opts ...GroupPurgeOption) *GroupPurgeWorker {
+	options := groupPurgeOptions{
+		purgeInterval: defaultGroupPurgeInterval,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return &GroupPurgeWorker{
+		service:       service,
+		purgeInterval: options.purgeInterval,
+		stopCh:        make(chan struct{}),
+	}
+}
+
+// Start launches the background purge goroutine. It is a no-op if the
+// service is nil.
+func (w *GroupPurgeWorker) Start(ctx context.Context) {
+	if w.service == nil {
+		slog.Warn("GroupPurgeWorker: no service configured, skipping startup")
+		return
+	}
+	w.wg.Go(func() {
+		w.run(ctx)
+	})
+	slog.Info("Group purge worker started", "interval", w.purgeInterval)
+}
+
+// Stop signals the worker to stop and waits for it to finish.
+func (w *GroupPurgeWorker) Stop() {
+	w.stopOnce.Do(func() {
+		close(w.stopCh)
+	})
+	w.wg.Wait()
+	slog.Info("Group purge worker stopped")
+}
+
+func (w *GroupPurgeWorker) run(ctx context.Context) {
+	ticker := time.NewTicker(w.purgeInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			w.tick(ctx)
+		}
+	}
+}
+
+// tick runs a single purge+expire sweep. Errors are logged but do not stop
+// the worker — a transient failure is expected to be retried on the next
+// tick.
+func (w *GroupPurgeWorker) tick(ctx context.Context) {
+	if purged, failed, err := w.service.PurgeOnce(ctx); err != nil {
+		slog.Error("Group purge sweep failed", "error", err)
+	} else {
+		if purged > 0 {
+			groupsPurgedTotal.Add(float64(purged))
+			slog.Info("Group purge sweep completed", "groups_purged", purged, "groups_failed", failed)
+		} else {
+			slog.Debug("Group purge sweep completed", "groups_purged", 0, "groups_failed", failed)
+		}
+		if failed > 0 {
+			groupsPurgeFailuresTotal.Add(float64(failed))
+		}
+	}
+
+	if expired, err := w.service.CleanExpiredInvites(ctx); err != nil {
+		slog.Error("Expired invite cleanup failed", "error", err)
+	} else if expired > 0 {
+		groupInvitesExpiredPurgedTotal.Add(float64(expired))
+		slog.Info("Expired invites cleaned up", "count", expired)
+	} else {
+		slog.Debug("Expired invites cleaned up", "count", 0)
+	}
+}


### PR DESCRIPTION
Closes #1309.

## Summary

Adds a dedicated housekeeping worker that hard-deletes `LocationGroups` marked `pending_deletion` and sweeps expired unused invites. Chosen options from the issue:

- **1c — Audit used invites.** Used invites are snapshotted into a new `group_invites_audit` table before the parent group is deleted; unused ones are discarded.
- **2i — Housekeeping also purges expired unused invites.** Single worker, single sweep, both concerns handled.

## Isolation

All cross-tenant / cross-group work runs under the `inventario_background_worker` PostgreSQL role via `DoAsBackgroundWorker`. Each of `location_groups`, `group_invites`, and the new `group_invites_audit` table gets a `USING(true)` bypass policy for that role, while `inventario_app` retains its strict tenant-scoped policy.

## What's in this PR

**Model + registries**
- `models.GroupInviteAudit` with RLS annotations and `NewGroupInviteAuditFromInvite` constructor.
- Memory + Postgres registries for the audit table (`Create`, `ListByTenant`, `ListByOriginalGroup`).
- Postgres + memory `GroupPurger` implementations that delete dependents in FK-safe order using service-mode transactions.

**Service + worker**
- `services.GroupPurgeService`:
  - `PurgeOnce(ctx) (purged, failed int, err error)` — per-group: list pending → snapshot used invites → fail-fast physical blob delete → purge dependents → delete group row.
  - `CleanExpiredInvites(ctx) (deleted int, err error)` — cross-tenant sweep of unused expired invites.
- `services.GroupPurgeWorker` — ticker-based, mirrors `RefreshTokenCleanupWorker`, graceful `Start`/`Stop`, `WithGroupPurgeInterval` option.
- Prometheus counters: `inventario_groups_purged_total`, `inventario_groups_purge_failures_total`, `inventario_group_invites_expired_purged_total`.

**Wiring**
- `defaults.Workers.GroupPurgeInterval` (default `5m`) + `GetGroupPurgeInterval()`.
- `bootstrap.Config.GroupPurgeInterval` + `GROUP_PURGE_INTERVAL` env + `--group-purge-interval` flag.
- `WorkerDurations.GroupPurgeInterval` plumbed through `ParseWorkerDurations`.
- `StartGroupPurgeWorker` registered alongside `RefreshTokenCleanupWorker` under `WorkerHousekeeping`; added to `run/all`.

**Schema migration** — `1776973984_phase8_add_group_invites_audit.{up,down}.sql` (generated via `inventool db migrations generate`). Creates the table, indexes, FKs (`created_by`, `used_by` → `users`), and both RLS policies.

## Tests

**Memory (unit) — `go/services/group_purge_service_test.go`**
- `PurgeOnce_HappyPath` — pending group purged, files (incl. physical blob) removed, audit row written, active group survives.
- `PurgeOnce_SkipsActive` — active-only factory is a no-op.
- `CleanExpiredInvites` — unused-expired removed; used-expired + unused-active preserved.
- `PurgeOnce_Reentrancy` — second sweep is a no-op; exactly one audit row per purged group.

**PostgreSQL (integration, `-tags=postgres`) — `go/registry/postgres/group_purger_test.go`**
- `TestGroupPurgeService_Postgres_CrossTenantRLSBypass` — two tenants each with a `pending_deletion` group and a used invite; one `PurgeOnce` call deletes both groups and writes audit rows for both tenants; verifies `inventario_background_worker`'s bypass policy end-to-end against a real schema.
- `TestGroupPurgeService_Postgres_CleanExpiredInvitesCrossTenant` — confirms Option 2i reaches across tenants while leaving used-expired and unused-active invites untouched.

## Verification

- `go build ./...` — clean.
- `go vet ./...` — clean (only pre-existing `internal/fileblob/drivertest` warnings).
- `go test ./services/... ./registry/memory/...` — passing.
- `golangci-lint run ./registry/postgres/... ./services/...` — 0 issues.
- `inventool db migrations generate --check` — schema in sync.
- With `POSTGRES_TEST_DSN` set: both new Postgres tests pass.

## Notes for review

- The audit table intentionally has no `group_id` FK (the group row is deleted). It does FK `created_by` / `used_by` to `users(id)`, which survive group purge.
- `GroupPurgeWorker` follows the exact lifecycle pattern of `RefreshTokenCleanupWorker` for consistency with the existing housekeeping workers.
- Running the full Postgres suite surfaced one pre-existing failure in `TestGroupInviteRegistry_GetByToken_And_ListActive` (TIMESTAMP-without-timezone bug comparing stored UTC against local `time.Now()`) — reproduces without any of this PR's changes. Left out of scope; happy to address in a separate PR.