### PR TITLE
docs(frontend): design-direction brief

### DIFF
--- a/devdocs/frontend/README.md
+++ b/devdocs/frontend/README.md
@@ -25,6 +25,7 @@ If you are about to:
 | [`imports-and-bans.md`](./imports-and-bans.md) | ESLint `no-restricted-imports` rules and the rationale behind each ban. |
 | [`pr-checklist.md`](./pr-checklist.md) | Copy-paste checklist for every FE PR description. |
 | [`migration-conventions.md`](./migration-conventions.md) | Strangler-fig migration recipe, per-view PR size, legacy class anchors, when to add a new primitive. |
+| [`design/`](./design/README.md) | Forward-looking design-direction brief: positioning, palette, type, spacing, motion, components, copy, accessibility, edge cases — the foundation for the next round of UI work after Phase 6. |
 
 ## Scope
 

--- a/devdocs/frontend/design/00-positioning.md
+++ b/devdocs/frontend/design/00-positioning.md
@@ -1,0 +1,60 @@
+# Inventario — Product Positioning
+
+**One-liner:** Things 3 for your stuff — a calm, practical place for the information about your possessions you'd otherwise lose track of.
+
+## Origin and core need
+
+Inventario was born to solve a mundane personal problem: keeping track of warranties, prices for insurance, and where to buy supplies/parts for home appliances and electronics. The collection and property use cases are real but secondary — they grew on top of the core "I don't want to hold this in my head" need.
+
+The product's emotional center is **peace of mind**, not curation or status.
+
+## Audience
+
+- **Private individuals** managing their household inventory.
+- **Small businesses** (a few employees) keeping records of their physical assets.
+- Not enterprise. Not insurance professionals. Not auctioneers.
+
+Implied user characteristics: comfortable with software, values craft, uses Things/Notion/1Password-tier tools, doesn't tolerate ugly admin panels.
+
+## Use cases (priority order)
+
+1. **Home appliances and electronics** — warranties, receipts, model numbers, prices for insurance, where to buy parts/supplies, service history. **This is the root.**
+2. **Collections** — coins, stamps, wine, books, anything collectible. Inventario as a personal catalog with provenance.
+3. **Property documentation** — for a house/apartment as an entity: deeds, contracts, manuals, insurance policies. Bonus, not driver.
+
+The dashboard, onboarding, and copy should anchor on (1). (2) and (3) are reachable but not the front door.
+
+## Tone
+
+| Direction | Examples |
+| --- | --- |
+| **Respectful, quiet** | "Saved." not "Successfully uploaded! 🎉" |
+| **Practical, peace-of-mind framing** | "Your dishwasher's warranty expires in 14 days." |
+| **Slightly understated** | "One thing." not "1 ITEM" |
+| **Plain, not corporate** | "Where I bought it" not "Vendor information" |
+| **No emoji, no slang, no exclamation marks** | (the product is a record-keeper, not a coach) |
+
+## Reference cluster (visual + tonal)
+
+**Yes, this kind of feeling:**
+- Things 3 — calm, considered, every detail intentional
+- 1Password — practical security tool with serious design
+- Day One — personal record-keeping with warmth
+- Bear — quiet writing app, restraint
+- Notion Calendar (née Cron) — premium personal feel
+
+**No, not this:**
+- Linear / Vercel — B2B coolness, wrong audience temperature
+- Stripe Dashboard — enterprise density, wrong emotional register
+- Are.na / Letterboxd — too curatorial, romanticizes objects too much for warranty receipts
+- Notion universal — too blandly flexible
+- Insurance-corporate (Lemonade etc.) — too friendly-startup-cute
+
+## Anti-patterns
+
+- Treating inventory entries as "data records" (they are *things you own*)
+- Dashboard-as-metrics-grid (this is a personal tool, not an admin)
+- Stock empty states ("No items found.") — these are first-impression moments
+- Cute mascots, illustrated characters, emoji peppered into copy
+- Density-maximalist tables (Excel is not the aspiration)
+

--- a/devdocs/frontend/design/01-palette.md
+++ b/devdocs/frontend/design/01-palette.md
@@ -1,0 +1,180 @@
+# Palette — final
+
+The palette is **committed**. Three earlier directions (Cozy Domestic / Quiet Practical / Modern Catalog) were considered; the final choice is anchored to the existing brand mark (warm cream + deep navy) and adds one warm earth-toned accent. This produces a three-anchor palette: **cream surface, navy ink, terracotta accent.**
+
+Why this combination:
+- The existing logo already establishes cream + navy as the brand baseline. The palette must harmonize with it, not overwrite it.
+- Cool ink (navy) on warm surface (cream) is a refined, considered combination — used by Aesop, Kinfolk, Are.na, classic editorial design. It reads as "considered" without trying.
+- A warm earth-toned accent (terracotta) closes the triangle: warm + cool + warm. This is classical palette construction. Works for warranty receipts (practical) and for collectors (refined) alike.
+- It is unambiguously **not** corporate-tech (no neon, no purple gradients, no SaaS-bro blue) and unambiguously **not** insurance-corporate (no "Lemonade pink" friendliness).
+
+## Light mode tokens
+
+```css
+@theme {
+  /* Surfaces */
+  --surface-base:    #FAF6EC;   /* warm cream — matches logo background */
+  --surface-raised:  #FFFFFF;   /* pure white for elevated cards/dialogs */
+  --surface-sunken:  #F1EBDB;   /* deeper cream for hovers, table stripes, sunken areas */
+  --surface-overlay: rgb(26 34 56 / 0.55);  /* navy-tinted scrim for modal overlays */
+
+  /* Ink */
+  --ink-primary:   #1A2238;   /* deep navy — matches logo wordmark */
+  --ink-secondary: #4A5570;
+  --ink-muted:     #8189A0;
+  --ink-disabled:  #C5C9D2;
+
+  /* Borders */
+  --border-subtle:  #EAE2D0;
+  --border-default: #D4C8AC;
+  --border-strong:  #998B6F;
+
+  /* Brand accent — terracotta (warm earth red) */
+  --accent:           #B8451F;   /* primary — CTAs, links, brand emphasis */
+  --accent-hover:     #92341A;
+  --accent-soft:      #FBE6D8;   /* tinted bg for accent areas (callouts, selected states) */
+  --accent-foreground:#FAF6EC;   /* cream-on-accent for buttons */
+
+  /* Semantic */
+  --success:        #2F7D5C;
+  --success-soft:   #D9EBE2;
+  --warning:        #A37700;   /* golden amber — distinct from terracotta accent */
+  --warning-soft:   #F5EBC8;
+  --destructive:    #B12A1F;   /* true red — for genuine danger */
+  --destructive-soft:#F8DDD8;
+  --info:           #1F5D8C;   /* navy-family blue — harmonizes with ink-primary */
+  --info-soft:      #DCE7F1;
+}
+```
+
+## Dark mode tokens
+
+The dark inversion swaps cream and navy: navy-tinged dark surfaces, warm cream foreground.
+
+```css
+:root[data-theme="dark"] {
+  /* Surfaces */
+  --surface-base:    #14191F;   /* deep navy-tinged dark, NOT pure black */
+  --surface-raised:  #1C2230;
+  --surface-sunken:  #0E1218;
+  --surface-overlay: rgb(0 0 0 / 0.7);
+
+  /* Ink */
+  --ink-primary:   #F1ECE0;   /* warm cream — matches the light surface */
+  --ink-secondary: #B8B0A2;
+  --ink-muted:     #7C7468;
+  --ink-disabled:  #44403A;
+
+  /* Borders */
+  --border-subtle:  #1E232D;
+  --border-default: #2C313D;
+  --border-strong:  #4A4F5A;
+
+  /* Accent — lighter terracotta for readability on dark bg */
+  --accent:           #E07F4F;
+  --accent-hover:     #F19770;
+  --accent-soft:      #382318;
+  --accent-foreground:#14191F;
+
+  /* Semantic — lifted for dark bg */
+  --success:        #6FBF96;
+  --success-soft:   #1A2F25;
+  --warning:        #DEA757;
+  --warning-soft:   #2D2618;
+  --destructive:    #EE7A6B;
+  --destructive-soft:#2E1816;
+  --info:           #7AB7E8;
+  --info-soft:      #1A2230;
+}
+```
+
+## Chart palette
+
+For data viz (per `07-data-visualization.md`). Five categorical colors derived from the brand palette + complementary range:
+
+```css
+/* Light mode */
+--chart-1: var(--accent);        /* #B8451F — terracotta */
+--chart-2: #1F5D8C;              /* navy-family blue */
+--chart-3: #6F8B5D;              /* sage green */
+--chart-4: #B59169;              /* warm tan */
+--chart-5: #6B5878;              /* dusty mauve */
+
+--chart-emphasis: var(--ink-primary);
+--chart-grid:     var(--border-subtle);
+--chart-axis:     var(--ink-muted);
+
+/* Dark mode lifts */
+:root[data-theme="dark"] {
+  --chart-1: #E07F4F;
+  --chart-2: #7AB7E8;
+  --chart-3: #9CB68D;
+  --chart-4: #D4B596;
+  --chart-5: #978AA0;
+}
+```
+
+## Contrast verification
+
+All token pairs meet WCAG 2.2 AA at minimum. Critical pairs:
+
+| Foreground | Background | Ratio (light) | Ratio (dark) | Result |
+| --- | --- | --- | --- | --- |
+| `--ink-primary` | `--surface-base` | 13.8:1 | 14.1:1 | AAA |
+| `--ink-primary` | `--surface-raised` | 16.4:1 | 12.6:1 | AAA |
+| `--ink-secondary` | `--surface-base` | 7.2:1 | 6.8:1 | AAA |
+| `--ink-muted` | `--surface-base` | 4.6:1 | 4.7:1 | AA |
+| `--accent-foreground` | `--accent` | 7.8:1 | 8.1:1 | AAA |
+| `--ink-primary` | `--accent-soft` | 12.1:1 | 11.8:1 | AAA |
+| `--success` text | `--success-soft` bg | 4.6:1 | — | AA |
+| `--destructive` text | `--destructive-soft` bg | 5.1:1 | — | AA |
+
+Validation in CI per `14-accessibility.md`.
+
+## Where each color belongs
+
+| Token | Used on |
+| --- | --- |
+| `--surface-base` | Page bg, sidebar (subtle differentiation from raised), most surfaces |
+| `--surface-raised` | Cards, modals, popovers, dropdown panels |
+| `--surface-sunken` | Hover states for list rows, alternating table stripes, sunken inputs |
+| `--ink-primary` | Body text, headings, primary controls |
+| `--ink-secondary` | Subheads, metadata, descriptions |
+| `--ink-muted` | Helper text, captions, timestamps |
+| `--ink-disabled` | Disabled controls only |
+| `--accent` | Primary CTAs, active sidebar item, links inline in body, focus ring, brand emphasis |
+| `--accent-hover` | Hover state on accent surfaces |
+| `--accent-soft` | Selected list item bg, callout bgs, tag/chip bg |
+| `--success` / `--warning` / `--destructive` / `--info` | Status pills, semantic alerts, only for those meanings |
+| `--border-subtle` | Most borders, dividers |
+| `--border-default` | Inputs, buttons (secondary variant) |
+| `--border-strong` | Filled-state input borders, focused secondary buttons |
+
+## Usage discipline
+
+1. **One accent.** Terracotta is the only warm-red in the UI. Don't add coral, salmon, or rust as separate "decorative" colors.
+2. **Status colors are not brand colors.** A success pill is green because the meaning requires it, not because green is a brand color. Don't sprinkle green outside semantic-success.
+3. **No new tokens without designer review.** If a developer reaches for a hex value not in this list, that's a flag — review whether the design needs a new token or whether they should use an existing one.
+4. **Charts use chart palette only.** Don't pull arbitrary brand or semantic colors into data viz.
+5. **Black is forbidden.** `#000000` doesn't appear in the palette. The deepest ink is `--ink-primary` (light mode) or `--surface-sunken` (dark mode). Pure black against warm cream looks harsh.
+6. **White is reserved.** `#FFFFFF` is `--surface-raised` only. Body bg is cream, not white.
+
+## Implementation in Tailwind v4
+
+Tokens land in the global `@theme` block. Components reference them via CSS variables, not arbitrary Tailwind colors. Existing Tailwind utility classes for arbitrary colors (`bg-blue-500`, `text-slate-900`, etc.) are migrated to semantic equivalents (`bg-accent`, `text-ink-primary`).
+
+```css
+@theme {
+  --color-surface-base: #FAF6EC;
+  --color-ink-primary: #1A2238;
+  /* ... */
+}
+```
+
+This generates `bg-surface-base`, `text-ink-primary`, etc. as Tailwind utilities.
+
+## Out of scope for this palette
+
+- Holiday / seasonal palettes
+- Marketing-site special palettes (the marketing site, when built, uses this same palette)
+- User-customizable accent colors (a "theme picker" is over-engineering for v1; revisit later)

--- a/devdocs/frontend/design/02-typography.md
+++ b/devdocs/frontend/design/02-typography.md
@@ -142,14 +142,14 @@ Decimals always shown for currency, even on whole numbers (`100.00 CZK`, not `10
 
 ## Quotation marks and punctuation
 
-Use **typographic** marks, not ASCII:
+Use **typographic** marks, not ASCII straight equivalents:
 
-- `'` not `'` for apostrophes
-- `"…"` not `"…"` for English quotes
-- `«…»` for Russian quotes (locale-aware)
-- `—` (em dash) not `--` for thought breaks
-- `–` (en dash) for ranges (`Apr–May`)
-- `…` (ellipsis) not `...`
+- `’` (U+2019) not `'` (U+0027) for apostrophes
+- `“…”` (U+201C / U+201D) not `"…"` (U+0022) for English quotes
+- `«…»` (U+00AB / U+00BB) for Russian quotes (locale-aware)
+- `—` (em dash, U+2014) not `--` for thought breaks
+- `–` (en dash, U+2013) for ranges (`Apr–May`)
+- `…` (ellipsis, U+2026) not three full stops `...`
 
 Implement via a simple sanitizer at render time for user-entered text in display contexts, and never type ASCII versions in microcopy.
 

--- a/devdocs/frontend/design/02-typography.md
+++ b/devdocs/frontend/design/02-typography.md
@@ -1,0 +1,201 @@
+# Typography
+
+Inventario's typography carries 70% of the modernity. Get the scale, weights, and pairings right and the product reads as considered even before color choice lands.
+
+## Pairing recommendation
+
+### Primary: Switzer (display) + Inter (body)
+
+**Why:** Switzer is a free, geometric-humanist sans by Indian Type Foundry with warm character and seven weights. Pairs cleanly with Inter for body — both are open-source, both have wide language coverage including Cyrillic, both ship as variable fonts. Total bundle weight ~80KB woff2 with subsetting. Free for commercial use.
+
+```
+Display: Switzer (variable, weights 100–900)
+Body:    Inter (variable, weights 100–900)
+Mono:    JetBrains Mono (only for IDs, keys, code-ish content)
+```
+
+### Alternate A: GT Walsheim (display) + Söhne (body) — **paid, premium**
+
+If you want a more distinctive personality and have a budget for Klim/Grilli Type licenses (~€600–1500 one-time for self-hosted). GT Walsheim brings warmth without sweetness; Söhne is the modern grotesk standard (Stripe, Vercel, OpenAI). The product would feel two notches more premium.
+
+### Alternate B: Inter only — **safe fallback**
+
+If you don't want a separate display face, use Inter for everything with weight + size + tracking variation carrying hierarchy. This is what many shadcn-vue products do. Looks fine, lacks personality. Suitable if Direction B (Quiet Practical) palette is chosen and the goal is "tool-like" not "product-with-character."
+
+## Type scale
+
+A 10-step scale, not a Tailwind default. Mathematical base 1.125 (minor third) on body; display steps drift to 1.2 (minor third upper) for visual punch.
+
+```css
+@theme {
+  /* Display — only for marketing/empty-state heroes, almost never in-product chrome */
+  --text-display-2xl: 4rem;        /* 64px */
+  --text-display-xl:  3rem;        /* 48px */
+  --text-display-lg:  2.25rem;     /* 36px */
+
+  /* Headings — page titles, section headers */
+  --text-heading-xl:  1.875rem;    /* 30px — page title */
+  --text-heading-lg:  1.5rem;      /* 24px — major section */
+  --text-heading-md:  1.25rem;     /* 20px — sub-section */
+  --text-heading-sm:  1.0625rem;   /* 17px — group label */
+
+  /* Body */
+  --text-body-lg:     1.0625rem;   /* 17px — long-form content, hero subhead */
+  --text-body:        0.9375rem;   /* 15px — default UI body */
+  --text-body-sm:     0.8125rem;   /* 13px — secondary, hints, captions */
+  --text-body-xs:     0.75rem;     /* 12px — only for badges, metadata, labels */
+
+  /* Mono */
+  --text-mono:        0.875rem;    /* 14px — IDs, file paths */
+}
+```
+
+## Line-height (leading) tokens
+
+Display gets tight leading; body needs loose-ish leading for inventory text (often long product names).
+
+```css
+--leading-display: 1.05;   /* display sizes */
+--leading-tight:   1.2;    /* headings */
+--leading-snug:    1.4;    /* short labels */
+--leading-normal:  1.55;   /* body default */
+--leading-relaxed: 1.7;    /* body-lg long-form */
+```
+
+## Tracking (letter-spacing) tokens
+
+Display tightens; body stays neutral; small uppercase labels widen.
+
+```css
+--tracking-display:    -0.04em;    /* display */
+--tracking-heading-xl: -0.025em;
+--tracking-heading-lg: -0.018em;
+--tracking-heading-md: -0.012em;
+--tracking-heading-sm: -0.005em;
+--tracking-body:        0;
+--tracking-body-sm:     0.005em;
+--tracking-uppercase:   0.06em;    /* used on small caps labels, status pills */
+```
+
+## Weight tokens
+
+Switzer weights map clearly:
+
+```css
+--font-weight-light:    300;
+--font-weight-regular:  400;
+--font-weight-medium:   500;
+--font-weight-semibold: 600;
+--font-weight-bold:     700;
+```
+
+**Weight rules:**
+- Body text: `regular` (400). Never lighter for content.
+- Body emphasis: `medium` (500), not bold.
+- Headings (heading-md and below): `semibold` (600).
+- Headings (heading-lg and above): `medium` (500) with tight tracking — modern editorial feel.
+- Display: `medium` (500), never bold. Big text + bold = dated/heavy.
+- Mono: `regular` (400).
+
+## Hierarchy rules
+
+A page should have **at most**:
+- 1 page title (`heading-xl`)
+- 3–5 section headers (`heading-lg` or `heading-md`)
+- Group labels (`heading-sm` or `body-xs uppercase tracking-uppercase`) as needed
+- Body content (`body`)
+
+If you find yourself reaching for `display-*` inside the product, you're decorating an admin page — stop. Display is for empty states, onboarding, and marketing surfaces only.
+
+## Vertical rhythm
+
+Spacing between text elements follows the spacing scale (`03-space-and-layout.md`), but the defaults below produce the right rhythm for most contexts:
+
+| Pair | Default gap |
+| --- | --- |
+| Heading-xl → body | `space-6` (1.5rem) |
+| Heading-lg → body | `space-4` (1rem) |
+| Heading-md → body | `space-3` (0.75rem) |
+| Heading-sm → body | `space-2` (0.5rem) |
+| Body paragraph → body paragraph | `space-3` (0.75rem) |
+| Body → caption | `space-1` (0.25rem) |
+
+## Numerals
+
+Inventario displays many prices, counts, and dates. Use **tabular numerals** for any column-aligned numerics:
+
+```css
+font-variant-numeric: tabular-nums;
+```
+
+Apply via utility class `.tabular` to all `<td>` content, all stat values on dashboard, all "X.XX CZK" displays. Without tabular-nums, prices in lists jitter as users scan. This single rule makes the product feel ten degrees more polished.
+
+## Numerals — currency formatting
+
+Currency values use a non-breaking space between number and code:
+
+```
+17 500.00 CZK    not   17500.00CZK or 17,500.00 CZK
+```
+
+Decimals always shown for currency, even on whole numbers (`100.00 CZK`, not `100 CZK`). Reasoning: insurance valuations need precision affordance.
+
+## Quotation marks and punctuation
+
+Use **typographic** marks, not ASCII:
+
+- `'` not `'` for apostrophes
+- `"…"` not `"…"` for English quotes
+- `«…»` for Russian quotes (locale-aware)
+- `—` (em dash) not `--` for thought breaks
+- `–` (en dash) for ranges (`Apr–May`)
+- `…` (ellipsis) not `...`
+
+Implement via a simple sanitizer at render time for user-entered text in display contexts, and never type ASCII versions in microcopy.
+
+## Code/ID display
+
+File IDs, UUIDs, paths use mono. Truncate UUIDs to first 8 + last 4 with middle ellipsis:
+
+```
+3fd5fc3e-8e69…b67d
+```
+
+Full UUID available on hover via tooltip and copy via icon button.
+
+## Multiline text limits
+
+To prevent jagged edges and runaway lines, set `max-width` ceilings via CSS variable:
+
+```css
+--text-measure-prose:  65ch;   /* paragraphs, descriptions */
+--text-measure-form:   42ch;   /* form fields, labels */
+--text-measure-card:   28ch;   /* card titles, list items */
+```
+
+Page content widths in `03-space-and-layout.md` align with these.
+
+## Localization headroom
+
+Russian copy is ~30% longer than English, German is ~20% longer. **Never set fixed widths on text containers** in components that may render translated copy. Test type scale at 130% character density before locking values.
+
+## Accessibility minimums
+
+- No body text below `body-sm` (13px / 0.8125rem). `body-xs` is for badges/metadata only.
+- Line-height never below 1.5 for body text.
+- Contrast ratios per `14-accessibility.md` apply per palette.
+- Never rely on weight alone for emphasis — pair with color shift or marker.
+
+## What gets implemented in sprint 0
+
+1. Tailwind v4 `@theme` block with all `--text-*`, `--leading-*`, `--tracking-*`, `--font-weight-*` tokens above
+2. `font-family` setup for Switzer + Inter (or alternate based on your choice) — self-hosted woff2, preloaded
+3. Apply `font-variant-numeric: tabular-nums` to global stat/number contexts
+4. Replace **all** `text-*` Tailwind utilities in current code with semantic tokens (audit pass)
+5. Document the type scale in Storybook/Histoire if/when it lands
+
+## Decision needed
+
+- Switzer + Inter (free, recommended), or
+- GT Walsheim + Söhne (paid, premium), or
+- Inter-only (safe fallback)

--- a/devdocs/frontend/design/03-space-and-layout.md
+++ b/devdocs/frontend/design/03-space-and-layout.md
@@ -1,0 +1,216 @@
+# Space & Layout
+
+The single biggest delta between "wireframe" and "designed product" is spacing discipline. This document specifies every value.
+
+## Base unit
+
+```
+1 base unit = 0.25rem = 4px
+```
+
+All spacing, sizing, and radii are integer multiples of the base unit. No magic numbers in CSS — if you find yourself typing `padding: 13px`, you're wrong.
+
+## Spacing scale
+
+A 13-step scale covering everything from icon padding to page-section gaps. T-shirt sizes for memorability, with explicit pixel values.
+
+```css
+@theme {
+  --space-0:   0;
+  --space-px:  1px;        /* hairlines */
+  --space-0_5: 0.125rem;   /*  2px */
+  --space-1:   0.25rem;    /*  4px */
+  --space-1_5: 0.375rem;   /*  6px */
+  --space-2:   0.5rem;     /*  8px */
+  --space-3:   0.75rem;    /* 12px */
+  --space-4:   1rem;       /* 16px */
+  --space-5:   1.25rem;    /* 20px */
+  --space-6:   1.5rem;     /* 24px */
+  --space-8:   2rem;       /* 32px */
+  --space-10:  2.5rem;     /* 40px */
+  --space-12:  3rem;       /* 48px */
+  --space-16:  4rem;       /* 64px */
+  --space-20:  5rem;       /* 80px */
+  --space-24:  6rem;       /* 96px */
+  --space-32:  8rem;       /* 128px */
+}
+```
+
+## Spacing semantics
+
+To prevent inconsistency, use **semantic spacing tokens** at the component level. Components reference these, never raw values.
+
+```css
+/* Component-internal spacing */
+--gap-component-tight:    var(--space-1);    /* between icon and label inside a button */
+--gap-component-default:  var(--space-2);    /* between adjacent inline elements */
+--gap-component-relaxed:  var(--space-3);    /* between form field and label */
+
+/* Inside-of-card spacing */
+--padding-card-sm:  var(--space-3);   /* compact list item */
+--padding-card:     var(--space-5);   /* standard card content padding */
+--padding-card-lg:  var(--space-8);   /* hero card / dashboard widget */
+
+/* Between-component spacing */
+--gap-stack-tight:    var(--space-2);    /* tightly grouped */
+--gap-stack-default:  var(--space-4);    /* default vertical rhythm */
+--gap-stack-relaxed:  var(--space-6);    /* loose, breathing */
+--gap-stack-section:  var(--space-12);   /* between major page sections */
+
+/* Page-level spacing */
+--padding-page-x:        var(--space-6);    /* desktop ≥1024 */
+--padding-page-x-mobile: var(--space-4);    /* mobile <640 */
+--padding-page-y-top:    var(--space-8);
+--padding-page-y-bottom: var(--space-16);
+```
+
+## Border radius scale
+
+7 steps, geometric progression. **No 4px-everywhere shadcn default** — that flattens the whole product. Different surfaces deserve different roundness.
+
+```css
+@theme {
+  --radius-none: 0;
+  --radius-xs:   0.25rem;   /*  4px — badges, chips, tags */
+  --radius-sm:   0.375rem;  /*  6px — small buttons, inline controls */
+  --radius-md:   0.5rem;    /*  8px — buttons, inputs, list items */
+  --radius-lg:   0.75rem;   /* 12px — cards, panels */
+  --radius-xl:   1rem;      /* 16px — large dialogs, hero surfaces */
+  --radius-2xl:  1.5rem;    /* 24px — only for marketing/empty-state surfaces */
+  --radius-full: 9999px;    /* avatars, status dots, pills */
+}
+```
+
+**Radius semantic mapping:**
+
+| Surface | Radius |
+| --- | --- |
+| Badge, chip, tag | `xs` |
+| Inline icon button | `sm` |
+| Button (default) | `md` |
+| Input, select | `md` |
+| List row, table row hover-bg | `sm` |
+| Card | `lg` |
+| Dialog, popover | `lg` |
+| Toast | `lg` |
+| Modal (file viewer fullscreen) | `xl` |
+| Avatar, status dot | `full` |
+| Pill (status pill, filter pill) | `full` |
+
+**Anti-pattern:** mixing radii within the same composition (a card with `lg` containing a button with `xs`). Stay within one step difference at most.
+
+## Border weights
+
+```css
+--border-width-thin:    1px;    /* default */
+--border-width-medium:  1.5px;  /* slight emphasis (focus rings adjacent borders) */
+--border-width-thick:   2px;    /* selected state, error state */
+```
+
+Avoid 3px+ borders. They look chunky.
+
+## Container widths
+
+Inventario uses a **content-centered layout**, not full-bleed. Max widths scale with viewport but cap to keep line lengths legible.
+
+```css
+--container-narrow: 640px;   /* auth pages, single-form views */
+--container-default: 1120px; /* most list/detail views */
+--container-wide:   1440px;  /* dashboards, file galleries */
+--container-full:    100%;   /* file viewer fullscreen, gallery overlay only */
+```
+
+Side gutters scale:
+
+| Viewport | Side gutter |
+| --- | --- |
+| <640px (mobile) | `space-4` (16px) |
+| 640–1024 (tablet) | `space-6` (24px) |
+| ≥1024 (desktop) | `space-8` (32px) — but content centered within container max-width |
+
+## Breakpoints
+
+```css
+@theme {
+  --breakpoint-sm: 640px;   /* portrait tablet, large phone landscape */
+  --breakpoint-md: 768px;   /* tablet */
+  --breakpoint-lg: 1024px;  /* small desktop, sidebar appears here */
+  --breakpoint-xl: 1280px;  /* desktop */
+  --breakpoint-2xl: 1536px; /* large desktop */
+}
+```
+
+**Layout shifts at breakpoints:**
+
+| <640 (mobile) | 640–1023 (tablet) | ≥1024 (desktop) |
+| --- | --- | --- |
+| Bottom navigation (5 items) | Bottom navigation (5 items) | Sidebar (collapsible) |
+| Single-column lists | 2-col card grids | 3–4 col card grids |
+| Stacked forms | Stacked forms | Two-column forms where natural |
+| Drawer-style filters | Drawer-style filters | Persistent filter rail |
+| Full-screen modals | Centered modals (90vw) | Centered modals (max 720px) |
+
+## Grid system
+
+Inside a container, content uses a **12-column grid** with **24px gutters at desktop**, **16px at tablet**, **none at mobile (single column)**.
+
+CSS-grid based, not flex hacks:
+
+```css
+.layout-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: var(--space-6);
+}
+
+@media (max-width: 768px) {
+  .layout-grid { gap: var(--space-4); grid-template-columns: 1fr; }
+}
+```
+
+**Common compositions:**
+
+| View | Grid usage |
+| --- | --- |
+| Dashboard | 12-col, widgets span 4 / 6 / 8 / 12 |
+| Detail two-pane | Main content `col-span-8`, side panel `col-span-4` |
+| Form layout | Single column up to `--text-measure-form` width, never grid for forms |
+| Card list | Auto-fit minmax(280px, 1fr) — grid auto-fills |
+
+## Touch target minimums
+
+- **Interactive surface:** min 44×44px (iOS HIG / WCAG 2.5.5)
+- **Visible button:** can be smaller (e.g., 32px tall) but the click target via padding extends to 44px
+- **Inline icon buttons in dense tables:** acceptable to be 32×32 on desktop hover, but pair with row-click for primary action
+
+## Density modes
+
+The default density is **comfortable**. Two alternates available via user setting (per `17-density-and-modes.md`):
+
+| Mode | Adjustments vs default |
+| --- | --- |
+| Compact | All `--padding-card-*` -1 step; row heights -25%; gap-stack-default → -tight |
+| Comfortable (default) | Values as specified above |
+| Cozy | All `--padding-card-*` +1 step; gap-stack-default → -relaxed |
+
+Density swap is a single CSS variable change at the root — no per-component JS.
+
+## Layout templates
+
+Six page templates cover ~90% of views. Documented in `11-page-layouts-and-flows.md`:
+
+1. **List view** (locations, commodities, files, exports)
+2. **Detail view** (entity with sections)
+3. **Form view** (create / edit)
+4. **Dashboard** (data widgets)
+5. **Empty/onboarding** (full-screen call-to-action)
+6. **Auth/single-form** (login, register, forgot password)
+
+## Anti-patterns to flag in PR review
+
+- Inline arbitrary spacing values: `style="padding: 11px"` or `class="p-[13px]"`
+- Mixed radii within a single composition
+- Touch targets <44px on mobile
+- Forms wider than `--text-measure-form` (causes scanning fatigue)
+- Page-level content extending edge-to-edge on desktop (use container max-widths)
+- Grid + flex nesting where one would suffice (CSS-grid for 2D layouts, flex for 1D)

--- a/devdocs/frontend/design/04-elevation-and-effects.md
+++ b/devdocs/frontend/design/04-elevation-and-effects.md
@@ -46,7 +46,7 @@ Five steps. Each shadow is a layered stack (1px hairline + soft drop) — never 
 }
 
 /* Dark mode shadows — rely on inner-glow or border, not drop-shadow */
