### PR TITLE
[#1401] INVENTARIO_FRONTEND={legacy|new} dual-bundle handler

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -154,17 +154,34 @@ jobs:
         with:
           node-version: ${{ steps.vars.outputs.node_version }}
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: |
+            frontend/package-lock.json
+            frontend-react/package-lock.json
 
-      - name: Install frontend dependencies
+      - name: Install frontend dependencies (legacy Vue)
         run: npm ci
         working-directory: frontend
 
-      - name: Build frontend
+      - name: Install frontend dependencies (React)
+        # Both bundles are embedded into the binary during the epic #1397
+        # dual-frontend window. INVENTARIO_FRONTEND={legacy|new} picks at
+        # runtime which one is served; both must exist at compile time
+        # because go/apiserver/apiserver_with_frontend.go imports both.
+        run: npm ci
+        working-directory: frontend-react
+
+      - name: Build frontend (legacy Vue)
         # Embedded by go build -tags=with_frontend (frontend/frontend.go uses
         # go:embed all:dist).
         run: npm run build
         working-directory: frontend
+
+      - name: Build frontend (React)
+        # Embedded by go build -tags=with_frontend (frontend-react/frontend.go
+        # uses go:embed all:dist). The cutover PR (#1423) drops these two
+        # React-bundle steps together with the legacy bundle deletion.
+        run: npm run build
+        working-directory: frontend-react
 
       - name: Build darwin/arm64 binary
         # macOS e2e lane (macos-latest == Apple Silicon) consumes this

--- a/.github/workflows/frontend-embed-smoke-test.yml
+++ b/.github/workflows/frontend-embed-smoke-test.yml
@@ -6,12 +6,18 @@ on:
       - master
     paths:
       - 'frontend/**'
+      - 'frontend-react/**'
       - 'go/apiserver/frontend_embed_test.go'
+      - 'go/apiserver/frontend_bundle_test.go'
+      - 'go/apiserver/apiserver_with_frontend.go'
       - '.github/workflows/frontend-embed-smoke-test.yml'
   pull_request:
     paths:
       - 'frontend/**'
+      - 'frontend-react/**'
       - 'go/apiserver/frontend_embed_test.go'
+      - 'go/apiserver/frontend_bundle_test.go'
+      - 'go/apiserver/apiserver_with_frontend.go'
       - '.github/workflows/frontend-embed-smoke-test.yml'
 
 concurrency:
@@ -40,7 +46,9 @@ jobs:
         with:
           node-version: ${{ steps.vars.outputs.node_version }}
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: |
+            frontend/package-lock.json
+            frontend-react/package-lock.json
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -49,9 +57,17 @@ jobs:
           cache: true
           cache-dependency-path: go/go.sum
 
-      - name: Build frontend
+      - name: Build legacy Vue frontend
         run: npm ci && npm run build
         working-directory: frontend
+
+      - name: Build React frontend
+        # apiserver_with_frontend.go imports both frontend/ and frontend-react/
+        # for the bundle-aware FrontendHandler (#1401), so compiling
+        # ./apiserver/... with `with_frontend` requires both bundles to be
+        # present. Both build steps go away in the cutover PR (#1423).
+        run: npm ci && npm run build
+        working-directory: frontend-react
 
       - name: Install Go dependencies
         run: go mod download
@@ -59,12 +75,8 @@ jobs:
 
       - name: Run embed smoke test
         # Requires -tags with_frontend so that frontend.GetDist() is compiled in.
-        # Scoped to ./apiserver (no /...) so the React-bundle embed test in
-        # ./apiserver/frontendreactembed/ — which depends on frontend-react/
-        # being built — is not pulled in by this workflow, which only builds
-        # the legacy frontend.
-        # The test walks the embedded dist/assets directory and fails if no
-        # underscore-prefixed Vite chunks are found — which would indicate that
-        # the //go:embed directive is missing the "all:" prefix.
-        run: go test -v -tags with_frontend -run TestFrontendEmbed_UnderscorePrefixedFilesArePresent ./apiserver
+        # The legacy underscore-marker test stays here; the bundle-discriminator
+        # tests in frontend_bundle_test.go run in the same package and exercise
+        # both bundles, so they're swept in by the unfiltered ./apiserver scope.
+        run: go test -v -tags with_frontend ./apiserver
         working-directory: go

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,12 @@ project_name: inventario
 
 before:
   hooks:
-    # Build frontend assets first
+    # Build both frontend bundles. Both are embedded into the binary during the
+    # epic #1397 dual-frontend window — INVENTARIO_FRONTEND={legacy|new} picks
+    # which one is served at runtime. Once the cutover PR (#1423) lands, the
+    # second hook goes away with the legacy bundle.
     - make build-frontend
+    - make build-frontend-react
 
 builds:
   - binary: inventario

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -104,6 +104,14 @@ export INVENTARIO_UPLOAD_LOCATION="file:///var/lib/inventario/uploads?create_dir
 # Security configuration (REQUIRED for production)
 export INVENTARIO_RUN_JWT_SECRET="$(openssl rand -hex 32)"
 
+# Frontend bundle selection (optional, transitional — see epic #1397)
+# legacy = Vue bundle (default, current production behaviour)
+# new    = React bundle (in active rewrite, not yet at feature parity)
+# Equivalent CLI flag: --frontend-bundle. Both flag and env var are removed
+# at the cutover PR; production deployments should keep this unset until
+# parity is announced.
+export INVENTARIO_FRONTEND="legacy"
+
 # Worker configuration (optional)
 export INVENTARIO_RUN_MAX_CONCURRENT_EXPORTS="3"
 export INVENTARIO_RUN_MAX_CONCURRENT_IMPORTS="1"

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -167,6 +167,7 @@ type Params struct {
 	EmailService               services.EmailService              // Transactional email service (queue + providers)
 	PublicURL                  string                             // Public base URL used in transactional links
 	RedisPinger                RedisPinger                        // Optional Redis dependency check for /readyz
+	FrontendBundle             string                             // Which embedded SPA to serve at /; "legacy" or "new" (epic #1397, removed at cutover)
 }
 
 func (p *Params) Validate() error {
@@ -373,7 +374,7 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 	})
 
 	// use Frontend as a root directory
