### PR TITLE
[docs] Screenshot script + how-to for the React frontend

### DIFF
--- a/devdocs/frontend-react/screenshots.md
+++ b/devdocs/frontend-react/screenshots.md
@@ -111,16 +111,18 @@ active, so the script doesn't need to know it ahead of time.
 ### 6. Stop the server
 
 ```bash
-lsof -ti:3333 | xargs kill
+PID=$(lsof -ti:3333) && kill "$PID"
 ```
 
-(Or just Ctrl-C the foreground process if you ran it that way.)
+(Works on Linux and macOS; no-ops silently when nothing is bound.
+Or just Ctrl-C the foreground process if you ran it that way.)
 
 ## Common issues
 
 - **`bind: address already in use` on port 3333.** Another inventario
   instance — or any other dev server — is bound. Kill it with
-  `lsof -ti:3333 | xargs kill`.
+  `PID=$(lsof -ti:3333) && kill "$PID"` (Linux/macOS; no-ops if nothing
+  is bound).
 - **Login API returns 401.** The seed step didn't run or hit a different
   process. Re-run `curl -X POST .../api/v1/seed` against the same port.
 - **Dashboard shows "0 items" + empty recent list.** The seed succeeded

--- a/devdocs/frontend-react/screenshots.md
+++ b/devdocs/frontend-react/screenshots.md
@@ -1,0 +1,147 @@
+# Local screenshots of the React frontend
+
+How to spin up the new React frontend (#1397) end-to-end on your machine
+and capture screenshots of every key page. Useful for PR demos, design
+reviews, or anyone asking "что вообще видно сейчас?".
+
+The script we use, `e2e/screenshots-react.mjs`, is the React-side twin of
+the legacy `e2e/screenshots.mjs` (which still targets the Vue bundle and
+is left untouched).
+
+## Prerequisites
+
+- Node.js 20+, npm
+- Go 1.26+
+- Playwright browsers installed in `e2e/` (one-time):
+  ```bash
+  cd e2e && npm install && npm run install-browsers
+  ```
+
+## Step-by-step
+
+### 1. Build both frontend bundles
+
+The Go binary embeds **both** the Vue and the React bundles at build time
+(via `//go:embed` packages gated on the `with_frontend` build tag). The
+runtime flag `--frontend-bundle=new|legacy` (or env `INVENTARIO_FRONTEND`)
+just selects which one to serve at `/`. So both `dist/` directories must
+exist before `go build` will succeed.
+
+```bash
+make build-frontend          # Vue → frontend/dist/
+make build-frontend-react    # React → frontend-react/dist/
+```
+
+### 2. Build the binary
+
+```bash
+mkdir -p bin
+cd go/cmd/inventario && \
+  go build -tags with_frontend -o ../../../bin/inventario .
+```
+
+Skipping the tag (or the `make build-backend-nofe` target) gives you a
+binary without any embedded frontend — useful for API-only work, useless
+for screenshots.
+
+### 3. Run the server with the React bundle
+
+```bash
+./bin/inventario run \
+  --addr=":3333" \
+  --db-dsn="memory://" \
+  --frontend-bundle=new \
+  --no-auth-rate-limit \
+  --no-global-rate-limit
+```
+
+`memory://` means data lives in process memory and goes away on restart —
+fine for screenshots, useless for anything else. Drop the rate-limit
+flags in a real run; they're convenient when bursting requests during
+seeding + scripted login.
+
+Verify the React bundle is serving:
+
+```bash
+curl -s http://localhost:3333/ | grep -i "<title>"
+# → <title>Inventario</title>      (both bundles use this title)
+curl -s http://localhost:3333/ | grep -o 'index-[A-Za-z0-9_]*\.js'
+# → matches the hash in frontend-react/dist/assets/
+```
+
+### 4. Seed the database
+
+```bash
+curl -X POST http://localhost:3333/api/v1/seed
+# → {"message":"Database seeded successfully","status":"success"}
+```
+
+The seeder creates `admin@test-org.com` / `testpassword123` plus a "Test
+Organization" tenant, a "Default" group, and a few locations / areas /
+commodities so the dashboard isn't empty. Source: `go/debug/seeddata/`.
+
+### 5. Run the screenshot script
+
+```bash
+BASE_URL=http://localhost:3333 \
+  OUT=tmp-screenshots-react \
+  node e2e/screenshots-react.mjs
+```
+
+What it captures (filename → page):
+
+| File                       | URL pattern                       | What you see                                 |
+| -------------------------- | --------------------------------- | -------------------------------------------- |
+| `01-login.png`             | `/login`                          | Sign-in form (#1407)                         |
+| `02-register.png`          | `/register`                       | Account creation (#1407)                     |
+| `03-forgot-password.png`   | `/forgot-password`                | Password reset request (#1407)               |
+| `04-not-found.png`         | `/some-nonexistent-route`         | Styled NotFound (#1404)                      |
+| `10-dashboard.png`         | `/g/:slug/`                       | Dashboard with stat cards + recent (#1408)   |
+| `11-locations.png`         | `/g/:slug/locations`              | Locations list with nested areas (#1409)     |
+| `12-locations-new.png`     | `/g/:slug/locations/new`          | Location-create dialog opens via deep link   |
+| `13-location-detail.png`   | `/g/:slug/locations/:id`          | Single-location detail (#1409)               |
+| `14-area-detail.png`       | `/g/:slug/areas/:id`              | Area detail with parent breadcrumb (#1409)   |
+| `20-profile.png`           | `/profile`                        | Profile (#1414)                              |
+| `21-settings.png`          | `/settings`                       | Settings (#1414)                             |
+
+The slug is read off the URL the server redirects to after login — the
+dual-bundle handler points "/" at `/g/<first-slug>/` once a group is
+active, so the script doesn't need to know it ahead of time.
+
+### 6. Stop the server
+
+```bash
+lsof -ti:3333 | xargs kill
+```
+
+(Or just Ctrl-C the foreground process if you ran it that way.)
+
+## Common issues
+
+- **`bind: address already in use` on port 3333.** Another inventario
+  instance — or any other dev server — is bound. Kill it with
+  `lsof -ti:3333 | xargs kill`.
+- **Login API returns 401.** The seed step didn't run or hit a different
+  process. Re-run `curl -X POST .../api/v1/seed` against the same port.
+- **Dashboard shows "0 items" + empty recent list.** The seed succeeded
+  but the in-memory DB was reset by a server restart between seeding
+  and screenshotting. Re-seed.
+- **`bundle=new` log line says `legacy`.** You forgot
+  `--frontend-bundle=new` (or `INVENTARIO_FRONTEND=new`). The default
+  selection comes from `go/cmd/inventario/run/bootstrap/config.go`.
+- **`go:embed` build error: `pattern "all:dist": no matching files`.**
+  You didn't run `make build-frontend` and `make build-frontend-react`
+  first. Both `dist/` directories must exist for the embed to compile.
+- **Sidebar shows `common:nav.preferences` literally.** Known: the
+  preferences nav entry resolves a key the catalog doesn't have yet.
+  Tracked separately; doesn't affect the rest of the UI.
+
+## Updating the URL list
+
+Add a row to the `groupPages` array (or the public-routes block) in
+`e2e/screenshots-react.mjs`. Keep the filename prefix monotonic so the
+output ordering reads top-to-bottom for a reviewer.
+
+For pages that need a specific record (e.g. a commodity with a long
+name), drive Playwright into the page first via the seeded fixture and
+take the shot there — don't hard-code IDs that the seeder regenerates.

--- a/devdocs/frontend-react/screenshots.md
+++ b/devdocs/frontend-react/screenshots.md
@@ -2,15 +2,15 @@
 
 How to spin up the new React frontend (#1397) end-to-end on your machine
 and capture screenshots of every key page. Useful for PR demos, design
-reviews, or anyone asking "что вообще видно сейчас?".
+reviews, or anyone asking "what can you actually see right now?".
 
-The script we use, `e2e/screenshots-react.mjs`, is the React-side twin of
-the legacy `e2e/screenshots.mjs` (which still targets the Vue bundle and
-is left untouched).
+The script we use, `e2e/screenshots-react.mjs`, is the React-side variant
+of the screenshot flow. The legacy Vue screenshot flow remains separate
+and is left untouched.
 
 ## Prerequisites
 
-- Node.js 20+, npm
+- Node.js 24.14.1, npm
 - Go 1.26+
 - Playwright browsers installed in `e2e/` (one-time):
   ```bash

--- a/e2e/screenshots-react.mjs
+++ b/e2e/screenshots-react.mjs
@@ -115,7 +115,10 @@ try {
 
   const slug = slugFromUrl()
   if (!slug) {
-    console.warn("⚠ no group slug in URL; skipping group-scoped pages")
+    console.error(
+      "✖ no group slug in URL after login — seeded data may be missing or the server redirected to /no-group",
+    )
+    process.exitCode = 1
   } else {
     console.log(`-> active group slug: ${slug}`)
     const groupPages = [
@@ -159,18 +162,19 @@ try {
         }
       }
     }
-
-    // Profile + settings — independent of /g/:slug/.
-    console.log("-> /profile")
-    await page.goto(`${BASE_URL}/profile`, { waitUntil: "domcontentloaded" })
-    await settle()
-    await shoot("20-profile")
-
-    console.log("-> /settings")
-    await page.goto(`${BASE_URL}/settings`, { waitUntil: "domcontentloaded" })
-    await settle()
-    await shoot("21-settings")
   }
+
+  // Profile + settings — independent of /g/:slug/, captured regardless of
+  // whether a group slug was found.
+  console.log("-> /profile")
+  await page.goto(`${BASE_URL}/profile`, { waitUntil: "domcontentloaded" })
+  await settle()
+  await shoot("20-profile")
+
+  console.log("-> /settings")
+  await page.goto(`${BASE_URL}/settings`, { waitUntil: "domcontentloaded" })
+  await settle()
+  await shoot("21-settings")
 } catch (err) {
   console.error("Screenshot run failed:", err)
   process.exitCode = 1

--- a/e2e/screenshots-react.mjs
+++ b/e2e/screenshots-react.mjs
@@ -1,5 +1,5 @@
 // Standalone Playwright script — login and screenshot the *new* React
-// frontend (epic #1397). Mirrors `e2e/screenshots.mjs` (legacy Vue) but
+// frontend (epic #1397). Follows the legacy Vue screenshot flow, but
 // hits the React route layout: every authenticated page lives under
 // /g/:groupSlug/* once a group is active.
 //
@@ -61,9 +61,15 @@ async function login() {
     const body = await resp.text().catch(() => "")
     throw new Error(`Login failed ${resp.status()}: ${body.slice(0, 300)}`)
   }
-  await page
-    .waitForURL((url) => !url.toString().includes("/login"), { timeout: 15000 })
-    .catch(() => {})
+  try {
+    await page.waitForURL((url) => !url.toString().includes("/login"), { timeout: 15000 })
+  } catch (err) {
+    const currentURL = page.url()
+    if (currentURL.includes("/login")) {
+      throw new Error(`Login succeeded but UI did not leave /login (current URL: ${currentURL})`)
+    }
+    throw err
+  }
   await settle()
   console.log(`   post-login url: ${page.url()}`)
 }

--- a/e2e/screenshots-react.mjs
+++ b/e2e/screenshots-react.mjs
@@ -1,0 +1,173 @@
+// Standalone Playwright script — login and screenshot the *new* React
+// frontend (epic #1397). Mirrors `e2e/screenshots.mjs` (legacy Vue) but
+// hits the React route layout: every authenticated page lives under
+// /g/:groupSlug/* once a group is active.
+//
+// Usage:
+//   1. Build both frontends so the embed packages compile:
+//        make build-frontend && make build-frontend-react
+//   2. Build the binary with the with_frontend tag:
+//        cd go/cmd/inventario && go build -tags with_frontend -o ../../../bin/inventario .
+//   3. Run the binary with the React bundle selected:
+//        ./bin/inventario run --frontend-bundle=new --db-dsn=memory:// \
+//          --no-auth-rate-limit --no-global-rate-limit
+//   4. Seed the DB:
+//        curl -X POST http://localhost:3333/api/v1/seed
+//   5. Run this script:
+//        BASE_URL=http://localhost:3333 OUT=tmp-screenshots-react \
+//          node e2e/screenshots-react.mjs
+
+import { chromium } from "playwright"
+import { mkdirSync } from "fs"
+import { join } from "path"
+
+const BASE_URL = process.env.BASE_URL || "http://localhost:3333"
+const OUT = process.env.OUT || "tmp-screenshots-react"
+const EMAIL = process.env.EMAIL || "admin@test-org.com"
+const PASSWORD = process.env.PASSWORD || "testpassword123"
+
+mkdirSync(OUT, { recursive: true })
+
+const browser = await chromium.launch({ headless: true })
+const context = await browser.newContext({ viewport: { width: 1440, height: 900 } })
+const page = await context.newPage()
+
+page.on("pageerror", (err) => console.error("PAGE ERROR:", err.message))
+page.on("console", (msg) => {
+  if (msg.type() === "error") console.error("CONSOLE ERR:", msg.text())
+})
+
+async function settle() {
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 5000 })
+  } catch {
+    /* fine — some pages keep streaming a fetch */
+  }
+  await page.waitForTimeout(500)
+}
+
+async function login() {
+  console.log(`-> login as ${EMAIL}`)
+  await page.goto(`${BASE_URL}/login`, { waitUntil: "domcontentloaded" })
+  await page.waitForSelector('input[type="email"]', { timeout: 15000 })
+  await page.fill('input[type="email"]', EMAIL)
+  await page.fill('input[type="password"]', PASSWORD)
+  const respPromise = page.waitForResponse((r) => r.url().includes("/api/v1/auth/login"), {
+    timeout: 20000,
+  })
+  await page.click('button[type="submit"]')
+  const resp = await respPromise
+  if (resp.status() !== 200) {
+    const body = await resp.text().catch(() => "")
+    throw new Error(`Login failed ${resp.status()}: ${body.slice(0, 300)}`)
+  }
+  await page
+    .waitForURL((url) => !url.toString().includes("/login"), { timeout: 15000 })
+    .catch(() => {})
+  await settle()
+  console.log(`   post-login url: ${page.url()}`)
+}
+
+async function shoot(name, full = true) {
+  const file = join(OUT, `${name}.png`)
+  await page.screenshot({ path: file, fullPage: full })
+  console.log(`   saved ${file}`)
+}
+
+// Resolve the active group slug from the URL after login. The router
+// redirects "/" to "/g/<first-slug>/" so we can read the slug straight
+// off the post-login URL — but if the user lands on "/no-group" we
+// won't have a slug at all.
+function slugFromUrl() {
+  const m = page.url().match(/\/g\/([^/]+)/)
+  return m ? m[1] : null
+}
+
+try {
+  // Public pages — no auth required.
+  console.log("-> /login (unauthenticated)")
+  await page.goto(`${BASE_URL}/login`, { waitUntil: "domcontentloaded" })
+  await settle()
+  await shoot("01-login")
+
+  console.log("-> /register")
+  await page.goto(`${BASE_URL}/register`, { waitUntil: "domcontentloaded" })
+  await settle()
+  await shoot("02-register")
+
+  console.log("-> /forgot-password")
+  await page.goto(`${BASE_URL}/forgot-password`, { waitUntil: "domcontentloaded" })
+  await settle()
+  await shoot("03-forgot-password")
+
+  console.log("-> /some-nonexistent-route (NotFound)")
+  await page.goto(`${BASE_URL}/some-nonexistent-route`, { waitUntil: "domcontentloaded" })
+  await settle()
+  await shoot("04-not-found")
+
+  await login()
+
+  const slug = slugFromUrl()
+  if (!slug) {
+    console.warn("⚠ no group slug in URL; skipping group-scoped pages")
+  } else {
+    console.log(`-> active group slug: ${slug}`)
+    const groupPages = [
+      { name: "10-dashboard", path: `/g/${slug}/` },
+      { name: "11-locations", path: `/g/${slug}/locations` },
+      { name: "12-locations-new", path: `/g/${slug}/locations/new` },
+    ]
+    for (const p of groupPages) {
+      console.log(`-> ${p.path}`)
+      await page.goto(`${BASE_URL}${p.path}`, { waitUntil: "domcontentloaded", timeout: 20000 })
+      await settle()
+      if (page.url().includes("/login")) {
+        console.warn(`   redirected to login on ${p.path}`)
+      }
+      await shoot(p.name)
+    }
+
+    // Drill into the first location's detail page if the seed has any.
+    console.log(`-> /g/${slug}/locations (probe first location)`)
+    await page.goto(`${BASE_URL}/g/${slug}/locations`, { waitUntil: "domcontentloaded" })
+    await settle()
+    const firstCard = page.locator('[data-testid="location-card"]').first()
+    if ((await firstCard.count()) > 0) {
+      const link = firstCard.locator("a").first()
+      const href = await link.getAttribute("href")
+      if (href) {
+        console.log(`-> location detail ${href}`)
+        await page.goto(`${BASE_URL}${href}`, { waitUntil: "domcontentloaded" })
+        await settle()
+        await shoot("13-location-detail")
+        // Drill again into the first area on the detail page if any.
+        const areaRow = page.locator('[data-testid="location-detail-area"] a').first()
+        if ((await areaRow.count()) > 0) {
+          const areaHref = await areaRow.getAttribute("href")
+          if (areaHref) {
+            console.log(`-> area detail ${areaHref}`)
+            await page.goto(`${BASE_URL}${areaHref}`, { waitUntil: "domcontentloaded" })
+            await settle()
+            await shoot("14-area-detail")
+          }
+        }
+      }
+    }
+
+    // Profile + settings — independent of /g/:slug/.
+    console.log("-> /profile")
+    await page.goto(`${BASE_URL}/profile`, { waitUntil: "domcontentloaded" })
+    await settle()
+    await shoot("20-profile")
+
+    console.log("-> /settings")
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "domcontentloaded" })
+    await settle()
+    await shoot("21-settings")
+  }
+} catch (err) {
+  console.error("Screenshot run failed:", err)
+  process.exitCode = 1
+} finally {
+  await browser.close()
+}


### PR DESCRIPTION
Follow-up to #1445 — the screenshot tooling commit landed on `feat/1409-locations-areas` after #1445 was already merged, so it never made master. Cherry-picking it here as a standalone PR.

## What's added

- **`e2e/screenshots-react.mjs`** — Playwright-driven capture script for the new React frontend, twin of the legacy `e2e/screenshots.mjs`. Logs in as the seeded `admin@test-org.com`, reads the active group slug off the post-login redirect, and shoots every public + authenticated page #1404 / #1407 / #1408 / #1409 / #1414 surface today. Uses `data-testid` selectors we already shipped (`location-card`, `location-detail-area`) so it survives the seeder regenerating UUIDs.
- **`devdocs/frontend-react/screenshots.md`** — step-by-step how-to: build both bundles, `go build -tags with_frontend`, run with `--frontend-bundle=new`, POST `/api/v1/seed`, then run the script. Common-issues section covers the three things I hit locally (port collision, missing `dist/` for embed, login API 401 from a stale process).

## Test plan

- [ ] CI green (no source changes; just docs + a standalone script).
- [ ] Locally: follow the doc end-to-end, confirm all 12 PNGs land in `OUT=`.