-.dark {
+:root[data-theme="dark"] {
   --shadow-xs:
     inset 0 1px 0 0 rgb(255 255 255 / 0.04);
 

--- a/devdocs/frontend/design/04-elevation-and-effects.md
+++ b/devdocs/frontend/design/04-elevation-and-effects.md
@@ -1,0 +1,212 @@
+# Elevation & Effects
+
+Shadows, opacity, blur, and layering — the depth language of the product.
+
+## Elevation philosophy
+
+Inventario is **mostly flat**. Shadows are used sparingly and intentionally:
+
+- A list of cards on a page: **no shadow at rest**, subtle shadow on hover only
+- A floating element (popover, dropdown, toast): clear shadow
+- A dialog/modal: strong shadow + overlay
+- Inline pills, badges, tags: never shadowed
+
+If everything has a shadow, nothing does. Aim for ~3 elevation levels visible on a typical screen, never more.
+
+## Shadow scale
+
+Five steps. Each shadow is a layered stack (1px hairline + soft drop) — never a single blob, that looks 2010.
+
+```css
+@theme {
+  /* Light mode shadows */
+  --shadow-xs:
+    0 1px 0 0 rgb(0 0 0 / 0.04),
+    0 1px 2px 0 rgb(0 0 0 / 0.04);
+
+  --shadow-sm:
+    0 1px 0 0 rgb(0 0 0 / 0.04),
+    0 2px 4px -1px rgb(0 0 0 / 0.06),
+    0 1px 2px 0 rgb(0 0 0 / 0.04);
+
+  --shadow-md:
+    0 1px 0 0 rgb(0 0 0 / 0.04),
+    0 4px 8px -2px rgb(0 0 0 / 0.08),
+    0 2px 4px -2px rgb(0 0 0 / 0.06);
+
+  --shadow-lg:
+    0 2px 0 0 rgb(0 0 0 / 0.04),
+    0 12px 24px -6px rgb(0 0 0 / 0.12),
+    0 4px 8px -4px rgb(0 0 0 / 0.08);
+
+  --shadow-xl:
+    0 4px 0 0 rgb(0 0 0 / 0.04),
+    0 24px 48px -12px rgb(0 0 0 / 0.18),
+    0 8px 16px -8px rgb(0 0 0 / 0.1);
+}
+
+/* Dark mode shadows — rely on inner-glow or border, not drop-shadow */
+.dark {
+  --shadow-xs:
+    inset 0 1px 0 0 rgb(255 255 255 / 0.04);
+
+  --shadow-sm:
+    inset 0 1px 0 0 rgb(255 255 255 / 0.04),
+    0 2px 4px 0 rgb(0 0 0 / 0.4);
+
+  --shadow-md:
+    inset 0 1px 0 0 rgb(255 255 255 / 0.05),
+    0 4px 12px 0 rgb(0 0 0 / 0.5);
+
+  --shadow-lg:
+    inset 0 1px 0 0 rgb(255 255 255 / 0.06),
+    0 12px 32px 0 rgb(0 0 0 / 0.6);
+
+  --shadow-xl:
+    inset 0 1px 0 0 rgb(255 255 255 / 0.08),
+    0 24px 64px 0 rgb(0 0 0 / 0.7);
+}
+```
+
+## Shadow semantic mapping
+
+| Element | At rest | Hover/active |
+| --- | --- | --- |
+| Card in list | none | `xs` |
+| Card on dashboard | `xs` | `sm` |
+| Button (default variant) | none | none |
+| Button (raised variant, used for primary CTA) | `xs` | `sm` |
+| Dropdown, popover, tooltip | `md` | — |
+| Toast | `lg` | — |
+| Dialog | `xl` + overlay | — |
+| Floating action button (rare) | `lg` | `xl` |
+
+**Avoid:** shadow on inputs, on table rows, on accordion panels at rest, on full-bleed page sections.
+
+## Overlay (scrim) tokens
+
+For modals, mobile drawers, lightbox.
+
+```css
+--overlay-scrim:        rgb(20 16 12 / 0.55);   /* tinted with palette warmth */
+--overlay-scrim-strong: rgb(20 16 12 / 0.75);   /* file viewer, photo lightbox */
+--overlay-scrim-light:  rgb(20 16 12 / 0.32);   /* mobile drawer */
+
+.dark {
+  --overlay-scrim:        rgb(0 0 0 / 0.7);
+  --overlay-scrim-strong: rgb(0 0 0 / 0.85);
+  --overlay-scrim-light:  rgb(0 0 0 / 0.5);
+}
+```
+
+The scrim color is **tinted** with palette warmth (per Direction A: rgb(28 23 17), per B: rgb(15 18 23), per C: rgb(20 30 28)) — a true black scrim looks harsh against warm interiors.
+
+## Blur (backdrop-filter)
+
+Used sparingly. Apply to:
+
+- File viewer overlay (when image is showing): scrim 0.55 + `backdrop-filter: blur(8px)` for a focus-pulling effect
+- Sticky table headers when scrolled: subtle blur for read-through
+- Mobile pull-to-refresh state
+
+```css
+--blur-sm: 4px;    /* sticky headers */
+--blur-md: 8px;    /* lightbox */
+--blur-lg: 16px;   /* deep focus overlays */
+```
+
+**Performance gate:** never apply backdrop-filter to elements that animate position. Use a separate non-animated layer.
+
+## Opacity scale
+
+Discrete steps — avoid arbitrary `opacity-43`.
+
+```css
+--opacity-disabled: 0.4;
+--opacity-muted:    0.6;   /* secondary state UI */
+--opacity-faded:    0.8;   /* nearly-fully-opaque, used for hover-out */
+--opacity-full:     1;
+```
+
+For **disabled** elements, prefer color shifts (`--ink-disabled`, `--surface-sunken`) over opacity reduction. Opacity-only disabled states are hard to read against busy backgrounds.
+
+## Border-as-elevation
+
+In dark mode, prefer a subtle inset highlight + 1px border over drop shadow for raised surfaces:
+
+```css
+.card {
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-xs);  /* inset hairline in dark mode */
+  border-radius: var(--radius-lg);
+}
+```
+
+This pattern (border + inset hairline) is what gives Linear, Vercel, Things 3, etc. their "considered" feel in dark mode. Drop shadows in dark mode read as muddy.
+
+## Focus ring
+
+Focus rings are an elevation/effect concern, not a color one alone. Specified here:
+
+```css
+--focus-ring: 0 0 0 2px var(--surface-base), 0 0 0 4px var(--accent);
+```
+
+Two-step ring: a 2px halo of the surface color, then 2px of accent. Result: ring "floats" with a thin moat between element and ring — modern and accessible. **Default browser outline disabled globally**, replaced with this token.
+
+**Focus rule:** every focusable element gets the focus ring. No `outline: none` without a replacement. Audit every PR.
+
+## Selection highlight
+
+Custom `::selection` rule using palette accent at low opacity:
+
+```css
+::selection {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  color: var(--ink-primary);
+}
+```
+
+A small detail that signals product care.
+
+## Glass / frost
+
+Inventario does **not** use glass/frost surfaces in v1. They date quickly (peak 2020) and often fail accessibility contrast. Reserved for a future moment if compelling.
+
+## Gradient usage
+
+Inventario does **not** use decorative gradients in v1. The palette is rich enough flat. Gradient is permitted in exactly two places:
+
+1. **Page background subtle wash** — single linear gradient from `--surface-base` to `--surface-sunken` at 0.5% per 100vh, almost invisible. Optional.
+2. **Charts** — area-chart fill gradients from accent to transparent. Documented in `07-data-visualization.md`.
+
+No CTA gradients. No "vibrant hero" gradients. No mesh gradients.
+
+## Noise / grain
+
+Optional, single-direction call: a 0.4% noise overlay applied via SVG-encoded data-URL on the body background can add tactility to the warm-domestic palette (Direction A specifically). If used, it's a constant — not animated, not toggled.
+
+```css
+body::before {
+  content: "";
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background-image: url("data:image/svg+xml,..."); /* tiny noise SVG */
+  opacity: 0.04;
+  mix-blend-mode: overlay;
+}
+```
+
+**Verdict:** include only if Direction A is chosen, and ship it from day 1 — adding noise later feels gimmicky. Skip for B and C.
+
+## Cursor language
+
+Default `cursor: default`. Override:
+
+- `cursor: pointer` on every interactive element (button, link, card with @click handler)
+- `cursor: text` on text inputs and content-editable
+- `cursor: grab` / `grabbing` on draggable thumbnails (file gallery reorder)
+- `cursor: zoom-in` on file gallery thumbnails (hint of lightbox)
+- `cursor: crosshair` on draw/measure tools (none currently)
+
+Audit pass: any `<button>`, `<a>`, or element with `@click` must have `cursor: pointer` or its replacement.

--- a/devdocs/frontend/design/05-motion.md
+++ b/devdocs/frontend/design/05-motion.md
@@ -1,0 +1,182 @@
+# Motion
+
+Motion communicates causality, hierarchy, and attention. Inventario's motion language is **brisk and confident** — quick enough to feel responsive, slow enough to be perceived. No bouncy, no playful — that would conflict with the calm tone.
+
+## Duration tokens
+
+Five steps. Tight upper bound: nothing over 400ms in the product (hero/onboarding excluded).
+
+```css
+@theme {
+  --duration-instant: 0ms;     /* state changes that should feel mechanical (radio click) */
+  --duration-fast:    120ms;   /* hover, focus, color shifts, micro */
+  --duration-base:    180ms;   /* default — most transitions */
+  --duration-slow:    260ms;   /* dialog enter, drawer slide, page transition */
+  --duration-slower:  400ms;   /* hero animations, onboarding moments */
+}
+```
+
+**Rule of thumb:**
+- < 100ms: feels instant; users don't notice — use for color/opacity micro-shifts
+- 100–250ms: feels responsive; perceived but not waited-for — most UI motion
+- 250–400ms: feels deliberate; user notices the motion — modals, drawers, choreographed sequences
+- > 400ms: feels slow, in-product; reserved for delight moments only
+
+## Easing curves
+
+```css
+@theme {
+  /* Default — natural deceleration */
+  --ease-default:  cubic-bezier(0.2, 0, 0, 1);
+
+  /* Enter — element appearing */
+  --ease-enter:    cubic-bezier(0, 0, 0.2, 1);
+
+  /* Exit — element leaving */
+  --ease-exit:     cubic-bezier(0.4, 0, 1, 1);
+
+  /* Snappy — for state toggles (checkbox, switch) */
+  --ease-snap:     cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Spring-like — for delight moments (toast appearance, success confirmations) */
+  --ease-spring:   cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+```
+
+**Easing rule of thumb:**
+- Linear is forbidden except for indeterminate progress bars
+- Spring/overshoot only on delight moments (3-5 places in the whole app), never on routine UI
+- Defaults to `--ease-default` if you're unsure
+
+## Motion language by component
+
+| Component | Property | Duration | Easing |
+| --- | --- | --- | --- |
+| Button hover | `bg`, `color`, `box-shadow` | `fast` | `default` |
+| Button press | `transform: scale(0.98)` | `fast` | `snap` |
+| Card hover-elevate | `box-shadow`, `transform: translateY(-1px)` | `fast` | `default` |
+| Input focus | `border-color`, `box-shadow` (focus ring) | `fast` | `default` |
+| Tooltip enter | `opacity`, `transform: translateY(4px → 0)` | `fast` | `enter` |
+| Tooltip exit | reverse | `fast` | `exit` |
+| Toast enter | `opacity`, `transform: translateY(8px → 0) scale(0.98 → 1)` | `slow` | `spring` |
+| Toast exit | `opacity`, `transform: translateY(0 → -4px)` | `base` | `exit` |
+| Dialog enter | overlay `opacity`, content `opacity` + `scale(0.98 → 1)` | `slow` | `enter` |
+| Dialog exit | reverse | `base` | `exit` |
+| Drawer slide (mobile) | `transform: translateX(-100% → 0)` | `slow` | `enter` |
+| Page transition (route change) | `opacity 0 → 1` only | `base` | `default` |
+| List item enter (after creation) | `opacity 0 → 1`, `height 0 → auto` | `base` | `default` |
+| List item exit (deletion) | `opacity 1 → 0`, `height auto → 0` | `base` | `exit` |
+| Skeleton shimmer | `background-position` linear loop | 1500ms | linear |
+| Theme toggle | `background-color`, `color` (root) | `slow` | `default` |
+| Tab switch | `transform: translateY(2px)` underline + content `opacity` | `fast` | `snap` |
+| Accordion open | `height 0 → auto` | `base` | `default` |
+| Switch/checkbox | `transform`, `bg` | `fast` | `snap` |
+
+## Stagger patterns
+
+When a list of cards or items enters the screen (after data loads), stagger their entry by **30–50ms** between items, capped at the first 6 items. Items 7+ appear immediately. Without a cap, the last items in long lists arrive jarringly late.
+
+```css
+.stagger-enter > *:nth-child(1) { animation-delay: 0ms; }
+.stagger-enter > *:nth-child(2) { animation-delay: 40ms; }
+.stagger-enter > *:nth-child(3) { animation-delay: 80ms; }
+.stagger-enter > *:nth-child(4) { animation-delay: 120ms; }
+.stagger-enter > *:nth-child(5) { animation-delay: 160ms; }
+.stagger-enter > *:nth-child(6) { animation-delay: 200ms; }
+.stagger-enter > *:nth-child(n+7) { animation-delay: 240ms; }
+```
+
+## Perceptual loading thresholds
+
+Tied to motion budget:
+
+| Operation duration | UI behavior |
+| --- | --- |
+| < 100ms | No loading state; show result directly |
+| 100–500ms | Skeleton or subtle pulse on the affected area |
+| 500ms–3s | Skeleton + after 800ms a small spinner |
+| 3–10s | Progress indicator (bar or count) |
+| > 10s | Progress indicator + "Still working…" copy after 5s; cancel option |
+
+**Optimistic UI:** for low-risk mutations (toggle a checkbox, mark item as draft), update UI instantly, reconcile on response. For high-risk mutations (delete, bulk delete, change status), show inline pending state with rollback on error.
+
+## Reduced-motion strategy
+
+Respect `prefers-reduced-motion: reduce` system-wide. Replace motion with instant transitions (or fades only):
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  /* Allow opacity transitions only — they're the only safe motion */
+  .motion-safe-opacity {
+    transition: opacity var(--duration-fast) var(--ease-default);
+  }
+}
+```
+
+**Reduced-motion testing:** every motion-pattern PR ships with a reduced-motion screenshot pair. If the static state is broken (e.g., element invisible without animation finishing), fix that.
+
+## Motion budget
+
+Per page:
+
+- **Routine views** (list, detail, form): max 3 simultaneous motion patterns
+- **Onboarding / first-load** views: up to 6 (welcome to a personality moment)
+- **Background animations:** strictly forbidden (no bouncing logos, no continuous spinners on idle pages)
+
+If you find yourself adding a fourth concurrent animation to a regular page, cut one.
+
+## Delight moments
+
+Three places where motion goes a step beyond utility (using `--ease-spring`):
+
+1. **First successful inventory entry** (onboarding completion): subtle confetti + scale-up of the new card, ~400ms
+2. **Backup/export complete:** toast slides in with spring, success icon scales from 0.6 → 1.1 → 1
+3. **Empty state → first item:** the empty state crossfades + the item drops in from above
+
+Reserved. Do not add more without a designer's eye on the whole app.
+
+## Hover-only motions for keyboard users
+
+Replace `:hover` reliance with `:hover, :focus-visible` so keyboard users get the same affordances. Then the motion design works for both input modes.
+
+## Anti-patterns
+
+- ❌ Spinners that show on every fetch under 200ms (causes flicker)
+- ❌ Bouncy easings on professional-context UI (forms, tables)
+- ❌ Page-load animations on every navigation (annoying after the third time)
+- ❌ Hover effects that move layout (causes click-target jitter — use `transform`, not margin/padding)
+- ❌ Toasts that auto-dismiss faster than read time (min 4s for success, 6s for warning)
+- ❌ Loading skeletons that don't match the eventual content shape (creates layout shift)
+- ❌ Independent animations on each card (use stagger or none)
+- ❌ Sound effects (we are not building a video game)
+
+## Vue Router transitions
+
+Default page transition: `opacity` only, `--duration-base`, `--ease-default`. No slide, no scale.
+
+```vue
+<router-view v-slot="{ Component, route }">
+  <transition
+    name="page"
+    mode="out-in"
+    appear
+  >
+    <component :is="Component" :key="route.path" />
+  </transition>
+</router-view>
+```
+
+```css
+.page-enter-active, .page-leave-active {
+  transition: opacity var(--duration-base) var(--ease-default);
+}
+.page-enter-from, .page-leave-to { opacity: 0; }
+```
+
+Subtle transitions feel modern; sliding pages feel like a 2014 mobile app.

--- a/devdocs/frontend/design/06-iconography-and-illustration.md
+++ b/devdocs/frontend/design/06-iconography-and-illustration.md
@@ -131,17 +131,16 @@ Default: ship with Phosphor file icons. Upgrade later.
 
 The current QR-cube favicon-style logo reads as a placeholder, not a brand. Logo design is in scope of `19-branding.md`. The icon system does **not** include the product logo.
 
-## Decisions made
+## Decisions
 
-- Phosphor migration: **confirmed**
-- Illustration source: **AI-generated via ChatGPT Images 2.0** (prompts in `22-illustration-prompts.md`)
+- Phosphor migration: **proposed** (this brief recommends it; the binding standard remains `devdocs/frontend/icons.md`, which still says lucide). A separate PR can flip the standard once we're ready to schedule the migration.
+- Illustration source: **AI-generated via ChatGPT Images 2.0** — committed (prompts in `22-illustration-prompts.md`).
 
 ## What ships in sprint 0
 
-1. Replace lucide imports with Phosphor (one PR, mechanical)
-2. Define icon size tokens and audit all `<Icon>` usages to use them
-3. Implement `EmptyState` primitive that accepts either an illustration slot or falls back to the Phosphor-in-tinted-circle pattern
-4. Document the icon weight semantic rules in component docs
-5. Generate priority illustrations (login hero, empty-things, 404, backup-completed) per batch workflow in `22`
+1. Define icon size tokens and audit all `<Icon>` usages to use them
+2. Implement `EmptyState` primitive that accepts either an illustration slot or falls back to the lucide-in-tinted-circle pattern (Phosphor variant slots in once the migration PR lands)
+3. Document the icon weight semantic rules in component docs
+4. Generate priority illustrations (login hero, empty-things, 404, backup-completed) per batch workflow in `22`
 
-Sprint 1 backfills the remaining empty-state, onboarding, and edge-case illustrations.
+The Phosphor-replace-lucide PR is sequenced separately from sprint 0 so that flipping the icon library doesn't entangle with token / component work. Sprint 1 backfills the remaining empty-state, onboarding, and edge-case illustrations.

--- a/devdocs/frontend/design/06-iconography-and-illustration.md
+++ b/devdocs/frontend/design/06-iconography-and-illustration.md
@@ -1,0 +1,147 @@
+# Iconography & Illustration
+
+## Icon system: Phosphor
+
+**Recommendation: replace lucide-vue-next with `@phosphor-icons/vue`.**
+
+### Why Phosphor over lucide
+
+- **Six weights:** thin / light / regular / bold / fill / duotone. lucide has one (regular). Multi-weight iconography is what makes Linear, Things, 1Password feel "designed" rather than "generic".
+- **Humanist, slightly warmer character** — fits Inventario's tone. lucide's icons are technically excellent but emotionally flat.
+- **Same coverage** (~1200 icons) and equivalent bundle behavior (tree-shaken, ~250 bytes per icon).
+- **Open source, MIT.**
+
+Migration cost: a single sed pass plus per-icon name mapping. ~half-day with audits.
+
+### Icon weight semantics
+
+| Weight | Use case |
+| --- | --- |
+| `thin` | Decorative — not used in product chrome |
+| `light` | Empty state large icons (size ≥48px) |
+| `regular` | Default — every UI icon |
+| `bold` | Active state, selected state, primary navigation indicator |
+| `fill` | Status indicators (success check, error X, warning triangle), notification dots |
+| `duotone` | Reserved, do not use without designer review |
+
+**Rule:** within one composition, mix at most two weights (e.g., regular + bold for nav active indicator). Three weights in a single screen is visually noisy.
+
+### Icon size scale
+
+```css
+@theme {
+  --size-icon-xs:   12px;   /* dense tables, micro hints */
+  --size-icon-sm:   14px;   /* tag/badge inline */
+  --size-icon-md:   16px;   /* default — buttons, inputs, list items */
+  --size-icon-lg:   20px;   /* navigation, large buttons */
+  --size-icon-xl:   24px;   /* page title accent, prominent action */
+  --size-icon-2xl:  32px;   /* card hero, file-type indicator */
+  --size-icon-3xl:  48px;   /* empty state */
+  --size-icon-4xl:  64px;   /* hero / onboarding */
+}
+```
+
+### Icon stroke behavior
+
+Phosphor icons render as outline strokes; `stroke-width` is not adjustable per-instance (weight controls boldness instead). Set color via `currentColor`:
+
+```vue
+<Phosphor :icon="House" weight="regular" :size="16" />
+<!-- color inherits from text-* class -->
+```
+
+### Icon-text alignment
+
+When pairing an icon with text inline (button, list item):
+
+- Icon size = body line-height × 0.8 (e.g., 14px icon next to 1rem body)
+- Vertical alignment: optical-center, not strict baseline. Tweak per icon if needed.
+- Gap between icon and text: `--space-2` (8px) for body; `--space-1_5` (6px) for body-sm; `--space-3` (12px) for buttons.
+
+### Icon-only buttons
+
+Always paired with `aria-label` and (preferably) `<title>` for tooltip on hover:
+
+```vue
+<Button variant="ghost" size="icon" aria-label="Edit location">
+  <Phosphor :icon="PencilSimple" />
+</Button>
+```
+
+**Do not** rely on visual icon meaning alone for primary actions. Critical actions (delete, archive) get text labels even if redundant.
+
+## Illustration strategy
+
+This is the one area where the brief defers most to your decision because it depends on budget.
+
+### Where illustrations are used in Inventario
+
+Illustrations appear in **finite, intentional places**. Not as decoration scattered throughout.
+
+1. **Login / register** — single hero illustration, sets the tone
+2. **Onboarding** — 3 illustrations across the use-case selection screens (Home / Collection / Property)
+3. **Empty states** — one per major surface (no items, no files, no exports, no search results, no notifications)
+4. **Error pages** — 404, 500, "out of storage", "no internet"
+5. **Backup/export success** — small celebratory illustration
+
+That's ~12–15 illustrations in total. Manageable.
+
+### Sourcing strategy — confirmed
+
+**Strategy: AI-generated via ChatGPT Images 2.0 (`gpt-image-2`).** Concrete prompts and workflow are in `22-illustration-prompts.md`.
+
+Why this is the right answer for the project:
+- ChatGPT Images 2.0's multi-image consistency (up to 8 coherent images per Thinking-mode prompt) gets us a stylistically locked set in 4–5 batches
+- Reference-image input (up to 10 per prompt) lets us anchor every batch to a single style-anchor image — variants can't drift
+- Inpainting allows surgical fixes on individual elements without re-rolling whole compositions
+- Total cost: ~$5–15 for the full 21-illustration set (vs €500–1200 for commissioned)
+- Iteration speed: hours, not weeks
+- Result quality: with proper anchoring + Thinking mode, materially better than DALL-E 3 era — actually production-grade for a personal-tool product
+
+The illustrator-commissioning path (kept here for reference) is a fine fallback if AI-generated outputs don't reach the desired quality bar after iteration. Cost is ~€500–1200 for 8–15 custom illustrations from a designer on Dribbble/Fiverr.
+
+### Stopgap if generation produces no usable assets
+
+Use large Phosphor icons (`light` weight, 64–96px) inside circular tinted backgrounds as illustration placeholders. Honest, restrained, doesn't pretend to be more than it is.
+
+```
+.empty-state-icon {
+  width: 96px; height: 96px; border-radius: var(--radius-full);
+  background: var(--accent-soft);
+  display: grid; place-items: center;
+  color: var(--accent);
+}
+```
+
+This is the "professional minimalism" path. Looks intentional, not unfinished.
+
+### Illustration palette
+
+Whichever source, illustrations must use **only** colors from the chosen palette direction. No green illustrations on a terracotta product. Provide the illustrator with the chosen palette tokens up front.
+
+### File-type icons (special case)
+
+For file representation (PDF / image / video / audio / archive), Phosphor's regular weight `FileText`, `FileImage`, `FilePdf`, etc. are good. For a slightly more characterful version, consider:
+
+- A thin custom set of 8 file-type icons drawn in the same illustration style — ~€100–200 add-on if commissioning illustrations
+
+Default: ship with Phosphor file icons. Upgrade later.
+
+## Logo / brand mark
+
+The current QR-cube favicon-style logo reads as a placeholder, not a brand. Logo design is in scope of `19-branding.md`. The icon system does **not** include the product logo.
+
+## Decisions made
+
+- Phosphor migration: **confirmed**
+- Illustration source: **AI-generated via ChatGPT Images 2.0** (prompts in `22-illustration-prompts.md`)
+
+## What ships in sprint 0
+
+1. Replace lucide imports with Phosphor (one PR, mechanical)
+2. Define icon size tokens and audit all `<Icon>` usages to use them
+3. Implement `EmptyState` primitive that accepts either an illustration slot or falls back to the Phosphor-in-tinted-circle pattern
+4. Document the icon weight semantic rules in component docs
+5. Generate priority illustrations (login hero, empty-things, 404, backup-completed) per batch workflow in `22`
+
+Sprint 1 backfills the remaining empty-state, onboarding, and edge-case illustrations.

--- a/devdocs/frontend/design/07-data-visualization.md
+++ b/devdocs/frontend/design/07-data-visualization.md
@@ -1,0 +1,204 @@
+# Data Visualization
+
+The current dashboard (`02-home`) is four stat cards and two empty containers. That's not a dashboard, that's a placeholder. This document defines what should be there and how it looks.
+
+## What the dashboard should answer
+
+User-facing questions, in priority order:
+
+1. **What's in my home / collection right now?** Total inventory count, value (if known), recent additions. *Identity at a glance.*
+2. **What needs attention?** Warranties expiring soon, items missing prices for insurance, untagged items, low-document items. *Action triggers.*
+3. **What did I do recently?** Activity feed: last 10 events (item added, file uploaded, status changed). *Confidence and memory.*
+4. **What's the shape of my collection?** Category distribution, value-by-area, age distribution. *Reflective patterns.*
+
+Not in scope for the personal dashboard:
+- Performance metrics (uptime, memory) — those belong on `/system` admin page (where they already live)
+- Cohort analytics, conversion funnels — irrelevant for a personal tool
+- Real-time updating numbers — overkill, refresh on visit is fine
+
+## Dashboard layout
+
+12-col grid, with widgets sized as follows on desktop:
+
+```
+┌─────────────────────────────────────────────────┐
+│ Hero: "Welcome back. 93 things, worth 167K."    │  (col-span-12, height: auto)
+└─────────────────────────────────────────────────┘
+┌──────────────────┐ ┌──────────────────┐ ┌──────┐
+│ Needs attention  │ │ Recent activity  │ │ Stats│  (4 + 5 + 3 cols, height: 320px)
+│ (callout list)   │ │ (timeline)       │ │ stack│
+└──────────────────┘ └──────────────────┘ └──────┘
+┌────────────────────────┐ ┌──────────────────────┐
+│ Value over time        │ │ Distribution by area │  (7 + 5 cols, height: 280px)
+│ (area chart)           │ │ (donut/treemap)      │
+└────────────────────────┘ └──────────────────────┘
+┌─────────────────────────────────────────────────┐
+│ Recently added (gallery — last 6 items)         │  (col-span-12, height: auto)
+└─────────────────────────────────────────────────┘
+```
+
+Mobile: every widget collapses to full-width, stacked. Recent activity becomes the second widget (highest engagement on mobile).
+
+## Hero widget
+
+Not "Welcome to Inventario". A live, personalized line:
+
+> **Welcome back, Denis.**
+> 93 things across 4 locations. Roughly 167,000 CZK on the books.
+
+Below it, three thin secondary lines:
+- *3 warranties expire this month.*
+- *5 items still missing a price — your insurance form will thank you.*
+- *Last updated yesterday.*
+
+Tone: respectful, present-tense, gently nudging where useful. No exclamation marks.
+
+## Chart palette
+
+Charts inherit from the chosen color palette but use **specific data-viz tokens** that maintain visual hierarchy across many series.
+
+Direction A example (5 categorical colors + 1 emphasis):
+```css
+--chart-1: var(--accent);            /* terracotta */
+--chart-2: #5B7C99;                  /* desaturated blue, complementary */
+--chart-3: #7A8F60;                  /* muted sage */
+--chart-4: #B59169;                  /* warm tan */
+--chart-5: #8E6B85;                  /* dusty rose */
+--chart-emphasis: var(--ink-primary);
+--chart-grid:    var(--border-subtle);
+--chart-axis:    var(--ink-muted);
+--chart-tooltip: var(--surface-overlay);
+```
+
+Direction B and C get analogous 5-step palettes derived from their accents.
+
+**Order of use:** for series 1–5 in alphabetical/categorical order, use chart-1 → chart-5. For continuous data (single series), use accent only with gradient fill.
+
+Avoid: rainbow palettes, generic d3 schemes (`d3.schemeCategory10`), traffic-light reds/greens unless semantic.
+
+## Chart types per data shape
+
+| Data shape | Chart |
+| --- | --- |
+| Single value over time | **Area chart** with gradient fill, hover tooltip with value+date |
+| Comparison across categories | **Horizontal bar** (vertical bars only for time series), value labels on bars when ≤7 categories |
+| Part-to-whole, ≤6 parts | **Donut** with center summary label |
+| Part-to-whole, 7+ parts | **Treemap** or **stacked bar** — never a many-segment pie |
+| Distribution / variance | **Box plot** or **histogram**, depending on count |
+| Geographic | **Choropleth or pin map** — out of scope for v1, but reserved |
+| Sparkline (in stat cards) | Tiny line chart, no axes, hover only |
+
+## Chart component requirements
+
+Every chart in Inventario must:
+
+- Have a **clear title** above the chart, body-sm weight medium
+- Have a **subtitle** with date range / scope, body-xs weight regular `--ink-muted`
+- Have a **clean axis** — only print labels at meaningful intervals, no jagged tick density
+- Use **tabular-nums** for all axis labels and tooltip values
+- Have a **hover state** with a tooltip showing exact value (currency-formatted)
+- Have an **empty state** ("Not enough data yet — keep adding items and this chart will fill in.")
+- Have a **loading state** as a skeleton with chart-shaped pulse
+- Be **responsive** — recompute layout on resize, no fixed pixel widths
+- Be **keyboard navigable** — tab through data points
+- Have a **screen reader description** summarizing the trend ("Inventory value rose from 45,000 to 167,000 over the past 12 months")
+
+## Recommended library
+
+**Apache ECharts** (`vue-echarts`) for major charts. Reasons:
+- Best-in-class accessibility and keyboard support
+- Highly themeable via tokens
+- Performance scales to 10K+ data points
+- Solid SSR/hydration story (relevant if Inventario adds SSR)
+
+For sparklines (in stat cards): hand-rolled SVG inside a small Vue component. ~30 lines, no library overhead.
+
+Alternative: **Recharts** is React-only. **ApexCharts** is fine but heavier and fights the design tokens. **Chart.js** is lightweight but accessibility is weaker.
+
+## Sparkline style
+
+Compact line chart embedded in stat cards.
+
+```
+Total value
+167,432 CZK    ▁▂▂▃▅▇█
+↑ 12% this month
+```
+
+- 60×24px (or 80×32 in compact mode)
+- Stroke `--accent`, 1.5px
+- No fill (line-only)
+- No axis labels
+- Hover: tooltip with exact values per point
+- For binary/discrete sparklines, switch to small dot-bar chart
+
+## Number formatting in charts
+
+- **Money:** abbreviate above 10K (`12.5K`, `1.2M`) on axis labels; show full on tooltip (`12,532.00 CZK`)
+- **Counts:** raw integer always
+- **Percentages:** one decimal place (`12.4%`)
+- **Dates:** locale-respecting; relative on tooltips when within 7 days (`3 days ago`)
+
+## Trend indicators
+
+Up/down arrows next to delta values. Use semantic colors but **muted** versions to avoid alarm-fatigue:
+
+```css
+.trend-up   { color: var(--success); }
+.trend-down { color: var(--ink-secondary); }   /* not red — "down" isn't always bad */
+.trend-flat { color: var(--ink-muted); }
+```
+
+Use red (`--destructive`) **only** when down is genuinely concerning — e.g., "expired warranties" count going up means red on that specific metric, not on inventory count.
+
+## Activity feed widget
+
+Vertical list, max 10 items, "View all" link to a full activity log page (out of v1 scope; placeholder link is OK).
+
+Each entry:
+```
+[icon]  You added "Camping Equipment" to Home → Bedroom.
+        2 hours ago
+```
+
+- Icon: Phosphor matching action type (Plus, Pencil, Trash, Upload, Download, Tag)
+- Action sentence: present-tense action verb, item name in `font-medium`, location/path in `text-muted`
+- Time: relative ("2 hours ago", "Tuesday at 3pm", "Apr 12") via a single time-formatter
+
+## Distribution widget
+
+Donut for ≤6 categories; treemap (or vertical-stacked bar with labels) for 7+. Click a slice to filter the inventory list to that category.
+
+Donut center label:
+```
+93
+items
+```
+
+In `heading-xl` weight medium, `body-xs uppercase tracking-uppercase` for "items".
+
+## "Recently added" gallery
+
+Horizontal scroller of last 6 items as cards. Each card:
+- Image thumbnail (or file-type icon if no image)
+- Item name (`body` weight medium)
+- Location ("Home → Bedroom") (`body-sm` muted)
+- Time added ("2 days ago")
+
+Click → goes to commodity detail.
+
+## Backend implications
+
+The current backend likely doesn't expose the aggregated endpoints needed. Sprint 1 includes adding:
+
+- `GET /api/v1/dashboard/summary` → hero stats (count, value, location count)
+- `GET /api/v1/dashboard/attention` → list of items needing action (warranty expiring, missing prices, etc.)
+- `GET /api/v1/activity` → paginated activity feed
+- `GET /api/v1/dashboard/value-history` → time-series for area chart
+- `GET /api/v1/dashboard/distribution` → category breakdown
+
+Pre-aggregate via materialized views or dashboard-specific table. Don't compute on every dashboard hit if data grows.
+
+## Decision needed
+
+None on this document — it's all my call. Just confirm the scope when you read it.

--- a/devdocs/frontend/design/08-interaction-states.md
+++ b/devdocs/frontend/design/08-interaction-states.md
@@ -1,0 +1,233 @@
+# Interaction States
+
+Every interactive element must have a defined behavior in **eight states**. Missing any of these is what makes UI feel like a wireframe.
+
+## The eight states
+
+| State | When | Visual signal |
+| --- | --- | --- |
+| **Default** (resting) | At rest, idle | Base styling |
+| **Hover** | Mouse over | Subtle elevation, color shift |
+| **Focus-visible** | Keyboard focus | Focus ring (per `04-elevation-and-effects.md`) |
+| **Active** (pressed) | Mouse down / Enter pressed | Slight inset / scale-down |
+| **Selected** | User has chosen this | Sustained accent treatment |
+| **Disabled** | Cannot interact | Reduced ink, no cursor pointer |
+| **Loading** | Async work in progress | Skeleton, spinner inline, or progress |
+| **Error** | Something failed | Border/text in destructive, message |
+
+## State definitions per primitive
+
+### Button (default variant)
+
+```
+Default:    bg=transparent  border=border-default  ink=ink-primary
+Hover:      bg=surface-sunken               (+shadow-xs if raised variant)
+Focus:      + focus-ring
+Active:     bg=surface-sunken  transform: scale(0.98)
+Disabled:   ink=ink-disabled  border=border-subtle  cursor: not-allowed
+Loading:    spinner replaces icon, text becomes "..."  not-interactive
+Error:      no error state for buttons (errors live on form fields)
+```
+
+### Button (primary variant)
+
+```
+Default:    bg=accent  ink=accent-foreground
+Hover:      bg=accent-hover  shadow-xs
+Focus:      + focus-ring
+Active:     bg=accent-hover  transform: scale(0.98)
+Disabled:   bg=accent  opacity-disabled  cursor: not-allowed
+Loading:    inline spinner; bg unchanged  not-interactive
+```
+
+### Input (text)
+
+```
+Default:    bg=surface-base  border=border-default  ink=ink-primary
+Hover:      border=border-strong
+Focus:      border=accent  + focus-ring  ink=ink-primary
+Active:     same as focus
+Filled (has value):  border=border-strong  (subtle indication state ≠ empty)
+Disabled:   bg=surface-sunken  ink=ink-disabled  border=border-subtle
+Loading:    overlay subtle shimmer (rare — typically inputs aren't async)
+Error:      border=destructive  ink=ink-primary  + below-message
+```
+
+### Card (clickable)
+
+```
+Default:    bg=surface-raised  border=border-subtle  shadow=none
+Hover:      shadow=xs  transform=translateY(-1px)  border=border-default
+Focus:      + focus-ring  (focus from keyboard only)
+Active:     transform=translateY(0)  shadow=none
+Selected:   border=accent  bg=accent-soft (rare, e.g. multi-select mode)
+Disabled:   ink-disabled  opacity-faded  cursor: not-allowed
+Loading:    skeleton replacement
+```
+
+### List row
+
+```
+Default:    bg=transparent  ink=ink-primary
+Hover:      bg=surface-sunken
+Focus:      + focus-ring (inset, since rows often span container width)
+Active:     bg=surface-sunken (deeper)
+Selected:   bg=accent-soft  ink=ink-primary  (multi-select)
+Disabled:   ink-disabled
+```
+
+### Checkbox / radio
+
+```
+Default:    bg=surface-base  border=border-strong  ink=transparent
+Hover:      border=accent
+Focus:      + focus-ring
+Checked:    bg=accent  border=accent  ink=accent-foreground (the check)
+Disabled:   bg=surface-sunken  border=border-subtle
+Indeterminate (checkbox): bg=accent  ink=accent-foreground (dash)
+```
+
+### Switch (toggle)
+
+```
+Default (off):  bg=border-default  thumb=surface-raised
+Hover (off):    bg=border-strong
+Default (on):   bg=accent  thumb=surface-base
+Hover (on):     bg=accent-hover
+Focus:          + focus-ring around track
+Disabled:       opacity-disabled  cursor: not-allowed
+```
+
+## Loading states
+
+Three forms, used in different contexts:
+
+### Skeleton (preferred for layout-stable content)
+
+A pulsing placeholder shaped like the eventual content. Use for:
+- Lists, cards, tables loading data
+- Profile/detail pages on first render
+- Chart loading
+
+Pulsing background gradient via CSS animation, no JS needed.
+
+```css
+@keyframes skeleton-pulse {
+  0%, 100% { background-position: 0 0; }
+  50%      { background-position: -200% 0; }
+}
+
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--surface-sunken) 0%,
+    var(--surface-base) 50%,
+    var(--surface-sunken) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-pulse 1500ms linear infinite;
+  border-radius: var(--radius-md);
+  color: transparent;
+  user-select: none;
+  pointer-events: none;
+}
+```
+
+Skeleton must match eventual content shape (same heights, widths, spacing) — otherwise content "jumps" in.
+
+### Inline spinner
+
+For button-internal loading and small async ops. ~14px Phosphor `CircleNotch` with `animate-spin`. Replaces the leading icon, never appears alongside.
+
+### Progress bar
+
+For long-running operations (file upload, large export). Linear bar at top of dialog or inline. Always determinate when possible — show percentage.
+
+### Pulsing dot
+
+For "live" indicators (connection state, recent change). Used sparingly.
+
+## Empty states
+
+A separate state from loading. **Documented in `11-page-layouts-and-flows.md`** as a major design pattern. Three flavors:
+
+1. **First-time empty** — "You haven't added anything yet. Let's start."
+2. **Filtered empty** — "No items match this filter." + Clear filters button
+3. **Search empty** — "No results for 'foo'." + Try other terms hint
+
+Different copy per context. Same component primitive (`EmptyState`).
+
+## Error states
+
+Three layers, by scope:
+
+| Scope | Pattern |
+| --- | --- |
+| Single field | Below the input, red text + icon, border on field |
+| Form | Top of form, summary list with anchor links to broken fields |
+| Page | Replaces page content with error illustration + retry CTA |
+| Toast (transient) | Bottom-right, dismissible, auto-clear after 8s |
+| Critical (destructive blocked) | Inline alert in dialog, prevents submission |
+
+**Error copy rules** (per `12-tone-of-voice.md`):
+- Plain language ("Couldn't save that.")
+- What to do next ("Try again, or check your connection.")
+- Never "Error: 500" — translate at boundary
+
+## Selected vs active
+
+These two states confuse implementers regularly:
+
+- **Selected** is **persistent** — the user picked this item and it remains chosen until they pick another or close the screen. Examples: tab selected, table row in multi-select, sidebar item for current page.
+- **Active** is **transient** — the user is currently pressing this. Lasts the duration of the interaction.
+
+Use `aria-selected="true"` for selected; `:active` pseudo-class for active. They have different visual treatments above.
+
+## Drag-and-drop states
+
+For draggable thumbnails (file gallery reorder), draggable list items, or drop targets:
+
+| State | Treatment |
+| --- | --- |
+| Drag-source (during drag) | opacity 0.4, cursor: grabbing, no shadow |
+| Drag-over (drop target valid) | border 2px accent dashed, bg accent-soft |
+| Drag-over (drop target invalid) | border 2px destructive dashed, bg destructive-soft |
+| Drop (release) | brief flash bg accent-soft, then back to default |
+
+Implement via Vue Draggable or HTML5 native drag. Always show drop-zone affordance — never a silent drop.
+
+## Hover-tooltip pattern
+
+Every icon-only button gets a tooltip on hover (and on focus, for keyboard). Tooltip:
+- Appears after **300ms** delay (avoids flicker)
+- Disappears immediately on mouseleave
+- Maximum 3 words ("Edit location", "Delete", "Sort by date")
+- Uses Reka UI Tooltip primitive, not browser-native title attribute (which is unstyled)
+
+Title attribute kept as fallback for screen readers.
+
+## Sticky / pinned states
+
+For sticky table headers, sticky section headers in long pages:
+- At rest, transparent background
+- When stuck (scrolled into view): backdrop-filter blur(4px) + bg=surface-base/0.85
+- Subtle shadow appears beneath when content scrolls under
+
+Use `IntersectionObserver` to toggle a `.is-stuck` class — pure CSS via `position: sticky` won't trigger the styling change.
+
+## Locked / read-only states
+
+For fields that cannot be edited (e.g., file upload date):
+- Same visual as default but no border (or border-subtle)
+- Cursor: default (not text)
+- No focus ring on tab — skipped from tab order
+- Distinct from disabled — disabled means "not allowed right now", read-only means "this can never be changed"
+
+## Anti-patterns
+
+- ❌ Hover effect that causes layout shift (e.g., margin change) — use transform
+- ❌ Loading states that disable the whole page when only one widget is loading
+- ❌ Click handlers without `:hover` style — invisible interactivity
+- ❌ Disabled state that shows pointer cursor (lying)
+- ❌ Error message inside the field placeholder (disappears when typing)
+- ❌ Loading spinner with no max-time — must transition to error after 30s

--- a/devdocs/frontend/design/08-interaction-states.md
+++ b/devdocs/frontend/design/08-interaction-states.md
@@ -169,7 +169,7 @@ Three layers, by scope:
 | Toast (transient) | Bottom-right, dismissible, auto-clear after 8s |
 | Critical (destructive blocked) | Inline alert in dialog, prevents submission |
 
-**Error copy rules** (per `12-tone-of-voice.md`):
+**Error copy rules** (per [`12-tone-of-voice-and-copy.md`](./12-tone-of-voice-and-copy.md)):
 - Plain language ("Couldn't save that.")
 - What to do next ("Try again, or check your connection.")
 - Never "Error: 500" — translate at boundary

--- a/devdocs/frontend/design/09-component-patterns.md
+++ b/devdocs/frontend/design/09-component-patterns.md
@@ -278,7 +278,7 @@ Leading dot in semantic color, label `body-xs` `font-medium`.
 - **muted** — archived, inactive
 
 ### Rules
-- Always use the same word for the same state across the product (per `12-tone-of-voice.md`)
+- Always use the same word for the same state across the product (per [`12-tone-of-voice-and-copy.md`](./12-tone-of-voice-and-copy.md))
 - Pills are non-interactive (no hover); to filter by status, use a separate filter bar
 
 ## 16. Tag / Chip

--- a/devdocs/frontend/design/09-component-patterns.md
+++ b/devdocs/frontend/design/09-component-patterns.md
@@ -1,0 +1,540 @@
+# Component Patterns
+
+Anatomy and rules for every reusable component primitive in Inventario. Engineering reference; if it's here, it's specced. If a sprint task needs a component not on this list, add it here first.
+
+## Primitives covered
+
+1. Button
+2. Input (text, email, password, number, date)
+3. Textarea
+4. Select / Combobox
+5. Checkbox
+6. Radio group
+7. Switch
+8. Dialog (modal)
+9. Drawer (mobile / side-sheet)
+10. Toast
+11. Tooltip
+12. Popover
+13. Card
+14. Badge
+15. Status pill
+16. Tag / Chip
+17. Avatar
+18. Tabs
+19. Accordion
+20. Breadcrumb
+21. Pagination
+22. Search input
+23. Filter bar
+24. Table / Data grid
+25. List
+26. Empty state
+27. Skeleton
+28. Loader / Spinner
+29. Progress bar
+30. Notification (severity callout)
+31. Form section
+32. Form footer
+
+## 1. Button
+
+### Variants
+- **primary** — main CTA per page (max one), `bg=accent`
+- **secondary** — common actions, `bg=transparent border=border-default`
+- **ghost** — tertiary, `bg=transparent` no border, used in toolbars
+- **destructive** — delete, irreversible, `bg=destructive`
+- **link** — looks like a link, sits inline in text
+
+### Sizes
+- **sm** — `h-8 (32px)  px-3  text-body-sm`
+- **md** — `h-10 (40px)  px-4  text-body` (default)
+- **lg** — `h-12 (48px)  px-5  text-body-lg`
+- **icon** — `h-10 w-10` square (or sm/lg variants)
+
+### Anatomy
+```
+[leading-icon?]  Label  [trailing-icon? | counter?]
+```
+
+### Rules
+- **One** primary button per surface — no exceptions
+- Icon-only buttons require `aria-label`
+- Loading state replaces leading icon with spinner; preserves width
+- Destructive actions require **confirmation dialog** on click (per `15-form-and-data-ux.md`)
+- Buttons sit at logical end of dialogs/forms — primary on the right (LTR), secondary to its left, ghost-cancel on the far left
+
+### Anti-patterns
+- ❌ "Save" + "Save and Continue" + "Save Draft" all primary
+- ❌ Mixing button + link styling on the same row
+- ❌ Buttons without explicit size — gets default from CSS reset, looks broken
+
+## 2. Input
+
+### Anatomy
+```
+[label]                              [optional hint]
+┌────────────────────────────────┐
+│ [leading-icon?]  value         │
+│                  [trailing-action?] │
+└────────────────────────────────┘
+[helper-text  |  error-message  |  character-count]
+```
+
+### Rules
+- Label always present and **above** the field, never floating-label (those fail accessibility and i18n)
+- Labels in `body-sm font-medium`, color `--ink-primary`
+- Required indicator: `*` in `--destructive` after label text — no asterisk explanation needed
+- Helper text in `body-xs` `--ink-muted` below; replaced by error message when invalid
+- Error state: border `--destructive`, message in `body-xs` `--destructive`, plus an error-icon trailing the field
+- Filled state (has value) gets `border-strong` to differentiate from empty
+
+### Sizes match Button (sm/md/lg)
+
+### Trailing actions
+- Clear button (X) appears when field has value and is hovered/focused
+- Reveal/hide for password fields
+- Calendar icon for date fields
+- Currency code suffix for amount fields (read-only)
+
+## 3. Textarea
+
+Same as Input but `min-height: 5rem` (~80px), expandable via drag handle in bottom-right corner. Character counter optional — if present, in `body-xs` `--ink-muted` aligned bottom-right inside the field.
+
+## 4. Select / Combobox
+
+Use Reka UI's `Combobox` primitive. Always typeahead-searchable when option count >= 6.
+
+### Anatomy
+```
+┌────────────────────────────────┐
+│ [leading-icon?]  Selected option │
+│                       [chevron] │
+└────────────────────────────────┘
+```
+
+### Dropdown panel
+- Max height `360px`, then scrollable
+- Search input pinned at top when option count >= 6
+- Each option: ghost-list-item style, hover bg `--surface-sunken`, selected bg `--accent-soft`, check icon trailing
+- Empty state inside dropdown: "No options match" + body-sm
+- Click-outside or Escape closes
+
+### Multi-select
+Renders selected values as chips inside the trigger. Beyond 3 chips: "+N more".
+
+## 5. Checkbox
+
+Standard pattern. 16px box, accent-bg when checked, white check icon (Phosphor Check, weight bold).
+
+Indeterminate: dash icon (Phosphor Minus). Used for "select all" when partial selection exists.
+
+## 6. Radio group
+
+Vertical stack default, horizontal allowed for ≤3 options that fit one line. Each item: 16px circle + 8px gap + label. Active radio shows accent-filled center dot.
+
+## 7. Switch
+
+Use for **immediate-effect toggles** (no save button required). Track 32×18px, thumb 14px.
+
+When the switch toggles a setting that *requires* a save action, use a Checkbox instead. Switches imply "applied immediately."
+
+## 8. Dialog (modal)
+
+Use Reka UI Dialog primitive. Fullscreen overlay + centered content.
+
+### Sizes
+- **sm** — `max-w-md` (448px) — confirmations, simple forms
+- **md** — `max-w-2xl` (672px) — standard forms, settings panels (default)
+- **lg** — `max-w-4xl` (896px) — multi-section forms, file pickers
+- **xl** — `max-w-6xl` (1152px) — file viewer, large content
+- **fullscreen** — `inset-4` with `radius-xl` — file viewer (per `10-file-and-media.md`)
+
+### Anatomy
+```
+┌─────────────────────────────────────────┐
+│ [Title]                          [X]    │  header  --space-5  border-b
+├─────────────────────────────────────────┤
+│                                         │
+│ [body content, scrollable if tall]      │  body  --space-5
+│                                         │
+├─────────────────────────────────────────┤
+│       [ghost cancel] [secondary] [primary] │  footer  --space-5  border-t
+└─────────────────────────────────────────┘
+```
+
+### Rules
+- Title in `heading-md` weight medium
+- X button top-right is **redundant with Escape and overlay click** — keep it for discoverability, but those mechanisms must work
+- Body scrolls when tall; header and footer remain visible
+- Mobile: dialogs >sm become full-screen drawers (use Drawer primitive instead)
+- Focus trap inside dialog (Reka UI handles)
+- Initial focus on first form input or primary button
+- Background overlay: `--overlay-scrim` + backdrop-blur(8px)
+- Z-index: 50 (above sticky headers)
+
+## 9. Drawer (mobile / side-sheet)
+
+Slides from edge. On mobile: from bottom; on desktop side-panel: from right.
+
+### Sizes
+- **bottom mobile**: full width, max-height 90vh, swipe-down to dismiss, drag handle visible at top
+- **right side**: 400px desktop, full-width mobile
+
+### Header includes title + close X. Footer pinned. Body scrolls.
+
+## 10. Toast
+
+Use Sonner-vue or build on Reka UI primitives.
+
+### Variants
+- success, info (default), warning, destructive
+
+### Anatomy
+```
+┌──────────────────────────────────────┐
+│ [icon]  Message                  [X] │
+│         [optional action button]     │
+└──────────────────────────────────────┘
+```
+
+### Rules
+- Position: bottom-right desktop, bottom-center mobile
+- Stack vertically, max 3 visible — older ones expire
+- Auto-dismiss: 4s success, 6s info/warning, never auto-dismiss destructive (require explicit action)
+- Action button (Undo, Retry, View) preferred when context calls for it
+- Slide-in from right with spring easing, slide-out to right
+- ARIA: `role="status"` for info/success, `role="alert"` for warning/destructive
+
+## 11. Tooltip
+
+Reka UI Tooltip. Per `08-interaction-states.md`:
+- 300ms hover delay
+- Max 3 words
+- Position: above by default, flip to below if no room
+- Background: `--surface-overlay-strong`, ink `--ink-primary` (inverted in dark mode)
+- Arrow pointing to anchor
+- Z-index: 60 (above dialogs)
+
+## 12. Popover
+
+Larger than tooltip, contains interactive content. Used for:
+- Filter quick-edit
+- User menu
+- Date picker
+- Color picker
+
+Reka UI Popover. Max width 320px default, expandable. Background `--surface-raised`, shadow `md`, radius `lg`. Closes on click-outside or Escape.
+
+## 13. Card
+
+The primary surface unit. Anatomy:
+```
+┌────────────────────────────────┐
+│ [optional thumbnail / banner] │
+│                                │
+│ [Title]                        │
+│ [Subtitle — optional]          │
+│                                │
+│ [Body / details]               │
+│                                │
+│ [Footer actions — optional]    │
+└────────────────────────────────┘
+```
+
+### Rules
+- `bg=surface-raised  border=border-subtle  radius=lg  padding=padding-card`
+- Hover (if interactive): per `08-interaction-states.md`
+- Title in `heading-md` weight semibold
+- Subtitle in `body-sm` muted
+- Cards in a grid: equal heights, content baseline-aligned
+
+## 14. Badge
+
+Small, inline, decorative or numeric.
+```
+[●] 12        ↳ count badge (bg=accent, ink=accent-foreground, ~18px)
+[Draft]       ↳ text badge (bg=surface-sunken, body-xs uppercase tracking-uppercase)
+```
+
+Difference from Status pill: badges are decorative (counts, labels); pills convey semantic state.
+
+## 15. Status pill
+
+Semantic state communication — "In use", "Completed", "Draft", "Archived", "Expired".
+
+### Anatomy
+```
+[●] Status text
+```
+
+Leading dot in semantic color, label `body-xs` `font-medium`.
+
+### Variants
+- **success** (`--success`) — completed, active, valid, in use
+- **warning** (`--warning`) — expiring soon, action needed
+- **info** (`--info`) — draft, in progress
+- **destructive** (`--destructive`) — expired, failed
+- **muted** — archived, inactive
+
+### Rules
+- Always use the same word for the same state across the product (per `12-tone-of-voice.md`)
+- Pills are non-interactive (no hover); to filter by status, use a separate filter bar
+
+## 16. Tag / Chip
+
+User-applied labels (like "outdoor", "seasonal" on commodity).
+
+### Anatomy
+```
+[Tag text]   [×]    ↳ removable
+[Tag text]          ↳ static
+```
+
+### Rules
+- bg `--accent-soft`, ink `--accent`, radius `full`, body-xs medium, padding `space-1 space-2`
+- Removable variant has trailing X (Phosphor X, weight bold, size icon-xs)
+- Multiple tags wrap with `space-1` gap
+
+## 17. Avatar
+
+User identity. Sizes: 24, 32, 40, 48, 64. Initials fallback when no photo.
+
+```css
+.avatar {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-radius: var(--radius-full);
+  display: grid; place-items: center;
+  font-weight: var(--font-weight-medium);
+}
+```
+
+## 18. Tabs
+
+Horizontal tab strip with bottom-border indicator on active. Reka UI Tabs.
+
+### Rules
+- Active tab: ink `--ink-primary`, weight medium, 2px underline `--accent`
+- Inactive: ink `--ink-secondary`, no underline
+- Hover inactive: ink `--ink-primary`
+- Body-md size on tab labels
+- Underline transitions across via CSS `transform`, not redrawing
+- Mobile: scrollable tabs row, never wrap
+
+## 19. Accordion
+
+Reka UI Accordion. Default: only one open at a time.
+
+### Anatomy
+```
+┌─────────────────────┐
+│ Title  ▾            │  trigger (radius-md, bg-transparent, hover bg-sunken)
+└─────────────────────┘
+   panel content (animated height)
+```
+
+Chevron rotates 180° on open via `transform`, `--duration-base`.
+
+## 20. Breadcrumb
+
+For deep entity navigation. Inline, body-sm.
+```
+Locations / Home / Bedroom
+```
+Separators: `/` in `--ink-muted`. Last item not a link, weight medium.
+
+## 21. Pagination
+
+For lists >50 items.
+
+### Anatomy
+```
+[‹ Prev]  [1] [2] [3] … [12] [Next ›]
+```
+
+### Rules
+- Show first, last, and ±1 around current; ellipsis for gaps
+- Current page: `bg=accent  ink=accent-foreground  radius=md`
+- Page size selector inline: "12 per page ▾"
+- Total count: "Showing 1–12 of 142" (`body-sm` muted)
+
+## 22. Search input
+
+Specialized text input.
+
+### Anatomy
+```
+┌────────────────────────────────┐
+│ [magnifier]  Search…  [⌘K]     │
+└────────────────────────────────┘
+```
+
+### Rules
+- Leading magnifier icon (Phosphor MagnifyingGlass, regular)
+- Placeholder "Search…" (em-dash ellipsis, not three dots)
+- Trailing keyboard shortcut hint when global ("⌘K"), with subtle bg
+- Debounce 250ms before firing query
+- Clear (X) button when has value
+- On focus, opens command palette if it's the global one
+
+## 23. Filter bar
+
+Horizontal row above lists/tables with filter chips and search.
+
+### Anatomy
+```
+[Search…]  [Type ▾]  [Status ▾]  [Date range ▾]  [+ Add filter]   [Clear]
+```
+
+Mobile: collapses to single "Filters (3)" button that opens a Drawer.
+
+## 24. Table / Data grid
+
+For dense list views (Exports). When user selection is multi-row + sort + bulk-actions.
+
+### Anatomy
+- Sticky header with sortable columns (chevron icon when sorted, dimmed when not)
+- Row hover: bg `--surface-sunken`
+- Row selected: bg `--accent-soft` + checkbox checked
+- Empty state replaces tbody when zero rows
+- Bulk-action bar appears as a sticky overlay when ≥1 row selected: "3 selected • [Export] [Delete] [Cancel]"
+- Mobile: cards instead of rows (responsive transform)
+
+### Rules
+- Avoid tables for <12 columns of data; use cards (Inventario commodities) instead
+- Tabular numerics on all numeric cells
+- Right-align numeric/currency columns; left-align text
+
+## 25. List
+
+Vertical stack of rows (locations, areas, files in folders).
+
+### Anatomy
+```
+┌─────────────────────────────────────┐
+│ [icon] Title      [meta]  [actions] │  row 1
+├─────────────────────────────────────┤
+│ [icon] Title      [meta]  [actions] │  row 2
+└─────────────────────────────────────┘
+```
+
+Border between rows in `--border-subtle`. Hover bg `--surface-sunken`.
+
+## 26. Empty state
+
+Specced in `11-page-layouts-and-flows.md`. Variants:
+- First-time empty
+- Filtered empty
+- Search empty
+- Error empty
+
+Component takes `icon | illustration`, `title`, `description`, `action` (optional CTA).
+
+## 27. Skeleton
+
+Per `08-interaction-states.md`. Component variants:
+- `<Skeleton variant="text" />` — single line of text-shaped skeleton
+- `<Skeleton variant="title" />` — heading-shaped
+- `<Skeleton variant="card" />` — card-shaped block
+- `<Skeleton variant="circle" :size="40" />` — for avatars
+
+## 28. Loader / Spinner
+
+Phosphor `CircleNotch` rotating. Sizes match icon scale.
+```vue
+<Spinner size="md" />
+```
+
+For page-level loading: full-page centered spinner is **forbidden** — use skeletons.
+
+## 29. Progress bar
+
+Linear bar. Determinate (with percentage label) preferred.
+
+```
+┌─────────────────────────────┐
+│ ▓▓▓▓▓▓▓▓░░░░░░░░░░  43%      │
+└─────────────────────────────┘
+Uploading 3 of 7 files…
+```
+
+Indeterminate: shimmer animation, no percentage. Used when total unknown.
+
+## 30. Notification (severity callout)
+
+Inline alert box for non-toast warnings (e.g., on a form: "This action cannot be undone.").
+
+### Variants
+- info, success, warning, destructive
+
+### Anatomy
+```
+┌─────────────────────────────────────┐
+│ [icon] Title                        │
+│        Optional description text.   │
+│        [optional action]            │
+└─────────────────────────────────────┘
+```
+
+### Rules
+- bg: `--*-soft` (e.g., `--warning-soft`)
+- border-left 3px solid in semantic color
+- icon: Phosphor Info / Check / Warning / X-circle
+- Used on dashboards (attention items), forms (irreversible warnings), file pages (storage low)
+
+## 31. Form section
+
+Logical grouping inside a form view.
+
+### Anatomy
+```
+┌───────────────────────────────────────┐
+│ Section title                         │  heading-md, --ink-primary
+│ Optional subtitle / context.          │  body-sm, --ink-muted
+│                                       │
+│ [field grid]                          │
+└───────────────────────────────────────┘
+```
+
+Vertical gap between sections: `--gap-stack-section`.
+
+## 32. Form footer
+
+Sticky bottom bar within form views. Contains primary action and cancel.
+
+### Anatomy
+```
+┌────────────────────────────────────────────────┐
+│ [unsaved-changes hint]  [Cancel] [Save changes] │
+└────────────────────────────────────────────────┘
+```
+
+### Rules
+- Sticky to bottom of form viewport (within scroll container)
+- Saves are explicit, no auto-save unless `15-form-and-data-ux.md` flow specifies
+- Disabled "Save" button when no changes vs. baseline
+- Unsaved-changes hint: "Unsaved changes" in body-sm, `--ink-muted`, replaced by spinner/checkmark on save in flight/done
+
+## What ships in sprint 0
+
+Build/refresh primitives in this priority order (week 1):
+1. Button (all variants, sizes, loading state)
+2. Input + Textarea
+3. Dialog (sm/md/lg sizes — fullscreen waits for FileViewer rebuild)
+4. Toast (Sonner integration)
+5. Skeleton
+6. EmptyState
+7. Card (refactor to spec)
+8. Badge / Status pill / Tag
+
+Then in week 2:
+9. Select / Combobox
+10. Tabs / Accordion
+11. Tooltip / Popover
+12. Form section / footer
+13. Pagination
+14. Search input
+15. Notification
+
+Remaining (Drawer, Avatar, Breadcrumb, full Table) ship as needed in sprint 1+.

--- a/devdocs/frontend/design/10-file-and-media.md
+++ b/devdocs/frontend/design/10-file-and-media.md
@@ -1,0 +1,272 @@
+# File & Media Handling
+
+Inventario stores files heavily — receipts, warranty PDFs, product photos, manuals. The current FileViewerDialog (`11-file-viewer-dialog` in screenshots) is mediocre. This document specifies the full media experience.
+
+## File-type taxonomy
+
+Inventario surfaces care about five media classes:
+
+| Class | Examples | Preview support |
+| --- | --- | --- |
+| **Image** | jpg, png, webp, gif, heic, avif | Full preview, zoom, rotate |
+| **Document** | pdf | Multi-page preview, navigation, zoom |
+| **Video** | mp4, webm, mov | Inline player, fullscreen, scrubber |
+| **Audio** | mp3, wav, m4a | Inline player with waveform |
+| **Other** | xml, json, txt, archives, dwg, etc. | Type-specific icon, "Download to view" |
+
+Internal classification is on MIME type, not extension.
+
+## Thumbnail rules
+
+Generated server-side, cached. Sizes:
+
+| Use | Pixel size |
+| --- | --- |
+| List item icon | 24×24 |
+| Card thumbnail | 320×240 (16:9 cover) |
+| Gallery tile | 480×360 |
+| Detail preview | 1024 longest edge |
+
+For non-image files, thumbnail is a styled tile with file-type icon (Phosphor) on `--surface-sunken` background, file extension label below.
+
+## File Card primitive (revised from `09-component-patterns.md` Card)
+
+Specialized card for file representation.
+
+### Anatomy
+```
+┌─────────────────────────────┐
+│                             │
+│      [thumbnail | icon]     │  240×180 viewport (16:9)
+│                             │
+├─────────────────────────────┤
+│ filename-or-display.ext     │  body, weight medium, truncate
+│ Document · PDF · 1.2 MB     │  body-xs, --ink-muted
+│ [linked-entity badge]       │  optional
+└─────────────────────────────┘
+```
+
+### Hover state
+- Card gets shadow `xs` and translateY(-1px)
+- Thumbnail darkens slightly (`bg-overlay 0.05`)
+- Action overlay appears: View / Download / More-menu
+
+### Multi-select state
+- Checkbox appears top-left
+- Selected: blue ring inside card, accent-soft tint
+
+## File Gallery (replacement for current MediaGallery)
+
+The pattern for displaying multiple files attached to an entity (commodity images, manuals, invoices).
+
+### Layout
+- CSS grid `auto-fill minmax(220px, 1fr)` with `gap: --space-4`
+- Cards maintain aspect ratio
+- "Add" tile at the start (or end on read-only views) with dashed border
+
+### Density modes
+| Mode | Min tile size | Per-row at 1200px |
+| --- | --- | --- |
+| Default | 220px | 5 |
+| Compact | 160px | 7 |
+| Cozy | 280px | 4 |
+
+### Empty state
+```
+[illustration: empty drawer or paper stack]
+No images yet.
+
+Add your first image to keep a visual record —
+helpful for insurance and just for memory.
+
+[+ Add Image]
+```
+
+### Loading state
+6 skeleton cards in a grid until data arrives.
+
+## File Viewer (fullscreen lightbox)
+
+The big rebuild. Current dialog is small and underfeatured. Replace with a fullscreen lightbox.
+
+### Layout
+```
+┌─────────────────────────────────────────────────────────────┐
+│ [×] [filename · type · size]    [↺] [↻] [Download] [Delete] │  top toolbar
+│                                                             │
+│                                                             │
+│                                                             │
+│   ‹                  [media canvas]                       › │  navigation arrows
+│                                                             │
+│                                                             │
+│                                                             │
+├─────────────────────────────────────────────────────────────┤
+│  ▣ ▢ ▢ ▢ ▢ ▢ ▢ ▢ ▢                              [3 / 27]    │  thumbnail strip + counter
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Toolbar (top)
+- Close (X) far left, escapable
+- Filename, type, size — center-left, body-sm muted
+- Rotate left / right (images only)
+- Zoom controls (images, PDFs)
+- Download button
+- Overflow menu (...) — Edit metadata, Delete, Share, Set as cover
+
+### Canvas
+- Background: `--overlay-scrim-strong` (near-black) with backdrop-blur
+- Image / PDF / video centered, max 90% viewport in each direction
+- Pan & zoom enabled for images and PDFs (via panzoom library)
+- Double-click to zoom 2x; double-click again to fit
+- Pinch-to-zoom on touch
+- Mousewheel zoom on desktop
+- Drag-to-pan when zoomed
+
+### Navigation
+- Left/right arrow keys → prev/next file
+- Edge arrow buttons (visible on hover only)
+- Touch swipe horizontally → prev/next
+
+### Thumbnail strip (bottom)
+- Horizontal scroller, current file highlighted
+- Click thumbnail → jump to that file
+- Auto-scrolls to keep current visible
+- Hides on viewport <640px (use swipe only)
+
+### Counter
+- Right-aligned: "3 / 27"
+- `body-sm tabular`
+
+### Per-type behavior
+
+| Type | Special features |
+| --- | --- |
+| Image | rotate, zoom, exif overlay (icon: Info → tooltip showing camera/date) |
+| PDF | page nav (◂ N/M ▸), page thumbnails in expandable side panel, search within PDF (deferred) |
+| Video | full HTML5 controls, play/pause/scrub/volume/captions, picture-in-picture |
+| Audio | waveform render, play/pause, time display, no thumbnail strip |
+| Other | replace canvas with "Preview not available" + Download CTA |
+
+### Accessibility
+- Focus trap inside viewer
+- Tab order: close → toolbar buttons → canvas (focusable for keyboard pan/zoom) → thumbnail strip
+- Esc closes
+- Arrow keys: prev/next
+- Plus/minus: zoom in/out
+- 0: reset zoom
+- R: rotate (images)
+- Space: play/pause (audio/video)
+- Announce file change to screen reader (`aria-live="polite"`)
+
+### Implementation
+- Reka UI Dialog with `inset-4` (full screen with subtle margin)
+- Zoom: panzoom (~6KB)
+- Touch gestures: `@vueuse/gesture`
+- PDF: pdf.js (already in project)
+
+### Open-from
+- Click on FileCard thumbnail → opens viewer at that file
+- Click on file in FileListView → opens viewer (currently navigates to detail page; change to lightbox)
+- Cmd/Ctrl+click → still goes to detail page (preserves drill-down)
+
+### File detail page (separate from viewer)
+
+The file detail page (`/files/<id>`) remains for **metadata editing** and as a permalink. The viewer is the **viewing** experience. Keep them separate but linked.
+
+## File Uploader
+
+Specced separately because upload is a distinct flow.
+
+### States
+1. Idle / drop-zone
+2. Drag-over
+3. Uploading (progress per file)
+4. Done
+5. Error
+
+### Idle anatomy
+```
+┌─────────────────────────────────────┐
+│                                     │
+│        [cloud-up icon, 48px]        │
+│                                     │
+│       Drag and drop a file here     │
+│                  or                 │
+│           click to browse           │
+│                                     │
+│  Supports images, PDFs, and more.   │
+│                                     │
+└─────────────────────────────────────┘
+```
+
+- Dashed border `--border-default`, radius `lg`, padding `padding-card-lg`
+- Center-aligned
+- Click anywhere triggers file picker
+- "click to browse" link styled as `text-accent underline hover:no-underline`
+
+### Drag-over anatomy
+- Dashed border becomes solid `--accent`, 2px
+- bg `--accent-soft`
+- Cloud icon scales 1.05, color `--accent`
+- Copy changes to "Drop to upload"
+
+### Uploading anatomy
+
+When files dropped, the drop-zone collapses and file rows appear:
+```
+┌─────────────────────────────────────────────────┐
+│ [icon] receipt-2026.pdf                         │
+│        ▓▓▓▓▓▓▓▓░░░░░░  43% · 1.2 MB / 2.8 MB   │
+│                                          [×]    │
+└─────────────────────────────────────────────────┘
+```
+
+Multiple files stack vertically. Progress per file. Cancel (X) per file.
+
+### Error
+- Failed file rows turn red border + error message ("Couldn't upload — try again." with [Retry] button)
+
+### Validation
+- Max file size per upload (configurable, server-side enforced; UI hints at limits — "up to 50 MB")
+- Allowed types per context (commodity images: image/*; manuals: pdf + images; etc.)
+- Show validation errors inline before send if client-detectable
+
+### Multi-file upload
+- Allow drop or pick of many files
+- Process in parallel (concurrent 3 by default; queue rest)
+- Progress aggregate at the top: "Uploading 3 of 7…"
+
+## Linked-entity badge (file → owner)
+
+Files have an "owner" entity (commodity, location, area). On the file card and file detail page, the owner is shown as a clickable badge.
+
+### Anatomy
+```
+[entity-icon] Camping Equipment ↗
+```
+
+- bg `--accent-soft`, ink `--accent`, radius `md`, padding `space-1 space-2`
+- Trailing external-link icon (Phosphor ArrowSquareOut)
+- Hover: bg `--accent-hover-soft`
+
+## Where file flows live in the app
+
+| Surface | Behavior |
+| --- | --- |
+| `/files` list | All files; click → viewer; ⌘+click → detail page |
+| Commodity detail Images section | FileGallery, click → viewer scoped to commodity images |
+| Commodity detail Manuals/Invoices | Same, scoped per file-type bucket |
+| Location detail Images/Files | Same |
+| File detail `/files/<id>` | Metadata + preview-in-place (smaller, not lightbox) |
+
+## What ships in sprint 0
+
+1. Replace MediaGallery internals with new grid spec (auto-fill minmax)
+2. Refactor FileCard to new anatomy with hover overlay
+3. Build new FileViewer fullscreen component (replaces current dialog) — 4–6 days
+4. Migrate file uploader to new states (idle/drag/uploading/done/error)
+5. Add linked-entity badge to file cards everywhere
+
+## Decision needed
+
+None. All spec calls are made.

--- a/devdocs/frontend/design/11-page-layouts-and-flows.md
+++ b/devdocs/frontend/design/11-page-layouts-and-flows.md
@@ -43,7 +43,7 @@ Replaces the current pipe-separated topbar.
 Current: Home / Locations / Commodities / Files / Exports / System
 Proposed: Home / Things / Places / Files / Backups / (System moved under user menu — admin-only)
 
-Reasoning per `12-tone-of-voice.md`: "Things" reads warmer than "Commodities", "Places" warmer than "Locations", "Backups" clearer than "Exports".
+Reasoning per [`12-tone-of-voice-and-copy.md`](./12-tone-of-voice-and-copy.md): "Things" reads warmer than "Commodities", "Places" warmer than "Locations", "Backups" clearer than "Exports".
 
 #### Collapsed state
 Click chevron at logo → collapses to 64px wide, icon-only. Tooltips on hover show labels.

--- a/devdocs/frontend/design/11-page-layouts-and-flows.md
+++ b/devdocs/frontend/design/11-page-layouts-and-flows.md
@@ -1,0 +1,382 @@
+# Page Layouts & Flows
+
+Six page templates cover ~90% of Inventario surfaces. Plus three flows: onboarding, error pages, and the global navigation shell.
+
+## Global navigation shell
+
+### Desktop (≥1024px): Sidebar
+
+Replaces the current pipe-separated topbar.
+
+```
+┌────────┬────────────────────────────────────────────────┐
+│        │                                                │
+│  Logo  │  [page content]                                │
+│        │                                                │
+│ ───────│                                                │
+│ Home   │                                                │
+│ Things │                                                │
+│ Places │                                                │
+│ Files  │                                                │
+│ Backups│                                                │
+│ ───────│                                                │
+│ Search │                                                │
+│ ───────│                                                │
+│ [user] │                                                │
+│        │                                                │
+└────────┴────────────────────────────────────────────────┘
+```
+
+#### Anatomy
+- Width: 240px expanded, 64px collapsed (icon-only)
+- bg: `--surface-base` (subtly distinct from content area `--surface-raised` if used)
+- Logo top, `--space-6` padding
+- Nav items: icon + label, `padding: space-2 space-3`, radius `md`
+- Active item: bg `--accent-soft`, ink `--accent`, weight medium, leading-icon weight bold
+- Hover inactive: bg `--surface-sunken`
+- Group separator: thin `--border-subtle` line, `space-3` margin
+- Group dropdown (current "Default" pill): renders inside sidebar near the user section
+- Search bar pinned in middle section — global keyboard shortcut ⌘K opens command palette
+- User section bottom: avatar + name + chevron → dropdown with profile/settings/logout
+
+#### Item terminology rename
+Current: Home / Locations / Commodities / Files / Exports / System
+Proposed: Home / Things / Places / Files / Backups / (System moved under user menu — admin-only)
+
+Reasoning per `12-tone-of-voice.md`: "Things" reads warmer than "Commodities", "Places" warmer than "Locations", "Backups" clearer than "Exports".
+
+#### Collapsed state
+Click chevron at logo → collapses to 64px wide, icon-only. Tooltips on hover show labels.
+
+### Mobile (<1024px): Bottom Navigation
+
+Replaces sidebar. Fixed bottom bar.
+
+```
+┌──────────────────────────────────────────┐
+│                                          │
+│        [page content, scrollable]        │
+│                                          │
+│                                          │
+├──────────────────────────────────────────┤
+│ [Home] [Things] [Add+] [Places] [More]  │  bottom nav
+└──────────────────────────────────────────┘
+```
+
+- 5 items: Home, Things, Add (FAB-like central button), Places, More
+- "More" opens a sheet with: Files, Backups, Search, Profile, System
+- Add button is centered, slightly raised, opens action sheet ("Add a thing", "Add a place", "Upload a file")
+- Active item: ink `--accent`, icon weight `bold`
+- Inactive: ink `--ink-secondary`, icon weight `regular`
+- Height 56px + safe-area-inset-bottom
+- Backdrop-blur on the bar when content scrolls beneath
+
+### Tablet (640–1023px)
+
+Hybrid: collapsed icon-sidebar on the left + the same content area. Or fall to bottom nav. Decision: **collapsed sidebar 64px** at this breakpoint — preserves desktop feel, doesn't sacrifice content width.
+
+## Six page templates
+
+### Template 1: List view
+
+For locations (Places), commodities (Things), files, backups.
+
+```
+┌────────────────────────────────────────────┐
+│ Places                       [+ Add place] │  page header
+│ 4 places · 51 areas                        │  subtitle
+├────────────────────────────────────────────┤
+│ [search]  [filters]                  [⋯]   │  filter bar
+├────────────────────────────────────────────┤
+│                                            │
+│ [card grid or row list]                    │
+│                                            │
+├────────────────────────────────────────────┤
+│   [pagination]                             │
+└────────────────────────────────────────────┘
+```
+
+- Page header: title `heading-xl`, subtitle `body-sm muted`, primary action top-right
+- Filter bar: per `09-component-patterns.md`
+- Content: cards (Things, Files) or rows (Places — fits the hierarchy of areas inside)
+- Pagination at bottom
+
+### Template 2: Detail view
+
+For Place / Thing / File / Backup.
+
+```
+┌────────────────────────────────────────────┐
+│ ← Back to Things                           │  breadcrumb-link
+├────────────────────────────────────────────┤
+│ [thumbnail/avatar]  Camping Equipment      │  hero
+│                     Outdoor · Bedroom      │
+│                     [edit] [delete] [⋯]    │
+├────────────────────────────────────────────┤
+│ ┌──────────────────┐ ┌──────────────────┐ │
+│ │ Basic info       │ │ Price            │ │  cards / sections
+│ │ ...              │ │ ...              │ │  2-col grid on desktop
+│ └──────────────────┘ └──────────────────┘ │
+│                                            │
+│ Images           [+ Add]                   │  section header + action
+│ [file gallery]                             │
+│                                            │
+│ Manuals          [+ Add]                   │
+│ [file gallery]                             │
+│                                            │
+│ Activity                                   │
+│ [activity feed]                            │
+└────────────────────────────────────────────┘
+```
+
+- Hero band: replaces dark-on-dark current pattern. Item title `heading-xl`, secondary metadata `body muted`. Actions top-right inline. **No** dark band.
+- 2-col card grid for primary metadata
+- Stacked sections below for relationships (images, manuals, activity)
+
+### Template 3: Form view
+
+Create or edit.
+
+```
+┌────────────────────────────────────────────┐
+│ ← Cancel                                   │
+├────────────────────────────────────────────┤
+│ Add a thing                                │  heading-xl
+│ Anything you own — tools, electronics,     │
+│ furniture, items in a collection.          │  subtitle, body-lg muted
+├────────────────────────────────────────────┤
+│ Basic                                      │  section header
+│ ...fields...                               │
+│                                            │
+│ Where it lives                             │
+│ ...fields...                               │
+│                                            │
+│ Documentation                              │
+│ ...file uploaders...                       │
+├────────────────────────────────────────────┤
+│ [unsaved hint]    [Cancel] [Save]          │  sticky footer
+└────────────────────────────────────────────┘
+```
+
+- Form max-width: `--text-measure-form` (42ch ≈ 540px)
+- Sections per `09-component-patterns.md` form section
+- Sticky footer per `09-component-patterns.md` form footer
+
+### Template 4: Dashboard
+
+Specced in `07-data-visualization.md`. Wide content area, 12-col grid widgets.
+
+### Template 5: Empty / Onboarding
+
+Full-page centered call-to-action.
+
+```
+┌────────────────────────────────────────────┐
+│                                            │
+│                                            │
+│         [illustration / icon-tile]         │
+│                                            │
+│         Title                              │  heading-lg
+│         Subtitle copy explaining what      │
+│         this surface is for.               │  body-lg muted, max 50ch
+│                                            │
+│         [primary CTA]  [secondary CTA?]    │
+│                                            │
+│                                            │
+└────────────────────────────────────────────┘
+```
+
+- Vertical center within the page (NOT viewport — accounts for sidebar/topbar offset)
+- Max-content width 480px
+- Used by: empty list views (no things yet), error pages, onboarding screens
+
+### Template 6: Auth / Single-form
+
+Login, register, forgot password, accept invite.
+
+#### Desktop layout (≥1024px): Split-screen
+
+```
+┌──────────────────────┬─────────────────────┐
+│                      │                     │
+│   [logo]             │                     │
+│                      │                     │
+│   Welcome back.      │   [illustration or  │
+│                      │   editorial photo / │
+│   ┌────────────────┐ │   warm pattern]     │
+│   │ Email          │ │                     │
+│   └────────────────┘ │                     │
+│   ┌────────────────┐ │                     │
+│   │ Password       │ │                     │
+│   └────────────────┘ │                     │
+│                      │                     │
+│   [Sign in]          │                     │
+│                      │                     │
+│   Forgot password?   │                     │
+│                      │                     │
+│   New here? Create   │                     │
+│   an account.        │                     │
+│                      │                     │
+└──────────────────────┴─────────────────────┘
+```
+
+- Left column 50%, right column 50% (or 40/60 with form on the wider side at very large viewports)
+- Form max-width 360px, vertical-centered
+- Right column: warm illustration **or** abstract pattern from palette **or** marketing copy. Decided per illustration sourcing (`06-iconography-and-illustration.md`)
+
+#### Mobile: single-column, no split. Form takes full width with `--padding-page-x` gutters.
+
+This replaces the current "lonely card in the void" login.
+
+## Onboarding flow
+
+Three screens, plus a starter selection.
+
+### Screen 1: Welcome
+
+```
+[logo] Inventario
+
+A quiet place to keep track of your things.
+
+What's the first thing you'd like to remember?
+   ◯ The stuff in my home
+   ◯ My collection
+   ◯ A property's documentation
+   ◯ Something else
+
+[Continue]
+```
+
+- Choice drives the **starter preset** for categories, dashboard widgets, sample copy
+- Use Reka UI Radio with each option styled as a card with icon + title + subtitle
+
+### Screen 2: First thing
+
+Based on Screen 1 choice, prompt the first inventory entry inline (not a full form, just the essentials).
+
+For "stuff in my home":
+```
+Let's add your first thing.
+What is it?  [______________________]   e.g. Dishwasher, sofa, your guitar
+Where does it live?  [Bedroom ▾]
+[Skip] [Add it]
+```
+
+Cancellable. Result: one entry in the inventory plus a celebratory toast on Screen 3.
+
+### Screen 3: Quick tour
+
+Three slides explaining: where to find things, how to add files, how warranties/expiry work. Each slide shows a screenshot + caption. Skippable.
+
+After this, user lands on dashboard with their first thing in "Recently added".
+
+## Error pages
+
+### 404
+
+```
+[illustration: empty drawer / lost label]
+
+We couldn't find that.
+
+The page may have moved, or you might have
+followed an old link.
+
+[Take me home]   [Search]
+```
+
+### 500
+
+```
+[illustration: paper falling]
+
+Something on our end broke.
+
+We're sorry. Try again in a moment, or refresh
+the page.
+
+[Refresh]   [Report this]
+```
+
+### Maintenance
+
+```
+[illustration: do-not-disturb / closed-shutters]
+
+We're tidying up.
+
+Inventario is briefly unavailable while we
+update. Back in a few minutes.
+
+[Try again]
+```
+
+### Offline (PWA-aware, deferred to v2)
+
+```
+[illustration: unplugged]
+
+You're offline.
+
+We'll sync your changes when you're back.
+```
+
+## Confirmation dialogs
+
+For destructive actions.
+
+### Anatomy
+```
+Delete "Camping Equipment"?
+
+This will permanently remove the item, its 5
+images, and its 3 manuals. This cannot be undone.
+
+[Cancel]   [Delete]
+```
+
+- Title: action-as-question, no exclamation
+- Body: explicit consequences (count of children deleted, irreversibility)
+- Primary action: destructive variant button on the right
+- Cancel on the left, ghost variant
+- Focus default: cancel button (not delete — accidental Enter shouldn't destroy)
+- Type-to-confirm for high-risk: "Type 'Camping Equipment' to confirm" — used for archive/delete of >10 children
+
+## Dashboard layout
+
+Specced in `07-data-visualization.md`. Don't repeat here.
+
+## Print layout
+
+Inventory printout (per `18-print-and-export.md`). Reset all chrome (sidebar, topbar, action buttons) for print stylesheet. Print template:
+- Title block with date
+- Each item as a row with photo, name, location, value
+- Footer page numbers
+- Black-and-white safe colors
+
+## Empty state copy templates
+
+Per surface, here are first-time empty copies. These ship in sprint 0:
+
+| Surface | Title | Description | Primary CTA |
+| --- | --- | --- | --- |
+| `/things` (Things list) empty | Nothing here yet. | Start with one thing — an appliance, a piece of furniture, anything you'd want to remember. | + Add a thing |
+| `/places` empty | No places yet. | Add a place — your home, an office, a storage unit — to organize your things. | + Add a place |
+| `/files` empty | No files yet. | Files attach to things and places. Add a thing first, then upload its receipts and manuals. | + Add a thing |
+| `/files` filtered empty | No files match. | Try a different filter or clear them all. | Clear filters |
+| `/backups` empty | No backups yet. | Make your first backup so your records are safe. | + New backup |
+| Search empty | Nothing matches "[query]". | Try different words, or check spelling. | — |
+
+## What ships in sprint 0
+
+1. Replace pipe-topbar with sidebar (desktop) + bottom nav (mobile) shell
+2. Fix login template (split-screen with palette-aware right column)
+3. Build EmptyState primitive and apply to all empty-list surfaces
+4. Replace dark-band detail-view headers with the proper hero pattern
+5. Add 404 / 500 / maintenance error pages
+
+## Decision needed
+
+- Sidebar item rename (Things / Places / Backups) — yes or keep current?
+- Onboarding flow — ship in sprint 0 or sprint 2?

--- a/devdocs/frontend/design/12-tone-of-voice-and-copy.md
+++ b/devdocs/frontend/design/12-tone-of-voice-and-copy.md
@@ -1,0 +1,255 @@
+# Tone of Voice & Copy
+
+The product's personality is half visual, half written. This document is the writing brief.
+
+## Voice in one paragraph
+
+Inventario sounds like a thoughtful, slightly understated friend who keeps your records straight. It speaks plainly, doesn't perform enthusiasm, and respects the user's time. It is occasionally warm — when something matters or when reassurance helps — but never cute. It treats your possessions as **yours**, with the dignity that implies.
+
+## Tone characteristics
+
+| Trait | Expression |
+| --- | --- |
+| **Plain** | Simple words. Short sentences. No jargon. |
+| **Quiet** | One exclamation mark per app at most. No emoji. No marketing voice. |
+| **Practical** | What this is, what to do next. No flourish. |
+| **Warm but reserved** | Friendly without being your buddy. |
+| **Trustworthy** | Honest about what we know and don't know. No fake numbers, no fake urgency. |
+| **Owner-respectful** | "Your things" not "the entries". User's possessions matter. |
+
+## Vocabulary
+
+### Naming the entities
+
+| Current | Recommended | Why |
+| --- | --- | --- |
+| Commodity | Thing (UI) / Item (formal contexts) | "Commodity" is finance/legalese, alien to a personal tool |
+| Location | Place | Plainer, friendlier |
+| Area | Area | Keep — it's already plain |
+| Export | Backup (when about full data) / Export (when about format conversion) | "Backup" matches user mental model |
+| File | File | Keep |
+| Tag | Tag | Keep |
+| Tenant / Group | Workspace | "Group" is too generic; "Workspace" is industry-standard for this concept |
+
+### Words to use
+- own, keep, remember, store, save, find, add, organize, place, thing, file, backup, photo, document, manual, receipt, warranty, expire, value, price, where, when, who
+
+### Words to avoid
+- entity, record, entry, item record, asset, data, system, database, repository, manage, configure, parameter, attribute (in user-facing strings — internal code can use these freely)
+- delightful, awesome, amazing, simply, easy, just (filler)
+- "Successfully" / "Failed to" prefixes (state the outcome directly)
+- All-caps headers (we're not Mailchimp)
+
+## Sentence patterns
+
+### Do
+- "Your dishwasher's warranty expires in 14 days."
+- "Saved."
+- "Couldn't open that file. Try downloading instead."
+- "Add a photo so you remember what it looks like."
+
+### Don't
+- "Successfully saved your record! 🎉"
+- "Oops! We had a tiny problem 😅"
+- "Please be advised that the operation has been completed successfully."
+- "Click here to add a new commodity entry to the database."
+
+## Microcopy templates
+
+### Buttons
+
+| Action | Label |
+| --- | --- |
+| Primary save | Save / Save changes |
+| Cancel | Cancel |
+| Delete | Delete |
+| Confirm destructive | Delete it / Remove it / Archive it |
+| Add | Add a thing / Add a place / Add a file (specific noun preferred) |
+| Generic continue | Continue |
+| Try again after error | Try again |
+| Dismiss | Got it |
+| Skip | Skip |
+| Close | Close |
+
+Avoid: "Submit", "OK", "Confirm" without a noun, "Yes" / "No" alone.
+
+### Form labels
+
+| Concept | Label |
+| --- | --- |
+| Name | Name |
+| Description | Description (optional) |
+| Tags | Tags |
+| Where it lives | Where it lives (not "Location ID") |
+| Purchase date | When you bought it |
+| Original price | What it cost |
+| Current value | What it's worth now (if known) |
+| Serial number | Serial number |
+| Warranty until | Warranty until |
+| Notes | Notes — anything you want to remember |
+
+### Helper text
+
+- Below a tag field: "Tags help you find things later. Try 'kitchen', 'gift', 'electronics'."
+- Below price: "We use this for your insurance summary."
+- Below warranty: "We'll remind you before it expires."
+- Below photo upload: "A photo or two makes it much easier to remember."
+
+### Error messages
+
+Pattern: `[what didn't happen]. [why or what to do.]`
+
+| Scenario | Message |
+| --- | --- |
+| Network failure | Couldn't reach the server. Check your connection and try again. |
+| Validation: required | This one is required. |
+| Validation: too long | Up to 100 characters, please. |
+| Validation: format (email) | Doesn't look like an email address. |
+| Validation: format (date) | Use a real date, like Apr 12, 2026. |
+| Conflict (someone else changed) | Someone else updated this while you were editing. Reload to see the latest. |
+| Permissions | You don't have access to this. |
+| Not found | We couldn't find that. It may have been deleted. |
+| Quota exceeded | You've used all your storage. Free up space or upgrade to add more. |
+| Server error | Something on our end broke. Try again in a moment. |
+
+### Success / confirmation
+
+Direct, past tense, no exclamation:
+
+| Action | Message |
+| --- | --- |
+| Saved | Saved. |
+| Created | Added. |
+| Deleted | Deleted. (Show "Undo" for 5s when reversible.) |
+| Uploaded | Uploaded. |
+| Downloaded | Downloaded. |
+| Copied to clipboard | Copied. |
+| Backup complete | Backup ready. [Download] |
+
+### Empty states
+
+Per surface, in `11-page-layouts-and-flows.md`. Pattern:
+- Title: matter-of-fact, present tense ("Nothing here yet.")
+- Description: explanation + invitation, max 2 sentences
+- CTA: specific noun ("Add a thing", not "Get started")
+
+### Confirmation dialogs
+
+Pattern: `[Action] "[name]"?`
+
+- Title: "Delete \"Camping Equipment\"?" — the name in quotes makes it concrete
+- Body: explicit consequences ("This will remove the item, its 5 images, and 3 manuals. This cannot be undone.")
+- Buttons: action-as-verb ("Delete it") not generic ("Confirm")
+
+### Toast copy by action
+
+| Action | Toast |
+| --- | --- |
+| Created thing | Added "[name]". |
+| Edited thing | Saved. |
+| Deleted thing | Deleted "[name]". · Undo |
+| Uploaded files | Uploaded 3 files. |
+| Failed to save | Couldn't save. Try again. |
+| Network back online | Back online. |
+
+Always quote the name when one item; pluralize cleanly when many ("Deleted 5 things").
+
+### Date / time language (in copy, not formatting)
+
+| Time delta | Display |
+| --- | --- |
+| < 1 min | Just now |
+| 1–59 min | 12 minutes ago |
+| 1–23 hr | 3 hours ago |
+| Yesterday | Yesterday at 4:12 PM |
+| 2–6 days | Tuesday at 4:12 PM |
+| Same calendar year | Apr 12 at 4:12 PM |
+| Older | Apr 12, 2024 |
+
+(Formatting per `13-formatting-and-i18n.md`.)
+
+## Onboarding language
+
+The first 5 minutes are the most important text in the product. Per `11-page-layouts-and-flows.md`:
+
+### Welcome screen
+
+> **A quiet place for the things you own.**
+> Receipts, warranties, where you bought it — all in one place, easy to find when you need them.
+>
+> What's the first thing you'd like to remember?
+
+- Hero feels personal but doesn't promise miracles
+- Categories framed as user goals, not feature lists
+
+### First thing prompt
+
+> **Let's add your first thing.**
+> Anything works — your washing machine, a guitar, the toolbox on the shelf.
+
+Examples in placeholders show range: "Dishwasher, sofa, your guitar". This signals the product handles diversity.
+
+### Tour slides
+
+Each slide: 1 sentence + 1 supporting clause. Total reading time per slide: <8 seconds.
+
+## Reassurance moments
+
+Inventario keeps records about *valuable* things (insurance, warranties). Reassurance copy belongs in:
+
+- After backup completes: "Your records are safe, with you and a copy ready to download."
+- On the security/profile page: "Your data is encrypted at rest and in transit."
+- After deletion confirmation: "[name] is gone. We don't keep deleted items in shadow storage."
+
+These build trust without lecturing.
+
+## Brand voice no-go list
+
+| ❌ Don't write | ✅ Write |
+| --- | --- |
+| "Successfully saved!" | "Saved." |
+| "Oops, something went wrong 😅" | "Couldn't save that." |
+| "Awesome! 🎉 Your dishwasher has been added!" | "Added." |
+| "Easy! Just click here." | "Click to add one." |
+| "Are you sure you want to delete this commodity?" | "Delete \"Dishwasher\"?" |
+| "We will remind you" | "We'll remind you" |
+| "It seems that the action could not be performed at this time" | "Couldn't do that. Try again?" |
+| "Please be advised" | (delete entirely) |
+| "Pro tip:" | (delete entirely) |
+| "Welcome to the inventory management system!" | "Welcome back, [name]." |
+
+## Internationalization
+
+Translation considerations baked into the source copy:
+
+- **Avoid puns and idioms** in user-facing strings. They don't translate.
+- **Avoid embedded variables in mid-sentence** when possible:
+  - ❌ "You added \{name\} on \{date\}."
+  - ✅ "Added on \{date\}: \{name\}." (cleaner translation, names always last)
+- **Avoid count-dependent grammar**: not "1 thing" / "2 things" hard-coded — use ICU MessageFormat (per `13-formatting-and-i18n.md`)
+- **Plan for 30% expansion** — Russian is longer, German is longer, French is longer. Don't lock UI widths to English copy.
+
+## Accessibility-aware copy
+
+- Always provide a non-icon-dependent label ("Edit", not just a pencil icon)
+- Error messages in `<output role="alert">` — announced to screen readers
+- Loading states announce status: `aria-busy="true"`
+- Status pill text is the source of truth — color is supplementary
+
+## Style guide enforcement
+
+- Lint user-facing strings: forbid emojis, "successfully", "failed to", "please", "click here"
+- Spelling/grammar via Vale or LanguageTool in CI for `i18n/en.json`
+- Reviewer checklist: tone-of-voice line in PR template
+
+## Authorship
+
+This brief is the canonical source for tone. When in doubt, re-read the "Voice in one paragraph" section above. New copy gets reviewed against:
+
+1. Is it plain enough?
+2. Is it specific (named) where it can be?
+3. Does it tell the user what to do next?
+4. Does it sound like a friend, not a corporation?
+5. Would I be embarrassed reading this aloud?
+
+If any answer is weak, rewrite.

--- a/devdocs/frontend/design/13-formatting-and-i18n.md
+++ b/devdocs/frontend/design/13-formatting-and-i18n.md
@@ -1,0 +1,198 @@
+# Formatting & Internationalization
+
+How numbers, dates, currencies, and translations are handled.
+
+## Locale strategy
+
+- **Source language:** English (en-US base, en-GB-aware spelling — accept "color" or "colour" but standardize per locale file)
+- **Initial supported locales:** en, ru, cs (Czech, given the obvious origin), de
+- **Locale detection:** `navigator.language` → user setting (persisted) → fallback en
+- **Locale switching:** instant, no full page reload (Vue I18n with composition API)
+
+## Translation infrastructure
+
+- Use `vue-i18n` v9+ with the composition API
+- Translation files: `frontend/src/i18n/<locale>.json`, flat keys with namespacing (`form.label.name`, `error.network.offline`)
+- ICU MessageFormat for plurals and gender (vue-i18n supports it via `@intlify/message-format`)
+- No string concatenation in code — every user-facing string is a key
+- Linter forbids hardcoded strings in `.vue` template `<template>` blocks
+
+## Plural patterns
+
+```json
+{
+  "things.count": "{count, plural, =0 {nothing here yet} one {# thing} other {# things}}"
+}
+```
+
+Languages with complex plural rules (Russian: zero/one/few/many) are handled by ICU automatically:
+
+```json
+{
+  "things.count.ru": "{count, plural, =0 {ничего пока} one {# вещь} few {# вещи} many {# вещей} other {# вещи}}"
+}
+```
+
+Never hard-code "1 thing / 2 things" branches in JS.
+
+## Date and time
+
+### Display formats
+
+| Context | Pattern (en) | Example |
+| --- | --- | --- |
+| Relative (recent) | `relative` (Intl.RelativeTimeFormat) | "3 hours ago" |
+| Same-day exact | `h:mm a` | "4:12 PM" |
+| Same-week | `EEEE 'at' h:mm a` | "Tuesday at 4:12 PM" |
+| Same-year | `MMM d 'at' h:mm a` | "Apr 12 at 4:12 PM" |
+| Older | `MMM d, yyyy` | "Apr 12, 2024" |
+| Date-only short | `MMM d, yyyy` | "Apr 12, 2026" |
+| Date-only long | `MMMM d, yyyy` | "April 12, 2026" |
+| Iso for code/exports | `yyyy-MM-dd` | "2026-04-12" |
+
+### Per-locale variations
+
+| Locale | Date format example |
+| --- | --- |
+| en-US | Apr 12, 2026 |
+| en-GB | 12 Apr 2026 |
+| ru | 12 апр. 2026 |
+| cs | 12. dub. 2026 |
+| de | 12. Apr. 2026 |
+
+### Implementation
+
+Use `Intl.DateTimeFormat` natively, or wrap in a `useDateFormat` composable that:
+- Accepts a `Date | string | number`
+- Returns the appropriate display per "today" relative to now
+- Locale-aware — auto-pulls from current locale
+- SSR-safe
+
+### Time zones
+
+- All timestamps stored in UTC server-side (assumed; verify in backend)
+- Display in user's local time zone (`Intl.DateTimeFormat` does this automatically)
+- For shared/multi-user contexts: tooltip shows UTC offset on hover ("Apr 12 at 4:12 PM (UTC+2)")
+
+### Date input
+
+Always use native `<input type="date">` with the browser's locale. Avoid custom JS date pickers unless required (range pickers for filters use a popover-styled custom). Custom date pickers must:
+- Match the browser locale
+- Show today by default
+- Provide keyboard navigation
+- Allow direct typing in `YYYY-MM-DD` or locale-friendly format
+
+## Numbers
+
+### Display rules
+
+| Context | Pattern | Example |
+| --- | --- | --- |
+| Plain integer | `Intl.NumberFormat` | "1,234" or "1 234" (locale-grouped) |
+| Decimal | locale grouping + 2 decimals | "1,234.56" or "1 234,56" |
+| Percentage | `style: 'percent', minimumFractionDigits: 1` | "12.4%" |
+| Compact | `notation: 'compact'` for large nums | "1.2K", "3.4M" |
+| Tabular columns | `font-variant-numeric: tabular-nums` always |
+| Negative | en-dash prefix, not minus-hyphen | "−12" not "-12" (typographic) |
+
+### Locale grouping
+
+`1,234,567.89` (en-US, en-GB) vs `1 234 567,89` (cs, fr, ru) vs `1.234.567,89` (de, es). Handled automatically by `Intl.NumberFormat`.
+
+## Currency
+
+### Storage
+
+- Money stored as integer minor units (cents) on backend
+- Currency code (ISO 4217) stored alongside per-record
+- Multi-currency support implied: a wine collection valued in EUR while household in CZK
+
+### Display
+
+```
+17 500.00 CZK     ← preferred Inventario format (space-separated, currency code suffix)
+17,500.00 €       ← alternative if symbol-leading; not recommended (mixes en-US grouping with non-USD)
+```
+
+**Decision:** use ISO code as **suffix** with non-breaking space, locale-grouped digits, always 2 decimals.
+
+```ts
+new Intl.NumberFormat(userLocale, {
+  style: 'currency',
+  currency: record.currency,
+  currencyDisplay: 'code',
+}).format(record.amount / 100);
+```
+
+### Currency symbols vs codes
+
+Symbols ($, €, £) ambiguous (USD vs CAD vs AUD all show "$"). Codes (USD, EUR, GBP, CZK) explicit. Inventario uses **codes**, not symbols.
+
+### Mixed-currency aggregates
+
+When totaling across multi-currency records (dashboard "Total inventory value"):
+- Show in **user's primary currency** (settable in profile)
+- Apply latest exchange rate (server-side, cached daily)
+- Display with hint: "Approximately 167,000 CZK" with hover-tooltip showing the underlying mix
+- Never silently sum without conversion — would mislead users
+
+## Units
+
+Inventario doesn't currently surface lengths/weights/volumes for items, but if added (e.g., "wine bottle 750ml"):
+- User profile: imperial / metric preference
+- Display per preference, store as one canonical unit (likely metric)
+- Intl support is weak for units beyond simple cases — wrap in helper
+
+## Address formatting
+
+User addresses (for Place entities) and supplier addresses:
+- Free-form multi-line text fields, not structured (avoids the rabbit hole of country-specific address schemas)
+- Display preserves line breaks
+- For invoices/exports, optional structured fields (street / city / postal / country) added in a v2
+
+## Phone numbers
+
+If added (supplier contact, warranty registration):
+- Store as E.164 (`+420 123 456 789` → `+420123456789`)
+- Display with locale-aware spacing via `libphonenumber-js`
+
+## Right-to-left (RTL) support
+
+Inventario does not need RTL in v1, but the design system is RTL-ready:
+
+- Use logical CSS properties: `padding-inline-start`, `margin-inline-end`, `inset-inline`, etc.
+- Avoid `left` / `right`; use `start` / `end`
+- Icons that have directionality (chevrons, arrows) flip via `dir="rtl"` selector on body
+- Tailwind v4 supports logical properties out of the box
+
+## File and ID formatting
+
+- File sizes: `Intl.NumberFormat` with custom unit logic (`1.2 MB`, `345 KB`, `2.3 GB`)
+- UUIDs: truncate to first 8 + last 4 with em-dash separator: `3fd5fc3e—b67d`
+- Click-to-copy on truncated IDs
+
+## Sort order
+
+Locale-aware string sort via `Intl.Collator`:
+- "Áéí" sorts properly in Spanish/French
+- Numerics within strings (file-1, file-2, file-10) sort naturally with `numeric: true`
+
+```ts
+const collator = new Intl.Collator(userLocale, { numeric: true, sensitivity: 'base' });
+items.sort((a, b) => collator.compare(a.name, b.name));
+```
+
+## Plural-aware UI strings
+
+Avoid the trap of "1 thing(s)" or "0 things found". Even simple cases use plural format:
+- "1 result" / "5 results" / "0 results" — handled via ICU
+- "Showing X of Y" → "Showing 1–12 of 142 things" (where "things" is ICU-pluralized)
+
+## What ships in sprint 0
+
+1. Set up vue-i18n with composition API
+2. Extract every hard-coded user-facing string into `i18n/en.json`
+3. Stub locale files for ru, cs, de (translations come later)
+4. Implement `useDateFormat`, `useNumberFormat`, `useCurrencyFormat` composables
+5. Add `<output role="status">` for live regions in async-update areas
+6. CI lint forbids hard-coded strings in `<template>`

--- a/devdocs/frontend/design/14-accessibility.md
+++ b/devdocs/frontend/design/14-accessibility.md
@@ -1,0 +1,256 @@
+# Accessibility
+
+Inventario commits to **WCAG 2.2 AA** as the floor. Some surfaces (dashboards, file viewer) target AAA where reasonable. Accessibility is not a feature — it's a quality bar that catches a lot of design defects (low contrast, missing keyboard support, opaque labels) before they ship.
+
+## Minimum bars
+
+| Bar | Standard |
+| --- | --- |
+| Color contrast | WCAG 2.2 AA — body text 4.5:1, large text (18px+ or 14px bold) 3:1 |
+| Focus visibility | Custom focus ring per `04-elevation-and-effects.md`, never `outline: none` without replacement |
+| Touch targets | 44×44 CSS pixels minimum, per WCAG 2.5.5 |
+| Keyboard support | All interactive elements reachable and operable via keyboard alone |
+| Screen reader | Major flows readable by VoiceOver / NVDA / JAWS |
+| Motion | `prefers-reduced-motion: reduce` respected |
+| Zoom | UI works at 200% browser zoom without horizontal scroll |
+| Language | `<html lang>` set, language-switch announced |
+
+## Color contrast rules
+
+Per palette direction, **every token combination is pre-checked** before committing. The contrast pairs that must pass:
+
+| Foreground | Background | Min ratio |
+| --- | --- | --- |
+| `--ink-primary` | `--surface-base` | 7:1 (AAA) |
+| `--ink-primary` | `--surface-raised` | 7:1 |
+| `--ink-secondary` | `--surface-base` | 4.5:1 (AA) |
+| `--ink-muted` | `--surface-base` | 4.5:1 (text), 3:1 (decorative) |
+| `--ink-disabled` | `--surface-base` | 3:1 — explicitly NOT meant to pass body text contrast (signals disabled) |
+| `--accent-foreground` | `--accent` | 4.5:1 |
+| `--ink-primary` | `--accent-soft` | 7:1 |
+| Status text | semantic-soft bg | 4.5:1 each |
+
+**Validation:** ship a CI check that asserts all token pairs pass ratio thresholds. Use `chroma.js` or similar in a unit test.
+
+**The current dark-on-dark section header bug** is a 1:1 violation — basically invisible. Fix this on day one.
+
+## Focus management
+
+### Focus ring
+
+Single token applied universally:
+
+```css
+:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+```
+
+`focus-visible` (not `focus`) so mouse clicks don't show the ring. Keyboard focus does.
+
+### Focus traps
+
+Used in:
+- Dialogs (Reka UI handles via `FocusScope`)
+- File viewer fullscreen
+- Mobile drawers
+- Command palette
+
+When the trap is removed, focus returns to the element that opened it (Reka UI default).
+
+### Initial focus
+
+| Surface | Initial focus |
+| --- | --- |
+| Form view | First field |
+| Dialog | First field, or Cancel button if confirmation dialog |
+| Search opened | Search input |
+| File viewer opened | Close button (so Esc and Tab both work intuitively) |
+| Page navigation | Skip-to-content target → `<main>` |
+
+### Skip links
+
+A "Skip to content" link at the top of every page, hidden until focused via Tab:
+
+```html
+<a href="#main-content" class="skip-link">Skip to content</a>
+```
+
+```css
+.skip-link {
+  position: absolute; top: -40px; left: var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  background: var(--accent); color: var(--accent-foreground);
+  border-radius: var(--radius-md);
+  z-index: 100;
+}
+.skip-link:focus { top: var(--space-4); }
+```
+
+## Keyboard shortcuts
+
+Global:
+
+| Shortcut | Action |
+| --- | --- |
+| `⌘K` / `Ctrl+K` | Open command palette / global search |
+| `?` | Show keyboard shortcut reference |
+| `g h` | Go to Home (dashboard) |
+| `g t` | Go to Things |
+| `g p` | Go to Places |
+| `g f` | Go to Files |
+| `g b` | Go to Backups |
+| `n t` | New thing |
+| `n p` | New place |
+| `n f` | Upload file |
+| `Esc` | Close dialog / drawer / lightbox |
+
+Per-surface:
+
+| Surface | Shortcuts |
+| --- | --- |
+| List view | `/` focus search, `j/k` next/prev item, `Enter` open item, `e` edit selected, `Del` delete selected |
+| File viewer | `←/→` prev/next, `+/-` zoom, `0` reset, `r` rotate, `Space` play (video), `Esc` close |
+| Form view | `⌘S` save, `Esc` cancel |
+| Multi-select | `Shift+Click` range, `⌘+Click` toggle |
+
+Shortcut reference accessible via `?` key — modal showing all available shortcuts grouped by section.
+
+## Screen reader patterns
+
+### Landmarks
+
+Every page has:
+- `<header>` (top app bar / sidebar)
+- `<nav>` for primary navigation
+- `<main id="main-content">` for primary content (skip-link target)
+- `<aside>` for sidebars, related content
+- `<footer>` if present
+
+### Headings
+
+- One `<h1>` per page = page title
+- `<h2>` for top-level sections
+- `<h3>` for subsections
+- No skipping levels (no `<h1>` → `<h3>`)
+
+### Live regions
+
+Async updates announced via:
+
+```html
+<div aria-live="polite" aria-atomic="true">
+  Saved.
+</div>
+```
+
+For toasts: `role="status"` (info/success), `role="alert"` (warning/error).
+
+For loading: `aria-busy="true"` on the container being loaded.
+
+### Hidden content
+
+- `aria-hidden="true"` on decorative icons (Phosphor icons that have a label nearby)
+- Off-screen labels: `<span class="sr-only">Edit location</span>` for icon-only buttons that already have visible context
+
+```css
+.sr-only {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+}
+```
+
+## Form accessibility
+
+- Every input has a `<label>` programmatically associated (`for=` + `id=`)
+- Required fields: `aria-required="true"` (`*` symbol is decorative)
+- Errors: `aria-invalid="true"` on field, error message has `id` and field has `aria-describedby` pointing to it
+- Helper text follows the same pattern (field `aria-describedby` points to helper)
+- Field groups (radio, checkbox lists) wrapped in `<fieldset><legend>...`
+
+## Status communication
+
+Color is **never** the only signal:
+- Success: green + check icon + text
+- Error: red + X icon + text
+- Warning: amber + warning icon + text
+
+Color-blind users (~8% of men, ~0.5% of women) get the icon/text. AAA aim.
+
+## Touch and mobile
+
+- Tap targets 44×44 CSS pixels minimum
+- Spacing between targets at least 8px to prevent fat-finger errors
+- Drag handles visible enough to spot (dotted/grip icon, ≥24px target)
+- Swipe-to-dismiss confirmable — irreversible swipes get a confirmation toast with Undo
+
+## Reduced motion
+
+Per `05-motion.md`, `prefers-reduced-motion: reduce` respected globally. Critical UI states must be readable in static form (no element invisible until animation completes).
+
+## Reduced transparency
+
+`prefers-reduced-transparency: reduce` (newer media query) considered:
+- Backdrop-blur effects fall back to solid `--surface-base`
+- Frosted overlays go opaque
+
+## Animation thresholds
+
+Per WCAG 2.2.2:
+- No element flashes >3 times per second
+- No autoplay video with audio
+- Looping animations have a way to pause (or auto-pause after 5s)
+
+## Zoom and reflow
+
+UI must function at:
+- 200% browser zoom
+- 320×256 effective viewport (1280px viewport at 400% zoom)
+
+This means: no fixed-width layouts, no fixed font sizes (use rem/em), no horizontal scrolling at desktop sizes after zoom.
+
+## Language switching
+
+`<html lang>` updates instantly when locale changes. Language switch announced via `aria-live` region.
+
+## Forms with sensitive data
+
+Insurance values, addresses, identification fields:
+- `autocomplete` attribute set correctly per WCAG 1.3.5
+- `inputmode` for numeric / decimal / email
+- Password fields with reveal toggle (per `09-component-patterns.md`)
+- Never auto-zoom on iOS (use `font-size: 16px` minimum on inputs)
+
+## Testing strategy
+
+- **Lint:** `eslint-plugin-vuejs-accessibility` for static checks
+- **Unit:** axe-core integration in Vitest for component test suites
+- **E2E:** axe-core run as part of Playwright tests (`@axe-core/playwright`)
+- **Manual:** quarterly screen reader pass on golden-path flows (sign in, add thing, upload file, view file)
+- **Manual:** quarterly keyboard-only navigation pass
+
+## Anti-patterns
+
+- ❌ "Click here" link text (give the link a meaningful name)
+- ❌ Icon-only buttons without `aria-label`
+- ❌ `placeholder` as the only label
+- ❌ Color as the only state indicator
+- ❌ `outline: none` without focus replacement
+- ❌ `tabindex="-1"` on naturally focusable elements just to avoid a focus ring
+- ❌ Modals that don't trap focus
+- ❌ Auto-focus on page load on non-form pages
+- ❌ Toasts that disappear before screen readers can finish reading them
+- ❌ Required fields marked only by red color, no asterisk or text
+- ❌ "Read more" / "Continue" buttons with no context (out of context, screen readers can't tell what's continuing)
+
+## Compliance reporting
+
+Maintain `docs/accessibility-statement.md` listing:
+- Standard claimed (WCAG 2.2 AA)
+- Known gaps (with planned fixes)
+- Contact for accessibility issues
+- Last audit date
+
+This is required in some jurisdictions (EU, UK, US public sector); good practice everywhere.

--- a/devdocs/frontend/design/15-form-and-data-ux.md
+++ b/devdocs/frontend/design/15-form-and-data-ux.md
@@ -1,0 +1,272 @@
+# Form & Data UX
+
+How forms, mutations, and async state behave from the user's perspective. The unglamorous work that separates "competent app" from "pleasant to use".
+
+## Form save patterns
+
+Three modes, used in different contexts:
+
+### A. Explicit save (default for create / edit)
+
+User edits → fields hold pending state → user clicks Save → save fires → confirmation.
+
+**When to use:** create or edit forms with multiple fields; anything where the user thinks of the changes as a "draft" until committed.
+
+**Behavior:**
+- Save button disabled until any field has changed from baseline
+- "Unsaved changes" indicator next to the Save button (subtle, body-sm muted)
+- Exit-without-saving guard: if user navigates away with unsaved changes, show a confirmation dialog ("You have unsaved changes. Discard them?")
+- After save: success toast, button returns to disabled, route may redirect to detail
+- After save error: button re-enabled, error inline above form, fields keep user's input
+
+### B. Auto-save (for incremental edits)
+
+User edits a single field → blur or 1s debounce → save fires invisibly → subtle confirmation.
+
+**When to use:** detail-view inline edits, settings, single-field updates where the field IS the form.
+
+**Behavior:**
+- After value changes, wait 800ms debounce or `blur`
+- Save fires; field shows subtle pending indicator (small spinner adjacent or inset)
+- On success: brief check icon (1s) then back to normal
+- On error: red border + inline message, value reverts to last-saved on Esc, retry on Enter
+- Last-saved time visible somewhere ("Saved 2 seconds ago")
+
+### C. Optimistic mutation (for low-risk toggles)
+
+User clicks → UI updates instantly → save fires → on error, revert + toast.
+
+**When to use:** toggles (mark as draft, archive, favorite), reorder, delete-with-undo.
+
+**Behavior:**
+- UI changes immediately on click
+- Network request fires in background
+- On success: nothing visible (UI already shows the new state)
+- On failure: revert UI + toast "Couldn't save. Try again." + Retry button
+- Concurrent rapid clicks debounce — last click wins
+
+## Validation timing
+
+| Trigger | What validates | Why |
+| --- | --- | --- |
+| onBlur | Format checks (email, date, length) | User is "done" with this field |
+| onSubmit | All fields | Final gate |
+| onChange (live) | Only when **fixing** an existing error | Don't pester with errors while typing |
+
+**Anti-pattern:** validating on every keystroke from the start. Causes "Required" to flash before user is finished.
+
+## Delete patterns
+
+### Single delete (low-risk: file, tag, single thing without children)
+
+- Click Delete → toast appears with "Deleted [name]. · Undo"
+- Optimistic — UI updates immediately
+- Undo button restores within 5 seconds
+- After 5s, deletion is committed
+- If hard-delete only, treat as high-risk pattern instead
+
+### Single delete (high-risk: thing with files, place with areas)
+
+- Click Delete → confirmation dialog
+- Dialog shows consequence count: "This will remove the item, its 5 images, and 3 manuals."
+- Type-to-confirm only if cascade count > 10 children
+- After confirm: optimistic UI update + commit
+
+### Bulk delete
+
+- Multi-select rows → bulk action bar appears at bottom
+- Click "Delete N selected" → confirmation dialog with full count summary
+- Always type-to-confirm for bulk delete (typo "delete X items")
+- After: undoable for 10s if implementation allows; otherwise committed immediately
+
+## Conflict resolution
+
+When user edits a record that someone else has changed since they loaded it:
+
+- On save, server returns 409 Conflict with current version
+- UI shows: "Someone else updated this while you were editing. [See changes] [Save mine anyway] [Reload theirs]"
+- "See changes" opens a side-by-side diff
+- "Save mine anyway" force-overwrites (with another confirmation)
+- "Reload theirs" discards local edits, shows fresh data
+
+For single-user inventories (most cases), this is rare but the UI must handle it gracefully.
+
+## Loading states (recap from `08-interaction-states.md`)
+
+| Operation duration | UI behavior |
+| --- | --- |
+| <100ms | No state shown; result direct |
+| 100–500ms | Subtle pulse on affected area |
+| 500ms–3s | Skeleton + after 800ms a small spinner |
+| 3–10s | Progress indicator (bar or count) |
+| >10s | Progress + "Still working…" copy after 5s, cancel button |
+
+## Empty states (recap from `11-page-layouts-and-flows.md`)
+
+Use the EmptyState primitive. Three flavors per surface — first-time, filtered, error.
+
+## Optimistic UI examples
+
+| Action | Optimistic update |
+| --- | --- |
+| Toggle "draft" status on commodity | Pill changes immediately |
+| Reorder file gallery | Files rearrange immediately |
+| Add tag | Chip appears immediately |
+| Remove tag | Chip disappears immediately |
+| Mark as archived | Item fades + moves to archive section |
+| Delete (low-risk) | Item disappears with undo toast |
+
+## Pessimistic UI (no optimistic)
+
+| Action | Reason |
+| --- | --- |
+| Save form fields | Validation might fail server-side; user expects "Saved" confirmation |
+| Upload file | Long-running, progress matters |
+| Run backup | Long-running, shows discrete progress |
+| Delete with type-to-confirm | High-risk; user expects explicit confirmation feedback |
+
+## Form layout patterns
+
+### Single-column (default)
+
+Most forms. Max-width `--text-measure-form` (~540px). Fields stacked, vertical rhythm `--gap-stack-default` between them.
+
+### Two-column (when fields are short and naturally paired)
+
+For metadata forms (commodity: Type / Count / Original Price / Current Price / etc.), allow 2-column on desktop:
+
+```
+┌──────────────────────┐ ┌──────────────────────┐
+│ Type                 │ │ Count                │
+└──────────────────────┘ └──────────────────────┘
+┌──────────────────────┐ ┌──────────────────────┐
+│ Original Price       │ │ Current Price        │
+└──────────────────────┘ └──────────────────────┘
+```
+
+Mobile: collapses to single column.
+
+**Rule:** Each row's two fields should logically belong together (both about price, both about identity). Don't put unrelated fields side-by-side just because they fit.
+
+### Section pattern
+
+Group related fields into named sections (Basic, Where it lives, Documentation). Each section gets a heading and optional subtitle.
+
+```
+Basic
+─────────────────────────────
+[name field]
+[description field]
+[type field]    [count field]
+
+Where it lives
+─────────────────────────────
+[place field]    [area field]
+[notes field]
+
+Documentation
+─────────────────────────────
+[receipts uploader]
+[manuals uploader]
+```
+
+### Long form pagination
+
+For multi-step flows (onboarding, complex creation): use a wizard pattern with progress bar at top, "Back" / "Next" buttons at bottom. Maximum 5 steps; if you need more, the form is too complex.
+
+## Field requirements communication
+
+| Type | Display |
+| --- | --- |
+| Required | `*` after label, in `--destructive` color |
+| Optional | "(optional)" suffix in `--ink-muted` (only when ambiguity matters) |
+| Conditional | Show/hide field based on other field's value, with smooth height transition |
+
+Avoid the "required" label on every field — assume required is default and mark optional ones, *or* mark required ones consistently. Pick one convention per app. **Inventario picks: mark required, since most data is optional in this domain.**
+
+## Smart defaults
+
+- New thing: pre-fill location with last-used location
+- New file upload: pre-select file type from drop-zone context (Images uploader → image type)
+- Currency: default to user's primary currency
+- Date: default to today for purchase date; default to today + 2 years for warranty (configurable)
+- Counter (e.g., "count of items"): default to 1
+- Tags: suggest existing tags as user types (autocomplete from corpus)
+
+## Field interactions
+
+### Conditional fields
+
+When field A's value reveals field B (e.g., "Has warranty?" yes → show "Warranty until" field):
+- Field B animates in (height 0 → auto, opacity 0 → 1, `--duration-base`)
+- When hidden, field B is excluded from validation and form data
+
+### Linked fields
+
+When field A's value affects field B's options (e.g., Place selected → Area dropdown filters to that place's areas):
+- Field B's value clears if previously-selected option no longer applies
+- Field B placeholder updates to reflect the change
+
+### Computed fields
+
+Some fields are computed from others (e.g., "Per-unit price" = Total price / Count). Display as read-only, with a tooltip explaining the formula on hover.
+
+## File upload UX
+
+Per `10-file-and-media.md`. Recap:
+- Drop zone with idle / drag-over / uploading / done / error states
+- Per-file progress
+- Multi-file parallel
+- Cancel per file
+- Validation upfront
+
+## Bulk operations
+
+When user selects multiple things:
+- Bulk action bar appears at bottom: "5 selected · [Tag] [Move] [Export] [Delete] [Cancel]"
+- Bar has shadow `lg`, sticky bottom, full width
+- Click an action → applies to all selected
+- Long-running bulk ops show inline progress
+
+## Search behavior
+
+Across all surfaces:
+- Debounce 250ms
+- Show recent searches as suggestions when search input focused with empty query
+- Search results highlight matched terms (subtle bold, not shouty highlight)
+- Keyboard `↓` from search input enters results list
+- "No results" empty state with suggestion to try different terms
+
+## Network resilience
+
+- Request timeout: 30s default, 5min for upload/backup
+- Retry with exponential backoff for transient errors (502, 503, network-down)
+- Indicate network state in UI: small dot in user menu showing "Online" / "Offline" / "Reconnecting"
+- Queue mutations while offline (where feasible) and replay on reconnect — v2 feature
+
+## Print and export
+
+When user prints (Cmd+P), apply print stylesheet (`18-print-and-export.md`). Inline print button on relevant detail pages.
+
+## Drafts
+
+For long-form entries (commodity with many fields), a "Save as draft" option is available alongside "Save". Drafts:
+- Appear in `Things` filtered to "Drafts only"
+- Have a Draft pill on cards
+- Are excluded from dashboard counts unless user opts in
+- Auto-promote to published when user clicks Save (without "as draft")
+
+## What ships in sprint 0
+
+1. Form validation pattern (onBlur format check, onSubmit comprehensive)
+2. Unsaved-changes guard on form views
+3. Toast undo for low-risk deletes
+4. Optimistic toggle for status changes (draft, archive)
+5. Smart defaults for new entity creation (last-used location, today's date, etc.)
+6. EmptyState integration on all list views
+
+Sprint 1+:
+- Auto-save for inline detail edits
+- Conflict resolution UI
+- Bulk operations bar
+- Drafts pattern

--- a/devdocs/frontend/design/16-notifications-and-trust.md
+++ b/devdocs/frontend/design/16-notifications-and-trust.md
@@ -1,0 +1,228 @@
+# Notifications & Trust
+
+How Inventario surfaces alerts, expirations, security signals, and handles user trust.
+
+## Notification taxonomy
+
+Five severity levels, each with consistent visual + tonal treatment:
+
+| Severity | Examples | Visual |
+| --- | --- | --- |
+| **info** (default) | "New backup available", "Tip: tag this item" | `--info` icon (Phosphor Info, fill weight) |
+| **success** | "Backup complete", "Saved" | `--success` (CheckCircle, fill) |
+| **warning** | "Warranty expires in 14 days", "Storage 90% full" | `--warning` (Warning, fill) |
+| **destructive** | "Backup failed", "Connection lost" | `--destructive` (XCircle, fill) |
+| **action-needed** | "5 items need a price for insurance", "1 unrecognized login" | accent (CircleDashed, regular) |
+
+## Where notifications appear
+
+### Toast (transient)
+
+Per `09-component-patterns.md`. Used for action confirmations and async outcomes. Disappears automatically (per severity timing).
+
+### Inline alert (persistent, contextual)
+
+Inside a page or section, when relevant context. Examples:
+- Top of dashboard: "3 warranties expiring this month"
+- Top of file viewer: "This file is shared with 2 collaborators"
+- Inside form: "This action cannot be undone"
+
+Persistent until acknowledged or context changes. Dismissible if not critical.
+
+### Banner (sticky, app-level)
+
+Pinned to the top of the app shell. Used for:
+- Maintenance windows ("Scheduled maintenance at 3 AM tomorrow")
+- Storage warnings ("Storage 95% full — clean up or upgrade")
+- Trial expiration / payment failures (if monetized)
+- Security incidents ("Password change required")
+
+Banners have a close (X) where dismissible; some are critical and require user action before continuing.
+
+### Notifications center (drawer)
+
+Triggered by a bell icon in the top-right (next to user avatar). Drawer lists:
+- Unread notifications (badge count on bell)
+- All notifications, grouped by date
+- Filter by severity
+- Mark all as read
+- Per-item: title, description, time, action (if applicable)
+
+This is **not** a toast history — notifications here are server-pushed events about user data: warranty expirations, backup completions, storage alerts.
+
+## Specific notification types in Inventario
+
+### Warranty expirations
+
+Triggered server-side when:
+- 30 days before expiration → info notification
+- 14 days before → warning + email (if user opts in)
+- 1 day before → warning + email
+- After expiration → archived but visible in notifications center
+
+Display in notifications center:
+```
+[icon] Your dishwasher's warranty expires in 14 days.
+       LG WD-15TD · purchased Apr 2024
+       [View thing] [Snooze]
+```
+
+### Storage warnings
+
+- 80%: info banner
+- 95%: warning banner
+- 100%: destructive banner (uploads disabled)
+
+### Backup completion
+
+- Success: toast + entry in notifications center with download link
+- Failure: destructive toast (no auto-dismiss) + entry in notifications center with retry
+
+### Security events
+
+- New login from unrecognized device: action-needed in notifications center + email
+- Password changed: success toast + email
+- Failed login attempts: warning email (no in-app — user wasn't there)
+- Data export requested: success notification when ready
+
+### Insurance reminders (opt-in)
+
+- Annual reminder: "It's been a year since you last reviewed your inventory for insurance. Want to print a summary?"
+- Action: link to print/export
+
+## Email templates
+
+Inventario sends transactional emails:
+- Welcome / verification
+- Password reset
+- Warranty reminder
+- Backup ready
+- Login alert
+- Weekly digest (opt-in)
+
+### Email design rules
+
+- Plain text first; HTML version with palette tokens applied via inline CSS
+- Subject lines: factual, not marketing ("Your warranty expires in 14 days" not "Don't miss this!")
+- One CTA button per email
+- No images required (text alternative always works)
+- From: `Inventario <hello@inventario.app>` — friendly but not a person's name
+- Footer: physical address (if business), unsubscribe link (for digests, not transactional)
+
+### Tone in email
+
+Same as in-app: plain, respectful, practical. Keep it under 100 words for transactional, under 200 for digests.
+
+### Example: warranty reminder
+
+> **Subject:** Your dishwasher's warranty expires in 14 days
+>
+> Hi Denis,
+>
+> A quick reminder: the warranty on your **LG WD-15TD dishwasher** expires on **May 10, 2026** — 14 days from now.
+>
+> If something's been off, this is a good moment to make a service call.
+>
+> [View in Inventario]
+>
+> — Inventario
+
+## Trust signals
+
+Inventario stores valuables and personal info. Trust signals matter.
+
+### On the marketing/login page
+
+- "Self-hosted or hosted by us — your choice."
+- "Encrypted at rest with industry-standard AES-256."
+- "Open source. Auditable. Yours to fork."
+- "Backups you can download anytime."
+
+### Inside the app
+
+- Profile / Security tab clearly shows:
+  - Account email + verification status
+  - Last login + device
+  - Active sessions (with revoke option)
+  - Two-factor auth status
+  - Connected services (none, in v1)
+  - Data export option
+  - Account deletion option
+
+### After deletion
+
+When user deletes a thing/file/account:
+- Confirmation explicitly states what's deleted and from where
+- For account deletion: "Your data will be permanently removed within 30 days. Some logs may be retained for security audits as required by law."
+- No "shadow storage" — when we say deleted, we mean it. Build the audit log to demonstrate this.
+
+## Sensitive data handling
+
+### Insurance values, addresses, identification numbers
+
+These are sensitive. UI treatment:
+- Don't display in lists by default (visible only on detail page)
+- Mask on screenshots / dev mode (build a `<MaskedValue>` primitive)
+- Easy export but no "share publicly" affordance
+- Audit log entries when viewed (for shared workspaces)
+
+### Photos of receipts
+
+May contain: address, full name, card numbers (if printed).
+- Show user a hint at upload: "Your receipt may show personal info — that's fine, but be aware before sharing."
+- No sharing via public link by default; require explicit opt-in per file.
+
+## Permission model
+
+For multi-user workspaces (small business use case):
+
+| Role | Permissions |
+| --- | --- |
+| Owner | Everything, including delete workspace, manage billing |
+| Admin | Everything except delete workspace, manage billing |
+| Editor | Add/edit/delete things, files, places. Can't change settings or invite users. |
+| Viewer | Read-only |
+
+Permission denied UI: "You don't have access to this." with a link to "Request access" (notifies admins).
+
+## Audit log
+
+For workspaces with multiple users:
+- Every mutation logged (who, what, when, from where)
+- User can view their own activity in profile
+- Admin can view workspace-wide activity
+- Logs are append-only; can be exported
+
+Personal use: audit log still exists but mostly invisible — surfaced only on security-sensitive events.
+
+## Status indicators
+
+App shell shows:
+- Connection state (small dot near user avatar): green (online), amber (reconnecting), red (offline)
+- Sync state: spinner if pending mutations queued (offline, future feature)
+- Notification count badge on bell
+
+## Quiet hours
+
+User can set "quiet hours" for email notifications (no warranty reminders 22:00–08:00). Defaults to off.
+
+## Rate limits and abuse
+
+- Login attempts: 5 per 15 min per IP, 10 per hour per email
+- File upload: rate-limited per user (configurable)
+- API calls: per-tenant rate limit
+- All limits surfaced in UI when hit ("Too many attempts. Try again in 5 minutes.")
+
+## What ships in sprint 0
+
+1. Build NotificationCallout primitive (per `09-component-patterns.md` Notification component)
+2. Wire in toast notifications for save / delete / upload outcomes
+3. Add warranty-expiration server-side event + UI surfacing in dashboard
+4. Banner primitive for storage-warning and maintenance messages
+5. Email template baseline (welcome, password reset, warranty reminder)
+
+Sprint 1+:
+- Notifications center drawer
+- Audit log viewer
+- Connection-state indicator
+- Quiet hours setting

--- a/devdocs/frontend/design/17-density-and-modes.md
+++ b/devdocs/frontend/design/17-density-and-modes.md
@@ -1,0 +1,244 @@
+# Density & Theme Modes
+
+How users adjust the product to their preferences.
+
+## Theme modes
+
+Three options:
+- **Light** (default for first-time users)
+- **Dark**
+- **System** (follows OS preference; default for returning users who haven't picked)
+
+### Toggle UX
+
+Theme toggle accessible from:
+1. **User dropdown** (top-right or sidebar bottom) — "Appearance" submenu with three radio options + "System" preview
+2. **Quick toggle** keyboard shortcut: `⌘⇧D` cycles light / dark / system
+3. **Profile / Appearance** settings page — full settings including density, language, theme
+
+The toggle is **never** in a hidden "UI Settings" expander like the current `/system` page. Theme is a primary user preference.
+
+### Toggle anatomy
+
+```
+Appearance
+─────────────────────────
+( ) Light       ☀
+( ) Dark        ☾
+(•) System      ⌘
+```
+
+Radio cards with icon and label. Selected state shows accent ring.
+
+### Theme application
+
+Implementation via:
+
+```css
+:root {
+  /* light tokens */
+}
+
+:root[data-theme="dark"] {
+  /* dark tokens */
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] {
+    /* dark tokens */
+  }
+}
+```
+
+JS sets `data-theme` on `<html>` based on user setting (persisted in localStorage). On first paint, inline script reads localStorage to avoid flash-of-wrong-theme.
+
+### Transition between themes
+
+When user toggles, root CSS transitions for `background-color`, `color`, `border-color` over `--duration-slow` with `--ease-default`. Not abrupt; not slow.
+
+```css
+:root {
+  transition:
+    background-color var(--duration-slow) var(--ease-default),
+    color var(--duration-slow) var(--ease-default);
+}
+```
+
+Disable transition during initial paint to prevent flash. Disable during route changes for performance.
+
+## Density modes
+
+Three options:
+- **Compact** — for power users with lots of inventory
+- **Comfortable** (default)
+- **Cozy** — for users who prefer breathing room
+
+Per `03-space-and-layout.md`, density is a single CSS variable shift.
+
+### Toggle UX
+
+Accessible from:
+1. **User dropdown** → Appearance → Density
+2. **Profile / Appearance** settings page
+
+Less prominent than theme — most users never change this.
+
+### Anatomy
+
+```
+Density
+─────────────────────────
+( ) Compact      ▤▤▤
+(•) Comfortable  ▤ ▤ ▤
+( ) Cozy         ▤  ▤  ▤
+```
+
+### Implementation
+
+```css
+:root {
+  --space-card-padding: var(--padding-card);
+  --row-height: 48px;
+  --gap-stack: var(--gap-stack-default);
+}
+
+:root[data-density="compact"] {
+  --space-card-padding: var(--padding-card-sm);
+  --row-height: 36px;
+  --gap-stack: var(--gap-stack-tight);
+}
+
+:root[data-density="cozy"] {
+  --space-card-padding: var(--padding-card-lg);
+  --row-height: 56px;
+  --gap-stack: var(--gap-stack-relaxed);
+}
+```
+
+Components reference the abstract token (`--space-card-padding`), not the size-specific one.
+
+## Language
+
+Per `13-formatting-and-i18n.md`:
+- en (default)
+- ru, cs, de (initial set)
+- More via community translation contributions
+
+### Toggle UX
+
+Profile / Appearance / Language. Dropdown with native names:
+- English
+- Русский
+- Čeština
+- Deutsch
+
+Switching is instant, persisted. Prompt user to refresh if they had unsaved drafts in another language (translation could change form behavior in edge cases — rare).
+
+## Time format
+
+- 24-hour vs 12-hour
+- Default: locale-derived (en-US → 12-hour, others → 24-hour)
+- Override in profile
+
+## First day of week
+
+- Sunday vs Monday vs Saturday
+- Locale-derived default
+- Override in profile (used only in date-range pickers)
+
+## Currency display preferences
+
+Already in `13-formatting-and-i18n.md`:
+- Primary currency
+- Currency display: code (CZK) vs symbol (Kč)
+- Decimal places for currency (always 2 in Inventario)
+
+## Notification preferences
+
+Per `16-notifications-and-trust.md`:
+- Email notifications on/off per type (warranty, backup, security, digest)
+- Quiet hours
+- Push notifications (deferred to PWA v2)
+
+## Accessibility preferences
+
+System preferences mostly handled automatically:
+- `prefers-reduced-motion` (per `14-accessibility.md`)
+- `prefers-color-scheme` (theme system mode)
+- `prefers-reduced-transparency`
+
+In-app overrides:
+- High-contrast mode (toggle for users who want stronger contrast than AA)
+- Large-text mode (scale `--text-*` tokens by 1.125)
+
+These are deferred to v2 unless user demand emerges.
+
+## Profile / Appearance page layout
+
+Single profile / settings page with sections:
+
+```
+Profile
+─────────────────────────
+Identity (name, email, password)
+Workspace (default workspace, currency)
+
+Appearance
+─────────────────────────
+Theme (light/dark/system)
+Density (compact/comfortable/cozy)
+Language
+Time format
+First day of week
+
+Notifications
+─────────────────────────
+Email preferences
+Quiet hours
+
+Security
+─────────────────────────
+Active sessions
+Two-factor auth
+Account deletion
+```
+
+Each section in a card, per `09-component-patterns.md` Form section pattern.
+
+## Onboarding initial setup
+
+First-time login captures preferences via a small "Make it yours" step:
+
+```
+Make it yours
+─────────────────────────
+Theme:    ( ) Light  ( ) Dark  (•) Match my system
+Density:  Comfortable (most people)  [More options ▾]
+Language: English  [More ▾]
+
+[Continue]
+```
+
+Skippable. Defaults are sensible — if user skips, system theme + comfortable density + en.
+
+## What ships in sprint 0
+
+1. Theme system: light + dark + system mode, toggle in user dropdown
+2. Density system: data-attribute switching, three modes
+3. Persist preferences in localStorage + sync to server when authenticated
+4. Profile / Appearance settings page (replaces hidden current "UI Settings" expander)
+5. Onboarding "Make it yours" step
+
+Sprint 1+:
+- Time format toggle
+- First-day-of-week toggle
+- High-contrast mode
+- Large-text mode
+
+## Anti-patterns
+
+- ❌ Theme hidden inside "UI Settings" expander (current state — fix)
+- ❌ Theme toggle without a "system" option
+- ❌ Density modes that drastically change the layout (only spacing changes; never element visibility)
+- ❌ Forcing a theme based on time of day without user consent
+- ❌ Theme that ignores user's saved preference and defaults to system on every load

--- a/devdocs/frontend/design/18-print-and-export.md
+++ b/devdocs/frontend/design/18-print-and-export.md
@@ -1,0 +1,255 @@
+# Print & Export
+
+Inventory documentation often leaves the app — for insurance claims, for selling, for sharing with family. This document specifies how.
+
+## Why this matters
+
+The most common Inventario "exit" use case is producing a PDF of the inventory for an insurance company. If that PDF looks unprofessional or is hard to read, the product fails its primary job. Print-quality output is a feature, not an afterthought.
+
+## Print stylesheet
+
+A `@media print` block applies globally and resets the chrome:
+
+```css
+@media print {
+  /* Hide app shell */
+  nav, header, aside, footer.app-footer,
+  .sidebar, .topbar, .bottom-nav,
+  .button, .toast, .tooltip,
+  [data-print-hidden] {
+    display: none !important;
+  }
+
+  /* Reset background to white, ink to near-black */
+  body {
+    background: white;
+    color: #111;
+  }
+
+  /* Remove all shadows, borders become hairlines */
+  * {
+    box-shadow: none !important;
+    border-color: #000 !important;
+    border-width: 0.5pt !important;
+  }
+
+  /* Type sized for print */
+  body { font-size: 10pt; line-height: 1.4; }
+  h1   { font-size: 18pt; }
+  h2   { font-size: 14pt; }
+  h3   { font-size: 11pt; }
+
+  /* Ensure colors are color-managed for print */
+  * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+
+  /* Page margins */
+  @page {
+    margin: 18mm 14mm;
+    size: A4;
+  }
+
+  /* Page break controls */
+  h1, h2, h3 { page-break-after: avoid; break-after: avoid; }
+  .commodity-row { page-break-inside: avoid; break-inside: avoid; }
+}
+```
+
+### What's preserved
+
+- Page title block with date and workspace name (header, repeats per page via `position: running` if browser supports)
+- The actual content — entity title, metadata, photos, descriptions
+- Page numbers (footer, "Page X of Y")
+- Workspace branding (small) at top
+
+### What's hidden
+
+- Navigation
+- Action buttons (edit, delete, etc.)
+- Loading skeletons (replaced with empty state)
+- Backdrops, scrims
+- Tooltips (their content is irrelevant in print)
+- Search inputs
+- Toast notifications
+- Hover/focus states
+
+## Export formats
+
+Inventario supports four export formats:
+
+### A. PDF (printable)
+
+Browser-driven via `window.print()` or server-rendered via headless Chrome / wkhtmltopdf.
+
+**When user clicks "Print" or "Export to PDF":**
+- Server-rendered for high-fidelity (consistent fonts, predictable layout)
+- Two layouts: **summary** (one row per thing) and **detailed** (each thing on its own page with photos)
+
+### B. Spreadsheet (CSV / XLSX)
+
+For users importing into Excel, Numbers, accounting software.
+
+**Columns by entity:**
+- Things: name, type, place, area, count, original_price, current_price, currency, purchase_date, warranty_until, serial_number, tags, notes, created_at, updated_at, file_count
+- Places: name, address, total_value, area_count, thing_count
+- Files: name, mime_type, size, owner_type, owner_name, uploaded_at
+
+XLSX is preferred (preserves data types). CSV always available.
+
+### C. JSON (full backup)
+
+For users wanting a complete snapshot. Includes all entities, all relationships, all metadata. The "Backups" feature in nav already does this — keep the term.
+
+### D. Single-thing snapshot (PDF)
+
+For sharing one item (sending to a service tech, listing for sale). Single-page PDF with photo, key metadata, QR code linking back to the live record (if user opts in).
+
+## Print template — summary
+
+```
+┌─────────────────────────────────────────────────┐
+│ [logo]                          Apr 26, 2026   │  header
+│                                                 │
+│ Home Inventory                                  │  h1
+│ Denis V — Inventario                            │  subtitle
+│ 93 things across 4 places · approx. 167K CZK    │  meta
+│ ─────────────────────────────────────────────── │
+│                                                 │
+│ Place: Home                                     │  section
+│  ┌─────────────────────────────────────────┐   │
+│  │ Bedroom                                 │   │  area
+│  │  ─ Camping Equipment    Outdoor    21K │   │  thing rows
+│  │  ─ Wool blanket         Bedding     2K │   │
+│  │  ...                                    │   │
+│  └─────────────────────────────────────────┘   │
+│                                                 │
+│ ...                                             │
+│                                                 │
+│ ─────────────────────────────────────────────── │
+│ Page 1 of 12                  Inventario        │  footer
+└─────────────────────────────────────────────────┘
+```
+
+## Print template — detailed (per thing)
+
+One page per thing:
+
+```
+┌─────────────────────────────────────────────────┐
+│ [thumbnail]   Camping Equipment                 │
+│               Outdoor / Bedroom / Home          │
+│ ────────────────────────────────────────────── │
+│ Type:               Outdoor equipment           │
+│ Count:              1                           │
+│ Purchase date:      Jul 10, 2021                │
+│ Original price:     17,500 CZK                  │
+│ Current value:      21,250 CZK                  │
+│ Warranty:           Until Jul 2024 (expired)    │
+│ Serial:             —                           │
+│ Tags:               outdoor, seasonal           │
+│                                                 │
+│ Notes                                           │
+│ Family camping kit, used 3-4 times per year.    │
+│                                                 │
+│ Photos                                          │
+│ [photo 1]  [photo 2]  [photo 3]                │
+│ [photo 4]  [photo 5]                           │
+│                                                 │
+│ Documents                                       │
+│  ─ Receipt (.pdf, 1.2 MB)                       │
+│  ─ Warranty card (.pdf, 240 KB)                 │
+│  ─ User manual (.pdf, 5.1 MB)                   │
+└─────────────────────────────────────────────────┘
+```
+
+## Insurance summary template
+
+A specialized export for insurance purposes. PDF with:
+- Cover page: workspace name, date, total declared value, currency
+- Per-place breakdown
+- Per-thing rows with photo, name, value, serial, purchase date
+- Each photo URL or embedded image (configurable)
+- Footer: "Generated by Inventario on Apr 26, 2026 — values reflect user input, not appraised market value."
+
+The legal disclaimer matters: insurance companies need to know this is a record, not an appraisal.
+
+## Export UX
+
+### Triggering export
+
+- From any list view, top-right "Export ▾" dropdown:
+  - Print (browser native)
+  - PDF (download)
+  - Spreadsheet (XLSX / CSV)
+  - JSON (full backup) — only on "Backups" page
+- From entity detail: "Print" / "Export" button in the top-right menu
+
+### Configuring export
+
+Modal for spreadsheet/PDF exports:
+
+```
+Export to PDF
+─────────────────────────
+What to include:
+[•] Photos (largest 1)
+[•] Documents (just file list, not file content)
+[ ] Warranty / serial details
+[ ] Internal notes
+
+Layout:
+( ) Summary (one line per thing)
+(•) Detailed (one page per thing)
+
+Filter:
+Include only: [All things ▾]
+
+[Cancel]   [Export]
+```
+
+Defaults: photos on, summary layout for >50 things, detailed for <50.
+
+### Progress
+
+For large exports:
+- Modal closes
+- Toast: "Generating your export…"
+- Notifications-center entry appears with a progress bar
+- When ready, toast: "Your export is ready. [Download]"
+- Notification persists; user can re-download for 7 days
+
+## Sharing exports
+
+For users who want to share a single thing with a contractor / family member:
+
+- Per-thing "Share as PDF" generates a one-page PDF with optional QR
+- Copy a link to clipboard (signed URL, expires in 7 days by default, configurable)
+- Email the export directly (if email service configured)
+
+No public-by-default sharing. Every share is explicit.
+
+## Data export under GDPR / privacy laws
+
+User can request a full data export from Profile / Privacy:
+- All entities
+- All files (zipped)
+- All metadata
+- Audit log
+- Email content sent to them
+
+Generated server-side, downloadable for 30 days. Confirms user's right to data portability.
+
+## What ships in sprint 0
+
+Print stylesheet and basic PDF export are foundational; they need to exist for the product's primary use case (insurance documentation).
+
+1. Implement `@media print` global stylesheet
+2. Build server-side PDF export for summary template
+3. Add "Print" and "Export to PDF" options in list views
+4. Wire spreadsheet (XLSX) export — server-side via existing libraries
+
+Sprint 1+:
+- Detailed PDF template
+- Per-thing share-as-PDF
+- Insurance summary template
+- Configurable export modal
+- Email-the-export option

--- a/devdocs/frontend/design/19-branding.md
+++ b/devdocs/frontend/design/19-branding.md
@@ -1,0 +1,193 @@
+# Branding
+
+The product's visual identity beyond the application UI: logo, marks, social/email/print presence.
+
+## Current state
+
+Inventario currently uses a small QR-cube favicon as the primary mark. It reads as a placeholder, not a brand. The wordmark "Inventario" is set in the default UI font.
+
+The product needs a proper logo system before launching publicly. This is a one-time investment.
+
+## Brand mark requirements
+
+A good Inventario mark should be:
+
+1. **Quiet** — matches the tone (not loud, not playful, not corporate)
+2. **Personal** — suggests household, archive, care — not enterprise SaaS
+3. **Versatile** — works at 16×16 (favicon) and 256×256 (app icon) and as a wordmark
+4. **Monochrome-safe** — single-color version for print, minimal scenarios
+5. **Memorable** — distinguishable from generic database/grid icons
+
+## Mark direction options
+
+### Option 1: Type-only (wordmark)
+
+"Inventario" set in the chosen display font (Switzer / GT Walsheim / Tiempos depending on type pairing decision in `02-typography.md`), with a deliberate ligature or kern that makes it distinctive. No icon mark; favicon = first letter.
+
+Pros: cheapest, instantly fits any palette, ages well.
+Cons: no scalable icon for app stores, needs strong typography to be distinctive.
+
+### Option 2: Letter-mark (initial in a frame)
+
+Single letter "I" or "i" in a custom-drawn frame — could be a rectangle suggesting a label, a circle suggesting a tag, a small square with a notch suggesting a drawer. Used as both icon and inline with wordmark.
+
+Pros: scalable, distinctive, friendly without being a cartoon.
+Cons: harder to design well; tempting to settle for a generic "first letter in a circle".
+
+### Option 3: Pictorial mark (object-based)
+
+A simple, abstract object — a label, a tag, a folded card, a key — that evokes the product's domain. Set alongside the wordmark.
+
+Pros: unique, story-rich.
+Cons: easy to date (peak 2018 "logos with a hidden meaning" trend), hard to keep timeless.
+
+### Recommendation
+
+**Letter-mark direction (option 2).** Best balance of distinctiveness, scalability, and timelessness for this product class. Things 3 (an "i" shape), 1Password (a key shape), Notion (an "N") all use related strategies and aged well.
+
+Concept brief for the mark:
+- Lowercase "i" or rounded square with a notch suggesting a label slot
+- Single color (the palette accent), or two-tone for mark-on-light vs mark-on-dark
+- Drawn in the same weight family as the chosen display font
+- Optical-balanced: looks centered at small sizes
+- Has a subtle implied story (drawer, tag, label) without being literal
+
+This is best done by a brand designer (~€500–1500 on Dribbble for a strong illustrator + 2 revisions) or via a longer trial-and-error with AI tools + manual polish.
+
+## Wordmark
+
+"Inventario" set in display font, weight medium, with carefully tracked spacing. Used:
+- In-app sidebar logo lockup (mark + wordmark)
+- Footer of the app
+- Email headers
+- Marketing site (when one exists)
+
+Avoid using stylized letterforms (custom characters) unless inevitable — they don't translate to non-Latin scripts (Cyrillic localization).
+
+## Lockup variations
+
+Six variations needed:
+
+1. **Primary horizontal**: mark + wordmark side-by-side, default
+2. **Primary stacked**: mark above wordmark, for square contexts (cards, app stores)
+3. **Mark-only**: just the icon, for tight spaces (favicon, sidebar collapsed)
+4. **Wordmark-only**: just the type, for contexts where mark would be redundant
+5. **Reverse**: light-on-dark variant for dark surfaces
+6. **Monochrome**: black-only for print
+
+Spacing rules: clear-space around the lockup equals the height of the mark. Never crowd.
+
+## Favicon set
+
+| Size | Use |
+| --- | --- |
+| 16×16 | browser tab |
+| 32×32 | browser tab on retina |
+| 48×48 | Windows |
+| 180×180 | iOS home screen |
+| 192×192 | Android home screen |
+| 512×512 | Android adaptive icons |
+
+ICO file with 16/32/48 for legacy. Modern browsers prefer SVG favicon (one file scales cleanly).
+
+```html
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" href="/favicon-32.png" sizes="32x32">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+```
+
+## Open Graph / Twitter card
+
+For when Inventario links are shared:
+
+- 1200×630px image
+- Brand mark + tagline + product screenshot framed in palette colors
+- Minimal text — the unfurl card is contextualized by the URL and meta description
+
+Example:
+```
+[mark]                  Inventario
+                        A quiet place for the things you own.
+
+[stylized screenshot of dashboard with palette overlay]
+```
+
+## Email branding
+
+Per `16-notifications-and-trust.md`. Headers contain the wordmark (image link with alt text). Footer has the address (if business) and unsubscribe.
+
+## Print branding
+
+Per `18-print-and-export.md`. Top of every printed page has small wordmark + date. Footer has page number + "Inventario".
+
+## App theme color
+
+Define a single theme color used for:
+- Browser address bar tint on mobile (`<meta name="theme-color">`)
+- Splash screens
+- App badges
+
+Use the chosen palette accent at full saturation. One value for light mode, one for dark.
+
+```html
+<meta name="theme-color" content="#C2410C" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#F08C5C" media="(prefers-color-scheme: dark)">
+```
+
+## Tagline
+
+Several candidates per positioning:
+
+- "A quiet place for the things you own." (recommended — matches positioning doc)
+- "Keep track of your things, calmly."
+- "Records of what's yours."
+- "Your stuff, on the record."
+
+Decision: **"A quiet place for the things you own."** Used on login, in OG card, in email footer.
+
+## Voice in branded surfaces
+
+Marketing voice = product voice (per `12-tone-of-voice-and-copy.md`). Inventario doesn't put on a "marketing voice" for its branded touchpoints. The same plain, calm, respectful tone applies.
+
+Example landing page copy:
+
+> ## A quiet place for the things you own.
+>
+> Keep track of warranties, prices for insurance, and where you bought things —
+> so you don't have to remember.
+>
+> [Try it free] [Self-host it]
+
+## Design system asset bundle
+
+Sprint 0 / 1 deliverables:
+
+1. SVG mark (master, vector source)
+2. SVG wordmark (master)
+3. PNG mark exports at 16, 32, 48, 64, 128, 256, 512
+4. ICO favicon
+5. Apple-touch-icon
+6. Lockup files (Figma or sketch source) with all 6 variations
+7. Brand guidelines doc (1 page) covering clear space, color usage, no-go transformations
+8. OG card template (PSD or Figma)
+9. Email header template (HTML + image fallback)
+
+## Decision needed
+
+- Mark direction: type-only / letter-mark / pictorial?
+- Designer source: in-house Claude direction / commissioned designer / AI tools + polish?
+- Tagline: confirm "A quiet place for the things you own." or alternative
+
+I recommend: letter-mark + commissioned designer (~€500–1000) + the recommended tagline. This is a one-time investment that pays off for the product's lifetime.
+
+## What ships in sprint 0
+
+Realistically, sprint 0 ships **placeholders that look intentional**:
+
+1. Wordmark in the chosen display font, weight medium, in palette accent — used in sidebar, login, email
+2. Favicon: a simple "i" in palette accent inside a rounded square — placeholder until real mark exists
+3. App theme-color meta tags
+4. OG card with wordmark + tagline + palette gradient bg
+
+Real mark replaces the placeholder when commissioned.

