### PR TITLE
[#1409] Locations + Areas — list, detail, dialog-based CRUD

### DIFF
--- a/frontend-react/i18next.config.ts
+++ b/frontend-react/i18next.config.ts
@@ -70,6 +70,11 @@ export default defineConfig({
       // (admin | user); missing keys surface in the dev console via the
       // saveMissing handler.
       "members:roles.*",
+      // locations:validation.* — schema messages in
+      // features/{locations,areas}/schemas.ts hold the keys as plain
+      // strings, surfaced through RHF errors[name].message → t() at
+      // render time. Same pattern as auth:validation.* / groups:validation.*.
+      "locations:validation.*",
     ],
   },
 })

--- a/frontend-react/src/app/router.tsx
+++ b/frontend-react/src/app/router.tsx
@@ -16,6 +16,15 @@ import { Shell } from "@/app/Shell"
 const DashboardPage = lazy(() =>
   import("@/pages/Dashboard").then((m) => ({ default: m.DashboardPage }))
 )
+const LocationsListPage = lazy(() =>
+  import("@/pages/locations/LocationsListPage").then((m) => ({ default: m.LocationsListPage }))
+)
+const LocationDetailPage = lazy(() =>
+  import("@/pages/locations/LocationDetailPage").then((m) => ({ default: m.LocationDetailPage }))
+)
+const AreaDetailPage = lazy(() =>
+  import("@/pages/areas/AreaDetailPage").then((m) => ({ default: m.AreaDetailPage }))
+)
 const NotFoundPage = lazy(() =>
   import("@/pages/NotFound").then((m) => ({ default: m.NotFoundPage }))
 )
