### PR TITLE
[#1485] BE export+restore files via unified surface

### DIFF
--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -4952,6 +4952,7 @@ export type components = {
             deleted_at?: string;
             description?: string;
             error_message?: string;
+            file_count?: number;
             file_id?: string;
             /** @description Deprecated: will be removed after migration */
             file_path?: string;
@@ -5126,6 +5127,7 @@ export type components = {
             error_count?: number;
             error_message?: string;
             export_id?: string;
+            file_count?: number;
             id?: string;
             image_count?: number;
             invoice_count?: number;

--- a/go/backup/export/parser/parser.go
+++ b/go/backup/export/parser/parser.go
@@ -95,6 +95,14 @@ func parseTopLevelToken(t xml.StartElement, exportType *models.ExportType, decod
 		if err := countCommodities(decoder, stats); err != nil {
 			return errxtrace.Wrap("failed to count commodities", err)
 		}
+	case "files":
+		// New unified-files <files> section introduced in #1485. Counts
+		// each <file> child and estimates the inline base64 <data>
+		// payload size, mirroring the existing per-attachment-section
+		// pattern from the legacy <images>/<invoices>/<manuals> code.
+		if err := countFiles(decoder, "files", &stats.FileCount, stats); err != nil {
+			return errxtrace.Wrap("failed to count files", err)
+		}
 	default:
 		return errxtrace.Wrap("unsupported top-level element", ErrUnsupportedExportType, errx.Attrs("element", t.Name.Local))
 	}

--- a/go/backup/export/parser/service_import_test.go
+++ b/go/backup/export/parser/service_import_test.go
@@ -230,3 +230,45 @@ func TestExportService_parseXMLMetadata_WithoutFileData(t *testing.T) {
 	// Verify that no binary data size was detected (files without data elements)
 	c.Assert(stats.BinaryDataSize, qt.Equals, int64(0), qt.Commentf("Expected no binary data size for files without data, got %d", stats.BinaryDataSize))
 }
+
+// TestParseXMLMetadata_FilesSection guards the import-flow regression
+// flagged on PR #1493: ParseXMLMetadata previously errored on every
+// top-level element other than <locations>/<areas>/<commodities>, so
+// any backup produced by the new export side (which always emits
+// <files>) would fail the metadata-extraction step and never reach the
+// completed-export state.
+//
+// The fix added a <files> top-level case that counts <file> children
+// into stats.FileCount and accumulates their inline <data> base64 size
+// into stats.BinaryDataSize via the same `countFiles` helper used by
+// the legacy <images>/<invoices>/<manuals> sections.
+func TestParseXMLMetadata_FilesSection(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	// Two file rows: one with inline base64 <data>, one without.
+	// `dGVzdA==` is base64 for "test" (4 bytes raw). The size estimator
+	// uses (base64Length * 3 / 4), so the reported BinaryDataSize is the
+	// *approximate* original size — small inputs round to 6 here.
+	xmlContent := `<?xml version="1.0" encoding="UTF-8"?>
+<inventory exportType="full_database">
+  <files>
+    <file id="f1">
+      <linkedEntityType>commodity</linkedEntityType>
+      <path>p1</path>
+      <originalPath>p1.bin</originalPath>
+      <data>dGVzdA==</data>
+    </file>
+    <file id="f2">
+      <path>p2</path>
+      <originalPath>p2.bin</originalPath>
+    </file>
+  </files>
+</inventory>`
+
+	stats, exportType, err := parser.ParseXMLMetadata(ctx, strings.NewReader(xmlContent))
+	c.Assert(err, qt.IsNil, qt.Commentf("parser must accept <files> top-level element"))
+	c.Assert(exportType, qt.Equals, models.ExportTypeFullDatabase)
+	c.Assert(stats.FileCount, qt.Equals, 2, qt.Commentf("two <file> children counted"))
+	c.Assert(stats.BinaryDataSize > 0, qt.IsTrue, qt.Commentf("inline <data> contributes to BinaryDataSize"))
+}

--- a/go/backup/export/service.go
+++ b/go/backup/export/service.go
@@ -193,6 +193,7 @@ func (s *ExportService) ProcessExport(ctx context.Context, exportID string) erro
 	export.ImageCount = stats.ImageCount
 	export.InvoiceCount = stats.InvoiceCount
 	export.ManualCount = stats.ManualCount
+	export.FileCount = stats.FileCount
 	export.BinaryDataSize = stats.BinaryDataSize
 
 	// Get file size using user context

--- a/go/backup/export/service.go
+++ b/go/backup/export/service.go
@@ -401,61 +401,16 @@ func (s *ExportService) streamXMLExport(ctx context.Context, export models.Expor
 			return nil, errxtrace.Wrap("failed to stream full database", err)
 		}
 	case models.ExportTypeLocations:
-		locUUIDMap, err := s.buildLocationUUIDMap(ctx)
-		if err != nil {
-			return nil, errxtrace.Wrap("failed to build location UUID map", err)
-		}
-		areaUUIDMap, err := s.buildAreaUUIDMap(ctx)
-		if err != nil {
-			return nil, errxtrace.Wrap("failed to build area UUID map", err)
-		}
-		commodityUUIDMap, err := s.buildCommodityUUIDMap(ctx)
-		if err != nil {
-			return nil, errxtrace.Wrap("failed to build commodity UUID map", err)
-		}
-		if err := s.streamLocations(ctx, writer, export, stats); err != nil {
-			return nil, errxtrace.Wrap("failed to stream locations", err)
-		}
-		if err := s.streamFiles(ctx, writer, export, stats, locUUIDMap, areaUUIDMap, commodityUUIDMap, nil); err != nil {
-			return nil, errxtrace.Wrap("failed to stream files", err)
+		if err := s.streamLocationsExport(ctx, writer, export, stats); err != nil {
+			return nil, err
 		}
 	case models.ExportTypeAreas:
-		locUUIDMap, err := s.buildLocationUUIDMap(ctx)
-		if err != nil {
-			return nil, errxtrace.Wrap("failed to build location UUID map", err)
-		}
-		areaUUIDMap, err := s.buildAreaUUIDMap(ctx)
-		if err != nil {
-			return nil, errxtrace.Wrap("failed to build area UUID map", err)
-		}
-		commodityUUIDMap, err := s.buildCommodityUUIDMap(ctx)
-		if err != nil {
-			return nil, errxtrace.Wrap("failed to build commodity UUID map", err)
-		}
-		if err := s.streamAreas(ctx, writer, export, stats, locUUIDMap); err != nil {
-			return nil, errxtrace.Wrap("failed to stream areas", err)
-		}
-		if err := s.streamFiles(ctx, writer, export, stats, locUUIDMap, areaUUIDMap, commodityUUIDMap, nil); err != nil {
-			return nil, errxtrace.Wrap("failed to stream files", err)
+		if err := s.streamAreasExport(ctx, writer, export, stats); err != nil {
+			return nil, err
 		}
 	case models.ExportTypeCommodities:
-		locUUIDMap, err := s.buildLocationUUIDMap(ctx)
-		if err != nil {
-			return nil, errxtrace.Wrap("failed to build location UUID map", err)
-		}
-		areaUUIDMap, err := s.buildAreaUUIDMap(ctx)
-		if err != nil {
-			return nil, errxtrace.Wrap("failed to build area UUID map", err)
-		}
-		commodityUUIDMap, err := s.buildCommodityUUIDMap(ctx)
-		if err != nil {
-			return nil, errxtrace.Wrap("failed to build commodity UUID map", err)
-		}
-		if err := s.streamCommodities(ctx, writer, export, stats, areaUUIDMap); err != nil {
-			return nil, errxtrace.Wrap("failed to stream commodities", err)
-		}
-		if err := s.streamFiles(ctx, writer, export, stats, locUUIDMap, areaUUIDMap, commodityUUIDMap, nil); err != nil {
-			return nil, errxtrace.Wrap("failed to stream files", err)
+		if err := s.streamCommoditiesExport(ctx, writer, export, stats); err != nil {
+			return nil, err
 		}
 	case models.ExportTypeSelectedItems:
 		if err := s.streamSelectedItems(ctx, writer, export, stats); err != nil {
@@ -475,6 +430,84 @@ func (s *ExportService) streamXMLExport(ctx context.Context, export models.Expor
 	}
 
 	return stats, nil
+}
+
+// entityUUIDMaps bundles the three DB-ID → UUID maps that streamFiles
+// needs to resolve linked_entity_id during export. Built once per export
+// call and shared across all entity-class streamers + streamFiles.
+type entityUUIDMaps struct {
+	Locations   map[string]string
+	Areas       map[string]string
+	Commodities map[string]string
+}
+
+// buildAllUUIDMaps materialises the three maps (locations, areas,
+// commodities) in one shot. Used by every whole-class export type to
+// avoid duplicating the three buildXUUIDMap calls per case in the
+// switch in streamXMLExport (which was tripping gocognit).
+func (s *ExportService) buildAllUUIDMaps(ctx context.Context) (entityUUIDMaps, error) {
+	locMap, err := s.buildLocationUUIDMap(ctx)
+	if err != nil {
+		return entityUUIDMaps{}, errxtrace.Wrap("failed to build location UUID map", err)
+	}
+	areaMap, err := s.buildAreaUUIDMap(ctx)
+	if err != nil {
+		return entityUUIDMaps{}, errxtrace.Wrap("failed to build area UUID map", err)
+	}
+	comMap, err := s.buildCommodityUUIDMap(ctx)
+	if err != nil {
+		return entityUUIDMaps{}, errxtrace.Wrap("failed to build commodity UUID map", err)
+	}
+	return entityUUIDMaps{Locations: locMap, Areas: areaMap, Commodities: comMap}, nil
+}
+
+// streamLocationsExport handles ExportTypeLocations — streams the
+// locations entity class plus the group-wide files section. Extracted
+// from streamXMLExport to keep that switch small enough for gocognit.
+func (s *ExportService) streamLocationsExport(ctx context.Context, writer io.Writer, export models.Export, stats *types.ExportStats) error {
+	maps, err := s.buildAllUUIDMaps(ctx)
+	if err != nil {
+		return err
+	}
+	if err := s.streamLocations(ctx, writer, export, stats); err != nil {
+		return errxtrace.Wrap("failed to stream locations", err)
+	}
+	if err := s.streamFiles(ctx, writer, export, stats, maps.Locations, maps.Areas, maps.Commodities, nil); err != nil {
+		return errxtrace.Wrap("failed to stream files", err)
+	}
+	return nil
+}
+
+// streamAreasExport handles ExportTypeAreas — areas entity class plus
+// the group-wide files section.
+func (s *ExportService) streamAreasExport(ctx context.Context, writer io.Writer, export models.Export, stats *types.ExportStats) error {
+	maps, err := s.buildAllUUIDMaps(ctx)
+	if err != nil {
+		return err
+	}
+	if err := s.streamAreas(ctx, writer, export, stats, maps.Locations); err != nil {
+		return errxtrace.Wrap("failed to stream areas", err)
+	}
+	if err := s.streamFiles(ctx, writer, export, stats, maps.Locations, maps.Areas, maps.Commodities, nil); err != nil {
+		return errxtrace.Wrap("failed to stream files", err)
+	}
+	return nil
+}
+
+// streamCommoditiesExport handles ExportTypeCommodities — commodities
+// entity class plus the group-wide files section.
+func (s *ExportService) streamCommoditiesExport(ctx context.Context, writer io.Writer, export models.Export, stats *types.ExportStats) error {
+	maps, err := s.buildAllUUIDMaps(ctx)
+	if err != nil {
+		return err
+	}
+	if err := s.streamCommodities(ctx, writer, export, stats, maps.Areas); err != nil {
+		return errxtrace.Wrap("failed to stream commodities", err)
+	}
+	if err := s.streamFiles(ctx, writer, export, stats, maps.Locations, maps.Areas, maps.Commodities, nil); err != nil {
+		return errxtrace.Wrap("failed to stream files", err)
+	}
+	return nil
 }
 
 // streamFullDatabase streams all database content to the writer and tracks statistics
@@ -1244,79 +1277,26 @@ func (s *ExportService) streamFiles(
 	}()
 
 	for _, file := range files {
-		if file == nil || file.File == nil {
+		if !shouldEmitFile(file, scope) {
 			continue
 		}
-
-		// Skip the export's own backup blobs to avoid self-reference.
-		if file.LinkedEntityType == "export" {
-			continue
-		}
-
-		// Apply the selected_items scope, if any. Standalone files (no
-		// linked entity) are only included for full/whole-class exports.
-		if scope != nil {
-			if !inSelectedScope(file, scope) {
-				continue
-			}
-		}
-
 		linkedID, ok := resolveLinkedEntityUUID(file, locUUIDMap, areaUUIDMap, commodityUUIDMap)
 		if !ok {
-			// The linked entity wasn't visible to this user (RLS may have
-			// hidden it) or its UUID couldn't be resolved. Skip rather
-			// than emit a dangling reference.
+			// The linked entity wasn't visible to this user (RLS may
+			// have hidden it) or its UUID couldn't be resolved. Skip
+			// rather than emit a dangling reference.
 			continue
 		}
-
-		xmlFile := XMLFile{
-			ID:               file.UUID,
-			LinkedEntityType: file.LinkedEntityType,
-			LinkedEntityID:   linkedID,
-			LinkedEntityMeta: file.LinkedEntityMeta,
-			Type:             string(file.Type),
-			Category:         string(file.Category),
-			Title:            file.Title,
-			Description:      file.Description,
-			Tags:             []string(file.Tags),
-			Path:             file.Path,
-			OriginalPath:     file.OriginalPath,
-			Extension:        file.Ext,
-			MimeType:         file.MIMEType,
-			CreatedAt:        file.CreatedAt.UTC().Format(time.RFC3339),
-			UpdatedAt:        file.UpdatedAt.UTC().Format(time.RFC3339),
-		}
-
-		if !export.IncludeFileData {
-			// No blob data: encode the metadata-only struct in one shot.
-			if err := encoder.Encode(&xmlFile); err != nil {
-				return errxtrace.Wrap("failed to encode file metadata", err)
+		xmlFile := buildXMLFile(file, linkedID)
+		if export.IncludeFileData {
+			if err := s.emitFileWithData(ctx, encoder, &xmlFile, &bucket, stats); err != nil {
+				return err
 			}
-			stats.FileCount++
 			continue
 		}
-
-		// IncludeFileData: stream the blob through base64 directly into
-		// the XML output. Open the bucket lazily on the first such row.
-		if bucket == nil {
-			bucket, err = blob.OpenBucket(ctx, s.uploadLocation)
-			if err != nil {
-				return errxtrace.Wrap("failed to open blob bucket for file data", err)
-			}
+		if err := emitFileMetadataOnly(encoder, &xmlFile, stats); err != nil {
+			return err
 		}
-		size, err := s.streamFileWithData(ctx, encoder, &xmlFile, bucket)
-		if err != nil {
-			// Missing blobs are common during dev (manual deletes, orphan
-			// rows). Don't abort the whole export — fall through to the
-			// metadata-only emission so the row still round-trips.
-			if encErr := encoder.Encode(&xmlFile); encErr != nil {
-				return errxtrace.Wrap("failed to encode file metadata after blob read failure", encErr)
-			}
-			stats.FileCount++
-			continue
-		}
-		stats.BinaryDataSize += size
-		stats.FileCount++
 	}
 
 	endElement := xml.EndElement{Name: xml.Name{Local: "files"}}
@@ -1326,6 +1306,87 @@ func (s *ExportService) streamFiles(
 	if err := encoder.Flush(); err != nil {
 		return errxtrace.Wrap("failed to flush encoder", err)
 	}
+	return nil
+}
+
+// shouldEmitFile is the cheap-pre-resolve filter for streamFiles: returns
+// false for nil rows, files without an embedded *File, the export's own
+// backup-bundle blobs, and (when scope is set) rows that aren't linked
+// to one of the selected entities. Pulled out of the streamFiles loop
+// to keep its cognitive complexity below the gocognit threshold.
+func shouldEmitFile(file *models.FileEntity, scope *selectedFileScope) bool {
+	if file == nil || file.File == nil {
+		return false
+	}
+	if file.LinkedEntityType == "export" {
+		return false
+	}
+	if scope != nil && !inSelectedScope(file, scope) {
+		return false
+	}
+	return true
+}
+
+// buildXMLFile materialises the on-disk XMLFile shape from a FileEntity
+// row, with the linked_entity_id replaced by the resolved UUID. Doesn't
+// touch the blob — the bucket open/stream happens in emitOneFile when
+// IncludeFileData is true.
+func buildXMLFile(file *models.FileEntity, linkedID string) XMLFile {
+	return XMLFile{
+		ID:               file.UUID,
+		LinkedEntityType: file.LinkedEntityType,
+		LinkedEntityID:   linkedID,
+		LinkedEntityMeta: file.LinkedEntityMeta,
+		Type:             string(file.Type),
+		Category:         string(file.Category),
+		Title:            file.Title,
+		Description:      file.Description,
+		Tags:             []string(file.Tags),
+		Path:             file.Path,
+		OriginalPath:     file.OriginalPath,
+		Extension:        file.Ext,
+		MimeType:         file.MIMEType,
+		CreatedAt:        file.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:        file.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// emitFileMetadataOnly writes the metadata-only `<file>` element via
+// `encoder.Encode` of the XMLFile struct. Used when IncludeFileData is
+// false on the export — the row metadata round-trips, but no blob bytes
+// are inlined. Two small helpers (this + emitFileWithData) replace the
+// flag-parameter shape that revive flagged.
+func emitFileMetadataOnly(encoder *xml.Encoder, xmlFile *XMLFile, stats *types.ExportStats) error {
+	if err := encoder.Encode(xmlFile); err != nil {
+		return errxtrace.Wrap("failed to encode file metadata", err)
+	}
+	stats.FileCount++
+	return nil
+}
+
+// emitFileWithData writes the streaming `<file>` element where the blob
+// is base64-encoded into the XML in 32 KiB chunks via streamFileWithData.
+// Opens the bucket lazily through the caller's `*blob.Bucket` pointer so
+// the close/defer stays in streamFiles. On a blob-read failure (missing
+// object, transient I/O), the row falls back to the metadata-only path
+// so the export doesn't abort over a single orphan row.
+func (s *ExportService) emitFileWithData(ctx context.Context, encoder *xml.Encoder, xmlFile *XMLFile, bucket **blob.Bucket, stats *types.ExportStats) error {
+	if *bucket == nil {
+		b, err := blob.OpenBucket(ctx, s.uploadLocation)
+		if err != nil {
+			return errxtrace.Wrap("failed to open blob bucket for file data", err)
+		}
+		*bucket = b
+	}
+	size, err := s.streamFileWithData(ctx, encoder, xmlFile, *bucket)
+	if err != nil {
+		// Missing blobs are common during dev (manual deletes, orphan
+		// rows). Don't abort the whole export — fall through to the
+		// metadata-only emission so the row still round-trips.
+		return emitFileMetadataOnly(encoder, xmlFile, stats)
+	}
+	stats.BinaryDataSize += size
+	stats.FileCount++
 	return nil
 }
 
@@ -1388,95 +1449,109 @@ func (s *ExportService) streamFileWithData(
 //
 // `omitempty` semantics are preserved: empty strings / nil slices skip
 // their element entirely, matching xml.Marshal's behavior. Tag changes
-// to XMLFile must be mirrored here — there's a regression test that
-// round-trips a fully populated XMLFile through both paths to keep the
-// two implementations in lock-step.
+// to XMLFile must be mirrored here.
+//
+// The function is split into three field-group helpers (linkage / tags /
+// file basics) so the per-helper cognitive complexity stays well below
+// the gocognit threshold; encodeFileMetadataTokens itself is just the
+// composition order.
 func encodeFileMetadataTokens(encoder *xml.Encoder, xmlFile *XMLFile) error {
-	emit := func(name, value string) error {
-		if value == "" {
-			return nil
-		}
-		start := xml.StartElement{Name: xml.Name{Local: name}}
-		if err := encoder.EncodeToken(start); err != nil {
+	if err := encodeFileLinkageFields(encoder, xmlFile); err != nil {
+		return err
+	}
+	if err := encodeFileTags(encoder, xmlFile.Tags); err != nil {
+		return err
+	}
+	return encodeFileBasicFields(encoder, xmlFile)
+}
+
+// emitOptionalElement writes a `<name>value</name>` element token
+// triplet only when value is non-empty (xml.Marshal's `omitempty`
+// behavior for string fields, replicated for the streaming path).
+func emitOptionalElement(encoder *xml.Encoder, name, value string) error {
+	if value == "" {
+		return nil
+	}
+	return emitRequiredElement(encoder, name, value)
+}
+
+// emitRequiredElement writes a `<name>value</name>` element token
+// triplet unconditionally — used for fields that the XMLFile struct
+// declares without `omitempty`.
+func emitRequiredElement(encoder *xml.Encoder, name, value string) error {
+	start := xml.StartElement{Name: xml.Name{Local: name}}
+	if err := encoder.EncodeToken(start); err != nil {
+		return err
+	}
+	if err := encoder.EncodeToken(xml.CharData(value)); err != nil {
+		return err
+	}
+	return encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: name}})
+}
+
+// encodeFileLinkageFields emits the linked-entity + classification
+// fields (linkedEntityType / linkedEntityId / linkedEntityMeta / type /
+// category / title / description). Each is `omitempty` on the struct.
+func encodeFileLinkageFields(encoder *xml.Encoder, xmlFile *XMLFile) error {
+	if err := emitOptionalElement(encoder, "linkedEntityType", xmlFile.LinkedEntityType); err != nil {
+		return err
+	}
+	if err := emitOptionalElement(encoder, "linkedEntityId", xmlFile.LinkedEntityID); err != nil {
+		return err
+	}
+	if err := emitOptionalElement(encoder, "linkedEntityMeta", xmlFile.LinkedEntityMeta); err != nil {
+		return err
+	}
+	if err := emitOptionalElement(encoder, "type", xmlFile.Type); err != nil {
+		return err
+	}
+	if err := emitOptionalElement(encoder, "category", xmlFile.Category); err != nil {
+		return err
+	}
+	if err := emitOptionalElement(encoder, "title", xmlFile.Title); err != nil {
+		return err
+	}
+	return emitOptionalElement(encoder, "description", xmlFile.Description)
+}
+
+// encodeFileTags emits the `<tags><tag>x</tag>...</tags>` block, or
+// nothing when the slice is empty (matches `tags>tag,omitempty`).
+func encodeFileTags(encoder *xml.Encoder, tags []string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+	tagsStart := xml.StartElement{Name: xml.Name{Local: "tags"}}
+	if err := encoder.EncodeToken(tagsStart); err != nil {
+		return err
+	}
+	for _, tag := range tags {
+		if err := emitOptionalElement(encoder, "tag", tag); err != nil {
 			return err
 		}
-		if err := encoder.EncodeToken(xml.CharData(value)); err != nil {
-			return err
-		}
-		return encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: name}})
 	}
+	return encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: "tags"}})
+}
 
-	if err := emit("linkedEntityType", xmlFile.LinkedEntityType); err != nil {
+// encodeFileBasicFields emits the file-shape fields (path / originalPath
+// / extension / mimeType / createdAt / updatedAt). path + originalPath
+// are required (no omitempty on the struct); the rest are optional.
+func encodeFileBasicFields(encoder *xml.Encoder, xmlFile *XMLFile) error {
+	if err := emitRequiredElement(encoder, "path", xmlFile.Path); err != nil {
 		return err
 	}
-	if err := emit("linkedEntityId", xmlFile.LinkedEntityID); err != nil {
+	if err := emitRequiredElement(encoder, "originalPath", xmlFile.OriginalPath); err != nil {
 		return err
 	}
-	if err := emit("linkedEntityMeta", xmlFile.LinkedEntityMeta); err != nil {
+	if err := emitOptionalElement(encoder, "extension", xmlFile.Extension); err != nil {
 		return err
 	}
-	if err := emit("type", xmlFile.Type); err != nil {
+	if err := emitOptionalElement(encoder, "mimeType", xmlFile.MimeType); err != nil {
 		return err
 	}
-	if err := emit("category", xmlFile.Category); err != nil {
+	if err := emitOptionalElement(encoder, "createdAt", xmlFile.CreatedAt); err != nil {
 		return err
 	}
-	if err := emit("title", xmlFile.Title); err != nil {
-		return err
-	}
-	if err := emit("description", xmlFile.Description); err != nil {
-		return err
-	}
-
-	if len(xmlFile.Tags) > 0 {
-		tagsStart := xml.StartElement{Name: xml.Name{Local: "tags"}}
-		if err := encoder.EncodeToken(tagsStart); err != nil {
-			return err
-		}
-		for _, tag := range xmlFile.Tags {
-			if err := emit("tag", tag); err != nil {
-				return err
-			}
-		}
-		if err := encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: "tags"}}); err != nil {
-			return err
-		}
-	}
-
-	// path / originalPath are required (no omitempty on the struct);
-	// emit unconditionally so a deserializer's required-field checks
-	// don't trip on a missing element.
-	pathStart := xml.StartElement{Name: xml.Name{Local: "path"}}
-	if err := encoder.EncodeToken(pathStart); err != nil {
-		return err
-	}
-	if err := encoder.EncodeToken(xml.CharData(xmlFile.Path)); err != nil {
-		return err
-	}
-	if err := encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: "path"}}); err != nil {
-		return err
-	}
-	originalStart := xml.StartElement{Name: xml.Name{Local: "originalPath"}}
-	if err := encoder.EncodeToken(originalStart); err != nil {
-		return err
-	}
-	if err := encoder.EncodeToken(xml.CharData(xmlFile.OriginalPath)); err != nil {
-		return err
-	}
-	if err := encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: "originalPath"}}); err != nil {
-		return err
-	}
-
-	if err := emit("extension", xmlFile.Extension); err != nil {
-		return err
-	}
-	if err := emit("mimeType", xmlFile.MimeType); err != nil {
-		return err
-	}
-	if err := emit("createdAt", xmlFile.CreatedAt); err != nil {
-		return err
-	}
-	return emit("updatedAt", xmlFile.UpdatedAt)
+	return emitOptionalElement(encoder, "updatedAt", xmlFile.UpdatedAt)
 }
 
 // streamBase64Content streams blob content from reader into the XML

--- a/go/backup/export/service.go
+++ b/go/backup/export/service.go
@@ -1133,9 +1133,17 @@ func (s *ExportService) streamCommodityDirectly(ctx context.Context, encoder *xm
 }
 
 // XMLFile mirrors the on-disk shape of a single <file> element inside the
-// export's <files> section. The export side marshals from this struct;
-// the restore side decodes into restore/types.XMLFile (kept separate so
-// the restore package doesn't pull export-package transitively).
+// export's <files> section. Used as-is for metadata-only emission via
+// encoder.Encode; when IncludeFileData=true the encoder takes the
+// streaming path through streamFileWithData, which token-emits the same
+// element shape interleaved with chunked base64 <data>. Restore side
+// decodes into restore/types.XMLFile (separate copy so the restore
+// package doesn't pull export-package transitively).
+//
+// No Data field: the streaming path never builds the base64 string in
+// memory, and the metadata-only path never emits <data>. If a future
+// change wants to inline-buffer base64, add it explicitly rather than
+// repurpose this struct.
 type XMLFile struct {
 	XMLName          xml.Name `xml:"file"`
 	ID               string   `xml:"id,attr"`
@@ -1153,7 +1161,6 @@ type XMLFile struct {
 	MimeType         string   `xml:"mimeType,omitempty"`
 	CreatedAt        string   `xml:"createdAt,omitempty"`
 	UpdatedAt        string   `xml:"updatedAt,omitempty"`
-	Data             string   `xml:"data,omitempty"` // Base64-encoded blob, only when IncludeFileData is true.
 }
 
 // selectedFileScope narrows the file export to a specific set of selected
@@ -1198,10 +1205,10 @@ func (s *ExportService) buildCommodityUUIDMap(ctx context.Context) (map[string]s
 // are included. Standalone files (LinkedEntityType="") are emitted only when
 // scope is nil.
 //
-// When export.IncludeFileData is true, each file's blob content is read from
-// the upload bucket, base64-encoded, and inlined as a <data> element. The
-// blob payload is loaded into memory in full per file — that matches the
-// pre-#1421 code path; chunked streaming is a future optimization.
+// When export.IncludeFileData is true, each file's blob content is streamed
+// through a chunked base64 encoder (32 KiB) directly into the XML output —
+// no full-blob buffering. Restores the pre-#1421 streaming behavior; the
+// post-#1421 stub had been writing the whole blob to memory before encoding.
 func (s *ExportService) streamFiles(
 	ctx context.Context,
 	writer io.Writer,
@@ -1279,31 +1286,35 @@ func (s *ExportService) streamFiles(
 			UpdatedAt:        file.UpdatedAt.UTC().Format(time.RFC3339),
 		}
 
-		if export.IncludeFileData {
-			if bucket == nil {
-				bucket, err = blob.OpenBucket(ctx, s.uploadLocation)
-				if err != nil {
-					return errxtrace.Wrap("failed to open blob bucket for file data", err)
-				}
+		if !export.IncludeFileData {
+			// No blob data: encode the metadata-only struct in one shot.
+			if err := encoder.Encode(&xmlFile); err != nil {
+				return errxtrace.Wrap("failed to encode file metadata", err)
 			}
-			data, size, err := s.readFileBase64(ctx, bucket, file.OriginalPath)
-			if err != nil {
-				// Missing blobs are common during dev (manual deletes,
-				// orphan rows). Log on stats but don't fail the entire
-				// export — surface the row metadata without <data>.
-				stats.FileCount++
-				if encErr := encoder.Encode(&xmlFile); encErr != nil {
-					return errxtrace.Wrap("failed to encode file metadata", encErr)
-				}
-				continue
-			}
-			xmlFile.Data = data
-			stats.BinaryDataSize += size
+			stats.FileCount++
+			continue
 		}
 
-		if err := encoder.Encode(&xmlFile); err != nil {
-			return errxtrace.Wrap("failed to encode file", err)
+		// IncludeFileData: stream the blob through base64 directly into
+		// the XML output. Open the bucket lazily on the first such row.
+		if bucket == nil {
+			bucket, err = blob.OpenBucket(ctx, s.uploadLocation)
+			if err != nil {
+				return errxtrace.Wrap("failed to open blob bucket for file data", err)
+			}
 		}
+		size, err := s.streamFileWithData(ctx, encoder, &xmlFile, bucket)
+		if err != nil {
+			// Missing blobs are common during dev (manual deletes, orphan
+			// rows). Don't abort the whole export — fall through to the
+			// metadata-only emission so the row still round-trips.
+			if encErr := encoder.Encode(&xmlFile); encErr != nil {
+				return errxtrace.Wrap("failed to encode file metadata after blob read failure", encErr)
+			}
+			stats.FileCount++
+			continue
+		}
+		stats.BinaryDataSize += size
 		stats.FileCount++
 	}
 
@@ -1317,20 +1328,204 @@ func (s *ExportService) streamFiles(
 	return nil
 }
 
-// readFileBase64 reads a blob fully into memory and returns it base64-encoded
-// alongside the raw byte size (for BinaryDataSize stats).
-func (s *ExportService) readFileBase64(ctx context.Context, bucket *blob.Bucket, blobKey string) (string, int64, error) {
-	reader, err := bucket.NewReader(ctx, blobKey, nil)
+// streamFileWithData emits a single <file> element with chunked base64 blob
+// data, streamed straight from the bucket. The metadata sub-elements are
+// emitted as discrete tokens (mirrors the XMLFile struct's xml tags) so we
+// can interleave the streaming <data> element without falling back to a
+// full-buffer round-trip through xml.Marshal.
+//
+// Returns the raw (pre-encoding) blob size for BinaryDataSize tracking.
+func (s *ExportService) streamFileWithData(
+	ctx context.Context,
+	encoder *xml.Encoder,
+	xmlFile *XMLFile,
+	bucket *blob.Bucket,
+) (int64, error) {
+	reader, err := bucket.NewReader(ctx, xmlFile.OriginalPath, nil)
 	if err != nil {
-		return "", 0, errxtrace.Wrap("failed to open blob reader", err, errx.Attrs("blob_key", blobKey))
+		return 0, errxtrace.Wrap("failed to open blob reader", err, errx.Attrs("blob_key", xmlFile.OriginalPath))
 	}
 	defer reader.Close()
 
-	raw, err := io.ReadAll(reader)
-	if err != nil {
-		return "", 0, errxtrace.Wrap("failed to read blob content", err, errx.Attrs("blob_key", blobKey))
+	fileStart := xml.StartElement{
+		Name: xml.Name{Local: "file"},
+		Attr: []xml.Attr{{Name: xml.Name{Local: "id"}, Value: xmlFile.ID}},
 	}
-	return base64.StdEncoding.EncodeToString(raw), int64(len(raw)), nil
+	if err := encoder.EncodeToken(fileStart); err != nil {
+		return 0, errxtrace.Wrap("failed to encode file start element", err)
+	}
+
+	if err := encodeFileMetadataTokens(encoder, xmlFile); err != nil {
+		return 0, err
+	}
+
+	dataStart := xml.StartElement{Name: xml.Name{Local: "data"}}
+	if err := encoder.EncodeToken(dataStart); err != nil {
+		return 0, errxtrace.Wrap("failed to encode data start element", err)
+	}
+
+	rawSize, err := streamBase64Content(encoder, reader)
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to stream file content", err, errx.Attrs("blob_key", xmlFile.OriginalPath))
+	}
+
+	dataEnd := xml.EndElement{Name: xml.Name{Local: "data"}}
+	if err := encoder.EncodeToken(dataEnd); err != nil {
+		return 0, errxtrace.Wrap("failed to encode data end element", err)
+	}
+	fileEnd := xml.EndElement{Name: xml.Name{Local: "file"}}
+	if err := encoder.EncodeToken(fileEnd); err != nil {
+		return 0, errxtrace.Wrap("failed to encode file end element", err)
+	}
+	return rawSize, nil
+}
+
+// encodeFileMetadataTokens emits the xml-tagged metadata sub-elements of
+// a <file> element via discrete encoder tokens, mirroring the XMLFile
+// struct's xml tags so the streaming output stays bit-identical to the
+// metadata-only `encoder.Encode(&xmlFile)` path.
+//
+// `omitempty` semantics are preserved: empty strings / nil slices skip
+// their element entirely, matching xml.Marshal's behavior. Tag changes
+// to XMLFile must be mirrored here — there's a regression test that
+// round-trips a fully populated XMLFile through both paths to keep the
+// two implementations in lock-step.
+func encodeFileMetadataTokens(encoder *xml.Encoder, xmlFile *XMLFile) error {
+	emit := func(name, value string) error {
+		if value == "" {
+			return nil
+		}
+		start := xml.StartElement{Name: xml.Name{Local: name}}
+		if err := encoder.EncodeToken(start); err != nil {
+			return err
+		}
+		if err := encoder.EncodeToken(xml.CharData(value)); err != nil {
+			return err
+		}
+		return encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: name}})
+	}
+
+	if err := emit("linkedEntityType", xmlFile.LinkedEntityType); err != nil {
+		return err
+	}
+	if err := emit("linkedEntityId", xmlFile.LinkedEntityID); err != nil {
+		return err
+	}
+	if err := emit("linkedEntityMeta", xmlFile.LinkedEntityMeta); err != nil {
+		return err
+	}
+	if err := emit("type", xmlFile.Type); err != nil {
+		return err
+	}
+	if err := emit("category", xmlFile.Category); err != nil {
+		return err
+	}
+	if err := emit("title", xmlFile.Title); err != nil {
+		return err
+	}
+	if err := emit("description", xmlFile.Description); err != nil {
+		return err
+	}
+
+	if len(xmlFile.Tags) > 0 {
+		tagsStart := xml.StartElement{Name: xml.Name{Local: "tags"}}
+		if err := encoder.EncodeToken(tagsStart); err != nil {
+			return err
+		}
+		for _, tag := range xmlFile.Tags {
+			if err := emit("tag", tag); err != nil {
+				return err
+			}
+		}
+		if err := encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: "tags"}}); err != nil {
+			return err
+		}
+	}
+
+	// path / originalPath are required (no omitempty on the struct);
+	// emit unconditionally so a deserializer's required-field checks
+	// don't trip on a missing element.
+	pathStart := xml.StartElement{Name: xml.Name{Local: "path"}}
+	if err := encoder.EncodeToken(pathStart); err != nil {
+		return err
+	}
+	if err := encoder.EncodeToken(xml.CharData(xmlFile.Path)); err != nil {
+		return err
+	}
+	if err := encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: "path"}}); err != nil {
+		return err
+	}
+	originalStart := xml.StartElement{Name: xml.Name{Local: "originalPath"}}
+	if err := encoder.EncodeToken(originalStart); err != nil {
+		return err
+	}
+	if err := encoder.EncodeToken(xml.CharData(xmlFile.OriginalPath)); err != nil {
+		return err
+	}
+	if err := encoder.EncodeToken(xml.EndElement{Name: xml.Name{Local: "originalPath"}}); err != nil {
+		return err
+	}
+
+	if err := emit("extension", xmlFile.Extension); err != nil {
+		return err
+	}
+	if err := emit("mimeType", xmlFile.MimeType); err != nil {
+		return err
+	}
+	if err := emit("createdAt", xmlFile.CreatedAt); err != nil {
+		return err
+	}
+	return emit("updatedAt", xmlFile.UpdatedAt)
+}
+
+// streamBase64Content streams blob content from reader into the XML
+// encoder as base64-encoded chardata, in 32 KiB chunks. Returns the raw
+// (pre-encoding) byte count read from the reader. Ported verbatim from
+// the pre-#1479 export path so memory pressure stays flat regardless of
+// blob size.
+func streamBase64Content(encoder *xml.Encoder, reader io.Reader) (int64, error) {
+	xmlWriter := &xmlBase64Writer{encoder: encoder}
+	base64Encoder := base64.NewEncoder(base64.StdEncoding, xmlWriter)
+
+	const chunkSize = 32 * 1024
+	buf := make([]byte, chunkSize)
+	var rawTotal int64
+
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			if _, writeErr := base64Encoder.Write(buf[:n]); writeErr != nil {
+				closeErr := base64Encoder.Close()
+				return 0, errors.Join(errxtrace.Wrap("failed to write chunk to base64 encoder", writeErr), closeErr)
+			}
+			rawTotal += int64(n)
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			closeErr := base64Encoder.Close()
+			return 0, errors.Join(errxtrace.Wrap("failed to read blob chunk", err), closeErr)
+		}
+	}
+
+	if err := base64Encoder.Close(); err != nil {
+		return 0, errxtrace.Wrap("failed to close base64 encoder", err)
+	}
+	return rawTotal, nil
+}
+
+// xmlBase64Writer adapts xml.Encoder to io.Writer so a streaming
+// base64.NewEncoder can drive the chardata emission directly.
+type xmlBase64Writer struct {
+	encoder *xml.Encoder
+}
+
+func (w *xmlBase64Writer) Write(p []byte) (int, error) {
+	if err := w.encoder.EncodeToken(xml.CharData(p)); err != nil {
+		return 0, err
+	}
+	return len(p), nil
 }
 
 // resolveLinkedEntityUUID maps a file's linked_entity_id (a DB primary key)

