### PR TITLE
[#1412] FE Tags page + BE per-row usage and stats

### DIFF
--- a/e2e/screenshots.mjs
+++ b/e2e/screenshots.mjs
@@ -512,6 +512,174 @@ try {
       console.warn(`   filtered-invoices shot failed (${err.message}); skipping`)
     }
   }
+
+  // Tags page (#1412): empty state + create dialog + populated list +
+  // edit dialog + both delete-confirm variants (not-in-use vs in-use
+  // with force-delete). The in-use case requires a real BE side-effect
+  // (attach the tag to a commodity) — done inside page.evaluate so the
+  // fetch picks up the React app's auth token from localStorage.
+  //
+  // Slug naming: the seed + prior runs may already have a `kitchen`
+  // slug auto-created from commodity tags arrays, so the BE returns a
+  // non-zero usage count even though we just created the tag fresh.
+  // To capture the not-in-use confirm dialog we use a per-run unique
+  // slug (`scratch-<ts>`) that the seed never references; for the
+  // in-use shot we deliberately reuse `kitchen` so the dialog renders
+  // a realistic count + plural copy.
+  const slugForTags = slugFromUrl() ?? slug
+  if (slugForTags) {
+    const scratchLabel = `Scratch ${Date.now()}`
+    const scratchSlug = scratchLabel.toLowerCase().replace(/[^a-z0-9]+/g, "-")
+
+    console.log(`-> /g/${slugForTags}/tags`)
+    await page.goto(`${BASE_URL}/g/${slugForTags}/tags`, { waitUntil: "domcontentloaded" })
+    await settle()
+    await shoot("40-tags-list")
+
+    // Step 41 — open the create dialog. Type a label so the slug
+    // auto-derives + picks a color so the preview pill renders.
+    try {
+      await page.click('[data-testid="tags-create-button"]')
+      await page.waitForSelector('[data-testid="tag-form-dialog"]', { timeout: 5000 })
+      await page.fill('[data-testid="tag-form-label"]', scratchLabel)
+      await page.click('[data-testid="tag-form-color-amber"]')
+      await settle(200)
+      await shoot("41-tags-create-dialog", false)
+      await page.click('[data-testid="tag-form-submit"]')
+      await page.waitForSelector('[data-testid="tag-form-dialog"]', {
+        state: "detached",
+        timeout: 5000,
+      })
+      await page.waitForSelector(`[data-testid="tag-row-${scratchSlug}"]`, { timeout: 5000 })
+      await settle()
+      await shoot("42-tags-list-populated")
+    } catch (err) {
+      console.warn(`   tags create flow failed (${err.message}); skipping 41-42`)
+      await page.keyboard.press("Escape").catch(() => {})
+      await settle(200)
+    }
+
+    // Step 43 — edit dialog with prefilled values (the slug auto-
+    // derive is suppressed in edit mode, so this shot exercises that
+    // path explicitly).
+    try {
+      const editBtn = page.locator(`[data-testid="tag-row-${scratchSlug}-edit"]`)
+      if ((await editBtn.count()) > 0) {
+        await editBtn.click()
+        await page.waitForSelector('[data-testid="tag-form-dialog"]', { timeout: 5000 })
+        await settle(200)
+        await shoot("43-tags-edit-dialog", false)
+        await page.click('[data-testid="tag-form-cancel"]')
+        await page.waitForSelector('[data-testid="tag-form-dialog"]', {
+          state: "detached",
+          timeout: 5000,
+        })
+        await settle(200)
+      }
+    } catch (err) {
+      console.warn(`   tags edit dialog failed (${err.message}); skipping 43`)
+      await page.keyboard.press("Escape").catch(() => {})
+      await settle(200)
+    }
+
+    // Step 44 — delete-confirm for a NOT-in-use tag. The scratch tag
+    // we just created has zero usage, so this surfaces the simple
+    // "Delete tag?" / "This cannot be undone." dialog. We cancel so
+    // the row survives for step 45.
+    try {
+      const deleteBtn = page.locator(`[data-testid="tag-row-${scratchSlug}-delete"]`)
+      if ((await deleteBtn.count()) > 0) {
+        await deleteBtn.click()
+        await page.waitForSelector('[data-testid="confirm-dialog"]', { timeout: 5000 })
+        await settle(200)
+        await shoot("44-tags-delete-confirm", false)
+        await page.click('[data-testid="confirm-cancel"]')
+        await page.waitForSelector('[data-testid="confirm-dialog"]', {
+          state: "detached",
+          timeout: 5000,
+        })
+        await settle(200)
+      }
+    } catch (err) {
+      console.warn(`   tags delete-confirm failed (${err.message}); skipping 44`)
+      await page.keyboard.press("Escape").catch(() => {})
+      await settle(200)
+    }
+
+    // Step 45 — in-use delete-confirm with the "Force delete" button.
+    // Attach the scratch slug to the first commodity via direct fetch
+    // (re-using the React app's stored auth + CSRF tokens), reload,
+    // then click delete on the row to trigger the in-use confirm.
+    try {
+      const attachResult = await page.evaluate(
+        async ({ slug, tagSlug }) => {
+          const token = localStorage.getItem("inventario_token")
+          const csrf = sessionStorage.getItem("inventario_csrf_token")
+          if (!token || !csrf) return { ok: false, reason: "no auth tokens in storage" }
+          const headers = {
+            "Content-Type": "application/vnd.api+json",
+            Accept: "application/vnd.api+json",
+            Authorization: `Bearer ${token}`,
+            "X-CSRF-Token": csrf,
+          }
+          const listResp = await fetch(`/api/v1/g/${slug}/commodities`, { headers })
+          if (!listResp.ok) return { ok: false, reason: `list ${listResp.status}` }
+          const listBody = await listResp.json()
+          const first = listBody?.data?.[0]
+          if (!first?.id) return { ok: false, reason: "no commodity to attach to" }
+          const detailResp = await fetch(`/api/v1/g/${slug}/commodities/${first.id}`, {
+            headers,
+          })
+          if (!detailResp.ok) return { ok: false, reason: `detail ${detailResp.status}` }
+          const detail = await detailResp.json()
+          const attrs = detail?.data?.attributes ?? {}
+          const tags = Array.from(new Set([...(attrs.tags ?? []), tagSlug]))
+          const putResp = await fetch(`/api/v1/g/${slug}/commodities/${first.id}`, {
+            method: "PUT",
+            headers,
+            body: JSON.stringify({
+              data: {
+                id: first.id,
+                type: "commodities",
+                attributes: { ...attrs, tags },
+              },
+            }),
+          })
+          if (!putResp.ok) return { ok: false, reason: `put ${putResp.status}` }
+          return { ok: true }
+        },
+        { slug: slugForTags, tagSlug: scratchSlug },
+      )
+      if (!attachResult.ok) {
+        console.warn(
+          `   could not attach scratch slug to a commodity (${attachResult.reason}); 45 will mirror 44`,
+        )
+      } else {
+        // Reload so the page re-fetches usage and the row reflects "1 item".
+        await page.reload()
+        await page.waitForSelector(`[data-testid="tag-row-${scratchSlug}"]`, { timeout: 5000 })
+        await settle(300)
+      }
+
+      const deleteBtn = page.locator(`[data-testid="tag-row-${scratchSlug}-delete"]`)
+      if ((await deleteBtn.count()) > 0) {
+        await deleteBtn.click()
+        await page.waitForSelector('[data-testid="confirm-dialog"]', { timeout: 5000 })
+        await settle(200)
+        await shoot("45-tags-delete-in-use-confirm", false)
+        await page.click('[data-testid="confirm-cancel"]')
+        await page.waitForSelector('[data-testid="confirm-dialog"]', {
+          state: "detached",
+          timeout: 5000,
+        })
+        await settle(200)
+      }
+    } catch (err) {
+      console.warn(`   tags in-use confirm failed (${err.message}); skipping 45`)
+      await page.keyboard.press("Escape").catch(() => {})
+      await settle(200)
+    }
+  }
 } catch (err) {
   console.error("Screenshot run failed:", err)
   process.exitCode = 1

--- a/e2e/tests/includes/group-url.ts
+++ b/e2e/tests/includes/group-url.ts
@@ -13,6 +13,7 @@ const FLAT_DATA_PREFIXES = [
   '/files',
   '/exports',
   '/system',
+  '/tags',
 ] as const;
 
 function extractSlugFromUrl(url: string): string | null {

--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -1,14 +1,14 @@
-import { expect, type APIRequestContext, type Page } from "@playwright/test";
+import { expect, type APIRequestContext, type Page } from '@playwright/test'
 
-import { test } from "../fixtures/app-fixture.js";
-import { navigateWithAuth } from "./includes/auth.js";
+import { test } from '../fixtures/app-fixture.js'
+import { navigateWithAuth } from './includes/auth.js'
 import {
   createCommodityViaAPI,
   ensureLocationAndArea,
   extractApiAuth,
   resolveActiveGroup,
   type ApiAuth,
-} from "./includes/commodities-api.js";
+} from './includes/commodities-api.js'
 
 /**
  * E2E coverage for the Tags page (#1412).
@@ -16,7 +16,7 @@ import {
  * Covers the issue's E2E acceptance line:
  *   create → rename → assign to an item → delete with force.
  *
- * The "assign to an item" step is done via the BE (PATCH commodity)
+ * The "assign to an item" step is done via the BE (PUT commodity)
  * because the Tags page itself does not own the assignment surface —
  * tags are attached on the commodity / file detail pages. The point
  * here is that the BE rewrite (slug change) propagates to existing
@@ -25,8 +25,8 @@ import {
  */
 
 async function gotoTags(page: Page): Promise<void> {
-  await navigateWithAuth(page, "/tags");
-  await expect(page.getByTestId("page-tags")).toBeVisible();
+  await navigateWithAuth(page, '/tags')
+  await expect(page.getByTestId('page-tags')).toBeVisible()
 }
 
 async function attachTagToCommodity(
@@ -36,108 +36,116 @@ async function attachTagToCommodity(
   commodityId: string,
   tagSlug: string,
 ): Promise<void> {
+  const headers = {
+    'Content-Type': 'application/vnd.api+json',
+    Accept: 'application/vnd.api+json',
+    Authorization: `Bearer ${auth.accessToken}`,
+    'X-CSRF-Token': auth.csrfToken,
+  }
+  // BE PUT replaces the full entity, so re-fetch attributes first and
+  // splice in the new tag slug. A partial body (`{ tags: [...] }` only)
+  // returns 422 ("cannot be blank" for every other field).
+  const getResp = await request.get(
+    `/api/v1/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(commodityId)}`,
+    { headers },
+  )
+  if (!getResp.ok()) {
+    throw new Error(
+      `attachTagToCommodity: GET /commodities/${commodityId} → ${getResp.status()} ${await getResp.text()}`,
+    )
+  }
+  const body = (await getResp.json()) as {
+    data: { id: string; type: string; attributes: Record<string, unknown> }
+  }
+  const existingTags = (body.data.attributes.tags as string[] | undefined) ?? []
+  const merged = Array.from(new Set([...existingTags, tagSlug]))
+
   const resp = await request.put(
     `/api/v1/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(commodityId)}`,
     {
-      headers: {
-        "Content-Type": "application/vnd.api+json",
-        Accept: "application/vnd.api+json",
-        Authorization: `Bearer ${auth.accessToken}`,
-        "X-CSRF-Token": auth.csrfToken,
-      },
+      headers,
       data: {
         data: {
           id: commodityId,
-          type: "commodities",
-          attributes: { tags: [tagSlug] },
+          type: 'commodities',
+          attributes: { ...body.data.attributes, tags: merged },
         },
       },
     },
-  );
+  )
   if (!resp.ok()) {
     throw new Error(
       `attachTagToCommodity: PUT /commodities/${commodityId} → ${resp.status()} ${await resp.text()}`,
-    );
+    )
   }
 }
 
-test.describe("Tags page", () => {
-  test("renders the page shell with stats + create CTA", async ({ page }) => {
-    await gotoTags(page);
-    await expect(page.getByTestId("tags-stats-tags-total")).toBeVisible();
-    await expect(page.getByTestId("tags-stats-items-tagged")).toBeVisible();
-    await expect(page.getByTestId("tags-stats-items-untagged")).toBeVisible();
-    await expect(page.getByTestId("tags-create-button")).toBeVisible();
-  });
+test.describe('Tags page', () => {
+  test('renders the page shell with stats + create CTA', async ({ page }) => {
+    await gotoTags(page)
+    await expect(page.getByTestId('tags-stats-tags-total')).toBeVisible()
+    await expect(page.getByTestId('tags-stats-items-tagged')).toBeVisible()
+    await expect(page.getByTestId('tags-stats-items-untagged')).toBeVisible()
+    await expect(page.getByTestId('tags-create-button')).toBeVisible()
+  })
 
-  test("create → rename → attach → force-delete full flow", async ({
-    page,
-    request,
-  }) => {
+  test('create → rename → attach → force-delete full flow', async ({ page, request }) => {
     // Unique label so parallel runs / re-runs don't collide.
-    const initialLabel = `E2E Initial ${Date.now()}`;
-    const renamedSlug = `e2e-renamed-${Date.now()}`;
+    const initialLabel = `E2E Initial ${Date.now()}`
+    const renamedSlug = `e2e-renamed-${Date.now()}`
 
-    await gotoTags(page);
+    await gotoTags(page)
 
     // --- Create ---
-    await page.getByTestId("tags-create-button").click();
-    await expect(page.getByTestId("tag-form-dialog")).toBeVisible();
-    await page.getByTestId("tag-form-label").fill(initialLabel);
+    await page.getByTestId('tags-create-button').click()
+    await expect(page.getByTestId('tag-form-dialog')).toBeVisible()
+    await page.getByTestId('tag-form-label').fill(initialLabel)
     // Slug auto-derives from label; verify before submitting.
-    const derivedSlug = await page.getByTestId("tag-form-slug").inputValue();
-    expect(derivedSlug.length).toBeGreaterThan(0);
-    await page.getByTestId("tag-form-color-amber").click();
-    await page.getByTestId("tag-form-submit").click();
-    await expect(page.getByTestId("tag-form-dialog")).not.toBeVisible();
-    const initialRow = page.getByTestId(`tag-row-${derivedSlug}`);
-    await expect(initialRow).toBeVisible();
+    const derivedSlug = await page.getByTestId('tag-form-slug').inputValue()
+    expect(derivedSlug.length).toBeGreaterThan(0)
+    await page.getByTestId('tag-form-color-amber').click()
+    await page.getByTestId('tag-form-submit').click()
+    await expect(page.getByTestId('tag-form-dialog')).not.toBeVisible()
+    const initialRow = page.getByTestId(`tag-row-${derivedSlug}`)
+    await expect(initialRow).toBeVisible()
 
     // --- Rename --- (the slug change is what we care about — it
     // proves the rename rewrite path; the BE rewrites JSONB refs in
     // commodities + files, which we exercise on the next step).
-    await page.getByTestId(`tag-row-${derivedSlug}-edit`).click();
-    await expect(page.getByTestId("tag-form-dialog")).toBeVisible();
-    await page.getByTestId("tag-form-slug").fill(renamedSlug);
-    await page.getByTestId("tag-form-color-blue").click();
-    await page.getByTestId("tag-form-submit").click();
-    await expect(page.getByTestId("tag-form-dialog")).not.toBeVisible();
-    const renamedRow = page.getByTestId(`tag-row-${renamedSlug}`);
-    await expect(renamedRow).toBeVisible();
+    await page.getByTestId(`tag-row-${derivedSlug}-edit`).click()
+    await expect(page.getByTestId('tag-form-dialog')).toBeVisible()
+    await page.getByTestId('tag-form-slug').fill(renamedSlug)
+    await page.getByTestId('tag-form-color-blue').click()
+    await page.getByTestId('tag-form-submit').click()
+    await expect(page.getByTestId('tag-form-dialog')).not.toBeVisible()
+    const renamedRow = page.getByTestId(`tag-row-${renamedSlug}`)
+    await expect(renamedRow).toBeVisible()
 
     // --- Attach to a commodity via BE ---
-    const auth = await extractApiAuth(page);
-    const group = await resolveActiveGroup(request, auth);
-    const { areaId } = await ensureLocationAndArea(request, auth, group.slug);
+    const auth = await extractApiAuth(page)
+    const group = await resolveActiveGroup(request, auth)
+    const { areaId } = await ensureLocationAndArea(request, auth, group.slug)
     const commodity = await createCommodityViaAPI(
       request,
       auth,
       group.slug,
       { name: `tag-target-${Date.now()}`, areaId },
       group.mainCurrency,
-    );
-    await attachTagToCommodity(
-      request,
-      auth,
-      group.slug,
-      commodity.id,
-      renamedSlug,
-    );
+    )
+    await attachTagToCommodity(request, auth, group.slug, commodity.id, renamedSlug)
 
     // Reload so the page picks up the fresh usage count.
-    await page.reload();
-    await expect(page.getByTestId(`tag-row-${renamedSlug}`)).toBeVisible();
-    await expect(
-      page.getByTestId(`tag-row-${renamedSlug}-usage`),
-    ).toContainText("1 item");
+    await page.reload()
+    await expect(page.getByTestId(`tag-row-${renamedSlug}`)).toBeVisible()
+    await expect(page.getByTestId(`tag-row-${renamedSlug}-usage`)).toContainText('1 item')
 
     // --- Force-delete --- (in-use → confirm dialog uses the
     // "Force delete" button; useConfirm renders its accept button as
     // `confirm-accept` regardless of label, so we click that.)
-    await page.getByTestId(`tag-row-${renamedSlug}-delete`).click();
-    await expect(page.getByTestId("confirm-dialog")).toBeVisible();
-    await expect(page.getByTestId("confirm-dialog")).toContainText("in use");
-    await page.getByTestId("confirm-accept").click();
-    await expect(page.getByTestId(`tag-row-${renamedSlug}`)).not.toBeVisible();
-  });
-});
+    await page.getByTestId(`tag-row-${renamedSlug}-delete`).click()
+    await expect(page.getByTestId('confirm-dialog')).toBeVisible()
+    await expect(page.getByTestId('confirm-dialog')).toContainText('in use')
+    await page.getByTestId('confirm-accept').click()
+    await expect(page.getByTestId(`tag-row-${renamedSlug}`)).not.toBeVisible()
+  })
+})

