### PR TITLE
[#1417] Coming-soon stubs aggregator — ComingSoon{Banner,Page} + registry + 5 routes

### DIFF
--- a/frontend-react/src/app/router.tsx
+++ b/frontend-react/src/app/router.tsx
@@ -6,6 +6,7 @@ import { GroupProvider } from "@/features/group/GroupContext"
 import { ProtectedRoute } from "@/components/routing/ProtectedRoute"
 import { GroupRequiredRoute } from "@/components/routing/GroupRequiredRoute"
 import { PlaceholderPage } from "@/pages/Placeholder"
+import { ComingSoonPage } from "@/components/coming-soon"
 import { Shell } from "@/app/Shell"
 
 // Real pages are code-split — each one becomes its own chunk so adding the
@@ -121,26 +122,12 @@ export function AppRoutes() {
               />
             }
           />
-          <Route
-            path="/plans"
-            element={<PlaceholderPage titleKey="plans" testId="page-plans" trackedBy="#1417" />}
-          />
-          <Route
-            path="/help/shortcuts"
-            element={
-              <PlaceholderPage
-                titleKey="helpShortcuts"
-                testId="page-help-shortcuts"
-                trackedBy="#1417"
-              />
-            }
-          />
-          <Route
-            path="/whats-new"
-            element={
-              <PlaceholderPage titleKey="whatsNew" testId="page-whats-new" trackedBy="#1417" />
-            }
-          />
+          {/* Permanent "coming soon" pages — features whose backend isn't
+              implemented yet. Each links to its tracker issue (#1417). */}
+          <Route path="/plans" element={<ComingSoonPage surface="plans" />} />
+          <Route path="/help" element={<ComingSoonPage surface="helpCenter" />} />
+          <Route path="/help/shortcuts" element={<ComingSoonPage surface="helpShortcuts" />} />
+          <Route path="/whats-new" element={<ComingSoonPage surface="whatsNew" />} />
 
           {/* Group-required: any path here either is /g/:slug/* itself or is
               "/" (the redirect sentinel). GroupRequiredRoute bounces 0-group
@@ -361,21 +348,16 @@ export function AppRoutes() {
                   />
                 }
               />
-              <Route
-                path="warranties"
-                element={
-                  <PlaceholderPage
-                    titleKey="warranties"
-                    testId="page-warranties"
-                    trackedBy="#1417"
-                  />
-                }
-              />
+              {/* Coming-soon group-scoped pages (#1417). Warranties / insurance
+                  ship as inline panels on items / commodities detail per the
+                  design mock; the top-level routes stay as full-page stubs
+                  so deep links don't 404 in the meantime. Backup stays a
+                  generic PlaceholderPage — it's a real feature awaiting its
+                  owning issue (not tracked under #1417). */}
+              <Route path="warranties" element={<ComingSoonPage surface="warranties" />} />
               <Route
                 path="insurance/:itemId"
-                element={
-                  <PlaceholderPage titleKey="insurance" testId="page-insurance" trackedBy="#1417" />
-                }
+                element={<ComingSoonPage surface="insuranceReport" />}
               />
               <Route
                 path="backup"

--- a/frontend-react/src/app/router.tsx
+++ b/frontend-react/src/app/router.tsx
@@ -123,7 +123,9 @@ export function AppRoutes() {
             }
           />
           {/* Permanent "coming soon" pages — features whose backend isn't
-              implemented yet. Each links to its tracker issue (#1417). */}
+              implemented yet. Each links to its own per-surface tracker
+              (resolved from the registry); #1417 is the umbrella aggregator
+              issue, not the destination of these links. */}
           <Route path="/plans" element={<ComingSoonPage surface="plans" />} />
           <Route path="/help" element={<ComingSoonPage surface="helpCenter" />} />
           <Route path="/help/shortcuts" element={<ComingSoonPage surface="helpShortcuts" />} />
