### PR TITLE
[#1488] BE postgres tag integration tests + atomic registry methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,11 @@ Support for multiple database backends via DSN:
 ### Pointer Allocation Style
 - When code needs a pointer copy of an existing value, prefer the direct `new(value)` form at the use site (for example, `m.users[user.ID] = new(user)`) instead of copy-then-address patterns through intermediate locals.
 - Do not introduce `ptrTo`, `toPtr`, or similar helper wrappers whose only purpose is manufacturing pointers; prefer the direct allocation form unless the helper adds real behavior beyond pointer construction.
+- **Go 1.26+ extends the `new` builtin's operand from a type to an expression** — this is the spec change that makes the form above legal. Quoting the [Go 1.26 release notes](https://tip.golang.org/doc/go1.26): *"The built-in `new` function, which creates a new variable, now allows its operand to be an expression, specifying the initial value of the variable."* If `expr` has type `T`, then `new(expr)` allocates a `T`, **initializes it to the value of `expr`**, and returns a `*T`. Concrete examples from this codebase:
+  - `new(changedAt)` where `changedAt` is a `time.Time` parameter → returns a `*time.Time` pointing to a copy of `changedAt` (NOT a zero-valued pointer).
+  - `m.users[user.ID] = new(user)` where `user` is a `models.User` value → stores a `*models.User` initialized from `user`.
+  - `Age: new(yearsSince(born))` from the official spec example → returns a `*int` initialized to the call's result.
+- **Common misreading to avoid:** `new(x)` where `x` looks like a value is *not* the legacy `new(T)` form returning a zero-valued pointer; it is the Go 1.26 expression form returning a pointer initialized with `x`. The project requires Go 1.26+ (see Technology Stack), so this form is always intended.
 
 ### Database Migrations
 - Use Ptah struct annotations for schema definition

--- a/go/registry/errors.go
+++ b/go/registry/errors.go
@@ -22,4 +22,12 @@ var (
 	ErrResourceLimitExceeded    = errx.NewSentinel("resource limit exceeded")
 	ErrConcurrencyLimitExceeded = errx.NewSentinel("concurrency limit exceeded")
 	ErrTooManyRequests          = errx.NewSentinel("too many requests")
+
+	// ErrTagInUse signals that a tag still has commodity / file
+	// references and DeleteAtomic was invoked with force=false. Returned
+	// alongside the populated TagUsage so callers can render the
+	// breakdown without a second round-trip. Defined here (not in
+	// services) so registry implementations can return it directly from
+	// inside the lock-protected delete path.
+	ErrTagInUse = errx.NewSentinel("tag is in use")
 )

--- a/go/registry/memory/tags.go
+++ b/go/registry/memory/tags.go
@@ -2,10 +2,14 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
+	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"github.com/go-extras/go-kit/must"
 
@@ -13,6 +17,16 @@ import (
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 )
+
+// tagAtomicMu serializes RenameAtomic / DeleteAtomic in the memory
+// backend. Coarse but correct — the in-memory registry's iterate-then-
+// update pattern (List → Update per tag) is not internally tx-safe, and
+// memory tests don't exercise concurrency anyway. The lock is package-
+// scoped because RenameAtomic/DeleteAtomic also need to block concurrent
+// callers across all groups (the test scaffold uses a single registry
+// set; cross-group is enforced by groupID filtering inside the existing
+// methods, not by separate lock buckets).
+var tagAtomicMu sync.Mutex
 
 // TagRegistryFactory creates TagRegistry instances with proper context.
 // The factory stores references to the commodity + file factories so the
@@ -444,6 +458,81 @@ func (r *TagRegistry) StripSlugReferences(ctx context.Context, slug string) (com
 		fileCount++
 	}
 	return commodityCount, fileCount, nil
+}
+
+// RenameAtomic mirrors the postgres semantics: re-read the tag, run the
+// slug-clash check, rewrite JSONB references, and update the tag row,
+// all under the same mutex. The memory backend doesn't have separate
+// transactions — the mutex is the entire serialization mechanism.
+func (r *TagRegistry) RenameAtomic(ctx context.Context, id, newLabel, newSlug string, newColor models.TagColor) (*models.Tag, error) {
+	tagAtomicMu.Lock()
+	defer tagAtomicMu.Unlock()
+
+	current, err := r.Get(ctx, id)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to look up tag", err)
+	}
+
+	updated := *current
+	updated.UpdatedAt = time.Now()
+	if strings.TrimSpace(newLabel) != "" {
+		updated.Label = newLabel
+	}
+	if newColor != "" {
+		updated.Color = newColor
+	}
+
+	slugChanged := newSlug != "" && newSlug != current.Slug
+	if slugChanged {
+		updated.Slug = newSlug
+		clash, clashErr := r.GetBySlug(ctx, newSlug)
+		if clashErr != nil && !errors.Is(clashErr, registry.ErrNotFound) {
+			return nil, errxtrace.Wrap("failed to check slug availability", clashErr)
+		}
+		if clash != nil && clash.ID != current.ID {
+			return nil, errxtrace.Wrap("target slug is already used by another tag",
+				registry.ErrAlreadyExists, errx.Attrs("slug", newSlug))
+		}
+		if _, _, err := r.RewriteSlugReferences(ctx, current.Slug, newSlug); err != nil {
+			return nil, errxtrace.Wrap("failed to rewrite slug references", err)
+		}
+	}
+
+	final, err := r.Update(ctx, updated)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to update tag", err)
+	}
+	return final, nil
+}
+
+// DeleteAtomic mirrors the postgres semantics: usage check + strip (when
+// force=true) + delete, all under the same mutex.
+func (r *TagRegistry) DeleteAtomic(ctx context.Context, id string, force bool) (registry.TagUsage, error) {
+	tagAtomicMu.Lock()
+	defer tagAtomicMu.Unlock()
+
+	current, err := r.Get(ctx, id)
+	if err != nil {
+		return registry.TagUsage{}, errxtrace.Wrap("failed to look up tag", err)
+	}
+
+	usage, err := r.GetUsage(ctx, current.Slug)
+	if err != nil {
+		return registry.TagUsage{}, errxtrace.Wrap("failed to compute tag usage", err)
+	}
+
+	if usage.Commodities+usage.Files > 0 && !force {
+		return usage, registry.ErrTagInUse
+	}
+	if usage.Commodities+usage.Files > 0 {
+		if _, _, err := r.StripSlugReferences(ctx, current.Slug); err != nil {
+			return usage, errxtrace.Wrap("failed to strip slug references", err)
+		}
+	}
+	if err := r.Delete(ctx, id); err != nil {
+		return usage, errxtrace.Wrap("failed to delete tag", err)
+	}
+	return usage, nil
 }
 
 // replaceTagSlug rewrites every occurrence of oldSlug in a ValuerSlice[string]

--- a/go/registry/memory/tags.go
+++ b/go/registry/memory/tags.go
@@ -19,13 +19,26 @@ import (
 )
 
 // tagAtomicMu serializes RenameAtomic / DeleteAtomic in the memory
-// backend. Coarse but correct — the in-memory registry's iterate-then-
-// update pattern (List → Update per tag) is not internally tx-safe, and
-// memory tests don't exercise concurrency anyway. The lock is package-
-// scoped because RenameAtomic/DeleteAtomic also need to block concurrent
-// callers across all groups (the test scaffold uses a single registry
-// set; cross-group is enforced by groupID filtering inside the existing
-// methods, not by separate lock buckets).
+// backend with each other so the iterate-then-update sequences they run
+// (List → Update per tag) don't interleave.
+//
+// **Scope caveat:** the lock does NOT cover commodity / file Create or
+// Update on the memory backend — those write paths persist into the
+// shared in-memory map under their own per-registry lock and don't
+// touch tagAtomicMu. A concurrent memory-backend commodity write could
+// therefore still leave a JSONB reference to a slug DeleteAtomic is
+// about to remove, or use a slug RenameAtomic is currently rewriting.
+// We accept that gap because:
+//   - memory backend exists for unit tests / single-process flows;
+//     none of those exercise concurrent writes (postgres is the
+//     production target with the real cross-tx coordination — see
+//     ensureTagRowsInTx + pg_advisory_xact_lock in registry/postgres);
+//   - closing it would require routing every commodity / file write
+//     through a per-slug serialization layer in the memory backend
+//     for no production benefit.
+//
+// If a future use case puts the memory backend under concurrent write
+// load, this is the spot to fix.
 var tagAtomicMu sync.Mutex
 
 // TagRegistryFactory creates TagRegistry instances with proper context.
