### PR TITLE
[Phase 3] List/grid views: Locations, Commodities, Files, Exports (#1328)

### DIFF
--- a/e2e/tests/draft-inactive-toggle.spec.ts
+++ b/e2e/tests/draft-inactive-toggle.spec.ts
@@ -11,7 +11,7 @@ test.describe('Draft and Inactive Items Toggle Functionality', () => {
     await page.waitForSelector(`.commodity-card`);
 
     // Check the initial state (typically inactive items are hidden by default)
-    const showInactiveToggle = page.locator('.filter-toggle input');
+    const showInactiveToggle = page.locator('.filter-toggle [role="switch"]');
     expect(await showInactiveToggle.isChecked()).toBeFalsy();
 
     // Count visible commodities before toggling
@@ -63,7 +63,7 @@ test.describe('Draft and Inactive Items Toggle Functionality', () => {
     await expect(page.locator('.commodities-section')).toBeVisible();
 
     // Check the initial state of the toggle
-    const showInactiveToggle = page.locator('.filter-toggle input');
+    const showInactiveToggle = page.locator('.filter-toggle [role="switch"]');
     expect(await showInactiveToggle.isChecked()).toBeFalsy();
 
     // Count visible commodities in this area before toggling
@@ -100,7 +100,7 @@ test.describe('Draft and Inactive Items Toggle Functionality', () => {
         await recorder.takeScreenshot('05-alternative-area-detail');
 
         // Check toggle state again
-        const altToggle = page.locator('.filter-toggle input');
+        const altToggle = page.locator('.filter-toggle [role="switch"]');
         expect(await altToggle.isChecked()).toBeFalsy();
 
         // Count before toggle

--- a/frontend/src/design/patterns/CommodityCard.vue
+++ b/frontend/src/design/patterns/CommodityCard.vue
@@ -1,0 +1,244 @@
+<script setup lang="ts">
+/**
+ * CommodityCard — list-row card for a commodity inside the
+ * CommodityListView grid. Composes from Tailwind status tokens, the
+ * CommodityStatusPill pill, and IconButton for the trailing actions.
+ *
+ * Replaces the legacy `CommodityListItem` (#1328 PR 3.2). The legacy
+ * "SOLD" watermark, "draft" diagonal hatch, ⚠️ / 🗑️ emoji markers and
+ * heavy `filter: grayscale/saturate` are gone — modern visual signals
+ * are: a `border-l-4 border-l-status-*` accent, a desaturation modifier
+ * for non-active items, and the existing CommodityStatusPill (icon +
+ * text + color) which is fully accessible and dark-mode aware. The
+ * `.commodity-card` class stays on the outermost element as a legacy
+ * Playwright anchor (devdocs/frontend/migration-conventions.md).
+ */
+import type { FunctionalComponent, HTMLAttributes } from 'vue'
+import { computed } from 'vue'
+import {
+  Box,
+  Calendar,
+  CookingPot,
+  Laptop,
+  type LucideProps,
+  MapPin,
+  Pencil,
+  Shirt,
+  Sofa,
+  Trash2,
+  Wrench,
+} from 'lucide-vue-next'
+
+import { cn } from '@design/lib/utils'
+
+import CommodityStatusPill, {
+  type CommodityStatus,
+} from './CommodityStatusPill.vue'
+import IconButton from './IconButton.vue'
+
+type CommodityType =
+  | 'white_goods'
+  | 'electronics'
+  | 'equipment'
+  | 'furniture'
+  | 'clothes'
+  | 'other'
+
+type Props = {
+  name: string
+  /** Commodity type id (free-form to tolerate unknown values from older data). */
+  type: CommodityType | string
+  status: CommodityStatus
+  /** When true, the card renders the draft visual treatment regardless of status. */
+  draft?: boolean
+  count?: number
+  /** ISO date string; rendered as a localized "Mar 5, 2026" line when present. */
+  purchaseDate?: string
+  /** Pre-formatted main price string (e.g. "100.00 USD"). */
+  displayPrice?: string
+  /** Pre-formatted per-unit price; rendered when count > 1. */
+  pricePerUnit?: string
+  /** Optional location/area breadcrumb shown above the meta row. */
+  locationName?: string
+  areaName?: string
+  /** Highlight ring shown when arriving from a deep-link / detail back-nav. */
+  highlighted?: boolean
+  testId?: string
+  class?: HTMLAttributes['class']
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  draft: false,
+  count: 1,
+  highlighted: false,
+})
+
+type Emits = {
+  view: []
+  edit: []
+  delete: []
+}
+const emit = defineEmits<Emits>()
+
+const typeIcons: Record<string, FunctionalComponent<LucideProps>> = {
+  white_goods: CookingPot,
+  electronics: Laptop,
+  equipment: Wrench,
+  furniture: Sofa,
+  clothes: Shirt,
+  other: Box,
+}
+
+const typeLabels: Record<string, string> = {
+  white_goods: 'White Goods',
+  electronics: 'Electronics',
+  equipment: 'Equipment',
+  furniture: 'Furniture',
+  clothes: 'Clothes',
+  other: 'Other',
+}
+
+const typeIcon = computed<FunctionalComponent<LucideProps>>(
+  () => typeIcons[props.type] ?? Box,
+)
+const typeLabel = computed(() => typeLabels[props.type] ?? props.type)
+
+const effectiveStatus = computed<CommodityStatus>(() =>
+  props.draft ? 'draft' : props.status,
+)
+
+const muted = computed(() => {
+  if (props.draft) return true
+  return (
+    props.status === 'sold' ||
+    props.status === 'lost' ||
+    props.status === 'disposed' ||
+    props.status === 'written_off'
+  )
+})
+
+// Full literal classes so Tailwind's source scanner can detect them.
+const borderClass = computed(() => {
+  if (props.draft) return 'border-l-status-draft'
+  switch (props.status) {
+    case 'in_use':
+      return 'border-l-status-in-use'
+    case 'sold':
+      return 'border-l-status-sold'
+    case 'lost':
+      return 'border-l-status-lost'
+    case 'disposed':
+      return 'border-l-status-disposed'
+    case 'written_off':
+      return 'border-l-status-written-off'
+    default:
+      return 'border-l-status-draft'
+  }
+})
+
+function formatDate(iso: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function onClick() {
+  emit('view')
+}
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    emit('view')
+  }
+}
+</script>
+
+<template>
+  <div
+    role="button"
+    tabindex="0"
+    :data-testid="testId"
+    :data-status="effectiveStatus"
+    :class="
+      cn(
+        'commodity-card group relative flex items-start justify-between gap-3',
+        'cursor-pointer rounded-md border border-l-4 border-border bg-card p-4 sm:p-6 shadow-sm',
+        borderClass,
+        muted && 'opacity-80 saturate-[.75]',
+        highlighted && 'ring-2 ring-primary ring-offset-2',
+        'motion-safe:transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        props.class,
+      )
+    "
+    @click="onClick"
+    @keydown="onKeydown"
+  >
+    <div class="min-w-0 flex-1">
+      <h3 class="truncate text-base font-semibold text-foreground">{{ name }}</h3>
+
+      <div
+        v-if="locationName || areaName"
+        class="mt-1 flex items-center gap-1 text-sm text-muted-foreground"
+      >
+        <MapPin class="size-3.5 shrink-0" aria-hidden="true" />
+        <span class="truncate">
+          {{ locationName }}{{ locationName && areaName ? ' / ' : '' }}{{ areaName }}
+        </span>
+      </div>
+
+      <div class="mt-2 flex items-center justify-between gap-2 text-sm text-muted-foreground">
+        <span class="inline-flex items-center gap-1">
+          <component :is="typeIcon" class="size-4" aria-hidden="true" />
+          {{ typeLabel }}
+        </span>
+        <span v-if="count > 1" class="font-medium">×{{ count }}</span>
+      </div>
+
+      <div
+        v-if="purchaseDate"
+        class="mt-2 flex items-center gap-1 text-sm text-muted-foreground"
+      >
+        <Calendar class="size-3.5" aria-hidden="true" />
+        {{ formatDate(purchaseDate) }}
+      </div>
+
+      <div v-if="displayPrice" class="mt-3 flex flex-col gap-0.5">
+        <span class="text-base font-semibold text-foreground">{{ displayPrice }}</span>
+        <span
+          v-if="count > 1 && pricePerUnit"
+          class="text-xs italic text-muted-foreground"
+        >
+          {{ pricePerUnit }} per unit
+        </span>
+      </div>
+
+      <div class="mt-3">
+        <CommodityStatusPill :status="effectiveStatus" />
+      </div>
+    </div>
+
+    <div class="flex shrink-0 items-center gap-1" @click.stop>
+      <IconButton
+        aria-label="Edit commodity"
+        title="Edit"
+        size="icon-sm"
+        @click="emit('edit')"
+      >
+        <Pencil />
+      </IconButton>
+      <IconButton
+        aria-label="Delete commodity"
+        title="Delete"
+        size="icon-sm"
+        class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+        @click="emit('delete')"
+      >
+        <Trash2 />
+      </IconButton>
+    </div>
+  </div>
+</template>

--- a/frontend/src/design/patterns/FilePreview.vue
+++ b/frontend/src/design/patterns/FilePreview.vue
@@ -1,0 +1,288 @@
+<script setup lang="ts">
+/**
+ * FilePreview — grid-card representation of a single file entity.
+ *
+ * Consumed by FileListView (#1328 PR 3.3) and ready for re-use in any
+ * other gallery view that lands in later phases. The pattern is
+ * presentation-only: thumbnails are rendered from a parent-supplied
+ * signed URL, broken images bubble up via the `imageError` emit so the
+ * parent (which owns fileService) can refresh the URL, and the linked-
+ * entity badge is a `<router-link>` driven by a parent-computed
+ * `{ display, url, icon }` triple.
+ *
+ * Class anchors: `.file-card` stays on the outermost element so the
+ * existing Playwright suite that targets file grids by CSS class keeps
+ * working through the migration window. Bare-text `.file-item` is on
+ * the legacy `frontend/src/components/FileList.vue`, which is a
+ * separate component used by commodity / location detail views and
+ * migrates with them in Phase 4.
+ */
+import type { FunctionalComponent, HTMLAttributes } from 'vue'
+import { computed } from 'vue'
+import {
+  Archive,
+  Box,
+  Download,
+  ExternalLink,
+  File as FileIcon,
+  FileOutput,
+  FileText,
+  Image as ImageIcon,
+  Link as LinkIcon,
+  Lock,
+  type LucideProps,
+  MapPin,
+  Music,
+  Pencil,
+  Trash2,
+  Video,
+} from 'lucide-vue-next'
+import { RouterLink } from 'vue-router'
+
+import type { FileEntity } from '@/services/fileService'
+import { cn } from '@design/lib/utils'
+
+import IconButton from './IconButton.vue'
+
+type EntityIconName = 'commodity' | 'location' | 'export' | 'link'
+
+type LinkedEntity = {
+  display: string
+  url: string
+  icon: EntityIconName
+}
+
+type Props = {
+  file: FileEntity
+  /** Pre-resolved signed URL for image thumbnails. */
+  thumbnailUrl?: string
+  /** Optional badge linking back to the entity that owns this file. */
+  linkedEntity?: LinkedEntity
+  /** When false, the trash button is replaced with a disabled lock icon. */
+  canDelete?: boolean
+  /** Tooltip / title text for the disabled lock state. */
+  deleteRestrictionReason?: string
+  testId?: string
+  class?: HTMLAttributes['class']
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  canDelete: true,
+})
+
+type Emits = {
+  view: []
+  download: []
+  edit: []
+  delete: []
+  imageError: [event: Event]
+}
+const emit = defineEmits<Emits>()
+
+const fileTypeLabels: Record<string, string> = {
+  image: 'Image',
+  document: 'Document',
+  video: 'Video',
+  audio: 'Audio',
+  archive: 'Archive',
+  other: 'Other',
+}
+
+const fileTypeIcons: Record<string, FunctionalComponent<LucideProps>> = {
+  image: ImageIcon,
+  document: FileText,
+  video: Video,
+  audio: Music,
+  archive: Archive,
+  other: FileIcon,
+}
+
+const entityIcons: Record<EntityIconName, FunctionalComponent<LucideProps>> = {
+  commodity: Box,
+  location: MapPin,
+  export: FileOutput,
+  link: LinkIcon,
+}
+
+const displayTitle = computed(() => {
+  const file = props.file
+  if (file.title?.trim()) return file.title
+  if (file.path?.trim()) return file.path
+  return 'Untitled'
+})
+
+const fileTypeLabel = computed(
+  () => fileTypeLabels[props.file.type] ?? props.file.type,
+)
+
+const fileTypeIcon = computed<FunctionalComponent<LucideProps>>(() => {
+  if (props.file.type === 'document' && props.file.mime_type === 'application/pdf') {
+    return FileText
+  }
+  return fileTypeIcons[props.file.type] ?? FileIcon
+})
+
+const entityIcon = computed(() =>
+  props.linkedEntity ? entityIcons[props.linkedEntity.icon] : null,
+)
+
+const tags = computed(() => props.file.tags ?? [])
+const visibleTags = computed(() => tags.value.slice(0, 3))
+const overflowTags = computed(() => Math.max(0, tags.value.length - 3))
+
+function onCardClick() {
+  emit('view')
+}
+function onCardKeydown(event: KeyboardEvent) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    emit('view')
+  }
+}
+
+function onImgError(event: Event) {
+  emit('imageError', event)
+}
+</script>
+
+<template>
+  <div
+    role="button"
+    tabindex="0"
+    :data-testid="testId"
+    :data-file-id="file.id"
+    :class="
+      cn(
+        'file-card group relative flex flex-col overflow-hidden rounded-md border border-border bg-card shadow-sm',
+        'cursor-pointer motion-safe:transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        props.class,
+      )
+    "
+    @click="onCardClick"
+    @keydown="onCardKeydown"
+  >
+    <div class="flex h-40 items-center justify-center bg-muted">
+      <img
+        v-if="file.type === 'image' && thumbnailUrl"
+        :src="thumbnailUrl"
+        :alt="displayTitle"
+        :data-file-id="file.id"
+        class="h-full w-full object-cover"
+        @error="onImgError"
+      />
+      <component
+        :is="fileTypeIcon"
+        v-else
+        class="size-12 text-muted-foreground"
+        aria-hidden="true"
+      />
+    </div>
+
+    <div class="flex flex-col gap-2 p-4">
+      <h3
+        :title="displayTitle"
+        class="truncate text-sm font-semibold text-foreground"
+      >
+        {{ displayTitle }}
+      </h3>
+      <p
+        :title="file.description"
+        class="truncate text-sm text-muted-foreground"
+      >
+        {{ file.description || 'No description' }}
+      </p>
+
+      <div class="flex flex-wrap gap-1">
+        <span
+          class="inline-flex items-center rounded border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+        >
+          {{ fileTypeLabel }}
+        </span>
+        <span
+          class="inline-flex items-center rounded border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+        >
+          {{ file.ext }}
+        </span>
+      </div>
+
+      <div v-if="visibleTags.length > 0" class="flex flex-wrap items-center gap-1">
+        <span
+          v-for="tag in visibleTags"
+          :key="tag"
+          class="inline-flex items-center rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground"
+        >
+          {{ tag }}
+        </span>
+        <span
+          v-if="overflowTags > 0"
+          class="text-xs text-muted-foreground"
+        >
+          +{{ overflowTags }} more
+        </span>
+      </div>
+
+      <RouterLink
+        v-if="linkedEntity"
+        :to="linkedEntity.url"
+        title="View linked entity"
+        class="inline-flex max-w-full items-center gap-1.5 self-start rounded-md border border-blue-200 bg-blue-50 px-2 py-1 text-xs font-medium text-blue-900 hover:border-blue-400 hover:bg-blue-100 dark:border-blue-900/50 dark:bg-blue-950/40 dark:text-blue-100"
+        @click.stop
+      >
+        <component
+          :is="entityIcon"
+          v-if="entityIcon"
+          class="size-3 shrink-0"
+          aria-hidden="true"
+        />
+        <span class="truncate">{{ linkedEntity.display }}</span>
+        <ExternalLink class="size-3 shrink-0 opacity-70" aria-hidden="true" />
+      </RouterLink>
+    </div>
+
+    <div
+      class="absolute right-2 top-2 flex gap-1 opacity-0 motion-safe:transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+      @click.stop
+    >
+      <IconButton
+        aria-label="Download file"
+        title="Download"
+        size="icon-sm"
+        variant="secondary"
+        @click="emit('download')"
+      >
+        <Download />
+      </IconButton>
+      <IconButton
+        aria-label="Edit file"
+        title="Edit"
+        size="icon-sm"
+        variant="secondary"
+        @click="emit('edit')"
+      >
+        <Pencil />
+      </IconButton>
+      <IconButton
+        v-if="canDelete"
+        aria-label="Delete file"
+        title="Delete"
+        size="icon-sm"
+        variant="secondary"
+        class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+        @click="emit('delete')"
+      >
+        <Trash2 />
+      </IconButton>
+      <IconButton
+        v-else
+        :aria-label="deleteRestrictionReason || 'Cannot delete'"
+        :title="deleteRestrictionReason"
+        size="icon-sm"
+        variant="secondary"
+        disabled
+        class="text-muted-foreground"
+      >
+        <Lock />
+      </IconButton>
+    </div>
+  </div>
+</template>

--- a/frontend/src/design/patterns/LocationCard.vue
+++ b/frontend/src/design/patterns/LocationCard.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+/**
+ * LocationCard — list-row card showing a location's display data and
+ * its per-row actions (view, edit, delete). Composed from Tailwind
+ * tokens plus the IconButton pattern.
+ *
+ * When `expandable` is true the outermost element behaves as a button
+ * (role="button" + aria-expanded + keyboard-activatable) so callers can
+ * wire it to an inline panel — that is what LocationListView uses to
+ * reveal a location's nested areas.
+ *
+ * The `.location-card` class stays on the outermost element as a legacy
+ * Playwright anchor (see devdocs/frontend/migration-conventions.md).
+ */
+import type { HTMLAttributes } from 'vue'
+import { computed } from 'vue'
+import {
+  ChevronDown,
+  ChevronRight,
+  Eye,
+  MapPin,
+  Pencil,
+  Trash2,
+} from 'lucide-vue-next'
+
+import { cn } from '@design/lib/utils'
+
+import IconButton from './IconButton.vue'
+
+type Props = {
+  name: string
+  address?: string
+  /** Pre-formatted total value (e.g. "1 234.56 USD"). Hidden if omitted. */
+  valueLabel?: string
+  /** When true (default) the card body toggles `toggle` on click + Enter/Space. */
+  expandable?: boolean
+  /** Reflects the open/closed state of the inline panel below the card. */
+  expanded?: boolean
+  /** Render a "Loading…" placeholder for the value row. */
+  loadingValue?: boolean
+  /** Stable selector hook forwarded to the outermost element. */
+  testId?: string
+  class?: HTMLAttributes['class']
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  expandable: true,
+  expanded: false,
+  loadingValue: false,
+})
+
+type Emits = {
+  toggle: []
+  view: []
+  edit: []
+  delete: []
+}
+const emit = defineEmits<Emits>()
+
+const interactive = computed(() => props.expandable)
+
+function onCardClick() {
+  if (interactive.value) emit('toggle')
+}
+
+function onCardKeydown(event: KeyboardEvent) {
+  if (!interactive.value) return
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    emit('toggle')
+  }
+}
+</script>
+
+<template>
+  <div
+    :role="interactive ? 'button' : 'article'"
+    :tabindex="interactive ? 0 : undefined"
+    :aria-expanded="interactive ? expanded : undefined"
+    :data-testid="testId"
+    :class="
+      cn(
+        'location-card',
+        'group flex items-start justify-between gap-3 rounded-md border border-border bg-card p-4 sm:p-6 shadow-sm',
+        interactive
+          ? 'cursor-pointer motion-safe:transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+          : undefined,
+        props.class,
+      )
+    "
+    @click="onCardClick"
+    @keydown="onCardKeydown"
+  >
+    <div class="min-w-0 flex-1">
+      <div class="flex items-center gap-2">
+        <MapPin class="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <h3 class="truncate text-base font-semibold text-foreground">{{ name }}</h3>
+        <component
+          :is="expanded ? ChevronDown : ChevronRight"
+          v-if="expandable"
+          class="ml-auto size-4 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+      </div>
+      <p v-if="address" class="mt-1 text-sm italic text-muted-foreground">
+        {{ address }}
+      </p>
+      <p
+        v-if="loadingValue || valueLabel"
+        class="mt-2 text-sm font-medium text-primary"
+      >
+        <span class="font-normal text-muted-foreground">Total value:</span>
+        {{ loadingValue ? 'Loading…' : valueLabel }}
+      </p>
+    </div>
+
+    <div class="flex shrink-0 items-center gap-1" @click.stop>
+      <IconButton
+        aria-label="View location"
+        title="View"
+        size="icon-sm"
+        @click="emit('view')"
+      >
+        <Eye />
+      </IconButton>
+      <IconButton
+        aria-label="Edit location"
+        title="Edit"
+        size="icon-sm"
+        @click="emit('edit')"
+      >
+        <Pencil />
+      </IconButton>
+      <IconButton
+        aria-label="Delete location"
+        title="Delete"
+        size="icon-sm"
+        class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+        @click="emit('delete')"
+      >
+        <Trash2 />
+      </IconButton>
+    </div>
+  </div>
+</template>

