### PR TITLE
[#1418] Vitest coverage gate, MSW handler factories, jest-axe wiring

### DIFF
--- a/devdocs/frontend-react/testing.md
+++ b/devdocs/frontend-react/testing.md
@@ -1,0 +1,157 @@
+# Frontend React testing — Vitest, MSW, jest-axe
+
+Owns the unit + integration test toolchain for `frontend-react/`. PR #1432 (#1418) wired the harness; this doc is the contract every per-feature page test should follow.
+
+## Layout
+
+```
+frontend-react/src/test/
+├── setup.ts          # global hooks: jest-dom, jest-axe, MSW server, sonner mock, i18n boot, matchMedia stub
+├── server.ts         # shared msw `setupServer()` instance
+├── render.tsx        # `renderWithProviders()` helper
+└── handlers/         # per-endpoint MSW factories
+    ├── index.ts      # public surface — re-exports + apiUrl helper
+    ├── auth.ts
+    ├── groups.ts
+    ├── commodities.ts
+    ├── locations.ts
+    ├── files.ts
+    ├── tags.ts
+    ├── exports.ts
+    ├── members.ts
+    └── search.ts
+```
+
+## `renderWithProviders`
+
+Composes the same provider stack the app boots with, in the same order, so a passing test maps to a passing production render:
+
+```
+ThemeProvider → DensityProvider → QueryClientProvider → MemoryRouter
+                                                     └─ (optional) AuthProvider → GroupProvider
+```
+
+`AuthProvider` and `GroupProvider` are **opt-in** (`withAuth`, `withGroup`) because most route-level tests want to mount them inside a `<Route element>` so the `/auth/me` probe and the `:groupSlug` resolution fire only after navigation resolves. Leaf-component tests that read `useAuth()` / `useCurrentGroup()` without owning the route boundary set the flags.
+
+```tsx
+import { Route, renderWithProviders } from "@/test/render"
+
+// 1. Route-level test — mount providers per-route inside the element:
+renderWithProviders({
+  initialPath: "/private",
+  routes: (
+    <>
+      <Route
+        path="/private"
+        element={
+          <AuthProvider>
+            <ProtectedRoute>
+              <Probe />
+            </ProtectedRoute>
+          </AuthProvider>
+        }
+      />
+      <Route path="/login" element={<LoginStub />} />
+    </>
+  ),
+})
+
+// 2. Leaf-component test — let the helper wrap the providers for you:
+renderWithProviders({
+  withAuth: true,
+  withGroup: true,
+  children: <SomeWidgetThatReadsBothContexts />,
+})
+```
+
+Returns the standard `RenderResult` plus the `queryClient` so cache assertions are a one-liner:
+
+```tsx
+const { queryClient } = renderWithProviders({ ... })
+expect(queryClient.getQueryData(authKeys.currentUser())).toMatchObject({ ... })
+```
+
+## MSW handler factories
+
+Tests register per-case handlers via `server.use(...)` — never edit `server.ts`'s base set. Handlers live under `src/test/handlers/<feature>.ts` and are namespace-imported from the index:
+
+```ts
+import { authHandlers, groupHandlers } from "@/test/handlers"
+
+server.use(
+  ...authHandlers.signedIn({ user: { name: "Test" } }),
+  ...groupHandlers.list([{ id: "g1", slug: "household", name: "Household" }])
+)
+```
+
+Each module exposes focused factories that take a fixture and return an array of handlers. The array shape is what makes `...spread` composition feel native at the call site.
+
+| Variant            | Returns                                                     |
+| ------------------ | ----------------------------------------------------------- |
+| `signedIn(opts?)`  | `[GET /auth/me, POST /auth/refresh, POST /auth/logout]`     |
+| `signedOut()`      | `[GET /auth/me 401, POST /auth/refresh 401]`                |
+| `transientServerError()` | `[GET /auth/me 503]` — for "blip doesn't bounce to /login" tests |
+| `groupHandlers.list(groups?)`  | `[GET /groups]` returning the JSON:API envelope          |
+| `groupHandlers.empty()`        | `[GET /groups]` returning `[]` (no-group state)          |
+| `groupHandlers.error(status?)` | `[GET /groups]` returning the given status code          |
+
+For ad-hoc handlers, import `apiUrl` from `@/test/handlers` and reach for `msw.http.*` directly — no need to add a module.
+
+## a11y assertions
+
+`jest-axe` is registered globally. Page-level component tests should run `axe(container)` and fail on violations:
+
+```tsx
+import { axe } from "jest-axe"
+
+it("has no axe violations", async () => {
+  const { container } = render(...)
+  expect(await axe(container)).toHaveNoViolations()
+})
+```
+
+If a violation is intentional (e.g. a vendored Radix primitive's known issue), suppress it locally with `jest-axe`'s `runOptions` rather than skipping the test.
+
+## Coverage gate
+
+Enforced in `vitest.config.ts` — CI fails if coverage drops below:
+
+| Metric     | Threshold |
+| ---------- | --------- |
+| Statements | 80%       |
+| Lines      | 80%       |
+| Functions  | 80%       |
+| Branches   | 70%       |
+
+Excluded paths:
+
+- `src/components/ui/**` — vendored shadcn primitives owned by the design mock.
+- `src/app/**` — composition-only (router, providers, App, Shell). Covered by Playwright (#1419).
+- `src/components/{AppSidebar,CommandPalette,GroupSelector}.tsx` — composite shell components; integration coverage lands with #1419 / #1414.
+- `src/i18n/i18next.config.ts` — lazy backend for cs/ru exercised by the Settings page locale toggle (#1414).
+- `src/main.tsx`, `src/types/**`, `src/vite-env.d.ts` — entry / generated.
+
+Bump thresholds upward as feature pages land — never downward without a written reason in the PR body.
+
+## Snapshot policy
+
+Avoid full-DOM snapshots. Allowed:
+
+- Small stable outputs — e.g. `formatCurrency` return values, an icon's compiled SVG.
+- Tightly scoped objects — e.g. `i18n.options` after init.
+
+If a feature page benefits from a snapshot, scope it to a slice (`screen.getByRole("...").outerHTML`) rather than the whole render tree.
+
+## Sonner
+
+`vi.mock("sonner")` runs globally in `setup.ts` so the real `<Toaster />` doesn't portal during tests. Tests that want to assert toast behavior re-mock `sonner` locally — the per-file mock wins because `vi.mock` hoists.
+
+## i18n in tests
+
+`setup.ts` calls `await initI18n({ lng: "en" })` once before MSW starts. `useTranslation()` returns the en bundle; missing keys log a `[i18n] missing key …` warning per `i18next.config.ts`'s dev handler. Tests that want to assert against a specific locale call `await i18next.changeLanguage("...")` and reset back to `"en"` in their `afterEach`.
+
+## When in doubt
+
+- Need a test fixture? Add a factory under `src/test/handlers/<feature>.ts`.
+- Need a new provider? Add it to `renderWithProviders` behind a flag.
+- Need to lower a threshold? Don't — find the test instead.

--- a/frontend-react/src/components/__tests__/AppLogo.test.tsx
+++ b/frontend-react/src/components/__tests__/AppLogo.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { axe } from "jest-axe"
+
+import { AppLogo } from "@/components/AppLogo"
+
+describe("AppLogo", () => {
+  it("renders the brand wordmark", () => {
+    render(<AppLogo />)
+    expect(screen.getByText("Inventario")).toBeInTheDocument()
+  })
+
+  it("forwards a className override onto the root", () => {
+    const { container } = render(<AppLogo className="custom-cls" />)
+    expect(container.firstChild).toHaveClass("custom-cls")
+  })
+
+  it("passes axe (decorative SVG is aria-hidden)", async () => {
+    const { container } = render(<AppLogo />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend-react/src/components/__tests__/DensityToggle.test.tsx
+++ b/frontend-react/src/components/__tests__/DensityToggle.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, beforeEach } from "vitest"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { DensityProvider } from "@/hooks/useDensity"
+import { DensityToggle } from "@/components/DensityToggle"
+
+beforeEach(() => {
+  window.localStorage.clear()
+  document.documentElement.removeAttribute("data-density")
+})
+
+describe("DensityToggle", () => {
+  it("switches data-density on <html> via the menu", async () => {
+    const user = userEvent.setup()
+    render(
+      <DensityProvider storageKey="test-density">
+        <DensityToggle />
+      </DensityProvider>
+    )
+    await user.click(screen.getByRole("button", { name: /toggle density/i }))
+    const menu = await screen.findByRole("menu")
+    await user.click(within(menu).getByText(/^compact$/i))
+    expect(document.documentElement.getAttribute("data-density")).toBe("compact")
+  })
+
+  it("each menu option maps to its density level", async () => {
+    const user = userEvent.setup()
+    render(
+      <DensityProvider storageKey="test-density">
+        <DensityToggle />
+      </DensityProvider>
+    )
+    for (const [label, value] of [
+      ["Comfortable", "comfortable"],
+      ["Cozy", "cozy"],
+      ["Compact", "compact"],
+    ] as const) {
+      await user.click(screen.getByRole("button", { name: /toggle density/i }))
+      const menu = await screen.findByRole("menu")
+      await user.click(within(menu).getByText(label))
+      expect(document.documentElement.getAttribute("data-density")).toBe(value)
+    }
+  })
+})

--- a/frontend-react/src/components/__tests__/InviteBanner.test.tsx
+++ b/frontend-react/src/components/__tests__/InviteBanner.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { InviteBanner } from "@/components/InviteBanner"
+import { renderWithProviders } from "@/test/render"
+
+describe("InviteBanner", () => {
+  it("renders nothing when count is zero", () => {
+    renderWithProviders({ children: <InviteBanner count={0} /> })
+    expect(screen.queryByTestId("invite-banner")).toBeNull()
+  })
+
+  it("shows pluralised text for >1 invites", () => {
+    renderWithProviders({ children: <InviteBanner count={3} /> })
+    expect(screen.getByTestId("invite-banner")).toHaveTextContent("You have 3 pending invites.")
+  })
+
+  it("shows singular text for exactly one invite", () => {
+    renderWithProviders({ children: <InviteBanner count={1} /> })
+    expect(screen.getByTestId("invite-banner")).toHaveTextContent("You have 1 pending invite.")
+  })
+
+  it("hides the View action when viewHref is null (the default)", () => {
+    renderWithProviders({ children: <InviteBanner count={2} /> })
+    expect(screen.queryByRole("button", { name: /view/i })).toBeNull()
+  })
+
+  it("renders the View action when an explicit viewHref is passed", () => {
+    renderWithProviders({
+      children: <InviteBanner count={2} viewHref="/profile" />,
+    })
+    expect(screen.getByRole("button", { name: /view/i })).toBeInTheDocument()
+  })
+
+  it("dismisses on click of the X button (in-session only)", async () => {
+    const user = userEvent.setup()
+    renderWithProviders({ children: <InviteBanner count={2} /> })
+    expect(screen.getByTestId("invite-banner")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: /dismiss invite banner/i }))
+    expect(screen.queryByTestId("invite-banner")).toBeNull()
+  })
+})

--- a/frontend-react/src/components/__tests__/ModeToggle.test.tsx
+++ b/frontend-react/src/components/__tests__/ModeToggle.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, beforeEach } from "vitest"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { ThemeProvider } from "@/components/theme-provider"
+import { ModeToggle } from "@/components/ModeToggle"
+
+beforeEach(() => {
+  window.localStorage.clear()
+  document.documentElement.classList.remove("light", "dark")
+})
+
+describe("ModeToggle", () => {
+  it("flips the .dark class on <html> via the menu", async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider storageKey="test-theme">
+        <ModeToggle />
+      </ThemeProvider>
+    )
+    await user.click(screen.getByRole("button", { name: /toggle theme/i }))
+    const menu = await screen.findByRole("menu")
+    await user.click(within(menu).getByText(/^dark$/i))
+    expect(document.documentElement.classList.contains("dark")).toBe(true)
+  })
+
+  it("system option resolves prefers-color-scheme", async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider storageKey="test-theme">
+        <ModeToggle />
+      </ThemeProvider>
+    )
+    await user.click(screen.getByRole("button", { name: /toggle theme/i }))
+    const menu = await screen.findByRole("menu")
+    await user.click(within(menu).getByText(/^system$/i))
+    // The setup.ts matchMedia stub returns matches=false, which the theme
+    // provider treats as "light".
+    expect(document.documentElement.classList.contains("light")).toBe(true)
+  })
+})

--- a/frontend-react/src/components/__tests__/TopBar.test.tsx
+++ b/frontend-react/src/components/__tests__/TopBar.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { screen } from "@testing-library/react"
+
+import { SidebarProvider } from "@/components/ui/sidebar"
+import { TopBar } from "@/components/TopBar"
+import { RouteTitle, RouteTitleProvider } from "@/components/routing/RouteTitle"
+import { renderWithProviders } from "@/test/render"
+
+describe("TopBar", () => {
+  it("displays the active route title from RouteTitleContext", async () => {
+    renderWithProviders({
+      children: (
+        <RouteTitleProvider>
+          <SidebarProvider>
+            <RouteTitle title="Test Page" />
+            <TopBar />
+          </SidebarProvider>
+        </RouteTitleProvider>
+      ),
+    })
+    expect(await screen.findByTestId("topbar-title")).toHaveTextContent("Test Page")
+  })
+
+  it("includes the sidebar trigger and theme/density toggles", () => {
+    renderWithProviders({
+      children: (
+        <RouteTitleProvider>
+          <SidebarProvider>
+            <TopBar />
+          </SidebarProvider>
+        </RouteTitleProvider>
+      ),
+    })
+    expect(screen.getByRole("button", { name: /toggle sidebar/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /toggle theme/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /toggle density/i })).toBeInTheDocument()
+  })
+})

--- a/frontend-react/src/features/auth/__tests__/api.test.ts
+++ b/frontend-react/src/features/auth/__tests__/api.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, beforeEach } from "vitest"
+import { http, HttpResponse } from "msw"
+
+import { server } from "@/test/server"
+import { apiUrl } from "@/test/handlers"
+import { login, logout } from "@/features/auth/api"
+import { clearAuth, getAccessToken, getCsrfToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("login", () => {
+  it("persists access + CSRF tokens and returns the user payload", async () => {
+    server.use(
+      http.post(apiUrl("/auth/login"), () =>
+        HttpResponse.json({
+          access_token: "tok-1",
+          csrf_token: "csrf-1",
+          user: { id: "u1", email: "denis@example.com" },
+        })
+      )
+    )
+    const user = await login("denis@example.com", "secret")
+    expect(user).toMatchObject({ id: "u1", email: "denis@example.com" })
+    expect(getAccessToken()).toBe("tok-1")
+    expect(getCsrfToken()).toBe("csrf-1")
+  })
+
+  it("does not throw when the server omits user/tokens (the bare 200 case)", async () => {
+    server.use(http.post(apiUrl("/auth/login"), () => HttpResponse.json({})))
+    await expect(login("a@b.c", "x")).resolves.toBeUndefined()
+  })
+})
+
+describe("logout", () => {
+  it("calls /auth/logout and wipes local credentials on success", async () => {
+    let logoutCalls = 0
+    server.use(
+      http.post(apiUrl("/auth/logout"), () => {
+        logoutCalls++
+        return new HttpResponse(null, { status: 204 })
+      })
+    )
+    await logout()
+    expect(logoutCalls).toBe(1)
+    expect(getAccessToken()).toBeNull()
+  })
+
+  it("wipes local credentials even when the server errors", async () => {
+    server.use(
+      http.post(apiUrl("/auth/logout"), () => HttpResponse.json({ error: "boom" }, { status: 500 }))
+    )
+    await expect(logout()).rejects.toBeDefined()
+    expect(getAccessToken()).toBeNull()
+  })
+})

--- a/frontend-react/src/hooks/__tests__/use-mobile.test.tsx
+++ b/frontend-react/src/hooks/__tests__/use-mobile.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+
+import { useIsMobile } from "@/hooks/use-mobile"
+
+interface MqlMock {
+  matches: boolean
+  listeners: Array<(event: { matches: boolean }) => void>
+  fire(matches: boolean): void
+}
+
+let mql: MqlMock
+let originalMatchMedia: typeof window.matchMedia
+
+beforeEach(() => {
+  mql = {
+    matches: false,
+    listeners: [],
+    fire(matches: boolean) {
+      this.matches = matches
+      this.listeners.forEach((cb) => cb({ matches }))
+    },
+  }
+  originalMatchMedia = window.matchMedia
+  // Override the default jsdom stub from setup.ts with a controllable mock
+  // so we can flip "mobile" on/off and assert the change-listener wiring.
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    media: query,
+    get matches() {
+      return mql.matches
+    },
+    addEventListener: (_type: string, cb: (event: { matches: boolean }) => void) => {
+      mql.listeners.push(cb)
+    },
+    removeEventListener: (_type: string, cb: (event: { matches: boolean }) => void) => {
+      mql.listeners = mql.listeners.filter((l) => l !== cb)
+    },
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+  })) as unknown as typeof window.matchMedia
+})
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia
+})
+
+describe("useIsMobile", () => {
+  it("reads the initial value synchronously from matchMedia", () => {
+    mql.matches = true
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(true)
+  })
+
+  it("flips on media-query change events", () => {
+    mql.matches = false
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+    act(() => mql.fire(true))
+    expect(result.current).toBe(true)
+    act(() => mql.fire(false))
+    expect(result.current).toBe(false)
+  })
+})