-	r.Handle("/*", FrontendHandler())
+	r.Handle("/*", FrontendHandler(params.FrontendBundle))
 
 	return r
 }

--- a/go/apiserver/apiserver_with_frontend.go
+++ b/go/apiserver/apiserver_with_frontend.go
@@ -4,16 +4,35 @@ package apiserver
 
 import (
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 
 	"github.com/denisvmedia/inventario/frontend"
+	frontendreact "github.com/denisvmedia/inventario/frontend-react"
 )
 
-func FrontendHandler() http.Handler {
-	dist := frontend.GetDist()
-	fsys, _ := fs.Sub(dist, "dist")
+// Frontend bundle identifiers used by FrontendHandler. The validated form is
+// owned by cmd/inventario/run/bootstrap; this package keeps a private mirror
+// to avoid depending on cmd/* from apiserver/*. Keep these constants in sync
+// with the ones in bootstrap/config.go.
+const (
+	frontendBundleLegacy = "legacy"
+	frontendBundleNew    = "new"
+)
+
+// FrontendHandler returns the SPA handler for the requested bundle.
+//
+//   - "legacy": serves the Vue bundle from frontend/dist (today's behavior).
+//   - "new":    serves the React bundle from frontend-react/dist.
+//
+// An unknown value is logged and falls back to "legacy" — bootstrap.ValidateFrontendBundle
+// is the validation gate; this defense-in-depth keeps the binary serving
+// something rather than a 500 if the gate is ever bypassed.
+func FrontendHandler(bundle string) http.Handler {
+	dist, root := selectBundle(bundle)
+	fsys, _ := fs.Sub(dist, root)
 	fileServer := http.FileServer(http.FS(fsys))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +56,7 @@ func FrontendHandler() http.Handler {
 			_, _ = w.Write(recorder.Body.Bytes())
 			return
 		}
-		data, err := dist.ReadFile("dist/index.html")
+		data, err := dist.ReadFile(root + "/index.html")
 		if err != nil {
 			http.NotFound(w, r)
 			return
@@ -45,4 +64,21 @@ func FrontendHandler() http.Handler {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = w.Write(data)
 	})
+}
+
+// selectBundle returns the embed FS and the dist directory name inside it for
+// the requested bundle. Both bundles use a "dist" root because that's what
+// each frontend's vite build produces; selectBundle is forward-compatible if
+// that ever diverges.
+func selectBundle(bundle string) (fs.ReadFileFS, string) {
+	switch bundle {
+	case frontendBundleNew:
+		return frontendreact.GetDist(), "dist"
+	case frontendBundleLegacy:
+		return frontend.GetDist(), "dist"
+	default:
+		slog.Warn("Unknown frontend bundle requested; falling back to legacy",
+			"bundle", bundle, "valid", []string{frontendBundleLegacy, frontendBundleNew})
+		return frontend.GetDist(), "dist"
+	}
 }

--- a/go/apiserver/apiserver_with_frontend.go
+++ b/go/apiserver/apiserver_with_frontend.go
@@ -11,15 +11,7 @@ import (
 
 	"github.com/denisvmedia/inventario/frontend"
 	frontendreact "github.com/denisvmedia/inventario/frontend-react"
-)
-
-// Frontend bundle identifiers used by FrontendHandler. The validated form is
-// owned by cmd/inventario/run/bootstrap; this package keeps a private mirror
-// to avoid depending on cmd/* from apiserver/*. Keep these constants in sync
-// with the ones in bootstrap/config.go.
-const (
-	frontendBundleLegacy = "legacy"
-	frontendBundleNew    = "new"
+	"github.com/denisvmedia/inventario/internal/frontendbundle"
 )
 
 // FrontendHandler returns the SPA handler for the requested bundle.
@@ -27,12 +19,23 @@ const (
 //   - "legacy": serves the Vue bundle from frontend/dist (today's behavior).
 //   - "new":    serves the React bundle from frontend-react/dist.
 //
-// An unknown value is logged and falls back to "legacy" — bootstrap.ValidateFrontendBundle
-// is the validation gate; this defense-in-depth keeps the binary serving
-// something rather than a 500 if the gate is ever bypassed.
+// An unknown value is logged and falls back to "legacy" — frontendbundle.Validate
+// is the actual validation gate (run from bootstrap before any HTTP listener
+// starts); this defense-in-depth keeps the binary serving something rather
+// than a 500 if the gate is ever bypassed.
 func FrontendHandler(bundle string) http.Handler {
 	dist, root := selectBundle(bundle)
-	fsys, _ := fs.Sub(dist, root)
+	fsys, err := fs.Sub(dist, root)
+	if err != nil {
+		// Embed layout drift (root directory renamed/missing) is the only
+		// way fs.Sub can error in practice. Return a 500 handler instead of
+		// proceeding with a nil FS that http.FileServer would panic on.
+		slog.Error("Failed to prepare frontend filesystem",
+			"bundle", bundle, "root", root, "err", err)
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		})
+	}
 	fileServer := http.FileServer(http.FS(fsys))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -56,7 +59,7 @@ func FrontendHandler(bundle string) http.Handler {
 			_, _ = w.Write(recorder.Body.Bytes())
 			return
 		}
-		data, err := dist.ReadFile(root + "/index.html")
+		data, err := fs.ReadFile(dist, root+"/index.html")
 		if err != nil {
 			http.NotFound(w, r)
 			return
@@ -70,15 +73,15 @@ func FrontendHandler(bundle string) http.Handler {
 // the requested bundle. Both bundles use a "dist" root because that's what
 // each frontend's vite build produces; selectBundle is forward-compatible if
 // that ever diverges.
-func selectBundle(bundle string) (fs.ReadFileFS, string) {
+func selectBundle(bundle string) (fs.FS, string) {
 	switch bundle {
-	case frontendBundleNew:
+	case frontendbundle.New:
 		return frontendreact.GetDist(), "dist"
-	case frontendBundleLegacy:
+	case frontendbundle.Legacy:
 		return frontend.GetDist(), "dist"
 	default:
 		slog.Warn("Unknown frontend bundle requested; falling back to legacy",
-			"bundle", bundle, "valid", []string{frontendBundleLegacy, frontendBundleNew})
+			"bundle", bundle, "valid", frontendbundle.Valid)
 		return frontend.GetDist(), "dist"
 	}
 }

--- a/go/apiserver/apiserver_without_frontend.go
+++ b/go/apiserver/apiserver_without_frontend.go
@@ -4,7 +4,10 @@ package apiserver
 
 import "net/http"
 
-func FrontendHandler() http.Handler {
+// FrontendHandler returns a 404 handler when the binary is built without an
+// embedded frontend. The bundle argument is accepted for signature parity
+// with the with_frontend build but is ignored — there is nothing to serve.
+func FrontendHandler(_ string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	})

--- a/go/apiserver/frontend_bundle_test.go
+++ b/go/apiserver/frontend_bundle_test.go
@@ -1,0 +1,80 @@
+//go:build with_frontend
+
+package apiserver_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/apiserver"
+)
+
+// TestFrontendHandler_ServesLegacyByDefault verifies that the "legacy" bundle
+// returns the Vue index.html (root mount point id="app") when requested.
+//
+// Like the other apiserver_test.* embed tests, this one needs the Vue bundle
+// built first (npm run build in frontend/) and runs in CI under
+// frontend-embed-smoke-test.
+func TestFrontendHandler_ServesLegacyByDefault(t *testing.T) {
+	c := qt.New(t)
+
+	rec := getRoot(c, apiserver.FrontendHandler("legacy"))
+	body := rec.Body.String()
+
+	c.Assert(rec.Code, qt.Equals, http.StatusOK)
+	c.Assert(strings.Contains(body, `id="app"`), qt.IsTrue,
+		qt.Commentf(`legacy index.html should mount at <div id="app">; got: %s`, snippet(body)))
+	c.Assert(strings.Contains(body, `id="root"`), qt.IsFalse,
+		qt.Commentf("legacy bundle leaked the React mount id"))
+}
+
+// TestFrontendHandler_ServesReactBundle verifies that the "new" bundle
+// returns the React index.html (mount point id="root").
+//
+// Needs the React bundle built first (npm run build in frontend-react/) and
+// runs in CI under frontend-react-embed-smoke-test.
+func TestFrontendHandler_ServesReactBundle(t *testing.T) {
+	c := qt.New(t)
+
+	rec := getRoot(c, apiserver.FrontendHandler("new"))
+	body := rec.Body.String()
+
+	c.Assert(rec.Code, qt.Equals, http.StatusOK)
+	c.Assert(strings.Contains(body, `id="root"`), qt.IsTrue,
+		qt.Commentf(`React index.html should mount at <div id="root">; got: %s`, snippet(body)))
+	c.Assert(strings.Contains(body, `id="app"`), qt.IsFalse,
+		qt.Commentf("React bundle leaked the Vue mount id"))
+}
+
+// TestFrontendHandler_UnknownBundleFallsBackToLegacy verifies the safety net
+// in selectBundle: if validation is bypassed somehow, the handler still
+// serves something rather than 500-ing.
+func TestFrontendHandler_UnknownBundleFallsBackToLegacy(t *testing.T) {
+	c := qt.New(t)
+
+	rec := getRoot(c, apiserver.FrontendHandler("preact"))
+	body := rec.Body.String()
+
+	c.Assert(rec.Code, qt.Equals, http.StatusOK)
+	c.Assert(strings.Contains(body, `id="app"`), qt.IsTrue,
+		qt.Commentf("unknown bundle should fall back to legacy index.html"))
+}
+
+func getRoot(c *qt.C, h http.Handler) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(rec, req)
+	c.Logf("status=%d, content-type=%s", rec.Code, rec.Header().Get("Content-Type"))
+	return rec
+}
+
+func snippet(s string) string {
+	if len(s) > 200 {
+		return s[:200] + "…"
+	}
+	return s
+}

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -6,36 +6,29 @@
 package bootstrap
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/denisvmedia/inventario/internal/defaults"
+	"github.com/denisvmedia/inventario/internal/frontendbundle"
 )
 
