### PR TITLE
[#1407] Frontend-react auth pages — login, register, forgot/reset, verify, invite, no-group

### DIFF
--- a/frontend-react/i18next.config.ts
+++ b/frontend-react/i18next.config.ts
@@ -39,6 +39,19 @@ export default defineConfig({
     //   key set is enumerated in en/common.json's `nav` object; if a key
     //   here gets out of sync with the NavEntry list, the missing-key
     //   handler in dev surfaces it (saveMissing+console.warn).
-    preservePatterns: ["stubs:*", "common:nav.*"],
+    // `auth:validation.*` — zod schemas in src/features/auth/schemas.ts hold
+    //   the keys as plain strings (not t() calls); RHF's `errors[name].message`
+    //   carries them through to a t() call at render time, but the extractor
+    //   sees only the dynamic lookup.
+    // `auth:passwordStrength.*` and `auth:session.*` — both use index-table
+    //   lookups (`t(STRENGTH_LABELS[score])`, `t(SESSION_REASON_KEY[reason])`)
+    //   that the extractor can't statically resolve.
+    preservePatterns: [
+      "stubs:*",
+      "common:nav.*",
+      "auth:validation.*",
+      "auth:passwordStrength.*",
+      "auth:session.*",
+    ],
   },
 })

--- a/frontend-react/src/app/router.tsx
+++ b/frontend-react/src/app/router.tsx
@@ -21,6 +21,27 @@ const NotFoundPage = lazy(() =>
 const RootRedirect = lazy(() =>
   import("@/pages/RootRedirect").then((m) => ({ default: m.RootRedirect }))
 )
+const LoginPage = lazy(() =>
+  import("@/pages/auth/LoginPage").then((m) => ({ default: m.LoginPage }))
+)
+const RegisterPage = lazy(() =>
+  import("@/pages/auth/RegisterPage").then((m) => ({ default: m.RegisterPage }))
+)
+const ForgotPasswordPage = lazy(() =>
+  import("@/pages/auth/ForgotPasswordPage").then((m) => ({ default: m.ForgotPasswordPage }))
+)
+const ResetPasswordPage = lazy(() =>
+  import("@/pages/auth/ResetPasswordPage").then((m) => ({ default: m.ResetPasswordPage }))
+)
+const VerifyEmailPage = lazy(() =>
+  import("@/pages/auth/VerifyEmailPage").then((m) => ({ default: m.VerifyEmailPage }))
+)
+const InviteAcceptPage = lazy(() =>
+  import("@/pages/auth/InviteAcceptPage").then((m) => ({ default: m.InviteAcceptPage }))
+)
+const NoGroupPage = lazy(() =>
+  import("@/pages/NoGroupPage").then((m) => ({ default: m.NoGroupPage }))
+)
 
 // AppRoutes is the full route tree for the new React frontend. Most of the
 // pages still mount the shared PlaceholderPage stub: the routing skeleton is
@@ -51,51 +72,13 @@ export function AppRoutes() {
   return (
     <Suspense fallback={null}>
       <Routes>
-        {/* Public */}
-        <Route
-          path="/login"
-          element={<PlaceholderPage titleKey="login" testId="page-login" trackedBy="#1407" />}
-        />
-        <Route
-          path="/register"
-          element={<PlaceholderPage titleKey="register" testId="page-register" trackedBy="#1407" />}
-        />
-        <Route
-          path="/forgot-password"
-          element={
-            <PlaceholderPage
-              titleKey="forgotPassword"
-              testId="page-forgot-password"
-              trackedBy="#1407"
-            />
-          }
-        />
-        <Route
-          path="/reset-password"
-          element={
-            <PlaceholderPage
-              titleKey="resetPassword"
-              testId="page-reset-password"
-              trackedBy="#1407"
-            />
-          }
-        />
-        <Route
-          path="/verify-email"
-          element={
-            <PlaceholderPage titleKey="verifyEmail" testId="page-verify-email" trackedBy="#1407" />
-          }
-        />
-        <Route
-          path="/invite/:token"
-          element={
-            <PlaceholderPage
-              titleKey="inviteAccept"
-              testId="page-invite-accept"
-              trackedBy="#1407"
-            />
-          }
-        />
+        {/* Public — auth pages own their own full-screen layout (#1407). */}
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
+        <Route path="/verify-email" element={<VerifyEmailPage />} />
+        <Route path="/invite/:token" element={<InviteAcceptPage />} />
 
         {/* Authenticated subtree: GroupProvider mounts once at the top so
             every protected page reads currentGroup from the same source.
@@ -113,12 +96,7 @@ export function AppRoutes() {
           }
         >
           {/* Group-exempt: a logged-in user with zero groups can still reach these. */}
-          <Route
-            path="/no-group"
-            element={
-              <PlaceholderPage titleKey="noGroup" testId="page-no-group" trackedBy="#1413" />
-            }
-          />
+          <Route path="/no-group" element={<NoGroupPage />} />
           <Route
             path="/profile"
             element={<PlaceholderPage titleKey="profile" testId="page-profile" trackedBy="#1414" />}

--- a/frontend-react/src/components/auth/AuthLayout.tsx
+++ b/frontend-react/src/components/auth/AuthLayout.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from "react"
+import { useTranslation } from "react-i18next"
+import { Package } from "lucide-react"
+
+import { isFeatureEnabled } from "@/lib/feature-flags"
+
+interface AuthLayoutProps {
+  children: ReactNode
+}
+
+// Two-pane wrapper for every auth screen — decorative branding panel on the
+// left (lg+ only), form column on the right. The right column auto-centers
+// its child and caps width at `max-w-sm` so each page can pass its full
+// content tree without re-implementing the layout.
+//
+// Styling is taken straight from the inventario-design `AuthView` mock; the
+// stats-teaser strip in the bottom-left is hidden behind a feature flag
+// (#1390) until the values become real.
+export function AuthLayout({ children }: AuthLayoutProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex min-h-svh w-full">
+      <div className="hidden lg:flex lg:w-[44%] bg-primary flex-col justify-between p-10 relative overflow-hidden">
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 opacity-[0.04]"
+          style={{
+            backgroundImage:
+              "repeating-linear-gradient(0deg,transparent,transparent 39px,currentColor 39px,currentColor 40px),repeating-linear-gradient(90deg,transparent,transparent 39px,currentColor 39px,currentColor 40px)",
+          }}
+        />
+        <div className="relative z-10 flex items-center gap-2.5">
+          <div className="flex size-8 items-center justify-center rounded-lg bg-primary-foreground/10">
+            <Package className="size-4 text-primary-foreground" />
+          </div>
+          <span className="text-lg font-semibold text-primary-foreground">{t("common:brand")}</span>
+        </div>
+        <div className="relative z-10 space-y-4">
+          <blockquote className="text-2xl font-semibold leading-snug text-primary-foreground">
+            {t("auth:layout.tagline")}
+          </blockquote>
+          <div className="flex items-center gap-3">
+            <div aria-hidden="true" className="size-9 rounded-full bg-primary-foreground/15" />
+            <div>
+              <p className="text-sm font-medium text-primary-foreground">
+                {t("auth:layout.taglineAttribution")}
+              </p>
+              <p className="text-xs text-primary-foreground/60">
+                {t("auth:layout.taglineSubtitle")}
+              </p>
+            </div>
+          </div>
+        </div>
+        {isFeatureEnabled("AUTH_STATS_TEASER") ? (
+          <StatsTeaserStub />
+        ) : (
+          <div className="relative z-10" />
+        )}
+      </div>
+      <div className="flex flex-1 flex-col items-center justify-center bg-background px-6 py-12">
+        <div className="mb-8 flex items-center gap-2 lg:hidden">
+          <div className="flex size-7 items-center justify-center rounded-md bg-primary">
+            <Package className="size-4 text-primary-foreground" />
+          </div>
+          <span className="text-base font-semibold">{t("common:brand")}</span>
+        </div>
+        <div className="w-full max-w-sm">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+// Static placeholder strip — real numbers land in #1390. Kept here rather
+// than a separate component because nothing else renders it.
+function StatsTeaserStub() {
+  const { t } = useTranslation()
+  const items = [
+    { label: t("auth:layout.statsTeaser.itemsTracked"), value: "—" },
+    { label: t("auth:layout.statsTeaser.warrantiesActive"), value: "—" },
+    { label: t("auth:layout.statsTeaser.estValue"), value: "—" },
+  ]
+  return (
+    <div className="relative z-10 flex gap-3" data-testid="auth-stats-teaser">
+      {items.map((s) => (
+        <div
+          key={s.label}
+          className="flex-1 rounded-xl bg-primary-foreground/8 border border-primary-foreground/10 p-3 backdrop-blur-sm"
+        >
+          <p className="text-xl font-bold text-primary-foreground">{s.value}</p>
+          <p className="text-[11px] text-primary-foreground/60 mt-0.5">{s.label}</p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend-react/src/components/auth/OAuthRow.tsx
+++ b/frontend-react/src/components/auth/OAuthRow.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { isFeatureEnabled } from "@/lib/feature-flags"
+
+// Hidden by default — gated by `VITE_FEATURE_OAUTH_LOGIN`. Real OAuth
+// provider wiring is tracked under #1394; until then the buttons are pure
+// presentation (no onClick handlers) so a curious user clicking them in a
+// dev build does nothing.
+export function OAuthRow() {
+  const { t } = useTranslation()
+  if (!isFeatureEnabled("OAUTH_LOGIN")) return null
+  return (
+    <div className="space-y-4" data-testid="oauth-row">
+      <div className="relative">
+        <Separator />
+        <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-background px-2 text-xs text-muted-foreground">
+          {t("auth:oauth.divider")}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <Button variant="outline" className="gap-2 text-sm" type="button" disabled>
+          <GoogleGlyph />
+          {t("auth:oauth.google")}
+        </Button>
+        <Button variant="outline" className="gap-2 text-sm" type="button" disabled>
+          <GithubGlyph />
+          {t("auth:oauth.github")}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function GoogleGlyph() {
+  return (
+    <svg className="size-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z" />
+    </svg>
+  )
+}
+
+function GithubGlyph() {
+  return (
+    <svg className="size-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  )
+}

--- a/frontend-react/src/components/auth/PasswordInput.tsx
+++ b/frontend-react/src/components/auth/PasswordInput.tsx
@@ -1,0 +1,46 @@
+import { forwardRef, useState, type ComponentProps } from "react"
+import { Eye, EyeOff, Lock } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+
+type PasswordInputProps = Omit<ComponentProps<"input">, "type"> & {
+  // When true, hides the leading lock icon. Keeps line-up with sibling inputs
+  // that don't have a leading affordance.
+  hideLockIcon?: boolean
+}
+
+// Password field with eye toggle — used by every auth form. The toggle does
+// not change the field's React `value`, so RHF/zod stay oblivious. Accessible
+// label on the toggle button switches between "Show"/"Hide" via i18n.
+export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
+  function PasswordInput({ className, hideLockIcon, ...props }, ref) {
+    const { t } = useTranslation()
+    const [show, setShow] = useState(false)
+    return (
+      <div className="relative">
+        {!hideLockIcon ? (
+          <Lock
+            aria-hidden="true"
+            className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+          />
+        ) : null}
+        <Input
+          ref={ref}
+          type={show ? "text" : "password"}
+          className={cn(hideLockIcon ? "pr-9" : "pl-9 pr-9", className)}
+          {...props}
+        />
+        <button
+          type="button"
+          onClick={() => setShow((v) => !v)}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+          aria-label={show ? t("auth:passwordHide") : t("auth:passwordShow")}
+        >
+          {show ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        </button>
+      </div>
+    )
+  }
+)

--- a/frontend-react/src/components/auth/PasswordStrengthMeter.tsx
+++ b/frontend-react/src/components/auth/PasswordStrengthMeter.tsx
@@ -1,0 +1,80 @@
+import { useTranslation } from "react-i18next"
+
+import { cn } from "@/lib/utils"
+
+interface PasswordStrengthMeterProps {
+  password: string
+  // Hint copy under the meter. Defaults to a generic length+complexity nudge.
+  hintKey?: string
+  // data-testid passthrough; root only — the bars don't get individual ids.
+  testId?: string
+}
+
+// Returns 0..4. Heuristic only: length is the dominant signal, with extra
+// points for character-class mix (lower/upper/digit/symbol). Real entropy
+// scoring (zxcvbn) is tracked separately in #1381 — this stub is good
+// enough to drive the visual meter without pulling in a 700kb dictionary.
+export function scorePassword(password: string): 0 | 1 | 2 | 3 | 4 {
+  if (!password) return 0
+  let score = 0
+  if (password.length >= 8) score++
+  if (password.length >= 12) score++
+  const classes =
+    Number(/[a-z]/.test(password)) +
+    Number(/[A-Z]/.test(password)) +
+    Number(/[0-9]/.test(password)) +
+    Number(/[^a-zA-Z0-9]/.test(password))
+  if (classes >= 2) score++
+  if (classes >= 3 && password.length >= 10) score++
+  return Math.min(score, 4) as 0 | 1 | 2 | 3 | 4
+}
+
+const STRENGTH_LABELS = [
+  "auth:passwordStrength.empty",
+  "auth:passwordStrength.weak",
+  "auth:passwordStrength.fair",
+  "auth:passwordStrength.good",
+  "auth:passwordStrength.strong",
+] as const
+
+const BAR_COLORS = [
+  "bg-muted",
+  "bg-destructive/70",
+  "bg-amber-500/70",
+  "bg-emerald-500/70",
+  "bg-emerald-500",
+] as const
+
+export function PasswordStrengthMeter({
+  password,
+  hintKey = "auth:passwordStrength.hint",
+  testId,
+}: PasswordStrengthMeterProps) {
+  const { t } = useTranslation()
+  const score = scorePassword(password)
+  const labelText = t(STRENGTH_LABELS[score])
+  return (
+    <div className="space-y-1.5" data-testid={testId}>
+      <div
+        className="flex gap-1"
+        role="meter"
+        aria-label={t("auth:passwordStrength.label")}
+        aria-valuemin={0}
+        aria-valuemax={4}
+        aria-valuenow={score}
+        aria-valuetext={labelText}
+      >
+        {[1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            className={cn(
+              "h-1 flex-1 rounded-full transition-colors",
+              i <= score ? BAR_COLORS[score] : "bg-muted"
+            )}
+          />
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">{password ? labelText : t(hintKey)}</p>
+    </div>
+  )
+}

--- a/frontend-react/src/components/auth/TwoFactorStub.tsx
+++ b/frontend-react/src/components/auth/TwoFactorStub.tsx
@@ -1,0 +1,24 @@
+import { ShieldCheck } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+// Visible 2FA placeholder linked to #1380. The real flow (TOTP + recovery
+// codes) ships there; surfacing it here keeps the design parity with the
+// inventario-design AuthView while making the "tracked elsewhere" status
+// explicit instead of pretending the panel is just unused.
+export function TwoFactorStub() {
+  const { t } = useTranslation()
+  return (
+    <div
+      className="rounded-lg border border-dashed border-border bg-muted/40 p-3 flex items-start gap-2.5"
+      data-testid="two-factor-stub"
+    >
+      <ShieldCheck aria-hidden="true" className="size-4 mt-0.5 text-muted-foreground" />
+      <div className="space-y-0.5">
+        <p className="text-xs font-medium text-foreground">{t("auth:twoFactor.title")}</p>
+        <p className="text-[11px] text-muted-foreground leading-snug">
+          {t("auth:twoFactor.description", { ref: "#1380" })}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend-react/src/components/auth/__tests__/PasswordStrengthMeter.test.tsx
+++ b/frontend-react/src/components/auth/__tests__/PasswordStrengthMeter.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { axe } from "jest-axe"
+
+import { PasswordStrengthMeter, scorePassword } from "@/components/auth/PasswordStrengthMeter"
+
+describe("scorePassword", () => {
+  it("returns 0 for empty input", () => {
+    expect(scorePassword("")).toBe(0)
+  })
+
+  it("rewards length and character-class diversity", () => {
+    expect(scorePassword("short")).toBe(0)
+    expect(scorePassword("eightchr")).toBeGreaterThanOrEqual(1)
+    expect(scorePassword("Eightch1")).toBeGreaterThanOrEqual(2)
+    expect(scorePassword("LongerOne1")).toBeGreaterThanOrEqual(3)
+    expect(scorePassword("LongerOne1!")).toBeGreaterThanOrEqual(3)
+    expect(scorePassword("LongerOne123!")).toBe(4)
+  })
+})
+
+describe("<PasswordStrengthMeter />", () => {
+  it("renders the empty hint when password is blank", () => {
+    render(<PasswordStrengthMeter password="" />)
+    expect(screen.getByText(/8\+ characters/i)).toBeInTheDocument()
+  })
+
+  it("exposes a meter role with the current score", () => {
+    render(<PasswordStrengthMeter password="LongerOne123!" />)
+    const meter = screen.getByRole("meter")
+    expect(meter).toHaveAttribute("aria-valuenow", "4")
+  })
+
+  it("has no axe violations", async () => {
+    const { container } = render(<PasswordStrengthMeter password="LongerOne1" />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend-react/src/components/ui/alert.tsx
+++ b/frontend-react/src/components/ui/alert.tsx
@@ -1,0 +1,60 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn("col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/frontend-react/src/components/ui/badge.tsx
+++ b/frontend-react/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/frontend-react/src/components/ui/checkbox.tsx
+++ b/frontend-react/src/components/ui/checkbox.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/frontend-react/src/features/auth/__tests__/inviteHandoff.test.ts
+++ b/frontend-react/src/features/auth/__tests__/inviteHandoff.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  clearPendingInvite,
+  consumePendingInvite,
+  peekPendingInvite,
+  savePendingInvite,
+} from "@/features/auth/inviteHandoff"
+
+afterEach(() => {
+  clearPendingInvite()
+})
+
+describe("inviteHandoff", () => {
+  it("round-trips a saved invite via sessionStorage", () => {
+    savePendingInvite({ token: "tok-1", groupName: "Household" })
+    expect(peekPendingInvite()).toEqual({ token: "tok-1", groupName: "Household" })
+  })
+
+  it("consumePendingInvite returns the value and clears storage", () => {
+    savePendingInvite({ token: "tok-2" })
+    expect(consumePendingInvite()).toEqual({ token: "tok-2" })
+    expect(peekPendingInvite()).toBeNull()
+  })
+
+  it("ignores malformed sessionStorage entries", () => {
+    sessionStorage.setItem("inventario_pending_invite", "{not-json")
+    expect(peekPendingInvite()).toBeNull()
+  })
+
+  it("ignores entries missing a token", () => {
+    sessionStorage.setItem("inventario_pending_invite", JSON.stringify({ groupName: "Foo" }))
+    expect(peekPendingInvite()).toBeNull()
+  })
+})

--- a/frontend-react/src/features/auth/__tests__/schemas.test.ts
+++ b/frontend-react/src/features/auth/__tests__/schemas.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  forgotPasswordSchema,
+  loginSchema,
+  registerSchema,
+  resetPasswordSchema,
+} from "@/features/auth/schemas"
+
+describe("auth schemas", () => {
+  it("loginSchema requires non-empty email + password", () => {
+    expect(loginSchema.safeParse({ email: "", password: "x", rememberMe: false }).success).toBe(
+      false
+    )
+    expect(loginSchema.safeParse({ email: "a@b.c", password: "", rememberMe: false }).success).toBe(
+      false
+    )
+    expect(
+      loginSchema.safeParse({ email: "a@b.c", password: "x", rememberMe: false }).success
+    ).toBe(true)
+  })
+
+  it("registerSchema enforces name, email, password, terms acceptance", () => {
+    const base = { name: "Alex", email: "a@b.c", password: "secret", acceptTerms: true }
+    expect(registerSchema.safeParse(base).success).toBe(true)
+    expect(registerSchema.safeParse({ ...base, acceptTerms: false }).success).toBe(false)
+    expect(registerSchema.safeParse({ ...base, name: "" }).success).toBe(false)
+    expect(registerSchema.safeParse({ ...base, name: "x".repeat(256) }).success).toBe(false)
+  })
+
+  it("forgotPasswordSchema only validates non-empty email", () => {
+    expect(forgotPasswordSchema.safeParse({ email: "" }).success).toBe(false)
+    expect(forgotPasswordSchema.safeParse({ email: "a@b.c" }).success).toBe(true)
+  })
+
+  it("resetPasswordSchema requires 8+ chars and matching confirm", () => {
+    expect(
+      resetPasswordSchema.safeParse({ password: "short", confirmPassword: "short" }).success
+    ).toBe(false)
+    expect(
+      resetPasswordSchema.safeParse({ password: "longenough", confirmPassword: "different" })
+        .success
+    ).toBe(false)
+    const result = resetPasswordSchema.safeParse({
+      password: "longenough",
+      confirmPassword: "longenough",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("resetPasswordSchema attaches mismatch error to confirmPassword", () => {
+    const result = resetPasswordSchema.safeParse({
+      password: "longenough",
+      confirmPassword: "different1",
+    })
+    if (result.success) throw new Error("expected validation failure")
+    const issue = result.error.issues.find((i) => i.path.includes("confirmPassword"))
+    expect(issue?.message).toBe("auth:validation.passwordsMismatch")
+  })
+})

--- a/frontend-react/src/features/auth/__tests__/schemas.test.ts
+++ b/frontend-react/src/features/auth/__tests__/schemas.test.ts
@@ -9,15 +9,9 @@ import {
 
 describe("auth schemas", () => {
   it("loginSchema requires non-empty email + password", () => {
-    expect(loginSchema.safeParse({ email: "", password: "x", rememberMe: false }).success).toBe(
-      false
-    )
-    expect(loginSchema.safeParse({ email: "a@b.c", password: "", rememberMe: false }).success).toBe(
-      false
-    )
-    expect(
-      loginSchema.safeParse({ email: "a@b.c", password: "x", rememberMe: false }).success
-    ).toBe(true)
+    expect(loginSchema.safeParse({ email: "", password: "x" }).success).toBe(false)
+    expect(loginSchema.safeParse({ email: "a@b.c", password: "" }).success).toBe(false)
+    expect(loginSchema.safeParse({ email: "a@b.c", password: "x" }).success).toBe(true)
   })
 
   it("registerSchema enforces name, email, password, terms acceptance", () => {

--- a/frontend-react/src/features/auth/api.ts
+++ b/frontend-react/src/features/auth/api.ts
@@ -13,13 +13,26 @@ interface LoginResponse {
   user?: CurrentUser
 }
 
+interface MessageResponse {
+  message?: string
+}
+
+export interface RegisterRequest {
+  email: string
+  password: string
+  name: string
+  // When set, registration succeeds even if open registration is closed and
+  // the email-verification step is skipped. The token is NOT consumed here —
+  // the caller must POST /invites/{token}/accept after logging in (#1285).
+  invite_token?: string
+}
+
 export function getCurrentUser(signal?: AbortSignal): Promise<CurrentUser> {
   return http.get<CurrentUser>("/auth/me", { signal, authCheck: "user-initiated" })
 }
 
 // login persists the access + CSRF tokens before resolving so the very next
-// /auth/me probe sees them. The Auth pages issue (#1407) is what actually
-// renders a form on top of this; here it's exposed for AuthContext + tests.
+// /auth/me probe sees them.
 export async function login(email: string, password: string): Promise<CurrentUser | undefined> {
   const body = await http.post<LoginResponse>("/auth/login", { email, password })
   if (body.access_token) setAccessToken(body.access_token)
@@ -35,4 +48,41 @@ export async function logout(): Promise<void> {
     // wiping local credentials guarantees the UI can't keep using them.
     clearAuth()
   }
+}
+
+// register hits the unauthenticated /register endpoint. The server always
+// returns 200 with a generic message regardless of whether the email is
+// already taken (anti-enumeration), so callers should treat `message` as
+// success copy and never as an "email exists" probe.
+export async function register(req: RegisterRequest): Promise<string> {
+  const body = await http.post<MessageResponse>("/register", req)
+  return body.message ?? ""
+}
+
+// verifyEmail completes the sign-up flow with the token from the magic link.
+// The server returns either 200 with a message or a non-2xx — surfaced as
+// HttpError, which the page maps to "expired" / "invalid" copy.
+export async function verifyEmail(token: string): Promise<string> {
+  const body = await http.get<MessageResponse>(`/verify-email?token=${encodeURIComponent(token)}`)
+  return body.message ?? ""
+}
+
+export async function resendVerification(email: string): Promise<string> {
+  const body = await http.post<MessageResponse>("/resend-verification", { email })
+  return body.message ?? ""
+}
+
+// forgotPassword always resolves with a generic success message — the
+// backend returns the same body whether the email is known or not.
+export async function forgotPassword(email: string): Promise<string> {
+  const body = await http.post<MessageResponse>("/forgot-password", { email })
+  return body.message ?? ""
+}
+
+export async function resetPassword(token: string, newPassword: string): Promise<string> {
+  const body = await http.post<MessageResponse>("/reset-password", {
+    token,
+    new_password: newPassword,
+  })
+  return body.message ?? ""
 }

--- a/frontend-react/src/features/auth/hooks.ts
+++ b/frontend-react/src/features/auth/hooks.ts
@@ -2,7 +2,18 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { getAccessToken } from "@/lib/auth-storage"
 
-import { getCurrentUser, logout, type CurrentUser } from "./api"
+import {
+  forgotPassword,
+  getCurrentUser,
+  login,
+  logout,
+  register,
+  resendVerification,
+  resetPassword,
+  verifyEmail,
+  type CurrentUser,
+  type RegisterRequest,
+} from "./api"
 import { authKeys } from "./keys"
 
 // Reads the authenticated user. The query only runs when an access token is
@@ -41,5 +52,63 @@ export function useLogout() {
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: authKeys.all })
     },
+  })
+}
+
+interface LoginVars {
+  email: string
+  password: string
+}
+
+// Login mutation: on success, seed the cached user so ProtectedRoute can
+// short-circuit the boot probe and render the protected tree without a
+// /auth/me round-trip. We invalidate the auth namespace afterward so any
+// stale "user" data anywhere in the cache settles to the new identity.
+export function useLogin() {
+  const queryClient = useQueryClient()
+  return useMutation<CurrentUser | undefined, Error, LoginVars>({
+    mutationFn: ({ email, password }) => login(email, password),
+    onSuccess: (user) => {
+      if (user) {
+        queryClient.setQueryData(authKeys.currentUser(), user)
+      }
+      // Refresh anything else that depends on auth (e.g. groups list).
+      queryClient.invalidateQueries({ queryKey: authKeys.all })
+    },
+  })
+}
+
+export function useRegister() {
+  return useMutation<string, Error, RegisterRequest>({
+    mutationFn: (req) => register(req),
+  })
+}
+
+export function useVerifyEmail() {
+  return useMutation<string, Error, string>({
+    mutationFn: (token) => verifyEmail(token),
+  })
+}
+
+export function useResendVerification() {
+  return useMutation<string, Error, string>({
+    mutationFn: (email) => resendVerification(email),
+  })
+}
+
+export function useForgotPassword() {
+  return useMutation<string, Error, string>({
+    mutationFn: (email) => forgotPassword(email),
+  })
+}
+
+interface ResetPasswordVars {
+  token: string
+  newPassword: string
+}
+
+export function useResetPassword() {
+  return useMutation<string, Error, ResetPasswordVars>({
+    mutationFn: ({ token, newPassword }) => resetPassword(token, newPassword),
   })
 }

--- a/frontend-react/src/features/auth/inviteHandoff.ts
+++ b/frontend-react/src/features/auth/inviteHandoff.ts
@@ -1,0 +1,61 @@
+// Shared sessionStorage bridge for the invite → register/login flow.
+// When an unauthenticated user lands on /invite/<token>, the invite-accept
+// view stashes the token here before navigating to /register or /login;
+// the destination views read it back and auto-accept after auth.
+//
+// Scope is intentionally sessionStorage (not localStorage): the token must
+// not outlive the browser session, and a closed tab clears it.
+//
+// Storage key matches frontend/src/services/inviteHandoff.ts so a flow
+// started in the legacy bundle survives a switch to the new bundle and vice
+// versa during the dual-bundle migration window (#1397).
+
+const STORAGE_KEY = "inventario_pending_invite"
+
+export interface PendingInvite {
+  token: string
+  groupName?: string
+}
+
+function safeSession(): Storage | null {
+  if (typeof window === "undefined") return null
+  try {
+    return window.sessionStorage
+  } catch {
+    return null
+  }
+}
+
+export function savePendingInvite(invite: PendingInvite): void {
+  const s = safeSession()
+  if (!s) return
+  try {
+    s.setItem(STORAGE_KEY, JSON.stringify(invite))
+  } catch {
+    // Quota / serialization errors must not break the auth flow.
+  }
+}
+
+export function peekPendingInvite(): PendingInvite | null {
+  const s = safeSession()
+  if (!s) return null
+  const raw = s.getItem(STORAGE_KEY)
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as PendingInvite
+    if (!parsed || typeof parsed.token !== "string" || !parsed.token) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export function clearPendingInvite(): void {
+  safeSession()?.removeItem(STORAGE_KEY)
+}
+
+export function consumePendingInvite(): PendingInvite | null {
+  const peek = peekPendingInvite()
+  clearPendingInvite()
+  return peek
+}

--- a/frontend-react/src/features/auth/schemas.ts
+++ b/frontend-react/src/features/auth/schemas.ts
@@ -1,0 +1,53 @@
+import { z } from "zod"
+
+// Auth form schemas. Each schema mirrors the legacy `frontend/src/views/*View.schema.ts`
+// rules so the e2e behavior stays compatible during the dual-bundle window:
+// client-side validation is intentionally loose where the server owns the
+// real rule (email format, password complexity), surfacing only the gating
+// rules ("non-empty", "matches confirmation") that affect the submit button.
+//
+// Strings keep raw "Email is required" English fallbacks; pages translate
+// each error key via the auth namespace at render time. RHF's `errors[name]?.message`
+// holds these literal strings so tests don't need to plumb i18n into the
+// schemas themselves.
+
+export const loginSchema = z.object({
+  email: z.string().min(1, "auth:validation.emailRequired"),
+  password: z.string().min(1, "auth:validation.passwordRequired"),
+  rememberMe: z.boolean(),
+})
+export type LoginInput = z.infer<typeof loginSchema>
+
+export const registerSchema = z.object({
+  name: z.string().min(1, "auth:validation.nameRequired").max(255, "auth:validation.nameTooLong"),
+  email: z.string().min(1, "auth:validation.emailRequired"),
+  password: z.string().min(1, "auth:validation.passwordRequired"),
+  // Boolean refined to "must be true" rather than `z.literal(true)` so the
+  // inferred input type is just `boolean` — the form holds `false` until the
+  // user opts in, and zod surfaces the error at submit time.
+  acceptTerms: z.boolean().refine((v) => v === true, {
+    message: "auth:validation.termsRequired",
+  }),
+})
+export type RegisterInput = z.infer<typeof registerSchema>
+
+export const forgotPasswordSchema = z.object({
+  email: z.string().min(1, "auth:validation.emailRequired"),
+})
+export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>
+
+export const resetPasswordSchema = z
+  .object({
+    password: z.string().min(8, "auth:validation.passwordMinLength"),
+    confirmPassword: z.string().min(1, "auth:validation.passwordConfirmRequired"),
+  })
+  .superRefine((value, ctx) => {
+    if (value.password !== value.confirmPassword) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["confirmPassword"],
+        message: "auth:validation.passwordsMismatch",
+      })
+    }
+  })
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>

--- a/frontend-react/src/features/auth/schemas.ts
+++ b/frontend-react/src/features/auth/schemas.ts
@@ -11,10 +11,13 @@ import { z } from "zod"
 // holds these literal strings so tests don't need to plumb i18n into the
 // schemas themselves.
 
+// rememberMe is intentionally absent: the field existed in the design mock
+// but the auth-storage layer always uses localStorage, so a checkbox would
+// promise behavior we don't deliver. Re-add when the persistence story
+// supports a session-only mode (see #1414 / future TTL signal).
 export const loginSchema = z.object({
   email: z.string().min(1, "auth:validation.emailRequired"),
   password: z.string().min(1, "auth:validation.passwordRequired"),
-  rememberMe: z.boolean(),
 })
 export type LoginInput = z.infer<typeof loginSchema>
 

--- a/frontend-react/src/features/invite/api.ts
+++ b/frontend-react/src/features/invite/api.ts
@@ -1,0 +1,43 @@
+// Invite feature slice — public token-based invite flow + post-auth accept.
+// API paths come straight from the OpenAPI spec; both endpoints live OUTSIDE
+// the /g/{slug}/* group rewrite (the user has no slug yet at invite time).
+import { http } from "@/lib/http"
+import type { Schema } from "@/types"
+
+export type InviteInfo = NonNullable<Schema<"jsonapi.InviteInfoAttr">>
+export type GroupMembership = NonNullable<Schema<"models.GroupMembership">>
+
+interface InviteInfoEnvelope {
+  data?: {
+    attributes?: InviteInfo
+    type?: string
+  }
+}
+
+interface GroupMembershipEnvelope {
+  data?: {
+    id?: string
+    attributes?: GroupMembership
+    type?: string
+  }
+}
+
+// Public preview of an invite — does NOT require authentication. Returns
+// `{ group_name, group_icon?, expired, used }` so the page can decide
+// whether to offer "Accept", "Expired", or "Used".
+export async function getInviteInfo(token: string, signal?: AbortSignal): Promise<InviteInfo> {
+  const body = await http.get<InviteInfoEnvelope>(`/invites/${encodeURIComponent(token)}`, {
+    signal,
+  })
+  return body.data?.attributes ?? {}
+}
+
+// Accepts an invite as the currently authenticated user. Returns the new
+// membership (id + group_id) so callers can switch the active group right
+// after accept.
+export async function acceptInvite(token: string): Promise<GroupMembership & { id?: string }> {
+  const body = await http.post<GroupMembershipEnvelope>(
+    `/invites/${encodeURIComponent(token)}/accept`
+  )
+  return { ...(body.data?.attributes ?? {}), id: body.data?.id }
+}

--- a/frontend-react/src/features/invite/api.ts
+++ b/frontend-react/src/features/invite/api.ts
@@ -25,11 +25,22 @@ interface GroupMembershipEnvelope {
 // Public preview of an invite — does NOT require authentication. Returns
 // `{ group_name, group_icon?, expired, used }` so the page can decide
 // whether to offer "Accept", "Expired", or "Used".
+//
+// We deliberately throw when `data.attributes` is missing rather than
+// returning `{}`. An empty object is truthy and would slip past the
+// `!invite` guard in InviteAcceptPage; both `expired` and `used` would
+// read as `undefined`, falling into the "actionable" branch and offering
+// Accept on a token whose state we can't actually confirm. Throwing makes
+// the page render the invalid-invite panel instead — fail-closed.
 export async function getInviteInfo(token: string, signal?: AbortSignal): Promise<InviteInfo> {
   const body = await http.get<InviteInfoEnvelope>(`/invites/${encodeURIComponent(token)}`, {
     signal,
   })
-  return body.data?.attributes ?? {}
+  const attributes = body.data?.attributes
+  if (!attributes) {
+    throw new Error("Invite response is missing data.attributes")
+  }
+  return attributes
 }
 
 // Accepts an invite as the currently authenticated user. Returns the new

--- a/frontend-react/src/features/invite/hooks.ts
+++ b/frontend-react/src/features/invite/hooks.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { groupKeys } from "@/features/group/keys"
+
+import { acceptInvite, getInviteInfo, type GroupMembership, type InviteInfo } from "./api"
+import { inviteKeys } from "./keys"
+
+// Reads the public invite preview. Disabled when token is empty so the
+// caller can mount the hook before deciding whether to fire the request.
+export function useInviteInfo(token: string | undefined) {
+  return useQuery<InviteInfo>({
+    queryKey: inviteKeys.info(token ?? ""),
+    queryFn: ({ signal }) => getInviteInfo(token!, signal),
+    enabled: !!token,
+    retry: false,
+  })
+}
+
+// Accepts an invite. On success we invalidate the groups list so the new
+// membership shows up in the sidebar / RootRedirect immediately, without
+// waiting for a stale-time refresh.
+export function useAcceptInvite() {
+  const queryClient = useQueryClient()
+  return useMutation<GroupMembership & { id?: string }, Error, string>({
+    mutationFn: (token) => acceptInvite(token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: groupKeys.all })
+    },
+  })
+}

--- a/frontend-react/src/features/invite/keys.ts
+++ b/frontend-react/src/features/invite/keys.ts
@@ -1,0 +1,5 @@
+// Query-key factory for the invite feature slice.
+export const inviteKeys = {
+  all: ["invite"] as const,
+  info: (token: string) => [...inviteKeys.all, "info", token] as const,
+}

--- a/frontend-react/src/i18n/locales/en/auth.json
+++ b/frontend-react/src/i18n/locales/en/auth.json
@@ -1,1 +1,156 @@
-{}
+{
+  "fields": {
+    "confirmPassword": "Confirm password",
+    "confirmPasswordPlaceholder": "Repeat your password",
+    "email": "Email",
+    "emailPlaceholder": "you@example.com",
+    "name": "Full name",
+    "namePlaceholder": "Alex Johnson",
+    "newPassword": "New password",
+    "newPasswordPlaceholder": "At least 8 characters",
+    "password": "Password",
+    "passwordPlaceholder": "••••••••"
+  },
+  "forgot": {
+    "backToSignIn": "Back to sign in",
+    "checkSpam": "Check your spam folder",
+    "didntGetEmail": "Didn't get the email?",
+    "errorGeneric": "Failed to send the reset link. Please try again.",
+    "makeSureCorrect": "Make sure you entered the right address",
+    "resend": "Resend email",
+    "submit": "Send reset link",
+    "submitting": "Sending…",
+    "subtitle": "Enter your email and we'll send you a link to reset your password.",
+    "successFallback": "If that email exists in our system, you'll get a reset link shortly.",
+    "successTitle": "Check your email",
+    "title": "Forgot password?"
+  },
+  "invite": {
+    "accept": "Accept invitation",
+    "accepting": "Joining…",
+    "alreadyHaveAccount": "Already have an account?",
+    "backHome": "Go to home",
+    "decline": "Decline invitation",
+    "errorGeneric": "Failed to accept the invite. Please try again.",
+    "expiredBody": "This invite link has expired. Ask the group admin to generate a new one.",
+    "expiredTitle": "Invite expired",
+    "intro": "Join the inventory group below.",
+    "invalidBody": "This invite link is not valid or could not be loaded.",
+    "invalidTitle": "Invalid invite",
+    "joinGroup": "Join {{name}}",
+    "loading": "Loading invite…",
+    "memberRole": "Member",
+    "registerToAccept": "Register to accept",
+    "signInToAccept": "Sign in to accept",
+    "signInToAcceptLink": "Sign in to accept",
+    "usedBody": "This invite link has already been used.",
+    "usedTitle": "Already used",
+    "youreInvited": "You're invited!",
+    "yourRole": "Your role"
+  },
+  "layout": {
+    "statsTeaser": {
+      "estValue": "Est. value",
+      "itemsTracked": "Items tracked",
+      "warrantiesActive": "Warranties active"
+    },
+    "tagline": "\"Everything I own, where I can find it — warranties, values, and all the parts I keep forgetting to order.\"",
+    "taglineAttribution": "Personal inventory",
+    "taglineSubtitle": "for real life"
+  },
+  "login": {
+    "createOne": "Create one",
+    "dontHaveAccount": "Don't have an account?",
+    "errorGeneric": "Sign-in failed. Please check your details and try again.",
+    "forgotPassword": "Forgot password?",
+    "rememberMe": "Remember me for 30 days",
+    "submit": "Sign in",
+    "submitting": "Signing in…",
+    "subtitle": "Sign in to your inventory",
+    "title": "Welcome back"
+  },
+  "noGroup": {
+    "createGroup": "Create a new group",
+    "createGroupCta": "Create group",
+    "createGroupDescription": "Set up your own inventory and invite others.",
+    "description": "You don't belong to any inventory group yet. Create one to start tracking your belongings.",
+    "signOut": "Sign out instead",
+    "title": "Welcome to Inventario"
+  },
+  "oauth": {
+    "divider": "or continue with",
+    "github": "GitHub",
+    "google": "Google"
+  },
+  "passwordHide": "Hide password",
+  "passwordShow": "Show password",
+  "passwordStrength": {
+    "empty": "Set a password",
+    "fair": "Could be stronger",
+    "good": "Looking good",
+    "hint": "Use 8+ characters with letters and numbers.",
+    "label": "Password strength",
+    "strong": "Strong",
+    "weak": "Too weak"
+  },
+  "register": {
+    "alreadyHaveAccount": "Already have an account?",
+    "autoAcceptError": "Registered, but couldn't join the group automatically. Please sign in manually to continue.",
+    "errorGeneric": "Registration failed. Please try again.",
+    "joiningGroup": "Joining the group…",
+    "signIn": "Sign in",
+    "signInManually": "Sign in manually",
+    "submit": "Create account",
+    "submitting": "Creating account…",
+    "subtitle": "Start tracking your inventory for free",
+    "successFallback": "We've sent you a verification link to confirm your account.",
+    "successTitle": "Check your email",
+    "termsAccept": "I agree to the Terms of Service and Privacy Policy",
+    "title": "Create account"
+  },
+  "reset": {
+    "errorGeneric": "Failed to reset password. The link may have expired.",
+    "missingTokenBody": "Please request a new password reset link.",
+    "missingTokenTitle": "Invalid or missing reset token",
+    "requestNewLink": "Request reset link",
+    "signInWithNew": "Sign in with your new password",
+    "submit": "Reset password",
+    "submitting": "Resetting…",
+    "subtitle": "Choose a strong password for your account.",
+    "successFallback": "Your password has been reset. You can now sign in with your new password.",
+    "successTitle": "Password updated",
+    "title": "Set new password"
+  },
+  "session": {
+    "authRequired": "Please sign in to continue.",
+    "ended": "Your session has ended. Please sign in again.",
+    "expired": "Your session has expired. Please sign in again."
+  },
+  "twoFactor": {
+    "description": "Tracked separately under {{ref}} — coming soon.",
+    "title": "Two-factor authentication"
+  },
+  "validation": {
+    "emailRequired": "Email is required",
+    "nameRequired": "Full name is required",
+    "nameTooLong": "Name is too long",
+    "passwordConfirmRequired": "Please confirm your password",
+    "passwordMinLength": "Password must be at least 8 characters",
+    "passwordRequired": "Password is required",
+    "passwordsMismatch": "Passwords do not match",
+    "termsRequired": "You must accept the Terms of Service to continue"
+  },
+  "verify": {
+    "backToSignIn": "Back to sign in",
+    "continue": "Continue to app",
+    "expiredBody": "This verification link has expired. Links are valid for 24 hours.",
+    "expiredTitle": "Link expired",
+    "invalidBody": "This verification link is not valid or has already been used.",
+    "invalidTitle": "Invalid link",
+    "missingBody": "Please use the link from your verification email.",
+    "missingTitle": "No verification token provided",
+    "successFallback": "Your email address has been confirmed. You're all set to use Inventario.",
+    "successTitle": "Email verified!",
+    "verifying": "Verifying your email…"
+  }
+}

--- a/frontend-react/src/i18n/locales/en/auth.json
+++ b/frontend-react/src/i18n/locales/en/auth.json
@@ -63,7 +63,6 @@
     "dontHaveAccount": "Don't have an account?",
     "errorGeneric": "Sign-in failed. Please check your details and try again.",
     "forgotPassword": "Forgot password?",
-    "rememberMe": "Remember me for 30 days",
     "submit": "Sign in",
     "submitting": "Signing in…",
     "subtitle": "Sign in to your inventory",

--- a/frontend-react/src/lib/__tests__/safe-redirect.test.ts
+++ b/frontend-react/src/lib/__tests__/safe-redirect.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import { sanitizeRedirectPath } from "@/lib/safe-redirect"
+
+describe("sanitizeRedirectPath", () => {
+  it("returns the value unchanged for a normal in-app path", () => {
+    expect(sanitizeRedirectPath("/g/household/items")).toBe("/g/household/items")
+  })
+
+  it("falls back to / for null / undefined / empty / whitespace", () => {
+    expect(sanitizeRedirectPath(null)).toBe("/")
+    expect(sanitizeRedirectPath(undefined)).toBe("/")
+    expect(sanitizeRedirectPath("")).toBe("/")
+    expect(sanitizeRedirectPath("   ")).toBe("/")
+  })
+
+  it("rejects values that don't start with /", () => {
+    expect(sanitizeRedirectPath("g/household")).toBe("/")
+    expect(sanitizeRedirectPath("https://evil.example")).toBe("/")
+    expect(sanitizeRedirectPath("javascript:alert(1)")).toBe("/")
+  })
+
+  it("rejects protocol-relative URLs like //evil.example", () => {
+    expect(sanitizeRedirectPath("//evil.example")).toBe("/")
+    expect(sanitizeRedirectPath("//evil.example/foo")).toBe("/")
+  })
+
+  it("rejects Windows-style \\\\host backslash paths", () => {
+    expect(sanitizeRedirectPath("/\\evil.example")).toBe("/")
+  })
+
+  it("preserves the query string and fragment of in-app paths", () => {
+    expect(sanitizeRedirectPath("/items?filter=active#top")).toBe("/items?filter=active#top")
+  })
+})

--- a/frontend-react/src/lib/__tests__/server-error.test.ts
+++ b/frontend-react/src/lib/__tests__/server-error.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+
+import { HttpError } from "@/lib/http"
+import { parseServerError } from "@/lib/server-error"
+
+describe("parseServerError", () => {
+  it("returns the trimmed string body when the server replied with plain text", () => {
+    const err = new HttpError("boom", 400, "/x", "Email already taken  ")
+    expect(parseServerError(err, "fallback")).toBe("Email already taken")
+  })
+
+  it("returns the first JSON:API error detail", () => {
+    const err = new HttpError("boom", 400, "/x", {
+      errors: [{ detail: "Email already taken" }],
+    })
+    expect(parseServerError(err, "fallback")).toBe("Email already taken")
+  })
+
+  it("falls back to envelope.error when no JSON:API errors are present", () => {
+    const err = new HttpError("boom", 400, "/x", { error: "BadRequest" })
+    expect(parseServerError(err, "fallback")).toBe("BadRequest")
+  })
+
+  it("returns the fallback when nothing useful is in the body", () => {
+    const err = new HttpError("boom", 500, "/x", null)
+    expect(parseServerError(err, "Try again later")).toBe("Try again later")
+  })
+
+  it("returns the fallback for non-HttpError values without a message", () => {
+    expect(parseServerError({}, "fallback")).toBe("fallback")
+  })
+
+  it("returns plain Error message when present", () => {
+    expect(parseServerError(new Error("network"), "fallback")).toBe("network")
+  })
+})

--- a/frontend-react/src/lib/feature-flags.ts
+++ b/frontend-react/src/lib/feature-flags.ts
@@ -1,0 +1,25 @@
+// Tiny feature-flag reader. Each flag is a Vite env var like
+// `VITE_FEATURE_OAUTH_LOGIN=1` that maps to a boolean. Default is off.
+//
+// Real flag delivery (per-user, remote toggle) is out of scope for the new
+// frontend's first slice — for now this just exposes a single chokepoint so
+// auth-stub call sites (#1380 2FA, #1394 OAuth) don't sprinkle
+// `import.meta.env.VITE_…` directly through the component tree.
+
+// Single source of truth for the supported flag names — keep the union in
+// sync if you add a new VITE_FEATURE_<NAME>.
+export type FeatureFlag = "OAUTH_LOGIN" | "TWO_FACTOR_AUTH" | "AUTH_STATS_TEASER"
+
+function readFlag(name: FeatureFlag): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const env = (import.meta as any).env ?? {}
+  const raw = env[`VITE_FEATURE_${name}`]
+  if (typeof raw === "string") {
+    return raw === "1" || raw.toLowerCase() === "true"
+  }
+  return !!raw
+}
+
+export function isFeatureEnabled(name: FeatureFlag): boolean {
+  return readFlag(name)
+}

--- a/frontend-react/src/lib/http.ts
+++ b/frontend-react/src/lib/http.ts
@@ -216,7 +216,8 @@ function currentReturnTo(): string {
 async function handle401(
   url: string,
   originalPath: string,
-  init: HttpRequestInit
+  init: HttpRequestInit,
+  response: Response
 ): Promise<HttpResponse<unknown>> {
   // Background /auth/me probes during boot must not clear auth or redirect —
   // the legacy frontend's behavior we want to preserve so the user is not
@@ -224,8 +225,12 @@ async function handle401(
   if (init.authCheck === "background" && originalPath.startsWith("/auth/me")) {
     throw new HttpError("Unauthorized", 401, url, null)
   }
+  // For login/register/refresh, a 401 is an application-level error (bad
+  // credentials, invalid refresh token) — surface the body so callers can
+  // render the actual server message instead of a generic "unauthorized".
   if (NON_REFRESHABLE_AUTH_PATHS.has(originalPath) || init.skipAuthRefresh) {
-    throw new HttpError("Unauthorized", 401, url, null)
+    const data = await parseBody(response).catch(() => null)
+    throw new HttpError("Unauthorized", 401, url, data)
   }
   try {
     await refreshAccessToken()
@@ -266,7 +271,7 @@ async function performRequest<T = unknown>(
   if (newCsrf) setCsrfToken(newCsrf)
 
   if (response.status === 401) {
-    return (await handle401(url, path, init)) as HttpResponse<T>
+    return (await handle401(url, path, init, response)) as HttpResponse<T>
   }
   const data = (await parseBody(response)) as T
   if (!response.ok) {

--- a/frontend-react/src/lib/safe-redirect.ts
+++ b/frontend-react/src/lib/safe-redirect.ts
@@ -1,0 +1,24 @@
+// Sanitizes a `?redirect=` query value into a safe in-app path.
+//
+// Threat model: the redirect param is supposed to be an internal path written
+// by route guards (e.g. `/g/household/items`), but a user-crafted URL could
+// point it at `https://evil.example/`, `//evil.example`, or `\\evil.example`.
+// Passing those into `<Navigate to={…}>` or `navigate(…)` would happily send
+// the user off-domain on react-router 7.
+//
+// The rule: only accept values that begin with a single `/` and are not
+// followed by another `/` or `\`. Everything else falls back to `/`.
+
+const FALLBACK = "/"
+
+export function sanitizeRedirectPath(raw: string | null | undefined): string {
+  if (!raw) return FALLBACK
+  // Drop any whitespace-only / empty values.
+  const value = raw.trim()
+  if (!value) return FALLBACK
+  // Must start with a single `/` — refuses absolute URLs ("https://…",
+  // "//host/…"), protocol-relative paths, and Windows-style "\\host".
+  if (value[0] !== "/") return FALLBACK
+  if (value[1] === "/" || value[1] === "\\") return FALLBACK
+  return value
+}

--- a/frontend-react/src/lib/server-error.ts
+++ b/frontend-react/src/lib/server-error.ts
@@ -1,0 +1,49 @@
+// Tiny adapter that turns a thrown HttpError (or anything else) into a
+// human-readable string the auth pages can render under the form.
+//
+// Backend error envelopes seen in the wild:
+//   - JSON:API errors:     { errors: [{ detail: "…" }, …] }
+//   - Plain object error:  { error: "…", message: "…" }
+//   - Plain string body:   "Email already taken"
+//
+// All three reduce to a single message — the auth surface doesn't (yet)
+// surface per-field validation, so we don't bother building a field map.
+import { HttpError } from "./http"
+
+interface JsonApiError {
+  detail?: string
+  title?: string
+}
+
+interface ErrorEnvelope {
+  errors?: JsonApiError[]
+  error?: string
+  message?: string
+}
+
+function pickEnvelopeMessage(env: ErrorEnvelope): string | null {
+  const first = env.errors?.[0]
+  if (first?.detail) return first.detail
+  if (first?.title) return first.title
+  if (env.error) return env.error
+  if (env.message) return env.message
+  return null
+}
+
+// Returns a user-facing message. Pass `fallback` for the copy to use when no
+// useful detail can be extracted (e.g. a 5xx with a stringified HTML page).
+export function parseServerError(err: unknown, fallback: string): string {
+  if (err instanceof HttpError) {
+    const data = err.data
+    if (typeof data === "string") {
+      const trimmed = data.trim()
+      if (trimmed) return trimmed
+    } else if (data && typeof data === "object") {
+      const msg = pickEnvelopeMessage(data as ErrorEnvelope)
+      if (msg) return msg
+    }
+    return fallback
+  }
+  if (err instanceof Error && err.message) return err.message
+  return fallback
+}

--- a/frontend-react/src/pages/NoGroupPage.tsx
+++ b/frontend-react/src/pages/NoGroupPage.tsx
@@ -1,0 +1,80 @@
+import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
+import { ArrowRight, Building2, Plus } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { useLogout } from "@/features/auth/hooks"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+
+// NoGroupPage — onboarding landing for an authenticated user with zero
+// groups. Lives inside the Shell layout (it sits under the protected
+// subtree in the router) so the user gets the sidebar/topbar even before
+// they belong to a group. Pending-invite listing is tracked separately —
+// the invite-list endpoint isn't on this slice (#1413), so the design
+// mock's "or accept an invite" block is intentionally not rendered yet.
+export function NoGroupPage() {
+  const { t } = useTranslation()
+  const logoutMutation = useLogout()
+
+  return (
+    <>
+      <RouteTitle title={t("stubs:noGroup")} />
+      <div
+        className="flex flex-1 flex-col items-center justify-center py-12 px-2"
+        data-testid="no-group-page"
+      >
+        <div className="w-full max-w-md space-y-8">
+          <div className="text-center space-y-3">
+            <div className="flex justify-center">
+              <div className="relative flex items-center justify-center size-20">
+                <div aria-hidden="true" className="absolute size-20 rounded-full bg-muted/60" />
+                <div aria-hidden="true" className="absolute size-14 rounded-full bg-muted" />
+                <Building2
+                  className="relative size-8 text-muted-foreground/60"
+                  aria-hidden="true"
+                />
+              </div>
+            </div>
+            <h1 className="text-2xl font-semibold tracking-tight">{t("auth:noGroup.title")}</h1>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {t("auth:noGroup.description")}
+            </p>
+          </div>
+
+          <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+            <div className="flex items-center gap-3">
+              <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 shrink-0">
+                <Plus className="size-5 text-primary" aria-hidden="true" />
+              </div>
+              <div>
+                <p className="font-semibold text-sm">{t("auth:noGroup.createGroup")}</p>
+                <p className="text-xs text-muted-foreground">
+                  {t("auth:noGroup.createGroupDescription")}
+                </p>
+              </div>
+            </div>
+            <Button asChild className="w-full gap-2">
+              <Link to="/groups/new" data-testid="create-group-cta">
+                {t("auth:noGroup.createGroupCta")}
+                <ArrowRight className="size-4" />
+              </Link>
+            </Button>
+          </div>
+
+          <div className="text-center">
+            <Button
+              variant="ghost"
+              size="sm"
+              type="button"
+              disabled={logoutMutation.isPending}
+              onClick={() => logoutMutation.mutate()}
+              data-testid="no-group-signout"
+            >
+              {t("auth:noGroup.signOut")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend-react/src/pages/auth/ForgotPasswordPage.tsx
+++ b/frontend-react/src/pages/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
+import { ArrowLeft, ArrowRight, Mail } from "lucide-react"
+
+import { AuthLayout } from "@/components/auth/AuthLayout"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useForgotPassword } from "@/features/auth/hooks"
+import { forgotPasswordSchema, type ForgotPasswordInput } from "@/features/auth/schemas"
+import { parseServerError } from "@/lib/server-error"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+
+// ForgotPasswordPage — single-field form. The server returns an identical
+// success message regardless of whether the email exists, so once the form
+// resolves we always render the "check your email" state.
+export function ForgotPasswordPage() {
+  const { t } = useTranslation()
+  const mutation = useForgotPassword()
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [submittedEmail, setSubmittedEmail] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const form = useForm<ForgotPasswordInput>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: { email: "" },
+  })
+
+  useEffect(() => {
+    const sub = form.watch(() => {
+      if (serverError) setServerError(null)
+    })
+    return () => sub.unsubscribe()
+  }, [form, serverError])
+
+  async function onSubmit(values: ForgotPasswordInput) {
+    setServerError(null)
+    try {
+      const message = await mutation.mutateAsync(values.email.trim())
+      setSubmittedEmail(values.email.trim())
+      setSuccessMessage(message || t("auth:forgot.successFallback"))
+    } catch (err) {
+      setServerError(parseServerError(err, t("auth:forgot.errorGeneric")))
+    }
+  }
+
+  if (submittedEmail) {
+    return (
+      <AuthLayout>
+        <RouteTitle title={t("stubs:forgotPassword")} />
+        <div className="space-y-6 text-center" data-testid="forgot-success">
+          <div className="flex justify-center">
+            <div className="flex size-16 items-center justify-center rounded-full bg-primary/10">
+              <Mail className="size-8 text-primary" aria-hidden="true" />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {t("auth:forgot.successTitle")}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              {successMessage}
+              {submittedEmail ? (
+                <>
+                  {" "}
+                  <span className="font-medium text-foreground">{submittedEmail}</span>.
+                </>
+              ) : null}
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-muted/30 p-4 text-left space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              {t("auth:forgot.didntGetEmail")}
+            </p>
+            <ul className="text-xs text-muted-foreground space-y-1 list-disc list-inside">
+              <li>{t("auth:forgot.checkSpam")}</li>
+              <li>{t("auth:forgot.makeSureCorrect")}</li>
+            </ul>
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full mt-1"
+              type="button"
+              disabled={mutation.isPending}
+              onClick={() => {
+                if (submittedEmail) mutation.mutate(submittedEmail)
+              }}
+            >
+              {t("auth:forgot.resend")}
+            </Button>
+          </div>
+          <Link
+            to="/login"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
+          >
+            {t("auth:forgot.backToSignIn")}
+          </Link>
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  return (
+    <AuthLayout>
+      <RouteTitle title={t("stubs:forgotPassword")} />
+      <div className="space-y-6" data-testid="forgot-page">
+        <Link
+          to="/login"
+          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          {t("auth:forgot.backToSignIn")}
+        </Link>
+        <header className="space-y-1.5">
+          <h1 className="text-2xl font-semibold tracking-tight">{t("auth:forgot.title")}</h1>
+          <p className="text-sm text-muted-foreground">{t("auth:forgot.subtitle")}</p>
+        </header>
+
+        <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+          <div className="space-y-1.5">
+            <Label htmlFor="forgot-email">{t("auth:fields.email")}</Label>
+            <div className="relative">
+              <Mail
+                aria-hidden="true"
+                className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                id="forgot-email"
+                type="email"
+                autoComplete="email"
+                placeholder={t("auth:fields.emailPlaceholder")}
+                className="pl-9"
+                disabled={mutation.isPending}
+                aria-invalid={!!form.formState.errors.email}
+                data-testid="email"
+                {...form.register("email")}
+              />
+            </div>
+            {form.formState.errors.email ? (
+              <p className="text-xs text-destructive" data-testid="email-error">
+                {t(form.formState.errors.email.message ?? "")}
+              </p>
+            ) : null}
+          </div>
+
+          {serverError ? (
+            <Alert variant="destructive" data-testid="server-error">
+              <AlertDescription>{serverError}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <Button
+            type="submit"
+            className="w-full gap-2"
+            disabled={mutation.isPending}
+            data-testid="submit-button"
+          >
+            {mutation.isPending ? t("auth:forgot.submitting") : t("auth:forgot.submit")}
+            {!mutation.isPending ? <ArrowRight className="size-4" /> : null}
+          </Button>
+        </form>
+      </div>
+    </AuthLayout>
+  )
+}

--- a/frontend-react/src/pages/auth/ForgotPasswordPage.tsx
+++ b/frontend-react/src/pages/auth/ForgotPasswordPage.tsx
@@ -87,12 +87,21 @@ export function ForgotPasswordPage() {
               type="button"
               disabled={mutation.isPending}
               onClick={() => {
-                if (submittedEmail) mutation.mutate(submittedEmail)
+                if (!submittedEmail) return
+                setServerError(null)
+                mutation.mutateAsync(submittedEmail).catch((err: unknown) => {
+                  setServerError(parseServerError(err, t("auth:forgot.errorGeneric")))
+                })
               }}
             >
               {t("auth:forgot.resend")}
             </Button>
           </div>
+          {serverError ? (
+            <Alert variant="destructive" data-testid="resend-error">
+              <AlertDescription>{serverError}</AlertDescription>
+            </Alert>
+          ) : null}
           <Link
             to="/login"
             className="text-sm text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"

--- a/frontend-react/src/pages/auth/InviteAcceptPage.tsx
+++ b/frontend-react/src/pages/auth/InviteAcceptPage.tsx
@@ -32,9 +32,12 @@ export function InviteAcceptPage() {
   // Persist the handoff so unauth users can sign in and pick up where they
   // left off. Effect runs whenever we know the group name; if the user is
   // already authenticated we skip — they'll accept directly on this page.
+  // Expired/used invites are deliberately NOT stashed: /login and /register
+  // would auto-accept the token after auth and hit a guaranteed 4xx.
   useEffect(() => {
     if (!token || isAuthenticated) return
     if (!invite) return
+    if (invite.expired || invite.used) return
     savePendingInvite({ token, groupName: invite.group_name })
   }, [token, invite, isAuthenticated])
 

--- a/frontend-react/src/pages/auth/InviteAcceptPage.tsx
+++ b/frontend-react/src/pages/auth/InviteAcceptPage.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { useAuth } from "@/features/auth/AuthContext"
-import { savePendingInvite } from "@/features/auth/inviteHandoff"
+import { consumePendingInvite, savePendingInvite } from "@/features/auth/inviteHandoff"
 import { useAcceptInvite, useInviteInfo } from "@/features/invite/hooks"
 import { parseServerError } from "@/lib/server-error"
 import { RouteTitle } from "@/components/routing/RouteTitle"
@@ -101,6 +101,11 @@ export function InviteAcceptPage() {
     setAcceptError(null)
     try {
       await acceptMutation.mutateAsync(token)
+      // Consume any handoff entry — the token is now used, and an entry
+      // lingering in sessionStorage from this or an earlier aborted flow
+      // would otherwise feed /login's auto-accept on the next sign-in
+      // attempt and hit a guaranteed 4xx.
+      consumePendingInvite()
       // The mutation invalidates the groups list — RootRedirect will pick
       // up the new membership when GroupProvider mounts post-navigation.
       navigate("/", { replace: true })

--- a/frontend-react/src/pages/auth/InviteAcceptPage.tsx
+++ b/frontend-react/src/pages/auth/InviteAcceptPage.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Link, useNavigate, useParams } from "react-router-dom"
+import { ArrowRight, Building2, Mail } from "lucide-react"
+
+import { AuthLayout } from "@/components/auth/AuthLayout"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { useAuth } from "@/features/auth/AuthContext"
+import { savePendingInvite } from "@/features/auth/inviteHandoff"
+import { useAcceptInvite, useInviteInfo } from "@/features/invite/hooks"
+import { parseServerError } from "@/lib/server-error"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+
+// InviteAcceptPage — public page that shows invite preview info and offers
+// "Accept" or "Sign in to accept" depending on auth state. The handoff
+// pattern (#1285): unauthenticated users get the token stashed in
+// sessionStorage before being sent to /login or /register, and those pages
+// auto-accept after authentication completes.
+export function InviteAcceptPage() {
+  const { t } = useTranslation()
+  const { token: rawToken } = useParams<{ token: string }>()
+  const token = rawToken ?? ""
+  const navigate = useNavigate()
+  const { isAuthenticated } = useAuth()
+  const { data: invite, isLoading, isError } = useInviteInfo(token)
+  const acceptMutation = useAcceptInvite()
+  const [acceptError, setAcceptError] = useState<string | null>(null)
+
+  // Persist the handoff so unauth users can sign in and pick up where they
+  // left off. Effect runs whenever we know the group name; if the user is
+  // already authenticated we skip — they'll accept directly on this page.
+  useEffect(() => {
+    if (!token || isAuthenticated) return
+    if (!invite) return
+    savePendingInvite({ token, groupName: invite.group_name })
+  }, [token, invite, isAuthenticated])
+
+  if (isLoading) {
+    return (
+      <AuthLayout>
+        <RouteTitle title={t("stubs:inviteAccept")} />
+        <div className="text-center text-sm text-muted-foreground" data-testid="invite-loading">
+          {t("auth:invite.loading")}
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  if (isError || !invite) {
+    return (
+      <AuthLayout>
+        <RouteTitle title={t("stubs:inviteAccept")} />
+        <ErrorPanel
+          title={t("auth:invite.invalidTitle")}
+          body={t("auth:invite.invalidBody")}
+          ctaTo="/"
+          ctaLabel={t("auth:invite.backHome")}
+          testId="invite-invalid"
+        />
+      </AuthLayout>
+    )
+  }
+
+  if (invite.expired) {
+    return (
+      <AuthLayout>
+        <RouteTitle title={t("stubs:inviteAccept")} />
+        <ErrorPanel
+          title={t("auth:invite.expiredTitle")}
+          body={t("auth:invite.expiredBody")}
+          ctaTo="/"
+          ctaLabel={t("auth:invite.backHome")}
+          testId="invite-expired"
+        />
+      </AuthLayout>
+    )
+  }
+
+  if (invite.used) {
+    return (
+      <AuthLayout>
+        <RouteTitle title={t("stubs:inviteAccept")} />
+        <ErrorPanel
+          title={t("auth:invite.usedTitle")}
+          body={t("auth:invite.usedBody")}
+          ctaTo="/"
+          ctaLabel={t("auth:invite.backHome")}
+          testId="invite-used"
+        />
+      </AuthLayout>
+    )
+  }
+
+  async function onAccept() {
+    setAcceptError(null)
+    try {
+      await acceptMutation.mutateAsync(token)
+      // The mutation invalidates the groups list — RootRedirect will pick
+      // up the new membership when GroupProvider mounts post-navigation.
+      navigate("/", { replace: true })
+    } catch (err) {
+      setAcceptError(parseServerError(err, t("auth:invite.errorGeneric")))
+    }
+  }
+
+  const inviteRedirect = `/invite/${encodeURIComponent(token)}`
+
+  return (
+    <AuthLayout>
+      <RouteTitle title={t("stubs:inviteAccept")} />
+      <div className="space-y-6" data-testid="invite-page">
+        <header className="space-y-1.5">
+          <h1 className="text-2xl font-semibold tracking-tight">{t("auth:invite.youreInvited")}</h1>
+          <p className="text-sm text-muted-foreground">{t("auth:invite.intro")}</p>
+        </header>
+
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 shrink-0">
+              {invite.group_icon ? (
+                <span aria-hidden="true" className="text-lg">
+                  {invite.group_icon}
+                </span>
+              ) : (
+                <Building2 className="size-5 text-primary" aria-hidden="true" />
+              )}
+            </div>
+            <div className="min-w-0">
+              <p className="font-semibold text-sm">{invite.group_name ?? "—"}</p>
+            </div>
+          </div>
+          <Separator />
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-muted-foreground">{t("auth:invite.yourRole")}</p>
+            <Badge variant="secondary" className="text-xs">
+              {t("auth:invite.memberRole")}
+            </Badge>
+          </div>
+        </div>
+
+        {acceptError ? (
+          <Alert variant="destructive" data-testid="server-error">
+            <AlertDescription>{acceptError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {isAuthenticated ? (
+          <div className="flex flex-col gap-2">
+            <Button
+              className="w-full gap-2"
+              disabled={acceptMutation.isPending}
+              onClick={onAccept}
+              data-testid="invite-accept-btn"
+            >
+              {acceptMutation.isPending ? t("auth:invite.accepting") : t("auth:invite.accept")}
+              {!acceptMutation.isPending ? <ArrowRight className="size-4" /> : null}
+            </Button>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => navigate("/", { replace: true })}
+              disabled={acceptMutation.isPending}
+              data-testid="invite-decline-btn"
+            >
+              {t("auth:invite.decline")}
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <Button asChild className="w-full gap-2">
+              <Link
+                to={`/login?redirect=${encodeURIComponent(inviteRedirect)}`}
+                data-testid="invite-login-link"
+              >
+                <Mail aria-hidden="true" className="size-4" />
+                {t("auth:invite.signInToAccept")}
+              </Link>
+            </Button>
+            <Button asChild variant="outline" className="w-full">
+              <Link
+                to={`/register?redirect=${encodeURIComponent(inviteRedirect)}`}
+                data-testid="invite-register-link"
+              >
+                {t("auth:invite.registerToAccept")}
+              </Link>
+            </Button>
+            <p className="text-center text-xs text-muted-foreground">
+              {t("auth:invite.alreadyHaveAccount")}{" "}
+              <Link
+                to={`/login?redirect=${encodeURIComponent(inviteRedirect)}`}
+                className="font-medium text-foreground hover:underline underline-offset-4"
+              >
+                {t("auth:invite.signInToAcceptLink")}
+              </Link>
+            </p>
+          </div>
+        )}
+      </div>
+    </AuthLayout>
+  )
+}
+
+function ErrorPanel({
+  title,
+  body,
+  ctaTo,
+  ctaLabel,
+  testId,
+}: {
+  title: string
+  body: string
+  ctaTo: string
+  ctaLabel: string
+  testId: string
+}) {
+  return (
+    <div className="space-y-6 text-center" data-testid={testId}>
+      <div className="space-y-1.5">
+        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+        <p className="text-sm text-muted-foreground">{body}</p>
+      </div>
+      <Button asChild className="w-full">
+        <Link to={ctaTo}>{ctaLabel}</Link>
+      </Button>
+    </div>
+  )
+}

--- a/frontend-react/src/pages/auth/LoginPage.tsx
+++ b/frontend-react/src/pages/auth/LoginPage.tsx
@@ -11,7 +11,6 @@ import { PasswordInput } from "@/components/auth/PasswordInput"
 import { TwoFactorStub } from "@/components/auth/TwoFactorStub"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useAuth } from "@/features/auth/AuthContext"
@@ -43,7 +42,7 @@ export function LoginPage() {
 
   const form = useForm<LoginInput>({
     resolver: zodResolver(loginSchema),
-    defaultValues: { email: "", password: "", rememberMe: false },
+    defaultValues: { email: "", password: "" },
     mode: "onSubmit",
   })
 
@@ -176,11 +175,6 @@ export function LoginPage() {
             ) : null}
           </div>
 
-          <RememberMeCheckbox
-            checked={!!form.watch("rememberMe")}
-            onChange={(v) => form.setValue("rememberMe", v)}
-          />
-
           {serverError ? (
             <Alert variant="destructive" data-testid="server-error">
               <AlertDescription>{serverError}</AlertDescription>
@@ -212,29 +206,5 @@ export function LoginPage() {
         </p>
       </div>
     </AuthLayout>
-  )
-}
-
-// Lifted out so the controlled `useForm.watch` doesn't redraw the whole page
-// on each keystroke — only this row.
-function RememberMeCheckbox({
-  checked,
-  onChange,
-}: {
-  checked: boolean
-  onChange: (v: boolean) => void
-}) {
-  const { t } = useTranslation()
-  return (
-    <div className="flex items-center gap-2">
-      <Checkbox
-        id="login-remember"
-        checked={checked}
-        onCheckedChange={(v) => onChange(v === true)}
-      />
-      <Label htmlFor="login-remember" className="text-sm font-normal text-muted-foreground">
-        {t("auth:login.rememberMe")}
-      </Label>
-    </div>
   )
 }

--- a/frontend-react/src/pages/auth/LoginPage.tsx
+++ b/frontend-react/src/pages/auth/LoginPage.tsx
@@ -18,6 +18,7 @@ import { useAcceptInvite } from "@/features/invite/hooks"
 import { useLogin } from "@/features/auth/hooks"
 import { consumePendingInvite, peekPendingInvite } from "@/features/auth/inviteHandoff"
 import { loginSchema, type LoginInput } from "@/features/auth/schemas"
+import { sanitizeRedirectPath } from "@/lib/safe-redirect"
 import { parseServerError } from "@/lib/server-error"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 
@@ -61,9 +62,10 @@ export function LoginPage() {
   // If a deep-link or refresh lands an already-authenticated user here,
   // skip the form and bounce to wherever they were trying to go. Placed
   // after the hooks above to keep the Rules-of-Hooks call order stable.
+  // sanitizeRedirectPath rejects absolute / protocol-relative URLs so a
+  // crafted ?redirect= query can't open-redirect off the app.
   if (isAuthenticated) {
-    const redirect = params.get("redirect") || "/"
-    return <Navigate to={redirect} replace />
+    return <Navigate to={sanitizeRedirectPath(params.get("redirect"))} replace />
   }
 
   const isPending =
@@ -92,8 +94,7 @@ export function LoginPage() {
         // an error on the login page; the login itself succeeded.
       }
     }
-    const redirect = params.get("redirect") || "/"
-    navigate(redirect, { replace: true })
+    navigate(sanitizeRedirectPath(params.get("redirect")), { replace: true })
   }
 
   return (

--- a/frontend-react/src/pages/auth/LoginPage.tsx
+++ b/frontend-react/src/pages/auth/LoginPage.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useTranslation } from "react-i18next"
+import { Link, Navigate, useNavigate, useSearchParams } from "react-router-dom"
+import { ArrowRight, Mail } from "lucide-react"
+
+import { AuthLayout } from "@/components/auth/AuthLayout"
+import { OAuthRow } from "@/components/auth/OAuthRow"
+import { PasswordInput } from "@/components/auth/PasswordInput"
+import { TwoFactorStub } from "@/components/auth/TwoFactorStub"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useAuth } from "@/features/auth/AuthContext"
+import { useAcceptInvite } from "@/features/invite/hooks"
+import { useLogin } from "@/features/auth/hooks"
+import { consumePendingInvite, peekPendingInvite } from "@/features/auth/inviteHandoff"
+import { loginSchema, type LoginInput } from "@/features/auth/schemas"
+import { parseServerError } from "@/lib/server-error"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+
+const SESSION_REASON_KEY: Record<string, string> = {
+  session_expired: "auth:session.expired",
+  auth_required: "auth:session.authRequired",
+}
+
+// LoginPage — owns the sign-in form, the post-login redirect chain, and the
+// invite handoff (#1285): if the user came in through /invite/<token>, we
+// auto-accept after login and land them inside the joined group.
+export function LoginPage() {
+  const { t } = useTranslation()
+  const [params] = useSearchParams()
+  const navigate = useNavigate()
+  const { isAuthenticated } = useAuth()
+  const loginMutation = useLogin()
+  const acceptInviteMutation = useAcceptInvite()
+
+  const [pendingInvite] = useState(() => peekPendingInvite())
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const form = useForm<LoginInput>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: "", password: "", rememberMe: false },
+    mode: "onSubmit",
+  })
+
+  const reason = params.get("reason")
+  const sessionMessage = reason ? t(SESSION_REASON_KEY[reason] ?? "auth:session.ended") : null
+
+  // Reset the server error whenever the user edits a field, so a stale
+  // notice doesn't sit on top of valid input.
+  useEffect(() => {
+    const sub = form.watch(() => {
+      if (serverError) setServerError(null)
+    })
+    return () => sub.unsubscribe()
+  }, [form, serverError])
+
+  // If a deep-link or refresh lands an already-authenticated user here,
+  // skip the form and bounce to wherever they were trying to go. Placed
+  // after the hooks above to keep the Rules-of-Hooks call order stable.
+  if (isAuthenticated) {
+    const redirect = params.get("redirect") || "/"
+    return <Navigate to={redirect} replace />
+  }
+
+  const isPending =
+    loginMutation.isPending || acceptInviteMutation.isPending || form.formState.isSubmitting
+
+  async function onSubmit(values: LoginInput) {
+    setServerError(null)
+    try {
+      await loginMutation.mutateAsync({
+        email: values.email.trim(),
+        password: values.password,
+      })
+    } catch (err) {
+      setServerError(parseServerError(err, t("auth:login.errorGeneric")))
+      return
+    }
+    if (pendingInvite) {
+      try {
+        await acceptInviteMutation.mutateAsync(pendingInvite.token)
+        consumePendingInvite()
+        navigate("/", { replace: true })
+        return
+      } catch {
+        // Fall through to the normal redirect — the user can retry from
+        // /invite/<token> manually. We deliberately don't surface this as
+        // an error on the login page; the login itself succeeded.
+      }
+    }
+    const redirect = params.get("redirect") || "/"
+    navigate(redirect, { replace: true })
+  }
+
+  return (
+    <AuthLayout>
+      <RouteTitle title={t("stubs:login")} />
+      <div className="space-y-6" data-testid="login-page">
+        <header className="space-y-1.5">
+          <h1 className="text-2xl font-semibold tracking-tight">{t("auth:login.title")}</h1>
+          <p className="text-sm text-muted-foreground">{t("auth:login.subtitle")}</p>
+        </header>
+
+        {sessionMessage ? (
+          <Alert data-testid="session-message">
+            <AlertDescription>{sessionMessage}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {pendingInvite ? (
+          <Alert data-testid="pending-invite-banner">
+            <Mail aria-hidden="true" />
+            <AlertDescription>
+              {pendingInvite.groupName
+                ? t("auth:invite.joinGroup", { name: pendingInvite.groupName })
+                : t("auth:invite.signInToAccept")}
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+          <div className="space-y-1.5">
+            <Label htmlFor="login-email">{t("auth:fields.email")}</Label>
+            <div className="relative">
+              <Mail
+                aria-hidden="true"
+                className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                id="login-email"
+                type="email"
+                autoComplete="email"
+                placeholder={t("auth:fields.emailPlaceholder")}
+                className="pl-9"
+                disabled={isPending}
+                aria-invalid={!!form.formState.errors.email}
+                data-testid="email"
+                {...form.register("email")}
+              />
+            </div>
+            {form.formState.errors.email ? (
+              <p className="text-xs text-destructive" data-testid="email-error">
+                {t(form.formState.errors.email.message ?? "")}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="login-password">{t("auth:fields.password")}</Label>
+              <Link
+                to="/forgot-password"
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t("auth:login.forgotPassword")}
+              </Link>
+            </div>
+            <PasswordInput
+              id="login-password"
+              autoComplete="current-password"
+              placeholder={t("auth:fields.passwordPlaceholder")}
+              disabled={isPending}
+              aria-invalid={!!form.formState.errors.password}
+              data-testid="password"
+              {...form.register("password")}
+            />
+            {form.formState.errors.password ? (
+              <p className="text-xs text-destructive" data-testid="password-error">
+                {t(form.formState.errors.password.message ?? "")}
+              </p>
+            ) : null}
+          </div>
+
+          <RememberMeCheckbox
+            checked={!!form.watch("rememberMe")}
+            onChange={(v) => form.setValue("rememberMe", v)}
+          />
+
+          {serverError ? (
+            <Alert variant="destructive" data-testid="server-error">
+              <AlertDescription>{serverError}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <Button
+            type="submit"
+            className="w-full gap-2"
+            disabled={isPending}
+            data-testid="login-button"
+          >
+            {isPending ? t("auth:login.submitting") : t("auth:login.submit")}
+            {!isPending ? <ArrowRight className="size-4" /> : null}
+          </Button>
+        </form>
+
+        <OAuthRow />
+        <TwoFactorStub />
+
+        <p className="text-center text-sm text-muted-foreground">
+          {t("auth:login.dontHaveAccount")}{" "}
+          <Link
+            to="/register"
+            className="font-medium text-foreground hover:underline underline-offset-4"
+          >
+            {t("auth:login.createOne")}
+          </Link>
+        </p>
+      </div>
+    </AuthLayout>
+  )
+}
+
+// Lifted out so the controlled `useForm.watch` doesn't redraw the whole page
+// on each keystroke — only this row.
+function RememberMeCheckbox({
+  checked,
+  onChange,
+}: {
+  checked: boolean
+  onChange: (v: boolean) => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex items-center gap-2">
+      <Checkbox
+        id="login-remember"
+        checked={checked}
+        onCheckedChange={(v) => onChange(v === true)}
+      />
+      <Label htmlFor="login-remember" className="text-sm font-normal text-muted-foreground">
+        {t("auth:login.rememberMe")}
+      </Label>
+    </div>
+  )
+}

--- a/frontend-react/src/pages/auth/RegisterPage.tsx
+++ b/frontend-react/src/pages/auth/RegisterPage.tsx
@@ -1,0 +1,290 @@
+import { useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useTranslation } from "react-i18next"
+import { Link, useNavigate } from "react-router-dom"
+import { ArrowRight, CheckCircle2, Mail, User } from "lucide-react"
+
+import { AuthLayout } from "@/components/auth/AuthLayout"
+import { OAuthRow } from "@/components/auth/OAuthRow"
+import { PasswordInput } from "@/components/auth/PasswordInput"
+import { PasswordStrengthMeter } from "@/components/auth/PasswordStrengthMeter"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useAcceptInvite } from "@/features/invite/hooks"
+import { useLogin, useRegister } from "@/features/auth/hooks"
+import { consumePendingInvite, peekPendingInvite } from "@/features/auth/inviteHandoff"
+import { registerSchema, type RegisterInput } from "@/features/auth/schemas"
+import { parseServerError } from "@/lib/server-error"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+
+// RegisterPage — sign-up form with the optional invite-to-handoff path.
+// The server returns the same generic message whether the email is taken or
+// not (anti-enumeration), so we always surface success unless it 4xx/5xxs.
+export function RegisterPage() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const registerMutation = useRegister()
+  const loginMutation = useLogin()
+  const acceptInviteMutation = useAcceptInvite()
+
+  const [pendingInvite] = useState(() => peekPendingInvite())
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const [autoAcceptError, setAutoAcceptError] = useState<string | null>(null)
+
+  const form = useForm<RegisterInput>({
+    resolver: zodResolver(registerSchema),
+    defaultValues: {
+      name: "",
+      email: "",
+      password: "",
+      acceptTerms: false,
+    },
+  })
+
+  const passwordValue = form.watch("password") ?? ""
+
+  // Reset stale server error on edits.
+  useEffect(() => {
+    const sub = form.watch(() => {
+      if (serverError) setServerError(null)
+    })
+    return () => sub.unsubscribe()
+  }, [form, serverError])
+
+  const isPending =
+    registerMutation.isPending ||
+    loginMutation.isPending ||
+    acceptInviteMutation.isPending ||
+    form.formState.isSubmitting
+
+  async function onSubmit(values: RegisterInput) {
+    setServerError(null)
+    setAutoAcceptError(null)
+    let message: string
+    try {
+      message = await registerMutation.mutateAsync({
+        email: values.email.trim(),
+        password: values.password,
+        name: values.name.trim(),
+        invite_token: pendingInvite?.token,
+      })
+    } catch (err) {
+      setServerError(parseServerError(err, t("auth:register.errorGeneric")))
+      return
+    }
+    setSuccessMessage(message || t("auth:register.successFallback"))
+    if (pendingInvite) {
+      try {
+        await loginMutation.mutateAsync({
+          email: values.email.trim(),
+          password: values.password,
+        })
+        await acceptInviteMutation.mutateAsync(pendingInvite.token)
+        consumePendingInvite()
+        navigate("/", { replace: true })
+      } catch (err) {
+        setAutoAcceptError(parseServerError(err, t("auth:register.autoAcceptError")))
+      }
+    }
+  }
+
+  if (successMessage) {
+    return (
+      <AuthLayout>
+        <RouteTitle title={t("stubs:register")} />
+        <div className="space-y-6 text-center" data-testid="register-success">
+          <div className="flex justify-center">
+            <div className="flex size-16 items-center justify-center rounded-full bg-primary/10">
+              <CheckCircle2 className="size-8 text-primary" aria-hidden="true" />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {t("auth:register.successTitle")}
+            </h1>
+            <p className="text-sm text-muted-foreground">{successMessage}</p>
+          </div>
+          {pendingInvite && !autoAcceptError ? (
+            <p className="text-sm text-muted-foreground">{t("auth:register.joiningGroup")}</p>
+          ) : null}
+          {autoAcceptError ? (
+            <Alert variant="destructive" data-testid="auto-accept-error">
+              <AlertDescription>
+                {autoAcceptError}{" "}
+                <Link
+                  to={`/login?redirect=/invite/${encodeURIComponent(pendingInvite?.token ?? "")}`}
+                  className="font-medium underline underline-offset-4"
+                >
+                  {t("auth:register.signInManually")}
+                </Link>
+              </AlertDescription>
+            </Alert>
+          ) : null}
+          {!pendingInvite ? (
+            <p className="text-sm text-muted-foreground">
+              <Link
+                to="/login"
+                className="font-medium text-foreground hover:underline underline-offset-4"
+              >
+                {t("auth:forgot.backToSignIn")}
+              </Link>
+            </p>
+          ) : null}
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  return (
+    <AuthLayout>
+      <RouteTitle title={t("stubs:register")} />
+      <div className="space-y-6" data-testid="register-page">
+        <header className="space-y-1.5">
+          <h1 className="text-2xl font-semibold tracking-tight">{t("auth:register.title")}</h1>
+          <p className="text-sm text-muted-foreground">{t("auth:register.subtitle")}</p>
+        </header>
+
+        {pendingInvite ? (
+          <Alert data-testid="pending-invite-banner">
+            <Mail aria-hidden="true" />
+            <AlertDescription>
+              {t("auth:invite.joinGroup", {
+                name: pendingInvite.groupName ?? "",
+              })}
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+          <div className="space-y-1.5">
+            <Label htmlFor="register-name">{t("auth:fields.name")}</Label>
+            <div className="relative">
+              <User
+                aria-hidden="true"
+                className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                id="register-name"
+                autoComplete="name"
+                placeholder={t("auth:fields.namePlaceholder")}
+                className="pl-9"
+                disabled={isPending}
+                aria-invalid={!!form.formState.errors.name}
+                data-testid="name"
+                {...form.register("name")}
+              />
+            </div>
+            {form.formState.errors.name ? (
+              <p className="text-xs text-destructive" data-testid="name-error">
+                {t(form.formState.errors.name.message ?? "")}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="register-email">{t("auth:fields.email")}</Label>
+            <div className="relative">
+              <Mail
+                aria-hidden="true"
+                className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                id="register-email"
+                type="email"
+                autoComplete="email"
+                placeholder={t("auth:fields.emailPlaceholder")}
+                className="pl-9"
+                disabled={isPending}
+                aria-invalid={!!form.formState.errors.email}
+                data-testid="email"
+                {...form.register("email")}
+              />
+            </div>
+            {form.formState.errors.email ? (
+              <p className="text-xs text-destructive" data-testid="email-error">
+                {t(form.formState.errors.email.message ?? "")}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="register-password">{t("auth:fields.password")}</Label>
+            <PasswordInput
+              id="register-password"
+              autoComplete="new-password"
+              placeholder={t("auth:fields.newPasswordPlaceholder")}
+              disabled={isPending}
+              aria-invalid={!!form.formState.errors.password}
+              data-testid="password"
+              {...form.register("password")}
+            />
+            <PasswordStrengthMeter password={passwordValue} testId="register-password-strength" />
+            {form.formState.errors.password ? (
+              <p className="text-xs text-destructive" data-testid="password-error">
+                {t(form.formState.errors.password.message ?? "")}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex items-start gap-2 pt-1">
+            <Checkbox
+              id="register-terms"
+              checked={form.watch("acceptTerms")}
+              onCheckedChange={(v) =>
+                form.setValue("acceptTerms", v === true, {
+                  shouldValidate: form.formState.isSubmitted,
+                })
+              }
+              aria-invalid={!!form.formState.errors.acceptTerms}
+              data-testid="terms"
+            />
+            <Label
+              htmlFor="register-terms"
+              className="text-sm font-normal text-muted-foreground leading-relaxed"
+            >
+              {t("auth:register.termsAccept")}
+            </Label>
+          </div>
+          {form.formState.errors.acceptTerms ? (
+            <p className="text-xs text-destructive" data-testid="terms-error">
+              {t(form.formState.errors.acceptTerms.message ?? "")}
+            </p>
+          ) : null}
+
+          {serverError ? (
+            <Alert variant="destructive" data-testid="server-error">
+              <AlertDescription>{serverError}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <Button
+            type="submit"
+            className="w-full gap-2"
+            disabled={isPending}
+            data-testid="register-button"
+          >
+            {isPending ? t("auth:register.submitting") : t("auth:register.submit")}
+            {!isPending ? <ArrowRight className="size-4" /> : null}
+          </Button>
+        </form>
+
+        <OAuthRow />
+
+        <p className="text-center text-sm text-muted-foreground">
+          {t("auth:register.alreadyHaveAccount")}{" "}
+          <Link
+            to="/login"
+            className="font-medium text-foreground hover:underline underline-offset-4"
+          >
+            {t("auth:register.signIn")}
+          </Link>
+        </p>
+      </div>
+    </AuthLayout>
+  )
+}

--- a/frontend-react/src/pages/auth/ResetPasswordPage.tsx
+++ b/frontend-react/src/pages/auth/ResetPasswordPage.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useTranslation } from "react-i18next"
+import { Link, useSearchParams } from "react-router-dom"
+import { ArrowRight, CheckCircle2 } from "lucide-react"
+
+import { AuthLayout } from "@/components/auth/AuthLayout"
+import { PasswordInput } from "@/components/auth/PasswordInput"
+import { PasswordStrengthMeter } from "@/components/auth/PasswordStrengthMeter"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { useResetPassword } from "@/features/auth/hooks"
+import { resetPasswordSchema, type ResetPasswordInput } from "@/features/auth/schemas"
+import { parseServerError } from "@/lib/server-error"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+
+// ResetPasswordPage — token comes from `?token=…`. Three render states:
+//   1. Empty/missing token → invalid-link notice with a shortcut to forgot.
+//   2. Submitted successfully → success block with "sign in" CTA.
+//   3. Otherwise → the password / confirm form.
+export function ResetPasswordPage() {
+  const { t } = useTranslation()
+  const [params] = useSearchParams()
+  const token = params.get("token") ?? ""
+  const mutation = useResetPassword()
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const form = useForm<ResetPasswordInput>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  })
+  const passwordValue = form.watch("password") ?? ""
+
+  useEffect(() => {
+    const sub = form.watch(() => {
+      if (serverError) setServerError(null)
+    })
+    return () => sub.unsubscribe()
+  }, [form, serverError])
+
+  async function onSubmit(values: ResetPasswordInput) {
+    setServerError(null)
+    try {
+      const message = await mutation.mutateAsync({
+        token,
+        newPassword: values.password,
+      })
+      setSuccessMessage(message || t("auth:reset.successFallback"))
+    } catch (err) {
+      setServerError(parseServerError(err, t("auth:reset.errorGeneric")))
+    }
+  }
+
+  if (!token) {
+    return (
+      <AuthLayout>
+        <RouteTitle title={t("stubs:resetPassword")} />
+        <div className="space-y-6 text-center" data-testid="reset-missing-token">
+          <div className="space-y-1.5">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {t("auth:reset.missingTokenTitle")}
+            </h1>
+            <p className="text-sm text-muted-foreground">{t("auth:reset.missingTokenBody")}</p>
+          </div>
+          <Button asChild className="w-full">
+            <Link to="/forgot-password">{t("auth:reset.requestNewLink")}</Link>
+          </Button>
+          <Link
+            to="/login"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
+          >
+            {t("auth:forgot.backToSignIn")}
+          </Link>
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  if (successMessage) {
+    return (
+      <AuthLayout>
+        <RouteTitle title={t("stubs:resetPassword")} />
+        <div className="space-y-6 text-center" data-testid="reset-success">
+          <div className="flex justify-center">
+            <div className="flex size-16 items-center justify-center rounded-full bg-emerald-500/10">
+              <CheckCircle2 className="size-8 text-emerald-500" aria-hidden="true" />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {t("auth:reset.successTitle")}
+            </h1>
+            <p className="text-sm text-muted-foreground">{successMessage}</p>
+          </div>
+          <Button asChild className="w-full gap-2">
+            <Link to="/login">
+              {t("auth:reset.signInWithNew")}
+              <ArrowRight className="size-4" />
+            </Link>
+          </Button>
+        </div>
+      </AuthLayout>
+    )
+  }
+
+  return (
+    <AuthLayout>
+      <RouteTitle title={t("stubs:resetPassword")} />
+      <div className="space-y-6" data-testid="reset-page">
+        <header className="space-y-1.5">
+          <h1 className="text-2xl font-semibold tracking-tight">{t("auth:reset.title")}</h1>
+          <p className="text-sm text-muted-foreground">{t("auth:reset.subtitle")}</p>
+        </header>
+
+        <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+          <div className="space-y-1.5">
+            <Label htmlFor="reset-password">{t("auth:fields.newPassword")}</Label>
+            <PasswordInput
+              id="reset-password"
+              autoComplete="new-password"
+              placeholder={t("auth:fields.newPasswordPlaceholder")}
+              disabled={mutation.isPending}
+              aria-invalid={!!form.formState.errors.password}
+              data-testid="password"
+              {...form.register("password")}
+            />
+            <PasswordStrengthMeter password={passwordValue} testId="reset-password-strength" />
+            {form.formState.errors.password ? (
+              <p className="text-xs text-destructive" data-testid="password-error">
+                {t(form.formState.errors.password.message ?? "")}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="reset-confirm">{t("auth:fields.confirmPassword")}</Label>
+            <PasswordInput
+              id="reset-confirm"
+              autoComplete="new-password"
+              placeholder={t("auth:fields.confirmPasswordPlaceholder")}
+              disabled={mutation.isPending}
+              aria-invalid={!!form.formState.errors.confirmPassword}
+              data-testid="confirm-password"
+              {...form.register("confirmPassword")}
+            />
+            {form.formState.errors.confirmPassword ? (
+              <p className="text-xs text-destructive" data-testid="confirm-password-error">
+                {t(form.formState.errors.confirmPassword.message ?? "")}
+              </p>
+            ) : null}
+          </div>
+
+          {serverError ? (
+            <Alert variant="destructive" data-testid="server-error">
+              <AlertDescription>{serverError}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <Button
+            type="submit"
+            className="w-full gap-2"
+            disabled={mutation.isPending}
+            data-testid="submit-button"
+          >
+            {mutation.isPending ? t("auth:reset.submitting") : t("auth:reset.submit")}
+            {!mutation.isPending ? <ArrowRight className="size-4" /> : null}
+          </Button>
+        </form>
+      </div>
+    </AuthLayout>
+  )
+}

--- a/frontend-react/src/pages/auth/VerifyEmailPage.tsx
+++ b/frontend-react/src/pages/auth/VerifyEmailPage.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Link, useSearchParams } from "react-router-dom"
+import { ArrowRight, CheckCircle2, Clock, XCircle } from "lucide-react"
+
+import { AuthLayout } from "@/components/auth/AuthLayout"
+import { Button } from "@/components/ui/button"
+import { useVerifyEmail } from "@/features/auth/hooks"
+import { HttpError } from "@/lib/http"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+import { cn } from "@/lib/utils"
+
+type VerifyState = "verifying" | "success" | "expired" | "invalid" | "missing"
+
+// Heuristic: distinguish "expired" from "generic invalid" so the page can
+// offer "request new link" instead of just "back to sign in". The backend
+// surfaces both as 4xx with a string body, so we look at the message text.
+function classifyError(err: unknown): "expired" | "invalid" {
+  if (err instanceof HttpError) {
+    const data = err.data
+    const text = typeof data === "string" ? data : ""
+    if (/expir/i.test(text)) return "expired"
+  }
+  return "invalid"
+}
+
+export function VerifyEmailPage() {
+  const { t } = useTranslation()
+  const [params] = useSearchParams()
+  const token = params.get("token") ?? ""
+  const verifyMutation = useVerifyEmail()
+  const [state, setState] = useState<VerifyState>(token ? "verifying" : "missing")
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!token) return
+    let cancelled = false
+    verifyMutation
+      .mutateAsync(token)
+      .then((message) => {
+        if (cancelled) return
+        setSuccessMessage(message || t("auth:verify.successFallback"))
+        setState("success")
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setState(classifyError(err))
+      })
+    return () => {
+      cancelled = true
+    }
+    // mutateAsync identity is stable per render of the mutation hook; we
+    // want this effect to run exactly once on mount with the URL token.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token])
+
+  const config = pickConfig(state, t, successMessage)
+
+  return (
+    <AuthLayout>
+      <RouteTitle title={t("stubs:verifyEmail")} />
+      <div className="space-y-6 text-center" data-testid={`verify-${state}`}>
+        {config.icon ? (
+          <div className="flex justify-center">
+            <div
+              className={cn("flex size-16 items-center justify-center rounded-full", config.iconBg)}
+            >
+              <config.icon className={cn("size-8", config.iconColor)} aria-hidden="true" />
+            </div>
+          </div>
+        ) : null}
+        <div className="space-y-1.5">
+          <h1 className="text-2xl font-semibold tracking-tight">{config.title}</h1>
+          <p className="text-sm text-muted-foreground">{config.body}</p>
+        </div>
+        {config.action ? (
+          <Button asChild className="w-full gap-2">
+            <Link to={config.action.to}>
+              {config.action.label}
+              <ArrowRight className="size-4" />
+            </Link>
+          </Button>
+        ) : null}
+        {state !== "success" && state !== "verifying" ? (
+          <p className="text-sm text-muted-foreground">
+            <Link
+              to="/login"
+              className="font-medium text-foreground hover:underline underline-offset-4"
+            >
+              {t("auth:verify.backToSignIn")}
+            </Link>
+          </p>
+        ) : null}
+      </div>
+    </AuthLayout>
+  )
+}
+
+interface ScreenConfig {
+  icon: typeof CheckCircle2 | null
+  iconBg: string
+  iconColor: string
+  title: string
+  body: string
+  action: { to: string; label: string } | null
+}
+
+function pickConfig(
+  state: VerifyState,
+  t: (key: string) => string,
+  successMessage: string | null
+): ScreenConfig {
+  switch (state) {
+    case "verifying":
+      return {
+        icon: null,
+        iconBg: "",
+        iconColor: "",
+        title: t("auth:verify.verifying"),
+        body: "",
+        action: null,
+      }
+    case "success":
+      return {
+        icon: CheckCircle2,
+        iconBg: "bg-emerald-500/10",
+        iconColor: "text-emerald-500",
+        title: t("auth:verify.successTitle"),
+        body: successMessage ?? t("auth:verify.successFallback"),
+        action: { to: "/login", label: t("auth:verify.continue") },
+      }
+    case "expired":
+      return {
+        icon: Clock,
+        iconBg: "bg-amber-500/10",
+        iconColor: "text-amber-500",
+        title: t("auth:verify.expiredTitle"),
+        body: t("auth:verify.expiredBody"),
+        action: null,
+      }
+    case "invalid":
+      return {
+        icon: XCircle,
+        iconBg: "bg-destructive/10",
+        iconColor: "text-destructive",
+        title: t("auth:verify.invalidTitle"),
+        body: t("auth:verify.invalidBody"),
+        action: null,
+      }
+    case "missing":
+      return {
+        icon: XCircle,
+        iconBg: "bg-amber-500/10",
+        iconColor: "text-amber-500",
+        title: t("auth:verify.missingTitle"),
+        body: t("auth:verify.missingBody"),
+        action: null,
+      }
+  }
+}

--- a/frontend-react/src/pages/auth/VerifyEmailPage.tsx
+++ b/frontend-react/src/pages/auth/VerifyEmailPage.tsx
@@ -33,7 +33,17 @@ export function VerifyEmailPage() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!token) return
+    if (!token) {
+      setState("missing")
+      setSuccessMessage(null)
+      return
+    }
+    // Token swap (rare, but possible if the user hand-edits the URL or the
+    // route remounts with a different ?token=) — wipe the previous outcome
+    // before firing the new request so the user doesn't see stale "success"
+    // copy while the new token is verifying.
+    setState("verifying")
+    setSuccessMessage(null)
     let cancelled = false
     verifyMutation
       .mutateAsync(token)
@@ -50,7 +60,7 @@ export function VerifyEmailPage() {
       cancelled = true
     }
     // mutateAsync identity is stable per render of the mutation hook; we
-    // want this effect to run exactly once on mount with the URL token.
+    // want this effect to run on token change only.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token])
 

--- a/frontend-react/src/pages/auth/__tests__/ForgotPasswordPage.test.tsx
+++ b/frontend-react/src/pages/auth/__tests__/ForgotPasswordPage.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { http as msw, HttpResponse } from "msw"
 import { Route } from "react-router-dom"
-import { screen } from "@testing-library/react"
+import { screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import { ForgotPasswordPage } from "@/pages/auth/ForgotPasswordPage"
@@ -72,5 +72,27 @@ describe("<ForgotPasswordPage />", () => {
     await user.type(screen.getByTestId("email"), "alex@example.com")
     await user.click(screen.getByTestId("submit-button"))
     expect(await screen.findByTestId("server-error")).toHaveTextContent(/mailer down/i)
+  })
+
+  it("surfaces resend errors inline on the success state", async () => {
+    // First call succeeds; second call (resend) fails. The success branch
+    // must render an inline alert instead of swallowing the error.
+    let calls = 0
+    server.use(
+      msw.post(api("/forgot-password"), () => {
+        calls++
+        if (calls === 1) {
+          return HttpResponse.json({ message: "Reset link sent." })
+        }
+        return HttpResponse.json({ error: "Rate limited" }, { status: 429 })
+      })
+    )
+    const user = userEvent.setup()
+    renderForgot()
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.click(screen.getByTestId("submit-button"))
+    const success = await screen.findByTestId("forgot-success")
+    await user.click(within(success).getByRole("button", { name: /resend/i }))
+    expect(await screen.findByTestId("resend-error")).toHaveTextContent(/rate limited/i)
   })
 })

--- a/frontend-react/src/pages/auth/__tests__/ForgotPasswordPage.test.tsx
+++ b/frontend-react/src/pages/auth/__tests__/ForgotPasswordPage.test.tsx
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { ForgotPasswordPage } from "@/pages/auth/ForgotPasswordPage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+function renderForgot() {
+  return renderWithProviders({
+    initialPath: "/forgot-password",
+    routes: (
+      <Route
+        path="/forgot-password"
+        element={
+          <AuthProvider>
+            <ForgotPasswordPage />
+          </AuthProvider>
+        }
+      />
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<ForgotPasswordPage />", () => {
+  it("validates the email field before submission", async () => {
+    const user = userEvent.setup()
+    renderForgot()
+    await user.click(screen.getByTestId("submit-button"))
+    expect(await screen.findByTestId("email-error")).toBeInTheDocument()
+  })
+
+  it("renders the success state regardless of whether the email exists", async () => {
+    server.use(
+      msw.post(api("/forgot-password"), () =>
+        HttpResponse.json({
+          message: "If that email exists, you'll get a reset link.",
+        })
+      )
+    )
+    const user = userEvent.setup()
+    renderForgot()
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.click(screen.getByTestId("submit-button"))
+    expect(await screen.findByTestId("forgot-success")).toHaveTextContent(
+      /you'll get a reset link/i
+    )
+  })
+
+  it("surfaces server errors inline on 500", async () => {
+    server.use(
+      msw.post(api("/forgot-password"), () =>
+        HttpResponse.json({ error: "Mailer down" }, { status: 500 })
+      )
+    )
+    const user = userEvent.setup()
+    renderForgot()
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.click(screen.getByTestId("submit-button"))
+    expect(await screen.findByTestId("server-error")).toHaveTextContent(/mailer down/i)
+  })
+})

--- a/frontend-react/src/pages/auth/__tests__/InviteAcceptPage.test.tsx
+++ b/frontend-react/src/pages/auth/__tests__/InviteAcceptPage.test.tsx
@@ -11,7 +11,11 @@ import { server } from "@/test/server"
 import { clearAuth, setAccessToken } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
-import { clearPendingInvite, peekPendingInvite } from "@/features/auth/inviteHandoff"
+import {
+  clearPendingInvite,
+  peekPendingInvite,
+  savePendingInvite,
+} from "@/features/auth/inviteHandoff"
 
 const api = (path: string) => `${window.location.origin}/api/v1${path}`
 
@@ -133,5 +137,41 @@ describe("<InviteAcceptPage />", () => {
     const acceptBtn = await screen.findByTestId("invite-accept-btn")
     await user.click(acceptBtn)
     await waitFor(() => expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/"))
+  })
+
+  it("clears any sessionStorage handoff after a successful accept", async () => {
+    // Regression: a stale entry from an earlier aborted flow could otherwise
+    // sit in sessionStorage and feed /login's auto-accept on the next sign-in.
+    savePendingInvite({ token: "stale-tok", groupName: "OldHousehold" })
+    server.use(
+      msw.get(api("/auth/me"), () =>
+        HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+      ),
+      msw.get(api("/invites/fresh-tok"), () =>
+        HttpResponse.json({
+          data: {
+            type: "invite_info",
+            attributes: { group_name: "Household", expired: false, used: false },
+          },
+        })
+      ),
+      msw.post(api("/invites/fresh-tok/accept"), () =>
+        HttpResponse.json({ data: { id: "m1", attributes: { group_id: "g1" } } })
+      )
+    )
+    const user = userEvent.setup()
+    renderInvite("/invite/fresh-tok", { authenticated: true })
+    await user.click(await screen.findByTestId("invite-accept-btn"))
+    await waitFor(() => expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/"))
+    expect(peekPendingInvite()).toBeNull()
+  })
+
+  it("renders the invalid state when the server returns a malformed envelope", async () => {
+    // Regression: a `{ data: {} }` body with no `attributes` would previously
+    // be treated as actionable; getInviteInfo now throws so the page falls
+    // into the invalid-invite panel.
+    server.use(msw.get(api("/invites/weird-tok"), () => HttpResponse.json({ data: {} })))
+    renderInvite("/invite/weird-tok")
+    await waitFor(() => expect(screen.getByTestId("invite-invalid")).toBeInTheDocument())
   })
 })

--- a/frontend-react/src/pages/auth/__tests__/InviteAcceptPage.test.tsx
+++ b/frontend-react/src/pages/auth/__tests__/InviteAcceptPage.test.tsx
@@ -73,6 +73,24 @@ describe("<InviteAcceptPage />", () => {
     await waitFor(() => expect(screen.getByTestId("invite-expired")).toBeInTheDocument())
   })
 
+  it("does NOT stash expired/used invites in sessionStorage", async () => {
+    // Regression: previously the handoff effect ran for any loaded invite,
+    // so /login + /register would auto-accept tokens that can never succeed.
+    server.use(
+      msw.get(api("/invites/dead-tok"), () =>
+        HttpResponse.json({
+          data: {
+            type: "invite_info",
+            attributes: { group_name: "Household", expired: true, used: false },
+          },
+        })
+      )
+    )
+    renderInvite("/invite/dead-tok")
+    await waitFor(() => expect(screen.getByTestId("invite-expired")).toBeInTheDocument())
+    expect(peekPendingInvite()).toBeNull()
+  })
+
   it("for an unauthenticated user, stores the invite in sessionStorage and renders sign-in CTAs", async () => {
     server.use(
       msw.get(api("/invites/inv-tok"), () =>

--- a/frontend-react/src/pages/auth/__tests__/InviteAcceptPage.test.tsx
+++ b/frontend-react/src/pages/auth/__tests__/InviteAcceptPage.test.tsx
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route, useLocation } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { InviteAcceptPage } from "@/pages/auth/InviteAcceptPage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { clearPendingInvite, peekPendingInvite } from "@/features/auth/inviteHandoff"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="loc" data-pathname={loc.pathname} />
+}
+
+function renderInvite(initial: string, opts?: { authenticated?: boolean }) {
+  if (opts?.authenticated) setAccessToken("good-token")
+  return renderWithProviders({
+    initialPath: initial,
+    routes: (
+      <>
+        <Route
+          path="/invite/:token"
+          element={
+            <AuthProvider>
+              <InviteAcceptPage />
+            </AuthProvider>
+          }
+        />
+        <Route path="*" element={<LocationProbe />} />
+      </>
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  clearPendingInvite()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<InviteAcceptPage />", () => {
+  it("renders the invalid state when the invite lookup fails", async () => {
+    server.use(
+      msw.get(api("/invites/bad-tok"), () =>
+        HttpResponse.json({ error: "not found" }, { status: 404 })
+      )
+    )
+    renderInvite("/invite/bad-tok")
+    await waitFor(() => expect(screen.getByTestId("invite-invalid")).toBeInTheDocument())
+  })
+
+  it("renders the expired state when the invite is expired", async () => {
+    server.use(
+      msw.get(api("/invites/exp-tok"), () =>
+        HttpResponse.json({
+          data: {
+            type: "invite_info",
+            attributes: { group_name: "Household", expired: true, used: false },
+          },
+        })
+      )
+    )
+    renderInvite("/invite/exp-tok")
+    await waitFor(() => expect(screen.getByTestId("invite-expired")).toBeInTheDocument())
+  })
+
+  it("for an unauthenticated user, stores the invite in sessionStorage and renders sign-in CTAs", async () => {
+    server.use(
+      msw.get(api("/invites/inv-tok"), () =>
+        HttpResponse.json({
+          data: {
+            type: "invite_info",
+            attributes: { group_name: "Household", expired: false, used: false },
+          },
+        })
+      )
+    )
+    renderInvite("/invite/inv-tok")
+    await waitFor(() => expect(screen.getByTestId("invite-page")).toBeInTheDocument())
+    expect(screen.getByTestId("invite-login-link")).toBeInTheDocument()
+    expect(screen.getByTestId("invite-register-link")).toBeInTheDocument()
+    await waitFor(() =>
+      expect(peekPendingInvite()).toEqual({ token: "inv-tok", groupName: "Household" })
+    )
+  })
+
+  it("for an authenticated user, accepts the invite and redirects home", async () => {
+    server.use(
+      msw.get(api("/auth/me"), () =>
+        HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+      ),
+      msw.get(api("/invites/inv-tok"), () =>
+        HttpResponse.json({
+          data: {
+            type: "invite_info",
+            attributes: { group_name: "Household", expired: false, used: false },
+          },
+        })
+      ),
+      msw.post(api("/invites/inv-tok/accept"), () =>
+        HttpResponse.json({ data: { id: "m1", attributes: { group_id: "g1" } } })
+      )
+    )
+    const user = userEvent.setup()
+    renderInvite("/invite/inv-tok", { authenticated: true })
+    const acceptBtn = await screen.findByTestId("invite-accept-btn")
+    await user.click(acceptBtn)
+    await waitFor(() => expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/"))
+  })
+})

--- a/frontend-react/src/pages/auth/__tests__/LoginPage.test.tsx
+++ b/frontend-react/src/pages/auth/__tests__/LoginPage.test.tsx
@@ -128,4 +128,23 @@ describe("<LoginPage />", () => {
     const { container } = renderLogin()
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  it("falls back to / when ?redirect= points off the app (open-redirect guard)", async () => {
+    server.use(
+      msw.post(api("/auth/login"), () =>
+        HttpResponse.json({
+          access_token: "tok",
+          csrf_token: "csrf",
+          user: { id: "u1", email: "alex@example.com", name: "Alex" },
+        })
+      )
+    )
+    const user = userEvent.setup()
+    renderLogin("/login?redirect=//evil.example/foo")
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.type(screen.getByTestId("password"), "secret")
+    await user.click(screen.getByTestId("login-button"))
+    await waitFor(() => expect(getAccessToken()).toBe("tok"))
+    await waitFor(() => expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/"))
+  })
 })

--- a/frontend-react/src/pages/auth/__tests__/LoginPage.test.tsx
+++ b/frontend-react/src/pages/auth/__tests__/LoginPage.test.tsx
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route, useLocation } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { axe } from "jest-axe"
+
+import { LoginPage } from "@/pages/auth/LoginPage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth, getAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { clearPendingInvite, savePendingInvite } from "@/features/auth/inviteHandoff"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="loc" data-pathname={loc.pathname} data-search={loc.search} />
+}
+
+function renderLogin(initial = "/login") {
+  return renderWithProviders({
+    initialPath: initial,
+    routes: (
+      <>
+        <Route
+          path="/login"
+          element={
+            <AuthProvider>
+              <LoginPage />
+            </AuthProvider>
+          }
+        />
+        <Route path="*" element={<LocationProbe />} />
+      </>
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  clearPendingInvite()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<LoginPage />", () => {
+  it("validates required fields before submitting", async () => {
+    const user = userEvent.setup()
+    renderLogin()
+    await user.click(screen.getByTestId("login-button"))
+    expect(await screen.findByTestId("email-error")).toBeInTheDocument()
+    expect(screen.getByTestId("password-error")).toBeInTheDocument()
+  })
+
+  it("renders the session message when ?reason=session_expired is present", () => {
+    renderLogin("/login?reason=session_expired")
+    expect(screen.getByTestId("session-message")).toHaveTextContent(/session has expired/i)
+  })
+
+  it("submits credentials, stores the token, and navigates on success", async () => {
+    server.use(
+      msw.post(api("/auth/login"), async ({ request }) => {
+        const body = (await request.json()) as { email: string; password: string }
+        expect(body).toEqual({ email: "alex@example.com", password: "secret-pw" })
+        return HttpResponse.json({
+          access_token: "tok",
+          csrf_token: "csrf",
+          user: { id: "u1", email: "alex@example.com", name: "Alex" },
+        })
+      })
+    )
+    const user = userEvent.setup()
+    renderLogin("/login?redirect=/g/household")
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.type(screen.getByTestId("password"), "secret-pw")
+    await user.click(screen.getByTestId("login-button"))
+
+    await waitFor(() => expect(getAccessToken()).toBe("tok"))
+    await waitFor(() =>
+      expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/g/household")
+    )
+  })
+
+  it("surfaces the server error inline when the API returns 401", async () => {
+    server.use(
+      msw.post(api("/auth/login"), () =>
+        HttpResponse.json({ error: "Invalid credentials" }, { status: 401 })
+      )
+    )
+    const user = userEvent.setup()
+    renderLogin()
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.type(screen.getByTestId("password"), "wrong")
+    await user.click(screen.getByTestId("login-button"))
+    expect(await screen.findByTestId("server-error")).toHaveTextContent(/invalid credentials/i)
+  })
+
+  it("auto-accepts a pending invite after successful login", async () => {
+    savePendingInvite({ token: "inv-tok", groupName: "Household" })
+    let acceptCalls = 0
+    server.use(
+      msw.post(api("/auth/login"), () =>
+        HttpResponse.json({
+          access_token: "tok",
+          csrf_token: "csrf",
+          user: { id: "u1", email: "alex@example.com", name: "Alex" },
+        })
+      ),
+      msw.post(api("/invites/inv-tok/accept"), () => {
+        acceptCalls++
+        return HttpResponse.json({ data: { id: "m1", attributes: { group_id: "g1" } } })
+      })
+    )
+    const user = userEvent.setup()
+    renderLogin()
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.type(screen.getByTestId("password"), "secret")
+    await user.click(screen.getByTestId("login-button"))
+    await waitFor(() => expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/"))
+    expect(acceptCalls).toBe(1)
+  })
+
+  it("has no axe violations on the form", async () => {
+    const { container } = renderLogin()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend-react/src/pages/auth/__tests__/RegisterPage.test.tsx
+++ b/frontend-react/src/pages/auth/__tests__/RegisterPage.test.tsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { RegisterPage } from "@/pages/auth/RegisterPage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { clearPendingInvite } from "@/features/auth/inviteHandoff"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+function renderRegister() {
+  return renderWithProviders({
+    initialPath: "/register",
+    routes: (
+      <Route
+        path="/register"
+        element={
+          <AuthProvider>
+            <RegisterPage />
+          </AuthProvider>
+        }
+      />
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  clearPendingInvite()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<RegisterPage />", () => {
+  it("requires terms acceptance before submitting", async () => {
+    const user = userEvent.setup()
+    renderRegister()
+    await user.type(screen.getByTestId("name"), "Alex")
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.type(screen.getByTestId("password"), "secret-pw")
+    await user.click(screen.getByTestId("register-button"))
+    expect(await screen.findByTestId("terms-error")).toBeInTheDocument()
+  })
+
+  it("renders the success state with the server message", async () => {
+    server.use(
+      msw.post(api("/register"), async ({ request }) => {
+        const body = (await request.json()) as { email: string }
+        expect(body.email).toBe("alex@example.com")
+        return HttpResponse.json({
+          message: "We've sent you a verification link.",
+        })
+      })
+    )
+    const user = userEvent.setup()
+    renderRegister()
+    await user.type(screen.getByTestId("name"), "Alex")
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.type(screen.getByTestId("password"), "secret-pw")
+    await user.click(screen.getByTestId("terms"))
+    await user.click(screen.getByTestId("register-button"))
+    expect(await screen.findByTestId("register-success")).toHaveTextContent(/verification link/i)
+  })
+
+  it("surfaces the server error when the API returns 400", async () => {
+    server.use(
+      msw.post(api("/register"), () =>
+        HttpResponse.json(
+          { errors: [{ detail: "Registration is currently closed" }] },
+          { status: 400 }
+        )
+      )
+    )
+    const user = userEvent.setup()
+    renderRegister()
+    await user.type(screen.getByTestId("name"), "Alex")
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.type(screen.getByTestId("password"), "secret-pw")
+    await user.click(screen.getByTestId("terms"))
+    await user.click(screen.getByTestId("register-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("server-error")).toHaveTextContent(
+        /registration is currently closed/i
+      )
+    )
+  })
+})

--- a/frontend-react/src/pages/auth/__tests__/ResetPasswordPage.test.tsx
+++ b/frontend-react/src/pages/auth/__tests__/ResetPasswordPage.test.tsx
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { ResetPasswordPage } from "@/pages/auth/ResetPasswordPage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+function renderReset(path: string) {
+  return renderWithProviders({
+    initialPath: path,
+    routes: (
+      <Route
+        path="/reset-password"
+        element={
+          <AuthProvider>
+            <ResetPasswordPage />
+          </AuthProvider>
+        }
+      />
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<ResetPasswordPage />", () => {
+  it("shows a missing-token notice when ?token is absent", () => {
+    renderReset("/reset-password")
+    expect(screen.getByTestId("reset-missing-token")).toBeInTheDocument()
+  })
+
+  it("validates min length and matching confirmation", async () => {
+    const user = userEvent.setup()
+    renderReset("/reset-password?token=tok-1")
+    await user.type(screen.getByTestId("password"), "short")
+    await user.type(screen.getByTestId("confirm-password"), "different")
+    await user.click(screen.getByTestId("submit-button"))
+    expect(await screen.findByTestId("password-error")).toBeInTheDocument()
+  })
+
+  it("surfaces password mismatch error on the confirm field", async () => {
+    const user = userEvent.setup()
+    renderReset("/reset-password?token=tok-1")
+    await user.type(screen.getByTestId("password"), "longenough")
+    await user.type(screen.getByTestId("confirm-password"), "different1")
+    await user.click(screen.getByTestId("submit-button"))
+    expect(await screen.findByTestId("confirm-password-error")).toHaveTextContent(/match/i)
+  })
+
+  it("posts the new password and renders the success state", async () => {
+    server.use(
+      msw.post(api("/reset-password"), async ({ request }) => {
+        const body = (await request.json()) as { token: string; new_password: string }
+        expect(body.token).toBe("tok-1")
+        expect(body.new_password).toBe("longenough123")
+        return HttpResponse.json({ message: "Password updated." })
+      })
+    )
+    const user = userEvent.setup()
+    renderReset("/reset-password?token=tok-1")
+    await user.type(screen.getByTestId("password"), "longenough123")
+    await user.type(screen.getByTestId("confirm-password"), "longenough123")
+    await user.click(screen.getByTestId("submit-button"))
+    await waitFor(() =>
+      expect(screen.getByTestId("reset-success")).toHaveTextContent(/password updated/i)
+    )
+  })
+})

--- a/frontend-react/src/pages/auth/__tests__/VerifyEmailPage.test.tsx
+++ b/frontend-react/src/pages/auth/__tests__/VerifyEmailPage.test.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+
+import { VerifyEmailPage } from "@/pages/auth/VerifyEmailPage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+function renderVerify(path: string) {
+  return renderWithProviders({
+    initialPath: path,
+    routes: (
+      <Route
+        path="/verify-email"
+        element={
+          <AuthProvider>
+            <VerifyEmailPage />
+          </AuthProvider>
+        }
+      />
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<VerifyEmailPage />", () => {
+  it("shows the missing-token state when ?token is absent", () => {
+    renderVerify("/verify-email")
+    expect(screen.getByTestId("verify-missing")).toBeInTheDocument()
+  })
+
+  it("hits /verify-email and renders success on 200", async () => {
+    server.use(
+      msw.get(api("/verify-email"), ({ request }) => {
+        expect(new URL(request.url).searchParams.get("token")).toBe("tok-1")
+        return HttpResponse.json({ message: "Email verified!" })
+      })
+    )
+    renderVerify("/verify-email?token=tok-1")
+    await waitFor(() => expect(screen.getByTestId("verify-success")).toBeInTheDocument())
+    expect(screen.getByTestId("verify-success")).toHaveTextContent(/email verified/i)
+  })
+
+  it("renders the expired state when the server says the link expired", async () => {
+    server.use(
+      msw.get(api("/verify-email"), () =>
+        HttpResponse.json("verification link has expired", { status: 410 })
+      )
+    )
+    renderVerify("/verify-email?token=tok-1")
+    await waitFor(() => expect(screen.getByTestId("verify-expired")).toBeInTheDocument())
+  })
+
+  it("renders the invalid state for any other failure", async () => {
+    server.use(
+      msw.get(api("/verify-email"), () =>
+        HttpResponse.json({ error: "bad token" }, { status: 400 })
+      )
+    )
+    renderVerify("/verify-email?token=tok-1")
+    await waitFor(() => expect(screen.getByTestId("verify-invalid")).toBeInTheDocument())
+  })
+})

--- a/frontend-react/src/test/setup.ts
+++ b/frontend-react/src/test/setup.ts
@@ -28,6 +28,23 @@ if (!window.matchMedia) {
   })
 }
 
+// JSDOM doesn't ship with ResizeObserver either; radix-ui primitives
+// (Checkbox via @radix-ui/react-use-size) call into it during layout.
+// Stub it as a no-op so tests that mount those primitives don't crash.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+if (typeof window.ResizeObserver === "undefined") {
+  ;(window as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub
+}
+if (typeof globalThis.ResizeObserver === "undefined") {
+  ;(globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub
+}
+
 // Boot i18n once for the whole suite. The en bundle is already in memory
 // (statically imported by i18next.config.ts), so this resolves in a single
 // microtask and every useTranslation() in test render returns real strings


### PR DESCRIPTION
Closes #1407 (sub-issue of epic #1397). Builds on #1406 (app shell, merged via #1432) and the data + routing layers (#1403/#1404).

## Summary

Implements every unauthenticated and onboarding-adjacent page on the new React frontend, end-to-end against the existing backend.

- `/login`, `/register`, `/forgot-password`, `/reset-password`, `/verify-email`, `/invite/:token` — public, full-screen auth layout (no shell chrome).
- `/no-group` — under the protected Shell from #1406; onboarding when the user has zero groups.
- React Hook Form + zod schemas mirror the legacy `frontend/src/views/*View.schema.ts` rules; server errors surface inline (not as toasts); submit buttons disable in-flight.
- Shared `AuthLayout` (decorative panel + form column) lifted from the `inventario-design` mock's `AuthView`.
- Invite handoff (#1285) ported from the legacy bundle: an anonymous `/invite/<token>` visit stashes the token in `sessionStorage`, then `/login` and `/register` pick it up and auto-accept post-auth so the user lands inside the joined group.
- `PasswordStrengthMeter` is a length+class-mix heuristic; the real zxcvbn-based scoring stays tracked in #1381.
- `VerifyEmailPage` distinguishes expired vs invalid by inspecting the error body, mirroring the design mock's three states.

## Stub / feature-flag wiring

- 2FA panel (`TwoFactorStub`) renders as a visible "Tracked under #1380" placeholder.
- OAuth row hidden behind `VITE_FEATURE_OAUTH_LOGIN` (real flow is #1394).
- Auth stats teaser hidden behind `VITE_FEATURE_AUTH_STATS_TEASER` (#1390).
- Connected-accounts profile stub (#1395) — not touched here, lives on `/profile` (#1414).

## Drive-by fixes

- `lib/http.ts`: 401 on `/auth/login` (and other `NON_REFRESHABLE_AUTH_PATHS`) now reads the response body and threads it through `HttpError.data`, so pages render the actual server-side reason instead of a generic "Unauthorized". Regression test in `LoginPage.test.tsx`.
- `test/setup.ts`: stub `ResizeObserver` for jsdom (`@radix-ui/react-use-size` needs it; without the stub, the `Checkbox` primitive crashes in tests).
- `i18next.config.ts`: `preservePatterns` extended for the new dynamic-key spaces — `auth:validation.*`, `auth:passwordStrength.*`, `auth:session.*` — that aren't statically extractable.

## Backend endpoints touched (read-only)

- `POST /api/v1/auth/login`
- `POST /api/v1/register`, `GET /api/v1/verify-email`
- `POST /api/v1/forgot-password`, `POST /api/v1/reset-password`
- `GET /api/v1/invites/:token`, `POST /api/v1/invites/:token/accept`

(Issue body referenced `/registration`, `/password-reset/forgot`, etc. — those were aspirational; this PR uses the actual paths from the OpenAPI spec to match what the backend serves today.)

## Files

- `frontend-react/src/pages/auth/{Login,Register,ForgotPassword,ResetPassword,VerifyEmail,InviteAccept}Page.tsx` + tests
- `frontend-react/src/pages/NoGroupPage.tsx`
- `frontend-react/src/components/auth/{AuthLayout,PasswordInput,PasswordStrengthMeter,TwoFactorStub,OAuthRow}.tsx`
- `frontend-react/src/features/auth/{schemas,inviteHandoff,api,hooks}.ts` (extended)
- `frontend-react/src/features/invite/{api,hooks,keys}.ts` (new slice)
- `frontend-react/src/lib/{server-error,feature-flags}.ts`
- `frontend-react/src/components/ui/{alert,badge,checkbox}.tsx` (new shadcn primitives)
- i18n: `auth.json` populated with the full English copy

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (no warnings)
- [x] `npm run format:check` — clean
- [x] `npm test` — 142/142 vitest green, including 6 new page test files + schemas + inviteHandoff + server-error parser
- [x] `npm run build` — clean (no chunk-size regressions)
- [x] Component-level a11y check via `jest-axe` on `LoginPage` + `PasswordStrengthMeter`
- [ ] Playwright e2e for these pages — deferred to #1419 (the e2e port issue) per the routing PR's plan
- [ ] Manual: `INVENTARIO_FRONTEND=new ./inventario run`, walk through login → register → forgot/reset round-trip and an invite-accept flow

## Cross-refs

- Depends on routing (#1404), HTTP layer (#1403), shell (#1406).
- Stub references: #1380 (2FA), #1394 (OAuth), #1390 (auth stats), #1381 (password strength), #1395 (connected accounts).