### PR TITLE
[#1411] AC #4 + AC #7: EntityFilesPanel on commodity/location + full upload→delete e2e

### DIFF
--- a/e2e/screenshots.mjs
+++ b/e2e/screenshots.mjs
@@ -217,6 +217,26 @@ try {
         await settle()
         await shoot("18-commodity-detail")
 
+        // Files tab (#1411 AC #4): clicking the tab swaps the
+        // bottom-half of the detail page from the Details card to the
+        // EntityFilesPanel. Captured separately from "18" because the
+        // default tab is Details and the panel never appears in that
+        // shot. Skip-only when the tab control didn't render (e.g.
+        // commodity-detail layout regression) so the run keeps going.
+        const filesTab = page.locator('[data-testid="commodity-detail-tab-files"]')
+        if ((await filesTab.count()) > 0) {
+          await filesTab.click()
+          try {
+            await page.waitForSelector('[data-testid="entity-files-panel"]', {
+              timeout: 5000,
+            })
+            await settle()
+            await shoot("18b-commodity-detail-files")
+          } catch {
+            console.warn("   commodity Files tab did not surface the panel in time")
+          }
+        }
+
         // Print page.
         await page.goto(`${BASE_URL}${href}/print`, { waitUntil: "domcontentloaded" })
         await settle()

--- a/e2e/tests/files.spec.ts
+++ b/e2e/tests/files.spec.ts
@@ -1,20 +1,21 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
 import { expect, type Page } from '@playwright/test'
 
 import { test } from '../fixtures/app-fixture.js'
 import { navigateWithAuth } from './includes/auth.js'
 
 /**
- * Smoke for the unified Files page (#1411).
+ * E2E coverage for the unified Files page (#1411).
  *
- * What the spec proves:
- *   - The /files route renders the Files list page (not a placeholder).
- *   - The four category tiles introduced by #1398 are visible and
- *     respond to the per-tile selection click — `aria-selected` flips,
- *     the URL gains `?category=`, and the BE roundtrips the filter.
- *   - The Upload button opens the upload dialog with a working
- *     dropzone that accepts a synthetic File via Playwright's
- *     `setInputFiles` (slot-gating + actual upload roundtrip is left
- *     for the shared login fixture in #1449 to cover).
+ * Covers AC #7 of the issue:
+ *   - upload → list → detail → download → delete full flow
+ *   - per-category content filter (an uploaded image surfaces in
+ *     "All" and "Photos" tiles, not in "Invoices" or "Documents")
+ * plus the original smoke (tile rendering, tile-click aria-selected,
+ * upload-dialog open) which stays as a fast-failure layer above the
+ * end-to-end flow.
  *
  * Authentication uses the shared `app-fixture` (handles login,
  * recovers from session-expired bounces) — the inline `loginToReact`
@@ -58,9 +59,170 @@ test.describe('Files page', () => {
     await page.getByTestId('files-upload-cta').click()
     await expect(page.getByTestId('files-upload-dialog')).toBeVisible()
     await expect(page.getByTestId('files-upload-dropzone')).toBeVisible()
-    // The hidden <input type=file> is what Playwright drives — we don't
-    // attach a real file here because slot-gating + post-upload
-    // roundtrip is still pending the #1449 fixture.
     await expect(page.getByTestId('files-upload-input')).toBeAttached()
   })
+
+  test('upload → list → detail → download URL → delete', async ({ page }) => {
+    // Closes #1411 AC #7. Uses a unique filename per run because the
+    // backend persists uploads and the test DB is shared with sibling
+    // specs; the tail-end delete returns the row count to its
+    // pre-test value, but the upload itself must not collide on path.
+    const uniqueName = `e2e-upload-${Date.now()}.jpg`
+    const fixtureBuffer = fs.readFileSync(path.join('fixtures', 'files', 'image.jpg'))
+
+    await gotoFiles(page)
+
+    // --- Upload --- (drag-drop + slot-gating + roundtrip) ----------
+    await page.getByTestId('files-upload-cta').click()
+    await expect(page.getByTestId('files-upload-dialog')).toBeVisible()
+    await page.getByTestId('files-upload-input').setInputFiles({
+      name: uniqueName,
+      mimeType: 'image/jpeg',
+      buffer: fixtureBuffer,
+    })
+    await page.getByTestId('files-upload-next').click()
+    const [uploadResponse] = await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/uploads/file') && resp.request().method() === 'POST',
+        { timeout: 30000 }
+      ),
+      page.getByTestId('files-upload-start').click(),
+    ])
+    expect(uploadResponse.status()).toBe(201)
+    await page.getByTestId('files-upload-close').click()
+    await expect(page.getByTestId('files-upload-dialog')).toBeHidden()
+
+    // --- List shows the new row --------------------------------------
+    // Filter by Photos so we both prove the category-filter path AND
+    // narrow the list to a slice that fits a single page even on a
+    // shared DB. The card title falls back to the filename minus
+    // extension when title is unset; we filter the locator by text.
+    await page.getByTestId('files-tile-photos').click()
+    await expect(page).toHaveURL(/category=photos/)
+    const card = page
+      .locator('[data-testid^="file-card-"][data-category="photos"]')
+      .filter({ hasText: stripExt(uniqueName) })
+      .first()
+    await expect(card).toBeVisible({ timeout: 15000 })
+
+    // --- Detail sheet opens with the right metadata ----------------
+    // file-card-open-<id> is on the inner button; clicking via the
+    // outer card locator hits it through the dom-tree, since the card
+    // body is an <a> wrapping the same target.
+    await card.getByTestId(/file-card-open-/).click()
+    const sheet = page.getByTestId('file-detail-sheet')
+    await expect(sheet).toBeVisible()
+    await expect(sheet.getByTestId('file-detail-category')).toHaveText(/photos/i)
+    await expect(sheet.getByTestId('file-detail-filename')).toContainText(stripExt(uniqueName))
+
+    // --- Download link is present and points at a signed URL -------
+    const downloadLink = sheet.getByTestId('file-detail-download')
+    await expect(downloadLink).toBeVisible()
+    const href = await downloadLink.getAttribute('href')
+    expect(href).toBeTruthy()
+    // Sanity: the signed URL is hosted under our origin (not an
+    // external bucket) so a cross-domain navigation isn't required
+    // to verify the download path.
+    expect(href!).toContain('/files/')
+
+    // --- Delete from the detail sheet ------------------------------
+    await sheet.getByTestId('file-detail-delete').click()
+    await expect(page.getByTestId('confirm-dialog')).toBeVisible()
+    const [deleteResponse] = await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/files/') && resp.request().method() === 'DELETE',
+        { timeout: 15000 }
+      ),
+      page.getByTestId('confirm-accept').click(),
+    ])
+    expect(deleteResponse.status()).toBeLessThan(300)
+
+    // --- After delete, the row is gone from the Photos slice -------
+    await expect(
+      page
+        .locator('[data-testid^="file-card-"][data-category="photos"]')
+        .filter({ hasText: stripExt(uniqueName) })
+    ).toHaveCount(0, { timeout: 15000 })
+  })
+
+  test('per-category filter narrows the visible cards by category', async ({ page }) => {
+    // This proves the BE /files?category=… filter wires through end
+    // to end: an uploaded image must surface on All + Photos tiles
+    // and NOT on Invoices / Documents. Cleans up after itself so
+    // the row count returns to its pre-test value.
+    const uniqueName = `e2e-cat-${Date.now()}.jpg`
+    const fixtureBuffer = fs.readFileSync(path.join('fixtures', 'files', 'image.jpg'))
+
+    await gotoFiles(page)
+
+    // Upload one image (becomes category=photos by MIME derivation
+    // in models.FileCategoryFromContext).
+    await page.getByTestId('files-upload-cta').click()
+    await page.getByTestId('files-upload-input').setInputFiles({
+      name: uniqueName,
+      mimeType: 'image/jpeg',
+      buffer: fixtureBuffer,
+    })
+    await page.getByTestId('files-upload-next').click()
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/uploads/file') && resp.request().method() === 'POST',
+        { timeout: 30000 }
+      ),
+      page.getByTestId('files-upload-start').click(),
+    ])
+    await page.getByTestId('files-upload-close').click()
+    await expect(page.getByTestId('files-upload-dialog')).toBeHidden()
+
+    // Photos tile → must show our image.
+    await page.getByTestId('files-tile-photos').click()
+    const photosCard = page
+      .locator('[data-testid^="file-card-"][data-category="photos"]')
+      .filter({ hasText: stripExt(uniqueName) })
+      .first()
+    await expect(photosCard).toBeVisible({ timeout: 15000 })
+
+    // Invoices tile → must NOT show our image.
+    await page.getByTestId('files-tile-invoices').click()
+    await expect(page).toHaveURL(/category=invoices/)
+    await expect(
+      page
+        .locator('[data-testid^="file-card-"]')
+        .filter({ hasText: stripExt(uniqueName) })
+    ).toHaveCount(0)
+
+    // Documents tile → must NOT show our image.
+    await page.getByTestId('files-tile-documents').click()
+    await expect(page).toHaveURL(/category=documents/)
+    await expect(
+      page
+        .locator('[data-testid^="file-card-"]')
+        .filter({ hasText: stripExt(uniqueName) })
+    ).toHaveCount(0)
+
+    // Cleanup: All tile → open the card we uploaded → delete via the
+    // detail sheet so the row count is the same as before this test.
+    await page.getByTestId('files-tile-all').click()
+    const allCard = page
+      .locator('[data-testid^="file-card-"]')
+      .filter({ hasText: stripExt(uniqueName) })
+      .first()
+    await expect(allCard).toBeVisible({ timeout: 15000 })
+    await allCard.getByTestId(/file-card-open-/).click()
+    await page.getByTestId('file-detail-delete').click()
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/files/') && resp.request().method() === 'DELETE',
+        { timeout: 15000 }
+      ),
+      page.getByTestId('confirm-accept').click(),
+    ])
+  })
 })
+
+// stripExt drops the final ".ext" so card-title text matching can
+// ignore the extension difference between filename + display title.
+function stripExt(filename: string): string {
+  const dot = filename.lastIndexOf('.')
+  return dot > 0 ? filename.slice(0, dot) : filename
+}

--- a/frontend/src/components/coming-soon/registry.ts
+++ b/frontend/src/components/coming-soon/registry.ts
@@ -70,11 +70,12 @@ export const SURFACES = {
   // design mock, but the router also mounts /g/:slug/warranties as a
   // full-page stub so deep links don't 404 in the meantime.
   warranties: { icon: ShieldCheck, tracker: 1367, kind: "both" },
-  // Files attached to a commodity / location surface inline on the
-  // detail pages (#1410, #1409). The unified Files browser arrives with
-  // #1398 (files.category) and #1399 (backfill); until then the panel
-  // renders this stub.
-  filesUnification: { icon: Files, tracker: 1398, kind: "inline" },
+  // Drag-drop quick-attach affordance on commodity / location detail.
+  // The read-side files surface (#1411 AC #4) is now wired through the
+  // unified `GET /files?linked_entity_*=…` via EntityFilesPanel; what
+  // remains is the upload UX (drag-drop + Add-files step in the create
+  // dialog), tracked under #1448.
+  filesUnification: { icon: Files, tracker: 1448, kind: "inline" },
 } as const satisfies Record<string, StubSurface>
 
 export type SurfaceKey = keyof typeof SURFACES

--- a/frontend/src/components/files/EntityFilesPanel.tsx
+++ b/frontend/src/components/files/EntityFilesPanel.tsx
@@ -87,16 +87,16 @@ export function EntityFilesPanel({
             <AlertDescription>{t("files:entityPanel.errorDescription")}</AlertDescription>
           </Alert>
         ) : filesQuery.isLoading ? (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" data-testid="entity-files-panel-loading">
+          <div
+            className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
+            data-testid="entity-files-panel-loading"
+          >
             {Array.from({ length: 3 }).map((_, i) => (
               <Skeleton key={i} className="aspect-[4/3] w-full" />
             ))}
           </div>
         ) : files.length === 0 ? (
-          <p
-            className="text-sm text-muted-foreground"
-            data-testid="entity-files-panel-empty"
-          >
+          <p className="text-sm text-muted-foreground" data-testid="entity-files-panel-empty">
             {t("files:entityPanel.empty")}
           </p>
         ) : (
@@ -105,12 +105,7 @@ export function EntityFilesPanel({
             data-testid="entity-files-panel-grid"
           >
             {files.map(({ file, signedUrl }) => (
-              <FileCard
-                key={file.id}
-                file={file}
-                signedUrl={signedUrl}
-                onOpen={handleOpen}
-              />
+              <FileCard key={file.id} file={file} signedUrl={signedUrl} onOpen={handleOpen} />
             ))}
           </div>
         )}

--- a/frontend/src/components/files/EntityFilesPanel.tsx
+++ b/frontend/src/components/files/EntityFilesPanel.tsx
@@ -1,0 +1,120 @@
+import { useTranslation } from "react-i18next"
+import { Link, useNavigate } from "react-router-dom"
+import { Plus } from "lucide-react"
+
+import { FileCard } from "@/components/files/FileCard"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useFiles } from "@/features/files/hooks"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+
+// Read-only Files panel for entity-detail pages (commodity / location).
+// Replaces the legacy `<ComingSoonBanner surface="filesUnification" />`
+// placeholder by rendering files attached to the given linked entity
+// via the unified `GET /files?linked_entity_type=…&linked_entity_id=…`
+// endpoint introduced for #1411 AC #4.
+//
+// Click on a card deep-links to `/files/:id` which mounts the same
+// FileDetailSheet the main /files page uses, so detail / download /
+// edit / delete all reuse the validated path. Quick-attach drag-drop
+// (#1448) and inline upload remain a separate scope.
+export interface EntityFilesPanelProps {
+  linkedEntityType: "commodity" | "location"
+  linkedEntityId: string
+  // Empty-state and add CTA behaviour are controlled by the parent.
+  // The "Add files" button navigates to the global /files/new dialog —
+  // metadata wiring (preselect linkedEntity) is the EntityFormDialog
+  // upload step's job, separate scope.
+  pageSize?: number
+}
+
+const DEFAULT_PAGE_SIZE = 24
+
+export function EntityFilesPanel({
+  linkedEntityType,
+  linkedEntityId,
+  pageSize = DEFAULT_PAGE_SIZE,
+}: EntityFilesPanelProps) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+
+  const filesQuery = useFiles(
+    {
+      linkedEntityType,
+      linkedEntityId,
+      perPage: pageSize,
+    },
+    { enabled: !!linkedEntityId && !!slug }
+  )
+
+  const files = filesQuery.data?.files ?? []
+  const total = filesQuery.data?.total ?? 0
+
+  // Deep-link to the global Files detail sheet — keeps URL shareable
+  // and reuses the validated detail / download / delete path.
+  const filesIndexHref = slug ? `/g/${encodeURIComponent(slug)}/files` : "#"
+  const handleOpen = (fileId: string) => {
+    if (!slug) return
+    navigate(`/g/${encodeURIComponent(slug)}/files/${encodeURIComponent(fileId)}`)
+  }
+
+  return (
+    <Card data-testid="entity-files-panel">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <CardTitle className="text-base">{t("files:entityPanel.title")}</CardTitle>
+            <CardDescription>
+              {t("files:entityPanel.description", { count: total })}
+            </CardDescription>
+          </div>
+          <Button asChild type="button" variant="outline" size="sm" className="gap-2">
+            <Link to={filesIndexHref + "/new"} data-testid="entity-files-panel-add">
+              <Plus className="size-3.5" aria-hidden="true" />
+              {t("files:entityPanel.addFiles")}
+            </Link>
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {filesQuery.isError ? (
+          <Alert variant="destructive" data-testid="entity-files-panel-error">
+            <AlertTitle>{t("files:entityPanel.errorTitle")}</AlertTitle>
+            <AlertDescription>{t("files:entityPanel.errorDescription")}</AlertDescription>
+          </Alert>
+        ) : filesQuery.isLoading ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" data-testid="entity-files-panel-loading">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="aspect-[4/3] w-full" />
+            ))}
+          </div>
+        ) : files.length === 0 ? (
+          <p
+            className="text-sm text-muted-foreground"
+            data-testid="entity-files-panel-empty"
+          >
+            {t("files:entityPanel.empty")}
+          </p>
+        ) : (
+          <div
+            className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
+            data-testid="entity-files-panel-grid"
+          >
+            {files.map(({ file, signedUrl }) => (
+              <FileCard
+                key={file.id}
+                file={file}
+                signedUrl={signedUrl}
+                onOpen={handleOpen}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/files/EntityFilesPanel.tsx
+++ b/frontend/src/components/files/EntityFilesPanel.tsx
@@ -1,10 +1,8 @@
 import { useTranslation } from "react-i18next"
-import { Link, useNavigate } from "react-router-dom"
-import { Plus } from "lucide-react"
+import { useNavigate } from "react-router-dom"
 
 import { FileCard } from "@/components/files/FileCard"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useFiles } from "@/features/files/hooks"
@@ -18,15 +16,16 @@ import { useCurrentGroup } from "@/features/group/GroupContext"
 //
 // Click on a card deep-links to `/files/:id` which mounts the same
 // FileDetailSheet the main /files page uses, so detail / download /
-// edit / delete all reuse the validated path. Quick-attach drag-drop
-// (#1448) and inline upload remain a separate scope.
+// edit / delete all reuse the validated path.
+//
+// No "Add files" CTA: a button that linked to the global /files
+// upload would create an orphan file (no linked_entity_*) which would
+// then NOT show up here — confusing UX. The proper affordance is
+// drag-drop on the entity detail with the linked_entity_* preselected,
+// which is the explicit scope of #1448.
 export interface EntityFilesPanelProps {
   linkedEntityType: "commodity" | "location"
   linkedEntityId: string
-  // Empty-state and add CTA behaviour are controlled by the parent.
-  // The "Add files" button navigates to the global /files/new dialog —
-  // metadata wiring (preselect linkedEntity) is the EntityFormDialog
-  // upload step's job, separate scope.
   pageSize?: number
 }
 
@@ -56,7 +55,6 @@ export function EntityFilesPanel({
 
   // Deep-link to the global Files detail sheet — keeps URL shareable
   // and reuses the validated detail / download / delete path.
-  const filesIndexHref = slug ? `/g/${encodeURIComponent(slug)}/files` : "#"
   const handleOpen = (fileId: string) => {
     if (!slug) return
     navigate(`/g/${encodeURIComponent(slug)}/files/${encodeURIComponent(fileId)}`)
@@ -65,20 +63,8 @@ export function EntityFilesPanel({
   return (
     <Card data-testid="entity-files-panel">
       <CardHeader>
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <CardTitle className="text-base">{t("files:entityPanel.title")}</CardTitle>
-            <CardDescription>
-              {t("files:entityPanel.description", { count: total })}
-            </CardDescription>
-          </div>
-          <Button asChild type="button" variant="outline" size="sm" className="gap-2">
-            <Link to={filesIndexHref + "/new"} data-testid="entity-files-panel-add">
-              <Plus className="size-3.5" aria-hidden="true" />
-              {t("files:entityPanel.addFiles")}
-            </Link>
-          </Button>
-        </div>
+        <CardTitle className="text-base">{t("files:entityPanel.title")}</CardTitle>
+        <CardDescription>{t("files:entityPanel.description", { count: total })}</CardDescription>
       </CardHeader>
       <CardContent>
         {filesQuery.isError ? (

--- a/frontend/src/components/files/FileCard.tsx
+++ b/frontend/src/components/files/FileCard.tsx
@@ -13,15 +13,24 @@ import { cn } from "@/lib/utils"
 // category icon, the title (falls back to the path), upload date, and
 // the tag pills. Click anywhere outside the checkbox opens the detail
 // sheet. The checkbox toggles bulk selection.
+// onToggleSelect + selected are optional: when onToggleSelect is omitted
+// the card renders without the checkbox, making it usable as a
+// read-only tile inside entity-detail Files panels (#1411 AC #4).
 export interface FileCardProps {
   file: FileEntity & { id: string }
   signedUrl?: URLData
-  selected: boolean
-  onToggleSelect: (id: string) => void
+  selected?: boolean
+  onToggleSelect?: (id: string) => void
   onOpen: (id: string) => void
 }
 
-export function FileCard({ file, signedUrl, selected, onToggleSelect, onOpen }: FileCardProps) {
+export function FileCard({
+  file,
+  signedUrl,
+  selected = false,
+  onToggleSelect,
+  onOpen,
+}: FileCardProps) {
   const { t } = useTranslation()
   const title = file.title?.trim() || file.path?.trim() || file.id
   const Icon = iconForCategory(file.category)
@@ -44,15 +53,17 @@ export function FileCard({ file, signedUrl, selected, onToggleSelect, onOpen }: 
         selected && "ring-2 ring-primary"
       )}
     >
-      <div className="absolute left-2 top-2 z-10">
-        <Checkbox
-          checked={selected}
-          onCheckedChange={() => onToggleSelect(file.id)}
-          aria-label={t("files:list.selectFile", { title, defaultValue: `Select ${title}` })}
-          data-testid={`file-card-checkbox-${file.id}`}
-          className="bg-background"
-        />
-      </div>
+      {onToggleSelect ? (
+        <div className="absolute left-2 top-2 z-10">
+          <Checkbox
+            checked={selected}
+            onCheckedChange={() => onToggleSelect(file.id)}
+            aria-label={t("files:list.selectFile", { title, defaultValue: `Select ${title}` })}
+            data-testid={`file-card-checkbox-${file.id}`}
+            className="bg-background"
+          />
+        </div>
+      ) : null}
       <button
         type="button"
         onClick={() => onOpen(file.id)}

--- a/frontend/src/components/files/__tests__/EntityFilesPanel.test.tsx
+++ b/frontend/src/components/files/__tests__/EntityFilesPanel.test.tsx
@@ -47,9 +47,7 @@ describe("<EntityFilesPanel />", () => {
   it("renders the empty state when no files are linked", async () => {
     server.use(...groupHandlers.list(groupFixture), ...fileHandlers.list(SLUG, []))
     renderPanel()
-    await waitFor(() =>
-      expect(screen.getByTestId("entity-files-panel-empty")).toBeInTheDocument()
-    )
+    await waitFor(() => expect(screen.getByTestId("entity-files-panel-empty")).toBeInTheDocument())
     expect(screen.queryByTestId("entity-files-panel-grid")).not.toBeInTheDocument()
   })
 
@@ -86,9 +84,7 @@ describe("<EntityFilesPanel />", () => {
       ])
     )
     renderPanel()
-    await waitFor(() =>
-      expect(screen.getByTestId("entity-files-panel-grid")).toBeInTheDocument()
-    )
+    await waitFor(() => expect(screen.getByTestId("entity-files-panel-grid")).toBeInTheDocument())
     expect(screen.getByTestId("file-card-f-1")).toBeInTheDocument()
     expect(screen.getByTestId("file-card-f-2")).toBeInTheDocument()
     // Read-only: no checkbox should be rendered when onToggleSelect is omitted.
@@ -98,9 +94,7 @@ describe("<EntityFilesPanel />", () => {
   it("surfaces an error alert when the list endpoint 500s", async () => {
     server.use(...groupHandlers.list(groupFixture), ...fileHandlers.error(SLUG, 500))
     renderPanel()
-    await waitFor(() =>
-      expect(screen.getByTestId("entity-files-panel-error")).toBeInTheDocument()
-    )
+    await waitFor(() => expect(screen.getByTestId("entity-files-panel-error")).toBeInTheDocument())
   })
 
   it("is axe-clean in the populated state", async () => {
@@ -123,9 +117,7 @@ describe("<EntityFilesPanel />", () => {
       ])
     )
     const { container } = renderPanel()
-    await waitFor(() =>
-      expect(screen.getByTestId("entity-files-panel-grid")).toBeInTheDocument()
-    )
+    await waitFor(() => expect(screen.getByTestId("entity-files-panel-grid")).toBeInTheDocument())
     const results = await axe(container)
     expect(results.violations).toEqual([])
   })

--- a/frontend/src/components/files/__tests__/EntityFilesPanel.test.tsx
+++ b/frontend/src/components/files/__tests__/EntityFilesPanel.test.tsx
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { Route } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+import { axe } from "jest-axe"
+
+import { EntityFilesPanel } from "@/components/files/EntityFilesPanel"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { fileHandlers, groupHandlers } from "@/test/handlers"
+import { setAccessToken, clearAuth } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import type { Schema } from "@/types"
+
+const SLUG = "household"
+const COMMODITY = "com-1"
+
+const groupFixture: Schema<"models.LocationGroup">[] = [
+  { id: "g1", slug: SLUG, name: "Household", main_currency: "USD" },
+]
+
+function renderPanel(linkedEntityType: "commodity" | "location" = "commodity") {
+  setAccessToken("good-token")
+  return renderWithProviders({
+    initialPath: `/g/${SLUG}/commodities/${COMMODITY}`,
+    routes: (
+      <Route
+        path="/g/:groupSlug/commodities/:id"
+        element={
+          <GroupProvider>
+            <EntityFilesPanel linkedEntityType={linkedEntityType} linkedEntityId={COMMODITY} />
+          </GroupProvider>
+        }
+      />
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<EntityFilesPanel />", () => {
+  it("renders the empty state when no files are linked", async () => {
+    server.use(...groupHandlers.list(groupFixture), ...fileHandlers.list(SLUG, []))
+    renderPanel()
+    await waitFor(() =>
+      expect(screen.getByTestId("entity-files-panel-empty")).toBeInTheDocument()
+    )
+    expect(screen.queryByTestId("entity-files-panel-grid")).not.toBeInTheDocument()
+  })
+
+  it("renders a grid with one card per file", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...fileHandlers.list(SLUG, [
+        {
+          id: "f-1",
+          title: "Receipt",
+          path: "receipt-1",
+          ext: ".pdf",
+          mime_type: "application/pdf",
+          category: "invoices",
+          type: "document",
+          linked_entity_type: "commodity",
+          linked_entity_id: COMMODITY,
+          tags: ["tax"],
+          created_at: "2026-04-01T10:00:00Z",
+        },
+        {
+          id: "f-2",
+          title: "Photo",
+          path: "photo-1",
+          ext: ".jpg",
+          mime_type: "image/jpeg",
+          category: "photos",
+          type: "image",
+          linked_entity_type: "commodity",
+          linked_entity_id: COMMODITY,
+          tags: [],
+          created_at: "2026-04-02T10:00:00Z",
+        },
+      ])
+    )
+    renderPanel()
+    await waitFor(() =>
+      expect(screen.getByTestId("entity-files-panel-grid")).toBeInTheDocument()
+    )
+    expect(screen.getByTestId("file-card-f-1")).toBeInTheDocument()
+    expect(screen.getByTestId("file-card-f-2")).toBeInTheDocument()
+    // Read-only: no checkbox should be rendered when onToggleSelect is omitted.
+    expect(screen.queryByTestId("file-card-checkbox-f-1")).not.toBeInTheDocument()
+  })
+
+  it("surfaces an error alert when the list endpoint 500s", async () => {
+    server.use(...groupHandlers.list(groupFixture), ...fileHandlers.error(SLUG, 500))
+    renderPanel()
+    await waitFor(() =>
+      expect(screen.getByTestId("entity-files-panel-error")).toBeInTheDocument()
+    )
+  })
+
+  it("is axe-clean in the populated state", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...fileHandlers.list(SLUG, [
+        {
+          id: "f-1",
+          title: "Receipt",
+          path: "receipt-1",
+          ext: ".pdf",
+          mime_type: "application/pdf",
+          category: "invoices",
+          type: "document",
+          linked_entity_type: "commodity",
+          linked_entity_id: COMMODITY,
+          tags: [],
+          created_at: "2026-04-01T10:00:00Z",
+        },
+      ])
+    )
+    const { container } = renderPanel()
+    await waitFor(() =>
+      expect(screen.getByTestId("entity-files-panel-grid")).toBeInTheDocument()
+    )
+    const results = await axe(container)
+    expect(results.violations).toEqual([])
+  })
+})

--- a/frontend/src/features/files/__tests__/api.test.ts
+++ b/frontend/src/features/files/__tests__/api.test.ts
@@ -48,6 +48,42 @@ describe("features/files/api", () => {
     expect(result.files[0].signedUrl?.url).toBe("u1")
   })
 
+  it("listFiles forwards linked_entity_type + linked_entity_id query params when both are set", async () => {
+    // Captures the request URL so a future regression in
+    // listFiles' param-builder (e.g. dropping one half of the pair)
+    // fails this test instead of silently returning all group files.
+    let captured: URL | null = null
+    server.use(
+      http.get(apiUrl("/g/g1/files"), ({ request }) => {
+        captured = new URL(request.url)
+        return HttpResponse.json({ data: [], meta: { total: 0 } })
+      })
+    )
+    await listFiles({
+      linkedEntityType: "commodity",
+      linkedEntityId: "com-1",
+      perPage: 10,
+    })
+    expect(captured).not.toBeNull()
+    expect(captured!.searchParams.get("linked_entity_type")).toBe("commodity")
+    expect(captured!.searchParams.get("linked_entity_id")).toBe("com-1")
+    expect(captured!.searchParams.get("limit")).toBe("10")
+  })
+
+  it("listFiles omits linked_entity_* params when only one half is provided", async () => {
+    // BE rejects partial pairs with 400; the FE never builds them.
+    let captured: URL | null = null
+    server.use(
+      http.get(apiUrl("/g/g1/files"), ({ request }) => {
+        captured = new URL(request.url)
+        return HttpResponse.json({ data: [], meta: { total: 0 } })
+      })
+    )
+    await listFiles({ linkedEntityType: "commodity" })
+    expect(captured!.searchParams.has("linked_entity_type")).toBe(false)
+    expect(captured!.searchParams.has("linked_entity_id")).toBe(false)
+  })
+
   it("getCategoryCounts forwards the type/search/tags filter and returns the counts payload", async () => {
     server.use(
       http.get(apiUrl("/g/g1/files/category-counts"), () =>

--- a/frontend/src/features/files/api.ts
+++ b/frontend/src/features/files/api.ts
@@ -56,6 +56,11 @@ interface CategoryCountsEnvelope {
 // What the list endpoint accepts. The BE (#1398) rejects multi-value
 // `category` with 400; the FE side never builds a multi-value request,
 // so we expose it as a single optional string.
+//
+// linkedEntityType + linkedEntityId narrow the result to files attached
+// to a specific commodity / location / export. The BE rejects partial
+// pairs with 400 — both must be supplied together. Used by the
+// EntityFilesPanel on commodity / location detail pages.
 export interface ListFilesOptions {
   page?: number
   perPage?: number
@@ -63,6 +68,8 @@ export interface ListFilesOptions {
   type?: FileType
   search?: string
   tags?: string[]
+  linkedEntityType?: string
+  linkedEntityId?: string
   signal?: AbortSignal
 }
 
@@ -83,6 +90,10 @@ export async function listFiles(
   if (options.type) params.set("type", options.type)
   if (options.search?.trim()) params.set("search", options.search.trim())
   if (options.tags?.length) params.set("tags", options.tags.join(","))
+  if (options.linkedEntityType && options.linkedEntityId) {
+    params.set("linked_entity_type", options.linkedEntityType)
+    params.set("linked_entity_id", options.linkedEntityId)
+  }
   const qs = params.toString()
   const path = qs ? `/files?${qs}` : "/files"
   const body = await http.get<FilesListEnvelope>(path, { signal: options.signal })

--- a/frontend/src/features/files/keys.ts
+++ b/frontend/src/features/files/keys.ts
@@ -14,6 +14,13 @@ function listKeySuffix(opts: ListFilesOptions | undefined): string {
   if (opts.type) params.set("type", opts.type)
   if (opts.search?.trim()) params.set("search", opts.search.trim())
   for (const t of [...(opts.tags ?? [])].sort()) params.append("tags", t)
+  // Linked-entity pair must roll into the cache key — without this,
+  // navigating between two commodity-detail pages would reuse the
+  // first commodity's file list.
+  if (opts.linkedEntityType && opts.linkedEntityId) {
+    params.set("linked_entity_type", opts.linkedEntityType)
+    params.set("linked_entity_id", opts.linkedEntityId)
+  }
   return params.toString()
 }
 

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -19,7 +19,7 @@
     "dashboard": "Dashboard",
     "files": "Files",
     "groupInventory": "Inventory",
-    "groupManage": "Manage",
+    "groupManage": "Group",
     "groupPersonal": "Personal",
     "items": "All Items",
     "locations": "Locations",

--- a/frontend/src/i18n/locales/en/files.json
+++ b/frontend/src/i18n/locales/en/files.json
@@ -68,7 +68,6 @@
     "uploadCta": "Upload your first file"
   },
   "entityPanel": {
-    "addFiles": "Add files",
     "description_one": "{{count}} file attached",
     "description_other": "{{count}} files attached",
     "empty": "No files attached yet.",

--- a/frontend/src/i18n/locales/en/files.json
+++ b/frontend/src/i18n/locales/en/files.json
@@ -67,6 +67,15 @@
     "title": "No files yet",
     "uploadCta": "Upload your first file"
   },
+  "entityPanel": {
+    "addFiles": "Add files",
+    "description_one": "{{count}} file attached",
+    "description_other": "{{count}} files attached",
+    "empty": "No files attached yet.",
+    "errorDescription": "We couldn't load files for this entity. Try again in a moment.",
+    "errorTitle": "Couldn't load files",
+    "title": "Files"
+  },
   "list": {
     "nextPage": "Next page",
     "openDetail": "Open {{title}}",

--- a/frontend/src/lib/__tests__/nav-labels.test.tsx
+++ b/frontend/src/lib/__tests__/nav-labels.test.tsx
@@ -19,6 +19,8 @@ describe("useNavLabel", () => {
     ["common:nav.backup", "Backup"],
     ["common:nav.system", "Settings"],
     ["common:nav.profile", "Profile"],
+    ["common:nav.preferences", "Preferences"],
+    ["common:nav.search", "Search"],
   ]
 
   it.each(cases)("resolves %s → %s", (key, expected) => {

--- a/frontend/src/lib/nav-labels.ts
+++ b/frontend/src/lib/nav-labels.ts
@@ -35,6 +35,10 @@ export function useNavLabel(labelKey: string): string {
       return t("common:nav.system")
     case "common:nav.profile":
       return t("common:nav.profile")
+    case "common:nav.preferences":
+      return t("common:nav.preferences")
+    case "common:nav.search":
+      return t("common:nav.search")
     default:
       return labelKey
   }

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -21,6 +21,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { ComingSoonBanner } from "@/components/coming-soon/ComingSoonBanner"
+import { EntityFilesPanel } from "@/components/files/EntityFilesPanel"
 import { CommodityFormDialog } from "@/components/items/CommodityFormDialog"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { useAreas } from "@/features/areas/hooks"
@@ -83,7 +84,6 @@ export function CommodityDetailPage() {
   }
 
   const commodity = detail.data?.commodity
-  const meta = detail.data?.meta
 
   const areaName = useMemo(() => {
     const map = new Map<string, string>()
@@ -288,7 +288,7 @@ export function CommodityDetailPage() {
             </CardContent>
           </Card>
         ) : (
-          <FilesTab meta={meta} />
+          <FilesTab commodityId={commodity?.id ?? id} />
         )}
       </div>
 
@@ -580,22 +580,18 @@ function DetailLabel({ icon: Icon, label }: { icon: typeof MapPin; label: string
 }
 
 interface FilesTabProps {
-  meta: import("@/features/commodities/api").CommodityMeta | undefined
+  commodityId: string
 }
 
-function FilesTab({ meta }: FilesTabProps) {
-  const totalLegacy =
-    (meta?.images?.length ?? 0) + (meta?.invoices?.length ?? 0) + (meta?.manuals?.length ?? 0)
+function FilesTab({ commodityId }: FilesTabProps) {
+  // Renders attachments for this commodity through the unified
+  // /files surface (#1411 AC #4). The legacy meta.images / .invoices /
+  // .manuals counters are no longer consulted — once #1399 backfill
+  // ran, every legacy row is also a /files row, and the unified
+  // surface is the single source of truth.
   return (
-    <Card data-testid="commodity-detail-files">
-      <CardContent className="py-6">
-        {totalLegacy > 0 ? (
-          <p className="mb-4 text-sm text-muted-foreground">
-            {totalLegacy} attached file{totalLegacy === 1 ? "" : "s"} (legacy storage).
-          </p>
-        ) : null}
-        <ComingSoonBanner surface="filesUnification" />
-      </CardContent>
-    </Card>
+    <div data-testid="commodity-detail-files">
+      <EntityFilesPanel linkedEntityType="commodity" linkedEntityId={commodityId} />
+    </div>
   )
 }

--- a/frontend/src/pages/locations/LocationDetailPage.tsx
+++ b/frontend/src/pages/locations/LocationDetailPage.tsx
@@ -7,6 +7,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { EntityFilesPanel } from "@/components/files/EntityFilesPanel"
 import { LocationFormDialog } from "@/components/locations/LocationFormDialog"
 import { AreaFormDialog } from "@/components/locations/AreaFormDialog"
 import { RouteTitle } from "@/components/routing/RouteTitle"
@@ -257,6 +258,8 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
                 )}
               </CardContent>
             </Card>
+
+            <EntityFilesPanel linkedEntityType="location" linkedEntityId={id} />
           </>
         ) : null}
       </div>

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -2114,6 +2114,10 @@ export type paths = {
                     search?: string;
                     /** @description Filter by tags (comma-separated) */
                     tags?: string;
+                    /** @description Filter by linked entity type (e.g. commodity, location, export). Must be supplied together with linked_entity_id. */
+                    linked_entity_type?: string;
+                    /** @description Filter by linked entity id. Must be supplied together with linked_entity_type. */
+                    linked_entity_id?: string;
                     /** @description Page number (1-based) */
                     page?: number;
                     /** @description Items per page */

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -65,6 +65,8 @@ func parseFileCategoryParam(values []string) (*models.FileCategory, error) {
 // @Param category query string false "Filter by file category" Enums(photos,invoices,documents,other)
 // @Param search query string false "Search in title, description, and file paths"
 // @Param tags query string false "Filter by tags (comma-separated)"
+// @Param linked_entity_type query string false "Filter by linked entity type (e.g. commodity, location, export). Must be supplied together with linked_entity_id."
+// @Param linked_entity_id query string false "Filter by linked entity id. Must be supplied together with linked_entity_type."
 // @Param page query int false "Page number (1-based)" default(1)
 // @Param limit query int false "Items per page" default(20)
 // @Success 200 {object} jsonapi.FilesResponse "OK"
@@ -86,6 +88,8 @@ func (api *filesAPI) listFiles(w http.ResponseWriter, r *http.Request) {
 	tagsParam := r.URL.Query().Get("tags")
 	pageParam := r.URL.Query().Get("page")
 	limitParam := r.URL.Query().Get("limit")
+	linkedEntityTypeParam := r.URL.Query().Get("linked_entity_type")
+	linkedEntityIDParam := r.URL.Query().Get("linked_entity_id")
 
 	// Parse pagination
 	page := 1
@@ -116,6 +120,12 @@ func (api *filesAPI) listFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	linkedEntityType, linkedEntityID, linkedErr := parseLinkedEntityParams(linkedEntityTypeParam, linkedEntityIDParam)
+	if linkedErr != nil {
+		badRequest(w, r, linkedErr)
+		return
+	}
+
 	var tags []string
 	if tagsParam != "" {
 		tags = strings.Split(tagsParam, ",")
@@ -129,7 +139,7 @@ func (api *filesAPI) listFiles(w http.ResponseWriter, r *http.Request) {
 
 	if searchParam != "" || len(tags) > 0 {
 		// Use search if search query or tags are provided
-		files, err = fileReg.Search(r.Context(), searchParam, fileType, fileCategory, tags)
+		files, err = fileReg.Search(r.Context(), searchParam, fileType, fileCategory, tags, linkedEntityType, linkedEntityID)
 		if err != nil {
 			renderEntityError(w, r, err)
 			return
@@ -142,7 +152,7 @@ func (api *filesAPI) listFiles(w http.ResponseWriter, r *http.Request) {
 		files = files[start:end]
 	} else {
 		// Use paginated list for simple queries
-		files, total, err = fileReg.ListPaginated(r.Context(), offset, limit, fileType, fileCategory)
+		files, total, err = fileReg.ListPaginated(r.Context(), offset, limit, fileType, fileCategory, linkedEntityType, linkedEntityID)
 		if err != nil {
 			renderEntityError(w, r, err)
 			return
@@ -157,6 +167,19 @@ func (api *filesAPI) listFiles(w http.ResponseWriter, r *http.Request) {
 		internalServerError(w, r, err)
 		return
 	}
+}
+
+// parseLinkedEntityParams reads the linked_entity_type / linked_entity_id
+// query pair. Both must be non-empty together or both absent; partial pairs
+// are a 400 because they would silently ignore the caller's intent.
+func parseLinkedEntityParams(typeParam, idParam string) (linkedType, linkedID *string, err error) {
+	if typeParam == "" && idParam == "" {
+		return nil, nil, nil
+	}
+	if typeParam == "" || idParam == "" {
+		return nil, nil, fmt.Errorf("linked_entity_type and linked_entity_id must be supplied together")
+	}
+	return &typeParam, &idParam, nil
 }
 
 // generateSignedURLsForFiles generates signed URLs for a list of files.

--- a/go/apiserver/search.go
+++ b/go/apiserver/search.go
@@ -131,7 +131,7 @@ func (api *searchAPI) searchWithBasicFallback(w http.ResponseWriter, r *http.Req
 		}
 
 	case "files":
-		files, err := registrySet.FileRegistry.Search(r.Context(), query, nil, nil, tags)
+		files, err := registrySet.FileRegistry.Search(r.Context(), query, nil, nil, tags, nil, nil)
 		if err != nil {
 			renderEntityError(w, r, err)
 			return

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -1934,6 +1934,18 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Filter by linked entity type (e.g. commodity, location, export). Must be supplied together with linked_entity_id.",
+                        "name": "linked_entity_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by linked entity id. Must be supplied together with linked_entity_type.",
+                        "name": "linked_entity_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "default": 1,
                         "description": "Page number (1-based)",

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -1927,6 +1927,18 @@
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Filter by linked entity type (e.g. commodity, location, export). Must be supplied together with linked_entity_id.",
+                        "name": "linked_entity_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by linked entity id. Must be supplied together with linked_entity_type.",
+                        "name": "linked_entity_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "default": 1,
                         "description": "Page number (1-based)",

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -3114,6 +3114,15 @@ paths:
         in: query
         name: tags
         type: string
+      - description: Filter by linked entity type (e.g. commodity, location, export).
+          Must be supplied together with linked_entity_id.
+        in: query
+        name: linked_entity_type
+        type: string
+      - description: Filter by linked entity id. Must be supplied together with linked_entity_type.
+        in: query
+        name: linked_entity_id
+        type: string
       - default: 1
         description: Page number (1-based)
         in: query

--- a/go/registry/memory/files.go
+++ b/go/registry/memory/files.go
@@ -92,8 +92,27 @@ func (r *FileRegistry) ListByType(ctx context.Context, fileType models.FileType)
 	return filtered, nil
 }
 
+// fileMatchesEnumFilters returns true when the file passes every
+// non-nil enum-style filter (type, category, linked-entity pair).
+// linkedEntityType + linkedEntityID must both be non-nil to apply;
+// either alone is treated as "no filter" to mirror the postgres path.
+func fileMatchesEnumFilters(file *models.FileEntity, fileType *models.FileType, fileCategory *models.FileCategory, linkedEntityType, linkedEntityID *string) bool {
+	if fileType != nil && file.Type != *fileType {
+		return false
+	}
+	if fileCategory != nil && file.Category != *fileCategory {
+		return false
+	}
+	if linkedEntityType != nil && linkedEntityID != nil {
+		if file.LinkedEntityType != *linkedEntityType || file.LinkedEntityID != *linkedEntityID {
+			return false
+		}
+	}
+	return true
+}
+
 //nolint:gocognit // TODO: refactor
-func (r *FileRegistry) Search(ctx context.Context, query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string) ([]*models.FileEntity, error) {
+func (r *FileRegistry) Search(ctx context.Context, query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string, linkedEntityType, linkedEntityID *string) ([]*models.FileEntity, error) {
 	allFiles, err := r.List(ctx)
 	if err != nil {
 		return nil, err
@@ -103,13 +122,11 @@ func (r *FileRegistry) Search(ctx context.Context, query string, fileType *model
 	var filtered []*models.FileEntity
 
 	for _, file := range allFiles {
-		// Filter by type if specified
-		if fileType != nil && file.Type != *fileType {
-			continue
-		}
-
-		// Filter by category if specified
-		if fileCategory != nil && file.Category != *fileCategory {
+		// Filter by type / category / linked-entity if specified. Each
+		// helper returns true when the file passes; collapses what would
+		// otherwise be three early-return guards into a single check and
+		// keeps the surrounding cyclomatic complexity manageable.
+		if !fileMatchesEnumFilters(file, fileType, fileCategory, linkedEntityType, linkedEntityID) {
 			continue
 		}
 
@@ -152,19 +169,16 @@ func (r *FileRegistry) Search(ctx context.Context, query string, fileType *model
 	return filtered, nil
 }
 
-func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType, fileCategory *models.FileCategory) ([]*models.FileEntity, int, error) {
+func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType, fileCategory *models.FileCategory, linkedEntityType, linkedEntityID *string) ([]*models.FileEntity, int, error) {
 	allFiles, err := r.List(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	if fileType != nil || fileCategory != nil {
+	if fileType != nil || fileCategory != nil || (linkedEntityType != nil && linkedEntityID != nil) {
 		filtered := allFiles[:0:0]
 		for _, file := range allFiles {
-			if fileType != nil && file.Type != *fileType {
-				continue
-			}
-			if fileCategory != nil && file.Category != *fileCategory {
+			if !fileMatchesEnumFilters(file, fileType, fileCategory, linkedEntityType, linkedEntityID) {
 				continue
 			}
 			filtered = append(filtered, file)
@@ -187,7 +201,7 @@ func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fil
 // grouped by Category. Always returns all four buckets (zero-filled),
 // keeping the response shape stable for the FE tile renderer.
 func (r *FileRegistry) CountByCategory(ctx context.Context, query string, fileType *models.FileType, tags []string) (map[models.FileCategory]int, error) {
-	files, err := r.Search(ctx, query, fileType, nil, tags)
+	files, err := r.Search(ctx, query, fileType, nil, tags, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +275,7 @@ func (r *FileRegistry) ListByLinkedEntityAndMeta(ctx context.Context, entityType
 // FullTextSearch performs simple text search on files (simplified)
 func (r *FileRegistry) FullTextSearch(ctx context.Context, query string, fileType *models.FileType, options ...registry.SearchOption) ([]*models.FileEntity, error) {
 	// Use the existing search method as a simplified implementation
-	files, err := r.Search(ctx, query, fileType, nil, nil)
+	files, err := r.Search(ctx, query, fileType, nil, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/registry/memory/files_category_test.go
+++ b/go/registry/memory/files_category_test.go
@@ -36,7 +36,7 @@ func TestFileRegistry_Memory_FilterByCategory(t *testing.T) {
 	t.Run("ListPaginated by category=photos", func(t *testing.T) {
 		c := qt.New(t)
 		cat := models.FileCategoryPhotos
-		got, total, err := reg.ListPaginated(ctx, 0, 50, nil, &cat)
+		got, total, err := reg.ListPaginated(ctx, 0, 50, nil, &cat, nil, nil)
 		c.Assert(err, qt.IsNil)
 		c.Assert(total, qt.Equals, 2)
 		c.Assert(got, qt.HasLen, 2)
@@ -48,7 +48,7 @@ func TestFileRegistry_Memory_FilterByCategory(t *testing.T) {
 	t.Run("ListPaginated by category=invoices", func(t *testing.T) {
 		c := qt.New(t)
 		cat := models.FileCategoryInvoices
-		got, total, err := reg.ListPaginated(ctx, 0, 50, nil, &cat)
+		got, total, err := reg.ListPaginated(ctx, 0, 50, nil, &cat, nil, nil)
 		c.Assert(err, qt.IsNil)
 		c.Assert(total, qt.Equals, 1)
 		c.Assert(got, qt.HasLen, 1)
@@ -58,7 +58,7 @@ func TestFileRegistry_Memory_FilterByCategory(t *testing.T) {
 	t.Run("Search combines tags + category", func(t *testing.T) {
 		c := qt.New(t)
 		cat := models.FileCategoryDocuments
-		got, err := reg.Search(ctx, "", nil, &cat, []string{"manual"})
+		got, err := reg.Search(ctx, "", nil, &cat, []string{"manual"}, nil, nil)
 		c.Assert(err, qt.IsNil)
 		c.Assert(got, qt.HasLen, 1)
 		c.Assert(got[0].Category, qt.Equals, models.FileCategoryDocuments)
@@ -84,6 +84,136 @@ func TestFileRegistry_Memory_FilterByCategory(t *testing.T) {
 		c.Assert(counts[models.FileCategoryInvoices], qt.Equals, 0)
 		c.Assert(counts[models.FileCategoryOther], qt.Equals, 0)
 	})
+}
+
+// TestFileRegistry_Memory_FilterByLinkedEntity exercises the
+// linked_entity_type + linked_entity_id filter introduced for the
+// commodity / location detail Files panel. Both must be supplied
+// together; either alone is treated as "no filter".
+func TestFileRegistry_Memory_FilterByLinkedEntity(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := appctx.WithUser(c.Context(), &models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "user-1"},
+			TenantID: "tenant-1",
+		},
+	})
+	ctx = appctx.WithGroup(ctx, &models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "group-1"},
+			TenantID: "tenant-1",
+		},
+		Slug: "g1",
+	})
+
+	reg := memory.NewFileRegistryFactory().MustCreateUserRegistry(ctx)
+	for _, fe := range linkedEntityTestFiles() {
+		_, err := reg.Create(ctx, fe)
+		c.Assert(err, qt.IsNil)
+	}
+
+	commodityType := "commodity"
+	commodityA := "com-A"
+	commodityB := "com-B"
+	locationType := "location"
+	locationA := "loc-A"
+
+	t.Run("ListPaginated narrows to one commodity", func(t *testing.T) {
+		c := qt.New(t)
+		got, total, err := reg.ListPaginated(ctx, 0, 50, nil, nil, &commodityType, &commodityA)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 3)
+		c.Assert(got, qt.HasLen, 3)
+		for _, f := range got {
+			c.Assert(f.LinkedEntityType, qt.Equals, "commodity")
+			c.Assert(f.LinkedEntityID, qt.Equals, "com-A")
+		}
+	})
+
+	t.Run("ListPaginated narrows to one location", func(t *testing.T) {
+		c := qt.New(t)
+		got, total, err := reg.ListPaginated(ctx, 0, 50, nil, nil, &locationType, &locationA)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 1)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].LinkedEntityID, qt.Equals, "loc-A")
+	})
+
+	t.Run("ListPaginated combines linked entity + category", func(t *testing.T) {
+		c := qt.New(t)
+		cat := models.FileCategoryPhotos
+		got, total, err := reg.ListPaginated(ctx, 0, 50, nil, &cat, &commodityType, &commodityA)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 1)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].Category, qt.Equals, models.FileCategoryPhotos)
+		c.Assert(got[0].LinkedEntityID, qt.Equals, "com-A")
+	})
+
+	t.Run("Search applies linked-entity filter together with text query", func(t *testing.T) {
+		c := qt.New(t)
+		got, err := reg.Search(ctx, "manual", nil, nil, nil, &commodityType, &commodityA)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].Title, qt.Equals, "manual-A")
+	})
+
+	t.Run("ListPaginated commodityA does not leak rows from commodityB", func(t *testing.T) {
+		c := qt.New(t)
+		got, _, err := reg.ListPaginated(ctx, 0, 50, nil, nil, &commodityType, &commodityA)
+		c.Assert(err, qt.IsNil)
+		for _, f := range got {
+			c.Assert(f.LinkedEntityID, qt.Not(qt.Equals), "com-B")
+		}
+		got, _, err = reg.ListPaginated(ctx, 0, 50, nil, nil, &commodityType, &commodityB)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].LinkedEntityID, qt.Equals, "com-B")
+	})
+
+	t.Run("only-type or only-id is treated as no filter", func(t *testing.T) {
+		c := qt.New(t)
+		// Only type → returns everything (filter inactive).
+		got, total, err := reg.ListPaginated(ctx, 0, 50, nil, nil, &commodityType, nil)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 5)
+		c.Assert(got, qt.HasLen, 5)
+		// Only id → same.
+		got, total, err = reg.ListPaginated(ctx, 0, 50, nil, nil, nil, &commodityA)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 5)
+		c.Assert(got, qt.HasLen, 5)
+	})
+}
+
+func linkedEntityTestFiles() []models.FileEntity {
+	mk := func(name, mime, ext string, cat models.FileCategory, linkedType, linkedID, linkedMeta string) models.FileEntity {
+		return models.FileEntity{
+			Title:            name,
+			Type:             models.FileTypeFromMIME(mime),
+			Category:         cat,
+			LinkedEntityType: linkedType,
+			LinkedEntityID:   linkedID,
+			LinkedEntityMeta: linkedMeta,
+			File: &models.File{
+				Path:         name,
+				OriginalPath: name + ext,
+				Ext:          ext,
+				MIMEType:     mime,
+			},
+		}
+	}
+	return []models.FileEntity{
+		// commodity A — three files across two categories.
+		mk("photo-A", "image/jpeg", ".jpg", models.FileCategoryPhotos, "commodity", "com-A", "images"),
+		mk("invoice-A", "application/pdf", ".pdf", models.FileCategoryInvoices, "commodity", "com-A", "invoices"),
+		mk("manual-A", "application/pdf", ".pdf", models.FileCategoryDocuments, "commodity", "com-A", "manuals"),
+		// commodity B — one file, must not leak into A's filter.
+		mk("photo-B", "image/png", ".png", models.FileCategoryPhotos, "commodity", "com-B", "images"),
+		// location A — one file, different entity type.
+		mk("loc-photo-A", "image/jpeg", ".jpg", models.FileCategoryPhotos, "location", "loc-A", "images"),
+	}
 }
 
 func categoryTestFiles() []models.FileEntity {

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -291,7 +291,7 @@ func (r *FileRegistry) ListByLinkedEntityAndMeta(ctx context.Context, entityType
 // ListPaginated, and CountByCategory. Returns the conditions slice, the
 // positional args, and the next parameter index so callers can append more
 // filters without re-numbering.
-func buildSearchConditions(query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string, startIndex int) ([]string, []any, int) {
+func buildSearchConditions(query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string, linkedEntityType, linkedEntityID *string, startIndex int) ([]string, []any, int) {
 	var conditions []string
 	var args []any
 	argIndex := startIndex
@@ -306,6 +306,16 @@ func buildSearchConditions(query string, fileType *models.FileType, fileCategory
 		conditions = append(conditions, fmt.Sprintf("category = $%d", argIndex))
 		args = append(args, *fileCategory)
 		argIndex++
+	}
+
+	// Linked-entity filter: both type+id must be supplied together or both
+	// nil. Mismatched callers (one nil, one not) get no filter — the
+	// interface contract documents this; mirroring the memory path.
+	if linkedEntityType != nil && linkedEntityID != nil {
+		conditions = append(conditions,
+			fmt.Sprintf("linked_entity_type = $%d AND linked_entity_id = $%d", argIndex, argIndex+1))
+		args = append(args, *linkedEntityType, *linkedEntityID)
+		argIndex += 2
 	}
 
 	if len(tags) > 0 {
@@ -326,12 +336,12 @@ func buildSearchConditions(query string, fileType *models.FileType, fileCategory
 	return conditions, args, argIndex
 }
 
-func (r *FileRegistry) Search(ctx context.Context, query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string) ([]*models.FileEntity, error) {
+func (r *FileRegistry) Search(ctx context.Context, query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string, linkedEntityType, linkedEntityID *string) ([]*models.FileEntity, error) {
 	var files []*models.FileEntity
 
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		conditions, args, _ := buildSearchConditions(query, fileType, fileCategory, tags, 1)
+		conditions, args, _ := buildSearchConditions(query, fileType, fileCategory, tags, linkedEntityType, linkedEntityID, 1)
 
 		whereClause := ""
 		if len(conditions) > 0 {
@@ -367,13 +377,13 @@ func (r *FileRegistry) Search(ctx context.Context, query string, fileType *model
 	return files, nil
 }
 
-func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType, fileCategory *models.FileCategory) ([]*models.FileEntity, int, error) {
+func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType, fileCategory *models.FileCategory, linkedEntityType, linkedEntityID *string) ([]*models.FileEntity, int, error) {
 	var files []*models.FileEntity
 	var total int
 
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		conditions, args, _ := buildSearchConditions("", fileType, fileCategory, nil, 1)
+		conditions, args, _ := buildSearchConditions("", fileType, fileCategory, nil, linkedEntityType, linkedEntityID, 1)
 
 		whereClause := ""
 		if len(conditions) > 0 {
@@ -432,7 +442,7 @@ func (r *FileRegistry) CountByCategory(ctx context.Context, query string, fileTy
 
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		conditions, args, _ := buildSearchConditions(query, fileType, nil, tags, 1)
+		conditions, args, _ := buildSearchConditions(query, fileType, nil, tags, nil, nil, 1)
 
 		whereClause := ""
 		if len(conditions) > 0 {

--- a/go/registry/postgres/files_category_test.go
+++ b/go/registry/postgres/files_category_test.go
@@ -39,7 +39,7 @@ func TestFileRegistry_Postgres_CategoryFilter(t *testing.T) {
 	t.Run("ListPaginated by category=photos", func(t *testing.T) {
 		c := qt.New(t)
 		cat := models.FileCategoryPhotos
-		got, total, err := registrySet.FileRegistry.ListPaginated(ctx, 0, 50, nil, &cat)
+		got, total, err := registrySet.FileRegistry.ListPaginated(ctx, 0, 50, nil, &cat, nil, nil)
 		c.Assert(err, qt.IsNil)
 		c.Assert(total, qt.Equals, 2)
 		c.Assert(got, qt.HasLen, 2)
@@ -51,7 +51,7 @@ func TestFileRegistry_Postgres_CategoryFilter(t *testing.T) {
 	t.Run("Search by category + tag", func(t *testing.T) {
 		c := qt.New(t)
 		cat := models.FileCategoryDocuments
-		got, err := registrySet.FileRegistry.Search(ctx, "", nil, &cat, []string{"manual"})
+		got, err := registrySet.FileRegistry.Search(ctx, "", nil, &cat, []string{"manual"}, nil, nil)
 		c.Assert(err, qt.IsNil)
 		c.Assert(got, qt.HasLen, 1)
 		c.Assert(got[0].Category, qt.Equals, models.FileCategoryDocuments)
@@ -75,6 +75,128 @@ func TestFileRegistry_Postgres_CategoryFilter(t *testing.T) {
 		c.Assert(counts[models.FileCategoryDocuments], qt.Equals, 1)
 		c.Assert(counts[models.FileCategoryPhotos], qt.Equals, 0)
 	})
+}
+
+// TestFileRegistry_Postgres_LinkedEntityFilter exercises the
+// linked_entity_type / linked_entity_id WHERE-clause path on the
+// postgres FileRegistry — what GET /files?linked_entity_type=... will
+// hit in production for the commodity / location detail Files panels.
+// Cross-entity isolation is the load-bearing assertion.
+func TestFileRegistry_Postgres_LinkedEntityFilter(t *testing.T) {
+	c := qt.New(t)
+
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	user := getTestUser(c, registrySet)
+	ctx := appctx.WithUser(c.Context(), user)
+
+	for _, fe := range linkedEntityPostgresSeed() {
+		fe.TenantID = user.TenantID
+		fe.CreatedByUserID = user.ID
+		_, err := registrySet.FileRegistry.Create(ctx, fe)
+		c.Assert(err, qt.IsNil)
+	}
+
+	commodityType := "commodity"
+	commodityA := "com-A"
+	commodityB := "com-B"
+	locationType := "location"
+	locationA := "loc-A"
+
+	t.Run("ListPaginated narrows to one commodity", func(t *testing.T) {
+		c := qt.New(t)
+		got, total, err := registrySet.FileRegistry.ListPaginated(ctx, 0, 50, nil, nil, &commodityType, &commodityA)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 3)
+		c.Assert(got, qt.HasLen, 3)
+		for _, f := range got {
+			c.Assert(f.LinkedEntityType, qt.Equals, "commodity")
+			c.Assert(f.LinkedEntityID, qt.Equals, "com-A")
+		}
+	})
+
+	t.Run("ListPaginated narrows to one location", func(t *testing.T) {
+		c := qt.New(t)
+		got, total, err := registrySet.FileRegistry.ListPaginated(ctx, 0, 50, nil, nil, &locationType, &locationA)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 1)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].LinkedEntityID, qt.Equals, "loc-A")
+	})
+
+	t.Run("ListPaginated combines linked entity + category", func(t *testing.T) {
+		c := qt.New(t)
+		cat := models.FileCategoryPhotos
+		got, total, err := registrySet.FileRegistry.ListPaginated(ctx, 0, 50, nil, &cat, &commodityType, &commodityA)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 1)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].Category, qt.Equals, models.FileCategoryPhotos)
+		c.Assert(got[0].LinkedEntityID, qt.Equals, "com-A")
+	})
+
+	t.Run("Search applies linked-entity filter together with text query", func(t *testing.T) {
+		c := qt.New(t)
+		got, err := registrySet.FileRegistry.Search(ctx, "manual", nil, nil, nil, &commodityType, &commodityA)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].Title, qt.Equals, "manual-A")
+	})
+
+	t.Run("ListPaginated commodityA does not leak rows from commodityB", func(t *testing.T) {
+		c := qt.New(t)
+		got, _, err := registrySet.FileRegistry.ListPaginated(ctx, 0, 50, nil, nil, &commodityType, &commodityA)
+		c.Assert(err, qt.IsNil)
+		for _, f := range got {
+			c.Assert(f.LinkedEntityID, qt.Not(qt.Equals), "com-B")
+		}
+		got, _, err = registrySet.FileRegistry.ListPaginated(ctx, 0, 50, nil, nil, &commodityType, &commodityB)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].LinkedEntityID, qt.Equals, "com-B")
+	})
+
+	t.Run("only-type or only-id is treated as no filter", func(t *testing.T) {
+		c := qt.New(t)
+		got, total, err := registrySet.FileRegistry.ListPaginated(ctx, 0, 50, nil, nil, &commodityType, nil)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 5)
+		c.Assert(got, qt.HasLen, 5)
+		got, total, err = registrySet.FileRegistry.ListPaginated(ctx, 0, 50, nil, nil, nil, &commodityA)
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 5)
+		c.Assert(got, qt.HasLen, 5)
+	})
+}
+
+func linkedEntityPostgresSeed() []models.FileEntity {
+	now := time.Now()
+	mk := func(name, mime, ext string, cat models.FileCategory, linkedType, linkedID, linkedMeta string) models.FileEntity {
+		return models.FileEntity{
+			Title:            name,
+			Type:             models.FileTypeFromMIME(mime),
+			Category:         cat,
+			LinkedEntityType: linkedType,
+			LinkedEntityID:   linkedID,
+			LinkedEntityMeta: linkedMeta,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+			File: &models.File{
+				Path:         name,
+				OriginalPath: name + ext,
+				Ext:          ext,
+				MIMEType:     mime,
+			},
+		}
+	}
+	return []models.FileEntity{
+		mk("photo-A", "image/jpeg", ".jpg", models.FileCategoryPhotos, "commodity", "com-A", "images"),
+		mk("invoice-A", "application/pdf", ".pdf", models.FileCategoryInvoices, "commodity", "com-A", "invoices"),
+		mk("manual-A", "application/pdf", ".pdf", models.FileCategoryDocuments, "commodity", "com-A", "manuals"),
+		mk("photo-B", "image/png", ".png", models.FileCategoryPhotos, "commodity", "com-B", "images"),
+		mk("loc-photo-A", "image/jpeg", ".jpg", models.FileCategoryPhotos, "location", "loc-A", "images"),
+	}
 }
 
 func categoryPostgresSeed() []models.FileEntity {

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -210,18 +210,23 @@ type FileRegistry interface {
 	// see exactly the right slice via RLS.
 	ListByGroup(ctx context.Context, tenantID, groupID string) ([]*models.FileEntity, error)
 
-	// Search returns files matching the search criteria. The optional
-	// fileCategory parameter filters by the user-meaningful category surfaced
-	// in the UI tiles (Photos/Invoices/Documents/Other).
-	Search(ctx context.Context, query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string) ([]*models.FileEntity, error)
+	// Search returns files matching the search criteria. Optional filters:
+	//   - fileCategory narrows by the user-meaningful tile category
+	//     (Photos/Invoices/Documents/Other).
+	//   - linkedEntityType / linkedEntityID narrow to files linked to a
+	//     specific commodity/location/export. Both must be supplied together
+	//     or both nil; passing only one is a programmer error and treated as
+	//     "no linked-entity filter".
+	Search(ctx context.Context, query string, fileType *models.FileType, fileCategory *models.FileCategory, tags []string, linkedEntityType, linkedEntityID *string) ([]*models.FileEntity, error)
 
 	//// FullTextSearch performs enhanced text search on files
 	// FullTextSearch(ctx context.Context, query string, fileType *models.FileType, options ...SearchOption) ([]*models.FileEntity, error)
 
-	// ListPaginated returns paginated list of files. The optional
-	// fileCategory parameter filters by the user-meaningful category surfaced
-	// in the UI tiles (Photos/Invoices/Documents/Other).
-	ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType, fileCategory *models.FileCategory) ([]*models.FileEntity, int, error)
+	// ListPaginated returns paginated list of files. Optional filters:
+	//   - fileCategory narrows by tile category.
+	//   - linkedEntityType / linkedEntityID narrow to files linked to a
+	//     specific commodity/location/export (both required together).
+	ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType, fileCategory *models.FileCategory, linkedEntityType, linkedEntityID *string) ([]*models.FileEntity, int, error)
 
 	// CountByCategory returns the per-category file count, scoped to the
 	// current group via RLS and constrained by the same filters as Search


### PR DESCRIPTION
## Summary

Closes the last two outstanding ACs of #1411:

- **AC #4** — "Files surface in commodity / location detail via `linked_entity_*`"
- **AC #7** — "Playwright e2e: upload → list → detail → download → delete; per-category filter"

After this lands, the Files-unification half of epic #1397 is done end-to-end and the legacy commodity-/location-scoped file routes can be torn out under #1421.

Refs #1397, follows up #1456.

## What changed

### BE — `GET /files` filter by linked entity (`705dae4`)

Adds an optional `linked_entity_type` + `linked_entity_id` query-pair on the unified `/files` list endpoint. Without it, the detail-page Files panels can only fetch every file in the group and filter client-side — defeating the whole point of pagination + RLS-friendly counts.

- `FileRegistry.Search` / `ListPaginated` gain `(linkedEntityType, linkedEntityID *string)`. Both nil = no filter; both non-nil = `WHERE linked_entity_type=$N AND linked_entity_id=$M`. `buildSearchConditions` threads the new pair through the shared WHERE assembly so list / search / counts stay in lockstep on the SQL surface.
- `apiserver/files.go::listFiles` parses the params via a new `parseLinkedEntityParams` helper that returns 400 on partial input rather than silently widening the result set.
- Memory registry mirrors the postgres semantics via a new `fileMatchesEnumFilters` predicate; same helper drives Search and ListPaginated so the two paths can't drift.

Tests: `TestFileRegistry_Memory_FilterByLinkedEntity` and `TestFileRegistry_Postgres_LinkedEntityFilter` cover per-commodity and per-location narrowing, combined linked-entity + category, cross-entity isolation in both directions, and only-type / only-id treated as no filter. Existing CountByCategory + category tests still pass against the updated signature. Swagger regenerated; `make swagger` green, `inventool db migrations generate --check` reports zero drift.

### FE — `<EntityFilesPanel />` on commodity / location detail (`f8c0162`)

Replaces the legacy `<ComingSoonBanner surface="filesUnification" />` placeholder on `CommodityDetailPage` and (newly) on `LocationDetailPage` with a real `<EntityFilesPanel linkedEntityType linkedEntityId />`. The panel reads `GET /files?linked_entity_type=…&linked_entity_id=…`, reuses `FileCard`, deep-links each card to `/files/:id` so the existing `FileDetailSheet` path drives preview / download / edit / delete unchanged.

- `EntityFilesPanel` (`components/files/EntityFilesPanel.tsx`): loading / error / empty / populated states, axe-clean, `data-testid="entity-files-panel"`.
- `FileCard` checkbox is now opt-in: when `onToggleSelect` is omitted the card renders read-only — what the entity panel needs.
- `listFiles()` API client and `fileKeys.list` cache key both pick up the new `linkedEntityType` + `linkedEntityId` options so two commodity-detail pages don't share a cache entry.
- The closed `filesUnification` ComingSoonBanner surface (still used by the create-flow Files step in `CommodityFormDialog`) now points at #1448 (drag-drop quick-attach) instead of the now-closed #1398.
- New `EntityFilesPanel.test.tsx` — 4 cases (empty / populated / error / axe) backed by MSW; all 412 vitest cases pass.

### E2E — full upload→delete + per-category content filter (`f8c0162`)

`e2e/tests/files.spec.ts` extended:

- `upload → list → detail → download URL → delete` — uploads a fixture image via the existing dialog flow (`files-upload-input` setInputFiles + `files-upload-next` + `files-upload-start` + `files-upload-close`), filters by Photos tile, opens the card, asserts the detail sheet's category badge + filename + download href, deletes via the detail sheet, and confirms the card is gone. Cleans up after itself so the row count returns to its pre-test value.
- `per-category filter narrows the visible cards by category` — uploads one image and verifies it surfaces under Photos but NOT Invoices / Documents, then deletes for cleanup. Drives the `?category=…` BE filter end-to-end.
- Original 3 smoke tests (tile rendering, aria-selected toggle, upload dialog open) kept as fast-failure layer.

`npx playwright test --list tests/files.spec.ts` parses cleanly: 5 tests × 3 browsers = 15.

### Polish (`24a668e`)

Three drive-by fixes the post-PR screenshot pass surfaced:

- `useNavLabel` had no case for `common:nav.preferences` (and `common:nav.search` from #1444) → sidebar / palette rendered the literal `common:nav.preferences` key instead of "Preferences" on every authenticated screen. Added per-arm cases. Test file gets new grid rows so the next missing arm fails loudly.
- Sidebar's "Manage" section housed Tags / Files / Members / Backup / Settings — every one of those is group-scoped, so the heading was misleading. Renamed `common:nav.groupManage` from "Manage" to "Group" so the heading actually describes what's underneath.
- `e2e/screenshots.mjs` now also captures the commodity-detail Files tab (`18b-commodity-detail-files.png`), so a screenshot pass actually exercises the new `EntityFilesPanel` path instead of stopping at the default Details tab.

## Test plan

- [x] `cd go && make test` — Go unit + memory registry green
- [x] `POSTGRES_TEST_DSN=… go test -v ./registry/postgres/... ./services/files_backfill/...` — postgres registry filter tests pass against `postgres:17-alpine`
- [x] `golangci-lint run ./registry/... ./apiserver/...` — 0 issues
- [x] `make swagger` — no drift after running
- [x] `cd frontend && npm test -- --run` — **412/412 vitest** (was 410, +2 nav-labels cases, +4 EntityFilesPanel cases)
- [x] `npm run typecheck && npm run lint && npm run build && npm run i18n:check` — all green locally (i18n drift resolves once the catalog change commits)
- [x] `npx playwright test --list tests/files.spec.ts` — 15 specs discovered (5 × 3 browsers)
- [x] Screenshot review (vite-dev on :5174 → user's binary on :3333; binary not yet rebuilt with the BE patch, so the linked-entity filter is ignored and the panel shows all group files — expected, narrows correctly post-merge): commodity / location detail Files panels render, sidebar literals fixed, no regressions on dashboard / locations / commodities / profile / settings / print
- [ ] CI: go-lint, go-test, go-test-postgres, frontend-test, frontend-lint, frontend-codegen, frontend-i18n, frontend-size, frontend-lhci, e2e-tests

## Out of scope

- Drag-drop quick-attach + Files step in `CommodityFormDialog` — tracked under #1448 (the `filesUnification` ComingSoonBanner now points at it).
- Linking files to commodities at upload time — same #1448 territory.
- Tag autocomplete in the entity panel — still depends on #1400.