-// Frontend bundle identifiers. The active selection is driven by either the
-// --frontend-bundle CLI flag or the INVENTARIO_FRONTEND env var (CLI flag
-// takes precedence; see RegisterFlags). The dual-bundle window is part of
-// epic #1397; the cutover PR removes both the flag and these constants.
+// Re-exports of frontendbundle so existing call sites (and tests) keep using
+// bootstrap.FrontendBundleLegacy etc. without importing the helper package
+// directly. The single source of truth for the names lives in
+// internal/frontendbundle so apiserver and bootstrap never drift.
 const (
-	FrontendBundleLegacy = "legacy"
-	FrontendBundleNew    = "new"
+	FrontendBundleLegacy = frontendbundle.Legacy
+	FrontendBundleNew    = frontendbundle.New
 )
 
-// ValidFrontendBundles enumerates the accepted INVENTARIO_FRONTEND / --frontend-bundle
-// values. Exposed for help text and validation messages.
-var ValidFrontendBundles = []string{FrontendBundleLegacy, FrontendBundleNew}
+// ValidFrontendBundles re-exports the canonical list from frontendbundle for
+// the same drift-prevention reason. Help text references it.
+var ValidFrontendBundles = frontendbundle.Valid
 
-// ValidateFrontendBundle returns nil when the bundle name is recognised and a
-// helpful error otherwise. Called from Build during startup so misconfigured
-// deployments fail fast with a clear message instead of degrading to legacy
-// silently.
+// ValidateFrontendBundle delegates to frontendbundle.Validate; kept here as a
+// thin alias so RegisterFlags / buildServerParams call sites read clearly.
 func ValidateFrontendBundle(bundle string) error {
-	switch bundle {
-	case FrontendBundleLegacy, FrontendBundleNew:
-		return nil
-	default:
-		return fmt.Errorf("invalid frontend bundle %q: must be one of %v (set via --frontend-bundle or INVENTARIO_FRONTEND)", bundle, ValidFrontendBundles)
-	}
+	return frontendbundle.Validate(bundle)
 }
 
 // Config holds every flag read by `inventario run` and its subcommands. The

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -6,8 +6,37 @@
 package bootstrap
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/denisvmedia/inventario/internal/defaults"
 )