@@ -143,58 +152,15 @@ export function AppRoutes() {
             <Route path="/" element={<RootRedirect />} />
             <Route path="/g/:groupSlug">
               <Route index element={<DashboardPage />} />
-              <Route
-                path="locations"
-                element={
-                  <PlaceholderPage titleKey="locations" testId="page-locations" trackedBy="#1409" />
-                }
-              />
-              <Route
-                path="locations/new"
-                element={
-                  <PlaceholderPage
-                    titleKey="locationNew"
-                    testId="page-location-new"
-                    trackedBy="#1409"
-                  />
-                }
-              />
-              <Route
-                path="locations/:id"
-                element={
-                  <PlaceholderPage
-                    titleKey="locationDetail"
-                    testId="page-location-detail"
-                    trackedBy="#1409"
-                  />
-                }
-              />
+              <Route path="locations" element={<LocationsListPage />} />
+              <Route path="locations/new" element={<LocationsListPage initialMode="create" />} />
+              <Route path="locations/:id" element={<LocationDetailPage />} />
               <Route
                 path="locations/:id/edit"
-                element={
-                  <PlaceholderPage
-                    titleKey="locationEdit"
-                    testId="page-location-edit"
-                    trackedBy="#1409"
-                  />
-                }
+                element={<LocationDetailPage initialMode="edit" />}
               />
-              <Route
-                path="areas/:id"
-                element={
-                  <PlaceholderPage
-                    titleKey="areaDetail"
-                    testId="page-area-detail"
-                    trackedBy="#1409"
-                  />
-                }
-              />
-              <Route
-                path="areas/:id/edit"
-                element={
-                  <PlaceholderPage titleKey="areaEdit" testId="page-area-edit" trackedBy="#1409" />
-                }
-              />
+              <Route path="areas/:id" element={<AreaDetailPage />} />
+              <Route path="areas/:id/edit" element={<AreaDetailPage initialMode="edit" />} />
               <Route
                 path="commodities"
                 element={

--- a/frontend-react/src/components/locations/AreaFormDialog.tsx
+++ b/frontend-react/src/components/locations/AreaFormDialog.tsx
@@ -134,11 +134,14 @@ export function AreaFormDialog({
                 control={form.control}
                 name="location_id"
                 render={({ field }) => (
+                  // Spread `field` so name / ref / onBlur land on the
+                  // <select> too — without ref the form's focus-on-error
+                  // logic targets nothing, and without onBlur RHF's
+                  // touched/dirty tracking goes stale on this control.
                   <select
+                    {...field}
                     id="area-location"
                     className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-                    value={field.value}
-                    onChange={field.onChange}
                     disabled={isPending}
                     aria-invalid={!!form.formState.errors.location_id}
                     data-testid="area-location-select"

--- a/frontend-react/src/components/locations/AreaFormDialog.tsx
+++ b/frontend-react/src/components/locations/AreaFormDialog.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from "react"
+import { Controller, useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useTranslation } from "react-i18next"
+
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import type { Area } from "@/features/areas/api"
+import { areaSchema, type AreaFormInput } from "@/features/areas/schemas"
+import type { Location } from "@/features/locations/api"
+import { parseServerError } from "@/lib/server-error"
+
+interface AreaFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  // When provided, edit mode; prefills name + parent location.
+  area?: Area | null
+  // Available parent locations. The dialog hides the picker when only
+  // one location exists (the parent is forced) and surfaces a `<select>`
+  // when there are several. The list page is responsible for fetching
+  // these.
+  locations: Location[]
+  // Initial parent — used when launching create from a specific
+  // location's detail page so the dialog doesn't ask "where".
+  defaultLocationId?: string
+  onSubmit: (values: AreaFormInput) => Promise<unknown>
+  isPending?: boolean
+}
+
+export function AreaFormDialog({
+  open,
+  onOpenChange,
+  area,
+  locations,
+  defaultLocationId,
+  onSubmit,
+  isPending = false,
+}: AreaFormDialogProps) {
+  const { t } = useTranslation()
+  const [serverError, setServerError] = useState<string | null>(null)
+  const isEdit = !!area
+
+  const form = useForm<AreaFormInput>({
+    resolver: zodResolver(areaSchema),
+    defaultValues: {
+      name: "",
+      // Pick a sensible default so the form isn't locked on first
+      // mount. Edit mode overwrites this in the effect below.
+      location_id: defaultLocationId ?? locations[0]?.id ?? "",
+    },
+  })
+
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        name: area?.name ?? "",
+        location_id: area?.location_id ?? defaultLocationId ?? locations[0]?.id ?? "",
+      })
+      setServerError(null)
+    }
+  }, [open, area, defaultLocationId, locations, form])
+
+  async function handle(values: AreaFormInput) {
+    setServerError(null)
+    try {
+      await onSubmit(values)
+      onOpenChange(false)
+    } catch (err) {
+      setServerError(parseServerError(err, t("locations:areaDialog.errorGeneric")))
+    }
+  }
+
+  // Hide the parent picker when a single location exists — the value
+  // is already forced in defaults and surfacing a one-option `<select>`
+  // is just visual noise.
+  const showLocationPicker = locations.length > 1
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md" data-testid="area-form-dialog">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit ? t("locations:areaDialog.editTitle") : t("locations:areaDialog.createTitle")}
+          </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? t("locations:areaDialog.editDescription")
+              : t("locations:areaDialog.createDescription")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          id="area-form"
+          className="flex flex-col gap-4 py-1"
+          onSubmit={form.handleSubmit(handle)}
+          noValidate
+        >
+          <div className="space-y-1.5">
+            <Label htmlFor="area-name">
+              {t("locations:areaDialog.nameLabel")}
+              <span className="ms-0.5 text-destructive">*</span>
+            </Label>
+            <Input
+              id="area-name"
+              placeholder={t("locations:areaDialog.namePlaceholder")}
+              autoComplete="off"
+              maxLength={200}
+              disabled={isPending}
+              aria-invalid={!!form.formState.errors.name}
+              data-testid="area-name-input"
+              {...form.register("name")}
+            />
+            {form.formState.errors.name ? (
+              <p className="text-xs text-destructive" data-testid="area-name-error">
+                {t(form.formState.errors.name.message ?? "")}
+              </p>
+            ) : null}
+          </div>
+
+          {showLocationPicker ? (
+            <div className="space-y-1.5">
+              <Label htmlFor="area-location">{t("locations:areaDialog.locationLabel")}</Label>
+              <Controller
+                control={form.control}
+                name="location_id"
+                render={({ field }) => (
+                  <select
+                    id="area-location"
+                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                    value={field.value}
+                    onChange={field.onChange}
+                    disabled={isPending}
+                    aria-invalid={!!form.formState.errors.location_id}
+                    data-testid="area-location-select"
+                  >
+                    {locations.map((l) => (
+                      <option key={l.id} value={l.id}>
+                        {l.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              />
+              {form.formState.errors.location_id ? (
+                <p className="text-xs text-destructive" data-testid="area-location-error">
+                  {t(form.formState.errors.location_id.message ?? "")}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {serverError ? (
+            <Alert variant="destructive" data-testid="area-form-server-error">
+              <AlertDescription>{serverError}</AlertDescription>
+            </Alert>
+          ) : null}
+        </form>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+            data-testid="area-form-cancel"
+          >
+            {t("common:actions.cancel")}
+          </Button>
+          <Button
+            type="submit"
+            form="area-form"
+            disabled={isPending}
+            data-testid="area-form-submit"
+          >
+            {isPending
+              ? t("locations:areaDialog.submitting")
+              : isEdit
+                ? t("locations:areaDialog.editSubmit")
+                : t("locations:areaDialog.createSubmit")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend-react/src/components/locations/LocationFormDialog.tsx
+++ b/frontend-react/src/components/locations/LocationFormDialog.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useTranslation } from "react-i18next"
+
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import type { Location } from "@/features/locations/api"
+import { locationSchema, type LocationFormInput } from "@/features/locations/schemas"
+import { parseServerError } from "@/lib/server-error"
+
+interface LocationFormDialogProps {
+  // True opens the dialog. Closing fires `onOpenChange(false)`.
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  // When provided the dialog is in edit mode and prefills the form.
+  // `null` / `undefined` = create.
+  location?: Location | null
+  // Submit handler. Throws translate-able server errors which the
+  // dialog renders as an inline `<Alert />`. The dialog calls
+  // `onOpenChange(false)` on success itself; the host doesn't need to.
+  onSubmit: (values: LocationFormInput) => Promise<unknown>
+  // True while the host's mutation is in flight; disables submit + form
+  // controls.
+  isPending?: boolean
+}
+
+// LocationFormDialog renders the create / edit form as a modal —
+// matches the design mock's `LocationDialog` and the issue's mock
+// parity rule ("modals over the list page when invoked from there;
+// full pages when deep-linked"). The list page mounts it at any time
+// and toggles `open`; deep-link routes (`/locations/new`,
+// `/locations/:id/edit`) open it on mount via the same prop.
+export function LocationFormDialog({
+  open,
+  onOpenChange,
+  location,
+  onSubmit,
+  isPending = false,
+}: LocationFormDialogProps) {
+  const { t } = useTranslation()
+  const [serverError, setServerError] = useState<string | null>(null)
+  const isEdit = !!location
+
+  const form = useForm<LocationFormInput>({
+    resolver: zodResolver(locationSchema),
+    defaultValues: { name: "", address: "" },
+  })
+
+  // Reset the form whenever the dialog reopens or the editing target
+  // changes — without this, opening the dialog after editing one
+  // location would prefill with the previous location's name.
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        name: location?.name ?? "",
+        address: location?.address ?? "",
+      })
+      setServerError(null)
+    }
+  }, [open, location, form])
+
+  async function handle(values: LocationFormInput) {
+    setServerError(null)
+    try {
+      await onSubmit(values)
+      onOpenChange(false)
+    } catch (err) {
+      setServerError(parseServerError(err, t("locations:dialog.errorGeneric")))
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg" data-testid="location-form-dialog">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit ? t("locations:dialog.editTitle") : t("locations:dialog.createTitle")}
+          </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? t("locations:dialog.editDescription")
+              : t("locations:dialog.createDescription")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          id="location-form"
+          className="flex flex-col gap-4 py-1"
+          onSubmit={form.handleSubmit(handle)}
+          noValidate
+        >
+          <div className="space-y-1.5">
+            <Label htmlFor="location-name">
+              {t("locations:dialog.nameLabel")}
+              <span className="ms-0.5 text-destructive">*</span>
+            </Label>
+            <Input
+              id="location-name"
+              placeholder={t("locations:dialog.namePlaceholder")}
+              autoComplete="off"
+              maxLength={200}
+              disabled={isPending}
+              aria-invalid={!!form.formState.errors.name}
+              data-testid="location-name-input"
+              {...form.register("name")}
+            />
+            {form.formState.errors.name ? (
+              <p className="text-xs text-destructive" data-testid="location-name-error">
+                {t(form.formState.errors.name.message ?? "")}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="location-address">{t("locations:dialog.addressLabel")}</Label>
+            <Input
+              id="location-address"
+              placeholder={t("locations:dialog.addressPlaceholder")}
+              autoComplete="off"
+              maxLength={2000}
+              disabled={isPending}
+              aria-invalid={!!form.formState.errors.address}
+              data-testid="location-address-input"
+              {...form.register("address")}
+            />
+            {form.formState.errors.address ? (
+              <p className="text-xs text-destructive" data-testid="location-address-error">
+                {t(form.formState.errors.address.message ?? "")}
+              </p>
+            ) : null}
+            <p className="text-[11px] text-muted-foreground">{t("locations:dialog.addressHelp")}</p>
+          </div>
+
+          {serverError ? (
+            <Alert variant="destructive" data-testid="location-form-server-error">
+              <AlertDescription>{serverError}</AlertDescription>
+            </Alert>
+          ) : null}
+        </form>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+            data-testid="location-form-cancel"
+          >
+            {t("common:actions.cancel")}
+          </Button>
+          <Button
+            type="submit"
+            form="location-form"
+            disabled={isPending}
+            data-testid="location-form-submit"
+          >
+            {isPending
+              ? t("locations:dialog.submitting")
+              : isEdit
+                ? t("locations:dialog.editSubmit")
+                : t("locations:dialog.createSubmit")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend-react/src/features/areas/__tests__/hooks.test.tsx
+++ b/frontend-react/src/features/areas/__tests__/hooks.test.tsx
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { Route, Routes } from "react-router-dom"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
+import { type ReactNode } from "react"
+
+import { useAreas, useDeleteArea, useUpdateArea } from "@/features/areas/hooks"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { server } from "@/test/server"
+import { areaHandlers, groupHandlers } from "@/test/handlers"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { areaKeys } from "@/features/areas/keys"
+import type { Schema } from "@/types"
+
+const SLUG = "household"
+const groupFixture: Schema<"models.LocationGroup">[] = [
+  { id: "g1", slug: SLUG, name: "Household", main_currency: "USD" },
+]
+
+function areaResource(id: string, attrs: { name: string; location_id: string }) {
+  return { id, type: "areas", attributes: { ...attrs, id } }
+}
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={[`/g/${SLUG}`]}>
+          <Routes>
+            <Route
+              path="/g/:groupSlug"
+              element={<GroupProvider>{children as React.ReactElement}</GroupProvider>}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+  }
+}
+
+function newClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+})
+
+describe("useAreas + mutations", () => {
+  it("rolls the list back when an optimistic update fails", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, [areaResource("a1", { name: "Original", location_id: "loc1" })]),
+      ...areaHandlers.updateError(SLUG, "a1", 500)
+    )
+    const client = newClient()
+    const { result } = renderHook(() => ({ list: useAreas(), update: useUpdateArea("a1") }), {
+      wrapper: makeWrapper(client),
+    })
+
+    await waitFor(() => expect(result.current.list.data?.length).toBe(1))
+    expect(result.current.list.data?.[0].name).toBe("Original")
+
+    await result.current.update.mutateAsync({ name: "Renamed" }).catch(() => {
+      /* expected */
+    })
+
+    await waitFor(() => {
+      const list = client.getQueryData<{ name?: string }[]>(areaKeys.list(SLUG))
+      expect(list?.[0].name).toBe("Original")
+    })
+  })
+
+  it("rolls the list back when an optimistic delete fails", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, [areaResource("a1", { name: "Workshop", location_id: "loc1" })]),
+      ...areaHandlers.removeError(SLUG, "a1", 500)
+    )
+    const client = newClient()
+    const { result } = renderHook(() => ({ list: useAreas(), remove: useDeleteArea() }), {
+      wrapper: makeWrapper(client),
+    })
+
+    await waitFor(() => expect(result.current.list.data?.length).toBe(1))
+
+    await result.current.remove.mutateAsync("a1").catch(() => {
+      /* expected */
+    })
+
+    await waitFor(() => {
+      const list = client.getQueryData<unknown[]>(areaKeys.list(SLUG))
+      expect(list).toHaveLength(1)
+    })
+  })
+})

--- a/frontend-react/src/features/areas/api.ts
+++ b/frontend-react/src/features/areas/api.ts
@@ -1,0 +1,79 @@
+// Pure data-layer for areas. An area belongs to exactly one location
+// (`location_id` on the BE model). Hooks live in `./hooks.ts`.
+import { http } from "@/lib/http"
+import type { Schema } from "@/types"
+
+export type Area = Schema<"models.Area">
+
+interface AreaResource {
+  id: string
+  type: string
+  attributes: Area
+}
+
+interface AreasListResponse {
+  data: AreaResource[]
+  meta?: {
+    areas?: number
+    page?: number
+    per_page?: number
+    total_pages?: number
+  }
+}
+
+interface AreaResponse {
+  data?: { id?: string; type?: string; attributes?: Area }
+}
+
+function envelope(attrs: Partial<Area>) {
+  return { data: { type: "areas", attributes: attrs } }
+}
+
+export async function listAreas(
+  options: { perPage?: number; signal?: AbortSignal } = {}
+): Promise<Area[]> {
+  const params = new URLSearchParams()
+  if (options.perPage !== undefined) params.set("per_page", String(options.perPage))
+  const qs = params.toString()
+  const path = qs ? `/areas?${qs}` : "/areas"
+  const body = await http.get<AreasListResponse>(path, { signal: options.signal })
+  return (body.data ?? []).map((item) => ({ ...item.attributes, id: item.id }))
+}
+
+export async function getArea(id: string, signal?: AbortSignal): Promise<Area> {
+  const body = await http.get<AreaResponse>(`/areas/${encodeURIComponent(id)}`, { signal })
+  if (!body.data?.attributes) {
+    throw new Error(`Area ${id} response missing data.attributes`)
+  }
+  return { ...body.data.attributes, id: body.data.id }
+}
+
+export interface CreateAreaRequest {
+  name: string
+  location_id: string
+}
+
+export async function createArea(req: CreateAreaRequest): Promise<Area> {
+  const body = await http.post<AreaResponse>("/areas", envelope(req))
+  if (!body.data?.attributes) {
+    throw new Error("Create-area response missing data.attributes")
+  }
+  return { ...body.data.attributes, id: body.data.id }
+}
+
+export interface UpdateAreaRequest {
+  name?: string
+  location_id?: string
+}
+
+export async function updateArea(id: string, req: UpdateAreaRequest): Promise<Area> {
+  const body = await http.put<AreaResponse>(`/areas/${encodeURIComponent(id)}`, envelope(req))
+  if (!body.data?.attributes) {
+    throw new Error("Update-area response missing data.attributes")
+  }
+  return { ...body.data.attributes, id: body.data.id }
+}
+
+export async function deleteArea(id: string): Promise<void> {
+  await http.del<void>(`/areas/${encodeURIComponent(id)}`)
+}

--- a/frontend-react/src/features/areas/hooks.ts
+++ b/frontend-react/src/features/areas/hooks.ts
@@ -54,29 +54,42 @@ export function useCreateArea() {
 }
 
 // Optimistic rename / re-parent. Same shape as
-// `useUpdateLocation` — patch the list snapshot, roll back on
-// error, settle by invalidating both list and detail.
+// `useUpdateLocation` — patch both list AND detail snapshots so a
+// rename from the area detail page updates the heading immediately
+// rather than waiting for onSettled to refetch. Roll back both on
+// error, settle by invalidating both queries.
 export function useUpdateArea(id: string) {
   const qc = useQueryClient()
   const { currentGroup } = useCurrentGroup()
   const slug = currentGroup?.slug ?? ""
   const listKey = areaKeys.list(slug)
   const detailKey = areaKeys.detail(slug, id)
-  return useMutation<Area, Error, UpdateAreaRequest, { previousList?: Area[] }>({
+  return useMutation<
+    Area,
+    Error,
+    UpdateAreaRequest,
+    { previousList?: Area[]; previousDetail?: Area }
+  >({
     mutationFn: (req) => updateArea(id, req),
     onMutate: async (req) => {
       await qc.cancelQueries({ queryKey: listKey })
+      await qc.cancelQueries({ queryKey: detailKey })
       const previousList = qc.getQueryData<Area[]>(listKey)
+      const previousDetail = qc.getQueryData<Area>(detailKey)
       if (previousList) {
         qc.setQueryData<Area[]>(
           listKey,
           previousList.map((a) => (a.id === id ? { ...a, ...req } : a))
         )
       }
-      return { previousList }
+      if (previousDetail) {
+        qc.setQueryData<Area>(detailKey, { ...previousDetail, ...req })
+      }
+      return { previousList, previousDetail }
     },
     onError: (_err, _req, ctx) => {
       if (ctx?.previousList) qc.setQueryData(listKey, ctx.previousList)
+      if (ctx?.previousDetail) qc.setQueryData(detailKey, ctx.previousDetail)
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: listKey })

--- a/frontend-react/src/features/areas/hooks.ts
+++ b/frontend-react/src/features/areas/hooks.ts
@@ -1,0 +1,113 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useCurrentGroup } from "@/features/group/GroupContext"
+
+import {
+  createArea,
+  deleteArea,
+  getArea,
+  listAreas,
+  updateArea,
+  type Area,
+  type CreateAreaRequest,
+  type UpdateAreaRequest,
+} from "./api"
+import { areaKeys } from "./keys"
+
+interface QueryOptions {
+  enabled?: boolean
+}
+
+export function useAreas({ enabled = true }: QueryOptions = {}) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useQuery<Area[]>({
+    queryKey: areaKeys.list(slug),
+    queryFn: ({ signal }) => listAreas({ signal }),
+    enabled,
+  })
+}
+
+export function useArea(id: string | undefined, { enabled = true }: QueryOptions = {}) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useQuery<Area>({
+    queryKey: areaKeys.detail(slug, id ?? ""),
+    queryFn: ({ signal }) => {
+      if (!id) throw new Error("useArea called without an id")
+      return getArea(id, signal)
+    },
+    enabled: enabled && !!id,
+  })
+}
+
+export function useCreateArea() {
+  const qc = useQueryClient()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useMutation<Area, Error, CreateAreaRequest>({
+    mutationFn: (req) => createArea(req),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: areaKeys.list(slug) })
+    },
+  })
+}
+
+// Optimistic rename / re-parent. Same shape as
+// `useUpdateLocation` — patch the list snapshot, roll back on
+// error, settle by invalidating both list and detail.
+export function useUpdateArea(id: string) {
+  const qc = useQueryClient()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  const listKey = areaKeys.list(slug)
+  const detailKey = areaKeys.detail(slug, id)
+  return useMutation<Area, Error, UpdateAreaRequest, { previousList?: Area[] }>({
+    mutationFn: (req) => updateArea(id, req),
+    onMutate: async (req) => {
+      await qc.cancelQueries({ queryKey: listKey })
+      const previousList = qc.getQueryData<Area[]>(listKey)
+      if (previousList) {
+        qc.setQueryData<Area[]>(
+          listKey,
+          previousList.map((a) => (a.id === id ? { ...a, ...req } : a))
+        )
+      }
+      return { previousList }
+    },
+    onError: (_err, _req, ctx) => {
+      if (ctx?.previousList) qc.setQueryData(listKey, ctx.previousList)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: listKey })
+      qc.invalidateQueries({ queryKey: detailKey })
+    },
+  })
+}
+
+export function useDeleteArea() {
+  const qc = useQueryClient()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  const listKey = areaKeys.list(slug)
+  return useMutation<void, Error, string, { previousList?: Area[] }>({
+    mutationFn: (id) => deleteArea(id),
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: listKey })
+      const previousList = qc.getQueryData<Area[]>(listKey)
+      if (previousList) {
+        qc.setQueryData<Area[]>(
+          listKey,
+          previousList.filter((a) => a.id !== id)
+        )
+      }
+      return { previousList }
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previousList) qc.setQueryData(listKey, ctx.previousList)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: listKey })
+    },
+  })
+}