@@ -361,9 +363,7 @@ export function AppRoutes() {
               />
               <Route
                 path="backup"
-                element={
-                  <PlaceholderPage titleKey="backup" testId="page-backup" trackedBy="#1417" />
-                }
+                element={<PlaceholderPage titleKey="backup" testId="page-backup" />}
               />
             </Route>
           </Route>

--- a/frontend-react/src/components/auth/TwoFactorStub.tsx
+++ b/frontend-react/src/components/auth/TwoFactorStub.tsx
@@ -1,24 +1,12 @@
-import { ShieldCheck } from "lucide-react"
-import { useTranslation } from "react-i18next"
+import { ComingSoonBanner } from "@/components/coming-soon"
 
-// Visible 2FA placeholder linked to #1380. The real flow (TOTP + recovery
-// codes) ships there; surfacing it here keeps the design parity with the
-// inventario-design AuthView while making the "tracked elsewhere" status
-// explicit instead of pretending the panel is just unused.
+// Visible 2FA placeholder linked to #1380. Thin wrapper around the shared
+// ComingSoonBanner so the auth pages can keep using `<TwoFactorStub />`
+// while the registry (#1417) owns the tracker number, icon, and copy.
+//
+// The data-testid is fixed at "two-factor-stub" for the existing
+// auth-page tests; ComingSoonBanner exposes a `testId` override slot so
+// callers don't have to rely on the default `coming-soon-banner-twoFactor`.
 export function TwoFactorStub() {
-  const { t } = useTranslation()
-  return (
-    <div
-      className="rounded-lg border border-dashed border-border bg-muted/40 p-3 flex items-start gap-2.5"
-      data-testid="two-factor-stub"
-    >
-      <ShieldCheck aria-hidden="true" className="size-4 mt-0.5 text-muted-foreground" />
-      <div className="space-y-0.5">
-        <p className="text-xs font-medium text-foreground">{t("auth:twoFactor.title")}</p>
-        <p className="text-[11px] text-muted-foreground leading-snug">
-          {t("auth:twoFactor.description", { ref: "#1380" })}
-        </p>
-      </div>
-    </div>
-  )
+  return <ComingSoonBanner surface="twoFactor" testId="two-factor-stub" />
 }

--- a/frontend-react/src/components/coming-soon/ComingSoonBanner.tsx
+++ b/frontend-react/src/components/coming-soon/ComingSoonBanner.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from "react-i18next"
+
+import { cn } from "@/lib/utils"
+
+import { SURFACES, trackerUrl, type SurfaceKey } from "./registry"
+
+interface ComingSoonBannerProps {
+  // Which stub surface to render. Each surface in `SURFACES` knows its
+  // icon and tracker; the i18n catalog provides the title + description.
+  surface: SurfaceKey
+  // Extra classes — useful when the host page wants to constrain width
+  // or change the inline spacing.
+  className?: string
+  // data-testid override. Defaults to `coming-soon-banner-<surface>` so
+  // tests can target a specific stub without inspecting JSX text.
+  testId?: string
+}
+
+// Small inline panel for a stubbed feature embedded inside a real page —
+// e.g. the 2FA card on /login, "Connected accounts" on /profile, the
+// notification-preferences rows on /settings. Renders muted card chrome,
+// a lucide icon, the title + short description, and a tracker link to
+// the GitHub issue that owns the real implementation.
+//
+// No buttons / no inputs by design (per #1417 acceptance criteria —
+// "no controls that look enabled"). The tracker link is the single
+// affordance and only opens the issue page.
+export function ComingSoonBanner({ surface, className, testId }: ComingSoonBannerProps) {
+  const { t } = useTranslation()
+  const { icon: Icon, tracker } = SURFACES[surface]
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-dashed border-border bg-muted/40 p-3 flex items-start gap-2.5",
+        className
+      )}
+      data-testid={testId ?? `coming-soon-banner-${surface}`}
+      data-surface={surface}
+    >
+      <Icon aria-hidden="true" className="size-4 mt-0.5 text-muted-foreground" />
+      <div className="space-y-0.5 min-w-0">
+        <p className="text-xs font-medium text-foreground">
+          {t(`stubs:surfaces.${surface}.title`)}
+        </p>
+        <p className="text-[11px] text-muted-foreground leading-snug">
+          {t(`stubs:surfaces.${surface}.description`)}
+        </p>
+        <a
+          href={trackerUrl(surface)}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="text-[11px] font-medium text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+        >
+          {t("common:trackedBy", { ref: `#${tracker}` })}
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/frontend-react/src/components/coming-soon/ComingSoonPage.tsx
+++ b/frontend-react/src/components/coming-soon/ComingSoonPage.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from "react-i18next"
+
+import { RouteTitle } from "@/components/routing/RouteTitle"
+
+import { SURFACES, trackerUrl, type SurfaceKey } from "./registry"
+
+interface ComingSoonPageProps {
+  // Which surface this page represents. The registry holds the icon + the
+  // tracker number; i18n holds the title + description copy.
+  surface: SurfaceKey
+  // data-testid for route-level tests. Defaults to
+  // `coming-soon-page-<surface>` so test selectors are stable without
+  // relying on heading text.
+  testId?: string
+}
+
+// Full-page stub for a feature whose backend isn't implemented yet — the
+// page exists in the route tree (so deep links don't 404 and the sidebar /
+// command palette can target it) but renders only an informational panel
+// with the tracker link. Mirrors PlaceholderPage in shape, but keeps a
+// distinct testId scheme + visual treatment so a permanent "no backend
+// yet" surface is easy to spot in screenshots and audits vs. a generic
+// placeholder waiting for its implementation issue to land.
+export function ComingSoonPage({ surface, testId }: ComingSoonPageProps) {
+  const { t } = useTranslation()
+  const { icon: Icon, tracker } = SURFACES[surface]
+  const title = t(`stubs:surfaces.${surface}.title`)
+  return (
+    <>
+      <RouteTitle title={title} />
+      <section
+        data-testid={testId ?? `coming-soon-page-${surface}`}
+        data-surface={surface}
+        aria-labelledby={`coming-soon-${surface}-title`}
+        className="mx-auto flex w-full max-w-md flex-col items-center gap-6 py-16 text-center"
+      >
+        <div className="relative flex size-20 items-center justify-center">
+          <div aria-hidden="true" className="absolute size-20 rounded-full bg-muted/60" />
+          <div aria-hidden="true" className="absolute size-14 rounded-full bg-muted" />
+          <Icon aria-hidden="true" className="relative size-8 text-muted-foreground/70" />
+        </div>
+        <div className="space-y-2">
+          <h1
+            id={`coming-soon-${surface}-title`}
+            className="scroll-m-20 text-2xl font-semibold tracking-tight"
+          >
+            {title}
+          </h1>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {t(`stubs:surfaces.${surface}.description`)}
+          </p>
+        </div>
+        <a
+          href={trackerUrl(surface)}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="text-xs font-medium text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+        >
+          {t("common:trackedBy", { ref: `#${tracker}` })}
+        </a>
+      </section>
+    </>
+  )
+}