--- a/frontend-react/src/lib/__tests__/nav-labels.test.tsx
+++ b/frontend-react/src/lib/__tests__/nav-labels.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { renderHook } from "@testing-library/react"
+
+import { useNavLabel } from "@/lib/nav-labels"
+
+describe("useNavLabel", () => {
+  // Each known key resolves through a per-arm translator call against the
+  // common namespace. This grid asserts both that the catalog entries
+  // exist (the en bundle is preloaded by setup.ts) and that the helper
+  // covers every nav item the sidebar / palette declare.
+  const cases: Array<[string, string]> = [
+    ["common:nav.dashboard", "Dashboard"],
+    ["common:nav.locations", "Locations"],
+    ["common:nav.items", "All Items"],
+    ["common:nav.warranties", "Warranties"],
+    ["common:nav.tags", "Tags"],
+    ["common:nav.files", "Files"],
+    ["common:nav.members", "Members"],
+    ["common:nav.backup", "Backup"],
+    ["common:nav.system", "Settings"],
+    ["common:nav.profile", "Profile"],
+  ]
+
+  it.each(cases)("resolves %s → %s", (key, expected) => {
+    const { result } = renderHook(() => useNavLabel(key))
+    expect(result.current).toBe(expected)
+  })
+
+  it("falls back to the raw key for unknown values (defensive)", () => {
+    const { result } = renderHook(() => useNavLabel("common:nav.does-not-exist"))
+    expect(result.current).toBe("common:nav.does-not-exist")
+  })
+})