--- a/frontend-react/src/features/areas/keys.ts
+++ b/frontend-react/src/features/areas/keys.ts
@@ -1,0 +1,8 @@
+// TanStack Query keys for the areas slice. Scoped by group slug to
+// keep the cache aligned with the http client's /g/{slug}/ rewrite.
+export const areaKeys = {
+  all: ["area"] as const,
+  group: (slug: string) => [...areaKeys.all, slug] as const,
+  list: (slug: string) => [...areaKeys.group(slug), "list"] as const,
+  detail: (slug: string, id: string) => [...areaKeys.group(slug), "detail", id] as const,
+}

--- a/frontend-react/src/features/areas/schemas.ts
+++ b/frontend-react/src/features/areas/schemas.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+const NAME_REQUIRED = "locations:validation.areaNameRequired"
+const NAME_TOO_LONG = "locations:validation.areaNameTooLong"
+const LOCATION_REQUIRED = "locations:validation.areaLocationRequired"
+
+export const areaSchema = z.object({
+  name: z.string().trim().min(1, NAME_REQUIRED).max(200, NAME_TOO_LONG),
+  location_id: z.string().min(1, LOCATION_REQUIRED),
+})
+export type AreaFormInput = z.infer<typeof areaSchema>

--- a/frontend-react/src/features/locations/__tests__/hooks.test.tsx
+++ b/frontend-react/src/features/locations/__tests__/hooks.test.tsx
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { Route, Routes } from "react-router-dom"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
+import { type ReactNode } from "react"
+
+import { useDeleteLocation, useLocations, useUpdateLocation } from "@/features/locations/hooks"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { server } from "@/test/server"
+import { groupHandlers, locationHandlers } from "@/test/handlers"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { locationKeys } from "@/features/locations/keys"
+import type { Schema } from "@/types"
+
+const SLUG = "household"
+const groupFixture: Schema<"models.LocationGroup">[] = [
+  { id: "g1", slug: SLUG, name: "Household", main_currency: "USD" },
+]
+
+function locationResource(id: string, attrs: { name: string; address?: string }) {
+  return { id, type: "locations", attributes: { ...attrs, id } }
+}
+
+// Wrap hooks in a fresh QueryClient + MemoryRouter pointing at /g/:slug
+// so GroupProvider's useParams resolves the slug. retry:false keeps
+// rejected mutations deterministic.
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={[`/g/${SLUG}`]}>
+          <Routes>
+            <Route
+              path="/g/:groupSlug"
+              element={<GroupProvider>{children as React.ReactElement}</GroupProvider>}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+  }
+}
+
+function newClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+})
+
+describe("useLocations + mutations", () => {
+  it("rolls the list back when an optimistic update fails", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Original" })]),
+      ...locationHandlers.updateError(SLUG, "loc1", 500)
+    )
+    const client = newClient()
+    const { result } = renderHook(
+      () => ({
+        list: useLocations(),
+        update: useUpdateLocation("loc1"),
+      }),
+      { wrapper: makeWrapper(client) }
+    )
+
+    await waitFor(() => expect(result.current.list.data?.length).toBe(1))
+    expect(result.current.list.data?.[0].name).toBe("Original")
+
+    // Optimistic update flips the name immediately, then the server
+    // returns 500 and the snapshot restores the pre-mutation list.
+    await result.current.update.mutateAsync({ name: "Renamed" }).catch(() => {
+      /* expected */
+    })
+
+    await waitFor(() => {
+      const list = client.getQueryData<{ name?: string }[]>(locationKeys.list(SLUG))
+      expect(list?.[0].name).toBe("Original")
+    })
+  })
+
+  it("rolls the list back when an optimistic delete fails", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Garage" })]),
+      ...locationHandlers.removeError(SLUG, "loc1", 500)
+    )
+    const client = newClient()
+    const { result } = renderHook(() => ({ list: useLocations(), remove: useDeleteLocation() }), {
+      wrapper: makeWrapper(client),
+    })
+
+    await waitFor(() => expect(result.current.list.data?.length).toBe(1))
+
+    await result.current.remove.mutateAsync("loc1").catch(() => {
+      /* expected */
+    })
+
+    await waitFor(() => {
+      const list = client.getQueryData<unknown[]>(locationKeys.list(SLUG))
+      expect(list).toHaveLength(1)
+    })
+  })
+})

--- a/frontend-react/src/features/locations/api.ts
+++ b/frontend-react/src/features/locations/api.ts
@@ -1,0 +1,90 @@
+// Pure data-layer for locations. The Inventario backend models a
+// location as `name + address`; the design mock's "icon" / "description"
+// pair maps to "address" (no icon column server-side). Hooks live in
+// `./hooks.ts`.
+import { http } from "@/lib/http"
+import type { Schema } from "@/types"
+
+export type Location = Schema<"models.Location">
+
+interface LocationResource {
+  id: string
+  type: string
+  attributes: Location
+}
+
+interface LocationsListResponse {
+  data: LocationResource[]
+  meta?: {
+    locations?: number
+    page?: number
+    per_page?: number
+    total_pages?: number
+  }
+}
+
+interface LocationResponse {
+  data?: { id?: string; type?: string; attributes?: Location }
+}
+
+function envelope(attrs: Partial<Location>) {
+  return { data: { type: "locations", attributes: attrs } }
+}
+
+// Returns every location for the active group. The list is small
+// (typically single-digit) so the dashboard / location picker can
+// reasonably load it in one go without paging.
+export async function listLocations(
+  options: { perPage?: number; signal?: AbortSignal } = {}
+): Promise<Location[]> {
+  const params = new URLSearchParams()
+  if (options.perPage !== undefined) params.set("per_page", String(options.perPage))
+  const qs = params.toString()
+  const path = qs ? `/locations?${qs}` : "/locations"
+  const body = await http.get<LocationsListResponse>(path, { signal: options.signal })
+  return (body.data ?? []).map((item) => ({ ...item.attributes, id: item.id }))
+}
+
+export async function getLocation(id: string, signal?: AbortSignal): Promise<Location> {
+  const body = await http.get<LocationResponse>(`/locations/${encodeURIComponent(id)}`, { signal })
+  if (!body.data?.attributes) {
+    throw new Error(`Location ${id} response missing data.attributes`)
+  }
+  return { ...body.data.attributes, id: body.data.id }
+}
+
+export interface CreateLocationRequest {
+  name: string
+  // Free-text "where is this" (the mock calls it "description"; the BE
+  // calls it "address"). Empty string is allowed — the mock has no
+  // required-field constraint here.
+  address?: string
+}
+
+export async function createLocation(req: CreateLocationRequest): Promise<Location> {
+  const body = await http.post<LocationResponse>("/locations", envelope(req))
+  if (!body.data?.attributes) {
+    throw new Error("Create-location response missing data.attributes")
+  }
+  return { ...body.data.attributes, id: body.data.id }
+}
+
+export interface UpdateLocationRequest {
+  name?: string
+  address?: string
+}
+
+export async function updateLocation(id: string, req: UpdateLocationRequest): Promise<Location> {
+  const body = await http.put<LocationResponse>(
+    `/locations/${encodeURIComponent(id)}`,
+    envelope(req)
+  )
+  if (!body.data?.attributes) {
+    throw new Error("Update-location response missing data.attributes")
+  }
+  return { ...body.data.attributes, id: body.data.id }
+}
+
+export async function deleteLocation(id: string): Promise<void> {
+  await http.del<void>(`/locations/${encodeURIComponent(id)}`)
+}

--- a/frontend-react/src/features/locations/hooks.ts
+++ b/frontend-react/src/features/locations/hooks.ts
@@ -1,0 +1,133 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useCurrentGroup } from "@/features/group/GroupContext"
+
+import {
+  createLocation,
+  deleteLocation,
+  getLocation,
+  listLocations,
+  updateLocation,
+  type CreateLocationRequest,
+  type Location,
+  type UpdateLocationRequest,
+} from "./api"
+import { locationKeys } from "./keys"
+
+interface QueryOptions {
+  // Gate the query — typically `!!currentGroup`. The locations
+  // endpoint is /g/{slug}/locations after the http rewrite, so firing
+  // before the GroupProvider has populated the slug slot 404s.
+  enabled?: boolean
+}
+
+export function useLocations({ enabled = true }: QueryOptions = {}) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useQuery<Location[]>({
+    queryKey: locationKeys.list(slug),
+    queryFn: ({ signal }) => listLocations({ signal }),
+    enabled,
+  })
+}
+
+export function useLocation(id: string | undefined, { enabled = true }: QueryOptions = {}) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useQuery<Location>({
+    queryKey: locationKeys.detail(slug, id ?? ""),
+    queryFn: ({ signal }) => {
+      if (!id) throw new Error("useLocation called without an id")
+      return getLocation(id, signal)
+    },
+    enabled: enabled && !!id,
+  })
+}
+
+// Common refetch on success: invalidate the list (so a fresh
+// list-without-the-deleted-row / list-with-the-new-row arrives) plus
+// the affected detail key. We do NOT refetch the detail when it's the
+// row we just removed — TanStack will discard the cached error itself
+// once the matching component unmounts.
+function useInvalidate() {
+  const qc = useQueryClient()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return {
+    list: () => qc.invalidateQueries({ queryKey: locationKeys.list(slug) }),
+    detail: (id: string) => qc.invalidateQueries({ queryKey: locationKeys.detail(slug, id) }),
+  }
+}
+
+export function useCreateLocation() {
+  const invalidate = useInvalidate()
+  return useMutation<Location, Error, CreateLocationRequest>({
+    mutationFn: (req) => createLocation(req),
+    onSuccess: () => {
+      invalidate.list()
+    },
+  })
+}
+
+// Optimistic rename: the list query gets patched in-place so the new
+// name shows immediately. On failure we restore the snapshot taken
+// before the mutation fired.
+export function useUpdateLocation(id: string) {
+  const qc = useQueryClient()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  const listKey = locationKeys.list(slug)
+  const detailKey = locationKeys.detail(slug, id)
+  return useMutation<Location, Error, UpdateLocationRequest, { previousList?: Location[] }>({
+    mutationFn: (req) => updateLocation(id, req),
+    onMutate: async (req) => {
+      await qc.cancelQueries({ queryKey: listKey })
+      const previousList = qc.getQueryData<Location[]>(listKey)
+      if (previousList) {
+        qc.setQueryData<Location[]>(
+          listKey,
+          previousList.map((l) => (l.id === id ? { ...l, ...req } : l))
+        )
+      }
+      return { previousList }
+    },
+    onError: (_err, _req, ctx) => {
+      if (ctx?.previousList) qc.setQueryData(listKey, ctx.previousList)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: listKey })
+      qc.invalidateQueries({ queryKey: detailKey })
+    },
+  })
+}
+
+// Optimistic delete: the list query removes the row immediately so
+// the UI doesn't lag the action. On failure the snapshot is restored
+// (and the user sees the row reappear, which is the "rollback" the
+// AC asks for).
+export function useDeleteLocation() {
+  const qc = useQueryClient()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  const listKey = locationKeys.list(slug)
+  return useMutation<void, Error, string, { previousList?: Location[] }>({
+    mutationFn: (id) => deleteLocation(id),
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: listKey })
+      const previousList = qc.getQueryData<Location[]>(listKey)
+      if (previousList) {
+        qc.setQueryData<Location[]>(
+          listKey,
+          previousList.filter((l) => l.id !== id)
+        )
+      }
+      return { previousList }
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previousList) qc.setQueryData(listKey, ctx.previousList)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: listKey })
+    },
+  })
+}

