### PR TITLE
[#1398] BE: files.category enum + filtered list + counts

### DIFF
--- a/frontend-react/src/types/api.d.ts
+++ b/frontend-react/src/types/api.d.ts
@@ -2108,6 +2108,8 @@ export type paths = {
                 query?: {
                     /** @description Filter by file type */
                     type?: "image" | "document" | "video" | "audio" | "archive" | "other";
+                    /** @description Filter by file category */
+                    category?: "photos" | "invoices" | "documents" | "other";
                     /** @description Search in title, description, and file paths */
                     search?: string;
                     /** @description Filter by tags (comma-separated) */
@@ -2130,6 +2132,15 @@ export type paths = {
                     };
                     content: {
                         "application/vnd.api+json": components["schemas"]["jsonapi.FilesResponse"];
+                    };
+                };
+                /** @description Invalid query parameter */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
             };
@@ -2229,6 +2240,52 @@ export type paths = {
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/files/category-counts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * File category counts
+         * @description Per-category file counts, respecting the same filters as GET /files
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Filter by file type */
+                    type?: "image" | "document" | "video" | "audio" | "archive" | "other";
+                    /** @description Search in title, description, and file paths */
+                    search?: string;
+                    /** @description Filter by tags (comma-separated) */
+                    tags?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.FileCategoryCountsResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -4947,6 +5004,36 @@ export type components = {
             data?: components["schemas"]["jsonapi.ExportResponseData"][];
             meta?: components["schemas"]["jsonapi.ExportsMeta"];
         };
+        "jsonapi.FileCategoryCounts": {
+            /**
+             * Format: int64
+             * @example 11
+             */
+            all?: number;
+            /**
+             * Format: int64
+             * @example 1
+             */
+            documents?: number;
+            /**
+             * Format: int64
+             * @example 5
+             */
+            invoices?: number;
+            /**
+             * Format: int64
+             * @example 2
+             */
+            other?: number;
+            /**
+             * Format: int64
+             * @example 3
+             */
+            photos?: number;
+        };
+        "jsonapi.FileCategoryCountsResponse": {
+            data?: components["schemas"]["jsonapi.FileCategoryCounts"];
+        };
         "jsonapi.FileMeta": {
             /** @description Map of file ID to signed URLs and thumbnails */
             signed_urls?: {
@@ -5504,7 +5591,14 @@ export type components = {
         "models.ExportStatus": "pending" | "in_progress" | "completed" | "failed";
         /** @enum {string} */
         "models.ExportType": "full_database" | "selected_items" | "locations" | "areas" | "commodities" | "imported";
+        /** @enum {string} */
+        "models.FileCategory": "photos" | "invoices" | "documents" | "other";
         "models.FileEntity": {
+            /**
+             * @description Category is the user-meaningful classification surfaced in the UI
+             *     (Photos/Invoices/Documents/Other).
+             */
+            category?: components["schemas"]["models.FileCategory"];
             /** @description CreatedAt is when the file was created */
             created_at?: string;
             /** @description Description is an optional description of the file */

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -36,6 +36,26 @@ type filesAPI struct {
 	thumbnailConfig    services.ThumbnailGenerationConfig
 }
 
+// parseFileCategoryParam reads the `?category=` query parameter, validating
+// the value against the closed enum. Multi-value (`?category=a&category=b`)
+// returns an error so the caller can render a 400; the FE tile UI is
+// single-select so multi-value would always be operator error.
+func parseFileCategoryParam(values []string) (*models.FileCategory, error) {
+	if len(values) == 0 || values[0] == "" {
+		return nil, nil
+	}
+	if len(values) > 1 {
+		return nil, errors.New("category query parameter accepts a single value")
+	}
+	cat := models.FileCategory(values[0])
+	for _, valid := range models.ValidFileCategories {
+		if cat == valid {
+			return &cat, nil
+		}
+	}
+	return nil, fmt.Errorf("invalid category %q (allowed: photos, invoices, documents, other)", values[0])
+}
+
 // listFiles lists all files with optional filtering and pagination.
 // @Summary List files
 // @Description get files with optional filtering
@@ -43,11 +63,13 @@ type filesAPI struct {
 // @Accept json-api
 // @Produce json-api
 // @Param type query string false "Filter by file type" Enums(image,document,video,audio,archive,other)
+// @Param category query string false "Filter by file category" Enums(photos,invoices,documents,other)
 // @Param search query string false "Search in title, description, and file paths"
 // @Param tags query string false "Filter by tags (comma-separated)"
 // @Param page query int false "Page number (1-based)" default(1)
 // @Param limit query int false "Items per page" default(20)
 // @Success 200 {object} jsonapi.FilesResponse "OK"
+// @Failure 400 {object} jsonapi.Errors "Invalid query parameter"
 // @Router /files [get].
 func (api *filesAPI) listFiles(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
@@ -89,6 +111,12 @@ func (api *filesAPI) listFiles(w http.ResponseWriter, r *http.Request) {
 		fileType = &ft
 	}
 
+	fileCategory, err := parseFileCategoryParam(r.URL.Query()["category"])
+	if err != nil {
+		badRequest(w, r, err)
+		return
+	}
+
 	var tags []string
 	if tagsParam != "" {
 		tags = strings.Split(tagsParam, ",")
@@ -99,11 +127,10 @@ func (api *filesAPI) listFiles(w http.ResponseWriter, r *http.Request) {
 
 	var files []*models.FileEntity
 	var total int
-	var err error
 
 	if searchParam != "" || len(tags) > 0 {
 		// Use search if search query or tags are provided
-		files, err = fileReg.Search(r.Context(), searchParam, fileType, tags)
+		files, err = fileReg.Search(r.Context(), searchParam, fileType, fileCategory, tags)
 		if err != nil {
 			renderEntityError(w, r, err)
 			return
@@ -116,7 +143,7 @@ func (api *filesAPI) listFiles(w http.ResponseWriter, r *http.Request) {
 		files = files[start:end]
 	} else {
 		// Use paginated list for simple queries
-		files, total, err = fileReg.ListPaginated(r.Context(), offset, limit, fileType)
+		files, total, err = fileReg.ListPaginated(r.Context(), offset, limit, fileType, fileCategory)
 		if err != nil {
 			renderEntityError(w, r, err)
 			return
@@ -202,7 +229,8 @@ func (api *filesAPI) createFile(w http.ResponseWriter, r *http.Request) {
 		},
 		Title:            input.Data.Attributes.Title,
 		Description:      input.Data.Attributes.Description,
-		Type:             models.FileTypeOther, // Default type, should be updated when file is uploaded
+		Type:             models.FileTypeOther,                                                                                             // Default type, should be updated when file is uploaded
+		Category:         models.FileCategoryFromContext(input.Data.Attributes.LinkedEntityType, input.Data.Attributes.LinkedEntityMeta, ""), // Re-derived on upload once MIME is known
 		Tags:             input.Data.Attributes.Tags,
 		LinkedEntityType: input.Data.Attributes.LinkedEntityType,
 		LinkedEntityID:   input.Data.Attributes.LinkedEntityID,
@@ -340,6 +368,7 @@ func (api *filesAPI) updateFile(w http.ResponseWriter, r *http.Request) {
 	// Auto-detect file type from MIME type if available
 	if file.File != nil && file.MIMEType != "" {
 		file.Type = models.FileTypeFromMIME(file.MIMEType)
+		file.Category = models.FileCategoryFromContext(file.LinkedEntityType, file.LinkedEntityMeta, file.MIMEType)
 	}
 
 	updatedFile, err := fileReg.Update(r.Context(), *file)
@@ -431,6 +460,60 @@ func (api *filesAPI) generateSignedURL(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// listCategoryCounts returns per-category file counts for the current group,
+// scoped by the same `type`/`search`/`tags` filters as GET /files. The four
+// buckets (photos/invoices/documents/other) are always present in the
+// response so the FE tile renderer can rely on a stable shape; `all` is the
+// sum across the four buckets.
+//
+// @Summary File category counts
+// @Description Per-category file counts, respecting the same filters as GET /files
+// @Tags files
+// @Accept json-api
+// @Produce json-api
+// @Param type query string false "Filter by file type" Enums(image,document,video,audio,archive,other)
+// @Param search query string false "Search in title, description, and file paths"
+// @Param tags query string false "Filter by tags (comma-separated)"
+// @Success 200 {object} jsonapi.FileCategoryCountsResponse "OK"
+// @Router /files/category-counts [get].
+func (api *filesAPI) listCategoryCounts(w http.ResponseWriter, r *http.Request) {
+	registrySet := RegistrySetFromContext(r.Context())
+	if registrySet == nil {
+		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+		return
+	}
+
+	typeParam := r.URL.Query().Get("type")
+	searchParam := r.URL.Query().Get("search")
+	tagsParam := r.URL.Query().Get("tags")
+
+	var fileType *models.FileType
+	if typeParam != "" {
+		ft := models.FileType(typeParam)
+		fileType = &ft
+	}
+
+	var tags []string
+	if tagsParam != "" {
+		tags = strings.Split(tagsParam, ",")
+		for i, tag := range tags {
+			tags[i] = strings.TrimSpace(tag)
+		}
+	}
+
+	counts, err := registrySet.FileRegistry.CountByCategory(r.Context(), searchParam, fileType, tags)
+	if err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
+
+	response := jsonapi.NewFileCategoryCountsResponse(counts)
+	if err := render.Render(w, r, response); err != nil {
+		internalServerError(w, r, err)
+		return
+	}
+}
+
 // Files sets up the files API routes.
 // bulkDeleteFiles deletes a list of files (record + physical blob) in a
 // single request.
@@ -482,6 +565,10 @@ func Files(params Params) func(r chi.Router) {
 	return func(r chi.Router) {
 		r.Get("/", api.listFiles)   // GET /files
 		r.Post("/", api.createFile) // POST /files
+		// Aggregator for the per-category tiles on the FE Files page (#1411).
+		// Mounted before `/{fileID}` so chi routes the slug here rather than
+		// treating it as an id.
+		r.Get("/category-counts", api.listCategoryCounts) // GET /files/category-counts
 		// Bulk endpoint (#1330 PR 5.5). Mounted before `/{fileID}` so chi
 		// routes `/bulk-delete` here rather than treating the slug as an id.
 		r.Post("/bulk-delete", api.bulkDeleteFiles) // POST /files/bulk-delete

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -9,6 +9,7 @@ import (
 	"mime"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -48,10 +49,8 @@ func parseFileCategoryParam(values []string) (*models.FileCategory, error) {
 		return nil, errors.New("category query parameter accepts a single value")
 	}
 	cat := models.FileCategory(values[0])
-	for _, valid := range models.ValidFileCategories {
-		if cat == valid {
-			return &cat, nil
-		}
+	if slices.Contains(models.ValidFileCategories, cat) {
+		return &cat, nil
 	}
 	return nil, fmt.Errorf("invalid category %q (allowed: photos, invoices, documents, other)", values[0])
 }
@@ -227,10 +226,12 @@ func (api *filesAPI) createFile(w http.ResponseWriter, r *http.Request) {
 			GroupID:         appctx.GroupIDFromContext(r.Context()),
 			CreatedByUserID: user.ID,
 		},
-		Title:            input.Data.Attributes.Title,
-		Description:      input.Data.Attributes.Description,
-		Type:             models.FileTypeOther,                                                                                             // Default type, should be updated when file is uploaded
-		Category:         models.FileCategoryFromContext(input.Data.Attributes.LinkedEntityType, input.Data.Attributes.LinkedEntityMeta, ""), // Re-derived on upload once MIME is known
+		Title:       input.Data.Attributes.Title,
+		Description: input.Data.Attributes.Description,
+		// Type and Category are placeholder defaults; both are re-derived
+		// in updateFile once the upload sets the MIME type.
+		Type:             models.FileTypeOther,
+		Category:         models.FileCategoryOther,
 		Tags:             input.Data.Attributes.Tags,
 		LinkedEntityType: input.Data.Attributes.LinkedEntityType,
 		LinkedEntityID:   input.Data.Attributes.LinkedEntityID,

--- a/go/apiserver/files_category_test.go
+++ b/go/apiserver/files_category_test.go
@@ -1,0 +1,54 @@
+package apiserver
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+)
+
+// parseFileCategoryParam is unexported, so this test lives in the apiserver
+// package itself rather than apiserver_test. Keeps the helper internal while
+// still pinning behaviour for the four legal values + the rejection paths.
+func TestParseFileCategoryParam(t *testing.T) {
+	t.Run("absent param returns nil", func(t *testing.T) {
+		c := qt.New(t)
+		got, err := parseFileCategoryParam(nil)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.IsNil)
+	})
+
+	t.Run("empty string returns nil", func(t *testing.T) {
+		c := qt.New(t)
+		got, err := parseFileCategoryParam([]string{""})
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.IsNil)
+	})
+
+	t.Run("each valid value parses", func(t *testing.T) {
+		c := qt.New(t)
+		for _, valid := range models.ValidFileCategories {
+			got, err := parseFileCategoryParam([]string{string(valid)})
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.IsNotNil)
+			c.Assert(*got, qt.Equals, valid)
+		}
+	})
+
+	t.Run("invalid value returns error", func(t *testing.T) {
+		c := qt.New(t)
+		got, err := parseFileCategoryParam([]string{"warranty"})
+		c.Assert(got, qt.IsNil)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, "invalid category")
+	})
+
+	t.Run("multi-value rejected", func(t *testing.T) {
+		c := qt.New(t)
+		got, err := parseFileCategoryParam([]string{"photos", "invoices"})
+		c.Assert(got, qt.IsNil)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, "single value")
+	})
+}

--- a/go/apiserver/search.go
+++ b/go/apiserver/search.go
@@ -131,7 +131,7 @@ func (api *searchAPI) searchWithBasicFallback(w http.ResponseWriter, r *http.Req
 		}
 
 	case "files":
-		files, err := registrySet.FileRegistry.Search(r.Context(), query, nil, tags)
+		files, err := registrySet.FileRegistry.Search(r.Context(), query, nil, nil, tags)
 		if err != nil {
 			renderEntityError(w, r, err)
 			return

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -137,6 +137,7 @@ func (api *uploadsAPI) handleImageUpload(w http.ResponseWriter, r *http.Request)
 		Title:            pathWithoutExt, // Use filename as title
 		Description:      "",
 		Type:             models.FileTypeImage,
+		Category:         models.FileCategoryFromContext("commodity", "images", f.MIMEType),
 		Tags:             []string{},
 		LinkedEntityType: "commodity",
 		LinkedEntityID:   entityID,
@@ -258,6 +259,7 @@ func (api *uploadsAPI) handleManualUpload(w http.ResponseWriter, r *http.Request
 		Title:            pathWithoutExt, // Use filename as title
 		Description:      "",
 		Type:             fileType, // Use auto-detected type
+		Category:         models.FileCategoryFromContext("commodity", "manuals", f.MIMEType),
 		Tags:             []string{},
 		LinkedEntityType: "commodity",
 		LinkedEntityID:   entityID,
@@ -379,6 +381,7 @@ func (api *uploadsAPI) handleInvoiceUpload(w http.ResponseWriter, r *http.Reques
 		Title:            pathWithoutExt, // Use filename as title
 		Description:      "",
 		Type:             fileType, // Use auto-detected type
+		Category:         models.FileCategoryFromContext("commodity", "invoices", f.MIMEType),
 		Tags:             []string{},
 		LinkedEntityType: "commodity",
 		LinkedEntityID:   entityID,
@@ -493,6 +496,7 @@ func (api *uploadsAPI) handleFileUpload(w http.ResponseWriter, r *http.Request) 
 		Title:       pathWithoutExt, // Use filename as default title
 		Description: "",             // Empty description
 		Type:        fileType,
+		Category:    models.FileCategoryFromMIME(f.MIMEType),
 		Tags:        []string{}, // Empty tags
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -603,6 +607,7 @@ func (api *uploadsAPI) handleLocationImageUpload(w http.ResponseWriter, r *http.
 		Title:            pathWithoutExt,
 		Description:      "",
 		Type:             models.FileTypeImage,
+		Category:         models.FileCategoryFromContext("location", "images", f.MIMEType),
 		Tags:             []string{},
 		LinkedEntityType: "location",
 		LinkedEntityID:   entityID,
@@ -705,6 +710,7 @@ func (api *uploadsAPI) handleLocationFileUpload(w http.ResponseWriter, r *http.R
 		Title:            pathWithoutExt,
 		Description:      "",
 		Type:             fileType,
+		Category:         models.FileCategoryFromContext("location", "files", f.MIMEType),
 		Tags:             []string{},
 		LinkedEntityType: "location",
 		LinkedEntityID:   entityID,

--- a/go/backup/export/service.go
+++ b/go/backup/export/service.go
@@ -260,6 +260,7 @@ func (s *ExportService) createExportFileEntity(ctx context.Context, exportID, de
 		Title:            fmt.Sprintf("Export: %s", description),
 		Description:      fmt.Sprintf("Export file generated on %s", now.Format("2006-01-02 15:04:05")),
 		Type:             models.FileTypeDocument, // XML files are documents
+		Category:         models.FileCategoryOther, // Export bundles aren't user-facing files; they live outside the four UI tiles
 		Tags:             []string{"export", "xml"},
 		LinkedEntityType: "export",
 		LinkedEntityID:   exportID,

--- a/go/backup/export/service.go
+++ b/go/backup/export/service.go
@@ -259,7 +259,7 @@ func (s *ExportService) createExportFileEntity(ctx context.Context, exportID, de
 		},
 		Title:            fmt.Sprintf("Export: %s", description),
 		Description:      fmt.Sprintf("Export file generated on %s", now.Format("2006-01-02 15:04:05")),
-		Type:             models.FileTypeDocument, // XML files are documents
+		Type:             models.FileTypeDocument,  // XML files are documents
 		Category:         models.FileCategoryOther, // Export bundles aren't user-facing files; they live outside the four UI tiles
 		Tags:             []string{"export", "xml"},
 		LinkedEntityType: "export",

--- a/go/backup/import/service.go
+++ b/go/backup/import/service.go
@@ -122,6 +122,7 @@ func (s *ImportService) createImportFileEntity(ctx context.Context, export *mode
 		Title:            fmt.Sprintf("Import: %s", description),
 		Description:      fmt.Sprintf("Imported export file uploaded on %s", now.Format("2006-01-02 15:04:05")),
 		Type:             models.FileTypeDocument, // XML files are documents
+		Category:         models.FileCategoryOther, // Export bundles aren't user-facing files; they live outside the four UI tiles
 		Tags:             []string{"export", "xml", "imported"},
 		LinkedEntityType: "export",
 		LinkedEntityID:   exportID,

--- a/go/backup/import/service.go
+++ b/go/backup/import/service.go
@@ -121,7 +121,7 @@ func (s *ImportService) createImportFileEntity(ctx context.Context, export *mode
 	fileEntity := models.FileEntity{
 		Title:            fmt.Sprintf("Import: %s", description),
 		Description:      fmt.Sprintf("Imported export file uploaded on %s", now.Format("2006-01-02 15:04:05")),
-		Type:             models.FileTypeDocument, // XML files are documents
+		Type:             models.FileTypeDocument,  // XML files are documents
 		Category:         models.FileCategoryOther, // Export bundles aren't user-facing files; they live outside the four UI tiles
 		Tags:             []string{"export", "xml", "imported"},
 		LinkedEntityType: "export",

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -1910,6 +1910,18 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "photos",
+                            "invoices",
+                            "documents",
+                            "other"
+                        ],
+                        "type": "string",
+                        "description": "Filter by file category",
+                        "name": "category",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "description": "Search in title, description, and file paths",
                         "name": "search",
@@ -1941,6 +1953,12 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.FilesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }
@@ -2019,6 +2037,57 @@ const docTemplate = `{
                         "description": "Bad request body",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/files/category-counts": {
+            "get": {
+                "description": "Per-category file counts, respecting the same filters as GET /files",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "files"
+                ],
+                "summary": "File category counts",
+                "parameters": [
+                    {
+                        "enum": [
+                            "image",
+                            "document",
+                            "video",
+                            "audio",
+                            "archive",
+                            "other"
+                        ],
+                        "type": "string",
+                        "description": "Filter by file type",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search in title, description, and file paths",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tags (comma-separated)",
+                        "name": "tags",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileCategoryCountsResponse"
                         }
                     }
                 }
@@ -4690,6 +4759,44 @@ const docTemplate = `{
                 }
             }
         },
+        "jsonapi.FileCategoryCounts": {
+            "type": "object",
+            "properties": {
+                "all": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 11
+                },
+                "documents": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 1
+                },
+                "invoices": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 5
+                },
+                "other": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 2
+                },
+                "photos": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 3
+                }
+            }
+        },
+        "jsonapi.FileCategoryCountsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.FileCategoryCounts"
+                }
+            }
+        },
         "jsonapi.FileMeta": {
             "type": "object",
             "properties": {
@@ -6006,9 +6113,32 @@ const docTemplate = `{
                 "ExportTypeImported"
             ]
         },
+        "models.FileCategory": {
+            "type": "string",
+            "enum": [
+                "photos",
+                "invoices",
+                "documents",
+                "other"
+            ],
+            "x-enum-varnames": [
+                "FileCategoryPhotos",
+                "FileCategoryInvoices",
+                "FileCategoryDocuments",
+                "FileCategoryOther"
+            ]
+        },
         "models.FileEntity": {
             "type": "object",
             "properties": {
+                "category": {
+                    "description": "Category is the user-meaningful classification surfaced in the UI\n(Photos/Invoices/Documents/Other). Defaults to 'other' so the\nfollow-up backfill (#1399) can re-classify legacy rows in place.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.FileCategory"
+                        }
+                    ]
+                },
                 "created_at": {
                     "description": "CreatedAt is when the file was created",
                     "type": "string"

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -6132,7 +6132,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "category": {
-                    "description": "Category is the user-meaningful classification surfaced in the UI\n(Photos/Invoices/Documents/Other). Defaults to 'other' so the\nfollow-up backfill (#1399) can re-classify legacy rows in place.",
+                    "description": "Category is the user-meaningful classification surfaced in the UI\n(Photos/Invoices/Documents/Other).",
                     "allOf": [
                         {
                             "$ref": "#/definitions/models.FileCategory"

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -1903,6 +1903,18 @@
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "photos",
+                            "invoices",
+                            "documents",
+                            "other"
+                        ],
+                        "type": "string",
+                        "description": "Filter by file category",
+                        "name": "category",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "description": "Search in title, description, and file paths",
                         "name": "search",
@@ -1934,6 +1946,12 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.FilesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }
@@ -2012,6 +2030,57 @@
                         "description": "Bad request body",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/files/category-counts": {
+            "get": {
+                "description": "Per-category file counts, respecting the same filters as GET /files",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "files"
+                ],
+                "summary": "File category counts",
+                "parameters": [
+                    {
+                        "enum": [
+                            "image",
+                            "document",
+                            "video",
+                            "audio",
+                            "archive",
+                            "other"
+                        ],
+                        "type": "string",
+                        "description": "Filter by file type",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search in title, description, and file paths",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tags (comma-separated)",
+                        "name": "tags",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileCategoryCountsResponse"
                         }
                     }
                 }
@@ -4683,6 +4752,44 @@
                 }
             }
         },
+        "jsonapi.FileCategoryCounts": {
+            "type": "object",
+            "properties": {
+                "all": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 11
+                },
+                "documents": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 1
+                },
+                "invoices": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 5
+                },
+                "other": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 2
+                },
+                "photos": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 3
+                }
+            }
+        },
+        "jsonapi.FileCategoryCountsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.FileCategoryCounts"
+                }
+            }
+        },
         "jsonapi.FileMeta": {
             "type": "object",
             "properties": {
@@ -5999,9 +6106,32 @@
                 "ExportTypeImported"
             ]
         },
+        "models.FileCategory": {
+            "type": "string",
+            "enum": [
+                "photos",
+                "invoices",
+                "documents",
+                "other"
+            ],
+            "x-enum-varnames": [
+                "FileCategoryPhotos",
+                "FileCategoryInvoices",
+                "FileCategoryDocuments",
+                "FileCategoryOther"
+            ]
+        },
         "models.FileEntity": {
             "type": "object",
             "properties": {
+                "category": {
+                    "description": "Category is the user-meaningful classification surfaced in the UI\n(Photos/Invoices/Documents/Other). Defaults to 'other' so the\nfollow-up backfill (#1399) can re-classify legacy rows in place.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.FileCategory"
+                        }
+                    ]
+                },
                 "created_at": {
                     "description": "CreatedAt is when the file was created",
                     "type": "string"

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -6125,7 +6125,7 @@
             "type": "object",
             "properties": {
                 "category": {
-                    "description": "Category is the user-meaningful classification surfaced in the UI\n(Photos/Invoices/Documents/Other). Defaults to 'other' so the\nfollow-up backfill (#1399) can re-classify legacy rows in place.",
+                    "description": "Category is the user-meaningful classification surfaced in the UI\n(Photos/Invoices/Documents/Other).",
                     "allOf": [
                         {
                             "$ref": "#/definitions/models.FileCategory"

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -449,6 +449,34 @@ definitions:
       meta:
         $ref: '#/definitions/jsonapi.ExportsMeta'
     type: object
+  jsonapi.FileCategoryCounts:
+    properties:
+      all:
+        example: 11
+        format: int64
+        type: integer
+      documents:
+        example: 1
+        format: int64
+        type: integer
+      invoices:
+        example: 5
+        format: int64
+        type: integer
+      other:
+        example: 2
+        format: int64
+        type: integer
+      photos:
+        example: 3
+        format: int64
+        type: integer
+    type: object
+  jsonapi.FileCategoryCountsResponse:
+    properties:
+      data:
+        $ref: '#/definitions/jsonapi.FileCategoryCounts'
+    type: object
   jsonapi.FileMeta:
     properties:
       signed_urls:
@@ -1347,8 +1375,27 @@ definitions:
     - ExportTypeAreas
     - ExportTypeCommodities
     - ExportTypeImported
+  models.FileCategory:
+    enum:
+    - photos
+    - invoices
+    - documents
+    - other
+    type: string
+    x-enum-varnames:
+    - FileCategoryPhotos
+    - FileCategoryInvoices
+    - FileCategoryDocuments
+    - FileCategoryOther
   models.FileEntity:
     properties:
+      category:
+        allOf:
+        - $ref: '#/definitions/models.FileCategory'
+        description: |-
+          Category is the user-meaningful classification surfaced in the UI
+          (Photos/Invoices/Documents/Other). Defaults to 'other' so the
+          follow-up backfill (#1399) can re-classify legacy rows in place.
       created_at:
         description: CreatedAt is when the file was created
         type: string
@@ -3051,6 +3098,15 @@ paths:
         in: query
         name: type
         type: string
+      - description: Filter by file category
+        enum:
+        - photos
+        - invoices
+        - documents
+        - other
+        in: query
+        name: category
+        type: string
       - description: Search in title, description, and file paths
         in: query
         name: search
@@ -3076,6 +3132,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/jsonapi.FilesResponse'
+        "400":
+          description: Invalid query parameter
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
       summary: List files
       tags:
       - files
@@ -3234,6 +3294,41 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: Bulk-delete files
+      tags:
+      - files
+  /files/category-counts:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: Per-category file counts, respecting the same filters as GET /files
+      parameters:
+      - description: Filter by file type
+        enum:
+        - image
+        - document
+        - video
+        - audio
+        - archive
+        - other
+        in: query
+        name: type
+        type: string
+      - description: Search in title, description, and file paths
+        in: query
+        name: search
+        type: string
+      - description: Filter by tags (comma-separated)
+        in: query
+        name: tags
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.FileCategoryCountsResponse'
+      summary: File category counts
       tags:
       - files
   /files/download/files/{fileID}:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1394,8 +1394,7 @@ definitions:
         - $ref: '#/definitions/models.FileCategory'
         description: |-
           Category is the user-meaningful classification surfaced in the UI
-          (Photos/Invoices/Documents/Other). Defaults to 'other' so the
-          follow-up backfill (#1399) can re-classify legacy rows in place.
+          (Photos/Invoices/Documents/Other).
       created_at:
         description: CreatedAt is when the file was created
         type: string

--- a/go/jsonapi/files.go
+++ b/go/jsonapi/files.go
@@ -85,6 +85,42 @@ func NewFilesResponse(files []*models.FileEntity, total int) *FilesResponse {
 	}
 }
 
+// FileCategoryCounts is the per-category count payload for the four UI tiles.
+// `All` is the sum across the four buckets, scoped to the same filters as the
+// containing GET /files/category-counts request.
+type FileCategoryCounts struct {
+	Photos    int `json:"photos" example:"3" format:"int64"`
+	Invoices  int `json:"invoices" example:"5" format:"int64"`
+	Documents int `json:"documents" example:"1" format:"int64"`
+	Other     int `json:"other" example:"2" format:"int64"`
+	All       int `json:"all" example:"11" format:"int64"`
+}
+
+// FileCategoryCountsResponse is the JSON:API envelope for category counts.
+type FileCategoryCountsResponse struct {
+	Data FileCategoryCounts `json:"data"`
+}
+
+// NewFileCategoryCountsResponse fills the four buckets from the registry map
+// and computes `All` so callers don't have to. Missing buckets are treated as
+// zero, matching the registry contract.
+func NewFileCategoryCountsResponse(counts map[models.FileCategory]int) *FileCategoryCountsResponse {
+	data := FileCategoryCounts{
+		Photos:    counts[models.FileCategoryPhotos],
+		Invoices:  counts[models.FileCategoryInvoices],
+		Documents: counts[models.FileCategoryDocuments],
+		Other:     counts[models.FileCategoryOther],
+	}
+	data.All = data.Photos + data.Invoices + data.Documents + data.Other
+	return &FileCategoryCountsResponse{Data: data}
+}
+
+// Render renders the FileCategoryCountsResponse as an HTTP response.
+func (fr *FileCategoryCountsResponse) Render(_w http.ResponseWriter, r *http.Request) error {
+	render.Status(r, http.StatusOK)
+	return nil
+}
+
 // NewFilesResponseWithSignedUrls creates a new FilesResponse instance with signed URLs.
 func NewFilesResponseWithSignedUrls(files []*models.FileEntity, total int, signedUrls map[string]URLData) *FilesResponse {
 	// Ensure Data is never nil to maintain consistent JSON output

--- a/go/jsonapi/files_category_test.go
+++ b/go/jsonapi/files_category_test.go
@@ -1,0 +1,63 @@
+package jsonapi_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/jsonapi"
+	"github.com/denisvmedia/inventario/models"
+)
+
+func TestNewFileCategoryCountsResponse(t *testing.T) {
+	t.Run("populates all four buckets and computes all", func(t *testing.T) {
+		c := qt.New(t)
+
+		counts := map[models.FileCategory]int{
+			models.FileCategoryPhotos:    3,
+			models.FileCategoryInvoices:  5,
+			models.FileCategoryDocuments: 1,
+			models.FileCategoryOther:     2,
+		}
+		resp := jsonapi.NewFileCategoryCountsResponse(counts)
+		c.Assert(resp.Data.Photos, qt.Equals, 3)
+		c.Assert(resp.Data.Invoices, qt.Equals, 5)
+		c.Assert(resp.Data.Documents, qt.Equals, 1)
+		c.Assert(resp.Data.Other, qt.Equals, 2)
+		c.Assert(resp.Data.All, qt.Equals, 11)
+	})
+
+	t.Run("missing buckets default to zero", func(t *testing.T) {
+		c := qt.New(t)
+
+		resp := jsonapi.NewFileCategoryCountsResponse(map[models.FileCategory]int{
+			models.FileCategoryPhotos: 4,
+		})
+		c.Assert(resp.Data.Photos, qt.Equals, 4)
+		c.Assert(resp.Data.Invoices, qt.Equals, 0)
+		c.Assert(resp.Data.Documents, qt.Equals, 0)
+		c.Assert(resp.Data.Other, qt.Equals, 0)
+		c.Assert(resp.Data.All, qt.Equals, 4)
+	})
+
+	t.Run("JSON shape matches the FE tile renderer contract", func(t *testing.T) {
+		c := qt.New(t)
+
+		resp := jsonapi.NewFileCategoryCountsResponse(map[models.FileCategory]int{
+			models.FileCategoryPhotos:   1,
+			models.FileCategoryInvoices: 2,
+		})
+		raw, err := json.Marshal(resp)
+		c.Assert(err, qt.IsNil)
+
+		var parsed map[string]map[string]int
+		err = json.Unmarshal(raw, &parsed)
+		c.Assert(err, qt.IsNil)
+		c.Assert(parsed["data"]["photos"], qt.Equals, 1)
+		c.Assert(parsed["data"]["invoices"], qt.Equals, 2)
+		c.Assert(parsed["data"]["documents"], qt.Equals, 0)
+		c.Assert(parsed["data"]["other"], qt.Equals, 0)
+		c.Assert(parsed["data"]["all"], qt.Equals, 3)
+	})
+}

--- a/go/models/file_category_test.go
+++ b/go/models/file_category_test.go
@@ -1,0 +1,128 @@
+package models_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+)
+
+func TestFileCategoryFromMIME(t *testing.T) {
+	cases := []struct {
+		mime string
+		want models.FileCategory
+	}{
+		{"image/jpeg", models.FileCategoryPhotos},
+		{"image/png", models.FileCategoryPhotos},
+		{"image/heic", models.FileCategoryPhotos},
+		{"application/pdf", models.FileCategoryDocuments},
+		{"text/plain", models.FileCategoryDocuments},
+		{"text/csv", models.FileCategoryDocuments},
+		{"application/msword", models.FileCategoryDocuments},
+		{"application/vnd.openxmlformats-officedocument.wordprocessingml.document", models.FileCategoryDocuments},
+		{"application/vnd.ms-excel", models.FileCategoryDocuments},
+		{"application/json", models.FileCategoryDocuments},
+		{"video/mp4", models.FileCategoryOther},
+		{"audio/mpeg", models.FileCategoryOther},
+		{"application/zip", models.FileCategoryOther},
+		{"application/octet-stream", models.FileCategoryOther},
+		{"", models.FileCategoryOther},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.mime, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(models.FileCategoryFromMIME(tc.mime), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestFileCategoryFromContext(t *testing.T) {
+	cases := []struct {
+		name             string
+		linkedEntityType string
+		linkedEntityMeta string
+		mime             string
+		want             models.FileCategory
+	}{
+		// Legacy commodity bucket names take precedence over MIME type so the
+		// "manuals" bucket lands in Documents even for image scans.
+		{"commodity/images PDF still photos by bucket name",
+			"commodity", "images", "application/pdf", models.FileCategoryPhotos},
+		{"commodity/manuals image still documents by bucket name",
+			"commodity", "manuals", "image/jpeg", models.FileCategoryDocuments},
+		{"commodity/invoices image still invoices by bucket name",
+			"commodity", "invoices", "image/jpeg", models.FileCategoryInvoices},
+		{"location/images uses photos bucket",
+			"location", "images", "image/png", models.FileCategoryPhotos},
+		// Location/files has no bucket-name hint; falls through to MIME.
+		{"location/files PDF falls through to documents via MIME",
+			"location", "files", "application/pdf", models.FileCategoryDocuments},
+		{"location/files unknown MIME falls through to other",
+			"location", "files", "video/mp4", models.FileCategoryOther},
+		// Standalone (no linked entity) and export both fall through to MIME.
+		{"standalone image",
+			"", "", "image/jpeg", models.FileCategoryPhotos},
+		{"standalone PDF",
+			"", "", "application/pdf", models.FileCategoryDocuments},
+		{"export bundles fall through to MIME",
+			"export", "xml-1.0", "application/xml", models.FileCategoryOther},
+		// Unknown commodity meta falls through to MIME (defensive).
+		{"unknown commodity meta falls through to MIME",
+			"commodity", "weird", "image/jpeg", models.FileCategoryPhotos},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := models.FileCategoryFromContext(tc.linkedEntityType, tc.linkedEntityMeta, tc.mime)
+			c.Assert(got, qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestFileEntity_ValidateWithContext_Category(t *testing.T) {
+	t.Run("rejects empty category", func(t *testing.T) {
+		c := qt.New(t)
+		fe := buildValidFileEntity()
+		fe.Category = ""
+		err := fe.ValidateWithContext(context.Background())
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, "category")
+	})
+
+	t.Run("rejects unknown category", func(t *testing.T) {
+		c := qt.New(t)
+		fe := buildValidFileEntity()
+		fe.Category = models.FileCategory("warranty")
+		err := fe.ValidateWithContext(context.Background())
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, "category")
+	})
+
+	t.Run("accepts each of the four valid categories", func(t *testing.T) {
+		c := qt.New(t)
+		for _, cat := range models.ValidFileCategories {
+			fe := buildValidFileEntity()
+			fe.Category = cat
+			err := fe.ValidateWithContext(context.Background())
+			c.Assert(err, qt.IsNil, qt.Commentf("category %q should be accepted", cat))
+		}
+	})
+}
+
+func buildValidFileEntity() models.FileEntity {
+	return models.FileEntity{
+		Title:    "doc",
+		Type:     models.FileTypeDocument,
+		Category: models.FileCategoryDocuments,
+		File: &models.File{
+			Path:         "doc",
+			OriginalPath: "doc.pdf",
+			Ext:          ".pdf",
+			MIMEType:     "application/pdf",
+		},
+	}
+}

--- a/go/models/models.go
+++ b/go/models/models.go
@@ -129,6 +129,70 @@ func FileTypeFromMIME(mimeType string) FileType {
 	}
 }
 
+// FileCategory is the user-meaningful classification surfaced as the four
+// tiles in the design mock (Photos / Invoices / Documents / Other). Distinct
+// from FileType, which is MIME-derived and drives behavior (thumbnailing,
+// preview selection). Each file belongs to exactly one category; the set is
+// closed and changes are a code+migration change, not data-driven.
+type FileCategory string
+
+const (
+	FileCategoryPhotos    FileCategory = "photos"
+	FileCategoryInvoices  FileCategory = "invoices"
+	FileCategoryDocuments FileCategory = "documents"
+	FileCategoryOther     FileCategory = "other"
+)
+
+// ValidFileCategories is the closed set accepted by validation, the SQL
+// CHECK constraint, and the GET /files?category= filter.
+var ValidFileCategories = []FileCategory{
+	FileCategoryPhotos,
+	FileCategoryInvoices,
+	FileCategoryDocuments,
+	FileCategoryOther,
+}
+
+// FileCategoryFromContext picks the user-meaningful category for a newly
+// uploaded file. Legacy commodity/location bucket names take precedence over
+// the MIME-type fallback so a "manuals" bucket lands in Documents even when
+// the file is e.g. a JPEG scan, matching the mock's tile semantics.
+func FileCategoryFromContext(linkedEntityType, linkedEntityMeta, mimeType string) FileCategory {
+	switch linkedEntityType {
+	case "commodity":
+		switch linkedEntityMeta {
+		case "images":
+			return FileCategoryPhotos
+		case "invoices":
+			return FileCategoryInvoices
+		case "manuals":
+			return FileCategoryDocuments
+		}
+	case "location":
+		if linkedEntityMeta == "images" {
+			return FileCategoryPhotos
+		}
+	}
+	return FileCategoryFromMIME(mimeType)
+}
+
+// FileCategoryFromMIME is the MIME-only fallback used when no linked-entity
+// hint is available (e.g. standalone uploads via POST /uploads/file).
+func FileCategoryFromMIME(mimeType string) FileCategory {
+	switch {
+	case strings.HasPrefix(mimeType, "image/"):
+		return FileCategoryPhotos
+	case mimeType == "application/pdf",
+		strings.HasPrefix(mimeType, "text/"),
+		mimeType == "application/msword",
+		mimeType == "application/json",
+		strings.HasPrefix(mimeType, "application/vnd.ms-"),
+		strings.HasPrefix(mimeType, "application/vnd.openxmlformats-"):
+		return FileCategoryDocuments
+	default:
+		return FileCategoryOther
+	}
+}
+
 type StringSlice []string
 
 func (s *StringSlice) Scan(value any) error {
@@ -177,6 +241,16 @@ type FileEntity struct {
 	// Type represents the category of the file (image, document, etc.)
 	//migrator:schema:field name="type" type="TEXT" not_null="true"
 	Type FileType `json:"type" db:"type"`
+
+	// Category is the user-meaningful classification surfaced in the UI
+	// (Photos/Invoices/Documents/Other). Defaults to 'other' so the
+	// follow-up backfill (#1399) can re-classify legacy rows in place.
+	// The closed enum is enforced via Go validation in ValidateWithContext;
+	// no DB CHECK constraint is added because ptah's drift detector doesn't
+	// yet recognize column-level `check=` annotations, mirroring the
+	// existing `Type` field's pattern.
+	//migrator:schema:field name="category" type="TEXT" not_null="true" default="other"
+	Category FileCategory `json:"category" db:"category"`
 
 	// Tags are optional tags for categorization and search
 	//migrator:schema:field name="tags" type="JSONB"
@@ -239,6 +313,11 @@ type FileIndexes struct {
 	//migrator:schema:index name="files_type_created_idx" fields="type,created_at" table="files"
 	_ int
 
+	// Composite index for tenant+group+category — backs the per-category list
+	// on GET /files?category= and the GET /files/category-counts aggregator.
+	//migrator:schema:index name="idx_files_tenant_group_category" fields="tenant_id,group_id,category" table="files"
+	_ int
+
 	// Index for linked entity queries
 	//migrator:schema:index name="files_linked_entity_idx" fields="linked_entity_type,linked_entity_id" table="files"
 	_ int
@@ -269,6 +348,9 @@ func (fe *FileEntity) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&fe.Type, validation.Required, validation.In(
 			FileTypeImage, FileTypeDocument, FileTypeVideo,
 			FileTypeAudio, FileTypeArchive, FileTypeOther,
+		)),
+		validation.Field(&fe.Category, validation.Required, validation.In(
+			FileCategoryPhotos, FileCategoryInvoices, FileCategoryDocuments, FileCategoryOther,
 		)),
 		validation.Field(&fe.LinkedEntityType, validation.In("", "commodity", "export", "location")),
 		validation.Field(&fe.File, validation.Required),

--- a/go/models/models.go
+++ b/go/models/models.go
@@ -143,8 +143,8 @@ const (
 	FileCategoryOther     FileCategory = "other"
 )
 
-// ValidFileCategories is the closed set accepted by validation, the SQL
-// CHECK constraint, and the GET /files?category= filter.
+// ValidFileCategories is the closed set accepted by validation and the
+// GET /files?category= filter.
 var ValidFileCategories = []FileCategory{
 	FileCategoryPhotos,
 	FileCategoryInvoices,
@@ -243,12 +243,7 @@ type FileEntity struct {
 	Type FileType `json:"type" db:"type"`
 
 	// Category is the user-meaningful classification surfaced in the UI
-	// (Photos/Invoices/Documents/Other). Defaults to 'other' so the
-	// follow-up backfill (#1399) can re-classify legacy rows in place.
-	// The closed enum is enforced via Go validation in ValidateWithContext;
-	// no DB CHECK constraint is added because ptah's drift detector doesn't
-	// yet recognize column-level `check=` annotations, mirroring the
-	// existing `Type` field's pattern.
+	// (Photos/Invoices/Documents/Other).
 	//migrator:schema:field name="category" type="TEXT" not_null="true" default="other"
 	Category FileCategory `json:"category" db:"category"`
 

--- a/go/registry/memory/files.go
+++ b/go/registry/memory/files.go
@@ -93,7 +93,7 @@ func (r *FileRegistry) ListByType(ctx context.Context, fileType models.FileType)
 }
 
 //nolint:gocognit // TODO: refactor
-func (r *FileRegistry) Search(ctx context.Context, query string, fileType *models.FileType, tags []string) ([]*models.FileEntity, error) {
+func (r *FileRegistry) Search(ctx context.Context, query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string) ([]*models.FileEntity, error) {
 	allFiles, err := r.List(ctx)
 	if err != nil {
 		return nil, err
@@ -105,6 +105,11 @@ func (r *FileRegistry) Search(ctx context.Context, query string, fileType *model
 	for _, file := range allFiles {
 		// Filter by type if specified
 		if fileType != nil && file.Type != *fileType {
+			continue
+		}
+
+		// Filter by category if specified
+		if fileCategory != nil && file.Category != *fileCategory {
 			continue
 		}
 
@@ -147,18 +152,24 @@ func (r *FileRegistry) Search(ctx context.Context, query string, fileType *model
 	return filtered, nil
 }
 
-func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType) ([]*models.FileEntity, int, error) {
-	var allFiles []*models.FileEntity
-	var err error
-
-	if fileType != nil {
-		allFiles, err = r.ListByType(ctx, *fileType)
-	} else {
-		allFiles, err = r.List(ctx)
-	}
-
+func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType, fileCategory *models.FileCategory) ([]*models.FileEntity, int, error) {
+	allFiles, err := r.List(ctx)
 	if err != nil {
 		return nil, 0, err
+	}
+
+	if fileType != nil || fileCategory != nil {
+		filtered := allFiles[:0:0]
+		for _, file := range allFiles {
+			if fileType != nil && file.Type != *fileType {
+				continue
+			}
+			if fileCategory != nil && file.Category != *fileCategory {
+				continue
+			}
+			filtered = append(filtered, file)
+		}
+		allFiles = filtered
 	}
 
 	total := len(allFiles)
@@ -170,6 +181,27 @@ func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fil
 
 	paginatedFiles := allFiles[start:end]
 	return paginatedFiles, total, nil
+}
+
+// CountByCategory aggregates files matching the same filters as Search,
+// grouped by Category. Always returns all four buckets (zero-filled),
+// keeping the response shape stable for the FE tile renderer.
+func (r *FileRegistry) CountByCategory(ctx context.Context, query string, fileType *models.FileType, tags []string) (map[models.FileCategory]int, error) {
+	files, err := r.Search(ctx, query, fileType, nil, tags)
+	if err != nil {
+		return nil, err
+	}
+
+	counts := map[models.FileCategory]int{
+		models.FileCategoryPhotos:    0,
+		models.FileCategoryInvoices:  0,
+		models.FileCategoryDocuments: 0,
+		models.FileCategoryOther:     0,
+	}
+	for _, file := range files {
+		counts[file.Category]++
+	}
+	return counts, nil
 }
 
 // ListByLinkedEntity returns files linked to a specific entity
@@ -229,7 +261,7 @@ func (r *FileRegistry) ListByLinkedEntityAndMeta(ctx context.Context, entityType
 // FullTextSearch performs simple text search on files (simplified)
 func (r *FileRegistry) FullTextSearch(ctx context.Context, query string, fileType *models.FileType, options ...registry.SearchOption) ([]*models.FileEntity, error) {
 	// Use the existing search method as a simplified implementation
-	files, err := r.Search(ctx, query, fileType, nil)
+	files, err := r.Search(ctx, query, fileType, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/registry/memory/files_category_test.go
+++ b/go/registry/memory/files_category_test.go
@@ -1,0 +1,111 @@
+package memory_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+func TestFileRegistry_Memory_FilterByCategory(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := appctx.WithUser(c.Context(), &models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "user-1"},
+			TenantID: "tenant-1",
+		},
+	})
+	ctx = appctx.WithGroup(ctx, &models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "group-1"},
+			TenantID: "tenant-1",
+		},
+		Slug: "g1",
+	})
+
+	reg := memory.NewFileRegistryFactory().MustCreateUserRegistry(ctx)
+	for _, fe := range categoryTestFiles() {
+		_, err := reg.Create(ctx, fe)
+		c.Assert(err, qt.IsNil)
+	}
+
+	t.Run("ListPaginated by category=photos", func(t *testing.T) {
+		c := qt.New(t)
+		cat := models.FileCategoryPhotos
+		got, total, err := reg.ListPaginated(ctx, 0, 50, nil, &cat)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 2)
+		c.Assert(got, qt.HasLen, 2)
+		for _, f := range got {
+			c.Assert(f.Category, qt.Equals, models.FileCategoryPhotos)
+		}
+	})
+
+	t.Run("ListPaginated by category=invoices", func(t *testing.T) {
+		c := qt.New(t)
+		cat := models.FileCategoryInvoices
+		got, total, err := reg.ListPaginated(ctx, 0, 50, nil, &cat)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 1)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].Category, qt.Equals, models.FileCategoryInvoices)
+	})
+
+	t.Run("Search combines tags + category", func(t *testing.T) {
+		c := qt.New(t)
+		cat := models.FileCategoryDocuments
+		got, err := reg.Search(ctx, "", nil, &cat, []string{"manual"})
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].Category, qt.Equals, models.FileCategoryDocuments)
+	})
+
+	t.Run("CountByCategory returns all four buckets", func(t *testing.T) {
+		c := qt.New(t)
+		counts, err := reg.CountByCategory(ctx, "", nil, nil)
+		c.Assert(err, qt.IsNil)
+		c.Assert(counts, qt.HasLen, 4)
+		c.Assert(counts[models.FileCategoryPhotos], qt.Equals, 2)
+		c.Assert(counts[models.FileCategoryInvoices], qt.Equals, 1)
+		c.Assert(counts[models.FileCategoryDocuments], qt.Equals, 1)
+		c.Assert(counts[models.FileCategoryOther], qt.Equals, 1)
+	})
+
+	t.Run("CountByCategory respects tag filter", func(t *testing.T) {
+		c := qt.New(t)
+		counts, err := reg.CountByCategory(ctx, "", nil, []string{"manual"})
+		c.Assert(err, qt.IsNil)
+		c.Assert(counts[models.FileCategoryPhotos], qt.Equals, 0)
+		c.Assert(counts[models.FileCategoryDocuments], qt.Equals, 1)
+		c.Assert(counts[models.FileCategoryInvoices], qt.Equals, 0)
+		c.Assert(counts[models.FileCategoryOther], qt.Equals, 0)
+	})
+}
+
+func categoryTestFiles() []models.FileEntity {
+	mk := func(name, mime, ext string, cat models.FileCategory, tags ...string) models.FileEntity {
+		return models.FileEntity{
+			Title:    name,
+			Type:     models.FileTypeFromMIME(mime),
+			Category: cat,
+			Tags:     tags,
+			File: &models.File{
+				Path:         name,
+				OriginalPath: name + ext,
+				Ext:          ext,
+				MIMEType:     mime,
+			},
+		}
+	}
+	return []models.FileEntity{
+		mk("photo-1", "image/jpeg", ".jpg", models.FileCategoryPhotos, "lounge"),
+		mk("photo-2", "image/png", ".png", models.FileCategoryPhotos),
+		mk("invoice-1", "application/pdf", ".pdf", models.FileCategoryInvoices, "tax"),
+		mk("manual-1", "application/pdf", ".pdf", models.FileCategoryDocuments, "manual"),
+		mk("clip-1", "video/mp4", ".mp4", models.FileCategoryOther),
+	}
+}

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -287,37 +287,51 @@ func (r *FileRegistry) ListByLinkedEntityAndMeta(ctx context.Context, entityType
 	return files, nil
 }
 
-func (r *FileRegistry) Search(ctx context.Context, query string, fileType *models.FileType, tags []string) ([]*models.FileEntity, error) {
+// buildSearchConditions assembles WHERE-clause fragments shared by Search,
+// ListPaginated, and CountByCategory. Returns the conditions slice, the
+// positional args, and the next parameter index so callers can append more
+// filters (e.g. category) without re-numbering.
+func buildSearchConditions(query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string, startIndex int) ([]string, []any, int) {
+	var conditions []string
+	var args []any
+	argIndex := startIndex
+
+	if fileType != nil {
+		conditions = append(conditions, fmt.Sprintf("type = $%d", argIndex))
+		args = append(args, *fileType)
+		argIndex++
+	}
+
+	if fileCategory != nil {
+		conditions = append(conditions, fmt.Sprintf("category = $%d", argIndex))
+		args = append(args, *fileCategory)
+		argIndex++
+	}
+
+	if len(tags) > 0 {
+		conditions = append(conditions, fmt.Sprintf("tags @> $%d", argIndex))
+		tagsJSON, _ := json.Marshal(tags)
+		args = append(args, tagsJSON)
+		argIndex++
+	}
+
+	if query != "" {
+		searchCondition := fmt.Sprintf("(title ILIKE $%d OR description ILIKE $%d OR path ILIKE $%d OR original_path ILIKE $%d)", argIndex, argIndex+1, argIndex+2, argIndex+3)
+		conditions = append(conditions, searchCondition)
+		searchPattern := "%" + query + "%"
+		args = append(args, searchPattern, searchPattern, searchPattern, searchPattern)
+		argIndex += 4
+	}
+
+	return conditions, args, argIndex
+}
+
+func (r *FileRegistry) Search(ctx context.Context, query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string) ([]*models.FileEntity, error) {
 	var files []*models.FileEntity
 
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		var conditions []string
-		var args []any
-		argIndex := 1
-
-		// Add type filter if specified
-		if fileType != nil {
-			conditions = append(conditions, fmt.Sprintf("type = $%d", argIndex))
-			args = append(args, *fileType)
-			argIndex++
-		}
-
-		// Add tags filter if specified
-		if len(tags) > 0 {
-			conditions = append(conditions, fmt.Sprintf("tags @> $%d", argIndex))
-			tagsJSON, _ := json.Marshal(tags)
-			args = append(args, tagsJSON)
-			argIndex++
-		}
-
-		// Add text search if specified
-		if query != "" {
-			searchCondition := fmt.Sprintf("(title ILIKE $%d OR description ILIKE $%d OR path ILIKE $%d OR original_path ILIKE $%d)", argIndex, argIndex+1, argIndex+2, argIndex+3)
-			conditions = append(conditions, searchCondition)
-			searchPattern := "%" + query + "%"
-			args = append(args, searchPattern, searchPattern, searchPattern, searchPattern)
-		}
+		conditions, args, _ := buildSearchConditions(query, fileType, fileCategory, tags, 1)
 
 		whereClause := ""
 		if len(conditions) > 0 {
@@ -353,46 +367,32 @@ func (r *FileRegistry) Search(ctx context.Context, query string, fileType *model
 	return files, nil
 }
 
-func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType) ([]*models.FileEntity, int, error) {
+func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType, fileCategory *models.FileCategory) ([]*models.FileEntity, int, error) {
 	var files []*models.FileEntity
 	var total int
 
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		// First get the total count
-		var countQuery string
-		var countArgs []any
+		conditions, args, _ := buildSearchConditions("", fileType, fileCategory, nil, 1)
 
-		if fileType != nil {
-			countQuery = fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE type = $1`, r.tableNames.Files())
-			countArgs = []any{*fileType}
-		} else {
-			countQuery = fmt.Sprintf(`SELECT COUNT(*) FROM %s`, r.tableNames.Files())
+		whereClause := ""
+		if len(conditions) > 0 {
+			whereClause = "WHERE " + strings.Join(conditions, " AND ")
 		}
 
-		err := tx.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total)
+		countQuery := fmt.Sprintf(`SELECT COUNT(*) FROM %s %s`, r.tableNames.Files(), whereClause)
+		err := tx.QueryRowContext(ctx, countQuery, args...).Scan(&total)
 		if err != nil {
 			return errxtrace.Wrap("failed to count files", err)
 		}
 
-		// Then get the paginated results
-		var dataQuery string
-		var dataArgs []any
-
-		if fileType != nil {
-			dataQuery = fmt.Sprintf(`
-				SELECT * FROM %s
-				WHERE type = $1
-				ORDER BY created_at DESC
-				LIMIT $2 OFFSET $3`, r.tableNames.Files())
-			dataArgs = []any{*fileType, limit, offset}
-		} else {
-			dataQuery = fmt.Sprintf(`
-				SELECT * FROM %s
-				ORDER BY created_at DESC
-				LIMIT $1 OFFSET $2`, r.tableNames.Files())
-			dataArgs = []any{limit, offset}
-		}
+		dataArgs := append([]any{}, args...)
+		dataArgs = append(dataArgs, limit, offset)
+		dataQuery := fmt.Sprintf(`
+			SELECT * FROM %s
+			%s
+			ORDER BY created_at DESC
+			LIMIT $%d OFFSET $%d`, r.tableNames.Files(), whereClause, len(args)+1, len(args)+2)
 
 		rows, err := tx.QueryxContext(ctx, dataQuery, dataArgs...)
 		if err != nil {
@@ -416,4 +416,54 @@ func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fil
 	}
 
 	return files, total, nil
+}
+
+// CountByCategory aggregates files matching the same filters as Search,
+// grouped by Category. The four buckets are always present in the result
+// (zero-filled when missing) so the FE tile renderer can rely on a stable
+// shape.
+func (r *FileRegistry) CountByCategory(ctx context.Context, query string, fileType *models.FileType, tags []string) (map[models.FileCategory]int, error) {
+	counts := map[models.FileCategory]int{
+		models.FileCategoryPhotos:    0,
+		models.FileCategoryInvoices:  0,
+		models.FileCategoryDocuments: 0,
+		models.FileCategoryOther:     0,
+	}
+
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		conditions, args, _ := buildSearchConditions(query, fileType, nil, tags, 1)
+
+		whereClause := ""
+		if len(conditions) > 0 {
+			whereClause = "WHERE " + strings.Join(conditions, " AND ")
+		}
+
+		sqlQuery := fmt.Sprintf(`
+			SELECT category, COUNT(*) FROM %s
+			%s
+			GROUP BY category`, r.tableNames.Files(), whereClause)
+
+		rows, err := tx.QueryxContext(ctx, sqlQuery, args...)
+		if err != nil {
+			return errxtrace.Wrap("failed to count files by category", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var category models.FileCategory
+			var count int
+			if err := rows.Scan(&category, &count); err != nil {
+				return errxtrace.Wrap("failed to scan category count", err)
+			}
+			counts[category] = count
+		}
+
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to count files by category", err)
+	}
+
+	return counts, nil
 }

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -290,7 +290,7 @@ func (r *FileRegistry) ListByLinkedEntityAndMeta(ctx context.Context, entityType
 // buildSearchConditions assembles WHERE-clause fragments shared by Search,
 // ListPaginated, and CountByCategory. Returns the conditions slice, the
 // positional args, and the next parameter index so callers can append more
-// filters (e.g. category) without re-numbering.
+// filters without re-numbering.
 func buildSearchConditions(query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string, startIndex int) ([]string, []any, int) {
 	var conditions []string
 	var args []any

--- a/go/registry/postgres/files_category_test.go
+++ b/go/registry/postgres/files_category_test.go
@@ -1,0 +1,105 @@
+package postgres_test
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// TestFileRegistry_Postgres_CategoryFilter exercises the category WHERE-clause
+// path on the postgres FileRegistry — the actual path GET /files?category= will
+// take in production. CountByCategory is verified end-to-end against a real
+// SQL GROUP BY so we catch ordering / scan / RLS regressions that the memory
+// fast-path would miss.
+func TestFileRegistry_Postgres_CategoryFilter(t *testing.T) {
+	c := qt.New(t)
+
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	user := getTestUser(c, registrySet)
+	ctx := appctx.WithUser(c.Context(), user)
+	// setupTestRegistrySet wires the user-aware registry to a specific group
+	// already; the FileRegistry resolves the group from its closure, not the
+	// context. Loading a LocationGroup into ctx here would only matter for
+	// services that read GroupIDFromContext directly — none of which we hit
+	// from this test.
+
+	for _, fe := range categoryPostgresSeed() {
+		fe.TenantID = user.TenantID
+		fe.CreatedByUserID = user.ID
+		_, err := registrySet.FileRegistry.Create(ctx, fe)
+		c.Assert(err, qt.IsNil)
+	}
+
+	t.Run("ListPaginated by category=photos", func(t *testing.T) {
+		c := qt.New(t)
+		cat := models.FileCategoryPhotos
+		got, total, err := registrySet.FileRegistry.ListPaginated(ctx, 0, 50, nil, &cat)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 2)
+		c.Assert(got, qt.HasLen, 2)
+		for _, f := range got {
+			c.Assert(f.Category, qt.Equals, models.FileCategoryPhotos)
+		}
+	})
+
+	t.Run("Search by category + tag", func(t *testing.T) {
+		c := qt.New(t)
+		cat := models.FileCategoryDocuments
+		got, err := registrySet.FileRegistry.Search(ctx, "", nil, &cat, []string{"manual"})
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].Category, qt.Equals, models.FileCategoryDocuments)
+	})
+
+	t.Run("CountByCategory returns all four buckets, even empty ones", func(t *testing.T) {
+		c := qt.New(t)
+		counts, err := registrySet.FileRegistry.CountByCategory(ctx, "", nil, nil)
+		c.Assert(err, qt.IsNil)
+		c.Assert(counts, qt.HasLen, 4)
+		c.Assert(counts[models.FileCategoryPhotos], qt.Equals, 2)
+		c.Assert(counts[models.FileCategoryInvoices], qt.Equals, 1)
+		c.Assert(counts[models.FileCategoryDocuments], qt.Equals, 1)
+		c.Assert(counts[models.FileCategoryOther], qt.Equals, 1)
+	})
+
+	t.Run("CountByCategory respects search filter", func(t *testing.T) {
+		c := qt.New(t)
+		counts, err := registrySet.FileRegistry.CountByCategory(ctx, "manual", nil, nil)
+		c.Assert(err, qt.IsNil)
+		c.Assert(counts[models.FileCategoryDocuments], qt.Equals, 1)
+		c.Assert(counts[models.FileCategoryPhotos], qt.Equals, 0)
+	})
+}
+
+func categoryPostgresSeed() []models.FileEntity {
+	now := time.Now()
+	mk := func(name, mime, ext string, cat models.FileCategory, tags ...string) models.FileEntity {
+		return models.FileEntity{
+			Title:     name,
+			Type:      models.FileTypeFromMIME(mime),
+			Category:  cat,
+			Tags:      tags,
+			CreatedAt: now,
+			UpdatedAt: now,
+			File: &models.File{
+				Path:         name,
+				OriginalPath: name + ext,
+				Ext:          ext,
+				MIMEType:     mime,
+			},
+		}
+	}
+	return []models.FileEntity{
+		mk("photo-1", "image/jpeg", ".jpg", models.FileCategoryPhotos, "lounge"),
+		mk("photo-2", "image/png", ".png", models.FileCategoryPhotos),
+		mk("invoice-1", "application/pdf", ".pdf", models.FileCategoryInvoices, "tax"),
+		mk("manual-1", "application/pdf", ".pdf", models.FileCategoryDocuments, "manual"),
+		mk("clip-1", "video/mp4", ".mp4", models.FileCategoryOther),
+	}
+}

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -210,14 +210,24 @@ type FileRegistry interface {
 	// see exactly the right slice via RLS.
 	ListByGroup(ctx context.Context, tenantID, groupID string) ([]*models.FileEntity, error)
 
-	// Search returns files matching the search criteria
-	Search(ctx context.Context, query string, fileType *models.FileType, tags []string) ([]*models.FileEntity, error)
+	// Search returns files matching the search criteria. The optional
+	// fileCategory parameter filters by the user-meaningful category surfaced
+	// in the UI tiles (Photos/Invoices/Documents/Other).
+	Search(ctx context.Context, query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string) ([]*models.FileEntity, error)
 
 	//// FullTextSearch performs enhanced text search on files
 	// FullTextSearch(ctx context.Context, query string, fileType *models.FileType, options ...SearchOption) ([]*models.FileEntity, error)
 
-	// ListPaginated returns paginated list of files
-	ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType) ([]*models.FileEntity, int, error)
+	// ListPaginated returns paginated list of files. The optional
+	// fileCategory parameter filters by the user-meaningful category surfaced
+	// in the UI tiles (Photos/Invoices/Documents/Other).
+	ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType, fileCategory *models.FileCategory) ([]*models.FileEntity, int, error)
+
+	// CountByCategory returns the per-category file count, scoped to the
+	// current group via RLS and constrained by the same filters as Search
+	// (text query, file type, tags). Backs the GET /files/category-counts
+	// endpoint that drives the four-tile UI on the Files page.
+	CountByCategory(ctx context.Context, query string, fileType *models.FileType, tags []string) (map[models.FileCategory]int, error)
 }
 
 type ThumbnailGenerationJobRegistry interface {

--- a/go/schema/migrations/_sqldata/1777567470_add_files_category.down.sql
+++ b/go/schema/migrations/_sqldata/1777567470_add_files_category.down.sql
@@ -1,0 +1,9 @@
+-- Migration rollback
+-- Generated on: 2026-04-30T18:44:30+02:00
+-- Direction: DOWN
+
+DROP INDEX IF EXISTS idx_files_tenant_group_category;
+-- Remove columns from table: files --
+-- ALTER statements: --
+ALTER TABLE files DROP COLUMN category CASCADE;
+-- WARNING: Dropping column files.category with CASCADE - This will delete data and dependent objects! --

--- a/go/schema/migrations/_sqldata/1777567470_add_files_category.up.sql
+++ b/go/schema/migrations/_sqldata/1777567470_add_files_category.up.sql
@@ -1,0 +1,8 @@
+-- Migration generated from schema differences
+-- Generated on: 2026-04-30T18:44:30+02:00
+-- Direction: UP
+
+-- Add/modify columns for table: files --
+-- ALTER statements: --
+ALTER TABLE files ADD COLUMN category TEXT NOT NULL DEFAULT 'other';
+CREATE INDEX IF NOT EXISTS idx_files_tenant_group_category ON files (tenant_id, group_id, category);


### PR DESCRIPTION
## Summary

Adds a `Category` enum (`photos | invoices | documents | other`) on the unified `files` table — the user-meaningful classification driving the four-tile UI on the upcoming React Files page (#1411). Distinct from the existing MIME-derived `Type`; each file belongs to exactly one category.

Closes the BE half of #1398 / folds in #1372. Required prereq for the FE Files page (#1411) and the legacy file-routes cutover (#1421).

## What changed

**Model + migration**
- `models.FileEntity.Category` typed string + `FileCategoryFromContext` derivation. Legacy `commodity/{images,invoices,manuals}` and `location/images` bucket names take precedence over MIME so a "manuals" bucket lands in Documents even for image scans. Standalone uploads + `location/files` fall through to MIME.
- Migration `1777567470_add_files_category` — `ALTER TABLE files ADD COLUMN category TEXT NOT NULL DEFAULT 'other'` + composite index `(tenant_id, group_id, category)` to back the per-category list and the counts aggregator under RLS.
- `ValidateWithContext` rejects empty + unknown categories.

**Registry**
- `FileRegistry.Search` and `ListPaginated` gain an optional `*FileCategory` filter.
- New `CountByCategory(ctx, query, fileType, tags)` returns the four buckets always zero-filled — keeps the FE tile renderer's response shape stable.
- Postgres path goes through a shared `buildSearchConditions` helper so list / count assemble the WHERE clause identically.
- No `boltdb` impl exists for files; only memory + postgres are touched.

**API**
- `GET /files?category=` parses + validates against the closed enum. Multi-value (`?category=a&category=b`) and unknown values both return 400.
- New `GET /files/category-counts`, mounted before `/{fileID}`, respects the same `type` / `search` / `tags` filters and returns `{photos, invoices, documents, other, all}`.
- All `FileEntity` creation paths (uploads.go ×6, files.go createFile, backup export/import) set `Category` via `FileCategoryFromContext`. `updateFile` re-derives category alongside `Type` once the MIME is known.
- Swagger annotations regenerated (`docs/swagger.{yaml,json}`).

## Tests

- **Model**: derivation table for both `FileCategoryFromMIME` and `FileCategoryFromContext`; validation rejects empty + unknown categories and accepts each of the four legal values.
- **jsonapi**: `NewFileCategoryCountsResponse` populates buckets, computes `all`, and the JSON shape matches the FE renderer contract.
- **apiserver**: `parseFileCategoryParam` enumerated (absent / empty / each valid / invalid / multi-value).
- **Memory registry**: list-by-category, Search with `tags+category`, `CountByCategory` (all-bucket return + tag-filter respect).
- **Postgres registry**: same coverage exercising the real `WHERE category=` and `GROUP BY category` SQL paths under RLS.

All non-pg tests run by default; postgres tests skip without `POSTGRES_TEST_DSN` (verified locally with the dockerized DB — pass).

## Notes

- **DB-level `CHECK` constraint deliberately omitted.** Ptah's drift detector doesn't yet recognize column-level `check=` annotations and the existing `Type` enum field follows the same pattern. Go validation enforces the closed enum at every API boundary; can revisit once ptah adds CHECK detection.
- **File backfill** (legacy `images` / `invoices` / `manuals` rows → categorized `files` rows) is the follow-up #1399. Until that lands, existing rows pick up the `'other'` default; new uploads get derived correctly.
- `make swagger` was re-run; `inventool db migrations generate --check` reports zero drift after the migration applies.

## Test plan

- [ ] `make test` (Go unit + memory registry)
- [ ] `POSTGRES_TEST_DSN=… make test-postgres` (or equivalent) — postgres registry tests
- [ ] `make migrate-lint` — schema-drift gate green
- [ ] `make swagger` — no diff after running
- [ ] Manual: `GET /files?category=photos`, `GET /files/category-counts`, invalid category returns 400

Refs #1397, blocks #1411, follow-up #1399.