@@ -507,6 +520,8 @@ func (r *TagRegistry) RenameAtomic(ctx context.Context, id, newLabel, newSlug st
 
 // DeleteAtomic mirrors the postgres semantics: usage check + strip (when
 // force=true) + delete, all under the same mutex.
+//
+//revive:disable-next-line:flag-parameter
 func (r *TagRegistry) DeleteAtomic(ctx context.Context, id string, force bool) (registry.TagUsage, error) {
 	tagAtomicMu.Lock()
 	defer tagAtomicMu.Unlock()

--- a/go/registry/postgres/commodities.go
+++ b/go/registry/postgres/commodities.go
@@ -87,8 +87,14 @@ func (r *CommodityRegistry) Create(ctx context.Context, commodity models.Commodi
 	reg := r.newSQLRegistry()
 
 	createdCommodity, err := reg.Create(ctx, commodity, func(ctx context.Context, tx *sqlx.Tx) error {
-		_, err := r.getArea(ctx, tx, commodity.AreaID)
-		return err
+		if _, err := r.getArea(ctx, tx, commodity.AreaID); err != nil {
+			return err
+		}
+		// Auto-create / row-lock referenced tag rows inside this same tx
+		// so a concurrent DeleteTag(force=true) on one of these slugs
+		// can't leave us with an orphan JSONB reference at commit. See
+		// ensureTagRowsInTx in tags.go for the full lock invariant.
+		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, []string(commodity.Tags))
 	})
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to create commodity", err)
@@ -311,8 +317,14 @@ func (r *CommodityRegistry) Update(ctx context.Context, commodity models.Commodi
 	reg := r.newSQLRegistry()
 
 	err := reg.Update(ctx, commodity, func(ctx context.Context, tx *sqlx.Tx, dbCommodity models.Commodity) error {
-		_, err := r.getArea(ctx, tx, commodity.AreaID)
-		return err
+		if _, err := r.getArea(ctx, tx, commodity.AreaID); err != nil {
+			return err
+		}
+		// Same orphan-prevention as in Create — an Update that adds new
+		// tag slugs needs to grab the per-(group, slug) lock + upsert the
+		// tag row before the JSONB column is rewritten by the surrounding
+		// Update query.
+		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, []string(commodity.Tags))
 	})
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to update commodity", err)

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -113,7 +113,11 @@ func (r *FileRegistry) Create(ctx context.Context, file models.FileEntity) (*mod
 
 	reg := r.newSQLRegistry()
 
-	createdFile, err := reg.Create(ctx, file, nil)
+	createdFile, err := reg.Create(ctx, file, func(ctx context.Context, tx *sqlx.Tx) error {
+		// Same orphan-prevention as in CommodityRegistry.Create — see
+		// ensureTagRowsInTx in tags.go for the cross-tx invariant.
+		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, []string(file.Tags))
+	})
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to create file", err)
 	}
@@ -124,7 +128,9 @@ func (r *FileRegistry) Create(ctx context.Context, file models.FileEntity) (*mod
 func (r *FileRegistry) Update(ctx context.Context, file models.FileEntity) (*models.FileEntity, error) {
 	reg := r.newSQLRegistry()
 
-	err := reg.Update(ctx, file, nil)
+	err := reg.Update(ctx, file, func(ctx context.Context, tx *sqlx.Tx, dbFile models.FileEntity) error {
+		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, []string(file.Tags))
+	})
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to update file", err)
 	}

--- a/go/registry/postgres/group_invites_test.go
+++ b/go/registry/postgres/group_invites_test.go
@@ -19,7 +19,15 @@ func inviteFor(tenantID, groupID, createdByUserID string, expires time.Time) mod
 		GroupID:             groupID,
 		Token:               token,
 		CreatedBy:           createdByUserID,
-		ExpiresAt:           expires,
+		// Normalize to UTC: expires_at is a TIMESTAMP (no tz) column, so
+		// pgx serializes the wall-clock components in time.Local on
+		// write and reconstructs the value with location=UTC on read.
+		// On a non-UTC dev machine (e.g. CEST) that round-trip skews the
+		// instant by the offset, making "1 hour ago" look like a future
+		// timestamp to ListActiveByGroup's `ExpiresAt.After(now)` check.
+		// CI runs in UTC so the bug never surfaces there. Forcing UTC
+		// here keeps the wall-clock components stable across timezones.
+		ExpiresAt: expires.UTC(),
 	}
 }
 

--- a/go/registry/postgres/tags.go
+++ b/go/registry/postgres/tags.go
@@ -2,9 +2,16 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
+	"slices"
+	"sort"
 	"strings"
+	"time"
+	"unicode"
 
+	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"github.com/go-extras/go-kit/must"
 	"github.com/jmoiron/sqlx"
@@ -447,6 +454,276 @@ func (r *TagRegistry) RewriteSlugReferences(ctx context.Context, oldSlug, newSlu
 		return 0, 0, errxtrace.Wrap("failed to rewrite slug references", err)
 	}
 	return commodityCount, fileCount, nil