--- a/frontend-react/src/features/locations/hooks.ts
+++ b/frontend-react/src/features/locations/hooks.ts
@@ -69,30 +69,44 @@ export function useCreateLocation() {
   })
 }
 
-// Optimistic rename: the list query gets patched in-place so the new
-// name shows immediately. On failure we restore the snapshot taken
-// before the mutation fired.
+// Optimistic rename: both the list and the detail query get patched
+// in-place so the new name shows immediately wherever the location is
+// rendered. On failure we restore the snapshots taken before the
+// mutation fired. (The detail patch matters when the user edits from
+// LocationDetailPage — without it the heading wouldn't update until
+// onSettled refetched.)
 export function useUpdateLocation(id: string) {
   const qc = useQueryClient()
   const { currentGroup } = useCurrentGroup()
   const slug = currentGroup?.slug ?? ""
   const listKey = locationKeys.list(slug)
   const detailKey = locationKeys.detail(slug, id)
-  return useMutation<Location, Error, UpdateLocationRequest, { previousList?: Location[] }>({
+  return useMutation<
+    Location,
+    Error,
+    UpdateLocationRequest,
+    { previousList?: Location[]; previousDetail?: Location }
+  >({
     mutationFn: (req) => updateLocation(id, req),
     onMutate: async (req) => {
       await qc.cancelQueries({ queryKey: listKey })
+      await qc.cancelQueries({ queryKey: detailKey })
       const previousList = qc.getQueryData<Location[]>(listKey)
+      const previousDetail = qc.getQueryData<Location>(detailKey)
       if (previousList) {
         qc.setQueryData<Location[]>(
           listKey,
           previousList.map((l) => (l.id === id ? { ...l, ...req } : l))
         )
       }
-      return { previousList }
+      if (previousDetail) {
+        qc.setQueryData<Location>(detailKey, { ...previousDetail, ...req })
+      }
+      return { previousList, previousDetail }
     },
     onError: (_err, _req, ctx) => {
       if (ctx?.previousList) qc.setQueryData(listKey, ctx.previousList)
+      if (ctx?.previousDetail) qc.setQueryData(detailKey, ctx.previousDetail)
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: listKey })

--- a/frontend-react/src/features/locations/keys.ts
+++ b/frontend-react/src/features/locations/keys.ts
@@ -1,0 +1,11 @@
+// TanStack Query keys for the locations slice. Scoped by group slug
+// for the same reason as commodities (#1408): the http client rewrites
+// /locations -> /g/{slug}/locations, so without the slug embedded in
+// the key, switching groups would reuse a stale cache while the network
+// fetched fresh data.
+export const locationKeys = {
+  all: ["location"] as const,
+  group: (slug: string) => [...locationKeys.all, slug] as const,
+  list: (slug: string) => [...locationKeys.group(slug), "list"] as const,
+  detail: (slug: string, id: string) => [...locationKeys.group(slug), "detail", id] as const,
+}

--- a/frontend-react/src/features/locations/schemas.ts
+++ b/frontend-react/src/features/locations/schemas.ts
@@ -1,0 +1,21 @@
+import { z } from "zod"
+
+// Validation schemas for the location create/edit form. i18n keys live
+// in the `locations` namespace under `validation`; pages translate
+// `errors[name].message` at render time the same way the group forms
+// do (#1413).
+
+const NAME_REQUIRED = "locations:validation.nameRequired"
+const NAME_TOO_LONG = "locations:validation.nameTooLong"
+const ADDRESS_TOO_LONG = "locations:validation.addressTooLong"
+
+export const locationSchema = z.object({
+  name: z.string().trim().min(1, NAME_REQUIRED).max(200, NAME_TOO_LONG),
+  // Maps to the BE's `address`; the design mock calls it "description".
+  // Empty string flows through — the BE accepts that as "no address".
+  // We avoid `.default("")` here because zod 3 makes the input type
+  // include `undefined` (default fills it in) which then disagrees
+  // with react-hook-form's resolver expecting input == output.
+  address: z.string().trim().max(2000, ADDRESS_TOO_LONG),
+})
+export type LocationFormInput = z.infer<typeof locationSchema>

--- a/frontend-react/src/i18n/locales/en/common.json
+++ b/frontend-react/src/i18n/locales/en/common.json
@@ -3,6 +3,7 @@
     "back": "Back",
     "cancel": "Cancel",
     "confirm": "Confirm",
+    "delete": "Delete",
     "goHome": "Go home"
   },
   "brand": "Inventario",

--- a/frontend-react/src/i18n/locales/en/locations.json
+++ b/frontend-react/src/i18n/locales/en/locations.json
@@ -4,7 +4,7 @@
     "errorDescription": "We couldn't load this area. Refresh the page to retry, or head back to the locations list.",
     "errorTitle": "Unable to load area",
     "fallbackTitle": "Area",
-    "itemsSoonDescription": "The per-area item list lands once the items page (#1410) ships.",
+    "itemsSoonDescription": "The per-area item list is coming soon.",
     "itemsSoonTitle": "Items coming soon"
   },
   "areaDialog": {

--- a/frontend-react/src/i18n/locales/en/locations.json
+++ b/frontend-react/src/i18n/locales/en/locations.json
@@ -1,1 +1,90 @@
-{}
+{
+  "areaDetail": {
+    "back": "Back to location",
+    "errorDescription": "We couldn't load this area. Refresh the page to retry, or head back to the locations list.",
+    "errorTitle": "Unable to load area",
+    "fallbackTitle": "Area",
+    "itemsSoonDescription": "The per-area item list lands once the items page (#1410) ships.",
+    "itemsSoonTitle": "Items coming soon"
+  },
+  "areaDialog": {
+    "createDescription": "Add an area inside a location — e.g. Kitchen, Garage, Office.",
+    "createSubmit": "Add area",
+    "createTitle": "Add area",
+    "editDescription": "Update this area's name or move it to another location.",
+    "editSubmit": "Save changes",
+    "editTitle": "Edit area",
+    "errorGeneric": "Something went wrong. Try again, or contact support if the problem persists.",
+    "locationLabel": "Parent location",
+    "nameLabel": "Name",
+    "namePlaceholder": "e.g. Kitchen, Living Room, Workshop…",
+    "submitting": "Saving…"
+  },
+  "delete": {
+    "areaDescription": "Items already filed in this area will lose their area assignment. This cannot be undone.",
+    "areaTitle": "Delete area \"{{name}}\"?",
+    "locationDescription": "This cannot be undone.",
+    "locationDescriptionWithAreas_one": "This will also delete {{count}} area inside it. This cannot be undone.",
+    "locationDescriptionWithAreas_other": "This will also delete {{count}} areas inside it. This cannot be undone.",
+    "locationTitle": "Delete location \"{{name}}\"?"
+  },
+  "detail": {
+    "areasDescription_one": "{{count}} area",
+    "areasDescription_other": "{{count}} areas",
+    "areasEmpty": "No areas yet. Add one to start organising what's stored in this location.",
+    "areasTitle": "Areas",
+    "back": "Back to locations",
+    "edit": "Edit",
+    "errorDescription": "We couldn't load this location. Refresh the page to retry, or head back to the list.",
+    "errorTitle": "Unable to load location",
+    "fallbackTitle": "Location"
+  },
+  "dialog": {
+    "addressHelp": "Optional. A street address, room location, or any free-text note.",
+    "addressLabel": "Address",
+    "addressPlaceholder": "e.g. 12 Elm Street, Apartment 4B",
+    "createDescription": "Add a new physical location to your group — house, garage, storage unit, anywhere you keep things.",
+    "createSubmit": "Add location",
+    "createTitle": "Add location",
+    "editDescription": "Update the name or address for this location.",
+    "editSubmit": "Save changes",
+    "editTitle": "Edit location",
+    "errorGeneric": "Something went wrong. Try again, or contact support if the problem persists.",
+    "nameLabel": "Name",
+    "namePlaceholder": "e.g. Main House, Garage, Cottage…",
+    "submitting": "Saving…"
+  },
+  "list": {
+    "addArea": "Add area",
+    "addLocation": "Add location",
+    "deleteArea": "Delete area {{name}}",
+    "deleteLocation": "Delete location",
+    "documentTitle": "Locations",
+    "emptyDescription": "Locations are the physical places you keep things — houses, units, vehicles, anywhere your items live. Add your first one to start organising.",
+    "emptyTitle": "No locations yet",
+    "errorDescription": "We couldn't load your locations. Refresh the page to retry, or contact support if the problem keeps happening.",
+    "errorTitle": "Unable to load locations",
+    "heading": "Locations",
+    "searchEmpty": "No locations match your search.",
+    "searchPlaceholder": "Search locations or areas…",
+    "subtitle": "Where your inventory lives — physical places, plus the areas inside them."
+  },
+  "toast": {
+    "areaCreated": "Area created.",
+    "areaDeleted": "Area deleted.",
+    "areaDeleteError": "Could not delete area. Try again.",
+    "areaUpdated": "Area updated.",
+    "locationCreated": "Location created.",
+    "locationDeleted": "Location deleted.",
+    "locationDeleteError": "Could not delete location. Try again.",
+    "locationUpdated": "Location updated."
+  },
+  "validation": {
+    "addressTooLong": "Address is too long.",
+    "areaLocationRequired": "Pick a parent location.",
+    "areaNameRequired": "Area name is required.",
+    "areaNameTooLong": "Area name is too long.",
+    "nameRequired": "Location name is required.",
+    "nameTooLong": "Location name is too long."
+  }
+}

--- a/frontend-react/src/pages/areas/AreaDetailPage.tsx
+++ b/frontend-react/src/pages/areas/AreaDetailPage.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from "react"
+import { Link, useMatch, useNavigate, useParams } from "react-router-dom"
+import { useTranslation } from "react-i18next"
+import { ArrowLeft, MapPin, Package, Pencil, Trash2 } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { AreaFormDialog } from "@/components/locations/AreaFormDialog"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+import { useArea, useDeleteArea, useUpdateArea } from "@/features/areas/hooks"
+import { useLocation, useLocations } from "@/features/locations/hooks"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { useAppToast } from "@/hooks/useAppToast"
+import { useConfirm } from "@/hooks/useConfirm"
+
+interface AreaDetailPageProps {
+  initialMode?: "edit"
+}
+
+// /areas/:id — single-area detail. Shows the area name and its parent
+// location's breadcrumb. Edit + delete are the only actions today; the
+// per-area commodity list lands once the items page (#1410) ships and
+// can take an `?area=:id` filter.
+export function AreaDetailPage({ initialMode }: AreaDetailPageProps = {}) {
+  const { t } = useTranslation()
+  const params = useParams<{ id: string }>()
+  const id = params.id ?? ""
+  const navigate = useNavigate()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug
+
+  const area = useArea(id, { enabled: !!currentGroup })
+  // Fetch the parent location for the breadcrumb. The detail endpoint
+  // doesn't include the parent's name, so we hit /locations/:id once
+  // the area resolves.
+  const parent = useLocation(area.data?.location_id, {
+    enabled: !!area.data?.location_id,
+  })
+  const allLocations = useLocations({ enabled: !!currentGroup })
+  const updateArea = useUpdateArea(id)
+  const deleteArea = useDeleteArea()
+
+  const toast = useAppToast()
+  const confirm = useConfirm()
+
+  const [editOpen, setEditOpen] = useState(initialMode === "edit")
+
+  const editMatch = useMatch({ path: "/g/:groupSlug/areas/:id/edit", end: true })
+  useEffect(() => {
+    if (editMatch && !editOpen) setEditOpen(true)
+  }, [editMatch, editOpen])
+
+  function closeDialog() {
+    setEditOpen(false)
+    if (editMatch && slug && id) {
+      navigate(`/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(id)}`, {
+        replace: true,
+      })
+    }
+  }
+
+  async function handleEdit(values: { name: string; location_id: string }) {
+    await updateArea.mutateAsync(values)
+    toast.success(t("locations:toast.areaUpdated"))
+  }
+
+  async function handleDelete() {
+    if (!id) return
+    const ok = await confirm({
+      title: t("locations:delete.areaTitle", { name: area.data?.name ?? "" }),
+      description: t("locations:delete.areaDescription"),
+      confirmLabel: t("common:actions.delete"),
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await deleteArea.mutateAsync(id)
+      toast.success(t("locations:toast.areaDeleted"))
+      if (slug && area.data?.location_id) {
+        navigate(
+          `/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(area.data.location_id)}`,
+          { replace: true }
+        )
+      } else if (slug) {
+        navigate(`/g/${encodeURIComponent(slug)}/locations`, { replace: true })
+      }
+    } catch {
+      toast.error(t("locations:toast.areaDeleteError"))
+    }
+  }
+
+  if (area.isError) {
+    return (
+      <div className="flex flex-col gap-6 p-6 max-w-3xl mx-auto w-full">
+        <RouteTitle title={t("locations:areaDetail.errorTitle")} />
+        <Alert variant="destructive" data-testid="area-detail-error">
+          <AlertTitle>{t("locations:areaDetail.errorTitle")}</AlertTitle>
+          <AlertDescription>{t("locations:areaDetail.errorDescription")}</AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  const backHref =
+    slug && area.data?.location_id
+      ? `/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(area.data.location_id)}`
+      : slug
+        ? `/g/${encodeURIComponent(slug)}/locations`
+        : "#"
+
+  return (
+    <>
+      <RouteTitle title={area.data?.name ?? t("locations:areaDetail.fallbackTitle")} />
+      <div
+        className="flex flex-col gap-6 p-6 max-w-3xl mx-auto w-full"
+        data-testid="page-area-detail"
+      >
+        <Link
+          to={backHref}
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          {parent.data ? parent.data.name : t("locations:areaDetail.back")}
+        </Link>
+
+        {area.isLoading ? (
+          <div className="space-y-3" data-testid="area-detail-loading">
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-4 w-96" />
+          </div>
+        ) : area.data ? (
+          <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+                <Package className="size-5 text-muted-foreground" aria-hidden="true" />
+                <span className="truncate">{area.data.name}</span>
+              </h1>
+              {parent.data ? (
+                <p className="mt-1 text-sm text-muted-foreground inline-flex items-center gap-1.5">
+                  <MapPin className="size-3.5" aria-hidden="true" />
+                  {parent.data.name}
+                </p>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setEditOpen(true)}
+                data-testid="area-detail-edit"
+                className="gap-2"
+              >
+                <Pencil className="size-4" aria-hidden="true" />
+                {t("locations:detail.edit")}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleDelete}
+                data-testid="area-detail-delete"
+                className="gap-2"
+              >
+                <Trash2 className="size-4 text-destructive" aria-hidden="true" />
+                {t("common:actions.delete")}
+              </Button>
+            </div>
+          </header>
+        ) : null}
+
+        <Alert data-testid="area-detail-items-soon">
+          <AlertTitle>{t("locations:areaDetail.itemsSoonTitle")}</AlertTitle>
+          <AlertDescription>{t("locations:areaDetail.itemsSoonDescription")}</AlertDescription>
+        </Alert>
+      </div>
+
+      <AreaFormDialog
+        open={editOpen}
+        onOpenChange={(open) => (open ? null : closeDialog())}
+        area={area.data}
+        locations={allLocations.data ?? []}
+        onSubmit={handleEdit}
+        isPending={updateArea.isPending}
+      />
+    </>
+  )
+}

--- a/frontend-react/src/pages/areas/__tests__/AreaDetailPage.test.tsx
+++ b/frontend-react/src/pages/areas/__tests__/AreaDetailPage.test.tsx
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { Route } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+
+import { AreaDetailPage } from "@/pages/areas/AreaDetailPage"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { ConfirmProvider } from "@/hooks/useConfirm"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { areaHandlers, groupHandlers, locationHandlers } from "@/test/handlers"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import type { Schema } from "@/types"
+
+const SLUG = "household"
+const groupFixture: Schema<"models.LocationGroup">[] = [
+  { id: "g1", slug: SLUG, name: "Household", main_currency: "USD" },
+]
+
+function locationResource(id: string, attrs: { name: string; address?: string }) {
+  return { id, type: "locations", attributes: { ...attrs, id } }
+}
+
+function areaResource(id: string, attrs: { name: string; location_id: string }) {
+  return { id, type: "areas", attributes: { ...attrs, id } }
+}
+
+function renderDetail(initialPath: string, props: { initialMode?: "edit" } = {}) {
+  setAccessToken("good-token")
+  return renderWithProviders({
+    initialPath,
+    routes: (
+      <Route
+        path="/g/:groupSlug/areas/:id"
+        element={
+          <ConfirmProvider>
+            <GroupProvider>
+              <AreaDetailPage {...props} />
+            </GroupProvider>
+          </ConfirmProvider>
+        }
+      />
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<AreaDetailPage />", () => {
+  it("renders the area's name + parent-location breadcrumb", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.detail(
+        SLUG,
+        "a1",
+        areaResource("a1", {
+          name: "Kitchen",
+          location_id: "loc1",
+        })
+      ),
+      ...locationHandlers.detail(
+        SLUG,
+        "loc1",
+        locationResource("loc1", {
+          name: "Main House",
+        })
+      ),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Main House" })])
+    )
+    renderDetail(`/g/${SLUG}/areas/a1`)
+    await waitFor(() => expect(screen.getByText("Kitchen")).toBeInTheDocument())
+    // Parent-location resolves on a chained fetch (area → location_id
+    // → /locations/:id), so wait again for the breadcrumb.
+    await waitFor(() => {
+      expect(screen.getAllByText("Main House").length).toBeGreaterThan(0)
+    })
+    // The "items coming soon" alert references #1410.
+    expect(screen.getByTestId("area-detail-items-soon")).toBeInTheDocument()
+  })
+
+  it("auto-opens the edit dialog when initialMode='edit'", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.detail(
+        SLUG,
+        "a1",
+        areaResource("a1", {
+          name: "Workshop",
+          location_id: "loc1",
+        })
+      ),
+      ...locationHandlers.detail(SLUG, "loc1", locationResource("loc1", { name: "Garage" })),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Garage" })])
+    )
+    renderDetail(`/g/${SLUG}/areas/a1`, { initialMode: "edit" })
+    expect(await screen.findByTestId("area-form-dialog")).toBeInTheDocument()
+  })
+})

--- a/frontend-react/src/pages/locations/LocationDetailPage.tsx
+++ b/frontend-react/src/pages/locations/LocationDetailPage.tsx
@@ -1,0 +1,281 @@
+import { useEffect, useState } from "react"
+import { Link, useMatch, useNavigate, useParams } from "react-router-dom"
+import { useTranslation } from "react-i18next"
+import { ArrowLeft, ChevronRight, MapPin, Pencil, Plus, Trash2 } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { LocationFormDialog } from "@/components/locations/LocationFormDialog"
+import { AreaFormDialog } from "@/components/locations/AreaFormDialog"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+import { useAreas, useCreateArea, useDeleteArea } from "@/features/areas/hooks"
+import {
+  useDeleteLocation,
+  useLocation,
+  useLocations,
+  useUpdateLocation,
+} from "@/features/locations/hooks"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { useAppToast } from "@/hooks/useAppToast"
+import { useConfirm } from "@/hooks/useConfirm"
+import type { Area } from "@/features/areas/api"
+
+interface LocationDetailPageProps {
+  initialMode?: "edit"
+}
+
+// /locations/:id — single-location detail. Renders metadata + the
+// location's areas, with edit / add-area / delete actions. The
+// /locations/:id/edit deep link mounts this same component with
+// `initialMode="edit"`; both routes auto-open the matching dialog.
+export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}) {
+  const { t } = useTranslation()
+  const params = useParams<{ id: string }>()
+  const id = params.id ?? ""
+  const navigate = useNavigate()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug
+
+  const location = useLocation(id, { enabled: !!currentGroup })
+  const allLocations = useLocations({ enabled: !!currentGroup })
+  const allAreas = useAreas({ enabled: !!currentGroup })
+  const updateLocation = useUpdateLocation(id)
+  const deleteLocation = useDeleteLocation()
+  const createArea = useCreateArea()
+  const deleteArea = useDeleteArea()
+
+  const toast = useAppToast()
+  const confirm = useConfirm()
+
+  type DialogState = { kind: "none" } | { kind: "edit" } | { kind: "create-area" }
+  const [dialog, setDialog] = useState<DialogState>(() =>
+    initialMode === "edit" ? { kind: "edit" } : { kind: "none" }
+  )
+
+  const editMatch = useMatch({ path: "/g/:groupSlug/locations/:id/edit", end: true })
+  useEffect(() => {
+    if (editMatch && dialog.kind === "none") setDialog({ kind: "edit" })
+  }, [editMatch, dialog.kind])
+
+  function closeDialog() {
+    setDialog({ kind: "none" })
+    if (editMatch && slug && id) {
+      navigate(`/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(id)}`, {
+        replace: true,
+      })
+    }
+  }
+
+  async function handleEditLocation(values: { name: string; address: string }) {
+    await updateLocation.mutateAsync({ name: values.name, address: values.address })
+    toast.success(t("locations:toast.locationUpdated"))
+  }
+
+  async function handleCreateArea(values: { name: string; location_id: string }) {
+    await createArea.mutateAsync(values)
+    toast.success(t("locations:toast.areaCreated"))
+  }
+
+  async function handleDelete() {
+    if (!location.data?.id) return
+    const areaCount = (allAreas.data ?? []).filter((a) => a.location_id === id).length
+    const ok = await confirm({
+      title: t("locations:delete.locationTitle", { name: location.data.name ?? "" }),
+      description:
+        areaCount > 0
+          ? t("locations:delete.locationDescriptionWithAreas", { count: areaCount })
+          : t("locations:delete.locationDescription"),
+      confirmLabel: t("common:actions.delete"),
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await deleteLocation.mutateAsync(location.data.id)
+      toast.success(t("locations:toast.locationDeleted"))
+      if (slug) navigate(`/g/${encodeURIComponent(slug)}/locations`, { replace: true })
+    } catch {
+      toast.error(t("locations:toast.locationDeleteError"))
+    }
+  }
+
+  async function handleDeleteArea(area: Area) {
+    if (!area.id) return
+    const ok = await confirm({
+      title: t("locations:delete.areaTitle", { name: area.name ?? "" }),
+      description: t("locations:delete.areaDescription"),
+      confirmLabel: t("common:actions.delete"),
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await deleteArea.mutateAsync(area.id)
+      toast.success(t("locations:toast.areaDeleted"))
+    } catch {
+      toast.error(t("locations:toast.areaDeleteError"))
+    }
+  }
+
+  if (location.isError) {
+    return (
+      <div className="flex flex-col gap-6 p-6 max-w-3xl mx-auto w-full">
+        <RouteTitle title={t("locations:detail.errorTitle")} />
+        <Alert variant="destructive" data-testid="location-detail-error">
+          <AlertTitle>{t("locations:detail.errorTitle")}</AlertTitle>
+          <AlertDescription>{t("locations:detail.errorDescription")}</AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  const myAreas = (allAreas.data ?? []).filter((a) => a.location_id === id)
+  const backHref = slug ? `/g/${encodeURIComponent(slug)}/locations` : "#"
+
+  return (
+    <>
+      <RouteTitle title={location.data?.name ?? t("locations:detail.fallbackTitle")} />
+      <div
+        className="flex flex-col gap-6 p-6 max-w-3xl mx-auto w-full"
+        data-testid="page-location-detail"
+      >
+        <Link
+          to={backHref}
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          {t("locations:detail.back")}
+        </Link>
+
+        {location.isLoading ? (
+          <div className="space-y-3" data-testid="location-detail-loading">
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-4 w-96" />
+          </div>
+        ) : location.data ? (
+          <>
+            <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0">
+                <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+                  <MapPin className="size-5 text-muted-foreground" aria-hidden="true" />
+                  <span className="truncate">{location.data.name}</span>
+                </h1>
+                {location.data.address ? (
+                  <p className="mt-1 text-muted-foreground">{location.data.address}</p>
+                ) : null}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setDialog({ kind: "edit" })}
+                  data-testid="location-detail-edit"
+                  className="gap-2"
+                >
+                  <Pencil className="size-4" aria-hidden="true" />
+                  {t("locations:detail.edit")}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleDelete}
+                  data-testid="location-detail-delete"
+                  className="gap-2"
+                >
+                  <Trash2 className="size-4 text-destructive" aria-hidden="true" />
+                  {t("common:actions.delete")}
+                </Button>
+              </div>
+            </header>
+
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <CardTitle className="text-base">{t("locations:detail.areasTitle")}</CardTitle>
+                    <CardDescription>
+                      {t("locations:detail.areasDescription", { count: myAreas.length })}
+                    </CardDescription>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setDialog({ kind: "create-area" })}
+                    data-testid="location-detail-add-area"
+                    className="gap-2"
+                  >
+                    <Plus className="size-3.5" aria-hidden="true" />
+                    {t("locations:list.addArea")}
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {myAreas.length === 0 ? (
+                  <p
+                    className="text-sm text-muted-foreground"
+                    data-testid="location-detail-areas-empty"
+                  >
+                    {t("locations:detail.areasEmpty")}
+                  </p>
+                ) : (
+                  <ul className="divide-y divide-border rounded-md border border-border">
+                    {myAreas.map((area) => {
+                      const areaHref =
+                        slug && area.id
+                          ? `/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(area.id)}`
+                          : "#"
+                      return (
+                        <li
+                          key={area.id}
+                          className="flex items-center justify-between px-3 py-2"
+                          data-testid="location-detail-area"
+                        >
+                          <Link
+                            to={areaHref}
+                            className="flex items-center gap-2 text-sm hover:underline min-w-0"
+                          >
+                            <ChevronRight
+                              className="size-3.5 text-muted-foreground"
+                              aria-hidden="true"
+                            />
+                            <span className="truncate">{area.name}</span>
+                          </Link>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleDeleteArea(area)}
+                            aria-label={t("locations:list.deleteArea", { name: area.name ?? "" })}
+                          >
+                            <Trash2 className="size-3.5 text-destructive" aria-hidden="true" />
+                          </Button>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                )}
+              </CardContent>
+            </Card>
+          </>
+        ) : null}
+      </div>
+
+      <LocationFormDialog
+        open={dialog.kind === "edit"}
+        onOpenChange={(open) => (open ? null : closeDialog())}
+        location={location.data}
+        onSubmit={handleEditLocation}
+        isPending={updateLocation.isPending}
+      />
+      <AreaFormDialog
+        open={dialog.kind === "create-area"}
+        onOpenChange={(open) => (open ? null : setDialog({ kind: "none" }))}
+        locations={allLocations.data ?? []}
+        defaultLocationId={id}
+        onSubmit={handleCreateArea}
+        isPending={createArea.isPending}
+      />
+    </>
+  )
+}

--- a/frontend-react/src/pages/locations/LocationsListPage.tsx
+++ b/frontend-react/src/pages/locations/LocationsListPage.tsx
@@ -1,0 +1,377 @@
+import { useEffect, useMemo, useState } from "react"
+import { Link, useMatch, useNavigate } from "react-router-dom"
+import { useTranslation } from "react-i18next"
+import { ChevronRight, MapPin, Plus, Search, Trash2 } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { LocationFormDialog } from "@/components/locations/LocationFormDialog"
+import { AreaFormDialog } from "@/components/locations/AreaFormDialog"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+import { useAreas, useCreateArea, useDeleteArea } from "@/features/areas/hooks"
+import { useCreateLocation, useDeleteLocation, useLocations } from "@/features/locations/hooks"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { useAppToast } from "@/hooks/useAppToast"
+import { useConfirm } from "@/hooks/useConfirm"
+import type { Area } from "@/features/areas/api"
+import type { Location } from "@/features/locations/api"
+
+interface LocationsListPageProps {
+  // When mounted at /locations/new the dialog opens on first paint.
+  initialMode?: "create"
+}
+
+// /locations — list of every location in the active group, with the
+// nested areas surfaced inline. Add buttons open the matching dialog
+// (`LocationFormDialog` / `AreaFormDialog`); both dialogs are also
+// reachable via /locations/new — that route mounts this same page
+// with `initialMode="create"` so a deep link can open the create
+// modal on top of the list.
+export function LocationsListPage({ initialMode }: LocationsListPageProps = {}) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { currentGroup } = useCurrentGroup()
+  const enabled = !!currentGroup
+  const slug = currentGroup?.slug
+
+  const locations = useLocations({ enabled })
+  const areas = useAreas({ enabled })
+  const createLocation = useCreateLocation()
+  const deleteLocation = useDeleteLocation()
+  const createArea = useCreateArea()
+  const deleteArea = useDeleteArea()
+
+  const toast = useAppToast()
+  const confirm = useConfirm()
+
+  // Search filters locations + their areas client-side. The list is
+  // typically small (single-digit) so paging / server-side search
+  // would be over-engineered.
+  const [query, setQuery] = useState("")
+
+  // Dialog state. We track both kinds in one state slot so the page
+  // never tries to mount two modals at once.
+  type DialogState =
+    | { kind: "none" }
+    | { kind: "create-location" }
+    | { kind: "create-area"; locationId?: string }
+  const [dialog, setDialog] = useState<DialogState>(() =>
+    initialMode === "create" ? { kind: "create-location" } : { kind: "none" }
+  )
+
+  // Deep link: /locations/new auto-opens the create dialog. Closing
+  // the dialog navigates back to /locations so the URL doesn't keep
+  // re-opening the dialog on a re-render.
+  const newMatch = useMatch({ path: "/g/:groupSlug/locations/new", end: true })
+  useEffect(() => {
+    if (newMatch && dialog.kind === "none") {
+      setDialog({ kind: "create-location" })
+    }
+  }, [newMatch, dialog.kind])
+
+  function closeDialog() {
+    setDialog({ kind: "none" })
+    if (newMatch && slug) {
+      navigate(`/g/${encodeURIComponent(slug)}/locations`, { replace: true })
+    }
+  }
+
+  const filteredLocations = useMemo(() => {
+    const list = locations.data ?? []
+    if (!query.trim()) return list
+    const q = query.trim().toLowerCase()
+    const areaList = areas.data ?? []
+    return list.filter((l) => {
+      if ((l.name ?? "").toLowerCase().includes(q)) return true
+      if ((l.address ?? "").toLowerCase().includes(q)) return true
+      // A location matches if any of its areas match the query — keeps
+      // search useful when the user remembers the room name but not
+      // the building it's in.
+      return areaList.some(
+        (a) => a.location_id === l.id && (a.name ?? "").toLowerCase().includes(q)
+      )
+    })
+  }, [locations.data, areas.data, query])
+
+  async function handleCreateLocation(values: { name: string; address: string }) {
+    await createLocation.mutateAsync({ name: values.name, address: values.address })
+    toast.success(t("locations:toast.locationCreated"))
+  }
+
+  async function handleCreateArea(values: { name: string; location_id: string }) {
+    await createArea.mutateAsync(values)
+    toast.success(t("locations:toast.areaCreated"))
+  }
+
+  async function handleDeleteLocation(loc: Location) {
+    if (!loc.id) return
+    const areaCount = (areas.data ?? []).filter((a) => a.location_id === loc.id).length
+    const ok = await confirm({
+      title: t("locations:delete.locationTitle", { name: loc.name ?? "" }),
+      // Surface the orphan count so the user can't blow away a populated
+      // location by accident. Areas belonging to the location go with
+      // it server-side; the legacy frontend renders this same warning.
+      description:
+        areaCount > 0
+          ? t("locations:delete.locationDescriptionWithAreas", { count: areaCount })
+          : t("locations:delete.locationDescription"),
+      confirmLabel: t("common:actions.delete"),
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await deleteLocation.mutateAsync(loc.id)
+      toast.success(t("locations:toast.locationDeleted"))
+    } catch {
+      toast.error(t("locations:toast.locationDeleteError"))
+    }
+  }
+
+  async function handleDeleteArea(area: Area) {
+    if (!area.id) return
+    const ok = await confirm({
+      title: t("locations:delete.areaTitle", { name: area.name ?? "" }),
+      description: t("locations:delete.areaDescription"),
+      confirmLabel: t("common:actions.delete"),
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await deleteArea.mutateAsync(area.id)
+      toast.success(t("locations:toast.areaDeleted"))
+    } catch {
+      toast.error(t("locations:toast.areaDeleteError"))
+    }
+  }
+
+  const isLoading = locations.isLoading || areas.isLoading
+  const isError = locations.isError || areas.isError
+  const isEmpty = !isLoading && !isError && (locations.data ?? []).length === 0
+
+  return (
+    <>
+      <RouteTitle title={t("locations:list.documentTitle")} />
+      <div
+        className="flex flex-col gap-6 p-6 max-w-5xl mx-auto w-full"
+        data-testid="page-locations"
+      >
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">
+              {t("locations:list.heading")}
+            </h1>
+            <p className="mt-1 text-muted-foreground leading-7">{t("locations:list.subtitle")}</p>
+          </div>
+          <Button
+            type="button"
+            onClick={() => setDialog({ kind: "create-location" })}
+            data-testid="locations-add-button"
+            className="gap-2"
+          >
+            <Plus className="size-4" aria-hidden="true" />
+            {t("locations:list.addLocation")}
+          </Button>
+        </header>
+
+        {!isEmpty && !isError ? (
+          <div className="relative">
+            <Search
+              className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <Input
+              type="search"
+              placeholder={t("locations:list.searchPlaceholder")}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="pl-9"
+              data-testid="locations-search"
+            />
+          </div>
+        ) : null}
+
+        {isError ? (
+          <Alert variant="destructive" data-testid="locations-error">
+            <AlertTitle>{t("locations:list.errorTitle")}</AlertTitle>
+            <AlertDescription>{t("locations:list.errorDescription")}</AlertDescription>
+          </Alert>
+        ) : isLoading ? (
+          <div className="space-y-3" data-testid="locations-loading">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <Card key={i}>
+                <CardHeader>
+                  <Skeleton className="h-5 w-40" />
+                  <Skeleton className="h-3 w-64" />
+                </CardHeader>
+              </Card>
+            ))}
+          </div>
+        ) : isEmpty ? (
+          <Card data-testid="locations-empty">
+            <CardHeader>
+              <CardTitle>{t("locations:list.emptyTitle")}</CardTitle>
+              <CardDescription>{t("locations:list.emptyDescription")}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button
+                type="button"
+                onClick={() => setDialog({ kind: "create-location" })}
+                data-testid="locations-empty-cta"
+                className="gap-2"
+              >
+                <Plus className="size-4" aria-hidden="true" />
+                {t("locations:list.addLocation")}
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <ul className="space-y-3">
+            {filteredLocations.map((loc) => {
+              const locAreas = (areas.data ?? []).filter((a) => a.location_id === loc.id)
+              return (
+                <li key={loc.id}>
+                  <LocationCard
+                    location={loc}
+                    areas={locAreas}
+                    onAddArea={() => setDialog({ kind: "create-area", locationId: loc.id })}
+                    onDeleteLocation={() => handleDeleteLocation(loc)}
+                    onDeleteArea={(a) => handleDeleteArea(a)}
+                  />
+                </li>
+              )
+            })}
+            {filteredLocations.length === 0 ? (
+              <li className="text-sm text-muted-foreground" data-testid="locations-search-empty">
+                {t("locations:list.searchEmpty")}
+              </li>
+            ) : null}
+          </ul>
+        )}
+      </div>
+
+      <LocationFormDialog
+        open={dialog.kind === "create-location"}
+        onOpenChange={(open) => (open ? null : closeDialog())}
+        onSubmit={handleCreateLocation}
+        isPending={createLocation.isPending}
+      />
+      <AreaFormDialog
+        open={dialog.kind === "create-area"}
+        onOpenChange={(open) => (open ? null : setDialog({ kind: "none" }))}
+        locations={locations.data ?? []}
+        defaultLocationId={dialog.kind === "create-area" ? dialog.locationId : undefined}
+        onSubmit={handleCreateArea}
+        isPending={createArea.isPending}
+      />
+    </>
+  )
+}
+
+interface LocationCardProps {
+  location: Location
+  areas: Area[]
+  onAddArea: () => void
+  onDeleteLocation: () => void
+  onDeleteArea: (area: Area) => void
+}
+
+// LocationCard owns one location + its inline area list. Extracted as
+// a separate component so the list page stays readable; nothing here
+// needs hooks on its own (parent owns state + mutations).
+function LocationCard({
+  location,
+  areas,
+  onAddArea,
+  onDeleteLocation,
+  onDeleteArea,
+}: LocationCardProps) {
+  const { t } = useTranslation()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug
+  const detailHref =
+    slug && location.id
+      ? `/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(location.id)}`
+      : "#"
+
+  return (
+    <Card data-testid="location-card" data-location-id={location.id}>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <MapPin className="size-4 text-muted-foreground" aria-hidden="true" />
+              <Link to={detailHref} className="hover:underline truncate">
+                {location.name}
+              </Link>
+            </CardTitle>
+            {location.address ? (
+              <CardDescription className="truncate">{location.address}</CardDescription>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onAddArea}
+              data-testid="location-card-add-area"
+              className="gap-1.5"
+            >
+              <Plus className="size-3.5" aria-hidden="true" />
+              {t("locations:list.addArea")}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onDeleteLocation}
+              data-testid="location-card-delete"
+              aria-label={t("locations:list.deleteLocation")}
+            >
+              <Trash2 className="size-4 text-destructive" aria-hidden="true" />
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      {areas.length > 0 ? (
+        <CardContent className="pt-0">
+          <ul className="divide-y divide-border rounded-md border border-border">
+            {areas.map((area) => {
+              const areaHref =
+                slug && area.id
+                  ? `/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(area.id)}`
+                  : "#"
+              return (
+                <li
+                  key={area.id}
+                  className="flex items-center justify-between px-3 py-2"
+                  data-testid="location-card-area"
+                >
+                  <Link
+                    to={areaHref}
+                    className="flex items-center gap-2 text-sm hover:underline min-w-0"
+                  >
+                    <ChevronRight className="size-3.5 text-muted-foreground" aria-hidden="true" />
+                    <span className="truncate">{area.name}</span>
+                  </Link>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onDeleteArea(area)}
+                    aria-label={t("locations:list.deleteArea", { name: area.name ?? "" })}
+                  >
+                    <Trash2 className="size-3.5 text-destructive" aria-hidden="true" />
+                  </Button>
+                </li>
+              )
+            })}
+          </ul>
+        </CardContent>
+      ) : null}
+    </Card>
+  )
+}

--- a/frontend-react/src/pages/locations/__tests__/LocationDetailPage.test.tsx
+++ b/frontend-react/src/pages/locations/__tests__/LocationDetailPage.test.tsx
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { Route } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+
+import { LocationDetailPage } from "@/pages/locations/LocationDetailPage"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { ConfirmProvider } from "@/hooks/useConfirm"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { areaHandlers, groupHandlers, locationHandlers } from "@/test/handlers"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import type { Schema } from "@/types"
+
+const SLUG = "household"
+const groupFixture: Schema<"models.LocationGroup">[] = [
+  { id: "g1", slug: SLUG, name: "Household", main_currency: "USD" },
+]
+
+function locationResource(id: string, attrs: { name: string; address?: string }) {
+  return { id, type: "locations", attributes: { ...attrs, id } }
+}
+
+function areaResource(id: string, attrs: { name: string; location_id: string }) {
+  return { id, type: "areas", attributes: { ...attrs, id } }
+}
+
+function renderDetail(initialPath: string, props: { initialMode?: "edit" } = {}) {
+  setAccessToken("good-token")
+  return renderWithProviders({
+    initialPath,
+    routes: (
+      <Route
+        path="/g/:groupSlug/locations/:id"
+        element={
+          <ConfirmProvider>
+            <GroupProvider>
+              <LocationDetailPage {...props} />
+            </GroupProvider>
+          </ConfirmProvider>
+        }
+      />
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<LocationDetailPage />", () => {
+  it("renders the location's metadata and its area list", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.detail(
+        SLUG,
+        "loc1",
+        locationResource("loc1", {
+          name: "Main House",
+          address: "12 Elm St",
+        })
+      ),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Main House" })]),
+      ...areaHandlers.list(SLUG, [
+        areaResource("a1", { name: "Kitchen", location_id: "loc1" }),
+        areaResource("a2", { name: "Workshop", location_id: "loc1" }),
+        areaResource("a3", { name: "Other-Group", location_id: "loc-other" }),
+      ])
+    )
+    renderDetail(`/g/${SLUG}/locations/loc1`)
+    await waitFor(() => expect(screen.getByText("Main House")).toBeInTheDocument())
+    expect(screen.getByText("12 Elm St")).toBeInTheDocument()
+    // Only the two areas whose location_id === loc1 are surfaced.
+    const rows = await screen.findAllByTestId("location-detail-area")
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toHaveTextContent("Kitchen")
+  })
+
+  it("auto-opens the edit dialog when initialMode='edit'", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.detail(SLUG, "loc1", locationResource("loc1", { name: "Garage" })),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Garage" })]),
+      ...areaHandlers.list(SLUG, [])
+    )
+    renderDetail(`/g/${SLUG}/locations/loc1`, { initialMode: "edit" })
+    expect(await screen.findByTestId("location-form-dialog")).toBeInTheDocument()
+  })
+
+  it("renders the empty-areas copy when the location has no areas", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.detail(SLUG, "loc2", locationResource("loc2", { name: "Cottage" })),
+      ...locationHandlers.list(SLUG, [locationResource("loc2", { name: "Cottage" })]),
+      ...areaHandlers.list(SLUG, [])
+    )
+    renderDetail(`/g/${SLUG}/locations/loc2`)
+    await waitFor(() => expect(screen.getByText("Cottage")).toBeInTheDocument())
+    expect(screen.getByTestId("location-detail-areas-empty")).toBeInTheDocument()
+  })
+})