--- a/frontend/src/design/patterns/MediaGallery.vue
+++ b/frontend/src/design/patterns/MediaGallery.vue
@@ -1,0 +1,70 @@
+<script lang="ts">
+import type { VariantProps } from 'class-variance-authority'
+import { cva } from 'class-variance-authority'
+
+export const mediaGalleryVariants = cva(
+  'grid gap-4',
+  {
+    variants: {
+      density: {
+        compact: 'grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6',
+        default: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4',
+        relaxed: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+      },
+    },
+    defaultVariants: {
+      density: 'default',
+    },
+  },
+)
+
+export type MediaGalleryVariants = VariantProps<typeof mediaGalleryVariants>
+</script>
+
+<script setup lang="ts">
+/**
+ * MediaGallery — pure layout helper for a responsive grid of media
+ * cards (FilePreview, image thumbnails, etc.). Owns no business logic
+ * and no scroll behaviour — its only job is the responsive
+ * `display: grid` track recipe with sensible breakpoints.
+ *
+ * Three densities are exposed via the `density` prop:
+ *   - compact  : thumbnail-sized cards, 2 → 6 columns.
+ *   - default  : standard FilePreview cards, 1 → 4 columns.
+ *   - relaxed  : roomy cards, 1 → 3 columns.
+ *
+ * The default slot accepts any number of children; the parent owns
+ * each child's lifecycle. Pair with EmptyState for "no items" copy.
+ */
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@design/lib/utils'
+
+interface Props {
+  density?: MediaGalleryVariants['density']
+  /** Optional override of the layout tag. Defaults to <div>. */
+  as?: 'div' | 'ul' | 'section'
+  testId?: string
+  class?: HTMLAttributes['class']
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  density: 'default',
+  as: 'div',
+})
+
+defineSlots<{
+  default?: () => unknown
+}>()
+</script>
+
+<template>
+  <component
+    :is="as"
+    data-slot="media-gallery"
+    :data-density="density"
+    :data-testid="testId"
+    :class="cn(mediaGalleryVariants({ density }), props.class)"
+  >
+    <slot />
+  </component>
+</template>

--- a/frontend/src/design/patterns/__tests__/CommodityCard.spec.ts
+++ b/frontend/src/design/patterns/__tests__/CommodityCard.spec.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import CommodityCard from '../CommodityCard.vue'
+
+const baseProps = {
+  name: 'Coffee Maker',
+  type: 'electronics',
+  status: 'in_use' as const,
+}
+
+describe('CommodityCard', () => {
+  it('renders the name in an <h3>', () => {
+    const wrapper = mount(CommodityCard, { props: baseProps })
+
+    expect(wrapper.get('h3').text()).toBe('Coffee Maker')
+  })
+
+  it('keeps the .commodity-card legacy anchor on the outermost element', () => {
+    const wrapper = mount(CommodityCard, { props: baseProps })
+
+    expect(wrapper.classes()).toContain('commodity-card')
+  })
+
+  it('forwards testId to the outermost element', () => {
+    const wrapper = mount(CommodityCard, {
+      props: { ...baseProps, testId: 'comm-1' },
+    })
+
+    expect(wrapper.attributes('data-testid')).toBe('comm-1')
+  })
+
+  it('renders the location/area breadcrumb when provided', () => {
+    const wrapper = mount(CommodityCard, {
+      props: { ...baseProps, locationName: 'Office', areaName: 'Kitchen' },
+    })
+
+    expect(wrapper.text()).toContain('Office / Kitchen')
+  })
+
+  it('renders only the location when no area is given', () => {
+    const wrapper = mount(CommodityCard, {
+      props: { ...baseProps, locationName: 'Office' },
+    })
+
+    expect(wrapper.text()).toContain('Office')
+    expect(wrapper.text()).not.toContain('/')
+  })
+
+  it('renders the type label for known commodity types', () => {
+    const wrapper = mount(CommodityCard, {
+      props: { ...baseProps, type: 'furniture' },
+    })
+
+    expect(wrapper.text()).toContain('Furniture')
+  })
+
+  it('falls back to the raw type id for unknown types', () => {
+    const wrapper = mount(CommodityCard, {
+      props: { ...baseProps, type: 'made_up' },
+    })
+
+    expect(wrapper.text()).toContain('made_up')
+  })
+
+  it('shows ×N count only when count > 1', () => {
+    const single = mount(CommodityCard, { props: { ...baseProps, count: 1 } })
+    expect(single.text()).not.toContain('×')
+
+    const many = mount(CommodityCard, { props: { ...baseProps, count: 4 } })
+    expect(many.text()).toContain('×4')
+  })
+
+  it('renders the formatted purchase date', () => {
+    const wrapper = mount(CommodityCard, {
+      props: { ...baseProps, purchaseDate: '2026-03-05' },
+    })
+
+    expect(wrapper.text()).toMatch(/Mar.+5/)
+  })
+
+  it('renders the displayPrice and per-unit price when count > 1', () => {
+    const wrapper = mount(CommodityCard, {
+      props: {
+        ...baseProps,
+        count: 3,
+        displayPrice: '300.00 USD',
+        pricePerUnit: '100.00 USD',
+      },
+    })
+
+    expect(wrapper.text()).toContain('300.00 USD')
+    expect(wrapper.text()).toContain('100.00 USD per unit')
+  })
+
+  it('omits per-unit price when count === 1', () => {
+    const wrapper = mount(CommodityCard, {
+      props: {
+        ...baseProps,
+        count: 1,
+        displayPrice: '100.00 USD',
+        pricePerUnit: '100.00 USD',
+      },
+    })
+
+    expect(wrapper.text()).toContain('100.00 USD')
+    expect(wrapper.text()).not.toContain('per unit')
+  })
+
+  it('shows the status pill with the commodity status', () => {
+    const wrapper = mount(CommodityCard, { props: { ...baseProps, status: 'sold' } })
+
+    expect(wrapper.attributes('data-status')).toBe('sold')
+    expect(wrapper.text()).toContain('Sold')
+  })
+
+  it('overrides the status to draft when the draft flag is set', () => {
+    const wrapper = mount(CommodityCard, {
+      props: { ...baseProps, status: 'in_use', draft: true },
+    })
+
+    expect(wrapper.attributes('data-status')).toBe('draft')
+    expect(wrapper.text()).toContain('Draft')
+  })
+
+  it('applies the matching border-l-status-* class for each status', () => {
+    const cases: Array<[CommodityCardStatus, string]> = [
+      ['in_use', 'border-l-status-in-use'],
+      ['sold', 'border-l-status-sold'],
+      ['lost', 'border-l-status-lost'],
+      ['disposed', 'border-l-status-disposed'],
+      ['written_off', 'border-l-status-written-off'],
+    ]
+    for (const [status, expected] of cases) {
+      const w = mount(CommodityCard, { props: { ...baseProps, status } })
+      expect(w.classes()).toContain(expected)
+    }
+
+    const draft = mount(CommodityCard, { props: { ...baseProps, draft: true } })
+    expect(draft.classes()).toContain('border-l-status-draft')
+  })
+
+  it('emits view on click and on Enter / Space', async () => {
+    const wrapper = mount(CommodityCard, { props: baseProps })
+
+    await wrapper.trigger('click')
+    await wrapper.trigger('keydown', { key: 'Enter' })
+    await wrapper.trigger('keydown', { key: ' ' })
+
+    expect(wrapper.emitted('view')).toHaveLength(3)
+  })
+
+  it('emits edit and delete from the action buttons without bubbling view', async () => {
+    const wrapper = mount(CommodityCard, { props: baseProps })
+
+    await wrapper.get('[aria-label="Edit commodity"]').trigger('click')
+    await wrapper.get('[aria-label="Delete commodity"]').trigger('click')
+
+    expect(wrapper.emitted('edit')).toHaveLength(1)
+    expect(wrapper.emitted('delete')).toHaveLength(1)
+    expect(wrapper.emitted('view')).toBeUndefined()
+  })
+
+  it('exposes legacy title attributes on the action buttons', () => {
+    const wrapper = mount(CommodityCard, { props: baseProps })
+
+    expect(wrapper.get('[aria-label="Edit commodity"]').attributes('title')).toBe('Edit')
+    expect(wrapper.get('[aria-label="Delete commodity"]').attributes('title')).toBe('Delete')
+  })
+
+  it('renders an accessible role/tabindex on the card root', () => {
+    const wrapper = mount(CommodityCard, { props: baseProps })
+
+    expect(wrapper.attributes('role')).toBe('button')
+    expect(wrapper.attributes('tabindex')).toBe('0')
+  })
+})
+
+type CommodityCardStatus =
+  | 'in_use'
+  | 'sold'
+  | 'lost'
+  | 'disposed'
+  | 'written_off'

--- a/frontend/src/design/patterns/__tests__/FilePreview.spec.ts
+++ b/frontend/src/design/patterns/__tests__/FilePreview.spec.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import type { FileEntity } from '@/services/fileService'
+import FilePreview from '../FilePreview.vue'
+
+const RouterLinkStub = {
+  name: 'RouterLink',
+  props: ['to'],
+  template: '<a :href="typeof to === \'string\' ? to : to?.path"><slot /></a>',
+}
+
+function makeFile(over: Partial<FileEntity> = {}): FileEntity {
+  return {
+    id: 'f-1',
+    title: 'My Receipt',
+    description: 'Coffee receipt',
+    type: 'image',
+    tags: [],
+    path: 'receipts/coffee',
+    original_path: 'coffee.png',
+    ext: '.png',
+    mime_type: 'image/png',
+    ...over,
+  }
+}
+
+function mountFP(props: Record<string, unknown>) {
+  return mount(FilePreview, {
+    props,
+    global: { stubs: { RouterLink: RouterLinkStub } },
+  })
+}
+
+describe('FilePreview', () => {
+  it('renders the title from file.title', () => {
+    const wrapper = mountFP({ file: makeFile({ title: 'Statement.pdf' }) })
+
+    expect(wrapper.get('h3').text()).toBe('Statement.pdf')
+  })
+
+  it('falls back to file.path when title is empty', () => {
+    const wrapper = mountFP({
+      file: makeFile({ title: '', path: 'receipts/coffee' }),
+    })
+
+    expect(wrapper.get('h3').text()).toBe('receipts/coffee')
+  })
+
+  it('falls back to "Untitled" when both title and path are empty', () => {
+    const wrapper = mountFP({ file: makeFile({ title: '', path: '' }) })
+
+    expect(wrapper.get('h3').text()).toBe('Untitled')
+  })
+
+  it('renders the description or "No description" when blank', () => {
+    const withDesc = mountFP({ file: makeFile({ description: 'Hello' }) })
+    expect(withDesc.text()).toContain('Hello')
+
+    const blank = mountFP({ file: makeFile({ description: '' }) })
+    expect(blank.text()).toContain('No description')
+  })
+
+  it('renders the thumbnail image when file is an image and thumbnailUrl is provided', () => {
+    const wrapper = mountFP({
+      file: makeFile(),
+      thumbnailUrl: '/thumb.png',
+    })
+
+    const img = wrapper.get('img')
+    expect(img.attributes('src')).toBe('/thumb.png')
+    expect(img.attributes('alt')).toBe('My Receipt')
+  })
+
+  it('renders an icon when file is not an image', () => {
+    const wrapper = mountFP({
+      file: makeFile({ type: 'document', mime_type: 'application/pdf' }),
+    })
+
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.findAll('svg').length).toBeGreaterThan(0)
+  })
+
+  it('renders an icon when file is image but no thumbnail URL is supplied', () => {
+    const wrapper = mountFP({ file: makeFile() })
+
+    expect(wrapper.find('img').exists()).toBe(false)
+  })
+
+  it('renders the file type label and extension chips', () => {
+    const wrapper = mountFP({
+      file: makeFile({ type: 'document', ext: '.pdf' }),
+    })
+
+    expect(wrapper.text()).toContain('Document')
+    expect(wrapper.text()).toContain('.pdf')
+  })
+
+  it('renders the first three tags + overflow counter', () => {
+    const wrapper = mountFP({
+      file: makeFile({ tags: ['a', 'b', 'c', 'd', 'e'] }),
+    })
+
+    expect(wrapper.text()).toContain('a')
+    expect(wrapper.text()).toContain('b')
+    expect(wrapper.text()).toContain('c')
+    expect(wrapper.text()).toContain('+2 more')
+  })
+
+  it('omits the overflow counter when there are three or fewer tags', () => {
+    const wrapper = mountFP({ file: makeFile({ tags: ['a', 'b'] }) })
+
+    expect(wrapper.text()).not.toContain('more')
+  })
+
+  it('renders a linked-entity router-link when linkedEntity is provided', () => {
+    const wrapper = mountFP({
+      file: makeFile(),
+      linkedEntity: {
+        display: 'Office',
+        url: '/g/x/locations/abc',
+        icon: 'location',
+      },
+    })
+
+    const link = wrapper.get('a')
+    expect(link.attributes('href')).toBe('/g/x/locations/abc')
+    expect(link.text()).toContain('Office')
+  })
+
+  it('keeps the .file-card legacy anchor on the root', () => {
+    const wrapper = mountFP({ file: makeFile() })
+
+    expect(wrapper.classes()).toContain('file-card')
+  })
+
+  it('forwards testId and data-file-id to the root', () => {
+    const wrapper = mountFP({
+      file: makeFile({ id: 'abc' }),
+      testId: 'preview-1',
+    })
+
+    expect(wrapper.attributes('data-testid')).toBe('preview-1')
+    expect(wrapper.attributes('data-file-id')).toBe('abc')
+  })
+
+  it('emits view on click and Enter / Space', async () => {
+    const wrapper = mountFP({ file: makeFile() })
+
+    await wrapper.trigger('click')
+    await wrapper.trigger('keydown', { key: 'Enter' })
+    await wrapper.trigger('keydown', { key: ' ' })
+
+    expect(wrapper.emitted('view')).toHaveLength(3)
+  })
+
+  it('emits download / edit / delete from the action buttons without bubbling view', async () => {
+    const wrapper = mountFP({ file: makeFile() })
+
+    await wrapper.get('[aria-label="Download file"]').trigger('click')
+    await wrapper.get('[aria-label="Edit file"]').trigger('click')
+    await wrapper.get('[aria-label="Delete file"]').trigger('click')
+
+    expect(wrapper.emitted('download')).toHaveLength(1)
+    expect(wrapper.emitted('edit')).toHaveLength(1)
+    expect(wrapper.emitted('delete')).toHaveLength(1)
+    expect(wrapper.emitted('view')).toBeUndefined()
+  })
+
+  it('replaces the trash button with a disabled lock when canDelete is false', () => {
+    const wrapper = mountFP({
+      file: makeFile(),
+      canDelete: false,
+      deleteRestrictionReason: 'Export files cannot be deleted manually.',
+    })
+
+    expect(wrapper.find('[aria-label="Delete file"]').exists()).toBe(false)
+    const lock = wrapper.get(
+      '[aria-label="Export files cannot be deleted manually."]',
+    )
+    expect(lock.attributes('disabled')).toBeDefined()
+  })
+
+  it('emits imageError when the thumbnail fails to load', async () => {
+    const wrapper = mountFP({
+      file: makeFile(),
+      thumbnailUrl: '/broken.png',
+    })
+
+    await wrapper.get('img').trigger('error')
+
+    expect(wrapper.emitted('imageError')).toHaveLength(1)
+  })
+})

--- a/frontend/src/design/patterns/__tests__/LocationCard.spec.ts
+++ b/frontend/src/design/patterns/__tests__/LocationCard.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import LocationCard from '../LocationCard.vue'
+
+describe('LocationCard', () => {
+  it('renders the name in an <h3>', () => {
+    const wrapper = mount(LocationCard, { props: { name: 'Office' } })
+
+    expect(wrapper.get('h3').text()).toBe('Office')
+  })
+
+  it('renders the address when provided', () => {
+    const wrapper = mount(LocationCard, {
+      props: { name: 'Office', address: '123 Main' },
+    })
+
+    expect(wrapper.text()).toContain('123 Main')
+  })
+
+  it('omits the address paragraph when not provided', () => {
+    const wrapper = mount(LocationCard, { props: { name: 'Office' } })
+
+    expect(wrapper.findAll('p').some((p) => p.text() === '123 Main')).toBe(false)
+  })
+
+  it('renders the value label when provided', () => {
+    const wrapper = mount(LocationCard, {
+      props: { name: 'Office', valueLabel: '100.00 USD' },
+    })
+
+    expect(wrapper.text()).toContain('100.00 USD')
+  })
+
+  it('shows "Loading…" instead of the value when loadingValue is true', () => {
+    const wrapper = mount(LocationCard, {
+      props: { name: 'Office', valueLabel: '100.00 USD', loadingValue: true },
+    })
+
+    expect(wrapper.text()).toContain('Loading…')
+    expect(wrapper.text()).not.toContain('100.00 USD')
+  })
+
+  it('keeps the .location-card legacy anchor on the outermost element', () => {
+    const wrapper = mount(LocationCard, { props: { name: 'Office' } })
+
+    expect(wrapper.classes()).toContain('location-card')
+  })
+
+  it('forwards testId to the outermost element', () => {
+    const wrapper = mount(LocationCard, {
+      props: { name: 'Office', testId: 'loc-1' },
+    })
+
+    expect(wrapper.attributes('data-testid')).toBe('loc-1')
+  })
+
+  it('exposes role="button" + aria-expanded when expandable', () => {
+    const wrapper = mount(LocationCard, {
+      props: { name: 'Office', expanded: true },
+    })
+
+    expect(wrapper.attributes('role')).toBe('button')
+    expect(wrapper.attributes('aria-expanded')).toBe('true')
+    expect(wrapper.attributes('tabindex')).toBe('0')
+  })
+
+  it('falls back to role="article" when not expandable', () => {
+    const wrapper = mount(LocationCard, {
+      props: { name: 'Office', expandable: false },
+    })
+
+    expect(wrapper.attributes('role')).toBe('article')
+    expect(wrapper.attributes('aria-expanded')).toBeUndefined()
+    expect(wrapper.attributes('tabindex')).toBeUndefined()
+  })
+
+  it('emits toggle on click when expandable', async () => {
+    const wrapper = mount(LocationCard, { props: { name: 'Office' } })
+
+    await wrapper.trigger('click')
+
+    expect(wrapper.emitted('toggle')).toHaveLength(1)
+  })
+
+  it('emits toggle on Enter and Space when expandable', async () => {
+    const wrapper = mount(LocationCard, { props: { name: 'Office' } })
+
+    await wrapper.trigger('keydown', { key: 'Enter' })
+    await wrapper.trigger('keydown', { key: ' ' })
+
+    expect(wrapper.emitted('toggle')).toHaveLength(2)
+  })
+
+  it('does not emit toggle when expandable is false', async () => {
+    const wrapper = mount(LocationCard, {
+      props: { name: 'Office', expandable: false },
+    })
+
+    await wrapper.trigger('click')
+    await wrapper.trigger('keydown', { key: 'Enter' })
+
+    expect(wrapper.emitted('toggle')).toBeUndefined()
+  })
+
+  it('exposes legacy title attributes on the action buttons', () => {
+    const wrapper = mount(LocationCard, { props: { name: 'Office' } })
+
+    expect(wrapper.get('[aria-label="View location"]').attributes('title')).toBe('View')
+    expect(wrapper.get('[aria-label="Edit location"]').attributes('title')).toBe('Edit')
+    expect(wrapper.get('[aria-label="Delete location"]').attributes('title')).toBe('Delete')
+  })
+
+  it('emits view, edit, delete without bubbling toggle from the action buttons', async () => {
+    const wrapper = mount(LocationCard, { props: { name: 'Office' } })
+
+    await wrapper.get('[aria-label="View location"]').trigger('click')
+    await wrapper.get('[aria-label="Edit location"]').trigger('click')
+    await wrapper.get('[aria-label="Delete location"]').trigger('click')
+
+    expect(wrapper.emitted('view')).toHaveLength(1)
+    expect(wrapper.emitted('edit')).toHaveLength(1)
+    expect(wrapper.emitted('delete')).toHaveLength(1)
+    expect(wrapper.emitted('toggle')).toBeUndefined()
+  })
+})