--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -1,0 +1,143 @@
+import { expect, type APIRequestContext, type Page } from "@playwright/test";
+
+import { test } from "../fixtures/app-fixture.js";
+import { navigateWithAuth } from "./includes/auth.js";
+import {
+  createCommodityViaAPI,
+  ensureLocationAndArea,
+  extractApiAuth,
+  resolveActiveGroup,
+  type ApiAuth,
+} from "./includes/commodities-api.js";
+
+/**
+ * E2E coverage for the Tags page (#1412).
+ *
+ * Covers the issue's E2E acceptance line:
+ *   create → rename → assign to an item → delete with force.
+ *
+ * The "assign to an item" step is done via the BE (PATCH commodity)
+ * because the Tags page itself does not own the assignment surface —
+ * tags are attached on the commodity / file detail pages. The point
+ * here is that the BE rewrite (slug change) propagates to existing
+ * commodities, and that the Tags page surfaces a non-zero usage count
+ * which then forces the delete flow through the in-use confirm dialog.
+ */
+
+async function gotoTags(page: Page): Promise<void> {
+  await navigateWithAuth(page, "/tags");
+  await expect(page.getByTestId("page-tags")).toBeVisible();
+}
+
+async function attachTagToCommodity(
+  request: APIRequestContext,
+  auth: ApiAuth,
+  slug: string,
+  commodityId: string,
+  tagSlug: string,
+): Promise<void> {
+  const resp = await request.put(
+    `/api/v1/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(commodityId)}`,
+    {
+      headers: {
+        "Content-Type": "application/vnd.api+json",
+        Accept: "application/vnd.api+json",
+        Authorization: `Bearer ${auth.accessToken}`,
+        "X-CSRF-Token": auth.csrfToken,
+      },
+      data: {
+        data: {
+          id: commodityId,
+          type: "commodities",
+          attributes: { tags: [tagSlug] },
+        },
+      },
+    },
+  );
+  if (!resp.ok()) {
+    throw new Error(
+      `attachTagToCommodity: PUT /commodities/${commodityId} → ${resp.status()} ${await resp.text()}`,
+    );
+  }
+}
+
+test.describe("Tags page", () => {
+  test("renders the page shell with stats + create CTA", async ({ page }) => {
+    await gotoTags(page);
+    await expect(page.getByTestId("tags-stats-tags-total")).toBeVisible();
+    await expect(page.getByTestId("tags-stats-items-tagged")).toBeVisible();
+    await expect(page.getByTestId("tags-stats-items-untagged")).toBeVisible();
+    await expect(page.getByTestId("tags-create-button")).toBeVisible();
+  });
+
+  test("create → rename → attach → force-delete full flow", async ({
+    page,
+    request,
+  }) => {
+    // Unique label so parallel runs / re-runs don't collide.
+    const initialLabel = `E2E Initial ${Date.now()}`;
+    const renamedSlug = `e2e-renamed-${Date.now()}`;
+
+    await gotoTags(page);
+
+    // --- Create ---
+    await page.getByTestId("tags-create-button").click();
+    await expect(page.getByTestId("tag-form-dialog")).toBeVisible();
+    await page.getByTestId("tag-form-label").fill(initialLabel);
+    // Slug auto-derives from label; verify before submitting.
+    const derivedSlug = await page.getByTestId("tag-form-slug").inputValue();
+    expect(derivedSlug.length).toBeGreaterThan(0);
+    await page.getByTestId("tag-form-color-amber").click();
+    await page.getByTestId("tag-form-submit").click();
+    await expect(page.getByTestId("tag-form-dialog")).not.toBeVisible();
+    const initialRow = page.getByTestId(`tag-row-${derivedSlug}`);
+    await expect(initialRow).toBeVisible();
+
+    // --- Rename --- (the slug change is what we care about — it
+    // proves the rename rewrite path; the BE rewrites JSONB refs in
+    // commodities + files, which we exercise on the next step).
+    await page.getByTestId(`tag-row-${derivedSlug}-edit`).click();
+    await expect(page.getByTestId("tag-form-dialog")).toBeVisible();
+    await page.getByTestId("tag-form-slug").fill(renamedSlug);
+    await page.getByTestId("tag-form-color-blue").click();
+    await page.getByTestId("tag-form-submit").click();
+    await expect(page.getByTestId("tag-form-dialog")).not.toBeVisible();
+    const renamedRow = page.getByTestId(`tag-row-${renamedSlug}`);
+    await expect(renamedRow).toBeVisible();
+
+    // --- Attach to a commodity via BE ---
+    const auth = await extractApiAuth(page);
+    const group = await resolveActiveGroup(request, auth);
+    const { areaId } = await ensureLocationAndArea(request, auth, group.slug);
+    const commodity = await createCommodityViaAPI(
+      request,
+      auth,
+      group.slug,
+      { name: `tag-target-${Date.now()}`, areaId },
+      group.mainCurrency,
+    );
+    await attachTagToCommodity(
+      request,
+      auth,
+      group.slug,
+      commodity.id,
+      renamedSlug,
+    );
+
+    // Reload so the page picks up the fresh usage count.
+    await page.reload();
+    await expect(page.getByTestId(`tag-row-${renamedSlug}`)).toBeVisible();
+    await expect(
+      page.getByTestId(`tag-row-${renamedSlug}-usage`),
+    ).toContainText("1 item");
+
+    // --- Force-delete --- (in-use → confirm dialog uses the
+    // "Force delete" button; useConfirm renders its accept button as
+    // `confirm-accept` regardless of label, so we click that.)
+    await page.getByTestId(`tag-row-${renamedSlug}-delete`).click();
+    await expect(page.getByTestId("confirm-dialog")).toBeVisible();
+    await expect(page.getByTestId("confirm-dialog")).toContainText("in use");
+    await page.getByTestId("confirm-accept").click();
+    await expect(page.getByTestId(`tag-row-${renamedSlug}`)).not.toBeVisible();
+  });
+});