--- a/frontend-react/src/pages/locations/__tests__/LocationsListPage.test.tsx
+++ b/frontend-react/src/pages/locations/__tests__/LocationsListPage.test.tsx
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { Route } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { axe } from "jest-axe"
+
+import { LocationsListPage } from "@/pages/locations/LocationsListPage"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { ConfirmProvider } from "@/hooks/useConfirm"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { areaHandlers, groupHandlers, locationHandlers } from "@/test/handlers"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import type { Schema } from "@/types"
+
+const SLUG = "household"
+const groupFixture: Schema<"models.LocationGroup">[] = [
+  { id: "g1", slug: SLUG, name: "Household", main_currency: "USD" },
+]
+
+function locationResource(id: string, attrs: { name: string; address?: string }) {
+  return { id, type: "locations", attributes: { ...attrs, id } }
+}
+
+function areaResource(id: string, attrs: { name: string; location_id: string }) {
+  return { id, type: "areas", attributes: { ...attrs, id } }
+}
+
+function renderList(initialPath = `/g/${SLUG}/locations`) {
+  setAccessToken("good-token")
+  return renderWithProviders({
+    initialPath,
+    routes: (
+      <Route
+        path="/g/:groupSlug/locations"
+        element={
+          <ConfirmProvider>
+            <GroupProvider>
+              <LocationsListPage />
+            </GroupProvider>
+          </ConfirmProvider>
+        }
+      />
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<LocationsListPage />", () => {
+  it("renders heading + empty state for a group with no locations", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.list(SLUG, []),
+      ...areaHandlers.list(SLUG, [])
+    )
+    renderList()
+    await waitFor(() => {
+      expect(screen.queryByTestId("locations-empty")).toBeInTheDocument()
+    })
+  })
+
+  it("renders locations + their nested areas", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.list(SLUG, [
+        locationResource("loc1", { name: "Main House", address: "12 Elm St" }),
+        locationResource("loc2", { name: "Garage" }),
+      ]),
+      ...areaHandlers.list(SLUG, [
+        areaResource("a1", { name: "Kitchen", location_id: "loc1" }),
+        areaResource("a2", { name: "Workshop", location_id: "loc2" }),
+      ])
+    )
+    renderList()
+    await waitFor(() => expect(screen.getAllByTestId("location-card")).toHaveLength(2))
+    expect(screen.getByText("Main House")).toBeInTheDocument()
+    expect(screen.getByText("12 Elm St")).toBeInTheDocument()
+    expect(screen.getByText("Kitchen")).toBeInTheDocument()
+    expect(screen.getByText("Workshop")).toBeInTheDocument()
+  })
+
+  it("filters by query against location and area names", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.list(SLUG, [
+        locationResource("loc1", { name: "Main House" }),
+        locationResource("loc2", { name: "Garage" }),
+      ]),
+      ...areaHandlers.list(SLUG, [areaResource("a1", { name: "Kitchen", location_id: "loc1" })])
+    )
+    renderList()
+    await waitFor(() => expect(screen.getAllByTestId("location-card")).toHaveLength(2))
+    const search = screen.getByTestId("locations-search")
+    const user = userEvent.setup()
+    await user.type(search, "kitchen")
+    // Searching by area name surfaces the parent location only.
+    await waitFor(() => {
+      expect(screen.getAllByTestId("location-card")).toHaveLength(1)
+      expect(screen.getByText("Main House")).toBeInTheDocument()
+    })
+  })
+
+  it("opens the create dialog from the header CTA", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.list(SLUG, []),
+      ...areaHandlers.list(SLUG, [])
+    )
+    renderList()
+    const user = userEvent.setup()
+    // Wait for the page's data fetch to settle before clicking — Radix
+    // Dialog can swallow the open signal if the click lands during
+    // React's first commit.
+    await screen.findByTestId("locations-empty")
+    await user.click(screen.getByTestId("locations-add-button"))
+    expect(await screen.findByTestId("location-form-dialog")).toBeInTheDocument()
+  })
+
+  it("auto-opens the create dialog when mounted at /locations/new", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.list(SLUG, []),
+      ...areaHandlers.list(SLUG, [])
+    )
+    setAccessToken("good-token")
+    renderWithProviders({
+      initialPath: `/g/${SLUG}/locations/new`,
+      routes: (
+        <>
+          <Route
+            path="/g/:groupSlug/locations"
+            element={
+              <ConfirmProvider>
+                <GroupProvider>
+                  <LocationsListPage />
+                </GroupProvider>
+              </ConfirmProvider>
+            }
+          />
+          <Route
+            path="/g/:groupSlug/locations/new"
+            element={
+              <ConfirmProvider>
+                <GroupProvider>
+                  <LocationsListPage initialMode="create" />
+                </GroupProvider>
+              </ConfirmProvider>
+            }
+          />
+        </>
+      ),
+    })
+    expect(await screen.findByTestId("location-form-dialog")).toBeInTheDocument()
+  })
+
+  it("has no axe violations once data has loaded", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Main House" })]),
+      ...areaHandlers.list(SLUG, [])
+    )
+    const { container } = renderList()
+    await waitFor(() => expect(screen.getAllByTestId("location-card")).toHaveLength(1))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend-react/src/test/handlers/areas.ts
+++ b/frontend-react/src/test/handlers/areas.ts
@@ -34,10 +34,19 @@ export function update(slug: string, id: string, response: unknown) {
   ]
 }
 