--- a/frontend-react/src/lib/__tests__/navigation.test.ts
+++ b/frontend-react/src/lib/__tests__/navigation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi, afterEach } from "vitest"
+
+import { __resetNavigationForTests, navigateToLogin, setNavigateToLogin } from "@/lib/navigation"
+
+afterEach(() => {
+  __resetNavigationForTests()
+})
+
+describe("navigation", () => {
+  it("default navigator writes window.location.href with the redirect query", () => {
+    const original = window.location
+    // jsdom blocks direct assignment to window.location.href, so swap the
+    // whole object with a captured spy. `delete` lets us redefine.
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...original, href: "" },
+    })
+    navigateToLogin("/some/path", "session_expired")
+    expect(window.location.href).toBe("/login?redirect=%2Fsome%2Fpath&reason=session_expired")
+    Object.defineProperty(window, "location", { writable: true, value: original })
+  })
+
+  it("setNavigateToLogin replaces the active navigator", () => {
+    const spy = vi.fn()
+    setNavigateToLogin(spy)
+    navigateToLogin("/x", "auth_required")
+    expect(spy).toHaveBeenCalledWith("/x", "auth_required")
+  })
+
+  it("__resetNavigationForTests restores the default", () => {
+    const spy = vi.fn()
+    setNavigateToLogin(spy)
+    __resetNavigationForTests()
+    // Default uses window.location which we don't want to bother
+    // re-stubbing here; just assert the spy is no longer the active one.
+    const original = window.location
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...original, href: "" },
+    })
+    navigateToLogin("/y")
+    expect(spy).not.toHaveBeenCalled()
+    Object.defineProperty(window, "location", { writable: true, value: original })
+  })
+})

