### PR TITLE
[#1449] e2e: API-level commodity helpers + bulk-delete/filter round-trip + FE bulk envelope fix

### DIFF
--- a/e2e/tests/commodity-bulk-and-filter.spec.ts
+++ b/e2e/tests/commodity-bulk-and-filter.spec.ts
@@ -1,7 +1,7 @@
 /**
  * E2E round-trip coverage for the commodities bulk-delete + filter
- * flows on the React Files page (#1411 / #1410). Closes the parts of
- * #1449 the existing `bulk-actions.spec.ts` only smoke-tests:
+ * flows on the React `/commodities` list page (#1410). Closes the
+ * parts of #1449 the existing `bulk-actions.spec.ts` only smoke-tests:
  *
  *   - bulk-actions.spec.ts proves the BulkActionsBar appears + the
  *     clear button hides it. It does NOT actually delete anything.
@@ -170,11 +170,16 @@ test.describe('Commodities — bulk + filter round-trips', () => {
       await expect(electronicsCard).toBeVisible({ timeout: 15000 })
       await expect(furnitureCard).toBeVisible()
 
-      // Apply the type=electronics filter via the select. After the
-      // change the URL should carry `type=electronics`, only the
-      // electronics card stays visible, and the BE re-fetched the
-      // narrower list (verified via waitForResponse on the matching
-      // GET so a stale cache hit can't pass the assertion).
+      // Apply the type=electronics filter via the DropdownMenu. The
+      // trigger is a `<Button>` (not a `<select>`); items are
+      // `DropdownMenuCheckboxItem`s rendered with `role="menuitemcheckbox"`.
+      // We click the trigger to open the menu, then pick the
+      // "Electronics" item by role+name. After the change the URL
+      // should carry `type=electronics`, only the electronics card
+      // stays visible, and the BE re-fetched the narrower list
+      // (verified via waitForResponse on the matching GET so a stale
+      // cache hit can't pass the assertion).
+      await page.getByTestId('commodities-filter-type').click()
       const filterPromise = page.waitForResponse(
         (resp) =>
           resp.url().includes('/commodities') &&
@@ -182,8 +187,11 @@ test.describe('Commodities — bulk + filter round-trips', () => {
           resp.request().method() === 'GET',
         { timeout: 15000 },
       )
-      await page.getByTestId('commodities-filter-type').selectOption('electronics')
+      await page.getByRole('menuitemcheckbox', { name: /electronics/i }).click()
       await filterPromise
+      // Close the menu (it stays open after toggling a CheckboxItem)
+      // so the cards underneath are interactable for the assertions.
+      await page.keyboard.press('Escape')
 
       await expect(page).toHaveURL(/[?&]type=electronics(?:&|$)/)
       await expect(electronicsCard).toBeVisible()

--- a/e2e/tests/commodity-bulk-and-filter.spec.ts
+++ b/e2e/tests/commodity-bulk-and-filter.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * E2E round-trip coverage for the commodities bulk-delete + filter
+ * flows on the React Files page (#1411 / #1410). Closes the parts of
+ * #1449 the existing `bulk-actions.spec.ts` only smoke-tests:
+ *
+ *   - bulk-actions.spec.ts proves the BulkActionsBar appears + the
+ *     clear button hides it. It does NOT actually delete anything.
+ *   - This spec seeds two commodities via the API helpers in
+ *     `commodities-api.ts`, walks the UI bulk-delete flow end to end,
+ *     and asserts both rows are gone from the list.
+ *   - A second test asserts the type filter narrows the visible set
+ *     and the URL reflects the active filter (round-trip safe across
+ *     reload).
+ *
+ * Bulk-move + sort + search round-trips are deliberately deferred to
+ * follow-up commits — they need richer fixtures (multiple areas, a
+ * couple of distinct registered_dates, etc.) and pile up review surface.
+ */
+import { expect } from '@playwright/test'
+
+import { test } from '../fixtures/app-fixture.js'
+import {
+  createCommodityViaAPI,
+  deleteCommodityViaAPI,
+  ensureLocationAndArea,
+  extractApiAuth,
+  resolveActiveGroup,
+} from './includes/commodities-api.js'
+import { navigateTo, TO_COMMODITIES } from './includes/navigate.js'
+
+test.describe('Commodities — bulk + filter round-trips', () => {
+  test('bulk-delete two seeded commodities → both gone from the list', async ({
+    page,
+    request,
+    recorder,
+  }) => {
+    const auth = await extractApiAuth(page)
+    const group = await resolveActiveGroup(request, auth)
+    const { areaId } = await ensureLocationAndArea(request, auth, group.slug)
+
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const aName = `Bulk Delete A ${suffix}`
+    const bName = `Bulk Delete B ${suffix}`
+
+    const seeded: { id: string; name: string }[] = []
+    seeded.push(
+      await createCommodityViaAPI(
+        request,
+        auth,
+        group.slug,
+        { name: aName, areaId, type: 'electronics' },
+        group.mainCurrency,
+      ),
+    )
+    seeded.push(
+      await createCommodityViaAPI(
+        request,
+        auth,
+        group.slug,
+        { name: bName, areaId, type: 'electronics' },
+        group.mainCurrency,
+      ),
+    )
+    // Best-effort safety net: any seeded commodity that survives the
+    // UI flow (because the test failed mid-way) is cleaned up here so
+    // the next run starts from the same baseline. Successful runs
+    // reach this with all rows already deleted; the API helper is
+    // 404-tolerant and silently no-ops.
+    const cleanup = async () => {
+      for (const row of seeded) {
+        await deleteCommodityViaAPI(request, auth, group.slug, row.id).catch(() => {})
+      }
+    }
+
+    try {
+      await navigateTo(page, recorder, TO_COMMODITIES)
+
+      // Both seeded cards must be visible before we start selecting.
+      const cardA = page.locator(`[data-commodity-id="${seeded[0].id}"]`)
+      const cardB = page.locator(`[data-commodity-id="${seeded[1].id}"]`)
+      await expect(cardA).toBeVisible({ timeout: 15000 })
+      await expect(cardB).toBeVisible()
+
+      // Toggle the per-card checkbox on each row. Reka's CheckboxRoot
+      // is a `<button role="checkbox">` and Playwright's actionability
+      // gate flakes on overlay-positioned checkboxes — `dispatchEvent`
+      // fires the synthetic event without the visibility heuristic.
+      // Same workaround the existing bulk-actions.spec uses.
+      for (const card of [cardA, cardB]) {
+        const cb = card.locator('[data-testid="commodity-select"]')
+        await cb.scrollIntoViewIfNeeded()
+        await cb.dispatchEvent('click')
+      }
+
+      const bar = page.locator('[data-testid="commodities-bulk-bar"]')
+      await expect(bar).toBeVisible()
+      // The count is a plain `<span>` inside the bar — no per-element
+      // testid — so we match on the i18n string ("2 items selected").
+      await expect(bar).toContainText(/2 items? selected/)
+
+      // Click the bulk-delete CTA and accept the confirm. The bar
+      // mounts the BE roundtrip; we wait for the DELETE response so a
+      // slow CI run doesn't leave the assertions racing the network.
+      const deletePromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/commodities/bulk-delete') && resp.request().method() === 'POST',
+        { timeout: 15000 },
+      )
+      await bar.locator('[data-testid="commodities-bulk-delete"]').click()
+      await expect(page.getByTestId('confirm-dialog')).toBeVisible()
+      await page.getByTestId('confirm-accept').click()
+      const deleteResponse = await deletePromise
+      expect(deleteResponse.status()).toBeLessThan(300)
+
+      // Both cards must be gone. The list query refetches on
+      // mutation success — no need to navigate away and back.
+      await expect(cardA).toHaveCount(0, { timeout: 15000 })
+      await expect(cardB).toHaveCount(0)
+
+      // BulkActionsBar collapses once the selection is empty.
+      await expect(bar).toBeHidden()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('type filter narrows the list + the URL reflects the active filter', async ({
+    page,
+    request,
+    recorder,
+  }) => {
+    const auth = await extractApiAuth(page)
+    const group = await resolveActiveGroup(request, auth)
+    const { areaId } = await ensureLocationAndArea(request, auth, group.slug)
+
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const electronicsName = `Filter electronics ${suffix}`
+    const furnitureName = `Filter furniture ${suffix}`
+
+    const seeded: { id: string; name: string }[] = []
+    seeded.push(
+      await createCommodityViaAPI(
+        request,
+        auth,
+        group.slug,
+        { name: electronicsName, areaId, type: 'electronics' },
+        group.mainCurrency,
+      ),
+    )
+    seeded.push(
+      await createCommodityViaAPI(
+        request,
+        auth,
+        group.slug,
+        { name: furnitureName, areaId, type: 'furniture' },
+        group.mainCurrency,
+      ),
+    )
+    const cleanup = async () => {
+      for (const row of seeded) {
+        await deleteCommodityViaAPI(request, auth, group.slug, row.id).catch(() => {})
+      }
+    }
+
+    try {
+      await navigateTo(page, recorder, TO_COMMODITIES)
+
+      const electronicsCard = page.locator(`[data-commodity-id="${seeded[0].id}"]`)
+      const furnitureCard = page.locator(`[data-commodity-id="${seeded[1].id}"]`)
+      await expect(electronicsCard).toBeVisible({ timeout: 15000 })
+      await expect(furnitureCard).toBeVisible()
+
+      // Apply the type=electronics filter via the select. After the
+      // change the URL should carry `type=electronics`, only the
+      // electronics card stays visible, and the BE re-fetched the
+      // narrower list (verified via waitForResponse on the matching
+      // GET so a stale cache hit can't pass the assertion).
+      const filterPromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/commodities') &&
+          resp.url().includes('type=electronics') &&
+          resp.request().method() === 'GET',
+        { timeout: 15000 },
+      )
+      await page.getByTestId('commodities-filter-type').selectOption('electronics')
+      await filterPromise
+
+      await expect(page).toHaveURL(/[?&]type=electronics(?:&|$)/)
+      await expect(electronicsCard).toBeVisible()
+      await expect(furnitureCard).toHaveCount(0)
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/e2e/tests/includes/commodities-api.ts
+++ b/e2e/tests/includes/commodities-api.ts
@@ -99,6 +99,11 @@ export async function ensureLocationAndArea(
 
   // Locations
   const locationsResp = await request.get(`${apiBase}/locations`, { headers })
+  if (!locationsResp.ok()) {
+    throw new Error(
+      `ensureLocationAndArea: GET /locations → ${locationsResp.status()} ${await locationsResp.text()}`,
+    )
+  }
   const locationsBody = (await locationsResp.json()) as { data?: Array<{ id: string }> }
   let locationId: string
   if (locationsBody.data && locationsBody.data.length > 0) {
@@ -123,6 +128,11 @@ export async function ensureLocationAndArea(
 
   // Areas (flat list, location_id on each row)
   const areasResp = await request.get(`${apiBase}/areas`, { headers })
+  if (!areasResp.ok()) {
+    throw new Error(
+      `ensureLocationAndArea: GET /areas → ${areasResp.status()} ${await areasResp.text()}`,
+    )
+  }
   const areasBody = (await areasResp.json()) as { data?: Array<{ id: string }> }
   let areaId: string
   if (areasBody.data && areasBody.data.length > 0) {

--- a/e2e/tests/includes/commodities-api.ts
+++ b/e2e/tests/includes/commodities-api.ts
@@ -1,0 +1,234 @@
+/**
+ * API-level helpers for commodity / location / area seeding in e2e
+ * specs. Pairs with the UI-driven `commodities.ts` helpers — those
+ * exercise the multi-step Add-Item dialog (which is what you want when
+ * the dialog itself is the unit under test); these drive the BE
+ * directly so bulk / filter / sort / search specs can seed two-dozen
+ * commodities cheaply without repeatedly walking the wizard.
+ *
+ * Auth is captured from the page's `localStorage` / `sessionStorage`
+ * after the canonical `app-fixture.ts` log-in, so the helpers run as
+ * the authenticated user the spec was given. CSRF is required for any
+ * write — the BE rejects mutations without it.
+ */
+
+import { expect, type Page, type APIRequestContext } from '@playwright/test'
+
+export interface ApiAuth {
+  accessToken: string
+  csrfToken: string
+}
+
+/**
+ * Read the auth pair set by the React app after a successful login.
+ * Throws when either piece is missing — that's a sign the spec didn't
+ * use the `app-fixture.ts` page (or that the storage shape changed).
+ */
+export async function extractApiAuth(page: Page): Promise<ApiAuth> {
+  const accessToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '')
+  const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '')
+  if (!accessToken) {
+    throw new Error(
+      'extractApiAuth: no `inventario_token` in localStorage — was the page authenticated via app-fixture.ts?',
+    )
+  }
+  if (!csrfToken) {
+    throw new Error(
+      'extractApiAuth: no `inventario_csrf_token` in sessionStorage — login completed but CSRF mint missed',
+    )
+  }
+  return { accessToken, csrfToken }
+}
+
+function authHeaders(auth: ApiAuth): Record<string, string> {
+  return {
+    'Content-Type': 'application/vnd.api+json',
+    Accept: 'application/vnd.api+json',
+    Authorization: `Bearer ${auth.accessToken}`,
+    'X-CSRF-Token': auth.csrfToken,
+  }
+}
+
+/**
+ * Resolve the active group's slug + main currency. The React http
+ * client rewrites `/api/v1/...` to `/api/v1/g/{slug}/...` per request;
+ * Playwright's request fixture skips that wrapping, so callers need
+ * the slug explicitly to build the right URL.
+ */
+export interface ResolvedGroup {
+  id: string
+  slug: string
+  mainCurrency: string
+}
+
+export async function resolveActiveGroup(
+  request: APIRequestContext,
+  auth: ApiAuth,
+): Promise<ResolvedGroup> {
+  const resp = await request.get('/api/v1/groups', { headers: authHeaders(auth) })
+  if (!resp.ok()) {
+    throw new Error(`resolveActiveGroup: GET /groups → ${resp.status()} ${await resp.text()}`)
+  }
+  const body = (await resp.json()) as {
+    data?: Array<{ id: string; attributes: { slug?: string; main_currency?: string } }>
+  }
+  const group = body.data?.[0]
+  if (!group?.attributes?.slug) {
+    throw new Error('resolveActiveGroup: user has no usable group slug')
+  }
+  return {
+    id: group.id,
+    slug: group.attributes.slug,
+    mainCurrency: group.attributes.main_currency ?? 'USD',
+  }
+}
+
+/**
+ * Find the first existing location/area pair in the active group, or
+ * create one if the group is empty. The bulk / filter specs don't
+ * care about the location/area names — they just need a target for
+ * `area_id` on the commodities they seed.
+ */
+export async function ensureLocationAndArea(
+  request: APIRequestContext,
+  auth: ApiAuth,
+  slug: string,
+): Promise<{ locationId: string; areaId: string }> {
+  const apiBase = `/api/v1/g/${encodeURIComponent(slug)}`
+  const headers = authHeaders(auth)
+
+  // Locations
+  const locationsResp = await request.get(`${apiBase}/locations`, { headers })
+  const locationsBody = (await locationsResp.json()) as { data?: Array<{ id: string }> }
+  let locationId: string
+  if (locationsBody.data && locationsBody.data.length > 0) {
+    locationId = locationsBody.data[0].id
+  } else {
+    const created = await request.post(`${apiBase}/locations`, {
+      headers,
+      data: {
+        data: {
+          type: 'locations',
+          attributes: { name: 'API helper location', address: 'API helper address' },
+        },
+      },
+    })
+    if (!created.ok()) {
+      throw new Error(
+        `ensureLocationAndArea: POST /locations → ${created.status()} ${await created.text()}`,
+      )
+    }
+    locationId = (await created.json()).data.id
+  }
+
+  // Areas (flat list, location_id on each row)
+  const areasResp = await request.get(`${apiBase}/areas`, { headers })
+  const areasBody = (await areasResp.json()) as { data?: Array<{ id: string }> }
+  let areaId: string
+  if (areasBody.data && areasBody.data.length > 0) {
+    areaId = areasBody.data[0].id
+  } else {
+    const created = await request.post(`${apiBase}/areas`, {
+      headers,
+      data: {
+        data: {
+          type: 'areas',
+          attributes: { name: 'API helper area', location_id: locationId },
+        },
+      },
+    })
+    if (!created.ok()) {
+      throw new Error(
+        `ensureLocationAndArea: POST /areas → ${created.status()} ${await created.text()}`,
+      )
+    }
+    areaId = (await created.json()).data.id
+  }
+
+  return { locationId, areaId }
+}
+
+export interface CreateCommodityParams {
+  name: string
+  shortName?: string
+  type?: string
+  status?: 'in_use' | 'sold' | 'lost' | 'disposed' | 'written_off'
+  areaId: string
+  count?: number
+  originalPrice?: number
+  /** ISO-4217. Defaults to the group's main currency. */
+  currency?: string
+  draft?: boolean
+}
+
+/**
+ * POST /commodities with the same JSON:API envelope the
+ * CommodityFormDialog submits. Returns the new commodity's id.
+ *
+ * Defaults: count=1, status=in_use, type=other, originalPrice=0,
+ * currency = group's main currency. The BE enforces
+ * converted_original_price=0 when purchase currency matches main, so
+ * we pass 0 explicitly.
+ */
+export async function createCommodityViaAPI(
+  request: APIRequestContext,
+  auth: ApiAuth,
+  slug: string,
+  params: CreateCommodityParams,
+  groupMainCurrency = 'USD',
+): Promise<{ id: string; name: string }> {
+  const currency = params.currency ?? groupMainCurrency
+  const resp = await request.post(`/api/v1/g/${encodeURIComponent(slug)}/commodities`, {
+    headers: authHeaders(auth),
+    data: {
+      data: {
+        type: 'commodities',
+        attributes: {
+          name: params.name,
+          short_name: params.shortName ?? params.name.slice(-20),
+          type: params.type ?? 'other',
+          status: params.status ?? 'in_use',
+          area_id: params.areaId,
+          count: params.count ?? 1,
+          purchase_date: '2026-01-01',
+          original_price: params.originalPrice ?? 0,
+          original_price_currency: currency,
+          current_price: params.originalPrice ?? 0,
+          converted_original_price: 0,
+          draft: params.draft ?? false,
+        },
+      },
+    },
+  })
+  if (!resp.ok()) {
+    throw new Error(
+      `createCommodityViaAPI: POST /commodities → ${resp.status()} ${await resp.text()}`,
+    )
+  }
+  const body = await resp.json()
+  expect(body?.data?.id, 'createCommodityViaAPI: response missing data.id').toBeTruthy()
+  return { id: body.data.id as string, name: params.name }
+}
+
+/**
+ * DELETE a commodity by id. Best-effort cleanup — silent on 404 so
+ * test teardown doesn't blow up if a previous step already removed
+ * the row.
+ */
+export async function deleteCommodityViaAPI(
+  request: APIRequestContext,
+  auth: ApiAuth,
+  slug: string,
+  id: string,
+): Promise<void> {
+  const resp = await request.delete(
+    `/api/v1/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}`,
+    { headers: authHeaders(auth) },
+  )
+  if (resp.status() === 404) return
+  if (!resp.ok() && resp.status() !== 204) {
+    throw new Error(
+      `deleteCommodityViaAPI: DELETE /commodities/${id} → ${resp.status()} ${await resp.text()}`,
+    )
+  }
+}

--- a/frontend/src/features/commodities/api.ts
+++ b/frontend/src/features/commodities/api.ts
@@ -170,16 +170,25 @@ export async function deleteCommodity(id: string): Promise<void> {
   await http.del<void>(`/commodities/${encodeURIComponent(id)}`)
 }
 
-// Bulk delete: BE accepts `{ ids: [...] }` and returns no body on 204.
+// Bulk delete: BE binds `BulkIDsRequest` (jsonapi/bulk.go) which
+// requires the `{data:{type,attributes:{ids}}}` JSON:API envelope —
+// passing `{ids}` flat used to 422 with "missing data.attributes".
+// Discovered while writing the e2e bulk-delete round-trip in #1449.
 export async function bulkDeleteCommodities(ids: string[]): Promise<void> {
-  await http.post<void>("/commodities/bulk-delete", { ids })
+  await http.post<void>("/commodities/bulk-delete", {
+    data: { type: "commodities", attributes: { ids } },
+  })
 }
 
 // Bulk move: relocates the listed commodities to a single target area.
-// BE returns the updated rows; we don't propagate them — the optimistic
-// cache update in the hook is enough.
+// Same envelope shape as bulk-delete (BulkMoveRequest, with the
+// destination area_id under attributes). BE returns the updated rows;
+// we don't propagate them — the optimistic cache update in the hook
+// is enough.
 export async function bulkMoveCommodities(ids: string[], areaId: string): Promise<void> {
-  await http.post<void>("/commodities/bulk-move", { ids, area_id: areaId })
+  await http.post<void>("/commodities/bulk-move", {
+    data: { type: "commodities", attributes: { ids, area_id: areaId } },
+  })
 }
 
 // Returns the global / per-location / per-area value totals for the


### PR DESCRIPTION
## Summary

First chunk of #1449. Adds API-level seeding helpers + the first two real round-trip tests the issue is asking for, and fixes a production bug surfaced while authoring them.

Refs #1397. Follows up #1410 / #1411.

## What changed

### New: `e2e/tests/includes/commodities-api.ts`
Pairs with the existing UI-driven `commodities.ts` (which exercises the multi-step Add-Item dialog). The new helpers drive the BE directly via Playwright's `request` fixture so bulk / filter specs can seed two-dozen rows cheaply without re-walking the wizard.

- `extractApiAuth(page)` — reads `inventario_token` (localStorage) + `inventario_csrf_token` (sessionStorage) the React app sets after canonical `app-fixture.ts` login.
- `resolveActiveGroup(request, auth)` — returns the group's slug + main currency. The React http client rewrites `/api/v1/...` → `/api/v1/g/{slug}/...` per request; the Playwright `request` fixture skips that wrap, so callers need the slug explicitly.
- `ensureLocationAndArea(request, auth, slug)` — find or create a location/area pair. Specs don't care about the names, they need an `area_id` to point at.
- `createCommodityViaAPI(...)` — posts the same JSON:API envelope `CommodityFormDialog` submits.
- `deleteCommodityViaAPI(...)` — 404-tolerant cleanup helper.

### New: `e2e/tests/commodity-bulk-and-filter.spec.ts`
Two tests on `/commodities`:

1. **bulk-delete two seeded commodities → both gone** — seeds via API, opens the list, toggles the per-card `commodity-select` checkbox on both rows (uses the same `dispatchEvent('click')` workaround as `bulk-actions.spec.ts` for Reka's overlay-positioned CheckboxRoot), confirms the BulkActionsBar reflects the count, walks the canonical `confirm-dialog`, waits for the BE bulk-delete response, and asserts both cards are gone.
2. **type filter narrows the list + the URL reflects the active filter** — seeds one `electronics` + one `furniture` row, applies the type filter via `commodities-filter-type`, asserts the URL gains `?type=electronics`, only the electronics card stays visible, and the BE was actually re-queried (`waitForResponse` predicate keys on the URL containing `type=electronics`).

Both tests do their cleanup in a `try / finally` so a failure mid-flow doesn't leak rows.

### Drive-by FE fix: bulk-delete / bulk-move JSON:API envelope
Discovered while wiring up the e2e bulk-delete test:
- `bulkDeleteCommodities(ids)` was posting `{ ids }` flat to `/commodities/bulk-delete`.
- `bulkMoveCommodities(ids, areaId)` was posting `{ ids, area_id }` flat to `/commodities/bulk-move`.
- Both BE handlers bind `BulkIDsRequest` / `BulkMoveRequest` (`go/jsonapi/bulk.go`), whose `Bind()` rejects with "missing data.attributes" unless the body is wrapped as `{data:{type,attributes:{...}}}`.

Existing vitest cases passed because their MSW handlers don't validate the request body shape — only end-to-end runs against the real BE catch this. Fixed in `frontend/src/features/commodities/api.ts`; both calls now wrap correctly.

## Out of scope (deferred to follow-up commits / PRs)

- **Bulk-move round-trip** — needs a second area to move into, more setup.
- **Sort by `registered_date desc` round-trip** — needs commodities seeded with distinct `created_at` values.
- **Search by partial name round-trip** — straightforward but piles on with the others.

The new helpers are the foundation those follow-ups will import unchanged.

## Test plan

- [x] `npx playwright test --list tests/commodity-bulk-and-filter.spec.ts` — 6 tests discovered (2 × 3 browsers), no parse errors.
- [x] `cd frontend && npm test -- --run` — **414/414 vitest** (FE bulk-call wrap fix doesn't break unit tests because MSW handlers don't validate body shape).
- [x] `cd frontend && npm run typecheck && npm run lint` — clean.
- [ ] CI: `e2e-tests` — green on the new spec.
- [ ] CI: `frontend-test`, `frontend-lint`, `frontend-codegen-drift`, `frontend-i18n` — green.