+export function updateError(slug: string, id: string, status = 500) {
+  return [
+    http.put(apiUrl(`/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(id)}`), () =>
+      HttpResponse.json({ error: "boom" }, { status })
+    ),
+  ]
+}
+
 export function remove(slug: string, id: string) {
   return [
-    http.delete(apiUrl(`/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(id)}`), () =>
-      HttpResponse.json(null, { status: 204 })
+    http.delete(
+      apiUrl(`/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(id)}`),
+      () => new HttpResponse(null, { status: 204 })
     ),
   ]
 }

--- a/frontend-react/src/test/handlers/areas.ts
+++ b/frontend-react/src/test/handlers/areas.ts
@@ -1,0 +1,51 @@
+import { http, HttpResponse } from "msw"
+
+import { apiUrl } from "."
+
+export function list(slug: string, items: unknown[] = []) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/areas`), () =>
+      HttpResponse.json({ data: items })
+    ),
+  ]
+}
+
+export function detail(slug: string, id: string, item: unknown) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(id)}`), () =>
+      HttpResponse.json({ data: item })
+    ),
+  ]
+}
+
+export function create(slug: string, response: unknown) {
+  return [
+    http.post(apiUrl(`/g/${encodeURIComponent(slug)}/areas`), () =>
+      HttpResponse.json({ data: response }, { status: 201 })
+    ),
+  ]
+}
+
+export function update(slug: string, id: string, response: unknown) {
+  return [
+    http.put(apiUrl(`/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(id)}`), () =>
+      HttpResponse.json({ data: response })
+    ),
+  ]
+}
+
+export function remove(slug: string, id: string) {
+  return [
+    http.delete(apiUrl(`/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(id)}`), () =>
+      HttpResponse.json(null, { status: 204 })
+    ),
+  ]
+}
+
+export function removeError(slug: string, id: string, status = 500) {
+  return [
+    http.delete(apiUrl(`/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(id)}`), () =>
+      HttpResponse.json({ error: "boom" }, { status })
+    ),
+  ]
+}