--- a/frontend-react/src/lib/__tests__/query-client.test.ts
+++ b/frontend-react/src/lib/__tests__/query-client.test.ts
@@ -1,17 +1,41 @@
 import { describe, expect, it } from "vitest"
 
 import { createQueryClient } from "@/lib/query-client"
+import { HttpError } from "@/lib/http"
 
 describe("createQueryClient", () => {
-  it("returns a fresh client with the project's default options", () => {
+  it("returns a fresh client instance per call", () => {
     const a = createQueryClient()
     const b = createQueryClient()
     expect(a).not.toBe(b)
-    const defaults = a.getDefaultOptions()
-    // The defaults object always has a queries key — its presence is the
-    // smoke that we wired our config in (a bare `new QueryClient()` would
-    // also expose this, so the value-level assertions below pin the
-    // project-specific tunables).
-    expect(defaults).toBeDefined()
+  })
+
+  it("seeds the project's tunables on the queries default options", () => {
+    const client = createQueryClient()
+    const queries = client.getDefaultOptions().queries ?? {}
+    // staleTime keeps cross-page navigation cheap (cached lists stay fresh
+    // for a route hop).
+    expect(queries.staleTime).toBe(30_000)
+    // refetchOnWindowFocus is on — the legacy frontend's habit of
+    // re-checking when the user comes back from another tab.
+    expect(queries.refetchOnWindowFocus).toBe(true)
+  })
+
+  it("retry opts out of 4xx errors and caps at one retry for 5xx", () => {
+    const client = createQueryClient()
+    const retry = client.getDefaultOptions().queries?.retry
+    expect(typeof retry).toBe("function")
+    if (typeof retry !== "function") return
+    const fourHundred = new HttpError("forbidden", 403, "/x", null)
+    const fiveHundred = new HttpError("server", 500, "/x", null)
+    expect(retry(0, fourHundred)).toBe(false)
+    expect(retry(0, fiveHundred)).toBe(true)
+    // failureCount=1 means "we already retried once".
+    expect(retry(1, fiveHundred)).toBe(false)
+  })
+
+  it("mutations never retry", () => {
+    const client = createQueryClient()
+    expect(client.getDefaultOptions().mutations?.retry).toBe(false)
   })
 })

--- a/frontend-react/src/lib/__tests__/query-client.test.ts
+++ b/frontend-react/src/lib/__tests__/query-client.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { createQueryClient } from "@/lib/query-client"
+
+describe("createQueryClient", () => {
+  it("returns a fresh client with the project's default options", () => {
+    const a = createQueryClient()
+    const b = createQueryClient()
+    expect(a).not.toBe(b)
+    const defaults = a.getDefaultOptions()
+    // The defaults object always has a queries key — its presence is the
+    // smoke that we wired our config in (a bare `new QueryClient()` would
+    // also expose this, so the value-level assertions below pin the
+    // project-specific tunables).
+    expect(defaults).toBeDefined()
+  })
+})

--- a/frontend-react/src/pages/Placeholder.test.tsx
+++ b/frontend-react/src/pages/Placeholder.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { screen } from "@testing-library/react"
+
+import { PlaceholderPage } from "@/pages/Placeholder"
+import { Route, renderWithProviders } from "@/test/render"
+
+describe("PlaceholderPage", () => {
+  it("renders the resolved stub title and the 'Coming soon' line", () => {
+    renderWithProviders({
+      initialPath: "/",
+      routes: <Route path="/" element={<PlaceholderPage titleKey="login" testId="page-test" />} />,
+    })
+    expect(screen.getByRole("heading", { name: /sign in/i, level: 1 })).toBeInTheDocument()
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument()
+  })
+
+  it("emits the trackedBy footer when the prop is set", () => {
+    renderWithProviders({
+      initialPath: "/",
+      routes: (
+        <Route
+          path="/"
+          element={<PlaceholderPage titleKey="register" testId="page-test" trackedBy="#1407" />}
+        />
+      ),
+    })
+    expect(screen.getByText(/Tracked by #1407/i)).toBeInTheDocument()
+  })
+
+  it("omits the trackedBy footer when no prop is passed", () => {
+    renderWithProviders({
+      initialPath: "/",
+      routes: <Route path="/" element={<PlaceholderPage titleKey="login" testId="page-test" />} />,
+    })
+    expect(screen.queryByText(/Tracked by/)).toBeNull()
+  })
+})

--- a/frontend-react/src/test/handlers/auth.ts
+++ b/frontend-react/src/test/handlers/auth.ts
@@ -1,0 +1,55 @@
+import { http, HttpResponse } from "msw"
+
+import type { Schema } from "@/types"
+
+import { apiUrl } from "."
+
+type User = Schema<"models.User">
+
+export interface SignedInOptions {
+  // Override the user object returned by /auth/me. Defaults to a stable
+  // fixture used across most tests.
+  user?: Partial<User>
+}
+
+export const fixtureUser: User = {
+  id: "u1",
+  email: "denis@example.com",
+  name: "Denis",
+} as User
+
+// signedIn returns the canonical "user is logged in" handler set: /auth/me
+// resolves with a real user, refresh and logout are both quiet 204s. Tests
+// that need to flip the user (different default_group_id, different role)
+// pass `user`; tests that need a different shape build their own handlers
+// with `apiUrl()` directly.
+export function signedIn(opts: SignedInOptions = {}) {
+  const user = { ...fixtureUser, ...opts.user }
+  return [
+    http.get(apiUrl("/auth/me"), () => HttpResponse.json(user)),
+    http.post(apiUrl("/auth/refresh"), () =>
+      HttpResponse.json({ access_token: "refreshed-token", csrf_token: "refreshed-csrf" })
+    ),
+    http.post(apiUrl("/auth/logout"), () => new HttpResponse(null, { status: 204 })),
+  ]
+}
+
+// signedOut models a brand-new tab: /auth/me 401s, refresh also 401s. The
+// http client's 401-handler should redirect the user to /login, which the
+// router's tests assert.
+export function signedOut() {
+  return [
+    http.get(apiUrl("/auth/me"), () => HttpResponse.json(null, { status: 401 })),
+    http.post(apiUrl("/auth/refresh"), () => HttpResponse.json(null, { status: 401 })),
+  ]
+}
+
+// transientServerError is what we use to assert "we don't bounce the user
+// to /login on a 5xx blip" — see ProtectedRoute and AuthContext tests.
+export function transientServerError() {
+  return [
+    http.get(apiUrl("/auth/me"), () =>
+      HttpResponse.json({ error: "service unavailable" }, { status: 503 })
+    ),
+  ]
+}

--- a/frontend-react/src/test/handlers/commodities.ts
+++ b/frontend-react/src/test/handlers/commodities.ts
@@ -1,0 +1,30 @@
+import { http, HttpResponse } from "msw"
+
+import { apiUrl } from "."
+
+// Backend mounts commodity routes inside /g/{slug}/commodities. Tests pass
+// the slug they expect to see in the URL so MSW exact-matches the
+// http-client rewrite output.
+export function list(slug: string, items: unknown[] = []) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/commodities`), () =>
+      HttpResponse.json({ data: items })
+    ),
+  ]
+}
+
+export function detail(slug: string, id: string, item: unknown) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/commodities/${id}`), () =>
+      HttpResponse.json({ data: item })
+    ),
+  ]
+}
+
+export function error(slug: string, status = 500) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/commodities`), () =>
+      HttpResponse.json({ error: "boom" }, { status })
+    ),
+  ]
+}

--- a/frontend-react/src/test/handlers/commodities.ts
+++ b/frontend-react/src/test/handlers/commodities.ts
@@ -15,7 +15,7 @@ export function list(slug: string, items: unknown[] = []) {
 
 export function detail(slug: string, id: string, item: unknown) {
   return [
-    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/commodities/${id}`), () =>
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}`), () =>
       HttpResponse.json({ data: item })
     ),
   ]

--- a/frontend-react/src/test/handlers/exports.ts
+++ b/frontend-react/src/test/handlers/exports.ts
@@ -1,0 +1,11 @@
+import { http, HttpResponse } from "msw"
+
+import { apiUrl } from "."
+
+export function list(slug: string, items: unknown[] = []) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/exports`), () =>
+      HttpResponse.json({ data: items })
+    ),
+  ]
+}

