### PR TITLE
[#1448] FE quick-attach on commodity/location detail (drag-drop + button)

### DIFF
--- a/e2e/screenshots.mjs
+++ b/e2e/screenshots.mjs
@@ -79,6 +79,123 @@ async function shoot(name, full = true) {
   console.log(`   saved ${file}`)
 }
 
+// 1×1 transparent PNG used as the upload payload for the #1448
+// quick-attach screenshots. Small + valid so the BE accepts it; the
+// thumbnail in the panel renders as a near-empty card, which is the
+// point — we want the panel state, not the file content itself.
+const TINY_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+  "base64",
+)
+
+// Capture the four #1448 quick-attach surfaces on a given entity
+// detail page (works for both commodity and location). Order:
+//
+//   <prefix>a  open Attach dialog (linkedEntity title)
+//   <prefix>b  drop overlay synthesised via dispatchEvent
+//   <prefix>c  dialog after files are queued (Step 1 → the list row)
+//   <prefix>d  panel after a successful upload (file card visible)
+//
+// `pageTestId` is the wrapper's data-testid (page-commodity-detail or
+// page-location-detail). `prefix` is the file-name prefix (e.g. "18c"
+// for commodity, "13b" for location). `entityName` is what we expect
+// to see in the dialog title (e.g. "Camping Equipment", "Home").
+async function captureQuickAttach(pageTestId, prefix, entityName) {
+  const attachBtn = page.locator('[data-testid="entity-files-panel-attach"]')
+  if ((await attachBtn.count()) === 0) {
+    console.warn(`   ${prefix}: attach button missing on ${pageTestId}; skipping`)
+    return
+  }
+
+  // Step a — dialog opened from the button. Should display
+  // "Attach files to {name}" in the title via linkedEntity.name.
+  console.log(`-> ${prefix}a: ${entityName} attach dialog`)
+  await attachBtn.click()
+  await page.waitForSelector('[data-testid="files-upload-dialog"]')
+  await settle()
+  await shoot(`${prefix}a-attach-dialog`, false)
+  await page.keyboard.press("Escape")
+  await settle(200)
+
+  // Step b — drop overlay. We hand-roll a DataTransfer in the page
+  // context and pass the JSHandle so the synthesised DragEvent
+  // carries `types: ["Files"]` (the hook gates on that).
+  console.log(`-> ${prefix}b: ${entityName} drop overlay`)
+  const dt = await page.evaluateHandle(() => {
+    const t = new DataTransfer()
+    t.items.add(new File(["x"], "evidence.png", { type: "image/png" }))
+    return t
+  })
+  await page.dispatchEvent(`[data-testid="${pageTestId}"]`, "dragenter", {
+    dataTransfer: dt,
+  })
+  try {
+    await page.waitForSelector('[data-testid="entity-drop-overlay"]', { timeout: 3000 })
+    await settle(200)
+    await shoot(`${prefix}b-drop-overlay`, false)
+  } catch {
+    console.warn(`   ${prefix}b: overlay did not appear; skipping`)
+  }
+  // Clear the drag state. dragleave decrements the counter; we
+  // only entered once so a single leave returns to "no drag".
+  await page.dispatchEvent(`[data-testid="${pageTestId}"]`, "dragleave", {
+    dataTransfer: dt,
+  })
+  await settle(200)
+
+  // Step c — dialog with files queued. We open the dialog again and
+  // feed a file through the hidden input (faster + more reliable
+  // than synthesising a real drop, which jsdom and headless Chromium
+  // both treat differently from a user gesture).
+  console.log(`-> ${prefix}c: ${entityName} dialog with file queued`)
+  await attachBtn.click()
+  await page.waitForSelector('[data-testid="files-upload-dropzone"]')
+  await page.setInputFiles('[data-testid="files-upload-input"]', {
+    name: "evidence.png",
+    mimeType: "image/png",
+    buffer: TINY_PNG,
+  })
+  try {
+    await page.waitForSelector('[data-testid="files-upload-list"]', { timeout: 3000 })
+    await settle(200)
+    await shoot(`${prefix}c-dialog-queued`, false)
+  } catch {
+    console.warn(`   ${prefix}c: file did not queue; skipping`)
+    await page.keyboard.press("Escape")
+    return
+  }
+
+  // Step d — run the full upload flow and capture the panel after
+  // the dialog closes. Sequence: Next → metadata → Upload → wait
+  // done → Close. Real multipart POST hits /api/v1/.../uploads/file
+  // and the linkage PUT hits /api/v1/.../files/{id}; the file ends
+  // up in the binary's uploadLocation (default ./bin/uploads/).
+  console.log(`-> ${prefix}d: ${entityName} panel after upload`)
+  try {
+    await page.click('[data-testid="files-upload-next"]')
+    await page.waitForSelector('[data-testid="files-upload-metadata-list"]', { timeout: 3000 })
+    await page.click('[data-testid="files-upload-start"]')
+    await page.waitForSelector(
+      '[data-testid^="files-upload-progress-item-"][data-status="done"]',
+      { timeout: 15000 },
+    )
+    const closeBtn = page.locator('[data-testid="files-upload-close"]')
+    await closeBtn.waitFor({ timeout: 5000 })
+    await closeBtn.click()
+    // Wait for the panel to refetch (invalidate.all() fires after
+    // the batch finishes) and surface the new file card.
+    await page.waitForSelector('[data-testid="entity-files-panel-grid"]', { timeout: 8000 })
+    await settle(400)
+    await shoot(`${prefix}d-panel-after-upload`)
+  } catch (err) {
+    console.warn(`   ${prefix}d: upload flow failed (${err.message}); skipping`)
+    // Try to dismiss any lingering dialog so the rest of the run
+    // doesn't get stuck.
+    await page.keyboard.press("Escape").catch(() => {})
+    await settle(200)
+  }
+}
+
 // Resolve the active group slug from the URL after login. The router
 // redirects "/" to "/g/<first-slug>/" so we can read the slug straight
 // off the post-login URL — but if the user lands on "/no-group" we