+}
+
+// acquireTagAdvisoryLock takes a transaction-scoped postgres advisory lock
+// keyed on (group, key). The two-int4 form lets us pack a per-group +
+// per-tag-attribute pair into one lock space without a hash collision
+// across groups. xact-scoped means we don't have to release explicitly —
+// COMMIT/ROLLBACK does it.
+func acquireTagAdvisoryLock(ctx context.Context, tx *sqlx.Tx, groupID, key string) error {
+	_, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))`, groupID, key)
+	if err != nil {
+		return errxtrace.Wrap("failed to acquire tag advisory lock", err, errx.Attrs("group_id", groupID, "key", key))
+	}
+	return nil
+}
+
+// defaultTagLabelFromSlug mirrors services.defaultLabelFromSlug — split a
+// kebab-case slug on '-' and Title-case each word. Duplicated here so the
+// registry's own auto-create path doesn't import services (which would be
+// a cycle: services imports registry).
+func defaultTagLabelFromSlug(slug string) string {
+	parts := strings.Split(slug, "-")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		runes := []rune(p)
+		runes[0] = unicode.ToUpper(runes[0])
+		parts[i] = string(runes)
+	}
+	return strings.Join(parts, " ")
+}
+
+// ensureTagRowsInTx is the cross-tx safety net for the orphan-reference
+// race surfaced by #1488: a commodity / file insert that references a
+// slug must not commit if a concurrent DeleteTag already removed (or is
+// removing) the tags row for that slug.
+//
+// For each (group, slug) we (a) take a per-(group, slug) xact advisory
+// lock — which DeleteAtomic also takes — so we serialize against an
+// in-flight delete on the same slug, and (b) run INSERT ... ON CONFLICT
+// DO NOTHING. If the delete already committed, our INSERT creates a
+// fresh tag row; if it hadn't yet, the deleter blocks until our tx
+// commits, then re-checks usage (which now includes our new row) and
+// either refuses (force=false) or re-strips (force=true).
+//
+// Slugs are deduplicated and sorted before locking so the lock
+// acquisition order is deterministic across writers — eliminates
+// deadlock potential when two writers reference overlapping slug sets.
+func ensureTagRowsInTx(ctx context.Context, tx *sqlx.Tx, tableNames store.TableNames, tenantID, groupID, userID string, slugs []string) error {
+	if len(slugs) == 0 || groupID == "" {
+		return nil
+	}
+	cleaned := make([]string, 0, len(slugs))
+	seen := make(map[string]struct{}, len(slugs))
+	for _, s := range slugs {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		cleaned = append(cleaned, s)
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	sort.Strings(cleaned)
+
+	selectForUpdate := fmt.Sprintf(
+		`SELECT 1 FROM %s WHERE group_id = $1 AND slug = $2 FOR UPDATE`, tableNames.Tags())
+	insertQuery := fmt.Sprintf(`
+		INSERT INTO %s (id, tenant_id, group_id, slug, label, color, created_by_user_id)
+		VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6)
+		ON CONFLICT (group_id, slug) DO NOTHING`, tableNames.Tags())
+
+	for _, slug := range cleaned {
+		if err := acquireTagAdvisoryLock(ctx, tx, groupID, "slug:"+slug); err != nil {
+			return err
+		}
+		// SELECT FOR UPDATE — if the row exists, take a row-level lock so
+		// a concurrent DeleteAtomic (which also does FOR UPDATE on the
+		// same row) blocks until our tx commits. ON CONFLICT DO NOTHING
+		// alone is not sufficient: it skips the INSERT but doesn't lock
+		// the existing row, so a concurrent delete that committed
+		// before us would still leave us with an orphan reference.
+		var dummy int
+		err := tx.QueryRowContext(ctx, selectForUpdate, groupID, slug).Scan(&dummy)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			// Row gone (or never existed) — INSERT a fresh one. ON
+			// CONFLICT DO NOTHING is the safety net for two concurrent
+			// inserters racing on the same brand-new slug.
+			if _, err := tx.ExecContext(ctx, insertQuery,
+				tenantID, groupID, slug, defaultTagLabelFromSlug(slug), models.DefaultTagColor, userID); err != nil {
+				return errxtrace.Wrap("failed to insert tag row", err, errx.Attrs("slug", slug))
+			}
+		case err != nil:
+			return errxtrace.Wrap("failed to lock existing tag row", err, errx.Attrs("slug", slug))
+		}
+	}
+	return nil
+}
+
+// RenameAtomic does the slug-clash check, JSONB rewrite, and tags-row
+// update inside a single transaction held under a per-(group, tag id)
+// advisory lock. Two parallel renames of the same tag id serialize on
+// the lock; the second re-reads the row inside its lock and renames
+// from whatever slug the first one settled on.
+func (r *TagRegistry) RenameAtomic(ctx context.Context, id, newLabel, newSlug string, newColor models.TagColor) (*models.Tag, error) {
+	var final *models.Tag
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		if err := acquireTagAdvisoryLock(ctx, tx, r.groupID, "id:"+id); err != nil {
+			return err
+		}
+
+		var current models.Tag
+		err := tx.QueryRowxContext(ctx,
+			fmt.Sprintf(`SELECT * FROM %s WHERE id = $1 FOR UPDATE`, r.tableNames.Tags()),
+			id).StructScan(&current)
+		if errors.Is(err, sql.ErrNoRows) {
+			return errxtrace.Wrap("failed to look up tag", registry.ErrNotFound, errx.Attrs("id", id))
+		}
+		if err != nil {
+			return errxtrace.Wrap("failed to look up tag", err)
+		}
+
+		updated := current
+		updated.UpdatedAt = time.Now()
+		if strings.TrimSpace(newLabel) != "" {
+			updated.Label = newLabel
+		}
+		if newColor != "" {
+			updated.Color = newColor
+		}
+
+		slugChanged := newSlug != "" && newSlug != current.Slug
+		if slugChanged {
+			// Lock both old and new slugs in canonical order — coordinates
+			// with concurrent commodity/file inserts that might want to
+			// reference either side of the rename.
+			slugLocks := []string{current.Slug, newSlug}
+			sort.Strings(slugLocks)
+			slugLocks = slices.Compact(slugLocks)
+			for _, s := range slugLocks {
+				if err := acquireTagAdvisoryLock(ctx, tx, r.groupID, "slug:"+s); err != nil {
+					return err
+				}
+			}
+
+			// Pre-emptive slug-clash check, inside the lock — relying on
+			// the unique index alone would still work, but yields a worse
+			// error message (Postgres-level uniqueness violation vs.
+			// our domain ErrAlreadyExists).
+			var clashID string
+			clashErr := tx.QueryRowContext(ctx,
+				fmt.Sprintf(`SELECT id FROM %s WHERE slug = $1 AND id != $2 LIMIT 1`, r.tableNames.Tags()),
+				newSlug, id).Scan(&clashID)
+			switch {
+			case errors.Is(clashErr, sql.ErrNoRows):
+				// no clash — proceed
+			case clashErr != nil:
+				return errxtrace.Wrap("failed to check slug availability", clashErr)
+			default:
+				return errxtrace.Wrap("target slug is already used by another tag",
+					registry.ErrAlreadyExists, errx.Attrs("slug", newSlug))
+			}
+
+			updated.Slug = newSlug
+			rewriteCommQuery := fmt.Sprintf(
+				`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
+				r.tableNames.Commodities(), jsonbReplaceSlugExpr(1, 2))
+			if _, err := tx.ExecContext(ctx, rewriteCommQuery, current.Slug, newSlug); err != nil {
+				return errxtrace.Wrap("failed to rewrite commodity tags", err)
+			}
+			rewriteFileQuery := fmt.Sprintf(
+				`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
+				r.tableNames.Files(), jsonbReplaceSlugExpr(1, 2))
+			if _, err := tx.ExecContext(ctx, rewriteFileQuery, current.Slug, newSlug); err != nil {
+				return errxtrace.Wrap("failed to rewrite file tags", err)
+			}
+		}
+
+		var result models.Tag
+		err = tx.QueryRowxContext(ctx, fmt.Sprintf(
+			`UPDATE %s SET slug = $1, label = $2, color = $3, updated_at = $4 WHERE id = $5 RETURNING *`,
+			r.tableNames.Tags()),
+			updated.Slug, updated.Label, updated.Color, updated.UpdatedAt, id).StructScan(&result)
+		if err != nil {
+			return errxtrace.Wrap("failed to update tag row", err)
+		}
+		final = &result
+		return nil
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to rename tag atomically", err)
+	}
+	return final, nil
+}
+
+// DeleteAtomic checks usage, strips JSONB references (when force=true),
+// and deletes the tags row inside one tx held under per-(group, id) +
+// per-(group, slug) xact advisory locks. The slug lock is what
+// coordinates with concurrent commodity / file inserts via
+// ensureTagRowsInTx — they take the same lock and either see the deleted
+// row gone (and re-INSERT a fresh one via ON CONFLICT DO NOTHING) or
+// block until our tx commits.
+//
+// When force=false and usage > 0, returns the populated TagUsage along
+// with registry.ErrTagInUse and rolls back without mutating state.
+func (r *TagRegistry) DeleteAtomic(ctx context.Context, id string, force bool) (registry.TagUsage, error) {
+	var usage registry.TagUsage
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		if err := acquireTagAdvisoryLock(ctx, tx, r.groupID, "id:"+id); err != nil {
+			return err
+		}
+
+		var current models.Tag
+		err := tx.QueryRowxContext(ctx,
+			fmt.Sprintf(`SELECT * FROM %s WHERE id = $1 FOR UPDATE`, r.tableNames.Tags()),
+			id).StructScan(&current)
+		if errors.Is(err, sql.ErrNoRows) {
+			return errxtrace.Wrap("failed to look up tag", registry.ErrNotFound, errx.Attrs("id", id))
+		}
+		if err != nil {
+			return errxtrace.Wrap("failed to look up tag", err)
+		}
+
+		if err := acquireTagAdvisoryLock(ctx, tx, r.groupID, "slug:"+current.Slug); err != nil {
+			return err
+		}
+
+		usageQuery := fmt.Sprintf(
+			`SELECT (SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array($1::text)),
+			        (SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array($1::text))`,
+			r.tableNames.Commodities(), r.tableNames.Files())
+		if err := tx.QueryRowxContext(ctx, usageQuery, current.Slug).Scan(&usage.Commodities, &usage.Files); err != nil {
+			return errxtrace.Wrap("failed to compute tag usage", err)
+		}
+
+		if usage.Commodities+usage.Files > 0 && !force {
+			return registry.ErrTagInUse
+		}
+		if usage.Commodities+usage.Files > 0 {
+			stripCommQuery := fmt.Sprintf(
+				`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
+				r.tableNames.Commodities(), jsonbStripSlugExpr(1))
+			if _, err := tx.ExecContext(ctx, stripCommQuery, current.Slug); err != nil {
+				return errxtrace.Wrap("failed to strip commodity tags", err)
+			}
+			stripFileQuery := fmt.Sprintf(
+				`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
+				r.tableNames.Files(), jsonbStripSlugExpr(1))
+			if _, err := tx.ExecContext(ctx, stripFileQuery, current.Slug); err != nil {
+				return errxtrace.Wrap("failed to strip file tags", err)
+			}
+		}
+
+		if _, err := tx.ExecContext(ctx,
+			fmt.Sprintf(`DELETE FROM %s WHERE id = $1`, r.tableNames.Tags()), id); err != nil {
+			return errxtrace.Wrap("failed to delete tag row", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return usage, err
+	}
+	return usage, nil
 }
 
 func (r *TagRegistry) StripSlugReferences(ctx context.Context, slug string) (commodityRows, fileRows int, err error) {

--- a/go/registry/postgres/tags.go
+++ b/go/registry/postgres/tags.go
@@ -558,6 +558,56 @@ func ensureTagRowsInTx(ctx context.Context, tx *sqlx.Tx, tableNames store.TableN
 	return nil
 }
 
+// renameRewriteSlug runs the JSONB-rewrite half of RenameAtomic — slug
+// locks, clash check, and the two table updates — inside the caller's
+// tx. Lifted out of RenameAtomic so the orchestrator stays under
+// gocognit's threshold without losing the lock-and-rewrite invariant.
+func (r *TagRegistry) renameRewriteSlug(ctx context.Context, tx *sqlx.Tx, id, oldSlug, newSlug string) error {
+	// Lock both old and new slugs in canonical order — coordinates
+	// with concurrent commodity/file inserts that might want to
+	// reference either side of the rename.
+	slugLocks := []string{oldSlug, newSlug}
+	sort.Strings(slugLocks)
+	slugLocks = slices.Compact(slugLocks)
+	for _, s := range slugLocks {
+		if err := acquireTagAdvisoryLock(ctx, tx, r.groupID, "slug:"+s); err != nil {
+			return err
+		}
+	}
+
+	// Pre-emptive slug-clash check, inside the lock — relying on
+	// the unique index alone would still work, but yields a worse
+	// error message (Postgres-level uniqueness violation vs. our
+	// domain ErrAlreadyExists).
+	var clashID string
+	clashErr := tx.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT id FROM %s WHERE slug = $1 AND id != $2 LIMIT 1`, r.tableNames.Tags()),
+		newSlug, id).Scan(&clashID)
+	switch {
+	case errors.Is(clashErr, sql.ErrNoRows):
+		// no clash — proceed
+	case clashErr != nil:
+		return errxtrace.Wrap("failed to check slug availability", clashErr)
+	default:
+		return errxtrace.Wrap("target slug is already used by another tag",
+			registry.ErrAlreadyExists, errx.Attrs("slug", newSlug))
+	}
+
+	rewriteCommQuery := fmt.Sprintf(
+		`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
+		r.tableNames.Commodities(), jsonbReplaceSlugExpr(1, 2))
+	if _, err := tx.ExecContext(ctx, rewriteCommQuery, oldSlug, newSlug); err != nil {
+		return errxtrace.Wrap("failed to rewrite commodity tags", err)
+	}
+	rewriteFileQuery := fmt.Sprintf(
+		`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
+		r.tableNames.Files(), jsonbReplaceSlugExpr(1, 2))
+	if _, err := tx.ExecContext(ctx, rewriteFileQuery, oldSlug, newSlug); err != nil {
+		return errxtrace.Wrap("failed to rewrite file tags", err)
+	}
+	return nil
+}
+
 // RenameAtomic does the slug-clash check, JSONB rewrite, and tags-row
 // update inside a single transaction held under a per-(group, tag id)
 // advisory lock. Two parallel renames of the same tag id serialize on