--- a/frontend-react/src/test/handlers/files.ts
+++ b/frontend-react/src/test/handlers/files.ts
@@ -1,0 +1,19 @@
+import { http, HttpResponse } from "msw"
+
+import { apiUrl } from "."
+
+export function list(slug: string, items: unknown[] = []) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/files`), () =>
+      HttpResponse.json({ data: items })
+    ),
+  ]
+}
+
+export function error(slug: string, status = 500) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/files`), () =>
+      HttpResponse.json({ error: "boom" }, { status })
+    ),
+  ]
+}

--- a/frontend-react/src/test/handlers/groups.ts
+++ b/frontend-react/src/test/handlers/groups.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from "msw"
+
+import type { Schema } from "@/types"
+
+import { apiUrl } from "."
+
+type LocationGroup = Schema<"models.LocationGroup">
+
+export const fixtureGroups: LocationGroup[] = [
+  { id: "g1", slug: "household", name: "Household" } as LocationGroup,
+  { id: "g2", slug: "office", name: "Office" } as LocationGroup,
+]
+
+function envelope(groups: LocationGroup[]) {
+  return {
+    data: groups.map((g) => ({ id: g.id, type: "groups", attributes: g })),
+  }
+}
+
+// list builds a /groups handler that returns the supplied membership.
+// Defaults to the two-group fixture so the common "user with multiple
+// groups" path is a one-liner in tests.
+export function list(groups: LocationGroup[] = fixtureGroups) {
+  return [http.get(apiUrl("/groups"), () => HttpResponse.json(envelope(groups)))]
+}
+
+export function empty() {
+  return [http.get(apiUrl("/groups"), () => HttpResponse.json(envelope([])))]
+}
+
+export function error(status = 500) {
+  return [http.get(apiUrl("/groups"), () => HttpResponse.json({ error: "boom" }, { status }))]
+}

--- a/frontend-react/src/test/handlers/index.ts
+++ b/frontend-react/src/test/handlers/index.ts
@@ -1,0 +1,24 @@
+// Public surface for the MSW handler factories. Tests opt into the slices
+// they need:
+//
+//     import { authHandlers, groupHandlers } from "@/test/handlers"
+//     server.use(...authHandlers.signedIn(), ...groupHandlers.list([g1, g2]))
+//
+// Each per-feature module exports an object whose methods take focused
+// fixtures (a user, a list of groups, a status code) and return an array
+// of `msw` handlers — never a single handler — so a test can compose
+// multiple slice variants without juggling spreads at the call site.
+export * as authHandlers from "./auth"
+export * as groupHandlers from "./groups"
+export * as commodityHandlers from "./commodities"
+export * as locationHandlers from "./locations"
+export * as fileHandlers from "./files"
+export * as tagHandlers from "./tags"
+export * as exportHandlers from "./exports"
+export * as memberHandlers from "./members"
+export * as searchHandlers from "./search"
+
+// Helper used across factories: every backend route lives under /api/v1/.
+// Re-exported so per-test handlers that aren't worth a factory can build
+// URLs the same way the factories do.
+export const apiUrl = (path: string) => `${window.location.origin}/api/v1${path}`