--- a/frontend-react/src/test/handlers/index.ts
+++ b/frontend-react/src/test/handlers/index.ts
@@ -11,6 +11,7 @@
 export * as authHandlers from "./auth"
 export * as groupHandlers from "./groups"
 export * as commodityHandlers from "./commodities"
+export * as areaHandlers from "./areas"
 export * as locationHandlers from "./locations"
 export * as fileHandlers from "./files"
 export * as tagHandlers from "./tags"

--- a/frontend-react/src/test/handlers/locations.ts
+++ b/frontend-react/src/test/handlers/locations.ts
@@ -25,3 +25,43 @@ export function error(slug: string, status = 500) {
     ),
   ]
 }
+
+export function create(slug: string, response: unknown) {
+  return [
+    http.post(apiUrl(`/g/${encodeURIComponent(slug)}/locations`), () =>
+      HttpResponse.json({ data: response }, { status: 201 })
+    ),
+  ]
+}
+
+export function update(slug: string, id: string, response: unknown) {
+  return [
+    http.put(apiUrl(`/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(id)}`), () =>
+      HttpResponse.json({ data: response })
+    ),
+  ]
+}
+
+export function updateError(slug: string, id: string, status = 500) {
+  return [
+    http.put(apiUrl(`/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(id)}`), () =>
+      HttpResponse.json({ error: "boom" }, { status })
+    ),
+  ]
+}
+
+export function remove(slug: string, id: string) {
+  return [
+    http.delete(apiUrl(`/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(id)}`), () =>
+      HttpResponse.json(null, { status: 204 })
+    ),
+  ]
+}
+
+export function removeError(slug: string, id: string, status = 500) {
+  return [
+    http.delete(apiUrl(`/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(id)}`), () =>
+      HttpResponse.json({ error: "boom" }, { status })
+    ),
+  ]
+}

