### PR TITLE
[#1414] Frontend-react Profile + Settings pages

### DIFF
--- a/frontend-react/i18next.config.ts
+++ b/frontend-react/i18next.config.ts
@@ -46,12 +46,21 @@ export default defineConfig({
     // `auth:passwordStrength.*` and `auth:session.*` — both use index-table
     //   lookups (`t(STRENGTH_LABELS[score])`, `t(SESSION_REASON_KEY[reason])`)
     //   that the extractor can't statically resolve.
+    // `settings:sections.*`, `settings:appearance.themeOptions.*`,
+    //   `settings:appearance.localeOptions.*`, `settings:help.rows.*` —
+    //   the SettingsPage builds keys from registry maps (theme ids,
+    //   supported languages, section ids, help-row ids), so the extractor
+    //   sees only the template literal and can't enumerate the entries.
     preservePatterns: [
       "stubs:*",
       "common:nav.*",
       "auth:validation.*",
       "auth:passwordStrength.*",
       "auth:session.*",
+      "settings:sections.*",
+      "settings:appearance.themeOptions.*",
+      "settings:appearance.localeOptions.*",
+      "settings:help.rows.*",
     ],
   },
 })

--- a/frontend-react/src/app/router.tsx
+++ b/frontend-react/src/app/router.tsx
@@ -43,6 +43,15 @@ const InviteAcceptPage = lazy(() =>
 const NoGroupPage = lazy(() =>
   import("@/pages/NoGroupPage").then((m) => ({ default: m.NoGroupPage }))
 )
+const ProfilePage = lazy(() =>
+  import("@/pages/ProfilePage").then((m) => ({ default: m.ProfilePage }))
+)
+const EditProfilePage = lazy(() =>
+  import("@/pages/EditProfilePage").then((m) => ({ default: m.EditProfilePage }))
+)
+const SettingsPage = lazy(() =>
+  import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage }))
+)
 
 // AppRoutes is the full route tree for the new React frontend. Most of the
 // pages still mount the shared PlaceholderPage stub: the routing skeleton is
@@ -98,10 +107,9 @@ export function AppRoutes() {
         >
           {/* Group-exempt: a logged-in user with zero groups can still reach these. */}
           <Route path="/no-group" element={<NoGroupPage />} />
-          <Route
-            path="/profile"
-            element={<PlaceholderPage titleKey="profile" testId="page-profile" trackedBy="#1414" />}
-          />
+          <Route path="/profile" element={<ProfilePage />} />
+          <Route path="/profile/edit" element={<EditProfilePage />} />
+          <Route path="/settings" element={<SettingsPage />} />
           <Route
             path="/groups/new"
             element={

--- a/frontend-react/src/components/AppSidebar.tsx
+++ b/frontend-react/src/components/AppSidebar.tsx
@@ -8,6 +8,7 @@ import {
   Package,
   Settings,
   ShieldCheck,
+  SlidersHorizontal,
   Tag,
   User,
   Users,
@@ -115,12 +116,13 @@ const MANAGE: NavEntry[] = [
   },
 ]
 
-// Personal section currently has just Profile; the legacy "Preferences"
-// row pointed at /profile too (same destination as Profile), which made it
-// impossible to reach a distinct preferences screen from the sidebar. The
-// real preferences UI lands with the Settings page (#1414); the entry is
-// re-added there with its own route.
-const PERSONAL: NavEntry[] = [{ labelKey: "common:nav.profile", to: () => "/profile", icon: User }]
+// Personal section: Profile + Preferences. Both routes are group-exempt
+// (mounted under /profile and /settings rather than under /g/:slug/*) so
+// the slug-aware NavEntry.to() returns a constant path.
+const PERSONAL: NavEntry[] = [
+  { labelKey: "common:nav.profile", to: () => "/profile", icon: User },
+  { labelKey: "common:nav.preferences", to: () => "/settings", icon: SlidersHorizontal },
+]
 
 interface NavRowProps {
   entry: NavEntry

--- a/frontend-react/src/components/CommandPalette.tsx
+++ b/frontend-react/src/components/CommandPalette.tsx
@@ -8,6 +8,7 @@ import {
   Search,
   Settings,
   ShieldCheck,
+  SlidersHorizontal,
   Tag,
   User,
   Users,
@@ -83,6 +84,7 @@ const NAVIGATION: PaletteEntry[] = [
     icon: Settings,
   },
   { labelKey: "common:nav.profile", to: () => "/profile", icon: User },
+  { labelKey: "common:nav.preferences", to: () => "/settings", icon: SlidersHorizontal },
 ]
 
 // Translation keys above are full namespace-qualified paths (e.g.

--- a/frontend-react/src/features/auth/api.ts
+++ b/frontend-react/src/features/auth/api.ts
@@ -86,3 +86,32 @@ export async function resetPassword(token: string, newPassword: string): Promise
   })
   return body.message ?? ""
 }
+
+// updateProfile patches the authenticated user's profile. The backend
+// accepts only `name` and `default_group_id` — email is read-only here
+// (changing it requires the verification flow which lives elsewhere).
+//
+// `default_group_id` semantics (#1263): undefined → leave unchanged,
+// null → clear the preference, string → set to that group UUID. The
+// backend validates the membership.
+export interface UpdateProfileRequest {
+  name: string
+  default_group_id?: string | null
+}
+
+export async function updateProfile(req: UpdateProfileRequest): Promise<CurrentUser> {
+  return http.put<CurrentUser>("/auth/me", req)
+}
+
+export interface ChangePasswordRequest {
+  current_password: string
+  new_password: string
+}
+
+// changePassword posts the credentials. On success the backend invalidates
+// every session — the caller is responsible for following up with logout()
+// + redirect to /login so the UI doesn't keep using a now-revoked token.
+export async function changePassword(req: ChangePasswordRequest): Promise<string> {
+  const body = await http.post<MessageResponse>("/auth/change-password", req)
+  return body.message ?? ""
+}

--- a/frontend-react/src/features/auth/hooks.ts
+++ b/frontend-react/src/features/auth/hooks.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { getAccessToken } from "@/lib/auth-storage"
 
 import {
+  changePassword,
   forgotPassword,
   getCurrentUser,
   login,
@@ -10,9 +11,12 @@ import {
   register,
   resendVerification,
   resetPassword,
+  updateProfile,
   verifyEmail,
+  type ChangePasswordRequest,
   type CurrentUser,
   type RegisterRequest,
+  type UpdateProfileRequest,
 } from "./api"
 import { authKeys } from "./keys"
 
@@ -110,5 +114,30 @@ interface ResetPasswordVars {
 export function useResetPassword() {
   return useMutation<string, Error, ResetPasswordVars>({
     mutationFn: ({ token, newPassword }) => resetPassword(token, newPassword),
+  })
+}
+
+// Updates the authenticated user's profile (name + default_group_id).
+// On success we set the new user object directly into the cache so the
+// next /auth/me read short-circuits and consumers see the fresh values
+// immediately, then invalidate the auth namespace so anything tied to
+// the user identity (e.g. RootRedirect's default_group_id) refetches.
+export function useUpdateProfile() {
+  const queryClient = useQueryClient()
+  return useMutation<CurrentUser, Error, UpdateProfileRequest>({
+    mutationFn: (req) => updateProfile(req),
+    onSuccess: (user) => {
+      queryClient.setQueryData(authKeys.currentUser(), user)
+      queryClient.invalidateQueries({ queryKey: authKeys.all })
+    },
+  })
+}
+
+// Changes the user's password. The backend invalidates every active
+// session on success — call sites should treat the resolution as a
+// "you are about to be logged out" cue (sign-out + /login redirect).
+export function useChangePassword() {
+  return useMutation<string, Error, ChangePasswordRequest>({
+    mutationFn: (req) => changePassword(req),
   })
 }

--- a/frontend-react/src/features/auth/schemas.ts
+++ b/frontend-react/src/features/auth/schemas.ts
@@ -54,3 +54,43 @@ export const resetPasswordSchema = z
     }
   })
 export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>
+
+// Edits a logged-in user's profile from /profile/edit. Email is omitted
+// because the backend ignores it on PUT /auth/me. default_group_id is
+// validated against the user's actual memberships at submit time, not
+// here in the schema (zod doesn't know which groups the user belongs
+// to); empty string is mapped to null in the page handler.
+export const profileEditSchema = z.object({
+  name: z.string().min(1, "auth:validation.nameRequired").max(255, "auth:validation.nameTooLong"),
+  defaultGroupId: z.string(),
+})
+export type ProfileEditInput = z.infer<typeof profileEditSchema>
+
+// Cross-field rule on /profile/edit's password card — current required,
+// new required and ≥8 chars (matching the reset-password rule), confirm
+// must match new, and new must differ from current to surface the
+// "this is the same password you already had" mistake without a server
+// round-trip.
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, "auth:validation.passwordRequired"),
+    newPassword: z.string().min(8, "auth:validation.passwordMinLength"),
+    confirmPassword: z.string().min(1, "auth:validation.passwordConfirmRequired"),
+  })
+  .superRefine((value, ctx) => {
+    if (value.newPassword !== value.confirmPassword) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["confirmPassword"],
+        message: "auth:validation.passwordsMismatch",
+      })
+    }
+    if (value.newPassword === value.currentPassword) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["newPassword"],
+        message: "auth:validation.passwordSameAsCurrent",
+      })
+    }
+  })
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>