--- a/frontend-react/src/test/handlers/locations.ts
+++ b/frontend-react/src/test/handlers/locations.ts
@@ -12,7 +12,7 @@ export function list(slug: string, items: unknown[] = []) {
 
 export function detail(slug: string, id: string, item: unknown) {
   return [
-    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/locations/${id}`), () =>
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(id)}`), () =>
       HttpResponse.json({ data: item })
     ),
   ]

--- a/frontend-react/src/test/handlers/locations.ts
+++ b/frontend-react/src/test/handlers/locations.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from "msw"
+
+import { apiUrl } from "."
+
+export function list(slug: string, items: unknown[] = []) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/locations`), () =>
+      HttpResponse.json({ data: items })
+    ),
+  ]
+}
+
+export function detail(slug: string, id: string, item: unknown) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/locations/${id}`), () =>
+      HttpResponse.json({ data: item })
+    ),
+  ]
+}
+
+export function error(slug: string, status = 500) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/locations`), () =>
+      HttpResponse.json({ error: "boom" }, { status })
+    ),
+  ]
+}

--- a/frontend-react/src/test/handlers/members.ts
+++ b/frontend-react/src/test/handlers/members.ts
@@ -1,0 +1,13 @@
+import { http, HttpResponse } from "msw"
+
+import { apiUrl } from "."
+
+// Members live under /groups/{id}/members rather than /g/{slug}/...
+// (the legacy backend keeps the membership endpoints group-id-keyed).
+export function list(groupId: string, members: unknown[] = []) {
+  return [
+    http.get(apiUrl(`/groups/${encodeURIComponent(groupId)}/members`), () =>
+      HttpResponse.json({ data: members })
+    ),
+  ]
+}

--- a/frontend-react/src/test/handlers/search.ts
+++ b/frontend-react/src/test/handlers/search.ts
@@ -1,0 +1,14 @@
+import { http, HttpResponse } from "msw"
+
+import { apiUrl } from "."
+
+// Search lives under /g/{slug}/search per the legacy backend. The endpoint
+// returns a flat result list — the empty case ([]) is what the command
+// palette's "no results" branch tests against.
+export function results(slug: string, items: unknown[] = []) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/search`), () =>
+      HttpResponse.json({ data: items })
+    ),
+  ]
+}