--- a/frontend-react/src/test/handlers/locations.ts
+++ b/frontend-react/src/test/handlers/locations.ts
@@ -52,8 +52,9 @@ export function updateError(slug: string, id: string, status = 500) {
 
 export function remove(slug: string, id: string) {
   return [
-    http.delete(apiUrl(`/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(id)}`), () =>
-      HttpResponse.json(null, { status: 204 })
+    http.delete(
+      apiUrl(`/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(id)}`),
+      () => new HttpResponse(null, { status: 204 })
     ),
   ]
 }


### PR DESCRIPTION
Closes #1409. Part of epic #1397.

## Summary

- Real pages at `/locations`, `/locations/:id`, `/areas/:id` (and the matching `/new` + `/:id/edit` deep-link variants). The list view follows `inventario-design/src/views/LocationPickerView.tsx`: each location is a card with its inline area list, plus search + empty state.
- CRUD flows are dialog overlays (`LocationFormDialog` / `AreaFormDialog`) per the issue's mock-parity rule. Deep links (`/locations/new`, `/locations/:id/edit`, `/areas/:id/edit`) mount the same component with an `initialMode` prop so the dialog opens on first paint, and closing it `replace`-navigates back to the canonical URL.
- Optimistic rename + delete on both slices, with snapshot rollback on error. Test cases simulate 500s and assert the list reverts.

## Data layer

- `features/locations/{api,hooks,keys,schemas}.ts` and `features/areas/{api,hooks,keys,schemas}.ts` — full CRUD against the BE's existing `/locations` and `/areas` endpoints. Query keys are scoped by `currentGroup.slug` (same convention as commodities in #1408) so the cache stays aligned with the http client's `/g/{slug}/` rewrite.
- `useUpdateLocation` / `useDeleteLocation` (and the area equivalents) wire `onMutate` → snapshot + patch, `onError` → restore, `onSettled` → invalidate. Tested via MSW 500 fixtures.

## Pages

- **`LocationsListPage`** — header CTA + search + a `LocationCard` per location. Each card shows the address (the BE field that maps to the mock's "description") and an inline area list. Empty-state Card and skeletons handled.
- **`LocationDetailPage`** — single-location header + edit / delete / add-area buttons + nested area list. Useful as the destination for the dashboard's "X items in this location" breadcrumb later.
- **`AreaDetailPage`** — area name + parent-location breadcrumb. The per-area items list is a stub `<Alert>` referencing #1410.

## Dialogs

- **`LocationFormDialog`** — create + edit modal. The BE model is `name + address`; the mock's `description` field maps to `address`. We don't ship an icon picker because the BE doesn't store an icon for locations (calling that out as a follow-up).
- **`AreaFormDialog`** — create + edit modal. Parent-location `<select>` is hidden when only one location exists; the dialog accepts a `defaultLocationId` prop so the create-from-detail flow doesn't ask "where".

## Out of scope (follow-ups)

- **Linked files** on the location detail — depends on `/files` filter support in #1411.
- **Icons** for locations and areas — the BE doesn't have a column today; would need a small schema bump.
- **Three-pane `LocationPickerView` desktop layout** — this PR ships the stacked layout. The side-by-side view from the mock can land as a separate PR if it's worth the complexity.
- **E2E happy-path** (Playwright). The Vitest + jest-axe coverage is the v1 gate. The full create-location → add-area → assign-item flow lands alongside the items page (#1410), where the chain has somewhere to terminate.

## Test plan

- [ ] CI: typecheck, lint, format, test, i18n drift, codegen drift, size-limit, LHCI all green.
- [ ] Local smoke: log into a seeded group → land on `/g/:slug/locations` → add a location → add an area inside it → rename via the edit dialog → verify the row updates in-place (optimistic) → delete and confirm the cascade warning when the location has areas.
- [ ] Direct-link to `/locations/new` and `/locations/:id/edit` and confirm the dialog opens on first paint; close → URL replaces with the canonical detail/list path.
- [ ] Optimistic rollback: kill backend, rename a location, confirm the row reverts to the original name without a page reload.