### PR TITLE
[#1422] OpenAPI drift gate — `make swagger` wrapper + devdoc

### DIFF
--- a/.github/workflows/go-swagger-docs.yml
+++ b/.github/workflows/go-swagger-docs.yml
@@ -34,13 +34,11 @@ jobs:
         working-directory: go
 
       - name: Regenerate Swagger docs
-        run: go tool swag init --output docs
-        working-directory: go
+        run: make swagger
 
       - name: Check for uncommitted changes in docs/
         run: |
-          if ! git diff --exit-code -- docs/; then
-            echo "Swagger docs are out of sync. Please run 'go tool swag init --output docs' and commit the changes." >&2
+          if ! git diff --exit-code -- go/docs/; then
+            echo "Swagger docs are out of sync. Please run 'make swagger' and commit the changes." >&2
             exit 1
           fi
-        working-directory: go

--- a/.github/workflows/go-swagger-docs.yml
+++ b/.github/workflows/go-swagger-docs.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Regenerate Swagger docs
         run: make swagger
 
-      - name: Check for uncommitted changes in docs/
+      - name: Check for uncommitted changes in go/docs/
         run: |
           if ! git diff --exit-code -- go/docs/; then
             echo "Swagger docs are out of sync. Please run 'make swagger' and commit the changes." >&2

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ typecheck-frontend-react:
 # Regenerate the OpenAPI/Swagger spec from the Go handler annotations.
 # Output is go/docs/swagger.{yaml,json,go}. The CI workflow
 # go-swagger-docs.yml runs the same command and fails on `git diff`,
-# so any annotation change must be paired with a regenerated docs/.
+# so any annotation change must be paired with regenerated go/docs/.
 # See devdocs/backend/openapi.md.
 .PHONY: swagger
 swagger:

--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,18 @@ lint-frontend-react:
 typecheck-frontend-react:
 	$(CD) $(FRONTEND_REACT_DIR) && npm run typecheck
 
+# Regenerate the OpenAPI/Swagger spec from the Go handler annotations.
+# Output is go/docs/swagger.{yaml,json,go}. The CI workflow
+# go-swagger-docs.yml runs the same command and fails on `git diff`,
+# so any annotation change must be paired with a regenerated docs/.
+# See devdocs/backend/openapi.md.
+.PHONY: swagger
+swagger:
+	$(CD) $(BACKEND_DIR) && $(GO_CMD) tool swag init --output docs
+
 # Regenerate React frontend's TypeScript types from go/docs/swagger.json.
-# Run after `go tool swag init --output docs` whenever a swagger annotation
-# changes. CI guards against drift via `codegen-frontend-react-check`.
+# Run after `make swagger` whenever a swagger annotation changes. CI
+# guards against drift via `codegen-frontend-react-check`.
 .PHONY: codegen-frontend-react
 codegen-frontend-react:
 	$(CD) $(FRONTEND_REACT_DIR) && npm run codegen

--- a/devdocs/backend/openapi.md
+++ b/devdocs/backend/openapi.md
@@ -2,17 +2,17 @@
 
 The backend's HTTP surface is described by an OpenAPI 2.0 spec generated from
 [swag](https://github.com/swaggo/swag) annotations on the handler functions.
-The spec lives at:
+Those annotations are the source of truth. The generated artifacts live at:
 
-- `go/docs/swagger.yaml` — human-readable, source of truth checked into the
+- `go/docs/swagger.yaml` — generated, human-readable spec checked into the
   repo.
-- `go/docs/swagger.json` — same spec in JSON, consumed by the React frontend's
-  TypeScript codegen (`frontend-react/npm run codegen`).
-- `go/docs/docs.go` — Go bindings registered by `apiserver.go` so the
-  `/swagger/*` UI route can serve the spec at runtime.
+- `go/docs/swagger.json` — generated JSON form of the same spec, consumed by
+  the React frontend's TypeScript codegen (`make codegen-frontend-react`).
+- `go/docs/docs.go` — generated Go bindings registered by `apiserver.go` so
+  the `/swagger/*` UI route can serve the spec at runtime.
 
-All three files are regenerated together by a single command. They must stay
-in sync with the annotations; CI fails any PR where they don't.
+All three files are regenerated together by a single command from the
+annotations and must stay in sync with them; CI fails any PR where they don't.
 
 ## Adding or changing an endpoint
 
@@ -24,19 +24,19 @@ in sync with the annotations; CI fails any PR where they don't.
    `go tool swag init --output docs` inside `go/`. The tool walks the package,
    parses annotations, and rewrites all three files in `go/docs/`.
 3. Run `make codegen-frontend-react` to regenerate the TypeScript types in
-   `frontend-react/src/types/openapi.ts`.
-4. Commit `go/docs/*` and `frontend-react/src/types/openapi.ts` together in
+   `frontend-react/src/types/api.d.ts`. Run this whenever step 2 changes
+   `go/docs/swagger.json` — including documentation-only annotation changes,
+   since the generated `.d.ts` carries JSDoc derived from each operation's
+   `@Summary` / `@Description`.
+4. Commit `go/docs/*` and `frontend-react/src/types/api.d.ts` together in
    the same PR as the handler change.
-
-If you only changed comments / documentation strings (no shape change), step 3
-is a no-op.
 
 ## CI gates
 
 | Workflow | Job | What it catches |
 | --- | --- | --- |
 | `go-swagger-docs.yml` | Check Swagger Docs Sync | `make swagger` produces a non-empty diff against `go/docs/` — i.e. annotations and committed spec disagree. |
-| `frontend-react-codegen.yml` | codegen-check | `npm run codegen:check` produces a non-empty diff against `frontend-react/src/types/openapi.ts` — i.e. the generated TS types are stale relative to `swagger.json`. |
+| `frontend-react-codegen.yml` | codegen-check | `npm run codegen:check` produces a non-empty diff against `frontend-react/src/types/api.d.ts` — i.e. the generated TS types are stale relative to `swagger.json`. |
 
 Both gates run on every push and pull request. They fail fast if the spec or
 generated types drift from the source annotations.

--- a/devdocs/backend/openapi.md
+++ b/devdocs/backend/openapi.md
@@ -1,0 +1,70 @@
+# OpenAPI / Swagger
+
+The backend's HTTP surface is described by an OpenAPI 2.0 spec generated from
+[swag](https://github.com/swaggo/swag) annotations on the handler functions.
+The spec lives at:
+
+- `go/docs/swagger.yaml` — human-readable, source of truth checked into the
+  repo.
+- `go/docs/swagger.json` — same spec in JSON, consumed by the React frontend's
+  TypeScript codegen (`frontend-react/npm run codegen`).
+- `go/docs/docs.go` — Go bindings registered by `apiserver.go` so the
+  `/swagger/*` UI route can serve the spec at runtime.
+
+All three files are regenerated together by a single command. They must stay
+in sync with the annotations; CI fails any PR where they don't.
+
+## Adding or changing an endpoint
+
+1. Add or update the swag annotation block above the handler function. See
+   any existing handler in `go/apiserver/*.go` for the conventions (the
+   `commodities.go` file is a good reference — it covers list / detail /
+   create / update / delete / bulk shapes).
+2. Run `make swagger` from the repository root. This calls
+   `go tool swag init --output docs` inside `go/`. The tool walks the package,
+   parses annotations, and rewrites all three files in `go/docs/`.
+3. Run `make codegen-frontend-react` to regenerate the TypeScript types in
+   `frontend-react/src/types/openapi.ts`.
+4. Commit `go/docs/*` and `frontend-react/src/types/openapi.ts` together in
+   the same PR as the handler change.
+
+If you only changed comments / documentation strings (no shape change), step 3
+is a no-op.
+
+## CI gates
+
+| Workflow | Job | What it catches |
+| --- | --- | --- |
+| `go-swagger-docs.yml` | Check Swagger Docs Sync | `make swagger` produces a non-empty diff against `go/docs/` — i.e. annotations and committed spec disagree. |
+| `frontend-react-codegen.yml` | codegen-check | `npm run codegen:check` produces a non-empty diff against `frontend-react/src/types/openapi.ts` — i.e. the generated TS types are stale relative to `swagger.json`. |
+
+Both gates run on every push and pull request. They fail fast if the spec or
+generated types drift from the source annotations.
+
+## Reproducing a CI failure locally
+
+If `Check Swagger Docs Sync` fails on your PR:
+
+```bash
+make swagger
+git status -- go/docs/
+git diff -- go/docs/
+```
+
+The diff shows what the workflow saw. Commit it.
+
+If `codegen-check` fails:
+
+```bash
+make codegen-frontend-react
+git status -- frontend-react/src/types/
+```
+
+## What's NOT yet checked
+
+The current drift gate verifies that the spec matches the annotations in code,
+and that the FE types match the spec. It does **not** verify that every
+registered chi route has a matching swagger operation — i.e. an endpoint can
+exist in code with no annotation at all and the gate will pass. That coverage
+check (and the cleanup of currently-undocumented group-scoped routes under
+`/g/{groupSlug}/...`) is tracked separately under epic #1397.


### PR DESCRIPTION
Closes part of #1422 (epic #1397). The route-coverage piece is split out into #1442.

## Summary

- `make swagger` — new Makefile target wrapping `go tool swag init --output docs` so devs run the same command CI runs.
- `.github/workflows/go-swagger-docs.yml` — switched from a duplicated swag invocation to `make swagger`. Single source of truth: change the command in the Makefile and CI follows.
- `devdocs/backend/openapi.md` — new doc covering the add-an-endpoint workflow, what each existing gate catches (`go-swagger-docs.yml` for spec drift, `frontend-react-codegen.yml` for FE-types drift), and how to reproduce a CI failure locally. Calls out the not-yet-implemented route-coverage check explicitly.

## Why the scope is reduced

The original #1422 listed three acceptance criteria:

1. ✅ `make swagger` produces deterministic output.
2. ✅ CI fails when annotations and docs disagree — already shipped via `go-swagger-docs.yml`; this PR just consolidates the contract.
3. ⏸ Coverage script passes (every chi route documented).

A prototype walker (chi.Walk + swagger.json diff) revealed 132 mismatches between the live router and `docs/swagger.json`: 78 group-scoped routes under `/api/v1/g/{groupSlug}/...` have no annotation, and 72 swag-documented operations reference the pre-group-scoped paths (`/areas/{id}` etc.) that no longer exist. Reconciling annotations is its own piece of work, larger than #1422 was sized for, so it moves to **#1442** along with the strict gate.

The frontend's `http.ts` papers over the divergence at request time by prepending `/g/{slug}/` itself — nothing is broken in production, but the spec is wrong as a contract.

## Test plan

- [x] Run `make swagger` from the worktree — exits clean, regenerates `go/docs/swagger.{yaml,json,go}` byte-identical to what's checked in (deterministic output).
- [x] Run `make swagger` twice in a row — second run produces no `git diff`.
- [ ] CI: `Swagger Docs Sync` job passes (it runs the same `make swagger` and `git diff --exit-code`).
- [ ] CI: no other workflows regress.

## Out of scope (tracked elsewhere)

- Annotation reconciliation + strict route-coverage gate → #1442.
- FE codegen workflow → already gated by `frontend-react-codegen.yml`, untouched here.