--- a/frontend-react/src/features/auth/schemas.ts
+++ b/frontend-react/src/features/auth/schemas.ts
@@ -61,7 +61,15 @@ export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>
 // here in the schema (zod doesn't know which groups the user belongs
 // to); empty string is mapped to null in the page handler.
 export const profileEditSchema = z.object({
-  name: z.string().min(1, "auth:validation.nameRequired").max(255, "auth:validation.nameTooLong"),
+  // Trim before validating: a value like "   " would otherwise pass the
+  // .min(1) check, then values.name.trim() would be empty on submit and
+  // the server would reject it. Trimming inside the schema keeps the
+  // client-side check aligned with what's actually sent on the wire.
+  name: z
+    .string()
+    .trim()
+    .min(1, "auth:validation.nameRequired")
+    .max(255, "auth:validation.nameTooLong"),
   defaultGroupId: z.string(),
 })
 export type ProfileEditInput = z.infer<typeof profileEditSchema>

--- a/frontend-react/src/i18n/locales/en/auth.json
+++ b/frontend-react/src/i18n/locales/en/auth.json
@@ -132,6 +132,7 @@
     "passwordConfirmRequired": "Please confirm your password",
     "passwordMinLength": "Password must be at least 8 characters",
     "passwordRequired": "Password is required",
+    "passwordSameAsCurrent": "New password must differ from your current one",
     "passwordsMismatch": "Passwords do not match",
     "termsRequired": "You must accept the Terms of Service to continue"
   },

--- a/frontend-react/src/i18n/locales/en/settings.json
+++ b/frontend-react/src/i18n/locales/en/settings.json
@@ -20,6 +20,11 @@
       "ru": "Русский"
     },
     "themeLabel": "Theme",
