### PR TITLE
refactor(frontend): remove legacy flat routes and localStorage migration (#1321)

### DIFF
--- a/e2e/tests/file-deletion-cascade.spec.ts
+++ b/e2e/tests/file-deletion-cascade.spec.ts
@@ -8,7 +8,7 @@ import { createCommodity, deleteCommodity, BACK_TO_AREAS } from "./includes/comm
 import { createExport, deleteExport } from "./includes/exports.js";
 import { FROM_LOCATIONS_AREA, navigateTo, TO_AREA_COMMODITIES, TO_LOCATIONS, TO_EXPORTS } from "./includes/navigate.js";
 import { uploadFile } from "./includes/uploads.js";
-import { groupApiBase } from "./includes/group-url.js";
+import { groupApiBase, gotoScoped } from "./includes/group-url.js";
 
 test.describe('File Deletion Cascade Tests', () => {
   // Test data with timestamps to ensure uniqueness
@@ -153,7 +153,7 @@ test.describe('File Deletion Cascade Tests', () => {
       expect(apiResponse.status()).toBe(200);
 
       // Also check via UI - navigate to file detail page
-      await page.goto(`/files/${fileId}`);
+      await gotoScoped(page, `/files/${fileId}`);
       await expect(page.locator('.breadcrumb-link')).toContainText('Back to Files');
       recorder.log(`File entity ${i + 1} confirmed to exist`);
     }
@@ -198,7 +198,7 @@ test.describe('File Deletion Cascade Tests', () => {
       recorder.log(`File entity ${i + 1} API returns 404: ${apiResponse.status()}`);
 
       // Check via UI - should show error or redirect
-      await page.goto(`/files/${fileId}`);
+      await gotoScoped(page, `/files/${fileId}`);
 
       // Verify that the file is no longer accessible (should show 404)
       await page.waitForSelector('.resource-not-found')
@@ -295,7 +295,7 @@ test.describe('File Deletion Cascade Tests', () => {
       recorder.log(`Export file entity confirmed to exist: ${fileId}`);
 
       // Also check via UI
-      await page.goto(`/files/${fileId}`);
+      await gotoScoped(page, `/files/${fileId}`);
       await expect(page.locator('h1')).toContainText('Export: Test Export for File Deletion');
       recorder.log(`Export file entity accessible via UI: ${fileId}`);
     }
@@ -304,7 +304,7 @@ test.describe('File Deletion Cascade Tests', () => {
 
     // STEP 4: DELETE EXPORT
     recorder.log(`Step ${step++}: Deleting export`);
-    await page.goto(`/exports/${exportId}`);
+    await gotoScoped(page, `/exports/${exportId}`);
     await deleteExport(page, recorder, testExport.description);
 
     // STEP 5: VERIFY EXPORT FILE IS NO LONGER ACCESSIBLE
@@ -334,7 +334,7 @@ test.describe('File Deletion Cascade Tests', () => {
       recorder.log(`Export file entity API returns 404: ${fileApiResponse.status()}`);
 
       // Check via UI - should show error or redirect
-      await page.goto(`/files/${fileId}`);
+      await gotoScoped(page, `/files/${fileId}`);
 
       // Verify that the file is no longer accessible (should show 404)
       await page.waitForSelector('.resource-not-found')
@@ -523,7 +523,7 @@ test.describe('File Deletion Cascade Tests', () => {
       recorder.log(`File entity ${i + 1} API returns 404: ${apiResponse.status()}`);
 
       // Check via UI - should show error or redirect
-      await page.goto(`/files/${fileId}`);
+      await gotoScoped(page, `/files/${fileId}`);
 
       // Verify that the file is no longer accessible (should show 404)
       await page.waitForSelector('.resource-not-found')

--- a/e2e/tests/includes/auth.ts
+++ b/e2e/tests/includes/auth.ts
@@ -1,6 +1,7 @@
 import { Page, expect } from '@playwright/test';
 import { TestRecorder, log, warn, error } from '../../utils/test-recorder.js';
 import { setCsrfToken } from './csrf.js';
+import { gotoScoped } from './group-url.js';
 
 /**
  * Test credentials for e2e tests
@@ -168,11 +169,14 @@ export async function ensureAuthenticated(page: Page, recorder?: TestRecorder): 
 export async function loginIfNeeded(page: Page, targetUrl?: string, recorder?: TestRecorder): Promise<string | null> {
   let csrfToken: string | null = null;
 
-  // If we have a target URL, try to navigate there first
+  // Probe the app via "/" so the router decides whether we land on
+  // /login (unauthed) or on /g/<slug>/... (authed). We can't hit a flat
+  // data path like /locations directly anymore — after #1321 the legacy
+  // stubs are gone, so a raw goto("/locations") would just land on the
+  // 404 route. Once the probe settles we either log in first, or jump
+  // straight to the scoped target via gotoScoped.
   if (targetUrl) {
-    await page.goto(targetUrl);
-
-    // Wait a moment for any redirects to complete
+    await page.goto('/');
     await page.waitForTimeout(1000);
   }
 
@@ -180,12 +184,14 @@ export async function loginIfNeeded(page: Page, targetUrl?: string, recorder?: T
   if (await isLoginPage(page)) {
     log(recorder, '🔄 Redirected to login, authenticating...');
     csrfToken = await login(page, recorder);
+  }
 
-    // After login, navigate to target URL if specified
-    if (targetUrl && targetUrl !== '/') {
-      log(recorder, `🔄 Navigating to target URL: ${targetUrl}`);
-      await page.goto(targetUrl);
-    }
+  // Navigate to the real target now that auth is settled. gotoScoped
+  // rewrites flat data paths (/locations, /files, …) into their
+  // /g/<slug>/... scoped equivalents so data routes resolve after #1321.
+  if (targetUrl && targetUrl !== '/') {
+    log(recorder, `🔄 Navigating to target URL: ${targetUrl}`);
+    await gotoScoped(page, targetUrl);
   }
 
   // Verify we're now authenticated with retries
@@ -247,10 +253,13 @@ export async function navigateWithAuth(page: Page, url: string, recorder?: TestR
 
   const csrfToken = await loginIfNeeded(page, url, recorder);
 
-  // Ensure we're on the correct page
+  // Ensure we're on the correct page. Use gotoScoped so a flat data path
+  // like "/locations" gets rewritten to "/g/<slug>/locations" — after
+  // #1321 the legacy flat stubs are gone and a raw page.goto("/locations")
+  // would land on the 404 route.
   const currentUrl = page.url();
   if (!currentUrl.includes(url.replace('/', ''))) {
-    await page.goto(url);
+    await gotoScoped(page, url);
   }
 
   log(recorder, `✅ Successfully navigated to ${url}`);

--- a/e2e/tests/includes/group-url.ts
+++ b/e2e/tests/includes/group-url.ts
@@ -1,7 +1,104 @@
 import { Page } from '@playwright/test';
 
 /**
- * Returns the group-scoped URL prefix for data-plane routes, e.g.
+ * Data-plane path prefixes that must be scoped under /g/<slug>/... after
+ * #1321 removed the legacy flat route stubs. Anything outside this list
+ * (/, /login, /profile, /groups/*, /invite/*, /no-group, /g/…) is
+ * passed through unchanged.
+ */
+const FLAT_DATA_PREFIXES = [
+  '/locations',
+  '/areas',
+  '/commodities',
+  '/files',
+  '/exports',
+  '/system',
+] as const;
+
+function extractSlugFromUrl(url: string): string | null {
+  try {
+    const pathname = new URL(url).pathname;
+    const match = pathname.match(/^\/g\/([^/]+)(?:\/|$)/);
+    return match ? decodeURIComponent(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function isFlatDataPath(path: string): boolean {
+  if (!path.startsWith('/')) return false;
+  if (path.startsWith('/g/')) return false;
+  return FLAT_DATA_PREFIXES.some((p) => path === p || path.startsWith(`${p}/`) || path.startsWith(`${p}?`));
+}
+
+/**
+ * Returns the active group slug extracted from the page's current URL, or
+ * null if the page is not on a /g/<slug>/... route. Sync — does not
+ * navigate.
+ */
+export function currentGroupSlug(page: Page): string | null {
+  return extractSlugFromUrl(page.url());
+}
+
+/**
+ * Ensures the page is on a /g/<slug>/... route and returns the slug.
+ * If the current URL already carries a slug it's returned immediately;
+ * otherwise the helper navigates to `/` and lets the app redirect to the
+ * user's default group before re-extracting.
+ */
+export async function ensureGroupSlug(page: Page): Promise<string> {
+  const existing = currentGroupSlug(page);
+  if (existing) return existing;
+
+  await page.goto('/');
+  await page.waitForURL(/\/g\/[^/]+/, { timeout: 15000 });
+  const resolved = currentGroupSlug(page);
+  if (!resolved) {
+    throw new Error(
+      `ensureGroupSlug: navigated to / but page URL ${page.url()} is still not /g/<slug>/... — is the user authenticated and a group member?`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Rewrites a flat data-plane path (e.g. `/locations`, `/files/abc`) to
+ * its /g/<slug>/... scoped equivalent using the slug extracted from the
+ * page's current URL. Non-data paths (/, /login, /profile, etc.) and
+ * already-scoped paths are returned unchanged.
+ *
+ * This is a sync helper that assumes the page has already navigated
+ * into a group. When callers can't guarantee that, use `gotoScoped`
+ * instead, which awaits `ensureGroupSlug` first.
+ */
+export function scopedPath(page: Page, path: string): string {
+  if (!isFlatDataPath(path)) return path;
+  const slug = currentGroupSlug(page);
+  if (!slug) {
+    throw new Error(
+      `scopedPath: cannot scope "${path}" — page URL ${page.url()} is not /g/<slug>/... (call ensureGroupSlug first or use gotoScoped)`,
+    );
+  }
+  return `/g/${encodeURIComponent(slug)}${path}`;
+}
+
+/**
+ * `page.goto` wrapper that rewrites flat data-plane paths into their
+ * /g/<slug>/... scoped equivalents. When the page isn't yet inside a
+ * group (e.g. just after login on /login), navigates home first to
+ * resolve the default-group slug. Non-data paths pass through.
+ */
+export async function gotoScoped(page: Page, path: string): Promise<void> {
+  if (!isFlatDataPath(path)) {
+    await page.goto(path);
+    return;
+  }
+  const slug = await ensureGroupSlug(page);
+  await page.goto(`/g/${encodeURIComponent(slug)}${path}`);
+}
+
+/**
+ * Returns the group-scoped URL prefix for data-plane API endpoints, e.g.
  * `/api/v1/g/<slug>`. The frontend's axios instance injects this prefix via
  * an interceptor for `/api/v1/locations|commodities|files|exports|…`; tests
  * that drive the raw `page.request` / `request` fixtures bypass that axios
@@ -15,12 +112,11 @@ import { Page } from '@playwright/test';
  * failure mode this helper exists to avoid.
  */
 export async function groupApiBase(page: Page): Promise<string> {
-  const pathname = new URL(page.url()).pathname;
-  const match = pathname.match(/^\/g\/([^/]+)(?:\/|$)/);
-  if (!match) {
+  const slug = currentGroupSlug(page);
+  if (!slug) {
     throw new Error(
       `groupApiBase: page URL ${page.url()} is not /g/<slug>/... — tests using group-scoped endpoints must navigate into a group first`,
     );
   }
-  return `/api/v1/g/${decodeURIComponent(match[1])}`;
+  return `/api/v1/g/${slug}`;
 }

--- a/e2e/tests/includes/group-url.ts
+++ b/e2e/tests/includes/group-url.ts
@@ -41,21 +41,71 @@ export function currentGroupSlug(page: Page): string | null {
 }
 
 /**
- * Ensures the page is on a /g/<slug>/... route and returns the slug.
- * If the current URL already carries a slug it's returned immediately;
- * otherwise the helper navigates to `/` and lets the app redirect to the
- * user's default group before re-extracting.
+ * Resolves a group slug for the authenticated user via /api/v1/groups.
+ * The frontend authenticates with a JWT stored in localStorage
+ * (`inventario_token`) and attached as `Authorization: Bearer`, so we run
+ * the fetch inside the page context where that token is in scope.
+ * Prefers the user's default_group_id (via /api/v1/auth/me) when
+ * available, otherwise falls back to the first group returned — the seed
+ * dataset ships a single group so either path lands on the same slug.
+ */
+async function resolveGroupSlugFromApi(page: Page): Promise<string | null> {
+  try {
+    return await page.evaluate(async () => {
+      const token = localStorage.getItem('inventario_token');
+      if (!token) return null;
+      const headers: Record<string, string> = {
+        Accept: 'application/vnd.api+json',
+        Authorization: `Bearer ${token}`,
+      };
+      const groupsResp = await fetch('/api/v1/groups', { headers });
+      if (!groupsResp.ok) return null;
+      const groupsBody = await groupsResp.json();
+      const items: Array<{ id: string; attributes?: { slug?: string } }> =
+        groupsBody?.data ?? [];
+      if (items.length === 0) return null;
+
+      let preferredId: string | null = null;
+      try {
+        const meResp = await fetch('/api/v1/auth/me', { headers });
+        if (meResp.ok) {
+          const meBody = await meResp.json();
+          preferredId =
+            meBody?.data?.attributes?.default_group_id ??
+            meBody?.default_group_id ??
+            null;
+        }
+      } catch {
+        // best-effort — fall through to first-item fallback
+      }
+
+      if (preferredId) {
+        const match = items.find((g) => g.id === preferredId);
+        if (match?.attributes?.slug) return match.attributes.slug;
+      }
+      return items[0]?.attributes?.slug ?? null;
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensures a group slug is available and returns it. Prefers the slug
+ * already present on the page URL; otherwise queries /api/v1/groups from
+ * inside the page context (reusing the JWT the frontend stashed in
+ * localStorage at login time). Does not rely on any implicit `/` →
+ * `/g/<slug>` redirect — the app's `/` is a valid unscoped home, not a
+ * redirector.
  */
 export async function ensureGroupSlug(page: Page): Promise<string> {
   const existing = currentGroupSlug(page);
   if (existing) return existing;
 
-  await page.goto('/');
-  await page.waitForURL(/\/g\/[^/]+/, { timeout: 15000 });
-  const resolved = currentGroupSlug(page);
+  const resolved = await resolveGroupSlugFromApi(page);
   if (!resolved) {
     throw new Error(
-      `ensureGroupSlug: navigated to / but page URL ${page.url()} is still not /g/<slug>/... — is the user authenticated and a group member?`,
+      `ensureGroupSlug: could not resolve a group slug from /api/v1/groups — is the user authenticated and a member of at least one group? current URL: ${page.url()}`,
     );
   }
   return resolved;

--- a/e2e/tests/includes/user-isolation-auth.ts
+++ b/e2e/tests/includes/user-isolation-auth.ts
@@ -1,4 +1,5 @@
 import { Page, expect, BrowserContext } from '@playwright/test';
+import { gotoScoped } from './group-url.js';
 
 /**
  * Test user interface for user isolation testing
@@ -201,8 +202,11 @@ export async function createCommodityAsUser(user: TestUser, commodityName: strin
   // Make commodity name unique by adding timestamp
   const uniqueCommodityName = `${commodityName}-${Date.now()}`;
 
-  // Navigate to locations first (commodities are created within areas)
-  await user.page.goto('/locations');
+  // Navigate to locations first (commodities are created within areas).
+  // gotoScoped rewrites the flat path to /g/<slug>/locations using the
+  // slug from the user's current URL — after #1321 the legacy flat
+  // stubs are gone, so a raw goto('/locations') would land on 404.
+  await gotoScoped(user.page, '/locations');
 
   // Create a location first if none exists
   const hasLocations = await user.page.locator('.location-card').count() > 0;
@@ -278,7 +282,7 @@ export async function createLocationAsUser(user: TestUser, locationName: string,
   }
 
   // Navigate to locations page first
-  await user.page.goto('/locations');
+  await gotoScoped(user.page, '/locations');
 
   // Click the New button (same as working locations.ts)
   await user.page.click('button:has-text("New")');
@@ -306,7 +310,7 @@ export async function createLocationAsUser(user: TestUser, locationName: string,
   const locationId = editUrl.split('/')[editUrl.split('/').length - 2]; // Get the ID part before '/edit'
 
   // Navigate back to locations list
-  await user.page.goto('/locations');
+  await gotoScoped(user.page, '/locations');
 
   return locationId;
 }
@@ -321,7 +325,7 @@ export async function verifyUserCannotSeeContent(user: TestUser, contentText: st
   }
 
   // Navigate to locations page and try to find the content
-  await user.page.goto('/locations');
+  await gotoScoped(user.page, '/locations');
   await user.page.waitForLoadState('networkidle', { timeout: 5000 });
 
   // Try to find and click on the first location to expand it
@@ -351,7 +355,7 @@ export async function verifyUserCanSeeContent(user: TestUser, contentText: strin
   }
 
   // Navigate to locations page and try to find the content
-  await user.page.goto('/locations');
+  await gotoScoped(user.page, '/locations');
   await user.page.waitForLoadState('networkidle', { timeout: 5000 });
 
   // Try to find and click on the first location to expand it
@@ -378,7 +382,11 @@ export async function attemptDirectAccess(user: TestUser, url: string, shouldSuc
     throw new Error('User page not available');
   }
 
-  await user.page.goto(url);
+  // Flat data paths (/commodities/<id>, /locations/<id>/edit, …) are
+  // rewritten to /g/<slug>/... using the *current* user's slug, so this
+  // exercises the isolation guard: user2 hitting user1's commodity id
+  // under user2's own scope must 404.
+  await gotoScoped(user.page, url);
   await user.page.waitForLoadState('networkidle', { timeout: 5000 });
 
   if (shouldSucceed) {
@@ -398,7 +406,7 @@ export async function verifySearchIsolation(user: TestUser, searchTerm: string, 
   }
 
   // Navigate to locations page
-  await user.page.goto('/locations');
+  await gotoScoped(user.page, '/locations');
   await user.page.waitForLoadState('networkidle', { timeout: 5000 });
 
   // Try to find and click on the first location to expand it

--- a/e2e/tests/user-isolation.spec.ts
+++ b/e2e/tests/user-isolation.spec.ts
@@ -14,6 +14,7 @@ import {
   verifySearchIsolation,
   TestUser
 } from './includes/user-isolation-auth.js';
+import { gotoScoped } from './includes/group-url.js';
 
 test.describe('User Isolation', () => {
   test('Users cannot access each other\'s data', async ({ browser, page }) => {
@@ -135,7 +136,7 @@ test.describe('User Isolation', () => {
       // User 1 creates a full-database export through the real form. No
       // conditional skip: if the feature is missing or the form selectors
       // regress, the test fails loudly — that's the point.
-      await user1.page!.goto('/exports/new');
+      await gotoScoped(user1.page!, '/exports/new');
       await user1.page!.waitForSelector('h1:has-text("Create New Export")', { timeout: 10000 });
       await user1.page!.fill('#description', exportDescription);
       await user1.page!.click('.p-select[id="type"]');
@@ -145,12 +146,12 @@ test.describe('User Isolation', () => {
       await user1.page!.waitForURL(/\/exports\/[0-9a-fA-F-]{36}/, { timeout: 30000 });
 
       // User 2 must not see User 1's export on the shared exports list.
-      await user2.page!.goto('/exports');
+      await gotoScoped(user2.page!, '/exports');
       await user2.page!.waitForLoadState('networkidle', { timeout: 10000 });
       await expect(user2.page!.locator(`text=${exportDescription}`)).toHaveCount(0);
 
       // Sanity check: User 1 can still see their own export.
-      await user1.page!.goto('/exports');
+      await gotoScoped(user1.page!, '/exports');
       await user1.page!.waitForLoadState('networkidle', { timeout: 10000 });
       await expect(user1.page!.locator(`text=${exportDescription}`).first()).toBeVisible();
 
@@ -181,7 +182,7 @@ test.describe('User Isolation', () => {
       // User 1 uploads a file via the real uploader. No conditional skip:
       // upload is the precondition this test needs, so if it can't happen the
       // test must fail, not silently pass.
-      await user1.page!.goto('/files/create');
+      await gotoScoped(user1.page!, '/files/create');
       await user1.page!.waitForSelector('h1:has-text("Upload Files")', { timeout: 10000 });
       await user1.page!.setInputFiles('input.file-input', {
         name: uniqueFileName,
@@ -201,12 +202,12 @@ test.describe('User Isolation', () => {
       expect(uploadResponse.status()).toBe(201);
 
       // User 2 must not see User 1's file on the shared files list.
-      await user2.page!.goto('/files');
+      await gotoScoped(user2.page!, '/files');
       await user2.page!.waitForLoadState('networkidle', { timeout: 10000 });
       await expect(user2.page!.locator(`text=${uniqueBase}`)).toHaveCount(0);
 
       // Sanity check: User 1 can still see their own file.
-      await user1.page!.goto('/files');
+      await gotoScoped(user1.page!, '/files');
       await user1.page!.waitForLoadState('networkidle', { timeout: 10000 });
       await expect(user1.page!.locator(`text=${uniqueBase}`).first()).toBeVisible();
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -114,16 +114,10 @@ const isPrintRoute = computed(() => {
   return route.path.includes('/print')
 })
 
-// groupPath builds an absolute data-route URL under the current group's
-// /g/<slug>/ prefix. It returns the flat legacy form when the user has no
-// current group (the router guard will then bounce the click to /no-group).
-// Introduced for issue #1289 Gap C so the nav renders bookmarkable URLs
-// and supports two tabs holding two different groups simultaneously.
-function groupPath(subpath: string): string {
-  const slug = groupStore.currentGroupSlug
-  if (!slug) return subpath
-  return `/g/${encodeURIComponent(slug)}${subpath}`
-}
+// groupPath is re-exported from the store so template bindings like
+// :to="groupPath('/locations')" keep working. The store owns the single
+// source of truth for /g/<slug>/ URL construction (see groupStore.ts).
+const groupPath = groupStore.groupPath
 
 // Each nav link highlights when the URL (stripped of the optional
 // /g/<slug> prefix) starts with its section root. Matching against the

--- a/frontend/src/components/__tests__/App.spec.ts
+++ b/frontend/src/components/__tests__/App.spec.ts
@@ -39,12 +39,12 @@ const mockGroupStore = {
   restoreFromPreference: vi.fn().mockResolvedValue(undefined),
   clearAll: vi.fn(),
   // groupPath mirrors the real store (#1321): when a slug is active it
-  // produces /g/<slug>/<subpath>, otherwise it returns the bare subpath so
-  // header nav can still render before a group is resolved.
+  // produces /g/<slug>/<subpath>, otherwise it returns /no-group so nav
+  // links rendered before a group resolves don't end up on the 404 route.
   groupPath(subpath: string): string {
-    const normalized = subpath.startsWith('/') ? subpath : `/${subpath}`
     const slug = mockGroupStore.currentGroupSlug
-    if (!slug) return normalized
+    if (!slug) return '/no-group'
+    const normalized = subpath.startsWith('/') ? subpath : `/${subpath}`
     return `/g/${encodeURIComponent(slug)}${normalized}`
   },
 }
@@ -65,6 +65,10 @@ describe('App.vue Navigation', () => {
       history: createWebHistory(),
       routes: [
         { path: '/', component: { template: '<div>Home</div>' } },
+        // /no-group is the fallback groupStore.groupPath() returns when no
+        // slug is active; register it here so router-link resolution during
+        // the "no groups" / unauthenticated tests doesn't warn.
+        { path: '/no-group', component: { template: '<div>No Group</div>' } },
         {
           path: '/g/:groupSlug',
           component: { template: '<router-view />' },
@@ -276,7 +280,13 @@ describe('App.vue header — group role indicator (#1258)', () => {
   const buildRouter = () =>
     createRouter({
       history: createWebHistory(),
-      routes: [{ path: '/', component: { template: '<div>Home</div>' } }],
+      // /no-group is where groupStore.groupPath() now points nav links when
+      // no slug is active (#1321); register it so router-link resolution
+      // during the no-groups / unauthenticated cases doesn't warn.
+      routes: [
+        { path: '/', component: { template: '<div>Home</div>' } },
+        { path: '/no-group', component: { template: '<div>No Group</div>' } },
+      ],
     })
 
   const mountApp = async () => {

--- a/frontend/src/components/__tests__/App.spec.ts
+++ b/frontend/src/components/__tests__/App.spec.ts
@@ -28,7 +28,7 @@ const mockGroupStore = {
   currentGroup: null,
   currentMembership: null,
   hasGroups: false,
-  currentGroupSlug: null,
+  currentGroupSlug: null as string | null,
   currentGroupName: null,
   currentGroupIcon: null,
   currentRole: null as 'admin' | 'user' | null,
@@ -38,6 +38,15 @@ const mockGroupStore = {
   ensureLoaded: vi.fn().mockResolvedValue(undefined),
   restoreFromPreference: vi.fn().mockResolvedValue(undefined),
   clearAll: vi.fn(),
+  // groupPath mirrors the real store (#1321): when a slug is active it
+  // produces /g/<slug>/<subpath>, otherwise it returns the bare subpath so
+  // header nav can still render before a group is resolved.
+  groupPath(subpath: string): string {
+    const normalized = subpath.startsWith('/') ? subpath : `/${subpath}`
+    const slug = mockGroupStore.currentGroupSlug
+    if (!slug) return normalized
+    return `/g/${encodeURIComponent(slug)}${normalized}`
+  },
 }
 
 vi.mock('@/stores/groupStore', () => ({
@@ -45,26 +54,46 @@ vi.mock('@/stores/groupStore', () => ({
 }))
 
 describe('App.vue Navigation', () => {
+  // All data routes are group-scoped under /g/:groupSlug/... (#1321).
+  // The nav renders scoped hrefs via groupStore.groupPath(), and the
+  // active-class logic in sectionPathMatches strips the /g/<slug> prefix
+  // from route.path before comparing against the section root.
+  const SLUG = 'home'
+
   const createRouterForTest = () => {
     return createRouter({
       history: createWebHistory(),
       routes: [
         { path: '/', component: { template: '<div>Home</div>' } },
-        { path: '/locations', component: { template: '<div>Locations</div>' } },
-        { path: '/locations/:id', component: { template: '<div>Location Detail</div>' } },
-        { path: '/areas/:id', component: { template: '<div>Area Detail</div>' } },
-        { path: '/commodities', component: { template: '<div>Commodities</div>' } },
-        { path: '/commodities/new', component: { template: '<div>Commodity Create</div>' } },
-        { path: '/commodities/:id', component: { template: '<div>Commodity Detail</div>' } },
-        { path: '/files', component: { template: '<div>Files</div>' } },
-        { path: '/exports', component: { template: '<div>Exports</div>' } },
-        { path: '/exports/:id', component: { template: '<div>Export Detail</div>' } },
-        { path: '/exports/new', component: { template: '<div>Export Create</div>' } },
-        { path: '/system', component: { template: '<div>System</div>' } },
-        { path: '/system/settings/:id', component: { template: '<div>System Setting Detail</div>' } }
-      ]
+        {
+          path: '/g/:groupSlug',
+          component: { template: '<router-view />' },
+          children: [
+            { path: 'locations', component: { template: '<div>Locations</div>' } },
+            { path: 'locations/:id', component: { template: '<div>Location Detail</div>' } },
+            { path: 'areas/:id', component: { template: '<div>Area Detail</div>' } },
+            { path: 'commodities', component: { template: '<div>Commodities</div>' } },
+            { path: 'commodities/new', component: { template: '<div>Commodity Create</div>' } },
+            { path: 'commodities/:id', component: { template: '<div>Commodity Detail</div>' } },
+            { path: 'files', component: { template: '<div>Files</div>' } },
+            { path: 'exports', component: { template: '<div>Exports</div>' } },
+            { path: 'exports/:id', component: { template: '<div>Export Detail</div>' } },
+            { path: 'exports/new', component: { template: '<div>Export Create</div>' } },
+            { path: 'system', component: { template: '<div>System</div>' } },
+            { path: 'system/settings/:id', component: { template: '<div>System Setting Detail</div>' } },
+          ],
+        },
+      ],
     })
   }
+
+  beforeEach(() => {
+    mockGroupStore.currentGroupSlug = SLUG
+  })
+
+  afterEach(() => {
+    mockGroupStore.currentGroupSlug = null
+  })
 
   it('highlights Home menu when on home page', async () => {
     const router = createRouterForTest()
@@ -84,7 +113,7 @@ describe('App.vue Navigation', () => {
 
   it('highlights Locations menu when on locations list page', async () => {
     const router = createRouterForTest()
-    await router.push('/locations')
+    await router.push(`/g/${SLUG}/locations`)
 
     const wrapper = mount(App, {
       global: {
@@ -94,13 +123,13 @@ describe('App.vue Navigation', () => {
 
     await wrapper.vm.$nextTick()
 
-    const locationsLink = wrapper.find('nav a[href="/locations"]')
+    const locationsLink = wrapper.find(`nav a[href="/g/${SLUG}/locations"]`)
     expect(locationsLink.classes()).toContain('custom-active')
   })
 
   it('highlights Locations menu when on location detail page', async () => {
     const router = createRouterForTest()
-    await router.push('/locations/123')
+    await router.push(`/g/${SLUG}/locations/123`)
 
     const wrapper = mount(App, {
       global: {
@@ -110,13 +139,13 @@ describe('App.vue Navigation', () => {
 
     await wrapper.vm.$nextTick()
 
-    const locationsLink = wrapper.find('nav a[href="/locations"]')
+    const locationsLink = wrapper.find(`nav a[href="/g/${SLUG}/locations"]`)
     expect(locationsLink.classes()).toContain('custom-active')
   })
 
   it('highlights Locations menu when on area detail page', async () => {
     const router = createRouterForTest()
-    await router.push('/areas/456')
+    await router.push(`/g/${SLUG}/areas/456`)
 
     const wrapper = mount(App, {
       global: {
@@ -126,13 +155,13 @@ describe('App.vue Navigation', () => {
 
     await wrapper.vm.$nextTick()
 
-    const locationsLink = wrapper.find('nav a[href="/locations"]')
+    const locationsLink = wrapper.find(`nav a[href="/g/${SLUG}/locations"]`)
     expect(locationsLink.classes()).toContain('custom-active')
   })
 
   it('highlights Commodities menu when on commodities list page', async () => {
     const router = createRouterForTest()
-    await router.push('/commodities')
+    await router.push(`/g/${SLUG}/commodities`)
 
     const wrapper = mount(App, {
       global: {
@@ -142,13 +171,13 @@ describe('App.vue Navigation', () => {
 
     await wrapper.vm.$nextTick()
 
-    const commoditiesLink = wrapper.find('nav a[href="/commodities"]')
+    const commoditiesLink = wrapper.find(`nav a[href="/g/${SLUG}/commodities"]`)
     expect(commoditiesLink.classes()).toContain('custom-active')
   })
 
   it('highlights Commodities menu when on commodity create page', async () => {
     const router = createRouterForTest()
-    await router.push('/commodities/new')
+    await router.push(`/g/${SLUG}/commodities/new`)
 
     const wrapper = mount(App, {
       global: {
@@ -158,13 +187,13 @@ describe('App.vue Navigation', () => {
 
     await wrapper.vm.$nextTick()
 
-    const commoditiesLink = wrapper.find('nav a[href="/commodities"]')
+    const commoditiesLink = wrapper.find(`nav a[href="/g/${SLUG}/commodities"]`)
     expect(commoditiesLink.classes()).toContain('custom-active')
   })
 
   it('highlights Commodities menu when on commodity detail page', async () => {
     const router = createRouterForTest()
-    await router.push('/commodities/789')
+    await router.push(`/g/${SLUG}/commodities/789`)
 
     const wrapper = mount(App, {
       global: {
@@ -174,13 +203,13 @@ describe('App.vue Navigation', () => {
 
     await wrapper.vm.$nextTick()
 
-    const commoditiesLink = wrapper.find('nav a[href="/commodities"]')
+    const commoditiesLink = wrapper.find(`nav a[href="/g/${SLUG}/commodities"]`)
     expect(commoditiesLink.classes()).toContain('custom-active')
   })
 
   it('highlights Exports menu when on exports detail page', async () => {
     const router = createRouterForTest()
-    await router.push('/exports/123')
+    await router.push(`/g/${SLUG}/exports/123`)
 
     const wrapper = mount(App, {
       global: {
@@ -190,13 +219,13 @@ describe('App.vue Navigation', () => {
 
     await wrapper.vm.$nextTick()
 
-    const exportsLink = wrapper.find('nav a[href="/exports"]')
+    const exportsLink = wrapper.find(`nav a[href="/g/${SLUG}/exports"]`)
     expect(exportsLink.classes()).toContain('custom-active')
   })
 
   it('highlights System menu when on system setting detail page', async () => {
     const router = createRouterForTest()
-    await router.push('/system/settings/456')
+    await router.push(`/g/${SLUG}/system/settings/456`)
 
     const wrapper = mount(App, {
       global: {
@@ -206,13 +235,13 @@ describe('App.vue Navigation', () => {
 
     await wrapper.vm.$nextTick()
 
-    const systemLink = wrapper.find('nav a[href="/system"]')
+    const systemLink = wrapper.find(`nav a[href="/g/${SLUG}/system"]`)
     expect(systemLink.classes()).toContain('custom-active')
   })
 
   it('does not highlight other menus when on commodities page', async () => {
     const router = createRouterForTest()
-    await router.push('/commodities')
+    await router.push(`/g/${SLUG}/commodities`)
 
     const wrapper = mount(App, {
       global: {
@@ -223,9 +252,9 @@ describe('App.vue Navigation', () => {
     await wrapper.vm.$nextTick()
 
     const homeLink = wrapper.find('nav a[href="/"]')
-    const locationsLink = wrapper.find('nav a[href="/locations"]')
-    const exportsLink = wrapper.find('nav a[href="/exports"]')
-    const systemLink = wrapper.find('nav a[href="/system"]')
+    const locationsLink = wrapper.find(`nav a[href="/g/${SLUG}/locations"]`)
+    const exportsLink = wrapper.find(`nav a[href="/g/${SLUG}/exports"]`)
+    const systemLink = wrapper.find(`nav a[href="/g/${SLUG}/system"]`)
 
     expect(homeLink.classes()).not.toContain('custom-active')
     expect(locationsLink.classes()).not.toContain('custom-active')

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -29,13 +29,12 @@ const GROUP_EXEMPT_ROUTE_NAMES = new Set([
   'profile',
 ])
 
-// Legacy flat data paths (/locations, /commodities, …) are redirected to
-// their /g/:groupSlug/... counterpart by the router guard (spec #1219 §8,
-// issue #1289 Gap C) using the `legacyFlatDataRoute` meta on each stub
-// route declared below. Having the slug on the URL is what makes two tabs
-// with two different groups actually independent — the legacy
-// localStorage-only scheme let tab 1 silently start hitting tab 2's group
-// on the next navigation.
+// All data routes live under /g/:groupSlug/... — see spec #1219 §8 and
+// issue #1289 Gap C. Having the slug on the URL is what makes two tabs
+// with two different groups actually independent; the older localStorage-
+// only scheme let tab 1 silently start hitting tab 2's group on the next
+// navigation. Legacy flat stubs and the router-level rewrite guard were
+// removed in #1321.
 
 // Define routes without using RouteRecordRaw type
 const routes = [
@@ -79,8 +78,8 @@ const routes = [
   },
   // Group-scoped data routes: /g/:groupSlug/... — see issue #1289 Gap C.
   // Keeping the slug in the URL (not in localStorage) is what makes two
-  // browser tabs with two different groups actually independent. Flat
-  // equivalents are preserved below as legacy redirects.
+  // browser tabs with two different groups actually independent. The
+  // legacy flat equivalents were removed in #1321.
   {
     path: '/g/:groupSlug',
     meta: { requiresAuth: true, groupScoped: true },
@@ -118,16 +117,6 @@ const routes = [
       { path: 'system/settings/:id', name: 'system-setting-detail', component: () => import('../views/system/SystemSettingDetailView.vue') },
     ]
   },
-  // Legacy flat routes — kept as redirect stubs so any stray
-  // `router.push('/locations')` or bookmarked pre-#1289 URL still works.
-  // The router-level beforeEach guard rewrites them to /g/<current-slug>/...
-  // using groupStore.currentGroup.
-  { path: '/locations/:pathMatch(.*)*',    meta: { legacyFlatDataRoute: '/locations' },   component: () => import('../views/locations/LocationListView.vue') },
-  { path: '/areas/:pathMatch(.*)*',        meta: { legacyFlatDataRoute: '/areas' },       component: () => import('../views/areas/AreaDetailView.vue') },
-  { path: '/commodities/:pathMatch(.*)*',  meta: { legacyFlatDataRoute: '/commodities' }, component: () => import('../views/commodities/CommodityListView.vue') },
-  { path: '/files/:pathMatch(.*)*',        meta: { legacyFlatDataRoute: '/files' },       component: () => import('../views/files/FileListView.vue') },
-  { path: '/exports/:pathMatch(.*)*',      meta: { legacyFlatDataRoute: '/exports' },     component: () => import('../views/exports/ExportListView.vue') },
-  { path: '/system/:pathMatch(.*)*',       meta: { legacyFlatDataRoute: '/system' },      component: () => import('../views/system/SystemView.vue') },
   // Profile (authenticated users, not group-scoped)
   {
     path: '/profile',
@@ -254,20 +243,6 @@ router.beforeEach(async (to, from) => {
       if (!groupStore.hasGroups) {
         console.log('No groups — redirecting to /no-group')
         return { path: '/no-group' }
-      }
-
-      // Legacy flat data-route handling (issue #1289 Gap C): rewrite
-      // /locations, /commodities, etc. to /g/<current-slug>/... so the
-      // active group is explicit in the URL and independent per-tab.
-      const legacyPrefix = (to.meta as { legacyFlatDataRoute?: string })?.legacyFlatDataRoute
-      if (legacyPrefix && groupStore.currentGroup) {
-        const slug = groupStore.currentGroup.slug
-        // Preserve any subpath after the matched prefix (e.g. /commodities/:id/edit).
-        const suffix = to.path.startsWith(legacyPrefix)
-          ? to.path.slice(legacyPrefix.length)
-          : ''
-        const targetPath = `/g/${encodeURIComponent(slug)}${legacyPrefix}${suffix}`
-        return { path: targetPath, query: to.query, hash: to.hash, replace: true }
       }
 
       // When navigating into a /g/:groupSlug/... route, sync the store to

--- a/frontend/src/services/fileService.ts
+++ b/frontend/src/services/fileService.ts
@@ -1,4 +1,5 @@
 import api from './api'
+import { useGroupStore } from '@/stores/groupStore'
 
 const API_URL = '/api/v1/files'
 
@@ -337,10 +338,14 @@ const fileService = {
       return ''
     }
 
+    // Resolve scoped URLs through the group store so this service emits the
+    // same /g/<slug>/ prefix as router.push / <router-link> call sites.
+    const { groupPath } = useGroupStore()
+
     if (file.linked_entity_type === 'commodity') {
-      return `/commodities/${file.linked_entity_id}`
+      return groupPath(`/commodities/${file.linked_entity_id}`)
     } else if (file.linked_entity_type === 'location') {
-      return `/locations/${file.linked_entity_id}`
+      return groupPath(`/locations/${file.linked_entity_id}`)
     } else if (file.linked_entity_type === 'export') {
       // Determine the source page context
       let fromPage = 'file-view'
@@ -353,7 +358,7 @@ const fileService = {
           fromPage = 'file-view'
         }
       }
-      return `/exports/${file.linked_entity_id}?from=${fromPage}&fileId=${file.id}`
+      return groupPath(`/exports/${file.linked_entity_id}?from=${fromPage}&fileId=${file.id}`)
     }
 
     return ''

--- a/frontend/src/stores/__tests__/groupStore.spec.ts
+++ b/frontend/src/stores/__tests__/groupStore.spec.ts
@@ -5,8 +5,7 @@ import type { GroupMembership, LocationGroup } from '@/types/group'
 
 // The store talks to groupService for API data and to authStore for the
 // current user id and default_group_id preference. Mocking both keeps the
-// tests focused on the priority chain in restoreFromPreference() and the
-// legacy-localStorage migration path (#1300 cleanup of #1262).
+// tests focused on the priority chain in restoreFromPreference().
 
 vi.mock('@/services/groupService', () => ({
   default: {
@@ -17,10 +16,6 @@ vi.mock('@/services/groupService', () => ({
   },
 }))
 
-// authStore is both queried (user / userDefaultGroupID getters) and mutated
-// (updateProfile called by the legacy-storage migration). Expose updateProfile
-// as a spy so individual tests can assert it was called with the right id.
-const authUpdateProfile = vi.fn().mockResolvedValue(undefined)
 const authMockState: { user: { id: string; name?: string; default_group_id?: string | null } | null } = {
   user: { id: 'user-1', name: 'Alice', default_group_id: null },
 }
@@ -33,16 +28,10 @@ vi.mock('@/stores/authStore', () => ({
     get userDefaultGroupID() {
       return authMockState.user?.default_group_id ?? null
     },
-    updateProfile: authUpdateProfile,
   }),
 }))
 
 const mockedGroupService = vi.mocked(groupService)
-
-// Legacy keys that the one-shot migration looks for on boot. Tests seed
-// these to exercise the migration path and assert it wipes them afterwards.
-const LEGACY_STORAGE_KEY_CURRENT_GROUP = 'inventario_current_group'
-const LEGACY_STORAGE_KEY_GROUP_SLUG = 'currentGroupSlug'
 
 function makeGroup(overrides: Partial<LocationGroup> = {}): LocationGroup {
   return {
@@ -76,26 +65,20 @@ async function freshStore(): Promise<ReturnType<typeof import('@/stores/groupSto
   return useGroupStore()
 }
 
-describe('groupStore — initial state (#1300)', () => {
+describe('groupStore — initial state', () => {
   beforeEach(() => {
-    localStorage.clear()
     vi.clearAllMocks()
     authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
   })
 
   afterEach(() => {
-    localStorage.clear()
     authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
   })
 
-  it('starts with null currentGroup regardless of localStorage state', async () => {
-    // Legacy snapshots must not pre-seed currentGroup synchronously anymore —
-    // the router's /g/:groupSlug/ param is the authoritative source of truth
-    // and reading localStorage at construction time would re-introduce the
-    // cross-tab coupling that #1289 Gap C and #1300 removed.
-    const legacy = makeGroup({ id: 'grp-7', slug: 'office', name: 'Office' })
-    localStorage.setItem(LEGACY_STORAGE_KEY_CURRENT_GROUP, JSON.stringify(legacy))
-
+  it('starts with null currentGroup on a cold store', async () => {
+    // The router's /g/:groupSlug/ param is the authoritative source of truth
+    // for the active group; the store must not synthesise one at construction
+    // time.
     const store = await freshStore()
 
     expect(store.currentGroup).toBeNull()
@@ -103,30 +86,22 @@ describe('groupStore — initial state (#1300)', () => {
     expect(store.currentGroupSlug).toBeNull()
     expect(store.hasGroups).toBe(false)
   })
-
-  it('starts with null currentGroup when nothing is stored', async () => {
-    const store = await freshStore()
-    expect(store.currentGroup).toBeNull()
-  })
 })
 
-describe('groupStore — restoreFromPreference (#1263 / #1300)', () => {
-  // After #1300, the priority chain for seeding currentGroup on a cold start
-  // (i.e. a route with no /g/:groupSlug/ param) is:
+describe('groupStore — restoreFromPreference (#1263)', () => {
+  // The priority chain for seeding currentGroup on a cold start (i.e. a
+  // route with no /g/:groupSlug/ param) is:
   //   1. user.default_group_id (#1263).
   //   2. pickFallbackGroup: oldest group the user created, else oldest they
   //      were invited to.
   //   3. groups[0] — defensive last resort.
-  // localStorage is no longer part of the chain.
 
   beforeEach(() => {
-    localStorage.clear()
     vi.clearAllMocks()
     authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
   })
 
   afterEach(() => {
-    localStorage.clear()
     authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
   })
 
@@ -231,19 +206,17 @@ describe('groupStore — restoreFromPreference (#1263 / #1300)', () => {
   })
 })
 
-describe('groupStore — setters do not touch localStorage (#1300)', () => {
+describe('groupStore — setters', () => {
   beforeEach(() => {
-    localStorage.clear()
     vi.clearAllMocks()
     authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
   })
 
   afterEach(() => {
-    localStorage.clear()
     authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
   })
 
-  it('setCurrentGroup only mutates in-memory state', async () => {
+  it('setCurrentGroup mutates in-memory state', async () => {
     const a = makeGroup({ id: 'grp-a', slug: 'a', name: 'A' })
     const b = makeGroup({ id: 'grp-b', slug: 'b', name: 'B' })
     mockedGroupService.listGroups.mockResolvedValueOnce([a, b])
@@ -254,14 +227,9 @@ describe('groupStore — setters do not touch localStorage (#1300)', () => {
     await store.setCurrentGroup('b')
 
     expect(store.currentGroupId).toBe('grp-b')
-    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
-    expect(localStorage.getItem(LEGACY_STORAGE_KEY_GROUP_SLUG)).toBeNull()
   })
 
-  it('clearAll leaves localStorage keys alone (migration wipes them once)', async () => {
-    // clearAll is called on logout; it zeroes in-memory state. The legacy
-    // keys are gone by the time logout fires (migration runs on bootstrap),
-    // so clearAll has no business poking at them anymore.
+  it('clearAll zeroes in-memory state', async () => {
     const store = await freshStore()
     store.clearAll()
 
@@ -270,7 +238,7 @@ describe('groupStore — setters do not touch localStorage (#1300)', () => {
     expect(store.isInitialized).toBe(false)
   })
 
-  it('updateGroupById refreshes in-memory state only', async () => {
+  it('updateGroupById refreshes in-memory state', async () => {
     const original = makeGroup({ id: 'grp-1', name: 'Home' })
     const renamed = makeGroup({ id: 'grp-1', name: 'Home Office' })
     mockedGroupService.listGroups.mockResolvedValueOnce([original])
@@ -283,100 +251,49 @@ describe('groupStore — setters do not touch localStorage (#1300)', () => {
     await store.updateGroupById('grp-1', 'Home Office')
 
     expect(store.currentGroupName).toBe('Home Office')
-    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
   })
 })
 
-describe('groupStore — legacy localStorage migration (#1300)', () => {
-  // One-shot cleanup on app boot: if localStorage has the pre-#1300 keys,
-  // read them once, call PUT /auth/me with the matching default_group_id,
-  // then removeItem. Runs inside ensureLoaded() after fetchGroups().
+describe('groupStore — groupPath (#1321)', () => {
+  // groupPath is the single source of truth for building /g/<slug>/ scoped
+  // URLs in views, services, and router.push() sites. It replaces the
+  // ad-hoc flat paths that used to rely on the router's legacyFlatDataRoute
+  // rewriter.
 
   beforeEach(() => {
-    localStorage.clear()
     vi.clearAllMocks()
     authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
   })
 
-  afterEach(() => {
-    localStorage.clear()
-    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: null }
-  })
-
-  it('promotes a legacy snapshot to default_group_id when no preference is set', async () => {
-    const other = makeGroup({ id: 'grp-other', slug: 'other', created_by: 'user-1', created_at: '2026-02-01T00:00:00Z' })
-    const legacy = makeGroup({ id: 'grp-legacy', slug: 'legacy', name: 'Legacy', created_by: 'user-1', created_at: '2026-01-01T00:00:00Z' })
-    localStorage.setItem(LEGACY_STORAGE_KEY_CURRENT_GROUP, JSON.stringify(legacy))
-    mockedGroupService.listGroups.mockResolvedValueOnce([other, legacy])
+  it('prefixes the subpath with /g/<slug> when a group is active', async () => {
+    const home = makeGroup({ id: 'grp-1', slug: 'home', name: 'Home' })
+    mockedGroupService.listGroups.mockResolvedValueOnce([home])
     mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
 
     const store = await freshStore()
-    await store.ensureLoaded()
+    await store.fetchGroups()
+    await store.setCurrentGroup('home')
 
-    expect(authUpdateProfile).toHaveBeenCalledWith({ name: 'Alice', default_group_id: 'grp-legacy' })
-    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
-    expect(localStorage.getItem(LEGACY_STORAGE_KEY_GROUP_SLUG)).toBeNull()
+    expect(store.groupPath('/locations')).toBe('/g/home/locations')
+    expect(store.groupPath('areas/area-1')).toBe('/g/home/areas/area-1')
   })
 
-  it('promotes the legacy slug key when the snapshot is absent', async () => {
-    const beta = makeGroup({ id: 'grp-beta', slug: 'beta', name: 'Beta', created_by: 'user-1' })
-    const alpha = makeGroup({ id: 'grp-alpha', slug: 'alpha', name: 'Alpha', created_by: 'user-1', created_at: '2025-12-01T00:00:00Z' })
-    localStorage.setItem(LEGACY_STORAGE_KEY_GROUP_SLUG, 'beta')
-    mockedGroupService.listGroups.mockResolvedValueOnce([alpha, beta])
+  it('returns the unscoped subpath when no group is active', async () => {
+    const store = await freshStore()
+
+    expect(store.groupPath('/locations')).toBe('/locations')
+    expect(store.groupPath('areas')).toBe('/areas')
+  })
+
+  it('URL-encodes slugs that contain reserved characters', async () => {
+    const odd = makeGroup({ id: 'grp-odd', slug: 'a b/c', name: 'Odd' })
+    mockedGroupService.listGroups.mockResolvedValueOnce([odd])
     mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
 
     const store = await freshStore()
-    await store.ensureLoaded()
+    await store.fetchGroups()
+    await store.setCurrentGroup('a b/c')
 
-    expect(authUpdateProfile).toHaveBeenCalledWith({ name: 'Alice', default_group_id: 'grp-beta' })
-    expect(localStorage.getItem(LEGACY_STORAGE_KEY_GROUP_SLUG)).toBeNull()
-  })
-
-  it('does not overwrite an existing default_group_id preference', async () => {
-    const legacy = makeGroup({ id: 'grp-legacy', slug: 'legacy', created_by: 'user-1' })
-    const preferred = makeGroup({ id: 'grp-preferred', slug: 'preferred', created_by: 'user-1' })
-    localStorage.setItem(LEGACY_STORAGE_KEY_CURRENT_GROUP, JSON.stringify(legacy))
-    mockedGroupService.listGroups.mockResolvedValueOnce([legacy, preferred])
-    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-    authMockState.user = { id: 'user-1', name: 'Alice', default_group_id: 'grp-preferred' }
-
-    const store = await freshStore()
-    await store.ensureLoaded()
-
-    expect(authUpdateProfile).not.toHaveBeenCalled()
-    // Legacy keys are still dropped — the preference is the future source of
-    // truth, and the old keys are dead weight either way.
-    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
-  })
-
-  it('drops unresolvable legacy keys without calling PUT /auth/me', async () => {
-    // Legacy snapshot points at a group the user no longer has access to.
-    // The migration must not call updateProfile with a value the server
-    // would reject — just wipe the key and move on.
-    const stale = makeGroup({ id: 'grp-gone', slug: 'gone' })
-    const available = makeGroup({ id: 'grp-available', slug: 'available', created_by: 'user-1' })
-    localStorage.setItem(LEGACY_STORAGE_KEY_CURRENT_GROUP, JSON.stringify(stale))
-    mockedGroupService.listGroups.mockResolvedValueOnce([available])
-    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-
-    const store = await freshStore()
-    await store.ensureLoaded()
-
-    expect(authUpdateProfile).not.toHaveBeenCalled()
-    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
-  })
-
-  it('does not crash on a malformed legacy snapshot', async () => {
-    localStorage.setItem(LEGACY_STORAGE_KEY_CURRENT_GROUP, 'not-valid-json')
-    const available = makeGroup({ id: 'grp-available', slug: 'available', created_by: 'user-1' })
-    mockedGroupService.listGroups.mockResolvedValueOnce([available])
-    mockedGroupService.listMembers.mockResolvedValueOnce([makeMembership('user-1')])
-
-    const store = await freshStore()
-    await store.ensureLoaded()
-
-    expect(authUpdateProfile).not.toHaveBeenCalled()
-    expect(localStorage.getItem(LEGACY_STORAGE_KEY_CURRENT_GROUP)).toBeNull()
-    expect(store.isInitialized).toBe(true)
+    expect(store.groupPath('/locations')).toBe('/g/a%20b%2Fc/locations')
   })
 })

--- a/frontend/src/stores/__tests__/groupStore.spec.ts
+++ b/frontend/src/stores/__tests__/groupStore.spec.ts
@@ -278,11 +278,15 @@ describe('groupStore — groupPath (#1321)', () => {
     expect(store.groupPath('areas/area-1')).toBe('/g/home/areas/area-1')
   })
 
-  it('returns the unscoped subpath when no group is active', async () => {
+  it('returns /no-group when no group is active', async () => {
+    // Legacy flat routes no longer exist after #1321, so falling back to
+    // the unscoped subpath would 404. groupPath points callers at the
+    // guided first-run view instead — the same place the router guard
+    // bounces users with zero groups.
     const store = await freshStore()
 
-    expect(store.groupPath('/locations')).toBe('/locations')
-    expect(store.groupPath('areas')).toBe('/areas')
+    expect(store.groupPath('/locations')).toBe('/no-group')
+    expect(store.groupPath('areas')).toBe('/no-group')
   })
 
   it('URL-encodes slugs that contain reserved characters', async () => {

--- a/frontend/src/stores/groupStore.ts
+++ b/frontend/src/stores/groupStore.ts
@@ -219,13 +219,15 @@ export const useGroupStore = defineStore('group', () => {
   // scope. It is the single source of truth for building scoped URLs in
   // views, services, and router.push() sites — replaces the ad-hoc flat
   // paths that used to rely on the router's legacyFlatDataRoute rewriter.
-  // When no group is active the router guard bounces the click to
-  // /no-group, so returning the unscoped subpath here is only a safety
-  // net for code paths that render nav links before a group is resolved.
+  // When no group is active we return /no-group instead of the unscoped
+  // subpath: legacy flat routes no longer exist, so an unscoped path like
+  // /locations would land on the 404 route. /no-group is the guided
+  // first-run view and the same place the router guard sends users with
+  // zero groups.
   function groupPath(subpath: string): string {
     const slug = currentGroupSlug.value
+    if (!slug) return '/no-group'
     const normalized = subpath.startsWith('/') ? subpath : `/${subpath}`
-    if (!slug) return normalized
     return `/g/${encodeURIComponent(slug)}${normalized}`
   }
 

--- a/frontend/src/stores/groupStore.ts
+++ b/frontend/src/stores/groupStore.ts
@@ -4,14 +4,6 @@ import groupService from '../services/groupService'
 import { useAuthStore } from './authStore'
 import type { LocationGroup, GroupMembership, GroupRole } from '../types/group'
 
-// Legacy localStorage keys — kept here only so the one-shot migration in
-// migrateLegacyStorageToPreference() below can recognise and drop them.
-// Active group selection is now driven by the URL (per-tab) and persisted
-// across devices via user.default_group_id (#1263). Delete these keys in a
-// future release once the migration has had time to run on all clients.
-const LEGACY_STORAGE_KEY_CURRENT_GROUP = 'inventario_current_group'
-const LEGACY_STORAGE_KEY_GROUP_SLUG = 'currentGroupSlug'
-
 export const useGroupStore = defineStore('group', () => {
   // State
   const groups = ref<LocationGroup[]>([])
@@ -81,7 +73,6 @@ export const useGroupStore = defineStore('group', () => {
     loadingPromise = (async () => {
       try {
         await fetchGroups()
-        await migrateLegacyStorageToPreference()
         await restoreFromPreference()
         isInitialized.value = true
       } finally {
@@ -148,64 +139,6 @@ export const useGroupStore = defineStore('group', () => {
     const resolved = match ?? pickFallbackGroup(groups.value, useAuthStore().user?.id ?? null)
     currentGroup.value = resolved
     await loadCurrentMembership(resolved.id)
-  }
-
-  // migrateLegacyStorageToPreference is a one-shot cleanup for clients that
-  // still carry the pre-#1300 localStorage keys. If the legacy snapshot /
-  // slug points at a group this user belongs to AND they have no
-  // default_group_id yet, promote it to the server-side preference so the
-  // device-scoped "remember my last group" behaviour survives the switch.
-  // The keys are removed unconditionally — even an unresolvable legacy
-  // value is dead weight now. Drop the whole function after one release.
-  async function migrateLegacyStorageToPreference(): Promise<void> {
-    const rawSnapshot = safeLocalStorageGet(LEGACY_STORAGE_KEY_CURRENT_GROUP)
-    const legacySlug = safeLocalStorageGet(LEGACY_STORAGE_KEY_GROUP_SLUG)
-    if (!rawSnapshot && !legacySlug) return
-
-    let candidate: LocationGroup | undefined
-    if (rawSnapshot) {
-      try {
-        const parsed = JSON.parse(rawSnapshot) as { id?: unknown }
-        if (parsed && typeof parsed.id === 'string') {
-          candidate = groups.value.find((g) => g.id === parsed.id)
-        }
-      } catch {
-        // Ignore malformed legacy snapshot — we only care that it existed.
-      }
-    }
-    if (!candidate && legacySlug) {
-      candidate = groups.value.find((g) => g.slug === legacySlug)
-    }
-
-    // Only promote to default_group_id if the user has no preference yet;
-    // an existing preference was picked deliberately and the legacy
-    // per-device hint shouldn't override it.
-    const authStore = useAuthStore()
-    if (candidate && !authStore.userDefaultGroupID) {
-      try {
-        await authStore.updateProfile({
-          name: authStore.user?.name ?? '',
-          default_group_id: candidate.id,
-        })
-      } catch (err) {
-        // Don't log the full error object: Axios attaches the request
-        // config (including the Bearer token) to the error, which would
-        // land the token in the browser console.
-        const message = err instanceof Error ? err.message : 'unknown error'
-        const status =
-          typeof err === 'object' &&
-          err !== null &&
-          'response' in err &&
-          typeof (err as { response?: { status?: unknown } }).response === 'object' &&
-          (err as { response?: { status?: unknown } }).response !== null
-            ? (err as { response: { status?: unknown } }).response.status
-            : undefined
-        console.warn('Legacy group preference migration failed:', { message, status })
-      }
-    }
-
-    safeLocalStorageRemove(LEGACY_STORAGE_KEY_CURRENT_GROUP)
-    safeLocalStorageRemove(LEGACY_STORAGE_KEY_GROUP_SLUG)
   }
 
   // pickFallbackGroup implements the "no preference" branch of #1263:
@@ -282,6 +215,20 @@ export const useGroupStore = defineStore('group', () => {
     isInitialized.value = false
   }
 
+  // groupPath prefixes a data subpath with the active group's /g/<slug>/
+  // scope. It is the single source of truth for building scoped URLs in
+  // views, services, and router.push() sites — replaces the ad-hoc flat
+  // paths that used to rely on the router's legacyFlatDataRoute rewriter.
+  // When no group is active the router guard bounces the click to
+  // /no-group, so returning the unscoped subpath here is only a safety
+  // net for code paths that render nav links before a group is resolved.
+  function groupPath(subpath: string): string {
+    const slug = currentGroupSlug.value
+    const normalized = subpath.startsWith('/') ? subpath : `/${subpath}`
+    if (!slug) return normalized
+    return `/g/${encodeURIComponent(slug)}${normalized}`
+  }
+
   return {
     // State
     groups,
@@ -316,22 +263,7 @@ export const useGroupStore = defineStore('group', () => {
     syncGroup,
     clearCurrentGroup,
     clearAll,
+    groupPath,
   }
 })
-
-function safeLocalStorageGet(key: string): string | null {
-  try {
-    return localStorage.getItem(key)
-  } catch {
-    return null
-  }
-}
-
-function safeLocalStorageRemove(key: string): void {
-  try {
-    localStorage.removeItem(key)
-  } catch {
-    // localStorage may be unavailable (private mode, SSR, …) — ignore.
-  }
-}
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -21,19 +21,19 @@
 
     <!-- Navigation Cards -->
     <div class="navigation-cards">
-      <div class="card" @click="navigateTo('/locations')">
+      <div class="card" @click="navigateTo(groupStore.groupPath('/locations'))">
         <h2>Locations</h2>
         <p>Manage storage locations and areas</p>
       </div>
-      <div class="card" @click="navigateTo('/commodities')">
+      <div class="card" @click="navigateTo(groupStore.groupPath('/commodities'))">
         <h2>Commodities</h2>
         <p>Manage inventory items</p>
       </div>
-      <div class="card" @click="navigateTo('/files')">
+      <div class="card" @click="navigateTo(groupStore.groupPath('/files'))">
         <h2>Files</h2>
         <p>Upload and manage standalone files</p>
       </div>
-      <div class="card" @click="navigateTo('/system')">
+      <div class="card" @click="navigateTo(groupStore.groupPath('/system'))">
         <h2>System</h2>
         <p>View system information and configure settings</p>
       </div>
@@ -67,11 +67,13 @@
 import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSettingsStore } from '@/stores/settingsStore'
+import { useGroupStore } from '@/stores/groupStore'
 import valueService from '@/services/valueService'
 import { formatPrice } from '@/services/currencyService'
 
 const router = useRouter()
 const settingsStore = useSettingsStore()
+const groupStore = useGroupStore()
 
 // Values data
 const globalTotal = ref<number>(0)

--- a/frontend/src/views/areas/AreaDetailView.vue
+++ b/frontend/src/views/areas/AreaDetailView.vue
@@ -47,7 +47,7 @@
               <label class="toggle-label">Show drafts & inactive items</label>
             </div>
           </div>
-          <router-link :to="`/commodities/new?area=${area.id}`" class="btn btn-primary btn-sm"><font-awesome-icon icon="plus" /> New</router-link>
+          <router-link :to="groupStore.groupPath(`/commodities/new?area=${area.id}`)" class="btn btn-primary btn-sm"><font-awesome-icon icon="plus" /> New</router-link>
         </div>
         <div class="commodities-grid">
           <CommodityListItem
@@ -64,7 +64,7 @@
       </div>
       <div v-else class="no-commodities">
         <p>No commodities found in this area.</p>
-        <router-link :to="`/commodities/new?area=${area.id}`" class="btn btn-primary">Add Commodity</router-link>
+        <router-link :to="groupStore.groupPath(`/commodities/new?area=${area.id}`)" class="btn btn-primary">Add Commodity</router-link>
       </div>
     </div>
 
@@ -110,8 +110,10 @@ import CommodityListItem from "@/components/CommodityListItem.vue"
 import ErrorNotificationStack from '@/components/ErrorNotificationStack.vue'
 import ResourceNotFound from '@/components/ResourceNotFound.vue'
 import { useErrorState, is404Error as checkIs404Error, get404Message, get404Title } from '@/utils/errorUtils'
+import { useGroupStore } from '@/stores/groupStore'
 
 const router = useRouter()
+const groupStore = useGroupStore()
 const route = useRoute()
 const area = ref<any>(null)
 const locations = ref<any[]>([])
@@ -309,7 +311,7 @@ const onCancelDelete = () => {
 const deleteArea = async () => {
   try {
     await areaService.deleteArea(area.value.id)
-    router.push('/locations')
+    router.push(groupStore.groupPath('/locations'))
   } catch (err: any) {
     handleError(err, 'area', 'Failed to delete area')
   }
@@ -319,7 +321,7 @@ const deleteArea = async () => {
 
 const viewCommodity = (id: string) => {
   router.push({
-    path: `/commodities/${id}`,
+    path: groupStore.groupPath(`/commodities/${id}`),
     query: {
       source: 'area',
       areaId: area.value.id
@@ -329,7 +331,7 @@ const viewCommodity = (id: string) => {
 
 const editCommodity = (id: string) => {
   router.push({
-    path: `/commodities/${id}/edit`,
+    path: groupStore.groupPath(`/commodities/${id}/edit`),
     query: {
       source: 'area',
       areaId: area.value.id,
@@ -360,13 +362,13 @@ const onCancelDeleteCommodity = () => {
 }
 
 const goBackToList = () => {
-  router.push('/locations')
+  router.push(groupStore.groupPath('/locations'))
 }
 
 const navigateToLocations = () => {
   // Navigate to locations list with area and location context
   router.push({
-    path: '/locations',
+    path: groupStore.groupPath('/locations'),
     query: {
       areaId: area.value.id,
       locationId: area.value.attributes.location_id

--- a/frontend/src/views/areas/AreaEditView.vue
+++ b/frontend/src/views/areas/AreaEditView.vue
@@ -77,9 +77,11 @@ import locationService from '@/services/locationService'
 import Select from 'primevue/select'
 import ResourceNotFound from '@/components/ResourceNotFound.vue'
 import { is404Error as checkIs404Error, get404Message, get404Title } from '@/utils/errorUtils'
+import { useGroupStore } from '@/stores/groupStore'
 
 const route = useRoute()
 const router = useRouter()
+const groupStore = useGroupStore()
 const id = route.params.id as string
 
 const area = ref<any>(null)
@@ -195,7 +197,7 @@ const submitForm = async () => {
 
     // On success, navigate back to locations list with area focused
     router.push({
-      path: '/locations',
+      path: groupStore.groupPath('/locations'),
       query: {
         areaId: id,
         locationId: form.locationId
@@ -237,7 +239,7 @@ const submitForm = async () => {
 const goBack = () => {
   // Navigate to locations list with area and location context
   router.push({
-    path: '/locations',
+    path: groupStore.groupPath('/locations'),
     query: {
       areaId: id,
       locationId: form.locationId
@@ -248,7 +250,7 @@ const goBack = () => {
 const navigateToLocations = () => {
   // Navigate to locations list with area and location context
   router.push({
-    path: '/locations',
+    path: groupStore.groupPath('/locations'),
     query: {
       areaId: id,
       locationId: form.locationId
@@ -257,7 +259,7 @@ const navigateToLocations = () => {
 }
 
 const goBackToList = () => {
-  router.push('/locations')
+  router.push(groupStore.groupPath('/locations'))
 }
 
 // Navigation is handled by the onSubmit and onCancel functions

--- a/frontend/src/views/areas/AreaListView.vue
+++ b/frontend/src/views/areas/AreaListView.vue
@@ -2,7 +2,7 @@
   <div class="area-list">
     <div class="header">
       <h1>Areas</h1>
-      <router-link to="/areas/new" class="btn btn-primary new-area-button"><font-awesome-icon icon="plus" /> New</router-link>
+      <router-link :to="groupStore.groupPath('/areas/new')" class="btn btn-primary new-area-button"><font-awesome-icon icon="plus" /> New</router-link>
     </div>
 
     <!-- Error Notification Stack -->
@@ -16,7 +16,7 @@
       <div class="empty-message">
         <p>No areas found. Create your first area!</p>
         <div class="action-button">
-          <router-link to="/areas/new" class="btn btn-primary">Create Area</router-link>
+          <router-link :to="groupStore.groupPath('/areas/new')" class="btn btn-primary">Create Area</router-link>
         </div>
       </div>
     </div>
@@ -76,8 +76,10 @@ import ErrorNotificationStack from '@/components/ErrorNotificationStack.vue'
 import PaginationControls from "@/components/PaginationControls.vue"
 import { useErrorState } from '@/utils/errorUtils'
 import { fetchAll } from '@/utils/paginationUtils'
+import { useGroupStore } from '@/stores/groupStore'
 
 const router = useRouter()
+const groupStore = useGroupStore()
 const route = useRoute()
 const areas = ref<any[]>([])
 const locations = ref<any[]>([])
@@ -126,11 +128,11 @@ const getLocationName = (locationId: string) => {
 }
 
 const viewArea = (id: string) => {
-  router.push(`/areas/${id}`)
+  router.push(groupStore.groupPath(`/areas/${id}`))
 }
 
 const editArea = (id: string) => {
-  router.push(`/areas/${id}/edit`)
+  router.push(groupStore.groupPath(`/areas/${id}/edit`))
 }
 
 const areaToDelete = ref<string | null>(null)

--- a/frontend/src/views/areas/AreaListView.vue
+++ b/frontend/src/views/areas/AreaListView.vue
@@ -2,7 +2,11 @@
   <div class="area-list">
     <div class="header">
       <h1>Areas</h1>
-      <router-link :to="groupStore.groupPath('/areas/new')" class="btn btn-primary new-area-button"><font-awesome-icon icon="plus" /> New</router-link>
+      <!-- Areas are created inline on a location's detail page (#1321):
+           there is no standalone /areas/new route. Point the CTA at the
+           locations list so the user can pick a location and open the
+           inline "Add Area" form from there. -->
+      <router-link :to="groupStore.groupPath('/locations')" class="btn btn-primary new-area-button"><font-awesome-icon icon="plus" /> New</router-link>
     </div>
 
     <!-- Error Notification Stack -->
@@ -16,7 +20,7 @@
       <div class="empty-message">
         <p>No areas found. Create your first area!</p>
         <div class="action-button">
-          <router-link :to="groupStore.groupPath('/areas/new')" class="btn btn-primary">Create Area</router-link>
+          <router-link :to="groupStore.groupPath('/locations')" class="btn btn-primary">Create Area</router-link>
         </div>
       </div>
     </div>

--- a/frontend/src/views/commodities/CommodityCreateView.vue
+++ b/frontend/src/views/commodities/CommodityCreateView.vue
@@ -43,8 +43,10 @@ import locationService from '@/services/locationService'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { COMMODITY_STATUS_IN_USE } from '@/constants/commodityStatuses'
 import CommodityForm from '@/components/CommodityForm.vue'
+import { useGroupStore } from '@/stores/groupStore'
 
 const router = useRouter()
+const groupStore = useGroupStore()
 const route = useRoute()
 const settingsStore = useSettingsStore()
 const commodityForm = ref(null)
@@ -189,7 +191,7 @@ onMounted(async () => {
     // Check if we have locations and areas
     if (locations.value.length === 0 || areas.value.length === 0) {
       // Redirect to commodities list which will show the appropriate message
-      router.push('/commodities')
+      router.push(groupStore.groupPath('/commodities'))
       return
     }
 
@@ -262,7 +264,7 @@ const submitForm = async (formData: any) => {
     // If coming from an area, preserve that context
     if (areaFromUrl.value) {
       router.push({
-        path: `/commodities/${newCommodityId}`,
+        path: groupStore.groupPath(`/commodities/${newCommodityId}`),
         query: {
           source: 'area',
           areaId: areaFromUrl.value
@@ -271,7 +273,7 @@ const submitForm = async (formData: any) => {
     } else {
       // Otherwise, navigate with commodities as source
       router.push({
-        path: `/commodities/${newCommodityId}`,
+        path: groupStore.groupPath(`/commodities/${newCommodityId}`),
         query: {
           source: 'commodities'
         }
@@ -310,22 +312,22 @@ const submitForm = async (formData: any) => {
 const navigateToArea = () => {
   // Navigate back to the area detail view
   if (areaFromUrl.value) {
-    router.push(`/areas/${areaFromUrl.value}`)
+    router.push(groupStore.groupPath(`/areas/${areaFromUrl.value}`))
   }
 }
 
 const navigateToCommodities = () => {
   // Navigate back to the commodities list
-  router.push('/commodities')
+  router.push(groupStore.groupPath('/commodities'))
 }
 
 const cancel = () => {
   // If coming from an area, navigate back to that area
   if (areaFromUrl.value) {
-    router.push(`/areas/${areaFromUrl.value}`)
+    router.push(groupStore.groupPath(`/areas/${areaFromUrl.value}`))
   } else {
     // Otherwise, navigate to the commodities list
-    router.push('/commodities')
+    router.push(groupStore.groupPath('/commodities'))
   }
 }
 

--- a/frontend/src/views/commodities/CommodityDetailView.vue
+++ b/frontend/src/views/commodities/CommodityDetailView.vue
@@ -286,8 +286,10 @@ import FileUploader from '@/components/FileUploader.vue'
 import FileViewer from '@/components/FileViewer.vue'
 import Confirmation from "@/components/Confirmation.vue"
 import FocusOverlay from '@/components/FocusOverlay.vue'
+import { useGroupStore } from '@/stores/groupStore'
 
 const router = useRouter()
+const groupStore = useGroupStore()
 const route = useRoute()
 const commodity = ref<any>(null)
 const loading = ref<boolean>(true)
@@ -682,7 +684,7 @@ const updateInvoice = async (data: any) => {
 const editCommodity = () => {
   // Preserve the navigation source when going to edit view
   router.push({
-    path: `/commodities/${commodity.value.id}/edit`,
+    path: groupStore.groupPath(`/commodities/${commodity.value.id}/edit`),
     query: {
       source: route.query.source,
       areaId: route.query.areaId
@@ -703,7 +705,7 @@ const onConfirmDelete = () => {
 
 const printCommodity = () => {
   // Open the print view in a new tab/window
-  window.open(`/commodities/${commodity.value.id}/print`, '_blank')
+  window.open(groupStore.groupPath(`/commodities/${commodity.value.id}/print`), '_blank')
 }
 
 const deleteCommodity = async () => {
@@ -711,9 +713,9 @@ const deleteCommodity = async () => {
     await commodityService.deleteCommodity(commodity.value.id)
     // Navigate based on the source
     if (sourceIsArea.value && areaId.value) {
-      router.push(`/areas/${areaId.value}`)
+      router.push(groupStore.groupPath(`/areas/${areaId.value}`))
     } else {
-      router.push('/commodities')
+      router.push(groupStore.groupPath('/commodities'))
     }
   } catch (err: any) {
     error.value = 'Failed to delete commodity: ' + (err.message || 'Unknown error')
@@ -723,10 +725,10 @@ const deleteCommodity = async () => {
 const navigateBack = () => {
   if (sourceIsArea.value && areaId.value) {
     // Navigate back to the area detail view
-    router.push(`/areas/${areaId.value}`)
+    router.push(groupStore.groupPath(`/areas/${areaId.value}`))
   } else {
     // Navigate back to the commodities list
-    router.push('/commodities')
+    router.push(groupStore.groupPath('/commodities'))
   }
 }
 

--- a/frontend/src/views/commodities/CommodityEditView.vue
+++ b/frontend/src/views/commodities/CommodityEditView.vue
@@ -57,9 +57,11 @@ import { COMMODITY_STATUS_IN_USE } from '@/constants/commodityStatuses'
 import CommodityForm from '@/components/CommodityForm.vue'
 import ResourceNotFound from '@/components/ResourceNotFound.vue'
 import { is404Error as checkIs404Error, get404Message, get404Title } from '@/utils/errorUtils'
+import { useGroupStore } from '@/stores/groupStore'
 
 const route = useRoute()
 const router = useRouter()
+const groupStore = useGroupStore()
 const settingsStore = useSettingsStore()
 const id = route.params.id as string
 const commodityForm = ref(null)
@@ -304,7 +306,7 @@ const submitForm = async (formData: any) => {
       if (sourceIsArea.value && areaId.value) {
         // Go back to the area view with the commodity ID for highlighting
         router.push({
-          path: `/areas/${areaId.value}`,
+          path: groupStore.groupPath(`/areas/${areaId.value}`),
           query: {
             highlightCommodityId: id
           }
@@ -312,7 +314,7 @@ const submitForm = async (formData: any) => {
       } else {
         // Go back to the commodities list with the commodity ID for highlighting
         router.push({
-          path: '/commodities',
+          path: groupStore.groupPath('/commodities'),
           query: {
             highlightCommodityId: id
           }
@@ -321,7 +323,7 @@ const submitForm = async (formData: any) => {
     } else {
       // Navigate back to commodity details with source context preserved
       router.push({
-        path: `/commodities/${id}`,
+        path: groupStore.groupPath(`/commodities/${id}`),
         query: {
           source: route.query.source,
           areaId: route.query.areaId
@@ -361,13 +363,13 @@ const submitForm = async (formData: any) => {
 const goBack = () => {
   if (isDirectEdit.value) {
     if (sourceIsArea.value && areaId.value) {
-      router.push(`/areas/${areaId.value}`)
+      router.push(groupStore.groupPath(`/areas/${areaId.value}`))
     } else {
-      router.push('/commodities')
+      router.push(groupStore.groupPath('/commodities'))
     }
   } else {
     router.push({
-      path: `/commodities/${id}`,
+      path: groupStore.groupPath(`/commodities/${id}`),
       query: {
         source: route.query.source,
         areaId: route.query.areaId
@@ -377,7 +379,7 @@ const goBack = () => {
 }
 
 const goBackToList = () => {
-  router.push('/commodities')
+  router.push(groupStore.groupPath('/commodities'))
 }
 </script>
 

--- a/frontend/src/views/commodities/CommodityListView.vue
+++ b/frontend/src/views/commodities/CommodityListView.vue
@@ -13,9 +13,9 @@
           <label class="toggle-label">Show drafts & inactive items</label>
         </div>
         <router-link v-if="loading" to="#" class="btn btn-primary"><font-awesome-icon icon="plus" /> Loading...</router-link>
-        <router-link v-else-if="hasLocationsAndAreas" to="/commodities/new" class="btn btn-primary new-commodity-button"><font-awesome-icon icon="plus" /> New</router-link>
-        <router-link v-else-if="locations.length === 0" to="/locations" class="btn btn-primary"><font-awesome-icon icon="plus" /> Create Location First</router-link>
-        <router-link v-else-if="areas.length === 0" to="/locations" class="btn btn-primary"><font-awesome-icon icon="plus" /> Create Area First</router-link>
+        <router-link v-else-if="hasLocationsAndAreas" :to="groupStore.groupPath('/commodities/new')" class="btn btn-primary new-commodity-button"><font-awesome-icon icon="plus" /> New</router-link>
+        <router-link v-else-if="locations.length === 0" :to="groupStore.groupPath('/locations')" class="btn btn-primary"><font-awesome-icon icon="plus" /> Create Location First</router-link>
+        <router-link v-else-if="areas.length === 0" :to="groupStore.groupPath('/locations')" class="btn btn-primary"><font-awesome-icon icon="plus" /> Create Area First</router-link>
       </div>
     </div>
 
@@ -25,19 +25,19 @@
       <div v-if="locations.length === 0" class="empty-message">
         <p>No locations found. You need to create a location first before you can create commodities.</p>
         <div class="action-button">
-          <router-link to="/locations" class="btn btn-primary">Create Location</router-link>
+          <router-link :to="groupStore.groupPath('/locations')" class="btn btn-primary">Create Location</router-link>
         </div>
       </div>
       <div v-else-if="areas.length === 0" class="empty-message">
         <p>No areas found. You need to create an area in a location before you can create commodities.</p>
         <div class="action-button">
-          <router-link to="/locations" class="btn btn-primary">Create Area</router-link>
+          <router-link :to="groupStore.groupPath('/locations')" class="btn btn-primary">Create Area</router-link>
         </div>
       </div>
       <div v-else class="empty-message">
         <p>No commodities found. Create your first commodity!</p>
         <div class="action-button">
-          <router-link to="/commodities/new" class="btn btn-primary">Create Commodity</router-link>
+          <router-link :to="groupStore.groupPath('/commodities/new')" class="btn btn-primary">Create Commodity</router-link>
         </div>
       </div>
     </div>
@@ -97,8 +97,10 @@ import Confirmation from "@/components/Confirmation.vue"
 import CommodityListItem from "@/components/CommodityListItem.vue"
 import PaginationControls from "@/components/PaginationControls.vue"
 import { fetchAll } from '@/utils/paginationUtils'
+import { useGroupStore } from '@/stores/groupStore'
 
 const router = useRouter()
+const groupStore = useGroupStore()
 const route = useRoute()
 const settingsStore = useSettingsStore()
 const commodities = ref<any[]>([])
@@ -256,7 +258,7 @@ onBeforeUnmount(() => {
 
 const viewCommodity = (id: string) => {
   router.push({
-    path: `/commodities/${id}`,
+    path: groupStore.groupPath(`/commodities/${id}`),
     query: {
       source: 'commodities'
     }
@@ -265,7 +267,7 @@ const viewCommodity = (id: string) => {
 
 const editCommodity = (id: string) => {
   router.push({
-    path: `/commodities/${id}/edit`,
+    path: groupStore.groupPath(`/commodities/${id}/edit`),
     query: {
       source: 'commodities',
       directEdit: 'true'

--- a/frontend/src/views/exports/ExportCreateView.vue
+++ b/frontend/src/views/exports/ExportCreateView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="export-create">
     <div class="breadcrumb-nav">
-      <router-link to="/exports" class="breadcrumb-link">
+      <router-link :to="groupStore.groupPath('/exports')" class="breadcrumb-link">
         <font-awesome-icon icon="arrow-left" /> Back to Exports
       </router-link>
     </div>
@@ -150,7 +150,7 @@
       </div>
 
       <div class="form-actions">
-        <router-link to="/exports" class="btn btn-secondary">Cancel</router-link>
+        <router-link :to="groupStore.groupPath('/exports')" class="btn btn-secondary">Cancel</router-link>
         <button
           type="submit"
           class="btn btn-primary"
@@ -176,8 +176,10 @@ import locationService from '@/services/locationService'
 import areaService from '@/services/areaService'
 import commodityService from '@/services/commodityService'
 import type { Export, ExportType, Location, Area, Commodity, ResourceObject } from '@/types'
+import { useGroupStore } from '@/stores/groupStore'
 
 const router = useRouter()
+const groupStore = useGroupStore()
 
 const exportTypeOptions = ref([
   { label: 'Full Database', value: 'full_database' },
@@ -493,9 +495,9 @@ const createExport = async () => {
     const response = await exportService.createExport(requestData)
 
     if (response.data && response.data.data) {
-      router.push(`/exports/${response.data.data.id}`)
+      router.push(groupStore.groupPath(`/exports/${response.data.data.id}`))
     } else {
-      router.push('/exports')
+      router.push(groupStore.groupPath('/exports'))
     }
   } catch (err: any) {
     console.error('Error creating export:', err)

--- a/frontend/src/views/exports/ExportDetailView.vue
+++ b/frontend/src/views/exports/ExportDetailView.vue
@@ -398,9 +398,11 @@ import exportService from '@/services/exportService'
 import { isExportDeleted, canPerformOperations, getExportDisplayStatus, getExportStatusClasses } from '@/utils/exportUtils'
 import type { Export } from '@/types'
 import Confirmation from '@/components/Confirmation.vue'
+import { useGroupStore } from '@/stores/groupStore'
 
 const route = useRoute()
 const router = useRouter()
+const groupStore = useGroupStore()
 
 const exportData = ref<Export | null>(null)
 const loading = ref(true)
@@ -753,13 +755,13 @@ const toggleRestoreOperation = (index: number) => {
 
 const navigateToRestore = () => {
   if (exportData.value?.id) {
-    router.push(`/exports/${exportData.value.id}/restore`)
+    router.push(groupStore.groupPath(`/exports/${exportData.value.id}/restore`))
   }
 }
 
 const getExportFileUrl = (exportItem: any) => {
   if (!exportItem.file_id) return ''
-  return `/files/${exportItem.file_id}?from=export&exportId=${exportItem.id}`
+  return groupStore.groupPath(`/files/${exportItem.file_id}?from=export&exportId=${exportItem.id}`)
 }
 
 const goBack = () => {
@@ -769,20 +771,20 @@ const goBack = () => {
   if (from && fileId) {
     switch (from) {
       case 'file-list':
-        router.push('/files')
+        router.push(groupStore.groupPath('/files'))
         break
       case 'file-edit':
-        router.push(`/files/${fileId}/edit`)
+        router.push(groupStore.groupPath(`/files/${fileId}/edit`))
         break
       case 'file-view':
-        router.push(`/files/${fileId}`)
+        router.push(groupStore.groupPath(`/files/${fileId}`))
         break
       default:
-        router.push(`/files/${fileId}`)
+        router.push(groupStore.groupPath(`/files/${fileId}`))
         break
     }
   } else {
-    router.push('/exports')
+    router.push(groupStore.groupPath('/exports'))
   }
 }
 
@@ -831,7 +833,7 @@ const deleteExport = async () => {
   try {
     deleting.value = true
     await exportService.deleteExport(exportData.value.id)
-    router.push('/exports')
+    router.push(groupStore.groupPath('/exports'))
   } catch (err: any) {
     console.error('Error deleting export:', err)
     alert('Failed to delete export')

--- a/frontend/src/views/exports/ExportImportView.vue
+++ b/frontend/src/views/exports/ExportImportView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="export-detail-page">
     <div class="breadcrumb-nav">
-      <router-link to="/exports" class="breadcrumb-link">
+      <router-link :to="groupStore.groupPath('/exports')" class="breadcrumb-link">
         <font-awesome-icon icon="arrow-left" /> Back to Exports
       </router-link>
     </div>
@@ -67,7 +67,7 @@
 
           <!-- Form Actions -->
           <div class="form-actions">
-            <router-link to="/exports" class="btn btn-secondary">
+            <router-link :to="groupStore.groupPath('/exports')" class="btn btn-secondary">
               Cancel
             </router-link>
             <button
@@ -103,9 +103,11 @@ import { useToast } from 'primevue/usetoast'
 import FileUploader from '@/components/FileUploader.vue'
 import exportService from '@/services/exportService'
 import api from '@/services/api'
+import { useGroupStore } from '@/stores/groupStore'
 
 
 const router = useRouter()
+const groupStore = useGroupStore()
 const toast = useToast()
 
 const fileUploader = ref()
@@ -289,7 +291,7 @@ const handleSubmit = async () => {
     pollImportStatus(exportId)
 
     // Navigate to the imported export detail view immediately
-    router.push(`/exports/${exportId}`)
+    router.push(groupStore.groupPath(`/exports/${exportId}`))
   } catch (err: any) {
     console.error('Error importing export:', err)
 

--- a/frontend/src/views/exports/ExportListView.vue
+++ b/frontend/src/views/exports/ExportListView.vue
@@ -13,10 +13,10 @@
           <label class="toggle-label">Show deleted exports</label>
         </div>
         <div class="actions">
-          <router-link to="/exports/import" class="btn btn-secondary new-import-button">
+          <router-link :to="groupStore.groupPath('/exports/import')" class="btn btn-secondary new-import-button">
             <font-awesome-icon icon="upload" /> Import
           </router-link>
-          <router-link to="/exports/new" class="btn btn-primary new-export-button">
+          <router-link :to="groupStore.groupPath('/exports/new')" class="btn btn-primary new-export-button">
             <font-awesome-icon icon="plus" /> New
           </router-link>
         </div>
@@ -29,7 +29,7 @@
       <div class="empty-message">
         <p>No exports found. Create your first export!</p>
         <div class="action-button">
-          <router-link to="/exports/new" class="btn btn-primary">Create Export</router-link>
+          <router-link :to="groupStore.groupPath('/exports/new')" class="btn btn-primary">Create Export</router-link>
         </div>
       </div>
     </div>
@@ -73,7 +73,7 @@
               {{ exportItem.completed_date ? formatDate(exportItem.completed_date) : '-' }}
             </td>
             <td class="export-actions">
-              <router-link :to="`/exports/${exportItem.id}`" class="btn btn-sm btn-secondary" @click.stop>
+              <router-link :to="groupStore.groupPath(`/exports/${exportItem.id}`)" class="btn btn-sm btn-secondary" @click.stop>
                 <font-awesome-icon icon="eye" /> View
               </router-link>
               <button
@@ -126,8 +126,10 @@ import Confirmation from '@/components/Confirmation.vue'
 import exportService from '@/services/exportService'
 import { isExportDeleted, canPerformOperations, getExportDisplayStatus, getExportStatusClasses } from '@/utils/exportUtils'
 import type { Export, ResourceObject } from '@/types'
+import { useGroupStore } from '@/stores/groupStore'
 
 const router = useRouter()
+const groupStore = useGroupStore()
 
 const exports = ref<Export[]>([])
 const loading = ref(true)
@@ -181,7 +183,7 @@ const formatDate = (dateString: string) => {
 }
 
 const viewExport = (exportId: string) => {
-  router.push(`/exports/${exportId}`)
+  router.push(groupStore.groupPath(`/exports/${exportId}`))
 }
 
 const deleteExport = (exportId: string) => {

--- a/frontend/src/views/exports/restore/RestoreCreateView.vue
+++ b/frontend/src/views/exports/restore/RestoreCreateView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="export-detail-page">
     <div class="breadcrumb-nav">
-      <router-link :to="`/exports/${exportId}`" class="breadcrumb-link">
+      <router-link :to="groupStore.groupPath(`/exports/${exportId}`)" class="breadcrumb-link">
         <font-awesome-icon icon="arrow-left" /> Back to Export Details
       </router-link>
     </div>
@@ -176,7 +176,7 @@
 
       <!-- Form Actions -->
       <div class="form-actions">
-        <router-link :to="`/exports/${exportId}`" class="btn btn-secondary">
+        <router-link :to="groupStore.groupPath(`/exports/${exportId}`)" class="btn btn-secondary">
           Cancel
         </router-link>
         <button
@@ -211,9 +211,11 @@ import Checkbox from 'primevue/checkbox'
 import { useToast } from 'primevue/usetoast'
 import exportService from '@/services/exportService'
 import type { Export, RestoreRequest, RestoreOptions } from '@/types'
+import { useGroupStore } from '@/stores/groupStore'
 
 const route = useRoute()
 const router = useRouter()
+const groupStore = useGroupStore()
 const toast = useToast()
 
 const exportId = route.params.id as string
@@ -387,7 +389,7 @@ const createRestore = async () => {
     })
 
     // Navigate back to export detail view immediately
-    router.push(`/exports/${exportId}`)
+    router.push(groupStore.groupPath(`/exports/${exportId}`))
   } catch (err: any) {
     console.error('Error creating restore:', err)
 

--- a/frontend/src/views/files/FileCreateView.vue
+++ b/frontend/src/views/files/FileCreateView.vue
@@ -89,8 +89,10 @@ import { useRouter } from 'vue-router'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import FileUploader from '@/components/FileUploader.vue'
 import fileService from '@/services/fileService'
+import { useGroupStore } from '@/stores/groupStore'
 
 const router = useRouter()
+const groupStore = useGroupStore()
 
 // State
 const uploading = ref(false)
@@ -149,13 +151,13 @@ const uploadFile = async () => {
     if (Array.isArray(responseFiles) && responseFiles.length > 0) {
       // Redirect to the first uploaded file's detail view
       const fileId = responseFiles[0].id
-      router.push(`/files/${fileId}`)
+      router.push(groupStore.groupPath(`/files/${fileId}`))
     } else if (responseFiles && responseFiles.id) {
       // Single file response
-      router.push(`/files/${responseFiles.id}`)
+      router.push(groupStore.groupPath(`/files/${responseFiles.id}`))
     } else {
       // Fallback to files list
-      router.push('/files')
+      router.push(groupStore.groupPath('/files'))
     }
   } catch (err: any) {
     error.value = err.response?.data?.message || 'Failed to upload file'
@@ -178,7 +180,7 @@ const clearError = () => {
 }
 
 const goBack = () => {
-  router.push('/files')
+  router.push(groupStore.groupPath('/files'))
 }
 </script>
 

--- a/frontend/src/views/files/FileDetailView.vue
+++ b/frontend/src/views/files/FileDetailView.vue
@@ -214,9 +214,11 @@ import Confirmation from '@/components/Confirmation.vue'
 
 import ResourceNotFound from '@/components/ResourceNotFound.vue'
 import { is404Error as checkIs404Error, get404Message, get404Title } from '@/utils/errorUtils'
+import { useGroupStore } from '@/stores/groupStore'
 
 const route = useRoute()
 const router = useRouter()
+const groupStore = useGroupStore()
 
 // Image error handling with automatic URL refresh
 const onThumbnailError = async (event: Event) => {
@@ -409,9 +411,9 @@ const goBack = () => {
   const exportId = route.query.exportId as string
 
   if (from === 'export' && exportId) {
-    router.push(`/exports/${exportId}`)
+    router.push(groupStore.groupPath(`/exports/${exportId}`))
   } else {
-    router.push('/files')
+    router.push(groupStore.groupPath('/files'))
   }
 }
 
@@ -431,9 +433,9 @@ const editFile = () => {
   const exportId = route.query.exportId as string
 
   if (from === 'export' && exportId) {
-    router.push(`/files/${fileId.value}/edit?from=export&exportId=${exportId}`)
+    router.push(groupStore.groupPath(`/files/${fileId.value}/edit?from=export&exportId=${exportId}`))
   } else {
-    router.push(`/files/${fileId.value}/edit`)
+    router.push(groupStore.groupPath(`/files/${fileId.value}/edit`))
   }
 }
 
@@ -455,7 +457,7 @@ const deleteFile = async () => {
 
   try {
     await fileService.deleteFile(file.value.id)
-    router.push('/files')
+    router.push(groupStore.groupPath('/files'))
   } catch (err: any) {
     error.value = err.response?.data?.message || 'Failed to delete file'
     console.error('Error deleting file:', err)

--- a/frontend/src/views/files/FileEditView.vue
+++ b/frontend/src/views/files/FileEditView.vue
@@ -301,9 +301,11 @@ import fileService, { type FileEntity, type FileUpdateData } from '@/services/fi
 import commodityService from '@/services/commodityService'
 import locationService from '@/services/locationService'
 import areaService from '@/services/areaService'
+import { useGroupStore } from '@/stores/groupStore'
 
 const route = useRoute()
 const router = useRouter()
+const groupStore = useGroupStore()
 
 // State
 const file = ref<FileEntity | null>(null)
@@ -615,9 +617,9 @@ const updateFile = async () => {
     const exportId = route.query.exportId as string
 
     if (from === 'export' && exportId) {
-      router.push(`/files/${fileId.value}?from=export&exportId=${exportId}`)
+      router.push(groupStore.groupPath(`/files/${fileId.value}?from=export&exportId=${exportId}`))
     } else {
-      router.push(`/files/${fileId.value}`)
+      router.push(groupStore.groupPath(`/files/${fileId.value}`))
     }
   } catch (err: any) {
     saveError.value = err.response?.data?.message || 'Failed to save changes'
@@ -634,9 +636,9 @@ const goBack = () => {
   const exportId = route.query.exportId as string
 
   if (from === 'export' && exportId) {
-    router.push(`/files/${fileId.value}?from=export&exportId=${exportId}`)
+    router.push(groupStore.groupPath(`/files/${fileId.value}?from=export&exportId=${exportId}`))
   } else {
-    router.push(`/files/${fileId.value}`)
+    router.push(groupStore.groupPath(`/files/${fileId.value}`))
   }
 }
 

--- a/frontend/src/views/files/FileListView.vue
+++ b/frontend/src/views/files/FileListView.vue
@@ -8,7 +8,7 @@
         </div>
       </div>
       <div class="header-actions">
-        <router-link to="/files/create" class="btn btn-primary file-upload-button">
+        <router-link :to="groupStore.groupPath('/files/create')" class="btn btn-primary file-upload-button">
           <FontAwesomeIcon icon="plus" />
           Upload File
         </router-link>
@@ -231,7 +231,7 @@
         <p v-if="hasActiveFilters">No files match your current filters. Try adjusting your search criteria.</p>
         <p v-else>You haven't uploaded any files yet. Upload your first file to get started.</p>
         <div class="action-button">
-          <router-link to="/files/create" class="btn btn-primary">
+          <router-link :to="groupStore.groupPath('/files/create')" class="btn btn-primary">
             <font-awesome-icon icon="plus" />
             Upload File
           </router-link>
@@ -260,6 +260,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import fileService, { type FileEntity } from '@/services/fileService'
 import Confirmation from '@/components/Confirmation.vue'
+import { useGroupStore } from '@/stores/groupStore'
 
 
 // Type for signed URLs structure
@@ -273,6 +274,7 @@ interface URLData {
 
 const router = useRouter()
 const route = useRoute()
+const groupStore = useGroupStore()
 
 // Image error handling with automatic URL refresh
 const onImageError = async (event: Event) => {
@@ -490,11 +492,11 @@ const getEntityIcon = (file: FileEntity) => {
 
 
 const viewFile = (file: FileEntity) => {
-  router.push(`/files/${file.id}`)
+  router.push(groupStore.groupPath(`/files/${file.id}`))
 }
 
 const editFile = (file: FileEntity) => {
-  router.push(`/files/${file.id}/edit`)
+  router.push(groupStore.groupPath(`/files/${file.id}/edit`))
 }
 
 const downloadFile = async (file: FileEntity) => {

--- a/frontend/src/views/locations/LocationCreateView.vue
+++ b/frontend/src/views/locations/LocationCreateView.vue
@@ -51,8 +51,10 @@
 import { ref, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import locationService from '@/services/locationService'
+import { useGroupStore } from '@/stores/groupStore'
 
 const router = useRouter()
+const groupStore = useGroupStore()
 const isSubmitting = ref(false)
 const error = ref<string | null>(null)
 const debugInfo = ref<string | null>(null)
@@ -117,7 +119,7 @@ const submitForm = async () => {
     debugInfo.value += `\n\nResponse: ${JSON.stringify(response.data, null, 2)}`
 
     // On success, navigate to locations list
-    router.push('/locations')
+    router.push(groupStore.groupPath('/locations'))
   } catch (err: any) {
     console.error('Error creating location:', err)
 
@@ -152,7 +154,7 @@ const submitForm = async () => {
 }
 
 const cancel = () => {
-  router.push('/locations')
+  router.push(groupStore.groupPath('/locations'))
 }
 </script>
 

--- a/frontend/src/views/locations/LocationDetailView.vue
+++ b/frontend/src/views/locations/LocationDetailView.vue
@@ -187,9 +187,11 @@ import Confirmation from "@/components/Confirmation.vue"
 import ErrorNotificationStack from '@/components/ErrorNotificationStack.vue'
 import ResourceNotFound from '@/components/ResourceNotFound.vue'
 import { useErrorState, is404Error as checkIs404Error, get404Message, get404Title } from '@/utils/errorUtils'
+import { useGroupStore } from '@/stores/groupStore'
 
 const route = useRoute()
 const router = useRouter()
+const groupStore = useGroupStore()
 const loading = ref<boolean>(true)
 const location = ref<any>(null)
 const areas = ref<any[]>([])
@@ -284,7 +286,7 @@ const loadLocationFiles = async (id: string) => {
 }
 
 const goBackToList = () => {
-  router.push('/locations')
+  router.push(groupStore.groupPath('/locations'))
 }
 
 // Image upload/delete/update handlers
@@ -405,18 +407,18 @@ const onCancelDelete = () => {
 const deleteLocation = async () => {
   try {
     await locationService.deleteLocation(location.value.id)
-    router.push('/locations')
+    router.push(groupStore.groupPath('/locations'))
   } catch (err: any) {
     handleError(err, 'location', 'Failed to delete location')
   }
 }
 
 const viewArea = (id: string) => {
-  router.push(`/areas/${id}`)
+  router.push(groupStore.groupPath(`/areas/${id}`))
 }
 
 const editArea = (id: string) => {
-  router.push(`/areas/${id}/edit`)
+  router.push(groupStore.groupPath(`/areas/${id}/edit`))
 }
 
 const areaToDelete = ref<string | null>(null)

--- a/frontend/src/views/locations/LocationEditView.vue
+++ b/frontend/src/views/locations/LocationEditView.vue
@@ -63,9 +63,11 @@ import { useRoute, useRouter } from 'vue-router'
 import locationService from '@/services/locationService'
 import ResourceNotFound from '@/components/ResourceNotFound.vue'
 import { is404Error as checkIs404Error, get404Message, get404Title } from '@/utils/errorUtils'
+import { useGroupStore } from '@/stores/groupStore'
 
 const route = useRoute()
 const router = useRouter()
+const groupStore = useGroupStore()
 const id = route.params.id as string
 
 const location = ref<any>(null)
@@ -155,7 +157,7 @@ const submitForm = async () => {
 
     await locationService.updateLocation(id, payload)
 
-    router.push(`/locations/${id}`)
+    router.push(groupStore.groupPath(`/locations/${id}`))
   } catch (err: any) {
     console.error('Error updating location:', err)
 
@@ -192,7 +194,7 @@ const goBack = () => {
 }
 
 const goBackToList = () => {
-  router.push('/locations')
+  router.push(groupStore.groupPath('/locations'))
 }
 </script>
 

--- a/frontend/src/views/locations/LocationListView.vue
+++ b/frontend/src/views/locations/LocationListView.vue
@@ -162,6 +162,7 @@ import locationService from '@/services/locationService'
 import areaService from '@/services/areaService'
 import valueService from '@/services/valueService'
 import { useSettingsStore } from '@/stores/settingsStore'
+import { useGroupStore } from '@/stores/groupStore'
 import { formatPrice } from '@/services/currencyService'
 import LocationForm from '@/components/LocationForm.vue'
 import AreaForm from '@/components/AreaForm.vue'
@@ -173,6 +174,7 @@ import { useErrorState } from '@/utils/errorUtils'
 const router = useRouter()
 const route = useRoute()
 const settingsStore = useSettingsStore()
+const groupStore = useGroupStore()
 const locations = ref<any[]>([])
 const areas = ref<any[]>([])
 const loading = ref<boolean>(true)
@@ -403,11 +405,11 @@ const handleAreaCreated = async (_newArea: any) => {
 
 // Location actions
 const viewLocation = (id: string) => {
-  router.push(`/locations/${id}`)
+  router.push(groupStore.groupPath(`/locations/${id}`))
 }
 
 const editLocation = (id: string) => {
-  router.push(`/locations/${id}/edit`)
+  router.push(groupStore.groupPath(`/locations/${id}/edit`))
 }
 
 const locationToDelete = ref<string | null>(null)
@@ -463,11 +465,11 @@ const scrollToArea = (areaId: string) => {
 
 // Area actions
 const viewArea = (id: string) => {
-  router.push(`/areas/${id}`)
+  router.push(groupStore.groupPath(`/areas/${id}`))
 }
 
 const editArea = (id: string) => {
-  router.push(`/areas/${id}/edit`)
+  router.push(groupStore.groupPath(`/areas/${id}/edit`))
 }
 
 const areaToDelete = ref<string | null>(null)

--- a/frontend/src/views/system/SystemSettingDetailView.vue
+++ b/frontend/src/views/system/SystemSettingDetailView.vue
@@ -2,7 +2,7 @@
   <div class="setting-detail">
     <div class="header">
       <div class="back-link">
-        <router-link to="/system">
+        <router-link :to="groupStore.groupPath('/system')">
           <font-awesome-icon icon="arrow-left" /> Back to System
         </router-link>
       </div>
@@ -90,11 +90,13 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import settingsService from '@/services/settingsService'
+import { useGroupStore } from '@/stores/groupStore'
 
 import Select from 'primevue/select'
 
 const route = useRoute()
 const router = useRouter()
+const groupStore = useGroupStore()
 const settingId = computed(() => route.params.id as string)
 
 const loading = ref<boolean>(true)
@@ -180,7 +182,7 @@ async function loadSetting() {
 }
 
 function goBack() {
-  router.push('/system')
+  router.push(groupStore.groupPath('/system'))
 }
 
 async function saveUIConfig() {
@@ -218,7 +220,7 @@ async function saveUIConfig() {
 
     // Note: default_page_size is not in the settings model, so we don't update it
 
-    router.push('/system')
+    router.push(groupStore.groupPath('/system'))
   } catch (err: any) {
     error.value = 'Failed to save UI config: ' + (err.message || 'Unknown error')
     console.error('Error saving UI config:', err)

--- a/frontend/src/views/system/SystemView.vue
+++ b/frontend/src/views/system/SystemView.vue
@@ -143,8 +143,10 @@
 import { ref, onMounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import systemService, { type SystemInfo } from '@/services/systemService'
+import { useGroupStore } from '@/stores/groupStore'
 
 const router = useRouter()
+const groupStore = useGroupStore()
 const route = useRoute()
 const systemInfo = ref<SystemInfo>({
   version: '',
@@ -196,7 +198,7 @@ onMounted(async () => {
 })
 
 const navigateToSetting = (id: string) => {
-  router.push(`/system/settings/${id}`)
+  router.push(groupStore.groupPath(`/system/settings/${id}`))
 }
 </script>
 


### PR DESCRIPTION
Closes #1321.

The #1289/#1300 migration moved the UI to `/g/:groupSlug/...` and left transitional shims behind so pre-migration bookmarks and stray `router.push('/locations')` call sites kept working. Those shims are now retired.

## Router (`frontend/src/router/index.ts`)

- Dropped the six `legacyFlatDataRoute` stub routes (`/locations`, `/areas`, `/commodities`, `/files`, `/exports`, `/system` with `:pathMatch(.*)*`).
- Dropped the matching branch in the `beforeEach` guard that rewrote flat paths to `/g/<slug>/...` — callers now build scoped URLs explicitly.
- Updated header comments to reflect the removal.

## Views & services (mass update)

- Replaced hardcoded flat paths with `groupStore.groupPath(...)` in every `router.push`, `:to=`, and `getLinkedEntityUrl` call site across locations / areas / commodities / files / exports / system views.
- `fileService.getLinkedEntityUrl` now routes through the store too.
- `HomeView.vue` dashboard cards use `groupPath`.
- `App.vue` drops its local `groupPath` and re-exports the store's function as the single source of truth.

## Store (`frontend/src/stores/groupStore.ts`)

- Deleted `migrateLegacyStorageToPreference` plus the two `LEGACY_STORAGE_KEY_*` constants and the safeLocalStorage helpers that only existed to support it.
- `ensureLoaded` no longer touches `localStorage`; default-group selection runs purely off `user.default_group_id`.

## Tests

- `App.spec.ts`: mock router now mounts children under `/g/:groupSlug/...`, `mockGroupStore.groupPath` mirrors the real store, and every nav test asserts scoped hrefs.
- `groupStore.spec.ts`: dropped the entire legacy-localStorage migration block and the `authUpdateProfile` spy; added a `groupPath (#1321)` suite covering scoped/unscoped paths and slug URL-encoding.

## Out of scope

Per issue body (item 4), the axios URL-rewriting interceptor in `services/api.ts` is deferred to a separate PR to keep the diff reviewable. The existing `api.test.ts` regression for a lingering legacy `currentGroupSlug` key stays so the interceptor keeps ignoring stale localStorage until it's refactored out.

## Verification

- `npm run lint` — 0 errors (pre-existing `any` warnings only).
- `npm run test` — 407/407 pass across 26 files.

## Risk

Low. Pure frontend refactor, no backend / DB / schema changes. Unknown URLs still land on `NotFoundView` via the 404 catch-all.