--- a/go/backup/export/service.go
+++ b/go/backup/export/service.go
@@ -2,11 +2,13 @@ package export
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -107,16 +109,6 @@ type URL struct {
 	XMLName xml.Name `xml:"url"`
 	Name    string   `xml:"name,attr"`
 	Value   string   `xml:",chardata"`
-}
-
-type File struct {
-	XMLName      xml.Name `xml:"file"`
-	ID           string   `xml:"id,attr"`
-	Path         string   `xml:"path"`
-	OriginalPath string   `xml:"originalPath"`
-	Extension    string   `xml:"extension"`
-	MimeType     string   `xml:"mimeType"`
-	Data         string   `xml:"data,omitempty"` // Base64 encoded file data if include_file_data is true
 }
 
 // ExportService handles the background processing of export requests
@@ -370,6 +362,16 @@ func (s *ExportService) getFileSize(ctx context.Context, filePath string) (int64
 	return attrs.Size, nil
 }
 
+// ExportXML streams a single export to the provided writer and returns
+// the corresponding statistics. Mirrors ProcessExport's per-export flow
+// without the blob persistence + status updates — intended for tests
+// (round-trip and table-driven) that want the XML bytes in hand without
+// going through the on-disk bucket. Production code should still drive
+// the worker via ProcessExport.
+func ExportXML(s *ExportService, ctx context.Context, exp models.Export, writer io.Writer) (*types.ExportStats, error) {
+	return s.streamXMLExport(ctx, exp, writer)
+}
+
 // streamXMLExport streams XML data directly to the file writer and tracks statistics
 func (s *ExportService) streamXMLExport(ctx context.Context, export models.Export, writer io.Writer) (*types.ExportStats, error) {
 	stats := &types.ExportStats{}
@@ -398,24 +400,61 @@ func (s *ExportService) streamXMLExport(ctx context.Context, export models.Expor
 			return nil, errxtrace.Wrap("failed to stream full database", err)
 		}
 	case models.ExportTypeLocations:
+		locUUIDMap, err := s.buildLocationUUIDMap(ctx)
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to build location UUID map", err)
+		}
+		areaUUIDMap, err := s.buildAreaUUIDMap(ctx)
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to build area UUID map", err)
+		}
+		commodityUUIDMap, err := s.buildCommodityUUIDMap(ctx)
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to build commodity UUID map", err)
+		}
 		if err := s.streamLocations(ctx, writer, export, stats); err != nil {
 			return nil, errxtrace.Wrap("failed to stream locations", err)
+		}
+		if err := s.streamFiles(ctx, writer, export, stats, locUUIDMap, areaUUIDMap, commodityUUIDMap, nil); err != nil {
+			return nil, errxtrace.Wrap("failed to stream files", err)
 		}
 	case models.ExportTypeAreas:
 		locUUIDMap, err := s.buildLocationUUIDMap(ctx)
 		if err != nil {
 			return nil, errxtrace.Wrap("failed to build location UUID map", err)
 		}
-		if err := s.streamAreas(ctx, writer, export, stats, locUUIDMap); err != nil {
-			return nil, errxtrace.Wrap("failed to stream areas", err)
-		}
-	case models.ExportTypeCommodities:
 		areaUUIDMap, err := s.buildAreaUUIDMap(ctx)
 		if err != nil {
 			return nil, errxtrace.Wrap("failed to build area UUID map", err)
 		}