+    "themeOptions": {
+      "dark": "Dark",
+      "light": "Light",
+      "system": "System"
+    },
     "title": "Appearance"
   },
   "data": {
@@ -38,6 +43,8 @@
     "rows": {
       "documentation": "Documentation",
       "documentationDescription": "Browse guides and tutorials.",
+      "feedback": "Send feedback",
+      "feedbackDescription": "Help us improve Inventario.",
       "shortcuts": "Keyboard shortcuts",
       "shortcutsDescription": "View every keyboard shortcut used across the app.",
       "whatsNew": "What's new",
@@ -57,6 +64,7 @@
     "defaultGroupHelp": "After login you'll land in this group. Leave blank to fall back to the first group you created or were invited to.",
     "edit": {
       "cancel": "Cancel",
+      "emailReadOnlyHelp": "Email changes aren't available here yet — contact support to update the address on your account.",
       "errorGeneric": "Couldn't save your profile. Please try again.",
       "save": "Save changes",
       "saving": "Saving…",
@@ -86,6 +94,14 @@
     "subtitle": "Your account, identity, and group preferences.",
     "title": "My profile",
     "upgrade": "Upgrade"
+  },
+  "sections": {
+    "account": "Account",
+    "appearance": "Appearance",
+    "data": "Data & storage",
+    "help": "Help & support",
+    "notifications": "Notifications",
+    "privacy": "Privacy & security"
   },
   "signOut": "Sign out",
   "subtitle": "Manage your account and preferences.",

--- a/frontend-react/src/i18n/locales/en/settings.json
+++ b/frontend-react/src/i18n/locales/en/settings.json
@@ -1,1 +1,93 @@
-{}
+{
+  "account": {
+    "changePassword": "Change password",
+    "changePasswordDescription": "Update the password used to sign in to your account.",
+    "displayName": "Display name",
+    "editProfile": "Edit profile",
+    "email": "Email address",
+    "memberSince": "Member since",
+    "memberSinceUnknown": "—",
+    "title": "Account"
+  },
+  "appearance": {
+    "densityHelp": "Compact tightens header controls and listings. Stored on this device.",
+    "densityLabel": "Density",
+    "localeHelp": "Switches every translated string in the app. Stored on this device.",
+    "localeLabel": "Language",
+    "localeOptions": {
+      "cs": "Čeština",
+      "en": "English",
+      "ru": "Русский"
+    },
+    "themeLabel": "Theme",
+    "title": "Appearance"
+  },
+  "data": {
+    "dangerZoneDescription": "Once your account is deleted, all data is permanently removed.",
+    "dangerZoneTitle": "Danger zone",
+    "deleteAccount": "Delete account",
+    "deleteUnavailableConfirm": "Got it",
+    "deleteUnavailableDescription": "Self-service account deletion is on the roadmap. For now, contact support to remove your account.",
+    "deleteUnavailableTitle": "Account deletion is not yet available",
+    "exportCta": "Open exports",
+    "exportDescription": "Generate a JSON or CSV snapshot of your inventory.",
+    "exportTitle": "Export data",
+    "title": "Data & storage"
+  },
+  "help": {
+    "rows": {
+      "documentation": "Documentation",
+      "documentationDescription": "Browse guides and tutorials.",
+      "shortcuts": "Keyboard shortcuts",
+      "shortcutsDescription": "View every keyboard shortcut used across the app.",
+      "whatsNew": "What's new",
+      "whatsNewDescription": "See the latest features and updates."
+    },
+    "title": "Help & support",
+    "version": "Inventario · React rewrite (epic #1397)"
+  },
+  "notifications": {
+    "title": "Notifications"
+  },
+  "privacy": {
+    "title": "Privacy & security"
+  },
+  "profile": {
+    "defaultGroup": "Default group",
+    "defaultGroupHelp": "After login you'll land in this group. Leave blank to fall back to the first group you created or were invited to.",
+    "edit": {
+      "cancel": "Cancel",
+      "errorGeneric": "Couldn't save your profile. Please try again.",
+      "save": "Save changes",
+      "saving": "Saving…",
+      "subtitle": "Update your display name and default group.",
+      "successToast": "Profile saved.",
+      "title": "Edit profile"
+    },
+    "editProfile": "Edit profile",
+    "memberSince": "Member since {{date}}",
+    "noEmail": "No email on file",
+    "noGroupSelection": "No default (use fallback)",
+    "noGroupSet": "No default group set",
+    "password": {
+      "confirmLabel": "Confirm new password",
+      "currentLabel": "Current password",
+      "errorGeneric": "Couldn't change your password. Please try again.",
+      "incorrectCurrent": "Your current password is incorrect.",
+      "newLabel": "New password",
+      "submit": "Change password",
+      "submitting": "Changing…",
+      "subtitle": "Use a strong password you don't use anywhere else.",
+      "successBody": "You'll be signed out so the new password takes effect on every device.",
+      "successTitle": "Password changed",
+      "title": "Change password"
+    },
+    "planFree": "Free plan",
+    "subtitle": "Your account, identity, and group preferences.",
+    "title": "My profile",
+    "upgrade": "Upgrade"
+  },
+  "signOut": "Sign out",
+  "subtitle": "Manage your account and preferences.",
+  "title": "Preferences"
+}

--- a/frontend-react/src/pages/EditProfilePage.tsx
+++ b/frontend-react/src/pages/EditProfilePage.tsx
@@ -108,11 +108,22 @@ export function EditProfilePage() {
       })
       setPasswordSuccess(true)
       // The server invalidated every session — sign out locally and bounce
-      // to /login so the user re-authenticates with the new password.
+      // to /login so the user re-authenticates with the new password. The
+      // logout call is wrapped in a try/finally so a failed POST /auth/logout
+      // (network blip, server error) never strands the user on a "succeeded"
+      // page; navigation to /login fires regardless. Catching the rejection
+      // also keeps it from surfacing as an unhandled promise rejection.
       passwordForm.reset()
-      window.setTimeout(async () => {
-        await logoutMutation.mutateAsync()
-        navigate("/login")
+      window.setTimeout(() => {
+        void (async () => {
+          try {
+            await logoutMutation.mutateAsync()
+          } catch (logoutErr) {
+            console.warn("[EditProfile] Logout after password change failed:", logoutErr)
+          } finally {
+            navigate("/login")
+          }
+        })()
       }, 1500)
     } catch (err) {
       // 422 from the BE means "current password incorrect" — surface a
@@ -193,7 +204,7 @@ export function EditProfilePage() {
               />
             </div>
             <p className="text-[11px] text-muted-foreground">
-              {t("settings:account.email")} — {t("settings:profile.edit.subtitle")}
+              {t("settings:profile.edit.emailReadOnlyHelp")}
             </p>
           </div>
 

--- a/frontend-react/src/pages/EditProfilePage.tsx
+++ b/frontend-react/src/pages/EditProfilePage.tsx
@@ -1,0 +1,359 @@
+import { useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useTranslation } from "react-i18next"
+import { Link, useNavigate } from "react-router-dom"
+import { ArrowLeft, ArrowRight, CheckCircle2, Lock, Mail, User } from "lucide-react"
+
+import { ComingSoonBanner } from "@/components/coming-soon"
+import { PasswordInput } from "@/components/auth/PasswordInput"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useAuth } from "@/features/auth/AuthContext"
+import { useChangePassword, useLogout, useUpdateProfile } from "@/features/auth/hooks"
+import { useGroups } from "@/features/group/hooks"
+import {
+  changePasswordSchema,
+  profileEditSchema,
+  type ChangePasswordInput,
+  type ProfileEditInput,
+} from "@/features/auth/schemas"
+import { useAppToast } from "@/hooks/useAppToast"
+import { HttpError } from "@/lib/http"
+import { parseServerError } from "@/lib/server-error"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+
+// /profile/edit — two side-by-side forms in one page: profile fields
+// (name + default group) + password change. Email is intentionally
+// read-only because the backend ignores it on PUT /auth/me.
+export function EditProfilePage() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const { data: groups } = useGroups()
+  const toast = useAppToast()
+  const updateMutation = useUpdateProfile()
+  const changePasswordMutation = useChangePassword()
+  const logoutMutation = useLogout()
+
+  const [profileError, setProfileError] = useState<string | null>(null)
+  const [passwordError, setPasswordError] = useState<string | null>(null)
+  const [passwordSuccess, setPasswordSuccess] = useState(false)
+
+  const profileForm = useForm<ProfileEditInput>({
+    resolver: zodResolver(profileEditSchema),
+    defaultValues: {
+      name: user?.name ?? "",
+      defaultGroupId: user?.default_group_id ?? "",
+    },
+  })
+
+  const passwordForm = useForm<ChangePasswordInput>({
+    resolver: zodResolver(changePasswordSchema),
+    defaultValues: { currentPassword: "", newPassword: "", confirmPassword: "" },
+  })
+
+  // Sync default values once the auth probe finishes — useForm's defaults
+  // are read once on mount, so a Profile page hard-refresh that races the
+  // /auth/me probe needs an explicit reset.
+  useEffect(() => {
+    if (!user) return
+    profileForm.reset({
+      name: user.name ?? "",
+      defaultGroupId: user.default_group_id ?? "",
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id])
+
+  // Drop stale server errors when the user starts editing again.
+  useEffect(() => {
+    const sub = profileForm.watch(() => {
+      if (profileError) setProfileError(null)
+    })
+    return () => sub.unsubscribe()
+  }, [profileForm, profileError])
+  useEffect(() => {
+    const sub = passwordForm.watch(() => {
+      if (passwordError) setPasswordError(null)
+    })
+    return () => sub.unsubscribe()
+  }, [passwordForm, passwordError])
+
+  async function onProfileSubmit(values: ProfileEditInput) {
+    setProfileError(null)
+    try {
+      await updateMutation.mutateAsync({
+        name: values.name.trim(),
+        // Empty string in the select → null on the wire (clears the
+        // preference); a uuid sets it. Sending undefined would leave the
+        // server-side value untouched, which we don't want — the form is
+        // the source of truth on save.
+        default_group_id: values.defaultGroupId ? values.defaultGroupId : null,
+      })
+      toast.success(t("settings:profile.edit.successToast"))
+      navigate("/profile")
+    } catch (err) {
+      setProfileError(parseServerError(err, t("settings:profile.edit.errorGeneric")))
+    }
+  }
+
+  async function onPasswordSubmit(values: ChangePasswordInput) {
+    setPasswordError(null)
+    try {
+      await changePasswordMutation.mutateAsync({
+        current_password: values.currentPassword,
+        new_password: values.newPassword,
+      })
+      setPasswordSuccess(true)
+      // The server invalidated every session — sign out locally and bounce
+      // to /login so the user re-authenticates with the new password.
+      passwordForm.reset()
+      window.setTimeout(async () => {
+        await logoutMutation.mutateAsync()
+        navigate("/login")
+      }, 1500)
+    } catch (err) {
+      // 422 from the BE means "current password incorrect" — surface a
+      // dedicated message for that path; everything else falls back to
+      // the parsed server message.
+      if (err instanceof HttpError && err.status === 422) {
+        setPasswordError(t("settings:profile.password.incorrectCurrent"))
+        return
+      }
+      setPasswordError(parseServerError(err, t("settings:profile.password.errorGeneric")))
+    }
+  }
+
+  return (
+    <>
+      <RouteTitle title={t("settings:profile.edit.title")} />
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-8" data-testid="edit-profile-page">
+        <div className="space-y-1">
+          <Link
+            to="/profile"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="size-4" aria-hidden="true" />
+            {t("settings:profile.title")}
+          </Link>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {t("settings:profile.edit.title")}
+          </h1>
+          <p className="text-sm text-muted-foreground">{t("settings:profile.edit.subtitle")}</p>
+        </div>
+
+        <ComingSoonBanner surface="profilePhoto" />
+
+        <form
+          className="space-y-4 rounded-xl border border-border bg-card p-5"
+          onSubmit={profileForm.handleSubmit(onProfileSubmit)}
+          noValidate
+        >
+          <div className="space-y-1.5">
+            <Label htmlFor="profile-name">{t("auth:fields.name")}</Label>
+            <div className="relative">
+              <User
+                aria-hidden="true"
+                className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                id="profile-name"
+                autoComplete="name"
+                placeholder={t("auth:fields.namePlaceholder")}
+                className="pl-9"
+                disabled={updateMutation.isPending}
+                aria-invalid={!!profileForm.formState.errors.name}
+                data-testid="profile-name-input"
+                {...profileForm.register("name")}
+              />
+            </div>
+            {profileForm.formState.errors.name ? (
+              <p className="text-xs text-destructive" data-testid="profile-name-error">
+                {t(profileForm.formState.errors.name.message ?? "")}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="profile-email">{t("auth:fields.email")}</Label>
+            <div className="relative">
+              <Mail
+                aria-hidden="true"
+                className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                id="profile-email"
+                type="email"
+                value={user?.email ?? ""}
+                readOnly
+                disabled
+                className="pl-9 opacity-70"
+              />
+            </div>
+            <p className="text-[11px] text-muted-foreground">
+              {t("settings:account.email")} — {t("settings:profile.edit.subtitle")}
+            </p>
+          </div>
+
+          {(groups?.length ?? 0) > 0 ? (
+            <div className="space-y-1.5">
+              <Label htmlFor="profile-default-group">{t("settings:profile.defaultGroup")}</Label>
+              <select
+                id="profile-default-group"
+                disabled={updateMutation.isPending}
+                data-testid="profile-default-group-select"
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+                {...profileForm.register("defaultGroupId")}
+              >
+                <option value="">{t("settings:profile.noGroupSelection")}</option>
+                {groups?.map((g) => (
+                  <option key={g.id} value={g.id}>
+                    {g.name}
+                  </option>
+                ))}
+              </select>
+              <p className="text-[11px] text-muted-foreground">
+                {t("settings:profile.defaultGroupHelp")}
+              </p>
+            </div>
+          ) : null}
+
+          {profileError ? (
+            <Alert variant="destructive" data-testid="profile-server-error">
+              <AlertDescription>{profileError}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button asChild variant="ghost" type="button">
+              <Link to="/profile">{t("settings:profile.edit.cancel")}</Link>
+            </Button>
+            <Button
+              type="submit"
+              className="gap-2"
+              disabled={updateMutation.isPending}
+              data-testid="profile-save"
+            >
+              {updateMutation.isPending
+                ? t("settings:profile.edit.saving")
+                : t("settings:profile.edit.save")}
+              {!updateMutation.isPending ? <ArrowRight className="size-4" /> : null}
+            </Button>
+          </div>
+        </form>
+
+        <form
+          className="space-y-4 rounded-xl border border-border bg-card p-5"
+          onSubmit={passwordForm.handleSubmit(onPasswordSubmit)}
+          noValidate
+          data-testid="change-password-form"
+        >
+          <div className="flex items-start gap-3">
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted/60">
+              <Lock className="size-4 text-muted-foreground" aria-hidden="true" />
+            </div>
+            <div className="space-y-0.5">
+              <h2 className="text-base font-semibold">{t("settings:profile.password.title")}</h2>
+              <p className="text-sm text-muted-foreground">
+                {t("settings:profile.password.subtitle")}
+              </p>
+            </div>
+          </div>
+
+          {passwordSuccess ? (
+            <Alert data-testid="password-change-success">
+              <CheckCircle2 aria-hidden="true" />
+              <AlertDescription>
+                <strong>{t("settings:profile.password.successTitle")}</strong>
+                {" — "}
+                {t("settings:profile.password.successBody")}
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <>
+              <div className="space-y-1.5">
+                <Label htmlFor="current-password">
+                  {t("settings:profile.password.currentLabel")}
+                </Label>
+                <PasswordInput
+                  id="current-password"
+                  autoComplete="current-password"
+                  hideLockIcon
+                  disabled={changePasswordMutation.isPending}
+                  aria-invalid={!!passwordForm.formState.errors.currentPassword}
+                  data-testid="current-password"
+                  {...passwordForm.register("currentPassword")}
+                />
+                {passwordForm.formState.errors.currentPassword ? (
+                  <p className="text-xs text-destructive" data-testid="current-password-error">
+                    {t(passwordForm.formState.errors.currentPassword.message ?? "")}
+                  </p>
+                ) : null}
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="new-password">{t("settings:profile.password.newLabel")}</Label>
+                <PasswordInput
+                  id="new-password"
+                  autoComplete="new-password"
+                  hideLockIcon
+                  disabled={changePasswordMutation.isPending}
+                  aria-invalid={!!passwordForm.formState.errors.newPassword}
+                  data-testid="new-password"
+                  {...passwordForm.register("newPassword")}
+                />
+                {passwordForm.formState.errors.newPassword ? (
+                  <p className="text-xs text-destructive" data-testid="new-password-error">
+                    {t(passwordForm.formState.errors.newPassword.message ?? "")}
+                  </p>
+                ) : null}
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="confirm-password">
+                  {t("settings:profile.password.confirmLabel")}
+                </Label>
+                <PasswordInput
+                  id="confirm-password"
+                  autoComplete="new-password"
+                  hideLockIcon
+                  disabled={changePasswordMutation.isPending}
+                  aria-invalid={!!passwordForm.formState.errors.confirmPassword}
+                  data-testid="confirm-password"
+                  {...passwordForm.register("confirmPassword")}
+                />
+                {passwordForm.formState.errors.confirmPassword ? (
+                  <p className="text-xs text-destructive" data-testid="confirm-password-error">
+                    {t(passwordForm.formState.errors.confirmPassword.message ?? "")}
+                  </p>
+                ) : null}
+              </div>
+
+              {passwordError ? (
+                <Alert variant="destructive" data-testid="password-server-error">
+                  <AlertDescription>{passwordError}</AlertDescription>
+                </Alert>
+              ) : null}
+
+              <div className="flex justify-end pt-2">
+                <Button
+                  type="submit"
+                  variant="destructive"
+                  className="gap-2"
+                  disabled={changePasswordMutation.isPending}
+                  data-testid="change-password-submit"
+                >
+                  {changePasswordMutation.isPending
+                    ? t("settings:profile.password.submitting")
+                    : t("settings:profile.password.submit")}
+                </Button>
+              </div>
+            </>
+          )}
+        </form>
+      </div>
+    </>
+  )
+}

--- a/frontend-react/src/pages/ProfilePage.tsx
+++ b/frontend-react/src/pages/ProfilePage.tsx
@@ -27,7 +27,13 @@ export function ProfilePage() {
   const { user } = useAuth()
   const { data: groups } = useGroups()
 
-  const name = user?.name?.trim() || (user?.email?.split("@")[0] ?? "")
+  // Derived display name. While the /auth/me probe is in flight the
+  // user object is undefined, so this would be the empty string and the
+  // <h1> would render empty — axe flags that as `empty-heading`. We
+  // fall back to "—" so the heading always has a non-empty accessible
+  // name; the real name slots in once the probe resolves.
+  const derivedName = user?.name?.trim() || (user?.email?.split("@")[0] ?? "")
+  const name = derivedName || "—"
   const email = user?.email ?? t("settings:profile.noEmail")
   const memberSince = user?.created_at && formatDate(user.created_at, { style: "long" })
   const defaultGroup =

--- a/frontend-react/src/pages/ProfilePage.tsx
+++ b/frontend-react/src/pages/ProfilePage.tsx
@@ -1,0 +1,145 @@
+import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
+import { Building2, Calendar, Mail, Pencil, Zap } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { ComingSoonBanner } from "@/components/coming-soon"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+import { useAuth } from "@/features/auth/AuthContext"
+import { useGroups } from "@/features/group/hooks"
+import { formatDate } from "@/lib/intl"
+
+// Initials for the avatar fallback. "Alex Johnson" → "AJ", "alex" → "A".
+// We keep at most two letters and fall back to the email's local part if
+// `name` isn't available, then to "?" so the badge never reads as empty.
+function initialsFor(name?: string, email?: string): string {
+  const source = name?.trim() || (email?.split("@")[0] ?? "")
+  if (!source) return "?"
+  const parts = source.split(/\s+/).filter(Boolean)
+  const letters = (parts[0]?.[0] ?? "") + (parts[parts.length - 1]?.[0] ?? "")
+  return (letters || source[0] || "?").toUpperCase().slice(0, 2)
+}
+
+export function ProfilePage() {
+  const { t } = useTranslation()
+  const { user } = useAuth()
+  const { data: groups } = useGroups()
+
+  const name = user?.name?.trim() || (user?.email?.split("@")[0] ?? "")
+  const email = user?.email ?? t("settings:profile.noEmail")
+  const memberSince = user?.created_at && formatDate(user.created_at, { style: "long" })
+  const defaultGroup =
+    user?.default_group_id && groups
+      ? (groups.find((g) => g.id === user.default_group_id) ?? null)
+      : null
+
+  return (
+    <>
+      <RouteTitle title={t("settings:profile.title")} />
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6" data-testid="profile-page">
+        {/* Identity card. Banner + avatar + name + plan badge. The cover
+            stripe pattern is taken from the design mock; the avatar shows
+            initials because uploads are tracked under #1382. */}
+        <section className="rounded-2xl border border-border overflow-hidden">
+          <div className="relative h-24 bg-primary overflow-hidden">
+            <div
+              aria-hidden="true"
+              className="absolute inset-0 opacity-[0.07]"
+              style={{
+                backgroundImage:
+                  "repeating-linear-gradient(-45deg, currentColor 0, currentColor 1px, transparent 1px, transparent 10px)",
+              }}
+            />
+            <Button
+              asChild
+              variant="secondary"
+              size="sm"
+              className="absolute top-3 right-3 gap-1.5 bg-background/80 hover:bg-background/95 backdrop-blur-sm shadow-sm"
+            >
+              <Link to="/profile/edit" data-testid="profile-edit-link">
+                <Pencil className="size-3.5" />
+                {t("settings:profile.editProfile")}
+              </Link>
+            </Button>
+          </div>
+
+          <div className="px-5 pb-5">
+            <div className="flex items-end justify-between -mt-9 mb-3">
+              <div
+                className="flex size-[72px] items-center justify-center rounded-2xl bg-card border-4 border-background text-xl font-bold text-primary shadow-md"
+                aria-hidden="true"
+              >
+                {initialsFor(user?.name, user?.email)}
+              </div>
+              <div className="flex items-center gap-2 mb-1">
+                <Badge variant="outline" className="text-xs font-medium">
+                  {t("settings:profile.planFree")}
+                </Badge>
+                <Button asChild variant="outline" size="sm" className="gap-1.5 h-7 px-2.5 text-xs">
+                  <Link to="/plans" data-testid="profile-upgrade-link">
+                    <Zap className="size-3" />
+                    {t("settings:profile.upgrade")}
+                  </Link>
+                </Button>
+              </div>
+            </div>
+
+            <div className="space-y-0.5 mb-4">
+              <h1 className="text-xl font-bold tracking-tight" data-testid="profile-name">
+                {name}
+              </h1>
+              <p className="text-sm text-muted-foreground" data-testid="profile-email">
+                {email}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-x-4 gap-y-1.5">
+              {memberSince ? (
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Calendar className="size-3.5" aria-hidden="true" />
+                  <span>{t("settings:profile.memberSince", { date: memberSince })}</span>
+                </div>
+              ) : null}
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Building2 className="size-3.5" aria-hidden="true" />
+                <span data-testid="profile-default-group">
+                  {defaultGroup?.name
+                    ? `${t("settings:profile.defaultGroup")}: ${defaultGroup.name}`
+                    : t("settings:profile.noGroupSet")}
+                </span>
+              </div>
+              {email ? (
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Mail className="size-3.5" aria-hidden="true" />
+                  <span>{email}</span>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </section>
+
+        {/* Avatar upload tracker — visible per-section stub linked to #1382.
+            The decorative initials avatar above is the placeholder; this
+            banner is what tells the user uploads are coming. */}
+        <ComingSoonBanner surface="profilePhoto" />
+
+        <Separator />
+
+        <div className="text-sm text-muted-foreground">
+          <p>
+            {t("settings:profile.subtitle")}{" "}
+            <Link
+              to="/settings"
+              className="font-medium text-foreground hover:underline underline-offset-4"
+            >
+              {t("settings:title")}
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend-react/src/pages/SettingsPage.tsx
+++ b/frontend-react/src/pages/SettingsPage.tsx
@@ -1,0 +1,499 @@
+import { useState, type ReactNode } from "react"
+import { useTranslation } from "react-i18next"
+import { Link, useNavigate } from "react-router-dom"
+import {
+  ArrowRight,
+  Bell,
+  Check,
+  ChevronRight,
+  CircleHelp,
+  Database,
+  Download,
+  LogOut,
+  Monitor,
+  Moon,
+  Palette,
+  Shield,
+  Sun,
+  Trash2,
+  User,
+} from "lucide-react"
+
+import { ComingSoonBanner } from "@/components/coming-soon"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { useAuth } from "@/features/auth/AuthContext"
+import { useLogout } from "@/features/auth/hooks"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { useConfirm } from "@/hooks/useConfirm"
+import { useDensity, DENSITIES, type Density } from "@/hooks/useDensity"
+import { useTheme } from "@/components/theme-provider"
+import { i18next, SUPPORTED_LANGUAGES, type SupportedLanguage } from "@/i18n"
+import { formatDate } from "@/lib/intl"
+import { cn } from "@/lib/utils"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+
+type SectionId = "account" | "appearance" | "notifications" | "privacy" | "data" | "help"
+
+interface SectionMeta {
+  id: SectionId
+  // Lucide icon for the nav rail.
+  icon: typeof User
+}
+
+const SECTIONS: SectionMeta[] = [
+  { id: "account", icon: User },
+  { id: "appearance", icon: Palette },
+  { id: "notifications", icon: Bell },
+  { id: "privacy", icon: Shield },
+  { id: "data", icon: Database },
+  { id: "help", icon: CircleHelp },
+]
+
+// SettingsPage — preferences hub. Two-pane layout:
+//   - left rail: section nav + sign-out shortcut
+//   - right pane: the selected section's content
+//
+// Theme / density / locale persist to localStorage via the existing
+// providers and i18next detection cache; they don't round-trip to the
+// backend on this page (system-wide /settings is a separate admin scope
+// owned by the System view).
+export function SettingsPage() {
+  const { t } = useTranslation()
+  const [active, setActive] = useState<SectionId>("appearance")
+
+  return (
+    <>
+      <RouteTitle title={t("settings:title")} />
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-8" data-testid="settings-page">
+        <header className="space-y-1">
+          <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">
+            {t("settings:title")}
+          </h1>
+          <p className="text-sm text-muted-foreground">{t("settings:subtitle")}</p>
+        </header>
+
+        <div className="flex flex-col gap-6 md:flex-row">
+          <SettingsNav active={active} onSelect={setActive} />
+          <div className="min-w-0 flex-1">
+            {active === "account" ? <AccountSection /> : null}
+            {active === "appearance" ? <AppearanceSection /> : null}
+            {active === "notifications" ? <NotificationsSection /> : null}
+            {active === "privacy" ? <PrivacySection /> : null}
+            {active === "data" ? <DataSection /> : null}
+            {active === "help" ? <HelpSection /> : null}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+function SettingsNav({
+  active,
+  onSelect,
+}: {
+  active: SectionId
+  onSelect: (id: SectionId) => void
+}) {
+  const { t } = useTranslation()
+  const logoutMutation = useLogout()
+  const navigate = useNavigate()
+
+  async function handleSignOut() {
+    try {
+      await logoutMutation.mutateAsync()
+    } finally {
+      navigate("/login")
+    }
+  }
+
+  return (
+    <aside className="md:w-48 md:shrink-0">
+      <nav className="space-y-0.5" aria-label={t("settings:title")}>
+        {SECTIONS.map(({ id, icon: Icon }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onSelect(id)}
+            data-testid={`settings-nav-${id}`}
+            data-active={active === id ? "true" : undefined}
+            className={cn(
+              "flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors",
+              active === id
+                ? "bg-accent text-accent-foreground font-medium"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground"
+            )}
+            aria-current={active === id ? "page" : undefined}
+          >
+            <Icon className="size-4 shrink-0" aria-hidden="true" />
+            {t(`settings:sections.${id}`)}
+            {active === id ? (
+              <ChevronRight className="ml-auto size-3.5" aria-hidden="true" />
+            ) : null}
+          </button>
+        ))}
+        <Separator className="my-2" />
+        <button
+          type="button"
+          onClick={handleSignOut}
+          disabled={logoutMutation.isPending}
+          data-testid="settings-sign-out"
+          className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
+        >
+          <LogOut className="size-4 shrink-0" aria-hidden="true" />
+          {t("settings:signOut")}
+        </button>
+      </nav>
+    </aside>
+  )
+}
+
+function SectionTitle({ children }: { children: ReactNode }) {
+  return <h2 className="mb-4 text-base font-semibold">{children}</h2>
+}
+
+function SettingRow({
+  label,
+  description,
+  children,
+}: {
+  label: string
+  description?: string
+  children: ReactNode
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-3.5">
+      <div className="min-w-0">
+        <p className="text-sm font-medium">{label}</p>
+        {description ? (
+          <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  )
+}
+
+function AccountSection() {
+  const { t } = useTranslation()
+  const { user } = useAuth()
+  const { groups, currentGroup } = useCurrentGroup()
+  const memberSince = user?.created_at
+    ? formatDate(user.created_at, { style: "long" })
+    : t("settings:account.memberSinceUnknown")
+
+  // Show the group the user is currently looking at (URL slug) — falls
+  // back to "no default" if Settings is reached from a non-group route.
+  const groupLabel =
+    currentGroup?.name ??
+    (user?.default_group_id
+      ? (groups?.find((g) => g.id === user.default_group_id)?.name ?? "—")
+      : t("settings:profile.noGroupSelection"))
+
+  return (
+    <div className="space-y-6" data-testid="section-account">
+      <SectionTitle>{t("settings:account.title")}</SectionTitle>
+
+      <div className="rounded-xl border border-border bg-card p-4">
+        <div className="flex items-center gap-4">
+          <div
+            className="flex size-12 items-center justify-center rounded-full bg-primary text-base font-semibold text-primary-foreground"
+            aria-hidden="true"
+          >
+            {(user?.name?.[0] ?? user?.email?.[0] ?? "?").toUpperCase()}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-semibold">{user?.name ?? "—"}</p>
+            <p className="truncate text-sm text-muted-foreground">{user?.email ?? "—"}</p>
+            <Badge variant="secondary" className="mt-1 text-xs">
+              {t("settings:profile.planFree")}
+            </Badge>
+          </div>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/profile/edit" data-testid="settings-edit-profile">
+              {t("settings:account.editProfile")}
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="divide-y divide-border">
+        <SettingRow label={t("settings:account.displayName")}>
+          <span className="text-sm text-muted-foreground">{user?.name ?? "—"}</span>
+        </SettingRow>
+        <SettingRow label={t("settings:account.email")}>
+          <span className="text-sm text-muted-foreground">{user?.email ?? "—"}</span>
+        </SettingRow>
+        <SettingRow label={t("settings:profile.defaultGroup")}>
+          <span className="text-sm text-muted-foreground">{groupLabel}</span>
+        </SettingRow>
+        <SettingRow label={t("settings:account.memberSince")}>
+          <span className="text-sm text-muted-foreground">{memberSince}</span>
+        </SettingRow>
+        <SettingRow
+          label={t("settings:account.changePassword")}
+          description={t("settings:account.changePasswordDescription")}
+        >
+          <Button asChild variant="outline" size="sm">
+            <Link to="/profile/edit" data-testid="settings-change-password">
+              {t("settings:profile.password.title")}
+            </Link>
+          </Button>
+        </SettingRow>
+      </div>
+    </div>
+  )
+}
+
+function AppearanceSection() {
+  const { t, i18n } = useTranslation()
+  const { theme, setTheme } = useTheme()
+  const { density, setDensity } = useDensity()
+
+  const THEMES = [
+    { id: "system" as const, icon: Monitor },
+    { id: "light" as const, icon: Sun },
+    { id: "dark" as const, icon: Moon },
+  ]
+
+  const currentLanguage = (i18n.resolvedLanguage ?? "en") as SupportedLanguage
+
+  return (
+    <div className="space-y-6" data-testid="section-appearance">
+      <SectionTitle>{t("settings:appearance.title")}</SectionTitle>
+
+      <div>
+        <p className="mb-3 text-sm font-medium">{t("settings:appearance.themeLabel")}</p>
+        <div className="grid grid-cols-3 gap-3" role="radiogroup">
+          {THEMES.map(({ id, icon: Icon }) => (
+            <button
+              key={id}
+              type="button"
+              role="radio"
+              aria-checked={theme === id}
+              onClick={() => setTheme(id)}
+              data-testid={`theme-${id}`}
+              className={cn(
+                "flex flex-col items-center gap-2 rounded-xl border-2 p-4 transition-all",
+                theme === id
+                  ? "border-primary bg-primary/5"
+                  : "border-border hover:border-muted-foreground/40"
+              )}
+            >
+              <Icon
+                className={cn("size-5", theme === id ? "text-primary" : "text-muted-foreground")}
+                aria-hidden="true"
+              />
+              <span
+                className={cn(
+                  "text-xs font-medium",
+                  theme === id ? "text-primary" : "text-muted-foreground"
+                )}
+              >
+                {t(`settings:appearance.themeOptions.${id}`)}
+              </span>
+              {theme === id ? (
+                <span className="flex size-4 items-center justify-center rounded-full bg-primary">
+                  <Check className="size-2.5 text-primary-foreground" aria-hidden="true" />
+                </span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="divide-y divide-border">
+        <SettingRow
+          label={t("settings:appearance.densityLabel")}
+          description={t("settings:appearance.densityHelp")}
+        >
+          <select
+            value={density}
+            onChange={(e) => setDensity(e.target.value as Density)}
+            data-testid="density-select"
+            aria-label={t("settings:appearance.densityLabel")}
+            className="h-8 rounded-md border border-input bg-background px-2.5 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          >
+            {DENSITIES.map((d) => (
+              <option key={d} value={d}>
+                {t(`common:shell.density${d.charAt(0).toUpperCase()}${d.slice(1)}`)}
+              </option>
+            ))}
+          </select>
+        </SettingRow>
+
+        <SettingRow
+          label={t("settings:appearance.localeLabel")}
+          description={t("settings:appearance.localeHelp")}
+        >
+          <select
+            value={currentLanguage}
+            onChange={(e) => {
+              const next = e.target.value as SupportedLanguage
+              // i18next-browser-languagedetector caches to localStorage at
+              // key "inventario-language" — calling changeLanguage triggers
+              // that cache write, so reload picks the new locale up.
+              void i18next.changeLanguage(next)
+            }}
+            data-testid="locale-select"
+            aria-label={t("settings:appearance.localeLabel")}
+            className="h-8 rounded-md border border-input bg-background px-2.5 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          >
+            {SUPPORTED_LANGUAGES.map((lng) => (
+              <option key={lng} value={lng}>
+                {t(`settings:appearance.localeOptions.${lng}`)}
+              </option>
+            ))}
+          </select>
+        </SettingRow>
+      </div>
+    </div>
+  )
+}
+
+function NotificationsSection() {
+  const { t } = useTranslation()
+  return (
+    <div className="space-y-4" data-testid="section-notifications">
+      <SectionTitle>{t("settings:notifications.title")}</SectionTitle>
+      <ComingSoonBanner surface="notificationPreferences" />
+      <ComingSoonBanner surface="maintenanceReminders" />
+    </div>
+  )
+}
+
+function PrivacySection() {
+  const { t } = useTranslation()
+  return (
+    <div className="space-y-4" data-testid="section-privacy">
+      <SectionTitle>{t("settings:privacy.title")}</SectionTitle>
+      <ComingSoonBanner surface="twoFactor" />
+      <ComingSoonBanner surface="activeSessions" />
+      <ComingSoonBanner surface="loginHistory" />
+      <ComingSoonBanner surface="connectedAccounts" />
+    </div>
+  )
+}
+
+function DataSection() {
+  const { t } = useTranslation()
+  const { currentGroup } = useCurrentGroup()
+  const confirm = useConfirm()
+
+  // Account deletion isn't backend-supported yet; render a danger-zone
+  // panel that opens a confirm dialog explaining the limitation rather
+  // than fake a destructive action that does nothing.
+  async function handleDeleteAccount() {
+    await confirm({
+      title: t("settings:data.deleteUnavailableTitle"),
+      description: t("settings:data.deleteUnavailableDescription"),
+      confirmLabel: t("settings:data.deleteUnavailableConfirm"),
+      cancelLabel: t("settings:profile.edit.cancel"),
+      destructive: false,
+    })
+  }
+
+  return (
+    <div className="space-y-6" data-testid="section-data">
+      <SectionTitle>{t("settings:data.title")}</SectionTitle>
+
+      <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+        <div>
+          <p className="text-sm font-medium">{t("settings:data.exportTitle")}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {t("settings:data.exportDescription")}
+          </p>
+        </div>
+        {currentGroup?.slug ? (
+          <Button asChild size="sm" variant="outline" className="gap-1.5">
+            <Link
+              to={`/g/${encodeURIComponent(currentGroup.slug)}/exports`}
+              data-testid="settings-open-exports"
+            >
+              <Download className="size-3.5" aria-hidden="true" />
+              {t("settings:data.exportCta")}
+            </Link>
+          </Button>
+        ) : (
+          <p className="text-xs text-muted-foreground">{t("settings:profile.noGroupSet")}</p>
+        )}
+      </div>
+
+      <ComingSoonBanner surface="storageQuota" />
+
+      <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 space-y-2">
+        <p className="text-sm font-semibold text-destructive">
+          {t("settings:data.dangerZoneTitle")}
+        </p>
+        <p className="text-xs text-muted-foreground">{t("settings:data.dangerZoneDescription")}</p>
+        <Button
+          variant="outline"
+          size="sm"
+          className="text-destructive border-destructive/40 hover:bg-destructive/10 gap-1.5"
+          onClick={handleDeleteAccount}
+          data-testid="delete-account-button"
+        >
+          <Trash2 className="size-3.5" aria-hidden="true" />
+          {t("settings:data.deleteAccount")}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function HelpSection() {
+  const { t } = useTranslation()
+
+  // All four rows are stubs today: docs (#1384), shortcuts (#1385),
+  // what's new (#1386), feedback (#1387). Real destinations behind each
+  // route are ComingSoonPage already; this section mostly acts as a
+  // discovery aid + a place for #1387 to grow into a real form later.
+  type HelpRowKey = "documentation" | "shortcuts" | "whatsNew" | "feedback"
+  const rows: Array<{ key: HelpRowKey; href: string | null }> = [
+    { key: "documentation", href: "/help" },
+    { key: "shortcuts", href: "/help/shortcuts" },
+    { key: "whatsNew", href: "/whats-new" },
+    { key: "feedback", href: null },
+  ]
+
+  return (
+    <div className="space-y-4" data-testid="section-help">
+      <SectionTitle>{t("settings:help.title")}</SectionTitle>
+      <div className="rounded-xl border border-border divide-y divide-border">
+        {rows.map(({ key, href }) => {
+          if (!href) {
+            return (
+              <div key={key} className="p-4">
+                <ComingSoonBanner surface="sendFeedback" />
+              </div>
+            )
+          }
+          const labelKey = key as "documentation" | "shortcuts" | "whatsNew"
+          return (
+            <Link
+              key={key}
+              to={href}
+              data-testid={`help-row-${key}`}
+              className="flex items-center justify-between p-4 text-left transition-colors hover:bg-muted/50"
+            >
+              <div>
+                <p className="text-sm font-medium">{t(`settings:help.rows.${labelKey}`)}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  {t(`settings:help.rows.${labelKey}Description`)}
+                </p>
+              </div>
+              <ArrowRight className="size-4 text-muted-foreground" aria-hidden="true" />
+            </Link>
+          )
+        })}
+      </div>
+      <p className="text-center text-xs text-muted-foreground">{t("settings:help.version")}</p>
+    </div>
+  )
+}

--- a/frontend-react/src/pages/__tests__/EditProfilePage.test.tsx
+++ b/frontend-react/src/pages/__tests__/EditProfilePage.test.tsx
@@ -123,6 +123,13 @@ describe("<EditProfilePage />", () => {
   })
 
   it("posts a successful password change and triggers logout flow", async () => {
+    // Tried Vitest fake timers here per Copilot review feedback to skip
+    // the page's 1500ms post-success delay; both `vi.useFakeTimers()` up
+    // front and a "switch after form interactions" variant deadlocked
+    // because userEvent + RTL's waitFor + msw rely on real microtask
+    // scheduling. Real timers + a 3s waitFor budget is the working
+    // compromise: 1.5s page delay + ~200ms test overhead, well inside
+    // the per-test 5s budget.
     let logoutCalls = 0
     server.use(
       ...baseUserHandlers,
@@ -141,8 +148,6 @@ describe("<EditProfilePage />", () => {
     await user.type(screen.getByTestId("confirm-password"), "new-secure-pw-1")
     await user.click(screen.getByTestId("change-password-submit"))
     await waitFor(() => expect(screen.getByTestId("password-change-success")).toBeInTheDocument())
-    // Logout fires after a 1500ms timeout — bail out of the test if it
-    // doesn't fire within 3s rather than blocking forever.
     await waitFor(() => expect(logoutCalls).toBe(1), { timeout: 3000 })
   })
 

--- a/frontend-react/src/pages/__tests__/EditProfilePage.test.tsx
+++ b/frontend-react/src/pages/__tests__/EditProfilePage.test.tsx
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route, useLocation } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { EditProfilePage } from "@/pages/EditProfilePage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { ConfirmProvider } from "@/hooks/useConfirm"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="loc" data-pathname={loc.pathname} />
+}
+
+function renderEdit() {
+  setAccessToken("good-token")
+  return renderWithProviders({
+    initialPath: "/profile/edit",
+    routes: (
+      <>
+        <Route
+          path="/profile/edit"
+          element={
+            <AuthProvider>
+              <GroupProvider>
+                <ConfirmProvider>
+                  <EditProfilePage />
+                </ConfirmProvider>
+              </GroupProvider>
+            </AuthProvider>
+          }
+        />
+        <Route path="*" element={<LocationProbe />} />
+      </>
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+const baseUserHandlers = [
+  msw.get(api("/auth/me"), () =>
+    HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+  ),
+  msw.get(api("/groups"), () => HttpResponse.json({ data: [] })),
+]
+
+describe("<EditProfilePage />", () => {
+  it("validates name is required and ≤255 chars", async () => {
+    server.use(...baseUserHandlers)
+    const user = userEvent.setup()
+    renderEdit()
+    // Wait for the form's reset effect to run after the auth probe
+    // resolves — otherwise user.clear() races the reset and the field
+    // is repopulated with the user's name after we cleared it.
+    const nameInput = (await screen.findByTestId("profile-name-input")) as HTMLInputElement
+    await waitFor(() => expect(nameInput).toHaveValue("Alex"))
+    await user.clear(nameInput)
+    await user.click(screen.getByTestId("profile-save"))
+    expect(await screen.findByTestId("profile-name-error")).toBeInTheDocument()
+  })
+
+  it("submits name + default_group_id and navigates back to /profile", async () => {
+    let captured: { name: string; default_group_id: string | null } | null = null
+    server.use(
+      ...baseUserHandlers,
+      msw.put(api("/auth/me"), async ({ request }) => {
+        captured = (await request.json()) as typeof captured
+        return HttpResponse.json({
+          id: "u1",
+          email: "alex@example.com",
+          name: captured?.name,
+          default_group_id: captured?.default_group_id ?? undefined,
+        })
+      })
+    )
+    const user = userEvent.setup()
+    renderEdit()
+    const nameInput = (await screen.findByTestId("profile-name-input")) as HTMLInputElement
+    await waitFor(() => expect(nameInput).toHaveValue("Alex"))
+    await user.clear(nameInput)
+    await user.type(nameInput, "Alex 2")
+    await user.click(screen.getByTestId("profile-save"))
+    await waitFor(() =>
+      expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/profile")
+    )
+    expect(captured).toEqual({ name: "Alex 2", default_group_id: null })
+  })
+
+  it("password form rejects mismatched confirmation", async () => {
+    server.use(...baseUserHandlers)
+    const user = userEvent.setup()
+    renderEdit()
+    await user.type(await screen.findByTestId("current-password"), "old-pw-1")
+    await user.type(screen.getByTestId("new-password"), "newer-pw-1")
+    await user.type(screen.getByTestId("confirm-password"), "different1")
+    await user.click(screen.getByTestId("change-password-submit"))
+    expect(await screen.findByTestId("confirm-password-error")).toHaveTextContent(/match/i)
+  })
+
+  it("password form rejects when new === current", async () => {
+    server.use(...baseUserHandlers)
+    const user = userEvent.setup()
+    renderEdit()
+    await user.type(await screen.findByTestId("current-password"), "samepass1")
+    await user.type(screen.getByTestId("new-password"), "samepass1")
+    await user.type(screen.getByTestId("confirm-password"), "samepass1")
+    await user.click(screen.getByTestId("change-password-submit"))
+    expect(await screen.findByTestId("new-password-error")).toHaveTextContent(/differ/i)
+  })
+
+  it("posts a successful password change and triggers logout flow", async () => {
+    let logoutCalls = 0
+    server.use(
+      ...baseUserHandlers,
+      msw.post(api("/auth/change-password"), () =>
+        HttpResponse.json({ message: "Password changed" })
+      ),
+      msw.post(api("/auth/logout"), () => {
+        logoutCalls++
+        return new HttpResponse(null, { status: 204 })
+      })
+    )
+    const user = userEvent.setup()
+    renderEdit()
+    await user.type(await screen.findByTestId("current-password"), "old-pw-1")
+    await user.type(screen.getByTestId("new-password"), "new-secure-pw-1")
+    await user.type(screen.getByTestId("confirm-password"), "new-secure-pw-1")
+    await user.click(screen.getByTestId("change-password-submit"))
+    await waitFor(() => expect(screen.getByTestId("password-change-success")).toBeInTheDocument())
+    // Logout fires after a 1500ms timeout — bail out of the test if it
+    // doesn't fire within 3s rather than blocking forever.
+    await waitFor(() => expect(logoutCalls).toBe(1), { timeout: 3000 })
+  })
+
+  it("surfaces 'incorrect current password' on 422", async () => {
+    server.use(
+      ...baseUserHandlers,
+      msw.post(api("/auth/change-password"), () =>
+        HttpResponse.json({ error: "wrong" }, { status: 422 })
+      )
+    )
+    const user = userEvent.setup()
+    renderEdit()
+    await user.type(await screen.findByTestId("current-password"), "old-pw-1")
+    await user.type(screen.getByTestId("new-password"), "new-secure-pw-1")
+    await user.type(screen.getByTestId("confirm-password"), "new-secure-pw-1")
+    await user.click(screen.getByTestId("change-password-submit"))
+    expect(await screen.findByTestId("password-server-error")).toHaveTextContent(
+      /current password is incorrect/i
+    )
+  })
+})

--- a/frontend-react/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend-react/src/pages/__tests__/ProfilePage.test.tsx
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+import { axe } from "jest-axe"
+
+import { ProfilePage } from "@/pages/ProfilePage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+function renderProfile() {
+  setAccessToken("good-token")
+  return renderWithProviders({
+    initialPath: "/profile",
+    routes: (
+      <Route
+        path="/profile"
+        element={
+          <AuthProvider>
+            <GroupProvider>
+              <ProfilePage />
+            </GroupProvider>
+          </AuthProvider>
+        }
+      />
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<ProfilePage />", () => {
+  it("renders the user's name, email, and member-since", async () => {
+    server.use(
+      msw.get(api("/auth/me"), () =>
+        HttpResponse.json({
+          id: "u1",
+          email: "alex@example.com",
+          name: "Alex Johnson",
+          created_at: "2024-01-15T10:00:00Z",
+          default_group_id: "g1",
+        })
+      ),
+      msw.get(api("/groups"), () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "g1",
+              type: "groups",
+              attributes: { id: "g1", slug: "household", name: "Household" },
+            },
+          ],
+        })
+      )
+    )
+    renderProfile()
+    await waitFor(() =>
+      expect(screen.getByTestId("profile-name")).toHaveTextContent("Alex Johnson")
+    )
+    expect(screen.getByTestId("profile-email")).toHaveTextContent("alex@example.com")
+    expect(screen.getByTestId("profile-default-group")).toHaveTextContent("Household")
+  })
+
+  it("falls back to 'no group set' when default_group_id is unset", async () => {
+    server.use(
+      msw.get(api("/auth/me"), () =>
+        HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+      ),
+      msw.get(api("/groups"), () => HttpResponse.json({ data: [] }))
+    )
+    renderProfile()
+    await waitFor(() =>
+      expect(screen.getByTestId("profile-default-group")).toHaveTextContent(/no default group/i)
+    )
+  })
+
+  it("links to /profile/edit and /plans", async () => {
+    server.use(
+      msw.get(api("/auth/me"), () =>
+        HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+      ),
+      msw.get(api("/groups"), () => HttpResponse.json({ data: [] }))
+    )
+    renderProfile()
+    await waitFor(() => expect(screen.getByTestId("profile-edit-link")).toBeInTheDocument())
+    expect(screen.getByTestId("profile-edit-link")).toHaveAttribute("href", "/profile/edit")
+    expect(screen.getByTestId("profile-upgrade-link")).toHaveAttribute("href", "/plans")
+  })
+
+  it("has no axe violations", async () => {
+    server.use(
+      msw.get(api("/auth/me"), () =>
+        HttpResponse.json({
+          id: "u1",
+          email: "alex@example.com",
+          name: "Alex Johnson",
+          created_at: "2024-01-15T10:00:00Z",
+        })
+      ),
+      msw.get(api("/groups"), () => HttpResponse.json({ data: [] }))
+    )
+    const { container } = renderProfile()
+    // Wait for the heading to populate — axe flags an empty h1, and the
+    // h1 mounts before /auth/me resolves so a bare in-document check
+    // races the empty-heading window.
+    await waitFor(() =>
+      expect(screen.getByTestId("profile-name")).toHaveTextContent("Alex Johnson")
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend-react/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend-react/src/pages/__tests__/SettingsPage.test.tsx
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route, useLocation } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { axe } from "jest-axe"
+
+import { SettingsPage } from "@/pages/SettingsPage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { ThemeProvider } from "@/components/theme-provider"
+import { DensityProvider } from "@/hooks/useDensity"
+import { ConfirmProvider } from "@/hooks/useConfirm"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="loc" data-pathname={loc.pathname} />
+}
+
+function renderSettings() {
+  setAccessToken("good-token")
+  return renderWithProviders({
+    initialPath: "/settings",
+    routes: (
+      <>
+        <Route
+          path="/settings"
+          element={
+            <ThemeProvider defaultTheme="system" storageKey="theme-test-1414">
+              <DensityProvider defaultDensity="comfortable" storageKey="density-test-1414">
+                <AuthProvider>
+                  <GroupProvider>
+                    <ConfirmProvider>
+                      <SettingsPage />
+                    </ConfirmProvider>
+                  </GroupProvider>
+                </AuthProvider>
+              </DensityProvider>
+            </ThemeProvider>
+          }
+        />
+        <Route path="*" element={<LocationProbe />} />
+      </>
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  // Wipe persistence so the test starts from defaults each time.
+  localStorage.removeItem("theme-test-1414")
+  localStorage.removeItem("density-test-1414")
+})
+
+const baseHandlers = [
+  msw.get(api("/auth/me"), () =>
+    HttpResponse.json({
+      id: "u1",
+      email: "alex@example.com",
+      name: "Alex",
+      created_at: "2024-01-15T00:00:00Z",
+    })
+  ),
+  msw.get(api("/groups"), () => HttpResponse.json({ data: [] })),
+]
+
+describe("<SettingsPage />", () => {
+  it("renders the section nav with all 6 entries", async () => {
+    server.use(...baseHandlers)
+    renderSettings()
+    expect(await screen.findByTestId("settings-nav-account")).toBeInTheDocument()
+    expect(screen.getByTestId("settings-nav-appearance")).toBeInTheDocument()
+    expect(screen.getByTestId("settings-nav-notifications")).toBeInTheDocument()
+    expect(screen.getByTestId("settings-nav-privacy")).toBeInTheDocument()
+    expect(screen.getByTestId("settings-nav-data")).toBeInTheDocument()
+    expect(screen.getByTestId("settings-nav-help")).toBeInTheDocument()
+  })
+
+  it("appearance section is the default and shows theme/density/locale controls", async () => {
+    server.use(...baseHandlers)
+    renderSettings()
+    expect(await screen.findByTestId("section-appearance")).toBeInTheDocument()
+    expect(screen.getByTestId("theme-system")).toBeInTheDocument()
+    expect(screen.getByTestId("theme-light")).toBeInTheDocument()
+    expect(screen.getByTestId("theme-dark")).toBeInTheDocument()
+    expect(screen.getByTestId("density-select")).toBeInTheDocument()
+    expect(screen.getByTestId("locale-select")).toBeInTheDocument()
+  })
+
+  it("clicking a theme card persists the choice to localStorage", async () => {
+    server.use(...baseHandlers)
+    const user = userEvent.setup()
+    renderSettings()
+    await user.click(await screen.findByTestId("theme-dark"))
+    await waitFor(() => expect(localStorage.getItem("theme-test-1414")).toBe("dark"))
+  })
+
+  it("changing density persists via the provider", async () => {
+    server.use(...baseHandlers)
+    const user = userEvent.setup()
+    renderSettings()
+    const select = await screen.findByTestId("density-select")
+    await user.selectOptions(select, "compact")
+    await waitFor(() => expect(localStorage.getItem("density-test-1414")).toBe("compact"))
+  })
+
+  it("privacy section renders four ComingSoonBanner stubs", async () => {
+    server.use(...baseHandlers)
+    const user = userEvent.setup()
+    renderSettings()
+    await user.click(await screen.findByTestId("settings-nav-privacy"))
+    expect(screen.getByTestId("coming-soon-banner-twoFactor")).toBeInTheDocument()
+    expect(screen.getByTestId("coming-soon-banner-activeSessions")).toBeInTheDocument()
+    expect(screen.getByTestId("coming-soon-banner-loginHistory")).toBeInTheDocument()
+    expect(screen.getByTestId("coming-soon-banner-connectedAccounts")).toBeInTheDocument()
+  })
+
+  it("data section's delete button opens a confirm dialog explaining unavailability", async () => {
+    server.use(...baseHandlers)
+    const user = userEvent.setup()
+    renderSettings()
+    await user.click(await screen.findByTestId("settings-nav-data"))
+    await user.click(screen.getByTestId("delete-account-button"))
+    expect(await screen.findByText(/account deletion is not yet available/i)).toBeInTheDocument()
+  })
+
+  it("sign out POSTs /auth/logout and navigates to /login", async () => {
+    let logoutCalls = 0
+    server.use(
+      ...baseHandlers,
+      msw.post(api("/auth/logout"), () => {
+        logoutCalls++
+        return new HttpResponse(null, { status: 204 })
+      })
+    )
+    const user = userEvent.setup()
+    renderSettings()
+    await user.click(await screen.findByTestId("settings-sign-out"))
+    await waitFor(() =>
+      expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/login")
+    )
+    expect(logoutCalls).toBe(1)
+  })
+
+  it("has no axe violations on the appearance section", async () => {
+    server.use(...baseHandlers)
+    const { container } = renderSettings()
+    await waitFor(() => expect(screen.getByTestId("section-appearance")).toBeInTheDocument())
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
Closes #1414 (sub-issue of epic #1397). Builds on the data layer (#1403), routing (#1404), shell (#1406), auth pages (#1407), and the coming-soon registry (#1417).

## Summary

Three personal pages wired into the protected Shell:

- **`/profile`** (read-only) — cover banner + initials avatar + name + email + default-group label + member-since + Free-plan badge with link to `/plans`. Edit-profile CTA on the banner. `ComingSoonBanner` for the photo-upload stub (#1382).
- **`/profile/edit`** — two stacked forms: profile fields (name + default_group_id via `PUT /auth/me`) and a separate change-password form (`POST /auth/change-password`). On password success the page waits 1.5s, signs out, and bounces to `/login` so the user re-authenticates with the new password.
- **`/settings`** — 6 sections in a left-rail layout (Account / Appearance / Notifications / Privacy & security / Data & storage / Help & support) + a sign-out shortcut. Theme / density / locale persist to localStorage via the existing providers (#1406) and i18next-browser-languagedetector cache; no backend round-trip from this page (the system-wide `/settings` endpoint is admin scope, not user prefs).

## How the registry from #1417 pays off

Notifications and Privacy sections render *entirely* as `ComingSoonBanner` stubs straight from the registry — six stubs total (notifications, maintenance reminders, 2FA, active sessions, login history, connected accounts) with zero new component code. The Data section uses `storageQuota` and the Help section uses `sendFeedback` the same way. Adding the inline `profilePhoto` stub on Profile + Edit Profile is a one-liner each.

## Notable behaviors

- **No backend DELETE for /auth/me** — the danger-zone Delete-account button opens a confirm dialog explaining account deletion isn't yet wired (per the issue's "gated and tested" requirement) instead of faking a destructive action that does nothing.
- **422 on change-password → "current password is incorrect"** — explicit branch in the catch handler so the user sees the actual reason instead of a generic "request failed".
- **Profile-form sync after the auth probe** — `useForm` reads `defaultValues` once at mount, so the edit page resets the form on `user.id` change to handle hard-refresh races where the form mounts before `/auth/me` resolves. Tests cover this race by waiting for `nameInput` to populate before interacting.
- **Empty `<h1>` and axe** — the profile heading mounts with empty text until the user resolves; the axe test waits for `toHaveTextContent` first to avoid the empty-heading violation.

## Sidebar / command-palette

Added "Preferences" entry (Personal group, `SlidersHorizontal` icon) routing to `/settings`. The comment in `AppSidebar.tsx` that promised this finally resolved is gone — entry is real now.

## features/auth additions

- `api.ts`: `updateProfile()` (`PUT /auth/me`), `changePassword()` (`POST /auth/change-password`).
- `hooks.ts`: `useUpdateProfile` (sets fresh user into the cache + invalidates auth namespace) and `useChangePassword`.
- `schemas.ts`: `profileEditSchema` (name + defaultGroupId) + `changePasswordSchema` with cross-field `"new must differ from current"` rule.
- `auth:validation.passwordSameAsCurrent` i18n key for the new rule.

## i18n

- New `settings.json` catalog, fully populated.
- `i18next.config.ts` `preservePatterns` extended for dynamic key spaces in SettingsPage: `settings:sections.*`, `settings:appearance.themeOptions.*`, `settings:appearance.localeOptions.*`, `settings:help.rows.*`.

## Files

- `frontend-react/src/pages/{ProfilePage,EditProfilePage,SettingsPage}.tsx` + tests
- `frontend-react/src/features/auth/{api,hooks,schemas}.ts` (extended)
- `frontend-react/src/components/{AppSidebar,CommandPalette}.tsx` (Preferences entry)
- `frontend-react/src/app/router.tsx` (3 routes wired)
- `frontend-react/src/i18n/locales/en/{settings,auth}.json`
- `frontend-react/i18next.config.ts`

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test` — **224/224 vitest green** (11 new across 3 page test files)
- [x] `npm run build` clean
- [x] `npx i18next-cli extract --ci` clean
- [ ] Playwright e2e for these flows — deferred to a follow-up under #1419

## Cross-refs

Stubs from #1417 used here: 2FA (#1380), active sessions (#1378), login history (#1379), connected accounts (#1395), notification prefs (#1373), maintenance reminders (#1368), storage quota (#1388), profile photo (#1382), send feedback (#1387). None are closed by this PR.