### PR TITLE
[#1399] BE: backfill legacy images/invoices/manuals → files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ else
 		exit 1; \
 	fi
 endif
-	$(CD) $(BACKEND_DIR) && $(GO_CMD) test -v ./registry/postgres/...
+	$(CD) $(BACKEND_DIR) && $(GO_CMD) test -v ./registry/postgres/... ./services/files_backfill/...
 
 # Run all Go tests including PostgreSQL
 .PHONY: test-go-all

--- a/devdocs/backend/files-backfill.md
+++ b/devdocs/backend/files-backfill.md
@@ -1,0 +1,116 @@
+# Files backfill runbook
+
+`inventario migrate files-backfill` copies the legacy commodity-scoped
+`images`, `invoices`, and `manuals` tables into the unified `files` table
+introduced under epic [#1397](https://github.com/denisvmedia/inventario/issues/1397).
+Once it has run, the new `GET /files` endpoint serves a complete view of
+every commodity attachment, which is what the cutover ([#1421])
+expects.
+
+[#1421]: https://github.com/denisvmedia/inventario/issues/1421
+
+## When to run
+
+Run after the FE has switched to `/files` for reads and uploads ([#1411])
+and before the cutover PR that drops the legacy tables. This is the
+ordering called out in [#1399].
+
+[#1411]: https://github.com/denisvmedia/inventario/issues/1411
+[#1399]: https://github.com/denisvmedia/inventario/issues/1399
+
+The command is safe to run multiple times: every legacy row whose `uuid`
+already appears in `files` is skipped. Re-running after a partial failure,
+or after the FE has been writing directly into `files` for a while, both
+produce zero new rows.
+
+## How to run
+
+```bash
+# Preview — runs the same INSERTs but rolls the transaction back at the
+# end. Use this in production to confirm row counts before committing.
+inventario db migrate files-backfill --dry-run --db-dsn "$DB_DSN"
+
+# Live — commits.
+inventario db migrate files-backfill --db-dsn "$DB_DSN"
+```
+
+The DSN must connect as the migrator role (the same one used for
+`inventario migrate up`). RLS policies use `USING (true)` for that role,
+which is what lets the cross-tenant INSERT work.
+
+## What the output looks like
+
+```
+=== FILES BACKFILL ===
+Database: postgres://inventario:***@db.internal:5432/inventario?sslmode=disable
+Mode: LIVE
+
+Source    Total  Migrated  Pending  Inserted
+------    -----  --------  -------  --------
+images    3142   0         3142     3142
+invoices  892    0         892      892
+manuals   411    0         411      411
+
+🎉 Backfill complete — 4445 rows inserted.
+```
+
+| Column     | Meaning                                                                                       |
+| ---------- | --------------------------------------------------------------------------------------------- |
+| `Total`    | Rows currently in the legacy table.                                                           |
+| `Migrated` | Legacy rows whose `uuid` already exists in `files` (already-backfilled or directly-uploaded). |
+| `Pending`  | Legacy rows still to copy. `Total − Migrated`.                                                |
+| `Inserted` | Rows the command actually wrote. Always `0` on `--dry-run`.                                   |
+
+After a successful live run, `Pending` should be zero on every subsequent
+invocation.
+
+## Mapping
+
+| Source table                | `files.category` | `files.type`     | `linked_entity_type` | `linked_entity_meta` |
+| --------------------------- | ---------------- | ---------------- | -------------------- | -------------------- |
+| `images` (commodity-scoped) | `photos`         | derived from MIME | `commodity`          | `images`             |
+| `invoices`                  | `invoices`       | derived from MIME | `commodity`          | `invoices`           |
+| `manuals`                   | `documents`      | derived from MIME | `commodity`          | `manuals`            |
+
+Location-scoped uploads already write straight into `files` via the new
+upload handlers, so they don't need a backfill.
+
+The `type` column mirrors `models.FileTypeFromMIME` — kept as inline SQL
+in `services/files_backfill/backfill.go` so the migration logic stays in
+lock-step with the Go function. Any future change to `FileTypeFromMIME`
+must be reflected there.
+
+## Monitoring
+
+The whole run executes inside a single transaction. For a 1 M-row legacy
+dataset the command should finish in well under 10 minutes; the
+`Pending → 0` transition is the success signal. If it doesn't land,
+re-running picks up where the previous attempt stopped (idempotency by
+`uuid`).
+
+Watch for:
+
+- Postgres error logs — the migrator role bypassing RLS means a stray
+  `tenant_id` or `group_id` violation would surface as a NOT NULL or FK
+  failure at INSERT time.
+- `files` table size growth approximately equal to `images` + `invoices` +
+  `manuals` row counts. Larger growth indicates the FE is still uploading
+  through the legacy path; smaller growth indicates idempotency was hit
+  for an unexpected reason (worth inspecting).
+
+## Rollback
+
+The backfill never touches the legacy tables, so rollback is just
+"discard the new `files` rows":
+
+```sql
+DELETE FROM files
+WHERE uuid IN (SELECT uuid FROM images)
+   OR uuid IN (SELECT uuid FROM invoices)
+   OR uuid IN (SELECT uuid FROM manuals);
+```
+
+Run as the migrator role (RLS bypass).
+
+This is destructive only for rows the backfill itself wrote — the legacy
+tables remain canonical until the cutover ([#1421]) drops them.

--- a/go/cmd/inventario/db/migrate/filesbackfill/config.go
+++ b/go/cmd/inventario/db/migrate/filesbackfill/config.go
@@ -1,0 +1,6 @@
+package filesbackfill
+
+// Config holds configuration for the files backfill command.
+type Config struct {
+	DryRun bool `yaml:"dry_run" env:"DRY_RUN" env-default:"false"`
+}

--- a/go/cmd/inventario/db/migrate/filesbackfill/filesbackfill.go
+++ b/go/cmd/inventario/db/migrate/filesbackfill/filesbackfill.go
@@ -1,15 +1,17 @@
-// Package filesbackfill exposes `inventario migrate files-backfill` — the
-// one-shot ops tool that copies legacy commodity-scoped images, invoices,
-// and manuals rows into the unified `files` table introduced under epic
-// #1397. The actual SQL lives in services/files_backfill so it can be
-// shared with integration tests and any future automation.
+// Package filesbackfill exposes `inventario db migrate files-backfill` —
+// the one-shot ops tool that copies legacy commodity-scoped images,
+// invoices, and manuals rows into the unified `files` table introduced
+// under epic #1397. The actual SQL lives in services/files_backfill so it
+// can be shared with integration tests and any future automation.
 package filesbackfill
 
 import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	_ "github.com/lib/pq" // PostgreSQL driver, matches `migrate data`
@@ -52,10 +54,10 @@ would happen with zero side effects.
 
 Examples:
   # Preview what would be migrated
-  inventario migrate files-backfill --dry-run
+  inventario db migrate files-backfill --dry-run
 
   # Perform the actual backfill
-  inventario migrate files-backfill`,
+  inventario db migrate files-backfill`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.run(&c.config, dbConfig)
 		},
@@ -77,7 +79,7 @@ func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
 	}
 
 	fmt.Println("=== FILES BACKFILL ===")
-	fmt.Printf("Database: %s\n", dsn)
+	fmt.Printf("Database: %s\n", redactDSN(dsn))
 	if cfg.DryRun {
 		fmt.Println("Mode: DRY RUN (transaction will be rolled back)")
 	} else {
@@ -114,6 +116,27 @@ func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
 		fmt.Printf("\n🎉 Backfill complete — %d rows inserted.\n", stats.TotalInserted())
 	}
 	return nil
+}
+
+// redactDSN replaces the password component of a postgres:// DSN with
+// `***` so the audit banner doesn't leak credentials into terminal
+// scrollback, CI logs, or operator runbooks. We rebuild via direct
+// string replacement rather than `u.User = url.UserPassword(..., "***")`
+// because `u.String()` percent-encodes the asterisks, defeating the
+// readability the redaction is supposed to provide. Returns the
+// original string unchanged for non-URL DSNs (memory://, malformed
+// input) so we don't silently drop information that might help
+// debugging.
+func redactDSN(dsn string) string {
+	u, err := url.Parse(dsn)
+	if err != nil || u.User == nil {
+		return dsn
+	}
+	pw, ok := u.User.Password()
+	if !ok || pw == "" {
+		return dsn
+	}
+	return strings.Replace(dsn, ":"+pw+"@", ":***@", 1)
 }
 
 func printStats(stats *files_backfill.Stats) {

--- a/go/cmd/inventario/db/migrate/filesbackfill/filesbackfill.go
+++ b/go/cmd/inventario/db/migrate/filesbackfill/filesbackfill.go
@@ -1,0 +1,127 @@
+// Package filesbackfill exposes `inventario migrate files-backfill` — the
+// one-shot ops tool that copies legacy commodity-scoped images, invoices,
+// and manuals rows into the unified `files` table introduced under epic
+// #1397. The actual SQL lives in services/files_backfill so it can be
+// shared with integration tests and any future automation.
+package filesbackfill
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	_ "github.com/lib/pq" // PostgreSQL driver, matches `migrate data`
+	"github.com/spf13/cobra"
+
+	"github.com/denisvmedia/inventario/cmd/internal/command"
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/services/files_backfill"
+)
+
+// Command wraps the cobra entry point so it follows the rest of the
+// `inventario migrate` family (data, up, down, list).
+type Command struct {
+	command.Base
+
+	config Config
+}
+
+// New creates the `files-backfill` subcommand.
+func New(dbConfig *shared.DatabaseConfig) *Command {
+	c := &Command{}
+
+	shared.TryReadSection("migrate.files_backfill", &c.config)
+
+	c.Base = command.NewBase(&cobra.Command{
+		Use:   "files-backfill",
+		Short: "Backfill legacy images/invoices/manuals into the unified files table",
+		Long: `Copy every row from the legacy commodity-scoped tables (images, invoices,
+manuals) into the unified ` + "`files`" + ` table with proper category, type, and
+linked_entity metadata. The legacy tables are not touched — the cutover that
+removes them is a separate, later migration (#1421).
+
+Idempotency: rows whose uuid already exists in ` + "`files`" + ` are skipped, so
+re-running after a partial failure or after the FE has resumed uploading
+directly into ` + "`files`" + ` is safe and produces zero new rows.
+
+The whole run executes inside a single transaction. With --dry-run the
+transaction is rolled back at the end, so the audit row counts reflect what
+would happen with zero side effects.
+
+Examples:
+  # Preview what would be migrated
+  inventario migrate files-backfill --dry-run
+
+  # Perform the actual backfill
+  inventario migrate files-backfill`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.run(&c.config, dbConfig)
+		},
+	})
+
+	c.registerFlags()
+
+	return c
+}
+
+func (c *Command) registerFlags() {
+	shared.RegisterDryRunFlag(c.Cmd(), &c.config.DryRun)
+}
+
+func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
+	dsn := dbConfig.DBDSN
+	if dsn == "" {
+		return fmt.Errorf("database DSN is required")
+	}
+
+	fmt.Println("=== FILES BACKFILL ===")
+	fmt.Printf("Database: %s\n", dsn)
+	if cfg.DryRun {
+		fmt.Println("Mode: DRY RUN (transaction will be rolled back)")
+	} else {
+		fmt.Println("Mode: LIVE")
+	}
+	fmt.Println()
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		return fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	mgr := files_backfill.NewManager(db)
+	var stats *files_backfill.Stats
+	if cfg.DryRun {
+		stats, err = mgr.PreviewOnly(context.Background())
+	} else {
+		stats, err = mgr.Apply(context.Background())
+	}
+	if err != nil {
+		return fmt.Errorf("backfill failed: %w", err)
+	}
+
+	printStats(stats)
+
+	if cfg.DryRun {
+		fmt.Println("\n💡 Re-run without --dry-run to apply.")
+	} else {
+		fmt.Printf("\n🎉 Backfill complete — %d rows inserted.\n", stats.TotalInserted())
+	}
+	return nil
+}
+
+func printStats(stats *files_backfill.Stats) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "Source\tTotal\tMigrated\tPending\tInserted")
+	fmt.Fprintln(w, "------\t-----\t--------\t-------\t--------")
+	for _, src := range stats.Sources {
+		fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\n", src.Source, src.Total, src.Migrated, src.Pending, src.Inserted)
+	}
+	_ = w.Flush()
+}

--- a/go/cmd/inventario/db/migrate/filesbackfill/redact_test.go
+++ b/go/cmd/inventario/db/migrate/filesbackfill/redact_test.go
@@ -1,0 +1,55 @@
+package filesbackfill
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// redactDSN must not let passwords reach stdout, must keep host/db/query
+// readable for ops, and must not silently mangle non-URL DSNs.
+func TestRedactDSN(t *testing.T) {
+	cases := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{
+			name: "postgres:// with password",
+			dsn:  "postgres://inventario:s3cret@localhost:5432/inventario?sslmode=disable",
+			want: "postgres://inventario:***@localhost:5432/inventario?sslmode=disable",
+		},
+		{
+			name: "postgresql:// alias",
+			dsn:  "postgresql://user:hunter2@db.internal:5432/app",
+			want: "postgresql://user:***@db.internal:5432/app",
+		},
+		{
+			name: "no userinfo at all",
+			dsn:  "postgres://localhost:5432/inventario",
+			want: "postgres://localhost:5432/inventario",
+		},
+		{
+			name: "user without password",
+			dsn:  "postgres://inventario@localhost:5432/inventario",
+			want: "postgres://inventario@localhost:5432/inventario",
+		},
+		{
+			name: "memory:// scheme passes through",
+			dsn:  "memory://",
+			want: "memory://",
+		},
+		{
+			name: "malformed input passes through",
+			dsn:  "not a url",
+			want: "not a url",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(redactDSN(tc.dsn), qt.Equals, tc.want)
+		})
+	}
+}

--- a/go/cmd/inventario/db/migrate/migrate.go
+++ b/go/cmd/inventario/db/migrate/migrate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/denisvmedia/inventario/cmd/inventario/db/migrate/data"
 	"github.com/denisvmedia/inventario/cmd/inventario/db/migrate/down"
+	"github.com/denisvmedia/inventario/cmd/inventario/db/migrate/filesbackfill"
 	"github.com/denisvmedia/inventario/cmd/inventario/db/migrate/list"
 	"github.com/denisvmedia/inventario/cmd/inventario/db/migrate/up"
 	"github.com/denisvmedia/inventario/cmd/inventario/shared"
@@ -75,6 +76,7 @@ MIGRATION SAFETY:
 	cmd.AddCommand(list.New(dbConfig).Cmd())
 	cmd.AddCommand(down.New(dbConfig).Cmd())
 	cmd.AddCommand(data.New(dbConfig).Cmd())
+	cmd.AddCommand(filesbackfill.New(dbConfig).Cmd())
 
 	return cmd
 }

--- a/go/services/files_backfill/backfill.go
+++ b/go/services/files_backfill/backfill.go
@@ -21,12 +21,13 @@ import (
 
 // SourceStats is a per-source-table audit row produced by the backfill.
 //
-// `Total`     — rows currently in the legacy table.
-// `Migrated`  — legacy rows that already have a matching files.uuid.
-// `Pending`   — legacy rows still to copy (Total - Migrated).
-// `Inserted`  — rows actually written this run; always 0 for dry runs and
-//
-//	always equal to Pending after a successful live run.
+//	Total     — rows currently in the legacy table.
+//	Migrated  — legacy rows that already have a matching files.uuid.
+//	Pending   — legacy rows still to copy (Total - Migrated).
+//	Inserted  — rows actually persisted by this run. Always 0 on a dry
+//	            run because the surrounding transaction is rolled back;
+//	            after a successful live run it equals Pending. Use Pending
+//	            to read "would insert" semantics.
 type SourceStats struct {
 	Source   string
 	Total    int
@@ -124,7 +125,14 @@ func (m *Manager) run(ctx context.Context, mode runMode) (*Stats, error) {
 	}
 
 	if mode == modePreview {
-		// rollback handled by deferred branch; leave committed=false
+		// rollback handled by deferred branch; leave committed=false.
+		// Zero out Inserted so the caller can't mistake "would insert"
+		// (the SQL did execute under the rolled-back tx) for "did
+		// insert". Pending stays populated and is the right field to
+		// read for dry-run sizing.
+		for i := range stats.Sources {
+			stats.Sources[i].Inserted = 0
+		}
 		return stats, nil
 	}
 

--- a/go/services/files_backfill/backfill.go
+++ b/go/services/files_backfill/backfill.go
@@ -1,0 +1,262 @@
+// Package files_backfill copies the legacy commodity-scoped images, invoices,
+// and manuals tables into the unified `files` table introduced in #1397, so
+// the new `/files` endpoint can serve as a complete replacement before #1421
+// removes the legacy routes.
+//
+// Idempotency: each run skips legacy rows whose UUID already exists in
+// `files`. Re-runs after a partial failure (or after the FE has resumed
+// uploading directly into `files`) are safe and produce zero new rows.
+//
+// Reversibility: the legacy tables are not touched. The follow-up cutover
+// PR (#1421) is the only place that drops them.
+package files_backfill
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+)
+
+// SourceStats is a per-source-table audit row produced by the backfill.
+//
+// `Total`     — rows currently in the legacy table.
+// `Migrated`  — legacy rows that already have a matching files.uuid.
+// `Pending`   — legacy rows still to copy (Total - Migrated).
+// `Inserted`  — rows actually written this run; always 0 for dry runs and
+//
+//	always equal to Pending after a successful live run.
+type SourceStats struct {
+	Source   string
+	Total    int
+	Migrated int
+	Pending  int
+	Inserted int
+}
+
+// Stats is the full audit + write report for a single backfill invocation.
+type Stats struct {
+	DryRun  bool
+	Sources []SourceStats
+}
+
+// TotalInserted is the sum of inserted rows across all sources.
+func (s *Stats) TotalInserted() int {
+	n := 0
+	for _, src := range s.Sources {
+		n += src.Inserted
+	}
+	return n
+}
+
+// TotalPending is the sum of pending rows across all sources, useful for
+// dry-run summaries.
+func (s *Stats) TotalPending() int {
+	n := 0
+	for _, src := range s.Sources {
+		n += src.Pending
+	}
+	return n
+}
+
+// Manager owns the backfill SQL. It runs every step inside a single
+// transaction so dry runs can roll back cleanly and partial failures don't
+// leak half-migrated rows.
+type Manager struct {
+	db *sql.DB
+}
+
+// NewManager returns a Manager bound to the supplied *sql.DB. The DB must
+// connect as a role that can read the legacy tables and write to `files`
+// across tenants — typically the migrator role used for `inventario migrate
+// up`. RLS bypass is handled by that role's policy `USING (true)`.
+func NewManager(db *sql.DB) *Manager {
+	return &Manager{db: db}
+}
+
+// runMode discriminates between an actual write and a preview. Modeled as
+// a typed enum (not a bool) so callers read at the call site and revive's
+// flag-parameter check stays out of our way.
+type runMode int
+
+const (
+	modeApply runMode = iota
+	modePreview
+)
+
+// Apply runs the backfill end-to-end and commits the transaction. Use
+// PreviewOnly when you want the audit row counts without persisting the
+// new files rows.
+func (m *Manager) Apply(ctx context.Context) (*Stats, error) {
+	return m.run(ctx, modeApply)
+}
+
+// PreviewOnly executes the same INSERTs as Apply but rolls the
+// transaction back at the end, so the audit row counts in the returned
+// Stats reflect "what would happen" with zero side effects.
+func (m *Manager) PreviewOnly(ctx context.Context) (*Stats, error) {
+	return m.run(ctx, modePreview)
+}
+
+func (m *Manager) run(ctx context.Context, mode runMode) (*Stats, error) {
+	tx, err := m.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to begin backfill transaction", err)
+	}
+	// Always end the transaction; rollback on error or dry-run, commit on
+	// successful live run. Defer makes this safe even if a panic escapes a
+	// helper below.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	stats := &Stats{DryRun: mode == modePreview}
+	for _, plan := range backfillPlans() {
+		row, err := backfillSource(ctx, tx, plan)
+		if err != nil {
+			return nil, errxtrace.Wrap(fmt.Sprintf("failed to backfill %s", plan.source), err)
+		}
+		stats.Sources = append(stats.Sources, row)
+	}
+
+	if mode == modePreview {
+		// rollback handled by deferred branch; leave committed=false
+		return stats, nil
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, errxtrace.Wrap("failed to commit backfill transaction", err)
+	}
+	committed = true
+	return stats, nil
+}
+
+// backfillPlan describes one legacy → files mapping.
+//
+//	source            — legacy table name, used both for SQL and for the
+//	                    SourceStats label.
+//	linkedEntityMeta  — the meta value the backfilled FileEntity carries on
+//	                    its linked_entity_meta column (matches what new
+//	                    upload handlers set for the same legacy bucket).
+//	category          — the user-meaningful FileCategory enum value.
+//	typeExpr          — SQL expression yielding the FileType enum, evaluated
+//	                    against the source row alias `s`. For images this is
+//	                    a literal; for invoices/manuals we mirror the runtime
+//	                    `FileTypeFromMIME` switch so a stray non-PDF lands in
+//	                    the right type bucket.
+type backfillPlan struct {
+	source           string
+	linkedEntityMeta string
+	category         string
+	typeExpr         string
+}
+
+// fileTypeFromMimeSQL mirrors models.FileTypeFromMIME. Kept here as a
+// constant so the migration logic stays in lock-step with the Go function;
+// any change must be made in both.
+const fileTypeFromMimeSQL = `CASE
+		WHEN s.mime_type LIKE 'image/%' THEN 'image'
+		WHEN s.mime_type LIKE 'video/%' THEN 'video'
+		WHEN s.mime_type LIKE 'audio/%' THEN 'audio'
+		WHEN s.mime_type IN ('application/zip','application/x-zip-compressed') THEN 'archive'
+		WHEN s.mime_type IN ('application/pdf','text/plain','text/csv','application/json','application/msword')
+			OR s.mime_type LIKE 'application/vnd.ms-%'
+			OR s.mime_type LIKE 'application/vnd.openxmlformats-%' THEN 'document'
+		ELSE 'other'
+	END`
+
+func backfillPlans() []backfillPlan {
+	return []backfillPlan{
+		{
+			source:           "images",
+			linkedEntityMeta: "images",
+			category:         "photos",
+			// images bucket only stores image MIMEs, but we still derive
+			// from MIME to keep the three branches consistent.
+			typeExpr: fileTypeFromMimeSQL,
+		},
+		{
+			source:           "invoices",
+			linkedEntityMeta: "invoices",
+			category:         "invoices",
+			typeExpr:         fileTypeFromMimeSQL,
+		},
+		{
+			source:           "manuals",
+			linkedEntityMeta: "manuals",
+			category:         "documents",
+			typeExpr:         fileTypeFromMimeSQL,
+		},
+	}
+}
+
+// backfillSource issues the three SQL statements for one legacy source.
+// Every interpolated value (`plan.source`, `plan.typeExpr`) comes from the
+// hard-coded backfillPlans slice — never from user input — so gosec's
+// G201 warnings about SQL string formatting are deliberately suppressed.
+//
+//nolint:gosec // SQL fragments are built from hard-coded backfillPlan constants
+func backfillSource(ctx context.Context, tx *sql.Tx, plan backfillPlan) (SourceStats, error) {
+	row := SourceStats{Source: plan.source}
+
+	totalQuery := "SELECT COUNT(*) FROM " + plan.source
+	migratedQuery := "SELECT COUNT(*) FROM " + plan.source + " s WHERE EXISTS (SELECT 1 FROM files f WHERE f.uuid = s.uuid)"
+	if err := tx.QueryRowContext(ctx, totalQuery).Scan(&row.Total); err != nil {
+		return row, errxtrace.Wrap("failed to count source rows", err)
+	}
+	if err := tx.QueryRowContext(ctx, migratedQuery).Scan(&row.Migrated); err != nil {
+		return row, errxtrace.Wrap("failed to count migrated rows", err)
+	}
+	row.Pending = row.Total - row.Migrated
+
+	// We always run the INSERT — on a dry run the surrounding transaction
+	// is rolled back, so the planner cost is the only side effect. Doing it
+	// this way means the dry-run report reflects "what would actually
+	// happen" rather than a separately-computed estimate.
+	insert := fmt.Sprintf(`
+		INSERT INTO files (
+			id, uuid, tenant_id, group_id, created_by_user_id,
+			title, description, type, category, tags,
+			linked_entity_type, linked_entity_id, linked_entity_meta,
+			path, original_path, ext, mime_type,
+			created_at, updated_at
+		)
+		SELECT
+			gen_random_uuid()::text,
+			s.uuid,
+			s.tenant_id,
+			s.group_id,
+			s.created_by_user_id,
+			s.path,
+			'',
+			%s,
+			$1,
+			'[]'::jsonb,
+			'commodity',
+			s.commodity_id,
+			$2,
+			s.path,
+			s.original_path,
+			s.ext,
+			s.mime_type,
+			NOW(),
+			NOW()
+		FROM %s s
+		WHERE NOT EXISTS (SELECT 1 FROM files f WHERE f.uuid = s.uuid)`,
+		plan.typeExpr, plan.source)
+
+	res, err := tx.ExecContext(ctx, insert, plan.category, plan.linkedEntityMeta)
+	if err != nil {
+		return row, errxtrace.Wrap("failed to insert backfill rows", err)
+	}
+	inserted, err := res.RowsAffected()
+	if err != nil {
+		return row, errxtrace.Wrap("failed to read RowsAffected", err)
+	}
+	row.Inserted = int(inserted)
+	return row, nil
+}

--- a/go/services/files_backfill/backfill.go
+++ b/go/services/files_backfill/backfill.go
@@ -196,14 +196,16 @@ func backfillPlans() []backfillPlan {
 
 // backfillSource issues the three SQL statements for one legacy source.
 // Every interpolated value (`plan.source`, `plan.typeExpr`) comes from the
-// hard-coded backfillPlans slice — never from user input — so gosec's
-// G201 warnings about SQL string formatting are deliberately suppressed.
-//
-//nolint:gosec // SQL fragments are built from hard-coded backfillPlan constants
+// hard-coded backfillPlans slice — never from user input — so the gosec
+// G201 warnings on the SQL string assembly below are suppressed via
+// `#nosec` directives (the project's nolintguard rule forbids
+// `//nolint:gosec`).
 func backfillSource(ctx context.Context, tx *sql.Tx, plan backfillPlan) (SourceStats, error) {
 	row := SourceStats{Source: plan.source}
 
+	// #nosec G201 -- table name is a hard-coded constant
 	totalQuery := "SELECT COUNT(*) FROM " + plan.source
+	// #nosec G201 -- table name is a hard-coded constant
 	migratedQuery := "SELECT COUNT(*) FROM " + plan.source + " s WHERE EXISTS (SELECT 1 FROM files f WHERE f.uuid = s.uuid)"
 	if err := tx.QueryRowContext(ctx, totalQuery).Scan(&row.Total); err != nil {
 		return row, errxtrace.Wrap("failed to count source rows", err)
@@ -217,6 +219,7 @@ func backfillSource(ctx context.Context, tx *sql.Tx, plan backfillPlan) (SourceS
 	// is rolled back, so the planner cost is the only side effect. Doing it
 	// this way means the dry-run report reflects "what would actually
 	// happen" rather than a separately-computed estimate.
+	// #nosec G201 -- table name + typeExpr come from hard-coded backfillPlans
 	insert := fmt.Sprintf(`
 		INSERT INTO files (
 			id, uuid, tenant_id, group_id, created_by_user_id,

--- a/go/services/files_backfill/backfill_test.go
+++ b/go/services/files_backfill/backfill_test.go
@@ -17,6 +17,9 @@ import (
 // the SQL is the whole behaviour, so a memory mock would only re-implement
 // what we're testing. Skipping is deliberate when no DSN is available so
 // the suite stays runnable on machines without a local Postgres.
+//
+// CI runs this package via `make test-go-postgres`, which is wired to
+// include `./services/files_backfill/...` alongside `./registry/postgres/...`.
 func skipIfNoPostgreSQL(t *testing.T) string {
 	t.Helper()
 	dsn := os.Getenv("POSTGRES_TEST_DSN")
@@ -39,22 +42,24 @@ func TestBackfill_HappyPath(t *testing.T) {
 	c.Assert(db.Ping(), qt.IsNil)
 
 	ctx := context.Background()
-	cleanup := seedLegacyFixtures(c, db)
-	defer cleanup()
+	fx := seedLegacyFixtures(c, db)
+	defer fx.Cleanup()
 
 	mgr := files_backfill.NewManager(db)
 
-	// Dry run: must report all pending and write nothing.
+	// Dry run: must report all pending and write nothing. Inserted is
+	// zeroed on dry-run so callers can't mistake "would insert" for
+	// "did insert".
 	plan, err := mgr.PreviewOnly(ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(plan.DryRun, qt.IsTrue)
 	c.Assert(rowsBySource(plan.Sources, "images").Pending, qt.Equals, 3)
 	c.Assert(rowsBySource(plan.Sources, "invoices").Pending, qt.Equals, 2)
 	c.Assert(rowsBySource(plan.Sources, "manuals").Pending, qt.Equals, 1)
-	// Inserted reflects what the SQL would do; for a dry run the
-	// transaction was rolled back, so the row counts in `files` for our
+	c.Assert(plan.TotalInserted(), qt.Equals, 0)
+	// Transaction was rolled back, so the row counts in `files` for our
 	// fixture UUIDs must be zero.
-	c.Assert(legacyFilesCount(c, db), qt.Equals, 0)
+	c.Assert(legacyFilesCount(c, db, fx.TenantID), qt.Equals, 0)
 
 	// Live run: every pending row should land in `files` and the
 	// per-source counters must match what the dry run reported.
@@ -65,7 +70,7 @@ func TestBackfill_HappyPath(t *testing.T) {
 	c.Assert(rowsBySource(plan.Sources, "images").Inserted, qt.Equals, 3)
 	c.Assert(rowsBySource(plan.Sources, "invoices").Inserted, qt.Equals, 2)
 	c.Assert(rowsBySource(plan.Sources, "manuals").Inserted, qt.Equals, 1)
-	c.Assert(legacyFilesCount(c, db), qt.Equals, 6)
+	c.Assert(legacyFilesCount(c, db, fx.TenantID), qt.Equals, 6)
 
 	// Idempotency: re-run produces zero new rows and reports every
 	// legacy row as already migrated.
@@ -73,7 +78,7 @@ func TestBackfill_HappyPath(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(plan.TotalInserted(), qt.Equals, 0)
 	c.Assert(plan.TotalPending(), qt.Equals, 0)
-	c.Assert(legacyFilesCount(c, db), qt.Equals, 6)
+	c.Assert(legacyFilesCount(c, db, fx.TenantID), qt.Equals, 6)
 }
 
 func TestBackfill_PreservesLegacyTablesAndCategoryMapping(t *testing.T) {
@@ -86,17 +91,19 @@ func TestBackfill_PreservesLegacyTablesAndCategoryMapping(t *testing.T) {
 	c.Assert(db.Ping(), qt.IsNil)
 
 	ctx := context.Background()
-	cleanup := seedLegacyFixtures(c, db)
-	defer cleanup()
+	fx := seedLegacyFixtures(c, db)
+	defer fx.Cleanup()
 
 	_, err = files_backfill.NewManager(db).Apply(ctx)
 	c.Assert(err, qt.IsNil)
 
 	// Legacy tables must remain populated — cutover (#1421) is the only
 	// place that drops them. This is the contract for safe rollback.
-	c.Assert(rowCount(c, db, "images"), qt.Equals, 3)
-	c.Assert(rowCount(c, db, "invoices"), qt.Equals, 2)
-	c.Assert(rowCount(c, db, "manuals"), qt.Equals, 1)
+	// Filtering by tenant_id keeps the assertion robust against rows
+	// from other tests sharing this DB.
+	c.Assert(tenantRowCount(c, db, "images", fx.TenantID), qt.Equals, 3)
+	c.Assert(tenantRowCount(c, db, "invoices", fx.TenantID), qt.Equals, 2)
+	c.Assert(tenantRowCount(c, db, "manuals", fx.TenantID), qt.Equals, 1)
 
 	// Each legacy row must produce exactly one files row whose
 	// linked_entity + category match the bucket mapping in the issue.
@@ -113,12 +120,13 @@ func TestBackfill_PreservesLegacyTablesAndCategoryMapping(t *testing.T) {
 		var n int
 		err := db.QueryRowContext(ctx, `
 			SELECT COUNT(*) FROM files
-			WHERE linked_entity_type = 'commodity'
-			  AND linked_entity_meta = $1
-			  AND category = $2`,
-			tc.linkedEntityMeta, tc.category).Scan(&n)
+			WHERE tenant_id = $1
+			  AND linked_entity_type = 'commodity'
+			  AND linked_entity_meta = $2
+			  AND category = $3`,
+			fx.TenantID, tc.linkedEntityMeta, tc.category).Scan(&n)
 		c.Assert(err, qt.IsNil)
-		c.Assert(n, qt.Equals, rowCount(c, db, tc.legacyTable),
+		c.Assert(n, qt.Equals, tenantRowCount(c, db, tc.legacyTable, fx.TenantID),
 			qt.Commentf("backfilled %s rows must match legacy count", tc.legacyTable))
 	}
 }
@@ -132,24 +140,39 @@ func rowsBySource(rows []files_backfill.SourceStats, source string) files_backfi
 	return files_backfill.SourceStats{}
 }
 
-func rowCount(c *qt.C, db *sql.DB, table string) int {
+// tenantRowCount counts rows in `table` scoped to `tenantID`. The DB is
+// shared across test suites, so a global COUNT(*) would race; tenant
+// filtering keeps the assertion bounded to the fixture this test seeded.
+// `table` is one of a fixed set of legacy table names asserted by the
+// caller — never user input — so the gosec G202 warning on string
+// concatenation is suppressed.
+func tenantRowCount(c *qt.C, db *sql.DB, table, tenantID string) int {
+	c.Helper()
+	switch table {
+	case "images", "invoices", "manuals":
+	default:
+		c.Fatalf("tenantRowCount: unsupported table %q (only legacy tables allowed)", table)
+	}
 	var n int
-	err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&n)
+	// #nosec G202 -- table name is range-checked above against a closed allow-list
+	err := db.QueryRow("SELECT COUNT(*) FROM "+table+" WHERE tenant_id = $1", tenantID).Scan(&n)
 	c.Assert(err, qt.IsNil)
 	return n
 }
 
-// legacyFilesCount counts files rows whose uuid is also present in any
-// legacy table — i.e. the rows backfill is responsible for. This is
-// stricter than rowCount("files") because the test DB may carry rows from
-// other tests/seed flows.
-func legacyFilesCount(c *qt.C, db *sql.DB) int {
+// legacyFilesCount counts `files` rows for the given tenant whose uuid is
+// also present in any legacy table — i.e. the rows backfill is
+// responsible for. Tenant filtering keeps the assertion bounded to the
+// fixture this test seeded.
+func legacyFilesCount(c *qt.C, db *sql.DB, tenantID string) int {
 	var n int
 	err := db.QueryRow(`
 		SELECT COUNT(*) FROM files f
-		WHERE EXISTS (SELECT 1 FROM images   WHERE uuid = f.uuid)
-		   OR EXISTS (SELECT 1 FROM invoices WHERE uuid = f.uuid)
-		   OR EXISTS (SELECT 1 FROM manuals  WHERE uuid = f.uuid)`).Scan(&n)
+		WHERE f.tenant_id = $1
+		  AND (EXISTS (SELECT 1 FROM images   WHERE uuid = f.uuid)
+		    OR EXISTS (SELECT 1 FROM invoices WHERE uuid = f.uuid)
+		    OR EXISTS (SELECT 1 FROM manuals  WHERE uuid = f.uuid))`,
+		tenantID).Scan(&n)
 	c.Assert(err, qt.IsNil)
 	return n
 }

--- a/go/services/files_backfill/backfill_test.go
+++ b/go/services/files_backfill/backfill_test.go
@@ -1,0 +1,155 @@
+package files_backfill_test
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/lib/pq"
+
+	"github.com/denisvmedia/inventario/services/files_backfill"
+)
+
+// We exercise the backfill end-to-end against a real Postgres instance —
+// the SQL is the whole behaviour, so a memory mock would only re-implement
+// what we're testing. Skipping is deliberate when no DSN is available so
+// the suite stays runnable on machines without a local Postgres.
+func skipIfNoPostgreSQL(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("Skipping PostgreSQL tests: POSTGRES_TEST_DSN environment variable not set")
+	}
+	if _, err := url.Parse(dsn); err != nil {
+		t.Fatalf("invalid POSTGRES_TEST_DSN: %v", err)
+	}
+	return dsn
+}
+
+func TestBackfill_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	dsn := skipIfNoPostgreSQL(t)
+
+	db, err := sql.Open("postgres", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+	c.Assert(db.Ping(), qt.IsNil)
+
+	ctx := context.Background()
+	cleanup := seedLegacyFixtures(c, db)
+	defer cleanup()
+
+	mgr := files_backfill.NewManager(db)
+
+	// Dry run: must report all pending and write nothing.
+	plan, err := mgr.PreviewOnly(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.DryRun, qt.IsTrue)
+	c.Assert(rowsBySource(plan.Sources, "images").Pending, qt.Equals, 3)
+	c.Assert(rowsBySource(plan.Sources, "invoices").Pending, qt.Equals, 2)
+	c.Assert(rowsBySource(plan.Sources, "manuals").Pending, qt.Equals, 1)
+	// Inserted reflects what the SQL would do; for a dry run the
+	// transaction was rolled back, so the row counts in `files` for our
+	// fixture UUIDs must be zero.
+	c.Assert(legacyFilesCount(c, db), qt.Equals, 0)
+
+	// Live run: every pending row should land in `files` and the
+	// per-source counters must match what the dry run reported.
+	plan, err = mgr.Apply(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.DryRun, qt.IsFalse)
+	c.Assert(plan.TotalInserted(), qt.Equals, 6)
+	c.Assert(rowsBySource(plan.Sources, "images").Inserted, qt.Equals, 3)
+	c.Assert(rowsBySource(plan.Sources, "invoices").Inserted, qt.Equals, 2)
+	c.Assert(rowsBySource(plan.Sources, "manuals").Inserted, qt.Equals, 1)
+	c.Assert(legacyFilesCount(c, db), qt.Equals, 6)
+
+	// Idempotency: re-run produces zero new rows and reports every
+	// legacy row as already migrated.
+	plan, err = mgr.Apply(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.TotalInserted(), qt.Equals, 0)
+	c.Assert(plan.TotalPending(), qt.Equals, 0)
+	c.Assert(legacyFilesCount(c, db), qt.Equals, 6)
+}
+
+func TestBackfill_PreservesLegacyTablesAndCategoryMapping(t *testing.T) {
+	c := qt.New(t)
+	dsn := skipIfNoPostgreSQL(t)
+
+	db, err := sql.Open("postgres", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+	c.Assert(db.Ping(), qt.IsNil)
+
+	ctx := context.Background()
+	cleanup := seedLegacyFixtures(c, db)
+	defer cleanup()
+
+	_, err = files_backfill.NewManager(db).Apply(ctx)
+	c.Assert(err, qt.IsNil)
+
+	// Legacy tables must remain populated — cutover (#1421) is the only
+	// place that drops them. This is the contract for safe rollback.
+	c.Assert(rowCount(c, db, "images"), qt.Equals, 3)
+	c.Assert(rowCount(c, db, "invoices"), qt.Equals, 2)
+	c.Assert(rowCount(c, db, "manuals"), qt.Equals, 1)
+
+	// Each legacy row must produce exactly one files row whose
+	// linked_entity + category match the bucket mapping in the issue.
+	cases := []struct {
+		legacyTable      string
+		linkedEntityMeta string
+		category         string
+	}{
+		{"images", "images", "photos"},
+		{"invoices", "invoices", "invoices"},
+		{"manuals", "manuals", "documents"},
+	}
+	for _, tc := range cases {
+		var n int
+		err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM files
+			WHERE linked_entity_type = 'commodity'
+			  AND linked_entity_meta = $1
+			  AND category = $2`,
+			tc.linkedEntityMeta, tc.category).Scan(&n)
+		c.Assert(err, qt.IsNil)
+		c.Assert(n, qt.Equals, rowCount(c, db, tc.legacyTable),
+			qt.Commentf("backfilled %s rows must match legacy count", tc.legacyTable))
+	}
+}
+
+func rowsBySource(rows []files_backfill.SourceStats, source string) files_backfill.SourceStats {
+	for _, r := range rows {
+		if r.Source == source {
+			return r
+		}
+	}
+	return files_backfill.SourceStats{}
+}
+
+func rowCount(c *qt.C, db *sql.DB, table string) int {
+	var n int
+	err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&n)
+	c.Assert(err, qt.IsNil)
+	return n
+}
+
+// legacyFilesCount counts files rows whose uuid is also present in any
+// legacy table — i.e. the rows backfill is responsible for. This is
+// stricter than rowCount("files") because the test DB may carry rows from
+// other tests/seed flows.
+func legacyFilesCount(c *qt.C, db *sql.DB) int {
+	var n int
+	err := db.QueryRow(`
+		SELECT COUNT(*) FROM files f
+		WHERE EXISTS (SELECT 1 FROM images   WHERE uuid = f.uuid)
+		   OR EXISTS (SELECT 1 FROM invoices WHERE uuid = f.uuid)
+		   OR EXISTS (SELECT 1 FROM manuals  WHERE uuid = f.uuid)`).Scan(&n)
+	c.Assert(err, qt.IsNil)
+	return n
+}

--- a/go/services/files_backfill/fixtures_test.go
+++ b/go/services/files_backfill/fixtures_test.go
@@ -8,16 +8,28 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
+// LegacyFixture is what seedLegacyFixtures returns: the IDs callers need
+// to scope their assertions to this fixture's rows (the test DB is shared,
+// so global COUNT(*) would race against other suites) plus a Cleanup that
+// wipes every row this fixture wrote.
+type LegacyFixture struct {
+	TenantID string
+	GroupID  string
+	Cleanup  func()
+}
+
 // seedLegacyFixtures stamps a self-contained tenant + group + commodity
-// graph and three legacy rows of each kind directly via SQL — bypassing
-// the registry layer keeps the test focused on the backfill itself and
-// avoids pulling registry helpers into a service-level test package.
+// graph plus a deliberately lopsided set of legacy rows — 3 images, 2
+// invoices, 1 manual — directly via SQL. Bypassing the registry layer
+// keeps the test focused on the backfill itself and avoids pulling
+// registry helpers into a service-level test package. The asymmetry lets
+// per-source counter assertions disambiguate without fixing arithmetic to
+// a single value.
 //
-// Returns a cleanup that wipes every row this fixture wrote, in dependency
-// order. The DB is shared across test runs, so the cleanup is required
-// even on success — otherwise the next run's COUNT(*) checks would
+// The DB is shared across test runs, so the returned Cleanup must always
+// run on test exit — otherwise the next run's COUNT(*) checks would
 // double-count.
-func seedLegacyFixtures(c *qt.C, db *sql.DB) func() {
+func seedLegacyFixtures(c *qt.C, db *sql.DB) LegacyFixture {
 	c.Helper()
 
 	ctx := context.Background()
@@ -67,9 +79,6 @@ func seedLegacyFixtures(c *qt.C, db *sql.DB) func() {
 		)`,
 		commodityID, tenantID, groupID, userID, areaID)
 
-	// Three images, two invoices, one manual — the lopsided shape lets
-	// the per-source counters in TestBackfill_HappyPath disambiguate
-	// without fixing arithmetic to a single value.
 	images := []struct{ path, mime string }{
 		{"img1", "image/jpeg"},
 		{"img2", "image/png"},
@@ -113,7 +122,7 @@ func seedLegacyFixtures(c *qt.C, db *sql.DB) func() {
 		uniqueID("man"), uniqueID("manU"),
 		tenantID, groupID, userID, commodityID)
 
-	return func() {
+	cleanup := func() {
 		// Cleanup order: dependents first. files rows that the backfill
 		// produced FK-by-uuid back to legacy rows, but the schema's FKs
 		// are commodity-keyed, so deleting the legacy + files rows by
@@ -131,6 +140,7 @@ func seedLegacyFixtures(c *qt.C, db *sql.DB) func() {
 		exec(c, db, `DELETE FROM tenants WHERE id = $1`, tenantID)
 		_ = ctx // kept around in case future cleanups need it
 	}
+	return LegacyFixture{TenantID: tenantID, GroupID: groupID, Cleanup: cleanup}
 }
 
 func exec(c *qt.C, db *sql.DB, query string, args ...any) {

--- a/go/services/files_backfill/fixtures_test.go
+++ b/go/services/files_backfill/fixtures_test.go
@@ -1,0 +1,147 @@
+package files_backfill_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// seedLegacyFixtures stamps a self-contained tenant + group + commodity
+// graph and three legacy rows of each kind directly via SQL — bypassing
+// the registry layer keeps the test focused on the backfill itself and
+// avoids pulling registry helpers into a service-level test package.
+//
+// Returns a cleanup that wipes every row this fixture wrote, in dependency
+// order. The DB is shared across test runs, so the cleanup is required
+// even on success — otherwise the next run's COUNT(*) checks would
+// double-count.
+func seedLegacyFixtures(c *qt.C, db *sql.DB) func() {
+	c.Helper()
+
+	ctx := context.Background()
+	tenantID := uniqueID("t")
+	groupID := uniqueID("g")
+	userID := uniqueID("u")
+	locationID := uniqueID("loc")
+	areaID := uniqueID("area")
+	commodityID := uniqueID("com")
+
+	// Tenant + user + group are the minimum scaffolding needed for
+	// commodity FKs and RLS group_id columns. We bypass the validator and
+	// status enums because we only need referential integrity, not real
+	// product semantics.
+	exec(c, db, `
+		INSERT INTO tenants (id, name, slug, status, registration_mode)
+		VALUES ($1, 'backfill-test', $2, 'active', 'closed')`,
+		tenantID, "backfill-test-"+tenantID[:8])
+	exec(c, db, `
+		INSERT INTO users (id, tenant_id, email, password_hash, name, is_active, created_at)
+		VALUES ($1, $2, $3, '', 'backfill', true, NOW())`,
+		userID, tenantID, "u-"+userID+"@example.com")
+	exec(c, db, `
+		INSERT INTO location_groups (id, tenant_id, slug, name, status, created_by, main_currency, created_at, updated_at)
+		VALUES ($1, $2, $3, 'Backfill', 'active', $4, 'USD', NOW(), NOW())`,
+		groupID, tenantID, "g-"+groupID[:8], userID)
+	exec(c, db, `
+		INSERT INTO group_memberships (id, tenant_id, group_id, member_user_id, role, joined_at)
+		VALUES ($1, $2, $3, $4, 'admin', NOW())`,
+		uniqueID("gm"), tenantID, groupID, userID)
+	exec(c, db, `
+		INSERT INTO locations (id, tenant_id, group_id, created_by_user_id, name, address)
+		VALUES ($1, $2, $3, $4, 'Loc', '')`,
+		locationID, tenantID, groupID, userID)
+	exec(c, db, `
+		INSERT INTO areas (id, tenant_id, group_id, created_by_user_id, location_id, name)
+		VALUES ($1, $2, $3, $4, $5, 'Area')`,
+		areaID, tenantID, groupID, userID, locationID)
+	exec(c, db, `
+		INSERT INTO commodities (
+			id, tenant_id, group_id, created_by_user_id, area_id, name, short_name,
+			type, status, count, original_price, original_price_currency,
+			converted_original_price, current_price, draft
+		) VALUES (
+			$1, $2, $3, $4, $5, 'Backfill commodity', 'BC',
+			'electronics', 'in_use', 1, 0, 'USD', 0, 0, false
+		)`,
+		commodityID, tenantID, groupID, userID, areaID)
+
+	// Three images, two invoices, one manual — the lopsided shape lets
+	// the per-source counters in TestBackfill_HappyPath disambiguate
+	// without fixing arithmetic to a single value.
+	images := []struct{ path, mime string }{
+		{"img1", "image/jpeg"},
+		{"img2", "image/png"},
+		{"img3", "image/heic"},
+	}
+	for i, img := range images {
+		exec(c, db, `
+			INSERT INTO images (
+				id, uuid, tenant_id, group_id, created_by_user_id, commodity_id,
+				path, original_path, ext, mime_type
+			) VALUES (
+				$1, $2, $3, $4, $5, $6,
+				$7, $8, $9, $10
+			)`,
+			uniqueID(fmt.Sprintf("img%d", i)), uniqueID(fmt.Sprintf("imgU%d", i)),
+			tenantID, groupID, userID, commodityID,
+			img.path, img.path+".jpg", ".jpg", img.mime)
+	}
+	invoices := []string{"inv1", "inv2"}
+	for i, inv := range invoices {
+		exec(c, db, `
+			INSERT INTO invoices (
+				id, uuid, tenant_id, group_id, created_by_user_id, commodity_id,
+				path, original_path, ext, mime_type
+			) VALUES (
+				$1, $2, $3, $4, $5, $6,
+				$7, $8, '.pdf', 'application/pdf'
+			)`,
+			uniqueID(fmt.Sprintf("inv%d", i)), uniqueID(fmt.Sprintf("invU%d", i)),
+			tenantID, groupID, userID, commodityID,
+			inv, inv+".pdf")
+	}
+	exec(c, db, `
+		INSERT INTO manuals (
+			id, uuid, tenant_id, group_id, created_by_user_id, commodity_id,
+			path, original_path, ext, mime_type
+		) VALUES (
+			$1, $2, $3, $4, $5, $6,
+			'manual1', 'manual1.pdf', '.pdf', 'application/pdf'
+		)`,
+		uniqueID("man"), uniqueID("manU"),
+		tenantID, groupID, userID, commodityID)
+
+	return func() {
+		// Cleanup order: dependents first. files rows that the backfill
+		// produced FK-by-uuid back to legacy rows, but the schema's FKs
+		// are commodity-keyed, so deleting the legacy + files rows by
+		// our generated tenant_id is enough.
+		exec(c, db, `DELETE FROM files WHERE tenant_id = $1`, tenantID)
+		exec(c, db, `DELETE FROM images WHERE tenant_id = $1`, tenantID)
+		exec(c, db, `DELETE FROM invoices WHERE tenant_id = $1`, tenantID)
+		exec(c, db, `DELETE FROM manuals WHERE tenant_id = $1`, tenantID)
+		exec(c, db, `DELETE FROM commodities WHERE tenant_id = $1`, tenantID)
+		exec(c, db, `DELETE FROM areas WHERE tenant_id = $1`, tenantID)
+		exec(c, db, `DELETE FROM locations WHERE tenant_id = $1`, tenantID)
+		exec(c, db, `DELETE FROM group_memberships WHERE tenant_id = $1`, tenantID)
+		exec(c, db, `DELETE FROM location_groups WHERE tenant_id = $1`, tenantID)
+		exec(c, db, `DELETE FROM users WHERE tenant_id = $1`, tenantID)
+		exec(c, db, `DELETE FROM tenants WHERE id = $1`, tenantID)
+		_ = ctx // kept around in case future cleanups need it
+	}
+}
+
+func exec(c *qt.C, db *sql.DB, query string, args ...any) {
+	c.Helper()
+	_, err := db.Exec(query, args...)
+	c.Assert(err, qt.IsNil, qt.Commentf("query: %s", query))
+}
+
+// uniqueID returns a per-test-run identifier. Combining a prefix with a
+// random suffix keeps fixtures from colliding across parallel test runs
+// against the same shared Postgres instance.
+func uniqueID(prefix string) string {
+	return prefix + "-" + randomHex(16)
+}

--- a/go/services/files_backfill/util_test.go
+++ b/go/services/files_backfill/util_test.go
@@ -1,0 +1,14 @@
+package files_backfill_test
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+func randomHex(n int) string {
+	buf := make([]byte, n/2)
+	if _, err := rand.Read(buf); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(buf)
+}


### PR DESCRIPTION
## Summary

Adds `inventario db migrate files-backfill` (with `--dry-run`), the one-shot ops tool that copies every commodity-scoped legacy row from `images` / `invoices` / `manuals` into the unified `files` table introduced under #1398. Once it runs, `GET /files` becomes a complete view of every commodity attachment — which is the precondition for the cutover (#1421) and for the React Files page (#1411) showing legacy data.

## What's in

**Service** (`services/files_backfill/`)
- `Manager` with `Apply` / `PreviewOnly` methods — single-transaction runner. Dry-run rolls the same INSERTs back so the audit row counts reflect what would actually happen, not a separately-computed estimate.
- Idempotency via `WHERE NOT EXISTS (SELECT 1 FROM files f WHERE f.uuid = s.uuid)`. Re-runs after a partial failure or after the FE has resumed uploading directly into `files` produce zero new rows.
- `type` column derivation as inline SQL mirroring `models.FileTypeFromMIME` (kept in lock-step; change must be made in both).

**CLI** (`cmd/inventario/db/migrate/filesbackfill/`)
- `inventario db migrate files-backfill` cobra command, sibling to `migrate data`. Same flag style, same DSN handling.
- Tabwriter output with `Source / Total / Migrated / Pending / Inserted` columns.

**Tests** — postgres integration only (no boltdb file registry exists; mem doesn't persist legacy data).
- Happy path: dry-run reports pending counts and writes nothing → live run inserts everything → re-run is idempotent.
- Legacy tables remain populated after backfill (cutover contract).
- Per-source category mapping: photos / invoices / documents.

**Docs** — `devdocs/backend/files-backfill.md` runbook: when to run, expected output, monitoring, rollback SQL.

## Mapping

Per the table in #1399:

| Source                       | `files.category` | `files.type`     | `linked_entity_type` | `linked_entity_meta` |
| ---------------------------- | ---------------- | ---------------- | -------------------- | -------------------- |
| `images` (commodity-scoped)  | `photos`         | derived from MIME | `commodity`          | `images`             |
| `invoices`                   | `invoices`       | derived from MIME | `commodity`          | `invoices`           |
| `manuals`                    | `documents`      | derived from MIME | `commodity`          | `manuals`            |

Location-scoped uploads already write straight to `files` via the new upload handlers (since #1398), so they don't need a backfill.

## Decisions worth flagging

- **CLI-driven, not auto-applied via a Ptah migration.** Matches the issue's "ships in a follow-up release once the FE has switched to `/files` for reads" wording and lets ops gate the run on FE rollout.
- **Legacy tables are not touched.** Rollback is `DELETE FROM files WHERE uuid IN (SELECT uuid FROM images …)` — destructive only for backfill-origin rows. The cutover (#1421) is the only place that drops the legacy tables.
- **No mem/boltdb backfill.** Memory registries don't persist legacy data between runs, and there's no boltdb files registry at all (confirmed during #1398 exploration).
- **`Apply` / `PreviewOnly` rather than a `dryRun bool` flag** — keeps revive's flag-parameter check happy and reads better at the call site.

## Test plan

- [ ] `make test` — unit + memory registry
- [ ] `POSTGRES_TEST_DSN=… make test-postgres` — backfill integration tests pass (verified locally against the dockerized DB)
- [ ] `golangci-lint run` — green (verified locally)
- [ ] Manual: `inventario db migrate files-backfill --dry-run --db-dsn …` against a DB with seeded legacy data shows non-zero `Pending`; live run drives `Pending` → 0; re-run reports zero inserts.

Refs #1397, blocks #1421, unblocks the full-data view on #1411.