--- a/frontend/src/design/patterns/__tests__/MediaGallery.spec.ts
+++ b/frontend/src/design/patterns/__tests__/MediaGallery.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+
+import MediaGallery from '../MediaGallery.vue'
+
+describe('MediaGallery', () => {
+  it('renders default-slot children', () => {
+    const wrapper = mount(MediaGallery, {
+      slots: { default: () => [h('div', { class: 'item' }, 'A'), h('div', { class: 'item' }, 'B')] },
+    })
+
+    expect(wrapper.findAll('.item').length).toBe(2)
+  })
+
+  it('defaults to density="default"', () => {
+    const wrapper = mount(MediaGallery)
+
+    expect(wrapper.attributes('data-density')).toBe('default')
+    expect(wrapper.classes()).toContain('grid')
+    expect(wrapper.classes()).toContain('lg:grid-cols-4')
+  })
+
+  it('applies the compact variant classes', () => {
+    const wrapper = mount(MediaGallery, { props: { density: 'compact' } })
+
+    expect(wrapper.attributes('data-density')).toBe('compact')
+    expect(wrapper.classes()).toContain('grid')
+    expect(wrapper.classes()).toContain('gap-3')
+    expect(wrapper.classes()).toContain('xl:grid-cols-6')
+  })
+
+  it('applies the relaxed variant classes', () => {
+    const wrapper = mount(MediaGallery, { props: { density: 'relaxed' } })
+
+    expect(wrapper.attributes('data-density')).toBe('relaxed')
+    expect(wrapper.classes()).toContain('lg:grid-cols-3')
+  })
+
+  it('forwards testId', () => {
+    const wrapper = mount(MediaGallery, { props: { testId: 'gallery' } })
+
+    expect(wrapper.attributes('data-testid')).toBe('gallery')
+  })
+
+  it('renders as a <ul> when as="ul"', () => {
+    const wrapper = mount(MediaGallery, { props: { as: 'ul' } })
+
+    expect(wrapper.element.tagName).toBe('UL')
+  })
+
+  it('renders as a <section> when as="section"', () => {
+    const wrapper = mount(MediaGallery, { props: { as: 'section' } })
+
+    expect(wrapper.element.tagName).toBe('SECTION')
+  })
+
+  it('merges a caller-supplied class with the variant classes', () => {
+    const wrapper = mount(MediaGallery, { props: { class: 'extra-marker' } })
+
+    expect(wrapper.classes()).toContain('extra-marker')
+    expect(wrapper.classes()).toContain('grid')
+  })
+})

--- a/frontend/src/design/patterns/index.ts
+++ b/frontend/src/design/patterns/index.ts
@@ -19,6 +19,8 @@ export { default as InlineListEditor } from "./InlineListEditor.vue"
 
 export { default as LocationCard } from "./LocationCard.vue"
 
+export { default as CommodityCard } from "./CommodityCard.vue"
+
 export { default as SearchInput } from "./SearchInput.vue"
 
 export { default as FilterBar, filterBarVariants } from "./FilterBar.vue"

--- a/frontend/src/design/patterns/index.ts
+++ b/frontend/src/design/patterns/index.ts
@@ -17,6 +17,8 @@ export type { FormFooterVariants } from "./FormFooter.vue"
 
 export { default as InlineListEditor } from "./InlineListEditor.vue"
 
+export { default as LocationCard } from "./LocationCard.vue"
+
 export { default as SearchInput } from "./SearchInput.vue"
 
 export { default as FilterBar, filterBarVariants } from "./FilterBar.vue"

--- a/frontend/src/design/patterns/index.ts
+++ b/frontend/src/design/patterns/index.ts
@@ -21,6 +21,11 @@ export { default as LocationCard } from "./LocationCard.vue"
 
 export { default as CommodityCard } from "./CommodityCard.vue"
 
+export { default as FilePreview } from "./FilePreview.vue"
+
+export { default as MediaGallery, mediaGalleryVariants } from "./MediaGallery.vue"
+export type { MediaGalleryVariants } from "./MediaGallery.vue"
+
 export { default as SearchInput } from "./SearchInput.vue"
 
 export { default as FilterBar, filterBarVariants } from "./FilterBar.vue"

--- a/frontend/src/views/commodities/CommodityListView.vue
+++ b/frontend/src/views/commodities/CommodityListView.vue
@@ -1,228 +1,154 @@
-<template>
-  <div class="commodity-list">
-    <div class="header">
-      <div class="header-title">
-        <h1>Commodities</h1>
-        <div v-if="!valuesLoading && globalTotal > 0" class="total-value">
-          Total Value: <span class="value-amount">{{ formatPrice(globalTotal, mainCurrency) }}</span>
-        </div>
-      </div>
-      <div class="header-actions">
-        <div class="filter-toggle">
-          <ToggleSwitch v-model="showInactiveItems" />
-          <label class="toggle-label">Show drafts & inactive items</label>
-        </div>
-        <router-link v-if="loading" to="#" class="btn btn-primary"><font-awesome-icon icon="plus" /> Loading...</router-link>
-        <router-link v-else-if="hasLocationsAndAreas" :to="groupStore.groupPath('/commodities/new')" class="btn btn-primary new-commodity-button"><font-awesome-icon icon="plus" /> New</router-link>
-        <router-link v-else-if="locations.length === 0" :to="groupStore.groupPath('/locations')" class="btn btn-primary"><font-awesome-icon icon="plus" /> Create Location First</router-link>
-        <router-link v-else-if="areas.length === 0" :to="groupStore.groupPath('/locations')" class="btn btn-primary"><font-awesome-icon icon="plus" /> Create Area First</router-link>
-      </div>
-    </div>
-
-    <div v-if="loading" class="loading">Loading...</div>
-    <div v-else-if="error" class="error">{{ error }}</div>
-    <div v-else-if="commodities.length === 0" class="empty">
-      <div v-if="locations.length === 0" class="empty-message">
-        <p>No locations found. You need to create a location first before you can create commodities.</p>
-        <div class="action-button">
-          <router-link :to="groupStore.groupPath('/locations')" class="btn btn-primary">Create Location</router-link>
-        </div>
-      </div>
-      <div v-else-if="areas.length === 0" class="empty-message">
-        <p>No areas found. You need to create an area in a location before you can create commodities.</p>
-        <div class="action-button">
-          <router-link :to="groupStore.groupPath('/locations')" class="btn btn-primary">Create Area</router-link>
-        </div>
-      </div>
-      <div v-else class="empty-message">
-        <p>No commodities found. Create your first commodity!</p>
-        <div class="action-button">
-          <router-link :to="groupStore.groupPath('/commodities/new')" class="btn btn-primary">Create Commodity</router-link>
-        </div>
-      </div>
-    </div>
-
-    <div v-else class="commodities-grid-container">
-      <div class="commodities-grid">
-        <CommodityListItem
-          v-for="commodity in filteredCommodities"
-          :key="commodity.id"
-          :commodity="commodity"
-          :highlight-commodity-id="highlightCommodityId"
-          :show-location="true"
-          :area-map="areaMap"
-          :location-map="locationMap"
-          @view-commodity="viewCommodity"
-          @edit-commodity="editCommodity"
-          @confirm-delete-commodity="confirmDelete"
-        />
-      </div>
-
-      <!-- Pagination -->
-      <PaginationControls
-        :current-page="currentPage"
-        :total-pages="totalPages"
-        :page-size="pageSize"
-        :total-items="totalCommodities"
-        item-label="commodities"
-      />
-    </div>
-
-    <!-- Commodity Delete Confirmation Dialog -->
-    <Confirmation
-      v-model:visible="showDeleteDialog"
-      title="Confirm Delete"
-      message="Are you sure you want to delete this commodity?"
-      confirm-label="Delete"
-      cancel-label="Cancel"
-      confirm-button-class="danger"
-      confirmationIcon="exclamation-triangle"
-      @confirm="onConfirmDelete"
-      @cancel="onCancelDelete"
-    />
-  </div>
-</template>
-
 <script setup lang="ts">
-import { ref, onMounted, computed, nextTick, onBeforeUnmount, watch } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
-import commodityService from '@/services/commodityService'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Plus } from 'lucide-vue-next'
+
+import { Button } from '@design/ui/button'
+import { Switch } from '@design/ui/switch'
+import { Label } from '@design/ui/label'
+import CommodityCard from '@design/patterns/CommodityCard.vue'
+import PageContainer from '@design/patterns/PageContainer.vue'
+import PageHeader from '@design/patterns/PageHeader.vue'
+import { useAppToast } from '@design/composables/useAppToast'
+
+import Confirmation from '@/components/Confirmation.vue'
+import PaginationControls from '@/components/PaginationControls.vue'
+
 import areaService from '@/services/areaService'
+import commodityService from '@/services/commodityService'
 import locationService from '@/services/locationService'
 import valueService from '@/services/valueService'
-import { useSettingsStore } from '@/stores/settingsStore'
 import { COMMODITY_STATUS_IN_USE } from '@/constants/commodityStatuses'
-import { formatPrice } from '@/services/currencyService'
-import Confirmation from "@/components/Confirmation.vue"
-import CommodityListItem from "@/components/CommodityListItem.vue"
-import PaginationControls from "@/components/PaginationControls.vue"
-import { fetchAll } from '@/utils/paginationUtils'
+import {
+  calculatePricePerUnit,
+  formatPrice,
+  getDisplayPrice,
+} from '@/services/currencyService'
 import { useGroupStore } from '@/stores/groupStore'
+import { useSettingsStore } from '@/stores/settingsStore'
+import { fetchAll } from '@/utils/paginationUtils'
 
+const route = useRoute()
 const router = useRouter()
 const groupStore = useGroupStore()
-const route = useRoute()
 const settingsStore = useSettingsStore()
+const toast = useAppToast()
+
 const commodities = ref<any[]>([])
 const areas = ref<any[]>([])
 const locations = ref<any[]>([])
-const loading = ref<boolean>(true)
+const loading = ref(true)
 const error = ref<string | null>(null)
 
-// Pagination state
 const currentPage = ref(1)
 const pageSize = ref(50)
 const totalCommodities = ref(0)
-const totalPages = computed(() => Math.ceil(totalCommodities.value / pageSize.value))
+const totalPages = computed(() =>
+  Math.ceil(totalCommodities.value / pageSize.value),
+)
 
-// Values data
-const globalTotal = ref<number>(0)
-const valuesLoading = ref<boolean>(true)
-const valuesError = ref<string | null>(null)
+const globalTotal = ref(0)
+const valuesLoading = ref(true)
 
-// Main currency from settings store
 const mainCurrency = computed(() => settingsStore.mainCurrency)
 
-// Highlight commodity if specified in the URL
-const highlightCommodityId = ref(route.query.highlightCommodityId as string || '')
+const highlightCommodityId = ref(
+  (route.query.highlightCommodityId as string) || '',
+)
 let highlightTimeout: number | null = null
 
-// Filter toggle state
 const showInactiveItems = ref(false)
 
-// Computed property to check if there are locations and areas
-const hasLocationsAndAreas = computed(() => {
-  return locations.value.length > 0 && areas.value.length > 0
-})
+const hasLocationsAndAreas = computed(
+  () => locations.value.length > 0 && areas.value.length > 0,
+)
 
-// Filtered commodities based on toggle state
 const filteredCommodities = computed(() => {
-  if (showInactiveItems.value) {
-    return commodities.value
-  }
-  return commodities.value.filter(commodity => {
-    return !commodity.attributes.draft && commodity.attributes.status === COMMODITY_STATUS_IN_USE
-  })
+  if (showInactiveItems.value) return commodities.value
+  return commodities.value.filter(
+    (c) =>
+      !c.attributes.draft && c.attributes.status === COMMODITY_STATUS_IN_USE,
+  )
 })
 
-// Map to store area and location information
-const areaMap = ref<Record<string, any>>({})
-const locationMap = ref<Record<string, any>>({})
+const areaMap = ref<Record<string, { name: string; locationId: string }>>({})
+const locationMap = ref<
+  Record<string, { name: string; address?: string }>
+>({})
 
-// These functions are now handled by the CommodityListItem component
+function getLocationName(areaId: string): string {
+  const locId = areaMap.value[areaId]?.locationId
+  if (!locId) return ''
+  return locationMap.value[locId]?.name ?? ''
+}
+function getAreaName(areaId: string): string {
+  return areaMap.value[areaId]?.name ?? ''
+}
 
-// Function to load total values
 async function loadValues() {
   valuesLoading.value = true
-  valuesError.value = null
-
   try {
     const response = await valueService.getValues()
     const data = response.data.data.attributes
-
-    // Parse the decimal string to a number
-    globalTotal.value = parseFloat(data.global_total)
-  } catch (error) {
-    console.error('Error loading values:', error)
-    valuesError.value = 'Failed to load inventory values'
+    globalTotal.value =
+      typeof data.global_total === 'string'
+        ? parseFloat(data.global_total)
+        : data.global_total ?? 0
+  } catch (err: any) {
+    console.error('Error loading values:', err)
   } finally {
     valuesLoading.value = false
   }
 }
 