--- a/frontend/.size-limit.json
+++ b/frontend/.size-limit.json
@@ -12,7 +12,7 @@
   {
     "name": "CSS",
     "path": "dist/assets/index-*.css",
-    "limit": "14 KB",
+    "limit": "15 KB",
     "gzip": true
   },
   {

--- a/frontend/i18next.config.ts
+++ b/frontend/i18next.config.ts
@@ -109,6 +109,24 @@ export default defineConfig({
       "commodities:bulk.*",
       "commodities:toast.*",
       "commodities:list.subtitle*",
+      // tags:stats.* — TagsStatsBar renders five tiles via a const map
+      //   `{ key: 'tags_total', labelKey: 'tags:stats.tagsTotal' } …`,
+      //   so the `t(labelKey)` call is dynamic from the extractor's POV.
+      // tags:color.* — TagColorPicker uses `t(\`tags:color.${color}\`)`
+      //   over the closed enum (amber/green/blue/orange/red/muted).
+      // tags:validation.* — schema messages in features/tags/schemas.ts
+      //   are plain strings flowing through RHF errors[name].message →
+      //   t() at render time (same pattern as auth:validation.*).
+      // tags:list.usage{Items,Files}_* and tags:usage.{items,files}_* —
+      //   i18next pluralization suffixes; the extractor sees only the
+      //   singular form when t() is called with `count`.
+      "tags:stats.*",
+      "tags:color.*",
+      "tags:validation.*",
+      "tags:list.usageItems*",
+      "tags:list.usageFiles*",
+      "tags:usage.items*",
+      "tags:usage.files*",
     ],
   },
 })

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -93,6 +93,9 @@ const FilesListPage = lazy(() =>
 const FileEditPage = lazy(() =>
   import("@/pages/files/FileEditPage").then((m) => ({ default: m.FileEditPage }))
 )
+const TagsListPage = lazy(() =>
+  import("@/pages/tags/TagsListPage").then((m) => ({ default: m.TagsListPage }))
+)
 
 // AppRoutes is the full route tree for the new React frontend. Most of the
 // pages still mount the shared PlaceholderPage stub: the routing skeleton is
@@ -213,10 +216,7 @@ export function AppRoutes() {
               <Route path="files" element={<FilesListPage />} />
               <Route path="files/:id" element={<FilesListPage />} />
               <Route path="files/:id/edit" element={<FileEditPage />} />
-              <Route
-                path="tags"
-                element={<PlaceholderPage titleKey="tags" testId="page-tags" trackedBy="#1412" />}
-              />
+              <Route path="tags" element={<TagsListPage />} />
               <Route path="members" element={<MembersPage />} />
               <Route
                 path="exports"

--- a/frontend/src/components/tags/TagBadge.tsx
+++ b/frontend/src/components/tags/TagBadge.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/lib/utils"
+
+import type { TagColor } from "@/features/tags/api"
+
+// Tone classes are intentionally written out, not built via template
+// strings, so Tailwind's content scanner picks each variant up at build
+// time. Each token resolves to `var(--tag-{color})` (defined in
+// index.css) and the same name works in both light and dark mode — only
+// the underlying OKLCH lightness shifts.
+const TONE: Record<TagColor, string> = {
+  amber: "text-tag-amber border-tag-amber/40 bg-tag-amber/10",
+  green: "text-tag-green border-tag-green/40 bg-tag-green/10",
+  blue: "text-tag-blue border-tag-blue/40 bg-tag-blue/10",
+  orange: "text-tag-orange border-tag-orange/40 bg-tag-orange/10",
+  red: "text-tag-red border-tag-red/40 bg-tag-red/10",
+  muted: "text-tag-muted border-tag-muted/40 bg-tag-muted/10",
+}
+
+export interface TagBadgeProps {
+  label: string
+  color: TagColor
+  size?: "sm" | "md"
+  className?: string
+  testId?: string
+}
+
+export function TagBadge({ label, color, size = "md", className, testId }: TagBadgeProps) {
+  return (
+    <span
+      data-testid={testId}
+      className={cn(
+        "inline-flex items-center rounded-full border font-medium",
+        TONE[color],
+        size === "sm" ? "h-5 px-2 text-[11px]" : "h-6 px-2.5 text-xs",
+        className
+      )}
+    >
+      {label}
+    </span>
+  )
+}

--- a/frontend/src/components/tags/TagColorPicker.tsx
+++ b/frontend/src/components/tags/TagColorPicker.tsx
@@ -1,0 +1,63 @@
+import { Check } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { cn } from "@/lib/utils"
+
+import { TAG_COLORS, type TagColor } from "@/features/tags/api"
+
+const SWATCH: Record<TagColor, string> = {
+  amber: "bg-tag-amber",
+  green: "bg-tag-green",
+  blue: "bg-tag-blue",
+  orange: "bg-tag-orange",
+  red: "bg-tag-red",
+  muted: "bg-tag-muted",
+}
+
+export interface TagColorPickerProps {
+  value: TagColor
+  onChange: (next: TagColor) => void
+  testId?: string
+  disabled?: boolean
+}
+
+export function TagColorPicker({ value, onChange, testId, disabled }: TagColorPickerProps) {
+  const { t } = useTranslation(["tags"])
+  return (
+    <div
+      role="radiogroup"
+      aria-label={t("tags:color.selectLabel")}
+      className="flex flex-wrap items-center gap-2"
+      data-testid={testId}
+    >
+      {TAG_COLORS.map((color) => {
+        const selected = value === color
+        return (
+          <button
+            key={color}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-label={t(`tags:color.${color}`)}
+            disabled={disabled}
+            onClick={() => onChange(color)}
+            data-testid={testId ? `${testId}-${color}` : undefined}
+            className={cn(
+              "relative size-7 rounded-full ring-1 ring-border transition",
+              SWATCH[color],
+              selected ? "ring-2 ring-foreground ring-offset-2 ring-offset-background" : "",
+              disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer hover:scale-110"
+            )}
+          >
+            {selected ? (
+              <Check
+                aria-hidden="true"
+                className="absolute inset-0 m-auto size-4 text-background drop-shadow"
+              />
+            ) : null}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/tags/TagFormDialog.tsx
+++ b/frontend/src/components/tags/TagFormDialog.tsx
@@ -1,0 +1,199 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useEffect } from "react"
+import { Controller, useForm } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+import { TagBadge } from "./TagBadge"
+import { TagColorPicker } from "./TagColorPicker"
+import type { TagColor, TagEntity } from "@/features/tags/api"
+import { normaliseSlug, tagFormSchema, type TagFormInput } from "@/features/tags/schemas"
+
+export interface TagFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  mode: "create" | "edit"
+  // In edit mode the dialog prefills from this object. Caller preserves
+  // the id; the dialog only sends label/slug/color.
+  initialValues?: TagEntity
+  onSubmit: (values: { label: string; slug: string; color: TagColor }) => Promise<void>
+  isPending?: boolean
+}
+
+const DEFAULTS: TagFormInput = { label: "", slug: "", color: "muted" }
+
+export function TagFormDialog({
+  open,
+  onOpenChange,
+  mode,
+  initialValues,
+  onSubmit,
+  isPending = false,
+}: TagFormDialogProps) {
+  const { t } = useTranslation(["tags", "common"])
+  const {
+    control,
+    formState: { errors, isSubmitting },
+    handleSubmit,
+    register,
+    reset,
+    setValue,
+    watch,
+  } = useForm<TagFormInput>({
+    resolver: zodResolver(tagFormSchema),
+    defaultValues: DEFAULTS,
+  })
+
+  // Re-seed the form when the dialog re-opens or the underlying entity
+  // changes. Without this, switching from "edit kitchen" to "edit garden"
+  // without a remount would leave the previous form values visible for
+  // a frame (rhf keeps state across opens by default).
+  useEffect(() => {
+    if (!open) return
+    if (mode === "edit" && initialValues) {
+      reset({
+        label: initialValues.label ?? "",
+        slug: initialValues.slug ?? "",
+        color: (initialValues.color ?? "muted") as TagColor,
+      })
+    } else {
+      reset(DEFAULTS)
+    }
+  }, [open, mode, initialValues, reset])
+
+  // Live-derive slug from label while creating — only when the user
+  // hasn't manually edited the slug field. Edit mode skips this so a
+  // rename's slug change isn't accidentally clobbered by a label tweak.
+  const labelValue = watch("label")
+  const slugValue = watch("slug")
+  useEffect(() => {
+    if (mode !== "create") return
+    if (!labelValue) return
+    const next = normaliseSlug(labelValue)
+    // Only auto-fill when the slug field is either empty or still
+    // matches the previous auto-derived value (i.e. user hasn't typed
+    // anything custom). Tracking that by comparing to a normalised
+    // version of the label is good enough for the create flow.
+    if (slugValue === "" || slugValue === normaliseSlug(slugValue)) {
+      setValue("slug", next, { shouldValidate: false, shouldDirty: false })
+    }
+  }, [labelValue, mode, slugValue, setValue])
+
+  const colorWatch = watch("color")
+  const previewLabel = labelValue || t("tags:form.labelPlaceholder", { defaultValue: "Tag" })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md" data-testid="tag-form-dialog">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "create" ? t("tags:form.createTitle") : t("tags:form.editTitle")}
+          </DialogTitle>
+          <DialogDescription className="sr-only">{t("tags:description")}</DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={handleSubmit(async (values) => {
+            await onSubmit({
+              label: values.label,
+              slug: values.slug,
+              color: values.color as TagColor,
+            })
+          })}
+        >
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="tag-form-label">{t("tags:form.label")}</Label>
+            <Input
+              id="tag-form-label"
+              data-testid="tag-form-label"
+              placeholder={t("tags:form.labelPlaceholder")}
+              {...register("label")}
+            />
+            {errors.label?.message ? (
+              <p className="text-xs text-destructive" data-testid="tag-form-label-error">
+                {t(errors.label.message)}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="tag-form-slug">{t("tags:form.slug")}</Label>
+            <Input
+              id="tag-form-slug"
+              data-testid="tag-form-slug"
+              placeholder={t("tags:form.slugPlaceholder")}
+              {...register("slug")}
+            />
+            <p className="text-xs text-muted-foreground">{t("tags:form.slugHint")}</p>
+            {errors.slug?.message ? (
+              <p className="text-xs text-destructive" data-testid="tag-form-slug-error">
+                {t(errors.slug.message)}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>{t("tags:form.color")}</Label>
+            <Controller
+              control={control}
+              name="color"
+              render={({ field }) => (
+                <TagColorPicker
+                  value={field.value as TagColor}
+                  onChange={(c) => field.onChange(c)}
+                  testId="tag-form-color"
+                  disabled={isPending}
+                />
+              )}
+            />
+            {errors.color?.message ? (
+              <p className="text-xs text-destructive" data-testid="tag-form-color-error">
+                {t(errors.color.message)}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex items-center gap-2 rounded-md border bg-muted/30 px-3 py-2">
+            <span className="text-xs text-muted-foreground">Preview:</span>
+            <TagBadge
+              label={previewLabel}
+              color={colorWatch as TagColor}
+              testId="tag-form-preview"
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting || isPending}
+              data-testid="tag-form-cancel"
+            >
+              {t("tags:form.cancel")}
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSubmitting || isPending}
+              data-testid="tag-form-submit"
+            >
+              {mode === "create" ? t("tags:form.create") : t("tags:form.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/tags/TagFormDialog.tsx
+++ b/frontend/src/components/tags/TagFormDialog.tsx
@@ -44,7 +44,7 @@ export function TagFormDialog({
   const { t } = useTranslation(["tags", "common"])
   const {
     control,
-    formState: { errors, isSubmitting },
+    formState: { errors, isSubmitting, dirtyFields },
     handleSubmit,
     register,
     reset,
@@ -72,26 +72,27 @@ export function TagFormDialog({
     }
   }, [open, mode, initialValues, reset])
 
-  // Live-derive slug from label while creating — only when the user
-  // hasn't manually edited the slug field. Edit mode skips this so a
-  // rename's slug change isn't accidentally clobbered by a label tweak.
+  // Live-derive slug from label while creating — only while the slug
+  // field has NOT been user-edited. RHF's `dirtyFields.slug` flips true
+  // the moment the user types a custom slug, and never flips back
+  // (until reset()), so this is a stable signal: an unedited slug
+  // tracks the label; a user-edited slug stays put even if the user
+  // keeps tweaking the label.
   const labelValue = watch("label")
-  const slugValue = watch("slug")
   useEffect(() => {
     if (mode !== "create") return
-    if (!labelValue) return
-    const next = normaliseSlug(labelValue)
-    // Only auto-fill when the slug field is either empty or still
-    // matches the previous auto-derived value (i.e. user hasn't typed
-    // anything custom). Tracking that by comparing to a normalised
-    // version of the label is good enough for the create flow.
-    if (slugValue === "" || slugValue === normaliseSlug(slugValue)) {
-      setValue("slug", next, { shouldValidate: false, shouldDirty: false })
-    }
-  }, [labelValue, mode, slugValue, setValue])
+    if (dirtyFields.slug) return
+    setValue("slug", normaliseSlug(labelValue ?? ""), {
+      shouldValidate: false,
+      shouldDirty: false,
+    })
+  }, [labelValue, mode, dirtyFields.slug, setValue])
 
   const colorWatch = watch("color")
-  const previewLabel = labelValue || t("tags:form.labelPlaceholder", { defaultValue: "Tag" })
+  // Preview falls back to a dedicated key — using the input placeholder
+  // ("e.g. Kitchen") would render misleading sample text inside the
+  // pill itself.
+  const previewLabel = labelValue || t("tags:form.previewFallback")
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/frontend/src/components/tags/TagRow.tsx
+++ b/frontend/src/components/tags/TagRow.tsx
@@ -1,0 +1,76 @@
+import { Pencil, Trash2 } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+import { TagBadge } from "./TagBadge"
+import type { TagColor, TagEntity, TagUsage } from "@/features/tags/api"
+
+export interface TagRowProps {
+  tag: TagEntity & { id: string }
+  usage?: TagUsage
+  onEdit: () => void
+  onDelete: () => void
+  className?: string
+}
+
+export function TagRow({ tag, usage, onEdit, onDelete, className }: TagRowProps) {
+  const { t } = useTranslation(["tags"])
+  const items = usage?.commodities ?? 0
+  const files = usage?.files ?? 0
+  const usageNone = items === 0 && files === 0
+
+  return (
+    <div
+      data-testid={`tag-row-${tag.slug}`}
+      className={cn(
+        "flex flex-wrap items-center justify-between gap-3 rounded-md border bg-card px-4 py-3",
+        className
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <TagBadge label={tag.label ?? tag.slug ?? ""} color={(tag.color ?? "muted") as TagColor} />
+        <span className="truncate text-xs text-muted-foreground">{tag.slug}</span>
+      </div>
+
+      <div
+        className="flex items-center gap-3 text-xs text-muted-foreground"
+        data-testid={`tag-row-${tag.slug}-usage`}
+      >
+        {usageNone ? (
+          <span>{t("tags:list.usageNone")}</span>
+        ) : (
+          <>
+            <span>{t("tags:list.usageItems", { count: items })}</span>
+            <span aria-hidden="true">·</span>
+            <span>{t("tags:list.usageFiles", { count: files })}</span>
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={onEdit}
+          aria-label={t("tags:list.edit")}
+          data-testid={`tag-row-${tag.slug}-edit`}
+        >
+          <Pencil className="size-4" aria-hidden="true" />
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={onDelete}
+          aria-label={t("tags:list.delete")}
+          data-testid={`tag-row-${tag.slug}-delete`}
+        >
+          <Trash2 className="size-4" aria-hidden="true" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/tags/TagsStatsBar.tsx
+++ b/frontend/src/components/tags/TagsStatsBar.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from "react-i18next"
+
+import { Card, CardContent } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+
+import type { TagStats } from "@/features/tags/api"
+
+export interface TagsStatsBarProps {
+  stats?: TagStats
+  loading?: boolean
+  testId?: string
+}
+
+const FIELDS: Array<{ key: keyof TagStats; labelKey: string }> = [
+  { key: "tags_total", labelKey: "tags:stats.tagsTotal" },
+  { key: "items_tagged", labelKey: "tags:stats.itemsTagged" },
+  { key: "items_untagged", labelKey: "tags:stats.itemsUntagged" },
+  { key: "files_tagged", labelKey: "tags:stats.filesTagged" },
+  { key: "files_untagged", labelKey: "tags:stats.filesUntagged" },
+]
+
+export function TagsStatsBar({ stats, loading, testId }: TagsStatsBarProps) {
+  const { t } = useTranslation(["tags"])
+  return (
+    <div
+      className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5"
+      data-testid={testId ?? "tags-stats"}
+    >
+      {FIELDS.map(({ key, labelKey }) => {
+        const value = stats?.[key]
+        return (
+          <Card
+            key={key}
+            className="border-muted"
+            data-testid={`tags-stats-${key.replace(/_/g, "-")}`}
+          >
+            <CardContent className="flex flex-col gap-1 p-4">
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                {t(labelKey)}
+              </span>
+              <span
+                className={cn(
+                  "text-2xl font-semibold tabular-nums",
+                  loading && stats === undefined ? "text-muted-foreground" : ""
+                )}
+              >
+                {loading && stats === undefined ? "—" : (value ?? 0)}
+              </span>
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/tags/__tests__/TagBadge.test.tsx
+++ b/frontend/src/components/tags/__tests__/TagBadge.test.tsx
@@ -1,0 +1,33 @@
+import { axe } from "jest-axe"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { TagBadge } from "@/components/tags/TagBadge"
+
+describe("<TagBadge />", () => {
+  it("renders the supplied label", () => {
+    render(<TagBadge label="Kitchen" color="amber" />)
+    expect(screen.getByText("Kitchen")).toBeInTheDocument()
+  })
+
+  it("applies the tone class for the requested colour", () => {
+    const { container } = render(<TagBadge label="x" color="green" testId="tb" />)
+    const badge = container.querySelector('[data-testid="tb"]')
+    expect(badge?.className).toContain("text-tag-green")
+    expect(badge?.className).toContain("border-tag-green")
+    expect(badge?.className).toContain("bg-tag-green")
+  })
+
+  it("renders both size variants without crashing", () => {
+    const { rerender } = render(<TagBadge label="x" color="muted" size="sm" testId="tb" />)
+    expect(screen.getByTestId("tb").className).toContain("h-5")
+    rerender(<TagBadge label="x" color="muted" size="md" testId="tb" />)
+    expect(screen.getByTestId("tb").className).toContain("h-6")
+  })
+
+  it("is axe-clean", async () => {
+    const { container } = render(<TagBadge label="Kitchen" color="amber" />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/components/tags/__tests__/TagFormDialog.test.tsx
+++ b/frontend/src/components/tags/__tests__/TagFormDialog.test.tsx
@@ -14,9 +14,7 @@ describe("<TagFormDialog />", () => {
   it("auto-derives the slug from the label in create mode", async () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn().mockResolvedValue(undefined)
-    render(
-      <TagFormDialog open mode="create" onSubmit={onSubmit} onOpenChange={vi.fn()} />
-    )
+    render(<TagFormDialog open mode="create" onSubmit={onSubmit} onOpenChange={vi.fn()} />)
     const labelInput = screen.getByTestId("tag-form-label")
     const slugInput = screen.getByTestId("tag-form-slug") as HTMLInputElement
     await user.type(labelInput, "Kitchen Stuff")
@@ -26,9 +24,7 @@ describe("<TagFormDialog />", () => {
   it("submits with the typed values when valid", async () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn().mockResolvedValue(undefined)
-    render(
-      <TagFormDialog open mode="create" onSubmit={onSubmit} onOpenChange={vi.fn()} />
-    )
+    render(<TagFormDialog open mode="create" onSubmit={onSubmit} onOpenChange={vi.fn()} />)
     await user.type(screen.getByTestId("tag-form-label"), "Kitchen")
     // Color picker — pick green
     await user.click(screen.getByTestId("tag-form-color-green"))
@@ -43,9 +39,7 @@ describe("<TagFormDialog />", () => {
   it("shows the labelRequired error when label is empty", async () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn().mockResolvedValue(undefined)
-    render(
-      <TagFormDialog open mode="create" onSubmit={onSubmit} onOpenChange={vi.fn()} />
-    )
+    render(<TagFormDialog open mode="create" onSubmit={onSubmit} onOpenChange={vi.fn()} />)
     // Submit empty form — should fail validation, not call onSubmit
     await user.click(screen.getByTestId("tag-form-submit"))
     expect(await screen.findByTestId("tag-form-label-error")).toBeInTheDocument()

--- a/frontend/src/components/tags/__tests__/TagFormDialog.test.tsx
+++ b/frontend/src/components/tags/__tests__/TagFormDialog.test.tsx
@@ -1,0 +1,81 @@
+import { axe } from "jest-axe"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeAll, describe, expect, it, vi } from "vitest"
+
+import { TagFormDialog } from "@/components/tags/TagFormDialog"
+import { initI18n } from "@/i18n"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+describe("<TagFormDialog />", () => {
+  it("auto-derives the slug from the label in create mode", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <TagFormDialog open mode="create" onSubmit={onSubmit} onOpenChange={vi.fn()} />
+    )
+    const labelInput = screen.getByTestId("tag-form-label")
+    const slugInput = screen.getByTestId("tag-form-slug") as HTMLInputElement
+    await user.type(labelInput, "Kitchen Stuff")
+    expect(slugInput.value).toBe("kitchen-stuff")
+  })
+
+  it("submits with the typed values when valid", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <TagFormDialog open mode="create" onSubmit={onSubmit} onOpenChange={vi.fn()} />
+    )
+    await user.type(screen.getByTestId("tag-form-label"), "Kitchen")
+    // Color picker — pick green
+    await user.click(screen.getByTestId("tag-form-color-green"))
+    await user.click(screen.getByTestId("tag-form-submit"))
+    expect(onSubmit).toHaveBeenCalledWith({
+      label: "Kitchen",
+      slug: "kitchen",
+      color: "green",
+    })
+  })
+
+  it("shows the labelRequired error when label is empty", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <TagFormDialog open mode="create" onSubmit={onSubmit} onOpenChange={vi.fn()} />
+    )
+    // Submit empty form — should fail validation, not call onSubmit
+    await user.click(screen.getByTestId("tag-form-submit"))
+    expect(await screen.findByTestId("tag-form-label-error")).toBeInTheDocument()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it("prefills label/slug/color from initialValues in edit mode", () => {
+    render(
+      <TagFormDialog
+        open
+        mode="edit"
+        initialValues={{ id: "t1", slug: "garden", label: "Garden", color: "blue" }}
+        onSubmit={vi.fn()}
+        onOpenChange={vi.fn()}
+      />
+    )
+    expect((screen.getByTestId("tag-form-label") as HTMLInputElement).value).toBe("Garden")
+    expect((screen.getByTestId("tag-form-slug") as HTMLInputElement).value).toBe("garden")
+    // Selected swatch carries aria-checked=true.
+    expect(screen.getByTestId("tag-form-color-blue").getAttribute("aria-checked")).toBe("true")
+  })
+
+  it("is axe-clean while open", async () => {
+    const { baseElement } = render(
+      <TagFormDialog open mode="create" onSubmit={vi.fn()} onOpenChange={vi.fn()} />
+    )
+    // Use baseElement (instead of container) so the dialog portal,
+    // which Radix renders outside the test root, is included in the
+    // axe scan.
+    const results = await axe(baseElement)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/components/tags/__tests__/TagsStatsBar.test.tsx
+++ b/frontend/src/components/tags/__tests__/TagsStatsBar.test.tsx
@@ -1,0 +1,52 @@
+import { axe } from "jest-axe"
+import { render, screen } from "@testing-library/react"
+import { beforeAll, describe, expect, it } from "vitest"
+
+import { TagsStatsBar } from "@/components/tags/TagsStatsBar"
+import { initI18n } from "@/i18n"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+describe("<TagsStatsBar />", () => {
+  it("renders five tiles with the supplied counts", () => {
+    render(
+      <TagsStatsBar
+        stats={{
+          tags_total: 12,
+          items_tagged: 50,
+          items_untagged: 7,
+          files_tagged: 30,
+          files_untagged: 5,
+        }}
+      />
+    )
+    expect(screen.getByTestId("tags-stats-tags-total")).toHaveTextContent("12")
+    expect(screen.getByTestId("tags-stats-items-tagged")).toHaveTextContent("50")
+    expect(screen.getByTestId("tags-stats-items-untagged")).toHaveTextContent("7")
+    expect(screen.getByTestId("tags-stats-files-tagged")).toHaveTextContent("30")
+    expect(screen.getByTestId("tags-stats-files-untagged")).toHaveTextContent("5")
+  })
+
+  it("falls back to em-dashes while loading without data", () => {
+    render(<TagsStatsBar loading />)
+    expect(screen.getByTestId("tags-stats-tags-total")).toHaveTextContent("—")
+  })
+
+  it("is axe-clean with stats present", async () => {
+    const { container } = render(
+      <TagsStatsBar
+        stats={{
+          tags_total: 1,
+          items_tagged: 0,
+          items_untagged: 0,
+          files_tagged: 0,
+          files_untagged: 0,
+        }}
+      />
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/features/tags/__tests__/api.test.ts
+++ b/frontend/src/features/tags/__tests__/api.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http, HttpResponse } from "msw"
+
+import {
+  autocompleteTags,
+  createTag,
+  deleteTag,
+  getTag,
+  getTagStats,
+  listTags,
+  updateTag,
+} from "@/features/tags/api"
+import { setAccessToken, clearAuth } from "@/lib/auth-storage"
+import { __resetGroupContextForTests, setCurrentGroupSlug } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { server } from "@/test/server"
+import { apiUrl } from "@/test/handlers"
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("token")
+  setCurrentGroupSlug("g1")
+})
+
+describe("features/tags/api", () => {
+  it("listTags flattens TagListItem rows and exposes meta.usage as `usage`", async () => {
+    // BE emits `data: []TagListItem` — each row is a flattened Tag plus
+    // an optional inline `meta.usage` block when ?include=usage is set.
+    // See go/jsonapi/tags.go::TagListItem and apiserver/tags.go::listTags.
+    server.use(
+      http.get(apiUrl("/g/g1/tags"), () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "t1",
+              slug: "kitchen",
+              label: "Kitchen",
+              color: "amber",
+              meta: { usage: { commodities: 3, files: 1 } },
+            },
+            {
+              id: "t2",
+              slug: "garden",
+              label: "Garden",
+              color: "green",
+            },
+          ],
+          meta: { tags: 2, total: 2 },
+        })
+      )
+    )
+
+    const result = await listTags({ includeUsage: true })
+    expect(result.total).toBe(2)
+    expect(result.tags).toHaveLength(2)
+    expect(result.tags[0].tag.slug).toBe("kitchen")
+    expect(result.tags[0].tag).not.toHaveProperty("meta")
+    expect(result.tags[0].usage).toEqual({ commodities: 3, files: 1 })
+    expect(result.tags[1].usage).toBeUndefined()
+  })
+
+  it("listTags wires include/sort/order/q query params through to the BE", async () => {
+    let captured: URL | null = null
+    server.use(
+      http.get(apiUrl("/g/g1/tags"), ({ request }) => {
+        captured = new URL(request.url)
+        return HttpResponse.json({ data: [], meta: { tags: 0, total: 0 } })
+      })
+    )
+    await listTags({ search: "k", sort: "usage", order: "desc", includeUsage: true })
+    expect(captured).not.toBeNull()
+    expect(captured!.searchParams.get("q")).toBe("k")
+    expect(captured!.searchParams.get("sort")).toBe("usage")
+    expect(captured!.searchParams.get("order")).toBe("desc")
+    expect(captured!.searchParams.get("include")).toBe("usage")
+  })
+
+  it("getTagStats reads the flat envelope from /tags/stats", async () => {
+    server.use(
+      http.get(apiUrl("/g/g1/tags/stats"), () =>
+        HttpResponse.json({
+          data: {
+            tags_total: 12,
+            items_tagged: 50,
+            items_untagged: 7,
+            files_tagged: 30,
+            files_untagged: 5,
+          },
+        })
+      )
+    )
+    const stats = await getTagStats()
+    expect(stats.tags_total).toBe(12)
+    expect(stats.items_untagged).toBe(7)
+    expect(stats.files_tagged).toBe(30)
+  })
+
+  it("getTag returns flat attributes + usage from the JSON:API detail envelope", async () => {
+    server.use(
+      http.get(apiUrl("/g/g1/tags/t1"), () =>
+        HttpResponse.json({
+          id: "t1",
+          type: "tags",
+          attributes: { id: "t1", slug: "kitchen", label: "Kitchen", color: "amber" },
+          meta: { usage: { commodities: 2, files: 0 } },
+        })
+      )
+    )
+    const result = await getTag("t1")
+    expect(result.tag.slug).toBe("kitchen")
+    expect(result.tag.id).toBe("t1")
+    expect(result.usage?.commodities).toBe(2)
+  })
+
+  it("createTag posts a JSON:API envelope and returns the created tag", async () => {
+    server.use(
+      http.post(apiUrl("/g/g1/tags"), () =>
+        HttpResponse.json(
+          {
+            id: "new",
+            type: "tags",
+            attributes: { id: "new", slug: "kitchen", label: "Kitchen", color: "amber" },
+          },
+          { status: 201 }
+        )
+      )
+    )
+    const created = await createTag({ slug: "kitchen", label: "Kitchen", color: "amber" })
+    expect(created.id).toBe("new")
+    expect(created.slug).toBe("kitchen")
+  })
+
+  it("updateTag PATCHes via JSON:API and returns the updated tag", async () => {
+    server.use(
+      http.patch(apiUrl("/g/g1/tags/t1"), () =>
+        HttpResponse.json({
+          id: "t1",
+          type: "tags",
+          attributes: { id: "t1", slug: "kitchen-2", label: "Kitchen", color: "blue" },
+        })
+      )
+    )
+    const updated = await updateTag("t1", { slug: "kitchen-2", color: "blue" })
+    expect(updated.slug).toBe("kitchen-2")
+    expect(updated.color).toBe("blue")
+  })
+
+  it("deleteTag appends ?force=true when force is requested", async () => {
+    let capturedForce: string | null = null
+    server.use(
+      http.delete(apiUrl("/g/g1/tags/t1"), ({ request }) => {
+        capturedForce = new URL(request.url).searchParams.get("force")
+        return new HttpResponse(null, { status: 204 })
+      })
+    )
+    await deleteTag("t1", true)
+    expect(capturedForce).toBe("true")
+  })
+
+  it("deleteTag omits force when not requested", async () => {
+    let capturedForce: string | null = "untouched"
+    server.use(
+      http.delete(apiUrl("/g/g1/tags/t1"), ({ request }) => {
+        capturedForce = new URL(request.url).searchParams.get("force")
+        return new HttpResponse(null, { status: 204 })
+      })
+    )
+    await deleteTag("t1")
+    expect(capturedForce).toBeNull()
+  })
+
+  it("autocompleteTags reads the flat data envelope", async () => {
+    server.use(
+      http.get(apiUrl("/g/g1/tags/autocomplete"), () =>
+        HttpResponse.json({
+          data: [
+            { id: "t1", slug: "kitchen", label: "Kitchen", color: "amber" },
+            { id: "t2", slug: "kid-room", label: "Kid Room", color: "green" },
+          ],
+        })
+      )
+    )
+    const result = await autocompleteTags("ki")
+    expect(result).toHaveLength(2)
+    expect(result[0].slug).toBe("kitchen")
+  })
+})

--- a/frontend/src/features/tags/__tests__/hooks.test.tsx
+++ b/frontend/src/features/tags/__tests__/hooks.test.tsx
@@ -1,0 +1,197 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { type ReactNode } from "react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { GroupProvider } from "@/features/group/GroupContext"
+import {
+  useCreateTag,
+  useDeleteTag,
+  useTagAutocomplete,
+  useTagStats,
+  useTags,
+  useUpdateTag,
+} from "@/features/tags/hooks"
+import { tagKeys } from "@/features/tags/keys"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { groupHandlers, tagHandlers } from "@/test/handlers"
+import { server } from "@/test/server"
+import type { Schema } from "@/types"
+
+const SLUG = "household"
+const groupFixture: Schema<"models.LocationGroup">[] = [
+  { id: "g1", slug: SLUG, name: "Household", main_currency: "USD" },
+]
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={[`/g/${SLUG}`]}>
+          <Routes>
+            <Route
+              path="/g/:groupSlug"
+              element={<GroupProvider>{children as React.ReactElement}</GroupProvider>}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+  }
+}
+
+function newClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+})
+
+describe("features/tags/hooks", () => {
+  it("useTags returns the list keyed under the active group's slug", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...tagHandlers.list(SLUG, [
+        {
+          id: "t1",
+          slug: "kitchen",
+          label: "Kitchen",
+          color: "amber",
+          meta: { usage: { commodities: 2, files: 0 } },
+        },
+      ])
+    )
+    const client = newClient()
+    const { result } = renderHook(() => useTags({ includeUsage: true }), {
+      wrapper: makeWrapper(client),
+    })
+    await waitFor(() => expect(result.current.data?.tags.length).toBe(1))
+    expect(result.current.data?.tags[0].usage?.commodities).toBe(2)
+    // Cache is keyed under `tagKeys.list(slug, opts)`. Reading directly
+    // proves the slug propagated through GroupProvider into the hook.
+    const cached = client.getQueryData(tagKeys.list(SLUG, { includeUsage: true }))
+    expect(cached).toBeDefined()
+  })
+
+  it("useTagStats reads /tags/stats and exposes the flat payload", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...tagHandlers.stats(SLUG, {
+        tags_total: 5,
+        items_tagged: 3,
+        items_untagged: 1,
+        files_tagged: 2,
+        files_untagged: 4,
+      })
+    )
+    const client = newClient()
+    const { result } = renderHook(() => useTagStats(), { wrapper: makeWrapper(client) })
+    await waitFor(() => expect(result.current.data?.tags_total).toBe(5))
+    expect(result.current.data?.files_untagged).toBe(4)
+  })
+
+  it("useCreateTag returns the created tag and surfaces it in the list cache via invalidation", async () => {
+    let listCalls = 0
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...tagHandlers.create(SLUG, {
+        id: "t-new",
+        slug: "kitchen",
+        label: "Kitchen",
+        color: "amber",
+      })
+    )
+    // Custom list handler counts invocations so we can confirm the
+    // invalidation triggered a refetch.
+    const { http, HttpResponse } = await import("msw")
+    const { apiUrl } = await import("@/test/handlers")
+    server.use(
+      http.get(apiUrl(`/g/${SLUG}/tags`), () => {
+        listCalls += 1
+        return HttpResponse.json({
+          data: [],
+          meta: { tags: 0, total: 0 },
+        })
+      })
+    )
+    const client = newClient()
+    const { result } = renderHook(() => ({ list: useTags(), create: useCreateTag() }), {
+      wrapper: makeWrapper(client),
+    })
+    await waitFor(() => expect(result.current.list.data).toBeDefined())
+    const initialCalls = listCalls
+    const created = await result.current.create.mutateAsync({
+      slug: "kitchen",
+      label: "Kitchen",
+      color: "amber",
+    })
+    expect(created.slug).toBe("kitchen")
+    // The list query is observed by the hook; invalidation refetches it.
+    await waitFor(() => expect(listCalls).toBeGreaterThan(initialCalls))
+  })
+
+  it("useUpdateTag passes id + req to the patch endpoint", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...tagHandlers.update(SLUG, "t1", {
+        id: "t1",
+        slug: "kitchen-2",
+        label: "Kitchen",
+        color: "blue",
+      })
+    )
+    const client = newClient()
+    const { result } = renderHook(() => useUpdateTag(), { wrapper: makeWrapper(client) })
+    const updated = await result.current.mutateAsync({
+      id: "t1",
+      req: { slug: "kitchen-2", color: "blue" },
+    })
+    expect(updated.slug).toBe("kitchen-2")
+    expect(updated.color).toBe("blue")
+  })
+
+  it("useDeleteTag with force=true issues the force-delete request", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...tagHandlers.remove(SLUG, "t1", { conflict: true })
+    )
+    const client = newClient()
+    const { result } = renderHook(() => useDeleteTag(), { wrapper: makeWrapper(client) })
+    // Without force, conflict handler returns 409 → mutation rejects.
+    await expect(result.current.mutateAsync({ id: "t1" })).rejects.toThrow()
+    // With force, it returns 204.
+    await expect(result.current.mutateAsync({ id: "t1", force: true })).resolves.toBeUndefined()
+  })
+
+  it("useTagAutocomplete returns the flat data envelope", async () => {
+    server.use(...groupHandlers.list(groupFixture), ...tagHandlers.list(SLUG, []))
+    const { server: srv } = await import("@/test/server")
+    const { http, HttpResponse } = await import("msw")
+    const { apiUrl } = await import("@/test/handlers")
+    srv.use(
+      http.get(apiUrl(`/g/${SLUG}/tags/autocomplete`), () =>
+        HttpResponse.json({
+          data: [{ id: "t1", slug: "kitchen", label: "Kitchen", color: "amber" }],
+        })
+      )
+    )
+    const client = newClient()
+    const { result } = renderHook(() => useTagAutocomplete("ki"), {
+      wrapper: makeWrapper(client),
+    })
+    await waitFor(() => expect(result.current.data?.length).toBe(1))
+    expect(result.current.data?.[0].slug).toBe("kitchen")
+  })
+})

--- a/frontend/src/features/tags/api.ts
+++ b/frontend/src/features/tags/api.ts
@@ -1,0 +1,165 @@
+// Pure data-layer functions for the tags feature slice. Hooks live in
+// `./hooks.ts`. Backed by the `/tags` surface introduced under #1400 +
+// extended for #1412 with `?include=usage` (per-row meta) and
+// `/tags/stats` (group-wide adoption summary).
+import { http } from "@/lib/http"
+import type { Schema } from "@/types"
+
+export type TagEntity = Schema<"models.Tag">
+export type TagColor = Schema<"models.TagColor">
+export type TagUsage = Schema<"registry.TagUsage">
+export type TagStats = Schema<"registry.TagStats">
+
+export const TAG_COLORS: TagColor[] = ["amber", "green", "blue", "orange", "red", "muted"]
+
+export type TagSortField = "label" | "created_at" | "usage"
+export type TagSortOrder = "asc" | "desc"
+
+export interface ListTagsOptions {
+  page?: number
+  perPage?: number
+  search?: string
+  sort?: TagSortField
+  order?: TagSortOrder
+  includeUsage?: boolean
+  signal?: AbortSignal
+}
+
+// Per-row usage as it lands in the list response when ?include=usage is set.
+// Optional because the BE only attaches it when the include token is present.
+export interface ListedTag {
+  tag: TagEntity & { id: string }
+  usage?: TagUsage
+}
+
+// List envelope: tags are FLAT inside `data` (project convention), with
+// an optional inline `meta.usage` block per row when ?include=usage was
+// requested. Mirrors the FilesListEnvelope shape.
+interface TagsListEnvelope {
+  data: Array<TagEntity & { id: string; meta?: { usage?: TagUsage } }>
+  meta?: {
+    tags?: number
+    total?: number
+  }
+}
+
+interface TagDetailEnvelope {
+  id?: string
+  type?: string
+  attributes?: TagEntity
+  meta?: { usage?: TagUsage }
+}
+
+interface TagStatsEnvelope {
+  data: TagStats
+}
+
+export async function listTags(
+  options: ListTagsOptions = {}
+): Promise<{ tags: ListedTag[]; total: number }> {
+  const params = new URLSearchParams()
+  if (options.page !== undefined) params.set("page", String(options.page))
+  if (options.perPage !== undefined) params.set("per_page", String(options.perPage))
+  if (options.search?.trim()) params.set("q", options.search.trim())
+  if (options.sort) params.set("sort", options.sort)
+  if (options.order) params.set("order", options.order)
+  if (options.includeUsage) params.set("include", "usage")
+  const qs = params.toString()
+  const path = qs ? `/tags?${qs}` : "/tags"
+  const body = await http.get<TagsListEnvelope>(path, { signal: options.signal })
+  return {
+    tags: (body.data ?? []).map((row) => {
+      const { meta, ...rest } = row
+      return { tag: rest, usage: meta?.usage }
+    }),
+    total: body.meta?.total ?? body.data?.length ?? 0,
+  }
+}
+
+export async function getTagStats(signal?: AbortSignal): Promise<TagStats> {
+  const body = await http.get<TagStatsEnvelope>("/tags/stats", { signal })
+  return body.data
+}
+
+export async function getTag(
+  id: string,
+  signal?: AbortSignal
+): Promise<{ tag: TagEntity & { id: string }; usage?: TagUsage }> {
+  const body = await http.get<TagDetailEnvelope>(`/tags/${encodeURIComponent(id)}`, { signal })
+  if (!body.attributes) {
+    throw new Error(`Malformed /tags/${id} response: missing attributes`)
+  }
+  return { tag: { ...body.attributes, id: body.id ?? id }, usage: body.meta?.usage }
+}
+
+export interface CreateTagRequest {
+  slug: string
+  label: string
+  color: TagColor
+}
+
+export async function createTag(req: CreateTagRequest): Promise<TagEntity & { id: string }> {
+  const body = await http.post<TagDetailEnvelope>("/tags", {
+    data: { type: "tags", attributes: req },
+  })
+  if (!body.attributes) {
+    throw new Error("Malformed POST /tags response: missing attributes")
+  }
+  return { ...body.attributes, id: body.id ?? "" }
+}
+
+export interface UpdateTagRequest {
+  slug?: string
+  label?: string
+  color?: TagColor
+}
+
+export async function updateTag(
+  id: string,
+  req: UpdateTagRequest
+): Promise<TagEntity & { id: string }> {
+  const body = await http.patch<TagDetailEnvelope>(`/tags/${encodeURIComponent(id)}`, {
+    data: { id, type: "tags", attributes: req },
+  })
+  if (!body.attributes) {
+    throw new Error(`Malformed PATCH /tags/${id} response: missing attributes`)
+  }
+  return { ...body.attributes, id: body.id ?? id }
+}
+
+// deleteTag returns 409 with usage breakdown when force=false and the
+// tag is in use. The Tags page surfaces that error, then re-issues with
+// force=true after user confirmation. We don't unwrap the 409 body here
+// because the http client throws Error(message) on 409 and the page
+// reads the message directly.
+export async function deleteTag(id: string, force = false): Promise<void> {
+  const path = force
+    ? `/tags/${encodeURIComponent(id)}?force=true`
+    : `/tags/${encodeURIComponent(id)}`
+  await http.del<void>(path)
+}
+
+export interface TagAutocompleteEntry {
+  id: string
+  slug: string
+  label: string
+  color: TagColor
+}
+
+interface TagAutocompleteEnvelope {
+  data?: TagAutocompleteEntry[]
+}
+
+export async function autocompleteTags(
+  q: string,
+  limit = 10,
+  signal?: AbortSignal
+): Promise<TagAutocompleteEntry[]> {
+  const params = new URLSearchParams()
+  if (q.trim()) params.set("q", q.trim())
+  params.set("limit", String(limit))
+  const body = await http.get<TagAutocompleteEnvelope>(`/tags/autocomplete?${params.toString()}`, {
+    signal,
+  })
+  return body.data ?? []
+}

--- a/frontend/src/features/tags/api.ts
+++ b/frontend/src/features/tags/api.ts
@@ -10,7 +10,19 @@ export type TagColor = Schema<"models.TagColor">
 export type TagUsage = Schema<"registry.TagUsage">
 export type TagStats = Schema<"registry.TagStats">
 
-export const TAG_COLORS: TagColor[] = ["amber", "green", "blue", "orange", "red", "muted"]
+// `as const` keeps the literal-union type so downstream callers (e.g.
+// `z.enum(TAG_COLORS)`) infer `"amber"|"green"|…` rather than the
+// widened `string`. The `satisfies readonly TagColor[]` check ensures
+// we cannot accidentally drift away from the BE's models.TagColor enum
+// without a typecheck error.
+export const TAG_COLORS = [
+  "amber",
+  "green",
+  "blue",
+  "orange",
+  "red",
+  "muted",
+] as const satisfies readonly TagColor[]
 
 export type TagSortField = "label" | "created_at" | "usage"
 export type TagSortOrder = "asc" | "desc"

--- a/frontend/src/features/tags/hooks.ts
+++ b/frontend/src/features/tags/hooks.ts
@@ -1,0 +1,120 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useCurrentGroup } from "@/features/group/GroupContext"
+
+import {
+  autocompleteTags,
+  createTag,
+  deleteTag,
+  getTag,
+  getTagStats,
+  listTags,
+  updateTag,
+  type CreateTagRequest,
+  type ListTagsOptions,
+  type ListedTag,
+  type TagAutocompleteEntry,
+  type TagEntity,
+  type TagStats,
+  type TagUsage,
+  type UpdateTagRequest,
+} from "./api"
+import { tagKeys } from "./keys"
+
+interface QueryOptions {
+  enabled?: boolean
+}
+
+export function useTags(opts: ListTagsOptions = {}, query: QueryOptions = {}) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  const enabled = query.enabled ?? true
+  return useQuery<{ tags: ListedTag[]; total: number }>({
+    queryKey: tagKeys.list(slug, opts),
+    queryFn: ({ signal }) => listTags({ ...opts, signal }),
+    enabled,
+    placeholderData: (prev) => prev,
+  })
+}
+
+export function useTagStats({ enabled = true }: QueryOptions = {}) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useQuery<TagStats>({
+    queryKey: tagKeys.stats(slug),
+    queryFn: ({ signal }) => getTagStats(signal),
+    enabled,
+    placeholderData: (prev) => prev,
+  })
+}
+
+export function useTag(id: string | undefined, { enabled = true }: QueryOptions = {}) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useQuery<{ tag: TagEntity & { id: string }; usage?: TagUsage }>({
+    queryKey: tagKeys.detail(slug, id ?? ""),
+    queryFn: ({ signal }) => {
+      if (!id) throw new Error("useTag called without an id")
+      return getTag(id, signal)
+    },
+    enabled: enabled && !!id,
+  })
+}
+
+// invalidateAll wipes the entire tags namespace for the active group.
+// Used after every mutation because list queries are keyed by sort +
+// order + search + include flags, and a focused invalidation would miss
+// cached permutations the user can switch back to.
+function useInvalidate() {
+  const qc = useQueryClient()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return {
+    all: () => qc.invalidateQueries({ queryKey: tagKeys.group(slug) }),
+    detail: (id: string) => qc.invalidateQueries({ queryKey: tagKeys.detail(slug, id) }),
+  }
+}
+
+export function useCreateTag() {
+  const invalidate = useInvalidate()
+  return useMutation<TagEntity & { id: string }, Error, CreateTagRequest>({
+    mutationFn: (req) => createTag(req),
+    onSuccess: () => invalidate.all(),
+  })
+}
+
+interface UpdateTagVars {
+  id: string
+  req: UpdateTagRequest
+}
+
+export function useUpdateTag() {
+  const invalidate = useInvalidate()
+  return useMutation<TagEntity & { id: string }, Error, UpdateTagVars>({
+    mutationFn: ({ id, req }) => updateTag(id, req),
+    onSuccess: () => invalidate.all(),
+  })
+}
+
+interface DeleteTagVars {
+  id: string
+  force?: boolean
+}
+
+export function useDeleteTag() {
+  const invalidate = useInvalidate()
+  return useMutation<void, Error, DeleteTagVars>({
+    mutationFn: ({ id, force }) => deleteTag(id, force),
+    onSuccess: () => invalidate.all(),
+  })
+}
+
+export function useTagAutocomplete(q: string, limit = 10, { enabled = true }: QueryOptions = {}) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useQuery<TagAutocompleteEntry[]>({
+    queryKey: tagKeys.autocomplete(slug, q, limit),
+    queryFn: ({ signal }) => autocompleteTags(q, limit, signal),
+    enabled,
+  })
+}

--- a/frontend/src/features/tags/keys.ts
+++ b/frontend/src/features/tags/keys.ts
@@ -1,0 +1,27 @@
+import type { ListTagsOptions } from "./api"
+
+function listKeySuffix(opts: ListTagsOptions | undefined): string {
+  if (!opts) return ""
+  const params = new URLSearchParams()
+  if (opts.page !== undefined) params.set("page", String(opts.page))
+  if (opts.perPage !== undefined) params.set("limit", String(opts.perPage))
+  if (opts.search?.trim()) params.set("search", opts.search.trim())
+  if (opts.sort) params.set("sort", opts.sort)
+  if (opts.order) params.set("order", opts.order)
+  if (opts.includeUsage) params.set("include", "usage")
+  return params.toString()
+}
+
+// TanStack Query keys for the tags slice. Scoped by group slug because
+// the http client rewrites /tags -> /g/{slug}/tags; without the slug in
+// the key, navigating between groups would reuse the wrong cache.
+export const tagKeys = {
+  all: ["tag"] as const,
+  group: (slug: string) => [...tagKeys.all, slug] as const,
+  list: (slug: string, opts?: ListTagsOptions) =>
+    [...tagKeys.group(slug), "list", listKeySuffix(opts)] as const,
+  stats: (slug: string) => [...tagKeys.group(slug), "stats"] as const,
+  detail: (slug: string, id: string) => [...tagKeys.group(slug), "detail", id] as const,
+  autocomplete: (slug: string, q: string, limit: number) =>
+    [...tagKeys.group(slug), "autocomplete", q, limit] as const,
+}

--- a/frontend/src/features/tags/schemas.ts
+++ b/frontend/src/features/tags/schemas.ts
@@ -27,7 +27,7 @@ export const tagFormSchema = z.object({
     .min(1, "tags:validation.slugRequired")
     .max(64, "tags:validation.slugTooLong")
     .regex(slugPattern, "tags:validation.slugInvalid"),
-  color: z.enum(TAG_COLORS as [string, ...string[]], {
+  color: z.enum(TAG_COLORS, {
     message: "tags:validation.colorRequired",
   }),
 })

--- a/frontend/src/features/tags/schemas.ts
+++ b/frontend/src/features/tags/schemas.ts
@@ -1,0 +1,36 @@
+import { z } from "zod"
+
+import { TAG_COLORS } from "./api"
+
+// normaliseSlug mirrors models.NormalizeTagSlug on the BE: lowercase,
+// replace runs of non-alphanumerics with `-`, trim leading/trailing `-`.
+// Kept client-side so the create form can show a live preview as the
+// user types the label.
+export function normaliseSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+const slugPattern = /^[a-z0-9]+(-[a-z0-9]+)*$/
+
+export const tagFormSchema = z.object({
+  label: z
+    .string()
+    .trim()
+    .min(1, "tags:validation.labelRequired")
+    .max(64, "tags:validation.labelTooLong"),
+  slug: z
+    .string()
+    .trim()
+    .min(1, "tags:validation.slugRequired")
+    .max(64, "tags:validation.slugTooLong")
+    .regex(slugPattern, "tags:validation.slugInvalid"),
+  color: z.enum(TAG_COLORS as [string, ...string[]], {
+    message: "tags:validation.colorRequired",
+  }),
+})
+
+export type TagFormInput = z.input<typeof tagFormSchema>
+export type TagFormValues = z.output<typeof tagFormSchema>

--- a/frontend/src/i18n/locales/en/tags.json
+++ b/frontend/src/i18n/locales/en/tags.json
@@ -1,1 +1,85 @@
-{}
+{
+  "title": "Tags",
+  "description": "Manage labels you can attach to items and files. Renaming a tag rewrites its references everywhere; deleting one in use prompts you for confirmation.",
+  "stats": {
+    "tagsTotal": "Tags",
+    "itemsTagged": "Tagged items",
+    "itemsUntagged": "Untagged items",
+    "filesTagged": "Tagged files",
+    "filesUntagged": "Untagged files"
+  },
+  "search": {
+    "label": "Search tags",
+    "placeholder": "Search by label or slug…"
+  },
+  "list": {
+    "empty": "No tags yet — create your first one above.",
+    "emptyFiltered": "No tags match \"{{query}}\".",
+    "loadError": "Could not load tags: {{error}}",
+    "usageItems_one": "{{count}} item",
+    "usageItems_other": "{{count}} items",
+    "usageFiles_one": "{{count}} file",
+    "usageFiles_other": "{{count}} files",
+    "usageNone": "Not used yet",
+    "edit": "Edit tag",
+    "delete": "Delete tag",
+    "showUsage": "Show usage",
+    "hideUsage": "Hide usage"
+  },
+  "form": {
+    "label": "Label",
+    "labelPlaceholder": "e.g. Kitchen",
+    "slug": "Slug",
+    "slugPlaceholder": "kitchen",
+    "slugHint": "Lowercase letters, digits and dashes. Used as the identifier in JSONB references.",
+    "color": "Color",
+    "create": "Create tag",
+    "save": "Save changes",
+    "cancel": "Cancel",
+    "createTitle": "Create tag",
+    "editTitle": "Edit tag",
+    "createSuccess": "Tag created.",
+    "updateSuccess": "Tag updated.",
+    "createError": "Could not create tag: {{error}}",
+    "updateError": "Could not update tag: {{error}}"
+  },
+  "delete": {
+    "confirmTitle": "Delete tag?",
+    "confirmDescription": "Remove the tag \"{{label}}\" from this group. This cannot be undone.",
+    "confirmAction": "Delete",
+    "inUseTitle": "Tag is in use",
+    "inUseDescription": "\"{{label}}\" is referenced by {{items}} and {{files}}. Force-delete will strip those references first, then remove the tag.",
+    "forceAction": "Force delete",
+    "forceCancel": "Cancel",
+    "deleteSuccess": "Tag deleted.",
+    "deleteError": "Could not delete tag: {{error}}"
+  },
+  "usage": {
+    "items_one": "{{count}} item",
+    "items_other": "{{count}} items",
+    "files_one": "{{count}} file",
+    "files_other": "{{count}} files",
+    "loadError": "Could not load usage: {{error}}"
+  },
+  "color": {
+    "amber": "Amber",
+    "green": "Green",
+    "blue": "Blue",
+    "orange": "Orange",
+    "red": "Red",
+    "muted": "Muted",
+    "selectLabel": "Pick a color"
+  },
+  "validation": {
+    "labelRequired": "Label is required.",
+    "labelTooLong": "Label must be 64 characters or fewer.",
+    "slugRequired": "Slug is required.",
+    "slugTooLong": "Slug must be 64 characters or fewer.",
+    "slugInvalid": "Slug must be lowercase, kebab-cased.",
+    "colorRequired": "Pick a color."
+  },
+  "create": {
+    "button": "Create tag",
+    "title": "New tag"
+  }
+}

--- a/frontend/src/i18n/locales/en/tags.json
+++ b/frontend/src/i18n/locales/en/tags.json
@@ -1,85 +1,81 @@
 {
-  "title": "Tags",
+  "color": {
+    "amber": "Amber",
+    "blue": "Blue",
+    "green": "Green",
+    "muted": "Muted",
+    "orange": "Orange",
+    "red": "Red",
+    "selectLabel": "Pick a color"
+  },
+  "create": {
+    "button": "Create tag"
+  },
+  "delete": {
+    "confirmAction": "Delete",
+    "confirmDescription": "Remove the tag \"{{label}}\" from this group. This cannot be undone.",
+    "confirmTitle": "Delete tag?",
+    "deleteError": "Could not delete tag: {{error}}",
+    "deleteSuccess": "Tag deleted.",
+    "forceAction": "Force delete",
+    "forceCancel": "Cancel",
+    "inUseDescription": "\"{{label}}\" is referenced by {{items}} and {{files}}. Force-delete will strip those references first, then remove the tag.",
+    "inUseTitle": "Tag is in use"
+  },
   "description": "Manage labels you can attach to items and files. Renaming a tag rewrites its references everywhere; deleting one in use prompts you for confirmation.",
-  "stats": {
-    "tagsTotal": "Tags",
-    "itemsTagged": "Tagged items",
-    "itemsUntagged": "Untagged items",
-    "filesTagged": "Tagged files",
-    "filesUntagged": "Untagged files"
+  "form": {
+    "cancel": "Cancel",
+    "color": "Color",
+    "create": "Create tag",
+    "createError": "Could not create tag: {{error}}",
+    "createSuccess": "Tag created.",
+    "createTitle": "Create tag",
+    "editTitle": "Edit tag",
+    "label": "Label",
+    "labelPlaceholder": "e.g. Kitchen",
+    "save": "Save changes",
+    "slug": "Slug",
+    "slugHint": "Lowercase letters, digits and dashes. Used as the identifier in JSONB references.",
+    "slugPlaceholder": "kitchen",
+    "updateError": "Could not update tag: {{error}}",
+    "updateSuccess": "Tag updated."
+  },
+  "list": {
+    "delete": "Delete tag",
+    "edit": "Edit tag",
+    "empty": "No tags yet — create your first one above.",
+    "emptyFiltered": "No tags match \"{{query}}\".",
+    "loadError": "Could not load tags: {{error}}",
+    "usageFiles_one": "{{count}} file",
+    "usageFiles_other": "{{count}} files",
+    "usageItems_one": "{{count}} item",
+    "usageItems_other": "{{count}} items",
+    "usageNone": "Not used yet"
   },
   "search": {
     "label": "Search tags",
     "placeholder": "Search by label or slug…"
   },
-  "list": {
-    "empty": "No tags yet — create your first one above.",
-    "emptyFiltered": "No tags match \"{{query}}\".",
-    "loadError": "Could not load tags: {{error}}",
-    "usageItems_one": "{{count}} item",
-    "usageItems_other": "{{count}} items",
-    "usageFiles_one": "{{count}} file",
-    "usageFiles_other": "{{count}} files",
-    "usageNone": "Not used yet",
-    "edit": "Edit tag",
-    "delete": "Delete tag",
-    "showUsage": "Show usage",
-    "hideUsage": "Hide usage"
+  "stats": {
+    "filesTagged": "Tagged files",
+    "filesUntagged": "Untagged files",
+    "itemsTagged": "Tagged items",
+    "itemsUntagged": "Untagged items",
+    "tagsTotal": "Tags"
   },
-  "form": {
-    "label": "Label",
-    "labelPlaceholder": "e.g. Kitchen",
-    "slug": "Slug",
-    "slugPlaceholder": "kitchen",
-    "slugHint": "Lowercase letters, digits and dashes. Used as the identifier in JSONB references.",
-    "color": "Color",
-    "create": "Create tag",
-    "save": "Save changes",
-    "cancel": "Cancel",
-    "createTitle": "Create tag",
-    "editTitle": "Edit tag",
-    "createSuccess": "Tag created.",
-    "updateSuccess": "Tag updated.",
-    "createError": "Could not create tag: {{error}}",
-    "updateError": "Could not update tag: {{error}}"
-  },
-  "delete": {
-    "confirmTitle": "Delete tag?",
-    "confirmDescription": "Remove the tag \"{{label}}\" from this group. This cannot be undone.",
-    "confirmAction": "Delete",
-    "inUseTitle": "Tag is in use",
-    "inUseDescription": "\"{{label}}\" is referenced by {{items}} and {{files}}. Force-delete will strip those references first, then remove the tag.",
-    "forceAction": "Force delete",
-    "forceCancel": "Cancel",
-    "deleteSuccess": "Tag deleted.",
-    "deleteError": "Could not delete tag: {{error}}"
-  },
+  "title": "Tags",
   "usage": {
-    "items_one": "{{count}} item",
-    "items_other": "{{count}} items",
     "files_one": "{{count}} file",
     "files_other": "{{count}} files",
-    "loadError": "Could not load usage: {{error}}"
-  },
-  "color": {
-    "amber": "Amber",
-    "green": "Green",
-    "blue": "Blue",
-    "orange": "Orange",
-    "red": "Red",
-    "muted": "Muted",
-    "selectLabel": "Pick a color"
+    "items_one": "{{count}} item",
+    "items_other": "{{count}} items"
   },
   "validation": {
+    "colorRequired": "Pick a color.",
     "labelRequired": "Label is required.",
     "labelTooLong": "Label must be 64 characters or fewer.",
-    "slugRequired": "Slug is required.",
-    "slugTooLong": "Slug must be 64 characters or fewer.",
     "slugInvalid": "Slug must be lowercase, kebab-cased.",
-    "colorRequired": "Pick a color."
-  },
-  "create": {
-    "button": "Create tag",
-    "title": "New tag"
+    "slugRequired": "Slug is required.",
+    "slugTooLong": "Slug must be 64 characters or fewer."
   }
 }

--- a/frontend/src/i18n/locales/en/tags.json
+++ b/frontend/src/i18n/locales/en/tags.json
@@ -11,17 +11,6 @@
   "create": {
     "button": "Create tag"
   },
-  "delete": {
-    "confirmAction": "Delete",
-    "confirmDescription": "Remove the tag \"{{label}}\" from this group. This cannot be undone.",
-    "confirmTitle": "Delete tag?",
-    "deleteError": "Could not delete tag: {{error}}",
-    "deleteSuccess": "Tag deleted.",
-    "forceAction": "Force delete",
-    "forceCancel": "Cancel",
-    "inUseDescription": "\"{{label}}\" is referenced by {{items}} and {{files}}. Force-delete will strip those references first, then remove the tag.",
-    "inUseTitle": "Tag is in use"
-  },
   "description": "Manage labels you can attach to items and files. Renaming a tag rewrites its references everywhere; deleting one in use prompts you for confirmation.",
   "form": {
     "cancel": "Cancel",
@@ -33,6 +22,7 @@
     "editTitle": "Edit tag",
     "label": "Label",
     "labelPlaceholder": "e.g. Kitchen",
+    "previewFallback": "Tag",
     "save": "Save changes",
     "slug": "Slug",
     "slugHint": "Lowercase letters, digits and dashes. Used as the identifier in JSONB references.",
@@ -51,6 +41,17 @@
     "usageItems_one": "{{count}} item",
     "usageItems_other": "{{count}} items",
     "usageNone": "Not used yet"
+  },
+  "removal": {
+    "confirmAction": "Delete",
+    "confirmDescription": "Remove the tag \"{{label}}\" from this group. This cannot be undone.",
+    "confirmTitle": "Delete tag?",
+    "deleteError": "Could not delete tag: {{error}}",
+    "deleteSuccess": "Tag deleted.",
+    "forceAction": "Force delete",
+    "forceCancel": "Cancel",
+    "inUseDescription": "\"{{label}}\" is referenced by {{items}} and {{files}}. Force-delete will strip those references first, then remove the tag.",
+    "inUseTitle": "Tag is in use"
   },
   "search": {
     "label": "Search tags",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -45,6 +45,13 @@
   --color-status-expiring: var(--status-expiring);
   --color-status-expired: var(--status-expired);
   --color-status-none: var(--status-none);
+
+  --color-tag-amber: var(--tag-amber);
+  --color-tag-green: var(--tag-green);
+  --color-tag-blue: var(--tag-blue);
+  --color-tag-orange: var(--tag-orange);
+  --color-tag-red: var(--tag-red);
+  --color-tag-muted: var(--tag-muted);
 }
 
 /*
@@ -87,6 +94,22 @@
   --status-expiring: oklch(0.78 0.18 75);
   --status-expired: oklch(0.65 0.22 25);
   --status-none: oklch(0.6 0 0);
+
+  /*
+    Tag palette — six tones used as foreground + tinted background on
+    TagBadge pills. Names mirror models.TagColor on the BE
+    (amber/green/blue/orange/red/muted). The badge component reads each
+    via Tailwind utilities (`text-tag-amber`, `bg-tag-amber/15`,
+    `border-tag-amber/30`) so the same OKLCH lightness/chroma works for
+    both filled and outline rendering. .dark overrides nudge lightness
+    up so the same pill stays readable on the dark canvas.
+  */
+  --tag-amber: oklch(0.55 0.15 80);
+  --tag-green: oklch(0.55 0.15 145);
+  --tag-blue: oklch(0.55 0.15 240);
+  --tag-orange: oklch(0.6 0.18 50);
+  --tag-red: oklch(0.55 0.2 25);
+  --tag-muted: oklch(0.5 0.018 60);
 
   --chart-1: oklch(0.7 0.16 75);
   --chart-2: oklch(0.65 0.14 145);
@@ -137,6 +160,13 @@
   --status-expiring: oklch(0.72 0.18 75);
   --status-expired: oklch(0.62 0.22 25);
   --status-none: oklch(0.5 0 0);
+
+  --tag-amber: oklch(0.78 0.13 80);
+  --tag-green: oklch(0.75 0.14 145);
+  --tag-blue: oklch(0.75 0.13 240);
+  --tag-orange: oklch(0.78 0.15 50);
+  --tag-red: oklch(0.72 0.18 25);
+  --tag-muted: oklch(0.7 0.018 65);
 
   --chart-1: oklch(0.75 0.16 75);
   --chart-2: oklch(0.62 0.17 145);

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -1,0 +1,303 @@
+import { Plus, Search } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { useSearchParams } from "react-router-dom"
+
+import { TagFormDialog } from "@/components/tags/TagFormDialog"
+import { TagRow } from "@/components/tags/TagRow"
+import { TagsStatsBar } from "@/components/tags/TagsStatsBar"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  type CreateTagRequest,
+  type TagColor,
+  type TagEntity,
+  type TagSortField,
+  type TagSortOrder,
+  type UpdateTagRequest,
+} from "@/features/tags/api"
+import {
+  useCreateTag,
+  useDeleteTag,
+  useTagStats,
+  useTags,
+  useUpdateTag,
+} from "@/features/tags/hooks"
+import { useAppToast } from "@/hooks/useAppToast"
+import { useConfirm } from "@/hooks/useConfirm"
+
+// Search-input debounce keeps the page responsive on every keystroke
+// while still reflecting the typed value in the URL (so refreshes /
+// shareable links survive). 250ms is the same delay other "as-you-type"
+// surfaces in this codebase use.
+const SEARCH_DEBOUNCE_MS = 250
+
+interface DialogState {
+  open: boolean
+  mode: "create" | "edit"
+  tag?: TagEntity & { id: string }
+}
+
+export function TagsListPage() {
+  const { t } = useTranslation(["tags", "common"])
+  const toast = useAppToast()
+  const confirm = useConfirm()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const urlQuery = searchParams.get("q") ?? ""
+  const urlSort = (searchParams.get("sort") as TagSortField | null) ?? "label"
+  const urlOrder = (searchParams.get("order") as TagSortOrder | null) ?? "asc"
+
+  const [pendingSearch, setPendingSearch] = useState(urlQuery)
+  useEffect(() => setPendingSearch(urlQuery), [urlQuery])
+
+  // Debounced URL update — write the typed search into the URL after the
+  // user stops typing. The list query is keyed off the URL value (via
+  // useTags below), so this also drives refetching.
+  useEffect(() => {
+    const trimmed = pendingSearch.trim()
+    if (trimmed === urlQuery) return
+    const timer = window.setTimeout(() => {
+      const next = new URLSearchParams(searchParams)
+      if (trimmed) {
+        next.set("q", trimmed)
+      } else {
+        next.delete("q")
+      }
+      setSearchParams(next, { replace: true })
+    }, SEARCH_DEBOUNCE_MS)
+    return () => window.clearTimeout(timer)
+  }, [pendingSearch, urlQuery, searchParams, setSearchParams])
+
+  const listOpts = useMemo(
+    () => ({
+      search: urlQuery || undefined,
+      sort: urlSort,
+      order: urlOrder,
+      includeUsage: true,
+      perPage: 200,
+    }),
+    [urlQuery, urlSort, urlOrder]
+  )
+  const tagsQuery = useTags(listOpts)
+  const statsQuery = useTagStats()
+
+  const createMutation = useCreateTag()
+  const updateMutation = useUpdateTag()
+  const deleteMutation = useDeleteTag()
+
+  const [dialog, setDialog] = useState<DialogState>({ open: false, mode: "create" })
+
+  const items = tagsQuery.data?.tags ?? []
+  const isInitialLoading = tagsQuery.isLoading && !tagsQuery.data
+
+  function patchSort(value: string) {
+    const [field, order] = value.split(".") as [TagSortField, TagSortOrder]
+    const next = new URLSearchParams(searchParams)
+    next.set("sort", field)
+    next.set("order", order)
+    setSearchParams(next, { replace: true })
+  }
+
+  async function onCreateSubmit(values: CreateTagRequest) {
+    try {
+      await createMutation.mutateAsync(values)
+      toast.success(t("tags:form.createSuccess"))
+      setDialog({ open: false, mode: "create" })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error(t("tags:form.createError", { error: message }))
+    }
+  }
+
+  async function onEditSubmit(id: string, values: UpdateTagRequest) {
+    try {
+      await updateMutation.mutateAsync({ id, req: values })
+      toast.success(t("tags:form.updateSuccess"))
+      setDialog({ open: false, mode: "create" })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error(t("tags:form.updateError", { error: message }))
+    }
+  }
+
+  async function onDelete(tag: TagEntity & { id: string }, items: number, files: number) {
+    const inUse = items > 0 || files > 0
+    if (!inUse) {
+      const ok = await confirm({
+        title: t("tags:delete.confirmTitle"),
+        description: t("tags:delete.confirmDescription", { label: tag.label }),
+        confirmLabel: t("tags:delete.confirmAction"),
+        destructive: true,
+      })
+      if (!ok) return
+      try {
+        await deleteMutation.mutateAsync({ id: tag.id })
+        toast.success(t("tags:delete.deleteSuccess"))
+      } catch (err) {
+        toast.error(
+          t("tags:delete.deleteError", {
+            error: err instanceof Error ? err.message : String(err),
+          })
+        )
+      }
+      return
+    }
+
+    // In-use → confirm with stripped-references warning, then force.
+    const ok = await confirm({
+      title: t("tags:delete.inUseTitle"),
+      description: t("tags:delete.inUseDescription", {
+        label: tag.label,
+        items: t("tags:usage.items", { count: items }),
+        files: t("tags:usage.files", { count: files }),
+      }),
+      confirmLabel: t("tags:delete.forceAction"),
+      cancelLabel: t("tags:delete.forceCancel"),
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await deleteMutation.mutateAsync({ id: tag.id, force: true })
+      toast.success(t("tags:delete.deleteSuccess"))
+    } catch (err) {
+      toast.error(
+        t("tags:delete.deleteError", {
+          error: err instanceof Error ? err.message : String(err),
+        })
+      )
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6" data-testid="page-tags">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-2xl font-semibold tracking-tight">{t("tags:title")}</h1>
+          <p className="max-w-prose text-sm text-muted-foreground">{t("tags:description")}</p>
+        </div>
+        <Button
+          type="button"
+          onClick={() => setDialog({ open: true, mode: "create" })}
+          data-testid="tags-create-button"
+        >
+          <Plus className="mr-1.5 size-4" aria-hidden="true" />
+          {t("tags:create.button")}
+        </Button>
+      </header>
+
+      <TagsStatsBar stats={statsQuery.data} loading={statsQuery.isLoading} />
+
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="relative min-w-64 flex-1">
+          <Label htmlFor="tags-search-input" className="sr-only">
+            {t("tags:search.label")}
+          </Label>
+          <Search
+            className="absolute left-2 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            id="tags-search-input"
+            type="search"
+            value={pendingSearch}
+            onChange={(e) => setPendingSearch(e.target.value)}
+            placeholder={t("tags:search.placeholder")}
+            className="pl-8"
+            data-testid="tags-search-input"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label
+            htmlFor="tags-sort-select"
+            className="text-xs uppercase tracking-wide text-muted-foreground"
+          >
+            Sort
+          </Label>
+          <select
+            id="tags-sort-select"
+            data-testid="tags-sort"
+            className="h-9 rounded-md border border-input bg-background px-2 text-sm"
+            value={`${urlSort}.${urlOrder}`}
+            onChange={(e) => patchSort(e.target.value)}
+          >
+            <option value="label.asc">A → Z</option>
+            <option value="label.desc">Z → A</option>
+            <option value="usage.desc">Most used</option>
+            <option value="created_at.desc">Newest</option>
+          </select>
+        </div>
+      </div>
+
+      {isInitialLoading ? (
+        <div className="flex flex-col gap-2" data-testid="tags-list-loading">
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <Skeleton key={idx} className="h-14 w-full" />
+          ))}
+        </div>
+      ) : tagsQuery.isError ? (
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive"
+          role="alert"
+          data-testid="tags-list-error"
+        >
+          {t("tags:list.loadError", {
+            error: tagsQuery.error instanceof Error ? tagsQuery.error.message : "unknown",
+          })}
+        </div>
+      ) : items.length === 0 ? (
+        <div
+          className="rounded-md border bg-muted/30 px-4 py-10 text-center text-sm text-muted-foreground"
+          data-testid="tags-list-empty"
+        >
+          {urlQuery ? t("tags:list.emptyFiltered", { query: urlQuery }) : t("tags:list.empty")}
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-2" data-testid="tags-list">
+          {items.map(({ tag, usage }) => (
+            <li key={tag.id}>
+              <TagRow
+                tag={tag}
+                usage={usage}
+                onEdit={() =>
+                  setDialog({
+                    open: true,
+                    mode: "edit",
+                    tag,
+                  })
+                }
+                onDelete={() => onDelete(tag, usage?.commodities ?? 0, usage?.files ?? 0)}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <TagFormDialog
+        open={dialog.open}
+        onOpenChange={(open) =>
+          setDialog((prev) => (open ? prev : { open: false, mode: "create" }))
+        }
+        mode={dialog.mode}
+        initialValues={dialog.tag}
+        isPending={createMutation.isPending || updateMutation.isPending}
+        onSubmit={async (values) => {
+          if (dialog.mode === "edit" && dialog.tag) {
+            await onEditSubmit(dialog.tag.id, {
+              label: values.label,
+              slug: values.slug,
+              color: values.color as TagColor,
+            })
+          } else {
+            await onCreateSubmit(values)
+          }
+        }}
+      />
+    </div>
+  )
+}
+
+// Re-exports below are intentionally minimal: the page is consumed only
+// by the router. Tests import named pieces from features/tags directly.

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -34,6 +34,28 @@ import { useConfirm } from "@/hooks/useConfirm"
 // surfaces in this codebase use.
 const SEARCH_DEBOUNCE_MS = 250
 
+// Allowlist for ?sort= / ?order= query params — guards against a
+// hand-edited URL or a stale shared link slipping an unsupported value
+// through to the BE (which would 4xx) or rendering a blank `<select>`.
+const VALID_SORT_FIELDS = [
+  "label",
+  "created_at",
+  "usage",
+] as const satisfies readonly TagSortField[]
+const VALID_SORT_ORDERS = ["asc", "desc"] as const satisfies readonly TagSortOrder[]
+
+function parseSort(raw: string | null): TagSortField {
+  return (VALID_SORT_FIELDS as readonly string[]).includes(raw ?? "")
+    ? (raw as TagSortField)
+    : "label"
+}
+
+function parseOrder(raw: string | null): TagSortOrder {
+  return (VALID_SORT_ORDERS as readonly string[]).includes(raw ?? "")
+    ? (raw as TagSortOrder)
+    : "asc"
+}
+
 interface DialogState {
   open: boolean
   mode: "create" | "edit"
@@ -47,8 +69,8 @@ export function TagsListPage() {
   const [searchParams, setSearchParams] = useSearchParams()
 
   const urlQuery = searchParams.get("q") ?? ""
-  const urlSort = (searchParams.get("sort") as TagSortField | null) ?? "label"
-  const urlOrder = (searchParams.get("order") as TagSortOrder | null) ?? "asc"
+  const urlSort = parseSort(searchParams.get("sort"))
+  const urlOrder = parseOrder(searchParams.get("order"))
 
   const [pendingSearch, setPendingSearch] = useState(urlQuery)
   useEffect(() => setPendingSearch(urlQuery), [urlQuery])
@@ -127,18 +149,18 @@ export function TagsListPage() {
     const inUse = items > 0 || files > 0
     if (!inUse) {
       const ok = await confirm({
-        title: t("tags:delete.confirmTitle"),
-        description: t("tags:delete.confirmDescription", { label: tag.label }),
-        confirmLabel: t("tags:delete.confirmAction"),
+        title: t("tags:removal.confirmTitle"),
+        description: t("tags:removal.confirmDescription", { label: tag.label }),
+        confirmLabel: t("tags:removal.confirmAction"),
         destructive: true,
       })
       if (!ok) return
       try {
         await deleteMutation.mutateAsync({ id: tag.id })
-        toast.success(t("tags:delete.deleteSuccess"))
+        toast.success(t("tags:removal.deleteSuccess"))
       } catch (err) {
         toast.error(
-          t("tags:delete.deleteError", {
+          t("tags:removal.deleteError", {
             error: err instanceof Error ? err.message : String(err),
           })
         )
@@ -148,23 +170,23 @@ export function TagsListPage() {
 
     // In-use → confirm with stripped-references warning, then force.
     const ok = await confirm({
-      title: t("tags:delete.inUseTitle"),
-      description: t("tags:delete.inUseDescription", {
+      title: t("tags:removal.inUseTitle"),
+      description: t("tags:removal.inUseDescription", {
         label: tag.label,
         items: t("tags:usage.items", { count: items }),
         files: t("tags:usage.files", { count: files }),
       }),
-      confirmLabel: t("tags:delete.forceAction"),
-      cancelLabel: t("tags:delete.forceCancel"),
+      confirmLabel: t("tags:removal.forceAction"),
+      cancelLabel: t("tags:removal.forceCancel"),
       destructive: true,
     })
     if (!ok) return
     try {
       await deleteMutation.mutateAsync({ id: tag.id, force: true })
-      toast.success(t("tags:delete.deleteSuccess"))
+      toast.success(t("tags:removal.deleteSuccess"))
     } catch (err) {
       toast.error(
-        t("tags:delete.deleteError", {
+        t("tags:removal.deleteError", {
           error: err instanceof Error ? err.message : String(err),
         })
       )

--- a/frontend/src/pages/tags/__tests__/TagsListPage.test.tsx
+++ b/frontend/src/pages/tags/__tests__/TagsListPage.test.tsx
@@ -1,0 +1,117 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { axe } from "jest-axe"
+import { Route } from "react-router-dom"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { GroupProvider } from "@/features/group/GroupContext"
+import { ConfirmProvider } from "@/hooks/useConfirm"
+import { initI18n } from "@/i18n"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { TagsListPage } from "@/pages/tags/TagsListPage"
+import { groupHandlers, tagHandlers } from "@/test/handlers"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import type { Schema } from "@/types"
+
+const SLUG = "household"
+const groupFixture: Schema<"models.LocationGroup">[] = [
+  { id: "g1", slug: SLUG, name: "Household", main_currency: "USD" },
+]
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+})
+
+function renderPage() {
+  return renderWithProviders({
+    initialPath: `/g/${SLUG}/tags`,
+    routes: (
+      <Route
+        path="/g/:groupSlug/tags"
+        element={
+          <ConfirmProvider>
+            <GroupProvider>
+              <main>
+                <TagsListPage />
+              </main>
+            </GroupProvider>
+          </ConfirmProvider>
+        }
+      />
+    ),
+  })
+}
+
+function seed() {
+  server.use(
+    ...groupHandlers.list(groupFixture),
+    ...tagHandlers.stats(SLUG, {
+      tags_total: 2,
+      items_tagged: 5,
+      items_untagged: 1,
+      files_tagged: 3,
+      files_untagged: 2,
+    }),
+    ...tagHandlers.list(SLUG, [
+      {
+        id: "t1",
+        slug: "kitchen",
+        label: "Kitchen",
+        color: "amber",
+        meta: { usage: { commodities: 2, files: 0 } },
+      },
+      {
+        id: "t2",
+        slug: "garden",
+        label: "Garden",
+        color: "green",
+        meta: { usage: { commodities: 0, files: 0 } },
+      },
+    ])
+  )
+}
+
+describe("<TagsListPage />", () => {
+  it("renders the stats bar with values from /tags/stats", async () => {
+    seed()
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId("tags-stats-tags-total")).toHaveTextContent("2"))
+    expect(screen.getByTestId("tags-stats-items-tagged")).toHaveTextContent("5")
+    expect(screen.getByTestId("tags-stats-files-untagged")).toHaveTextContent("2")
+  })
+
+  it("renders one row per tag with the inline usage block", async () => {
+    seed()
+    renderPage()
+    expect(await screen.findByTestId("tag-row-kitchen")).toBeVisible()
+    expect(screen.getByTestId("tag-row-kitchen-usage")).toHaveTextContent("2 items")
+    expect(screen.getByTestId("tag-row-garden-usage")).toHaveTextContent(/Not used yet/i)
+  })
+
+  it("opens the create dialog from the CTA", async () => {
+    seed()
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId("tag-row-kitchen")
+    await user.click(screen.getByTestId("tags-create-button"))
+    expect(await screen.findByTestId("tag-form-dialog")).toBeVisible()
+  })
+
+  it("is axe-clean once data has loaded", async () => {
+    seed()
+    const { baseElement } = renderPage()
+    await screen.findByTestId("tag-row-kitchen")
+    const results = await axe(baseElement)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/handlers/tags.ts
+++ b/frontend/src/test/handlers/tags.ts
@@ -2,10 +2,99 @@ import { http, HttpResponse } from "msw"
 
 import { apiUrl } from "."
 
-export function list(slug: string, items: unknown[] = []) {
+// Default colour kept off-palette deliberately so tests that forget to
+// set one trigger a clear visual mismatch instead of a silent passthrough.
+type TagAttrs = { id: string; slug: string; label: string; color: string }
+type TagWithUsage = TagAttrs & { meta?: { usage?: { commodities: number; files: number } } }
+
+// list mirrors apiserver/tags.go::listTags → TagsResponse — entities are
+// FLAT inside `data` with an optional inline `meta.usage` block when the
+// caller passes ?include=usage. Mirrors the `meta` block on each row that
+// the BE renders via TagListItem (see go/jsonapi/tags.go).
+export function list(
+  slug: string,
+  items: TagWithUsage[] = [],
+  meta: Record<string, unknown> = {}
+) {
   return [
     http.get(apiUrl(`/g/${encodeURIComponent(slug)}/tags`), () =>
-      HttpResponse.json({ data: items })
+      HttpResponse.json({
+        data: items,
+        meta: { tags: items.length, total: items.length, ...meta },
+      })
     ),
+  ]
+}
+
+// stats backs GET /tags/stats — small flat envelope, NOT JSON:API.
+export function stats(
+  slug: string,
+  data: {
+    tags_total: number
+    items_tagged: number
+    items_untagged: number
+    files_tagged: number
+    files_untagged: number
+  }
+) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/tags/stats`), () =>
+      HttpResponse.json({ data })
+    ),
+  ]
+}
+
+export function detail(slug: string, id: string, attributes: TagAttrs, usage?: { commodities: number; files: number }) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/tags/${encodeURIComponent(id)}`), () =>
+      HttpResponse.json({
+        id,
+        type: "tags",
+        attributes,
+        meta: usage ? { usage } : undefined,
+      })
+    ),
+  ]
+}
+
+export function create(slug: string, attributes: TagAttrs) {
+  return [
+    http.post(apiUrl(`/g/${encodeURIComponent(slug)}/tags`), () =>
+      HttpResponse.json(
+        { id: attributes.id, type: "tags", attributes },
+        { status: 201 }
+      )
+    ),
+  ]
+}
+
+export function update(slug: string, id: string, attributes: TagAttrs) {
+  return [
+    http.patch(apiUrl(`/g/${encodeURIComponent(slug)}/tags/${encodeURIComponent(id)}`), () =>
+      HttpResponse.json({ id, type: "tags", attributes })
+    ),
+  ]
+}
+
+export function remove(slug: string, id: string, options: { conflict?: boolean } = {}) {
+  return [
+    http.delete(apiUrl(`/g/${encodeURIComponent(slug)}/tags/${encodeURIComponent(id)}`), ({ request }) => {
+      const url = new URL(request.url)
+      if (options.conflict && url.searchParams.get("force") !== "true") {
+        return HttpResponse.json(
+          {
+            errors: [
+              {
+                status: "409",
+                title: "tag is in use",
+                detail: "Pass force=true to strip references.",
+              },
+            ],
+          },
+          { status: 409 }
+        )
+      }
+      return new HttpResponse(null, { status: 204 })
+    }),
   ]
 }

--- a/frontend/src/test/handlers/tags.ts
+++ b/frontend/src/test/handlers/tags.ts
@@ -11,11 +11,7 @@ type TagWithUsage = TagAttrs & { meta?: { usage?: { commodities: number; files: 
 // FLAT inside `data` with an optional inline `meta.usage` block when the
 // caller passes ?include=usage. Mirrors the `meta` block on each row that
 // the BE renders via TagListItem (see go/jsonapi/tags.go).
-export function list(
-  slug: string,
-  items: TagWithUsage[] = [],
-  meta: Record<string, unknown> = {}
-) {
+export function list(slug: string, items: TagWithUsage[] = [], meta: Record<string, unknown> = {}) {
   return [
     http.get(apiUrl(`/g/${encodeURIComponent(slug)}/tags`), () =>
       HttpResponse.json({
@@ -44,7 +40,12 @@ export function stats(
   ]
 }
 
-export function detail(slug: string, id: string, attributes: TagAttrs, usage?: { commodities: number; files: number }) {
+export function detail(
+  slug: string,
+  id: string,
+  attributes: TagAttrs,
+  usage?: { commodities: number; files: number }
+) {
   return [
     http.get(apiUrl(`/g/${encodeURIComponent(slug)}/tags/${encodeURIComponent(id)}`), () =>
       HttpResponse.json({
@@ -60,10 +61,7 @@ export function detail(slug: string, id: string, attributes: TagAttrs, usage?: {
 export function create(slug: string, attributes: TagAttrs) {
   return [
     http.post(apiUrl(`/g/${encodeURIComponent(slug)}/tags`), () =>
-      HttpResponse.json(
-        { id: attributes.id, type: "tags", attributes },
-        { status: 201 }
-      )
+      HttpResponse.json({ id: attributes.id, type: "tags", attributes }, { status: 201 })
     ),
   ]
 }
@@ -78,23 +76,26 @@ export function update(slug: string, id: string, attributes: TagAttrs) {
 
 export function remove(slug: string, id: string, options: { conflict?: boolean } = {}) {
   return [
-    http.delete(apiUrl(`/g/${encodeURIComponent(slug)}/tags/${encodeURIComponent(id)}`), ({ request }) => {
-      const url = new URL(request.url)
-      if (options.conflict && url.searchParams.get("force") !== "true") {
-        return HttpResponse.json(
-          {
-            errors: [
-              {
-                status: "409",
-                title: "tag is in use",
-                detail: "Pass force=true to strip references.",
-              },
-            ],
-          },
-          { status: 409 }
-        )
+    http.delete(
+      apiUrl(`/g/${encodeURIComponent(slug)}/tags/${encodeURIComponent(id)}`),
+      ({ request }) => {
+        const url = new URL(request.url)
+        if (options.conflict && url.searchParams.get("force") !== "true") {
+          return HttpResponse.json(
+            {
+              errors: [
+                {
+                  status: "409",
+                  title: "tag is in use",
+                  detail: "Pass force=true to strip references.",
+                },
+              ],
+            },
+            { status: 409 }
+          )
+        }
+        return new HttpResponse(null, { status: 204 })
       }
-      return new HttpResponse(null, { status: 204 })
-    }),
+    ),
   ]
 }

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -3433,7 +3433,7 @@ export type paths = {
         };
         /**
          * List tags
-         * @description get tags with optional filtering
+         * @description get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.
          */
         get: {
             parameters: {
@@ -3448,6 +3448,8 @@ export type paths = {
                     page?: number;
                     /** @description Items per page */
                     per_page?: number;
+                    /** @description Comma-separated extras. 'usage' attaches per-row meta.usage. */
+                    include?: "usage";
                 };
                 header?: never;
                 path?: never;
@@ -3543,6 +3545,45 @@ export type paths = {
                     };
                     content: {
                         "application/vnd.api+json": components["schemas"]["jsonapi.TagAutocompleteResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/tags/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Tag adoption stats
+         * @description Returns total tags, plus tagged/untagged counts on commodities and files for the current group.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.TagStatsResponse"];
                     };
                 };
             };
@@ -4717,6 +4758,22 @@ export type components = {
         "jsonapi.TagAutocompleteResponse": {
             data?: components["schemas"]["jsonapi.TagAutocompleteEntry"][];
         };
+        "jsonapi.TagListItem": {
+            /** @description Color is one of the curated TagColor values. */
+            color?: components["schemas"]["models.TagColor"];
+            created_at?: string;
+            id?: string;
+            /** @description Label is the human-readable display name. */
+            label?: string;
+            meta?: components["schemas"]["jsonapi.TagMeta"];
+            /**
+             * @description Slug is the kebab-cased identifier referenced from
+             *     commodities.tags / files.tags JSONB arrays. Unique per group.
+             */
+            slug?: string;
+            updated_at?: string;
+            uuid?: string;
+        };
         "jsonapi.TagMeta": {
             usage?: components["schemas"]["registry.TagUsage"];
         };
@@ -4746,6 +4803,9 @@ export type components = {
              * @enum {string}
              */
             type?: "tags";
+        };
+        "jsonapi.TagStatsResponse": {
+            data?: components["schemas"]["registry.TagStats"];
         };
         "jsonapi.TagUpdateRequest": {
             data?: components["schemas"]["jsonapi.TagUpdateRequestDataWrapper"];
@@ -4777,7 +4837,7 @@ export type components = {
             total?: number;
         };
         "jsonapi.TagsResponse": {
-            data?: components["schemas"]["models.Tag"][];
+            data?: components["schemas"]["jsonapi.TagListItem"][];
             meta?: components["schemas"]["jsonapi.TagsMeta"];
         };
         "jsonapi.URLData": {
@@ -5139,6 +5199,13 @@ export type components = {
             name?: string;
             updated_at?: string;
             uuid?: string;
+        };
+        "registry.TagStats": {
+            files_tagged?: number;
+            files_untagged?: number;
+            items_tagged?: number;
+            items_untagged?: number;
+            tags_total?: number;
         };
         "registry.TagUsage": {
             commodities?: number;

--- a/go/apiserver/tags.go
+++ b/go/apiserver/tags.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -53,7 +54,7 @@ type tagsAPI struct {
 
 // listTags lists tags with pagination, optional q-search, and sort.
 // @Summary List tags
-// @Description get tags with optional filtering
+// @Description get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
@@ -62,6 +63,7 @@ type tagsAPI struct {
 // @Param order query string false "Sort direction (asc, desc)" default(asc)
 // @Param page query int false "Page number (1-based)" default(1)
 // @Param per_page query int false "Items per page" default(50)
+// @Param include query string false "Comma-separated extras. 'usage' attaches per-row meta.usage." Enums(usage)
 // @Success 200 {object} jsonapi.TagsResponse "OK"
 // @Router /tags [get].
 func (api *tagsAPI) listTags(w http.ResponseWriter, r *http.Request) {
@@ -87,10 +89,67 @@ func (api *tagsAPI) listTags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var usageBySlug map[string]registry.TagUsage
+	if includeHasToken(q.Get("include"), "usage") && len(tags) > 0 {
+		slugs := make([]string, 0, len(tags))
+		for _, t := range tags {
+			slugs = append(slugs, t.Slug)
+		}
+		usageBySlug, err = regSet.TagRegistry.GetUsageBatch(r.Context(), slugs)
+		if err != nil {
+			renderEntityError(w, r, err)
+			return
+		}
+	}
+
 	setPaginationHeaders(w, page, perPage, total)
-	if err := render.Render(w, r, jsonapi.NewTagsResponse(tags, total)); err != nil {
+	if err := render.Render(w, r, jsonapi.NewTagsResponseWithUsage(tags, total, usageBySlug)); err != nil {
 		internalServerError(w, r, err)
 	}
+}
+
+// getTagStats returns the group-wide tag adoption summary that backs the
+// Tags page stats bar: total tags + tagged/untagged counts on commodities
+// and files.
+// @Summary Tag adoption stats
+// @Description Returns total tags, plus tagged/untagged counts on commodities and files for the current group.
+// @Tags tags
+// @Accept json-api
+// @Produce json-api
+// @Success 200 {object} jsonapi.TagStatsResponse "OK"
+// @Router /tags/stats [get].
+func (api *tagsAPI) getTagStats(w http.ResponseWriter, r *http.Request) {
+	regSet := RegistrySetFromContext(r.Context())
+	if regSet == nil {
+		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+		return
+	}
+
+	stats, err := regSet.TagRegistry.GetStats(r.Context())
+	if err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
+
+	if err := render.Render(w, r, jsonapi.NewTagStatsResponse(stats)); err != nil {
+		internalServerError(w, r, err)
+	}
+}
+
+// includeHasToken returns true when the `?include=` query value contains
+// the requested token. The handler accepts comma-separated tokens — only
+// "usage" is recognised today, but the helper keeps the parsing in one
+// place so adding more (e.g. "stats") later is a one-liner.
+func includeHasToken(raw, token string) bool {
+	if raw == "" {
+		return false
+	}
+	for part := range strings.SplitSeq(raw, ",") {
+		if strings.TrimSpace(part) == token {
+			return true
+		}
+	}
+	return false
 }
 
 // autocompleteTags returns the top-N matching tags ranked by usage and recency.
@@ -298,6 +357,7 @@ func Tags(params Params) func(r chi.Router) {
 		r.Get("/", api.listTags)
 		r.Post("/", api.createTag)
 		r.Get("/autocomplete", api.autocompleteTags)
+		r.Get("/stats", api.getTagStats)
 		r.Route("/{tagID}", func(r chi.Router) {
 			r.Use(tagCtx())
 			r.Get("/", api.getTag)

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -2961,7 +2961,7 @@ const docTemplate = `{
         },
         "/tags": {
             "get": {
-                "description": "get tags with optional filtering",
+                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -3009,6 +3009,15 @@ const docTemplate = `{
                         "default": 50,
                         "description": "Items per page",
                         "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "usage"
+                        ],
+                        "type": "string",
+                        "description": "Comma-separated extras. 'usage' attaches per-row meta.usage.",
+                        "name": "include",
                         "in": "query"
                     }
                 ],
@@ -3093,6 +3102,29 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.TagAutocompleteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/tags/stats": {
+            "get": {
+                "description": "Returns total tags, plus tagged/untagged counts on commodities and files for the current group.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Tag adoption stats",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagStatsResponse"
                         }
                     }
                 }
@@ -4918,6 +4950,42 @@ const docTemplate = `{
                 }
             }
         },
+        "jsonapi.TagListItem": {
+            "type": "object",
+            "properties": {
+                "color": {
+                    "description": "Color is one of the curated TagColor values.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.TagColor"
+                        }
+                    ]
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "description": "Label is the human-readable display name.",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/jsonapi.TagMeta"
+                },
+                "slug": {
+                    "description": "Slug is the kebab-cased identifier referenced from\ncommodities.tags / files.tags JSONB arrays. Unique per group.",
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "uuid": {
+                    "type": "string"
+                }
+            }
+        },
         "jsonapi.TagMeta": {
             "type": "object",
             "properties": {
@@ -4996,6 +5064,14 @@ const docTemplate = `{
                 }
             }
         },
+        "jsonapi.TagStatsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/registry.TagStats"
+                }
+            }
+        },
         "jsonapi.TagUpdateRequest": {
             "type": "object",
             "properties": {
@@ -5066,7 +5142,7 @@ const docTemplate = `{
                 "data": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Tag"
+                        "$ref": "#/definitions/jsonapi.TagListItem"
                     }
                 },
                 "meta": {
@@ -6015,6 +6091,26 @@ const docTemplate = `{
                 },
                 "uuid": {
                     "type": "string"
+                }
+            }
+        },
+        "registry.TagStats": {
+            "type": "object",
+            "properties": {
+                "files_tagged": {
+                    "type": "integer"
+                },
+                "files_untagged": {
+                    "type": "integer"
+                },
+                "items_tagged": {
+                    "type": "integer"
+                },
+                "items_untagged": {
+                    "type": "integer"
+                },
+                "tags_total": {
+                    "type": "integer"
                 }
             }
         },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -2954,7 +2954,7 @@
         },
         "/tags": {
             "get": {
-                "description": "get tags with optional filtering",
+                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -3002,6 +3002,15 @@
                         "default": 50,
                         "description": "Items per page",
                         "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "usage"
+                        ],
+                        "type": "string",
+                        "description": "Comma-separated extras. 'usage' attaches per-row meta.usage.",
+                        "name": "include",
                         "in": "query"
                     }
                 ],
@@ -3086,6 +3095,29 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.TagAutocompleteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/tags/stats": {
+            "get": {
+                "description": "Returns total tags, plus tagged/untagged counts on commodities and files for the current group.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Tag adoption stats",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagStatsResponse"
                         }
                     }
                 }
@@ -4911,6 +4943,42 @@
                 }
             }
         },
+        "jsonapi.TagListItem": {
+            "type": "object",
+            "properties": {
+                "color": {
+                    "description": "Color is one of the curated TagColor values.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.TagColor"
+                        }
+                    ]
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "description": "Label is the human-readable display name.",
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/jsonapi.TagMeta"
+                },
+                "slug": {
+                    "description": "Slug is the kebab-cased identifier referenced from\ncommodities.tags / files.tags JSONB arrays. Unique per group.",
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "uuid": {
+                    "type": "string"
+                }
+            }
+        },
         "jsonapi.TagMeta": {
             "type": "object",
             "properties": {
@@ -4989,6 +5057,14 @@
                 }
             }
         },
+        "jsonapi.TagStatsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/registry.TagStats"
+                }
+            }
+        },
         "jsonapi.TagUpdateRequest": {
             "type": "object",
             "properties": {
@@ -5059,7 +5135,7 @@
                 "data": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/models.Tag"
+                        "$ref": "#/definitions/jsonapi.TagListItem"
                     }
                 },
                 "meta": {
@@ -6008,6 +6084,26 @@
                 },
                 "uuid": {
                     "type": "string"
+                }
+            }
+        },
+        "registry.TagStats": {
+            "type": "object",
+            "properties": {
+                "files_tagged": {
+                    "type": "integer"
+                },
+                "files_untagged": {
+                    "type": "integer"
+                },
+                "items_tagged": {
+                    "type": "integer"
+                },
+                "items_untagged": {
+                    "type": "integer"
+                },
+                "tags_total": {
+                    "type": "integer"
                 }
             }
         },

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -970,6 +970,31 @@ definitions:
           $ref: '#/definitions/jsonapi.TagAutocompleteEntry'
         type: array
     type: object
+  jsonapi.TagListItem:
+    properties:
+      color:
+        allOf:
+        - $ref: '#/definitions/models.TagColor'
+        description: Color is one of the curated TagColor values.
+      created_at:
+        type: string
+      id:
+        type: string
+      label:
+        description: Label is the human-readable display name.
+        type: string
+      meta:
+        $ref: '#/definitions/jsonapi.TagMeta'
+      slug:
+        description: |-
+          Slug is the kebab-cased identifier referenced from
+          commodities.tags / files.tags JSONB arrays. Unique per group.
+        type: string
+      updated_at:
+        type: string
+      uuid:
+        type: string
+    type: object
   jsonapi.TagMeta:
     properties:
       usage:
@@ -1021,6 +1046,11 @@ definitions:
         example: tags
         type: string
     type: object
+  jsonapi.TagStatsResponse:
+    properties:
+      data:
+        $ref: '#/definitions/registry.TagStats'
+    type: object
   jsonapi.TagUpdateRequest:
     properties:
       data:
@@ -1068,7 +1098,7 @@ definitions:
     properties:
       data:
         items:
-          $ref: '#/definitions/models.Tag'
+          $ref: '#/definitions/jsonapi.TagListItem'
         type: array
       meta:
         $ref: '#/definitions/jsonapi.TagsMeta'
@@ -1774,6 +1804,19 @@ definitions:
         type: string
       uuid:
         type: string
+    type: object
+  registry.TagStats:
+    properties:
+      files_tagged:
+        type: integer
+      files_untagged:
+        type: integer
+      items_tagged:
+        type: integer
+      items_untagged:
+        type: integer
+      tags_total:
+        type: integer
     type: object
   registry.TagUsage:
     properties:
@@ -3793,7 +3836,8 @@ paths:
     get:
       consumes:
       - application/vnd.api+json
-      description: get tags with optional filtering
+      description: get tags with optional filtering. Pass include=usage to attach
+        a per-row meta.usage block.
       parameters:
       - description: Search by label or slug
         in: query
@@ -3822,6 +3866,12 @@ paths:
         in: query
         name: per_page
         type: integer
+      - description: Comma-separated extras. 'usage' attaches per-row meta.usage.
+        enum:
+        - usage
+        in: query
+        name: include
+        type: string
       produces:
       - application/vnd.api+json
       responses:
@@ -3975,6 +4025,22 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.TagAutocompleteResponse'
       summary: Autocomplete tag suggestions
+      tags:
+      - tags
+  /tags/stats:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: Returns total tags, plus tagged/untagged counts on commodities
+        and files for the current group.
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.TagStatsResponse'
+      summary: Tag adoption stats
       tags:
       - tags
   /upload-slots/check:

--- a/go/jsonapi/tags.go
+++ b/go/jsonapi/tags.go
@@ -62,23 +62,67 @@ type TagsMeta struct {
 	Total int `json:"total" example:"100" format:"int64"`
 }
 
-// TagsResponse is a paginated list of tags.
-type TagsResponse struct {
-	Data []*models.Tag `json:"data"`
-	Meta TagsMeta      `json:"meta"`
+// TagListItem is a single row in a paginated tag list. It mirrors the
+// project's "FLAT in data" envelope (Tag fields hoisted to the top level)
+// and adds an optional per-resource `meta` block — populated only when the
+// caller passes `?include=usage`. The Tag pointer is intentionally
+// embedded (not nested under attributes) to stay symmetric with the rest
+// of the codebase's list responses (files, commodities).
+type TagListItem struct {
+	*models.Tag
+	Meta *TagMeta `json:"meta,omitempty"`
 }
 
+// TagsResponse is a paginated list of tags.
+type TagsResponse struct {
+	Data []*TagListItem `json:"data"`
+	Meta TagsMeta       `json:"meta"`
+}
+
+// NewTagsResponse builds a list response with no per-row usage meta.
 func NewTagsResponse(tags []*models.Tag, total int) *TagsResponse {
-	if tags == nil {
-		tags = []*models.Tag{}
+	return NewTagsResponseWithUsage(tags, total, nil)
+}
+
+// NewTagsResponseWithUsage builds a list response with per-row usage
+// meta sourced from the supplied slug→usage map. Tags whose slug is not
+// in the map render without a `meta` field. Pass nil to skip per-row
+// meta entirely (equivalent to NewTagsResponse).
+func NewTagsResponseWithUsage(tags []*models.Tag, total int, usageBySlug map[string]registry.TagUsage) *TagsResponse {
+	items := make([]*TagListItem, 0, len(tags))
+	for _, t := range tags {
+		item := &TagListItem{Tag: t}
+		if usageBySlug != nil {
+			if u, ok := usageBySlug[t.Slug]; ok {
+				usage := u
+				item.Meta = &TagMeta{Usage: &usage}
+			}
+		}
+		items = append(items, item)
 	}
 	return &TagsResponse{
-		Data: tags,
-		Meta: TagsMeta{Tags: len(tags), Total: total},
+		Data: items,
+		Meta: TagsMeta{Tags: len(items), Total: total},
 	}
 }
 
 func (*TagsResponse) Render(_ http.ResponseWriter, r *http.Request) error {
+	render.Status(r, http.StatusOK)
+	return nil
+}
+
+// TagStatsResponse is the payload for GET /tags/stats — a small flat
+// envelope (no JSON:API list shape) carrying the group-wide adoption
+// summary that backs the Tags page stats bar.
+type TagStatsResponse struct {
+	Data registry.TagStats `json:"data"`
+}
+
+func NewTagStatsResponse(stats registry.TagStats) *TagStatsResponse {
+	return &TagStatsResponse{Data: stats}
+}
+
+func (*TagStatsResponse) Render(_ http.ResponseWriter, r *http.Request) error {
 	render.Status(r, http.StatusOK)
 	return nil
 }

--- a/go/registry/memory/tags.go
+++ b/go/registry/memory/tags.go
@@ -238,12 +238,20 @@ func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[st
 		return out, nil
 	}
 
+	// Per-row seen-set so a commodity / file with a duplicated slug in
+	// its JSONB tags array is counted at most once — matches the
+	// postgres @> containment semantics and GetUsage's per-entity count.
 	commodities, err := r.commodityRegistry.List(ctx)
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to list commodities", err)
 	}
 	for _, c := range commodities {
+		seen := map[string]struct{}{}
 		for _, slug := range c.Tags {
+			if _, dup := seen[slug]; dup {
+				continue
+			}
+			seen[slug] = struct{}{}
 			if u, ok := out[slug]; ok {
 				u.Commodities++
 				out[slug] = u
@@ -256,7 +264,12 @@ func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[st
 		return nil, errxtrace.Wrap("failed to list files", err)
 	}
 	for _, f := range files {
+		seen := map[string]struct{}{}
 		for _, slug := range f.Tags {
+			if _, dup := seen[slug]; dup {
+				continue
+			}
+			seen[slug] = struct{}{}
 			if u, ok := out[slug]; ok {
 				u.Files++
 				out[slug] = u

--- a/go/registry/memory/tags.go
+++ b/go/registry/memory/tags.go
@@ -229,6 +229,80 @@ func (r *TagRegistry) Search(ctx context.Context, q string, limit int) ([]*model
 	return matched, nil
 }
 
+func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[string]registry.TagUsage, error) {
+	out := make(map[string]registry.TagUsage, len(slugs))
+	for _, s := range slugs {
+		out[s] = registry.TagUsage{}
+	}
+	if len(slugs) == 0 {
+		return out, nil
+	}
+
+	commodities, err := r.commodityRegistry.List(ctx)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list commodities", err)
+	}
+	for _, c := range commodities {
+		for _, slug := range c.Tags {
+			if u, ok := out[slug]; ok {
+				u.Commodities++
+				out[slug] = u
+			}
+		}
+	}
+
+	files, err := r.fileRegistry.List(ctx)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list files", err)
+	}
+	for _, f := range files {
+		for _, slug := range f.Tags {
+			if u, ok := out[slug]; ok {
+				u.Files++
+				out[slug] = u
+			}
+		}
+	}
+	return out, nil
+}
+
+func (r *TagRegistry) GetStats(ctx context.Context) (registry.TagStats, error) {
+	tags, err := r.List(ctx)
+	if err != nil {
+		return registry.TagStats{}, errxtrace.Wrap("failed to list tags", err)
+	}
+
+	commodities, err := r.commodityRegistry.List(ctx)
+	if err != nil {
+		return registry.TagStats{}, errxtrace.Wrap("failed to list commodities", err)
+	}
+	itemsTagged := 0
+	for _, c := range commodities {
+		if len(c.Tags) > 0 {
+			itemsTagged++
+		}
+	}
+
+	files, err := r.fileRegistry.List(ctx)
+	if err != nil {
+		return registry.TagStats{}, errxtrace.Wrap("failed to list files", err)
+	}
+	filesTagged := 0
+	for _, f := range files {
+		if len(f.Tags) > 0 {
+			filesTagged++
+		}
+	}
+
+	return registry.TagStats{
+		TagsTotal:     len(tags),
+		ItemsTagged:   itemsTagged,
+		ItemsUntagged: len(commodities) - itemsTagged,
+		FilesTagged:   filesTagged,
+		FilesUntagged: len(files) - filesTagged,
+	}, nil
+}
+
 func (r *TagRegistry) GetUsage(ctx context.Context, slug string) (registry.TagUsage, error) {
 	commodities, err := r.commodityRegistry.List(ctx)
 	if err != nil {

--- a/go/registry/memory/tags_test.go
+++ b/go/registry/memory/tags_test.go
@@ -245,6 +245,103 @@ func TestTagRegistry_Memory_SearchRanksByUsage(t *testing.T) {
 	c.Assert(got[2].Slug, qt.Equals, "beta")
 }
 
+func TestTagRegistry_Memory_GetUsageBatch(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagFixture(c, "group-1")
+
+	for _, slug := range []string{"kitchen", "appliance", "garden"} {
+		_, err := fx.tagReg.Create(fx.ctx, models.Tag{
+			Slug: slug, Label: slug, Color: models.TagColorMuted,
+		})
+		c.Assert(err, qt.IsNil)
+	}
+
+	_, err := fx.commodityReg.Create(fx.ctx, models.Commodity{
+		Name: "fridge", Status: models.CommodityStatusInUse, Type: models.CommodityTypeWhiteGoods,
+		Tags: models.ValuerSlice[string]{"kitchen", "appliance"},
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = fx.commodityReg.Create(fx.ctx, models.Commodity{
+		Name: "oven", Status: models.CommodityStatusInUse, Type: models.CommodityTypeWhiteGoods,
+		Tags: models.ValuerSlice[string]{"kitchen"},
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = fx.fileReg.Create(fx.ctx, models.FileEntity{
+		Title: "f", Type: models.FileTypeImage, Category: models.FileCategoryPhotos,
+		Tags: models.StringSlice{"appliance"},
+		File: &models.File{Path: "f", OriginalPath: "f.jpg", Ext: ".jpg", MIMEType: "image/jpeg"},
+	})
+	c.Assert(err, qt.IsNil)
+
+	usage, err := fx.tagReg.GetUsageBatch(fx.ctx, []string{"kitchen", "appliance", "garden"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(usage["kitchen"].Commodities, qt.Equals, 2)
+	c.Assert(usage["kitchen"].Files, qt.Equals, 0)
+	c.Assert(usage["appliance"].Commodities, qt.Equals, 1)
+	c.Assert(usage["appliance"].Files, qt.Equals, 1)
+	c.Assert(usage["garden"].Commodities, qt.Equals, 0)
+	c.Assert(usage["garden"].Files, qt.Equals, 0)
+
+	// Empty input returns empty map without touching the registries.
+	empty, err := fx.tagReg.GetUsageBatch(fx.ctx, nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(empty, qt.HasLen, 0)
+}
+
+func TestTagRegistry_Memory_GetStats(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagFixture(c, "group-1")
+
+	for _, slug := range []string{"a", "b", "c"} {
+		_, err := fx.tagReg.Create(fx.ctx, models.Tag{
+			Slug: slug, Label: slug, Color: models.TagColorMuted,
+		})
+		c.Assert(err, qt.IsNil)
+	}
+
+	// 2 tagged commodities + 1 untagged.
+	_, err := fx.commodityReg.Create(fx.ctx, models.Commodity{
+		Name: "x1", Status: models.CommodityStatusInUse, Type: models.CommodityTypeOther,
+		Tags: models.ValuerSlice[string]{"a"},
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = fx.commodityReg.Create(fx.ctx, models.Commodity{
+		Name: "x2", Status: models.CommodityStatusInUse, Type: models.CommodityTypeOther,
+		Tags: models.ValuerSlice[string]{"a", "b"},
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = fx.commodityReg.Create(fx.ctx, models.Commodity{
+		Name: "x3", Status: models.CommodityStatusInUse, Type: models.CommodityTypeOther,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// 1 tagged file + 2 untagged.
+	_, err = fx.fileReg.Create(fx.ctx, models.FileEntity{
+		Title: "f1", Type: models.FileTypeImage, Category: models.FileCategoryPhotos,
+		Tags: models.StringSlice{"c"},
+		File: &models.File{Path: "f1", OriginalPath: "f1.jpg", Ext: ".jpg", MIMEType: "image/jpeg"},
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = fx.fileReg.Create(fx.ctx, models.FileEntity{
+		Title: "f2", Type: models.FileTypeImage, Category: models.FileCategoryPhotos,
+		File: &models.File{Path: "f2", OriginalPath: "f2.jpg", Ext: ".jpg", MIMEType: "image/jpeg"},
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = fx.fileReg.Create(fx.ctx, models.FileEntity{
+		Title: "f3", Type: models.FileTypeImage, Category: models.FileCategoryPhotos,
+		File: &models.File{Path: "f3", OriginalPath: "f3.jpg", Ext: ".jpg", MIMEType: "image/jpeg"},
+	})
+	c.Assert(err, qt.IsNil)
+
+	stats, err := fx.tagReg.GetStats(fx.ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.TagsTotal, qt.Equals, 3)
+	c.Assert(stats.ItemsTagged, qt.Equals, 2)
+	c.Assert(stats.ItemsUntagged, qt.Equals, 1)
+	c.Assert(stats.FilesTagged, qt.Equals, 1)
+	c.Assert(stats.FilesUntagged, qt.Equals, 2)
+}
+
 func TestTagRegistry_Memory_CrossGroupIsolation(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/registry/postgres/tags.go
+++ b/go/registry/postgres/tags.go
@@ -274,24 +274,38 @@ func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[st
 
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		// Single round-trip: explode the requested slugs into a CTE and
-		// LEFT JOIN against per-row containment counts on commodities + files.
-		// jsonb_array_elements_text against commodities/files is filter-pushed
-		// by the GIN indexes on the @> path, so this stays cheap even on large
-		// row counts.
+		// Single-pass query: scan commodities + files at most once each
+		// (filtered by `tags ?| input` so the GIN index on the JSONB tags
+		// column drives the lookup), unnest the JSONB arrays once per row,
+		// COUNT(DISTINCT id) per slug to match the @> containment semantics
+		// (a row with duplicate slugs in its tags array still counts as 1),
+		// then LEFT JOIN back to the requested input list so missing slugs
+		// land as 0/0 instead of being dropped.
+		//
+		// Compared to the per-slug correlated-subquery approach, this is
+		// O(rows scanned once per table) vs O(slugs × rows) — important
+		// for the upcoming Tags page which fetches usage for the whole
+		// page (default per_page=50).
 		query := fmt.Sprintf(`
-			WITH input(slug) AS (SELECT unnest($1::text[]))
-			SELECT
-				input.slug,
-				COALESCE(
-					(SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array(input.slug)),
-					0
-				) AS commodities,
-				COALESCE(
-					(SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array(input.slug)),
-					0
-				) AS files
+			WITH input(slug) AS (SELECT unnest($1::text[])),
+			commodity_counts AS (
+				SELECT t.value AS slug, COUNT(DISTINCT id)::int AS cnt
+				FROM %s, jsonb_array_elements_text(tags) AS t(value)
+				WHERE tags ?| $1::text[]
+				GROUP BY t.value
+			),
+			file_counts AS (
+				SELECT t.value AS slug, COUNT(DISTINCT id)::int AS cnt
+				FROM %s, jsonb_array_elements_text(tags) AS t(value)
+				WHERE tags ?| $1::text[]
+				GROUP BY t.value
+			)
+			SELECT input.slug,
+				COALESCE(c.cnt, 0) AS commodities,
+				COALESCE(f.cnt, 0) AS files
 			FROM input
+			LEFT JOIN commodity_counts c ON c.slug = input.slug
+			LEFT JOIN file_counts f ON f.slug = input.slug
 		`, r.tableNames.Commodities(), r.tableNames.Files())
 
 		rows, err := tx.QueryxContext(ctx, query, slugs)

--- a/go/registry/postgres/tags.go
+++ b/go/registry/postgres/tags.go
@@ -263,6 +263,90 @@ func (r *TagRegistry) Search(ctx context.Context, q string, limit int) ([]*model
 	return tags, nil
 }
 
+func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[string]registry.TagUsage, error) {
+	out := make(map[string]registry.TagUsage, len(slugs))
+	for _, s := range slugs {
+		out[s] = registry.TagUsage{}
+	}
+	if len(slugs) == 0 {
+		return out, nil
+	}
+
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// Single round-trip: explode the requested slugs into a CTE and
+		// LEFT JOIN against per-row containment counts on commodities + files.
+		// jsonb_array_elements_text against commodities/files is filter-pushed
+		// by the GIN indexes on the @> path, so this stays cheap even on large
+		// row counts.
+		query := fmt.Sprintf(`
+			WITH input(slug) AS (SELECT unnest($1::text[]))
+			SELECT
+				input.slug,
+				COALESCE(
+					(SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array(input.slug)),
+					0
+				) AS commodities,
+				COALESCE(
+					(SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array(input.slug)),
+					0
+				) AS files
+			FROM input
+		`, r.tableNames.Commodities(), r.tableNames.Files())
+
+		rows, err := tx.QueryxContext(ctx, query, slugs)
+		if err != nil {
+			return errxtrace.Wrap("failed to batch-compute tag usage", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var slug string
+			var u registry.TagUsage
+			if err := rows.Scan(&slug, &u.Commodities, &u.Files); err != nil {
+				return errxtrace.Wrap("failed to scan tag usage", err)
+			}
+			out[slug] = u
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to compute tag usage batch", err)
+	}
+	return out, nil
+}
+
+func (r *TagRegistry) GetStats(ctx context.Context) (registry.TagStats, error) {
+	var stats registry.TagStats
+
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// One round-trip: each subquery is a sealed COUNT under the current
+		// RLS scope. `jsonb_array_length(COALESCE(tags, '[]'::jsonb)) > 0`
+		// treats NULL the same as []: untagged.
+		query := fmt.Sprintf(`
+			SELECT
+				(SELECT COUNT(*) FROM %s) AS tags_total,
+				(SELECT COUNT(*) FROM %s WHERE jsonb_array_length(COALESCE(tags, '[]'::jsonb)) > 0) AS items_tagged,
+				(SELECT COUNT(*) FROM %s WHERE jsonb_array_length(COALESCE(tags, '[]'::jsonb)) = 0) AS items_untagged,
+				(SELECT COUNT(*) FROM %s WHERE jsonb_array_length(COALESCE(tags, '[]'::jsonb)) > 0) AS files_tagged,
+				(SELECT COUNT(*) FROM %s WHERE jsonb_array_length(COALESCE(tags, '[]'::jsonb)) = 0) AS files_untagged
+		`,
+			r.tableNames.Tags(),
+			r.tableNames.Commodities(), r.tableNames.Commodities(),
+			r.tableNames.Files(), r.tableNames.Files(),
+		)
+		return tx.QueryRowxContext(ctx, query).Scan(
+			&stats.TagsTotal,
+			&stats.ItemsTagged, &stats.ItemsUntagged,
+			&stats.FilesTagged, &stats.FilesUntagged,
+		)
+	})
+	if err != nil {
+		return registry.TagStats{}, errxtrace.Wrap("failed to compute tag stats", err)
+	}
+	return stats, nil
+}
+
 func (r *TagRegistry) GetUsage(ctx context.Context, slug string) (registry.TagUsage, error) {
 	var usage registry.TagUsage
 

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -258,6 +258,17 @@ type TagUsage struct {
 	Files       int `json:"files"`
 }
 
+// TagStats is the group-wide tag adoption summary that backs the Tags page
+// stats bar. Tagged/untagged counts are derived from the JSONB tags array
+// on commodities + files (presence vs. emptiness, not per-tag breakdown).
+type TagStats struct {
+	TagsTotal     int `json:"tags_total"`
+	ItemsTagged   int `json:"items_tagged"`
+	ItemsUntagged int `json:"items_untagged"`
+	FilesTagged   int `json:"files_tagged"`
+	FilesUntagged int `json:"files_untagged"`
+}
+
 // TagRegistry is the group-scoped catalogue of tags. The tag-string
 // associations themselves continue to live in JSONB on commodities/files —
 // only the metadata (label, color, usage) lives here.
@@ -282,6 +293,18 @@ type TagRegistry interface {
 	// within the current group (commodities + files JSONB arrays
 	// containing this slug).
 	GetUsage(ctx context.Context, slug string) (TagUsage, error)
+
+	// GetUsageBatch returns per-slug usage for the given slugs in a single
+	// round-trip. Used by the GET /tags?include=usage list endpoint to
+	// avoid N+1 queries when the FE wants per-row usage for the whole
+	// page. Returned map is keyed by slug; missing slugs map to a zero
+	// TagUsage so callers can read it unconditionally.
+	GetUsageBatch(ctx context.Context, slugs []string) (map[string]TagUsage, error)
+
+	// GetStats returns the group-wide adoption summary for the Tags page
+	// stats bar: total tags, plus tagged/untagged counts on commodities
+	// and files. "Tagged" = jsonb_array_length(tags) > 0.
+	GetStats(ctx context.Context) (TagStats, error)
 
 	// RewriteSlugReferences atomically rewrites every commodities.tags +
 	// files.tags JSONB array entry from oldSlug to newSlug for the


### PR DESCRIPTION
Closes #1412. Builds on the BE first-class tags work merged in #1486.

## Summary

- **BE**: extend the `/tags` surface so the FE can render full per-row usage (clickable items + files) without N+1 round-trips, and add a group-wide stats endpoint backing the page's stats bar.
- **FE**: replace the `PlaceholderPage` at `/g/:groupSlug/tags` with a real Tags management page — list, create, rename, recolor, delete-with-force-when-in-use.
- **E2E**: spec covering create → rename → attach → force-delete.

Closes the issue's E2E acceptance line. The "assign to an item" step is API-driven because the assignment surface lives on commodity / file detail pages (#1410 / #1411) rather than the Tags page itself.

## What's in

### Backend

- `GET /tags?include=usage` — per-row inline `meta.usage` block on the existing `data: TagListItem[]` envelope. Implementation uses a new `TagRegistry.GetUsageBatch` that runs a single SQL with an `unnest($1::text[])` CTE on postgres (or one pass per slug in the memory registry). The list shape stays "FLAT in data" matching the project convention (see #1456 envelope memo) — `meta` is just a sibling field on each row when the include token is set.
- `GET /tags/stats` — single round-trip COUNT bundle returning `tags_total`, `items_tagged`, `items_untagged`, `files_tagged`, `files_untagged`. Untagged is `jsonb_array_length(COALESCE(tags, '[]'::jsonb)) = 0` so NULL and `[]` are counted together.
- Memory tests: `GetUsageBatch` (multi-slug + empty input) + `GetStats`. Postgres tests for the new SQL ride on top of #1488 (the JSONB-rewrite/strip + rename concurrency follow-up).
- Swagger + FE codegen regenerated.

### Frontend

- `frontend/src/features/tags/{api,keys,schemas,hooks}.ts` — typed TanStack Query layer mirroring `features/files/*` conventions.
- `frontend/src/components/tags/{TagBadge,TagColorPicker,TagFormDialog,TagRow,TagsStatsBar}.tsx`.
- `frontend/src/pages/tags/TagsListPage.tsx` (route lazy-loaded; sidebar entry was already wired).
- `--tag-{amber|green|blue|orange|red|muted}` CSS tokens (light + dark) in `index.css`, exposed as Tailwind utilities via `@theme inline` so `bg-tag-amber/10`, `text-tag-amber`, `border-tag-amber/40` all resolve.
- `i18n/locales/en/tags.json` populated. cs/ru kept empty (i18next falls back to en).
- 21 new vitest tests across the feature (api, components). Total suite: **451 passing**.
- e2e spec at `e2e/tests/tags.spec.ts`.

### Behavior notes

- **Search debounce** is 250ms into the URL `?q=` so refresh / shareable links survive.
- **Slug auto-derive** runs in create mode only; edit mode never clobbers a manually-typed slug.
- **Delete flow** uses `useConfirm`. Tag-not-in-use → simple confirm. Tag in-use (per the inline usage block on the row) → second-stage dialog with the usage breakdown + "Force delete" button that re-issues with `?force=true`.
- **Color picker** is a `radiogroup` with 6 swatches matching the BE enum exactly; the form's zod schema uses the same closed enum so client-side validation rejects unknown colors before they hit the BE.

### Trade-offs / scope calls

- **Per-row usage on the list response uses inline `meta` rather than full JSON:API resource wrapping.** The project's existing convention is FLAT-in-data (files, commodities follow it; see [memory `a928218c`](https://github.com/denisvmedia/inventario/issues/1411) on the Files envelope). Switching tags to wrapped JSON:API would be inconsistent for one entity. JSON:API spec allows `meta` on each resource regardless of wrapper shape, so the inline approach is conformant.
- **`includeUsage` is FE-driven, not always-on**: list responses default to no usage to keep `GET /tags` cheap for callers that don't render the page (e.g. autocomplete, dashboards).

## Test plan

- [ ] CI green: backend unit + integration, postgres, swagger drift, FE codegen drift, lint, prettier, vitest, e2e.
- [ ] Manual: create tag → rename slug → attach to a commodity (Items page) → see "Used by 1 item" on Tags page → delete → in-use confirm → Force delete → row gone.
- [ ] Manual: stats bar shows non-zero numbers in a populated group; light + dark mode pill colors readable.

## Follow-ups

- BE: apiserver-level integration tests for `?include=usage` and `/tags/stats` (memory registry covers them today; cross-group RLS check belongs alongside #1488).
- FE: per-tag detail page (clickable usage pills navigating to a "items + files using this tag" view) — out of scope for #1412 but a natural next step now that `meta.usage` is on every row.