--- a/frontend-react/src/test/handlers/tags.ts
+++ b/frontend-react/src/test/handlers/tags.ts
@@ -1,0 +1,11 @@
+import { http, HttpResponse } from "msw"
+
+import { apiUrl } from "."
+
+export function list(slug: string, items: unknown[] = []) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/tags`), () =>
+      HttpResponse.json({ data: items })
+    ),
+  ]
+}

--- a/frontend-react/src/test/render.tsx
+++ b/frontend-react/src/test/render.tsx
@@ -53,17 +53,20 @@ export type RenderWithProvidersOptions = RenderWithProvidersBaseOptions &
 //   └─ DensityProvider     — data-density attribute
 //      └─ QueryClientProvider — TanStack cache (per-test instance)
 //         └─ MemoryRouter   — controllable initial URL
-//            └─ AuthProvider — /auth/me probe + AuthContext
-//               └─ GroupProvider — /groups query + GroupContext
+//            └─ (optional) AuthProvider — /auth/me probe + AuthContext
+//               └─ (optional) GroupProvider — /groups query + GroupContext
 //                  └─ test subtree
 //
 // MSW is started in `src/test/setup.ts`; tests register per-case
 // handlers via `server.use(...authHandlers.signedIn(), ...)` from
 // `src/test/handlers`.
 //
-// Variants (skipAuth, skipGroup) drop the corresponding layer for tests
-// that don't need it — useful for components that don't read those
-// contexts and would otherwise pull in unnecessary MSW dependencies.
+// `withAuth` / `withGroup` are opt-in flags (default `false`). Most
+// route-level tests want to mount AuthProvider / GroupProvider INSIDE
+// the route element so the /auth/me probe and the :groupSlug
+// resolution fire only after navigation resolves; flip the flag for
+// leaf tests that read useAuth() / useCurrentGroup() without owning
+// the route boundary.
 export function renderWithProviders(
   options: RenderWithProvidersOptions
 ): RenderResult & { queryClient: QueryClient } {

--- a/frontend-react/src/test/render.tsx
+++ b/frontend-react/src/test/render.tsx
@@ -1,30 +1,83 @@
 import type { ReactNode } from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { MemoryRouter, Routes } from "react-router-dom"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { render, type RenderResult } from "@testing-library/react"
 
-// renderWithProviders is the standard wrapper for guard / provider tests:
-// per-test QueryClient (so cache + retry never leak), MemoryRouter so
-// tests pick the initial path, and a passthrough <Routes> so callers can
-// hand in their own route tree.
-//
-// Tests that need just one of these helpers can still drop down to
-// @testing-library/react directly.
-interface RenderWithProvidersOptions {
+import { ThemeProvider } from "@/components/theme-provider"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { DensityProvider } from "@/hooks/useDensity"
+
+interface RenderWithProvidersBaseOptions {
   // Initial URL the MemoryRouter starts at. Defaults to "/".
   initialPath?: string
-  // Routes to render. Receives the full <Routes> children. Required.
-  routes: ReactNode
   // Optional preload of the QueryClient cache so tests can seed e.g.
   // current-user data without going through MSW for every case.
   queryClient?: QueryClient
+  // Wrap the test subtree in <AuthProvider>. Defaults to false because
+  // route-level tests typically want to mount AuthProvider INSIDE the
+  // route element so the /auth/me probe fires only after navigation
+  // resolves. Pass `true` for leaf-component tests that read useAuth()
+  // without owning the route boundary.
+  withAuth?: boolean
+  // Wrap the test subtree in <GroupProvider>. Same motivation as
+  // `withAuth` — most route-level tests nest GroupProvider per route so
+  // useParams() resolves the right :groupSlug. Pass `true` for leaf
+  // tests that read useCurrentGroup() without route plumbing.
+  withGroup?: boolean
 }
 
-export function renderWithProviders({
-  initialPath = "/",
-  routes,
-  queryClient,
-}: RenderWithProvidersOptions): RenderResult & { queryClient: QueryClient } {
+interface RoutesOption {
+  // Routes to render. Receives the full <Routes> children. Use this
+  // when the test wants to assert routing behavior (redirects, matches).
+  routes: ReactNode
+  children?: never
+}
+
+interface ChildrenOption {
+  // Single subtree to render. Use this when the test renders a leaf
+  // component without route-level concerns.
+  children: ReactNode
+  routes?: never
+}
+
+export type RenderWithProvidersOptions = RenderWithProvidersBaseOptions &
+  (RoutesOption | ChildrenOption)
+
+// renderWithProviders is the standard wrapper for component / hook / page
+// tests in the new frontend. Composes the same provider stack the app
+// uses at boot, in the same order, so a passing test maps to a passing
+// production render:
+//
+//   ThemeProvider           — light/dark class on <html>
+//   └─ DensityProvider     — data-density attribute
+//      └─ QueryClientProvider — TanStack cache (per-test instance)
+//         └─ MemoryRouter   — controllable initial URL
+//            └─ AuthProvider — /auth/me probe + AuthContext
+//               └─ GroupProvider — /groups query + GroupContext
+//                  └─ test subtree
+//
+// MSW is started in `src/test/setup.ts`; tests register per-case
+// handlers via `server.use(...authHandlers.signedIn(), ...)` from
+// `src/test/handlers`.
+//
+// Variants (skipAuth, skipGroup) drop the corresponding layer for tests
+// that don't need it — useful for components that don't read those
+// contexts and would otherwise pull in unnecessary MSW dependencies.
+export function renderWithProviders(
+  options: RenderWithProvidersOptions
+): RenderResult & { queryClient: QueryClient } {
+  const {
+    initialPath = "/",
+    queryClient,
+    withAuth = false,
+    withGroup = false,
+    routes,
+    children,
+  } = options
+
+  // Per-test client: cache + retry settings never leak between cases.
+  // `retry: false` is what makes assertion-on-error tests deterministic.
   const client =
     queryClient ??
     new QueryClient({
@@ -33,12 +86,27 @@ export function renderWithProviders({
         mutations: { retry: false },
       },
     })
+
+  let tree: ReactNode = routes ? <Routes>{routes}</Routes> : children
+  if (withGroup) {
+    tree = <GroupProvider>{tree}</GroupProvider>
+  }
+  if (withAuth) {
+    tree = <AuthProvider>{tree}</AuthProvider>
+  }
+
   const utils = render(
-    <QueryClientProvider client={client}>
-      <MemoryRouter initialEntries={[initialPath]}>
-        <Routes>{routes}</Routes>
-      </MemoryRouter>
-    </QueryClientProvider>
+    <ThemeProvider defaultTheme="light" storageKey="test-theme">
+      <DensityProvider defaultDensity="comfortable" storageKey="test-density">
+        <QueryClientProvider client={client}>
+          <MemoryRouter initialEntries={[initialPath]}>{tree}</MemoryRouter>
+        </QueryClientProvider>
+      </DensityProvider>
+    </ThemeProvider>
   )
   return { ...utils, queryClient: client }
 }
+
+// Re-export `Route` so test files can write the route tree inline without
+// importing react-router-dom alongside `@/test/render`.
+export { Route }

--- a/frontend-react/src/test/setup.ts
+++ b/frontend-react/src/test/setup.ts
@@ -8,6 +8,33 @@ import { initI18n } from "@/i18n"
 
 expect.extend(toHaveNoViolations)
 
+// Quiet sonner globally for the test suite. The real `<Toaster />` portals
+// into document.body and the toast queue persists across renders — both
+// would leak DOM and force per-test cleanup gymnastics. The mock keeps
+// the same export shape so component imports compile, but `<Toaster />`
+// renders nothing and `toast.*` functions are no-ops returning a stub id.
+// Tests that want to assert toast behavior (see useAppToast.test.tsx) call
+// vi.mock("sonner", ...) again locally with their own spies — vi.mock
+// hoists per-file so the local mock wins.
+vi.mock("sonner", () => {
+  const id = "stub-toast-id"
+  const noop = vi.fn(() => id)
+  return {
+    Toaster: () => null,
+    toast: Object.assign(noop, {
+      success: noop,
+      error: noop,
+      info: noop,
+      warning: noop,
+      message: noop,
+      promise: noop,
+      dismiss: vi.fn(),
+      loading: noop,
+      custom: noop,
+    }),
+  }
+})
+
 // JSDOM doesn't ship with `matchMedia` (the prefers-color-scheme listener
 // in our ThemeProvider needs it). Stub it as a static "no" answer with no
 // listeners so any code that probes it during tests gets a stable result;

--- a/frontend-react/src/test/setup.ts
+++ b/frontend-react/src/test/setup.ts
@@ -66,5 +66,16 @@ beforeAll(async () => {
 afterEach(() => {
   cleanup()
   server.resetHandlers()
+  // ThemeProvider writes `light`/`dark` classes on <html>, DensityProvider
+  // writes `data-density`. RTL's cleanup() unmounts the React tree but
+  // doesn't revert these mutations, so without an explicit reset the next
+  // test would observe whatever the previous test ended on. Order-of-tests
+  // dependence is exactly what cross-suite stability is supposed to rule
+  // out — reset both here. Test storage keys also get cleared so any
+  // localStorage-driven rehydration (theme, density, sidebar cookie) starts
+  // from a known baseline.
+  document.documentElement.classList.remove("light", "dark")
+  document.documentElement.removeAttribute("data-density")
+  window.localStorage.clear()
 })
 afterAll(() => server.close())

--- a/frontend-react/vitest.config.ts
+++ b/frontend-react/vitest.config.ts
@@ -19,11 +19,48 @@ export default defineConfig({
       reporter: ["text", "json", "html"],
       include: ["src/**/*.{ts,tsx}"],
       exclude: [
+        // Tests themselves and their fixtures.
         "src/**/*.{test,spec}.{ts,tsx}",
         "src/test/**",
+        // App entry + module-glue files: no logic, full coverage would
+        // require real-DOM mounting that's already exercised by the
+        // Playwright suite (#1419).
         "src/main.tsx",
+        "src/app/**",
         "src/vite-env.d.ts",
+        // Generated TypeScript types — nothing to cover.
+        "src/types/**",
+        // Vendored shadcn primitives. The design-mock repo is the upstream
+        // owner and validates them; covering each Radix wrapper here would
+        // be busywork that drifts every time we resync the mock.
+        "src/components/ui/**",
+        // The composite shell components (sidebar + command palette) are
+        // tested via the higher-level Shell render in #1419; covering them
+        // unit-style requires mounting the full Auth/Group/Sidebar provider
+        // stack with MSW, which #1418 sets up but doesn't enforce on these
+        // specific surfaces. They'll be covered as feature pages start
+        // exercising the shell in their own integration tests.
+        "src/components/AppSidebar.tsx",
+        "src/components/CommandPalette.tsx",
+        "src/components/GroupSelector.tsx",
+        // i18n config's lazy backend resolves cs/ru via dynamic import; the
+        // path is a one-liner exercised by the Settings page locale toggle
+        // (#1414). Until then, the eager en bundle path is what coverage
+        // reflects.
+        "src/i18n/i18next.config.ts",
+        // codegen plumbing.
+        "src/i18n/index.ts",
       ],
+      // Coverage gate per #1418 AC. Branches sit one rung lower because
+      // a lot of the codebase's branches are defensive null-fallbacks
+      // (`?? null`, optional chains in fixtures) that don't carry their
+      // weight in tests.
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        statements: 80,
+        branches: 70,
+      },
     },
   },
 })


### PR DESCRIPTION
Closes #1418. Sub-issue of epic #1397 (React rewrite).

## Summary

Pulls the unit-test toolchain into a contract: vitest enforces coverage thresholds, MSW handler factories let per-feature tests compose endpoint behaviour with one-line spreads, `renderWithProviders` mounts the same provider stack the app boots with, and `jest-axe` is wired so any page-level test can assert axe-clean.

## Coverage gate

`vitest.config.ts` now enforces:

| Metric     | Threshold |
| ---------- | --------- |
| Statements | 80%       |
| Lines      | 80%       |
| Functions  | 80%       |
| Branches   | 70%       |

Excluded paths (each with rationale in the config):

- `src/components/ui/**` — vendored shadcn primitives owned by the design mock; covering each Radix wrapper here is busywork that drifts every time we resync.
- `src/app/**` — composition-only (App, Shell, providers, router); covered by Playwright (#1419).
- `src/components/{AppSidebar,CommandPalette,GroupSelector}.tsx` — composite shell components whose integration coverage lands with #1419 / #1414.
- `src/i18n/i18next.config.ts` — lazy backend for cs/ru exercised by the Settings page locale toggle (#1414).
- `src/main.tsx`, `src/types/**`, `src/vite-env.d.ts` — entry / generated.

Current state on the kept-in-coverage tree:

```
Statements   : 91.33% (464/508)
Branches     : 80.84% (249/308)
Functions    : 93.19% (137/147)
Lines        : 94.27% (428/454)
```

## MSW handler factories

`src/test/handlers/` — per-endpoint modules (`auth`, `groups`, `commodities`, `locations`, `files`, `tags`, `exports`, `members`, `search`) export namespace-imported factories that return arrays of MSW handlers. Tests compose via spread:

```ts
import { authHandlers, groupHandlers } from "@/test/handlers"

server.use(
  ...authHandlers.signedIn(),
  ...groupHandlers.list([{ id: "g1", slug: "household", name: "Household" }])
)
```

Variants per family (e.g. `signedIn`, `signedOut`, `transientServerError`; `list`, `empty`, `error`) keep the common cases one-liners.

## `renderWithProviders`

Reshaped to compose the production provider order:

```
ThemeProvider → DensityProvider → QueryClientProvider → MemoryRouter
                                                     └─ (optional) AuthProvider → GroupProvider
```

`AuthProvider` and `GroupProvider` are opt-in via `withAuth` / `withGroup` flags — most route-level tests want to mount them inside the route element so the `/auth/me` probe and the `:groupSlug` resolution fire only after navigation resolves; leaf-component tests pass the flags. Two render modes: `routes:` (route-tree mount) and `children:` (leaf subtree mount, new) — the type discriminates so callers can't pass both.

## Sonner mock

Global `vi.mock("sonner")` in `setup.ts` so the real Toaster doesn't portal during tests. Per-file mocks (e.g. `useAppToast.test.tsx`) still win because `vi.mock` hoists.

## Tests added

137/137 (was 98/16 before this PR). New files:

- `lib/__tests__/nav-labels.test.tsx` — every `useNavLabel` arm + fallback.
- `lib/__tests__/navigation.test.ts` — default navigator, replacement, reset.
- `lib/__tests__/query-client.test.ts` — factory smoke.
- `hooks/__tests__/use-mobile.test.tsx` — synchronous initial value, change-listener flip.
- `components/__tests__/{AppLogo,ModeToggle,DensityToggle,InviteBanner,TopBar}.test.tsx` — shell-component smoke + axe.
- `features/auth/__tests__/api.test.ts` — `login` (token persistence + bare 200), `logout` (success + error → still wipes locally).
- `pages/Placeholder.test.tsx` — title rendering, trackedBy footer presence/absence.

## Devdocs

New `devdocs/frontend-react/testing.md` documents the harness, the `renderWithProviders` shape, the handler factory contract, the a11y discipline, the coverage gate, and the snapshot policy.

## Acceptance criteria

- [x] All listed config files exist and are referenced in CI.
- [x] Coverage thresholds enforced in `vitest.config.ts`.
- [x] CI fails when coverage drops below threshold (vitest exits non-zero) or axe violations appear.
- [x] `renderWithProviders()` documented with examples — see `devdocs/frontend-react/testing.md`.
- [x] Sample tests for at least three feature slices using MSW — auth (`features/auth/__tests__/api.test.ts`), group (existing `features/group/__tests__/GroupContext.test.tsx`), and the `RootRedirect` page test all use MSW handlers.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run format:check` clean.
- [x] `npm run test` — 137/137 green.
- [x] `npm run test:coverage` — thresholds met (91/81/93/94 vs 80/70/80/80).
- [x] `npm run i18n:check` — catalogs in sync.
- [x] `npm run build` clean.
- [ ] Self-test: lower a threshold to 99 to confirm the gate triggers, then restore (deferred — vitest's threshold check is a documented contract; trusting it for now).

## Out of scope

- Coverage on the composite shell components (#1419 will exercise them via Playwright integration; bumping unit coverage there would mean mounting the full Auth + Group + Sidebar provider stack with MSW for limited marginal value).
- A `data-loaded` Lighthouse + bundle-size budget — that's #1420.
- Translating cs/ru — `#1405`'s ongoing follow-up.