+		commodityUUIDMap, err := s.buildCommodityUUIDMap(ctx)
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to build commodity UUID map", err)
+		}
+		if err := s.streamAreas(ctx, writer, export, stats, locUUIDMap); err != nil {
+			return nil, errxtrace.Wrap("failed to stream areas", err)
+		}
+		if err := s.streamFiles(ctx, writer, export, stats, locUUIDMap, areaUUIDMap, commodityUUIDMap, nil); err != nil {
+			return nil, errxtrace.Wrap("failed to stream files", err)
+		}
+	case models.ExportTypeCommodities:
+		locUUIDMap, err := s.buildLocationUUIDMap(ctx)
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to build location UUID map", err)
+		}
+		areaUUIDMap, err := s.buildAreaUUIDMap(ctx)
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to build area UUID map", err)
+		}
+		commodityUUIDMap, err := s.buildCommodityUUIDMap(ctx)
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to build commodity UUID map", err)
+		}
 		if err := s.streamCommodities(ctx, writer, export, stats, areaUUIDMap); err != nil {
 			return nil, errxtrace.Wrap("failed to stream commodities", err)
+		}
+		if err := s.streamFiles(ctx, writer, export, stats, locUUIDMap, areaUUIDMap, commodityUUIDMap, nil); err != nil {
+			return nil, errxtrace.Wrap("failed to stream files", err)
 		}
 	case models.ExportTypeSelectedItems:
 		if err := s.streamSelectedItems(ctx, writer, export, stats); err != nil {
@@ -439,8 +478,8 @@ func (s *ExportService) streamXMLExport(ctx context.Context, export models.Expor
 
 // streamFullDatabase streams all database content to the writer and tracks statistics
 func (s *ExportService) streamFullDatabase(ctx context.Context, writer io.Writer, export models.Export, stats *types.ExportStats) error {
-	// Build both UUID maps once here so streamAreas and streamCommodities can reuse
-	// them without issuing redundant List() calls for locations and areas.
+	// Build all three UUID maps once here so streamAreas, streamCommodities and
+	// streamFiles can reuse them without issuing redundant List() calls.
 	locUUIDMap, err := s.buildLocationUUIDMap(ctx)
 	if err != nil {
 		return errxtrace.Wrap("failed to build location UUID map", err)
@@ -448,6 +487,10 @@ func (s *ExportService) streamFullDatabase(ctx context.Context, writer io.Writer
 	areaUUIDMap, err := s.buildAreaUUIDMap(ctx)
 	if err != nil {
 		return errxtrace.Wrap("failed to build area UUID map", err)
+	}
+	commodityUUIDMap, err := s.buildCommodityUUIDMap(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to build commodity UUID map", err)
 	}
 
 	if err := s.streamLocations(ctx, writer, export, stats); err != nil {
@@ -458,6 +501,9 @@ func (s *ExportService) streamFullDatabase(ctx context.Context, writer io.Writer
 	}
 	if err := s.streamCommodities(ctx, writer, export, stats, areaUUIDMap); err != nil {
 		return errxtrace.Wrap("failed to stream commodities", err)
+	}
+	if err := s.streamFiles(ctx, writer, export, stats, locUUIDMap, areaUUIDMap, commodityUUIDMap, nil); err != nil {
+		return errxtrace.Wrap("failed to stream files", err)
 	}
 	return nil
 }
@@ -639,7 +685,7 @@ func (s *ExportService) streamCommodities(ctx context.Context, writer io.Writer,
 
 // streamSelectedItems streams selected items (locations, areas, commodities) to the writer and tracks statistics
 func (s *ExportService) streamSelectedItems(ctx context.Context, writer io.Writer, export models.Export, stats *types.ExportStats) error {
-	// Build both UUID maps once here so streamSelectedAreas and streamSelectedCommodities
+	// Build all three UUID maps once so the entity streams and streamFiles
 	// can reuse them without issuing redundant List() calls.
 	locUUIDMap, err := s.buildLocationUUIDMap(ctx)
 	if err != nil {
@@ -648,6 +694,10 @@ func (s *ExportService) streamSelectedItems(ctx context.Context, writer io.Write
 	areaUUIDMap, err := s.buildAreaUUIDMap(ctx)
 	if err != nil {
 		return errxtrace.Wrap("failed to build area UUID map", err)
+	}
+	commodityUUIDMap, err := s.buildCommodityUUIDMap(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to build commodity UUID map", err)
 	}
 
 	encoder := xml.NewEncoder(writer)
@@ -669,6 +719,19 @@ func (s *ExportService) streamSelectedItems(ctx context.Context, writer io.Write
 
 	if err := encoder.Flush(); err != nil {
 		return errxtrace.Wrap("failed to flush encoder", err)
+	}
+
+	// Files for selected_items are filtered to those linked to the selected
+	// entities. Standalone files (LinkedEntityType="") are intentionally not
+	// included — the user explicitly picked locations/areas/commodities and
+	// wouldn't expect unrelated standalone uploads to ride along.
+	scope := selectedFileScope{
+		Locations:   locations,
+		Areas:       areas,
+		Commodities: commodities,
+	}
+	if err := s.streamFiles(ctx, writer, export, stats, locUUIDMap, areaUUIDMap, commodityUUIDMap, &scope); err != nil {
+		return errxtrace.Wrap("failed to stream files", err)
 	}
 
 	return nil
@@ -1069,9 +1132,252 @@ func (s *ExportService) streamCommodityDirectly(ctx context.Context, encoder *xm
 	return nil
 }
 
-// streamFileAttachmentsDirectly was the streaming counterpart to addFileAttachments;
-// both are gone under #1421. New file export from `files` is a follow-up.
+// XMLFile mirrors the on-disk shape of a single <file> element inside the
+// export's <files> section. The export side marshals from this struct;
+// the restore side decodes into restore/types.XMLFile (kept separate so
+// the restore package doesn't pull export-package transitively).
+type XMLFile struct {
+	XMLName          xml.Name `xml:"file"`
+	ID               string   `xml:"id,attr"`
+	LinkedEntityType string   `xml:"linkedEntityType,omitempty"`
+	LinkedEntityID   string   `xml:"linkedEntityId,omitempty"`
+	LinkedEntityMeta string   `xml:"linkedEntityMeta,omitempty"`
+	Type             string   `xml:"type,omitempty"`
+	Category         string   `xml:"category,omitempty"`
+	Title            string   `xml:"title,omitempty"`
+	Description      string   `xml:"description,omitempty"`
+	Tags             []string `xml:"tags>tag,omitempty"`
+	Path             string   `xml:"path"`
+	OriginalPath     string   `xml:"originalPath"`
+	Extension        string   `xml:"extension,omitempty"`
+	MimeType         string   `xml:"mimeType,omitempty"`
+	CreatedAt        string   `xml:"createdAt,omitempty"`
+	UpdatedAt        string   `xml:"updatedAt,omitempty"`
+	Data             string   `xml:"data,omitempty"` // Base64-encoded blob, only when IncludeFileData is true.
+}
 
-// streamFileDataDirectly streams file data directly to XML encoder without loading into memory and tracks base64 size
+// selectedFileScope narrows the file export to a specific set of selected
+// entities for ExportTypeSelectedItems. Files are included iff their
+// linked_entity_type matches one of the categories below and their
+// linked_entity_id is in the corresponding DB-ID list.
+type selectedFileScope struct {
+	Locations   []string // DB IDs
+	Areas       []string // DB IDs
+	Commodities []string // DB IDs
+}
 
-// streamBase64Content streams file content as base64 encoded data in chunks directly to XML and tracks size
+// buildCommodityUUIDMap builds a map from commodity DB ID to immutable UUID,
+// used by streamFiles to resolve linked_entity_id (DB-id) → stable UUID for
+// the XML emission. Mirrors the existing location/area UUID-map helpers.
+func (s *ExportService) buildCommodityUUIDMap(ctx context.Context) (map[string]string, error) {
+	comReg, err := s.factorySet.CommodityRegistryFactory.CreateUserRegistry(ctx)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to create commodity registry for UUID map", err)
+	}
+	commodities, err := comReg.List(ctx)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list commodities for UUID map", err)
+	}
+	m := make(map[string]string, len(commodities))
+	for _, c := range commodities {
+		m[c.ID] = c.UUID
+	}
+	return m, nil
+}
+
+// streamFiles emits the <files> XML section. Reads from the unified `files`
+// table (group-scoped via the user registry's RLS context) and writes one
+// <file> element per row whose linked entity is in scope.
+//
+// Files linked to the export itself (linked_entity_type="export") are always
+// excluded — those are the export's own backup-bundle blobs and re-emitting
+// them in their own export would create a self-reference.
+//
+// When `scope` is nil all eligible files are emitted; when non-nil only files
+// whose linked entity (commodity/location/area, by DB ID) matches the scope
+// are included. Standalone files (LinkedEntityType="") are emitted only when
+// scope is nil.
+//
+// When export.IncludeFileData is true, each file's blob content is read from
+// the upload bucket, base64-encoded, and inlined as a <data> element. The
+// blob payload is loaded into memory in full per file — that matches the
+// pre-#1421 code path; chunked streaming is a future optimization.
+func (s *ExportService) streamFiles(
+	ctx context.Context,
+	writer io.Writer,
+	export models.Export,
+	stats *types.ExportStats,
+	locUUIDMap, areaUUIDMap, commodityUUIDMap map[string]string,
+	scope *selectedFileScope,
+) error {
+	fileReg, err := s.factorySet.FileRegistryFactory.CreateUserRegistry(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to get file registry", err)
+	}
+	files, err := fileReg.List(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to list files", err)
+	}
+
+	encoder := xml.NewEncoder(writer)
+	encoder.Indent("  ", "  ")
+
+	startElement := xml.StartElement{Name: xml.Name{Local: "files"}}
+	if err := encoder.EncodeToken(startElement); err != nil {
+		return errxtrace.Wrap("failed to encode files start element", err)
+	}
+
+	// Open the bucket lazily — only when at least one file needs blob data.
+	var bucket *blob.Bucket
+	defer func() {
+		if bucket != nil {
+			_ = bucket.Close()
+		}
+	}()
+
+	for _, file := range files {
+		if file == nil || file.File == nil {
+			continue
+		}
+
+		// Skip the export's own backup blobs to avoid self-reference.
+		if file.LinkedEntityType == "export" {
+			continue
+		}
+
+		// Apply the selected_items scope, if any. Standalone files (no
+		// linked entity) are only included for full/whole-class exports.
+		if scope != nil {
+			if !inSelectedScope(file, scope) {
+				continue
+			}
+		}
+
+		linkedID, ok := resolveLinkedEntityUUID(file, locUUIDMap, areaUUIDMap, commodityUUIDMap)
+		if !ok {
+			// The linked entity wasn't visible to this user (RLS may have
+			// hidden it) or its UUID couldn't be resolved. Skip rather
+			// than emit a dangling reference.
+			continue
+		}
+
+		xmlFile := XMLFile{
+			ID:               file.UUID,
+			LinkedEntityType: file.LinkedEntityType,
+			LinkedEntityID:   linkedID,
+			LinkedEntityMeta: file.LinkedEntityMeta,
+			Type:             string(file.Type),
+			Category:         string(file.Category),
+			Title:            file.Title,
+			Description:      file.Description,
+			Tags:             []string(file.Tags),
+			Path:             file.Path,
+			OriginalPath:     file.OriginalPath,
+			Extension:        file.Ext,
+			MimeType:         file.MIMEType,
+			CreatedAt:        file.CreatedAt.UTC().Format(time.RFC3339),
+			UpdatedAt:        file.UpdatedAt.UTC().Format(time.RFC3339),
+		}
+
+		if export.IncludeFileData {
+			if bucket == nil {
+				bucket, err = blob.OpenBucket(ctx, s.uploadLocation)
+				if err != nil {
+					return errxtrace.Wrap("failed to open blob bucket for file data", err)
+				}
+			}
+			data, size, err := s.readFileBase64(ctx, bucket, file.OriginalPath)
+			if err != nil {
+				// Missing blobs are common during dev (manual deletes,
+				// orphan rows). Log on stats but don't fail the entire
+				// export — surface the row metadata without <data>.
+				stats.FileCount++
+				if encErr := encoder.Encode(&xmlFile); encErr != nil {
+					return errxtrace.Wrap("failed to encode file metadata", encErr)
+				}
+				continue
+			}
+			xmlFile.Data = data
+			stats.BinaryDataSize += size
+		}
+
+		if err := encoder.Encode(&xmlFile); err != nil {
+			return errxtrace.Wrap("failed to encode file", err)
+		}
+		stats.FileCount++
+	}
+
+	endElement := xml.EndElement{Name: xml.Name{Local: "files"}}
+	if err := encoder.EncodeToken(endElement); err != nil {
+		return errxtrace.Wrap("failed to encode files end element", err)
+	}
+	if err := encoder.Flush(); err != nil {
+		return errxtrace.Wrap("failed to flush encoder", err)
+	}
+	return nil
+}
+
+// readFileBase64 reads a blob fully into memory and returns it base64-encoded
+// alongside the raw byte size (for BinaryDataSize stats).
+func (s *ExportService) readFileBase64(ctx context.Context, bucket *blob.Bucket, blobKey string) (string, int64, error) {
+	reader, err := bucket.NewReader(ctx, blobKey, nil)
+	if err != nil {
+		return "", 0, errxtrace.Wrap("failed to open blob reader", err, errx.Attrs("blob_key", blobKey))
+	}
+	defer reader.Close()
+
+	raw, err := io.ReadAll(reader)
+	if err != nil {
+		return "", 0, errxtrace.Wrap("failed to read blob content", err, errx.Attrs("blob_key", blobKey))
+	}
+	return base64.StdEncoding.EncodeToString(raw), int64(len(raw)), nil
+}
+
+// resolveLinkedEntityUUID maps a file's linked_entity_id (a DB primary key)
+// to the corresponding immutable UUID using the per-type UUID maps. Returns
+// (uuid, true) on success, ("", false) when the linked entity is unknown
+// (pruned, deleted, or never existed). Standalone files (LinkedEntityType="")
+// always return ("", true) since there's nothing to resolve.
+func resolveLinkedEntityUUID(
+	file *models.FileEntity,
+	locUUIDMap, areaUUIDMap, commodityUUIDMap map[string]string,
+) (string, bool) {
+	if file.LinkedEntityType == "" || file.LinkedEntityID == "" {
+		return "", true
+	}
+	switch file.LinkedEntityType {
+	case "commodity":
+		uuid, ok := commodityUUIDMap[file.LinkedEntityID]
+		return uuid, ok
+	case "location":
+		uuid, ok := locUUIDMap[file.LinkedEntityID]
+		return uuid, ok
+	case "area":
+		uuid, ok := areaUUIDMap[file.LinkedEntityID]
+		return uuid, ok
+	default:
+		// Unknown linked-entity-type means we can't safely round-trip it.
+		// Treat as standalone — but emit the type/meta so the restore
+		// side can decide what to do (likely also skip).
+		return "", true
+	}
+}
+
+// inSelectedScope reports whether a file should be included given the
+// selected_items scope. Only commodity/area/location-linked files are
+// considered; standalone files are excluded from selected exports because
+// the user picked specific entities.
+func inSelectedScope(file *models.FileEntity, scope *selectedFileScope) bool {
+	if file.LinkedEntityType == "" || file.LinkedEntityID == "" {
+		return false
+	}
+	switch file.LinkedEntityType {
+	case "commodity":
+		return slices.Contains(scope.Commodities, file.LinkedEntityID)
+	case "area":
+		return slices.Contains(scope.Areas, file.LinkedEntityID)
+	case "location":
+		return slices.Contains(scope.Locations, file.LinkedEntityID)
+	}
+	return false
+}

--- a/go/backup/export/types/types.go
+++ b/go/backup/export/types/types.go
@@ -5,8 +5,17 @@ type ExportStats struct {
 	LocationCount  int
 	AreaCount      int
 	CommodityCount int
+	// ImageCount/InvoiceCount/ManualCount are the legacy commodity-scoped
+	// attachment counts. Their SQL columns and model fields are preserved
+	// for historical row data per #1421, but new exports leave them at 0
+	// — file attachments now feed the unified FileCount instead.
 	ImageCount     int
 	InvoiceCount   int
 	ManualCount    int
+	// FileCount is the number of rows from the unified `files` table that
+	// were emitted in the `<files>` section of the export XML. Includes
+	// commodity-, location-, area-linked and standalone files; excludes
+	// the export's own backup-bundle FileEntity (linked_entity_type="export").
+	FileCount      int
 	BinaryDataSize int64
 }

--- a/go/backup/export/types/types.go
+++ b/go/backup/export/types/types.go
@@ -9,9 +9,9 @@ type ExportStats struct {
 	// attachment counts. Their SQL columns and model fields are preserved
 	// for historical row data per #1421, but new exports leave them at 0
 	// — file attachments now feed the unified FileCount instead.
-	ImageCount     int
-	InvoiceCount   int
-	ManualCount    int
+	ImageCount   int
+	InvoiceCount int
+	ManualCount  int
 	// FileCount is the number of rows from the unified `files` table that
 	// were emitted in the `<files>` section of the export XML. Includes
 	// commodity-, location-, area-linked and standalone files; excludes

--- a/go/backup/import/service.go
+++ b/go/backup/import/service.go
@@ -94,6 +94,7 @@ func (s *ImportService) ProcessImport(ctx context.Context, exportID, sourceFileP
 	exportRecord.ImageCount = stats.ImageCount
 	exportRecord.InvoiceCount = stats.InvoiceCount
 	exportRecord.ManualCount = stats.ManualCount
+	exportRecord.FileCount = stats.FileCount
 	exportRecord.BinaryDataSize = stats.BinaryDataSize
 	exportRecord.IncludeFileData = stats.BinaryDataSize > 0
 

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -1696,7 +1696,7 @@ func (l *RestoreOperationProcessor) processFile(
 	idMapping *types.IDMapping,
 	options types.RestoreOptions,
 ) error {
-	xmlFile, blobBytes, err := l.decodeFileElement(ctx, decoder, startElement, options)
+	xmlFile, blobBytes, err := l.decodeFileElement(ctx, decoder, startElement, existing, idMapping, options)
 	if err != nil {
 		return errxtrace.Wrap("failed to decode file element", err)
 	}
@@ -1918,10 +1918,31 @@ func (l *RestoreOperationProcessor) handleFileMergeUpdate(
 // Ordering invariant: <originalPath> must precede <data>. The export side
 // emits in that order; if a future format violates it, decodeFileElement
 // fails loudly rather than corrupt the bucket with an unknown key.
+//
+// Strategy-aware blob handling: by the time we hit <data>, every metadata
+// element (including linkedEntityType / linkedEntityId / the file's own
+// XML UUID) has already been decoded, so we have enough state to decide
+// up-front whether the blob is worth writing. The chardata is drained
+// into io.Discard rather than the bucket when:
+//   - DryRun is set, OR
+//   - linkedEntityType is set but its linkedEntityId doesn't resolve via
+//     IDMapping (the row would be rejected with an "unknown commodity"
+//     error in processFile and the blob would be an orphan), OR
+//   - strategy is MergeAdd and a file with the same UUID already exists
+//     in the destination (the row will be skipped — overwriting its
+//     blob with our copy would clobber whatever the destination's
+//     custodian had at that key).
+//
+// For MergeUpdate-with-existing the blob IS rewritten — that path is
+// the explicit "overwrite" semantic the strategy promises. For
+// FullReplace the destination's existing.Files map is empty so the
+// MergeAdd guard naturally falls through and the blob writes.
 func (l *RestoreOperationProcessor) decodeFileElement(
 	ctx context.Context,
 	decoder *xml.Decoder,
 	startElement *xml.StartElement,
+	existing *types.ExistingEntities,
+	idMapping *types.IDMapping,
 	options types.RestoreOptions,
 ) (*types.XMLFile, int64, error) {
 	var xmlFile types.XMLFile
@@ -1945,7 +1966,7 @@ func (l *RestoreOperationProcessor) decodeFileElement(
 				if xmlFile.OriginalPath == "" {
 					return nil, 0, errors.New("malformed export: <data> element preceded <originalPath>")
 				}
-				size, err := l.streamDecodeFileData(ctx, decoder, xmlFile.OriginalPath, options)
+				size, err := l.handleFileDataElement(ctx, decoder, &xmlFile, existing, idMapping, options)
 				if err != nil {
 					return nil, 0, errxtrace.Wrap("failed to stream file data", err, errx.Attrs("xml_id", xmlFile.ID))
 				}
@@ -1961,6 +1982,99 @@ func (l *RestoreOperationProcessor) decodeFileElement(
 			}
 		}
 	}
+}
+
+// handleFileDataElement is the dispatch point for <data> chardata: it
+// uses the strategy + existing-files map + IDMapping to decide whether
+// to stream the blob to the upload bucket or just count the decoded
+// byte size while draining to io.Discard. See decodeFileElement's
+// doc comment for the full decision matrix.
+func (l *RestoreOperationProcessor) handleFileDataElement(
+	ctx context.Context,
+	decoder *xml.Decoder,
+	xmlFile *types.XMLFile,
+	existing *types.ExistingEntities,
+	idMapping *types.IDMapping,
+	options types.RestoreOptions,
+) (int64, error) {
+	if shouldWriteFileBlob(xmlFile, existing, idMapping, options) {
+		return l.streamDecodeFileData(ctx, decoder, xmlFile.OriginalPath, options)
+	}
+	// Drain the chardata into io.Discard so the byte count still flows
+	// into BinaryDataSize for the operator's preview / size estimate.
+	return drainFileDataElement(decoder)
+}
+
+// shouldWriteFileBlob is the predicate behind handleFileDataElement.
+// Pulled out so processFile can reuse it for symmetric error handling
+// (e.g., asserting that a discard happened when expected). Returning
+// false for non-decidable cases (no linked entity to resolve) errs on
+// the side of "write" — matches the legacy pre-#1421 behavior.
+func shouldWriteFileBlob(
+	xmlFile *types.XMLFile,
+	existing *types.ExistingEntities,
+	idMapping *types.IDMapping,
+	options types.RestoreOptions,
+) bool {
+	if options.DryRun {
+		return false
+	}
+	if existing != nil && existing.Files != nil {
+		if _, dupe := existing.Files[xmlFile.ID]; dupe && options.Strategy == types.RestoreStrategyMergeAdd {
+			return false
+		}
+	}
+	// Linked-entity resolution: if the row will be rejected in
+	// processFile because the referenced commodity / location / area
+	// isn't in the IDMapping, the blob would be a permanent orphan.
+	if xmlFile.LinkedEntityType != "" && xmlFile.LinkedEntityID != "" {
+		if !linkedEntityResolves(xmlFile.LinkedEntityType, xmlFile.LinkedEntityID, idMapping) {
+			return false
+		}
+	}
+	return true
+}
+
+// linkedEntityResolves mirrors resolveLinkedEntityDBID's lookup for the
+// known linked-entity types but returns just the boolean — used by
+// shouldWriteFileBlob to short-circuit the blob write when the row
+// would have been rejected anyway. Unknown linked-entity types pass
+// through (forward-compat: a future format may add new types and we
+// don't want to silently drop their blobs).
+func linkedEntityResolves(linkedType, linkedXMLID string, idMapping *types.IDMapping) bool {
+	if idMapping == nil {
+		return true
+	}
+	switch linkedType {
+	case "commodity":
+		_, ok := idMapping.Commodities[linkedXMLID]
+		return ok
+	case "location":
+		_, ok := idMapping.Locations[linkedXMLID]
+		return ok
+	case "area":
+		_, ok := idMapping.Areas[linkedXMLID]
+		return ok
+	}
+	return true
+}
+
+// drainFileDataElement consumes the chardata of a <data> element via
+// the streaming base64 decoder into io.Discard, returning the raw
+// decoded byte count for stats. Used when decodeFileElement decides
+// the blob isn't worth writing (DryRun, MergeAdd dedup, unresolved
+// linkage).
+func drainFileDataElement(decoder *xml.Decoder) (int64, error) {
+	chardataReader := &xmlChardataReader{decoder: decoder, terminator: "data"}
+	base64Reader := base64.NewDecoder(base64.StdEncoding, chardataReader)
+	n, err := io.Copy(io.Discard, base64Reader)
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to drain base64 stream", err)
+	}
+	if !chardataReader.done {
+		return 0, errors.New("malformed export: <data> stream ended before </data>")
+	}
+	return n, nil
 }
 
 // decodeFileChild dispatches a single non-<data> sub-element of <file> to
@@ -2005,9 +2119,12 @@ func decodeFileChild(decoder *xml.Decoder, xmlFile *types.XMLFile, t *xml.StartE
 }
 
 // streamDecodeFileData consumes the chardata of a <data> element through a
-// streaming base64 decoder into either the upload bucket (under blobKey)
-// or io.Discard (DryRun, or no upload location configured). Returns the
-// raw decoded byte count read out of the base64 decoder.
+// streaming base64 decoder into the upload bucket under blobKey. Returns
+// the raw decoded byte count read out of the base64 decoder.
+//
+// Caller must have already decided that the blob is worth writing —
+// DryRun, MergeAdd-dedup, and unresolved-linkage cases route through
+// drainFileDataElement instead so they don't open the bucket at all.
 //
 // The upload bucket is opened per-file rather than amortized across the
 // import — same tradeoff as the export side. Imports of thousands of
@@ -2019,22 +2136,15 @@ func (l *RestoreOperationProcessor) streamDecodeFileData(
 	blobKey string,
 	options types.RestoreOptions,
 ) (int64, error) {
+	_ = options // strategy/dry-run already filtered by shouldWriteFileBlob
+	if l.uploadLocation == "" {
+		// Test fixtures may run without an upload bucket configured;
+		// fall through to a drain so the byte count still flows.
+		return drainFileDataElement(decoder)
+	}
+
 	chardataReader := &xmlChardataReader{decoder: decoder, terminator: "data"}
 	base64Reader := base64.NewDecoder(base64.StdEncoding, chardataReader)
-
-	if options.DryRun || l.uploadLocation == "" {
-		// DryRun (or test fixtures without a bucket): drain the stream
-		// to count decoded bytes for stats without writing.
-		n, err := io.Copy(io.Discard, base64Reader)
-		if err != nil {
-			return 0, errxtrace.Wrap("failed to drain base64 stream", err)
-		}
-		// Make sure we consumed </data> too.
-		if !chardataReader.done {
-			return 0, errors.New("malformed export: <data> stream ended before </data>")
-		}
-		return n, nil
-	}
 
 	bucket, err := blob.OpenBucket(ctx, l.uploadLocation)
 	if err != nil {

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/xml"
@@ -1636,6 +1635,12 @@ func (l *RestoreOperationProcessor) processFilesWithLogging(
 // strategy handler. The XML id attribute carries the immutable file UUID;
 // linkedEntityId references the linked commodity/location/area by their
 // UUID, resolved here to the destination DB ID via idMapping.
+//
+// We decode metadata via a manual token loop rather than DecodeElement so
+// the <data> element can be streamed directly from the XML decoder into
+// the destination blob via base64.NewDecoder. Buffering the whole
+// <data> chardata before writing — the post-#1421 stub's behavior — would
+// have inflated worker memory in proportion to the largest single blob.
 func (l *RestoreOperationProcessor) processFile(
 	ctx context.Context,
 	decoder *xml.Decoder,
@@ -1645,10 +1650,11 @@ func (l *RestoreOperationProcessor) processFile(
 	idMapping *types.IDMapping,
 	options types.RestoreOptions,
 ) error {
-	var xmlFile types.XMLFile
-	if err := decoder.DecodeElement(&xmlFile, startElement); err != nil {
-		return errxtrace.Wrap("failed to decode file", err)
+	xmlFile, blobBytes, err := l.decodeFileElement(ctx, decoder, startElement, options)
+	if err != nil {
+		return errxtrace.Wrap("failed to decode file element", err)
 	}
+	stats.BinaryDataSize += blobBytes
 
 	originalXMLID := xmlFile.ID
 
@@ -1694,7 +1700,7 @@ func (l *RestoreOperationProcessor) processFile(
 		fileEntity.GroupID = group.ID
 	}
 
-	if err := l.applyStrategyForFile(ctx, fileEntity, &xmlFile, originalXMLID, stats, existing, idMapping, options); err != nil {
+	if err := l.applyStrategyForFile(ctx, fileEntity, xmlFile, originalXMLID, stats, existing, idMapping, options); err != nil {
 		l.updateRestoreStep(ctx, stepName, models.RestoreStepResultError, err.Error())
 		return err
 	}
@@ -1794,7 +1800,8 @@ func (l *RestoreOperationProcessor) applyStrategyForFile(
 
 // handleFileFullReplace creates a new file row (used for FullReplace and
 // the create branch of MergeAdd / MergeUpdate). Preserves the immutable
-// XML UUID, writes the blob bytes when present, and tracks per-file stats.
+// XML UUID. The blob bytes were already streamed to the bucket by the
+// decode pass — this function only persists the row.
 func (l *RestoreOperationProcessor) handleFileFullReplace(
 	ctx context.Context,
 	fileEntity *models.FileEntity,
@@ -1805,6 +1812,7 @@ func (l *RestoreOperationProcessor) handleFileFullReplace(
 	idMapping *types.IDMapping,
 	options types.RestoreOptions,
 ) error {
+	_ = xmlFile // blob already streamed to bucket during decode
 	if !options.DryRun {
 		fileEntity.UUID = originalXMLID
 		fileEntity.Tags = ensureFileTags(fileEntity.Tags)
@@ -1816,19 +1824,9 @@ func (l *RestoreOperationProcessor) handleFileFullReplace(
 		if err != nil {
 			return errxtrace.Wrap("failed to create file row", err, errx.Attrs("xml_id", originalXMLID))
 		}
-		if err := l.writeFileBlob(ctx, xmlFile, stats); err != nil {
-			return err
-		}
 		existing.Files[originalXMLID] = created
 		idMapping.Files[originalXMLID] = created.ID
 		l.trackCreatedEntity(created.ID)
-	} else if len(xmlFile.Data) > 0 {
-		// Dry-run: surface the decoded binary size so callers can
-		// preview the disk-cost without actually writing anything.
-		raw, err := decodeFileBase64(xmlFile.Data)
-		if err == nil {
-			stats.BinaryDataSize += int64(len(raw))
-		}
 	}
 	stats.CreatedCount++
 	stats.FileCount++
@@ -1836,7 +1834,8 @@ func (l *RestoreOperationProcessor) handleFileFullReplace(
 }
 
 // handleFileMergeUpdate updates an existing file row in place. The file's
-// UUID and DB ID were already restored on fileEntity by the caller.
+// UUID and DB ID were already restored on fileEntity by the caller, and
+// the blob bytes were streamed during decode.
 func (l *RestoreOperationProcessor) handleFileMergeUpdate(
 	ctx context.Context,
 	fileEntity *models.FileEntity,
@@ -1846,6 +1845,7 @@ func (l *RestoreOperationProcessor) handleFileMergeUpdate(
 	existing *types.ExistingEntities,
 	options types.RestoreOptions,
 ) error {
+	_ = xmlFile // blob already streamed to bucket during decode
 	if !options.DryRun {
 		fileEntity.Tags = ensureFileTags(fileEntity.Tags)
 		fileReg, err := l.factorySet.FileRegistryFactory.CreateUserRegistry(ctx)
@@ -1856,86 +1856,204 @@ func (l *RestoreOperationProcessor) handleFileMergeUpdate(
 		if err != nil {
 			return errxtrace.Wrap("failed to update file row", err, errx.Attrs("xml_id", originalXMLID))
 		}
-		if err := l.writeFileBlob(ctx, xmlFile, stats); err != nil {
-			return err
-		}
 		existing.Files[originalXMLID] = updated
-	} else if len(xmlFile.Data) > 0 {
-		raw, err := decodeFileBase64(xmlFile.Data)
-		if err == nil {
-			stats.BinaryDataSize += int64(len(raw))
-		}
 	}
 	stats.UpdatedCount++
 	stats.FileCount++
 	return nil
 }
 
-// writeFileBlob writes the file's raw content (decoded from XML base64) to
-// the blob bucket under the file's OriginalPath. Skipped silently when the
-// XML didn't carry a <data> element (export ran with IncludeFileData=false).
+// decodeFileElement walks the children of a <file> StartElement, decoding
+// each metadata sub-element via DecodeElement and streaming the <data>
+// chardata directly into a blob writer in chunks. Returns the populated
+// XMLFile (without the bulk Data field — the bytes never reside in memory)
+// and the raw decoded blob byte count for stats.
 //
-// The XMLFile.Data slice carries the raw <data> chardata as emitted by the
-// export — base64-encoded text, not raw bytes. Go's xml package does not
-// auto-decode base64 for []byte fields, so we decode here before writing
-// the blob and tracking BinaryDataSize.
+// Ordering invariant: <originalPath> must precede <data>. The export side
+// emits in that order; if a future format violates it, decodeFileElement
+// fails loudly rather than corrupt the bucket with an unknown key.
+func (l *RestoreOperationProcessor) decodeFileElement(
+	ctx context.Context,
+	decoder *xml.Decoder,
+	startElement *xml.StartElement,
+	options types.RestoreOptions,
+) (*types.XMLFile, int64, error) {
+	var xmlFile types.XMLFile
+	for _, attr := range startElement.Attr {
+		if attr.Name.Local == "id" {
+			xmlFile.ID = attr.Value
+			break
+		}
+	}
+
+	var rawSize int64
+
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			return nil, 0, errxtrace.Wrap("failed to read file element token", err)
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "data" {
+				if xmlFile.OriginalPath == "" {
+					return nil, 0, errors.New("malformed export: <data> element preceded <originalPath>")
+				}
+				size, err := l.streamDecodeFileData(ctx, decoder, xmlFile.OriginalPath, options)
+				if err != nil {
+					return nil, 0, errxtrace.Wrap("failed to stream file data", err, errx.Attrs("xml_id", xmlFile.ID))
+				}
+				rawSize = size
+				continue
+			}
+			if err := decodeFileChild(decoder, &xmlFile, &t); err != nil {
+				return nil, 0, err
+			}
+		case xml.EndElement:
+			if t.Name.Local == "file" {
+				return &xmlFile, rawSize, nil
+			}
+		}
+	}
+}
+
+// decodeFileChild dispatches a single non-<data> sub-element of <file> to
+// the matching XMLFile field. Unknown elements are skipped via the
+// decoder's built-in element-skip — DecodeElement on a *struct{} consumes
+// the entire element subtree.
+func decodeFileChild(decoder *xml.Decoder, xmlFile *types.XMLFile, t *xml.StartElement) error {
+	switch t.Name.Local {
+	case "linkedEntityType":
+		return decoder.DecodeElement(&xmlFile.LinkedEntityType, t)
+	case "linkedEntityId":
+		return decoder.DecodeElement(&xmlFile.LinkedEntityID, t)
+	case "linkedEntityMeta":
+		return decoder.DecodeElement(&xmlFile.LinkedEntityMeta, t)
+	case "type":
+		return decoder.DecodeElement(&xmlFile.Type, t)
+	case "category":
+		return decoder.DecodeElement(&xmlFile.Category, t)
+	case "title":
+		return decoder.DecodeElement(&xmlFile.Title, t)
+	case "description":
+		return decoder.DecodeElement(&xmlFile.Description, t)
+	case "tags":
+		return decoder.DecodeElement(&xmlFile.Tags, t)
+	case "path":
+		return decoder.DecodeElement(&xmlFile.Path, t)
+	case "originalPath":
+		return decoder.DecodeElement(&xmlFile.OriginalPath, t)
+	case "extension":
+		return decoder.DecodeElement(&xmlFile.Extension, t)
+	case "mimeType":
+		return decoder.DecodeElement(&xmlFile.MimeType, t)
+	case "createdAt":
+		return decoder.DecodeElement(&xmlFile.CreatedAt, t)
+	case "updatedAt":
+		return decoder.DecodeElement(&xmlFile.UpdatedAt, t)
+	default:
+		// Skip unknown sub-elements (forward-compat with newer formats).
+		var ignored struct{}
+		return decoder.DecodeElement(&ignored, t)
+	}
+}
+
+// streamDecodeFileData consumes the chardata of a <data> element through a
+// streaming base64 decoder into either the upload bucket (under blobKey)
+// or io.Discard (DryRun, or no upload location configured). Returns the
+// raw decoded byte count read out of the base64 decoder.
 //
-// We open the bucket per-file rather than holding it across the loop so a
-// rollback in one file's create/update doesn't leak the bucket handle.
-// Callers that import many files might want to amortize this — that's a
-// future optimization once we have a real benchmark.
-func (l *RestoreOperationProcessor) writeFileBlob(ctx context.Context, xmlFile *types.XMLFile, stats *types.RestoreStats) error {
-	if len(xmlFile.Data) == 0 {
-		return nil
+// The upload bucket is opened per-file rather than amortized across the
+// import — same tradeoff as the export side. Imports of thousands of
+// files might want to hold the bucket open; that's a future optimization
+// once we have a benchmark.
+func (l *RestoreOperationProcessor) streamDecodeFileData(
+	ctx context.Context,
+	decoder *xml.Decoder,
+	blobKey string,
+	options types.RestoreOptions,
+) (int64, error) {
+	chardataReader := &xmlChardataReader{decoder: decoder, terminator: "data"}
+	base64Reader := base64.NewDecoder(base64.StdEncoding, chardataReader)
+
+	if options.DryRun || l.uploadLocation == "" {
+		// DryRun (or test fixtures without a bucket): drain the stream
+		// to count decoded bytes for stats without writing.
+		n, err := io.Copy(io.Discard, base64Reader)
+		if err != nil {
+			return 0, errxtrace.Wrap("failed to drain base64 stream", err)
+		}
+		// Make sure we consumed </data> too.
+		if !chardataReader.done {
+			return 0, errors.New("malformed export: <data> stream ended before </data>")
+		}
+		return n, nil
 	}
-	raw, err := decodeFileBase64(xmlFile.Data)
-	if err != nil {
-		return errxtrace.Wrap("failed to base64-decode file data", err, errx.Attrs("xml_id", xmlFile.ID))
-	}
-	if l.uploadLocation == "" {
-		// Tests may run without an upload bucket configured; the row is
-		// already persisted, just track the decoded size.
-		stats.BinaryDataSize += int64(len(raw))
-		return nil
-	}
+
 	bucket, err := blob.OpenBucket(ctx, l.uploadLocation)
 	if err != nil {
-		return errxtrace.Wrap("failed to open blob bucket for file write", err)
+		return 0, errxtrace.Wrap("failed to open blob bucket for streaming write", err)
 	}
 	defer bucket.Close()
 
-	writer, err := bucket.NewWriter(ctx, xmlFile.OriginalPath, nil)
+	writer, err := bucket.NewWriter(ctx, blobKey, nil)
 	if err != nil {
-		return errxtrace.Wrap("failed to create blob writer", err, errx.Attrs("blob_key", xmlFile.OriginalPath))
+		return 0, errxtrace.Wrap("failed to create blob writer", err, errx.Attrs("blob_key", blobKey))
 	}
-	if _, err := io.Copy(writer, bytes.NewReader(raw)); err != nil {
-		_ = writer.Close()
-		return errxtrace.Wrap("failed to write file blob", err, errx.Attrs("blob_key", xmlFile.OriginalPath))
+
+	n, copyErr := io.Copy(writer, base64Reader)
+	closeErr := writer.Close()
+	if copyErr != nil {
+		return 0, errxtrace.Wrap("failed to stream blob bytes", copyErr, errx.Attrs("blob_key", blobKey))
 	}
-	if err := writer.Close(); err != nil {
-		return errxtrace.Wrap("failed to close blob writer", err, errx.Attrs("blob_key", xmlFile.OriginalPath))
+	if closeErr != nil {
+		return 0, errxtrace.Wrap("failed to close blob writer", closeErr, errx.Attrs("blob_key", blobKey))
 	}
-	stats.BinaryDataSize += int64(len(raw))
-	return nil
+	if !chardataReader.done {
+		return 0, errors.New("malformed export: <data> stream ended before </data>")
+	}
+	return n, nil
 }
 
-// decodeFileBase64 decodes the chardata <data> element back to raw bytes.
-// Strips embedded whitespace (XML pretty-printing wraps base64 across
-// lines) before decoding.
-func decodeFileBase64(data []byte) ([]byte, error) {
-	// Fast path: no whitespace.
-	if !bytes.ContainsAny(data, " \n\r\t") {
-		return base64.StdEncoding.DecodeString(string(data))
-	}
-	cleaned := make([]byte, 0, len(data))
-	for _, b := range data {
-		switch b {
-		case ' ', '\n', '\r', '\t':
-			continue
+// xmlChardataReader exposes the decoder's chardata tokens (until the
+// matching `</terminator>` end element) as an io.Reader. Whitespace
+// introduced by pretty-printing is stripped on the fly so the underlying
+// base64 decoder sees a contiguous stream. Callers wrap this in
+// `base64.NewDecoder` and io.Copy into a destination writer.
+type xmlChardataReader struct {
+	decoder    *xml.Decoder
+	terminator string
+	buf        []byte // pending chardata bytes (whitespace-stripped)
+	done       bool
+}
+
+func (r *xmlChardataReader) Read(p []byte) (int, error) {
+	for len(r.buf) == 0 && !r.done {
+		tok, err := r.decoder.Token()
+		if err != nil {
+			return 0, err
 		}
-		cleaned = append(cleaned, b)
+		switch t := tok.(type) {
+		case xml.CharData:
+			for _, b := range t {
+				switch b {
+				case ' ', '\n', '\r', '\t':
+					continue
+				}
+				r.buf = append(r.buf, b)
+			}
+		case xml.EndElement:
+			if t.Name.Local == r.terminator {
+				r.done = true
+			}
+		}
 	}
-	return base64.StdEncoding.DecodeString(string(cleaned))
+	if r.done && len(r.buf) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, r.buf)
+	r.buf = r.buf[n:]
+	return n, nil
 }
 
 // ensureFileTags normalizes nil to empty so the registry's NOT NULL JSONB

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -1,7 +1,9 @@
 package processor
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -128,6 +130,7 @@ func (l *RestoreOperationProcessor) Process(ctx context.Context) error {
 	restoreOperation.ImageCount = stats.ImageCount
 	restoreOperation.InvoiceCount = stats.InvoiceCount
 	restoreOperation.ManualCount = stats.ManualCount
+	restoreOperation.FileCount = stats.FileCount
 	restoreOperation.BinaryDataSize = stats.BinaryDataSize
 	restoreOperation.ErrorCount = stats.ErrorCount
 
@@ -143,31 +146,12 @@ func (l *RestoreOperationProcessor) Process(ctx context.Context) error {
 	return nil
 }
 
-// skipSection skips an entire XML section
-func (l *RestoreOperationProcessor) skipSection(decoder *xml.Decoder, startElement *xml.StartElement) error {
-	depth := 1
-	for depth > 0 {
-		tok, err := decoder.Token()
-		if err != nil {
-			return errxtrace.Wrap("failed to read token while skipping section", err)
-		}
-
-		switch t := tok.(type) {
-		case xml.StartElement:
-			depth++
-		case xml.EndElement:
-			depth--
-			if depth == 0 && t.Name.Local == startElement.Name.Local {
-				return nil
-			}
-		}
-	}
-	return nil
-}
-
 // Legacy XML-attachment helpers (collectFiles / collectFile / processFile /
 // decodeBase64ToFile / validateCommodityOwnership) were removed under #1421
-// along with the legacy SQL tables they ultimately wrote to.
+// along with the legacy SQL tables they ultimately wrote to. The silent-skip
+// helper that handled pre-cutover backups was dropped under #1485 along with
+// the case in collectCommodityData — pre-cutover archives are explicitly not
+// supported.
 
 // validateOptions validates the restore options
 func (*RestoreOperationProcessor) validateOptions(options types.RestoreOptions) error {
@@ -186,6 +170,7 @@ func (l *RestoreOperationProcessor) loadExistingEntities(ctx context.Context, en
 	entities.Locations = make(map[string]*models.Location)
 	entities.Areas = make(map[string]*models.Area)
 	entities.Commodities = make(map[string]*models.Commodity)
+	entities.Files = make(map[string]*models.FileEntity)
 
 	// Load locations - index by immutable UUID (the stable XML identifier used in exports).
 	locReg, err := l.factorySet.LocationRegistryFactory.CreateUserRegistry(ctx)
@@ -226,15 +211,41 @@ func (l *RestoreOperationProcessor) loadExistingEntities(ctx context.Context, en
 		entities.Commodities[commodity.UUID] = commodity
 	}
 
-	// Legacy commodity-scoped image/invoice/manual loading was removed under
-	// #1421 along with the SQL tables they came from. The unified `files`
-	// table now owns commodity attachments; restoring those is a follow-up.
+	// Load files - index by immutable UUID. Excludes export-linked files
+	// (the export's own backup-bundle blobs); those aren't part of the
+	// content surface that round-trips through restore and creating a
+	// duplicate row for them would conflict with the export.FileID FK.
+	fileReg, err := l.factorySet.FileRegistryFactory.CreateUserRegistry(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to create user file registry", err)
+	}
+	files, err := fileReg.List(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to load existing files", err)
+	}
+	for _, file := range files {
+		if file.LinkedEntityType == "export" {
+			continue
+		}
+		entities.Files[file.UUID] = file
+	}
+
 	return nil
 }
 
-// clearExistingData removes all existing data for full replace strategy
+// clearExistingData removes all existing data for full replace strategy.
+// DeleteLocationRecursive cascades through areas + commodities and the
+// commodity step also deletes commodity-linked files via EntityService —
+// but location-, area-, and standalone-linked files don't cascade and would
+// remain as orphans (and worse: their UUIDs would collide with the restored
+// rows). After the location sweep we therefore make a second pass that
+// explicitly deletes every non-export file row in the user's group.
+//
+// Export-linked files (the export's own backup-bundle blobs) are
+// intentionally preserved — deleting them mid-restore would race with the
+// export.FileID FK pointing at the bundle we're currently reading from.
 func (l *RestoreOperationProcessor) clearExistingData(ctx context.Context) error {
-	// Delete all locations recursively (this will also delete areas and commodities)
+	// Delete all locations recursively (this will also delete areas, commodities, and commodity-linked files)
 	locReg := l.factorySet.LocationRegistryFactory.CreateServiceRegistry()
 	locations, err := locReg.List(ctx)
 	if err != nil {
@@ -243,6 +254,28 @@ func (l *RestoreOperationProcessor) clearExistingData(ctx context.Context) error
 	for _, location := range locations {
 		if err := l.entityService.DeleteLocationRecursive(ctx, location.ID); err != nil {
 			return errxtrace.Wrap("failed to delete location recursively", err, errx.Attrs("location_id", location.ID))
+		}
+	}
+
+	// Sweep remaining files (location-/area-linked + standalone) — see the
+	// comment on this function for why DeleteLocationRecursive isn't enough.
+	fileReg, err := l.factorySet.FileRegistryFactory.CreateUserRegistry(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to create user file registry for clear", err)
+	}
+	files, err := fileReg.List(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to list files for deletion", err)
+	}
+	for _, file := range files {
+		if file.LinkedEntityType == "export" {
+			continue
+		}
+		if err := fileReg.Delete(ctx, file.ID); err != nil {
+			if errors.Is(err, registry.ErrNotFound) {
+				continue
+			}
+			return errxtrace.Wrap("failed to delete file row", err, errx.Attrs("file_id", file.ID))
 		}
 	}
 
@@ -463,6 +496,14 @@ func (l *RestoreOperationProcessor) restoreTopLevelElements(
 		}
 		l.updateRestoreStep(ctx, "Processing commodities", models.RestoreStepResultSuccess,
 			fmt.Sprintf("Processed %d commodities", stats.CommodityCount))
+	case "files":
+		l.createRestoreStep(ctx, "Processing files", models.RestoreStepResultInProgress, "")
+		if err := l.processFilesWithLogging(ctx, decoder, stats, existingEntities, idMapping, options); err != nil {
+			l.updateRestoreStep(ctx, "Processing files", models.RestoreStepResultError, err.Error())
+			return errxtrace.Wrap("failed to process files", err)
+		}
+		l.updateRestoreStep(ctx, "Processing files", models.RestoreStepResultSuccess,
+			fmt.Sprintf("Processed %d files", stats.FileCount))
 	}
 	return nil
 }
@@ -503,6 +544,7 @@ func (l *RestoreOperationProcessor) restoreFromXML(
 		Locations:   make(map[string]string),
 		Areas:       make(map[string]string),
 		Commodities: make(map[string]string),
+		Files:       make(map[string]string),
 	}
 
 	if options.Strategy != types.RestoreStrategyFullReplace {
@@ -519,11 +561,15 @@ func (l *RestoreOperationProcessor) restoreFromXML(
 		for xmlID, entity := range existingEntities.Commodities {
 			idMapping.Commodities[xmlID] = entity.ID
 		}
+		for xmlID, entity := range existingEntities.Files {
+			idMapping.Files[xmlID] = entity.ID
+		}
 	} else {
 		// For full replace, initialize empty maps to track newly created entities
 		existingEntities.Locations = make(map[string]*models.Location)
 		existingEntities.Areas = make(map[string]*models.Area)
 		existingEntities.Commodities = make(map[string]*models.Commodity)
+		existingEntities.Files = make(map[string]*models.FileEntity)
 	}
 
 	// If full replace, clear existing data first
@@ -1138,15 +1184,11 @@ func (l *RestoreOperationProcessor) collectCommodityData(
 		if err := decoder.DecodeElement(&xmlCommodity.URLs, &t); err != nil {
 			return errxtrace.Wrap("failed to decode URLs", err)
 		}
-	case "images", "invoices", "manuals":
-		// Legacy commodity-scoped attachment sections were removed under #1421
-		// along with the SQL tables they wrote to. Older backups carry these
-		// sections; we silently skip them and let the (already-backfilled)
-		// data on the unified `files` table stand.
-		if err := l.skipSection(decoder, &t); err != nil {
-			return errxtrace.Wrap("failed to skip legacy attachment section", err)
-		}
 	}
+	// Legacy commodity-scoped <images>/<invoices>/<manuals> sections were
+	// removed under #1421 along with the SQL tables they wrote to.
+	// Pre-cutover archives are not supported per ops (no production data
+	// pre-dates the cutover) — encountering one falls through unhandled.
 
 	return nil
 }
@@ -1554,4 +1596,354 @@ func (l *RestoreOperationProcessor) getActionDescription(action string, options 
 	default:
 		return prefix + "perform unknown action"
 	}
+}
+
+// processFilesWithLogging walks the <file> children of <files>, decoding
+// each into a types.XMLFile and dispatching to processFile for strategy
+// resolution. Mirrors the locations / areas / commodities sweep pattern.
+func (l *RestoreOperationProcessor) processFilesWithLogging(
+	ctx context.Context,
+	decoder *xml.Decoder,
+	stats *types.RestoreStats,
+	existing *types.ExistingEntities,
+	idMapping *types.IDMapping,
+	options types.RestoreOptions,
+) error {
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			return errxtrace.Wrap("failed to read files token", err)
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "file" {
+				if err := l.processFile(ctx, decoder, &t, stats, existing, idMapping, options); err != nil {
+					stats.ErrorCount++
+					stats.Errors = append(stats.Errors, fmt.Sprintf("failed to process file: %v", err))
+					continue
+				}
+			}
+		case xml.EndElement:
+			if t.Name.Local == "files" {
+				return nil
+			}
+		}
+	}
+}
+
+// processFile decodes a single <file> element and dispatches it to the
+// strategy handler. The XML id attribute carries the immutable file UUID;
+// linkedEntityId references the linked commodity/location/area by their
+// UUID, resolved here to the destination DB ID via idMapping.
+func (l *RestoreOperationProcessor) processFile(
+	ctx context.Context,
+	decoder *xml.Decoder,
+	startElement *xml.StartElement,
+	stats *types.RestoreStats,
+	existing *types.ExistingEntities,
+	idMapping *types.IDMapping,
+	options types.RestoreOptions,
+) error {
+	var xmlFile types.XMLFile
+	if err := decoder.DecodeElement(&xmlFile, startElement); err != nil {
+		return errxtrace.Wrap("failed to decode file", err)
+	}
+
+	originalXMLID := xmlFile.ID
+
+	action := l.predictFileAction(xmlFile.ID, options, existing)
+	emoji := l.getEmojiForAction(action)
+	actionDesc := l.getActionDescription(action, options)
+	displayName := xmlFile.Title
+	if displayName == "" {
+		displayName = xmlFile.Path
+	}
+	stepName := fmt.Sprintf("%s File: %s", emoji, displayName)
+	l.createRestoreStep(ctx, stepName, models.RestoreStepResultInProgress, actionDesc)
+
+	// Resolve the linked entity to a destination DB ID via the IDMapping.
+	// Files referencing entities that weren't in the export (or that didn't
+	// resolve in this restore) are dropped with an error rather than create
+	// a row that points at nothing — the unique-on-UUID index would still
+	// allow restoring it later when the entity exists.
+	linkedDBID, ok := l.resolveLinkedEntityDBID(xmlFile.LinkedEntityType, xmlFile.LinkedEntityID, idMapping)
+	if !ok {
+		stats.ErrorCount++
+		msg := fmt.Sprintf("file %s references unknown %s %s", originalXMLID, xmlFile.LinkedEntityType, xmlFile.LinkedEntityID)
+		stats.Errors = append(stats.Errors, msg)
+		l.updateRestoreStep(ctx, stepName, models.RestoreStepResultError, msg)
+		return nil
+	}
+
+	fileEntity := xmlFile.ConvertToFileEntity(linkedDBID)
+
+	// Stamp tenant/group/created-by from current context. The user-aware
+	// registry would do this on Create, but for MergeUpdate we may go
+	// through Update instead, which preserves the existing entity's
+	// fields rather than re-populating from context.
+	user := appctx.UserFromContext(ctx)
+	if user == nil {
+		stats.ErrorCount++
+		l.updateRestoreStep(ctx, stepName, models.RestoreStepResultError, "missing user context")
+		return security.ErrNoUserContext
+	}
+	fileEntity.TenantID = user.TenantID
+	fileEntity.CreatedByUserID = user.ID
+	if group := appctx.GroupFromContext(ctx); group != nil {
+		fileEntity.GroupID = group.ID
+	}
+
+	if err := l.applyStrategyForFile(ctx, fileEntity, &xmlFile, originalXMLID, stats, existing, idMapping, options); err != nil {
+		l.updateRestoreStep(ctx, stepName, models.RestoreStepResultError, err.Error())
+		return err
+	}
+
+	l.updateRestoreStep(ctx, stepName, models.RestoreStepResultSuccess, "Completed")
+	return nil
+}
+
+// resolveLinkedEntityDBID maps an XML linked-entity reference (UUID) to the
+// destination DB ID using the IDMapping. Returns ("", true) for standalone
+// files (no linked entity to resolve) and ("", false) when the entity was
+// expected but not found in the mapping.
+func (l *RestoreOperationProcessor) resolveLinkedEntityDBID(
+	linkedEntityType, linkedEntityXMLID string,
+	idMapping *types.IDMapping,
+) (string, bool) {
+	if linkedEntityType == "" || linkedEntityXMLID == "" {
+		return "", true
+	}
+	switch linkedEntityType {
+	case "commodity":
+		id, ok := idMapping.Commodities[linkedEntityXMLID]
+		return id, ok
+	case "location":
+		id, ok := idMapping.Locations[linkedEntityXMLID]
+		return id, ok
+	case "area":
+		id, ok := idMapping.Areas[linkedEntityXMLID]
+		return id, ok
+	default:
+		// Unknown linked-entity-type: pass through the XML value verbatim
+		// and accept whatever the registry does with it. Avoids hard
+		// failures on linked-entity types added in future versions.
+		return linkedEntityXMLID, true
+	}
+}
+
+// predictFileAction is the file-specific equivalent of predictAction: it
+// keys on the in-memory existing-files map (populated for non-FullReplace
+// strategies) so the predicted action lines up with what
+// applyStrategyForFile will actually do.
+func (l *RestoreOperationProcessor) predictFileAction(xmlID string, options types.RestoreOptions, existing *types.ExistingEntities) string {
+	switch options.Strategy {
+	case types.RestoreStrategyFullReplace:
+		return "create"
+	case types.RestoreStrategyMergeAdd:
+		if _, ok := existing.Files[xmlID]; ok {
+			return "skip"
+		}
+		return "create"
+	case types.RestoreStrategyMergeUpdate:
+		if _, ok := existing.Files[xmlID]; ok {
+			return "update"
+		}
+		return "create"
+	default:
+		return "unknown"
+	}
+}
+
+// applyStrategyForFile dispatches a decoded XML file row to the matching
+// FullReplace / MergeAdd / MergeUpdate handler. The file's UUID acts as
+// the dedup key — DB-level idempotency is provided by the unique
+// idx_files_uuid index even when in-memory tracking misses.
+func (l *RestoreOperationProcessor) applyStrategyForFile(
+	ctx context.Context,
+	fileEntity *models.FileEntity,
+	xmlFile *types.XMLFile,
+	originalXMLID string,
+	stats *types.RestoreStats,
+	existing *types.ExistingEntities,
+	idMapping *types.IDMapping,
+	options types.RestoreOptions,
+) error {
+	existingFile := existing.Files[originalXMLID]
+
+	switch options.Strategy {
+	case types.RestoreStrategyFullReplace:
+		return l.handleFileFullReplace(ctx, fileEntity, xmlFile, originalXMLID, stats, existing, idMapping, options)
+	case types.RestoreStrategyMergeAdd:
+		if existingFile != nil {
+			stats.SkippedCount++
+			return nil
+		}
+		return l.handleFileFullReplace(ctx, fileEntity, xmlFile, originalXMLID, stats, existing, idMapping, options)
+	case types.RestoreStrategyMergeUpdate:
+		if existingFile == nil {
+			return l.handleFileFullReplace(ctx, fileEntity, xmlFile, originalXMLID, stats, existing, idMapping, options)
+		}
+		// Restore the destination DB ID + UUID before updating.
+		fileEntity.SetID(existingFile.ID)
+		fileEntity.UUID = existingFile.UUID
+		return l.handleFileMergeUpdate(ctx, fileEntity, xmlFile, originalXMLID, stats, existing, options)
+	}
+	return nil
+}
+
+// handleFileFullReplace creates a new file row (used for FullReplace and
+// the create branch of MergeAdd / MergeUpdate). Preserves the immutable
+// XML UUID, writes the blob bytes when present, and tracks per-file stats.
+func (l *RestoreOperationProcessor) handleFileFullReplace(
+	ctx context.Context,
+	fileEntity *models.FileEntity,
+	xmlFile *types.XMLFile,
+	originalXMLID string,
+	stats *types.RestoreStats,
+	existing *types.ExistingEntities,
+	idMapping *types.IDMapping,
+	options types.RestoreOptions,
+) error {
+	if !options.DryRun {
+		fileEntity.UUID = originalXMLID
+		fileEntity.Tags = ensureFileTags(fileEntity.Tags)
+		fileReg, err := l.factorySet.FileRegistryFactory.CreateUserRegistry(ctx)
+		if err != nil {
+			return errxtrace.Wrap("failed to create user file registry", err)
+		}
+		created, err := fileReg.Create(ctx, *fileEntity)
+		if err != nil {
+			return errxtrace.Wrap("failed to create file row", err, errx.Attrs("xml_id", originalXMLID))
+		}
+		if err := l.writeFileBlob(ctx, xmlFile, stats); err != nil {
+			return err
+		}
+		existing.Files[originalXMLID] = created
+		idMapping.Files[originalXMLID] = created.ID
+		l.trackCreatedEntity(created.ID)
+	} else if len(xmlFile.Data) > 0 {
+		// Dry-run: surface the decoded binary size so callers can
+		// preview the disk-cost without actually writing anything.
+		raw, err := decodeFileBase64(xmlFile.Data)
+		if err == nil {
+			stats.BinaryDataSize += int64(len(raw))
+		}
+	}
+	stats.CreatedCount++
+	stats.FileCount++
+	return nil
+}
+
+// handleFileMergeUpdate updates an existing file row in place. The file's
+// UUID and DB ID were already restored on fileEntity by the caller.
+func (l *RestoreOperationProcessor) handleFileMergeUpdate(
+	ctx context.Context,
+	fileEntity *models.FileEntity,
+	xmlFile *types.XMLFile,
+	originalXMLID string,
+	stats *types.RestoreStats,
+	existing *types.ExistingEntities,
+	options types.RestoreOptions,
+) error {
+	if !options.DryRun {
+		fileEntity.Tags = ensureFileTags(fileEntity.Tags)
+		fileReg, err := l.factorySet.FileRegistryFactory.CreateUserRegistry(ctx)
+		if err != nil {
+			return errxtrace.Wrap("failed to create user file registry", err)
+		}
+		updated, err := fileReg.Update(ctx, *fileEntity)
+		if err != nil {
+			return errxtrace.Wrap("failed to update file row", err, errx.Attrs("xml_id", originalXMLID))
+		}
+		if err := l.writeFileBlob(ctx, xmlFile, stats); err != nil {
+			return err
+		}
+		existing.Files[originalXMLID] = updated
+	} else if len(xmlFile.Data) > 0 {
+		raw, err := decodeFileBase64(xmlFile.Data)
+		if err == nil {
+			stats.BinaryDataSize += int64(len(raw))
+		}
+	}
+	stats.UpdatedCount++
+	stats.FileCount++
+	return nil
+}
+
+// writeFileBlob writes the file's raw content (decoded from XML base64) to
+// the blob bucket under the file's OriginalPath. Skipped silently when the
+// XML didn't carry a <data> element (export ran with IncludeFileData=false).
+//
+// The XMLFile.Data slice carries the raw <data> chardata as emitted by the
+// export — base64-encoded text, not raw bytes. Go's xml package does not
+// auto-decode base64 for []byte fields, so we decode here before writing
+// the blob and tracking BinaryDataSize.
+//
+// We open the bucket per-file rather than holding it across the loop so a
+// rollback in one file's create/update doesn't leak the bucket handle.
+// Callers that import many files might want to amortize this — that's a
+// future optimization once we have a real benchmark.
+func (l *RestoreOperationProcessor) writeFileBlob(ctx context.Context, xmlFile *types.XMLFile, stats *types.RestoreStats) error {
+	if len(xmlFile.Data) == 0 {
+		return nil
+	}
+	raw, err := decodeFileBase64(xmlFile.Data)
+	if err != nil {
+		return errxtrace.Wrap("failed to base64-decode file data", err, errx.Attrs("xml_id", xmlFile.ID))
+	}
+	if l.uploadLocation == "" {
+		// Tests may run without an upload bucket configured; the row is
+		// already persisted, just track the decoded size.
+		stats.BinaryDataSize += int64(len(raw))
+		return nil
+	}
+	bucket, err := blob.OpenBucket(ctx, l.uploadLocation)
+	if err != nil {
+		return errxtrace.Wrap("failed to open blob bucket for file write", err)
+	}
+	defer bucket.Close()
+
+	writer, err := bucket.NewWriter(ctx, xmlFile.OriginalPath, nil)
+	if err != nil {
+		return errxtrace.Wrap("failed to create blob writer", err, errx.Attrs("blob_key", xmlFile.OriginalPath))
+	}
+	if _, err := io.Copy(writer, bytes.NewReader(raw)); err != nil {
+		_ = writer.Close()
+		return errxtrace.Wrap("failed to write file blob", err, errx.Attrs("blob_key", xmlFile.OriginalPath))
+	}
+	if err := writer.Close(); err != nil {
+		return errxtrace.Wrap("failed to close blob writer", err, errx.Attrs("blob_key", xmlFile.OriginalPath))
+	}
+	stats.BinaryDataSize += int64(len(raw))
+	return nil
+}
+
+// decodeFileBase64 decodes the chardata <data> element back to raw bytes.
+// Strips embedded whitespace (XML pretty-printing wraps base64 across
+// lines) before decoding.
+func decodeFileBase64(data []byte) ([]byte, error) {
+	// Fast path: no whitespace.
+	if !bytes.ContainsAny(data, " \n\r\t") {
+		return base64.StdEncoding.DecodeString(string(data))
+	}
+	cleaned := make([]byte, 0, len(data))
+	for _, b := range data {
+		switch b {
+		case ' ', '\n', '\r', '\t':
+			continue
+		}
+		cleaned = append(cleaned, b)
+	}
+	return base64.StdEncoding.DecodeString(string(cleaned))
+}
+
+// ensureFileTags normalizes nil to empty so the registry's NOT NULL JSONB
+// constraint accepts the value. Mirrors the upload-time behavior in
+// apiserver/uploads.go where Tags is always at least [].
+func ensureFileTags(tags models.StringSlice) models.StringSlice {
+	if tags == nil {
+		return models.StringSlice{}
+	}
+	return tags
 }

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -234,17 +234,20 @@ func (l *RestoreOperationProcessor) loadExistingEntities(ctx context.Context, en
 
 // clearExistingData removes all existing data for full replace strategy.
 // DeleteLocationRecursive cascades through areas + commodities and the
-// commodity step also deletes commodity-linked files via EntityService —
-// but location-, area-, and standalone-linked files don't cascade and would
-// remain as orphans (and worse: their UUIDs would collide with the restored
-// rows). After the location sweep we therefore make a second pass that
-// explicitly deletes every non-export file row in the user's group.
+// commodity step also deletes commodity-linked files (rows + physical
+// blobs + thumbnails) via EntityService — but location-, area-, and
+// standalone-linked files don't cascade and would remain as orphans
+// (and worse: their UUIDs would collide with the restored rows, while
+// their physical blobs would leak in the upload bucket forever). After
+// the location sweep we make a second pass that calls FileService's
+// row+blob delete for every non-export file.
 //
 // Export-linked files (the export's own backup-bundle blobs) are
-// intentionally preserved — deleting them mid-restore would race with the
-// export.FileID FK pointing at the bundle we're currently reading from.
+// intentionally preserved — deleting them mid-restore would race with
+// the export.FileID FK pointing at the bundle we're currently reading
+// from.
 func (l *RestoreOperationProcessor) clearExistingData(ctx context.Context) error {
-	// Delete all locations recursively (this will also delete areas, commodities, and commodity-linked files)
+	// Delete all locations recursively (this will also delete areas, commodities, and commodity-linked files+blobs).
 	locReg := l.factorySet.LocationRegistryFactory.CreateServiceRegistry()
 	locations, err := locReg.List(ctx)
 	if err != nil {
@@ -256,8 +259,9 @@ func (l *RestoreOperationProcessor) clearExistingData(ctx context.Context) error
 		}
 	}
 
-	// Sweep remaining files (location-/area-linked + standalone) — see the
-	// comment on this function for why DeleteLocationRecursive isn't enough.
+	// Sweep remaining files (location-/area-linked + standalone) along
+	// with their physical blobs and thumbnails — see the comment above
+	// for why DeleteLocationRecursive isn't enough on its own.
 	fileReg, err := l.factorySet.FileRegistryFactory.CreateUserRegistry(ctx)
 	if err != nil {
 		return errxtrace.Wrap("failed to create user file registry for clear", err)
@@ -266,15 +270,16 @@ func (l *RestoreOperationProcessor) clearExistingData(ctx context.Context) error
 	if err != nil {
 		return errxtrace.Wrap("failed to list files for deletion", err)
 	}
+	fileService := services.NewFileService(l.factorySet, l.uploadLocation)
 	for _, file := range files {
 		if file.LinkedEntityType == "export" {
 			continue
 		}
-		if err := fileReg.Delete(ctx, file.ID); err != nil {
+		if err := fileService.DeleteFileWithPhysical(ctx, file.ID); err != nil {
 			if errors.Is(err, registry.ErrNotFound) {
 				continue
 			}
-			return errxtrace.Wrap("failed to delete file row", err, errx.Attrs("file_id", file.ID))
+			return errxtrace.Wrap("failed to delete file row+blob", err, errx.Attrs("file_id", file.ID))
 		}
 	}
 
@@ -1183,12 +1188,53 @@ func (l *RestoreOperationProcessor) collectCommodityData(
 		if err := decoder.DecodeElement(&xmlCommodity.URLs, &t); err != nil {
 			return errxtrace.Wrap("failed to decode URLs", err)
 		}
+	case "images", "invoices", "manuals":
+		// Legacy commodity-scoped attachment sections were removed under
+		// #1421 along with the SQL tables they wrote to. Pre-cutover
+		// archives are not supported per ops (no production data
+		// pre-dates the cutover) — but a pre-cutover backup walked
+		// through the decoder would otherwise just silently drop its
+		// attachment data while reporting ErrorCount=0. We loud-fail
+		// here so the operator notices: the rest of the restore proceeds
+		// (commodities and other top-level sections still get their
+		// chance), but the operation ends with a clear error in
+		// stats.Errors and a nonzero ErrorCount.
+		stats.ErrorCount++
+		stats.Errors = append(stats.Errors, fmt.Sprintf(
+			"unsupported pre-cutover attachment section <%s> on commodity %s; restore the data via a backup created after PR #1485 instead",
+			t.Name.Local, xmlCommodity.ID,
+		))
+		// Skip the section's body so the surrounding <commodity> loop
+		// doesn't trip on the children as unknown elements.
+		if err := skipElement(decoder, t.Name.Local); err != nil {
+			return errxtrace.Wrap("failed to skip legacy attachment section", err)
+		}
 	}
-	// Legacy commodity-scoped <images>/<invoices>/<manuals> sections were
-	// removed under #1421 along with the SQL tables they wrote to.
-	// Pre-cutover archives are not supported per ops (no production data
-	// pre-dates the cutover) — encountering one falls through unhandled.
 
+	return nil
+}
+
+// skipElement walks the decoder until the matching </name> closes the
+// element identified by `name`. Used for explicit skip-with-error paths
+// where we want to consume the unknown element's body and continue
+// rather than abort.
+func skipElement(decoder *xml.Decoder, name string) error {
+	depth := 1
+	for depth > 0 {
+		tok, err := decoder.Token()
+		if err != nil {
+			return errxtrace.Wrap("failed to read token while skipping element", err)
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			depth++
+		case xml.EndElement:
+			depth--
+			if depth == 0 && t.Name.Local == name {
+				return nil
+			}
+		}
+	}
 	return nil
 }
 

--- a/go/backup/restore/restore_files_test.go
+++ b/go/backup/restore/restore_files_test.go
@@ -433,26 +433,155 @@ func TestExportRestore_SelectedItemsScope(t *testing.T) {
 
 // TestExportRestore_CrossTenantIsolation guards that the FileRegistry's
 // user-mode RLS context (memory mode mirrors the postgres behavior) keeps
-// tenant A's export from including tenant B's files. Both tenants share
-// the same FactorySet but each runs export under its own context.
+// tenant A's export from including tenant B's files.
+//
+// Both tenants share a single FactorySet so the test actually exercises
+// the registry's per-user filtering (the previous version used two
+// separate `memory.NewFactorySet()` instances, which gave each tenant
+// its own store and would have masked an RLS regression — flagged by
+// Copilot on PR #1493). Each user gets their own tenant + group; the
+// commodities, files, and export streams all run under a context
+// carrying the user's identity, and the resulting XML is asserted not
+// to leak rows belonging to the other tenant.
 func TestExportRestore_CrossTenantIsolation(t *testing.T) {
 	c := qt.New(t)
 
 	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
-	tenantA := newFileFixture(c)
-	aFile := tenantA.makeFile(c, "a-photo", "image/jpeg", "commodity", tenantA.commodity.ID, "images")
+	factorySet := memory.NewFactorySet()
 
-	// Build a separate fixture for tenant B (separate factory + context).
-	tenantB := newFileFixture(c)
-	bFile := tenantB.makeFile(c, "b-photo", "image/jpeg", "commodity", tenantB.commodity.ID, "images")
+	tenantA, ctxA := stampTenantWithCommodityFile(c, factorySet, "tenant-A", "a-photo")
+	tenantB, ctxB := stampTenantWithCommodityFile(c, factorySet, "tenant-B", "b-photo")
 
-	xmlA := tenantA.runExport(c, models.ExportTypeFullDatabase, false, uploadLocation)
-	xmlB := tenantB.runExport(c, models.ExportTypeFullDatabase, false, uploadLocation)
+	svc := export.NewExportService(factorySet, uploadLocation)
+	exportXMLForTenant := func(ctx context.Context, t *crossTenantHandle) []byte {
+		exp := models.Export{
+			TenantGroupAwareEntityID: models.WithTenantGroupAwareEntityID("xt-export-"+t.tenantID, t.tenantID, t.groupID, t.userID),
+			Type:                     models.ExportTypeFullDatabase,
+			Status:                   models.ExportStatusPending,
+			IncludeFileData:          false,
+		}
+		var buf bytes.Buffer
+		_, err := export.ExportXML(svc, ctx, exp, &buf)
+		c.Assert(err, qt.IsNil)
+		return buf.Bytes()
+	}
 
-	c.Assert(string(xmlA), qt.Contains, aFile.UUID)
-	c.Assert(string(xmlA), qt.Not(qt.Contains), bFile.UUID, qt.Commentf("tenant A export must not contain tenant B files"))
-	c.Assert(string(xmlB), qt.Contains, bFile.UUID)
-	c.Assert(string(xmlB), qt.Not(qt.Contains), aFile.UUID, qt.Commentf("tenant B export must not contain tenant A files"))
+	xmlA := exportXMLForTenant(ctxA, tenantA)
+	xmlB := exportXMLForTenant(ctxB, tenantB)
+
+	// Tenant A's export must contain only its own file UUID; tenant B's
+	// must contain only its own. A regression where the file registry
+	// stops filtering by tenant context (RLS bypass, accidental
+	// service-mode list, etc.) would surface here as a leaked UUID.
+	c.Assert(string(xmlA), qt.Contains, tenantA.fileUUID)
+	c.Assert(string(xmlA), qt.Not(qt.Contains), tenantB.fileUUID,
+		qt.Commentf("tenant A export must not contain tenant B files"))
+	c.Assert(string(xmlB), qt.Contains, tenantB.fileUUID)
+	c.Assert(string(xmlB), qt.Not(qt.Contains), tenantA.fileUUID,
+		qt.Commentf("tenant B export must not contain tenant A files"))
+}
+
+// crossTenantHandle bundles the IDs needed to drive an export under one
+// tenant's context inside the cross-tenant isolation test. Lives next
+// to the test that uses it; not exported.
+type crossTenantHandle struct {
+	tenantID    string
+	userID      string
+	groupID     string
+	commodityID string
+	fileUUID    string
+}
+
+// stampTenantWithCommodityFile creates a tenant + user + group + the
+// minimal location/area/commodity hierarchy needed for a commodity-
+// linked file to round-trip through export, in the supplied (shared)
+// FactorySet. Returns a handle with the IDs the test cares about and a
+// context carrying the user + group so the user-aware registries
+// produced via CreateUserRegistry are properly scoped.
+func stampTenantWithCommodityFile(c *qt.C, factorySet *registry.FactorySet, tenantSlug, fileTitle string) (*crossTenantHandle, context.Context) {
+	tenantID := tenantSlug
+	must.Must(factorySet.TenantRegistry.Create(c.Context(), models.Tenant{
+		EntityID: models.EntityID{ID: tenantID},
+		Name:     tenantSlug,
+	}))
+	user := must.Must(factorySet.UserRegistry.Create(c.Context(), models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Email:               tenantSlug + "@example.com",
+		Name:                tenantSlug,
+		IsActive:            true,
+	}))
+	ctx := ensureGroupForUser(c.Context(), factorySet, user)
+	group := appctx.GroupFromContext(ctx)
+	c.Assert(group, qt.IsNotNil)
+
+	purchaseDate := models.ToPDate(models.Date("2024-01-01"))
+	locReg := must.Must(factorySet.LocationRegistryFactory.CreateUserRegistry(ctx))
+	loc := must.Must(locReg.Create(ctx, models.Location{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        tenantID,
+			GroupID:         group.ID,
+			CreatedByUserID: user.ID,
+		},
+		Name: "HQ-" + tenantSlug,
+	}))
+	areaReg := must.Must(factorySet.AreaRegistryFactory.CreateUserRegistry(ctx))
+	area := must.Must(areaReg.Create(ctx, models.Area{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        tenantID,
+			GroupID:         group.ID,
+			CreatedByUserID: user.ID,
+		},
+		Name:       "Office-" + tenantSlug,
+		LocationID: loc.ID,
+	}))
+	comReg := must.Must(factorySet.CommodityRegistryFactory.CreateUserRegistry(ctx))
+	commodity := must.Must(comReg.Create(ctx, models.Commodity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        tenantID,
+			GroupID:         group.ID,
+			CreatedByUserID: user.ID,
+		},
+		Name:                  "Workstation-" + tenantSlug,
+		ShortName:             "WS",
+		AreaID:                area.ID,
+		Status:                models.CommodityStatusInUse,
+		Type:                  models.CommodityTypeElectronics,
+		Count:                 1,
+		OriginalPriceCurrency: models.Currency("USD"),
+		PurchaseDate:          purchaseDate,
+	}))
+	fileReg := must.Must(factorySet.FileRegistryFactory.CreateUserRegistry(ctx))
+	now := time.Now().UTC().Truncate(time.Second)
+	created := must.Must(fileReg.Create(ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        tenantID,
+			GroupID:         group.ID,
+			CreatedByUserID: user.ID,
+		},
+		Title:            fileTitle,
+		Type:             models.FileTypeImage,
+		Category:         models.FileCategoryPhotos,
+		Tags:             models.StringSlice{},
+		LinkedEntityType: "commodity",
+		LinkedEntityID:   commodity.ID,
+		LinkedEntityMeta: "images",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		File: &models.File{
+			Path:         fileTitle,
+			OriginalPath: fileTitle + ".jpg",
+			Ext:          ".jpg",
+			MIMEType:     "image/jpeg",
+		},
+	}))
+
+	return &crossTenantHandle{
+		tenantID:    tenantID,
+		userID:      user.ID,
+		groupID:     group.ID,
+		commodityID: commodity.ID,
+		fileUUID:    created.UUID,
+	}, ctx
 }
 
 // writeBlob is a thin wrapper over the gocloud blob bucket so tests can
@@ -647,6 +776,143 @@ func TestExportRestore_FullReplaceClearsOrphanBlobs(t *testing.T) {
 	exists, err = bucket.Exists(c.Context(), bundleFile.OriginalPath)
 	c.Assert(err, qt.IsNil)
 	c.Assert(exists, qt.IsTrue, qt.Commentf("export-linked bundle blob must NOT be deleted by FullReplace"))
+}
+
+// TestExportRestore_MergeAddDoesNotOverwriteExistingBlob covers the
+// blob-write-vs-decide ordering called out by Copilot on PR #1493.
+// Before the fix, decodeFileElement streamed <data> into the bucket
+// at xmlFile.OriginalPath BEFORE the strategy handler decided whether
+// to skip the row; in MergeAdd, an already-present file UUID would
+// have its blob clobbered even though the row is skipped.
+//
+// This test stamps a file row + custom blob bytes in the destination
+// matching the source's UUID + OriginalPath, then runs MergeAdd. The
+// row count must stay at 1 (skip), and the destination blob bytes
+// must be the destination's original payload — not the source's.
+func TestExportRestore_MergeAddDoesNotOverwriteExistingBlob(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	src := newFileFixture(c)
+
+	// Source side: a commodity-linked file with known bytes.
+	srcFile := src.makeFile(c, "shared", "image/jpeg", "commodity", src.commodity.ID, "images")
+	writeBlob(c, uploadLocation, srcFile.OriginalPath, []byte("source-bytes"))
+
+	xmlBytes := src.runExport(c, models.ExportTypeFullDatabase, true, uploadLocation)
+
+	// Destination side: pre-stamp a file with the SAME UUID +
+	// OriginalPath but DIFFERENT bytes. The dst fixture's
+	// commodity has a different DB ID but the same UUID lifecycle
+	// is irrelevant here — we're testing the file dedup path.
+	dst := newFileFixture(c)
+	dstFileReg := must.Must(dst.factorySet.FileRegistryFactory.CreateUserRegistry(dst.ctx))
+	preExisting := must.Must(dstFileReg.Create(dst.ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			EntityID:        models.EntityID{UUID: srcFile.UUID},
+			TenantID:        dst.tenantID,
+			GroupID:         dst.groupID,
+			CreatedByUserID: dst.userID,
+		},
+		Title:            "destination-original",
+		Type:             models.FileTypeImage,
+		Category:         models.FileCategoryPhotos,
+		Tags:             models.StringSlice{},
+		LinkedEntityType: "commodity",
+		LinkedEntityID:   dst.commodity.ID,
+		LinkedEntityMeta: "images",
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+		File: &models.File{
+			Path:         srcFile.Path,
+			OriginalPath: srcFile.OriginalPath,
+			Ext:          srcFile.Ext,
+			MIMEType:     srcFile.MIMEType,
+		},
+	}))
+	c.Assert(preExisting.UUID, qt.Equals, srcFile.UUID)
+	writeBlob(c, uploadLocation, srcFile.OriginalPath, []byte("destination-bytes"))
+
+	proc := processor.NewRestoreOperationProcessor(
+		"restore-1485-mergeadd-dedup",
+		dst.factorySet,
+		services.NewEntityService(dst.factorySet, uploadLocation),
+		uploadLocation,
+	)
+	stats, err := proc.RestoreFromXML(dst.ctx, bytes.NewReader(xmlBytes), types.RestoreOptions{
+		Strategy:        types.RestoreStrategyMergeAdd,
+		IncludeFileData: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.ErrorCount, qt.Equals, 0, qt.Commentf("restore errors: %v", stats.Errors))
+
+	// MergeAdd must have classified the duplicate as Skipped (not
+	// Created or Updated) — and the bytes on disk must still be the
+	// destination's, not the source's.
+	c.Assert(stats.SkippedCount > 0, qt.IsTrue, qt.Commentf("file with existing UUID should classify as skipped"))
+	c.Assert(readBlob(c, uploadLocation, srcFile.OriginalPath), qt.DeepEquals, []byte("destination-bytes"),
+		qt.Commentf("MergeAdd dedup must not clobber the destination's existing blob"))
+}
+
+// TestExportRestore_DropsBlobOnUnresolvedLinkedEntity covers the second
+// half of Copilot's blob-eager-write concern: when a file references a
+// commodity / location / area that wasn't included in the same export
+// (so the IDMapping has nothing to resolve to), the row will be
+// rejected as `failed to process file: file ... references unknown
+// commodity ...`. Pre-fix, decodeFileElement still wrote the blob to
+// the bucket before that rejection — leaving an orphan blob with no
+// row pointing at it. The fix routes the <data> chardata into
+// io.Discard for that case.
+func TestExportRestore_DropsBlobOnUnresolvedLinkedEntity(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	dst := newFileFixture(c)
+
+	// Synthesize a <files>-only XML referencing a commodity UUID that
+	// isn't in the destination. The restore will reject the file row
+	// with an "unknown commodity" error, but the bucket must stay
+	// empty — the blob must NOT be written before the rejection.
+	const orphanFileUUID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+	const unknownCommodityUUID = "00000000-0000-0000-0000-deadbeefdead"
+	const orphanBlobKey = "orphan-blob-1745678901.jpg"
+	xmlContent := `<?xml version="1.0" encoding="UTF-8"?>
+<inventory exportType="full_database">
+  <files>
+    <file id="` + orphanFileUUID + `">
+      <linkedEntityType>commodity</linkedEntityType>
+      <linkedEntityId>` + unknownCommodityUUID + `</linkedEntityId>
+      <linkedEntityMeta>images</linkedEntityMeta>
+      <type>image</type>
+      <category>photos</category>
+      <path>orphan-blob</path>
+      <originalPath>` + orphanBlobKey + `</originalPath>
+      <extension>.jpg</extension>
+      <mimeType>image/jpeg</mimeType>
+      <data>b3JwaGFu</data>
+    </file>
+  </files>
+</inventory>`
+
+	proc := processor.NewRestoreOperationProcessor(
+		"restore-1485-orphan",
+		dst.factorySet,
+		services.NewEntityService(dst.factorySet, uploadLocation),
+		uploadLocation,
+	)
+	stats, err := proc.RestoreFromXML(dst.ctx, strings.NewReader(xmlContent), types.RestoreOptions{
+		Strategy:        types.RestoreStrategyMergeAdd,
+		IncludeFileData: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.ErrorCount > 0, qt.IsTrue, qt.Commentf("expected an error for the unresolved linked-entity reference"))
+
+	// Bucket must NOT contain the orphan blob.
+	bucket := must.Must(blob.OpenBucket(c.Context(), uploadLocation))
+	defer bucket.Close()
+	exists, err := bucket.Exists(c.Context(), orphanBlobKey)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsFalse, qt.Commentf("blob must not be written when linked-entity resolution fails"))
 }
 
 // Compile-time guard: keep us honest about the shape of types.RestoreStats.

--- a/go/backup/restore/restore_files_test.go
+++ b/go/backup/restore/restore_files_test.go
@@ -459,5 +459,111 @@ func readBlob(c *qt.C, uploadLocation, key string) []byte {
 	return out
 }
 
+// TestExportRestore_LargeBlobStreamingRoundTrip exercises the chunked
+// base64 encode/decode path on a blob that's deliberately larger than the
+// 32 KiB chunk size used by streamBase64Content / xmlChardataReader.
+//
+// What this proves:
+//   - Export streams the blob through xmlBase64Writer in chunks (the
+//     `<data>` element doesn't crash when the chardata size exceeds one
+//     CharData token's natural size).
+//   - Restore's xmlChardataReader reassembles arbitrary chardata-token
+//     boundaries (Go's xml.Decoder may split chardata across tokens at
+//     internal buffer boundaries — pretty-print whitespace also splits).
+//   - The base64 round-trip is byte-identical for non-trivial payloads.
+//
+// What this DOES NOT prove (and would need a separate benchmark/profile):
+//   - That memory residency stays bounded at chunk-size during the
+//     transfer. The streaming path's *correctness* is testable here;
+//     its *memory profile* is best verified with `go test -benchmem`
+//     against a multi-MB blob, which is out of scope for this unit.
+func TestExportRestore_LargeBlobStreamingRoundTrip(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	src := newFileFixture(c)
+
+	// 200 KiB of pseudo-random-looking bytes — large enough to span
+	// multiple 32 KiB chunks AND multiple xml.Decoder Token() reads.
+	// Using a byte ramp so any ordering corruption is visible.
+	const blobSize = 200 * 1024
+	bigBlob := make([]byte, blobSize)
+	for i := range bigBlob {
+		bigBlob[i] = byte(i % 251) // 251 is prime → avoids alignment with 32 KiB
+	}
+
+	bigFile := src.makeFile(c, "big-photo", "image/jpeg", "commodity", src.commodity.ID, "images")
+	writeBlob(c, uploadLocation, bigFile.OriginalPath, bigBlob)
+
+	xmlBytes := src.runExport(c, models.ExportTypeFullDatabase, true, uploadLocation)
+	c.Assert(string(xmlBytes), qt.Contains, "<data>")
+	c.Assert(string(xmlBytes), qt.Contains, "</data>")
+
+	// Restore on a fresh fixture using a SEPARATE bucket so we can verify
+	// the blob lands at the same OriginalPath as the source.
+	restoreLocation := "file://" + c.TempDir() + "?create_dir=1"
+	dst := newFileFixture(c)
+	proc := processor.NewRestoreOperationProcessor(
+		"restore-1485-large",
+		dst.factorySet,
+		services.NewEntityService(dst.factorySet, restoreLocation),
+		restoreLocation,
+	)
+	stats, err := proc.RestoreFromXML(dst.ctx, bytes.NewReader(xmlBytes), types.RestoreOptions{
+		Strategy:        types.RestoreStrategyFullReplace,
+		IncludeFileData: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.ErrorCount, qt.Equals, 0, qt.Commentf("restore errors: %v", stats.Errors))
+	c.Assert(stats.FileCount, qt.Equals, 1)
+	c.Assert(stats.BinaryDataSize, qt.Equals, int64(blobSize))
+
+	got := readBlob(c, restoreLocation, bigFile.OriginalPath)
+	c.Assert(len(got), qt.Equals, blobSize)
+	c.Assert(bytes.Equal(got, bigBlob), qt.IsTrue, qt.Commentf("blob bytes corrupted across streaming round-trip"))
+}
+
+// TestExportRestore_DryRunSkipsBlobWrite covers the DryRun branch on the
+// restore side: the streaming decoder still drains the <data> chardata
+// (so BinaryDataSize is reported for preview) but the destination bucket
+// stays empty.
+func TestExportRestore_DryRunSkipsBlobWrite(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	src := newFileFixture(c)
+	srcFile := src.makeFile(c, "preview", "image/jpeg", "commodity", src.commodity.ID, "images")
+	writeBlob(c, uploadLocation, srcFile.OriginalPath, []byte("preview-bytes"))
+
+	xmlBytes := src.runExport(c, models.ExportTypeFullDatabase, true, uploadLocation)
+
+	// Restore into a fresh empty bucket with DryRun=true. We use MergeAdd
+	// so the existing fixture commodity hierarchy is treated as already-
+	// present and validation falls through cleanly.
+	restoreLocation := "file://" + c.TempDir() + "?create_dir=1"
+	dst := newFileFixture(c)
+	proc := processor.NewRestoreOperationProcessor(
+		"restore-1485-dryrun",
+		dst.factorySet,
+		services.NewEntityService(dst.factorySet, restoreLocation),
+		restoreLocation,
+	)
+	stats, err := proc.RestoreFromXML(dst.ctx, bytes.NewReader(xmlBytes), types.RestoreOptions{
+		Strategy:        types.RestoreStrategyMergeAdd,
+		IncludeFileData: true,
+		DryRun:          true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.BinaryDataSize, qt.Equals, int64(len("preview-bytes")), qt.Commentf("dry-run should still surface decoded byte count"))
+
+	// Bucket must be empty — no row was created, no blob was written.
+	bucket, err := blob.OpenBucket(c.Context(), restoreLocation)
+	c.Assert(err, qt.IsNil)
+	defer bucket.Close()
+	exists, err := bucket.Exists(c.Context(), srcFile.OriginalPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsFalse, qt.Commentf("DryRun must not write blobs to the destination bucket"))
+}
+
 // Compile-time guard: keep us honest about the shape of types.RestoreStats.
 var _ = exporttypes.ExportStats{FileCount: 0}

--- a/go/backup/restore/restore_files_test.go
+++ b/go/backup/restore/restore_files_test.go
@@ -309,16 +309,23 @@ func TestExportRestore_ExcludesExportLinkedFiles(t *testing.T) {
 	c.Assert(bundleFile.LinkedEntityType, qt.Equals, "export")
 
 	xmlBytes := src.runExport(c, models.ExportTypeFullDatabase, false, uploadLocation)
-	c.Assert(strings.Contains(string(xmlBytes), bundleFile.UUID), qt.IsFalse,
+	c.Assert(string(xmlBytes), qt.Not(qt.Contains), bundleFile.UUID,
 		qt.Commentf("export-linked files must not be emitted in <files>"))
 }
 
-// TestExportRestore_LegacyAttachmentSectionsIgnored is the regression guard
-// for "drop the silent-skip code". A backup containing the pre-cutover
-// <images>/<invoices>/<manuals> commodity sections must parse cleanly
-// (no unknown-token errors, no panics) — they're simply ignored as the
-// surrounding commodity decoding falls through them.
-func TestExportRestore_LegacyAttachmentSectionsIgnored(t *testing.T) {
+// TestExportRestore_LegacyAttachmentSectionsRecorded is the regression
+// guard for the loud-fail policy on pre-cutover archives. A backup
+// carrying the legacy <images>/<invoices>/<manuals> commodity sections
+// must parse without panics, but each occurrence has to surface as a
+// stats.Errors entry with stats.ErrorCount incremented — silently
+// dropping their data with ErrorCount=0 misled operators into thinking
+// the legacy backup was restored intact (Copilot review on PR #1493).
+//
+// The surrounding commodity is still created (we don't abort the
+// commodity row over a legacy attachment section) so the rest of the
+// restore continues; only the attachment data is dropped, with the
+// operator informed.
+func TestExportRestore_LegacyAttachmentSectionsRecorded(t *testing.T) {
 	c := qt.New(t)
 
 	dst := newFileFixture(c)
@@ -375,9 +382,20 @@ func TestExportRestore_LegacyAttachmentSectionsIgnored(t *testing.T) {
 		Strategy: types.RestoreStrategyFullReplace,
 	})
 	c.Assert(err, qt.IsNil)
-	c.Assert(stats.ErrorCount, qt.Equals, 0, qt.Commentf("restore errors: %v", stats.Errors))
-	c.Assert(stats.CommodityCount, qt.Equals, 1)
+
+	// One commodity, three legacy attachment sections → ErrorCount==3.
+	c.Assert(stats.ErrorCount, qt.Equals, 3,
+		qt.Commentf("expected one error per legacy <images>/<invoices>/<manuals> section, got %v", stats.Errors))
+	c.Assert(stats.CommodityCount, qt.Equals, 1, qt.Commentf("commodity itself still restored"))
 	c.Assert(stats.FileCount, qt.Equals, 0, qt.Commentf("legacy attachment sections must NOT count as files"))
+
+	// Each error message points at the section name AND the commodity ID
+	// so an operator can find the offending row in the source backup.
+	joined := strings.Join(stats.Errors, "\n")
+	c.Assert(joined, qt.Contains, "<images>")
+	c.Assert(joined, qt.Contains, "<invoices>")
+	c.Assert(joined, qt.Contains, "<manuals>")
+	c.Assert(joined, qt.Contains, "cccccccc-cccc-cccc-cccc-cccccccccccc")
 }
 
 // TestExportRestore_SelectedItemsScope verifies that ExportTypeSelectedItems
@@ -409,8 +427,8 @@ func TestExportRestore_SelectedItemsScope(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	out := buf.String()
-	c.Assert(strings.Contains(out, wantedFile.UUID), qt.IsTrue, qt.Commentf("commodity-linked file should be in scope"))
-	c.Assert(strings.Contains(out, otherFile.UUID), qt.IsFalse, qt.Commentf("standalone file should NOT be in selected_items scope"))
+	c.Assert(out, qt.Contains, wantedFile.UUID, qt.Commentf("commodity-linked file should be in scope"))
+	c.Assert(out, qt.Not(qt.Contains), otherFile.UUID, qt.Commentf("standalone file should NOT be in selected_items scope"))
 }
 
 // TestExportRestore_CrossTenantIsolation guards that the FileRegistry's
@@ -431,10 +449,10 @@ func TestExportRestore_CrossTenantIsolation(t *testing.T) {
 	xmlA := tenantA.runExport(c, models.ExportTypeFullDatabase, false, uploadLocation)
 	xmlB := tenantB.runExport(c, models.ExportTypeFullDatabase, false, uploadLocation)
 
-	c.Assert(strings.Contains(string(xmlA), aFile.UUID), qt.IsTrue)
-	c.Assert(strings.Contains(string(xmlA), bFile.UUID), qt.IsFalse, qt.Commentf("tenant A export must not contain tenant B files"))
-	c.Assert(strings.Contains(string(xmlB), bFile.UUID), qt.IsTrue)
-	c.Assert(strings.Contains(string(xmlB), aFile.UUID), qt.IsFalse, qt.Commentf("tenant B export must not contain tenant A files"))
+	c.Assert(string(xmlA), qt.Contains, aFile.UUID)
+	c.Assert(string(xmlA), qt.Not(qt.Contains), bFile.UUID, qt.Commentf("tenant A export must not contain tenant B files"))
+	c.Assert(string(xmlB), qt.Contains, bFile.UUID)
+	c.Assert(string(xmlB), qt.Not(qt.Contains), aFile.UUID, qt.Commentf("tenant B export must not contain tenant A files"))
 }
 
 // writeBlob is a thin wrapper over the gocloud blob bucket so tests can
@@ -519,7 +537,7 @@ func TestExportRestore_LargeBlobStreamingRoundTrip(t *testing.T) {
 	c.Assert(stats.BinaryDataSize, qt.Equals, int64(blobSize))
 
 	got := readBlob(c, restoreLocation, bigFile.OriginalPath)
-	c.Assert(len(got), qt.Equals, blobSize)
+	c.Assert(got, qt.HasLen, blobSize)
 	c.Assert(bytes.Equal(got, bigBlob), qt.IsTrue, qt.Commentf("blob bytes corrupted across streaming round-trip"))
 }
 
@@ -563,6 +581,72 @@ func TestExportRestore_DryRunSkipsBlobWrite(t *testing.T) {
 	exists, err := bucket.Exists(c.Context(), srcFile.OriginalPath)
 	c.Assert(err, qt.IsNil)
 	c.Assert(exists, qt.IsFalse, qt.Commentf("DryRun must not write blobs to the destination bucket"))
+}
+
+// TestExportRestore_FullReplaceClearsOrphanBlobs guards the cleanup
+// behavior flagged on PR #1493: a FullReplace restore must wipe both
+// the row AND the physical blob for non-export files in the
+// destination, otherwise repeated restores leak storage and stale
+// thumbnails. Commodity-linked files cascade through
+// EntityService.DeleteCommodityRecursive (covered by existing tests);
+// this case verifies the second-pass sweep that catches
+// location-/area-linked + standalone files.
+func TestExportRestore_FullReplaceClearsOrphanBlobs(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	dst := newFileFixture(c)
+
+	// Stamp pre-existing data in the destination: a standalone file row
+	// + its physical blob. After FullReplace these must both be gone.
+	preExisting := dst.makeFile(c, "stale", "image/jpeg", "", "", "")
+	writeBlob(c, uploadLocation, preExisting.OriginalPath, []byte("stale-bytes"))
+
+	// And keep an export-linked file around so we can verify it's NOT
+	// touched (DeleteFileWithPhysical would race with the restore-input
+	// FK if we deleted the bundle the restore is reading from).
+	bundleFile := dst.makeFile(c, "bundle", "application/xml", "export", "stash-export", "xml-1.0")
+	writeBlob(c, uploadLocation, bundleFile.OriginalPath, []byte("bundle-bytes"))
+
+	// Empty-files XML (we just want to exercise clearExistingData via
+	// the FullReplace strategy entry point — no <files> to restore).
+	xmlContent := `<?xml version="1.0" encoding="UTF-8"?>
+<inventory exportType="full_database">
+  <locations></locations>
+  <areas></areas>
+  <commodities></commodities>
+  <files></files>
+</inventory>`
+
+	proc := processor.NewRestoreOperationProcessor(
+		"restore-1485-clear",
+		dst.factorySet,
+		services.NewEntityService(dst.factorySet, uploadLocation),
+		uploadLocation,
+	)
+	stats, err := proc.RestoreFromXML(dst.ctx, strings.NewReader(xmlContent), types.RestoreOptions{
+		Strategy: types.RestoreStrategyFullReplace,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.ErrorCount, qt.Equals, 0, qt.Commentf("restore errors: %v", stats.Errors))
+
+	// Pre-existing standalone row + blob both gone.
+	dstFileReg := must.Must(dst.factorySet.FileRegistryFactory.CreateUserRegistry(dst.ctx))
+	_, err = dstFileReg.Get(dst.ctx, preExisting.ID)
+	c.Assert(err, qt.IsNotNil, qt.Commentf("standalone row should be deleted"))
+	bucket := must.Must(blob.OpenBucket(c.Context(), uploadLocation))
+	defer bucket.Close()
+	exists, err := bucket.Exists(c.Context(), preExisting.OriginalPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsFalse, qt.Commentf("orphan standalone blob should be deleted from bucket"))
+
+	// Bundle (export-linked) file untouched: row still present, blob still there.
+	got, err := dstFileReg.Get(dst.ctx, bundleFile.ID)
+	c.Assert(err, qt.IsNil, qt.Commentf("export-linked bundle row must NOT be deleted by FullReplace"))
+	c.Assert(got.UUID, qt.Equals, bundleFile.UUID)
+	exists, err = bucket.Exists(c.Context(), bundleFile.OriginalPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exists, qt.IsTrue, qt.Commentf("export-linked bundle blob must NOT be deleted by FullReplace"))
 }
 
 // Compile-time guard: keep us honest about the shape of types.RestoreStats.

--- a/go/backup/restore/restore_files_test.go
+++ b/go/backup/restore/restore_files_test.go
@@ -1,0 +1,463 @@
+package restore_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"gocloud.dev/blob"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/backup/export"
+	exporttypes "github.com/denisvmedia/inventario/backup/export/types"
+	"github.com/denisvmedia/inventario/backup/restore/processor"
+	"github.com/denisvmedia/inventario/backup/restore/types"
+	_ "github.com/denisvmedia/inventario/internal/fileblob" // register fileblob driver
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// fileFixture is a per-test helper that builds a complete backup environment:
+// tenant, user, group, location, area, commodity, plus a few unified files
+// linked to the commodity / location / standalone. Returns the factory, the
+// authenticated context, and direct DB IDs for assertions.
+type fileFixture struct {
+	factorySet *registry.FactorySet
+	ctx        context.Context
+	tenantID   string
+	userID     string
+	groupID    string
+	locationID string
+	areaID     string
+	commodity  *models.Commodity
+}
+
+func newFileFixture(c *qt.C) *fileFixture {
+	user := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: "tenant-1485"},
+		Email:               "1485@example.com",
+		Name:                "File Restore User",
+		IsActive:            true,
+	}
+	tenant := models.Tenant{
+		EntityID: models.EntityID{ID: "tenant-1485"},
+		Name:     "Tenant 1485",
+	}
+
+	factorySet := memory.NewFactorySet()
+	must.Must(factorySet.TenantRegistry.Create(c.Context(), tenant))
+	createdUser := must.Must(factorySet.UserRegistry.Create(c.Context(), user))
+	ctx := ensureGroupForUser(c.Context(), factorySet, createdUser)
+	group := appctx.GroupFromContext(ctx)
+	c.Assert(group, qt.IsNotNil)
+
+	// Stamp a minimal hierarchy so files can be linked to real entities.
+	locReg := must.Must(factorySet.LocationRegistryFactory.CreateUserRegistry(ctx))
+	loc := must.Must(locReg.Create(ctx, models.Location{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        createdUser.TenantID,
+			GroupID:         group.ID,
+			CreatedByUserID: createdUser.ID,
+		},
+		Name:    "HQ",
+		Address: "1 Main",
+	}))
+	areaReg := must.Must(factorySet.AreaRegistryFactory.CreateUserRegistry(ctx))
+	area := must.Must(areaReg.Create(ctx, models.Area{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        createdUser.TenantID,
+			GroupID:         group.ID,
+			CreatedByUserID: createdUser.ID,
+		},
+		Name:       "Office",
+		LocationID: loc.ID,
+	}))
+	purchaseDate := models.ToPDate(models.Date("2024-01-01"))
+	comReg := must.Must(factorySet.CommodityRegistryFactory.CreateUserRegistry(ctx))
+	commodity := must.Must(comReg.Create(ctx, models.Commodity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        createdUser.TenantID,
+			GroupID:         group.ID,
+			CreatedByUserID: createdUser.ID,
+		},
+		Name:                  "Workstation",
+		ShortName:             "WS",
+		AreaID:                area.ID,
+		Status:                models.CommodityStatusInUse,
+		Type:                  models.CommodityTypeElectronics,
+		Count:                 1,
+		OriginalPriceCurrency: models.Currency("USD"),
+		PurchaseDate:          purchaseDate,
+	}))
+
+	return &fileFixture{
+		factorySet: factorySet,
+		ctx:        ctx,
+		tenantID:   createdUser.TenantID,
+		userID:     createdUser.ID,
+		groupID:    group.ID,
+		locationID: loc.ID,
+		areaID:     area.ID,
+		commodity:  commodity,
+	}
+}
+
+// makeFile creates a unified file row in the fixture's group with the given
+// link metadata. Returns the created row so the test can assert UUID parity
+// after round-trip.
+func (f *fileFixture) makeFile(c *qt.C, title, mime, linkedType, linkedID, linkedMeta string, tags ...string) *models.FileEntity {
+	now := time.Now().UTC().Truncate(time.Second)
+	fileReg := must.Must(f.factorySet.FileRegistryFactory.CreateUserRegistry(f.ctx))
+	created := must.Must(fileReg.Create(f.ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        f.tenantID,
+			GroupID:         f.groupID,
+			CreatedByUserID: f.userID,
+		},
+		Title:            title,
+		Description:      "for-1485",
+		Type:             models.FileTypeFromMIME(mime),
+		Category:         models.FileCategoryFromContext(linkedType, linkedMeta, mime),
+		Tags:             models.StringSlice(tags),
+		LinkedEntityType: linkedType,
+		LinkedEntityID:   linkedID,
+		LinkedEntityMeta: linkedMeta,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		File: &models.File{
+			Path:         "blob-" + title,
+			OriginalPath: "blob-" + title + ".bin",
+			Ext:          ".bin",
+			MIMEType:     mime,
+		},
+	}))
+	c.Assert(created.UUID, qt.Not(qt.Equals), "")
+	return created
+}
+
+// runExport drives the export service against the fixture's group and
+// returns the generated XML bytes — sidestepping the file-bucket round-trip
+// that ProcessExport does. We don't need that here because the round-trip
+// tests all read the XML directly into the restore processor.
+func (f *fileFixture) runExport(c *qt.C, exportType models.ExportType, includeFileData bool, uploadLocation string) []byte {
+	svc := export.NewExportService(f.factorySet, uploadLocation)
+	exp := models.Export{
+		TenantGroupAwareEntityID: models.WithTenantGroupAwareEntityID("export-1485", f.tenantID, f.groupID, f.userID),
+		Type:                     exportType,
+		Status:                   models.ExportStatusPending,
+		IncludeFileData:          includeFileData,
+	}
+	var buf bytes.Buffer
+	stats, err := export.ExportXML(svc, f.ctx, exp, &buf)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats, qt.IsNotNil)
+	return buf.Bytes()
+}
+
+// TestExportRestore_FileRoundTrip is the headline acceptance test for #1485.
+// Creates a hierarchy with three files (a commodity-linked image, a
+// commodity-linked invoice, and a standalone document), exports the entire
+// group, full-replaces into a fresh fixture, and verifies that every file
+// reappears with original metadata + remapped linked_entity_id pointing at
+// the new commodity DB row.
+func TestExportRestore_FileRoundTrip(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+
+	// --- Source group: three files of mixed categories.
+	src := newFileFixture(c)
+	commImage := src.makeFile(c, "photo", "image/jpeg", "commodity", src.commodity.ID, "images", "photos")
+	commInvoice := src.makeFile(c, "invoice", "application/pdf", "commodity", src.commodity.ID, "invoices", "billing")
+	standalone := src.makeFile(c, "guide", "text/plain", "", "", "")
+
+	// Drop a real blob alongside one of the rows so includeFileData=true
+	// has something to base64-encode on the way out. We use the same key
+	// the FileEntity recorded on creation so the export reads it back.
+	writeBlob(c, uploadLocation, commImage.OriginalPath, []byte("image-bytes"))
+	writeBlob(c, uploadLocation, commInvoice.OriginalPath, []byte("invoice-bytes"))
+	writeBlob(c, uploadLocation, standalone.OriginalPath, []byte("guide-bytes"))
+
+	xmlBytes := src.runExport(c, models.ExportTypeFullDatabase, true, uploadLocation)
+	c.Assert(string(xmlBytes), qt.Contains, "<files>")
+	c.Assert(string(xmlBytes), qt.Contains, "<file id=\""+commImage.UUID+"\"")
+	c.Assert(string(xmlBytes), qt.Contains, "<linkedEntityType>commodity</linkedEntityType>")
+	c.Assert(string(xmlBytes), qt.Contains, "<linkedEntityId>"+src.commodity.UUID+"</linkedEntityId>")
+
+	// --- Destination group: empty, then restore.
+	dst := newFileFixture(c)
+	// Wipe the destination's hierarchy so FullReplace can stamp the
+	// XML's UUIDs in cleanly. The fixture pre-stamped one
+	// location/area/commodity per the helper convention; the source XML
+	// will recreate equivalent ones with the source UUIDs.
+	dstStartCommodities := must.Must(must.Must(dst.factorySet.CommodityRegistryFactory.CreateUserRegistry(dst.ctx)).List(dst.ctx))
+	c.Assert(dstStartCommodities, qt.HasLen, 1)
+
+	proc := processor.NewRestoreOperationProcessor(
+		"restore-1485",
+		dst.factorySet,
+		services.NewEntityService(dst.factorySet, uploadLocation),
+		uploadLocation,
+	)
+	stats, err := proc.RestoreFromXML(dst.ctx, bytes.NewReader(xmlBytes), types.RestoreOptions{
+		Strategy:        types.RestoreStrategyFullReplace,
+		IncludeFileData: true,
+		DryRun:          false,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.ErrorCount, qt.Equals, 0, qt.Commentf("restore errors: %v", stats.Errors))
+	c.Assert(stats.FileCount, qt.Equals, 3)
+	c.Assert(stats.BinaryDataSize, qt.Equals, int64(len("image-bytes")+len("invoice-bytes")+len("guide-bytes")))
+
+	// --- Assertions: files reconstructed with original metadata + remapped IDs.
+	dstFileReg := must.Must(dst.factorySet.FileRegistryFactory.CreateUserRegistry(dst.ctx))
+	dstFiles := must.Must(dstFileReg.List(dst.ctx))
+	c.Assert(dstFiles, qt.HasLen, 3)
+
+	byUUID := make(map[string]*models.FileEntity, len(dstFiles))
+	for _, f := range dstFiles {
+		byUUID[f.UUID] = f
+	}
+
+	// Find the new commodity DB id (UUID == source commodity UUID).
+	dstCommReg := must.Must(dst.factorySet.CommodityRegistryFactory.CreateUserRegistry(dst.ctx))
+	dstCommodities := must.Must(dstCommReg.List(dst.ctx))
+	var newCommodityID string
+	for _, com := range dstCommodities {
+		if com.UUID == src.commodity.UUID {
+			newCommodityID = com.ID
+			break
+		}
+	}
+	c.Assert(newCommodityID, qt.Not(qt.Equals), "")
+
+	// Photo: linked to remapped commodity DB id, category=photos, tags preserved.
+	photo := byUUID[commImage.UUID]
+	c.Assert(photo, qt.IsNotNil)
+	c.Assert(photo.LinkedEntityType, qt.Equals, "commodity")
+	c.Assert(photo.LinkedEntityID, qt.Equals, newCommodityID, qt.Commentf("expected commodity ID remap"))
+	c.Assert(photo.LinkedEntityMeta, qt.Equals, "images")
+	c.Assert(photo.Category, qt.Equals, models.FileCategoryPhotos)
+	c.Assert([]string(photo.Tags), qt.DeepEquals, []string{"photos"})
+
+	// Invoice: same commodity, different meta + category.
+	invoice := byUUID[commInvoice.UUID]
+	c.Assert(invoice, qt.IsNotNil)
+	c.Assert(invoice.LinkedEntityType, qt.Equals, "commodity")
+	c.Assert(invoice.LinkedEntityID, qt.Equals, newCommodityID)
+	c.Assert(invoice.LinkedEntityMeta, qt.Equals, "invoices")
+	c.Assert(invoice.Category, qt.Equals, models.FileCategoryInvoices)
+
+	// Standalone: no link, no remap.
+	guide := byUUID[standalone.UUID]
+	c.Assert(guide, qt.IsNotNil)
+	c.Assert(guide.LinkedEntityType, qt.Equals, "")
+	c.Assert(guide.LinkedEntityID, qt.Equals, "")
+
+	// Blob round-trip: restored bucket has the same bytes.
+	c.Assert(readBlob(c, uploadLocation, commImage.OriginalPath), qt.DeepEquals, []byte("image-bytes"))
+	c.Assert(readBlob(c, uploadLocation, commInvoice.OriginalPath), qt.DeepEquals, []byte("invoice-bytes"))
+	c.Assert(readBlob(c, uploadLocation, standalone.OriginalPath), qt.DeepEquals, []byte("guide-bytes"))
+}
+
+// TestExportRestore_EmptyFileSection covers the empty-export AC: a group
+// with zero files emits an empty <files> section (rather than crashing or
+// producing malformed XML), and the restore-side accepts it cleanly.
+func TestExportRestore_EmptyFileSection(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	src := newFileFixture(c)
+
+	xmlBytes := src.runExport(c, models.ExportTypeFullDatabase, false, uploadLocation)
+	c.Assert(string(xmlBytes), qt.Contains, "<files>")
+	c.Assert(string(xmlBytes), qt.Contains, "</files>")
+
+	dst := newFileFixture(c)
+	proc := processor.NewRestoreOperationProcessor(
+		"restore-1485-empty",
+		dst.factorySet,
+		services.NewEntityService(dst.factorySet, uploadLocation),
+		uploadLocation,
+	)
+	stats, err := proc.RestoreFromXML(dst.ctx, bytes.NewReader(xmlBytes), types.RestoreOptions{
+		Strategy: types.RestoreStrategyFullReplace,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.FileCount, qt.Equals, 0)
+}
+
+// TestExportRestore_ExcludesExportLinkedFiles guards the rule that the
+// export's own backup-bundle FileEntity (linked_entity_type="export") does
+// NOT appear inside the <files> section it itself produces — that would
+// create a self-reference that the restore can't reconstruct safely.
+func TestExportRestore_ExcludesExportLinkedFiles(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	src := newFileFixture(c)
+
+	// Stamp an export-linked file directly. ProcessExport would create
+	// one for the bundle, but here we just want to verify the filter.
+	bundleFile := src.makeFile(c, "bundle", "application/xml", "export", "some-export-id", "xml-1.0")
+	c.Assert(bundleFile.LinkedEntityType, qt.Equals, "export")
+
+	xmlBytes := src.runExport(c, models.ExportTypeFullDatabase, false, uploadLocation)
+	c.Assert(strings.Contains(string(xmlBytes), bundleFile.UUID), qt.IsFalse,
+		qt.Commentf("export-linked files must not be emitted in <files>"))
+}
+
+// TestExportRestore_LegacyAttachmentSectionsIgnored is the regression guard
+// for "drop the silent-skip code". A backup containing the pre-cutover
+// <images>/<invoices>/<manuals> commodity sections must parse cleanly
+// (no unknown-token errors, no panics) — they're simply ignored as the
+// surrounding commodity decoding falls through them.
+func TestExportRestore_LegacyAttachmentSectionsIgnored(t *testing.T) {
+	c := qt.New(t)
+
+	dst := newFileFixture(c)
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+
+	xmlContent := `<?xml version="1.0" encoding="UTF-8"?>
+<inventory>
+  <locations>
+    <location id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa">
+      <locationName>Test Location</locationName>
+      <address>X</address>
+    </location>
+  </locations>
+  <areas>
+    <area id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb">
+      <areaName>Test Area</areaName>
+      <locationId>aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa</locationId>
+    </area>
+  </areas>
+  <commodities>
+    <commodity id="cccccccc-cccc-cccc-cccc-cccccccccccc">
+      <commodityName>Test Commodity</commodityName>
+      <shortName>TC</shortName>
+      <type>electronics</type>
+      <areaId>bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb</areaId>
+      <count>1</count>
+      <status>in_use</status>
+      <originalPrice>100</originalPrice>
+      <originalPriceCurrency>USD</originalPriceCurrency>
+      <convertedOriginalPrice>0</convertedOriginalPrice>
+      <currentPrice>100</currentPrice>
+      <purchaseDate>2024-01-01</purchaseDate>
+      <draft>false</draft>
+      <images>
+        <image id="legacy-image"><path>p</path><originalPath>p.jpg</originalPath><extension>.jpg</extension><mimeType>image/jpeg</mimeType></image>
+      </images>
+      <invoices>
+        <invoice id="legacy-invoice"><path>p</path><originalPath>p.pdf</originalPath><extension>.pdf</extension><mimeType>application/pdf</mimeType></invoice>
+      </invoices>
+      <manuals>
+        <manual id="legacy-manual"><path>p</path><originalPath>p.pdf</originalPath><extension>.pdf</extension><mimeType>application/pdf</mimeType></manual>
+      </manuals>
+    </commodity>
+  </commodities>
+</inventory>`
+
+	proc := processor.NewRestoreOperationProcessor(
+		"restore-1485-legacy",
+		dst.factorySet,
+		services.NewEntityService(dst.factorySet, uploadLocation),
+		uploadLocation,
+	)
+	stats, err := proc.RestoreFromXML(dst.ctx, strings.NewReader(xmlContent), types.RestoreOptions{
+		Strategy: types.RestoreStrategyFullReplace,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.ErrorCount, qt.Equals, 0, qt.Commentf("restore errors: %v", stats.Errors))
+	c.Assert(stats.CommodityCount, qt.Equals, 1)
+	c.Assert(stats.FileCount, qt.Equals, 0, qt.Commentf("legacy attachment sections must NOT count as files"))
+}
+
+// TestExportRestore_SelectedItemsScope verifies that ExportTypeSelectedItems
+// only emits files attached to the selected entities. Standalone files and
+// files on other commodities are filtered out.
+func TestExportRestore_SelectedItemsScope(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	src := newFileFixture(c)
+
+	// Selected commodity gets one file; an unrelated file (standalone) is
+	// also added to verify it's filtered out by the selected-items scope.
+	wantedFile := src.makeFile(c, "photo", "image/jpeg", "commodity", src.commodity.ID, "images", "tag-x")
+	otherFile := src.makeFile(c, "guide", "text/plain", "", "", "")
+
+	svc := export.NewExportService(src.factorySet, uploadLocation)
+	exp := models.Export{
+		TenantGroupAwareEntityID: models.WithTenantGroupAwareEntityID("export-selected-1485", src.tenantID, src.groupID, src.userID),
+		Type:                     models.ExportTypeSelectedItems,
+		Status:                   models.ExportStatusPending,
+		IncludeFileData:          false,
+		SelectedItems: models.ValuerSlice[models.ExportSelectedItem]{
+			{ID: src.commodity.ID, Type: models.ExportSelectedItemTypeCommodity},
+		},
+	}
+	var buf bytes.Buffer
+	_, err := export.ExportXML(svc, src.ctx, exp, &buf)
+	c.Assert(err, qt.IsNil)
+
+	out := buf.String()
+	c.Assert(strings.Contains(out, wantedFile.UUID), qt.IsTrue, qt.Commentf("commodity-linked file should be in scope"))
+	c.Assert(strings.Contains(out, otherFile.UUID), qt.IsFalse, qt.Commentf("standalone file should NOT be in selected_items scope"))
+}
+
+// TestExportRestore_CrossTenantIsolation guards that the FileRegistry's
+// user-mode RLS context (memory mode mirrors the postgres behavior) keeps
+// tenant A's export from including tenant B's files. Both tenants share
+// the same FactorySet but each runs export under its own context.
+func TestExportRestore_CrossTenantIsolation(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	tenantA := newFileFixture(c)
+	aFile := tenantA.makeFile(c, "a-photo", "image/jpeg", "commodity", tenantA.commodity.ID, "images")
+
+	// Build a separate fixture for tenant B (separate factory + context).
+	tenantB := newFileFixture(c)
+	bFile := tenantB.makeFile(c, "b-photo", "image/jpeg", "commodity", tenantB.commodity.ID, "images")
+
+	xmlA := tenantA.runExport(c, models.ExportTypeFullDatabase, false, uploadLocation)
+	xmlB := tenantB.runExport(c, models.ExportTypeFullDatabase, false, uploadLocation)
+
+	c.Assert(strings.Contains(string(xmlA), aFile.UUID), qt.IsTrue)
+	c.Assert(strings.Contains(string(xmlA), bFile.UUID), qt.IsFalse, qt.Commentf("tenant A export must not contain tenant B files"))
+	c.Assert(strings.Contains(string(xmlB), bFile.UUID), qt.IsTrue)
+	c.Assert(strings.Contains(string(xmlB), aFile.UUID), qt.IsFalse, qt.Commentf("tenant B export must not contain tenant A files"))
+}
+
+// writeBlob is a thin wrapper over the gocloud blob bucket so tests can
+// stamp the source-side file content the export will base64 into XML.
+func writeBlob(c *qt.C, uploadLocation, key string, data []byte) {
+	b := must.Must(blob.OpenBucket(c.Context(), uploadLocation))
+	defer b.Close()
+	w := must.Must(b.NewWriter(c.Context(), key, nil))
+	_, err := w.Write(data)
+	c.Assert(err, qt.IsNil)
+	c.Assert(w.Close(), qt.IsNil)
+}
+
+func readBlob(c *qt.C, uploadLocation, key string) []byte {
+	b := must.Must(blob.OpenBucket(c.Context(), uploadLocation))
+	defer b.Close()
+	r := must.Must(b.NewReader(c.Context(), key, nil))
+	defer r.Close()
+	out := make([]byte, r.Size())
+	_, err := r.Read(out)
+	c.Assert(err, qt.IsNil)
+	return out
+}
+
+// Compile-time guard: keep us honest about the shape of types.RestoreStats.
+var _ = exporttypes.ExportStats{FileCount: 0}

--- a/go/backup/restore/types/types.go
+++ b/go/backup/restore/types/types.go
@@ -36,10 +36,10 @@ type RestoreStats struct {
 	// attachment counts. Their SQL columns and model fields are kept for
 	// historical row data per #1421 but new restores leave them at 0 —
 	// file restores now feed the unified FileCount instead.
-	CommodityCount int      `json:"commodity_count"`
-	ImageCount     int      `json:"image_count"`
-	InvoiceCount   int      `json:"invoice_count"`
-	ManualCount    int      `json:"manual_count"`
+	CommodityCount int `json:"commodity_count"`
+	ImageCount     int `json:"image_count"`
+	InvoiceCount   int `json:"invoice_count"`
+	ManualCount    int `json:"manual_count"`
 	// FileCount is the number of rows from the unified `files` table that
 	// were created/updated by parsing the <files> section of the export XML.
 	FileCount      int      `json:"file_count"`

--- a/go/backup/restore/types/types.go
+++ b/go/backup/restore/types/types.go
@@ -30,12 +30,19 @@ const (
 
 // RestoreStats tracks statistics during restore operation
 type RestoreStats struct {
-	LocationCount  int      `json:"location_count"`
-	AreaCount      int      `json:"area_count"`
+	LocationCount int `json:"location_count"`
+	AreaCount     int `json:"area_count"`
+	// ImageCount/InvoiceCount/ManualCount are the legacy commodity-scoped
+	// attachment counts. Their SQL columns and model fields are kept for
+	// historical row data per #1421 but new restores leave them at 0 —
+	// file restores now feed the unified FileCount instead.
 	CommodityCount int      `json:"commodity_count"`
 	ImageCount     int      `json:"image_count"`
 	InvoiceCount   int      `json:"invoice_count"`
 	ManualCount    int      `json:"manual_count"`
+	// FileCount is the number of rows from the unified `files` table that
+	// were created/updated by parsing the <files> section of the export XML.
+	FileCount      int      `json:"file_count"`
 	BinaryDataSize int64    `json:"binary_data_size"`
 	ErrorCount     int      `json:"error_count"`
 	Errors         []string `json:"errors"`
@@ -47,12 +54,13 @@ type RestoreStats struct {
 
 // IDMapping tracks the mapping from XML IDs to actual database IDs.
 // Legacy Image/Invoice/Manual maps were removed under #1421 along with their
-// SQL tables; commodity attachments now live exclusively in the unified
-// `files` table.
+// SQL tables; commodity attachments live in the unified `files` table and
+// are tracked through the Files map below alongside the entity maps.
 type IDMapping struct {
-	Locations   map[string]string // XML ID -> Database ID
-	Areas       map[string]string // XML ID -> Database ID
-	Commodities map[string]string // XML ID -> Database ID
+	Locations   map[string]string // XML UUID -> Database ID
+	Areas       map[string]string // XML UUID -> Database ID
+	Commodities map[string]string // XML UUID -> Database ID
+	Files       map[string]string // XML UUID -> Database ID (unified files table)
 }
 
 // PendingFileData holds file data that needs to be processed after commodity creation
@@ -63,11 +71,12 @@ type PendingFileData struct {
 
 // ExistingEntities tracks existing entities in the database.
 // Legacy Image/Invoice/Manual entries were removed under #1421 — the unified
-// `files` table replaces them.
+// `files` table replaces them and is tracked via the Files map below.
 type ExistingEntities struct {
-	Locations   map[string]*models.Location
-	Areas       map[string]*models.Area
-	Commodities map[string]*models.Commodity
+	Locations   map[string]*models.Location   // XML UUID -> entity
+	Areas       map[string]*models.Area       // XML UUID -> entity
+	Commodities map[string]*models.Commodity  // XML UUID -> entity
+	Files       map[string]*models.FileEntity // XML UUID -> entity (unified files table)
 }
 
 // XMLInventory represents the root element of the XML export
@@ -220,14 +229,32 @@ type XMLManual struct {
 	Data         []byte   `xml:"data,omitempty"`
 }
 
-// XMLFile represents a single file with embedded base64 data
+// XMLFile represents a single file row from the unified `files` table as it
+// appears in the <files> section of an export. Mirrors the on-disk shape
+// emitted by export.XMLFile (see go/backup/export/service.go) and decoded
+// into restored FileEntity rows by the restore processor.
 type XMLFile struct {
-	ID           string `xml:"id,attr"`
-	Path         string `xml:"path"`
-	OriginalPath string `xml:"originalPath"`
-	Extension    string `xml:"extension"`
-	MimeType     string `xml:"mimeType"`
-	Data         []byte `xml:"data,omitempty"`
+	XMLName          xml.Name  `xml:"file"`
+	ID               string    `xml:"id,attr"`
+	LinkedEntityType string    `xml:"linkedEntityType,omitempty"`
+	LinkedEntityID   string    `xml:"linkedEntityId,omitempty"`
+	LinkedEntityMeta string    `xml:"linkedEntityMeta,omitempty"`
+	Type             string    `xml:"type,omitempty"`
+	Category         string    `xml:"category,omitempty"`
+	Title            string    `xml:"title,omitempty"`
+	Description      string    `xml:"description,omitempty"`
+	Tags             *XMLTags  `xml:"tags,omitempty"`
+	Path             string    `xml:"path"`
+	OriginalPath     string    `xml:"originalPath"`
+	Extension        string    `xml:"extension,omitempty"`
+	MimeType         string    `xml:"mimeType,omitempty"`
+	CreatedAt        string    `xml:"createdAt,omitempty"`
+	UpdatedAt        string    `xml:"updatedAt,omitempty"`
+	// Data carries the file's blob content as base64 when the export was
+	// run with IncludeFileData=true. The xml package automatically decodes
+	// the chardata into bytes for []byte fields, so callers receive raw
+	// bytes here, not the base64 string.
+	Data []byte `xml:"data,omitempty"`
 }
 
 // ConvertToLocation converts XMLLocation to models.Location
@@ -347,4 +374,62 @@ func (xf *XMLFile) ConvertToFile() *models.File {
 		Ext:          xf.Extension,
 		MIMEType:     xf.MimeType,
 	}
+}
+
+// ConvertToFileEntity builds a models.FileEntity from the XMLFile's metadata.
+// linkedEntityID is the *DB ID* of the linked entity in the destination
+// database (resolved by the caller via IDMapping). Pass "" for standalone
+// files. Tenant/group/user fields are intentionally left zero — callers
+// populate them from request context immediately before persisting.
+//
+// The file's immutable UUID is preserved so re-running the same restore is
+// idempotent and so cross-restore identity matches.
+//
+// CreatedAt / UpdatedAt fall back to time.Now() when the export omitted them
+// (older formats) or when parsing fails — the registry rejects zero
+// timestamps on NOT NULL columns so we always have to write something.
+func (xf *XMLFile) ConvertToFileEntity(linkedEntityID string) *models.FileEntity {
+	tags := []string{}
+	if xf.Tags != nil {
+		tags = xf.Tags.Tags
+	}
+
+	createdAt := parseTimestampOrNow(xf.CreatedAt)
+	updatedAt := parseTimestampOrNow(xf.UpdatedAt)
+
+	fileType := models.FileType(xf.Type)
+	if fileType == "" {
+		fileType = models.FileTypeFromMIME(xf.MimeType)
+	}
+	category := models.FileCategory(xf.Category)
+	if category == "" {
+		category = models.FileCategoryFromContext(xf.LinkedEntityType, xf.LinkedEntityMeta, xf.MimeType)
+	}
+
+	return &models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			EntityID: models.EntityID{UUID: xf.ID},
+		},
+		Title:            xf.Title,
+		Description:      xf.Description,
+		Type:             fileType,
+		Category:         category,
+		Tags:             models.StringSlice(tags),
+		LinkedEntityType: xf.LinkedEntityType,
+		LinkedEntityID:   linkedEntityID,
+		LinkedEntityMeta: xf.LinkedEntityMeta,
+		CreatedAt:        createdAt,
+		UpdatedAt:        updatedAt,
+		File:             xf.ConvertToFile(),
+	}
+}
+
+func parseTimestampOrNow(s string) time.Time {
+	if s == "" {
+		return time.Now()
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
+	}
+	return time.Now()
 }

--- a/go/backup/restore/types/types.go
+++ b/go/backup/restore/types/types.go
@@ -229,32 +229,34 @@ type XMLManual struct {
 	Data         []byte   `xml:"data,omitempty"`
 }
 
-// XMLFile represents a single file row from the unified `files` table as it
-// appears in the <files> section of an export. Mirrors the on-disk shape
-// emitted by export.XMLFile (see go/backup/export/service.go) and decoded
-// into restored FileEntity rows by the restore processor.
+// XMLFile represents a single file row from the unified `files` table as
+// it appears in the <files> section of an export. Mirrors the on-disk
+// shape emitted by export.XMLFile (see go/backup/export/service.go).
+//
+// Deliberate omission: there's no `Data` field here even though the
+// XML carries a `<data>` chardata element when IncludeFileData=true.
+// The decoder routes <data> chardata directly into the upload bucket
+// via streaming base64 decode (see processor.streamDecodeFileData) so
+// the blob bytes never reside in memory. Tests that assemble an XMLFile
+// to drive a fixture should write the raw bytes to the bucket
+// separately rather than trying to inline them on this struct.
 type XMLFile struct {
-	XMLName          xml.Name  `xml:"file"`
-	ID               string    `xml:"id,attr"`
-	LinkedEntityType string    `xml:"linkedEntityType,omitempty"`
-	LinkedEntityID   string    `xml:"linkedEntityId,omitempty"`
-	LinkedEntityMeta string    `xml:"linkedEntityMeta,omitempty"`
-	Type             string    `xml:"type,omitempty"`
-	Category         string    `xml:"category,omitempty"`
-	Title            string    `xml:"title,omitempty"`
-	Description      string    `xml:"description,omitempty"`
-	Tags             *XMLTags  `xml:"tags,omitempty"`
-	Path             string    `xml:"path"`
-	OriginalPath     string    `xml:"originalPath"`
-	Extension        string    `xml:"extension,omitempty"`
-	MimeType         string    `xml:"mimeType,omitempty"`
-	CreatedAt        string    `xml:"createdAt,omitempty"`
-	UpdatedAt        string    `xml:"updatedAt,omitempty"`
-	// Data carries the file's blob content as base64 when the export was
-	// run with IncludeFileData=true. The xml package automatically decodes
-	// the chardata into bytes for []byte fields, so callers receive raw
-	// bytes here, not the base64 string.
-	Data []byte `xml:"data,omitempty"`
+	XMLName          xml.Name `xml:"file"`
+	ID               string   `xml:"id,attr"`
+	LinkedEntityType string   `xml:"linkedEntityType,omitempty"`
+	LinkedEntityID   string   `xml:"linkedEntityId,omitempty"`
+	LinkedEntityMeta string   `xml:"linkedEntityMeta,omitempty"`
+	Type             string   `xml:"type,omitempty"`
+	Category         string   `xml:"category,omitempty"`
+	Title            string   `xml:"title,omitempty"`
+	Description      string   `xml:"description,omitempty"`
+	Tags             *XMLTags `xml:"tags,omitempty"`
+	Path             string   `xml:"path"`
+	OriginalPath     string   `xml:"originalPath"`
+	Extension        string   `xml:"extension,omitempty"`
+	MimeType         string   `xml:"mimeType,omitempty"`
+	CreatedAt        string   `xml:"createdAt,omitempty"`
+	UpdatedAt        string   `xml:"updatedAt,omitempty"`
 }
 
 // ConvertToLocation converts XMLLocation to models.Location

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -5462,6 +5462,9 @@ const docTemplate = `{
                 "error_message": {
                     "type": "string"
                 },
+                "file_count": {
+                    "type": "integer"
+                },
                 "file_id": {
                     "type": "string"
                 },
@@ -5877,6 +5880,9 @@ const docTemplate = `{
                 },
                 "export_id": {
                     "type": "string"
+                },
+                "file_count": {
+                    "type": "integer"
                 },
                 "id": {
                     "type": "string"

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -5455,6 +5455,9 @@
                 "error_message": {
                     "type": "string"
                 },
+                "file_count": {
+                    "type": "integer"
+                },
                 "file_id": {
                     "type": "string"
                 },
@@ -5870,6 +5873,9 @@
                 },
                 "export_id": {
                     "type": "string"
+                },
+                "file_count": {
+                    "type": "integer"
                 },
                 "id": {
                     "type": "string"

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1323,6 +1323,8 @@ definitions:
         type: string
       error_message:
         type: string
+      file_count:
+        type: integer
       file_id:
         type: string
       file_path:
@@ -1648,6 +1650,8 @@ definitions:
         type: string
       export_id:
         type: string
+      file_count:
+        type: integer
       id:
         type: string
       image_count:

--- a/go/models/export.go
+++ b/go/models/export.go
@@ -185,6 +185,8 @@ type Export struct {
 	InvoiceCount int `json:"invoice_count" db:"invoice_count" userinput:"false"`
 	//migrator:schema:field name="manual_count" type="INTEGER" default="0"
 	ManualCount int `json:"manual_count" db:"manual_count" userinput:"false"`
+	//migrator:schema:field name="file_count" type="INTEGER" default="0"
+	FileCount int `json:"file_count" db:"file_count" userinput:"false"`
 	//migrator:schema:field name="binary_data_size" type="BIGINT" default="0"
 	BinaryDataSize int64 `json:"binary_data_size" db:"binary_data_size" userinput:"false"`
 }

--- a/go/models/restore_operation.go
+++ b/go/models/restore_operation.go
@@ -91,6 +91,8 @@ type RestoreOperation struct {
 	InvoiceCount int `json:"invoice_count" db:"invoice_count" userinput:"false"`
 	//migrator:schema:field name="manual_count" type="INTEGER" default="0"
 	ManualCount int `json:"manual_count" db:"manual_count" userinput:"false"`
+	//migrator:schema:field name="file_count" type="INTEGER" default="0"
+	FileCount int `json:"file_count" db:"file_count" userinput:"false"`
 	//migrator:schema:field name="binary_data_size" type="BIGINT" default="0"
 	BinaryDataSize int64 `json:"binary_data_size" db:"binary_data_size" userinput:"false"`
 	//migrator:schema:field name="error_count" type="INTEGER" default="0"

--- a/go/schema/migrations/_sqldata/1777813586_add_export_restore_file_count.down.sql
+++ b/go/schema/migrations/_sqldata/1777813586_add_export_restore_file_count.down.sql
@@ -1,0 +1,13 @@
+-- Migration rollback
+-- Generated on: 2026-05-03T15:46:26+02:00
+-- Direction: DOWN
+
+-- Remove columns from table: exports --
+-- ALTER statements: --
+ALTER TABLE exports DROP COLUMN file_count CASCADE;
+-- WARNING: Dropping column exports.file_count with CASCADE - This will delete data and dependent objects! --
+
+-- Remove columns from table: restore_operations --
+-- ALTER statements: --
+ALTER TABLE restore_operations DROP COLUMN file_count CASCADE;
+-- WARNING: Dropping column restore_operations.file_count with CASCADE - This will delete data and dependent objects! --

--- a/go/schema/migrations/_sqldata/1777813586_add_export_restore_file_count.up.sql
+++ b/go/schema/migrations/_sqldata/1777813586_add_export_restore_file_count.up.sql
@@ -1,0 +1,11 @@
+-- Migration generated from schema differences
+-- Generated on: 2026-05-03T15:46:26+02:00
+-- Direction: UP
+
+-- Add/modify columns for table: exports --
+-- ALTER statements: --
+ALTER TABLE exports ADD COLUMN file_count INTEGER DEFAULT '0';
+
+-- Add/modify columns for table: restore_operations --
+-- ALTER statements: --
+ALTER TABLE restore_operations ADD COLUMN file_count INTEGER DEFAULT '0';


### PR DESCRIPTION
Closes #1485 (sub-issue of epic #1397). Direct follow-up to PR #1479, which retired the legacy `<images>/<invoices>/<manuals>` XML sections from the backup pipeline alongside the SQL tables they sourced. New backups have shipped without any file attachments since #1479 landed; this PR re-introduces export+restore from the unified `files` surface.

## What changed

- **New `<files>` section in the export XML.** Emitted from `streamFullDatabase`, `streamLocations`, `streamAreas`, `streamCommodities`, and `streamSelectedItems`. The first four emit every group-scoped row; selected_items filters to files linked to the picked entities. Files linked to the export itself (`linked_entity_type="export"`) are always excluded to avoid the self-reference that re-emitting the backup-bundle blob in its own export would create. `linked_entity_id` is written as the linked entity's immutable UUID (resolved via per-type DB-ID→UUID maps) so it round-trips even when the restore lands on fresh DB IDs.
- **New `<files>` section parser on restore.** Dispatches FullReplace / MergeAdd / MergeUpdate on the file's immutable UUID. `linked_entity_id` is remapped through `IDMapping` so a restored file lands on the destination commodity/location/area's new DB ID. The `Files` map was added to both `IDMapping` and `ExistingEntities` so MergeAdd/MergeUpdate dedup on file UUID like commodities already do.
- **`Export.FileCount` + `RestoreOperation.FileCount` columns** added via migration `1777813586_add_export_restore_file_count`. Tracked in `ExportStats` and `RestoreStats` and propagated end-to-end. Legacy `*.{Image,Invoice,Manual}Count` columns stay at 0 on new runs — they're kept for the historical-row-preservation decision recorded in #1479.
- **`clearExistingData` (FullReplace) now sweeps non-export file rows** after the location-recursive delete. `DeleteLocationRecursive` only cascades commodity-linked files via `EntityService`; without this sweep, location-/area-linked and standalone files would orphan, then collide with the restored rows on the unique-on-UUID index.
- **Silent-skip for legacy `<images>/<invoices>/<manuals>` removed** per the issue. Pre-cutover archives are explicitly not supported per ops (no production data pre-dates the cutover). The `skipSection` helper is gone since it had no other callers.
- **Chunked base64 streaming on both directions** (added in commit `5a0e3af` after a code review against the pre-#1479 path):
  - Export: `streamFileWithData` token-emits `<file>` + metadata + `<data>` interleaved with 32 KiB base64 chunks via `xmlBase64Writer`. No `io.ReadAll` of the source blob, no `EncodeToString` of the full payload.
  - Restore: `decodeFileElement` replaces `decoder.DecodeElement(&xmlFile, …)` with a manual token loop that detects `<data>` and routes its chardata through a new `xmlChardataReader` → `base64.NewDecoder` → `blob.Writer` chain. Whitespace stripping for pretty-printed XML is handled inside the reader. DryRun routes to `io.Discard` for byte counting without writing.
- **OpenAPI regenerated**; Vue FE codegen refreshed to surface the new `file_count` field.

## XML shape

```xml
<files>
  <file id="<file-uuid>">
    <linkedEntityType>commodity</linkedEntityType>
    <linkedEntityId><commodity-uuid></linkedEntityId>
    <linkedEntityMeta>images</linkedEntityMeta>
    <type>image</type>
    <category>photos</category>
    <title>...</title>
    <tags><tag>foo</tag></tags>
    <path>my-photo</path>
    <originalPath>my-photo-1745678901.jpg</originalPath>
    <extension>.jpg</extension>
    <mimeType>image/jpeg</mimeType>
    <createdAt>2026-05-01T00:00:00Z</createdAt>
    <updatedAt>2026-05-01T00:00:00Z</updatedAt>
    <data>BASE64...</data>  <!-- streamed in chunks when IncludeFileData=true -->
  </file>
</files>
```

## Behavioral comparison vs the pre-#1479 implementation

A code review against `master@ed48b0c1` (the commit just before #1479 dropped the legacy file paths) surfaced two areas where the new code intentionally differs from the old, plus one streaming regression that has now been fixed in this PR.

### 1. Envelope: same shape (XML with inline base64), NOT a ZIP
The issue text says "re-use the existing ZIP+XML pattern" but the **legacy code was XML-only with `<data>` chardata holding base64**. There's no `archive/zip` in `master@ed48b0c1:go/backup/export/service.go`; just `xml.NewEncoder` over a `blob.NewWriter`. This PR keeps that pattern — moving to a true ZIP envelope would be a much bigger refactor and is out of scope.

### 2. Restore blob-key write path: INTENTIONAL behavior change
**Legacy** (`master@ed48b0c1:go/backup/restore/processor/processor.go`, `decodeBase64ToFile` ~line 275): for every restored file it generated a **fresh** blob key via `filekit.UploadFileName(xmlFile.OriginalPath)` and rewrote both `xmlFile.Path` and `xmlFile.OriginalPath` to the new key.

**This PR**: writes the blob to the file's `OriginalPath` **verbatim**, overwriting whatever was at that key.

This is an intentional improvement, not a regression. The legacy fresh-key behavior was a workaround for the lack of a stable identity primitive on the old `images/invoices/manuals` rows — they had no UUID column, so cross-restore identity was tied to the (regenerated) blob key. The unified `files` table has a UUID and we use it as the dedup primitive (`IDMapping.Files`, `ExistingEntities.Files`). Preserving `OriginalPath` is consistent with that and gives idempotent re-restores; legacy could not.

Practical consequence to be aware of: a restore into a populated bucket will overwrite blobs at colliding `OriginalPath` keys. In normal operation this only happens on re-restore of the same export (where the bytes are identical), but a misconfigured restore into a shared bucket could clobber unrelated content. For the in-scope use case (per-tenant, per-group bucket prefixes) this isn't a concern.

### 3. Chunked streaming: was regressed in the first cut, FIXED in commit `5a0e3af`
The first commit on this branch buffered each blob fully in memory (`io.ReadAll` on export, `decoder.DecodeElement` of `<data>` `[]byte` on restore). **The pre-#1479 code streamed in 32 KiB chunks in both directions**, and so does this PR after the second commit:

- `streamBase64Content` + `xmlBase64Writer` ported verbatim on the export side.
- New `xmlChardataReader` + `base64.NewDecoder` chain on the restore side (legacy used per-`xml.CharData`-token base64 decode, which would've been buggy on chunks not aligned to 4-byte groups; the new reader sidesteps that by exposing a contiguous byte stream to `base64.NewDecoder`).

`TestExportRestore_LargeBlobStreamingRoundTrip` exercises a 200 KiB blob to verify chunk-boundary correctness end-to-end.

## Acceptance criteria

- [x] New backups contain a `<files>` section + matching blob entries (chunked base64 inline when `IncludeFileData=true`).
- [x] Round-trip: full export → restore on a clean DB → files reconstruct with original metadata + content (modulo remapped IDs if the linked entity was also restored fresh). Covered by `TestExportRestore_FileRoundTrip`.
- [x] Tags / category / `linked_entity_*` preserved across round-trip. Covered by the same test.
- [x] Cross-tenant RLS isolation preserved during both export and restore. `TestExportRestore_CrossTenantIsolation`.
- [x] Legacy `<images>/<invoices>/<manuals>` parsing fully removed (no silent-skip stub). `TestExportRestore_LegacyAttachmentSectionsIgnored`.
- [x] OpenAPI regenerated; drift CI green.
- [x] Integration tests: empty export, single-file export, multi-file (categories mix), cross-tenant export, full round-trip, large-file streaming behaviour.
  - Memory-registry coverage: `TestExportRestore_FileRoundTrip` (multi-category mix), `TestExportRestore_EmptyFileSection`, `TestExportRestore_ExcludesExportLinkedFiles`, `TestExportRestore_SelectedItemsScope`, `TestExportRestore_CrossTenantIsolation`, `TestExportRestore_LargeBlobStreamingRoundTrip`, `TestExportRestore_DryRunSkipsBlobWrite`.
  - **Deviation**: I did not add a separate postgres-registry round-trip — the unified `files` registry interface that this PR consumes is already covered by the existing files registry tests across both backends; the round-trip flow is registry-agnostic. Happy to add as a follow-up if reviewers want the explicit mirror.

## Out of scope per the issue

- Dropping `Export.{Image,Invoice,Manual}Count` / `RestoreOperation.{...}Count` columns — kept for historical row preservation per #1479.
- Backward-compat parsing of legacy archive format — explicitly not required.
- File-format negotiation / versioning — single new format is enough.

## Test plan

- [x] `go test ./backup/... ./apiserver/... ./models/... ./registry/... -count=1` green locally.
- [ ] CI green (Go tests + schema-drift on postgres).
- [ ] Manual smoke: spin up the dev stack, attach a few files to a commodity (mix of photos + a PDF invoice + a standalone file via /uploads/file), trigger a full-database export, then restore on a clean DB. Verify the Files page shows all rows with correct categories and the blobs render in the detail view.
- [ ] Manual smoke for FullReplace specifically: same flow but with pre-existing files in the destination — confirm the sweep clears them and they're replaced (no UUID-collision errors in the worker logs).