+
+// Frontend bundle identifiers. The active selection is driven by either the
+// --frontend-bundle CLI flag or the INVENTARIO_FRONTEND env var (CLI flag
+// takes precedence; see RegisterFlags). The dual-bundle window is part of
+// epic #1397; the cutover PR removes both the flag and these constants.
+const (
+	FrontendBundleLegacy = "legacy"
+	FrontendBundleNew    = "new"
+)
+
+// ValidFrontendBundles enumerates the accepted INVENTARIO_FRONTEND / --frontend-bundle
+// values. Exposed for help text and validation messages.
+var ValidFrontendBundles = []string{FrontendBundleLegacy, FrontendBundleNew}
+
+// ValidateFrontendBundle returns nil when the bundle name is recognised and a
+// helpful error otherwise. Called from Build during startup so misconfigured
+// deployments fail fast with a clear message instead of degrading to legacy
+// silently.
+func ValidateFrontendBundle(bundle string) error {
+	switch bundle {
+	case FrontendBundleLegacy, FrontendBundleNew:
+		return nil
+	default:
+		return fmt.Errorf("invalid frontend bundle %q: must be one of %v (set via --frontend-bundle or INVENTARIO_FRONTEND)", bundle, ValidFrontendBundles)
+	}
+}
 
 // Config holds every flag read by `inventario run` and its subcommands. The
 // struct is shared across subcommands because the overwhelming majority of