@@ -148,6 +265,19 @@ try {
         await page.goto(`${BASE_URL}${href}`, { waitUntil: "domcontentloaded" })
         await settle()
         await shoot("13-location-detail")
+
+        // #1448 quick-attach surfaces on the location detail page.
+        // Use the visible heading text as the entityName (we don't
+        // need to read it back — the dialog title we'll capture
+        // displays the same string the user sees).
+        const locationName =
+          (await page.locator("h1").first().textContent())?.trim() ?? "this location"
+        await captureQuickAttach("page-location-detail", "13q", locationName)
+        // captureQuickAttach navigates within the same page; the
+        // post-upload state leaves the panel showing the new file
+        // card, so the 14-area-detail probe below still works (it
+        // only navigates to a different URL).
+
         // Drill again into the first area on the detail page if any.
         const areaRow = page.locator('[data-testid="location-detail-area"] a').first()
         if ((await areaRow.count()) > 0) {
@@ -235,6 +365,15 @@ try {
           } catch {
             console.warn("   commodity Files tab did not surface the panel in time")
           }
+
+          // #1448 quick-attach surfaces on the commodity detail page.
+          // The Attach button + dropzone live on the Files tab, so
+          // run this after the tab click. The commodity heading text
+          // doubles as the entityName — same string surfaces in the
+          // dialog title via linkedEntity.name.
+          const commodityName =
+            (await page.locator("h1").first().textContent())?.trim() ?? "this item"
+          await captureQuickAttach("page-commodity-detail", "18q", commodityName)
         }
 
         // Print page.

--- a/e2e/screenshots.mjs
+++ b/e2e/screenshots.mjs
@@ -395,6 +395,123 @@ try {
   await page.goto(`${BASE_URL}/settings`, { waitUntil: "domcontentloaded" })
   await settle()
   await shoot("21-settings")
+
+  // Global Files page (#1411): list + 5 category tiles + Upload
+  // dialog three-step flow + file detail sheet + file edit page +
+  // category-filtered list. After the entity captures above this
+  // page already has a couple of files in it (one attached to a
+  // commodity, one to a location), so the empty-state shot doesn't
+  // apply here — we lean on the entity-detail panel shots
+  // (13-location-detail, 18b-commodity-detail-files) for the empty
+  // surface and skip a 30-files-empty shot.
+  // Fall back to the captured `slug` from after-login: by this
+  // point in the run we've navigated to /settings (no group prefix
+  // in the URL), so slugFromUrl() returns null on its own.
+  const slugForFiles = slugFromUrl() ?? slug
+  if (slugForFiles) {
+    console.log(`-> /g/${slugForFiles}/files`)
+    await page.goto(`${BASE_URL}/g/${slugForFiles}/files`, {
+      waitUntil: "domcontentloaded",
+    })
+    await settle()
+    await shoot("30-files-list")
+
+    // Step 31 — open the global Upload dialog (no linked entity, so
+    // the title reads "Upload files" instead of "Attach files to …").
+    const uploadCta = page.locator('[data-testid="files-upload-cta"]').first()
+    if ((await uploadCta.count()) > 0) {
+      try {
+        await uploadCta.click()
+        await page.waitForSelector('[data-testid="files-upload-dialog"]', {
+          timeout: 5000,
+        })
+        await settle()
+        await shoot("31-files-upload-step1", false)
+
+        // Feed a file through the hidden input, advance to step 2.
+        await page.setInputFiles('[data-testid="files-upload-input"]', {
+          name: "screenshot-fixture.png",
+          mimeType: "image/png",
+          buffer: TINY_PNG,
+        })
+        await page.waitForSelector('[data-testid="files-upload-list"]', { timeout: 3000 })
+        await page.click('[data-testid="files-upload-next"]')
+        await page.waitForSelector('[data-testid="files-upload-metadata-list"]', {
+          timeout: 3000,
+        })
+        await settle(200)
+        await shoot("32-files-upload-step2-metadata", false)
+
+        // Step 3 — kick off the upload, capture mid/post-progress.
+        await page.click('[data-testid="files-upload-start"]')
+        // Wait for the progress bar to render so the shot has its
+        // bar visible; one-file uploads finish near-instantly so by
+        // the time we screenshot the bar is full and "Close" enabled.
+        await page.waitForSelector('[data-testid="files-upload-progress"]', {
+          timeout: 3000,
+        })
+        await page.waitForSelector(
+          '[data-testid^="files-upload-progress-item-"][data-status="done"]',
+          { timeout: 15000 },
+        )
+        await settle(200)
+        await shoot("33-files-upload-step3-progress", false)
+
+        // Close the dialog → list refetches → 34 captures the new
+        // tile counts + grid card for the just-uploaded file.
+        await page.click('[data-testid="files-upload-close"]')
+        await page.waitForSelector('[data-testid="files-grid"]', { timeout: 5000 })
+        await settle(400)
+        await shoot("34-files-populated")
+      } catch (err) {
+        console.warn(`   files upload flow failed (${err.message}); skipping 31-34`)
+        await page.keyboard.press("Escape").catch(() => {})
+        await settle(200)
+      }
+    } else {
+      console.warn("   files-upload-cta missing; skipping 31-34")
+    }
+
+    // Step 35 — click the first file card to open the detail sheet
+    // (deep-links to /files/:id and renders FileDetailSheet).
+    const firstFileCard = page.locator('[data-testid^="file-card-open-"]').first()
+    if ((await firstFileCard.count()) > 0) {
+      try {
+        await firstFileCard.click()
+        await page.waitForSelector('[data-testid="file-detail-sheet"]', { timeout: 5000 })
+        await settle(300)
+        await shoot("35-file-detail-sheet")
+
+        // Step 36 — Edit metadata navigates to /files/:id/edit.
+        const editBtn = page.locator('[data-testid="file-detail-edit"]')
+        if ((await editBtn.count()) > 0) {
+          await editBtn.click()
+          // FileEditPage renders the same h1 "Edit file" + form;
+          // wait for the page to swap before screenshotting.
+          await page.waitForURL((u) => /\/files\/[^/]+\/edit$/.test(u.toString()), {
+            timeout: 5000,
+          })
+          await settle(300)
+          await shoot("36-file-edit")
+        }
+      } catch (err) {
+        console.warn(`   file detail/edit flow failed (${err.message}); skipping 35-36`)
+      }
+    }
+
+    // Step 37 — invoices-filtered list (likely empty since the
+    // fixture file landed under "photos"; the empty-filtered card
+    // is itself a meaningful state worth capturing).
+    try {
+      await page.goto(`${BASE_URL}/g/${slugForFiles}/files?category=invoices`, {
+        waitUntil: "domcontentloaded",
+      })
+      await settle()
+      await shoot("37-files-filtered-invoices")
+    } catch (err) {
+      console.warn(`   filtered-invoices shot failed (${err.message}); skipping`)
+    }
+  }
 } catch (err) {
   console.error("Screenshot run failed:", err)
   process.exitCode = 1

--- a/frontend/src/components/files/DropOverlay.tsx
+++ b/frontend/src/components/files/DropOverlay.tsx
@@ -1,0 +1,27 @@
+import { Upload } from "lucide-react"
+
+export interface DropOverlayProps {
+  label: string
+  hint?: string
+}
+
+// Visual cue rendered above the entity-detail page while the user
+// drags files over it (#1448 quick-attach). pointer-events-none so the
+// overlay never intercepts the drop event itself — the browser
+// dispatches drop to the topmost element that handled dragover, which
+// is the wrapper around this overlay, not the overlay.
+export function DropOverlay({ label, hint }: DropOverlayProps) {
+  return (
+    <div
+      role="presentation"
+      data-testid="entity-drop-overlay"
+      className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center rounded-md border-2 border-dashed border-primary bg-primary/10 backdrop-blur-sm"
+    >
+      <div className="flex flex-col items-center gap-2 text-primary">
+        <Upload className="size-8" aria-hidden="true" />
+        <p className="text-sm font-medium">{label}</p>
+        {hint ? <p className="text-xs text-primary/80">{hint}</p> : null}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/files/EntityFilesPanel.tsx
+++ b/frontend/src/components/files/EntityFilesPanel.tsx
@@ -1,32 +1,36 @@
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
+import { Upload } from "lucide-react"
 
 import { FileCard } from "@/components/files/FileCard"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useFiles } from "@/features/files/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 
-// Read-only Files panel for entity-detail pages (commodity / location).
-// Replaces the legacy `<ComingSoonBanner surface="filesUnification" />`
-// placeholder by rendering files attached to the given linked entity
-// via the unified `GET /files?linked_entity_type=…&linked_entity_id=…`
-// endpoint introduced for #1411 AC #4.
+// Files panel for entity-detail pages (commodity / location). Renders
+// files attached to the given linked entity via the unified
+// `GET /files?linked_entity_type=…&linked_entity_id=…` endpoint
+// introduced for #1411 AC #4.
 //
 // Click on a card deep-links to `/files/:id` which mounts the same
 // FileDetailSheet the main /files page uses, so detail / download /
 // edit / delete all reuse the validated path.
 //
-// No "Add files" CTA: a button that linked to the global /files
-// upload would create an orphan file (no linked_entity_*) which would
-// then NOT show up here — confusing UX. The proper affordance is
-// drag-drop on the entity detail with the linked_entity_* preselected,
-// which is the explicit scope of #1448.
+// `onAttachClick` (#1448): when provided, renders an "Attach files"
+// button in the header that opens an upload affordance with this
+// entity's linkage preselected. Without it, the panel stays read-only
+// — a generic "Add files" CTA would link to the global upload and
+// create an orphan file (no linked_entity_*), which would NOT show
+// up here. The detail page owns the dialog state because it also
+// hosts the page-level drag-drop catcher.
 export interface EntityFilesPanelProps {
   linkedEntityType: "commodity" | "location"
   linkedEntityId: string
   pageSize?: number
+  onAttachClick?: () => void
 }
 
 const DEFAULT_PAGE_SIZE = 24
@@ -35,6 +39,7 @@ export function EntityFilesPanel({
   linkedEntityType,
   linkedEntityId,
   pageSize = DEFAULT_PAGE_SIZE,
+  onAttachClick,
 }: EntityFilesPanelProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -62,9 +67,26 @@ export function EntityFilesPanel({
 
   return (
     <Card data-testid="entity-files-panel">
-      <CardHeader>
-        <CardTitle className="text-base">{t("files:entityPanel.title")}</CardTitle>
-        <CardDescription>{t("files:entityPanel.description", { count: total })}</CardDescription>
+      <CardHeader className="flex flex-row items-start justify-between gap-3">
+        <div className="min-w-0">
+          <CardTitle className="text-base">{t("files:entityPanel.title")}</CardTitle>
+          <CardDescription>
+            {t("files:entityPanel.description", { count: total })}
+          </CardDescription>
+        </div>
+        {onAttachClick ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onAttachClick}
+            data-testid="entity-files-panel-attach"
+            className="gap-1.5 shrink-0"
+          >
+            <Upload className="size-3.5" aria-hidden="true" />
+            {t("files:entityPanel.attach")}
+          </Button>
+        ) : null}
       </CardHeader>
       <CardContent>
         {filesQuery.isError ? (

--- a/frontend/src/components/files/EntityFilesPanel.tsx
+++ b/frontend/src/components/files/EntityFilesPanel.tsx
@@ -70,9 +70,7 @@ export function EntityFilesPanel({
       <CardHeader className="flex flex-row items-start justify-between gap-3">
         <div className="min-w-0">
           <CardTitle className="text-base">{t("files:entityPanel.title")}</CardTitle>
-          <CardDescription>
-            {t("files:entityPanel.description", { count: total })}
-          </CardDescription>
+          <CardDescription>{t("files:entityPanel.description", { count: total })}</CardDescription>
         </div>
         {onAttachClick ? (
           <Button

--- a/frontend/src/components/files/UploadFilesDialog.tsx
+++ b/frontend/src/components/files/UploadFilesDialog.tsx
@@ -40,12 +40,34 @@ interface FileItem {
 // Cache invalidation is deferred until the batch finishes — `useUploadFile`
 // no longer auto-invalidates per-mutation, so a 20-file upload doesn't
 // trigger 20 list/counts refetches while the dialog is still open.
+//
+// `linkedEntity` (#1448) preselects a commodity / location as the parent
+// of every uploaded file: after the multipart POST returns the new file
+// id, we PUT /files/{id} with `linked_entity_type` + `linked_entity_id`
+// so the file is attached, not orphaned. Linking failure marks the
+// item as failed (since the user's intent was "attach"); a metadata-
+// only failure when not linking stays non-fatal.
+//
+// `initialFiles` lets the page-level drop catcher pre-queue files into
+// the dialog so the user doesn't have to drop again — the dialog opens
+// in the select step with files already listed.
 export interface UploadFilesDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  linkedEntity?: {
+    type: "commodity" | "location"
+    id: string
+    name?: string
+  }
+  initialFiles?: File[]
 }
 
-export function UploadFilesDialog({ open, onOpenChange }: UploadFilesDialogProps) {
+export function UploadFilesDialog({
+  open,
+  onOpenChange,
+  linkedEntity,
+  initialFiles,
+}: UploadFilesDialogProps) {
   const { t } = useTranslation()
   const toast = useAppToast()
   const upload = useUploadFile()
@@ -63,6 +85,26 @@ export function UploadFilesDialog({ open, onOpenChange }: UploadFilesDialogProps
   useEffect(() => {
     if (!open) reset()
   }, [open, reset])
+
+  // Pre-queue files passed in by the page-level drop catcher. We seed
+  // once per `open` transition so a re-render with the same array does
+  // not duplicate items. The effect intentionally depends on `open`
+  // and the array identity — callers should pass a stable array (state)
+  // for the lifetime of the dialog, not a fresh `[...]` on every render.
+  useEffect(() => {
+    if (!open) return
+    if (!initialFiles?.length) return
+    setItems((prev) => {
+      if (prev.length > 0) return prev
+      return initialFiles.map((f) => ({
+        id: `${f.name}-${f.size}-${f.lastModified}-${Math.random().toString(36).slice(2, 8)}`,
+        file: f,
+        title: defaultTitle(f.name),
+        category: categoryFromMime(f.type),
+        status: "pending",
+      }))
+    })
+  }, [open, initialFiles])
 
   function defaultTitle(name: string): string {
     const lastDot = name.lastIndexOf(".")
@@ -117,17 +159,41 @@ export function UploadFilesDialog({ open, onOpenChange }: UploadFilesDialogProps
         const result = await upload.mutateAsync(item.file)
         // Apply per-file metadata overrides only if they differ from
         // the BE-derived defaults — avoids a no-op PUT for the common
-        // "user accepted defaults" path.
+        // "user accepted defaults" path. When `linkedEntity` is set,
+        // we ALWAYS PUT to attach the file (the BE upload endpoint
+        // does not read linked_entity_* off the multipart form), so
+        // the file becomes a child of the commodity / location instead
+        // of an orphan.
         const titleChanged = item.title !== defaultTitle(item.file.name)
         const categoryChanged = item.category !== result.file.category
-        if (titleChanged || categoryChanged) {
+        const needsLinking = !!linkedEntity
+        if (titleChanged || categoryChanged || needsLinking) {
           try {
             await updateFile(result.file.id, {
               title: item.title,
               category: item.category,
+              ...(linkedEntity
+                ? {
+                    linked_entity_type: linkedEntity.type,
+                    linked_entity_id: linkedEntity.id,
+                  }
+                : {}),
             })
-          } catch {
-            // Metadata update failure is non-fatal — the file is on
+          } catch (err) {
+            if (needsLinking) {
+              // Linking is the user's stated intent ("attach files to
+              // this commodity"). If it fails the file ended up as
+              // an orphan on disk — surface that as a per-item failure
+              // so the user can retry from the global Files page
+              // instead of silently believing the attach worked.
+              failed++
+              patchItem(item.id, {
+                status: "failed",
+                error: err instanceof Error ? err.message : String(err),
+              })
+              continue
+            }
+            // Metadata-only failure (no linking requested): file is on
             // disk; the user can edit it from the detail sheet later.
           }
         }
@@ -159,7 +225,13 @@ export function UploadFilesDialog({ open, onOpenChange }: UploadFilesDialogProps
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[80vh] sm:max-w-2xl" data-testid="files-upload-dialog">
         <DialogHeader>
-          <DialogTitle>{t("files:upload.title")}</DialogTitle>
+          <DialogTitle>
+            {linkedEntity?.name
+              ? t("files:upload.attachTitleWithName", { name: linkedEntity.name })
+              : linkedEntity
+                ? t("files:upload.attachTitle")
+                : t("files:upload.title")}
+          </DialogTitle>
           <DialogDescription>
             {step === "select"
               ? t("files:upload.step1DropHint")

--- a/frontend/src/components/files/__tests__/EntityFilesPanel.test.tsx
+++ b/frontend/src/components/files/__tests__/EntityFilesPanel.test.tsx
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { Route } from "react-router-dom"
 import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { axe } from "jest-axe"
 
 import { EntityFilesPanel } from "@/components/files/EntityFilesPanel"
@@ -20,7 +21,10 @@ const groupFixture: Schema<"models.LocationGroup">[] = [
   { id: "g1", slug: SLUG, name: "Household", main_currency: "USD" },
 ]
 
-function renderPanel(linkedEntityType: "commodity" | "location" = "commodity") {
+function renderPanel(
+  linkedEntityType: "commodity" | "location" = "commodity",
+  options: { onAttachClick?: () => void } = {}
+) {
   setAccessToken("good-token")
   return renderWithProviders({
     initialPath: `/g/${SLUG}/commodities/${COMMODITY}`,
@@ -29,7 +33,11 @@ function renderPanel(linkedEntityType: "commodity" | "location" = "commodity") {
         path="/g/:groupSlug/commodities/:id"
         element={
           <GroupProvider>
-            <EntityFilesPanel linkedEntityType={linkedEntityType} linkedEntityId={COMMODITY} />
+            <EntityFilesPanel
+              linkedEntityType={linkedEntityType}
+              linkedEntityId={COMMODITY}
+              onAttachClick={options.onAttachClick}
+            />
           </GroupProvider>
         }
       />
@@ -95,6 +103,23 @@ describe("<EntityFilesPanel />", () => {
     server.use(...groupHandlers.list(groupFixture), ...fileHandlers.error(SLUG, 500))
     renderPanel()
     await waitFor(() => expect(screen.getByTestId("entity-files-panel-error")).toBeInTheDocument())
+  })
+
+  it("hides the Attach files button when onAttachClick is not provided", async () => {
+    server.use(...groupHandlers.list(groupFixture), ...fileHandlers.list(SLUG, []))
+    renderPanel()
+    await waitFor(() => expect(screen.getByTestId("entity-files-panel-empty")).toBeInTheDocument())
+    expect(screen.queryByTestId("entity-files-panel-attach")).not.toBeInTheDocument()
+  })
+
+  it("renders the Attach files button and fires onAttachClick when clicked", async () => {
+    const user = userEvent.setup()
+    const onAttachClick = vi.fn()
+    server.use(...groupHandlers.list(groupFixture), ...fileHandlers.list(SLUG, []))
+    renderPanel("commodity", { onAttachClick })
+    const btn = await screen.findByTestId("entity-files-panel-attach")
+    await user.click(btn)
+    expect(onAttachClick).toHaveBeenCalledTimes(1)
   })
 
   it("is axe-clean in the populated state", async () => {

--- a/frontend/src/components/files/__tests__/UploadFilesDialog.test.tsx
+++ b/frontend/src/components/files/__tests__/UploadFilesDialog.test.tsx
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it } from "vitest"
+import { http, HttpResponse } from "msw"
 import { Route } from "react-router-dom"
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import { UploadFilesDialog } from "@/components/files/UploadFilesDialog"
+import type { UploadFilesDialogProps } from "@/components/files/UploadFilesDialog"
 import { GroupProvider } from "@/features/group/GroupContext"
 import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
-import { groupHandlers } from "@/test/handlers"
+import { apiUrl, fileHandlers, groupHandlers } from "@/test/handlers"
 import { setAccessToken, clearAuth } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
@@ -18,7 +20,9 @@ const groupFixture: Schema<"models.LocationGroup">[] = [
   { id: "g1", slug: SLUG, name: "Household", main_currency: "USD" },
 ]
 
-function renderDialog() {
+function renderDialog(
+  props: Partial<Omit<UploadFilesDialogProps, "open" | "onOpenChange">> = {}
+) {
   setAccessToken("good-token")
   return renderWithProviders({
     initialPath: `/g/${SLUG}/files`,
@@ -27,7 +31,7 @@ function renderDialog() {
         path="/g/:groupSlug/files"
         element={
           <GroupProvider>
-            <UploadFilesDialog open onOpenChange={() => {}} />
+            <UploadFilesDialog open onOpenChange={() => {}} {...props} />
           </GroupProvider>
         }
       />
@@ -101,6 +105,117 @@ describe("<UploadFilesDialog />", () => {
     expect(all[0].value).toBe("photos")
     expect(all[1].value).toBe("documents")
     expect(all[2].value).toBe("other")
+  })
+
+  it("seeds initialFiles from the page-level drop catcher and enables Next immediately", async () => {
+    server.use(...groupHandlers.list(groupFixture))
+    const dropped = [
+      new File(["x"], "from-page.png", { type: "image/png" }),
+      new File(["y"], "also.pdf", { type: "application/pdf" }),
+    ]
+    renderDialog({ initialFiles: dropped })
+    expect(await screen.findByText("from-page.png")).toBeInTheDocument()
+    expect(screen.getByText("also.pdf")).toBeInTheDocument()
+    expect(screen.getByTestId("files-upload-next")).not.toBeDisabled()
+  })
+
+  it("renders the linked-entity title when linkedEntity.name is provided", async () => {
+    server.use(...groupHandlers.list(groupFixture))
+    renderDialog({
+      linkedEntity: { type: "commodity", id: "com-9", name: "Vintage camera" },
+    })
+    expect(
+      await screen.findByRole("heading", { name: /attach files to vintage camera/i })
+    ).toBeInTheDocument()
+  })
+
+  it("PUTs linked_entity_* on every successful upload when linkedEntity is set", async () => {
+    const updateBodies: Array<Record<string, unknown>> = []
+    let capacityRequests = 0
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      // Upload slot check returns can_start_upload=true; the dialog
+      // gates startUpload behind this.
+      http.get(apiUrl(`/g/${SLUG}/upload-slots/check`), () => {
+        capacityRequests++
+        return HttpResponse.json({
+          data: {
+            attributes: {
+              operation_name: "files-upload",
+              active_uploads: 0,
+              max_uploads: 4,
+              available_uploads: 4,
+              can_start_upload: true,
+            },
+          },
+        })
+      }),
+      ...fileHandlers.upload(SLUG, {
+        title: "from-drop",
+        category: "photos",
+        mime_type: "image/png",
+      }),
+      http.put(apiUrl(`/g/${SLUG}/files/uploaded-1`), async ({ request }) => {
+        const body = (await request.json()) as { data?: { attributes?: Record<string, unknown> } }
+        updateBodies.push(body.data?.attributes ?? {})
+        return HttpResponse.json({
+          id: "uploaded-1",
+          type: "files",
+          attributes: body.data?.attributes ?? {},
+        })
+      })
+    )
+    const user = userEvent.setup()
+    const dropped = [new File(["x"], "from-drop.png", { type: "image/png" })]
+    renderDialog({
+      initialFiles: dropped,
+      linkedEntity: { type: "commodity", id: "com-9", name: "Camera" },
+    })
+    await screen.findByText("from-drop.png")
+    await user.click(screen.getByTestId("files-upload-next"))
+    await screen.findByTestId("files-upload-metadata-list")
+    await user.click(screen.getByTestId("files-upload-start"))
+    await waitFor(() => expect(screen.getByTestId("files-upload-progress")).toBeInTheDocument())
+    await waitFor(() => expect(updateBodies).toHaveLength(1))
+    expect(capacityRequests).toBeGreaterThanOrEqual(1)
+    const attrs = updateBodies[0]
+    expect(attrs.linked_entity_type).toBe("commodity")
+    expect(attrs.linked_entity_id).toBe("com-9")
+  })
+
+  it("marks an item as failed when the linkage PUT fails (orphan would otherwise be silent)", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      http.get(apiUrl(`/g/${SLUG}/upload-slots/check`), () =>
+        HttpResponse.json({
+          data: {
+            attributes: {
+              operation_name: "files-upload",
+              active_uploads: 0,
+              max_uploads: 4,
+              available_uploads: 4,
+              can_start_upload: true,
+            },
+          },
+        })
+      ),
+      ...fileHandlers.upload(SLUG, { title: "x", category: "photos" }),
+      http.put(apiUrl(`/g/${SLUG}/files/uploaded-1`), () =>
+        HttpResponse.json({ error: "linkage rejected" }, { status: 422 })
+      )
+    )
+    const user = userEvent.setup()
+    renderDialog({
+      initialFiles: [new File(["x"], "fail.png", { type: "image/png" })],
+      linkedEntity: { type: "commodity", id: "com-9" },
+    })
+    await screen.findByText("fail.png")
+    await user.click(screen.getByTestId("files-upload-next"))
+    await user.click(screen.getByTestId("files-upload-start"))
+    await waitFor(() => {
+      const progressItems = screen.getAllByTestId(/files-upload-progress-item-/)
+      expect(progressItems[0].getAttribute("data-status")).toBe("failed")
+    })
   })
 
   it("removes a queued file via the per-row remove button", async () => {

--- a/frontend/src/components/files/__tests__/UploadFilesDialog.test.tsx
+++ b/frontend/src/components/files/__tests__/UploadFilesDialog.test.tsx
@@ -20,9 +20,7 @@ const groupFixture: Schema<"models.LocationGroup">[] = [
   { id: "g1", slug: SLUG, name: "Household", main_currency: "USD" },
 ]
 
-function renderDialog(
-  props: Partial<Omit<UploadFilesDialogProps, "open" | "onOpenChange">> = {}
-) {
+function renderDialog(props: Partial<Omit<UploadFilesDialogProps, "open" | "onOpenChange">> = {}) {
   setAccessToken("good-token")
   return renderWithProviders({
     initialPath: `/g/${SLUG}/files`,

--- a/frontend/src/components/files/__tests__/useFileDropZone.test.tsx
+++ b/frontend/src/components/files/__tests__/useFileDropZone.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+
+import { DropOverlay } from "@/components/files/DropOverlay"
+import { useFileDropZone } from "@/components/files/useFileDropZone"
+
+interface HarnessProps {
+  onFiles: (files: File[]) => void
+  disabled?: boolean
+}
+
+// Tiny harness component that exercises the public surface of the
+// hook (bindProps + isDragging) so the test reads as a real consumer
+// would use it. Keeps us out of the renderHook-with-context weeds for
+// what is a pure DOM-event hook.
+function Harness({ onFiles, disabled }: HarnessProps) {
+  const dropZone = useFileDropZone({ onFiles, disabled })
+  return (
+    <div
+      data-testid="zone"
+      style={{ position: "relative", width: 200, height: 200 }}
+      {...dropZone.bindProps}
+    >
+      {dropZone.isDragging ? <DropOverlay label="Drop here" /> : null}
+      <span data-testid="dragging-flag">{dropZone.isDragging ? "yes" : "no"}</span>
+      <div data-testid="child" />
+    </div>
+  )
+}
+
+// jsdom's DataTransfer is incomplete (no constructor, no files setter).
+// We hand-roll an event-init payload that mirrors the parts the hook
+// actually reads: `types` (must include "Files" to count as a file
+// drag), `files`, and `dropEffect` (write target).
+function fileDragInit(files: File[] = [], includeFilesType = true): EventInit {
+  const types = includeFilesType ? ["Files"] : ["text/plain"]
+  return {
+    bubbles: true,
+    cancelable: true,
+    // @ts-expect-error — partial DataTransfer is what the hook needs.
+    dataTransfer: {
+      types,
+      files,
+      dropEffect: "none",
+    },
+  }
+}
+
+describe("useFileDropZone", () => {
+  it("flips isDragging on dragenter and renders the overlay", () => {
+    render(<Harness onFiles={() => {}} />)
+    const zone = screen.getByTestId("zone")
+
+    expect(screen.getByTestId("dragging-flag").textContent).toBe("no")
+    expect(screen.queryByTestId("entity-drop-overlay")).not.toBeInTheDocument()
+
+    fireEvent.dragEnter(zone, fileDragInit([new File(["x"], "a.png", { type: "image/png" })]))
+
+    expect(screen.getByTestId("dragging-flag").textContent).toBe("yes")
+    expect(screen.getByTestId("entity-drop-overlay")).toBeInTheDocument()
+  })
+
+  it("ignores non-file drags (text/url payloads) and never highlights", () => {
+    const onFiles = vi.fn()
+    render(<Harness onFiles={onFiles} />)
+    const zone = screen.getByTestId("zone")
+
+    fireEvent.dragEnter(zone, fileDragInit([], false))
+    fireEvent.dragOver(zone, fileDragInit([], false))
+    fireEvent.drop(zone, fileDragInit([], false))
+
+    expect(screen.getByTestId("dragging-flag").textContent).toBe("no")
+    expect(onFiles).not.toHaveBeenCalled()
+  })
+
+  it("calls onFiles with the dropped File[] and clears the dragging state", () => {
+    const onFiles = vi.fn()
+    render(<Harness onFiles={onFiles} />)
+    const zone = screen.getByTestId("zone")
+
+    const f1 = new File(["a"], "a.png", { type: "image/png" })
+    const f2 = new File(["b"], "b.pdf", { type: "application/pdf" })
+
+    fireEvent.dragEnter(zone, fileDragInit([f1, f2]))
+    expect(screen.getByTestId("dragging-flag").textContent).toBe("yes")
+
+    fireEvent.drop(zone, fileDragInit([f1, f2]))
+    expect(onFiles).toHaveBeenCalledTimes(1)
+    expect(onFiles.mock.calls[0][0]).toHaveLength(2)
+    expect(onFiles.mock.calls[0][0][0].name).toBe("a.png")
+    expect(onFiles.mock.calls[0][0][1].name).toBe("b.pdf")
+    expect(screen.getByTestId("dragging-flag").textContent).toBe("no")
+  })
+
+  it("uses a counter so dragging stays true while the cursor crosses children", () => {
+    render(<Harness onFiles={() => {}} />)
+    const zone = screen.getByTestId("zone")
+    const child = screen.getByTestId("child")
+    const init = () => fileDragInit([new File(["x"], "a.png", { type: "image/png" })])
+
+    fireEvent.dragEnter(zone, init())
+    fireEvent.dragEnter(child, init())
+    fireEvent.dragLeave(zone, init())
+    // One enter still outstanding — overlay should still be visible.
+    expect(screen.getByTestId("dragging-flag").textContent).toBe("yes")
+    fireEvent.dragLeave(child, init())
+    expect(screen.getByTestId("dragging-flag").textContent).toBe("no")
+  })
+
+  it("no-ops when disabled — drops are not consumed and onFiles is not called", () => {
+    const onFiles = vi.fn()
+    render(<Harness onFiles={onFiles} disabled />)
+    const zone = screen.getByTestId("zone")
+
+    fireEvent.dragEnter(zone, fileDragInit([new File(["x"], "a.png", { type: "image/png" })]))
+    fireEvent.drop(zone, fileDragInit([new File(["x"], "a.png", { type: "image/png" })]))
+
+    expect(screen.getByTestId("dragging-flag").textContent).toBe("no")
+    expect(onFiles).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/files/__tests__/useFileDropZone.test.tsx
+++ b/frontend/src/components/files/__tests__/useFileDropZone.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { fireEvent, render, screen } from "@testing-library/react"
+import { createEvent, fireEvent, render, screen } from "@testing-library/react"
 
 import { DropOverlay } from "@/components/files/DropOverlay"
 import { useFileDropZone } from "@/components/files/useFileDropZone"
@@ -115,6 +115,32 @@ describe("useFileDropZone", () => {
     fireEvent.dragEnter(zone, fileDragInit([new File(["x"], "a.png", { type: "image/png" })]))
     fireEvent.drop(zone, fileDragInit([new File(["x"], "a.png", { type: "image/png" })]))
 
+    expect(screen.getByTestId("dragging-flag").textContent).toBe("no")
+    expect(onFiles).not.toHaveBeenCalled()
+  })
+
+  it("still preventDefaults file drops while disabled (avoid browser navigate-to-file)", () => {
+    const onFiles = vi.fn()
+    render(<Harness onFiles={onFiles} disabled />)
+    const zone = screen.getByTestId("zone")
+    const file = new File(["x"], "a.png", { type: "image/png" })
+
+    // createEvent + fireEvent so we can read defaultPrevented after
+    // dispatch — otherwise fireEvent.drop returns whether the
+    // listener cancelled, which is also informative but brittle.
+    const enter = createEvent.dragEnter(zone, fileDragInit([file]))
+    fireEvent(zone, enter)
+    expect(enter.defaultPrevented).toBe(true)
+
+    const over = createEvent.dragOver(zone, fileDragInit([file]))
+    fireEvent(zone, over)
+    expect(over.defaultPrevented).toBe(true)
+
+    const drop = createEvent.drop(zone, fileDragInit([file]))
+    fireEvent(zone, drop)
+    expect(drop.defaultPrevented).toBe(true)
+
+    // Still no state flip + no callback.
     expect(screen.getByTestId("dragging-flag").textContent).toBe("no")
     expect(onFiles).not.toHaveBeenCalled()
   })

--- a/frontend/src/components/files/useFileDropZone.ts
+++ b/frontend/src/components/files/useFileDropZone.ts
@@ -42,9 +42,12 @@ export function useFileDropZone({
 
   const onDragEnter = useCallback(
     (e: React.DragEvent) => {
-      if (disabled) return
       if (!hasFiles(e)) return
+      // Always preventDefault on file drags, even when disabled —
+      // otherwise the browser's default navigate-to-file kicks in if
+      // a file lands on the page outside the dialog's own dropzone.
       e.preventDefault()
+      if (disabled) return
       counterRef.current += 1
       setIsDragging(true)
     },
@@ -53,9 +56,15 @@ export function useFileDropZone({
 
   const onDragOver = useCallback(
     (e: React.DragEvent) => {
-      if (disabled) return
       if (!hasFiles(e)) return
       e.preventDefault()
+      if (disabled) {
+        // Disabled but still file-drag — tell the browser "no drop"
+        // so the cursor reflects reality and the default navigation
+        // won't fire on the upcoming drop.
+        e.dataTransfer.dropEffect = "none"
+        return
+      }
       // Without dropEffect="copy" the browser falls back to the
       // no-drop cursor on some platforms even when the wrapper has a
       // valid drop handler.
@@ -76,9 +85,12 @@ export function useFileDropZone({
 
   const onDrop = useCallback(
     (e: React.DragEvent) => {
-      if (disabled) return
       if (!hasFiles(e)) return
+      // Same reason as dragenter/over: swallow the drop even when
+      // disabled so the browser doesn't navigate the tab to the
+      // dropped file. Just skip state updates + onFiles.
       e.preventDefault()
+      if (disabled) return
       counterRef.current = 0
       setIsDragging(false)
       const files = Array.from(e.dataTransfer.files ?? [])

--- a/frontend/src/components/files/useFileDropZone.ts
+++ b/frontend/src/components/files/useFileDropZone.ts
@@ -1,0 +1,91 @@
+import { useCallback, useRef, useState } from "react"
+
+export interface UseFileDropZoneOptions {
+  onFiles: (files: File[]) => void
+  disabled?: boolean
+}
+
+export interface FileDropZoneBindProps {
+  onDragEnter: (e: React.DragEvent) => void
+  onDragOver: (e: React.DragEvent) => void
+  onDragLeave: (e: React.DragEvent) => void
+  onDrop: (e: React.DragEvent) => void
+}
+
+export interface UseFileDropZoneResult {
+  isDragging: boolean
+  bindProps: FileDropZoneBindProps
+}
+
+// Page-level file-drop zone for entity-detail pages (#1448 quick-attach).
+// Only triggers for actual file drags — text/url payloads are ignored
+// so dragging a hyperlink onto the page doesn't open the upload modal.
+//
+// The dragenter/dragleave counter pattern keeps `isDragging` true
+// while the cursor crosses nested children of the drop area instead
+// of flickering off on every internal element boundary.
+export function useFileDropZone({
+  onFiles,
+  disabled,
+}: UseFileDropZoneOptions): UseFileDropZoneResult {
+  const [isDragging, setIsDragging] = useState(false)
+  const counterRef = useRef(0)
+
+  const hasFiles = (e: React.DragEvent): boolean => {
+    const types = e.dataTransfer?.types
+    if (!types) return false
+    for (let i = 0; i < types.length; i++) {
+      if (types[i] === "Files") return true
+    }
+    return false
+  }
+
+  const onDragEnter = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled) return
+      if (!hasFiles(e)) return
+      e.preventDefault()
+      counterRef.current += 1
+      setIsDragging(true)
+    },
+    [disabled]
+  )
+
+  const onDragOver = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled) return
+      if (!hasFiles(e)) return
+      e.preventDefault()
+      // Without dropEffect="copy" the browser falls back to the
+      // no-drop cursor on some platforms even when the wrapper has a
+      // valid drop handler.
+      e.dataTransfer.dropEffect = "copy"
+    },
+    [disabled]
+  )
+
+  const onDragLeave = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled) return
+      if (!hasFiles(e)) return
+      counterRef.current = Math.max(0, counterRef.current - 1)
+      if (counterRef.current === 0) setIsDragging(false)
+    },
+    [disabled]
+  )
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled) return
+      if (!hasFiles(e)) return
+      e.preventDefault()
+      counterRef.current = 0
+      setIsDragging(false)
+      const files = Array.from(e.dataTransfer.files ?? [])
+      if (files.length > 0) onFiles(files)
+    },
+    [disabled, onFiles]
+  )
+
+  return { isDragging, bindProps: { onDragEnter, onDragOver, onDragLeave, onDrop } }
+}

--- a/frontend/src/i18n/locales/en/files.json
+++ b/frontend/src/i18n/locales/en/files.json
@@ -68,8 +68,12 @@
     "uploadCta": "Upload your first file"
   },
   "entityPanel": {
+    "attach": "Attach files",
     "description_one": "{{count}} file attached",
     "description_other": "{{count}} files attached",
+    "dropHint": "Release to attach",
+    "dropOverlay_commodity": "Drop files to attach to this item",
+    "dropOverlay_location": "Drop files to attach to this location",
     "empty": "No files attached yet.",
     "errorDescription": "We couldn't load files for this entity. Try again in a moment.",
     "errorTitle": "Couldn't load files",
@@ -89,6 +93,8 @@
   "tagsPlaceholder": "Filter by tag",
   "title": "Files",
   "upload": {
+    "attachTitle": "Attach files",
+    "attachTitleWithName": "Attach files to {{name}}",
     "back": "Back",
     "close": "Close",
     "errors": {

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -21,7 +21,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { ComingSoonBanner } from "@/components/coming-soon/ComingSoonBanner"
+import { DropOverlay } from "@/components/files/DropOverlay"
 import { EntityFilesPanel } from "@/components/files/EntityFilesPanel"
+import { UploadFilesDialog } from "@/components/files/UploadFilesDialog"
+import { useFileDropZone } from "@/components/files/useFileDropZone"
 import { CommodityFormDialog } from "@/components/items/CommodityFormDialog"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { useAreas } from "@/features/areas/hooks"
@@ -70,6 +73,22 @@ export function CommodityDetailPage() {
   // so the URL stays meaningful.
   const editMatch = useMatch({ path: "/g/:groupSlug/commodities/:id/edit", end: true })
   const [editOpen, setEditOpen] = useState(false)
+  // #1448 quick-attach state. `pendingDropFiles` holds files seeded by
+  // the page-level drop catcher; the upload dialog reads them on open
+  // and queues them in the select step. The button-triggered open
+  // path leaves it empty so the user picks files inside the dialog.
+  const [uploadOpen, setUploadOpen] = useState(false)
+  const [pendingDropFiles, setPendingDropFiles] = useState<File[]>([])
+  const dropZone = useFileDropZone({
+    onFiles: (files) => {
+      setPendingDropFiles(files)
+      setUploadOpen(true)
+    },
+    // Don't catch new drags while the dialog is already open — its
+    // own dropzone takes over so a second drop doesn't bounce through
+    // the page wrapper.
+    disabled: uploadOpen,
+  })
   useEffect(() => {
     if (editMatch && !editOpen) setEditOpen(true)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only react to URL match changes; editOpen is intentionally read once
@@ -194,9 +213,16 @@ export function CommodityDetailPage() {
     <>
       <RouteTitle title={t("commodities:detail.documentTitle")} />
       <div
-        className="flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full"
+        className="relative flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full"
         data-testid="page-commodity-detail"
+        {...dropZone.bindProps}
       >
+        {dropZone.isDragging ? (
+          <DropOverlay
+            label={t("files:entityPanel.dropOverlay_commodity")}
+            hint={t("files:entityPanel.dropHint")}
+          />
+        ) : null}
         <Link
           to={listHref}
           className="text-sm text-muted-foreground hover:underline inline-flex items-center gap-1"
@@ -288,7 +314,13 @@ export function CommodityDetailPage() {
             </CardContent>
           </Card>
         ) : (
-          <FilesTab commodityId={commodity?.id ?? id} />
+          <FilesTab
+            commodityId={commodity?.id ?? id}
+            onAttachClick={() => {
+              setPendingDropFiles([])
+              setUploadOpen(true)
+            }}
+          />
         )}
       </div>
 
@@ -301,6 +333,20 @@ export function CommodityDetailPage() {
         defaultCurrency={currency}
         onSubmit={handleSave}
         isPending={update.isPending}
+      />
+
+      <UploadFilesDialog
+        open={uploadOpen}
+        onOpenChange={(open) => {
+          setUploadOpen(open)
+          if (!open) setPendingDropFiles([])
+        }}
+        linkedEntity={{
+          type: "commodity",
+          id: commodity?.id ?? id,
+          name: commodity?.name,
+        }}
+        initialFiles={pendingDropFiles}
       />
     </>
   )
@@ -581,17 +627,26 @@ function DetailLabel({ icon: Icon, label }: { icon: typeof MapPin; label: string
 
 interface FilesTabProps {
   commodityId: string
+  onAttachClick: () => void
 }
 
-function FilesTab({ commodityId }: FilesTabProps) {
+function FilesTab({ commodityId, onAttachClick }: FilesTabProps) {
   // Renders attachments for this commodity through the unified
   // /files surface (#1411 AC #4). The legacy meta.images / .invoices /
   // .manuals counters are no longer consulted — once #1399 backfill
   // ran, every legacy row is also a /files row, and the unified
   // surface is the single source of truth.
+  //
+  // `onAttachClick` opens the page-level upload dialog with the
+  // commodity preselected (#1448). The page also exposes a drag-drop
+  // overlay that opens the same dialog with files preloaded.
   return (
     <div data-testid="commodity-detail-files">
-      <EntityFilesPanel linkedEntityType="commodity" linkedEntityId={commodityId} />
+      <EntityFilesPanel
+        linkedEntityType="commodity"
+        linkedEntityId={commodityId}
+        onAttachClick={onAttachClick}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
@@ -9,12 +9,7 @@ import { GroupProvider } from "@/features/group/GroupContext"
 import { ConfirmProvider } from "@/hooks/useConfirm"
 import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
-import {
-  areaHandlers,
-  commodityHandlers,
-  fileHandlers,
-  groupHandlers,
-} from "@/test/handlers"
+import { areaHandlers, commodityHandlers, fileHandlers, groupHandlers } from "@/test/handlers"
 import { setAccessToken, clearAuth } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
@@ -250,9 +245,7 @@ describe("<CommodityDetailPage />", () => {
     fireEvent.dragEnter(page, init)
     expect(await screen.findByTestId("entity-drop-overlay")).toBeInTheDocument()
     fireEvent.dragLeave(page, init)
-    await waitFor(() =>
-      expect(screen.queryByTestId("entity-drop-overlay")).not.toBeInTheDocument()
-    )
+    await waitFor(() => expect(screen.queryByTestId("entity-drop-overlay")).not.toBeInTheDocument())
   })
 
   it("renders the not-found card when the commodity is missing", async () => {

--- a/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
@@ -9,7 +9,12 @@ import { GroupProvider } from "@/features/group/GroupContext"
 import { ConfirmProvider } from "@/hooks/useConfirm"
 import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
-import { areaHandlers, commodityHandlers, groupHandlers } from "@/test/handlers"
+import {
+  areaHandlers,
+  commodityHandlers,
+  fileHandlers,
+  groupHandlers,
+} from "@/test/handlers"
 import { setAccessToken, clearAuth } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
@@ -204,6 +209,50 @@ describe("<CommodityDetailPage />", () => {
       ),
     })
     expect(await screen.findByLabelText(/form steps/i)).toBeInTheDocument()
+  })
+
+  it("opens the upload dialog with the commodity name in the title from the Files tab Attach button (#1448)", async () => {
+    const user = userEvent.setup()
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.detail(SLUG, ID, commodityFixture),
+      ...fileHandlers.list(SLUG, [])
+    )
+    renderDetail()
+    await screen.findByTestId("commodity-detail-details")
+    await user.click(screen.getByTestId("commodity-detail-tab-files"))
+    const attach = await screen.findByTestId("entity-files-panel-attach")
+    await user.click(attach)
+    expect(
+      await screen.findByRole("heading", { name: /attach files to macbook pro 16/i })
+    ).toBeInTheDocument()
+  })
+
+  it("shows the drop overlay while files are dragged over the detail page (#1448)", async () => {
+    const { fireEvent } = await import("@testing-library/react")
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.detail(SLUG, ID, commodityFixture)
+    )
+    renderDetail()
+    const page = await screen.findByTestId("page-commodity-detail")
+    expect(screen.queryByTestId("entity-drop-overlay")).not.toBeInTheDocument()
+    const init = {
+      bubbles: true,
+      cancelable: true,
+      // jsdom-friendly partial DataTransfer — the hook only reads
+      // `types`, `files`, and `dropEffect`.
+      // @ts-expect-error partial init is intentional
+      dataTransfer: { types: ["Files"], files: [], dropEffect: "none" },
+    }
+    fireEvent.dragEnter(page, init)
+    expect(await screen.findByTestId("entity-drop-overlay")).toBeInTheDocument()
+    fireEvent.dragLeave(page, init)
+    await waitFor(() =>
+      expect(screen.queryByTestId("entity-drop-overlay")).not.toBeInTheDocument()
+    )
   })
 
   it("renders the not-found card when the commodity is missing", async () => {

--- a/frontend/src/pages/locations/LocationDetailPage.tsx
+++ b/frontend/src/pages/locations/LocationDetailPage.tsx
@@ -7,7 +7,10 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { DropOverlay } from "@/components/files/DropOverlay"
 import { EntityFilesPanel } from "@/components/files/EntityFilesPanel"
+import { UploadFilesDialog } from "@/components/files/UploadFilesDialog"
+import { useFileDropZone } from "@/components/files/useFileDropZone"
 import { LocationFormDialog } from "@/components/locations/LocationFormDialog"
 import { AreaFormDialog } from "@/components/locations/AreaFormDialog"
 import { RouteTitle } from "@/components/routing/RouteTitle"
@@ -54,6 +57,17 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
   const [dialog, setDialog] = useState<DialogState>(() =>
     initialMode === "edit" ? { kind: "edit" } : { kind: "none" }
   )
+
+  // #1448 quick-attach: same pattern as the commodity detail page.
+  const [uploadOpen, setUploadOpen] = useState(false)
+  const [pendingDropFiles, setPendingDropFiles] = useState<File[]>([])
+  const dropZone = useFileDropZone({
+    onFiles: (files) => {
+      setPendingDropFiles(files)
+      setUploadOpen(true)
+    },
+    disabled: uploadOpen,
+  })
 
   const editMatch = useMatch({ path: "/g/:groupSlug/locations/:id/edit", end: true })
   useEffect(() => {
@@ -137,9 +151,16 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
     <>
       <RouteTitle title={location.data?.name ?? t("locations:detail.fallbackTitle")} />
       <div
-        className="flex flex-col gap-6 p-6 max-w-3xl mx-auto w-full"
+        className="relative flex flex-col gap-6 p-6 max-w-3xl mx-auto w-full"
         data-testid="page-location-detail"
+        {...dropZone.bindProps}
       >
+        {dropZone.isDragging ? (
+          <DropOverlay
+            label={t("files:entityPanel.dropOverlay_location")}
+            hint={t("files:entityPanel.dropHint")}
+          />
+        ) : null}
         <Link
           to={backHref}
           className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
@@ -259,7 +280,14 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
               </CardContent>
             </Card>
 
-            <EntityFilesPanel linkedEntityType="location" linkedEntityId={id} />
+            <EntityFilesPanel
+              linkedEntityType="location"
+              linkedEntityId={id}
+              onAttachClick={() => {
+                setPendingDropFiles([])
+                setUploadOpen(true)
+              }}
+            />
           </>
         ) : null}
       </div>
@@ -278,6 +306,20 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
         defaultLocationId={id}
         onSubmit={handleCreateArea}
         isPending={createArea.isPending}
+      />
+
+      <UploadFilesDialog
+        open={uploadOpen}
+        onOpenChange={(open) => {
+          setUploadOpen(open)
+          if (!open) setPendingDropFiles([])
+        }}
+        linkedEntity={{
+          type: "location",
+          id,
+          name: location.data?.name,
+        }}
+        initialFiles={pendingDropFiles}
       />
     </>
   )

--- a/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
+++ b/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
@@ -1,13 +1,19 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { Route } from "react-router-dom"
 import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 
 import { LocationDetailPage } from "@/pages/locations/LocationDetailPage"
 import { GroupProvider } from "@/features/group/GroupContext"
 import { ConfirmProvider } from "@/hooks/useConfirm"
 import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
-import { areaHandlers, groupHandlers, locationHandlers } from "@/test/handlers"
+import {
+  areaHandlers,
+  fileHandlers,
+  groupHandlers,
+  locationHandlers,
+} from "@/test/handlers"
 import { clearAuth, setAccessToken } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
@@ -100,5 +106,46 @@ describe("<LocationDetailPage />", () => {
     renderDetail(`/g/${SLUG}/locations/loc2`)
     await waitFor(() => expect(screen.getByText("Cottage")).toBeInTheDocument())
     expect(screen.getByTestId("location-detail-areas-empty")).toBeInTheDocument()
+  })
+
+  it("opens the upload dialog with the location name in the title from the EntityFilesPanel Attach button (#1448)", async () => {
+    const user = userEvent.setup()
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.detail(SLUG, "loc1", locationResource("loc1", { name: "Garage" })),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Garage" })]),
+      ...areaHandlers.list(SLUG, []),
+      ...fileHandlers.list(SLUG, [])
+    )
+    renderDetail(`/g/${SLUG}/locations/loc1`)
+    const attach = await screen.findByTestId("entity-files-panel-attach")
+    await user.click(attach)
+    expect(
+      await screen.findByRole("heading", { name: /attach files to garage/i })
+    ).toBeInTheDocument()
+  })
+
+  it("shows the drop overlay while files are dragged over the location detail page (#1448)", async () => {
+    const { fireEvent } = await import("@testing-library/react")
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.detail(SLUG, "loc1", locationResource("loc1", { name: "Garage" })),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Garage" })]),
+      ...areaHandlers.list(SLUG, [])
+    )
+    renderDetail(`/g/${SLUG}/locations/loc1`)
+    const page = await screen.findByTestId("page-location-detail")
+    const init = {
+      bubbles: true,
+      cancelable: true,
+      // @ts-expect-error partial init is intentional
+      dataTransfer: { types: ["Files"], files: [], dropEffect: "none" },
+    }
+    fireEvent.dragEnter(page, init)
+    expect(await screen.findByTestId("entity-drop-overlay")).toBeInTheDocument()
+    fireEvent.dragLeave(page, init)
+    await waitFor(() =>
+      expect(screen.queryByTestId("entity-drop-overlay")).not.toBeInTheDocument()
+    )
   })
 })

--- a/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
+++ b/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
@@ -8,12 +8,7 @@ import { GroupProvider } from "@/features/group/GroupContext"
 import { ConfirmProvider } from "@/hooks/useConfirm"
 import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
-import {
-  areaHandlers,
-  fileHandlers,
-  groupHandlers,
-  locationHandlers,
-} from "@/test/handlers"
+import { areaHandlers, fileHandlers, groupHandlers, locationHandlers } from "@/test/handlers"
 import { clearAuth, setAccessToken } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
@@ -144,8 +139,6 @@ describe("<LocationDetailPage />", () => {
     fireEvent.dragEnter(page, init)
     expect(await screen.findByTestId("entity-drop-overlay")).toBeInTheDocument()
     fireEvent.dragLeave(page, init)
-    await waitFor(() =>
-      expect(screen.queryByTestId("entity-drop-overlay")).not.toBeInTheDocument()
-    )
+    await waitFor(() => expect(screen.queryByTestId("entity-drop-overlay")).not.toBeInTheDocument())
   })
 })

--- a/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
+++ b/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
@@ -126,7 +126,13 @@ describe("<LocationDetailPage />", () => {
       ...groupHandlers.list(groupFixture),
       ...locationHandlers.detail(SLUG, "loc1", locationResource("loc1", { name: "Garage" })),
       ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Garage" })]),
-      ...areaHandlers.list(SLUG, [])
+      ...areaHandlers.list(SLUG, []),
+      // EntityFilesPanel mounts unconditionally on the location
+      // detail page once location.data resolves. Without this stub
+      // its background GET /files would hit MSW's onUnhandledRequest:
+      // "error" hook (set in src/test/setup.ts) and surface as a
+      // post-test warning even if the assertions complete first.
+      ...fileHandlers.list(SLUG, [])
     )
     renderDetail(`/g/${SLUG}/locations/loc1`)
     const page = await screen.findByTestId("page-location-detail")


### PR DESCRIPTION
## Summary

Closes the only missing UX feature from #1410's original scope and unblocks the React side of the legacy commodity-/location-scoped attach flows that #1421 retired on the BE. Adds:

- A **page-level drag-drop catcher** on `/commodities/:id` and `/locations/:id`. Drop a file anywhere on the detail page → upload dialog opens with the files pre-queued and the linkage preset.
- An **"Attach files" toolbar button** on the `EntityFilesPanel` header. Click → upload dialog opens with the linkage preset (no files pre-queued).
- A **linkage-aware upload path**: every successful upload PUTs `/files/{id}` with `linked_entity_type` + `linked_entity_id` so the file is attached, not orphaned.

Refs #1397 (epic), follows up #1410 (items page) + #1411 / #1476 (Files surface).

## What changed

### New primitives

| File | Purpose |
|---|---|
| `frontend/src/components/files/useFileDropZone.ts` | `dragenter / over / leave / drop` hook with the counter pattern (no flicker over nested children), file-only filtering (text/url payloads ignored), and a `disabled` flag. |
| `frontend/src/components/files/DropOverlay.tsx` | `position: absolute` overlay rendered while dragging; `pointer-events-none` so it never swallows the drop event. |

### Extended components

- **`UploadFilesDialog`** — new optional props:
  - `linkedEntity?: { type: "commodity" \| "location"; id: string; name?: string }` — when set, every successful upload also PUTs `/files/{id}` with `linked_entity_type` / `linked_entity_id`. **Linkage failure marks the item as failed** (an orphan file would otherwise be silent — the user thinks "attached" but it's not). Title becomes "Attach files to {name}".
  - `initialFiles?: File[]` — files pre-queued by the page-level drop catcher. The dialog opens in the select step with files already listed; user can edit metadata and proceed without dropping again.
- **`EntityFilesPanel`** — new optional `onAttachClick?: () => void` prop. When set, renders an "Attach files" button in the card header. Without it, the panel stays read-only (the existing comment about "no Add files CTA → orphan file" is preserved as the rationale for keeping the prop opt-in).

### Page wiring

- **`CommodityDetailPage`** + **`LocationDetailPage`** — both wrap their content in the `dropZone.bindProps`, render the `DropOverlay` while dragging, host the `UploadFilesDialog` with the right linkage, and pass `onAttachClick` down to the panel. The dropzone is `disabled: uploadOpen` so a second drop while the dialog is open routes through the dialog's own dropzone instead of bouncing back to the page wrapper.

### i18n

New keys added to `en/files.json` only (cs / ru fall through to en per the existing config — covered by `i18n.test.ts`):

```
files:entityPanel.attach            "Attach files"
files:entityPanel.dropHint          "Release to attach"
files:entityPanel.dropOverlay_commodity  "Drop files to attach to this item"
files:entityPanel.dropOverlay_location   "Drop files to attach to this location"
files:upload.attachTitle            "Attach files"
files:upload.attachTitleWithName    "Attach files to {{name}}"
```

## Acceptance criteria

- [x] Drag-drop on the detail page uploads files and refreshes the Files tab. (Page-level drop → dialog opens with linkage preset → batch upload → final `invalidate.all()` refetches the panel's `useFiles({ linkedEntityType, linkedEntityId })` query.)
- [x] "Attach files" button opens the upload modal with this commodity / location preselected. (Title shows `Attach files to {name}`; PUT round-trip carries `linked_entity_type` / `linked_entity_id`.)
- [x] axe-clean. (Existing `EntityFilesPanel` axe test still green; the new toolbar button uses an `<Upload aria-hidden>` + visible label.)
- [x] Component test for the drop-zone behaviour (drag-enter highlight, drop-uploads, drop-cancel-on-non-file). 5 hook tests in `useFileDropZone.test.tsx` cover all three.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint . --ext .ts,.tsx` — clean.
- [x] `npx vitest run` — **429 / 429 green** (74 files). New tests: 5 hook + 2 panel + 4 dialog (incl. linked PUT round-trip + linkage-failure path) + 2 commodity-detail + 2 location-detail = **15 new tests**.
- [x] `npx vitest run --coverage` — Statements 81.21%, Functions 80.18%, Branches 71.92%, Lines 84.19% — all above thresholds.
- [x] `npm run build` — clean (pre-existing > 500 kB chunk warning is not introduced by this PR).
- [ ] CI: `frontend-tests`, `frontend-lint`, `frontend-codegen-drift`, `e2e-tests`.

## Out of scope (follow-ups)

- Re-enabling the `describe.skip` blocks in `e2e/tests/file-uploads.spec.ts` + `e2e/tests/location-file-uploads.spec.ts` — tracked in **#1474**. The helpers in `e2e/tests/includes/uploads.ts` still drive the legacy Vue-era selectors and need a re-port to the new quick-attach surface; that's a separate, more focused PR.
- The third skipped block (`file-deletion-cascade.spec.ts`) is also blocked on **#1415** (FE Exports), so it stays in #1474 for now.