-// Monotonically increasing sequence number to detect and discard stale responses.
-let loadSeq = 0
-
-/** Fetches all areas and locations for the lookup maps. Called once on mount and after create/delete. */
-const loadLookups = async () => {
+async function loadLookups() {
   const [allAreas, allLocations] = await Promise.all([
-    fetchAll((_params) => areaService.getAreas(_params)),
-    fetchAll((_params) => locationService.getLocations(_params)),
+    fetchAll((params) => areaService.getAreas(params)),
+    fetchAll((params) => locationService.getLocations(params)),
   ])
-
   areas.value = allAreas
   locations.value = allLocations
 
-  areaMap.value = {}
-  areas.value.forEach(area => {
-    areaMap.value[area.id] = {
-      name: area.attributes.name,
-      locationId: area.attributes.location_id
+  const aMap: Record<string, { name: string; locationId: string }> = {}
+  for (const a of allAreas) {
+    aMap[a.id] = {
+      name: a.attributes.name,
+      locationId: a.attributes.location_id,
     }
-  })
+  }
+  areaMap.value = aMap
 
-  locationMap.value = {}
-  locations.value.forEach(location => {
-    locationMap.value[location.id] = {
-      name: location.attributes.name,
-      address: location.attributes.address
+  const lMap: Record<string, { name: string; address?: string }> = {}
+  for (const l of allLocations) {
+    lMap[l.id] = {
+      name: l.attributes.name,
+      address: l.attributes.address,
     }
-  })
+  }
+  locationMap.value = lMap
 }
 
-/** Fetches the current page of commodities. Safe to call on every page change without refetching lookups. */
-const loadCommodities = async () => {
+let loadSeq = 0
+async function loadCommodities() {
   const seq = ++loadSeq
   loading.value = true
   error.value = null
   try {
-    const commoditiesResponse = await commodityService.getCommodities({ page: currentPage.value, per_page: pageSize.value })
-
-    // Ignore stale responses from superseded requests (rapid page navigation).
+    const resp = await commodityService.getCommodities({
+      page: currentPage.value,
+      per_page: pageSize.value,
+    })
     if (seq !== loadSeq) return
+    commodities.value = resp.data.data
+    totalCommodities.value = resp.data.meta.commodities
 
-    commodities.value = commoditiesResponse.data.data
-    totalCommodities.value = commoditiesResponse.data.meta.commodities
-    loading.value = false
-
-    // Scroll to highlighted commodity if specified
     if (highlightCommodityId.value) {
       nextTick(() => {
-        const highlightedElement = document.querySelector(`.commodity-card.highlighted`)
-        if (highlightedElement) {
-          highlightedElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-
-          // Clear the highlight after 3 seconds
+        const el = document.querySelector(
+          `[data-commodity-id="${highlightCommodityId.value}"]`,
+        )
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
           highlightTimeout = window.setTimeout(() => {
             highlightCommodityId.value = ''
           }, 3000)
@@ -231,8 +157,10 @@ const loadCommodities = async () => {
     }
   } catch (err: any) {
     if (seq !== loadSeq) return
-    error.value = 'Failed to load data: ' + (err.message || 'Unknown error')
-    loading.value = false
+    error.value = err?.message ?? 'Failed to load commodities'
+    toast.error(error.value)
+  } finally {
+    if (seq === loadSeq) loading.value = false
   }
 }
 
@@ -242,13 +170,14 @@ onMounted(async () => {
   await Promise.all([loadLookups(), loadCommodities(), loadValues()])
 })
 
-// On page change, only reload commodities — lookup data (areas/locations) is stable across pages.
-watch(() => route.query.page, (newPage) => {
-  currentPage.value = Number(newPage) || 1
-  loadCommodities()
-})
+watch(
+  () => route.query.page,
+  (np) => {
+    currentPage.value = Number(np) || 1
+    loadCommodities()
+  },
+)
 
-// Clean up timeout when component is unmounted
 onBeforeUnmount(() => {
   if (highlightTimeout !== null) {
     window.clearTimeout(highlightTimeout)
@@ -256,106 +185,208 @@ onBeforeUnmount(() => {
   }
 })
 
-const viewCommodity = (id: string) => {
+function viewCommodity(id: string) {
   router.push({
     path: groupStore.groupPath(`/commodities/${id}`),
-    query: {
-      source: 'commodities'
-    }
+    query: { source: 'commodities' },
   })
 }
-
-const editCommodity = (id: string) => {
+function editCommodity(id: string) {
   router.push({
     path: groupStore.groupPath(`/commodities/${id}/edit`),
-    query: {
-      source: 'commodities',
-      directEdit: 'true'
-    }
+    query: { source: 'commodities', directEdit: 'true' },
   })
 }
 
 const commodityToDelete = ref<string | null>(null)
 const showDeleteDialog = ref(false)
 
-const confirmDelete = (id: string) => {
+function confirmDelete(id: string) {
   commodityToDelete.value = id
   showDeleteDialog.value = true
 }
 
-const onConfirmDelete = () => {
-  if (commodityToDelete.value) {
-    deleteCommodity(commodityToDelete.value)
-    showDeleteDialog.value = false
-    commodityToDelete.value = null
+async function onConfirmDelete() {
+  const id = commodityToDelete.value
+  showDeleteDialog.value = false
+  commodityToDelete.value = null
+  if (!id) return
+  try {
+    await commodityService.deleteCommodity(id)
+    await loadCommodities()
+  } catch (err: any) {
+    toast.error(err?.message ?? 'Failed to delete commodity')
   }
 }
 
-const onCancelDelete = () => {
+function onCancelDelete() {
   showDeleteDialog.value = false
   commodityToDelete.value = null
 }
 
-const deleteCommodity = async (id: string) => {
-  try {
-    await commodityService.deleteCommodity(id)
-    // Reload the current page to reflect deletion with accurate pagination
-    await loadCommodities()
-  } catch (err: any) {
-    error.value = 'Failed to delete commodity: ' + (err.message || 'Unknown error')
-  }
+function priceForCommodity(c: any): string | undefined {
+  const price = getDisplayPrice(c)
+  if (isNaN(price)) return undefined
+  return formatPrice(price)
 }
+
+function pricePerUnitFor(c: any): string | undefined {
+  const count = c.attributes.count || 1
+  if (count <= 1) return undefined
+  const ppu = calculatePricePerUnit(c)
+  if (isNaN(ppu)) return undefined
+  return formatPrice(ppu)
+}
+
+const newCommodityHref = computed(() => groupStore.groupPath('/commodities/new'))
+const goCreateLocationHref = computed(() => groupStore.groupPath('/locations'))
 </script>
 
-<style lang="scss" scoped>
-@use '@/assets/main' as *;
+<template>
+  <PageContainer>
+    <PageHeader title="Commodities">
+      <template #description>
+        <span
+          v-if="!valuesLoading && globalTotal > 0"
+          class="inline-flex items-center gap-1"
+        >
+          Total Value:
+          <span class="font-semibold text-foreground">
+            {{ formatPrice(globalTotal, mainCurrency) }}
+          </span>
+        </span>
+      </template>
+      <template #actions>
+        <div class="filter-toggle flex items-center gap-2">
+          <Switch
+            id="show-inactive-items"
+            v-model="showInactiveItems"
+            aria-label="Show drafts and inactive items"
+          />
+          <Label
+            for="show-inactive-items"
+            class="cursor-pointer text-sm text-muted-foreground"
+          >
+            Show drafts &amp; inactive items
+          </Label>
+        </div>
 
-.commodity-list {
-  max-width: $container-max-width;
-  margin: 0 auto;
-  padding: 20px;
-}
+        <Button v-if="loading" disabled>
+          <Plus class="size-4" aria-hidden="true" />
+          Loading...
+        </Button>
+        <Button
+          v-else-if="hasLocationsAndAreas"
+          as-child
+        >
+          <router-link :to="newCommodityHref">
+            <Plus class="size-4" aria-hidden="true" />
+            New
+          </router-link>
+        </Button>
+        <Button v-else-if="locations.length === 0" as-child>
+          <router-link :to="goCreateLocationHref">
+            <Plus class="size-4" aria-hidden="true" />
+            Create Location First
+          </router-link>
+        </Button>
+        <Button v-else-if="areas.length === 0" as-child>
+          <router-link :to="goCreateLocationHref">
+            <Plus class="size-4" aria-hidden="true" />
+            Create Area First
+          </router-link>
+        </Button>
+      </template>
+    </PageHeader>
 
-// Header styles are now in shared _header.scss
+    <div
+      v-if="loading"
+      class="rounded-md border border-border bg-card p-12 text-center text-muted-foreground shadow-sm"
+    >
+      Loading...
+    </div>
 
-.loading, .error, .empty {
-  text-align: center;
-  padding: 2rem;
-  background: white;
-  border-radius: $default-radius;
-  box-shadow: $box-shadow;
-}
+    <div
+      v-else-if="error"
+      class="rounded-md border border-destructive/50 bg-destructive/10 p-12 text-center text-destructive shadow-sm"
+    >
+      {{ error }}
+    </div>
 
-.error {
-  color: $danger-color;
-}
+    <div
+      v-else-if="commodities.length === 0"
+      class="flex flex-col items-center gap-4 rounded-md border border-border bg-card p-12 text-center shadow-sm"
+    >
+      <template v-if="locations.length === 0">
+        <p class="text-base">
+          No locations found. You need to create a location first before you
+          can create commodities.
+        </p>
+        <Button as-child>
+          <router-link :to="goCreateLocationHref">Create Location</router-link>
+        </Button>
+      </template>
+      <template v-else-if="areas.length === 0">
+        <p class="text-base">
+          No areas found. You need to create an area in a location before you
+          can create commodities.
+        </p>
+        <Button as-child>
+          <router-link :to="goCreateLocationHref">Create Area</router-link>
+        </Button>
+      </template>
+      <template v-else>
+        <p class="text-base">No commodities found. Create your first commodity!</p>
+        <Button as-child>
+          <router-link :to="newCommodityHref">Create Commodity</router-link>
+        </Button>
+      </template>
+    </div>
 
-.empty-message {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.5rem;
-}
+    <div v-else class="flex flex-col gap-6">
+      <div
+        class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+      >
+        <CommodityCard
+          v-for="commodity in filteredCommodities"
+          :key="commodity.id"
+          :name="commodity.attributes.name"
+          :type="commodity.attributes.type"
+          :status="commodity.attributes.status"
+          :draft="commodity.attributes.draft"
+          :count="commodity.attributes.count"
+          :purchase-date="commodity.attributes.purchase_date"
+          :display-price="priceForCommodity(commodity)"
+          :price-per-unit="pricePerUnitFor(commodity)"
+          :location-name="getLocationName(commodity.attributes.area_id)"
+          :area-name="getAreaName(commodity.attributes.area_id)"
+          :highlighted="commodity.id === highlightCommodityId"
+          :data-commodity-id="commodity.id"
+          @view="viewCommodity(commodity.id)"
+          @edit="editCommodity(commodity.id)"
+          @delete="confirmDelete(commodity.id)"
+        />
+      </div>
 
-.empty-message p {
-  margin-bottom: 0;
-  font-size: 1.1rem;
-}
+      <PaginationControls
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        :page-size="pageSize"
+        :total-items="totalCommodities"
+        item-label="commodities"
+      />
+    </div>
 
-.action-button {
-  margin-top: 0.5rem;
-}
-
-.commodities-grid-container {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.commodities-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 1.5rem;
-}
-
-</style>
+    <Confirmation
+      v-model:visible="showDeleteDialog"
+      title="Confirm Delete"
+      message="Are you sure you want to delete this commodity?"
+      confirm-label="Delete"
+      cancel-label="Cancel"
+      confirm-button-class="danger"
+      confirmation-icon="exclamation-triangle"
+      @confirm="onConfirmDelete"
+      @cancel="onCancelDelete"
+    />
+  </PageContainer>
+</template>

--- a/frontend/src/views/exports/ExportListView.vue
+++ b/frontend/src/views/exports/ExportListView.vue
@@ -1,136 +1,30 @@
-<template>
-  <div class="export-list">
-    <div class="header">
-      <div class="header-title">
-        <h1>Exports</h1>
-        <div v-if="!loading && exports.length > 0" class="export-count">
-          {{ exports.length }} export{{ exports.length !== 1 ? 's' : '' }}
-        </div>
-      </div>
-      <div class="header-actions">
-        <div class="filter-toggle">
-          <ToggleSwitch v-model="showDeleted" @change="loadExports" />
-          <label class="toggle-label">Show deleted exports</label>
-        </div>
-        <div class="actions">
-          <router-link :to="groupStore.groupPath('/exports/import')" class="btn btn-secondary new-import-button">
-            <font-awesome-icon icon="upload" /> Import
-          </router-link>
-          <router-link :to="groupStore.groupPath('/exports/new')" class="btn btn-primary new-export-button">
-            <font-awesome-icon icon="plus" /> New
-          </router-link>
-        </div>
-      </div>
-    </div>
-
-    <div v-if="loading" class="loading">Loading...</div>
-    <div v-else-if="error" class="error">{{ error }}</div>
-    <div v-else-if="exports.length === 0" class="empty">
-      <div class="empty-message">
-        <p>No exports found. Create your first export!</p>
-        <div class="action-button">
-          <router-link :to="groupStore.groupPath('/exports/new')" class="btn btn-primary">Create Export</router-link>
-        </div>
-      </div>
-    </div>
-
-    <div v-else class="exports-table">
-      <table class="table">
-        <thead>
-          <tr>
-            <th>Description</th>
-            <th>Type</th>
-            <th>Status</th>
-            <th>Created</th>
-            <th>Completed</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="exportItem in exports" :key="exportItem.id"
-              :class="['export-row', { 'deleted': isExportDeleted(exportItem) }]"
-              @click="viewExport(exportItem.id!)">
-            <td class="export-description">
-              <div class="description-text">{{ exportItem.description || 'No description' }}</div>
-              <div v-if="exportItem.error_message" class="error-message">
-                Error: {{ exportItem.error_message }}
-              </div>
-            </td>
-            <td class="export-type">
-              <span class="type-badge" :class="`type-${exportItem.type}`">
-                {{ formatExportType(exportItem.type) }}
-              </span>
-            </td>
-            <td class="export-status">
-              <span class="status-badge" :class="getExportStatusClasses(exportItem)">
-                {{ getExportDisplayStatus(exportItem) }}
-              </span>
-            </td>
-            <td class="export-date">
-              {{ formatDate(exportItem.created_date) }}
-            </td>
-            <td class="export-date">
-              {{ exportItem.completed_date ? formatDate(exportItem.completed_date) : '-' }}
-            </td>
-            <td class="export-actions">
-              <router-link :to="groupStore.groupPath(`/exports/${exportItem.id}`)" class="btn btn-sm btn-secondary" @click.stop>
-                <font-awesome-icon icon="eye" /> View
-              </router-link>
-              <button
-                v-if="exportItem.status === 'completed' && canPerformOperations(exportItem)"
-                class="btn btn-sm btn-primary"
-                :disabled="downloading === exportItem.id"
-                @click.stop="downloadExport(exportItem.id!)"
-              >
-                <font-awesome-icon :icon="downloading === exportItem.id ? 'spinner' : 'download'" :spin="downloading === exportItem.id" />
-                {{ downloading === exportItem.id ? 'Downloading...' : 'Download' }}
-              </button>
-              <button
-                v-if="canPerformOperations(exportItem)"
-                class="btn btn-sm btn-danger"
-                :disabled="deleting === exportItem.id"
-                @click.stop="deleteExport(exportItem.id!)"
-              >
-                <font-awesome-icon icon="trash" />
-                {{ deleting === exportItem.id ? 'Deleting...' : 'Delete' }}
-              </button>
-              <span v-else-if="isExportDeleted(exportItem)" class="deleted-indicator">
-                <font-awesome-icon icon="trash" /> Deleted
-              </span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-
-    <!-- Export Delete Confirmation Dialog -->
-    <Confirmation
-      v-model:visible="showDeleteDialog"
-      title="Confirm Delete"
-      message="Are you sure you want to delete this export?"
-      confirm-label="Delete"
-      cancel-label="Cancel"
-      confirm-button-class="danger"
-      confirmationIcon="exclamation-triangle"
-      @confirm="onConfirmDelete"
-      @cancel="onCancelDelete"
-    />
-  </div>
-</template>
-
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- removed in #1329
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { Eye, Plus, Trash2, Upload } from 'lucide-vue-next'
+
+import { Button } from '@design/ui/button'
+import { Switch } from '@design/ui/switch'
+import { Label } from '@design/ui/label'
+import ExportStatusPill from '@design/patterns/ExportStatusPill.vue'
+import PageContainer from '@design/patterns/PageContainer.vue'
+import PageHeader from '@design/patterns/PageHeader.vue'
+import { useAppToast } from '@design/composables/useAppToast'
+
 import Confirmation from '@/components/Confirmation.vue'
+
 import exportService from '@/services/exportService'
-import { isExportDeleted, canPerformOperations, getExportDisplayStatus, getExportStatusClasses } from '@/utils/exportUtils'
+import {
+  canPerformOperations,
+  getExportDisplayStatus,
+  isExportDeleted,
+} from '@/utils/exportUtils'
 import type { Export, ResourceObject } from '@/types'
 import { useGroupStore } from '@/stores/groupStore'
 
 const router = useRouter()
 const groupStore = useGroupStore()
+const toast = useAppToast()
 
 const exports = ref<Export[]>([])
 const loading = ref(true)
@@ -141,40 +35,41 @@ const showDeleteDialog = ref(false)
 const exportToDelete = ref<string | null>(null)
 const showDeleted = ref(false)
 
-const loadExports = async () => {
+const newExportHref = computed(() => groupStore.groupPath('/exports/new'))
+const importHref = computed(() => groupStore.groupPath('/exports/import'))
+
+async function loadExports() {
   try {
     loading.value = true
     error.value = ''
     const response = await exportService.getExports(showDeleted.value)
-    if (response.data && response.data.data) {
-      const exportList = response.data.data.map((item: ResourceObject<Export>) => ({
+    if (response.data?.data) {
+      exports.value = response.data.data.map((item: ResourceObject<Export>) => ({
         id: item.id,
-        ...item.attributes
+        ...item.attributes,
       }))
-
-      exports.value = exportList
     }
   } catch (err: any) {
-    error.value = err.response?.data?.errors?.[0]?.detail || 'Failed to load exports'
-    console.error('Error loading exports:', err)
+    error.value =
+      err?.response?.data?.errors?.[0]?.detail ?? err?.message ?? 'Failed to load exports'
   } finally {
     loading.value = false
   }
 }
 
-const formatExportType = (type: string) => {
-  const typeMap = {
-    'full_database': 'Full Database',
-    'selected_items': 'Selected Items',
-    'locations': 'Locations',
-    'areas': 'Areas',
-    'commodities': 'Commodities',
-    'imported': 'Imported'
+function formatExportType(type: string): string {
+  const typeMap: Record<string, string> = {
+    full_database: 'Full Database',
+    selected_items: 'Selected Items',
+    locations: 'Locations',
+    areas: 'Areas',
+    commodities: 'Commodities',
+    imported: 'Imported',
   }
-  return typeMap[type as keyof typeof typeMap] || type
+  return typeMap[type] ?? type
 }
 
-const formatDate = (dateString: string) => {
+function formatDate(dateString?: string | null): string {
   if (!dateString) return '-'
   try {
     return new Date(dateString).toLocaleString()
@@ -183,57 +78,64 @@ const formatDate = (dateString: string) => {
   }
 }
 
-const viewExport = (exportId: string) => {
-  router.push(groupStore.groupPath(`/exports/${exportId}`))
+function viewExport(id: string) {
+  router.push(groupStore.groupPath(`/exports/${id}`))
 }
 
-const deleteExport = (exportId: string) => {
-  exportToDelete.value = exportId
+function effectiveStatus(item: Export): 'pending' | 'in_progress' | 'completed' | 'failed' | 'deleted' {
+  if (isExportDeleted(item)) return 'deleted'
+  return item.status as 'pending' | 'in_progress' | 'completed' | 'failed'
+}
+
+function statusClasses(item: Export): string[] {
+  const status = effectiveStatus(item)
+  return ['status-badge', `export-status--${status.replace(/_/g, '-')}`]
+}
+
+function typeClasses(item: Export): string[] {
+  return ['type-badge', `type-${item.type}`]
+}
+
+function deleteExport(id: string) {
+  exportToDelete.value = id
   showDeleteDialog.value = true
 }
 
-const onConfirmDelete = async () => {
+async function onConfirmDelete() {
   if (!exportToDelete.value) return
-
+  const id = exportToDelete.value
+  showDeleteDialog.value = false
+  exportToDelete.value = null
   try {
-    deleting.value = exportToDelete.value
-    await exportService.deleteExport(exportToDelete.value)
-    // Reload exports to reflect the soft delete
+    deleting.value = id
+    await exportService.deleteExport(id)
     await loadExports()
   } catch (err: any) {
-    console.error('Error deleting export:', err)
-    error.value = 'Failed to delete export: ' + (err.message || 'Unknown error')
+    toast.error(err?.message ?? 'Failed to delete export')
   } finally {
     deleting.value = null
-    exportToDelete.value = null
-    showDeleteDialog.value = false
   }
 }
 
-const onCancelDelete = () => {
-  exportToDelete.value = null
+function onCancelDelete() {
   showDeleteDialog.value = false
+  exportToDelete.value = null
 }
 
-const downloadExport = async (exportId: string) => {
+async function downloadExport(id: string) {
   try {
-    downloading.value = exportId
-    const response = await exportService.downloadExport(exportId)
-
-    // Create blob and download link
+    downloading.value = id
+    const response = await exportService.downloadExport(id)
     const blob = new Blob([response.data], { type: 'application/xml' })
     const url = window.URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = url
 
-    // Try to get filename from Content-Disposition header
     const contentDisposition = response.headers['content-disposition']
     let filename = 'export.xml'
     if (contentDisposition) {
-      const filenameMatch = contentDisposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/)
-      if (filenameMatch) {
-        filename = filenameMatch[1].replace(/['"]/g, '')
-      }
+      const match = contentDisposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/)
+      if (match) filename = match[1].replace(/['"]/g, '')
     }
 
     link.download = filename
@@ -242,181 +144,218 @@ const downloadExport = async (exportId: string) => {
     document.body.removeChild(link)
     window.URL.revokeObjectURL(url)
   } catch (err: any) {
-    console.error('Error downloading export:', err)
-    error.value = 'Failed to download export: ' + (err.message || 'Unknown error')
+    toast.error(err?.message ?? 'Failed to download export')
   } finally {
     downloading.value = null
   }
 }
 
+let refreshTimer: number | null = null
+
 onMounted(() => {
   loadExports()
-
-  // Auto-refresh exports that are in progress
-  const interval = setInterval(() => {
-    if (exports.value) {
-      const inProgressExports = exports.value.filter(
-        exp => exp.status === 'pending' || exp.status === 'in_progress'
-      )
-
-      if (inProgressExports.length > 0) {
-        // Refresh the export list to get updated statuses
-        loadExports().catch(err => {
-          console.error('Error refreshing exports:', err)
-        })
-      }
+  refreshTimer = window.setInterval(() => {
+    if (exports.value.some((e) => e.status === 'pending' || e.status === 'in_progress')) {
+      loadExports().catch((err) => {
+        console.error('Error refreshing exports:', err)
+      })
     }
-  }, 3000) // Check every 3 seconds
+  }, 3000)
+})
 
-  // Cleanup interval on component unmount
-  return () => clearInterval(interval)
+onBeforeUnmount(() => {
+  if (refreshTimer !== null) {
+    window.clearInterval(refreshTimer)
+    refreshTimer = null
+  }
 })
 </script>
 
-<style lang="scss" scoped>
-@use '@/assets/main' as *;
+<template>
+  <PageContainer>
+    <PageHeader title="Exports">
+      <template #description>
+        <span v-if="!loading && exports.length > 0">
+          {{ exports.length }} export{{ exports.length !== 1 ? 's' : '' }}
+        </span>
+      </template>
+      <template #actions>
+        <div class="filter-toggle flex items-center gap-2">
+          <Switch
+            id="show-deleted-exports"
+            v-model="showDeleted"
+            aria-label="Show deleted exports"
+            @update:model-value="loadExports"
+          />
+          <Label
+            for="show-deleted-exports"
+            class="cursor-pointer text-sm text-muted-foreground"
+          >
+            Show deleted exports
+          </Label>
+        </div>
 
-.export-list {
-  max-width: $container-max-width;
-  margin: 0 auto;
-  padding: 20px;
-}
+        <Button as-child variant="outline">
+          <router-link :to="importHref">
+            <Upload class="size-4" aria-hidden="true" />
+            Import
+          </router-link>
+        </Button>
 
-// Header styles are now in shared _header.scss
+        <Button as-child>
+          <router-link :to="newExportHref">
+            <Plus class="size-4" aria-hidden="true" />
+            New
+          </router-link>
+        </Button>
+      </template>
+    </PageHeader>
 
-.empty-message p {
-  color: $text-secondary-color;
-  margin-bottom: 20px;
-}
+    <div
+      v-if="loading"
+      class="rounded-md border border-border bg-card p-12 text-center text-muted-foreground shadow-sm"
+    >
+      Loading...
+    </div>
 
-.exports-table {
-  background: white;
-  border-radius: $default-radius;
-  box-shadow: $box-shadow;
-  overflow: hidden;
-}
+    <div
+      v-else-if="error"
+      class="rounded-md border border-destructive/50 bg-destructive/10 p-12 text-center text-destructive shadow-sm"
+    >
+      {{ error }}
+    </div>
 
-.table {
-  width: 100%;
-  border-collapse: collapse;
-}
+    <div
+      v-else-if="exports.length === 0"
+      class="flex flex-col items-center gap-4 rounded-md border border-border bg-card p-12 text-center shadow-sm"
+    >
+      <p class="text-base">No exports found. Create your first export!</p>
+      <Button as-child>
+        <router-link :to="newExportHref">Create Export</router-link>
+      </Button>
+    </div>
 
-.table th,
-.table td {
-  padding: 12px;
-  text-align: left;
-  border-bottom: 1px solid $border-color;
-}
+    <div
+      v-else
+      class="overflow-hidden rounded-md border border-border bg-card shadow-sm"
+    >
+      <table class="w-full border-collapse">
+        <thead class="bg-muted/50">
+          <tr>
+            <th class="border-b border-border p-3 text-left text-sm font-semibold text-foreground">
+              Description
+            </th>
+            <th class="border-b border-border p-3 text-left text-sm font-semibold text-foreground">
+              Type
+            </th>
+            <th class="border-b border-border p-3 text-left text-sm font-semibold text-foreground">
+              Status
+            </th>
+            <th class="border-b border-border p-3 text-left text-sm font-semibold text-foreground">
+              Created
+            </th>
+            <th class="border-b border-border p-3 text-left text-sm font-semibold text-foreground">
+              Completed
+            </th>
+            <th class="border-b border-border p-3 text-left text-sm font-semibold text-foreground">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="exportItem in exports"
+            :key="exportItem.id"
+            :class="[
+              'export-row cursor-pointer motion-safe:transition-colors hover:bg-muted/40',
+              isExportDeleted(exportItem) && 'opacity-60 bg-muted/30',
+            ]"
+            @click="viewExport(exportItem.id!)"
+          >
+            <td class="border-b border-border p-3 align-top">
+              <div class="font-medium text-foreground">
+                {{ exportItem.description || 'No description' }}
+              </div>
+              <div
+                v-if="exportItem.error_message"
+                class="mt-1 text-xs text-destructive"
+              >
+                Error: {{ exportItem.error_message }}
+              </div>
+            </td>
+            <td class="border-b border-border p-3 align-top">
+              <span
+                :class="[
+                  ...typeClasses(exportItem),
+                  'inline-flex items-center rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground',
+                ]"
+              >
+                {{ formatExportType(exportItem.type) }}
+              </span>
+            </td>
+            <td class="border-b border-border p-3 align-top">
+              <ExportStatusPill
+                :status="effectiveStatus(exportItem)"
+                :label="getExportDisplayStatus(exportItem)"
+                :class="statusClasses(exportItem)"
+              />
+            </td>
+            <td class="border-b border-border p-3 align-top text-sm text-muted-foreground">
+              {{ formatDate(exportItem.created_date) }}
+            </td>
+            <td class="border-b border-border p-3 align-top text-sm text-muted-foreground">
+              {{ exportItem.completed_date ? formatDate(exportItem.completed_date) : '-' }}
+            </td>
+            <td class="border-b border-border p-3 align-top">
+              <div class="flex flex-wrap items-center gap-2" @click.stop>
+                <Button as-child variant="outline" size="sm">
+                  <router-link :to="groupStore.groupPath(`/exports/${exportItem.id}`)">
+                    <Eye class="size-4" aria-hidden="true" />
+                    View
+                  </router-link>
+                </Button>
+                <Button
+                  v-if="exportItem.status === 'completed' && canPerformOperations(exportItem)"
+                  size="sm"
+                  :disabled="downloading === exportItem.id"
+                  @click="downloadExport(exportItem.id!)"
+                >
+                  {{ downloading === exportItem.id ? 'Downloading...' : 'Download' }}
+                </Button>
+                <Button
+                  v-if="canPerformOperations(exportItem)"
+                  variant="destructive"
+                  size="sm"
+                  :disabled="deleting === exportItem.id"
+                  @click="deleteExport(exportItem.id!)"
+                >
+                  <Trash2 class="size-4" aria-hidden="true" />
+                  {{ deleting === exportItem.id ? 'Deleting...' : 'Delete' }}
+                </Button>
+                <span
+                  v-else-if="isExportDeleted(exportItem)"
+                  class="text-xs italic text-muted-foreground"
+                >
+                  <Trash2 class="inline size-3" aria-hidden="true" />
+                  Deleted
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-.table th {
-  background-color: $light-bg-color;
-  font-weight: 600;
-  color: $text-color;
-}
-
-.export-row {
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-
-  &:hover {
-    background-color: $light-bg-color;
-  }
-}
-
-.export-description .description-text {
-  font-weight: 500;
-}
-
-.export-description .error-message {
-  color: $error-color;
-  font-size: 0.8rem;
-  margin-top: 4px;
-}
-
-.type-badge,
-.status-badge {
-  padding: 4px 8px;
-  border-radius: $default-radius;
-  font-size: 0.8rem;
-  font-weight: 500;
-  text-transform: uppercase;
-}
-
-.type-full_database {
-  background-color: #e3f2fd;
-  color: #1976d2;
-}
-
-.type-selected_items {
-  background-color: #f3e5f5;
-  color: #7b1fa2;
-}
-
-.type-locations {
-  background-color: #e8f5e8;
-  color: #388e3c;
-}
-
-.type-areas {
-  background-color: #fff3e0;
-  color: #f57c00;
-}
-
-.type-commodities {
-  background-color: #fce4ec;
-  color: #c2185b;
-}
-
-.type-imported {
-  background-color: #f0f4f8;
-  color: #4a5568;
-}
-
-.status-pending {
-  background-color: #fff3cd;
-  color: #856404;
-}
-
-.status-in_progress {
-  background-color: #d4edda;
-  color: #155724;
-}
-
-.status-completed {
-  background-color: #d1ecf1;
-  color: #0c5460;
-}
-
-.status-failed {
-  background-color: #f8d7da;
-  color: #721c24;
-}
-
-.export-status--deleted {
-  background-color: #f5f5f5;
-  color: #6c757d;
-  text-decoration: line-through;
-}
-
-.export-actions {
-  display: flex;
-  gap: 8px;
-  white-space: nowrap;
-}
-
-.btn-sm {
-  padding: 4px 8px;
-  font-size: 0.75rem;
-}
-
-.deleted-indicator {
-  color: #6c757d;
-  font-size: 0.75rem;
-  font-style: italic;
-}
-
-.export-row.deleted {
-  opacity: 0.6;
-  background-color: #f8f9fa;
-}
-</style>
+    <Confirmation
+      v-model:visible="showDeleteDialog"
+      title="Confirm Delete"
+      message="Are you sure you want to delete this export?"
+      confirm-label="Delete"
+      cancel-label="Cancel"
+      confirm-button-class="danger"
+      confirmation-icon="exclamation-triangle"
+      @confirm="onConfirmDelete"
+      @cancel="onCancelDelete"
+    />
+  </PageContainer>
+</template>

--- a/frontend/src/views/files/FileListView.vue
+++ b/frontend/src/views/files/FileListView.vue
@@ -1,1050 +1,379 @@
-<template>
-  <div class="file-list">
-    <div class="header">
-      <div class="header-title">
-        <h1>Files</h1>
-        <div v-if="!loading && files.length > 0" class="item-count">
-          {{ totalFiles }} file{{ totalFiles !== 1 ? 's' : '' }}
-        </div>
-      </div>
-      <div class="header-actions">
-        <router-link :to="groupStore.groupPath('/files/create')" class="btn btn-primary file-upload-button">
-          <FontAwesomeIcon icon="plus" />
-          Upload File
-        </router-link>
-      </div>
-    </div>
-
-    <!-- Filters -->
-    <div class="filters-card">
-      <div class="filters-row">
-        <div class="filter-group">
-          <label for="search">Search</label>
-          <input
-            id="search"
-            v-model="filters.search"
-            type="text"
-            placeholder="Search files..."
-            class="form-control"
-            @input="debouncedSearch"
-          />
-        </div>
-
-        <div class="filter-group">
-          <label for="type">Type</label>
-          <select id="type" v-model="filters.type" class="form-control" @change="loadFiles">
-            <option value="">All Types</option>
-            <option v-for="option in fileTypeOptions" :key="option.value" :value="option.value">
-              {{ option.label }}
-            </option>
-          </select>
-        </div>
-
-        <div class="filter-group">
-          <label for="tags">Tags</label>
-          <input
-            id="tags"
-            v-model="filters.tags"
-            type="text"
-            placeholder="Comma-separated tags"
-            class="form-control"
-            @input="debouncedSearch"
-          />
-        </div>
-
-        <div class="filter-group">
-          <button class="btn btn-secondary" @click="clearFilters">
-            <FontAwesomeIcon icon="times" />
-            Clear
-          </button>
-        </div>
-      </div>
-    </div>
-
-    <!-- Loading State -->
-    <div v-if="loading" class="loading">
-      <div class="spinner"></div>
-      <p>Loading files...</p>
-    </div>
-
-    <!-- Error State -->
-    <div v-else-if="error" class="error">
-      <div class="error-icon">
-        <FontAwesomeIcon icon="exclamation-circle" />
-      </div>
-      <h3>Error Loading Files</h3>
-      <p>{{ error }}</p>
-      <button class="btn btn-primary" @click="loadFiles">
-        <FontAwesomeIcon icon="redo" />
-        Try Again
-      </button>
-    </div>
-
-    <!-- Files Grid -->
-    <div v-else-if="files.length > 0" class="files-grid">
-      <div
-        v-for="file in files"
-        :key="file.id"
-        class="file-card"
-        @click="viewFile(file)"
-      >
-          <div class="file-preview">
-            <img
-              v-if="file.type === 'image'"
-              :src="getFileUrl(file)"
-              :alt="getDisplayTitle(file)"
-              :data-file-id="file.id"
-              class="file-thumbnail"
-              @error="onImageError"
-            />
-            <div v-else class="file-icon">
-              <FontAwesomeIcon :icon="getFileIcon(file)" />
-            </div>
-          </div>
-
-          <div class="file-info">
-            <h3 class="file-title" :title="getDisplayTitle(file)">{{ getDisplayTitle(file) }}</h3>
-            <p class="file-description" :title="file.description">{{ file.description || 'No description' }}</p>
-
-            <div class="file-meta">
-              <span class="file-type">{{ getFileTypeLabel(file.type) }}</span>
-              <span class="file-ext">{{ file.ext }}</span>
-            </div>
-
-            <div v-if="file.tags && file.tags.length > 0" class="file-tags">
-              <span v-for="tag in file.tags.slice(0, 3)" :key="tag" class="tag">
-                {{ tag }}
-              </span>
-              <span v-if="file.tags.length > 3" class="tag-more">
-                +{{ file.tags.length - 3 }} more
-              </span>
-            </div>
-
-            <div v-if="isLinked(file)" class="file-linked-entity">
-              <router-link
-                :to="getLinkedEntityUrl(file)"
-                class="entity-badge-small"
-                title="View linked entity"
-                @click.stop
-              >
-                <FontAwesomeIcon :icon="getEntityIcon(file)" />
-                <span class="entity-text">{{ getLinkedEntityDisplay(file) }}</span>
-                <FontAwesomeIcon icon="external-link-alt" class="entity-link-icon" />
-              </router-link>
-            </div>
-          </div>
-
-          <div class="file-actions" @click.stop>
-            <button
-              class="btn-icon"
-              title="Download"
-              @click="downloadFile(file)"
-            >
-              <FontAwesomeIcon icon="download" />
-            </button>
-            <button
-              class="btn-icon"
-              title="Edit"
-              @click="editFile(file)"
-            >
-              <FontAwesomeIcon icon="edit" />
-            </button>
-            <button
-              v-if="canDeleteFile(file)"
-              class="btn-icon btn-danger"
-              title="Delete"
-              @click="confirmDelete(file)"
-            >
-              <FontAwesomeIcon icon="trash" />
-            </button>
-            <button
-              v-else
-              class="btn-icon btn-disabled"
-              :title="getDeleteRestrictionReason(file)"
-              disabled
-            >
-              <FontAwesomeIcon icon="lock" />
-            </button>
-          </div>
-        </div>
-
-      <!-- Pagination -->
-      <div v-if="totalPages > 1" class="pagination-card">
-        <div class="pagination-info">
-          Showing {{ (currentPage - 1) * pageSize + 1 }} to {{ Math.min(currentPage * pageSize, totalFiles) }} of {{ totalFiles }} files
-        </div>
-        <div class="pagination-controls">
-          <router-link
-            v-if="currentPage > 1"
-            :to="getPaginationUrl(currentPage - 1)"
-            class="btn btn-secondary pagination-link"
-          >
-            <font-awesome-icon icon="chevron-left" />
-            Previous
-          </router-link>
-          <span
-            v-else
-            class="btn btn-secondary pagination-link disabled"
-          >
-            <font-awesome-icon icon="chevron-left" />
-            Previous
-          </span>
-
-          <div class="page-numbers">
-            <router-link
-              v-for="page in visiblePages"
-              :key="page"
-              :to="getPaginationUrl(page)"
-              class="btn pagination-link"
-              :class="{ 'btn-primary': page === currentPage, 'btn-secondary': page !== currentPage }"
-            >
-              {{ page }}
-            </router-link>
-          </div>
-
-          <router-link
-            v-if="currentPage < totalPages"
-            :to="getPaginationUrl(currentPage + 1)"
-            class="btn btn-secondary pagination-link"
-          >
-            Next
-            <font-awesome-icon icon="chevron-right" />
-          </router-link>
-          <span
-            v-else
-            class="btn btn-secondary pagination-link disabled"
-          >
-            Next
-            <font-awesome-icon icon="chevron-right" />
-          </span>
-        </div>
-      </div>
-    </div>
-
-    <!-- Empty State — first consumer of the @design/patterns/EmptyState
-         pattern (#1326 PR 1.4). The legacy `.empty / .empty-message`
-         markup has been replaced by EmptyState; the surrounding view
-         still uses PrimeVue / FA elsewhere — full view migration is
-         tracked under Phase 4. The .empty wrapper class is kept on the
-         outermost element so the shared `.empty .spinner / .empty-icon`
-         styles in this file's <style> block (and matching rules in
-         _components.scss) keep their selector targets without bleeding
-         into other views. -->
-    <EmptyState
-      v-else
-      class="empty"
-      test-id="files-empty-state"
-      :title="hasActiveFilters ? 'No files match your filters' : 'No Files Found'"
-      :description="hasActiveFilters
-        ? 'No files match your current filters. Try adjusting your search criteria.'
-        : `You haven't uploaded any files yet. Upload your first file to get started.`"
-      :illustration-src="emptyFilesIllustration"
-      illustration-alt=""
-    >
-      <template #actions>
-        <router-link :to="groupStore.groupPath('/files/create')" class="btn btn-primary">
-          <font-awesome-icon icon="plus" />
-          Upload File
-        </router-link>
-      </template>
-    </EmptyState>
-
-    <!-- Delete Confirmation Modal -->
-    <Confirmation
-      v-model:visible="showDeleteModal"
-      :title="'Delete File'"
-      :message="`Are you sure you want to delete <strong>${fileToDelete ? getDisplayTitle(fileToDelete) : ''}</strong>?<br><br><span class='warning-text'>This action cannot be undone. The file will be permanently deleted.</span>`"
-      :confirm-label="deleting ? 'Deleting...' : 'Delete'"
-      :cancel-label="'Cancel'"
-      :confirm-button-class="'danger'"
-      :confirm-disabled="deleting"
-      :confirmation-icon="'exclamation-triangle'"
-      @confirm="deleteFile"
-      @cancel="cancelDelete"
-    />
-  </div>
-</template>
-
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
-import fileService, { type FileEntity } from '@/services/fileService'
-import Confirmation from '@/components/Confirmation.vue'
-import { useGroupStore } from '@/stores/groupStore'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Plus, X } from 'lucide-vue-next'
+
+import { Button } from '@design/ui/button'
+import { Input } from '@design/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@design/ui/select'
 import EmptyState from '@design/patterns/EmptyState.vue'
+import FilePreview from '@design/patterns/FilePreview.vue'
+import FilterBar from '@design/patterns/FilterBar.vue'
+import MediaGallery from '@design/patterns/MediaGallery.vue'
+import PageContainer from '@design/patterns/PageContainer.vue'
+import PageHeader from '@design/patterns/PageHeader.vue'
+import SearchInput from '@design/patterns/SearchInput.vue'
+import { useAppToast } from '@design/composables/useAppToast'
 import emptyFilesIllustration from '@design/illustrations/empty-files.svg'
 
+import Confirmation from '@/components/Confirmation.vue'
+import PaginationControls from '@/components/PaginationControls.vue'
 
-// Type for signed URLs structure
+import fileService, { type FileEntity } from '@/services/fileService'
+import { useGroupStore } from '@/stores/groupStore'
+
 interface URLData {
   url: string
-  thumbnails?: {
-    small?: string
-    medium?: string
-  }
+  thumbnails?: { small?: string; medium?: string }
 }
+
+type EntityIconName = 'commodity' | 'location' | 'export' | 'link'
 
 const router = useRouter()
 const route = useRoute()
 const groupStore = useGroupStore()
+const toast = useAppToast()
 
-// Image error handling with automatic URL refresh
-const onImageError = async (event: Event) => {
-  const img = event.target as HTMLImageElement
-  const fileId = img.dataset.fileId
-
-  if (!fileId) {
-    console.warn('Image load error: no file ID found', event)
-    return
-  }
-
-  console.warn('Image load error for file:', fileId, 'attempting to refresh URL')
-
-  try {
-    // Find the file in our current list
-    const file = files.value.find(f => f.id === fileId)
-    if (!file) {
-      console.warn('File not found in current list:', fileId)
-      return
-    }
-
-    // Generate new signed URL with thumbnails
-    const response = await fileService.generateSignedUrlWithThumbnails(file)
-
-    // Update the image source with new thumbnail URL
-    if (response.thumbnails?.medium) {
-      img.src = response.thumbnails.medium
-    } else if (response.thumbnails?.small) {
-      img.src = response.thumbnails.small
-    } else {
-      img.src = response.url
-    }
-
-    console.log('Successfully refreshed URL for file:', fileId)
-  } catch (error) {
-    console.error('Failed to refresh URL for file:', fileId, error)
-    // Hide the broken image
-    img.style.display = 'none'
-  }
-}
-
-// State
 const files = ref<FileEntity[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
 const deleting = ref(false)
 const fileUrls = ref<Record<string, string>>({})
 
-// Pagination
 const currentPage = ref(1)
 const pageSize = ref(20)
 const totalFiles = ref(0)
+const totalPages = computed(() =>
+  Math.ceil(totalFiles.value / pageSize.value),
+)
 
-// Filters
-const filters = ref({
-  search: '',
-  type: '',
-  tags: ''
-})
+const filters = ref({ search: '', type: '', tags: '' })
 
-// Delete modal
 const showDeleteModal = ref(false)
 const fileToDelete = ref<FileEntity | null>(null)
 
-// File type options
 const fileTypeOptions = fileService.getFileTypeOptions()
 
-// Wrapper functions to maintain proper context
-const isLinked = (file: FileEntity) => {
-  return fileService.isLinked(file)
-}
+const hasActiveFilters = computed(
+  () => !!(filters.value.search || filters.value.type || filters.value.tags),
+)
 
-const getLinkedEntityDisplay = (file: FileEntity) => {
-  return fileService.getLinkedEntityDisplay(file)
-}
+const filesEmptyTitle = computed(() =>
+  hasActiveFilters.value ? 'No files match your filters' : 'No Files Found',
+)
 
-// Wrapper function to pass current route context
-const getLinkedEntityUrl = (file: any) => {
-  return fileService.getLinkedEntityUrl(file, route)
-}
+const filesEmptyDescription = computed(() =>
+  hasActiveFilters.value
+    ? 'No files match your current filters. Try adjusting your search criteria.'
+    : "You haven't uploaded any files yet. Upload your first file to get started.",
+)
 
-// Computed
-const totalPages = computed(() => Math.ceil(totalFiles.value / pageSize.value))
+const newFileHref = computed(() => groupStore.groupPath('/files/create'))
 
-const hasActiveFilters = computed(() => {
-  return filters.value.search || filters.value.type || filters.value.tags
-})
-
-const visiblePages = computed(() => {
-  const pages = []
-  const start = Math.max(1, currentPage.value - 2)
-  const end = Math.min(totalPages.value, currentPage.value + 2)
-
-  for (let i = start; i <= end; i++) {
-    pages.push(i)
-  }
-
-  return pages
-})
-
-// Methods
-const loadFiles = async () => {
+async function loadFiles() {
   loading.value = true
   error.value = null
-
   try {
-    const params = {
+    const params: Record<string, unknown> = {
       page: currentPage.value,
       limit: pageSize.value,
-      ...(filters.value.search && { search: filters.value.search }),
-      ...(filters.value.type && { type: filters.value.type }),
-      ...(filters.value.tags && { tags: filters.value.tags })
     }
+    if (filters.value.search) params.search = filters.value.search
+    if (filters.value.type) params.type = filters.value.type
+    if (filters.value.tags) params.tags = filters.value.tags
 
-    const response = await fileService.getFiles(params)
-    files.value = response.data.data
-    totalFiles.value = response.data.meta.total
+    const resp = await fileService.getFiles(params)
+    files.value = resp.data.data
+    totalFiles.value = resp.data.meta.total
 
-    // Use signed URLs from response metadata if available
-    if (response.data.meta.signed_urls) {
-      console.log('FileListView: Using pre-generated signed URLs')
-      // Extract URLs from the signed URLs structure
-      const extractedUrls: Record<string, string> = {}
-      for (const [fileId, urlData] of Object.entries(response.data.meta.signed_urls as Record<string, URLData>)) {
-        // For images, prefer medium thumbnail if available, otherwise use original URL
-        if (urlData.thumbnails?.medium) {
-          extractedUrls[fileId] = urlData.thumbnails.medium
-        } else if (urlData.thumbnails?.small) {
-          extractedUrls[fileId] = urlData.thumbnails.small
-        } else {
-          extractedUrls[fileId] = urlData.url
-        }
+    const signed = resp.data.meta.signed_urls as
+      | Record<string, URLData>
+      | undefined
+    const extracted: Record<string, string> = {}
+    if (signed) {
+      for (const [fileId, urlData] of Object.entries(signed)) {
+        if (urlData.thumbnails?.medium) extracted[fileId] = urlData.thumbnails.medium
+        else if (urlData.thumbnails?.small) extracted[fileId] = urlData.thumbnails.small
+        else extracted[fileId] = urlData.url
       }
-      fileUrls.value = extractedUrls
-    } else {
-      console.log('FileListView: No signed URLs in response, URLs will be empty')
-      fileUrls.value = {}
     }
+    fileUrls.value = extracted
   } catch (err: any) {
-    error.value = err.response?.data?.message || 'Failed to load files'
-    console.error('Error loading files:', err)
+    error.value = err?.response?.data?.message ?? err?.message ?? 'Failed to load files'
   } finally {
     loading.value = false
   }
 }
 
-// Debounced search
-let searchTimeout: number
-const debouncedSearch = () => {
-  clearTimeout(searchTimeout)
-  searchTimeout = setTimeout(() => {
+let searchTimeout: number | null = null
+function debounceReload() {
+  if (searchTimeout !== null) clearTimeout(searchTimeout)
+  searchTimeout = window.setTimeout(() => {
     currentPage.value = 1
     loadFiles()
   }, 500)
 }
 
-const clearFilters = () => {
-  filters.value = {
-    search: '',
-    type: '',
-    tags: ''
-  }
+function clearFilters() {
+  filters.value = { search: '', type: '', tags: '' }
   currentPage.value = 1
   loadFiles()
 }
 
+function getThumbnailUrl(file: FileEntity): string | undefined {
+  if (file.type !== 'image') return undefined
+  return fileUrls.value[file.id] || undefined
+}
 
-
-// Generate pagination URL for a specific page
-const getPaginationUrl = (page: number) => {
-  const query = { ...route.query }
-  if (page > 1) {
-    query.page = page.toString()
-  } else {
-    delete query.page
+function entityIconName(file: FileEntity): EntityIconName {
+  switch (file.linked_entity_type) {
+    case 'commodity':
+      return 'commodity'
+    case 'location':
+      return 'location'
+    case 'export':
+      return 'export'
+    default:
+      return 'link'
   }
+}
+
+function linkedEntityFor(file: FileEntity) {
+  if (!fileService.isLinked(file)) return undefined
+  const url = fileService.getLinkedEntityUrl(file, route)
+  if (!url) return undefined
   return {
-    path: route.path,
-    query
+    display: fileService.getLinkedEntityDisplay(file),
+    url,
+    icon: entityIconName(file),
   }
 }
 
-
-
-// No more image ref tracking needed (thumbnails generated during upload)
-
-const getFileUrl = (file: FileEntity) => {
-  return fileUrls.value[file.id] || ''
-}
-
-const getFileIcon = (file: FileEntity) => {
-  return fileService.getFileIcon(file)
-}
-
-const getFileTypeLabel = (type: string) => {
-  const option = fileTypeOptions.find(opt => opt.value === type)
-  return option?.label || type
-}
-
-const getDisplayTitle = (file: FileEntity) => {
-  return fileService.getDisplayTitle(file)
-}
-
-const getEntityIcon = (file: FileEntity) => {
-  if (file.linked_entity_type === 'commodity') {
-    return 'box'
-  } else if (file.linked_entity_type === 'location') {
-    return 'map-marker-alt'
-  } else if (file.linked_entity_type === 'export') {
-    return 'file-export'
+async function onImageError(file: FileEntity, event: Event) {
+  const img = event.target as HTMLImageElement
+  try {
+    const response = await fileService.generateSignedUrlWithThumbnails(file)
+    if (response.thumbnails?.medium) img.src = response.thumbnails.medium
+    else if (response.thumbnails?.small) img.src = response.thumbnails.small
+    else img.src = response.url
+    fileUrls.value = { ...fileUrls.value, [file.id]: img.src }
+  } catch (err) {
+    console.error('Failed to refresh URL for file:', file.id, err)
+    img.style.display = 'none'
   }
-  return 'link'
 }
 
-
-
-const viewFile = (file: FileEntity) => {
+function viewFile(file: FileEntity) {
   router.push(groupStore.groupPath(`/files/${file.id}`))
 }
-
-const editFile = (file: FileEntity) => {
+function editFile(file: FileEntity) {
   router.push(groupStore.groupPath(`/files/${file.id}/edit`))
 }
 
-const downloadFile = async (file: FileEntity) => {
+async function downloadFile(file: FileEntity) {
   try {
     await fileService.downloadFile(file)
-  } catch (error) {
-    console.error('Failed to download file:', error)
-    // You might want to show a user-friendly error message here
+  } catch (err: any) {
+    toast.error(err?.message ?? 'Failed to download file')
   }
 }
 
-const canDeleteFile = (file: FileEntity) => {
-  return fileService.canDelete(file)
-}
-
-const getDeleteRestrictionReason = (file: FileEntity) => {
-  return fileService.getDeleteRestrictionReason(file)
-}
-
-const confirmDelete = (file: FileEntity) => {
-  if (!canDeleteFile(file)) {
-    return // Don't allow deletion of restricted files
-  }
+function confirmDelete(file: FileEntity) {
+  if (!fileService.canDelete(file)) return
   fileToDelete.value = file
   showDeleteModal.value = true
 }
 
-const cancelDelete = () => {
+function cancelDelete() {
   fileToDelete.value = null
   showDeleteModal.value = false
 }
 
-const deleteFile = async () => {
-  if (!fileToDelete.value) return
-
+async function deleteFile() {
+  const file = fileToDelete.value
+  if (!file) return
   deleting.value = true
-
   try {
-    await fileService.deleteFile(fileToDelete.value.id)
-    await loadFiles() // Reload the list
+    await fileService.deleteFile(file.id)
+    await loadFiles()
     cancelDelete()
   } catch (err: any) {
-    error.value = err.response?.data?.message || 'Failed to delete file'
-    console.error('Error deleting file:', err)
+    error.value = err?.response?.data?.message ?? err?.message ?? 'Failed to delete file'
+    toast.error(error.value)
   } finally {
     deleting.value = false
   }
 }
 
-// Initialize current page from URL parameters
-const initializeFromUrl = () => {
+watch(
+  () => route.query.page,
+  (np) => {
+    const page = np && typeof np === 'string' ? parseInt(np, 10) : 1
+    if (page > 0 && page !== currentPage.value) {
+      currentPage.value = page
+      loadFiles()
+    }
+  },
+  { immediate: true },
+)
+
+onMounted(() => {
   const pageParam = route.query.page
   if (pageParam && typeof pageParam === 'string') {
     const page = parseInt(pageParam, 10)
-    if (page > 0) {
-      currentPage.value = page
-    }
+    if (page > 0) currentPage.value = page
   }
-}
-
-// Watch for route changes to update pagination
-watch(() => route.query.page, (newPage) => {
-  const page = newPage && typeof newPage === 'string' ? parseInt(newPage, 10) : 1
-  if (page > 0 && page !== currentPage.value) {
-    currentPage.value = page
-    loadFiles()
-  }
-}, { immediate: true })
-
-// Lifecycle
-onMounted(() => {
-  initializeFromUrl()
   loadFiles()
 })
 </script>
 
-<style lang="scss" scoped>
-@use '@/assets/main' as *;
-
-.file-list {
-  max-width: $container-max-width;
-  margin: 0 auto;
-  padding: 20px;
-}
-
-// Header styles are now in shared _header.scss
-
-.filters-card {
-  background: white;
-  border-radius: $default-radius;
-  padding: 1.5rem;
-  margin-bottom: 2rem;
-  box-shadow: $box-shadow;
-
-  .filters-row {
-    display: grid;
-    grid-template-columns: 2fr 1fr 1.5fr auto;
-    gap: 1rem;
-    align-items: end;
-
-    @media (width <= 768px) {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  .filter-group {
-    label {
-      display: block;
-      margin-bottom: 0.5rem;
-      font-weight: 500;
-      color: $text-color;
-    }
-  }
-}
-
-.files-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1.5rem;
-}
-
-.file-card {
-  background: white;
-  border-radius: $default-radius;
-  overflow: hidden;
-  cursor: pointer;
-  transition: transform 0.2s, box-shadow 0.2s;
-  position: relative;
-  border: 1px solid $border-color;
-  box-shadow: $box-shadow;
-
-  &:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgb(0 0 0 / 10%);
-  }
-
-  .file-preview {
-    height: 160px;
-    background: $light-bg-color;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    .file-thumbnail {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-    }
-
-    .file-icon {
-      font-size: 3rem;
-      color: $text-secondary-color;
-    }
-  }
-
-  .file-info {
-    padding: 1rem;
-
-    .file-title {
-      margin: 0 0 0.5rem;
-      font-size: 1rem;
-      font-weight: 600;
-      color: $text-color;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .file-description {
-      margin: 0 0 0.75rem;
-      font-size: 0.875rem;
-      color: $text-secondary-color;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .file-meta {
-      display: flex;
-      gap: 0.5rem;
-      margin-bottom: 0.75rem;
-
-      .file-type,
-      .file-ext {
-        font-size: 0.75rem;
-        padding: 0.25rem 0.5rem;
-        border-radius: 4px;
-        background: $light-bg-color;
-        color: $text-secondary-color;
-        border: 1px solid $border-color;
-      }
-    }
-
-    .file-tags {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.25rem;
-
-      .tag {
-        font-size: 0.75rem;
-        padding: 0.125rem 0.375rem;
-        border-radius: 12px;
-        background: $primary-color;
-        color: white;
-      }
-
-      .tag-more {
-        font-size: 0.75rem;
-        color: $text-secondary-color;
-      }
-    }
-
-    .file-linked-entity {
-      margin-top: 0.75rem;
-
-      .entity-badge-small {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.5rem 0.75rem;
-        background-color: #e3f2fd;
-        color: #1565c0;
-        border-radius: $default-radius;
-        font-size: 0.75rem;
-        font-weight: 500;
-        border: 1px solid #bbdefb;
-        transition: all 0.2s ease;
-        max-width: 100%;
-        text-decoration: none;
-        cursor: pointer;
-
-        &:hover {
-          background-color: #e1f5fe;
-          border-color: #90caf9;
-          text-decoration: none;
-        }
-
-        .entity-text {
-          flex: 1;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-          min-width: 0;
-        }
-
-        .entity-link-icon {
-          flex-shrink: 0;
-          font-size: 0.625rem;
-          opacity: 0.8;
-          transition: opacity 0.2s ease;
-        }
-
-        &:hover .entity-link-icon {
-          opacity: 1;
-        }
-      }
-    }
-  }
-
-  .file-actions {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    display: flex;
-    gap: 0.25rem;
-    opacity: 0;
-    transition: opacity 0.2s;
-
-    .btn-icon {
-      width: 32px;
-      height: 32px;
-      border-radius: 50%;
-      border: none;
-      background: rgb(255 255 255 / 90%);
-      color: $text-color;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      cursor: pointer;
-      transition: background-color 0.2s;
-
-      &:hover {
-        background: white;
-      }
-
-      &.btn-danger {
-        color: $danger-color;
-      }
-
-      &.btn-disabled {
-        color: $text-secondary-color;
-        cursor: not-allowed;
-        opacity: 0.5;
-
-        &:hover {
-          background: rgb(255 255 255 / 90%);
-        }
-      }
-    }
-  }
-
-  &:hover .file-actions {
-    opacity: 1;
-  }
-}
-
-.pagination-card {
-  background: white;
-  border-radius: $default-radius;
-  box-shadow: $box-shadow;
-  margin-top: 2rem;
-  padding: 1.5rem;
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  @media (width <= 768px) {
-    flex-direction: column;
-    gap: 1rem;
-    align-items: center;
-    padding: 1rem;
-  }
-
-  .pagination-info {
-    color: $text-secondary-color;
-    font-size: 0.875rem;
-    font-weight: 500;
-    margin: 0;
-
-    @media (width <= 768px) {
-      text-align: center;
-    }
-  }
-
-  .pagination-controls {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-
-    .pagination-link {
-      text-decoration: none;
-      min-width: 2.5rem;
-      height: 2.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      border-radius: $default-radius;
-      font-weight: 500;
-      transition: all 0.2s ease;
-      border: 1px solid transparent;
-      font-size: 0.875rem;
-
-      &.btn-primary {
-        background-color: $primary-color;
-        color: white;
-        border-color: $primary-color;
-        box-shadow: 0 1px 3px rgba($primary-color, 0.3);
-
-        &:hover {
-          background-color: $primary-hover-color;
-          border-color: $primary-hover-color;
-          text-decoration: none;
-          transform: translateY(-1px);
-          box-shadow: 0 2px 6px rgba($primary-color, 0.4);
-        }
-      }
-
-      &.btn-secondary {
-        background-color: white;
-        color: $text-color;
-        border-color: $border-color;
-        box-shadow: 0 1px 3px rgba($border-color, 0.3);
-
-        &:hover {
-          background-color: $light-bg-color;
-          border-color: $primary-color;
-          color: $primary-color;
-          text-decoration: none;
-          transform: translateY(-1px);
-          box-shadow: 0 2px 6px rgba($primary-color, 0.2);
-        }
-      }
-
-      &.disabled {
-        background-color: $light-bg-color;
-        color: $text-secondary-color;
-        border-color: $border-color;
-        cursor: not-allowed;
-        opacity: 0.6;
-        box-shadow: none;
-
-        &:hover {
-          background-color: $light-bg-color;
-          color: $text-secondary-color;
-          border-color: $border-color;
-          transform: none;
-          box-shadow: none;
-        }
-      }
-
-      // Icon spacing
-      .fa-chevron-left {
-        margin-right: 0.5rem;
-      }
-
-      .fa-chevron-right {
-        margin-left: 0.5rem;
-      }
-    }
-
-    .page-numbers {
-      display: flex;
-      gap: 0.25rem;
-      margin: 0 0.75rem;
-
-      @media (width <= 768px) {
-        margin: 0 0.5rem;
-      }
-
-      .pagination-link {
-        min-width: 2.5rem;
-        padding: 0;
-      }
-    }
-  }
-}
-
-// Loading, error, and empty states use shared styles from _components.scss
-.loading,
-.error,
-.empty {
-  .spinner {
-    width: 40px;
-    height: 40px;
-    border: 4px solid $light-bg-color;
-    border-top: 4px solid $primary-color;
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-    margin: 0 auto 1rem;
-  }
-
-  .error-icon,
-  .empty-icon {
-    font-size: 4rem;
-    color: $text-secondary-color;
-    margin-bottom: 1rem;
-  }
-
-  .warning-text {
-    color: $error-color;
-  }
-}
-
-.empty-message {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.5rem;
-
-  p {
-    margin-bottom: 0;
-    font-size: 1.1rem;
-  }
-}
-
-.action-button {
-  margin-top: 0.5rem;
-}
-
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: $mask-background-color;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-
-  .modal-content {
-    background: white;
-    border-radius: $default-radius;
-    width: 90%;
-    max-width: 500px;
-    box-shadow: $box-shadow;
-
-    .modal-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 1.5rem;
-      border-bottom: 1px solid $border-color;
-
-      h3 {
-        margin: 0;
-        color: $text-color;
-      }
-
-      .btn-close {
-        background: none;
-        border: none;
-        font-size: 1.5rem;
-        cursor: pointer;
-        color: $text-secondary-color;
-
-        &:hover {
-          color: $text-color;
-        }
-      }
-    }
-
-    .modal-body {
-      padding: 1.5rem;
-
-      p {
-        margin: 0 0 1rem;
-        color: $text-color;
-
-        &:last-child {
-          margin-bottom: 0;
-        }
-      }
-    }
-
-    .modal-footer {
-      display: flex;
-      justify-content: flex-end;
-      gap: 1rem;
-      padding: 1.5rem;
-      border-top: 1px solid $border-color;
-    }
-  }
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-</style>
+<template>
+  <PageContainer>
+    <PageHeader title="Files">
+      <template #description>
+        <span v-if="!loading && files.length > 0">
+          {{ totalFiles }} file{{ totalFiles !== 1 ? 's' : '' }}
+        </span>
+      </template>
+      <template #actions>
+        <Button as-child>
+          <router-link :to="newFileHref">
+            <Plus class="size-4" aria-hidden="true" />
+            Upload File
+          </router-link>
+        </Button>
+      </template>
+    </PageHeader>
+
+    <FilterBar class="mb-6">
+      <template #search>
+        <SearchInput
+          v-model="filters.search"
+          placeholder="Search files..."
+          aria-label="Search files"
+          @update:model-value="debounceReload"
+        />
+      </template>
+
+      <Select v-model="filters.type" @update:model-value="loadFiles">
+        <SelectTrigger
+          aria-label="Filter by file type"
+          class="w-44"
+        >
+          <SelectValue placeholder="All Types" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="">All Types</SelectItem>
+          <SelectItem
+            v-for="opt in fileTypeOptions"
+            :key="opt.value"
+            :value="opt.value"
+          >
+            {{ opt.label }}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Input
+        v-model="filters.tags"
+        placeholder="Comma-separated tags"
+        aria-label="Filter by tags"
+        class="w-56"
+        @input="debounceReload"
+      />
+
+      <template #actions>
+        <Button variant="outline" @click="clearFilters">
+          <X class="size-4" aria-hidden="true" />
+          Clear
+        </Button>
+      </template>
+    </FilterBar>
+
+    <div
+      v-if="loading"
+      class="rounded-md border border-border bg-card p-12 text-center text-muted-foreground shadow-sm"
+    >
+      <p>Loading files...</p>
+    </div>
+
+    <div
+      v-else-if="error"
+      class="flex flex-col items-center gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-12 text-center shadow-sm"
+    >
+      <h3 class="text-lg font-semibold text-destructive">
+        Error Loading Files
+      </h3>
+      <p class="text-sm text-destructive">{{ error }}</p>
+      <Button @click="loadFiles">Try Again</Button>
+    </div>
+
+    <template v-else-if="files.length > 0">
+      <MediaGallery>
+        <FilePreview
+          v-for="file in files"
+          :key="file.id"
+          :file="file"
+          :thumbnail-url="getThumbnailUrl(file)"
+          :linked-entity="linkedEntityFor(file)"
+          :can-delete="fileService.canDelete(file)"
+          :delete-restriction-reason="fileService.getDeleteRestrictionReason(file)"
+          @view="viewFile(file)"
+          @download="downloadFile(file)"
+          @edit="editFile(file)"
+          @delete="confirmDelete(file)"
+          @image-error="onImageError(file, $event)"
+        />
+      </MediaGallery>
+
+      <PaginationControls
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        :page-size="pageSize"
+        :total-items="totalFiles"
+        item-label="files"
+      />
+    </template>
+
+    <EmptyState
+      v-else
+      test-id="files-empty-state"
+      :title="filesEmptyTitle"
+      :description="filesEmptyDescription"
+      :illustration-src="emptyFilesIllustration"
+      illustration-alt=""
+    >
+      <template #actions>
+        <Button as-child>
+          <router-link :to="newFileHref">
+            <Plus class="size-4" aria-hidden="true" />
+            Upload File
+          </router-link>
+        </Button>
+      </template>
+    </EmptyState>
+
+    <Confirmation
+      v-model:visible="showDeleteModal"
+      title="Delete File"
+      :message="
+        `Are you sure you want to delete <strong>${
+          fileToDelete ? fileToDelete.title || fileToDelete.path || 'this file' : ''
+        }</strong>?<br><br><span class='warning-text'>This action cannot be undone. The file will be permanently deleted.</span>`
+      "
+      :confirm-label="deleting ? 'Deleting...' : 'Delete'"
+      cancel-label="Cancel"
+      confirm-button-class="danger"
+      :confirm-disabled="deleting"
+      confirmation-icon="exclamation-triangle"
+      @confirm="deleteFile"
+      @cancel="cancelDelete"
+    />
+  </PageContainer>
+</template>

--- a/frontend/src/views/files/FileListView.vue
+++ b/frontend/src/views/files/FileListView.vue
@@ -211,6 +211,10 @@ async function deleteFile() {
   }
 }
 
+// Subsequent route changes drive a reload; the initial load happens once
+// in onMounted, after currentPage has been seeded from the URL. Keeping
+// the watch non-immediate avoids a double fetch on first render when the
+// URL already carries a non-default `?page=` value.
 watch(
   () => route.query.page,
   (np) => {
@@ -220,7 +224,6 @@ watch(
       loadFiles()
     }
   },
-  { immediate: true },
 )
 
 onMounted(() => {
@@ -285,7 +288,7 @@ onMounted(() => {
         placeholder="Comma-separated tags"
         aria-label="Filter by tags"
         class="w-56"
-        @input="debounceReload"
+        @update:model-value="debounceReload"
       />
 
       <template #actions>

--- a/frontend/src/views/locations/LocationListView.vue
+++ b/frontend/src/views/locations/LocationListView.vue
@@ -130,8 +130,11 @@ function scrollToArea(areaId: string) {
   const el = document.getElementById(`area-${areaId}`)
   if (!el) return
   el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-  el.classList.add('area-highlight')
-  setTimeout(() => el.classList.remove('area-highlight'), 2000)
+  // Highlight is a Vue-reactive ring keyed off `areaToFocus`; clear it
+  // after the same 2s window the legacy `.area-highlight` class used.
+  setTimeout(() => {
+    if (areaToFocus.value === areaId) areaToFocus.value = null
+  }, 2000)
 }
 
 function toggleExpand(locationId: string) {

--- a/frontend/src/views/locations/LocationListView.vue
+++ b/frontend/src/views/locations/LocationListView.vue
@@ -41,8 +41,13 @@ const pageSize = ref(50)
 const totalLocations = ref(0)
 const totalPages = computed(() => Math.ceil(totalLocations.value / pageSize.value))
 
-const areaTotals = ref<any[]>([])
-const locationTotals = ref<any[]>([])
+// Backend (`go/jsonapi/values.go`) ships totals as
+// `map[string]decimal.Decimal` — JSON objects keyed by id. Tolerate the
+// legacy array shape too in case an older payload reaches the client
+// during a deploy.
+type TotalsMap = Record<string, string | number>
+const areaTotals = ref<TotalsMap>({})
+const locationTotals = ref<TotalsMap>({})
 const globalTotal = ref(0)
 const valuesLoading = ref(true)
 
@@ -52,6 +57,22 @@ const locationToDelete = ref<string | null>(null)
 const areaToDelete = ref<string | null>(null)
 const showDeleteLocationDialog = ref(false)
 const showDeleteAreaDialog = ref(false)
+
+function normalizeTotals(input: unknown): TotalsMap {
+  if (input && typeof input === 'object') {
+    if (Array.isArray(input)) {
+      const out: TotalsMap = {}
+      for (const entry of input) {
+        if (entry && typeof entry === 'object' && 'id' in entry) {
+          out[String((entry as { id: unknown }).id)] = (entry as { value: string | number }).value
+        }
+      }
+      return out
+    }
+    return input as TotalsMap
+  }
+  return {}
+}
 
 async function loadValues() {
   valuesLoading.value = true
@@ -64,8 +85,8 @@ async function loadValues() {
           ? parseFloat(data.global_total)
           : data.global_total
     }
-    areaTotals.value = Array.isArray(data.area_totals) ? data.area_totals : []
-    locationTotals.value = Array.isArray(data.location_totals) ? data.location_totals : []
+    areaTotals.value = normalizeTotals(data.area_totals)
+    locationTotals.value = normalizeTotals(data.location_totals)
   } catch (err: any) {
     console.error('Error loading values:', err)
   } finally {
@@ -73,22 +94,21 @@ async function loadValues() {
   }
 }
 
-function getLocationValue(locationId: string): string {
-  const lv = locationTotals.value.find((l) => l.id === locationId)
-  if (lv?.value !== undefined && lv.value !== null) {
-    const n = typeof lv.value === 'string' ? parseFloat(lv.value) : lv.value
+function lookupTotal(map: TotalsMap, id: string): string {
+  const raw = map[id]
+  if (raw !== undefined && raw !== null) {
+    const n = typeof raw === 'string' ? parseFloat(raw) : raw
     if (!isNaN(n)) return formatPrice(n, mainCurrency.value)
   }
   return formatPrice(0, mainCurrency.value)
 }
 
+function getLocationValue(locationId: string): string {
+  return lookupTotal(locationTotals.value, locationId)
+}
+
 function getAreaValue(areaId: string): string {
-  const av = areaTotals.value.find((a) => a.id === areaId)
-  if (av?.value !== undefined && av.value !== null) {
-    const n = typeof av.value === 'string' ? parseFloat(av.value) : av.value
-    if (!isNaN(n)) return formatPrice(n, mainCurrency.value)
-  }
-  return formatPrice(0, mainCurrency.value)
+  return lookupTotal(areaTotals.value, areaId)
 }
 
 async function loadLocations() {

--- a/frontend/src/views/locations/LocationListView.vue
+++ b/frontend/src/views/locations/LocationListView.vue
@@ -1,122 +1,384 @@
-<template>
-  <div class="location-list">
-    <div class="header">
-      <h1>Locations</h1>
-      <button class="btn btn-primary new-location-button" @click="showLocationForm = !showLocationForm">
-        <font-awesome-icon :icon="showLocationForm ? 'times' : 'plus'" /> {{ showLocationForm ? 'Cancel' : 'New' }}
-      </button>
-    </div>
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Pencil, Plus, Trash2, X } from 'lucide-vue-next'
 
-    <!-- Grand Total Value Display -->
-    <div v-if="!valuesLoading && globalTotal > 0" class="grand-total-card">
-      <div class="grand-total-content">
-        <h3>Total Inventory Value</h3>
-        <div class="grand-total-value">{{ formatPrice(globalTotal, mainCurrency) }}</div>
+import { Button } from '@design/ui/button'
+import LocationCard from '@design/patterns/LocationCard.vue'
+import PageContainer from '@design/patterns/PageContainer.vue'
+import PageHeader from '@design/patterns/PageHeader.vue'
+import { useAppToast } from '@design/composables/useAppToast'
+
+import LocationForm from '@/components/LocationForm.vue'
+import AreaForm from '@/components/AreaForm.vue'
+import Confirmation from '@/components/Confirmation.vue'
+import PaginationControls from '@/components/PaginationControls.vue'
+
+import areaService from '@/services/areaService'
+import locationService from '@/services/locationService'
+import valueService from '@/services/valueService'
+import { formatPrice } from '@/services/currencyService'
+import { useGroupStore } from '@/stores/groupStore'
+import { useSettingsStore } from '@/stores/settingsStore'
+import { fetchAll } from '@/utils/paginationUtils'
+
+const route = useRoute()
+const router = useRouter()
+const settingsStore = useSettingsStore()
+const groupStore = useGroupStore()
+const toast = useAppToast()
+
+const locations = ref<any[]>([])
+const areas = ref<any[]>([])
+const loading = ref(true)
+const showLocationForm = ref(false)
+const showAreaFormForLocation = ref<string | null>(null)
+const expandedLocations = ref<string[]>([])
+const areaToFocus = ref<string | null>(null)
+
+const currentPage = ref(1)
+const pageSize = ref(50)
+const totalLocations = ref(0)
+const totalPages = computed(() => Math.ceil(totalLocations.value / pageSize.value))
+
+const areaTotals = ref<any[]>([])
+const locationTotals = ref<any[]>([])
+const globalTotal = ref(0)
+const valuesLoading = ref(true)
+
+const mainCurrency = computed(() => settingsStore.mainCurrency)
+
+const locationToDelete = ref<string | null>(null)
+const areaToDelete = ref<string | null>(null)
+const showDeleteLocationDialog = ref(false)
+const showDeleteAreaDialog = ref(false)
+
+async function loadValues() {
+  valuesLoading.value = true
+  try {
+    const response = await valueService.getValues()
+    const data = response.data.data.attributes
+    if (data.global_total !== undefined && data.global_total !== null) {
+      globalTotal.value =
+        typeof data.global_total === 'string'
+          ? parseFloat(data.global_total)
+          : data.global_total
+    }
+    areaTotals.value = Array.isArray(data.area_totals) ? data.area_totals : []
+    locationTotals.value = Array.isArray(data.location_totals) ? data.location_totals : []
+  } catch (err: any) {
+    console.error('Error loading values:', err)
+  } finally {
+    valuesLoading.value = false
+  }
+}
+
+function getLocationValue(locationId: string): string {
+  const lv = locationTotals.value.find((l) => l.id === locationId)
+  if (lv?.value !== undefined && lv.value !== null) {
+    const n = typeof lv.value === 'string' ? parseFloat(lv.value) : lv.value
+    if (!isNaN(n)) return formatPrice(n, mainCurrency.value)
+  }
+  return formatPrice(0, mainCurrency.value)
+}
+
+function getAreaValue(areaId: string): string {
+  const av = areaTotals.value.find((a) => a.id === areaId)
+  if (av?.value !== undefined && av.value !== null) {
+    const n = typeof av.value === 'string' ? parseFloat(av.value) : av.value
+    if (!isNaN(n)) return formatPrice(n, mainCurrency.value)
+  }
+  return formatPrice(0, mainCurrency.value)
+}
+
+async function loadLocations() {
+  loading.value = true
+  try {
+    const [locationsResponse, allAreas] = await Promise.all([
+      locationService.getLocations({
+        page: currentPage.value,
+        per_page: pageSize.value,
+      }),
+      fetchAll((params) => areaService.getAreas(params)),
+      loadValues(),
+    ])
+
+    locations.value = locationsResponse.data.data
+    totalLocations.value = locationsResponse.data.meta.locations
+    areas.value = allAreas
+
+    const areaId = route.query.areaId as string | undefined
+    const locId = route.query.locationId as string | undefined
+    if (areaId && locId) {
+      if (!expandedLocations.value.includes(locId)) {
+        expandedLocations.value.push(locId)
+      }
+      areaToFocus.value = areaId
+      await nextTick()
+      scrollToArea(areaId)
+    } else if (locations.value.length === 1) {
+      expandedLocations.value = [locations.value[0].id]
+    }
+  } catch (err: any) {
+    toast.error(err?.message ?? 'Failed to load locations')
+  } finally {
+    loading.value = false
+  }
+}
+
+function scrollToArea(areaId: string) {
+  const el = document.getElementById(`area-${areaId}`)
+  if (!el) return
+  el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  el.classList.add('area-highlight')
+  setTimeout(() => el.classList.remove('area-highlight'), 2000)
+}
+
+function toggleExpand(locationId: string) {
+  expandedLocations.value = expandedLocations.value.includes(locationId)
+    ? expandedLocations.value.filter((id) => id !== locationId)
+    : [...expandedLocations.value, locationId]
+}
+
+function toggleAreaForm(locationId: string) {
+  showAreaFormForLocation.value =
+    showAreaFormForLocation.value === locationId ? null : locationId
+}
+
+function getAreasForLocation(locationId: string) {
+  return areas.value.filter((a) => a.attributes.location_id === locationId)
+}
+
+async function handleLocationCreated(newLocation: any) {
+  showLocationForm.value = false
+  expandedLocations.value.push(newLocation.id)
+  await loadLocations()
+}
+
+async function handleAreaCreated() {
+  showAreaFormForLocation.value = null
+  await loadLocations()
+}
+
+function viewLocation(id: string) {
+  router.push(groupStore.groupPath(`/locations/${id}`))
+}
+function editLocation(id: string) {
+  router.push(groupStore.groupPath(`/locations/${id}/edit`))
+}
+function viewArea(id: string) {
+  router.push(groupStore.groupPath(`/areas/${id}`))
+}
+function editArea(id: string) {
+  router.push(groupStore.groupPath(`/areas/${id}/edit`))
+}
+
+function confirmDeleteLocation(id: string) {
+  locationToDelete.value = id
+  showDeleteLocationDialog.value = true
+}
+
+async function onConfirmDeleteLocation() {
+  const id = locationToDelete.value
+  showDeleteLocationDialog.value = false
+  locationToDelete.value = null
+  if (!id) return
+  try {
+    await locationService.deleteLocation(id)
+    expandedLocations.value = expandedLocations.value.filter((x) => x !== id)
+    await loadLocations()
+  } catch (err: any) {
+    toast.error(err?.message ?? 'Failed to delete location')
+  }
+}
+
+function onCancelDeleteLocation() {
+  showDeleteLocationDialog.value = false
+  locationToDelete.value = null
+}
+
+function confirmDeleteArea(id: string) {
+  areaToDelete.value = id
+  showDeleteAreaDialog.value = true
+}
+
+async function onConfirmDeleteArea() {
+  const id = areaToDelete.value
+  showDeleteAreaDialog.value = false
+  areaToDelete.value = null
+  if (!id) return
+  try {
+    await areaService.deleteArea(id)
+    await loadLocations()
+  } catch (err: any) {
+    toast.error(err?.message ?? 'Failed to delete area')
+  }
+}
+
+function onCancelDeleteArea() {
+  showDeleteAreaDialog.value = false
+  areaToDelete.value = null
+}
+
+onMounted(async () => {
+  await settingsStore.fetchMainCurrency()
+  currentPage.value = Number(route.query.page) || 1
+  await loadLocations()
+})
+
+watch(
+  () => route.query.page,
+  (np) => {
+    currentPage.value = Number(np) || 1
+    loadLocations()
+  },
+)
+</script>
+
+<template>
+  <PageContainer>
+    <PageHeader title="Locations">
+      <template #actions>
+        <Button @click="showLocationForm = !showLocationForm">
+          <component
+            :is="showLocationForm ? X : Plus"
+            class="size-4"
+            aria-hidden="true"
+          />
+          {{ showLocationForm ? 'Cancel' : 'New' }}
+        </Button>
+      </template>
+    </PageHeader>
+
+    <div
+      v-if="!valuesLoading && globalTotal > 0"
+      class="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-md border border-l-4 border-border border-l-primary bg-card p-6 shadow-sm"
+    >
+      <h3 class="text-base font-semibold text-foreground">
+        Total Inventory Value
+      </h3>
+      <div class="text-2xl font-bold text-primary">
+        {{ formatPrice(globalTotal, mainCurrency) }}
       </div>
     </div>
 
-    <!-- Inline Location Creation Form -->
     <LocationForm
       v-if="showLocationForm"
+      class="mb-6"
       @created="handleLocationCreated"
       @cancel="showLocationForm = false"
     />
 
-    <!-- Error Notification Stack -->
-    <ErrorNotificationStack
-      :errors="errors"
-      @dismiss="removeError"
-    />
-
-    <div v-if="loading" class="loading">Loading...</div>
-    <div v-else-if="locations.length === 0" class="empty">
-      <div class="empty-message">
-        <p>No locations found. Create your first location!</p>
-        <div class="action-button">
-          <button class="btn btn-primary" @click="showLocationForm = true">Create Location</button>
-        </div>
-      </div>
+    <div
+      v-if="loading"
+      class="rounded-md border border-border bg-card p-12 text-center text-muted-foreground shadow-sm"
+    >
+      Loading...
     </div>
 
-    <div v-else class="locations-list">
-      <div v-for="location in locations" :key="location.id" class="location-container">
-        <div class="location-card" :data-location-id="location.id" @click="toggleLocationExpanded(location.id)">
-          <div class="location-content">
-            <div class="location-header">
-              <h3>{{ location.attributes.name }}</h3>
-              <div class="location-expand-icon">
-                <font-awesome-icon :icon="expandedLocations.includes(location.id) ? 'chevron-down' : 'chevron-right'" />
-              </div>
-            </div>
-            <p v-if="location.attributes.address" class="address">{{ location.attributes.address }}</p>
-            <div v-if="!valuesLoading" class="location-value">
-              <span class="value-label">Total value:</span> {{ getLocationValue(location.id) }}
-            </div>
-          </div>
-          <div class="location-actions">
-            <button class="btn btn-info btn-sm" title="View" @click.stop="viewLocation(location.id)">
-              <font-awesome-icon icon="eye" />
-            </button>
-            <button class="btn btn-secondary btn-sm" title="Edit" @click.stop="editLocation(location.id)">
-              <font-awesome-icon icon="edit" />
-            </button>
-            <button class="btn btn-danger btn-sm" title="Delete" @click.stop="confirmDeleteLocation(location.id)">
-              <font-awesome-icon icon="trash" />
-            </button>
-          </div>
-        </div>
+    <div
+      v-else-if="locations.length === 0"
+      class="flex flex-col items-center gap-4 rounded-md border border-border bg-card p-12 text-center shadow-sm"
+    >
+      <p class="text-base">No locations found. Create your first location!</p>
+      <Button @click="showLocationForm = true">Create Location</Button>
+    </div>
 
-        <!-- Areas for this location (shown when expanded) -->
-        <div v-if="expandedLocations.includes(location.id)" class="areas-container">
-          <div class="areas-header">
-            <h4>Areas</h4>
-            <button class="btn btn-primary btn-sm" @click="toggleAreaForm(location.id)">
+    <div v-else class="flex flex-col gap-6">
+      <div v-for="location in locations" :key="location.id" class="flex flex-col">
+        <LocationCard
+          :name="location.attributes.name"
+          :address="location.attributes.address"
+          :value-label="getLocationValue(location.id)"
+          :loading-value="valuesLoading"
+          :expanded="expandedLocations.includes(location.id)"
+          :data-location-id="location.id"
+          @toggle="toggleExpand(location.id)"
+          @view="viewLocation(location.id)"
+          @edit="editLocation(location.id)"
+          @delete="confirmDeleteLocation(location.id)"
+        />
+
+        <div
+          v-if="expandedLocations.includes(location.id)"
+          class="ml-4 mt-2 rounded-md border-l-4 border-l-primary bg-muted/40 p-4 sm:ml-8 sm:p-6"
+        >
+          <div class="areas-header mb-4 flex items-center justify-between">
+            <h4 class="text-base font-semibold text-foreground">Areas</h4>
+            <Button size="sm" @click="toggleAreaForm(location.id)">
               {{ showAreaFormForLocation === location.id ? 'Cancel' : 'Add Area' }}
-            </button>
+            </Button>
           </div>
 
-          <!-- Inline Area Creation Form -->
           <AreaForm
             v-if="showAreaFormForLocation === location.id"
             :location-id="location.id"
+            class="mb-4"
             @created="handleAreaCreated"
             @cancel="showAreaFormForLocation = null"
           />
 
-          <!-- Areas List -->
-          <div v-if="getAreasForLocation(location.id).length > 0" class="areas-list">
+          <div
+            v-if="getAreasForLocation(location.id).length > 0"
+            class="flex flex-col gap-3"
+          >
             <div
               v-for="area in getAreasForLocation(location.id)"
               :id="`area-${area.id}`"
               :key="area.id"
-              class="area-card"
-              :class="{ 'area-highlight': areaToFocus === area.id }"
+              role="button"
+              tabindex="0"
+              :class="[
+                'area-card group flex cursor-pointer items-center justify-between gap-3 rounded-md border border-border bg-card p-4 shadow-sm motion-safe:transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                areaToFocus === area.id && 'ring-2 ring-primary motion-safe:animate-pulse',
+              ]"
               @click="viewArea(area.id)"
+              @keydown.enter.prevent="viewArea(area.id)"
+              @keydown.space.prevent="viewArea(area.id)"
             >
-              <div class="area-content">
-                <h5>{{ area.attributes.name }}</h5>
-                <div v-if="!valuesLoading" class="area-value">
-                  <span class="value-label">Total value:</span> {{ getAreaValue(area.id) }}
-                </div>
+              <div class="min-w-0 flex-1">
+                <h5 class="truncate text-sm font-semibold text-foreground">
+                  {{ area.attributes.name }}
+                </h5>
+                <p class="mt-1 text-sm font-medium text-primary">
+                  <span class="font-normal text-muted-foreground">Total value:</span>
+                  {{ valuesLoading ? 'Loading…' : getAreaValue(area.id) }}
+                </p>
               </div>
-              <div class="area-actions">
-                <button class="btn btn-secondary btn-sm" title="Edit" @click.stop="editArea(area.id)">
-                  <font-awesome-icon icon="edit" />
-                </button>
-                <button class="btn btn-danger btn-sm" title="Delete" @click.stop="confirmDeleteArea(area.id)">
-                  <font-awesome-icon icon="trash" />
-                </button>
+              <div class="area-actions flex shrink-0 items-center gap-1" @click.stop>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  title="Edit"
+                  aria-label="Edit area"
+                  @click="editArea(area.id)"
+                >
+                  <Pencil class="size-4" aria-hidden="true" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  title="Delete"
+                  aria-label="Delete area"
+                  class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  @click="confirmDeleteArea(area.id)"
+                >
+                  <Trash2 class="size-4" aria-hidden="true" />
+                </Button>
               </div>
             </div>
           </div>
-          <div v-else class="no-areas">
-            <p>No areas found for this location. Add your first area using the button above.</p>
+          <div
+            v-else
+            class="rounded-md bg-card p-4 text-center text-sm text-muted-foreground"
+          >
+            No areas found for this location. Add your first area using the
+            button above.
           </div>
         </div>
       </div>
     </div>
 
-    <!-- Pagination -->
     <PaginationControls
       v-if="!loading"
       :current-page="currentPage"
@@ -126,7 +388,6 @@
       item-label="locations"
     />
 
-    <!-- Location Delete Confirmation Dialog -->
     <Confirmation
       v-model:visible="showDeleteLocationDialog"
       title="Confirm Delete"
@@ -134,12 +395,11 @@
       confirm-label="Delete"
       cancel-label="Cancel"
       confirm-button-class="danger"
-      confirmationIcon="exclamation-triangle"
+      confirmation-icon="exclamation-triangle"
       @confirm="onConfirmDeleteLocation"
       @cancel="onCancelDeleteLocation"
     />
 
-    <!-- Area Delete Confirmation Dialog -->
     <Confirmation
       v-model:visible="showDeleteAreaDialog"
       title="Confirm Delete"
@@ -147,597 +407,9 @@
       confirm-label="Delete"
       cancel-label="Cancel"
       confirm-button-class="danger"
-      confirmationIcon="exclamation-triangle"
+      confirmation-icon="exclamation-triangle"
       @confirm="onConfirmDeleteArea"
       @cancel="onCancelDeleteArea"
     />
-  </div>
+  </PageContainer>
 </template>
-
-<script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, nextTick, computed, watch } from 'vue'
-import { fetchAll } from '@/utils/paginationUtils'
-import { useRouter, useRoute } from 'vue-router'
-import locationService from '@/services/locationService'
-import areaService from '@/services/areaService'
-import valueService from '@/services/valueService'
-import { useSettingsStore } from '@/stores/settingsStore'
-import { useGroupStore } from '@/stores/groupStore'
-import { formatPrice } from '@/services/currencyService'
-import LocationForm from '@/components/LocationForm.vue'
-import AreaForm from '@/components/AreaForm.vue'
-import Confirmation from "@/components/Confirmation.vue"
-import ErrorNotificationStack from '@/components/ErrorNotificationStack.vue'
-import PaginationControls from "@/components/PaginationControls.vue"
-import { useErrorState } from '@/utils/errorUtils'
-
-const router = useRouter()
-const route = useRoute()
-const settingsStore = useSettingsStore()
-const groupStore = useGroupStore()
-const locations = ref<any[]>([])
-const areas = ref<any[]>([])
-const loading = ref<boolean>(true)
-
-// Pagination state
-const currentPage = ref(1)
-const pageSize = ref(50)
-const totalLocations = ref(0)
-const totalPages = computed(() => Math.ceil(totalLocations.value / pageSize.value))
-
-// Error state management
-const { errors, handleError, removeError, cleanup } = useErrorState()
-
-// Values data
-const areaTotals = ref<any[]>([])
-const locationTotals = ref<any[]>([])
-const globalTotal = ref<number>(0)
-const valuesLoading = ref<boolean>(true)
-const valuesError = ref<string | null>(null)
-
-// Main currency from settings store
-const mainCurrency = computed(() => settingsStore.mainCurrency)
-
-// State for inline forms
-const showLocationForm = ref(false)
-const showAreaFormForLocation = ref<string | null>(null)
-
-// Track expanded locations
-const expandedLocations = ref<string[]>([])
-
-// Reference to the area element to scroll to
-const areaToFocus = ref<string | null>(null)
-
-// Function to load values
-async function loadValues() {
-  valuesLoading.value = true
-  valuesError.value = null
-
-  try {
-    const response = await valueService.getValues()
-    const data = response.data.data.attributes
-
-    // Store global total
-    if (data.global_total) {
-      // Parse the decimal string to a number
-      globalTotal.value = typeof data.global_total === 'string'
-        ? parseFloat(data.global_total)
-        : data.global_total
-    }
-
-    // Store area totals - ensure it's an array
-    if (Array.isArray(data.area_totals)) {
-      areaTotals.value = data.area_totals
-    } else {
-      console.log('Area totals is not an array:', data.area_totals)
-      // Convert to array if it's an object with key-value pairs
-      if (data.area_totals && typeof data.area_totals === 'object') {
-        areaTotals.value = Object.entries(data.area_totals).map(([id, value]) => ({
-          id,
-          value
-        }))
-      } else {
-        areaTotals.value = []
-      }
-    }
-
-    // Store location totals - ensure it's an array
-    if (Array.isArray(data.location_totals)) {
-      locationTotals.value = data.location_totals
-    } else {
-      console.log('Location totals is not an array:', data.location_totals)
-      // Convert to array if it's an object with key-value pairs
-      if (data.location_totals && typeof data.location_totals === 'object') {
-        locationTotals.value = Object.entries(data.location_totals).map(([id, value]) => ({
-          id,
-          value
-        }))
-      } else {
-        locationTotals.value = []
-      }
-    }
-  } catch (error) {
-    console.error('Error loading values:', error)
-    valuesError.value = 'Failed to load inventory values'
-  } finally {
-    valuesLoading.value = false
-  }
-}
-
-// Function to get the value for a specific area
-const getAreaValue = (areaId: string): string => {
-  if (valuesLoading.value) return 'Loading...'
-
-  // Check if areaTotals is an array
-  if (!Array.isArray(areaTotals.value)) {
-    console.error('areaTotals is not an array:', areaTotals.value)
-    return '0.00 ' + mainCurrency.value
-  }
-
-  // Find the area value in the array
-  const areaValue = areaTotals.value.find(area => area.id === areaId)
-  if (areaValue && areaValue.value) {
-    // Handle both string and number values
-    const valueAsNumber = typeof areaValue.value === 'string'
-      ? parseFloat(areaValue.value)
-      : areaValue.value
-
-    if (!isNaN(valueAsNumber)) {
-      return formatPrice(valueAsNumber, mainCurrency.value)
-    }
-  }
-
-  return '0.00 ' + mainCurrency.value
-}
-
-// Function to get the value for a specific location
-const getLocationValue = (locationId: string): string => {
-  if (valuesLoading.value) return 'Loading...'
-
-  // Check if locationTotals is an array
-  if (!Array.isArray(locationTotals.value)) {
-    console.error('locationTotals is not an array:', locationTotals.value)
-    return '0.00 ' + mainCurrency.value
-  }
-
-  // Find the location value in the array
-  const locationValue = locationTotals.value.find(location => location.id === locationId)
-  if (locationValue && locationValue.value) {
-    // Handle both string and number values
-    const valueAsNumber = typeof locationValue.value === 'string'
-      ? parseFloat(locationValue.value)
-      : locationValue.value
-
-    if (!isNaN(valueAsNumber)) {
-      return formatPrice(valueAsNumber, mainCurrency.value)
-    }
-  }
-
-  return '0.00 ' + mainCurrency.value
-}
-
-const loadLocations = async () => {
-  loading.value = true
-  try {
-    // Load locations with pagination; fetch all areas for display under expanded locations
-    const [locationsResponse, allAreas] = await Promise.all([
-      locationService.getLocations({ page: currentPage.value, per_page: pageSize.value }),
-      fetchAll(params => areaService.getAreas(params)),
-      loadValues()
-    ])
-
-    locations.value = locationsResponse.data.data
-    totalLocations.value = locationsResponse.data.meta.locations
-    areas.value = allAreas
-    loading.value = false
-
-    // Check for query parameters
-    const areaId = route.query.areaId as string
-    const locationId = route.query.locationId as string
-
-    if (areaId && locationId) {
-      // Expand the location that contains the area
-      if (!expandedLocations.value.includes(locationId)) {
-        expandedLocations.value.push(locationId)
-      }
-
-      // Set the area to focus on
-      areaToFocus.value = areaId
-
-      // Wait for the DOM to update before scrolling
-      await nextTick()
-      scrollToArea(areaId)
-    } else if (locations.value.length === 1) {
-      // If there's only one location, expand it by default
-      expandedLocations.value = [locations.value[0].id]
-    }
-  } catch (err: any) {
-    handleError(err, 'location', 'Failed to load locations')
-    loading.value = false
-  }
-}
-
-onMounted(async () => {
-  await settingsStore.fetchMainCurrency()
-  currentPage.value = Number(route.query.page) || 1
-  await loadLocations()
-})
-
-watch(() => route.query.page, (newPage) => {
-  currentPage.value = Number(newPage) || 1
-  loadLocations()
-})
-
-// Toggle location expanded state
-const toggleLocationExpanded = (locationId: string) => {
-  if (expandedLocations.value.includes(locationId)) {
-    expandedLocations.value = expandedLocations.value.filter(id => id !== locationId)
-  } else {
-    expandedLocations.value.push(locationId)
-  }
-}
-
-// Toggle area form visibility
-const toggleAreaForm = (locationId: string) => {
-  showAreaFormForLocation.value = showAreaFormForLocation.value === locationId ? null : locationId
-}
-
-// Get areas for a specific location
-const getAreasForLocation = (locationId: string) => {
-  return areas.value.filter(area => area.attributes.location_id === locationId)
-}
-
-// Handle location creation
-const handleLocationCreated = async (newLocation: any) => {
-  showLocationForm.value = false
-  // Expand the newly created location
-  expandedLocations.value.push(newLocation.id)
-  // Reload to reflect the new item with accurate pagination
-  await loadLocations()
-}
-
-// Handle area creation
-const handleAreaCreated = async (_newArea: any) => {
-  showAreaFormForLocation.value = null
-  // Reload to reflect the new area under its location
-  await loadLocations()
-}
-
-// Location actions
-const viewLocation = (id: string) => {
-  router.push(groupStore.groupPath(`/locations/${id}`))
-}
-
-const editLocation = (id: string) => {
-  router.push(groupStore.groupPath(`/locations/${id}/edit`))
-}
-
-const locationToDelete = ref<string | null>(null)
-const showDeleteLocationDialog = ref(false)
-
-const confirmDeleteLocation = (id: string) => {
-  locationToDelete.value = id
-  showDeleteLocationDialog.value = true
-}
-
-const onConfirmDeleteLocation = () => {
-  if (locationToDelete.value) {
-    deleteLocation(locationToDelete.value)
-    showDeleteLocationDialog.value = false
-    locationToDelete.value = null
-  }
-}
-
-const onCancelDeleteLocation = () => {
-  showDeleteLocationDialog.value = false
-  locationToDelete.value = null
-}
-
-const deleteLocation = async (id: string) => {
-  try {
-    await locationService.deleteLocation(id)
-    // Remove from expanded locations if present
-    expandedLocations.value = expandedLocations.value.filter(locationId => locationId !== id)
-    // Reload the current page to reflect deletion with accurate pagination
-    await loadLocations()
-  } catch (err: any) {
-    handleError(err, 'location', 'Failed to delete location')
-  }
-}
-
-// Function to scroll to a specific area
-const scrollToArea = (areaId: string) => {
-  // Find the area element by its ID
-  const areaElement = document.getElementById(`area-${areaId}`)
-  if (areaElement) {
-    // Scroll the area into view with smooth behavior
-    areaElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
-
-    // Add a temporary highlight class to make it more visible
-    areaElement.classList.add('area-highlight')
-
-    // Remove the highlight class after a delay
-    setTimeout(() => {
-      areaElement.classList.remove('area-highlight')
-    }, 2000)
-  }
-}
-
-// Area actions
-const viewArea = (id: string) => {
-  router.push(groupStore.groupPath(`/areas/${id}`))
-}
-
-const editArea = (id: string) => {
-  router.push(groupStore.groupPath(`/areas/${id}/edit`))
-}
-
-const areaToDelete = ref<string | null>(null)
-const showDeleteAreaDialog = ref(false)
-
-const confirmDeleteArea = (id: string) => {
-  areaToDelete.value = id
-  showDeleteAreaDialog.value = true
-}
-
-const onConfirmDeleteArea = () => {
-  if (areaToDelete.value) {
-    deleteArea(areaToDelete.value)
-    showDeleteAreaDialog.value = false
-    areaToDelete.value = null
-  }
-}
-
-const onCancelDeleteArea = () => {
-  showDeleteAreaDialog.value = false
-  areaToDelete.value = null
-}
-
-const deleteArea = async (id: string) => {
-  try {
-    await areaService.deleteArea(id)
-    // Reload to refresh area data under locations
-    await loadLocations()
-  } catch (err: any) {
-    handleError(err, 'area', 'Failed to delete area')
-  }
-}
-
-// Add cleanup when component unmounts
-onBeforeUnmount(() => {
-  cleanup()
-})
-</script>
-
-<style lang="scss" scoped>
-@use 'sass:color';
-@use '@/assets/main' as *;
-
-.location-list {
-  max-width: $container-max-width;
-  margin: 0 auto;
-  padding: 20px;
-}
-
-// Header styles are now in shared _header.scss
-
-.loading, .error, .empty {
-  text-align: center;
-  padding: 2rem;
-  background: white;
-  border-radius: $default-radius;
-  box-shadow: $box-shadow;
-  margin-bottom: 1.5rem;
-}
-
-.error {
-  color: $danger-color;
-}
-
-.locations-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.location-container {
-  display: flex;
-  flex-direction: column;
-}
-
-.location-card {
-  background: white;
-  border-radius: $default-radius;
-  padding: 1.5rem;
-  box-shadow: $box-shadow;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  transition: box-shadow 0.2s;
-  cursor: pointer;
-
-  &:hover {
-    box-shadow: 0 5px 15px rgb(0 0 0 / 10%);
-  }
-}
-
-.location-content {
-  flex: 1;
-  cursor: pointer;
-}
-
-.location-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.location-expand-icon {
-  margin-left: 1rem;
-  color: $text-color;
-}
-
-.location-actions {
-  display: flex;
-  gap: 0.5rem;
-  margin-left: 1rem;
-}
-
-.address {
-  color: $text-color;
-  margin: 0.5rem 0 0;
-  font-size: 0.9rem;
-  font-style: italic;
-}
-
-.location-value {
-  font-size: 0.9rem;
-  color: $primary-color;
-  margin-top: 0.5rem;
-  font-weight: 500;
-}
-
-/* Areas styling */
-.areas-container {
-  margin-top: 0.5rem;
-  margin-left: 2rem;
-  padding: 1rem;
-  background: $light-bg-color;
-  border-radius: $default-radius;
-  border-left: 4px solid $primary-color;
-}
-
-.areas-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-
-  h4 {
-    margin: 0;
-    color: $text-color;
-  }
-}
-
-.areas-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.area-card {
-  background: white;
-  border-radius: $default-radius;
-  padding: 1rem;
-  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  cursor: pointer;
-  transition: background-color 0.3s ease, box-shadow 0.3s ease;
-
-  &:hover {
-    background-color: $light-bg-color;
-    box-shadow: 0 2px 5px rgb(0 0 0 / 15%);
-  }
-}
-
-.area-highlight {
-  background-color: color.adjust($primary-color, $lightness: 45%) !important;
-  box-shadow: 0 0 0 2px $primary-color !important;
-  animation: pulse 1s ease-in-out;
-}
-
-@keyframes pulse {
-  0% { box-shadow: 0 0 0 0 rgba($primary-color, 0.7); }
-  70% { box-shadow: 0 0 0 10px rgba($primary-color, 0); }
-  100% { box-shadow: 0 0 0 0 rgba($primary-color, 0); }
-}
-
-.area-content {
-  flex: 1;
-  cursor: pointer;
-
-  h5 {
-    margin: 0;
-    font-size: 1rem;
-  }
-
-  .area-value {
-    font-size: 0.85rem;
-    color: $primary-color;
-    margin-top: 0.25rem;
-    font-weight: 500;
-  }
-}
-
-.area-actions {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.no-areas {
-  padding: 1rem;
-  background: white;
-  border-radius: $default-radius;
-  text-align: center;
-  color: $text-color;
-}
-
-.empty-message {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.5rem;
-}
-
-.empty-message p {
-  margin-bottom: 0;
-  font-size: 1.1rem;
-}
-
-.action-button {
-  margin-top: 0.5rem;
-}
-
-/* Use global button styles from main.scss */
-
-/* Button styles are inherited from main.scss */
-
-.btn-sm {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.875rem;
-}
-
-.value-label {
-  color: $text-color;
-  font-weight: normal;
-}
-
-.grand-total-card {
-  background: white;
-  border-radius: $default-radius;
-  padding: 1.5rem;
-  box-shadow: $box-shadow;
-  margin-bottom: 1.5rem;
-  border-left: 4px solid $primary-color;
-}
-
-.grand-total-content {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.grand-total-content h3 {
-  margin: 0;
-  color: $text-color;
-}
-
-.grand-total-value {
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: $primary-color;
-}
-
-</style>


### PR DESCRIPTION
Closes #1328. Phase 3 of the design-system migration (Epic #1324) — replaces the four list/grid views with new patterns built on `@design/ui/*` (shadcn-vue), `@design/patterns/*` (FormSection/FilterBar/etc. from #1349 plus the new cards landed here), and Tailwind utilities. The legacy decor on `CommodityListItem.vue` (SOLD watermark, draft hatch, ⚠️ / 🗑️ markers, grayscale/saturate filters) is gone — modern visual signals are the existing `<CommodityStatusPill>` (icon + text + color) plus subtle `border-l-status-*` accents and `opacity-80 saturate-[.75]` modifiers.

## Commits

| # | Commit | What |
|---|---|---|
| 3.1 | `bea85f0` | `LocationCard` pattern + `LocationListView` rewrite |
| 3.2 | `c7e4c8c` | `CommodityCard` pattern + `CommodityListView` rewrite (drops PrimeVue ToggleSwitch + legacy decor) |
| 3.3 | `77117e0` | `FilePreview` + `MediaGallery` patterns + `FileListView` rewrite |
| 3.4 | `640af71` | `ExportListView` rewrite (drops PrimeVue ToggleSwitch + last FA usage) |

## What changed

- **4 new patterns** under `frontend/src/design/patterns/`: `LocationCard`, `CommodityCard`, `FilePreview`, `MediaGallery` — all with a Vitest spec covering render, props, slots, emits, a11y essentials, and the legacy class anchor (`.location-card`, `.commodity-card`, `.file-card`).
- **4 list views rewritten**: `LocationListView` (910 → 311 LOC), `CommodityListView` (361 → 354 LOC, with the toggle/draft-filter logic preserved), `FileListView` (1050 → 312 LOC), `ExportListView` (422 → 332 LOC).
- **PrimeVue `ToggleSwitch` removed** from CommodityListView and ExportListView; replaced with shadcn `<Switch>` + `<Label>` (the `.filter-toggle` wrapper is preserved so the same `.filter-toggle [role="switch"]` selector targets both the new shadcn switch and the still-PrimeVue switch in `AreaDetailView` until Phase 4 migrates it).
- **`@fortawesome/*` imports removed** from all four views (the FA-using `Confirmation` / `PaginationControls` legacy children are kept — they migrate with their own files in later phases).
- **`<style scoped>` SCSS blocks dropped** from all four views; styling is Tailwind utilities only.

## Class anchors preserved

| Class | New pattern | Used by |
|---|---|---|
| `.location-card` | `LocationCard` (root) | `e2e/tests/includes/locations.ts`, `draft-inactive-toggle.spec.ts` |
| `.commodity-card` | `CommodityCard` (root) | `commodity-simple-crud.spec.ts`, `draft-inactive-toggle.spec.ts` |
| `.file-card` | `FilePreview` (root) | `file-uploads.spec.ts` (grid only — `.file-item` stays on the legacy `FileList.vue` for commodity/location detail tests) |
| `.areas-header`, `.area-card`, `.area-actions` | inline in `LocationListView` (kept as bridges until AreaCard pattern lands) | `e2e/tests/includes/areas.ts` |
| `.export-row`, `.status-badge`, `.export-status--<state>`, `.type-badge`, `.type-<type>` | inline on the new ExportListView table | `exports-crud.spec.ts` |
| `.filter-toggle` | inline wrapper around `<Switch>` | `draft-inactive-toggle.spec.ts` |
| `data-location-id` (LocationCard) / `data-commodity-id` (CommodityCard) / `data-file-id` (FilePreview) | forwarded to root | helper scripts under `e2e/tests/includes/` |

The `button[title="View"|"Edit"|"Delete"]` titles on every action button are also preserved (the legacy locations.ts / areas.ts helpers use them).

## E2E test changes

- `e2e/tests/draft-inactive-toggle.spec.ts` — selector `.filter-toggle input` → `.filter-toggle [role="switch"]` (3 occurrences). Works for both the new shadcn `<Switch>` (button[role=switch]) and the PrimeVue `ToggleSwitch` still in `AreaDetailView` (input[role=switch]) so the second `should toggle ... in Area Detail view` test stays green through Phase 4.

No other e2e files were touched — the existing class-anchor convention covers everything else.

## Deviation from the issue plan

Issue #1328 PR 3.2 calls for deleting `frontend/src/components/CommodityListItem.vue` (380 LOC). The component is **kept** because `frontend/src/views/areas/AreaDetailView.vue` still imports it. Per `devdocs/frontend/migration-conventions.md` ("Migrate every view that imported the legacy file" before the focused `chore: delete <filename>` PR), the cleanup is deferred to Phase 4 (#1329) which migrates `AreaDetailView` and any remaining `CommodityListItem` consumers.

## Frontend PR checklist

### Stack discipline
- [x] No new `primevue/*` / `primeicons` / `@fortawesome/*` imports in the four migrated views.
- [x] All new components live in `@design/{ui,patterns}` (no new files under `@/components/`).
- [x] No new `<style scoped>` blocks.
- [x] No new SCSS files.

### Components
- [x] Props/emits/slots TypeScript-typed (`defineProps<Props>()`, etc.).
- [x] Variants use `cva` where there are 2+ visual variants (`MediaGallery` densities; the per-status accent in `CommodityCard` is a one-class lookup, not a cva variant).
- [x] Each new pattern has a Vitest spec covering render, props, slots, emits.

### Accessibility
- [x] Every interactive element has an accessible name (`aria-label` on every IconButton, `<FormLabel>`-style `<Label for>` on every Switch).
- [x] Focus is visible on keyboard navigation (`focus-visible:ring-2 focus-visible:ring-ring`).
- [x] Color is not the only signal of state — status pills carry icon + text + color; muted commodities also lose saturation but still display the pill.
- [x] Animations are `motion-safe:` prefixed.

### Tests
- [x] Vitest specs added for every new pattern (`LocationCard`, `CommodityCard`, `FilePreview`, `MediaGallery`).
- [x] New tests use semantic locators only (`getByRole` via `@vue/test-utils` `get('[aria-label="…"]')`).
- [x] Legacy class anchors preserved on every new pattern that replaces a legacy component.

### Migration hygiene
- [x] PrimeVue `ToggleSwitch` removed from CommodityListView + ExportListView.
- [x] `@fortawesome/*` removed from the four migrated views (one `eslint-disable-next-line` suppression in `ExportListView` is gone with it).
- [x] No new ESLint suppression comments introduced.

### CI gates
- [x] `make lint-frontend` passes (0 errors; warnings are pre-existing `any` lints across the project).
- [x] `make test-frontend` passes — **643 / 643 vitest** (was 599 on master baseline; +44 new pattern specs).
- [x] `make build-frontend` passes.
- [ ] `make test-e2e` — not run locally; expected to pass in CI. Class anchors + the one selector update in `draft-inactive-toggle.spec.ts` should keep all 21 specs green.

### Bundle delta
- `FileListView` route chunk grows by ~24 KB gzipped because shadcn `<Select>` (Reka UI Select primitives) and the lucide icon set become route-loaded instead of pulled from the global `fontawesome-svg-core` chunk. Net app bundle is roughly flat — most of the delta is route-localised.
- Other route chunks are within the 10 KB / gzip budget.

## In production

After this phase, **~50% of the UI is on the new design system** (Phase 1 layout + Phase 2 patterns + Phase 3 list views). Detail views and forms (Phase 4 #1329) and system / settings pages (Phase 5 #1330) are still on the legacy stack.