@@ -64,6 +93,13 @@ type Config struct {
 	// workers`; `run apiserver` and `run all` expose those endpoints on Addr.
 	ProbeAddr string `yaml:"probe_addr" env:"PROBE_ADDR" env-default:":3334"`
 
+	// FrontendBundle picks which embedded SPA the binary serves at the root
+	// during the migration window: "legacy" (Vue) or "new" (React). The CLI
+	// flag is --frontend-bundle; the env var is INVENTARIO_FRONTEND (note the
+	// non-prefixed name — intentional because it's deployment-shaped, not
+	// run-config-shaped). Default applied in SetDefaults from the env var.
+	FrontendBundle string `yaml:"frontend_bundle" env-default:""`
+
 	EmailProvider        string `yaml:"email_provider" env:"EMAIL_PROVIDER" env-default:"stub"`
 	EmailFrom            string `yaml:"email_from" env:"EMAIL_FROM" env-default:""`
 	EmailReplyTo         string `yaml:"email_reply_to" env:"EMAIL_REPLY_TO" env-default:""`
@@ -86,6 +122,16 @@ type Config struct {
 // value. It is invoked by RegisterFlags after the config has been populated
 // from YAML/env so the flag registrations see the final defaults.
 func (c *Config) SetDefaults() {
+	if c.FrontendBundle == "" {
+		// INVENTARIO_FRONTEND is intentionally outside the cleanenv-managed
+		// INVENTARIO_RUN_* prefix scheme — the issue (#1401) specifies that
+		// exact spelling because it controls which bundle the deployment
+		// serves, not a `run` tunable.
+		c.FrontendBundle = os.Getenv("INVENTARIO_FRONTEND")
+	}
+	if c.FrontendBundle == "" {
+		c.FrontendBundle = FrontendBundleLegacy
+	}
 	if c.Addr == "" {
 		c.Addr = defaults.GetServerAddr()
 	}

--- a/go/cmd/inventario/run/bootstrap/config_test.go
+++ b/go/cmd/inventario/run/bootstrap/config_test.go
@@ -115,3 +115,59 @@ func TestConfigSetDefaults_WorkerTunablesPreserveExplicitValues(t *testing.T) {
 	c.Assert(cfg.ThumbnailJobBatchTimeout, qt.Equals, "45s")
 	c.Assert(cfg.DetachedThumbnailJobTimeout, qt.Equals, "4m")
 }
+
+func TestConfigSetDefaults_FrontendBundleDefaultsToLegacy(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("INVENTARIO_FRONTEND", "")
+
+	cfg := bootstrap.Config{}
+	cfg.SetDefaults()
+
+	c.Assert(cfg.FrontendBundle, qt.Equals, bootstrap.FrontendBundleLegacy)
+}
+
+func TestConfigSetDefaults_FrontendBundleReadsEnvVar(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("INVENTARIO_FRONTEND", "new")
+
+	cfg := bootstrap.Config{}
+	cfg.SetDefaults()
+
+	c.Assert(cfg.FrontendBundle, qt.Equals, bootstrap.FrontendBundleNew)
+}
+
+func TestConfigSetDefaults_FrontendBundlePreservesExplicitValue(t *testing.T) {
+	c := qt.New(t)
+	// Explicit field value (e.g. set via the --frontend-bundle CLI flag) must
+	// win over the env var; this guards against a future re-ordering of
+	// SetDefaults that would let the env clobber the flag.
+	t.Setenv("INVENTARIO_FRONTEND", "new")
+
+	cfg := bootstrap.Config{FrontendBundle: bootstrap.FrontendBundleLegacy}
+	cfg.SetDefaults()
+
+	c.Assert(cfg.FrontendBundle, qt.Equals, bootstrap.FrontendBundleLegacy)
+}
+
+func TestValidateFrontendBundle_AcceptsKnownValues(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(bootstrap.ValidateFrontendBundle(bootstrap.FrontendBundleLegacy), qt.IsNil)
+	c.Assert(bootstrap.ValidateFrontendBundle(bootstrap.FrontendBundleNew), qt.IsNil)
+}
+
+func TestValidateFrontendBundle_RejectsUnknownValue(t *testing.T) {
+	c := qt.New(t)
+
+	err := bootstrap.ValidateFrontendBundle("preact")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "preact")
+	c.Assert(err.Error(), qt.Contains, "INVENTARIO_FRONTEND")
+}
+
+func TestValidateFrontendBundle_RejectsEmptyValue(t *testing.T) {
+	c := qt.New(t)
+
+	err := bootstrap.ValidateFrontendBundle("")
+	c.Assert(err, qt.IsNotNil)
+}

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -17,6 +17,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 
 	flags := cmd.PersistentFlags()
 	flags.StringVar(&cfg.Addr, "addr", cfg.Addr, "Bind address for the server")
+	flags.StringVar(&cfg.FrontendBundle, "frontend-bundle", cfg.FrontendBundle, "Which embedded SPA to serve at /: legacy (Vue) or new (React). Also settable via INVENTARIO_FRONTEND. Removed in the epic #1397 cutover.")
 	flags.StringVar(&cfg.UploadLocation, "upload-location", cfg.UploadLocation, "Location for the uploaded files")
 	shared.RegisterDatabaseFlags(cmd, dbConfig)
 	flags.IntVar(&cfg.MaxConcurrentExports, "max-concurrent-exports", cfg.MaxConcurrentExports, "Maximum number of concurrent export processes")

--- a/go/cmd/inventario/run/bootstrap/server_params.go
+++ b/go/cmd/inventario/run/bootstrap/server_params.go
@@ -28,10 +28,17 @@ type serverSetup struct {
 // the close function is returned in serverSetup and lifetime ownership moves to
 // the caller.
 func buildServerParams(cfg *Config, factorySet *registry.FactorySet, dsn string) (_ serverSetup, err error) {
+	if err := ValidateFrontendBundle(cfg.FrontendBundle); err != nil {
+		slog.Error("Invalid frontend bundle configuration", "error", err)
+		return serverSetup{}, err
+	}
+	slog.Info("Serving frontend bundle", "bundle", cfg.FrontendBundle)
+
 	params := apiserver.Params{
 		FactorySet:     factorySet,
 		UploadLocation: cfg.UploadLocation,
 		StartTime:      time.Now(),
+		FrontendBundle: cfg.FrontendBundle,
 	}
 	params.EntityService = services.NewEntityService(factorySet, params.UploadLocation)
 	params.DebugInfo = debug.NewInfo(dsn, params.UploadLocation)

--- a/go/internal/frontendbundle/bundle.go
+++ b/go/internal/frontendbundle/bundle.go
@@ -1,0 +1,34 @@
+// Package frontendbundle holds the identifiers and validation for the
+// "which embedded SPA do we serve at /" knob, shared by the apiserver
+// handler and the run/bootstrap config so the two never drift.
+//
+// The dual-bundle window is part of epic #1397 (Vue → React rewrite); the
+// cutover PR (#1423) deletes this package together with the legacy bundle
+// itself.
+package frontendbundle
+
+import "fmt"
+
+// Bundle identifiers. The active selection is driven by the
+// --frontend-bundle CLI flag or the INVENTARIO_FRONTEND env var.
+const (
+	Legacy = "legacy"
+	New    = "new"
+)
+
+// Valid enumerates every accepted bundle name. Surfaced for help text and
+// validation messages so we don't repeat the list at each call site.
+var Valid = []string{Legacy, New}
+
+// Validate returns nil for a recognised bundle name and a helpful error
+// otherwise. Called by the bootstrap to fail fast at startup; the apiserver
+// handler treats it as defence-in-depth and falls back to the legacy bundle
+// rather than 500-ing if validation is somehow bypassed.
+func Validate(bundle string) error {
+	switch bundle {
+	case Legacy, New:
+		return nil
+	default:
+		return fmt.Errorf("invalid frontend bundle %q: must be one of %v (set via --frontend-bundle or INVENTARIO_FRONTEND)", bundle, Valid)
+	}
+}


### PR DESCRIPTION
Closes #1401. Sub-issue of epic #1397 (React rewrite).

## Summary

A single binary now serves either the legacy Vue bundle or the new React bundle at the root, gated by `INVENTARIO_FRONTEND={legacy|new}` (or the equivalent `--frontend-bundle` CLI flag). Default is `legacy` so production behaviour is unchanged; the dual-bundle window lives until the cutover PR (which removes both the flag and the env var).

## Behaviour

```
INVENTARIO_FRONTEND=legacy   # default — serves frontend/dist (today's behaviour)
INVENTARIO_FRONTEND=new      # serves frontend-react/dist
INVENTARIO_FRONTEND=preact   # startup fails with a clear error listing valid values
```

CLI flag `--frontend-bundle` takes precedence over the env var (cobra default). Selected bundle is logged at startup.

## Implementation

- `bootstrap.Config.FrontendBundle`, `ValidateFrontendBundle`, constants `FrontendBundleLegacy` / `FrontendBundleNew`.
- `SetDefaults` reads `INVENTARIO_FRONTEND` directly via `os.Getenv` — the issue (#1401) specifies that exact spelling because it shapes deployment, not a `run` tunable, so it lives outside the `INVENTARIO_RUN_*` cleanenv prefix scheme.
- `apiserver.Params.FrontendBundle` plumbs the choice into `apiserver.go`. `FrontendHandler(bundle string)` selects between `frontend.GetDist()` and `frontendreact.GetDist()`. Defence-in-depth: an unknown value at the handler level logs a warning and falls back to legacy (the real validation happens in `buildServerParams`, but the handler shouldn't 500 if the gate is ever bypassed).
- Both build-tag variants (`apiserver_with_frontend.go`, `apiserver_without_frontend.go`) updated to the new signature.
- `buildServerParams` validates first, then sets `params.FrontendBundle`, then logs.
- New `frontend-react/frontend.go` already exists from #1402, so no embed-FS work needed beyond using it.

## Tests

**Unit (bootstrap_test, 6 new):**
- `FrontendBundle` defaults to `legacy` when env unset.
- Reads `INVENTARIO_FRONTEND` when set.
- Explicit field value (CLI flag) beats the env var.
- `ValidateFrontendBundle` accepts `legacy` / `new`.
- Rejects an unknown value with a message naming the bad value and the env var.
- Rejects empty.

**Integration (apiserver_test, with_frontend, 3 new):**
- `GET /` against `FrontendHandler("legacy")` returns Vue's `<div id="app">` shell.
- `GET /` against `FrontendHandler("new")` returns React's `<div id="root">` shell.
- `FrontendHandler("preact")` falls back to legacy (the safety net).

Whole `apiserver/` and `bootstrap/` test suites still green; lint clean.

## DEPLOYMENT.md

Adds an `INVENTARIO_FRONTEND="legacy"` example with migration-window context — explains why the var exists and that production deployments should leave it unset until parity is announced.

## Test plan

- [ ] `go build -tags with_frontend ./...` passes
- [ ] `go build ./...` passes (no-frontend build still works)
- [ ] `go test ./cmd/inventario/run/bootstrap/...` green
- [ ] `go test -tags with_frontend ./apiserver/...` green
- [ ] Manual: `INVENTARIO_FRONTEND=new ./inventario run` serves the React `<div id="root">` shell at `/`
- [ ] Manual: `INVENTARIO_FRONTEND=legacy ./inventario run` (and unset) serves the Vue shell

## Out of scope

- Cutover (delete legacy frontend, remove the env var) → tracked in #1423.
- Wiring the React bundle through the e2e harness → can land separately on top of this once the React frontend has any login flow (waits on #1404 + #1407).