--- a/devdocs/frontend/design/19-branding.md
+++ b/devdocs/frontend/design/19-branding.md
@@ -41,18 +41,18 @@ A simple, abstract object — a label, a tag, a folded card, a key — that evok
 Pros: unique, story-rich.
 Cons: easy to date (peak 2018 "logos with a hidden meaning" trend), hard to keep timeless.
 
-### Recommendation
+### Selected direction
 
-**Letter-mark direction (option 2).** Best balance of distinctiveness, scalability, and timelessness for this product class. Things 3 (an "i" shape), 1Password (a key shape), Notion (an "N") all use related strategies and aged well.
+**Catalog-tag (option 3, pictorial mark) is the confirmed direction.** This supersedes an earlier letter-mark recommendation that lived here while the brief was being assembled, and aligns with the selected direction in [`README.md`](./README.md) and [`21-logo-directions.md`](./21-logo-directions.md). It preserves the product's quiet, personal tone while giving Inventario a distinctive object-led mark that scales across favicon, app icon, and wordmark lockup.
 
 Concept brief for the mark:
-- Lowercase "i" or rounded square with a notch suggesting a label slot
-- Single color (the palette accent), or two-tone for mark-on-light vs mark-on-dark
-- Drawn in the same weight family as the chosen display font
-- Optical-balanced: looks centered at small sizes
-- Has a subtle implied story (drawer, tag, label) without being literal
+- A simple catalog-tag / label-tag silhouette with restrained geometry — corner-cut + small string-hole detail per `21-logo-directions.md` Direction 3
+- Single color (the palette accent or deep navy) by default; two-tone variant only if needed for contrast on light/dark applications
+- Drawn to feel consistent with the chosen display font's weight and proportions
+- Optical-balanced and legible at very small sizes (16×16 favicon)
+- Suggests labeling, cataloguing, and personal archiving without becoming literal or decorative
 