@@ -591,50 +641,10 @@ func (r *TagRegistry) RenameAtomic(ctx context.Context, id, newLabel, newSlug st
 			updated.Color = newColor
 		}
 
-		slugChanged := newSlug != "" && newSlug != current.Slug
-		if slugChanged {
-			// Lock both old and new slugs in canonical order — coordinates
-			// with concurrent commodity/file inserts that might want to
-			// reference either side of the rename.
-			slugLocks := []string{current.Slug, newSlug}
-			sort.Strings(slugLocks)
-			slugLocks = slices.Compact(slugLocks)
-			for _, s := range slugLocks {
-				if err := acquireTagAdvisoryLock(ctx, tx, r.groupID, "slug:"+s); err != nil {
-					return err
-				}
-			}
-
-			// Pre-emptive slug-clash check, inside the lock — relying on
-			// the unique index alone would still work, but yields a worse
-			// error message (Postgres-level uniqueness violation vs.
-			// our domain ErrAlreadyExists).
-			var clashID string
-			clashErr := tx.QueryRowContext(ctx,
-				fmt.Sprintf(`SELECT id FROM %s WHERE slug = $1 AND id != $2 LIMIT 1`, r.tableNames.Tags()),
-				newSlug, id).Scan(&clashID)
-			switch {
-			case errors.Is(clashErr, sql.ErrNoRows):
-				// no clash — proceed
-			case clashErr != nil:
-				return errxtrace.Wrap("failed to check slug availability", clashErr)
-			default:
-				return errxtrace.Wrap("target slug is already used by another tag",
-					registry.ErrAlreadyExists, errx.Attrs("slug", newSlug))
-			}
-
+		if newSlug != "" && newSlug != current.Slug {
 			updated.Slug = newSlug
-			rewriteCommQuery := fmt.Sprintf(
-				`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
-				r.tableNames.Commodities(), jsonbReplaceSlugExpr(1, 2))
-			if _, err := tx.ExecContext(ctx, rewriteCommQuery, current.Slug, newSlug); err != nil {
-				return errxtrace.Wrap("failed to rewrite commodity tags", err)
-			}
-			rewriteFileQuery := fmt.Sprintf(
-				`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
-				r.tableNames.Files(), jsonbReplaceSlugExpr(1, 2))
-			if _, err := tx.ExecContext(ctx, rewriteFileQuery, current.Slug, newSlug); err != nil {
-				return errxtrace.Wrap("failed to rewrite file tags", err)
+			if err := r.renameRewriteSlug(ctx, tx, id, current.Slug, newSlug); err != nil {
+				return err
 			}
 		}
 
@@ -665,6 +675,8 @@ func (r *TagRegistry) RenameAtomic(ctx context.Context, id, newLabel, newSlug st
 //
 // When force=false and usage > 0, returns the populated TagUsage along
 // with registry.ErrTagInUse and rolls back without mutating state.
+//
+//revive:disable-next-line:flag-parameter
 func (r *TagRegistry) DeleteAtomic(ctx context.Context, id string, force bool) (registry.TagUsage, error) {
 	var usage registry.TagUsage
 	reg := r.newSQLRegistry()

--- a/go/registry/postgres/tags_test.go
+++ b/go/registry/postgres/tags_test.go
@@ -1,0 +1,539 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// tagPGFixture wires what every postgres tag test needs:
+//   - a shared *FactorySet for service-layer code (TagService) that resolves
+//     the group from ctx;
+//   - one user-aware *Set per group (registries with their groupID baked in,
+//     mirroring what the apiserver builds per request);
+//   - context values that carry user + group, ready to hand to TagService.
+//
+// The fixture is sized for two groups so cross-group RLS isolation can be
+// exercised — the most load-bearing assertion in #1488 beyond the SQL itself.
+type tagPGFixture struct {
+	factorySet *registry.FactorySet
+	groupASet  *registry.Set
+	groupBSet  *registry.Set
+	ctxA       context.Context
+	ctxB       context.Context
+	user       *models.User
+	groupAID   string
+	groupBID   string
+	areaAID    string
+	areaBID    string
+	dbx        *sqlx.DB
+}
+
+// newTagPGFixture re-creates the schema, seeds tenant+user+two groups, and
+// returns a fixture. setupTestRegistrySet drops + bootstraps before this
+// returns, so each call is hermetic.
+func newTagPGFixture(t *testing.T) tagPGFixture {
+	t.Helper()
+	c := qt.New(t)
+
+	groupASet, _ := setupTestRegistrySet(t)
+
+	dsn := skipIfNoPostgreSQL(t)
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	factorySet := postgres.NewFactorySet(dbx)
+
+	user := getTestUser(c, groupASet)
+
+	// Group A is the one setupTestRegistrySet created. Discover its ID via
+	// the service registry rather than threading it through the helper —
+	// keeps the shared scaffold untouched.
+	serviceSet := factorySet.CreateServiceRegistrySet()
+	groups, err := serviceSet.LocationGroupRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(groups, qt.HasLen, 1)
+	groupAID := groups[0].ID
+
+	groupBSlug, err := models.GenerateGroupSlug()
+	c.Assert(err, qt.IsNil)
+	groupB, err := serviceSet.LocationGroupRegistry.Create(context.Background(), models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: user.TenantID},
+		Name:                "Test Group B",
+		Slug:                groupBSlug,
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           user.ID,
+		MainCurrency:        models.Currency("USD"),
+	})
+	c.Assert(err, qt.IsNil)
+	groupBID := groupB.ID
+
+	groupBSet := postgres.NewRegistrySetWithUserAndGroupID(dbx, user.ID, user.TenantID, groupBID)
+
+	ctxA := tagCtxFor(user, groupAID)
+	ctxB := tagCtxFor(user, groupBID)
+
+	areaAID := seedTagArea(c, groupASet, ctxA)
+	areaBID := seedTagArea(c, groupBSet, ctxB)
+
+	return tagPGFixture{
+		factorySet: factorySet,
+		groupASet:  groupASet,
+		groupBSet:  groupBSet,
+		ctxA:       ctxA,
+		ctxB:       ctxB,
+		user:       user,
+		groupAID:   groupAID,
+		groupBID:   groupBID,
+		areaAID:    areaAID,
+		areaBID:    areaBID,
+		dbx:        dbx,
+	}
+}
+
+func tagCtxFor(user *models.User, groupID string) context.Context {
+	ctx := appctx.WithUser(context.Background(), user)
+	return appctx.WithGroup(ctx, &models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: groupID},
+			TenantID: user.TenantID,
+		},
+	})
+}
+
+func seedTagArea(c *qt.C, set *registry.Set, ctx context.Context) string {
+	c.Helper()
+	loc, err := set.LocationRegistry.Create(ctx, models.Location{
+		Name:    "Loc",
+		Address: "addr",
+	})
+	c.Assert(err, qt.IsNil)
+	area, err := set.AreaRegistry.Create(ctx, models.Area{
+		Name:       "Area",
+		LocationID: loc.GetID(),
+	})
+	c.Assert(err, qt.IsNil)
+	return area.GetID()
+}
+
+func seedTagCommodity(c *qt.C, set *registry.Set, ctx context.Context, areaID, name string, tags ...string) string {
+	c.Helper()
+	cmd, err := set.CommodityRegistry.Create(ctx, models.Commodity{
+		Name:                   name,
+		ShortName:              name,
+		Type:                   models.CommodityTypeOther,
+		AreaID:                 areaID,
+		Count:                  1,
+		OriginalPrice:          decimal.NewFromFloat(100.00),
+		OriginalPriceCurrency:  "USD",
+		ConvertedOriginalPrice: decimal.Zero,
+		CurrentPrice:           decimal.NewFromFloat(90.00),
+		Status:                 models.CommodityStatusInUse,
+		PurchaseDate:           models.ToPDate("2024-01-01"),
+		RegisteredDate:         models.ToPDate("2024-01-02"),
+		LastModifiedDate:       models.ToPDate("2024-01-03"),
+		Tags:                   tags,
+	})
+	c.Assert(err, qt.IsNil)
+	return cmd.GetID()
+}
+
+func seedTagFile(c *qt.C, set *registry.Set, ctx context.Context, name string, tags ...string) string {
+	c.Helper()
+	file, err := set.FileRegistry.Create(ctx, models.FileEntity{
+		Title:    name,
+		Type:     models.FileTypeImage,
+		Category: models.FileCategoryPhotos,
+		Tags:     tags,
+		File: &models.File{
+			Path:         name,
+			OriginalPath: name + ".jpg",
+			Ext:          ".jpg",
+			MIMEType:     "image/jpeg",
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	return file.GetID()
+}
+
+func mustCreateTag(c *qt.C, reg registry.TagRegistry, ctx context.Context, slug string) *models.Tag {
+	c.Helper()
+	tag, err := reg.Create(ctx, models.Tag{
+		Slug:  slug,
+		Label: slug,
+		Color: models.DefaultTagColor,
+	})
+	c.Assert(err, qt.IsNil)
+	return tag
+}
+
+// rawCommodityTagsText reads the literal JSONB column as text — needed to
+// distinguish `[]` from `null`, which both round-trip to an empty Go slice
+// after StructScan.
+func rawCommodityTagsText(c *qt.C, dbx *sqlx.DB, id string) string {
+	c.Helper()
+	var raw *string
+	err := dbx.QueryRowxContext(context.Background(),
+		`SELECT tags::text FROM commodities WHERE id = $1`, id).Scan(&raw)
+	c.Assert(err, qt.IsNil)
+	if raw == nil {
+		return "null"
+	}
+	return *raw
+}
+
+func TestTagRegistry_Postgres_RewriteSlugReferences(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen", "appliance")
+	fileID := seedTagFile(c, fx.groupASet, fx.ctxA, "fridge-photo", "kitchen")
+
+	commCount, fileCount, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, "kitchen", "kitchen-area")
+	c.Assert(err, qt.IsNil)
+	c.Assert(commCount, qt.Equals, 1)
+	c.Assert(fileCount, qt.Equals, 1)
+
+	cmd, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdID)
+	c.Assert(err, qt.IsNil)
+	// jsonb_agg(DISTINCT ...) doesn't promise input order — assert by membership.
+	c.Assert([]string(cmd.Tags), qt.Contains, "kitchen-area")
+	c.Assert([]string(cmd.Tags), qt.Contains, "appliance")
+	c.Assert([]string(cmd.Tags), qt.Not(qt.Contains), "kitchen")
+
+	file, err := fx.groupASet.FileRegistry.Get(fx.ctxA, fileID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(file.Tags), qt.DeepEquals, []string{"kitchen-area"})
+}
+
+func TestTagRegistry_Postgres_RewriteSlugReferences_DedupOnRenameOntoExisting(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	// Row already contains both old and new slugs — DISTINCT in jsonb_agg
+	// must collapse them to a single occurrence post-rewrite.
+	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen", "kitchen-area", "appliance")
+
+	commCount, _, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, "kitchen", "kitchen-area")
+	c.Assert(err, qt.IsNil)
+	c.Assert(commCount, qt.Equals, 1)
+
+	cmd, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(cmd.Tags), qt.HasLen, 2)
+	c.Assert([]string(cmd.Tags), qt.Contains, "kitchen-area")
+	c.Assert([]string(cmd.Tags), qt.Contains, "appliance")
+}
+
+func TestTagRegistry_Postgres_RewriteSlugReferences_CrossGroupIsolation(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	cmdA := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "in-A", "kitchen")
+	cmdB := seedTagCommodity(c, fx.groupBSet, fx.ctxB, fx.areaBID, "in-B", "kitchen")
+	fileB := seedTagFile(c, fx.groupBSet, fx.ctxB, "in-B-photo", "kitchen")
+
+	// Rewrite scoped to group A only.
+	commCount, fileCount, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, "kitchen", "kitchen-area")
+	c.Assert(err, qt.IsNil)
+	c.Assert(commCount, qt.Equals, 1)
+	c.Assert(fileCount, qt.Equals, 0)
+
+	gotA, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdA)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotA.Tags), qt.DeepEquals, []string{"kitchen-area"})
+
+	gotB, err := fx.groupBSet.CommodityRegistry.Get(fx.ctxB, cmdB)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotB.Tags), qt.DeepEquals, []string{"kitchen"},
+		qt.Commentf("group B's commodity must remain untouched after group-A rewrite"))
+
+	gotFileB, err := fx.groupBSet.FileRegistry.Get(fx.ctxB, fileB)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotFileB.Tags), qt.DeepEquals, []string{"kitchen"})
+}
+
+func TestTagRegistry_Postgres_RewriteSlugReferences_LeavesUnrelatedRowsAlone(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	emptyID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "no-tags")
+	otherID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "other", "appliance")
+	taggedID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen")
+
+	commCount, _, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, "kitchen", "kitchen-area")
+	c.Assert(err, qt.IsNil)
+	c.Assert(commCount, qt.Equals, 1, qt.Commentf("only the row containing the old slug is touched"))
+
+	gotEmpty, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, emptyID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotEmpty.Tags), qt.HasLen, 0)
+
+	gotOther, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, otherID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotOther.Tags), qt.DeepEquals, []string{"appliance"})
+
+	gotTagged, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, taggedID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotTagged.Tags), qt.DeepEquals, []string{"kitchen-area"})
+}
+
+func TestTagRegistry_Postgres_RewriteSlugReferences_NoOpWhenSlugUnchanged(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen")
+
+	commCount, fileCount, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, "kitchen", "kitchen")
+	c.Assert(err, qt.IsNil)
+	c.Assert(commCount, qt.Equals, 0)
+	c.Assert(fileCount, qt.Equals, 0)
+
+	cmd, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(cmd.Tags), qt.DeepEquals, []string{"kitchen"})
+}
+
+func TestTagRegistry_Postgres_StripSlugReferences(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen", "appliance")
+	fileID := seedTagFile(c, fx.groupASet, fx.ctxA, "fridge-photo", "kitchen")
+
+	commCount, fileCount, err := fx.groupASet.TagRegistry.StripSlugReferences(fx.ctxA, "kitchen")
+	c.Assert(err, qt.IsNil)
+	c.Assert(commCount, qt.Equals, 1)
+	c.Assert(fileCount, qt.Equals, 1)
+
+	cmd, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(cmd.Tags), qt.DeepEquals, []string{"appliance"})
+
+	file, err := fx.groupASet.FileRegistry.Get(fx.ctxA, fileID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(file.Tags), qt.HasLen, 0)
+}
+
+func TestTagRegistry_Postgres_StripSlugReferences_EmptyArrayNotNull(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	// Single-tag row → after strip the JSONB value must persist as `[]`,
+	// not `null`. Mismatch would break downstream code that calls
+	// jsonb_array_length on the column.
+	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen")
+
+	_, _, err := fx.groupASet.TagRegistry.StripSlugReferences(fx.ctxA, "kitchen")
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(rawCommodityTagsText(c, fx.dbx, cmdID), qt.Equals, "[]")
+}
+
+func TestTagRegistry_Postgres_StripSlugReferences_CrossGroupIsolation(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	cmdA := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "in-A", "kitchen", "appliance")
+	cmdB := seedTagCommodity(c, fx.groupBSet, fx.ctxB, fx.areaBID, "in-B", "kitchen")
+
+	commCount, _, err := fx.groupASet.TagRegistry.StripSlugReferences(fx.ctxA, "kitchen")
+	c.Assert(err, qt.IsNil)
+	c.Assert(commCount, qt.Equals, 1)
+
+	gotA, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdA)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotA.Tags), qt.DeepEquals, []string{"appliance"})
+
+	gotB, err := fx.groupBSet.CommodityRegistry.Get(fx.ctxB, cmdB)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotB.Tags), qt.DeepEquals, []string{"kitchen"})
+}
+
+// TestTagService_Postgres_RenameTag_RefusesPreemptivelyOnSlugClash asserts
+// the slug-clash check fires before any JSONB UPDATE — partial rewrite
+// would be the worst-of-both-worlds outcome.
+func TestTagService_Postgres_RenameTag_RefusesPreemptivelyOnSlugClash(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	srcTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen")
+	_ = mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen-area")
+	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen")
+
+	svc := services.NewTagService(fx.factorySet)
+	_, err := svc.RenameTag(fx.ctxA, srcTag.ID, "Kitchen Area", "kitchen-area", "")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.Is(err, registry.ErrAlreadyExists), qt.IsTrue,
+		qt.Commentf("expected ErrAlreadyExists, got %v", err))
+
+	cmd, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(cmd.Tags), qt.DeepEquals, []string{"kitchen"},
+		qt.Commentf("JSONB must be untouched when rename is refused — no partial rewrite"))
+}
+
+// TestTagService_Postgres_RenameTag_ParallelDifferentSourceSlugs covers two
+// renames operating on distinct tags in the same group: they share no
+// row-level state, so both must succeed and both rewrites must land.
+func TestTagService_Postgres_RenameTag_ParallelDifferentSourceSlugs(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	tagA := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "alpha")
+	tagB := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "beta")
+	cmdA := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "with-alpha", "alpha")
+	cmdB := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "with-beta", "beta")
+
+	svc := services.NewTagService(fx.factorySet)
+
+	var wg sync.WaitGroup
+	var errA, errB error
+	start := make(chan struct{})
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, errA = svc.RenameTag(fx.ctxA, tagA.ID, "Alpha 2", "alpha-2", "")
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		_, errB = svc.RenameTag(fx.ctxA, tagB.ID, "Beta 2", "beta-2", "")
+	}()
+	close(start)
+	wg.Wait()
+
+	c.Assert(errA, qt.IsNil)
+	c.Assert(errB, qt.IsNil)
+
+	gotA, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdA)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotA.Tags), qt.DeepEquals, []string{"alpha-2"})
+
+	gotB, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdB)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotB.Tags), qt.DeepEquals, []string{"beta-2"})
+
+	tagAFinal, err := fx.groupASet.TagRegistry.Get(fx.ctxA, tagA.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tagAFinal.Slug, qt.Equals, "alpha-2")
+	tagBFinal, err := fx.groupASet.TagRegistry.Get(fx.ctxA, tagB.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tagBFinal.Slug, qt.Equals, "beta-2")
+}
+
+// TestTagService_Postgres_RenameTag_ParallelSameSourceSlug is the racey one:
+// two parallel renames target the same tag id but pick different new slugs.
+// The invariant the issue calls out — "JSONB references match the surviving
+// tags row's slug" — is what we assert. If the implementation can't deliver
+// it, this test fails and exposes a real concurrency gap; we don't soften
+// the assertion to keep the bar honest.
+func TestTagService_Postgres_RenameTag_ParallelSameSourceSlug(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	srcTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen")
+	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen")
+
+	svc := services.NewTagService(fx.factorySet)
+
+	var wg sync.WaitGroup
+	var errA, errB error
+	start := make(chan struct{})
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, errA = svc.RenameTag(fx.ctxA, srcTag.ID, "K1", "k1", "")
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		_, errB = svc.RenameTag(fx.ctxA, srcTag.ID, "K2", "k2", "")
+	}()
+	close(start)
+	wg.Wait()
+
+	finalTag, err := fx.groupASet.TagRegistry.Get(fx.ctxA, srcTag.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(finalTag.Slug, qt.Matches, "k[12]",
+		qt.Commentf("surviving slug must be one of the two targets, got %q (errA=%v errB=%v)",
+			finalTag.Slug, errA, errB))
+
+	cmd, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(cmd.Tags), qt.DeepEquals, []string{finalTag.Slug},
+		qt.Commentf("JSONB ref %v must match surviving tag slug %q (errA=%v errB=%v)",
+			cmd.Tags, finalTag.Slug, errA, errB))
+}
+
+// TestTagService_Postgres_DeleteTag_ForceUnderConcurrentInsert covers the
+// atomicity invariant from the issue: under a force-delete racing with a
+// concurrent commodity insert that references the same slug, no commodity
+// may end up referencing a slug whose tags row no longer exists.
+//
+// We accept either of the two consistent end-states the issue lists:
+//   - insert wins → tag row survives, commodity points at it;
+//   - delete wins + insert auto-recreated → fresh tag row exists with the
+//     same slug, commodity points at the fresh row.
+//
+// What we refuse: a JSONB reference to a slug with no matching row.
+func TestTagService_Postgres_DeleteTag_ForceUnderConcurrentInsert(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	srcTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen")
+	_ = seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "existing", "kitchen")
+
+	svc := services.NewTagService(fx.factorySet)
+
+	var wg sync.WaitGroup
+	var errDel, errIns error
+	start := make(chan struct{})
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, errDel = svc.DeleteTag(fx.ctxA, srcTag.ID, true)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		// Mirrors the apiserver write path: normalize-and-ensure runs first
+		// (will auto-recreate if the tag was already deleted), then the
+		// commodity row is persisted with the resolved slug list.
+		slugs, ensErr := svc.NormalizeAndEnsureSlugs(fx.ctxA, []string{"kitchen"})
+		if ensErr != nil {
+			errIns = ensErr
+			return
+		}
+		seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "racer", slugs...)
+	}()
+	close(start)
+	wg.Wait()
+
+	// Whatever interleaving won, the invariant holds at the end.
+	allCmds, err := fx.groupASet.CommodityRegistry.List(fx.ctxA)
+	c.Assert(err, qt.IsNil)
+	for _, cmd := range allCmds {
+		for _, slug := range cmd.Tags {
+			_, lookupErr := fx.groupASet.TagRegistry.GetBySlug(fx.ctxA, slug)
+			c.Assert(lookupErr, qt.IsNil,
+				qt.Commentf("orphan reference: commodity %s -> tag slug %q with no matching row (errDel=%v errIns=%v)",
+					cmd.ID, slug, errDel, errIns))
+		}
+	}
+}

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -337,10 +337,11 @@ type TagRegistry interface {
 	// advisory lock so a concurrent commodity insert that would race
 	// orphan-references in serializes against this operation.
 	//
-	// When force=false and usage > 0, returns the usage breakdown and
-	// ErrTagInUse without mutating any state. ErrTagInUse is defined in
-	// the services package — registries don't import it; callers compare
-	// against errors.Is at the service-layer.
+	// When force=false and usage > 0, returns the usage breakdown
+	// alongside registry.ErrTagInUse (defined in registry/errors.go)
+	// without mutating any state. Callers compare via errors.Is.
+	//
+	//revive:disable-next-line:flag-parameter
 	DeleteAtomic(ctx context.Context, id string, force bool) (TagUsage, error)
 }
 

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -334,8 +334,9 @@ type TagRegistry interface {
 
 	// DeleteAtomic re-checks usage, strips JSONB references (when
 	// force=true), and deletes the tags row — all under a single
-	// advisory lock so a concurrent commodity insert that would race
-	// orphan-references in serializes against this operation.
+	// advisory lock, so a concurrent commodity insert that would
+	// otherwise leak an orphan JSONB reference serializes against this
+	// operation instead.
 	//
 	// When force=false and usage > 0, returns the usage breakdown
 	// alongside registry.ErrTagInUse (defined in registry/errors.go)

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -316,6 +316,32 @@ type TagRegistry interface {
 	// from commodities.tags + files.tags JSONB arrays for the current
 	// group. Used by force-delete. Returns (commodityRows, fileRows).
 	StripSlugReferences(ctx context.Context, slug string) (int, int, error)
+
+	// RenameAtomic re-reads the tag, validates the new slug isn't already
+	// owned by another tag, rewrites every JSONB reference, and writes
+	// the updated tags row — all under a single advisory lock on the tag
+	// id so two parallel renames of the same tag can't end with the
+	// JSONB references and the tags row pointing at different slugs.
+	//
+	// The slug used as the rewrite source is whatever the row holds at
+	// lock-acquisition time, not whatever the caller saw before this
+	// call: a previous concurrent rename moves the tag forward, and the
+	// next rename starts from there.
+	//
+	// Pass newSlug == "" to keep the existing slug. Empty newLabel /
+	// newColor leave the corresponding fields untouched.
+	RenameAtomic(ctx context.Context, id, newLabel, newSlug string, newColor models.TagColor) (*models.Tag, error)
+
+	// DeleteAtomic re-checks usage, strips JSONB references (when
+	// force=true), and deletes the tags row — all under a single
+	// advisory lock so a concurrent commodity insert that would race
+	// orphan-references in serializes against this operation.
+	//
+	// When force=false and usage > 0, returns the usage breakdown and
+	// ErrTagInUse without mutating any state. ErrTagInUse is defined in
+	// the services package — registries don't import it; callers compare
+	// against errors.Is at the service-layer.
+	DeleteAtomic(ctx context.Context, id string, force bool) (TagUsage, error)
 }
 
 type ThumbnailGenerationJobRegistry interface {

--- a/go/services/email_async_service.go
+++ b/go/services/email_async_service.go
@@ -141,12 +141,11 @@ func (s *AsyncEmailService) SendPasswordResetEmail(ctx context.Context, to, name
 
 // SendPasswordChangedEmail enqueues a password-changed security notification.
 func (s *AsyncEmailService) SendPasswordChangedEmail(ctx context.Context, to, name string, changedAt time.Time) error {
-	ts := changedAt
 	return s.enqueue(ctx, emailJob{
 		TemplateType: emailTemplatePasswordChange,
 		To:           to,
 		Name:         name,
-		ChangedAt:    &ts,
+		ChangedAt:    new(changedAt),
 	})
 }
 

--- a/go/services/tag_service.go
+++ b/go/services/tag_service.go
@@ -17,7 +17,12 @@ import (
 // ErrTagInUse is returned by DeleteTag when the tag still has commodity or
 // file references and `force=false`. The handler maps it to 409 with the
 // usage breakdown so the FE can surface the conflict.
-var ErrTagInUse = errors.New("tag is in use")
+//
+// Aliased onto registry.ErrTagInUse — the canonical sentinel lives in
+// the registry package so DeleteAtomic can return it directly from
+// inside the lock-protected tx, and the apiserver / FE behavior stays
+// unchanged for callers that compare against services.ErrTagInUse.
+var ErrTagInUse = registry.ErrTagInUse
 
 // TagService coordinates the tag entity with the JSONB associations on
 // commodities + files. The registry handles the per-table mechanics; the
@@ -140,60 +145,16 @@ func (s *TagService) NormalizeAndEnsureSlugs(ctx context.Context, raw []string) 
 
 // RenameTag mutates the metadata of an existing tag and, when the slug
 // changes, rewrites every JSONB reference on commodities + files in the
-// same group. The rewrite happens in a single registry transaction; the
-// metadata Update is a separate transaction immediately afterwards. A
-// failure between the two leaves a small inconsistency window where rows
-// have already been rewritten but the tag row still carries the old slug;
-// we accept that risk for now (issue's concurrency target is two parallel
-// renames, not crash recovery).
+// same group. The whole operation runs through TagRegistry.RenameAtomic,
+// which holds a per-(group, tag id) lock so two parallel renames of the
+// same tag serialize cleanly — the second re-reads the row inside its
+// lock and renames from whatever slug the first one settled on.
 func (s *TagService) RenameTag(ctx context.Context, id, newLabel, newSlug string, newColor models.TagColor) (*models.Tag, error) {
 	tagReg, err := s.factorySet.TagRegistryFactory.CreateUserRegistry(ctx)
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to create tag registry", err)
 	}
-
-	current, err := tagReg.Get(ctx, id)
-	if err != nil {
-		return nil, errxtrace.Wrap("failed to look up tag", err)
-	}
-
-	updated := *current
-	updated.UpdatedAt = time.Now()
-	if strings.TrimSpace(newLabel) != "" {
-		updated.Label = newLabel
-	}
-	if newColor != "" {
-		updated.Color = newColor
-	}
-
-	slugChanged := newSlug != "" && newSlug != current.Slug
-	if slugChanged {
-		updated.Slug = newSlug
-		// Refuse pre-emptively if a different tag already owns the new slug
-		// — relying on the unique index to fail later would still work but
-		// produces a worse error message.
-		clash, err := tagReg.GetBySlug(ctx, newSlug)
-		if err != nil && !errors.Is(err, registry.ErrNotFound) {
-			return nil, errxtrace.Wrap("failed to check slug availability", err)
-		}
-		if clash != nil && clash.ID != current.ID {
-			return nil, errxtrace.Wrap(
-				"target slug is already used by another tag",
-				registry.ErrAlreadyExists,
-				errx.Attrs("slug", newSlug),
-			)
-		}
-
-		if _, _, err := tagReg.RewriteSlugReferences(ctx, current.Slug, newSlug); err != nil {
-			return nil, errxtrace.Wrap("failed to rewrite slug references", err)
-		}
-	}
-
-	final, err := tagReg.Update(ctx, updated)
-	if err != nil {
-		return nil, errxtrace.Wrap("failed to update tag", err)
-	}
-	return final, nil
+	return tagReg.RenameAtomic(ctx, id, newLabel, newSlug, newColor)
 }
 
 // DeleteTag removes a tag. When force=false and the tag has any reference
@@ -202,35 +163,19 @@ func (s *TagService) RenameTag(ctx context.Context, id, newLabel, newSlug string
 // `force` mirrors the public ?force= query parameter — splitting this
 // into two methods would just push the flag into the apiserver layer.
 //
+// The whole operation runs through TagRegistry.DeleteAtomic, which holds
+// a per-(group, tag id) + per-(group, slug) lock so a concurrent
+// commodity / file insert that would otherwise leak an orphan JSONB
+// reference serializes against the delete via the same slug lock taken
+// in the insert path.
+//
 //revive:disable-next-line:flag-parameter
 func (s *TagService) DeleteTag(ctx context.Context, id string, force bool) (registry.TagUsage, error) {
 	tagReg, err := s.factorySet.TagRegistryFactory.CreateUserRegistry(ctx)
 	if err != nil {
 		return registry.TagUsage{}, errxtrace.Wrap("failed to create tag registry", err)
 	}
-
-	current, err := tagReg.Get(ctx, id)
-	if err != nil {
-		return registry.TagUsage{}, errxtrace.Wrap("failed to look up tag", err)
-	}
-
-	usage, err := tagReg.GetUsage(ctx, current.Slug)
-	if err != nil {
-		return registry.TagUsage{}, errxtrace.Wrap("failed to compute tag usage", err)
-	}
-	if usage.Commodities+usage.Files > 0 && !force {
-		return usage, ErrTagInUse
-	}
-	if usage.Commodities+usage.Files > 0 {
-		if _, _, err := tagReg.StripSlugReferences(ctx, current.Slug); err != nil {
-			return usage, errxtrace.Wrap("failed to strip slug references", err)
-		}
-	}
-
-	if err := tagReg.Delete(ctx, id); err != nil {
-		return usage, errxtrace.Wrap("failed to delete tag", err)
-	}
-	return usage, nil
+	return tagReg.DeleteAtomic(ctx, id, force)
 }
 
 // defaultLabelFromSlug produces a sensible display label for an


### PR DESCRIPTION
Closes #1488 (BE postgres integration tests for tag JSONB rewrite/strip
and rename concurrency). The deterministic test cases surfaced two real
race windows in `TagService` — fixed in the same PR rather than handed
off as follow-ups, since both fixes are contained.

## What

### Tests (`go/registry/postgres/tags_test.go`, 10 cases)

`RewriteSlugReferences`:
- happy path (commodities + files JSONB rewritten)
- dedup on rename-onto-existing (`jsonb_agg(DISTINCT …)` collapses)
- cross-group RLS isolation
- leaves-unrelated-rows-alone (`@>` filter)
- no-op when `oldSlug == newSlug`

`StripSlugReferences`:
- happy path
- empty-array (literal `[]`, not `NULL`) post-strip — verified via raw
  JSONB column read
- cross-group RLS isolation

`TagService.RenameTag`:
- pre-emptive slug-clash refusal — no partial rewrite if the new slug
  is already owned
- parallel renames of **different** source slugs both succeed
- parallel renames of the **same** source slug end consistent (JSONB
  references match the surviving `tags` row's slug)

`TagService.DeleteTag(force=true)`:
- under a concurrent commodity insert targeting the same slug, no
  commodity ends up referencing a slug whose `tags` row is gone

### Concurrency fixes

New `TagRegistry.RenameAtomic` / `DeleteAtomic`:
- Whole orchestration (clash-check + rewrite + `tags`-row update for
  rename; usage-check + strip + delete for delete) runs in **one tx**
  held under per-`(group, tag id)` `pg_advisory_xact_lock` + `SELECT …
  FOR UPDATE` on the row. Two parallel renames of the same tag id
  serialize on the lock; the second re-reads the row inside its lock
  and renames from whatever slug the first one settled on.
- `DeleteAtomic` additionally takes the `(group, slug)` lock so
  concurrent commodity / file inserts that auto-create the same slug
  serialize against the delete.

Postgres `CommodityRegistry` / `FileRegistry` `Create` + `Update`:
- Run `ensureTagRowsInTx` inside the same tx as the row insert/update.
- For each referenced slug: take the `(group, slug)` advisory lock,
  `SELECT … FOR UPDATE` the existing tag row, or `INSERT … ON CONFLICT
  DO NOTHING` when missing. The `FOR UPDATE` is what prevents the
  cross-tx orphan that `ON CONFLICT` alone wouldn't — if a deleter
  holds the row exclusively, we wait; if the deleter already committed,
  we `INSERT` a fresh tag row.

`TagService.RenameTag` / `DeleteTag` are now thin pass-throughs.

`registry.ErrTagInUse` moves into the registry package (canonical
source); `services.ErrTagInUse` stays as a back-compat alias so
apiserver / FE callers that compare via `errors.Is` keep working.

### Drive-by

`go/registry/postgres/group_invites_test.go`: normalize `ExpiresAt` to
UTC in the `inviteFor` helper. The `expires_at` column is `TIMESTAMP`
(no tz), pgx serializes wall-clock components in `time.Local` on write
and reconstructs them with location=UTC on read — on a non-UTC dev
machine that round-trip skews the instant by the offset and makes
`TestGroupInviteRegistry_GetByToken_And_ListActive` flaky locally.
CI runs in UTC and never saw it.

## Verification

- 16 pg integration tests pass under `-race` (148s).
- Race tests stress-run 8/8 (vs. ~1/5 failure pre-fix).
- Memory backend implements `RenameAtomic` / `DeleteAtomic` via a
  coarse package-level mutex (memory tests don't exercise concurrency).
- `services` and `apiserver` test suites green; no behavior change at
  the apiserver layer.

## Test plan

- [ ] CI `go-test-postgres` workflow green
- [ ] CI `go-test` workflow green
- [ ] Manual: rename a tag from the FE Tags page; verify commodities
      reflect the new slug
- [ ] Manual: force-delete a tag with usage; verify the tag row is
      gone and the JSONB references on commodities/files are stripped