### PR TITLE
[#1415] FE Exports / Imports / Restores

### DIFF
--- a/e2e/tests/exports-react.spec.ts
+++ b/e2e/tests/exports-react.spec.ts
@@ -68,12 +68,12 @@ test.describe('Exports / Restores (React)', () => {
     await page.getByTestId('wizard-description').fill(`E2E full DB ${Date.now()}`)
     await page.getByTestId('wizard-submit').click()
 
-    // --- Step 3: URL must flip to ?step=3&id=<uuid> first. Asserting the
-    // URL before the DOM gives us a clearer failure mode if the mutation
-    // succeeds but the URL update is dropped (vs. an opaque "DOM didn't
-    // appear" timeout). Then poll the export status until terminal.
-    await expect.poll(() => page.url(), { timeout: 15_000 }).toMatch(/[?&]step=3(&|$)/)
-    await expect(page.getByTestId('wizard-step-3-content')).toBeVisible({ timeout: 15_000 })
+    // --- Step 3: the wizard advances off the createMutation result, not
+    // the URL. (react-router-dom v7's setSearchParams from inside an
+    // async callback was dropping under load on CI; the wizard now
+    // renders step 3 directly from `createMutation.data`, with the URL
+    // updated as a best-effort side effect — see ExportNewPage.tsx.)
+    await expect(page.getByTestId('wizard-step-3-content')).toBeVisible({ timeout: 30_000 })
     await expect(page.getByTestId('wizard-download')).toBeVisible({ timeout: 60_000 })
 
     // --- Open the detail page, kick off a dry-run merge_add restore ---

--- a/e2e/tests/exports-react.spec.ts
+++ b/e2e/tests/exports-react.spec.ts
@@ -77,10 +77,10 @@ test.describe('Exports / Restores (React)', () => {
     await expect(page.getByTestId('export-detail-restore')).toBeEnabled({ timeout: 60_000 })
     await page.getByTestId('export-detail-restore').click()
     await expect(page.getByTestId('page-export-restore')).toBeVisible()
-    // BE requires description (jsonapi/restore_operations.go validation);
-    // the FE hint says "Optional" — that mismatch is a separate
-    // follow-up. For now fill it so the test exercises the full happy
-    // path. Defaults: merge_add + dry_run + include_file_data.
+    // Description is required on both sides — BE validation
+    // (jsonapi/restore_operations.go: Required + Length 1..500) and the
+    // FE form (`required` + submit-disabled until non-empty). Defaults
+    // for the rest: merge_add + dry_run + include_file_data.
     await page.getByTestId('restore-description').fill(`E2E dry-run ${Date.now()}`)
     await page.getByTestId('restore-submit').click()
 

--- a/e2e/tests/exports-react.spec.ts
+++ b/e2e/tests/exports-react.spec.ts
@@ -68,10 +68,13 @@ test.describe('Exports / Restores (React)', () => {
     await page.getByTestId('wizard-description').fill(`E2E full DB ${Date.now()}`)
     await page.getByTestId('wizard-submit').click()
 
-    // --- Step 3: poll until the export reaches a terminal state. The
-    // refetchInterval is 2s; 30s is generous head-room for slow CI.
-    await expect(page.getByTestId('wizard-step-3-content')).toBeVisible()
-    await expect(page.getByTestId('wizard-download')).toBeVisible({ timeout: 30_000 })
+    // --- Step 3: URL must flip to ?step=3&id=<uuid> first. Asserting the
+    // URL before the DOM gives us a clearer failure mode if the mutation
+    // succeeds but the URL update is dropped (vs. an opaque "DOM didn't
+    // appear" timeout). Then poll the export status until terminal.
+    await expect.poll(() => page.url(), { timeout: 15_000 }).toMatch(/[?&]step=3(&|$)/)
+    await expect(page.getByTestId('wizard-step-3-content')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId('wizard-download')).toBeVisible({ timeout: 60_000 })
 
     // --- Open the detail page, kick off a dry-run merge_add restore ---
     await page.getByRole('link', { name: 'Open' }).first().click()

--- a/e2e/tests/exports-react.spec.ts
+++ b/e2e/tests/exports-react.spec.ts
@@ -68,17 +68,15 @@ test.describe('Exports / Restores (React)', () => {
     await page.getByTestId('wizard-description').fill(`E2E full DB ${Date.now()}`)
     await page.getByTestId('wizard-submit').click()
 
-    // --- Step 3: the wizard advances off the createMutation result, not
-    // the URL. (react-router-dom v7's setSearchParams from inside an
-    // async callback was dropping under load on CI; the wizard now
-    // renders step 3 directly from `createMutation.data`, with the URL
-    // updated as a best-effort side effect — see ExportNewPage.tsx.)
-    await expect(page.getByTestId('wizard-step-3-content')).toBeVisible({ timeout: 30_000 })
-    await expect(page.getByTestId('wizard-download')).toBeVisible({ timeout: 60_000 })
-
-    // --- Open the detail page, kick off a dry-run merge_add restore ---
-    await page.getByRole('link', { name: 'Open' }).first().click()
-    await expect(page.getByTestId('page-export-detail')).toBeVisible()
+    // --- The wizard navigates straight to the detail page on success
+    // (no in-wizard "step 3" — driving a step transition off the
+    // createMutation result on this surface was racy under React 19 +
+    // react-router-dom v7 in production; the detail page is the
+    // canonical "watch this export" surface anyway).
+    await expect(page.getByTestId('page-export-detail')).toBeVisible({ timeout: 30_000 })
+    // Wait for the export to reach a terminal state so the Restore CTA
+    // unlocks — otherwise the click below races the polling loop.
+    await expect(page.getByTestId('export-detail-restore')).toBeEnabled({ timeout: 60_000 })
     await page.getByTestId('export-detail-restore').click()
     await expect(page.getByTestId('page-export-restore')).toBeVisible()
     // Defaults are merge_add + dry_run + include_file_data — submit as-is.

--- a/e2e/tests/exports-react.spec.ts
+++ b/e2e/tests/exports-react.spec.ts
@@ -43,8 +43,8 @@ test.describe('Exports / Restores (React)', () => {
     request,
   }) => {
     // --- Seed a minimal location / area / commodity so the export
-    // captures something meaningful (otherwise the polling loop in step
-    // 3 just races the empty-database fast path).
+    // captures something meaningful (otherwise the detail-page status
+    // poll just races the empty-database fast path).
     const auth = await extractApiAuth(page)
     const group = await resolveActiveGroup(request, auth)
     const { areaId } = await ensureLocationAndArea(request, auth, group.slug)
@@ -68,18 +68,20 @@ test.describe('Exports / Restores (React)', () => {
     await page.getByTestId('wizard-description').fill(`E2E full DB ${Date.now()}`)
     await page.getByTestId('wizard-submit').click()
 
-    // --- The wizard navigates straight to the detail page on success
-    // (no in-wizard "step 3" — driving a step transition off the
-    // createMutation result on this surface was racy under React 19 +
-    // react-router-dom v7 in production; the detail page is the
-    // canonical "watch this export" surface anyway).
+    // --- The wizard navigates straight to the detail page on success.
+    // The detail page is the canonical "watch this export" surface
+    // (status badge polling, download/restore CTAs, restore history).
     await expect(page.getByTestId('page-export-detail')).toBeVisible({ timeout: 30_000 })
     // Wait for the export to reach a terminal state so the Restore CTA
     // unlocks — otherwise the click below races the polling loop.
     await expect(page.getByTestId('export-detail-restore')).toBeEnabled({ timeout: 60_000 })
     await page.getByTestId('export-detail-restore').click()
     await expect(page.getByTestId('page-export-restore')).toBeVisible()
-    // Defaults are merge_add + dry_run + include_file_data — submit as-is.
+    // BE requires description (jsonapi/restore_operations.go validation);
+    // the FE hint says "Optional" — that mismatch is a separate
+    // follow-up. For now fill it so the test exercises the full happy
+    // path. Defaults: merge_add + dry_run + include_file_data.
+    await page.getByTestId('restore-description').fill(`E2E dry-run ${Date.now()}`)
     await page.getByTestId('restore-submit').click()
 
     // --- Restore appears in history; poll until status flips to a

--- a/e2e/tests/exports-react.spec.ts
+++ b/e2e/tests/exports-react.spec.ts
@@ -1,0 +1,98 @@
+import { expect, type Page } from '@playwright/test'
+
+import { test } from '../fixtures/app-fixture.js'
+import { navigateWithAuth } from './includes/auth.js'
+import {
+  createCommodityViaAPI,
+  ensureLocationAndArea,
+  extractApiAuth,
+  resolveActiveGroup,
+} from './includes/commodities-api.js'
+
+/**
+ * E2E coverage for the React Exports/Imports/Restores surface (#1415).
+ *
+ * Covers the issue's E2E acceptance line: create an export, then run a
+ * (dry-run) restore from it. Import-cycle coverage (download → re-upload
+ * via /exports/import → restore) is intentionally deferred to a follow-up
+ * — the file-staging + multipart upload roundtrip is sensitive to the
+ * docker volume layout under the e2e stack and bumps runtime by ~10s.
+ *
+ * The legacy `exports-crud.spec.ts` is left skipped (it mounts on
+ * PrimeVue selectors that no longer exist after the React cutover); this
+ * spec replaces its export-create coverage. Re-enable that file or
+ * delete it once the helpers in `e2e/tests/includes/exports.ts` are
+ * ported to React selectors.
+ */
+
+async function gotoExports(page: Page): Promise<void> {
+  await navigateWithAuth(page, '/exports')
+  await expect(page.getByTestId('page-exports')).toBeVisible()
+}
+
+test.describe('Exports / Restores (React)', () => {
+  test('renders the page shell with retention banner + create CTA', async ({ page }) => {
+    await gotoExports(page)
+    await expect(page.getByTestId('exports-retention-banner')).toBeVisible()
+    await expect(page.getByTestId('exports-create-button')).toBeVisible()
+    await expect(page.getByTestId('exports-import-button')).toBeVisible()
+  })
+
+  test('wizard creates a full_database export, then a dry-run restore lands in history', async ({
+    page,
+    request,
+  }) => {
+    // --- Seed a minimal location / area / commodity so the export
+    // captures something meaningful (otherwise the polling loop in step
+    // 3 just races the empty-database fast path).
+    const auth = await extractApiAuth(page)
+    const group = await resolveActiveGroup(request, auth)
+    const { areaId } = await ensureLocationAndArea(request, auth, group.slug)
+    await createCommodityViaAPI(
+      request,
+      auth,
+      group.slug,
+      { name: `exports-react-${Date.now()}`, areaId },
+      group.mainCurrency,
+    )
+
+    // --- Step 1: open wizard, full_database default is fine ---
+    await gotoExports(page)
+    await page.getByTestId('exports-create-button').click()
+    await expect(page).toHaveURL(/\/exports\/new/)
+    await expect(page.getByTestId('wizard-step-1-content')).toBeVisible()
+    await page.getByTestId('wizard-next').click()
+
+    // --- Step 2: confirm + submit ---
+    await expect(page.getByTestId('wizard-step-2-content')).toBeVisible()
+    await page.getByTestId('wizard-description').fill(`E2E full DB ${Date.now()}`)
+    await page.getByTestId('wizard-submit').click()
+
+    // --- Step 3: poll until the export reaches a terminal state. The
+    // refetchInterval is 2s; 30s is generous head-room for slow CI.
+    await expect(page.getByTestId('wizard-step-3-content')).toBeVisible()
+    await expect(page.getByTestId('wizard-download')).toBeVisible({ timeout: 30_000 })
+
+    // --- Open the detail page, kick off a dry-run merge_add restore ---
+    await page.getByRole('link', { name: 'Open' }).first().click()
+    await expect(page.getByTestId('page-export-detail')).toBeVisible()
+    await page.getByTestId('export-detail-restore').click()
+    await expect(page.getByTestId('page-export-restore')).toBeVisible()
+    // Defaults are merge_add + dry_run + include_file_data — submit as-is.
+    await page.getByTestId('restore-submit').click()
+
+    // --- Restore appears in history; poll until status flips to a
+    // terminal value (the restore worker writes ~immediately for an
+    // empty / minimal dataset).
+    await expect(page.getByTestId('page-export-detail')).toBeVisible()
+    const restoresList = page.getByTestId('restores-list')
+    await expect(restoresList).toBeVisible({ timeout: 30_000 })
+    const firstRestore = restoresList.locator('[data-testid^="restore-row-"]').first()
+    await expect(firstRestore).toBeVisible()
+    // Status badge must reach completed (or failed — surface either
+    // outcome to keep the test stable across worker timing).
+    await expect(
+      firstRestore.locator('[data-testid="status-completed"], [data-testid="status-failed"]'),
+    ).toBeVisible({ timeout: 30_000 })
+  })
+})

--- a/frontend/i18next.config.ts
+++ b/frontend/i18next.config.ts
@@ -127,6 +127,36 @@ export default defineConfig({
       "tags:list.usageFiles*",
       "tags:usage.items*",
       "tags:usage.files*",
+      // exports:status.* — ExportStatusBadge resolves the badge label via
+      //   `t(\`exports:status.${status}\`)` over the closed
+      //   ExportStatus | RestoreStatus union.
+      // exports:scope.* — ExportRow / ExportDetailPage build the scope
+      //   label via `t(\`exports:scope.${exp.type ?? 'fullDatabase'}\`)`
+      //   over models.ExportType.
+      // exports:restore.strategyLabel.* /
+      // exports:restore.strategyDescription.* — restore form + history list
+      //   build them via `t(\`exports:restore.strategyLabel.${strategy}\`)`
+      //   over the closed RESTORE_STRATEGIES union.
+      // exports:detail.counts.* — list / detail call
+      //   `t('exports:detail.counts.locations', { count })` etc.; the
+      //   `_one` / `_other` plural suffixes need to survive extract.
+      "exports:status.*",
+      "exports:scope.*",
+      "exports:restore.strategyLabel.*",
+      "exports:restore.strategyDescription.*",
+      "exports:detail.counts.*",
+      "exports:detail.scopeSelectedItems*",
+      // exports:wizard.scope.* — Step1 of the New-export wizard reads
+      //   `t(titleKey)` / `t(hintKey)` where the keys are passed in from
+      //   the parent page as `"exports:wizard.scope.<option>"`. Closed
+      //   set: full_database / selected_items.
+      "exports:wizard.scope.*",
+      // exports:wizard.step*Title — WizardSteps maps over a const items
+      //   array `{ index, titleKey: "exports:wizard.stepNTitle" }` and
+      //   resolves the label via `t(item.titleKey)`. Static-analysis
+      //   only sees the static usages of step1Title / step3Title; the
+      //   step2Title key is reached only via the array.
+      "exports:wizard.step*Title",
     ],
   },
 })

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from "react"
-import { Outlet, Route, Routes } from "react-router-dom"
+import { Navigate, Outlet, Route, Routes, useParams } from "react-router-dom"
 
 import { AuthProvider } from "@/features/auth/AuthContext"
 import { GroupProvider } from "@/features/group/GroupContext"
@@ -95,6 +95,21 @@ const FileEditPage = lazy(() =>
 )
 const TagsListPage = lazy(() =>
   import("@/pages/tags/TagsListPage").then((m) => ({ default: m.TagsListPage }))
+)
+const ExportsListPage = lazy(() =>
+  import("@/pages/exports/ExportsListPage").then((m) => ({ default: m.ExportsListPage }))
+)
+const ExportNewPage = lazy(() =>
+  import("@/pages/exports/ExportNewPage").then((m) => ({ default: m.ExportNewPage }))
+)
+const ExportDetailPage = lazy(() =>
+  import("@/pages/exports/ExportDetailPage").then((m) => ({ default: m.ExportDetailPage }))
+)
+const ExportImportPage = lazy(() =>
+  import("@/pages/exports/ExportImportPage").then((m) => ({ default: m.ExportImportPage }))
+)
+const ExportRestorePage = lazy(() =>
+  import("@/pages/exports/ExportRestorePage").then((m) => ({ default: m.ExportRestorePage }))
 )
 
 // AppRoutes is the full route tree for the new React frontend. Most of the
@@ -218,52 +233,11 @@ export function AppRoutes() {
               <Route path="files/:id/edit" element={<FileEditPage />} />
               <Route path="tags" element={<TagsListPage />} />
               <Route path="members" element={<MembersPage />} />
-              <Route
-                path="exports"
-                element={
-                  <PlaceholderPage titleKey="exports" testId="page-exports" trackedBy="#1415" />
-                }
-              />
-              <Route
-                path="exports/new"
-                element={
-                  <PlaceholderPage
-                    titleKey="exportNew"
-                    testId="page-export-new"
-                    trackedBy="#1415"
-                  />
-                }
-              />
-              <Route
-                path="exports/import"
-                element={
-                  <PlaceholderPage
-                    titleKey="exportImport"
-                    testId="page-export-import"
-                    trackedBy="#1415"
-                  />
-                }
-              />
-              <Route
-                path="exports/:id"
-                element={
-                  <PlaceholderPage
-                    titleKey="exportDetail"
-                    testId="page-export-detail"
-                    trackedBy="#1415"
-                  />
-                }
-              />
-              <Route
-                path="exports/:id/restore"
-                element={
-                  <PlaceholderPage
-                    titleKey="exportRestore"
-                    testId="page-export-restore"
-                    trackedBy="#1415"
-                  />
-                }
-              />
+              <Route path="exports" element={<ExportsListPage />} />
+              <Route path="exports/new" element={<ExportNewPage />} />
+              <Route path="exports/import" element={<ExportImportPage />} />
+              <Route path="exports/:id" element={<ExportDetailPage />} />
+              <Route path="exports/:id/restore" element={<ExportRestorePage />} />
               <Route path="search" element={<SearchPage />} />
               <Route
                 path="system"
@@ -284,18 +258,17 @@ export function AppRoutes() {
               {/* Coming-soon group-scoped pages (#1417). Warranties / insurance
                   ship as inline panels on items / commodities detail per the
                   design mock; the top-level routes stay as full-page stubs
-                  so deep links don't 404 in the meantime. Backup stays a
-                  generic PlaceholderPage — it's a real feature awaiting its
-                  owning issue (not tracked under #1417). */}
+                  so deep links don't 404 in the meantime. */}
               <Route path="warranties" element={<ComingSoonPage surface="warranties" />} />
               <Route
                 path="insurance/:itemId"
                 element={<ComingSoonPage surface="insuranceReport" />}
               />
-              <Route
-                path="backup"
-                element={<PlaceholderPage titleKey="backup" testId="page-backup" />}
-              />
+              {/* /backup is a soft alias for /exports — the design mock's
+                  "BackupView" landing page. Sidebar still labels the entry
+                  "Backup" but the user lands on the unified Backup &
+                  Exports page. */}
+              <Route path="backup" element={<BackupRedirect />} />
             </Route>
           </Route>
         </Route>
@@ -305,6 +278,16 @@ export function AppRoutes() {
       </Routes>
     </Suspense>
   )
+}
+
+// /g/:slug/backup is a soft alias for /g/:slug/exports — the sidebar
+// still calls the section "Backup" (matching the design mock) but the
+// page itself lives at /exports. Kept as a redirect rather than deleted
+// so deep links from older builds keep working.
+function BackupRedirect() {
+  const params = useParams()
+  const slug = params.groupSlug ?? ""
+  return <Navigate to={`/g/${encodeURIComponent(slug)}/exports`} replace />
 }
 
 // Re-export AuthProvider so providers.tsx wires it once at the app root.

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -106,7 +106,7 @@ const MANAGE: NavEntry[] = [
   },
   {
     labelKey: "common:nav.backup",
-    to: (slug) => (slug ? `/g/${encodeURIComponent(slug)}/backup` : null),
+    to: (slug) => (slug ? `/g/${encodeURIComponent(slug)}/exports` : null),
     icon: HardDriveDownload,
   },
   {

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -79,7 +79,7 @@ const NAVIGATION: PaletteEntry[] = [
   },
   {
     labelKey: "common:nav.backup",
-    to: (slug) => (slug ? `/g/${encodeURIComponent(slug)}/backup` : null),
+    to: (slug) => (slug ? `/g/${encodeURIComponent(slug)}/exports` : null),
     icon: HardDriveDownload,
   },
   {

--- a/frontend/src/components/exports/ExportRow.tsx
+++ b/frontend/src/components/exports/ExportRow.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom"
 import { ExportStatusBadge } from "@/components/exports/ExportStatusBadge"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { type Export, exportDownloadPath, isExportTerminal } from "@/features/export/api"
+import { type Export, isExportTerminal, useExportDownloadHref } from "@/features/export/api"
 import { formatBytes, formatDateTime } from "@/lib/intl"
 import { cn } from "@/lib/utils"
 
@@ -23,19 +23,21 @@ function totalItemCount(e: Export): number {
 }
 
 // Renders a single export as a card-style row. The download CTA is
-// rendered as an `<a>` rather than a button so the browser handles the
-// stream natively (Bearer + cookie are replayed by the BE; the CSRF
-// header isn't needed for GET).
+// rendered as an `<a>` so the browser handles the stream natively; the
+// JWT-protected endpoint receives the access token via `?token=` (the
+// BE accepts it in addition to Authorization headers).
 export function ExportRow({ export: exp, detailHref, groupSlug, onDelete }: ExportRowProps) {
   const { t } = useTranslation(["exports"])
   const isDeleted = !!exp.deleted_at
   const isTerminal = isExportTerminal(exp.status)
   const isCompleted = exp.status === "completed"
-  const downloadHref = exportDownloadPath(exp.id, groupSlug)
+  const downloadHref = useExportDownloadHref(exp.id, groupSlug)
   const scopeLabel =
     exp.type === "selected_items"
       ? t("exports:detail.scopeSelectedItems", { count: exp.selected_items?.length ?? 0 })
-      : t(`exports:scope.${exp.type ?? "full_database"}`, t("exports:scope.full_database"))
+      : t(`exports:scope.${exp.type ?? "full_database"}`, {
+          defaultValue: t("exports:scope.full_database"),
+        })
 
   return (
     <div
@@ -86,16 +88,13 @@ export function ExportRow({ export: exp, detailHref, groupSlug, onDelete }: Expo
           asChild
           size="sm"
           variant="outline"
-          disabled={!isTerminal || !isCompleted || isDeleted}
-          aria-disabled={!isTerminal || !isCompleted || isDeleted}
-          className={cn((!isTerminal || !isCompleted || isDeleted) && "pointer-events-none")}
+          disabled={!isTerminal || !isCompleted || isDeleted || !downloadHref}
+          aria-disabled={!isTerminal || !isCompleted || isDeleted || !downloadHref}
+          className={cn(
+            (!isTerminal || !isCompleted || isDeleted || !downloadHref) && "pointer-events-none"
+          )}
         >
-          <a
-            href={downloadHref}
-            data-testid={`export-row-${exp.id}-download`}
-            // The list page renders a row per export. The download is a
-            // top-level GET; let the browser handle save-as.
-          >
+          <a href={downloadHref ?? "#"} data-testid={`export-row-${exp.id}-download`}>
             <Download className="mr-1.5 size-4" aria-hidden="true" />
             {t("exports:actions.download")}
           </a>

--- a/frontend/src/components/exports/ExportRow.tsx
+++ b/frontend/src/components/exports/ExportRow.tsx
@@ -1,0 +1,119 @@
+import { Download, Trash2 } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
+
+import { ExportStatusBadge } from "@/components/exports/ExportStatusBadge"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { type Export, exportDownloadPath, isExportTerminal } from "@/features/export/api"
+import { formatBytes, formatDateTime } from "@/lib/intl"
+import { cn } from "@/lib/utils"
+
+export interface ExportRowProps {
+  export: Export
+  detailHref: string
+  groupSlug: string
+  onDelete: () => void
+}
+
+function totalItemCount(e: Export): number {
+  return (
+    (e.location_count ?? 0) + (e.area_count ?? 0) + (e.commodity_count ?? 0) + (e.file_count ?? 0)
+  )
+}
+
+// Renders a single export as a card-style row. The download CTA is
+// rendered as an `<a>` rather than a button so the browser handles the
+// stream natively (Bearer + cookie are replayed by the BE; the CSRF
+// header isn't needed for GET).
+export function ExportRow({ export: exp, detailHref, groupSlug, onDelete }: ExportRowProps) {
+  const { t } = useTranslation(["exports"])
+  const isDeleted = !!exp.deleted_at
+  const isTerminal = isExportTerminal(exp.status)
+  const isCompleted = exp.status === "completed"
+  const downloadHref = exportDownloadPath(exp.id, groupSlug)
+  const scopeLabel =
+    exp.type === "selected_items"
+      ? t("exports:detail.scopeSelectedItems", { count: exp.selected_items?.length ?? 0 })
+      : t(`exports:scope.${exp.type ?? "full_database"}`, t("exports:scope.full_database"))
+
+  return (
+    <div
+      data-testid={`export-row-${exp.id}`}
+      className={cn(
+        "flex flex-wrap items-center justify-between gap-3 rounded-md border bg-card px-4 py-3",
+        isDeleted && "opacity-60"
+      )}
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            to={detailHref}
+            className="truncate text-sm font-medium hover:underline"
+            data-testid={`export-row-${exp.id}-link`}
+          >
+            {exp.description?.trim() ? exp.description : scopeLabel}
+          </Link>
+          {exp.imported && (
+            <Badge variant="secondary" data-testid={`export-row-${exp.id}-imported`}>
+              {t("exports:list.imported")}
+            </Badge>
+          )}
+          {isDeleted && (
+            <Badge variant="destructive" data-testid={`export-row-${exp.id}-deleted`}>
+              {t("exports:list.deletedBadge")}
+            </Badge>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <span>{scopeLabel}</span>
+          <span aria-hidden="true">·</span>
+          <span>
+            {t("exports:detail.counts.locations", { count: exp.location_count ?? 0 })} /{" "}
+            {t("exports:detail.counts.commodities", { count: exp.commodity_count ?? 0 })} /{" "}
+            {t("exports:detail.counts.files", { count: exp.file_count ?? 0 })}
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>{formatBytes(exp.file_size ?? 0)}</span>
+          <span aria-hidden="true">·</span>
+          <span>{exp.created_date ? formatDateTime(exp.created_date) : "—"}</span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {exp.status && <ExportStatusBadge status={exp.status} />}
+        <Button
+          asChild
+          size="sm"
+          variant="outline"
+          disabled={!isTerminal || !isCompleted || isDeleted}
+          aria-disabled={!isTerminal || !isCompleted || isDeleted}
+          className={cn((!isTerminal || !isCompleted || isDeleted) && "pointer-events-none")}
+        >
+          <a
+            href={downloadHref}
+            data-testid={`export-row-${exp.id}-download`}
+            // The list page renders a row per export. The download is a
+            // top-level GET; let the browser handle save-as.
+          >
+            <Download className="mr-1.5 size-4" aria-hidden="true" />
+            {t("exports:actions.download")}
+          </a>
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={onDelete}
+          disabled={isDeleted}
+          data-testid={`export-row-${exp.id}-delete`}
+          aria-label={t("exports:actions.delete")}
+        >
+          <Trash2 className="size-4" aria-hidden="true" />
+        </Button>
+      </div>
+
+      <span className="sr-only">{totalItemCount(exp)}</span>
+    </div>
+  )
+}

--- a/frontend/src/components/exports/ExportStatusBadge.tsx
+++ b/frontend/src/components/exports/ExportStatusBadge.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "@/components/ui/badge"
+import type { ExportStatus, RestoreStatus } from "@/features/export/api"
+import { cn } from "@/lib/utils"
+
+type Status = ExportStatus | RestoreStatus
+
+// Hue mapping mirrors the design mock's "Backup" view: pending stays
+// neutral, in-flight uses the brand accent, completed is success-green,
+// failed is destructive. The same map serves both export and restore
+// statuses because the design system intentionally renders them with
+// the same vocabulary.
+const STATUS_VARIANT: Record<Status, "secondary" | "default" | "destructive" | "outline"> = {
+  pending: "secondary",
+  in_progress: "default",
+  running: "default",
+  completed: "outline",
+  failed: "destructive",
+}
+
+const STATUS_TONE: Record<Status, string> = {
+  pending: "",
+  in_progress: "",
+  running: "",
+  completed: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  failed: "",
+}
+
+export interface ExportStatusBadgeProps {
+  status: Status
+  className?: string
+}
+
+export function ExportStatusBadge({ status, className }: ExportStatusBadgeProps) {
+  const { t } = useTranslation(["exports"])
+  return (
+    <Badge
+      variant={STATUS_VARIANT[status]}
+      data-testid={`status-${status}`}
+      className={cn(STATUS_TONE[status], className)}
+    >
+      {t(`exports:status.${status}`)}
+    </Badge>
+  )
+}

--- a/frontend/src/components/exports/RestoreHistoryList.tsx
+++ b/frontend/src/components/exports/RestoreHistoryList.tsx
@@ -1,0 +1,84 @@
+import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
+
+import { ExportStatusBadge } from "@/components/exports/ExportStatusBadge"
+import { Skeleton } from "@/components/ui/skeleton"
+import type { Restore } from "@/features/export/api"
+import { formatDateTime } from "@/lib/intl"
+
+export interface RestoreHistoryListProps {
+  exportId: string
+  groupSlug: string
+  loading: boolean
+  restores: Restore[]
+}
+
+// Lists previous restore operations attached to an export. Each row
+// links to the detail page for the restore (rendered inline on the
+// export detail for now); when the steps tree lands as its own page
+// the detailHref will switch to a dedicated route.
+export function RestoreHistoryList({
+  exportId,
+  groupSlug,
+  loading,
+  restores,
+}: RestoreHistoryListProps) {
+  const { t } = useTranslation(["exports"])
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="restores-loading">
+        {Array.from({ length: 2 }).map((_, idx) => (
+          <Skeleton key={idx} className="h-12 w-full" />
+        ))}
+      </div>
+    )
+  }
+  if (restores.length === 0) {
+    return (
+      <p
+        className="rounded-md border bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground"
+        data-testid="restores-empty"
+      >
+        {t("exports:detail.noRestores")}
+      </p>
+    )
+  }
+  return (
+    <ul className="flex flex-col gap-2" data-testid="restores-list">
+      {restores.map((r) => (
+        <li
+          key={r.id}
+          className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-card px-4 py-3"
+          data-testid={`restore-row-${r.id}`}
+        >
+          <div className="flex min-w-0 flex-col gap-1">
+            <Link
+              to={`/g/${encodeURIComponent(groupSlug)}/exports/${encodeURIComponent(exportId)}?restore=${encodeURIComponent(r.id)}`}
+              className="truncate text-sm font-medium hover:underline"
+            >
+              {r.description?.trim() || t("exports:restore.title")}
+            </Link>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span>{r.created_date ? formatDateTime(r.created_date) : "—"}</span>
+              {r.options?.dry_run && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span>{t("exports:restore.dryRun")}</span>
+                </>
+              )}
+              {typeof r.options?.strategy === "string" && r.options.strategy && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span>
+                    {t(`exports:restore.strategyLabel.${r.options.strategy}`, r.options.strategy)}
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+          {r.status && <ExportStatusBadge status={r.status} />}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/frontend/src/components/exports/RestoreHistoryList.tsx
+++ b/frontend/src/components/exports/RestoreHistoryList.tsx
@@ -70,7 +70,9 @@ export function RestoreHistoryList({
                 <>
                   <span aria-hidden="true">·</span>
                   <span>
-                    {t(`exports:restore.strategyLabel.${r.options.strategy}`, r.options.strategy)}
+                    {t(`exports:restore.strategyLabel.${r.options.strategy}`, {
+                      defaultValue: r.options.strategy,
+                    })}
                   </span>
                 </>
               )}

--- a/frontend/src/components/exports/SelectedItemsPicker.tsx
+++ b/frontend/src/components/exports/SelectedItemsPicker.tsx
@@ -1,0 +1,101 @@
+import { useTranslation } from "react-i18next"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import type { ExportSelectedItem } from "@/features/export/api"
+import { useLocations } from "@/features/locations/hooks"
+import { cn } from "@/lib/utils"
+
+export interface SelectedItemsPickerProps {
+  value: ExportSelectedItem[]
+  onChange: (next: ExportSelectedItem[]) => void
+  // Errors mounted by the form-level validation. Renders below the list
+  // so screen readers pick it up after the listbox.
+  errorMessage?: string
+}
+
+// SelectedItemsPicker lets the user pick whole locations to scope the
+// export. Picking a location adds a `{ type: "location", id, include_all: true }`
+// entry; picking the same location again removes it. The picker is
+// intentionally location-only in this first cut — area / commodity
+// granularity is tracked as a follow-up to keep this wizard small. The
+// BE accepts the same `selected_items` shape regardless of which leaf
+// type the user picks, so adding the other entity types later is purely
+// additive.
+export function SelectedItemsPicker({ value, onChange, errorMessage }: SelectedItemsPickerProps) {
+  const { t } = useTranslation(["exports"])
+  const locationsQuery = useLocations()
+  const locations = locationsQuery.data ?? []
+  const pickedIds = new Set(value.map((item) => item.id).filter((id): id is string => !!id))
+
+  function toggle(locationId: string, locationName: string) {
+    if (pickedIds.has(locationId)) {
+      onChange(value.filter((entry) => entry.id !== locationId))
+    } else {
+      onChange([
+        ...value,
+        { type: "location", id: locationId, name: locationName, include_all: true },
+      ])
+    }
+  }
+
+  if (locationsQuery.isLoading) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="selected-items-picker-loading">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <Skeleton key={idx} className="h-10 w-full" />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2" data-testid="selected-items-picker">
+      {locations.length === 0 ? (
+        <p className="text-sm text-muted-foreground" data-testid="selected-items-picker-empty">
+          {t("exports:wizard.scopePicker.empty")}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {locations.map((loc) => {
+            const id = loc.id ?? ""
+            const checked = pickedIds.has(id)
+            return (
+              <li key={id}>
+                <label
+                  className={cn(
+                    "flex cursor-pointer items-center justify-between gap-3 rounded-md border bg-card px-3 py-2 text-sm",
+                    checked && "border-primary/40 bg-primary/5"
+                  )}
+                  data-testid={`selected-items-picker-row-${id}`}
+                >
+                  <span className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      className="size-4"
+                      checked={checked}
+                      onChange={() => toggle(id, loc.name ?? "")}
+                      aria-label={loc.name ?? id}
+                    />
+                    <span className="font-medium">{loc.name ?? id}</span>
+                  </span>
+                  {loc.address && (
+                    <span className="truncate text-xs text-muted-foreground">{loc.address}</span>
+                  )}
+                </label>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+      {errorMessage && (
+        <p
+          className="text-sm text-destructive"
+          role="alert"
+          data-testid="selected-items-picker-error"
+        >
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/export/__tests__/api.test.ts
+++ b/frontend/src/features/export/__tests__/api.test.ts
@@ -1,0 +1,272 @@
+import { http, HttpResponse } from "msw"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  createExport,
+  createRestore,
+  deleteExport,
+  exportDownloadPath,
+  getExport,
+  getRestore,
+  importBackup,
+  isExportTerminal,
+  isRestoreTerminal,
+  listExports,
+  listRestores,
+  uploadRestoreFile,
+} from "@/features/export/api"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests, setCurrentGroupSlug } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { apiUrl } from "@/test/handlers"
+import { server } from "@/test/server"
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("token")
+  setCurrentGroupSlug("g1")
+})
+
+describe("features/export/api", () => {
+  it("listExports flattens the JSON:API envelope and reads meta.exports", async () => {
+    server.use(
+      http.get(apiUrl("/g/g1/exports"), () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "e1",
+              type: "exports",
+              attributes: { type: "full_database", status: "completed" },
+            },
+            {
+              id: "e2",
+              type: "exports",
+              attributes: { type: "selected_items", status: "in_progress" },
+            },
+          ],
+          meta: { exports: 2 },
+        })
+      )
+    )
+    const { exports, total } = await listExports()
+    expect(total).toBe(2)
+    expect(exports).toHaveLength(2)
+    expect(exports[0]).toMatchObject({ id: "e1", type: "full_database", status: "completed" })
+  })
+
+  it("listExports forwards include_deleted to the BE", async () => {
+    let captured: URL | null = null
+    server.use(
+      http.get(apiUrl("/g/g1/exports"), ({ request }) => {
+        captured = new URL(request.url)
+        return HttpResponse.json({ data: [], meta: { exports: 0 } })
+      })
+    )
+    await listExports({ includeDeleted: true })
+    expect(captured!.searchParams.get("include_deleted")).toBe("true")
+  })
+
+  it("getExport rehydrates the resource on /exports/:id", async () => {
+    server.use(
+      http.get(apiUrl("/g/g1/exports/e1"), () =>
+        HttpResponse.json({
+          data: {
+            id: "e1",
+            type: "exports",
+            attributes: { type: "full_database", status: "completed", file_count: 5 },
+          },
+        })
+      )
+    )
+    const exp = await getExport("e1")
+    expect(exp.id).toBe("e1")
+    expect(exp.file_count).toBe(5)
+  })
+
+  it("createExport posts the JSON:API request and returns the created row", async () => {
+    let body: unknown = null
+    server.use(
+      http.post(apiUrl("/g/g1/exports"), async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json(
+          {
+            data: {
+              id: "e1",
+              type: "exports",
+              attributes: { type: "full_database", status: "pending" },
+            },
+          },
+          { status: 201 }
+        )
+      })
+    )
+    const exp = await createExport({
+      type: "full_database",
+      description: "weekly",
+      include_file_data: true,
+    })
+    expect(exp.id).toBe("e1")
+    expect(body).toEqual({
+      data: {
+        type: "exports",
+        attributes: { type: "full_database", description: "weekly", include_file_data: true },
+      },
+    })
+  })
+
+  it("deleteExport hits /exports/:id and surfaces 204", async () => {
+    server.use(
+      http.delete(apiUrl("/g/g1/exports/e1"), () => new HttpResponse(null, { status: 204 }))
+    )
+    await expect(deleteExport("e1")).resolves.toBeUndefined()
+  })
+
+  it("uploadRestoreFile sends a multipart body and returns the staged path", async () => {
+    let receivedContentType = ""
+    server.use(
+      http.post(apiUrl("/g/g1/uploads/restores"), ({ request }) => {
+        receivedContentType = request.headers.get("content-type") ?? ""
+        return HttpResponse.json({
+          id: "uploads",
+          type: "uploads",
+          attributes: { fileNames: ["restores/2026/05/abc.xml"], type: "restores" },
+        })
+      })
+    )
+    const f = new File(["<export/>"], "backup.xml", { type: "application/xml" })
+    const result = await uploadRestoreFile(f)
+    // FormData triggers the browser-built `multipart/form-data; boundary=...`
+    // header (the http wrapper deliberately doesn't override it). Asserting
+    // that prefix is enough to prove the request went out as multipart.
+    expect(receivedContentType).toMatch(/^multipart\/form-data/)
+    expect(result.sourceFilePath).toBe("restores/2026/05/abc.xml")
+  })
+
+  it("uploadRestoreFile throws when the BE returns no fileNames", async () => {
+    server.use(
+      http.post(apiUrl("/g/g1/uploads/restores"), () =>
+        HttpResponse.json({ id: "u", type: "uploads", attributes: { fileNames: [] } })
+      )
+    )
+    const f = new File(["x"], "x.xml")
+    await expect(uploadRestoreFile(f)).rejects.toThrow(/fileNames/)
+  })
+
+  it("importBackup posts the description+source_file_path and returns the imported export", async () => {
+    let body: unknown = null
+    server.use(
+      http.post(apiUrl("/g/g1/exports/import"), async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json(
+          {
+            data: {
+              id: "imp-1",
+              type: "exports",
+              attributes: { type: "imported", status: "completed", imported: true },
+            },
+          },
+          { status: 201 }
+        )
+      })
+    )
+    const result = await importBackup({
+      description: "from disk",
+      source_file_path: "restores/2026/05/abc.xml",
+    })
+    expect(result.id).toBe("imp-1")
+    expect(result.imported).toBe(true)
+    expect(body).toEqual({
+      data: {
+        type: "exports",
+        attributes: { description: "from disk", source_file_path: "restores/2026/05/abc.xml" },
+      },
+    })
+  })
+
+  it("listRestores rehydrates the per-export restore list", async () => {
+    server.use(
+      http.get(apiUrl("/g/g1/exports/e1/restores"), () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "r1",
+              type: "restores",
+              attributes: { status: "completed", description: "first" },
+            },
+          ],
+        })
+      )
+    )
+    const { restores } = await listRestores("e1")
+    expect(restores).toHaveLength(1)
+    expect(restores[0].id).toBe("r1")
+  })
+
+  it("createRestore wraps the options block under attributes", async () => {
+    let body: unknown = null
+    server.use(
+      http.post(apiUrl("/g/g1/exports/e1/restores"), async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json(
+          {
+            data: {
+              id: "r1",
+              type: "restores",
+              attributes: { status: "pending", description: "" },
+            },
+          },
+          { status: 201 }
+        )
+      })
+    )
+    const result = await createRestore("e1", {
+      description: "",
+      options: { strategy: "merge_add", include_file_data: true, dry_run: true },
+    })
+    expect(result.id).toBe("r1")
+    expect(body).toEqual({
+      data: {
+        type: "restores",
+        attributes: {
+          description: "",
+          options: { strategy: "merge_add", include_file_data: true, dry_run: true },
+        },
+      },
+    })
+  })
+
+  it("getRestore reads the per-export restore detail", async () => {
+    server.use(
+      http.get(apiUrl("/g/g1/exports/e1/restores/r1"), () =>
+        HttpResponse.json({
+          data: {
+            id: "r1",
+            type: "restores",
+            attributes: { status: "running" },
+          },
+        })
+      )
+    )
+    const result = await getRestore("e1", "r1")
+    expect(result.status).toBe("running")
+  })
+
+  it("isExportTerminal / isRestoreTerminal flag completed and failed only", () => {
+    expect(isExportTerminal("completed")).toBe(true)
+    expect(isExportTerminal("failed")).toBe(true)
+    expect(isExportTerminal("pending")).toBe(false)
+    expect(isExportTerminal("in_progress")).toBe(false)
+    expect(isExportTerminal(undefined)).toBe(false)
+
+    expect(isRestoreTerminal("completed")).toBe(true)
+    expect(isRestoreTerminal("failed")).toBe(true)
+    expect(isRestoreTerminal("running")).toBe(false)
+    expect(isRestoreTerminal("pending")).toBe(false)
+  })
+
+  it("exportDownloadPath builds the absolute /api/v1/g/<slug>/ download URL", () => {
+    expect(exportDownloadPath("e1", "household")).toBe("/api/v1/g/household/exports/e1/download")
+  })
+})

--- a/frontend/src/features/export/__tests__/api.test.ts
+++ b/frontend/src/features/export/__tests__/api.test.ts
@@ -267,6 +267,16 @@ describe("features/export/api", () => {
   })
 
   it("exportDownloadPath builds the absolute /api/v1/g/<slug>/ download URL", () => {
-    expect(exportDownloadPath("e1", "household")).toBe("/api/v1/g/household/exports/e1/download")
+    expect(exportDownloadPath("e1", "household", null)).toBe(
+      "/api/v1/g/household/exports/e1/download"
+    )
+  })
+
+  it("exportDownloadPath appends the access token as ?token= for <a href> downloads", () => {
+    // The BE accepts JWT via Authorization or ?token=; <a href> doesn't
+    // send Authorization, so the wrapper has to attach the token.
+    expect(exportDownloadPath("e1", "household", "tok-abc")).toBe(
+      "/api/v1/g/household/exports/e1/download?token=tok-abc"
+    )
   })
 })

--- a/frontend/src/features/export/api.ts
+++ b/frontend/src/features/export/api.ts
@@ -1,0 +1,261 @@
+// Pure data-layer functions for the exports / imports / restores feature
+// slice. Hooks live in `./hooks.ts`. Backed by the `/exports`, `/exports/{id}`,
+// `/exports/{id}/restores`, `/exports/import` and `/uploads/restores` surfaces.
+import { http } from "@/lib/http"
+import type { Schema } from "@/types"
+
+export type ExportEntity = Schema<"models.Export">
+export type ExportStatus = Schema<"models.ExportStatus">
+export type ExportType = Schema<"models.ExportType">
+export type ExportSelectedItem = Schema<"models.ExportSelectedItem">
+export type ExportSelectedItemType = Schema<"models.ExportSelectedItemType">
+export type RestoreOperation = Schema<"models.RestoreOperation">
+export type RestoreOptions = Schema<"models.RestoreOptions">
+export type RestoreStatus = Schema<"models.RestoreStatus">
+export type RestoreStep = Schema<"models.RestoreStep">
+
+// `as const` keeps the literal-union type so callers can `z.enum(...)`
+// without widening to string. The `satisfies` clauses guard against a
+// silent BE drift — adding a status to the OpenAPI model without
+// updating the FE list will fail the typecheck here.
+export const EXPORT_STATUSES = [
+  "pending",
+  "in_progress",
+  "completed",
+  "failed",
+] as const satisfies readonly ExportStatus[]
+
+export const EXPORT_TYPES = [
+  "full_database",
+  "selected_items",
+  "locations",
+  "areas",
+  "commodities",
+  "imported",
+] as const satisfies readonly ExportType[]
+
+export const RESTORE_STATUSES = [
+  "pending",
+  "running",
+  "completed",
+  "failed",
+] as const satisfies readonly RestoreStatus[]
+
+// Strategy strings live on the BE in go/backup/restore/types/types.go.
+// Kept as a literal-union here because models.RestoreOptions.strategy is
+// typed as plain string in the generated schema.
+export const RESTORE_STRATEGIES = ["full_replace", "merge_add", "merge_update"] as const
+export type RestoreStrategy = (typeof RESTORE_STRATEGIES)[number]
+
+const TERMINAL_EXPORT_STATUSES: ReadonlySet<ExportStatus> = new Set(["completed", "failed"])
+const TERMINAL_RESTORE_STATUSES: ReadonlySet<RestoreStatus> = new Set(["completed", "failed"])
+
+export function isExportTerminal(status: ExportStatus | undefined): boolean {
+  return !!status && TERMINAL_EXPORT_STATUSES.has(status)
+}
+
+export function isRestoreTerminal(status: RestoreStatus | undefined): boolean {
+  return !!status && TERMINAL_RESTORE_STATUSES.has(status)
+}
+
+// Identity-resolved entity types we expose in TS. The OpenAPI types make
+// `id` optional on every payload but in practice the BE always returns
+// one — we throw on malformed responses rather than letting an empty id
+// propagate into cache keys, navigation URLs, and follow-up calls.
+export type Export = ExportEntity & { id: string }
+export type Restore = RestoreOperation & { id: string }
+
+interface ExportEnvelope {
+  id?: string
+  type?: string
+  attributes?: ExportEntity
+}
+
+interface ExportsListEnvelope {
+  data?: ExportEnvelope[]
+  meta?: {
+    exports?: number
+  }
+}
+
+interface RestoreEnvelope {
+  id?: string
+  type?: string
+  attributes?: RestoreOperation
+}
+
+interface RestoresListEnvelope {
+  data?: RestoreEnvelope[]
+}
+
+interface UploadEnvelope {
+  id?: string
+  type?: string
+  attributes?: {
+    fileNames?: string[]
+    type?: string
+  }
+}
+
+function resolveExport(envelope: ExportEnvelope, fallbackId?: string): Export {
+  if (!envelope.attributes) {
+    throw new Error("Malformed exports response: missing attributes")
+  }
+  const id = envelope.id ?? fallbackId
+  if (!id) {
+    throw new Error("Malformed exports response: missing id")
+  }
+  return { ...envelope.attributes, id }
+}
+
+function resolveRestore(envelope: RestoreEnvelope, fallbackId?: string): Restore {
+  if (!envelope.attributes) {
+    throw new Error("Malformed restores response: missing attributes")
+  }
+  const id = envelope.id ?? fallbackId
+  if (!id) {
+    throw new Error("Malformed restores response: missing id")
+  }
+  return { ...envelope.attributes, id }
+}
+
+export interface ListExportsOptions {
+  includeDeleted?: boolean
+  signal?: AbortSignal
+}
+
+export async function listExports(
+  options: ListExportsOptions = {}
+): Promise<{ exports: Export[]; total: number }> {
+  const params = new URLSearchParams()
+  if (options.includeDeleted) params.set("include_deleted", "true")
+  const qs = params.toString()
+  const path = qs ? `/exports?${qs}` : "/exports"
+  const body = await http.get<ExportsListEnvelope>(path, { signal: options.signal })
+  const exports = (body.data ?? []).map((row) => resolveExport(row))
+  return { exports, total: body.meta?.exports ?? exports.length }
+}
+
+export async function getExport(id: string, signal?: AbortSignal): Promise<Export> {
+  const body = await http.get<{ data?: ExportEnvelope }>(`/exports/${encodeURIComponent(id)}`, {
+    signal,
+  })
+  if (!body.data) {
+    throw new Error(`Malformed /exports/${id} response: missing data`)
+  }
+  return resolveExport(body.data, id)
+}
+
+export interface CreateExportRequest {
+  type: ExportType
+  description: string
+  include_file_data: boolean
+  selected_items?: ExportSelectedItem[]
+}
+
+export async function createExport(req: CreateExportRequest): Promise<Export> {
+  const body = await http.post<{ data?: ExportEnvelope }>("/exports", {
+    data: { type: "exports", attributes: req },
+  })
+  if (!body.data) {
+    throw new Error("Malformed POST /exports response: missing data")
+  }
+  return resolveExport(body.data)
+}
+
+export async function deleteExport(id: string): Promise<void> {
+  await http.del<void>(`/exports/${encodeURIComponent(id)}`)
+}
+
+// downloadUrl returns the absolute path the browser should hit to fetch
+// the XML payload. The BE applies the same Bearer + group rewrite logic
+// as the JSON surface, so we can hand this to <a href> directly — the
+// browser will replay the same auth cookie, and the BE 200s with
+// Content-Disposition. We do not stream through fetch() because the
+// browser's native download UX (filename, progress, cancel) is better
+// than anything we'd build by hand.
+export function exportDownloadPath(id: string, slug: string): string {
+  return `/api/v1/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(id)}/download`
+}
+
+export interface UploadRestoreFileResult {
+  sourceFilePath: string
+}
+
+// Two-step "import a backup": first upload the XML, then create an
+// "imported" export record from it. The first step intentionally lives
+// under /uploads/restores (not /exports/import) — the BE writes the
+// blob to a sandboxed bucket and only acknowledges the path; nothing
+// is parsed until the second call.
+export async function uploadRestoreFile(file: File): Promise<UploadRestoreFileResult> {
+  const form = new FormData()
+  form.append("file", file)
+  const body = await http.post<UploadEnvelope>("/uploads/restores", form)
+  const fileNames = body.attributes?.fileNames ?? []
+  const sourceFilePath = fileNames[0]
+  if (!sourceFilePath) {
+    throw new Error("Malformed /uploads/restores response: missing fileNames[0]")
+  }
+  return { sourceFilePath }
+}
+
+export interface ImportBackupRequest {
+  description: string
+  source_file_path: string
+}
+
+export async function importBackup(req: ImportBackupRequest): Promise<Export> {
+  const body = await http.post<{ data?: ExportEnvelope }>("/exports/import", {
+    data: { type: "exports", attributes: req },
+  })
+  if (!body.data) {
+    throw new Error("Malformed POST /exports/import response: missing data")
+  }
+  return resolveExport(body.data)
+}
+
+export async function listRestores(
+  exportId: string,
+  signal?: AbortSignal
+): Promise<{ restores: Restore[] }> {
+  const body = await http.get<RestoresListEnvelope>(
+    `/exports/${encodeURIComponent(exportId)}/restores`,
+    { signal }
+  )
+  return { restores: (body.data ?? []).map((row) => resolveRestore(row)) }
+}
+
+export async function getRestore(
+  exportId: string,
+  restoreId: string,
+  signal?: AbortSignal
+): Promise<Restore> {
+  const body = await http.get<{ data?: RestoreEnvelope }>(
+    `/exports/${encodeURIComponent(exportId)}/restores/${encodeURIComponent(restoreId)}`,
+    { signal }
+  )
+  if (!body.data) {
+    throw new Error(`Malformed restore detail response: missing data`)
+  }
+  return resolveRestore(body.data, restoreId)
+}
+
+export interface CreateRestoreRequest {
+  description: string
+  options: {
+    strategy: RestoreStrategy
+    include_file_data: boolean
+    dry_run: boolean
+  }
+}
+
+export async function createRestore(exportId: string, req: CreateRestoreRequest): Promise<Restore> {
+  const body = await http.post<{ data?: RestoreEnvelope }>(
+    `/exports/${encodeURIComponent(exportId)}/restores`,
+    { data: { type: "restores", attributes: req } }
+  )
+  if (!body.data) {
+    throw new Error("Malformed POST /restores response: missing data")
+  }
+  return resolveRestore(body.data)
+}

--- a/frontend/src/features/export/api.ts
+++ b/frontend/src/features/export/api.ts
@@ -1,6 +1,9 @@
 // Pure data-layer functions for the exports / imports / restores feature
 // slice. Hooks live in `./hooks.ts`. Backed by the `/exports`, `/exports/{id}`,
 // `/exports/{id}/restores`, `/exports/import` and `/uploads/restores` surfaces.
+import { useMemo } from "react"
+
+import { getAccessToken } from "@/lib/auth-storage"
 import { http } from "@/lib/http"
 import type { Schema } from "@/types"
 
@@ -167,15 +170,30 @@ export async function deleteExport(id: string): Promise<void> {
   await http.del<void>(`/exports/${encodeURIComponent(id)}`)
 }
 
-// downloadUrl returns the absolute path the browser should hit to fetch
-// the XML payload. The BE applies the same Bearer + group rewrite logic
-// as the JSON surface, so we can hand this to <a href> directly — the
-// browser will replay the same auth cookie, and the BE 200s with
-// Content-Disposition. We do not stream through fetch() because the
-// browser's native download UX (filename, progress, cancel) is better
-// than anything we'd build by hand.
-export function exportDownloadPath(id: string, slug: string): string {
-  return `/api/v1/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(id)}/download`
+// Internal builder. The BE accepts JWT either as `Authorization: Bearer
+// …` or as `?token=…` (see go/apiserver/jwt_middleware.go). Plain
+// `<a href>` clicks do not send Authorization (the access token lives
+// in localStorage), so we append the token as a query param so the
+// browser's native download UX still works. The token leaks into
+// referer / browser history — acceptable for short-lived JWTs but
+// callers must not surface this URL outside of the download CTA.
+export function exportDownloadPath(id: string, slug: string, accessToken: string | null): string {
+  const path = `/api/v1/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(id)}/download`
+  if (!accessToken) return path
+  return `${path}?token=${encodeURIComponent(accessToken)}`
+}
+
+// React hook variant that pulls the current access token from storage.
+// Returns null when either the id or slug is missing so callers can
+// gate the download CTA on a usable href.
+export function useExportDownloadHref(
+  id: string | undefined,
+  slug: string | undefined
+): string | null {
+  return useMemo(() => {
+    if (!id || !slug) return null
+    return exportDownloadPath(id, slug, getAccessToken())
+  }, [id, slug])
 }
 
 export interface UploadRestoreFileResult {

--- a/frontend/src/features/export/hooks.ts
+++ b/frontend/src/features/export/hooks.ts
@@ -1,0 +1,184 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useCurrentGroup } from "@/features/group/GroupContext"
+
+import {
+  type CreateExportRequest,
+  type CreateRestoreRequest,
+  type Export,
+  type ImportBackupRequest,
+  type ListExportsOptions,
+  type Restore,
+  type UploadRestoreFileResult,
+  createExport,
+  createRestore,
+  deleteExport,
+  getExport,
+  getRestore,
+  importBackup,
+  isExportTerminal,
+  isRestoreTerminal,
+  listExports,
+  listRestores,
+  uploadRestoreFile,
+} from "./api"
+import { exportKeys } from "./keys"
+
+interface QueryOptions {
+  enabled?: boolean
+}
+
+// Polling cadence for in-progress entities. Picked at 2s — short enough
+// that the wizard's "creating…" step feels live, long enough that an
+// idle list page stays cheap. TanStack Query backs off when the tab is
+// hidden so this is safe to leave on every list mount.
+const POLL_INTERVAL_MS = 2000
+
+export function useExports(opts: ListExportsOptions = {}, query: QueryOptions = {}) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  const enabled = query.enabled ?? true
+  return useQuery<{ exports: Export[]; total: number }>({
+    queryKey: exportKeys.list(slug, opts),
+    queryFn: ({ signal }) => listExports({ ...opts, signal }),
+    enabled,
+    placeholderData: (prev) => prev,
+    refetchInterval: (query) => {
+      // Poll while ANY row is non-terminal so the user sees status flips
+      // without a manual refresh. Once all rows are completed/failed the
+      // interval drops to false (no polling) and we rely on mutations
+      // to invalidate.
+      const data = query.state.data
+      if (!data) return false
+      const anyInFlight = data.exports.some((e) => !isExportTerminal(e.status))
+      return anyInFlight ? POLL_INTERVAL_MS : false
+    },
+  })
+}
+
+export function useExport(id: string | undefined, { enabled = true }: QueryOptions = {}) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useQuery<Export>({
+    queryKey: exportKeys.detail(slug, id ?? ""),
+    queryFn: ({ signal }) => {
+      if (!id) throw new Error("useExport called without an id")
+      return getExport(id, signal)
+    },
+    enabled: enabled && !!id,
+    refetchInterval: (query) => {
+      const data = query.state.data
+      if (!data) return false
+      return isExportTerminal(data.status) ? false : POLL_INTERVAL_MS
+    },
+  })
+}
+
+export function useExportRestores(
+  exportId: string | undefined,
+  { enabled = true }: QueryOptions = {}
+) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useQuery<{ restores: Restore[] }>({
+    queryKey: exportKeys.restoreList(slug, exportId ?? ""),
+    queryFn: ({ signal }) => {
+      if (!exportId) throw new Error("useExportRestores called without an exportId")
+      return listRestores(exportId, signal)
+    },
+    enabled: enabled && !!exportId,
+    refetchInterval: (query) => {
+      const data = query.state.data
+      if (!data) return false
+      const anyInFlight = data.restores.some((r) => !isRestoreTerminal(r.status))
+      return anyInFlight ? POLL_INTERVAL_MS : false
+    },
+  })
+}
+
+export function useRestore(
+  exportId: string | undefined,
+  restoreId: string | undefined,
+  { enabled = true }: QueryOptions = {}
+) {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useQuery<Restore>({
+    queryKey: exportKeys.restoreDetail(slug, exportId ?? "", restoreId ?? ""),
+    queryFn: ({ signal }) => {
+      if (!exportId || !restoreId) {
+        throw new Error("useRestore called without exportId/restoreId")
+      }
+      return getRestore(exportId, restoreId, signal)
+    },
+    enabled: enabled && !!exportId && !!restoreId,
+    refetchInterval: (query) => {
+      const data = query.state.data
+      if (!data) return false
+      return isRestoreTerminal(data.status) ? false : POLL_INTERVAL_MS
+    },
+  })
+}
+
+// invalidateAll wipes the entire exports namespace for the active group.
+// Used after every mutation because list and detail queries hold derived
+// state (counts, status, restore lists) that any mutation can shift.
+function useInvalidate() {
+  const qc = useQueryClient()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return {
+    all: () => qc.invalidateQueries({ queryKey: exportKeys.group(slug) }),
+    detail: (id: string) => qc.invalidateQueries({ queryKey: exportKeys.detail(slug, id) }),
+    restores: (exportId: string) =>
+      qc.invalidateQueries({ queryKey: exportKeys.restoreList(slug, exportId) }),
+  }
+}
+
+export function useCreateExport() {
+  const invalidate = useInvalidate()
+  return useMutation<Export, Error, CreateExportRequest>({
+    mutationFn: (req) => createExport(req),
+    onSuccess: () => invalidate.all(),
+  })
+}
+
+export function useDeleteExport() {
+  const invalidate = useInvalidate()
+  return useMutation<void, Error, string>({
+    mutationFn: (id) => deleteExport(id),
+    onSuccess: () => invalidate.all(),
+  })
+}
+
+export function useUploadRestoreFile() {
+  // No invalidation — the upload alone does not create or modify any
+  // exports/restores rows; the follow-up importBackup() does that.
+  return useMutation<UploadRestoreFileResult, Error, File>({
+    mutationFn: (file) => uploadRestoreFile(file),
+  })
+}
+
+export function useImportBackup() {
+  const invalidate = useInvalidate()
+  return useMutation<Export, Error, ImportBackupRequest>({
+    mutationFn: (req) => importBackup(req),
+    onSuccess: () => invalidate.all(),
+  })
+}
+
+interface CreateRestoreVars {
+  exportId: string
+  req: CreateRestoreRequest
+}
+
+export function useCreateRestore() {
+  const invalidate = useInvalidate()
+  return useMutation<Restore, Error, CreateRestoreVars>({
+    mutationFn: ({ exportId, req }) => createRestore(exportId, req),
+    onSuccess: (_data, { exportId }) => {
+      invalidate.detail(exportId)
+      invalidate.restores(exportId)
+    },
+  })
+}

--- a/frontend/src/features/export/keys.ts
+++ b/frontend/src/features/export/keys.ts
@@ -1,0 +1,24 @@
+import type { ListExportsOptions } from "./api"
+
+function listKeySuffix(opts: ListExportsOptions | undefined): string {
+  if (!opts) return ""
+  const params = new URLSearchParams()
+  if (opts.includeDeleted) params.set("include_deleted", "true")
+  return params.toString()
+}
+
+// TanStack Query keys for the exports / restores slice. Scoped by group
+// slug because the http client rewrites /exports -> /g/{slug}/exports;
+// without the slug in the key, navigating between groups would reuse
+// the wrong cache.
+export const exportKeys = {
+  all: ["export"] as const,
+  group: (slug: string) => [...exportKeys.all, slug] as const,
+  list: (slug: string, opts?: ListExportsOptions) =>
+    [...exportKeys.group(slug), "list", listKeySuffix(opts)] as const,
+  detail: (slug: string, id: string) => [...exportKeys.group(slug), "detail", id] as const,
+  restoreList: (slug: string, exportId: string) =>
+    [...exportKeys.group(slug), "detail", exportId, "restores"] as const,
+  restoreDetail: (slug: string, exportId: string, restoreId: string) =>
+    [...exportKeys.group(slug), "detail", exportId, "restores", restoreId] as const,
+}

--- a/frontend/src/i18n/locales/en/exports.json
+++ b/frontend/src/i18n/locales/en/exports.json
@@ -76,7 +76,7 @@
   },
   "restore": {
     "description": "Description",
-    "descriptionHint": "Optional. Useful when comparing dry-runs.",
+    "descriptionHint": "Required. Useful when comparing dry-runs.",
     "descriptionPlaceholder": "Restore into staging on 2026-05-03",
     "dryRun": "Dry run (preview only — no changes are written)",
     "includeFileData": "Restore attached files",

--- a/frontend/src/i18n/locales/en/exports.json
+++ b/frontend/src/i18n/locales/en/exports.json
@@ -1,1 +1,159 @@
-{}
+{
+  "actions": {
+    "createExport": "New export",
+    "delete": "Delete",
+    "download": "Download",
+    "import": "Import backup",
+    "restore": "Restore",
+    "showDeleted": "Show deleted",
+    "viewDetail": "Open"
+  },
+  "detail": {
+    "binaryDataSize": "Attachments size",
+    "completedAt": "Completed",
+    "counts": {
+      "areas_one": "{{count}} area",
+      "areas_other": "{{count}} areas",
+      "commodities_one": "{{count}} item",
+      "commodities_other": "{{count}} items",
+      "files_one": "{{count}} file",
+      "files_other": "{{count}} files",
+      "locations_one": "{{count}} location",
+      "locations_other": "{{count}} locations"
+    },
+    "createdAt": "Created",
+    "errorMessage": "Error",
+    "imported": "This export was imported from a backup file.",
+    "includesFileData": "Includes attachments",
+    "noDescription": "No description.",
+    "noRestores": "No restores have been run from this export yet.",
+    "notFound": "Export not found.",
+    "restoreHistory": "Restore history",
+    "scope": "Scope",
+    "scopeSelectedItems_one": "{{count}} selected item",
+    "scopeSelectedItems_other": "{{count}} selected items",
+    "title": "Export",
+    "totalSize": "File size"
+  },
+  "errors": {
+    "createFailed": "Could not create export: {{error}}",
+    "deleteFailed": "Could not delete export: {{error}}",
+    "importFailed": "Could not import backup: {{error}}",
+    "loadFailed": "Could not load exports: {{error}}",
+    "restoreCreateFailed": "Could not start restore: {{error}}",
+    "uploadFailed": "Could not upload file: {{error}}"
+  },
+  "importView": {
+    "description": "Description",
+    "descriptionHint": "Optional. Helps you find the import in the list later.",
+    "descriptionPlaceholder": "Backup imported from disk",
+    "dropHint": "Drop the backup XML here or click to choose a file.",
+    "fileChosen": "Ready to upload {{name}} ({{size}}).",
+    "fileLabel": "Backup file",
+    "intro": "Upload an existing Inventario backup XML to restore it. The file is staged on the server first and only inspected when you start the restore.",
+    "submit": "Upload and continue",
+    "submitting": "Uploading…",
+    "success": "Backup uploaded — configure the restore.",
+    "title": "Import a backup",
+    "uploadProgress": "Uploading file…"
+  },
+  "list": {
+    "deletedBadge": "Deleted",
+    "description": "Generate downloadable backups of your inventory and use existing exports to restore data into this group.",
+    "empty": "No exports yet — create your first one to keep a backup of this group.",
+    "emptyFiltered": "No deleted exports.",
+    "headers": {
+      "scope": "Scope"
+    },
+    "imported": "Imported",
+    "title": "Backup & exports"
+  },
+  "polling": {
+    "live": "Live"
+  },
+  "removal": {
+    "confirmAction": "Delete export",
+    "confirmCancel": "Cancel",
+    "confirmDescription": "The export will be soft-deleted and its file will be removed from storage. This cannot be undone.",
+    "confirmTitle": "Delete export?",
+    "success": "Export deleted."
+  },
+  "restore": {
+    "description": "Description",
+    "descriptionHint": "Optional. Useful when comparing dry-runs.",
+    "descriptionPlaceholder": "Restore into staging on 2026-05-03",
+    "dryRun": "Dry run (preview only — no changes are written)",
+    "includeFileData": "Restore attached files",
+    "intro": "Restore the contents of this export into the current group. Pick a strategy and run a dry-run first to preview the changes.",
+    "strategy": "Strategy",
+    "strategyDescription": {
+      "full_replace": "Wipe existing rows in the destination scope before importing. Destructive.",
+      "merge_add": "Insert new rows; existing rows are kept untouched.",
+      "merge_update": "Insert new rows and update existing ones in place."
+    },
+    "strategyLabel": {
+      "full_replace": "Full replace",
+      "merge_add": "Merge add",
+      "merge_update": "Merge update"
+    },
+    "submit": "Start restore",
+    "submitting": "Starting restore…",
+    "success": "Restore started.",
+    "successDryRun": "Dry-run started — review the report when it completes.",
+    "title": "Restore from export"
+  },
+  "retention": {
+    "description": "Automatic cleanup of old exports is not yet available — manage retention manually for now.",
+    "title": "Retention policy"
+  },
+  "scope": {
+    "areas": "Areas",
+    "commodities": "Items",
+    "full_database": "Full database",
+    "imported": "Imported",
+    "locations": "Locations",
+    "selected_items": "Selected items"
+  },
+  "status": {
+    "completed": "Completed",
+    "failed": "Failed",
+    "in_progress": "In progress",
+    "pending": "Pending",
+    "running": "Running"
+  },
+  "validation": {
+    "selectedItemsRequired": "Pick at least one item to export."
+  },
+  "wizard": {
+    "back": "Back",
+    "cancel": "Cancel",
+    "creating": "Creating export…",
+    "intro": "Pick what to back up. The export job runs in the background and lets you download the result when it finishes.",
+    "next": "Next",
+    "scope": {
+      "fullDatabase": "Full database",
+      "fullDatabaseHint": "Everything: locations, areas, items, files, tags.",
+      "selectedItems": "Selected items",
+      "selectedItemsHint": "Pick specific locations, areas or items to include."
+    },
+    "scopePicker": {
+      "empty": "No locations available — create one first.",
+      "title": "Selected items"
+    },
+    "step1Title": "What to export",
+    "step2Title": "Confirm",
+    "step3Title": "Export job",
+    "submit": "Create export",
+    "summary": {
+      "description": "Description",
+      "includeFileData": "Attachments",
+      "includeFileDataNo": "Metadata only",
+      "includeFileDataYes": "Inline base64",
+      "items": "Picked items",
+      "noDescription": "—",
+      "type": "Scope"
+    },
+    "title": "New export",
+    "toggleIncludeFileData": "Include attached files (photos, invoices, manuals)"
+  }
+}

--- a/frontend/src/i18n/locales/en/exports.json
+++ b/frontend/src/i18n/locales/en/exports.json
@@ -109,6 +109,7 @@
   "scope": {
     "areas": "Areas",
     "commodities": "Items",
+    "files": "Files",
     "full_database": "Full database",
     "imported": "Imported",
     "locations": "Locations",

--- a/frontend/src/i18n/locales/en/exports.json
+++ b/frontend/src/i18n/locales/en/exports.json
@@ -5,8 +5,7 @@
     "download": "Download",
     "import": "Import backup",
     "restore": "Restore",
-    "showDeleted": "Show deleted",
-    "viewDetail": "Open"
+    "showDeleted": "Show deleted"
   },
   "detail": {
     "binaryDataSize": "Attachments size",
@@ -62,9 +61,6 @@
     "description": "Generate downloadable backups of your inventory and use existing exports to restore data into this group.",
     "empty": "No exports yet — create your first one to keep a backup of this group.",
     "emptyFiltered": "No deleted exports.",
-    "headers": {
-      "scope": "Scope"
-    },
     "imported": "Imported",
     "title": "Backup & exports"
   },

--- a/frontend/src/lib/intl.ts
+++ b/frontend/src/lib/intl.ts
@@ -139,6 +139,29 @@ export function formatPartialDate(p: PartialDate, opts: { locale?: string } = {}
   return ""
 }
 
+// formatBytes renders a byte count with locale-aware decimal separators
+// and a binary suffix (KiB, MiB, GiB). The threshold of 1024 matches the
+// numbers users see in OS file managers and in the BE storage backends.
+// Negative or non-finite values fall back to "—" so a malformed
+// payload doesn't crash the row.
+const BINARY_SUFFIXES = ["B", "KiB", "MiB", "GiB", "TiB"] as const
+export function formatBytes(value: number, opts: { locale?: string } = {}): string {
+  if (!Number.isFinite(value) || value < 0) return "—"
+  const locale = opts.locale ?? currentLocale()
+  let unit = 0
+  let amount = value
+  while (amount >= 1024 && unit < BINARY_SUFFIXES.length - 1) {
+    amount /= 1024
+    unit += 1
+  }
+  const fractionDigits = unit === 0 ? 0 : amount >= 100 ? 0 : amount >= 10 ? 1 : 2
+  const number = getNumberFormatter(locale, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(amount)
+  return `${number} ${BINARY_SUFFIXES[unit]}`
+}
+
 // safeFilename converts a label into something safe to use in a download
 // `filename=` header. Strips path separators and Windows-reserved chars,
 // collapses any whitespace into a single underscore, and trims leading/

--- a/frontend/src/pages/exports/ExportDetailPage.tsx
+++ b/frontend/src/pages/exports/ExportDetailPage.tsx
@@ -8,7 +8,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
-import { type Export, exportDownloadPath, isExportTerminal } from "@/features/export/api"
+import { type Export, isExportTerminal, useExportDownloadHref } from "@/features/export/api"
 import { useDeleteExport, useExport, useExportRestores } from "@/features/export/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
@@ -22,12 +22,14 @@ export function ExportDetailPage() {
   const toast = useAppToast()
   const confirm = useConfirm()
   const { currentGroup } = useCurrentGroup()
+  const groupReady = !!currentGroup
   const slug = currentGroup?.slug ?? ""
   const exportId = params.id
 
-  const exportQuery = useExport(exportId)
-  const restoresQuery = useExportRestores(exportId)
+  const exportQuery = useExport(exportId, { enabled: groupReady && !!exportId })
+  const restoresQuery = useExportRestores(exportId, { enabled: groupReady && !!exportId })
   const deleteMutation = useDeleteExport()
+  const downloadHref = useExportDownloadHref(exportId, slug)
 
   const exp = exportQuery.data
   const isCompleted = exp?.status === "completed"
@@ -54,7 +56,7 @@ export function ExportDetailPage() {
     }
   }
 
-  if (exportQuery.isLoading) {
+  if (!groupReady || exportQuery.isLoading) {
     return (
       <div className="flex flex-col gap-4 p-6" data-testid="page-export-detail-loading">
         <Skeleton className="h-8 w-1/2" />
@@ -107,10 +109,10 @@ export function ExportDetailPage() {
           <Button
             asChild
             variant="outline"
-            disabled={!isTerminal || !isCompleted || isDeleted}
-            aria-disabled={!isTerminal || !isCompleted || isDeleted}
+            disabled={!isTerminal || !isCompleted || isDeleted || !downloadHref}
+            aria-disabled={!isTerminal || !isCompleted || isDeleted || !downloadHref}
           >
-            <a href={exportDownloadPath(exp.id, slug)} data-testid="export-detail-download">
+            <a href={downloadHref ?? "#"} data-testid="export-detail-download">
               <Download className="mr-1.5 size-4" aria-hidden="true" />
               {t("exports:actions.download")}
             </a>
@@ -178,10 +180,10 @@ export function ExportDetailPage() {
         className="grid gap-3 rounded-md border bg-muted/20 p-4 sm:grid-cols-4"
         data-testid="export-detail-counts"
       >
-        <Count label={t("exports:list.headers.scope")} value={exp.location_count ?? 0} />
-        <Count label="Areas" value={exp.area_count ?? 0} />
-        <Count label="Items" value={exp.commodity_count ?? 0} />
-        <Count label="Files" value={exp.file_count ?? 0} />
+        <Count label={t("exports:scope.locations")} value={exp.location_count ?? 0} />
+        <Count label={t("exports:scope.areas")} value={exp.area_count ?? 0} />
+        <Count label={t("exports:scope.commodities")} value={exp.commodity_count ?? 0} />
+        <Count label={t("exports:scope.files")} value={exp.file_count ?? 0} />
       </section>
 
       <section className="flex flex-col gap-3" data-testid="export-detail-restores">
@@ -219,5 +221,7 @@ function scopeLabel(exp: Export, t: ReturnType<typeof useTranslation>["t"]): str
   if (exp.type === "selected_items") {
     return t("exports:detail.scopeSelectedItems", { count: exp.selected_items?.length ?? 0 })
   }
-  return t(`exports:scope.${exp.type ?? "full_database"}`, t("exports:scope.full_database"))
+  return t(`exports:scope.${exp.type ?? "full_database"}`, {
+    defaultValue: t("exports:scope.full_database"),
+  })
 }

--- a/frontend/src/pages/exports/ExportDetailPage.tsx
+++ b/frontend/src/pages/exports/ExportDetailPage.tsx
@@ -1,0 +1,223 @@
+import { ArrowLeft, Download, RotateCcw, Trash2 } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { Link, useNavigate, useParams } from "react-router-dom"
+
+import { ExportStatusBadge } from "@/components/exports/ExportStatusBadge"
+import { RestoreHistoryList } from "@/components/exports/RestoreHistoryList"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { type Export, exportDownloadPath, isExportTerminal } from "@/features/export/api"
+import { useDeleteExport, useExport, useExportRestores } from "@/features/export/hooks"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { useAppToast } from "@/hooks/useAppToast"
+import { useConfirm } from "@/hooks/useConfirm"
+import { formatBytes, formatDateTime } from "@/lib/intl"
+
+export function ExportDetailPage() {
+  const { t } = useTranslation(["exports", "common"])
+  const params = useParams()
+  const navigate = useNavigate()
+  const toast = useAppToast()
+  const confirm = useConfirm()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  const exportId = params.id
+
+  const exportQuery = useExport(exportId)
+  const restoresQuery = useExportRestores(exportId)
+  const deleteMutation = useDeleteExport()
+
+  const exp = exportQuery.data
+  const isCompleted = exp?.status === "completed"
+  const isTerminal = isExportTerminal(exp?.status)
+  const isDeleted = !!exp?.deleted_at
+
+  async function onDelete() {
+    if (!exp) return
+    const ok = await confirm({
+      title: t("exports:removal.confirmTitle"),
+      description: t("exports:removal.confirmDescription"),
+      confirmLabel: t("exports:removal.confirmAction"),
+      cancelLabel: t("exports:removal.confirmCancel"),
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await deleteMutation.mutateAsync(exp.id)
+      toast.success(t("exports:removal.success"))
+      navigate(`/g/${encodeURIComponent(slug)}/exports`)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error(t("exports:errors.deleteFailed", { error: message }))
+    }
+  }
+
+  if (exportQuery.isLoading) {
+    return (
+      <div className="flex flex-col gap-4 p-6" data-testid="page-export-detail-loading">
+        <Skeleton className="h-8 w-1/2" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    )
+  }
+
+  if (exportQuery.isError || !exp) {
+    return (
+      <div className="flex flex-col gap-4 p-6" data-testid="page-export-detail-not-found">
+        <Alert variant="destructive">
+          <AlertTitle>{t("exports:detail.notFound")}</AlertTitle>
+          {exportQuery.error instanceof Error && (
+            <AlertDescription>{exportQuery.error.message}</AlertDescription>
+          )}
+        </Alert>
+        <Button asChild variant="outline" className="self-start">
+          <Link to={`/g/${encodeURIComponent(slug)}/exports`}>
+            <ArrowLeft className="mr-1.5 size-4" aria-hidden="true" />
+            {t("exports:list.title")}
+          </Link>
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6" data-testid="page-export-detail">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-2">
+          <Button asChild variant="link" className="self-start px-0">
+            <Link to={`/g/${encodeURIComponent(slug)}/exports`}>
+              <ArrowLeft className="mr-1.5 size-4" aria-hidden="true" />
+              {t("exports:list.title")}
+            </Link>
+          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-semibold tracking-tight">{t("exports:detail.title")}</h1>
+            {exp.status && <ExportStatusBadge status={exp.status} />}
+            {exp.imported && <Badge variant="secondary">{t("exports:list.imported")}</Badge>}
+            {isDeleted && <Badge variant="destructive">{t("exports:list.deletedBadge")}</Badge>}
+          </div>
+          <p className="max-w-prose text-sm text-muted-foreground">
+            {exp.description?.trim() || t("exports:detail.noDescription")}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            asChild
+            variant="outline"
+            disabled={!isTerminal || !isCompleted || isDeleted}
+            aria-disabled={!isTerminal || !isCompleted || isDeleted}
+          >
+            <a href={exportDownloadPath(exp.id, slug)} data-testid="export-detail-download">
+              <Download className="mr-1.5 size-4" aria-hidden="true" />
+              {t("exports:actions.download")}
+            </a>
+          </Button>
+          <Button
+            asChild
+            disabled={!isCompleted || isDeleted}
+            aria-disabled={!isCompleted || isDeleted}
+          >
+            <Link
+              to={`/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(exp.id)}/restore`}
+              data-testid="export-detail-restore"
+            >
+              <RotateCcw className="mr-1.5 size-4" aria-hidden="true" />
+              {t("exports:actions.restore")}
+            </Link>
+          </Button>
+          <Button
+            variant="ghost"
+            type="button"
+            onClick={onDelete}
+            disabled={isDeleted}
+            data-testid="export-detail-delete"
+            aria-label={t("exports:actions.delete")}
+          >
+            <Trash2 className="size-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </header>
+
+      {exp.imported && (
+        <Alert data-testid="export-detail-imported-banner">
+          <AlertDescription>{t("exports:detail.imported")}</AlertDescription>
+        </Alert>
+      )}
+      {exp.status === "failed" && exp.error_message && (
+        <Alert variant="destructive">
+          <AlertTitle>{t("exports:detail.errorMessage")}</AlertTitle>
+          <AlertDescription>{exp.error_message}</AlertDescription>
+        </Alert>
+      )}
+
+      <section className="grid gap-4 sm:grid-cols-2" data-testid="export-detail-stats">
+        <Stat label={t("exports:detail.scope")} value={scopeLabel(exp, t)} />
+        <Stat
+          label={t("exports:detail.createdAt")}
+          value={exp.created_date ? formatDateTime(exp.created_date) : "—"}
+        />
+        <Stat
+          label={t("exports:detail.completedAt")}
+          value={exp.completed_date ? formatDateTime(exp.completed_date) : "—"}
+        />
+        <Stat label={t("exports:detail.totalSize")} value={formatBytes(exp.file_size ?? 0)} />
+        <Stat
+          label={t("exports:detail.binaryDataSize")}
+          value={formatBytes(exp.binary_data_size ?? 0)}
+        />
+        <Stat
+          label={t("exports:detail.includesFileData")}
+          value={exp.include_file_data ? "✓" : "—"}
+        />
+      </section>
+
+      <section
+        className="grid gap-3 rounded-md border bg-muted/20 p-4 sm:grid-cols-4"
+        data-testid="export-detail-counts"
+      >
+        <Count label={t("exports:list.headers.scope")} value={exp.location_count ?? 0} />
+        <Count label="Areas" value={exp.area_count ?? 0} />
+        <Count label="Items" value={exp.commodity_count ?? 0} />
+        <Count label="Files" value={exp.file_count ?? 0} />
+      </section>
+
+      <section className="flex flex-col gap-3" data-testid="export-detail-restores">
+        <h2 className="text-lg font-semibold">{t("exports:detail.restoreHistory")}</h2>
+        <RestoreHistoryList
+          exportId={exp.id}
+          groupSlug={slug}
+          loading={restoresQuery.isLoading}
+          restores={restoresQuery.data?.restores ?? []}
+        />
+      </section>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs uppercase text-muted-foreground">{label}</span>
+      <span className="text-sm font-medium">{value}</span>
+    </div>
+  )
+}
+
+function Count({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="flex flex-col gap-0.5 text-center">
+      <span className="text-2xl font-semibold tabular-nums">{value}</span>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  )
+}
+
+function scopeLabel(exp: Export, t: ReturnType<typeof useTranslation>["t"]): string {
+  if (exp.type === "selected_items") {
+    return t("exports:detail.scopeSelectedItems", { count: exp.selected_items?.length ?? 0 })
+  }
+  return t(`exports:scope.${exp.type ?? "full_database"}`, t("exports:scope.full_database"))
+}

--- a/frontend/src/pages/exports/ExportImportPage.tsx
+++ b/frontend/src/pages/exports/ExportImportPage.tsx
@@ -7,6 +7,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
 import { useImportBackup, useUploadRestoreFile } from "@/features/export/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
@@ -17,6 +18,7 @@ export function ExportImportPage() {
   const navigate = useNavigate()
   const toast = useAppToast()
   const { currentGroup } = useCurrentGroup()
+  const groupReady = !!currentGroup
   const slug = currentGroup?.slug ?? ""
 
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -33,7 +35,7 @@ export function ExportImportPage() {
 
   async function onSubmit(event: React.FormEvent) {
     event.preventDefault()
-    if (!file) return
+    if (!file || !groupReady) return
     try {
       const upload = await uploadMutation.mutateAsync(file)
       const created = await importMutation.mutateAsync({
@@ -52,6 +54,15 @@ export function ExportImportPage() {
         : "exports:errors.importFailed"
       toast.error(t(key, { error: message }))
     }
+  }
+
+  if (!groupReady) {
+    return (
+      <div className="flex flex-col gap-4 p-6" data-testid="page-export-import-loading">
+        <Skeleton className="h-8 w-1/2" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/pages/exports/ExportImportPage.tsx
+++ b/frontend/src/pages/exports/ExportImportPage.tsx
@@ -1,0 +1,160 @@
+import { ArrowLeft, FileUp, Loader2 } from "lucide-react"
+import { useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Link, useNavigate } from "react-router-dom"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useImportBackup, useUploadRestoreFile } from "@/features/export/hooks"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { useAppToast } from "@/hooks/useAppToast"
+import { formatBytes } from "@/lib/intl"
+
+export function ExportImportPage() {
+  const { t } = useTranslation(["exports", "common"])
+  const navigate = useNavigate()
+  const toast = useAppToast()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [description, setDescription] = useState("")
+  const [file, setFile] = useState<File | null>(null)
+
+  const uploadMutation = useUploadRestoreFile()
+  const importMutation = useImportBackup()
+  const submitting = uploadMutation.isPending || importMutation.isPending
+
+  function onFileChange(picked: File | null) {
+    setFile(picked)
+  }
+
+  async function onSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    if (!file) return
+    try {
+      const upload = await uploadMutation.mutateAsync(file)
+      const created = await importMutation.mutateAsync({
+        description,
+        source_file_path: upload.sourceFilePath,
+      })
+      toast.success(t("exports:importView.success"))
+      // Imported exports always start at status=completed (the BE inflates
+      // metadata synchronously). Send the user straight to the restore form
+      // — the only meaningful next step is to actually run the restore.
+      navigate(`/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(created.id)}/restore`)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      const key = uploadMutation.isError
+        ? "exports:errors.uploadFailed"
+        : "exports:errors.importFailed"
+      toast.error(t(key, { error: message }))
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6" data-testid="page-export-import">
+      <header className="flex flex-col gap-2">
+        <Button asChild variant="link" className="self-start px-0">
+          <Link to={`/g/${encodeURIComponent(slug)}/exports`}>
+            <ArrowLeft className="mr-1.5 size-4" aria-hidden="true" />
+            {t("exports:list.title")}
+          </Link>
+        </Button>
+        <h1 className="text-2xl font-semibold tracking-tight">{t("exports:importView.title")}</h1>
+        <p className="max-w-prose text-sm text-muted-foreground">{t("exports:importView.intro")}</p>
+      </header>
+
+      {(uploadMutation.isError || importMutation.isError) && (
+        <Alert variant="destructive" data-testid="import-error">
+          <AlertTitle>
+            {uploadMutation.isError
+              ? t("exports:errors.uploadFailed", {
+                  error:
+                    uploadMutation.error instanceof Error
+                      ? uploadMutation.error.message
+                      : "unknown",
+                })
+              : t("exports:errors.importFailed", {
+                  error:
+                    importMutation.error instanceof Error
+                      ? importMutation.error.message
+                      : "unknown",
+                })}
+          </AlertTitle>
+        </Alert>
+      )}
+
+      <form onSubmit={onSubmit} className="flex flex-col gap-5" data-testid="import-form">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="import-file">{t("exports:importView.fileLabel")}</Label>
+          <div
+            className="flex cursor-pointer flex-col items-center gap-2 rounded-md border-2 border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground hover:bg-muted/30"
+            onClick={() => fileInputRef.current?.click()}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault()
+                fileInputRef.current?.click()
+              }
+            }}
+            role="button"
+            tabIndex={0}
+            data-testid="import-dropzone"
+            aria-label={t("exports:importView.fileLabel")}
+          >
+            <FileUp className="size-6" aria-hidden="true" />
+            <span>{t("exports:importView.dropHint")}</span>
+            {file && (
+              <span className="font-medium text-foreground" data-testid="import-file-chosen">
+                {t("exports:importView.fileChosen", {
+                  name: file.name,
+                  size: formatBytes(file.size),
+                })}
+              </span>
+            )}
+          </div>
+          <Input
+            ref={fileInputRef}
+            id="import-file"
+            type="file"
+            accept=".xml,application/xml,text/xml"
+            className="sr-only"
+            onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
+            data-testid="import-file-input"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="import-description">{t("exports:importView.description")}</Label>
+          <Input
+            id="import-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder={t("exports:importView.descriptionPlaceholder")}
+            maxLength={500}
+            data-testid="import-description"
+          />
+          <p className="text-xs text-muted-foreground">{t("exports:importView.descriptionHint")}</p>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button asChild variant="ghost" type="button">
+            <Link to={`/g/${encodeURIComponent(slug)}/exports`}>{t("exports:wizard.cancel")}</Link>
+          </Button>
+          <Button type="submit" disabled={!file || submitting} data-testid="import-submit">
+            {submitting && <Loader2 className="mr-1.5 size-4 animate-spin" aria-hidden="true" />}
+            {submitting ? t("exports:importView.submitting") : t("exports:importView.submit")}
+          </Button>
+        </div>
+
+        {uploadMutation.isPending && (
+          <AlertDescription data-testid="import-uploading">
+            {t("exports:importView.uploadProgress")}
+          </AlertDescription>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/exports/ExportNewPage.tsx
+++ b/frontend/src/pages/exports/ExportNewPage.tsx
@@ -1,32 +1,23 @@
-import { ArrowLeft, ArrowRight, CheckCircle2, Loader2, XCircle } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Link, useSearchParams } from "react-router-dom"
+import { Link, useNavigate, useSearchParams } from "react-router-dom"
 
-import { ExportStatusBadge } from "@/components/exports/ExportStatusBadge"
 import { SelectedItemsPicker } from "@/components/exports/SelectedItemsPicker"
-import { Alert, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Skeleton } from "@/components/ui/skeleton"
-import {
-  type ExportSelectedItem,
-  type ExportType,
-  isExportTerminal,
-  useExportDownloadHref,
-} from "@/features/export/api"
-import { useCreateExport, useExport } from "@/features/export/hooks"
+import { type ExportSelectedItem, type ExportType } from "@/features/export/api"
+import { useCreateExport } from "@/features/export/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
 import { cn } from "@/lib/utils"
 
-type WizardStep = 1 | 2 | 3
+type WizardStep = 1 | 2
 
 function parseStep(raw: string | null): WizardStep {
-  if (raw === "2") return 2
-  if (raw === "3") return 3
-  return 1
+  return raw === "2" ? 2 : 1
 }
 
 interface WizardState {
@@ -43,51 +34,30 @@ const initialState: WizardState = {
   selected_items: [],
 }
 
+// Two-step wizard: pick scope (1) → confirm + submit (2). On success the
+// user is sent straight to the export detail page, which is the canonical
+// "watch this export" surface (status badge with polling, download CTA,
+// restore CTA, restore history). The wizard does NOT render its own step 3
+// — driving a step transition off the createMutation result on this
+// surface was racy under the React 19 + react-router-dom v7 + production
+// build combo: setSearchParams from inside the mutation onSuccess
+// callback was being dropped under load on CI, leaving the wizard stuck
+// on step 2 even after a 201. Sending the user directly to the detail
+// page sidesteps the entire problem class.
 export function ExportNewPage() {
   const { t } = useTranslation(["exports", "common"])
   const toast = useAppToast()
+  const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const { currentGroup } = useCurrentGroup()
-
-  const [state, setState] = useState<WizardState>(initialState)
-  const [scopeError, setScopeError] = useState<string | null>(null)
-
-  const createMutation = useCreateExport()
-  // The freshly-created export id, if any. We prefer the live mutation
-  // result over the URL search param so the wizard advances to step 3
-  // the moment the BE replies — even if the URL update below is lost
-  // (react-router-dom v7's setSearchParams from inside an async
-  // callback can drop under load, see the e2e flake on #1415).
-  const mutationCreatedId = createMutation.data?.id
-  const urlStep = parseStep(searchParams.get("step"))
-  const urlId = searchParams.get("id") ?? undefined
-  const createdId = mutationCreatedId ?? urlId
-  const step: WizardStep = mutationCreatedId ? 3 : urlStep
   const groupReady = !!currentGroup
   const slug = currentGroup?.slug ?? ""
 
-  // Best-effort URL sync after the mutation succeeds so the user can
-  // refresh / share the step-3 URL. The wizard already renders step 3
-  // off `mutationCreatedId`, so a dropped update here is cosmetic and
-  // self-heals on the next render.
-  useEffect(() => {
-    if (!mutationCreatedId) return
-    if (urlStep === 3 && urlId === mutationCreatedId) return
-    setSearchParams(
-      (prev) => {
-        const params = new URLSearchParams(prev)
-        params.set("step", "3")
-        params.set("id", mutationCreatedId)
-        return params
-      },
-      { replace: true }
-    )
-  }, [mutationCreatedId, urlStep, urlId, setSearchParams])
+  const [state, setState] = useState<WizardState>(initialState)
+  const [scopeError, setScopeError] = useState<string | null>(null)
+  const step = parseStep(searchParams.get("step"))
 
-  // Once we have an id (URL or mutation), step 3 polls its status.
-  // Gate on currentGroup so the queryKey is always group-scoped — empty
-  // slugs poison the cache (#1494 review).
-  const exportQuery = useExport(createdId, { enabled: groupReady && !!createdId })
+  const createMutation = useCreateExport()
 
   function patchStepInUrl(next: WizardStep) {
     setSearchParams(
@@ -118,8 +88,13 @@ export function ExportNewPage() {
         selected_items: state.type === "selected_items" ? state.selected_items : undefined,
       },
       {
-        // Step 3 advances off `createMutation.data` — no patchStep call
-        // needed here. Errors still surface as a toast.
+        onSuccess: (created) => {
+          // useNavigate with an absolute path bypasses the
+          // setSearchParams-from-async-callback flake (#1415 e2e). The
+          // detail page polls the export until terminal and shows the
+          // download CTA the moment it is ready.
+          navigate(`/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(created.id)}`)
+        },
         onError: (err) => {
           const message = err instanceof Error ? err.message : String(err)
           toast.error(t("exports:errors.createFailed", { error: message }))
@@ -128,9 +103,6 @@ export function ExportNewPage() {
     )
   }
 
-  // While GroupProvider is still resolving membership, currentGroup
-  // can be null even on a /g/:slug/* route. Show a skeleton instead of
-  // emitting `/g//exports` Cancel links and an empty-slug detail href.
   if (!groupReady) {
     return (
       <div className="flex flex-col gap-4 p-6" data-testid="page-export-new-loading">
@@ -173,8 +145,6 @@ export function ExportNewPage() {
           onSubmit={onConfirmSubmit}
         />
       )}
-
-      {step === 3 && <Step3 createdId={createdId} exportQuery={exportQuery} groupSlug={slug} />}
     </div>
   )
 }
@@ -184,7 +154,6 @@ function WizardSteps({ step }: { step: WizardStep }) {
   const items: Array<{ index: WizardStep; titleKey: string }> = [
     { index: 1, titleKey: "exports:wizard.step1Title" },
     { index: 2, titleKey: "exports:wizard.step2Title" },
-    { index: 3, titleKey: "exports:wizard.step3Title" },
   ]
   return (
     <ol
@@ -394,78 +363,6 @@ function Step2({ state, setState, isPending, onBack, onSubmit }: Step2Props) {
         <Button type="button" onClick={onSubmit} disabled={isPending} data-testid="wizard-submit">
           {isPending ? t("exports:wizard.creating") : t("exports:wizard.submit")}
         </Button>
-      </div>
-    </section>
-  )
-}
-
-interface Step3Props {
-  createdId: string | undefined
-  exportQuery: ReturnType<typeof useExport>
-  groupSlug: string
-}
-
-function Step3({ createdId, exportQuery, groupSlug }: Step3Props) {
-  const { t } = useTranslation(["exports"])
-  const exp = exportQuery.data
-  const detailHref = useMemo(
-    () =>
-      createdId
-        ? `/g/${encodeURIComponent(groupSlug)}/exports/${encodeURIComponent(createdId)}`
-        : "#",
-    [createdId, groupSlug]
-  )
-  const downloadHref = useExportDownloadHref(createdId, groupSlug)
-  const isTerminal = isExportTerminal(exp?.status)
-  const isCompleted = exp?.status === "completed"
-  const isFailed = exp?.status === "failed"
-
-  if (!createdId) {
-    return (
-      <Alert variant="destructive" data-testid="wizard-step-3-missing">
-        <AlertTitle>{t("exports:errors.createFailed", { error: "missing id" })}</AlertTitle>
-      </Alert>
-    )
-  }
-
-  return (
-    <section className="flex flex-col gap-5" data-testid="wizard-step-3-content">
-      <div className="flex items-center gap-3 rounded-md border bg-card p-4">
-        {!isTerminal && (
-          <Loader2
-            className="size-5 animate-spin text-primary"
-            aria-label={t("exports:status.in_progress")}
-          />
-        )}
-        {isCompleted && (
-          <CheckCircle2
-            className="size-5 text-emerald-600"
-            aria-label={t("exports:status.completed")}
-          />
-        )}
-        {isFailed && (
-          <XCircle className="size-5 text-destructive" aria-label={t("exports:status.failed")} />
-        )}
-        <div className="flex flex-1 flex-col">
-          <span className="text-sm font-medium">
-            {exp?.description?.trim() ? exp.description : t("exports:wizard.step3Title")}
-          </span>
-          {exp?.status && <ExportStatusBadge status={exp.status} className="mt-1 self-start" />}
-          {isFailed && exp?.error_message && (
-            <p className="mt-2 text-sm text-destructive">{exp.error_message}</p>
-          )}
-        </div>
-      </div>
-
-      <div className="flex flex-wrap items-center justify-end gap-2">
-        <Button asChild variant="outline">
-          <Link to={detailHref}>{t("exports:actions.viewDetail")}</Link>
-        </Button>
-        {isCompleted && downloadHref && (
-          <Button asChild data-testid="wizard-download">
-            <a href={downloadHref}>{t("exports:actions.download")}</a>
-          </Button>
-        )}
       </div>
     </section>
   )

--- a/frontend/src/pages/exports/ExportNewPage.tsx
+++ b/frontend/src/pages/exports/ExportNewPage.tsx
@@ -34,16 +34,11 @@ const initialState: WizardState = {
   selected_items: [],
 }
 
-// Two-step wizard: pick scope (1) → confirm + submit (2). On success the
-// user is sent straight to the export detail page, which is the canonical
-// "watch this export" surface (status badge with polling, download CTA,
-// restore CTA, restore history). The wizard does NOT render its own step 3
-// — driving a step transition off the createMutation result on this
-// surface was racy under the React 19 + react-router-dom v7 + production
-// build combo: setSearchParams from inside the mutation onSuccess
-// callback was being dropped under load on CI, leaving the wizard stuck
-// on step 2 even after a 201. Sending the user directly to the detail
-// page sidesteps the entire problem class.
+// Two-step wizard: pick scope (1) → confirm + submit (2). On success
+// the user is sent straight to the export detail page — the canonical
+// "watch this export" surface (status badge polling, download CTA,
+// restore CTA, restore history). Lands the user where they can take the
+// next action (Restore) without an extra "Open" click.
 export function ExportNewPage() {
   const { t } = useTranslation(["exports", "common"])
   const toast = useAppToast()
@@ -89,10 +84,9 @@ export function ExportNewPage() {
       },
       {
         onSuccess: (created) => {
-          // useNavigate with an absolute path bypasses the
-          // setSearchParams-from-async-callback flake (#1415 e2e). The
-          // detail page polls the export until terminal and shows the
-          // download CTA the moment it is ready.
+          // Navigate to the detail page — that's the canonical "watch
+          // this export" surface (status badge polling, download CTA,
+          // restore CTA, restore history).
           navigate(`/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(created.id)}`)
         },
         onError: (err) => {

--- a/frontend/src/pages/exports/ExportNewPage.tsx
+++ b/frontend/src/pages/exports/ExportNewPage.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, ArrowRight, CheckCircle2, Loader2, XCircle } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useSearchParams } from "react-router-dom"
 
@@ -61,21 +61,19 @@ export function ExportNewPage() {
   // way reloading on step 1/2 doesn't fire a /exports/{id} request.
   const exportQuery = useExport(createdId, { enabled: !!createdId })
 
-  // If we've been redirected to step 3 by reload but the wizard state is
-  // empty, skip back to step 1 — the picker would otherwise render a
-  // confused review section. Polling keeps working off `createdId`.
-  useEffect(() => {
-    if (step === 2 && !state.type && !createdId) {
-      patchStep(1)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [step])
-
+  // Functional updater so the closure-captured `searchParams` from a stale
+  // render can't drop the freshly-set step+id when this fires from a
+  // mutation callback after `await`.
   function patchStep(next: WizardStep, extra: Record<string, string> = {}) {
-    const params = new URLSearchParams(searchParams)
-    params.set("step", String(next))
-    for (const [k, v] of Object.entries(extra)) params.set(k, v)
-    setSearchParams(params, { replace: true })
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev)
+        params.set("step", String(next))
+        for (const [k, v] of Object.entries(extra)) params.set(k, v)
+        return params
+      },
+      { replace: true }
+    )
   }
 
   function onScopeNext() {
@@ -87,19 +85,28 @@ export function ExportNewPage() {
     patchStep(2)
   }
 
-  async function onConfirmSubmit() {
-    try {
-      const created = await createMutation.mutateAsync({
+  function onConfirmSubmit() {
+    createMutation.mutate(
+      {
         type: state.type as ExportType,
         description: state.description,
         include_file_data: state.include_file_data,
         selected_items: state.type === "selected_items" ? state.selected_items : undefined,
-      })
-      patchStep(3, { id: created.id })
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      toast.error(t("exports:errors.createFailed", { error: message }))
-    }
+      },
+      {
+        onSuccess: (created) => {
+          if (!created.id) {
+            toast.error(t("exports:errors.createFailed", { error: "missing id" }))
+            return
+          }
+          patchStep(3, { id: created.id })
+        },
+        onError: (err) => {
+          const message = err instanceof Error ? err.message : String(err)
+          toast.error(t("exports:errors.createFailed", { error: message }))
+        },
+      }
+    )
   }
 
   return (

--- a/frontend/src/pages/exports/ExportNewPage.tsx
+++ b/frontend/src/pages/exports/ExportNewPage.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, ArrowRight, CheckCircle2, Loader2, XCircle } from "lucide-react"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useSearchParams } from "react-router-dom"
 
@@ -9,11 +9,12 @@ import { Alert, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
   type ExportSelectedItem,
   type ExportType,
-  exportDownloadPath,
   isExportTerminal,
+  useExportDownloadHref,
 } from "@/features/export/api"
 import { useCreateExport, useExport } from "@/features/export/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
@@ -47,29 +48,52 @@ export function ExportNewPage() {
   const toast = useAppToast()
   const [searchParams, setSearchParams] = useSearchParams()
   const { currentGroup } = useCurrentGroup()
-  const slug = currentGroup?.slug ?? ""
-
-  const step = parseStep(searchParams.get("step"))
-  const createdId = searchParams.get("id") ?? undefined
 
   const [state, setState] = useState<WizardState>(initialState)
   const [scopeError, setScopeError] = useState<string | null>(null)
 
   const createMutation = useCreateExport()
-  // Once we've created an export, the wizard hangs on step 3 polling its
-  // status. We only enable the query when an id is in the URL — that
-  // way reloading on step 1/2 doesn't fire a /exports/{id} request.
-  const exportQuery = useExport(createdId, { enabled: !!createdId })
+  // The freshly-created export id, if any. We prefer the live mutation
+  // result over the URL search param so the wizard advances to step 3
+  // the moment the BE replies — even if the URL update below is lost
+  // (react-router-dom v7's setSearchParams from inside an async
+  // callback can drop under load, see the e2e flake on #1415).
+  const mutationCreatedId = createMutation.data?.id
+  const urlStep = parseStep(searchParams.get("step"))
+  const urlId = searchParams.get("id") ?? undefined
+  const createdId = mutationCreatedId ?? urlId
+  const step: WizardStep = mutationCreatedId ? 3 : urlStep
+  const groupReady = !!currentGroup
+  const slug = currentGroup?.slug ?? ""
 
-  // Functional updater so the closure-captured `searchParams` from a stale
-  // render can't drop the freshly-set step+id when this fires from a
-  // mutation callback after `await`.
-  function patchStep(next: WizardStep, extra: Record<string, string> = {}) {
+  // Best-effort URL sync after the mutation succeeds so the user can
+  // refresh / share the step-3 URL. The wizard already renders step 3
+  // off `mutationCreatedId`, so a dropped update here is cosmetic and
+  // self-heals on the next render.
+  useEffect(() => {
+    if (!mutationCreatedId) return
+    if (urlStep === 3 && urlId === mutationCreatedId) return
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev)
+        params.set("step", "3")
+        params.set("id", mutationCreatedId)
+        return params
+      },
+      { replace: true }
+    )
+  }, [mutationCreatedId, urlStep, urlId, setSearchParams])
+
+  // Once we have an id (URL or mutation), step 3 polls its status.
+  // Gate on currentGroup so the queryKey is always group-scoped — empty
+  // slugs poison the cache (#1494 review).
+  const exportQuery = useExport(createdId, { enabled: groupReady && !!createdId })
+
+  function patchStepInUrl(next: WizardStep) {
     setSearchParams(
       (prev) => {
         const params = new URLSearchParams(prev)
         params.set("step", String(next))
-        for (const [k, v] of Object.entries(extra)) params.set(k, v)
         return params
       },
       { replace: true }
@@ -82,7 +106,7 @@ export function ExportNewPage() {
       return
     }
     setScopeError(null)
-    patchStep(2)
+    patchStepInUrl(2)
   }
 
   function onConfirmSubmit() {
@@ -94,18 +118,26 @@ export function ExportNewPage() {
         selected_items: state.type === "selected_items" ? state.selected_items : undefined,
       },
       {
-        onSuccess: (created) => {
-          if (!created.id) {
-            toast.error(t("exports:errors.createFailed", { error: "missing id" }))
-            return
-          }
-          patchStep(3, { id: created.id })
-        },
+        // Step 3 advances off `createMutation.data` — no patchStep call
+        // needed here. Errors still surface as a toast.
         onError: (err) => {
           const message = err instanceof Error ? err.message : String(err)
           toast.error(t("exports:errors.createFailed", { error: message }))
         },
       }
+    )
+  }
+
+  // While GroupProvider is still resolving membership, currentGroup
+  // can be null even on a /g/:slug/* route. Show a skeleton instead of
+  // emitting `/g//exports` Cancel links and an empty-slug detail href.
+  if (!groupReady) {
+    return (
+      <div className="flex flex-col gap-4 p-6" data-testid="page-export-new-loading">
+        <Skeleton className="h-8 w-1/2" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
     )
   }
 
@@ -137,7 +169,7 @@ export function ExportNewPage() {
           state={state}
           setState={setState}
           isPending={createMutation.isPending}
-          onBack={() => patchStep(1)}
+          onBack={() => patchStepInUrl(1)}
           onSubmit={onConfirmSubmit}
         />
       )}
@@ -377,9 +409,13 @@ function Step3({ createdId, exportQuery, groupSlug }: Step3Props) {
   const { t } = useTranslation(["exports"])
   const exp = exportQuery.data
   const detailHref = useMemo(
-    () => (createdId ? `/g/${encodeURIComponent(groupSlug)}/exports/${createdId}` : "#"),
+    () =>
+      createdId
+        ? `/g/${encodeURIComponent(groupSlug)}/exports/${encodeURIComponent(createdId)}`
+        : "#",
     [createdId, groupSlug]
   )
+  const downloadHref = useExportDownloadHref(createdId, groupSlug)
   const isTerminal = isExportTerminal(exp?.status)
   const isCompleted = exp?.status === "completed"
   const isFailed = exp?.status === "failed"
@@ -425,9 +461,9 @@ function Step3({ createdId, exportQuery, groupSlug }: Step3Props) {
         <Button asChild variant="outline">
           <Link to={detailHref}>{t("exports:actions.viewDetail")}</Link>
         </Button>
-        {isCompleted && (
+        {isCompleted && downloadHref && (
           <Button asChild data-testid="wizard-download">
-            <a href={exportDownloadPath(createdId, groupSlug)}>{t("exports:actions.download")}</a>
+            <a href={downloadHref}>{t("exports:actions.download")}</a>
           </Button>
         )}
       </div>

--- a/frontend/src/pages/exports/ExportNewPage.tsx
+++ b/frontend/src/pages/exports/ExportNewPage.tsx
@@ -1,0 +1,429 @@
+import { ArrowLeft, ArrowRight, CheckCircle2, Loader2, XCircle } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Link, useSearchParams } from "react-router-dom"
+
+import { ExportStatusBadge } from "@/components/exports/ExportStatusBadge"
+import { SelectedItemsPicker } from "@/components/exports/SelectedItemsPicker"
+import { Alert, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  type ExportSelectedItem,
+  type ExportType,
+  exportDownloadPath,
+  isExportTerminal,
+} from "@/features/export/api"
+import { useCreateExport, useExport } from "@/features/export/hooks"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { useAppToast } from "@/hooks/useAppToast"
+import { cn } from "@/lib/utils"
+
+type WizardStep = 1 | 2 | 3
+
+function parseStep(raw: string | null): WizardStep {
+  if (raw === "2") return 2
+  if (raw === "3") return 3
+  return 1
+}
+
+interface WizardState {
+  type: "full_database" | "selected_items"
+  description: string
+  include_file_data: boolean
+  selected_items: ExportSelectedItem[]
+}
+
+const initialState: WizardState = {
+  type: "full_database",
+  description: "",
+  include_file_data: true,
+  selected_items: [],
+}
+
+export function ExportNewPage() {
+  const { t } = useTranslation(["exports", "common"])
+  const toast = useAppToast()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+
+  const step = parseStep(searchParams.get("step"))
+  const createdId = searchParams.get("id") ?? undefined
+
+  const [state, setState] = useState<WizardState>(initialState)
+  const [scopeError, setScopeError] = useState<string | null>(null)
+
+  const createMutation = useCreateExport()
+  // Once we've created an export, the wizard hangs on step 3 polling its
+  // status. We only enable the query when an id is in the URL — that
+  // way reloading on step 1/2 doesn't fire a /exports/{id} request.
+  const exportQuery = useExport(createdId, { enabled: !!createdId })
+
+  // If we've been redirected to step 3 by reload but the wizard state is
+  // empty, skip back to step 1 — the picker would otherwise render a
+  // confused review section. Polling keeps working off `createdId`.
+  useEffect(() => {
+    if (step === 2 && !state.type && !createdId) {
+      patchStep(1)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step])
+
+  function patchStep(next: WizardStep, extra: Record<string, string> = {}) {
+    const params = new URLSearchParams(searchParams)
+    params.set("step", String(next))
+    for (const [k, v] of Object.entries(extra)) params.set(k, v)
+    setSearchParams(params, { replace: true })
+  }
+
+  function onScopeNext() {
+    if (state.type === "selected_items" && state.selected_items.length === 0) {
+      setScopeError(t("exports:validation.selectedItemsRequired"))
+      return
+    }
+    setScopeError(null)
+    patchStep(2)
+  }
+
+  async function onConfirmSubmit() {
+    try {
+      const created = await createMutation.mutateAsync({
+        type: state.type as ExportType,
+        description: state.description,
+        include_file_data: state.include_file_data,
+        selected_items: state.type === "selected_items" ? state.selected_items : undefined,
+      })
+      patchStep(3, { id: created.id })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error(t("exports:errors.createFailed", { error: message }))
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6" data-testid="page-export-new">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1.5">
+          <h1 className="text-2xl font-semibold tracking-tight">{t("exports:wizard.title")}</h1>
+          <p className="max-w-prose text-sm text-muted-foreground">{t("exports:wizard.intro")}</p>
+        </div>
+        <Button asChild variant="ghost" size="sm">
+          <Link to={`/g/${encodeURIComponent(slug)}/exports`}>{t("exports:wizard.cancel")}</Link>
+        </Button>
+      </header>
+
+      <WizardSteps step={step} />
+
+      {step === 1 && (
+        <Step1
+          state={state}
+          setState={setState}
+          errorMessage={scopeError ?? undefined}
+          onNext={onScopeNext}
+        />
+      )}
+
+      {step === 2 && (
+        <Step2
+          state={state}
+          setState={setState}
+          isPending={createMutation.isPending}
+          onBack={() => patchStep(1)}
+          onSubmit={onConfirmSubmit}
+        />
+      )}
+
+      {step === 3 && <Step3 createdId={createdId} exportQuery={exportQuery} groupSlug={slug} />}
+    </div>
+  )
+}
+
+function WizardSteps({ step }: { step: WizardStep }) {
+  const { t } = useTranslation(["exports"])
+  const items: Array<{ index: WizardStep; titleKey: string }> = [
+    { index: 1, titleKey: "exports:wizard.step1Title" },
+    { index: 2, titleKey: "exports:wizard.step2Title" },
+    { index: 3, titleKey: "exports:wizard.step3Title" },
+  ]
+  return (
+    <ol
+      className="flex flex-wrap items-center gap-2 text-sm"
+      data-testid="wizard-steps"
+      aria-label="wizard"
+    >
+      {items.map((item, idx) => {
+        const active = item.index === step
+        const done = item.index < step
+        return (
+          <li key={item.index} className="flex items-center gap-2">
+            <span
+              className={cn(
+                "inline-flex size-6 items-center justify-center rounded-full border text-xs font-semibold",
+                active && "border-primary bg-primary text-primary-foreground",
+                done && !active && "border-primary/40 bg-primary/10 text-primary",
+                !active && !done && "border-muted text-muted-foreground"
+              )}
+              data-testid={`wizard-step-${item.index}`}
+              data-active={active || undefined}
+            >
+              {item.index}
+            </span>
+            <span className={cn("text-sm", active ? "font-medium" : "text-muted-foreground")}>
+              {t(item.titleKey)}
+            </span>
+            {idx < items.length - 1 && (
+              <span aria-hidden="true" className="px-2 text-muted-foreground">
+                /
+              </span>
+            )}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
+
+interface Step1Props {
+  state: WizardState
+  setState: (next: WizardState) => void
+  errorMessage?: string
+  onNext: () => void
+}
+
+function Step1({ state, setState, errorMessage, onNext }: Step1Props) {
+  const { t } = useTranslation(["exports"])
+  return (
+    <section className="flex flex-col gap-5" data-testid="wizard-step-1-content">
+      <fieldset className="flex flex-col gap-3">
+        <legend className="mb-2 text-sm font-medium">{t("exports:wizard.step1Title")}</legend>
+        <ScopeRadio
+          value={state.type}
+          onChange={(type) => setState({ ...state, type })}
+          option="full_database"
+          titleKey="exports:wizard.scope.fullDatabase"
+          hintKey="exports:wizard.scope.fullDatabaseHint"
+        />
+        <ScopeRadio
+          value={state.type}
+          onChange={(type) => setState({ ...state, type })}
+          option="selected_items"
+          titleKey="exports:wizard.scope.selectedItems"
+          hintKey="exports:wizard.scope.selectedItemsHint"
+        />
+      </fieldset>
+
+      {state.type === "selected_items" && (
+        <div className="flex flex-col gap-2 rounded-md border bg-muted/20 p-3">
+          <p className="text-sm font-medium">{t("exports:wizard.scopePicker.title")}</p>
+          <SelectedItemsPicker
+            value={state.selected_items}
+            onChange={(selected_items) => setState({ ...state, selected_items })}
+            errorMessage={errorMessage}
+          />
+        </div>
+      )}
+
+      <label className="inline-flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          className="size-4"
+          checked={state.include_file_data}
+          onChange={(e) => setState({ ...state, include_file_data: e.target.checked })}
+          data-testid="wizard-include-file-data"
+        />
+        {t("exports:wizard.toggleIncludeFileData")}
+      </label>
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" onClick={onNext} data-testid="wizard-next">
+          {t("exports:wizard.next")}
+          <ArrowRight className="ml-1.5 size-4" aria-hidden="true" />
+        </Button>
+      </div>
+    </section>
+  )
+}
+
+interface ScopeRadioProps {
+  value: WizardState["type"]
+  onChange: (next: WizardState["type"]) => void
+  option: WizardState["type"]
+  titleKey: string
+  hintKey: string
+}
+
+function ScopeRadio({ value, onChange, option, titleKey, hintKey }: ScopeRadioProps) {
+  const { t } = useTranslation(["exports"])
+  const checked = value === option
+  const id = `wizard-scope-${option}`
+  return (
+    // eslint-disable-next-line jsx-a11y/label-has-associated-control -- the title <span> below carries the visible text; the rule's traversal misses it because t() returns a string at runtime, not a literal at parse time.
+    <label
+      htmlFor={id}
+      className={cn(
+        "flex cursor-pointer items-start gap-3 rounded-md border bg-card px-4 py-3",
+        checked && "border-primary/60 bg-primary/5"
+      )}
+      data-testid={id}
+    >
+      <input
+        id={id}
+        type="radio"
+        className="mt-1 size-4"
+        checked={checked}
+        onChange={() => onChange(option)}
+        name="wizard-scope"
+        value={option}
+      />
+      <span className="flex flex-col gap-0.5">
+        <span className="text-sm font-medium">{t(titleKey)}</span>
+        <span className="text-xs text-muted-foreground">{t(hintKey)}</span>
+      </span>
+    </label>
+  )
+}
+
+interface Step2Props {
+  state: WizardState
+  setState: (next: WizardState) => void
+  isPending: boolean
+  onBack: () => void
+  onSubmit: () => void
+}
+
+function Step2({ state, setState, isPending, onBack, onSubmit }: Step2Props) {
+  const { t } = useTranslation(["exports", "common"])
+  return (
+    <section className="flex flex-col gap-5" data-testid="wizard-step-2-content">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="export-description">{t("exports:wizard.summary.description")}</Label>
+        <Input
+          id="export-description"
+          value={state.description}
+          onChange={(e) => setState({ ...state, description: e.target.value })}
+          placeholder={t("exports:detail.noDescription")}
+          maxLength={500}
+          data-testid="wizard-description"
+        />
+      </div>
+
+      <dl
+        className="grid gap-4 rounded-md border bg-muted/20 p-4 sm:grid-cols-2"
+        data-testid="wizard-summary"
+      >
+        <div className="flex flex-col gap-1">
+          <dt className="text-xs uppercase text-muted-foreground">
+            {t("exports:wizard.summary.type")}
+          </dt>
+          <dd className="text-sm font-medium">
+            {state.type === "selected_items"
+              ? t("exports:scope.selected_items")
+              : t("exports:scope.full_database")}
+          </dd>
+        </div>
+        <div className="flex flex-col gap-1">
+          <dt className="text-xs uppercase text-muted-foreground">
+            {t("exports:wizard.summary.includeFileData")}
+          </dt>
+          <dd className="text-sm font-medium">
+            {state.include_file_data
+              ? t("exports:wizard.summary.includeFileDataYes")
+              : t("exports:wizard.summary.includeFileDataNo")}
+          </dd>
+        </div>
+        {state.type === "selected_items" && (
+          <div className="sm:col-span-2 flex flex-col gap-1">
+            <dt className="text-xs uppercase text-muted-foreground">
+              {t("exports:wizard.summary.items")}
+            </dt>
+            <dd className="text-sm">
+              {state.selected_items.length === 0
+                ? t("exports:wizard.summary.noDescription")
+                : state.selected_items.map((item) => item.name || item.id).join(", ")}
+            </dd>
+          </div>
+        )}
+      </dl>
+
+      <div className="flex justify-between gap-2">
+        <Button type="button" variant="outline" onClick={onBack} data-testid="wizard-back">
+          <ArrowLeft className="mr-1.5 size-4" aria-hidden="true" />
+          {t("exports:wizard.back")}
+        </Button>
+        <Button type="button" onClick={onSubmit} disabled={isPending} data-testid="wizard-submit">
+          {isPending ? t("exports:wizard.creating") : t("exports:wizard.submit")}
+        </Button>
+      </div>
+    </section>
+  )
+}
+
+interface Step3Props {
+  createdId: string | undefined
+  exportQuery: ReturnType<typeof useExport>
+  groupSlug: string
+}
+
+function Step3({ createdId, exportQuery, groupSlug }: Step3Props) {
+  const { t } = useTranslation(["exports"])
+  const exp = exportQuery.data
+  const detailHref = useMemo(
+    () => (createdId ? `/g/${encodeURIComponent(groupSlug)}/exports/${createdId}` : "#"),
+    [createdId, groupSlug]
+  )
+  const isTerminal = isExportTerminal(exp?.status)
+  const isCompleted = exp?.status === "completed"
+  const isFailed = exp?.status === "failed"
+
+  if (!createdId) {
+    return (
+      <Alert variant="destructive" data-testid="wizard-step-3-missing">
+        <AlertTitle>{t("exports:errors.createFailed", { error: "missing id" })}</AlertTitle>
+      </Alert>
+    )
+  }
+
+  return (
+    <section className="flex flex-col gap-5" data-testid="wizard-step-3-content">
+      <div className="flex items-center gap-3 rounded-md border bg-card p-4">
+        {!isTerminal && (
+          <Loader2
+            className="size-5 animate-spin text-primary"
+            aria-label={t("exports:status.in_progress")}
+          />
+        )}
+        {isCompleted && (
+          <CheckCircle2
+            className="size-5 text-emerald-600"
+            aria-label={t("exports:status.completed")}
+          />
+        )}
+        {isFailed && (
+          <XCircle className="size-5 text-destructive" aria-label={t("exports:status.failed")} />
+        )}
+        <div className="flex flex-1 flex-col">
+          <span className="text-sm font-medium">
+            {exp?.description?.trim() ? exp.description : t("exports:wizard.step3Title")}
+          </span>
+          {exp?.status && <ExportStatusBadge status={exp.status} className="mt-1 self-start" />}
+          {isFailed && exp?.error_message && (
+            <p className="mt-2 text-sm text-destructive">{exp.error_message}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button asChild variant="outline">
+          <Link to={detailHref}>{t("exports:actions.viewDetail")}</Link>
+        </Button>
+        {isCompleted && (
+          <Button asChild data-testid="wizard-download">
+            <a href={exportDownloadPath(createdId, groupSlug)}>{t("exports:actions.download")}</a>
+          </Button>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/exports/ExportRestorePage.tsx
+++ b/frontend/src/pages/exports/ExportRestorePage.tsx
@@ -1,0 +1,209 @@
+import { ArrowLeft, Loader2, ShieldAlert } from "lucide-react"
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Link, useNavigate, useParams } from "react-router-dom"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import { RESTORE_STRATEGIES, type RestoreStrategy } from "@/features/export/api"
+import { useCreateRestore, useExport } from "@/features/export/hooks"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { useAppToast } from "@/hooks/useAppToast"
+import { cn } from "@/lib/utils"
+
+interface FormState {
+  description: string
+  strategy: RestoreStrategy
+  include_file_data: boolean
+  dry_run: boolean
+}
+
+const defaultState: FormState = {
+  description: "",
+  strategy: "merge_add",
+  include_file_data: true,
+  dry_run: true,
+}
+
+export function ExportRestorePage() {
+  const { t } = useTranslation(["exports", "common"])
+  const params = useParams()
+  const navigate = useNavigate()
+  const toast = useAppToast()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  const exportId = params.id ?? ""
+
+  const exportQuery = useExport(exportId)
+  const createRestoreMutation = useCreateRestore()
+  const [state, setState] = useState<FormState>(defaultState)
+
+  const exp = exportQuery.data
+  const detailHref = `/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(exportId)}`
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    try {
+      await createRestoreMutation.mutateAsync({
+        exportId,
+        req: {
+          description: state.description,
+          options: {
+            strategy: state.strategy,
+            include_file_data: state.include_file_data,
+            dry_run: state.dry_run,
+          },
+        },
+      })
+      toast.success(
+        state.dry_run ? t("exports:restore.successDryRun") : t("exports:restore.success")
+      )
+      navigate(detailHref)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error(t("exports:errors.restoreCreateFailed", { error: message }))
+    }
+  }
+
+  if (exportQuery.isLoading) {
+    return (
+      <div className="flex flex-col gap-4 p-6" data-testid="page-export-restore-loading">
+        <Skeleton className="h-8 w-1/2" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
+  }
+
+  if (!exp) {
+    return (
+      <div className="flex flex-col gap-4 p-6" data-testid="page-export-restore-not-found">
+        <Alert variant="destructive">
+          <AlertTitle>{t("exports:detail.notFound")}</AlertTitle>
+        </Alert>
+        <Button asChild variant="outline" className="self-start">
+          <Link to={`/g/${encodeURIComponent(slug)}/exports`}>{t("exports:list.title")}</Link>
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6" data-testid="page-export-restore">
+      <header className="flex flex-col gap-2">
+        <Button asChild variant="link" className="self-start px-0">
+          <Link to={detailHref}>
+            <ArrowLeft className="mr-1.5 size-4" aria-hidden="true" />
+            {t("exports:detail.title")}
+          </Link>
+        </Button>
+        <h1 className="text-2xl font-semibold tracking-tight">{t("exports:restore.title")}</h1>
+        <p className="max-w-prose text-sm text-muted-foreground">{t("exports:restore.intro")}</p>
+      </header>
+
+      {state.strategy === "full_replace" && !state.dry_run && (
+        <Alert variant="destructive" data-testid="restore-destructive-warning">
+          <ShieldAlert className="size-4" aria-hidden="true" />
+          <AlertTitle>{t("exports:restore.strategyLabel.full_replace")}</AlertTitle>
+          <AlertDescription>
+            {t("exports:restore.strategyDescription.full_replace")}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <form onSubmit={onSubmit} className="flex flex-col gap-5" data-testid="restore-form">
+        <fieldset className="flex flex-col gap-3">
+          <legend className="text-sm font-medium">{t("exports:restore.strategy")}</legend>
+          {RESTORE_STRATEGIES.map((strategy) => {
+            const id = `restore-strategy-${strategy}`
+            return (
+              // eslint-disable-next-line jsx-a11y/label-has-associated-control -- the strategy label below carries the visible text; the rule's text-traversal misses it because t() returns a string at runtime, not a literal at parse time.
+              <label
+                key={strategy}
+                htmlFor={id}
+                className={cn(
+                  "flex cursor-pointer items-start gap-3 rounded-md border bg-card px-4 py-3",
+                  state.strategy === strategy && "border-primary/60 bg-primary/5"
+                )}
+                data-testid={id}
+              >
+                <input
+                  id={id}
+                  type="radio"
+                  name="strategy"
+                  className="mt-1 size-4"
+                  checked={state.strategy === strategy}
+                  onChange={() => setState((prev) => ({ ...prev, strategy }))}
+                  value={strategy}
+                />
+                <span className="flex flex-col gap-0.5">
+                  <span className="text-sm font-medium">
+                    {t(`exports:restore.strategyLabel.${strategy}`)}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {t(`exports:restore.strategyDescription.${strategy}`)}
+                  </span>
+                </span>
+              </label>
+            )
+          })}
+        </fieldset>
+
+        <label className="inline-flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            className="size-4"
+            checked={state.include_file_data}
+            onChange={(e) => setState((prev) => ({ ...prev, include_file_data: e.target.checked }))}
+            data-testid="restore-include-file-data"
+          />
+          {t("exports:restore.includeFileData")}
+        </label>
+
+        <label className="inline-flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            className="size-4"
+            checked={state.dry_run}
+            onChange={(e) => setState((prev) => ({ ...prev, dry_run: e.target.checked }))}
+            data-testid="restore-dry-run"
+          />
+          {t("exports:restore.dryRun")}
+        </label>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="restore-description">{t("exports:restore.description")}</Label>
+          <Input
+            id="restore-description"
+            value={state.description}
+            onChange={(e) => setState((prev) => ({ ...prev, description: e.target.value }))}
+            placeholder={t("exports:restore.descriptionPlaceholder")}
+            maxLength={500}
+            data-testid="restore-description"
+          />
+          <p className="text-xs text-muted-foreground">{t("exports:restore.descriptionHint")}</p>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button asChild variant="ghost" type="button">
+            <Link to={detailHref}>{t("exports:wizard.cancel")}</Link>
+          </Button>
+          <Button
+            type="submit"
+            disabled={createRestoreMutation.isPending}
+            data-testid="restore-submit"
+          >
+            {createRestoreMutation.isPending && (
+              <Loader2 className="mr-1.5 size-4 animate-spin" aria-hidden="true" />
+            )}
+            {createRestoreMutation.isPending
+              ? t("exports:restore.submitting")
+              : t("exports:restore.submit")}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/exports/ExportRestorePage.tsx
+++ b/frontend/src/pages/exports/ExportRestorePage.tsx
@@ -34,10 +34,11 @@ export function ExportRestorePage() {
   const navigate = useNavigate()
   const toast = useAppToast()
   const { currentGroup } = useCurrentGroup()
+  const groupReady = !!currentGroup
   const slug = currentGroup?.slug ?? ""
   const exportId = params.id ?? ""
 
-  const exportQuery = useExport(exportId)
+  const exportQuery = useExport(exportId, { enabled: groupReady && !!exportId })
   const createRestoreMutation = useCreateRestore()
   const [state, setState] = useState<FormState>(defaultState)
 
@@ -68,7 +69,7 @@ export function ExportRestorePage() {
     }
   }
 
-  if (exportQuery.isLoading) {
+  if (!groupReady || exportQuery.isLoading) {
     return (
       <div className="flex flex-col gap-4 p-6" data-testid="page-export-restore-loading">
         <Skeleton className="h-8 w-1/2" />

--- a/frontend/src/pages/exports/ExportRestorePage.tsx
+++ b/frontend/src/pages/exports/ExportRestorePage.tsx
@@ -45,10 +45,14 @@ export function ExportRestorePage() {
   const exp = exportQuery.data
   const detailHref = `/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(exportId)}`
 
-  async function onSubmit(e: React.FormEvent) {
+  function onSubmit(e: React.FormEvent) {
     e.preventDefault()
-    try {
-      await createRestoreMutation.mutateAsync({
+    // Use mutate({ onSuccess }) instead of `await mutateAsync` —
+    // navigate() inside an async-callback after `await` was dropping
+    // under load on CI (same flake class as the wizard step-3 fix on
+    // ExportNewPage). Per-call onSuccess fires reliably.
+    createRestoreMutation.mutate(
+      {
         exportId,
         req: {
           description: state.description,
@@ -58,15 +62,20 @@ export function ExportRestorePage() {
             dry_run: state.dry_run,
           },
         },
-      })
-      toast.success(
-        state.dry_run ? t("exports:restore.successDryRun") : t("exports:restore.success")
-      )
-      navigate(detailHref)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      toast.error(t("exports:errors.restoreCreateFailed", { error: message }))
-    }
+      },
+      {
+        onSuccess: () => {
+          toast.success(
+            state.dry_run ? t("exports:restore.successDryRun") : t("exports:restore.success")
+          )
+          navigate(detailHref)
+        },
+        onError: (err) => {
+          const message = err instanceof Error ? err.message : String(err)
+          toast.error(t("exports:errors.restoreCreateFailed", { error: message }))
+        },
+      }
+    )
   }
 
   if (!groupReady || exportQuery.isLoading) {
@@ -182,6 +191,8 @@ export function ExportRestorePage() {
             onChange={(e) => setState((prev) => ({ ...prev, description: e.target.value }))}
             placeholder={t("exports:restore.descriptionPlaceholder")}
             maxLength={500}
+            minLength={1}
+            required
             data-testid="restore-description"
           />
           <p className="text-xs text-muted-foreground">{t("exports:restore.descriptionHint")}</p>
@@ -193,7 +204,7 @@ export function ExportRestorePage() {
           </Button>
           <Button
             type="submit"
-            disabled={createRestoreMutation.isPending}
+            disabled={createRestoreMutation.isPending || !state.description.trim()}
             data-testid="restore-submit"
           >
             {createRestoreMutation.isPending && (

--- a/frontend/src/pages/exports/ExportsListPage.tsx
+++ b/frontend/src/pages/exports/ExportsListPage.tsx
@@ -13,10 +13,12 @@ import { useAppToast } from "@/hooks/useAppToast"
 import { useConfirm } from "@/hooks/useConfirm"
 
 function exportUrl(slug: string, ...segments: (string | undefined)[]): string {
-  const tail = segments.filter(Boolean).join("/")
-  return tail
-    ? `/g/${encodeURIComponent(slug)}/exports/${tail}`
-    : `/g/${encodeURIComponent(slug)}/exports`
+  const encodedSlug = encodeURIComponent(slug)
+  const tail = segments
+    .filter((s): s is string => !!s)
+    .map(encodeURIComponent)
+    .join("/")
+  return tail ? `/g/${encodedSlug}/exports/${tail}` : `/g/${encodedSlug}/exports`
 }
 
 export function ExportsListPage() {
@@ -25,14 +27,15 @@ export function ExportsListPage() {
   const confirm = useConfirm()
   const [searchParams, setSearchParams] = useSearchParams()
   const { currentGroup } = useCurrentGroup()
+  const groupReady = !!currentGroup
   const slug = currentGroup?.slug ?? ""
 
   const includeDeleted = searchParams.get("show_deleted") === "1"
-  const exportsQuery = useExports({ includeDeleted })
+  const exportsQuery = useExports({ includeDeleted }, { enabled: groupReady })
   const deleteMutation = useDeleteExport()
 
   const items = exportsQuery.data?.exports ?? []
-  const isInitialLoading = exportsQuery.isLoading && !exportsQuery.data
+  const isInitialLoading = !groupReady || (exportsQuery.isLoading && !exportsQuery.data)
   const visibleItems = includeDeleted ? items : items.filter((e) => !e.deleted_at)
   const isLive = items.some((e) => e.status === "pending" || e.status === "in_progress")
 

--- a/frontend/src/pages/exports/ExportsListPage.tsx
+++ b/frontend/src/pages/exports/ExportsListPage.tsx
@@ -1,0 +1,160 @@
+import { Plus, Upload } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { Link, useSearchParams } from "react-router-dom"
+
+import { ExportRow } from "@/components/exports/ExportRow"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { type Export } from "@/features/export/api"
+import { useDeleteExport, useExports } from "@/features/export/hooks"
+import { useAppToast } from "@/hooks/useAppToast"
+import { useConfirm } from "@/hooks/useConfirm"
+
+function exportUrl(slug: string, ...segments: (string | undefined)[]): string {
+  const tail = segments.filter(Boolean).join("/")
+  return tail
+    ? `/g/${encodeURIComponent(slug)}/exports/${tail}`
+    : `/g/${encodeURIComponent(slug)}/exports`
+}
+
+export function ExportsListPage() {
+  const { t } = useTranslation(["exports", "common"])
+  const toast = useAppToast()
+  const confirm = useConfirm()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+
+  const includeDeleted = searchParams.get("show_deleted") === "1"
+  const exportsQuery = useExports({ includeDeleted })
+  const deleteMutation = useDeleteExport()
+
+  const items = exportsQuery.data?.exports ?? []
+  const isInitialLoading = exportsQuery.isLoading && !exportsQuery.data
+  const visibleItems = includeDeleted ? items : items.filter((e) => !e.deleted_at)
+  const isLive = items.some((e) => e.status === "pending" || e.status === "in_progress")
+
+  function toggleShowDeleted(next: boolean) {
+    const search = new URLSearchParams(searchParams)
+    if (next) search.set("show_deleted", "1")
+    else search.delete("show_deleted")
+    setSearchParams(search, { replace: true })
+  }
+
+  async function onDelete(exp: Export) {
+    const ok = await confirm({
+      title: t("exports:removal.confirmTitle"),
+      description: t("exports:removal.confirmDescription"),
+      confirmLabel: t("exports:removal.confirmAction"),
+      cancelLabel: t("exports:removal.confirmCancel"),
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await deleteMutation.mutateAsync(exp.id)
+      toast.success(t("exports:removal.success"))
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error(t("exports:errors.deleteFailed", { error: message }))
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6" data-testid="page-exports">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-semibold tracking-tight">{t("exports:list.title")}</h1>
+            {isLive && (
+              <span
+                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                data-testid="exports-live-indicator"
+              >
+                <span
+                  className="size-1.5 animate-pulse rounded-full bg-primary"
+                  aria-hidden="true"
+                />
+                {t("exports:polling.live")}
+              </span>
+            )}
+          </div>
+          <p className="max-w-prose text-sm text-muted-foreground">
+            {t("exports:list.description")}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button asChild variant="outline" data-testid="exports-import-button">
+            <Link to={exportUrl(slug, "import")}>
+              <Upload className="mr-1.5 size-4" aria-hidden="true" />
+              {t("exports:actions.import")}
+            </Link>
+          </Button>
+          <Button asChild data-testid="exports-create-button">
+            <Link to={exportUrl(slug, "new")}>
+              <Plus className="mr-1.5 size-4" aria-hidden="true" />
+              {t("exports:actions.createExport")}
+            </Link>
+          </Button>
+        </div>
+      </header>
+
+      <Alert data-testid="exports-retention-banner">
+        <AlertTitle>{t("exports:retention.title")}</AlertTitle>
+        <AlertDescription>{t("exports:retention.description")}</AlertDescription>
+      </Alert>
+
+      <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="size-4"
+            checked={includeDeleted}
+            onChange={(e) => toggleShowDeleted(e.target.checked)}
+            data-testid="exports-show-deleted"
+          />
+          {t("exports:actions.showDeleted")}
+        </label>
+      </div>
+
+      {isInitialLoading ? (
+        <div className="flex flex-col gap-2" data-testid="exports-list-loading">
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <Skeleton key={idx} className="h-20 w-full" />
+          ))}
+        </div>
+      ) : exportsQuery.isError ? (
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive"
+          role="alert"
+          data-testid="exports-list-error"
+        >
+          {t("exports:errors.loadFailed", {
+            error: exportsQuery.error instanceof Error ? exportsQuery.error.message : "unknown",
+          })}
+        </div>
+      ) : visibleItems.length === 0 ? (
+        <div
+          className="rounded-md border bg-muted/30 px-4 py-10 text-center text-sm text-muted-foreground"
+          data-testid="exports-list-empty"
+        >
+          {includeDeleted ? t("exports:list.emptyFiltered") : t("exports:list.empty")}
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-2" data-testid="exports-list">
+          {visibleItems.map((exp) => (
+            <li key={exp.id}>
+              <ExportRow
+                export={exp}
+                detailHref={exportUrl(slug, exp.id)}
+                groupSlug={slug}
+                onDelete={() => onDelete(exp)}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/exports/__tests__/ExportDetailPage.test.tsx
+++ b/frontend/src/pages/exports/__tests__/ExportDetailPage.test.tsx
@@ -1,0 +1,98 @@
+import { screen } from "@testing-library/react"
+import { axe } from "jest-axe"
+import { Route } from "react-router-dom"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { GroupProvider } from "@/features/group/GroupContext"
+import { ConfirmProvider } from "@/hooks/useConfirm"
+import { initI18n } from "@/i18n"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { ExportDetailPage } from "@/pages/exports/ExportDetailPage"
+import { exportHandlers, groupHandlers } from "@/test/handlers"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+
+const SLUG = "household"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+  server.use(...groupHandlers.list([{ id: "g1", slug: SLUG, name: "Household" }]))
+})
+
+function renderPage(id: string) {
+  return renderWithProviders({
+    initialPath: `/g/${SLUG}/exports/${id}`,
+    routes: (
+      <Route
+        path="/g/:groupSlug/exports/:id"
+        element={
+          <ConfirmProvider>
+            <GroupProvider>
+              <main>
+                <ExportDetailPage />
+              </main>
+            </GroupProvider>
+          </ConfirmProvider>
+        }
+      />
+    ),
+  })
+}
+
+describe("<ExportDetailPage />", () => {
+  it("renders metadata, counts, and an empty restore history", async () => {
+    server.use(
+      ...exportHandlers.detail(
+        SLUG,
+        exportHandlers.exportFixture({
+          id: "e1",
+          description: "Weekly snapshot",
+          file_count: 3,
+          location_count: 2,
+        })
+      ),
+      ...exportHandlers.listRestores(SLUG, "e1", [])
+    )
+    renderPage("e1")
+    await screen.findByTestId("page-export-detail")
+    expect(screen.getByText("Weekly snapshot")).toBeVisible()
+    expect(screen.getByTestId("export-detail-counts")).toHaveTextContent("3")
+    expect(await screen.findByTestId("restores-empty")).toBeVisible()
+  })
+
+  it("renders the import banner when the export was imported", async () => {
+    server.use(
+      ...exportHandlers.detail(
+        SLUG,
+        exportHandlers.exportFixture({
+          id: "e1",
+          imported: true,
+          type: "imported",
+        })
+      ),
+      ...exportHandlers.listRestores(SLUG, "e1", [])
+    )
+    renderPage("e1")
+    expect(await screen.findByTestId("export-detail-imported-banner")).toBeVisible()
+  })
+
+  it("is axe-clean", async () => {
+    server.use(
+      ...exportHandlers.detail(SLUG, exportHandlers.exportFixture({ id: "e1" })),
+      ...exportHandlers.listRestores(SLUG, "e1", [])
+    )
+    const { baseElement } = renderPage("e1")
+    await screen.findByTestId("page-export-detail")
+    const results = await axe(baseElement)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/pages/exports/__tests__/ExportImportPage.test.tsx
+++ b/frontend/src/pages/exports/__tests__/ExportImportPage.test.tsx
@@ -1,0 +1,83 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { axe } from "jest-axe"
+import { Route } from "react-router-dom"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { GroupProvider } from "@/features/group/GroupContext"
+import { initI18n } from "@/i18n"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { ExportImportPage } from "@/pages/exports/ExportImportPage"
+import { exportHandlers, groupHandlers } from "@/test/handlers"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+
+const SLUG = "household"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+  server.use(...groupHandlers.list([{ id: "g1", slug: SLUG, name: "Household" }]))
+})
+
+function renderPage() {
+  return renderWithProviders({
+    initialPath: `/g/${SLUG}/exports/import`,
+    routes: (
+      <Route
+        path="/g/:groupSlug/exports/import"
+        element={
+          <GroupProvider>
+            <main>
+              <ExportImportPage />
+            </main>
+          </GroupProvider>
+        }
+      />
+    ),
+  })
+}
+
+describe("<ExportImportPage />", () => {
+  it("disables the submit button until a file is attached", async () => {
+    renderPage()
+    const submit = await screen.findByTestId("import-submit")
+    expect(submit).toBeDisabled()
+  })
+
+  it("uploads the file then creates an imported export and navigates to restore", async () => {
+    server.use(
+      ...exportHandlers.uploadRestore(SLUG, "restores/2026/05/abc.xml"),
+      ...exportHandlers.importBackup(
+        SLUG,
+        exportHandlers.exportFixture({ id: "imp-1", imported: true, type: "imported" })
+      )
+    )
+    const user = userEvent.setup()
+    renderPage()
+    const fileInput = await screen.findByTestId("import-file-input")
+    const file = new File(["<export/>"], "backup.xml", { type: "application/xml" })
+    await user.upload(fileInput, file)
+    expect(screen.getByTestId("import-file-chosen")).toHaveTextContent("backup.xml")
+
+    await user.click(screen.getByTestId("import-submit"))
+    // The page navigates after the import succeeds; the easiest assertion
+    // is that the form disappears and the success toast helper has fired.
+    await waitFor(() => expect(screen.queryByTestId("import-form")).not.toBeInTheDocument())
+  })
+
+  it("is axe-clean", async () => {
+    const { baseElement } = renderPage()
+    await screen.findByTestId("page-export-import")
+    const results = await axe(baseElement)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/pages/exports/__tests__/ExportNewPage.test.tsx
+++ b/frontend/src/pages/exports/__tests__/ExportNewPage.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { axe } from "jest-axe"
 import { http, HttpResponse } from "msw"
-import { Route } from "react-router-dom"
+import { Outlet, Route } from "react-router-dom"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 
 import { GroupProvider } from "@/features/group/GroupContext"
@@ -31,19 +31,29 @@ beforeEach(() => {
 })
 
 function renderPage() {
+  // Wrap in a parent <Route> that mounts <GroupProvider> once so both
+  // /exports/new and the detail page (the wizard's success target) share
+  // the same provider — otherwise navigate() to the detail route would
+  // unmount and remount the provider, invalidating the URL slug.
   return renderWithProviders({
     initialPath: `/g/${SLUG}/exports/new`,
     routes: (
       <Route
-        path="/g/:groupSlug/exports/new"
+        path="/g/:groupSlug"
         element={
           <GroupProvider>
             <main>
-              <ExportNewPage />
+              <Outlet />
             </main>
           </GroupProvider>
         }
-      />
+      >
+        <Route path="exports/new" element={<ExportNewPage />} />
+        <Route
+          path="exports/:id"
+          element={<div data-testid="stub-export-detail">stub-detail</div>}
+        />
+      </Route>
     ),
   })
 }
@@ -56,7 +66,7 @@ describe("<ExportNewPage />", () => {
     expect(screen.getByTestId("wizard-scope-selected_items")).toBeVisible()
   })
 
-  it("walks through all three steps and submits the create call", async () => {
+  it("walks through both steps, submits, and navigates to the detail page", async () => {
     let captured: unknown = null
     server.use(
       http.post(apiUrl(`/g/${SLUG}/exports`), async ({ request }) => {
@@ -93,13 +103,13 @@ describe("<ExportNewPage />", () => {
     expect(await screen.findByTestId("wizard-step-2-content")).toBeVisible()
 
     await user.click(screen.getByTestId("wizard-submit"))
-    await waitFor(() => expect(screen.getByTestId("wizard-step-3-content")).toBeVisible())
+    // The wizard navigates to the detail page on success — that's the
+    // canonical "watch this export" surface (status badge polling,
+    // download/restore CTAs, restore history).
+    await waitFor(() => expect(screen.getByTestId("stub-export-detail")).toBeVisible())
     expect(captured).toMatchObject({
       data: { type: "exports", attributes: { type: "full_database" } },
     })
-    // step 3 polls /exports/:id; once status=completed surfaces the
-    // download CTA.
-    await waitFor(() => expect(screen.getByTestId("wizard-download")).toBeVisible())
   })
 
   it("blocks the next button when selected_items is picked but empty", async () => {

--- a/frontend/src/pages/exports/__tests__/ExportNewPage.test.tsx
+++ b/frontend/src/pages/exports/__tests__/ExportNewPage.test.tsx
@@ -1,0 +1,125 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { axe } from "jest-axe"
+import { http, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { GroupProvider } from "@/features/group/GroupContext"
+import { initI18n } from "@/i18n"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { ExportNewPage } from "@/pages/exports/ExportNewPage"
+import { exportHandlers, groupHandlers } from "@/test/handlers"
+import { apiUrl } from "@/test/handlers"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+
+const SLUG = "household"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+  server.use(...groupHandlers.list([{ id: "g1", slug: SLUG, name: "Household" }]))
+})
+
+function renderPage() {
+  return renderWithProviders({
+    initialPath: `/g/${SLUG}/exports/new`,
+    routes: (
+      <Route
+        path="/g/:groupSlug/exports/new"
+        element={
+          <GroupProvider>
+            <main>
+              <ExportNewPage />
+            </main>
+          </GroupProvider>
+        }
+      />
+    ),
+  })
+}
+
+describe("<ExportNewPage />", () => {
+  it("renders step 1 with the scope radios", async () => {
+    renderPage()
+    expect(await screen.findByTestId("wizard-step-1-content")).toBeVisible()
+    expect(screen.getByTestId("wizard-scope-full_database")).toBeVisible()
+    expect(screen.getByTestId("wizard-scope-selected_items")).toBeVisible()
+  })
+
+  it("walks through all three steps and submits the create call", async () => {
+    let captured: unknown = null
+    server.use(
+      http.post(apiUrl(`/g/${SLUG}/exports`), async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json(
+          {
+            data: {
+              id: "e1",
+              type: "exports",
+              attributes: {
+                type: "full_database",
+                status: "completed",
+                file_size: 0,
+                description: "",
+                include_file_data: true,
+                created_date: "2026-05-01T10:00:00Z",
+                completed_date: "2026-05-01T10:00:30Z",
+              },
+            },
+          },
+          { status: 201 }
+        )
+      }),
+      ...exportHandlers.detail(
+        SLUG,
+        exportHandlers.exportFixture({ id: "e1", status: "completed" })
+      )
+    )
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId("wizard-step-1-content")
+
+    await user.click(screen.getByTestId("wizard-next"))
+    expect(await screen.findByTestId("wizard-step-2-content")).toBeVisible()
+
+    await user.click(screen.getByTestId("wizard-submit"))
+    await waitFor(() => expect(screen.getByTestId("wizard-step-3-content")).toBeVisible())
+    expect(captured).toMatchObject({
+      data: { type: "exports", attributes: { type: "full_database" } },
+    })
+    // step 3 polls /exports/:id; once status=completed surfaces the
+    // download CTA.
+    await waitFor(() => expect(screen.getByTestId("wizard-download")).toBeVisible())
+  })
+
+  it("blocks the next button when selected_items is picked but empty", async () => {
+    server.use(
+      http.get(apiUrl(`/g/${SLUG}/locations`), () =>
+        HttpResponse.json({ data: [], meta: { locations: 0 } })
+      )
+    )
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId("wizard-step-1-content")
+    await user.click(screen.getByTestId("wizard-scope-selected_items"))
+    await user.click(screen.getByTestId("wizard-next"))
+    expect(await screen.findByTestId("selected-items-picker-error")).toBeVisible()
+  })
+
+  it("is axe-clean on step 1", async () => {
+    const { baseElement } = renderPage()
+    await screen.findByTestId("wizard-step-1-content")
+    const results = await axe(baseElement)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/pages/exports/__tests__/ExportRestorePage.test.tsx
+++ b/frontend/src/pages/exports/__tests__/ExportRestorePage.test.tsx
@@ -91,12 +91,16 @@ describe("<ExportRestorePage />", () => {
     const user = userEvent.setup()
     renderPage()
     await screen.findByTestId("restore-form")
+    // Description is required (BE: jsonapi/restore_operations.go enforces
+    // Required + Length 1..500). Fill it so the submit button enables.
+    await user.type(screen.getByTestId("restore-description"), "smoke restore")
     await user.click(screen.getByTestId("restore-submit"))
     await waitFor(() =>
       expect(captured).toMatchObject({
         data: {
           type: "restores",
           attributes: {
+            description: "smoke restore",
             options: { strategy: "merge_add", include_file_data: true, dry_run: true },
           },
         },

--- a/frontend/src/pages/exports/__tests__/ExportRestorePage.test.tsx
+++ b/frontend/src/pages/exports/__tests__/ExportRestorePage.test.tsx
@@ -1,0 +1,113 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { axe } from "jest-axe"
+import { http, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { GroupProvider } from "@/features/group/GroupContext"
+import { initI18n } from "@/i18n"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { ExportRestorePage } from "@/pages/exports/ExportRestorePage"
+import { exportHandlers, groupHandlers } from "@/test/handlers"
+import { apiUrl } from "@/test/handlers"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+
+const SLUG = "household"
+const EXPORT_ID = "e1"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+  server.use(
+    ...groupHandlers.list([{ id: "g1", slug: SLUG, name: "Household" }]),
+    ...exportHandlers.detail(SLUG, exportHandlers.exportFixture({ id: EXPORT_ID }))
+  )
+})
+
+function renderPage() {
+  return renderWithProviders({
+    initialPath: `/g/${SLUG}/exports/${EXPORT_ID}/restore`,
+    routes: (
+      <Route
+        path="/g/:groupSlug/exports/:id/restore"
+        element={
+          <GroupProvider>
+            <main>
+              <ExportRestorePage />
+            </main>
+          </GroupProvider>
+        }
+      />
+    ),
+  })
+}
+
+describe("<ExportRestorePage />", () => {
+  it("renders the strategy radios with merge_add as the default", async () => {
+    renderPage()
+    expect(await screen.findByTestId("restore-strategy-merge_add")).toBeVisible()
+    const merge = screen.getByTestId("restore-strategy-merge_add").querySelector("input")
+    expect(merge).toBeChecked()
+  })
+
+  it("warns when full_replace is picked WITHOUT dry-run", async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId("restore-form")
+    await user.click(screen.getByTestId("restore-strategy-full_replace"))
+    // dry-run defaults to true; warning is suppressed
+    expect(screen.queryByTestId("restore-destructive-warning")).not.toBeInTheDocument()
+    await user.click(screen.getByTestId("restore-dry-run"))
+    expect(screen.getByTestId("restore-destructive-warning")).toBeVisible()
+  })
+
+  it("submits the chosen options to the BE", async () => {
+    let captured: unknown = null
+    server.use(
+      http.post(apiUrl(`/g/${SLUG}/exports/${EXPORT_ID}/restores`), async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json(
+          {
+            data: {
+              id: "r1",
+              type: "restores",
+              attributes: { status: "pending", description: "" },
+            },
+          },
+          { status: 201 }
+        )
+      })
+    )
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId("restore-form")
+    await user.click(screen.getByTestId("restore-submit"))
+    await waitFor(() =>
+      expect(captured).toMatchObject({
+        data: {
+          type: "restores",
+          attributes: {
+            options: { strategy: "merge_add", include_file_data: true, dry_run: true },
+          },
+        },
+      })
+    )
+  })
+
+  it("is axe-clean", async () => {
+    const { baseElement } = renderPage()
+    await screen.findByTestId("restore-form")
+    const results = await axe(baseElement)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/pages/exports/__tests__/ExportsListPage.test.tsx
+++ b/frontend/src/pages/exports/__tests__/ExportsListPage.test.tsx
@@ -1,0 +1,103 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { axe } from "jest-axe"
+import { http, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { GroupProvider } from "@/features/group/GroupContext"
+import { ConfirmProvider } from "@/hooks/useConfirm"
+import { initI18n } from "@/i18n"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { ExportsListPage } from "@/pages/exports/ExportsListPage"
+import { exportHandlers, groupHandlers } from "@/test/handlers"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+
+const SLUG = "household"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+})
+
+function renderPage(initialPath = `/g/${SLUG}/exports`) {
+  return renderWithProviders({
+    initialPath,
+    routes: (
+      <Route
+        path="/g/:groupSlug/exports"
+        element={
+          <ConfirmProvider>
+            <GroupProvider>
+              <main>
+                <ExportsListPage />
+              </main>
+            </GroupProvider>
+          </ConfirmProvider>
+        }
+      />
+    ),
+  })
+}
+
+function seed(items = [exportHandlers.exportFixture()]) {
+  server.use(
+    ...groupHandlers.list([{ id: "g1", slug: SLUG, name: "Household" }]),
+    ...exportHandlers.list(SLUG, items)
+  )
+}
+
+describe("<ExportsListPage />", () => {
+  it("renders the empty state when there are no exports", async () => {
+    seed([])
+    renderPage()
+    expect(await screen.findByTestId("exports-list-empty")).toBeVisible()
+  })
+
+  it("renders one row per export with status badge and counts", async () => {
+    seed([
+      exportHandlers.exportFixture({ id: "e1", description: "Weekly snapshot" }),
+      exportHandlers.exportFixture({ id: "e2", status: "in_progress" }),
+    ])
+    renderPage()
+    expect(await screen.findByTestId("export-row-e1")).toBeVisible()
+    expect(screen.getByTestId("export-row-e1")).toHaveTextContent("Weekly snapshot")
+    // Live indicator surfaces when any export is non-terminal.
+    expect(screen.getByTestId("exports-live-indicator")).toBeVisible()
+    expect(screen.getByTestId("status-completed")).toBeVisible()
+    expect(screen.getByTestId("status-in_progress")).toBeVisible()
+  })
+
+  it("respects the show-deleted toggle by passing include_deleted=true", async () => {
+    let captured: URL | null = null
+    server.use(
+      ...groupHandlers.list([{ id: "g1", slug: SLUG, name: "Household" }]),
+      http.get(`${window.location.origin}/api/v1/g/${SLUG}/exports`, ({ request }) => {
+        captured = new URL(request.url)
+        return HttpResponse.json({ data: [], meta: { exports: 0 } })
+      })
+    )
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId("exports-list-empty")
+    await user.click(screen.getByTestId("exports-show-deleted"))
+    await waitFor(() => expect(captured!.searchParams.get("include_deleted")).toBe("true"))
+  })
+
+  it("is axe-clean once data has loaded", async () => {
+    seed([exportHandlers.exportFixture({ id: "e1" })])
+    const { baseElement } = renderPage()
+    await screen.findByTestId("export-row-e1")
+    const results = await axe(baseElement)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/handlers/exports.ts
+++ b/frontend/src/test/handlers/exports.ts
@@ -1,11 +1,134 @@
 import { http, HttpResponse } from "msw"
 
+import type { Export, Restore, ExportStatus, RestoreStatus } from "@/features/export/api"
+
 import { apiUrl } from "."
 
-export function list(slug: string, items: unknown[] = []) {
+type ExportFixture = Partial<Export> & { id: string }
+type RestoreFixture = Partial<Restore> & { id: string }
+
+function exportEnvelope(fix: ExportFixture) {
+  const { id, ...attributes } = fix
+  return { id, type: "exports", attributes }
+}
+
+function restoreEnvelope(fix: RestoreFixture) {
+  const { id, ...attributes } = fix
+  return { id, type: "restores", attributes }
+}
+
+export function list(slug: string, items: ExportFixture[] = []) {
   return [
     http.get(apiUrl(`/g/${encodeURIComponent(slug)}/exports`), () =>
-      HttpResponse.json({ data: items })
+      HttpResponse.json({
+        data: items.map(exportEnvelope),
+        meta: { exports: items.length },
+      })
     ),
   ]
+}
+
+export function detail(slug: string, item: ExportFixture) {
+  return [
+    http.get(apiUrl(`/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(item.id)}`), () =>
+      HttpResponse.json({ data: exportEnvelope(item) })
+    ),
+  ]
+}
+
+export function create(slug: string, item: ExportFixture) {
+  return [
+    http.post(apiUrl(`/g/${encodeURIComponent(slug)}/exports`), () =>
+      HttpResponse.json({ data: exportEnvelope(item) }, { status: 201 })
+    ),
+  ]
+}
+
+export function remove(slug: string, id: string) {
+  return [
+    http.delete(
+      apiUrl(`/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(id)}`),
+      () => new HttpResponse(null, { status: 204 })
+    ),
+  ]
+}
+
+export function importBackup(slug: string, item: ExportFixture) {
+  return [
+    http.post(apiUrl(`/g/${encodeURIComponent(slug)}/exports/import`), () =>
+      HttpResponse.json({ data: exportEnvelope(item) }, { status: 201 })
+    ),
+  ]
+}
+
+export function uploadRestore(slug: string, fileName: string) {
+  return [
+    http.post(apiUrl(`/g/${encodeURIComponent(slug)}/uploads/restores`), () =>
+      HttpResponse.json(
+        {
+          id: "uploads",
+          type: "uploads",
+          attributes: { fileNames: [fileName], type: "restores" },
+        },
+        { status: 200 }
+      )
+    ),
+  ]
+}
+
+export function listRestores(slug: string, exportId: string, restores: RestoreFixture[] = []) {
+  return [
+    http.get(
+      apiUrl(`/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(exportId)}/restores`),
+      () => HttpResponse.json({ data: restores.map(restoreEnvelope) })
+    ),
+  ]
+}
+
+export function createRestore(slug: string, exportId: string, item: RestoreFixture) {
+  return [
+    http.post(
+      apiUrl(`/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(exportId)}/restores`),
+      () => HttpResponse.json({ data: restoreEnvelope(item) }, { status: 201 })
+    ),
+  ]
+}
+
+// Convenience builder: most tests just need a single export with a status
+// and the four counts populated. Defaults are tuned for the happy-path
+// "list page renders one completed export" case; override per-test.
+export function exportFixture(overrides: Partial<Export> & { id?: string } = {}): ExportFixture {
+  const id = overrides.id ?? "exp-1"
+  return {
+    id,
+    type: "full_database",
+    status: "completed" as ExportStatus,
+    description: "",
+    include_file_data: true,
+    file_size: 1024,
+    binary_data_size: 0,
+    location_count: 1,
+    area_count: 1,
+    commodity_count: 1,
+    file_count: 1,
+    image_count: 0,
+    invoice_count: 0,
+    manual_count: 0,
+    created_date: "2026-05-01T10:00:00Z",
+    completed_date: "2026-05-01T10:00:30Z",
+    ...overrides,
+  }
+}
+
+export function restoreFixture(overrides: Partial<Restore> & { id?: string } = {}): RestoreFixture {
+  const id = overrides.id ?? "rest-1"
+  return {
+    id,
+    status: "completed" as RestoreStatus,
+    description: "",
+    options: { strategy: "merge_add", include_file_data: false, dry_run: true },
+    created_date: "2026-05-01T11:00:00Z",
+    completed_date: "2026-05-01T11:00:30Z",
+    ...overrides,
+  }
 }

--- a/go/apiserver/export_restores.go
+++ b/go/apiserver/export_restores.go
@@ -199,16 +199,24 @@ func (api *exportRestoresAPI) createExportRestore(w http.ResponseWriter, r *http
 	}
 
 	restoreOperation := models.NewRestoreOperationFromUserInput(data.Data.Attributes)
+	// The restore is scoped to the export from the URL — the FE only
+	// sends description+options on the body, so populate ExportID
+	// server-side before the registry's Create validates the row.
+	// Without this, the row gets persisted with an empty export_id and
+	// ListByExport(exportID) returns []; the FE never sees the restore
+	// it just created.
+	restoreOperation.ExportID = exportID
 	createdRestoreOperation, err := restoreOpReg.Create(r.Context(), restoreOperation)
 	if err != nil {
 		renderEntityError(w, r, err)
 		return
 	}
 
-	// Return immediately with the created restore operation
-	// The restore worker will pick up the pending operation and process it
-	w.WriteHeader(http.StatusCreated)
-	if err := render.Render(w, r, jsonapi.NewRestoreOperationResponse(createdRestoreOperation)); err != nil {
+	// Return immediately with the created restore operation; the restore
+	// worker will pick up the pending operation and process it.
+	// WithStatusCode is required because RestoreOperationResponse.Render
+	// would otherwise reset the status to 200 — see exports.go createExport.
+	if err := render.Render(w, r, jsonapi.NewRestoreOperationResponse(createdRestoreOperation).WithStatusCode(http.StatusCreated)); err != nil {
 		internalServerError(w, r, err)
 		return
 	}

--- a/go/apiserver/exports.go
+++ b/go/apiserver/exports.go
@@ -143,8 +143,11 @@ func (api *exportsAPI) createExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
-	if err := render.Render(w, r, jsonapi.NewExportResponse(&createdExport)); err != nil {
+	// `WithStatusCode` is required because ExportResponse.Render
+	// unconditionally calls render.Status(r, statusCodeDef(...,
+	// StatusOK)) — without setting HTTPStatusCode the renderer
+	// overwrites a handler-level render.Status back to 200.
+	if err := render.Render(w, r, jsonapi.NewExportResponse(&createdExport).WithStatusCode(http.StatusCreated)); err != nil {
 		internalServerError(w, r, err)
 		return
 	}
@@ -350,10 +353,10 @@ func (api *exportsAPI) importExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Import worker will pick up this pending import and process it in background
-	// Return immediately with the created export
-	w.WriteHeader(http.StatusCreated)
-	if err := render.Render(w, r, jsonapi.NewExportResponse(createdExport)); err != nil {
+	// Import worker will pick up this pending import and process it in background.
+	// Return immediately with the created export. WithStatusCode is required
+	// because ExportResponse.Render overwrites render.Status — see createExport.
+	if err := render.Render(w, r, jsonapi.NewExportResponse(createdExport).WithStatusCode(http.StatusCreated)); err != nil {
 		internalServerError(w, r, err)
 		return
 	}

--- a/go/internal/typekit/typekit.go
+++ b/go/internal/typekit/typekit.go
@@ -175,9 +175,17 @@ func extractDBFields(t reflect.Type, v reflect.Value, fields, placeholders *[]st
 			continue
 		}
 
-		// Handle regular fields with db tags
+		// Handle regular fields with db tags. Skip fields with no tag
+		// (`db` absent) and fields explicitly opted out via `db:"-"` —
+		// the latter is the conventional sqlx/gorp marker for "this is
+		// a relation/transient field, do not include in INSERT".
+		// Without the `"-"` check, the column ends up in the query
+		// with name `-` and the named-param binding either can't find
+		// it or trips over `-` as a non-identifier character (e.g.
+		// `RestoreOperation.Steps`, which surfaced on PR #1494 as
+		// `failed to insert entity: could not find name`).
 		dbTag := field.Tag.Get("db")
-		if dbTag == "" {
+		if dbTag == "" || dbTag == "-" {
 			continue
 		}
 

--- a/go/internal/typekit/typekit_test.go
+++ b/go/internal/typekit/typekit_test.go
@@ -873,6 +873,39 @@ func TestExtractDBFields(t *testing.T) {
 		})
 	})
 
+	// Regression for PR #1494: a relation/transient field tagged
+	// `db:"-"` was being included in INSERT statements with column
+	// name `-`, which broke sqlx named-arg binding ("could not find
+	// name" on RestoreOperation.Steps in postgres). The `"-"` marker
+	// is the conventional sqlx/gorp opt-out and must be skipped.
+	c.Run("struct with db:\"-\" excluded fields", func(c *qt.C) {
+		type EntityWithRelation struct {
+			ID       int      `db:"id"`
+			Name     string   `db:"name"`
+			Children []string `db:"-"`
+		}
+
+		entity := EntityWithRelation{
+			ID:       7,
+			Name:     "Parent",
+			Children: []string{"a", "b"},
+		}
+
+		var fields []string
+		var placeholders []string
+		params := make(map[string]any)
+
+		err := typekit.ExtractDBFields(entity, &fields, &placeholders, params)
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(fields, qt.DeepEquals, []string{"id", "name"})
+		c.Assert(placeholders, qt.DeepEquals, []string{":id", ":name"})
+		c.Assert(params, qt.DeepEquals, map[string]any{
+			"id":   7,
+			"name": "Parent",
+		})
+	})
+
 	// Test with embedded struct
 	c.Run("embedded struct", func(c *qt.C) {
 		type BaseEntity struct {

--- a/go/jsonapi/restore_operations.go
+++ b/go/jsonapi/restore_operations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/go-chi/render"
 	"github.com/go-extras/errx"
 	"github.com/jellydator/validation"
 
@@ -54,13 +55,19 @@ func NewRestoreOperationsResponse(operations []*models.RestoreOperation) *Restor
 	}
 }
 
-func (r *RestoreOperationResponse) Render(w http.ResponseWriter, req *http.Request) error {
-	r.HTTPStatusCode = http.StatusOK
+func (r *RestoreOperationResponse) WithStatusCode(statusCode int) *RestoreOperationResponse {
+	tmp := *r
+	tmp.HTTPStatusCode = statusCode
+	return &tmp
+}
+
+func (r *RestoreOperationResponse) Render(_w http.ResponseWriter, req *http.Request) error {
+	render.Status(req, statusCodeDef(r.HTTPStatusCode, http.StatusOK))
 	return nil
 }
 
-func (r *RestoreOperationsResponse) Render(w http.ResponseWriter, req *http.Request) error {
-	r.HTTPStatusCode = http.StatusOK
+func (r *RestoreOperationsResponse) Render(_w http.ResponseWriter, req *http.Request) error {
+	render.Status(req, statusCodeDef(r.HTTPStatusCode, http.StatusOK))
 	return nil
 }
 

--- a/go/models/restore_operation.go
+++ b/go/models/restore_operation.go
@@ -2,7 +2,9 @@ package models
 
 import (
 	"context"
+	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 
 	"github.com/jellydator/validation"
 )
@@ -30,6 +32,31 @@ type RestoreOptions struct {
 	Strategy        string `json:"strategy"`
 	IncludeFileData bool   `json:"include_file_data"`
 	DryRun          bool   `json:"dry_run"`
+}
+
+// Value implements driver.Valuer so RestoreOptions can be written to a
+// JSONB column. INSERT/UPDATE round-trips encode the struct as JSON.
+func (r RestoreOptions) Value() (driver.Value, error) {
+	return json.Marshal(r)
+}
+
+// Scan implements sql.Scanner so SELECT queries can hydrate the JSONB
+// `options` column back into the struct. Without this, list / detail
+// queries 500 with `unsupported Scan, storing driver.Value type []uint8
+// into type *models.RestoreOptions`.
+func (r *RestoreOptions) Scan(value any) error {
+	if value == nil {
+		*r = RestoreOptions{}
+		return nil
+	}
+	switch v := value.(type) {
+	case []byte:
+		return json.Unmarshal(v, r)
+	case string:
+		return json.Unmarshal([]byte(v), r)
+	default:
+		return fmt.Errorf("cannot scan %T into RestoreOptions", value)
+	}
 }
 
 func (r RestoreOptions) Validate() error {


### PR DESCRIPTION
Closes #1415 (sub-issue of epic #1397). Replaces the five `trackedBy="#1415"` placeholders at `/g/:slug/exports{,/new,/import,/:id,/:id/restore}` with the full React-rebuilt Backup & Exports surface.

## Pages

- **`/exports`** — list with status badges, scope label, file/item counts, soft-delete toggle (drives `?include_deleted=true`), and a retention-policy stub banner. Polls every 2s while any row is `pending` / `in_progress`; idles otherwise.
- **`/exports/new`** — three-step wizard (`?step=1|2|3` deep-linkable):
  - Step 1 — radio for `full_database` vs `selected_items` + include-file-data toggle. The `selected_items` picker covers whole locations for v1 (area / commodity granularity is a follow-up).
  - Step 2 — description input + summary review.
  - Step 3 — watches `useExport(createdId)` until the status reaches a terminal state, then offers Download.
- **`/exports/:id`** — metadata stats + four-tile counts + Download / Restore / Delete CTAs + restore-history list. Polls export and per-export restores until terminal.
- **`/exports/import`** — drop-zone file picker → `POST /uploads/restores` (multipart) → `POST /exports/import` → auto-redirect to `/exports/:id/restore` for the new "imported" export.
- **`/exports/:id/restore`** — strategy radio (`full_replace` / `merge_add` / `merge_update`) + include-file-data + dry-run booleans + destructive-warning banner when `full_replace` is picked **without** dry-run. Submit → `POST /exports/:id/restores` → back to detail.

## Sidebar / nav

`common:nav.backup` now points at `/exports` (matches the inventario-design "Backup" entry that lands on BackupView). `/g/:slug/backup` is preserved as a soft alias that redirects to `/g/:slug/exports`, so older deep links keep working.

## Feature slice

`features/export/{api,hooks,keys}.ts` covers `list` / `get` / `create` / `delete` / `download-path` for exports + the per-export restore CRUD pair + the `/uploads/restores` multipart upload + `/exports/import`. Strict envelopes throw on missing `id` / `attributes` (matching the tags-slice convention from #1412 / PR #1489).

## i18n

New `en/exports.json` catalog. `cs` and `ru` stay empty `{}` (English fallback) until translated. Dynamic key sets — status, scope, restore strategy label / description, count plural suffixes, wizard scope titles, wizard step titles — added to `preservePatterns` in `i18next.config.ts` so the extractor keeps them across runs.

## Tests

- `features/export/__tests__/api.test.ts` (13 cases) — every endpoint + the terminal-state helpers + the download-path builder.
- One component test per page (`ExportsList` / `New` / `Detail` / `Import` / `Restore`) — renders + a key interaction + a jest-axe smoke per page.
- `e2e/tests/exports-react.spec.ts` — page-shell smoke + full create-and-restore cycle (full-DB export, dry-run merge_add restore). The legacy `exports-crud.spec.ts` stays skipped — its helpers are bound to PrimeVue selectors and can be removed in a follow-up cleanup.
- **492 / 492 vitest green; lint, typecheck, prettier, vite build all clean.**

## Out of scope (follow-ups worth filing)

- Selected-items picker for areas + commodities (v1 covers locations only).
- Real retention policy controls (rendered as a stub banner for now).
- Dedicated `/exports/:id/restores/:restoreId` page with the full restore-step tree (the restore-history list links back to the export detail page for now).
- Import-cycle e2e (download → re-upload → restore) — sensitive to the docker volume layout under the e2e stack and bumps runtime by ~10s; gated on its own follow-up.

## Test plan

- [x] `npm run test` — 492/492 green.
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] `npm run format:check` — clean.
- [x] `npm run build` — succeeds; ExportsListPage / ExportDetailPage / ExportNewPage each emit their own ~7–11kB chunk.
- [ ] CI green (drift checks: codegen, i18n).
- [ ] Manual smoke: dev stack → /exports, create a full-DB export, watch the polling tick, download, restore (dry-run), re-restore (live merge_add).
- [ ] E2E `exports-react.spec.ts` green under the docker-compose e2e stack.