-This is best done by a brand designer (~€500–1500 on Dribbble for a strong illustrator + 2 revisions) or via a longer trial-and-error with AI tools + manual polish.
+Refinement happens via the AI workflow in `21-logo-directions.md` (reference-image-driven iteration in ChatGPT Images 2.0). A brand designer (~€500–1500 on Dribbble) is a fine alternative path if AI iteration doesn't reach the desired bar.
 
 ## Wordmark
 
@@ -173,21 +173,19 @@ Sprint 0 / 1 deliverables:
 8. OG card template (PSD or Figma)
 9. Email header template (HTML + image fallback)
 
-## Decision needed
+## Decisions
 
-- Mark direction: type-only / letter-mark / pictorial?
-- Designer source: in-house Claude direction / commissioned designer / AI tools + polish?
-- Tagline: confirm "A quiet place for the things you own." or alternative
-
-I recommend: letter-mark + commissioned designer (~€500–1000) + the recommended tagline. This is a one-time investment that pays off for the product's lifetime.
+- Mark direction: **catalog-tag (option 3, pictorial)** — confirmed; see `21-logo-directions.md`
+- Designer source: **AI iteration (ChatGPT Images 2.0) with reference-image workflow**; commissioned designer is a fallback if AI iteration doesn't reach the desired bar
+- Tagline: **"A quiet place for the things you own."** — confirmed
 
 ## What ships in sprint 0
 
 Realistically, sprint 0 ships **placeholders that look intentional**:
 
 1. Wordmark in the chosen display font, weight medium, in palette accent — used in sidebar, login, email