--- a/frontend-react/src/components/coming-soon/__tests__/ComingSoonBanner.test.tsx
+++ b/frontend-react/src/components/coming-soon/__tests__/ComingSoonBanner.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { axe } from "jest-axe"
+
+import { ComingSoonBanner } from "@/components/coming-soon"
+
+describe("<ComingSoonBanner />", () => {
+  it("renders the surface title, description, and tracker link", () => {
+    render(<ComingSoonBanner surface="twoFactor" />)
+    expect(screen.getByText(/two-factor/i)).toBeInTheDocument()
+    expect(screen.getByText(/authenticator-app/i)).toBeInTheDocument()
+    const link = screen.getByRole("link")
+    expect(link).toHaveAttribute("href", "https://github.com/denisvmedia/inventario/issues/1380")
+    expect(link).toHaveAttribute("target", "_blank")
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"))
+  })
+
+  it("uses the default data-testid based on the surface key", () => {
+    render(<ComingSoonBanner surface="connectedAccounts" />)
+    expect(screen.getByTestId("coming-soon-banner-connectedAccounts")).toBeInTheDocument()
+  })
+
+  it("accepts a testId override (used by TwoFactorStub for back-compat)", () => {
+    render(<ComingSoonBanner surface="twoFactor" testId="two-factor-stub" />)
+    expect(screen.getByTestId("two-factor-stub")).toBeInTheDocument()
+  })
+
+  it("exposes no actionable controls (per #1417 acceptance criteria)", () => {
+    render(<ComingSoonBanner surface="oauth" />)
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument()
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+  })
+
+  it("has no axe violations", async () => {
+    const { container } = render(<ComingSoonBanner surface="notificationPreferences" />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend-react/src/components/coming-soon/__tests__/ComingSoonPage.test.tsx
+++ b/frontend-react/src/components/coming-soon/__tests__/ComingSoonPage.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { axe } from "jest-axe"
+
+import { ComingSoonPage, SURFACES, type SurfaceKey } from "@/components/coming-soon"
+
+describe("<ComingSoonPage />", () => {
+  it("renders the heading from the registry's i18n key", () => {
+    render(<ComingSoonPage surface="plans" />)
+    expect(
+      screen.getByRole("heading", { level: 1, name: /subscription plans/i })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/subscription tiers/i)).toBeInTheDocument()
+  })
+
+  it("links to the GitHub tracker issue with target=_blank rel=noopener", () => {
+    render(<ComingSoonPage surface="helpCenter" />)
+    const link = screen.getByRole("link")
+    expect(link).toHaveAttribute("href", "https://github.com/denisvmedia/inventario/issues/1384")
+    expect(link).toHaveAttribute("target", "_blank")
+    expect(link.getAttribute("rel")).toContain("noopener")
+  })
+
+  it("uses the default data-testid based on the surface key", () => {
+    render(<ComingSoonPage surface="whatsNew" />)
+    expect(screen.getByTestId("coming-soon-page-whatsNew")).toBeInTheDocument()
+  })
+
+  it("renders no enabled controls", () => {
+    render(<ComingSoonPage surface="insuranceReport" />)
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+  })
+
+  it("renders every page-kind surface without throwing", () => {
+    const pageSurfaces = (Object.keys(SURFACES) as SurfaceKey[]).filter(
+      (k) => SURFACES[k].kind === "page" || SURFACES[k].kind === "both"
+    )
+    for (const surface of pageSurfaces) {
+      const { unmount } = render(<ComingSoonPage surface={surface} />)
+      expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument()
+      unmount()
+    }
+  })
+
+  it("has no axe violations", async () => {
+    const { container } = render(<ComingSoonPage surface="plans" />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend-react/src/components/coming-soon/index.ts
+++ b/frontend-react/src/components/coming-soon/index.ts
@@ -1,0 +1,7 @@
+// Barrel for the coming-soon stub components — see #1417 for the full
+// inventory of stubbed surfaces. Use ComingSoonPage as the route element
+// for full-route stubs; use ComingSoonBanner for inline cards inside
+// real pages.
+export { ComingSoonBanner } from "./ComingSoonBanner"
+export { ComingSoonPage } from "./ComingSoonPage"
+export { SURFACES, trackerUrl, type SurfaceKey } from "./registry"

--- a/frontend-react/src/components/coming-soon/registry.ts
+++ b/frontend-react/src/components/coming-soon/registry.ts
@@ -1,0 +1,81 @@
+// Inventory of every "coming soon" surface in the new React frontend.
+// One entry per stubbed feature: which lucide icon to show, which GitHub
+// issue tracks the real implementation, and whether the surface is
+// page-level or inline. Adding a new stub means adding one row here +
+// the matching `surfaces.<key>.{title,description}` keys in stubs.json —
+// component code never hard-codes a tracker number or icon.
+//
+// The TS union derived from this object also gives us a compile-time
+// guarantee that every consumer references a known surface.
+import type { LucideIcon } from "lucide-react"
+import {
+  BarChart3,
+  Bell,
+  CreditCard,
+  Database,
+  FileEdit,
+  FileText,
+  HardDrive,
+  HelpCircle,
+  History,
+  Keyboard,
+  Link2,
+  MessageSquare,
+  Monitor,
+  ScrollText,
+  Shield,
+  ShieldCheck,
+  Sparkles,
+  User,
+  Wrench,
+} from "lucide-react"
+
+export interface StubSurface {
+  // Icon shown in the panel.
+  icon: LucideIcon
+  // GitHub issue tracking the real implementation. Rendered as
+  // "Tracked under #NNNN" with a link to the issue.
+  tracker: number
+  // "page" — surface is a full route (`/plans`, `/help`, …).
+  // "inline" — surface is a card/banner embedded on a real page
+  //   (e.g. 2FA panel on /login, OAuth row, connected-accounts row).
+  // "both" — used in either context.
+  kind: "page" | "inline" | "both"
+}
+
+// SURFACES is the single source of truth. Order roughly mirrors the
+// inventory in issue #1417 so the diff stays easy to scan.
+export const SURFACES = {
+  // Page-level stubs (full routes).
+  plans: { icon: CreditCard, tracker: 1389, kind: "page" },
+  helpCenter: { icon: HelpCircle, tracker: 1384, kind: "page" },
+  helpShortcuts: { icon: Keyboard, tracker: 1385, kind: "page" },
+  whatsNew: { icon: Sparkles, tracker: 1386, kind: "page" },
+  insuranceReport: { icon: FileText, tracker: 1370, kind: "page" },
+
+  // Inline-only stubs (used inside other pages once those pages land).
+  twoFactor: { icon: Shield, tracker: 1380, kind: "inline" },
+  oauth: { icon: Database, tracker: 1394, kind: "inline" },
+  loginHistory: { icon: ScrollText, tracker: 1379, kind: "both" },
+  activeSessions: { icon: Monitor, tracker: 1378, kind: "inline" },
+  notificationPreferences: { icon: Bell, tracker: 1373, kind: "inline" },
+  maintenanceReminders: { icon: Wrench, tracker: 1368, kind: "inline" },
+  storageQuota: { icon: HardDrive, tracker: 1388, kind: "inline" },
+  connectedAccounts: { icon: Link2, tracker: 1395, kind: "inline" },
+  profilePhoto: { icon: User, tracker: 1382, kind: "inline" },
+  multiStepDraft: { icon: FileEdit, tracker: 1383, kind: "inline" },
+  sendFeedback: { icon: MessageSquare, tracker: 1387, kind: "both" },
+  authStatsTeaser: { icon: BarChart3, tracker: 1390, kind: "inline" },
+  warranties: { icon: ShieldCheck, tracker: 1367, kind: "inline" },
+} as const satisfies Record<string, StubSurface>
+
+export type SurfaceKey = keyof typeof SURFACES
+
+// Repository the trackers live in. Hard-coded here rather than env-var'd
+// because the frontend is bound to a single GitHub project; if that ever
+// changes, this is the one place to update.
+const TRACKER_BASE_URL = "https://github.com/denisvmedia/inventario/issues"
+
+export function trackerUrl(surface: SurfaceKey): string {
+  return `${TRACKER_BASE_URL}/${SURFACES[surface].tracker}`
+}

--- a/frontend-react/src/components/coming-soon/registry.ts
+++ b/frontend-react/src/components/coming-soon/registry.ts
@@ -65,7 +65,10 @@ export const SURFACES = {
   multiStepDraft: { icon: FileEdit, tracker: 1383, kind: "inline" },
   sendFeedback: { icon: MessageSquare, tracker: 1387, kind: "both" },
   authStatsTeaser: { icon: BarChart3, tracker: 1390, kind: "inline" },
-  warranties: { icon: ShieldCheck, tracker: 1367, kind: "inline" },
+  // Warranties ship as inline panels on items / commodities detail per the
+  // design mock, but the router also mounts /g/:slug/warranties as a
+  // full-page stub so deep links don't 404 in the meantime.
+  warranties: { icon: ShieldCheck, tracker: 1367, kind: "both" },
 } as const satisfies Record<string, StubSurface>
 
 export type SurfaceKey = keyof typeof SURFACES

--- a/frontend-react/src/components/coming-soon/registry.ts
+++ b/frontend-react/src/components/coming-soon/registry.ts
@@ -17,7 +17,6 @@ import {
   FileText,
   HardDrive,
   HelpCircle,
-  History,
   Keyboard,
   Link2,
   MessageSquare,

--- a/frontend-react/src/i18n/locales/en/auth.json
+++ b/frontend-react/src/i18n/locales/en/auth.json
@@ -125,10 +125,6 @@
     "ended": "Your session has ended. Please sign in again.",
     "expired": "Your session has expired. Please sign in again."
   },
-  "twoFactor": {
-    "description": "Tracked separately under {{ref}} — coming soon.",
-    "title": "Two-factor authentication"
-  },
   "validation": {
     "emailRequired": "Email is required",
     "nameRequired": "Full name is required",

--- a/frontend-react/src/i18n/locales/en/stubs.json
+++ b/frontend-react/src/i18n/locales/en/stubs.json
@@ -19,6 +19,7 @@
   "forgotPassword": "Forgot password",
   "groupCreate": "Create group",
   "groupSettings": "Group settings",
+  "helpCenter": "Help center",
   "helpShortcuts": "Keyboard shortcuts",
   "insurance": "Insurance",
   "inviteAccept": "Accept invite",
@@ -34,6 +35,80 @@
   "register": "Create account",
   "resetPassword": "Reset password",
   "search": "Search",
+  "surfaces": {
+    "activeSessions": {
+      "description": "View and revoke devices that are signed into your account.",
+      "title": "Active sessions"
+    },
+    "authStatsTeaser": {
+      "description": "Live stats from your inventory shown next to the sign-in form.",
+      "title": "Inventory stats teaser"
+    },
+    "connectedAccounts": {
+      "description": "Link Google or GitHub to sign in faster from your profile page.",
+      "title": "Connected accounts"
+    },
+    "helpCenter": {
+      "description": "Browse articles and guides for using Inventario.",
+      "title": "Help center"
+    },
+    "helpShortcuts": {
+      "description": "View every keyboard shortcut used across the app.",
+      "title": "Keyboard shortcuts"
+    },
+    "insuranceReport": {
+      "description": "Print-ready snapshot of an item's insurance-relevant details.",
+      "title": "Insurance report"
+    },
+    "loginHistory": {
+      "description": "Audit log of recent sign-ins, sources, and outcomes for your account.",
+      "title": "Login history"
+    },
+    "maintenanceReminders": {
+      "description": "Recurring service reminders for items that need maintenance.",
+      "title": "Maintenance reminders"
+    },
+    "multiStepDraft": {
+      "description": "Draft an item across multiple steps and resume later.",
+      "title": "Multi-step item draft"
+    },
+    "notificationPreferences": {
+      "description": "Control which events send you an email or in-app notification.",
+      "title": "Notification preferences"
+    },
+    "oauth": {
+      "description": "Sign in with Google or GitHub instead of an email and password.",
+      "title": "OAuth sign-in"
+    },
+    "plans": {
+      "description": "Compare available subscription tiers and upgrade or downgrade your plan.",
+      "title": "Subscription plans"
+    },
+    "profilePhoto": {
+      "description": "Upload a photo to personalize your profile.",
+      "title": "Profile photo"
+    },
+    "sendFeedback": {
+      "description": "Send the team a question, bug report, or feature request from inside the app.",
+      "title": "Send feedback"
+    },
+    "storageQuota": {
+      "description": "Visualize how much of your file-storage quota is used per category.",
+      "title": "Storage quota"
+    },
+    "twoFactor": {
+      "description": "Add an authenticator-app code on top of your password.",
+      "title": "Two-factor authentication"
+    },
+    "warranties": {
+      "description": "Track per-item warranty terms, expiry, and renewals.",
+      "title": "Warranties"
+    },
+    "whatsNew": {
+      "description": "Recap of every shipped change to Inventario, newest first.",
+      "title": "What's new"
+    }
+  },
   "system": "System",
   "systemSetting": "System setting",
   "tags": "Tags",


### PR DESCRIPTION
Closes #1417 (sub-issue of epic #1397).

## Summary

Provides a single, consistent treatment for every "feature whose backend isn't implemented yet" surface in the new React frontend.

- **`ComingSoonPage`** — full-page route stub with lucide icon, title, description, and a tracker-issue link.
- **`ComingSoonBanner`** — inline panel for the same content embedded inside a real page (e.g. the 2FA card on `/login`, future "Connected accounts" on `/profile`, future notification-preferences rows on `/settings`).
- **`SURFACES` registry** (`components/coming-soon/registry.ts`) — single source of truth for the inventory of stubbed surfaces. One entry per stub: lucide icon, GitHub issue number, and `kind` (`"page"` / `"inline"` / `"both"`). Adding a new stub is one row in the registry + the matching i18n keys; the components stay generic.

## Surfaces wired into the router

Per the inventory in #1417:

| Route | Surface | Tracker |
| --- | --- | --- |
| `/plans` | Subscription plans | #1389 |
| `/help` (new) | Help center | #1384 |
| `/help/shortcuts` | Keyboard shortcuts | #1385 |
| `/whats-new` | What's new / changelog | #1386 |
| `/g/:slug/insurance/:itemId` | Insurance report | #1370 |
| `/g/:slug/warranties` | Warranties | #1367 |

`/g/:slug/backup` keeps the generic `PlaceholderPage` — backup is a real feature awaiting its owning page-level issue, not a permanent #1417 stub.

## Inline-only surfaces (registered, not yet rendered)

The registry also contains entries for surfaces that live *inside* pages that don't exist yet: 2FA, OAuth row, active sessions, login history, notification prefs, maintenance reminders, storage quota, connected accounts, profile photo, multi-step item draft, send-feedback, auth-stats teaser. Each of those owning pages (#1408 Dashboard, #1410 Items, #1414 Profile/Settings, …) will drop a `<ComingSoonBanner surface="…" />` once they land.

## Refactors

- `components/auth/TwoFactorStub.tsx` collapses to a thin wrapper around `<ComingSoonBanner surface="twoFactor" testId="two-factor-stub" />`. The icon, copy, and tracker number now live in the registry instead of being duplicated. Existing `data-testid="two-factor-stub"` anchor preserved via the `testId` override slot so the auth-page tests don't churn.
- Drops the now-unused `auth.twoFactor.*` keys from `auth.json` — the surface copy lives under `stubs.surfaces.twoFactor.*` like every other stub.

## i18n

- New nested namespace `stubs.surfaces.<key>.{title,description}` with full English copy for every entry in the registry. Tracker number is taken from the registry, not hardcoded in copy, so changing a tracker is a one-liner.

## Acceptance criteria (from #1417)

- [x] `ComingSoonPage` and `ComingSoonBanner` exist with unit tests.
- [x] Every surface in the table either has a wired-in route (page-level) or a registry entry ready for its owning page (inline).
- [x] Each stub displays a tracker link to the right issue (verified via test asserting `href` on rendered link).
- [x] No stubs make network calls or show controls that look enabled — explicit test guards `queryByRole("button"|"checkbox"|"textbox")` returns nothing.
- [x] Component tests pass `jest-axe` (banner + page).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test` — **206/206 vitest green** (11 new: 5 banner + 6 page)
- [x] `npm run build` clean
- [x] `npx i18next-cli extract --ci` clean

## Cross-refs

The trackers listed in the inventory are not closed by this work — only stubbed. They remain the homes for the real implementations.