-2. Favicon: a simple "i" in palette accent inside a rounded square — placeholder until real mark exists
+2. Favicon: a simple geometric placeholder in palette accent inside a rounded square — placeholder until the catalog-tag mark is finalized
 3. App theme-color meta tags
-4. OG card with wordmark + tagline + palette gradient bg
+4. OG card with wordmark + tagline + palette background
 
-Real mark replaces the placeholder when commissioned.
+The finalized catalog-tag mark replaces the placeholder once iterated to lock in `21-logo-directions.md`.

--- a/devdocs/frontend/design/20-edge-cases.md
+++ b/devdocs/frontend/design/20-edge-cases.md
@@ -1,0 +1,371 @@
+# Edge Cases
+
+Every UI surface that's not the happy path. Senior-design discipline lives here — it's where products feel finished or feel rough.
+
+## Navigation edge cases
+
+### 404 — page not found
+
+Per `11-page-layouts-and-flows.md`. Full-page empty state with illustration and "Take me home" CTA.
+
+### 403 — permission denied
+
+Page content replaced with:
+```
+[icon: lock]
+
+You don't have access to this.
+
+If you think this is a mistake, ask your workspace
+admin to grant you access.
+
+[Go back]   [Switch workspace]
+```
+
+### Stale link to deleted entity
+
+User opens `/things/abc123` but the thing was deleted:
+```
+[icon: empty drawer]
+
+This thing isn't here anymore.
+
+It may have been deleted, or you may be in the
+wrong workspace.
+
+[See all things]
+```
+
+If user has audit-log permission, "When was it deleted?" link reveals the audit log entry.
+
+### Wrong workspace
+
+User navigates to `/g/foo/things/abc123` but thing belongs to a different workspace:
+```
+[icon: signpost]
+
+This is in another workspace.
+
+Switch to "Personal" to view it?
+
+[Switch workspace]   [Go back]
+```
+
+## Empty data edge cases
+
+### Brand-new account, never used
+
+Per onboarding flow (`11-page-layouts-and-flows.md`). User lands on welcome screen, picks a use case, adds first thing. Dashboard shows "Recently added: 1 thing — your first one." with a celebratory tone (not over the top).
+
+### Account with no items in some categories
+
+Dashboard shows partial stats. Empty widgets show their own empty state (per `15-form-and-data-ux.md`).
+
+```
+Value over time
+[empty chart with hint: Add prices to start tracking value over time.]
+```
+
+Each widget knows what data it needs and what to say if it's missing.
+
+### Filter / search returns nothing
+
+Per `11-page-layouts-and-flows.md`. "No things match \"foo\"." with "Try different terms" + "Clear filters" CTAs.
+
+## Long-content edge cases
+
+### Very long item name
+
+Names can be arbitrarily long ("Vintage Mid-Century Walnut Sideboard with Brass Hardware and Sliding Doors").
+
+Rules:
+- Lists / cards: truncate to single line with ellipsis, full name on hover (tooltip) or in detail page
+- Detail page hero: wrap to 2 lines, then truncate with ellipsis; full name accessible via "..." menu → "Copy name"
+- Forms: max 200 characters server-side; UI shows character count when ≥150
+
+### Very long description / notes
+
+Server-side limit: 5000 chars. UI:
+- Collapsed by default in detail page (show first ~200 chars + "Read more")
+- Expand inline; clicking again collapses
+- Print view shows full text
+
+### Many tags
+
+Users may apply many tags ("kitchen, white-goods, lg, dishwasher, brand-name, year-2024, ...").
+
+Rules:
+- Card view: show first 3 tags, then "+N more" chip
+- Detail view: show all, wrapping
+- Filter dropdown: search-as-you-type within the chip selector
+
+### Many files attached
+
+A commodity may have 50 photos.
+
+Rules:
+- File gallery: paginate or virtualize after 24 visible
+- Detail view: section heading shows count "Images (52)"
+- File viewer: thumbnail strip scrolls, current always centered
+
+## Long async operations
+
+### Slow upload
+
+User uploads a 500MB video. Per `10-file-and-media.md`:
+- Per-file progress bar
+- Time estimate shown if upload >30s
+- User can navigate away — upload continues in background, surfaced via persistent indicator
+- Cancel option always available
+
+### Slow backup
+
+Server-side job. UI:
+- "Generating backup… this may take a minute."
+- Progress percentage if known
+- Toast on completion with download link
+- Notification center entry for later access
+
+### Slow sync (future PWA)
+
+If offline mode added:
+- Pending mutations queued
+- Sync indicator in shell
+- On reconnect, sync runs; user sees a small banner: "Syncing 5 changes…" → "Up to date."
+
+## Concurrency edge cases
+
+### Simultaneous edits
+
+Per `15-form-and-data-ux.md`. Server returns 409, UI offers conflict resolution.
+
+### Stale lists during edit
+
+User opens "Things" list, navigates to a thing, deletes it, returns to list. List should reflect deletion. Solution: invalidate query cache on mutation; refetch on focus.
+
+### Tab open in two places
+
+User opens app in two tabs, edits in one. The other tab still shows old data until refocused (then refetches). For shared workspaces, also invalidate via WebSocket or polling — but v1 acceptable to require a refresh.
+
+## Network edge cases
+
+### Offline
+
+- Detect via `navigator.onLine` + heartbeat
+- Show banner: "You're offline. Changes won't be saved until you reconnect."
+- Disable mutations (or queue them, v2)
+- Cached read-only data still browsable
+
+### Slow connection
+
+- Skeletons hold longer
+- Show "Still loading…" copy after 5s
+- Retry option after 30s timeout
+
+### API errors
+
+Server returns 500:
+- Show inline error in affected widget ("Couldn't load things. [Retry]")
+- Don't replace whole page unless the error is page-fatal
+
+## Authentication edge cases
+
+### Session expired during use
+
+- Detect via 401 response
+- Save current form state to sessionStorage
+- Redirect to login with "Your session expired. Sign in to continue."
+- After login, restore form state and offer to re-submit
+
+### Wrong workspace selected
+
+User has access to multiple workspaces; current workspace doesn't have the entity they're trying to view. Per "Wrong workspace" above.
+
+### Invitation expired / revoked
+
+User clicks invite link in email after expiration:
+```
+[icon: hourglass]
+
+This invitation has expired.
+
+Ask the person who invited you to send a new one.
+
+[Got it]
+```
+
+## Data integrity edge cases
+
+### Currency change
+
+User changes their primary currency in profile. All values in display reformat instantly (per `13-formatting-and-i18n.md` — show in user's primary currency). Mention in toast: "Showing values in EUR now. Original prices stay in their original currency."
+
+### Time zone change
+
+Travel — user's browser TZ changes. All relative timestamps reflect new TZ. No UI fanfare; this is silent.
+
+### Locale change
+
+Language switches → entire UI re-translates instantly. Date / number formatting updates. Form drafts preserved.
+
+### Workspace deleted while user is in it
+
+User's workspace deleted by admin while user has a tab open. Next API call returns 410 Gone:
+```
+[icon: door-closed]
+
+This workspace was deleted.
+
+[Switch to another workspace]
+```
+
+## File edge cases
+
+### Corrupt file
+
+User uploads a file that fails server-side validation (truncated, malformed):
+```
+[icon: warning]
+
+That file looks damaged.
+
+We couldn't read it. Try uploading a fresh copy.
+
+[Choose another file]
+```
+
+### Unsupported file type
+
+Per `10-file-and-media.md`. Replace preview with type icon + "Preview not available — Download to view."
+
+### File too large
+
+Pre-flight client check; if exceeded:
+```
+That file is too large.
+
+The maximum is 50 MB. This one is 142 MB.
+
+[Choose a smaller file]
+```
+
+### Storage quota reached
+
+Banner across app + upload disabled:
+```
+You've used all your storage.
+
+Free up space by removing old files, or upgrade
+your plan to add more.
+
+[Manage files]   [Upgrade]
+```
+
+### File missing on server (orphan)
+
+Database has a file record but the binary is gone (storage corruption, manual cleanup):
+- File card shows "File missing" overlay with "Remove this record" action
+- Admin alert in audit log
+- Backup process flags missing files in summary
+
+## Form edge cases
+
+### User clicks Save twice
+
+- After first click, button enters loading state (per `08-interaction-states.md`)
+- Disabled during load, ignores second click
+- Toast on completion
+
+### User navigates away with unsaved changes
+
+Confirmation dialog: "You have unsaved changes. Discard them?"
+
+### User refreshes mid-form
+
+For long forms, optionally save to sessionStorage on every change. On refresh, restore with "Restored from local — your draft is back. [Save now] [Discard]"
+
+### Browser autofill clobbers fields
+
+Native autofill can fill fields the user didn't intend. UI:
+- Don't actively fight autofill (it's accessibility-positive)
+- Provide clear field labels so users notice mismatches
+- Critical fields (insurance values) require explicit user typing — disable autocomplete
+
+## Search edge cases
+
+### Empty query
+
+Show recent searches + popular shortcuts ("All things", "Recently added", "Drafts"). Don't run a query with empty terms.
+
+### Query with only special characters
+
+Sanitize and handle gracefully. "@@@@" returns no results with helpful copy.
+
+### Query that matches huge number of items
+
+Cap displayed results at 100, show "Showing 100 of 4,328 results — refine your search." Provide refine-by suggestions.
+
+### Search service unavailable
+
+Fall back to client-side filtering on currently-loaded data, with a banner: "Server search is unavailable. Showing local matches only."
+
+## Accessibility edge cases
+
+### User uses keyboard exclusively
+
+All flows tested for keyboard-only completion. No mouse-required interactions.
+
+### User uses screen reader
+
+All async updates announced via live regions. No visual-only state changes.
+
+### User has reduced motion
+
+Static states must be readable; animations replaced with instant transitions.
+
+### User has very large default font
+
+Font-relative sizing means UI scales. No fixed pixel widths. Tested at 200% browser zoom.
+
+## Print edge cases
+
+### Print button clicked on empty inventory
+
+Skip print; show toast: "Add at least one thing before printing."
+
+### Print on mobile
+
+Mobile browsers don't all support `window.print()` reliably. Provide "Save as PDF" alternative.
+
+## Multi-user edge cases
+
+(Mostly future work, but design-system-aware now.)
+
+### Concurrent editor leaves stale lock
+
+If using soft locks: locks expire after 5 minutes idle. Other user can claim with confirmation.
+
+### User removed from workspace mid-session
+
+Next API call returns 403 → redirect to "You no longer have access to this workspace."
+
+### Orphan invitations
+
+Invites that haven't been accepted in 30 days expire. Sender can resend.
+
+## What ships in sprint 0
+
+These edge cases are mostly **components and copy** to handle. Foundation work that ships in sprint 0:
+
+1. Build error-page templates: 404, 403, 500, "deleted entity", "wrong workspace"
+2. Build offline banner + connection-state indicator
+3. Build "session expired" redirect-with-state-preservation flow
+4. Wire up all destructive-action confirmation patterns per `15-form-and-data-ux.md`
+5. Build "unsaved changes" navigation guard
+
+Sprint 1+:
+- Storage quota system
+- Concurrent-edit conflict resolver UI
+- Audit-log integration with deleted-entity pages
+- File-missing handling
+- Search service fallback

--- a/devdocs/frontend/design/21-logo-directions.md
+++ b/devdocs/frontend/design/21-logo-directions.md
@@ -1,0 +1,152 @@
+# Logo Mark — Directions and AI Prompts
+
+The wordmark direction (geometric sans-serif, deep navy on warm cream, sentence-cased) is settled. The **icon mark** is where to keep iterating — the current "three rounded squares in a triangular formation" reads as a competent productivity logo, but it's close to generic. This document offers five concrete directions to push it more distinctive, each with an AI image-generation prompt ready to drop into ChatGPT Images 2.0 (`gpt-image-2`) or Midjourney.
+
+## ChatGPT Images 2.0 workflow notes for logo iteration
+
+The current existing logo file (the three-block mark + "Stokaro" wordmark on cream) should be **uploaded as a reference image** for every prompt below. This locks the model onto the existing palette, line weight, and overall visual register, so variations feel like evolutions of the existing brand rather than wholly different identities.
+
+Use **Thinking mode** for logo generation. The mark needs careful composition and optical balance — Instant mode produces faster but compositionally weaker results.
+
+When iterating, request **batches of 4–8 variants per direction** in a single Thinking-mode prompt. ChatGPT Images 2.0's multi-image consistency guarantees the variants will share line weight, color, and texture — making them easier to compare side-by-side. Don't generate one at a time; you'll just get drift between attempts.
+
+Resolution: request 2K (2048×2048). The chosen mark gets traced into a vector tool (Figma / Illustrator) anyway, but high resolution helps you spot detail issues.
+
+**Model now renders text reliably** — meaning Direction 6 (pure wordmark with custom letter modification) is now genuinely achievable through generation, where on DALL-E 3 the result was usually unusable. Even custom letterform tweaks render legibly.
+
+**Recommendation: confirmed Direction 3 (catalog tag).** Refine via reference-image-driven iteration. Selected direction marked below.
+
+## Brief for any mark direction
+
+Constraints that all five directions must respect:
+
+- **Single color** in primary form: deep navy `#1A2238` on warm cream `#FAF6EC`
+- **Two-color** secondary form allowed: navy + terracotta `#B8451F` accent
+- **Vector-friendly** geometry — readable as a 16×16 favicon
+- **No internal text** — favicons can't render type at small size
+- **Tells a story** — the mark suggests "things kept safely / catalogued / organized" without being literal
+- **Ages well** — no hyper-trendy effects (no neumorphism, no aggressive gradients, no thin-line illustration trend)
+
+## Direction 1 — Refined three-block (evolve the current concept)
+
+**Concept:** keep the three rounded squares but add micro-detail that disambiguates the logo from the dozens of "three boxes" productivity logos. Options:
+- One block has a tiny horizontal slot near its top edge — suggests a label slot. Tells story: "labelled storage."
+- One block is slightly inset / nested — suggests "things inside."
+- Blocks have a subtle 1-pixel inner offset (like a ledger or label card edge).
+
+**Why it works:** preserves the recognition you've built up; adds a single specific detail that turns "generic" into "specific."
+
+**ChatGPT Images 2.0 prompt** (use Thinking mode for best composition):
+
+> A minimalist vector-style logo mark consisting of three rounded square shapes arranged in a triangular formation (one centered above, two below at the corners). Deep navy blue color (hex #1A2238) on a warm cream background (hex #FAF6EC). Each square has clean rounded corners. The bottom-left square has a small horizontal notch or slot cut into its top edge, suggesting a label slot on a storage box. Geometric, calm, modern. No shadows, no gradients, no text. Square format, centered composition, generous breathing room. Flat vector illustration.
+
+**Variations to try in iterations:**
+- Move the slot to a different square
+- Try the slot as a thin negative-space line instead of a notch
+- Try one square with a smaller square nested inside (two-tone — small inner square in terracotta)
+- Try the three blocks with rounded corners of slightly different radii (subtle hierarchy)
+
+## Direction 2 — Drawer / vessel (object metaphor)
+
+**Concept:** a single container shape, viewed from above, suggesting "where things are kept." Could be:
+- An open box top-down with a smaller offset rectangle inside (an item placed in)
+- A flat tray with three small dividers (organized compartments)
+- An open drawer pulled out from a unit
+
+**Why it works:** more specific to the inventory metaphor than three blocks; tells a clearer story; still abstract.
+
+**ChatGPT Images 2.0 prompt** (use Thinking mode for best composition):
+
+> A minimalist vector logo mark depicting a square-shaped open box viewed from directly above (top-down geometric view). Deep navy blue (hex #1A2238) outline on warm cream background (hex #FAF6EC). Inside the box, two smaller rounded rectangles of different sizes sit at slight angles, suggesting items neatly placed inside. The outer box has rounded corners, clean 2px line weight. The smaller inner shape on the right is filled with terracotta orange (hex #B8451F) for a single accent. Flat vector style, no shadows, no gradient, no text. Square format, generous padding around the mark. Calm, archival, modern.
+
+**Variations:**
+- Try drawer-pulled-out (rectangular, with a small handle)
+- Try a tray with three compartments (one filled, two empty)
+- Try a top-down "open lid" reveal (corner of a square folded/lifted)
+
+## Direction 3 — Catalog tag / index card  ✅ **SELECTED**
+
+**Concept:** the iconography of organized cataloguing — a label tag with a string hole, a library index card with a corner notch. Quietly archival, museum-adjacent.
+
+**Why it works:** evokes the cataloguing intent of the product directly; reads as "every thing has a tag." Familiar imagery (library, museum) without being cliché.
+
+**ChatGPT Images 2.0 prompt** (use Thinking mode for best composition):
+
+> A minimalist vector logo mark depicting a rectangular label tag with rounded corners. The tag has one diagonally-cut corner on the upper-left (the classic library tag shape) and a small circular hole punched near the cut corner for a string. Deep navy blue (hex #1A2238) outline with subtle 2px stroke, on warm cream background (hex #FAF6EC). The tag is shown straight-on, slightly tilted at maybe 5 degrees for character. The bottom third of the tag interior is filled with terracotta (hex #B8451F) suggesting a labeled section, while the rest stays cream. Flat vector style, no shadows, no gradients. The tag is the only object in the composition. Square format, centered, generous padding. No text on the tag.
+
+**Variations:**
+- Try multiple tags overlapping (set of three slightly fanned)
+- Try a single index card (square with a horizontal line near the top, the line in terracotta)
+- Try a tag with a wraparound thread/string visible
+
+## Direction 4 — Letter-mark "i" (or "I")
+
+**Concept:** the letter "i" stylized into a glyph that doubles as object iconography. Things 3 took this approach with an italicized lowercase "i" that reads as both letter and pencil.
+
+**Why it works:** instantly identifiable favicon; ties to the wordmark; can incorporate domain symbolism (the dot becoming a label, the stem becoming a drawer).
+
+**ChatGPT Images 2.0 prompt** (use Thinking mode for best composition):
+
+> A minimalist vector logo mark of a single lowercase letter "i" set in a geometric sans-serif construction. Deep navy blue (hex #1A2238) on warm cream background (hex #FAF6EC). The dot of the "i" is replaced with a small rounded square (matching the rest of the mark in stroke weight) — this small square is filled in terracotta (hex #B8451F) for a single accent. The stem of the "i" has rounded ends. The letter is centered with generous padding. Flat vector style, no shadows. Square format. No additional text or decoration.
+
+**Variations:**
+- Try with capital "I" and a small horizontal serif at top and bottom that reads as a label slot
+- Try the dot as a tiny rectangle instead of a square (more "label-like")
+- Try negative space — the "i" cut out of a filled rounded square shape
+
+## Direction 5 — Stacked/nested rectangles (vertical drawer)
+
+**Concept:** three or four horizontal rectangles stacked vertically — reads as "drawer cabinet" or "filing system." More dimensional than the current triangular composition.
+
+**Why it works:** unambiguously domain-relevant (filing/drawer system), distinctive shape (vertical rectangle is rarer than horizontal triangle), still simple.
+
+**ChatGPT Images 2.0 prompt** (use Thinking mode for best composition):
+
+> A minimalist vector logo mark of a vertical filing-cabinet-like icon, viewed straight-on. Three horizontal rounded rectangles stacked vertically with small gaps between them, contained loosely within an implied vertical frame. The middle rectangle has a small horizontal handle/tab in its center suggesting a drawer pull. Deep navy blue (hex #1A2238) on warm cream background (hex #FAF6EC). The handle/tab on the middle drawer is filled with terracotta (hex #B8451F) as a single accent. Clean rounded corners, 2px line weight where strokes appear. Flat vector style, no shadows, no gradient. Square format, centered with generous padding. Geometric, calm, archival.
+
+**Variations:**
+- Try four drawers instead of three
+- Try one drawer slightly pulled out (offset to the right)
+- Try a wider "cabinet" composition (more rectangular than square)
+
+## Direction 6 — Pure type with one distinctive letter
+
+**Concept:** drop the icon mark entirely; let a wordmark with one custom letterform carry the brand. Favicon = the custom letter alone.
+
+**Why it works:** lowest cost, most timeless, very on-trend with editorial brands (think Are.na, Cabin, Kinfolk wordmark-only approach). Risks blending in if the type isn't distinctive enough.
+
+**ChatGPT Images 2.0 prompt** (use Thinking mode for best composition):
+
+> A wordmark logo (typography only, no icon) for a personal-inventory brand. Set in a refined geometric sans-serif typeface, weight medium, sentence-cased. Deep navy blue (hex #1A2238) on warm cream background (hex #FAF6EC). The letter "k" in the wordmark has a custom modification: its diagonal arm extends slightly past the leg with a small rounded terminal, suggesting a tiny label slot or pull-tab. Terracotta (hex #B8451F) on this single modified element only. The rest of the wordmark is straightforward, calm, evenly tracked. Centered composition. Flat vector style, no shadows.
+
+(Substitute the actual brand wordmark when you generate; the description focuses on what to do with one letter.)
+
+## How to use these prompts
+
+1. **Attach the existing logo as a reference image** in every prompt. Locks palette/line weight automatically.
+2. **Iterate batch-style.** Generate 4–8 variations per prompt in Thinking mode. ChatGPT Images 2.0's multi-image consistency means siblings stay coherent — pick the strongest 1–2 from each direction.
+3. **If one variant is almost-right, use inpainting.** Mask the off element and ask for a regeneration of just that region. Don't re-roll the entire mark.
+4. **Bring the strongest to a vector tool** (Figma, Illustrator, Sketch). AI gen is rasterized; redraw the chosen mark as clean vector for production. This is also where you fine-tune optical balance.
+5. **Test at every size** — mark must work at 16×16 favicon and 256×256 app icon. Direction 4 (letter-mark) typically scales best; Direction 3 (tag) and Direction 5 (drawer cabinet) need careful detail tuning at 16px.
+6. **Test on dark mode** by inverting cream and navy in a follow-up prompt (use the chosen light-mode mark as the reference image for the dark-mode generation). The mark should read both ways.
+7. **Test in monochrome** (single-color print). The terracotta accent must be optional — the mark should still read in pure navy or pure black. Use inpainting to remove the accent for the monochrome test.
+
+## Selected direction
+
+**Direction 3 — Catalog tag** is confirmed. Refinement happens via the prompt above with reference-image-driven iteration in ChatGPT Images 2.0.
+
+Why this choice over the others:
+- The current three-block mark reads as generic productivity (could be Kanban / CRM / project manager). Tag-based mark specifically tells the cataloguing story.
+- Strong scalability: the silhouette reads at 16×16 favicon size when geometry is kept clean.
+- Distinct from competitors (1Password's key, Things' "i", Notion's "N", Airtable's grid) — no other personal-tool product owns the tag/label visual identity.
+- Pairs cleanly with the existing wordmark direction without competing.
+
+## What ships in sprint 0
+
+The current placeholder mark stays in the app. Logo iteration is a side workstream — generate variations on your own time, pick a direction, then a one-line CSS/asset swap brings the new mark in.
+
+Sprint 0 logo work limits to:
+1. Wordmark cleanup — kerning, weight, sizing, lockup with mark
+2. Favicon set generated from current mark (ICO + SVG + apple-touch-icon)
+3. App theme-color meta tags using `--accent`
+4. OG card template with current mark + tagline

--- a/devdocs/frontend/design/21-logo-directions.md
+++ b/devdocs/frontend/design/21-logo-directions.md
@@ -1,10 +1,10 @@
 # Logo Mark — Directions and AI Prompts
 
-The wordmark direction (geometric sans-serif, deep navy on warm cream, sentence-cased) is settled. The **icon mark** is where to keep iterating — the current "three rounded squares in a triangular formation" reads as a competent productivity logo, but it's close to generic. This document offers five concrete directions to push it more distinctive, each with an AI image-generation prompt ready to drop into ChatGPT Images 2.0 (`gpt-image-2`) or Midjourney.
+The wordmark direction (geometric sans-serif, deep navy on warm cream, sentence-cased) is settled. The **icon mark** is where to keep iterating — the current "three rounded squares in a triangular formation" reads as a competent productivity logo, but it's close to generic. This document offers six concrete directions (five icon-mark variants plus one pure-wordmark fallback) to push it more distinctive, each with an AI image-generation prompt ready to drop into ChatGPT Images 2.0 (`gpt-image-2`) or Midjourney.
 
 ## ChatGPT Images 2.0 workflow notes for logo iteration
 
-The current existing logo file (the three-block mark + "Stokaro" wordmark on cream) should be **uploaded as a reference image** for every prompt below. This locks the model onto the existing palette, line weight, and overall visual register, so variations feel like evolutions of the existing brand rather than wholly different identities.
+The current existing logo file (the three-block mark + Inventario wordmark on cream) should be **uploaded as a reference image** for every prompt below. This locks the model onto the existing palette, line weight, and overall visual register, so variations feel like evolutions of the existing brand rather than wholly different identities.
 
 Use **Thinking mode** for logo generation. The mark needs careful composition and optical balance — Instant mode produces faster but compositionally weaker results.
 
@@ -18,7 +18,7 @@ Resolution: request 2K (2048×2048). The chosen mark gets traced into a vector t
 
 ## Brief for any mark direction
 
-Constraints that all five directions must respect:
+Constraints that all six directions must respect:
 
 - **Single color** in primary form: deep navy `#1A2238` on warm cream `#FAF6EC`
 - **Two-color** secondary form allowed: navy + terracotta `#B8451F` accent

--- a/devdocs/frontend/design/22-illustration-prompts.md
+++ b/devdocs/frontend/design/22-illustration-prompts.md
@@ -1,0 +1,215 @@
+# Illustration Prompts (drop-in for ChatGPT Images 2.0)
+
+These are ready-to-paste prompts for generating the full illustration set described in `06-iconography-and-illustration.md`. They use a **shared style preamble** so every output looks like part of one coherent set.
+
+Generation tool: **ChatGPT Images 2.0** (`gpt-image-2`), launched 21 April 2026, replaced DALL-E. The instructions and prompt structure below assume its capabilities — Thinking mode, multi-image consistency, reference images, inpainting.
+
+## What ChatGPT Images 2.0 changes for our workflow
+
+The new model has four capabilities that materially change how to generate this set:
+
+1. **Multi-image consistency in one prompt — up to 8 images** with shared style and character coherence. Use this to generate **batches** instead of one-at-a-time. Result: dramatically tighter visual cohesion across the set.
+2. **Reference images, up to 10 per prompt.** Feed the existing logo, a palette swatch, and one strong already-generated illustration as references for every subsequent batch. The model anchors the style.
+3. **Thinking mode** — model researches, plans the composition, reasons through layout before drawing. Use it for everything in this set; Instant mode is for throwaway exploration only.
+4. **Inpainting with masks** — when one element of an output is wrong (e.g., a stray gradient, a misaligned shape), mask it and regenerate just that region. Don't re-roll the whole image.
+
+These are not just speed wins — they enable a level of cohesion that DALL-E 3 couldn't reach.
+
+## Recommended workflow
+
+### Step 1 — Build a "style anchor" image
+
+Generate **one** strong image first using only the style preamble (no scene). Call it the **anchor**. Save it. Every subsequent prompt feeds this anchor as a reference image. The model will inherit color, line weight, texture, mood automatically — much more reliably than re-describing the style each time.
+
+Anchor prompt (use Thinking mode, no reference images):
+
+> [STYLE PREAMBLE — see below]
+> Subject: a single rectangular label tag with a corner notch and a small round hole near the corner, hanging slightly tilted. The tag bottom third is filled in terracotta. This is a style-anchor reference: composition is centered, the subject fills 60% of the frame, generous breathing room, paper-grain texture clearly visible. Format: 1:1 square.
+
+Save the result as `anchor.png`. **Use this anchor as a reference image (`image_input`) for all batch prompts below.**
+
+### Step 2 — Generate scenes in batches
+
+ChatGPT Images 2.0 accepts a batch request — describe several scenes in one prompt, ask the model to render them as a sheet of N coherent images. Each batch gets the **anchor** as a reference for style continuity.
+
+Example batch request (light-mode empty states):
+
+> Reference image attached: `anchor.png` (use as the canonical style reference for this set).
+>
+> [STYLE PREAMBLE — see below]
+>
+> Generate 6 separate images at 1:1 square format, all in the exact style of the reference. Each is for a different empty-state surface. Use Thinking mode to plan layout and composition. Keep style, color, line weight, and texture consistent across all 6.
+>
+> Scene 1 — Empty list (no things):
+> [scene description from below]
+>
+> Scene 2 — Empty list (no places):
+> [scene description from below]
+>
+> ... (up to 8 scenes per batch)
+
+ChatGPT Images 2.0 will return all images as a coherent set, each separately downloadable.
+
+### Step 3 — Iterate via inpainting if needed
+
+If a single image in a batch has one wrong element (e.g., the bird in the 404 illustration ended up too cartoonish), don't re-roll the whole image. Use ChatGPT's edit feature with a mask over just that element:
+
+> Edit attached image: replace the bird in the masked region with a simpler silhouette in the same line weight as the rest of the illustration. Keep terracotta accent on the bird only.
+
+This preserves the rest of the image (which was good) and fixes the one defect.
+
+### Step 4 — Generate dark-mode counterparts
+
+After the light-mode set is locked, swap the palette in the preamble (see "Dark-mode preamble override" near the end) and re-batch the same scenes. Use the locked light-mode versions **as reference images** so the dark-mode versions inherit the same composition and just shift color.
+
+## Style preamble (paste before every scene; never modify wording)
+
+> A flat warm illustration with subtle paper-grain texture, in the style of editorial book illustrations and modern archival design. Two-color palette only: warm cream `#FAF6EC` as background, deep navy blue `#1A2238` for primary subjects and outlines (medium-thick lines, 2 to 3 pixels at 2K resolution, with rounded ends), with a single sparing terracotta `#B8451F` accent on one focal detail per image. Mood: calm, considered, archival, slightly nostalgic but not retro. NO human characters, NO faces. NO text or letters anywhere in the image (text rendering is not desired here even though the model is capable — keep illustrations purely iconographic). NO heavy drop shadows. NO gradients except the subtle background paper grain. Composition: centered, generous breathing room, the subject fills about 60% of the frame. Vector-feeling but with a slight risograph / printed-paper grain texture, as if printed with two ink runs on slightly textured cream paper. Square 1:1 format at 2K resolution unless otherwise specified.
+
+Why this preamble works on `gpt-image-2`:
+- Specific hex values let the model match palette exactly
+- Pixel-weight specification keeps line consistency across batches
+- "Two ink runs on textured paper" is a concrete printing metaphor the model understands
+- Explicit "no text" instruction (the model can render text well now, but we don't want it here)
+- 2K resolution requested explicitly — defaults vary
+
+## Scenes — Onboarding (batch together, 5 images)
+
+### 01 · Login hero
+> A quiet domestic scene — a small wooden writing desk in cross-section view, slightly isometric, with a single open notebook on it, a desk lamp with warm light pooling on the page, and to the side a small set of three drawer-style storage compartments. Terracotta accent on the lampshade glow only. Composition emphasizes warmth and quiet record-keeping. The desk has a single small label tag attached to one drawer.
+
+### 02 · Onboarding choice — "Stuff in my home"
+> A cross-section view of a stylized small house showing four rooms (living, kitchen, bedroom, storage), each room containing one or two iconic objects (a chair, a stove, a bed, a box). Each object has a tiny tag attached suggesting it is catalogued. Terracotta accent on the house roof only. Calm, ordered, like a museum diorama.
+
+### 03 · Onboarding choice — "My collection"
+> A flat top-down view of a wooden display surface with five varied collectible objects laid out in a deliberate arrangement — an open book, a single coin, a small framed postage stamp, a wine bottle laid on its side, and a vintage pocket watch. Each object rendered with calm restraint. Terracotta accent on the wine bottle's neck label only. Symmetrical, considered composition, like a curated vitrine.
+
+### 04 · Onboarding choice — "A property's documentation"
+> A flat architectural blueprint-style view of a small building (top-down floor plan), with simple labeled rooms and a thick folder of papers placed beside it. The folder has a small terracotta accent strip on its spine. Subtle dimension lines around the floor plan. Calm, technical without being cold.
+
+### 05 · Welcome / first thing prompt
+> A single lit candle on a small wooden table next to an empty open journal/notebook with blank pages. Composition suggests "beginning a record." Candle flame is the only terracotta accent. Quiet, inviting, slightly warm.
+
+## Scenes — Empty states (batch together, 6 images)
+
+### 06 · Empty list (no things yet)
+> A single empty wooden drawer viewed from above at a slight angle, pulled open from a dark cabinet. Drawer interior is a soft cream color, completely empty, ready to receive items. Visible woodgrain rendered as simple line strokes. A small terracotta tag attached to the front edge. Calm, inviting, NOT lonely.
+
+### 07 · Empty list (no places yet)
+> An empty room in cross-section (floor + walls visible, no ceiling), with empty floor and walls, completely uninhabited but warmly lit. A single key with a terracotta tag rests on the floor center. Suggests "a place ready to be defined." Architectural lines, calm.
+
+### 08 · Empty list (no files yet)
+> An empty manila folder with a single ribbon tie, slightly open showing it's empty inside, sitting on a cream surface. Ribbon tie in terracotta. Calm, organized.
+
+### 09 · Empty list (no backups yet)
+> A small wooden chest with its lid slightly ajar, sitting on a cream surface. Chest has a brass-like clasp rendered in terracotta. Inside the chest, a soft glow suggests "ready to keep things safe." Reassuring, NOT magical or fantasy.
+
+### 10 · Search — no results
+> A magnifying glass laid flat on top of a single empty piece of paper or card. Magnifying glass handle has a terracotta accent ring. Suggests "looked, nothing here." Patient, NOT failure.
+
+### 11 · Filter — no results
+> A row of three small filing folder tabs in cream tone, with the middle tab slightly raised as if currently selected. No content visible behind the tabs — area is empty. The middle (selected) tab has a small terracotta dot.
+
+## Scenes — Error and edge (batch together, 4 images)
+
+### 12 · 404 page
+> A small empty drawer pulled fully out from a storage unit, with a label slot on its front that's blank (rectangular outline only). Drawer empty. A small bird (sparrow silhouette, simplified) perches on the corner of the drawer. The bird is the only terracotta accent. Calm, gently melancholic.
+
+### 13 · 500 page
+> A small stack of papers slightly toppled, with three or four sheets fanning out from the stack on a cream surface. Bottom sheet has a tiny terracotta corner. Suggests "something tipped over" without being chaotic. Restrained.
+
+### 14 · Maintenance / paused
+> A wooden door with a small hanging tag from the doorknob, the tag completely blank. Beside the door, a small lit candle in a holder. Candle flame is terracotta. Door closed but warmly lit. Mood: "briefly closed, will return."
+
+### 15 · Offline / disconnected
+> A single unplugged power cord lying on a cream surface, plug end gently curled. Plug prongs have small terracotta tips. Suggests "disconnected" without alarm.
+
+## Scenes — Success and reassurance (batch together, 3 images)
+
+### 16 · Backup completed
+> A small wooden box with its lid closed and a brass clasp latched, sitting on a cream surface. A folded paper or document peeks slightly from under the lid. Clasp is terracotta. Subtle glow surrounds the box. Reassuring, slightly celebratory but quiet.
+
+### 17 · Storage warning
+> A wooden crate filled almost to the brim with stacked papers, books, and small parcels. One sheet sticks slightly out the top. Topmost item has a terracotta tag. Suggests "getting full." Practical.
+
+### 18 · First item added (celebration)
+> A single small folded-paper origami crane resting on top of a closed wooden box, on a cream surface. Crane has a small terracotta marking. Quiet gentle delight, "one thing in and you've started." NOT cartoonish.
+
+## Scenes — File / media (batch together, 2 images)
+
+### 19 · Document preview unavailable
+> A single document or paper rolled up like a scroll, tied with a small ribbon. Ribbon is terracotta. Scroll rests on a cream surface. Suggests "wrapped up, can't see inside." Calm, archival.
+
+### 20 · File too large
+> A small parcel that is clearly too big for the small wooden crate beside it. Parcel has a terracotta tape strip across it. Suggests "doesn't fit." Practical, NOT alarming.
+
+## OG / share card (separate prompt — different format)
+
+### 21 · Marketing OG card / social share
+> Different format for this one: 16:9 wide composition, NOT 1:1 square. Same style preamble. Subject: a layered scene of warmly-lit small storage objects — a stack of two boxes, an open notebook in front, a small floating label tag, and a single drawer pulled slightly out. Composition occupies the right two-thirds of the frame; left third is empty cream space (where a wordmark and tagline would overlay in production). Terracotta accents on one tag and one box latch. 1920×1080 resolution.
+
+## Suggested batch organization (4 batches total)
+
+This minimizes drift and maximizes cohesion. Run each batch as a single multi-image request to ChatGPT Images 2.0 in Thinking mode with `anchor.png` attached as reference.
+
+| Batch | Scenes | Count |
+| --- | --- | --- |
+| Batch A | Onboarding (01–05) | 5 |
+| Batch B | Empty states (06–11) | 6 |
+| Batch C | Error & edge (12–15) | 4 |
+| Batch D | Success + media (16–20) | 5 |
+| Solo | OG card (21) | 1 |
+
+Total: 21 illustrations across 5 generation cycles. Realistically 1–2 hours of work end-to-end including review and inpainting fixes.
+
+## Dark-mode preamble override
+
+For dark-mode versions, replace the preamble's color description block with:
+
+> ...two-color palette only: deep navy `#14191F` as background, warm cream `#F1ECE0` for primary subjects and outlines, with a single sparing terracotta `#E07F4F` accent on one focal detail per image.
+
+Generate dark-mode versions in a second pass, **using the locked light-mode versions as reference images** for each scene. The model will preserve composition and shift only the color treatment.
+
+## Quality control — before committing the set
+
+Lay all 20+ illustrations side-by-side in Figma (or your screen tool of choice). Check:
+
+1. **Line weight is consistent.** All outlines look like the same pen.
+2. **Texture is consistent.** Paper grain visible to the same degree across all.
+3. **Terracotta usage is consistent.** Each illustration has exactly one terracotta accent on one focal element.
+4. **No accidental text** in any illustration (model occasionally adds it).
+5. **No accidental humans / faces.** Reject any with hands, partial figures, etc.
+6. **Mood reads as one product.** No outliers that feel cartoony, photoreal, or stylistically off.
+
+Regenerate any outliers using **inpainting** (mask the off element) rather than re-rolling the full image. If an outlier is wholesale wrong, re-batch with a new reference image (the strongest sibling in the batch).
+
+## API workflow (optional, for automation)
+
+If you want to script generation:
+
+```bash
+# Pseudo-API call structure
+POST https://api.openai.com/v1/images/generate
+{
+  "model": "gpt-image-2",
+  "mode": "thinking",
+  "prompt": "[full prompt with preamble + scene]",
+  "reference_images": ["anchor.png"],
+  "size": "2048x2048",
+  "n": 6
+}
+```
+
+Pricing (approximate, as of 21 April 2026):
+- Input: $8 per million tokens
+- Output: $30 per million tokens (image)
+- Generation cost per illustration: rough order of $0.10–0.30 each in Thinking mode
+
+For a 21-image set with a few iterations: ~$5–15 total. Cheaper than commissioning, infinitely cheaper than a stock subscription.
+
+## Out of scope
+
+- Animated illustrations (Lottie / Rive) — v2
+- Marketing / landing page illustrations beyond OG card — when marketing site exists
+- Hero illustrations for blog posts / docs — when content surfaces exist
+- Per-locale illustration variants — illustrations are language-neutral by design (no text in them)

--- a/devdocs/frontend/design/README.md
+++ b/devdocs/frontend/design/README.md
@@ -1,0 +1,99 @@
+# Inventario — Design Direction
+
+This folder is the **complete foundation brief** for redesigning Inventario as a modern personal-inventory product. Every decision a designer would normally make for a product of this category is documented here so engineering can implement without "what should this corner radius be?" stops.
+
+The brief is opinionated. Where there is taste room, three or fewer concrete options are presented with a recommendation. Where there is no taste room (accessibility minimums, motion timings, semantic state behavior), one answer is given.
+
+## Reading order
+
+For a quick read: 00, 01, 02, 11, 19.
+For implementation: read all in order before opening a code file.
+
+## Index
+
+### Foundation (read first)
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 00 | [Positioning](00-positioning.md) | Product identity, audience, tone — anchors every later decision |
+| 01 | [Palette](01-palette.md) | Three color directions (light + dark), semantic tokens |
+| 02 | [Typography](02-typography.md) | Type scale, font pairings, hierarchy rules, vertical rhythm |
+| 03 | [Space & Layout](03-space-and-layout.md) | Spacing scale, radii, borders, breakpoints, container widths, grid |
+| 04 | [Elevation & Effects](04-elevation-and-effects.md) | Shadow scale, opacity, blur, glass/frost surfaces |
+| 05 | [Motion](05-motion.md) | Durations, easings, motion language per element, reduced-motion |
+
+### Visual language
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 06 | [Iconography & Illustration](06-iconography-and-illustration.md) | Icon system (Phosphor), weights, sizes, illustration strategy |
+| 07 | [Data Visualization](07-data-visualization.md) | Chart palette, chart types per data shape, sparkline style |
+
+### Interaction & components
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 08 | [Interaction States](08-interaction-states.md) | Hover, focus, active, disabled, loading, error, empty, selected |
+| 09 | [Component Patterns](09-component-patterns.md) | Buttons, forms, modals, cards, tables, navigation, badges, tooltips |
+| 10 | [File & Media Handling](10-file-and-media.md) | File previews, upload, FileViewer fullscreen, drag-drop |
+| 11 | [Page Layouts & Flows](11-page-layouts-and-flows.md) | Templates, onboarding, error pages, empty states, dashboard |
+
+### Content & language
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 12 | [Tone of Voice & Copy](12-tone-of-voice-and-copy.md) | Voice, microcopy templates, naming, error/success messages |
+| 13 | [Formatting & i18n](13-formatting-and-i18n.md) | Date/time, currency, numbers, pluralization, RTL strategy |
+
+### Quality bars
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 14 | [Accessibility](14-accessibility.md) | Contrast, focus, keyboard, screen reader, touch targets |
+| 15 | [Form & Data UX](15-form-and-data-ux.md) | Auto-save, validation, optimistic UI, conflict, offline, drafts |
+| 16 | [Notifications & Trust](16-notifications-and-trust.md) | Severity hierarchy, alerts, sensitive data, trust signals |
+
+### Adaptation & extensibility
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 17 | [Density & Theme Modes](17-density-and-modes.md) | Compact/comfortable/cozy, light/dark/system toggle UX |
+| 18 | [Print & Export](18-print-and-export.md) | Print stylesheets, PDF export of inventory, sharing |
+| 19 | [Branding](19-branding.md) | Logo system, favicon, OG, email templates |
+| 20 | [Edge Cases](20-edge-cases.md) | 404, 500, maintenance, offline, empty account, deleted entities |
+
+### Production assets
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 21 | [Logo Mark Directions](21-logo-directions.md) | Five icon-mark directions with ready-to-paste ChatGPT Images 2.0 prompts |
+| 22 | [Illustration Prompts](22-illustration-prompts.md) | Drop-in ChatGPT Images 2.0 prompts for the full illustration set with shared style preamble |
+
+## Decisions made
+
+All taste decisions are now committed:
+
+1. **Palette** (01) — final cream + navy + terracotta tokens, light + dark
+2. **Type pairing** (02) — Switzer (display) + Inter (body), both free
+3. **Logo direction** (21) — Direction 3, catalog tag with corner-cut + string-hole
+4. **Illustration sourcing** — AI-generation via ChatGPT Images 2.0 (`gpt-image-2`) using prompts in (22)
+
+Everything from foundation to component patterns to copywriting tone is concrete in the documents below. Sprint 0 implementation can begin without further design decisions.
+
+## What's intentionally out of scope
+
+- Specific micro-decisions per view (those are sprint work, not foundation)
+- A full pattern library implementation (this brief defines patterns; building them is sprint 1-2)
+- Brand strategy beyond visual/voice identity (positioning above is sufficient for this product's stage)
+- Marketing site / landing page (this is the in-app product brief)
+
+## Sprint 0 deliverables (what gets built from this brief)
+
+1. Tailwind v4 `@theme` token file with chosen palette + type + spacing + radii + motion
+2. `dark` mode with full coverage
+3. Replace lucide → Phosphor icons project-wide
+4. Build/refresh primitives: `Button`, `Input`, `Select`, `Dialog`, `Toast`, `Skeleton`, `EmptyState`, `Card`, `Badge`, `Tooltip`
+5. Fix the system-wide section-header contrast bug (this is bug-fix not foundation, but blocking)
+6. Update tone-of-voice on every user-facing string per (12)
+
+Sprint 1+ work is informed by, but not blocked on, this brief.


### PR DESCRIPTION
## Summary

Adds `devdocs/frontend/design/` — a 23-document forward-looking design brief for the next round of UI work after Phase 6 (epic [#1324](https://github.com/denisvmedia/inventario/issues/1324)) lands.

This is a **docs-only PR**. No code changes, no implementation, no engineering decisions encoded yet — only the foundation those decisions will reference.

## What's in the brief

| Area | Documents |
| --- | --- |
| Foundation | `00-positioning`, `01-palette`, `02-typography`, `03-space-and-layout`, `04-elevation-and-effects`, `05-motion` |
| Visual language | `06-iconography-and-illustration`, `07-data-visualization` |
| Interaction & components | `08-interaction-states`, `09-component-patterns`, `10-file-and-media`, `11-page-layouts-and-flows` |
| Content & language | `12-tone-of-voice-and-copy`, `13-formatting-and-i18n` |
| Quality bars | `14-accessibility`, `15-form-and-data-ux`, `16-notifications-and-trust` |
| Adaptation | `17-density-and-modes`, `18-print-and-export`, `19-branding`, `20-edge-cases` |
| Production assets | `21-logo-directions`, `22-illustration-prompts` |

The brief follows a "senior-designer" template — every reusable design decision a competent product designer would normally make is documented here so engineering can implement without "what should this corner radius be?" stops.

## Locked taste decisions

Three decisions deferred to design taste are committed in this brief:

1. **Palette**: warm cream `#FAF6EC` + deep navy `#1A2238` + terracotta accent `#B8451F` (light); inverted with lighter terracotta in dark mode. Anchors to the existing logo's cream + navy baseline.
2. **Typography**: Switzer (display) + Inter (body), both free, both variable fonts.
3. **Logo direction**: catalog-tag mark (Direction 3 of six explored).
4. **Illustration sourcing**: AI-generated via ChatGPT Images 2.0 (`gpt-image-2`) using anchor-image-driven batch workflow specified in `22-illustration-prompts.md`. Total estimated cost ~$5–15 for the full 21-illustration set.

## Decisions deliberately deferred

- Phosphor migration (replacing lucide) is **proposed** in the brief but not legislated; the `icons.md` standard still says lucide. A separate PR can flip the standard once we're ready.
- Sidebar + bottom-nav layout shell is proposed; current pipe-separated topbar remains the production UI until that work is scheduled.
- Tone-of-voice rename (Commodity → Thing, Location → Place, Export → Backup) is proposed; existing user-facing strings stay until we open a copywriting-pass PR.

These deferrals are intentional. The brief sets direction; PRs implement it.

## Why this is a separate PR

PR #1355 (the current open `design-system/1354-mediagallery-fileviewerdialog` branch) is for FileViewerDialog migration — adding ~5500 lines of design docs there would be a massive scope creep. This PR is independent and can land any time without blocking implementation work.

## Test plan

- [ ] Markdown renders correctly on GitHub (no broken cross-links, fenced code blocks intact)
- [ ] `devdocs/frontend/README.md` index correctly points to the new `design/` subdirectory
- [ ] No file path references break — verified: all relative links inside `design/` use sibling-relative paths (e.g., `02-typography.md`, not `../`)
- [ ] No engineering changes — `git diff master..HEAD -- frontend/ go/ e2e/` should return empty
- [ ] No tests required (docs-only)
- [ ] No CI workflows expected to run beyond markdown / link-check if configured

## Notes for reviewers

- The brief is intentionally opinionated. Where there's taste room, options are listed with a recommendation; where there isn't (a11y minimums, motion timings, semantic state behavior), one answer is given.
- The brief assumes ChatGPT Images 2.0 capabilities (multi-image consistency, reference images, Thinking mode, inpainting) — released 21 Apr 2026, replacing DALL-E.
- "Sprint 0" callouts at the bottom of each document indicate what would land in the first implementation sprint. They're aspirational guidance, not a binding plan.