### PR TITLE
[#1442] BE swagger route-coverage gate + reconcile group-scoped annotations

### DIFF
--- a/.github/workflows/go-swagger-docs.yml
+++ b/.github/workflows/go-swagger-docs.yml
@@ -47,3 +47,12 @@ jobs:
             echo "Swagger docs are out of sync. Please run 'make swagger' and commit the changes." >&2
             exit 1
           fi
+
+      - name: Check route coverage
+        # TestSwaggerRouteCoverage walks the chi router returned by
+        # apiserver.APIServer(...) and asserts every /api/v1/... route has a
+        # matching swag annotation in docs/swagger.json — and that no
+        # documented operation references a path that isn't registered.
+        # See devdocs/backend/openapi.md.
+        run: go test ./apiserver -run TestSwaggerRouteCoverage -count=1
+        working-directory: go

--- a/devdocs/backend/openapi.md
+++ b/devdocs/backend/openapi.md
@@ -36,10 +36,12 @@ annotations and must stay in sync with them; CI fails any PR where they don't.
 | Workflow | Job | What it catches |
 | --- | --- | --- |
 | `go-swagger-docs.yml` | Check Swagger Docs Sync | `make swagger` produces a non-empty diff against `go/docs/` — i.e. annotations and committed spec disagree. |
+| `go-swagger-docs.yml` | Check route coverage | `TestSwaggerRouteCoverage` walks the live chi router and the committed `swagger.json`. Fails if any registered `/api/v1/...` route is undocumented, or if any documented operation references a path that's no longer registered. |
 | `frontend-codegen.yml` | codegen-check | `npm run codegen:check` produces a non-empty diff against `frontend/src/types/api.d.ts` — i.e. the generated TS types are stale relative to `swagger.json`. |
 
-Both gates run on every push and pull request. They fail fast if the spec or
-generated types drift from the source annotations.
+All three gates run on every push and pull request. They fail fast if the spec
+or generated types drift from the source annotations, or if a new route lands
+without an annotation.
 
 ## Reproducing a CI failure locally
 
@@ -60,11 +62,29 @@ make codegen-frontend
 git status -- frontend/src/types/
 ```
 
-## What's NOT yet checked
+## Route coverage gate
 
-The current drift gate verifies that the spec matches the annotations in code,
-and that the FE types match the spec. It does **not** verify that every
-registered chi route has a matching swagger operation — i.e. an endpoint can
-exist in code with no annotation at all and the gate will pass. That coverage
-check (and the cleanup of currently-undocumented group-scoped routes under
-`/g/{groupSlug}/...`) is tracked separately under epic #1397.
+`go/apiserver/swagger_route_coverage_test.go` walks the chi router that
+`apiserver.APIServer(...)` returns and compares it to the operations declared
+in `go/docs/swagger.json`. It enforces a strict bidirectional invariant:
+
+- Every registered `/api/v1/...` route must have a matching `(method, path)`
+  in the spec.
+- Every documented operation must point at a path that is actually registered.
+
+The walker strips the `/api/v1` basePath, ignores the `/*` catch-all (the
+frontend embed), and only inspects the standard CRUD verbs (GET / POST / PUT /
+PATCH / DELETE) — anything else (HEAD, OPTIONS) doesn't need a swag block.
+
+When you add a route, add the matching `@Router` annotation in the same PR; the
+gate gives you a single failure listing the missing or stale entries so you
+can correct them in one round-trip with `make swagger`.
+
+### Group-scoped paths
+
+Most data routes live under `/api/v1/g/{groupSlug}/...`. Their annotations
+include the prefix in `@Router` and a `@Param groupSlug path string true
+"Group slug"` block. The non-group-scoped surfaces — `/auth/...`,
+`/system`, `/debug`, `/groups`, `/invites`, `/currencies`, `/seed`,
+`/files/download/...`, `/register`, `/forgot-password`, `/reset-password`,
+`/verify-email`, `/resend-verification` — keep their bare paths.

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -2,210 +2,6 @@
 // To regenerate: run `npm run codegen` (or `make codegen-frontend`).
 
 export type paths = {
-    "/areas": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List areas
-         * @description get areas
-         */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description Page number (default 1) */
-                    page?: number;
-                    /** @description Items per page (default 50, max 100) */
-                    per_page?: number;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.AreasResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        /**
-         * Create a new area
-         * @description add by area data
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: components["requestBodies"]["jsonapi.AreaRequest"];
-            responses: {
-                /** @description Area created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.AreaResponse"];
-                    };
-                };
-                /** @description Area not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description User-side request problem */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/areas/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get an area
-         * @description get area by ID
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Area ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.AreaResponse"];
-                    };
-                };
-            };
-        };
-        /**
-         * Update a area
-         * @description Update by area data
-         */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Area ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: components["requestBodies"]["jsonapi.AreaRequest"];
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.AreaResponse"];
-                    };
-                };
-                /** @description Area not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description User-side request problem */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        post?: never;
-        /**
-         * Delete an area
-         * @description Delete by area ID
-         */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Area ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description No content */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Area not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/auth/change-password": {
         parameters: {
             query?: never;
@@ -543,362 +339,6 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/commodities": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List commodities
-         * @description get commodities
-         */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description Page number (default 1) */
-                    page?: number;
-                    /** @description Items per page (default 50, max 100) */
-                    per_page?: number;
-                    /** @description Filter by commodity type; repeat to OR */
-                    type?: string[];
-                    /** @description Filter by status (in_use, sold, lost, disposed, written_off); repeat to OR */
-                    status?: string[];
-                    /** @description Filter by exact area ID */
-                    area_id?: string;
-                    /** @description Case-insensitive substring match on name + short_name */
-                    q?: string;
-                    /** @description Include drafts and non-in_use commodities (default false hides them) */
-                    include_inactive?: boolean;
-                    /** @description Sort field — name|registered_date|purchase_date|current_price|original_price|count, prefix with '-' for descending */
-                    sort?: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.CommoditiesResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        /**
-         * Create a new commodity
-         * @description Add a new commodity
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: components["requestBodies"]["jsonapi.CommodityRequest"];
-            responses: {
-                /** @description Commodity created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.CommodityResponse"];
-                    };
-                };
-                /** @description User-side request problem */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/commodities/bulk-delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Bulk-delete commodities
-         * @description Delete every commodity whose id appears in the body. The
-         *     response lists succeeded vs. failed ids so the frontend
-         *     can render partial-failure UX without parsing per-id HTTP
-         *     statuses.
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description List of commodity IDs to delete */
-            requestBody: {
-                content: {
-                    "application/vnd.api+json": components["schemas"]["jsonapi.BulkIDsRequest"];
-                };
-            };
-            responses: {
-                /** @description Per-id outcome */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.BulkResultResponse"];
-                    };
-                };
-                /** @description Bad request body */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/commodities/bulk-move": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Bulk-move commodities to a new area
-         * @description Update every commodity whose id appears in the body to
-         *     belong to the supplied area_id.
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description List of commodity IDs and the destination area_id */
-            requestBody: {
-                content: {
-                    "application/vnd.api+json": components["schemas"]["jsonapi.BulkMoveRequest"];
-                };
-            };
-            responses: {
-                /** @description Per-id outcome */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.BulkResultResponse"];
-                    };
-                };
-                /** @description Bad request body */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/commodities/values": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get total value of commodities
-         * @description Get the total value of commodities globally, by location, and by area
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.ValueResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/commodities/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get a commodity
-         * @description get commodity by ID
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Commodity ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.CommodityResponse"];
-                    };
-                };
-            };
-        };
-        /**
-         * Update a commodity
-         * @description Update a commodity
-         */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Commodity ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: components["requestBodies"]["jsonapi.CommodityRequest"];
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.CommodityResponse"];
-                    };
-                };
-                /** @description Commodity not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description User-side request problem */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        post?: never;
-        /**
-         * Delete a commodity
-         * @description Delete a commodity by ID and all its linked files
-         */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Commodity ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description No content */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Commodity not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/currencies": {
         parameters: {
             query?: never;
@@ -965,665 +405,6 @@ export type paths = {
                     };
                     content: {
                         "application/json": components["schemas"]["debug.Info"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/exports": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List exports
-         * @description get exports
-         */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description Include deleted exports */
-                    include_deleted?: boolean;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.ExportsResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        /**
-         * Create an export
-         * @description create a new export
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description Export */
-            requestBody: {
-                content: {
-                    "application/vnd.api+json": components["schemas"]["jsonapi.ExportCreateRequest"];
-                };
-            };
-            responses: {
-                /** @description Created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.ExportResponse"];
-                    };
-                };
-                /** @description Unprocessable Entity */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/exports/import": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Import XML export
-         * @description Import an uploaded XML export file and create an export record
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description Import request data */
-            requestBody: {
-                content: {
-                    "application/vnd.api+json": components["schemas"]["jsonapi.ImportExportRequest"];
-                };
-            };
-            responses: {
-                /** @description Created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.ExportResponse"];
-                    };
-                };
-                /** @description Bad Request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Unprocessable Entity */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/exports/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get an export
-         * @description get export by ID
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Export ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.ExportResponse"];
-                    };
-                };
-                /** @description Not Found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /**
-         * Delete an export
-         * @description delete an export
-         */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Export ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description No Content */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Not Found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/exports/{id}/download": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Download an export file
-         * @description Download an export XML file
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Export ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/octet-stream": string;
-                    };
-                };
-                /** @description Not Found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/octet-stream": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/exports/{id}/restores": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List export restore operations
-         * @description get restore operations for an export
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Export ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.RestoreOperationsResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        /**
-         * Create export restore operation
-         * @description create a new restore operation for an export
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Export ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            /** @description Restore operation data */
-            requestBody: {
-                content: {
-                    "application/vnd.api+json": components["schemas"]["jsonapi.RestoreOperationCreateRequest"];
-                };
-            };
-            responses: {
-                /** @description Created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.RestoreOperationResponse"];
-                    };
-                };
-                /** @description Bad request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/exports/{id}/restores/{restoreId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get export restore operation
-         * @description get restore operation by ID for an export
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Export ID */
-                    id: string;
-                    /** @description Restore Operation ID */
-                    restoreId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.RestoreOperationResponse"];
-                    };
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /**
-         * Delete export restore operation
-         * @description delete a restore operation for an export
-         */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Export ID */
-                    id: string;
-                    /** @description Restore Operation ID */
-                    restoreId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description No Content */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/files": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List files
-         * @description get files with optional filtering
-         */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description Filter by file type */
-                    type?: "image" | "document" | "video" | "audio" | "archive" | "other";
-                    /** @description Filter by file category */
-                    category?: "photos" | "invoices" | "documents" | "other";
-                    /** @description Search in title, description, and file paths */
-                    search?: string;
-                    /** @description Filter by tags (comma-separated) */
-                    tags?: string;
-                    /** @description Filter by linked entity type (e.g. commodity, location, export). Must be supplied together with linked_entity_id. */
-                    linked_entity_type?: string;
-                    /** @description Filter by linked entity id. Must be supplied together with linked_entity_type. */
-                    linked_entity_id?: string;
-                    /** @description Page number (1-based) */
-                    page?: number;
-                    /** @description Items per page */
-                    limit?: number;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.FilesResponse"];
-                    };
-                };
-                /** @description Invalid query parameter */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        /**
-         * Create a file entity
-         * @description create a new file entity with metadata (file upload handled separately)
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description File metadata */
-            requestBody: {
-                content: {
-                    "application/vnd.api+json": components["schemas"]["jsonapi.FileRequest"];
-                };
-            };
-            responses: {
-                /** @description Created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.FileResponse"];
-                    };
-                };
-                /** @description Validation error */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/files/bulk-delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Bulk-delete files
-         * @description Delete every file whose id appears in the body, including
-         *     the physical blob. The response lists succeeded vs.
-         *     failed ids so the frontend can render partial-failure UX
-         *     without parsing per-id HTTP statuses.
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description List of file IDs to delete */
-            requestBody: {
-                content: {
-                    "application/vnd.api+json": components["schemas"]["jsonapi.BulkIDsRequest"];
-                };
-            };
-            responses: {
-                /** @description Per-id outcome */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.BulkResultResponse"];
-                    };
-                };
-                /** @description Bad request body */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/files/category-counts": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * File category counts
-         * @description Per-category file counts, respecting the same filters as GET /files
-         */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description Filter by file type */
-                    type?: "image" | "document" | "video" | "audio" | "archive" | "other";
-                    /** @description Search in title, description, and file paths */
-                    search?: string;
-                    /** @description Filter by tags (comma-separated) */
-                    tags?: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.FileCategoryCountsResponse"];
                     };
                 };
             };
@@ -1758,190 +539,6 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/files/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get a file
-         * @description get file by ID
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description File ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.FileResponse"];
-                    };
-                };
-                /** @description File not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        /**
-         * Update a file
-         * @description update file metadata
-         */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description File ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            /** @description File update data */
-            requestBody: {
-                content: {
-                    "application/vnd.api+json": components["schemas"]["jsonapi.FileUpdateRequest"];
-                };
-            };
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.FileResponse"];
-                    };
-                };
-                /** @description File not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Validation error */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        post?: never;
-        /**
-         * Delete a file
-         * @description delete file and its associated file
-         */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description File ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description No Content */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description File not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/files/{id}/signed-url": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Generate signed URL for file download
-         * @description Generate a secure signed URL for downloading a file
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description File ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Signed URL */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "*/*": components["schemas"]["jsonapi.SignedFileURLResponse"];
-                    };
-                };
-                /** @description File not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "*/*": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/forgot-password": {
         parameters: {
             query?: never;
@@ -1996,6 +593,2521 @@ export type paths = {
                     };
                     content: {
                         "application/json": string;
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/areas": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List areas
+         * @description get areas
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Page number (default 1) */
+                    page?: number;
+                    /** @description Items per page (default 50, max 100) */
+                    per_page?: number;
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.AreasResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create a new area
+         * @description add by area data
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody: components["requestBodies"]["jsonapi.AreaRequest"];
+            responses: {
+                /** @description Area created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.AreaResponse"];
+                    };
+                };
+                /** @description Area not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description User-side request problem */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/areas/{areaID}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get an area
+         * @description get area by ID
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Area ID */
+                    areaID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.AreaResponse"];
+                    };
+                };
+            };
+        };
+        /**
+         * Update a area
+         * @description Update by area data
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Area ID */
+                    areaID: string;
+                };
+                cookie?: never;
+            };
+            requestBody: components["requestBodies"]["jsonapi.AreaRequest"];
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.AreaResponse"];
+                    };
+                };
+                /** @description Area not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description User-side request problem */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        /**
+         * Delete an area
+         * @description Delete by area ID
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Area ID */
+                    areaID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Area not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/commodities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List commodities
+         * @description get commodities
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Page number (default 1) */
+                    page?: number;
+                    /** @description Items per page (default 50, max 100) */
+                    per_page?: number;
+                    /** @description Filter by commodity type; repeat to OR */
+                    type?: string[];
+                    /** @description Filter by status (in_use, sold, lost, disposed, written_off); repeat to OR */
+                    status?: string[];
+                    /** @description Filter by exact area ID */
+                    area_id?: string;
+                    /** @description Case-insensitive substring match on name + short_name */
+                    q?: string;
+                    /** @description Include drafts and non-in_use commodities (default false hides them) */
+                    include_inactive?: boolean;
+                    /** @description Sort field — name|registered_date|purchase_date|current_price|original_price|count, prefix with '-' for descending */
+                    sort?: string;
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.CommoditiesResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create a new commodity
+         * @description Add a new commodity
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody: components["requestBodies"]["jsonapi.CommodityRequest"];
+            responses: {
+                /** @description Commodity created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.CommodityResponse"];
+                    };
+                };
+                /** @description User-side request problem */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/commodities/bulk-delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Bulk-delete commodities
+         * @description Delete every commodity whose id appears in the body. The
+         *     response lists succeeded vs. failed ids so the frontend
+         *     can render partial-failure UX without parsing per-id HTTP
+         *     statuses.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            /** @description List of commodity IDs to delete */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.BulkIDsRequest"];
+                };
+            };
+            responses: {
+                /** @description Per-id outcome */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.BulkResultResponse"];
+                    };
+                };
+                /** @description Bad request body */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/commodities/bulk-move": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Bulk-move commodities to a new area
+         * @description Update every commodity whose id appears in the body to
+         *     belong to the supplied area_id.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            /** @description List of commodity IDs and the destination area_id */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.BulkMoveRequest"];
+                };
+            };
+            responses: {
+                /** @description Per-id outcome */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.BulkResultResponse"];
+                    };
+                };
+                /** @description Bad request body */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/commodities/values": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get total value of commodities
+         * @description Get the total value of commodities globally, by location, and by area
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.ValueResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/commodities/{commodityID}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a commodity
+         * @description get commodity by ID
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Commodity ID */
+                    commodityID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.CommodityResponse"];
+                    };
+                };
+            };
+        };
+        /**
+         * Update a commodity
+         * @description Update a commodity
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Commodity ID */
+                    commodityID: string;
+                };
+                cookie?: never;
+            };
+            requestBody: components["requestBodies"]["jsonapi.CommodityRequest"];
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.CommodityResponse"];
+                    };
+                };
+                /** @description Commodity not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description User-side request problem */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        /**
+         * Delete a commodity
+         * @description Delete a commodity by ID and all its linked files
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Commodity ID */
+                    commodityID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Commodity not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/exports": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List exports
+         * @description get exports
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Include deleted exports */
+                    include_deleted?: boolean;
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.ExportsResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create an export
+         * @description create a new export
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            /** @description Export */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.ExportCreateRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.ExportResponse"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/exports/import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import XML export
+         * @description Import an uploaded XML export file and create an export record
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            /** @description Import request data */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.ImportExportRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.ExportResponse"];
+                    };
+                };
+                /** @description Bad Request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/exports/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get an export
+         * @description get export by ID
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Export ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.ExportResponse"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /**
+         * Delete an export
+         * @description delete an export
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Export ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/exports/{id}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download an export file
+         * @description Download an export XML file
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Export ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/octet-stream": string;
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/octet-stream": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/exports/{id}/restores": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List export restore operations
+         * @description get restore operations for an export
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Export ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.RestoreOperationsResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create export restore operation
+         * @description create a new restore operation for an export
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Export ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            /** @description Restore operation data */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.RestoreOperationCreateRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.RestoreOperationResponse"];
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/exports/{id}/restores/{restoreId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get export restore operation
+         * @description get restore operation by ID for an export
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Export ID */
+                    id: string;
+                    /** @description Restore Operation ID */
+                    restoreId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.RestoreOperationResponse"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /**
+         * Delete export restore operation
+         * @description delete a restore operation for an export
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Export ID */
+                    id: string;
+                    /** @description Restore Operation ID */
+                    restoreId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/files": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List files
+         * @description get files with optional filtering
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Filter by file type */
+                    type?: "image" | "document" | "video" | "audio" | "archive" | "other";
+                    /** @description Filter by file category */
+                    category?: "photos" | "invoices" | "documents" | "other";
+                    /** @description Search in title, description, and file paths */
+                    search?: string;
+                    /** @description Filter by tags (comma-separated) */
+                    tags?: string;
+                    /** @description Filter by linked entity type (e.g. commodity, location, export). Must be supplied together with linked_entity_id. */
+                    linked_entity_type?: string;
+                    /** @description Filter by linked entity id. Must be supplied together with linked_entity_type. */
+                    linked_entity_id?: string;
+                    /** @description Page number (1-based) */
+                    page?: number;
+                    /** @description Items per page */
+                    limit?: number;
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.FilesResponse"];
+                    };
+                };
+                /** @description Invalid query parameter */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create a file entity
+         * @description create a new file entity with metadata (file upload handled separately)
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            /** @description File metadata */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.FileRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.FileResponse"];
+                    };
+                };
+                /** @description Validation error */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/files/bulk-delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Bulk-delete files
+         * @description Delete every file whose id appears in the body, including
+         *     the physical blob. The response lists succeeded vs.
+         *     failed ids so the frontend can render partial-failure UX
+         *     without parsing per-id HTTP statuses.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            /** @description List of file IDs to delete */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.BulkIDsRequest"];
+                };
+            };
+            responses: {
+                /** @description Per-id outcome */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.BulkResultResponse"];
+                    };
+                };
+                /** @description Bad request body */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/files/category-counts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * File category counts
+         * @description Per-category file counts, respecting the same filters as GET /files
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Filter by file type */
+                    type?: "image" | "document" | "video" | "audio" | "archive" | "other";
+                    /** @description Search in title, description, and file paths */
+                    search?: string;
+                    /** @description Filter by tags (comma-separated) */
+                    tags?: string;
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.FileCategoryCountsResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/files/{fileID}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a file
+         * @description get file by ID
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description File ID */
+                    fileID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.FileResponse"];
+                    };
+                };
+                /** @description File not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        /**
+         * Update a file
+         * @description update file metadata
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description File ID */
+                    fileID: string;
+                };
+                cookie?: never;
+            };
+            /** @description File update data */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.FileUpdateRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.FileResponse"];
+                    };
+                };
+                /** @description File not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Validation error */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        /**
+         * Delete a file
+         * @description delete file and its associated file
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description File ID */
+                    fileID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description File not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/files/{fileID}/signed-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate signed URL for file download
+         * @description Generate a secure signed URL for downloading a file
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description File ID */
+                    fileID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Signed URL */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "*/*": components["schemas"]["jsonapi.SignedFileURLResponse"];
+                    };
+                };
+                /** @description File not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "*/*": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/locations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List locations
+         * @description get locations
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Page number (default 1) */
+                    page?: number;
+                    /** @description Items per page (default 50, max 100) */
+                    per_page?: number;
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.LocationsResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create a new location
+         * @description add by location data
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody: components["requestBodies"]["jsonapi.LocationRequest"];
+            responses: {
+                /** @description Location created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.LocationResponse"];
+                    };
+                };
+                /** @description Location not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description User-side request problem */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/locations/{locationID}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a location
+         * @description get location by ID
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Location ID */
+                    locationID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.LocationResponse"];
+                    };
+                };
+            };
+        };
+        /**
+         * Update a location
+         * @description Update by location data
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Location ID */
+                    locationID: string;
+                };
+                cookie?: never;
+            };
+            requestBody: components["requestBodies"]["jsonapi.LocationRequest"];
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.LocationResponse"];
+                    };
+                };
+                /** @description Location not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description User-side request problem */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        /**
+         * Delete a location
+         * @description Delete by location ID
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Location ID */
+                    locationID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Location not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Advanced search
+         * @description Perform advanced search across commodities, files, and other entities
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description Search query */
+                    q: string;
+                    /** @description Entity type to search */
+                    type?: "commodities" | "files" | "areas" | "locations";
+                    /** @description Maximum number of results */
+                    limit?: number;
+                    /** @description Number of results to skip */
+                    offset?: number;
+                    /** @description Filter by tags (comma-separated) */
+                    tags?: string;
+                    /** @description Tag operator */
+                    operator?: "AND" | "OR";
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Search results */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.SearchResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get current settings
+         * @description get current settings
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["models.SettingsObject"];
+                    };
+                };
+            };
+        };
+        /**
+         * Update settings
+         * @description update entire settings object
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            /** @description Settings object with documented snake_case field names */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["apiserver.SettingsUpdateRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["models.SettingsObject"];
+                    };
+                };
+                /** @description Bad Request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/settings/{field}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Patch setting
+         * @description update a specific setting field.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Setting field path (e.g., uiconfig.theme) */
+                    field: string;
+                };
+                cookie?: never;
+            };
+            /** @description Setting value envelope with required value. */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["apiserver.PatchSettingRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["models.SettingsObject"];
+                    };
+                };
+                /** @description Bad Request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/g/{groupSlug}/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List tags
+         * @description get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Search by label or slug */
+                    q?: string;
+                    /** @description Sort field (label, created_at, usage) */
+                    sort?: "label" | "created_at" | "usage";
+                    /** @description Sort direction (asc, desc) */
+                    order?: string;
+                    /** @description Page number (1-based) */
+                    page?: number;
+                    /** @description Items per page */
+                    per_page?: number;
+                    /** @description Comma-separated extras. 'usage' attaches per-row meta.usage. */
+                    include?: "usage";
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.TagsResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create a new tag
+         * @description add a tag with slug, label, color
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            /** @description Tag object */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.TagRequest"];
+                };
+            };
+            responses: {
+                /** @description Tag created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.TagResponse"];
+                    };
+                };
+                /** @description User-side request problem */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/tags/autocomplete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Autocomplete tag suggestions
+         * @description Top-N tags matching the query, ranked by usage desc + created_at desc.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Substring match against label and slug */
+                    q?: string;
+                    /** @description Maximum suggestions returned */
+                    limit?: number;
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.TagAutocompleteResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/tags/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Tag adoption stats
+         * @description Returns total tags, plus tagged/untagged counts on commodities and files for the current group.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.TagStatsResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/tags/{tagID}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a tag
+         * @description get tag by ID with usage breakdown
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Tag ID */
+                    tagID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.TagResponse"];
+                    };
+                };
+                /** @description Tag not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /**
+         * Delete a tag
+         * @description Delete tag by ID. Returns 409 with usage breakdown when in use; pass ?force=true to strip references.
+         */
+        delete: {
+            parameters: {
+                query?: {
+                    /** @description Strip JSONB references then delete */
+                    force?: boolean;
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Tag ID */
+                    tagID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Tag not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Tag is in use; pass force=true to strip references */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /**
+         * Update a tag
+         * @description Patch label/color/slug. Slug change rewrites JSONB references.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Tag ID */
+                    tagID: string;
+                };
+                cookie?: never;
+            };
+            /** @description Tag patch payload */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.TagUpdateRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.TagResponse"];
+                    };
+                };
+                /** @description Tag not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Slug already in use */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description User-side request problem */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/g/{groupSlug}/upload-slots/check": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Check upload capacity
+         * @description Check if user can start an upload for a specific operation
+         */
+        get: {
+            parameters: {
+                query: {
+                    /**
+                     * @description Operation name
+                     * @example image_upload
+                     */
+                    operation: string;
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Upload capacity available */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.UploadStatusResponse"];
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Too many concurrent uploads */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/upload-slots/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get upload status
+         * @description Get current upload status for a specific operation
+         */
+        get: {
+            parameters: {
+                query: {
+                    /**
+                     * @description Operation name
+                     * @example image_upload
+                     */
+                    operation: string;
+                };
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Upload status retrieved successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.UploadStatusResponse"];
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/uploads/file": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Upload a file
+         * @description Upload a single file of any type. The file is stored and a file entity is created without a linked entity.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "multipart/form-data": {
+                        /**
+                         * Format: binary
+                         * @description File to upload
+                         */
+                        file: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.FileResponse"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Internal Server Error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": string;
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/uploads/restores": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Upload restore file
+         * @description Upload an XML backup file to be used for a restore operation.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "multipart/form-data": {
+                        /**
+                         * Format: binary
+                         * @description XML backup file to upload
+                         */
+                        file: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.UploadResponse"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Internal Server Error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": string;
                     };
                 };
             };
@@ -2750,210 +3862,6 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/locations": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List locations
-         * @description get locations
-         */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description Page number (default 1) */
-                    page?: number;
-                    /** @description Items per page (default 50, max 100) */
-                    per_page?: number;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.LocationsResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        /**
-         * Create a new location
-         * @description add by location data
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: components["requestBodies"]["jsonapi.LocationRequest"];
-            responses: {
-                /** @description Location created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.LocationResponse"];
-                    };
-                };
-                /** @description Location not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description User-side request problem */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/locations/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get a location
-         * @description get location by ID
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Location ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.LocationResponse"];
-                    };
-                };
-            };
-        };
-        /**
-         * Update a location
-         * @description Update by location data
-         */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Location ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: components["requestBodies"]["jsonapi.LocationRequest"];
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.LocationResponse"];
-                    };
-                };
-                /** @description Location not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description User-side request problem */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        post?: never;
-        /**
-         * Delete a location
-         * @description Delete by location ID
-         */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Location ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description No content */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Location not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/register": {
         parameters: {
             query?: never;
@@ -3155,58 +4063,6 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/search": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Advanced search
-         * @description Perform advanced search across commodities, files, and other entities
-         */
-        get: {
-            parameters: {
-                query: {
-                    /** @description Search query */
-                    q: string;
-                    /** @description Entity type to search */
-                    type?: "commodities" | "files" | "areas" | "locations";
-                    /** @description Maximum number of results */
-                    limit?: number;
-                    /** @description Number of results to skip */
-                    offset?: number;
-                    /** @description Filter by tags (comma-separated) */
-                    tags?: string;
-                    /** @description Tag operator */
-                    operator?: "AND" | "OR";
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Search results */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.SearchResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/seed": {
         parameters: {
             query?: never;
@@ -3253,138 +4109,6 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
-    "/settings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get current settings
-         * @description get current settings
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["models.SettingsObject"];
-                    };
-                };
-            };
-        };
-        /**
-         * Update settings
-         * @description update entire settings object
-         */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description Settings object with documented snake_case field names */
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["apiserver.SettingsUpdateRequest"];
-                };
-            };
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["models.SettingsObject"];
-                    };
-                };
-                /** @description Bad Request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": string;
-                    };
-                };
-            };
-        };
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/settings/{field}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Patch setting
-         * @description update a specific setting field.
-         */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Setting field path (e.g., uiconfig.theme) */
-                    field: string;
-                };
-                cookie?: never;
-            };
-            /** @description Setting value envelope with required value. */
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["apiserver.PatchSettingRequest"];
-                };
-            };
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["models.SettingsObject"];
-                    };
-                };
-                /** @description Bad Request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": string;
-                    };
-                };
-            };
-        };
-        trace?: never;
-    };
     "/system": {
         parameters: {
             query?: never;
@@ -3418,601 +4142,6 @@ export type paths = {
         };
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/tags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List tags
-         * @description get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.
-         */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description Search by label or slug */
-                    q?: string;
-                    /** @description Sort field (label, created_at, usage) */
-                    sort?: "label" | "created_at" | "usage";
-                    /** @description Sort direction (asc, desc) */
-                    order?: string;
-                    /** @description Page number (1-based) */
-                    page?: number;
-                    /** @description Items per page */
-                    per_page?: number;
-                    /** @description Comma-separated extras. 'usage' attaches per-row meta.usage. */
-                    include?: "usage";
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.TagsResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        /**
-         * Create a new tag
-         * @description add a tag with slug, label, color
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description Tag object */
-            requestBody: {
-                content: {
-                    "application/vnd.api+json": components["schemas"]["jsonapi.TagRequest"];
-                };
-            };
-            responses: {
-                /** @description Tag created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.TagResponse"];
-                    };
-                };
-                /** @description User-side request problem */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/tags/autocomplete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Autocomplete tag suggestions
-         * @description Top-N tags matching the query, ranked by usage desc + created_at desc.
-         */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description Substring match against label and slug */
-                    q?: string;
-                    /** @description Maximum suggestions returned */
-                    limit?: number;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.TagAutocompleteResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/tags/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Tag adoption stats
-         * @description Returns total tags, plus tagged/untagged counts on commodities and files for the current group.
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.TagStatsResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/tags/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get a tag
-         * @description get tag by ID with usage breakdown
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Tag ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.TagResponse"];
-                    };
-                };
-                /** @description Tag not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /**
-         * Delete a tag
-         * @description Delete tag by ID. Returns 409 with usage breakdown when in use; pass ?force=true to strip references.
-         */
-        delete: {
-            parameters: {
-                query?: {
-                    /** @description Strip JSONB references then delete */
-                    force?: boolean;
-                };
-                header?: never;
-                path: {
-                    /** @description Tag ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description No content */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Tag not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Tag is in use; pass force=true to strip references */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        /**
-         * Update a tag
-         * @description Patch label/color/slug. Slug change rewrites JSONB references.
-         */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Tag ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            /** @description Tag patch payload */
-            requestBody: {
-                content: {
-                    "application/vnd.api+json": components["schemas"]["jsonapi.TagUpdateRequest"];
-                };
-            };
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.TagResponse"];
-                    };
-                };
-                /** @description Tag not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Slug already in use */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description User-side request problem */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        trace?: never;
-    };
-    "/upload-slots/check": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Check upload capacity
-         * @description Check if user can start an upload for a specific operation
-         */
-        get: {
-            parameters: {
-                query: {
-                    /**
-                     * @description Operation name
-                     * @example image_upload
-                     */
-                    operation: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Upload capacity available */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.UploadStatusResponse"];
-                    };
-                };
-                /** @description Bad request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Too many concurrent uploads */
-                429: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/upload-slots/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get upload status
-         * @description Get current upload status for a specific operation
-         */
-        get: {
-            parameters: {
-                query: {
-                    /**
-                     * @description Operation name
-                     * @example image_upload
-                     */
-                    operation: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Upload status retrieved successfully */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.UploadStatusResponse"];
-                    };
-                };
-                /** @description Bad request */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/uploads/file": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Upload a file
-         * @description Upload a single file of any type. The file is stored and a file entity is created without a linked entity.
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "multipart/form-data": {
-                        /**
-                         * Format: binary
-                         * @description File to upload
-                         */
-                        file: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.FileResponse"];
-                    };
-                };
-                /** @description Unprocessable Entity */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Internal Server Error */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": string;
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/uploads/restores": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Upload restore file
-         * @description Upload an XML backup file to be used for a restore operation.
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "multipart/form-data": {
-                        /**
-                         * Format: binary
-                         * @description XML backup file to upload
-                         */
-                        file: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.UploadResponse"];
-                    };
-                };
-                /** @description Unprocessable Entity */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Internal Server Error */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/vnd.api+json": string;
-                    };
-                };
-            };
-        };
         delete?: never;
         options?: never;
         head?: never;
@@ -5229,16 +5358,16 @@ export type components = {
                 "application/vnd.api+json": components["schemas"]["jsonapi.CommodityRequest"];
             };
         };
-        /** @description Group data */
-        "jsonapi.LocationGroupRequest": {
-            content: {
-                "application/vnd.api+json": components["schemas"]["jsonapi.LocationGroupRequest"];
-            };
-        };
         /** @description Location object */
         "jsonapi.LocationRequest": {
             content: {
                 "application/vnd.api+json": components["schemas"]["jsonapi.LocationRequest"];
+            };
+        };
+        /** @description Group data */
+        "jsonapi.LocationGroupRequest": {
+            content: {
+                "application/vnd.api+json": components["schemas"]["jsonapi.LocationGroupRequest"];
             };
         };
     };

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -464,7 +464,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/octet-stream": string;
+                        "application/octet-stream": components["schemas"]["jsonapi.Errors"];
                     };
                 };
             };
@@ -526,7 +526,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "image/jpeg": string;
+                        "image/jpeg": components["schemas"]["jsonapi.Errors"];
                     };
                 };
             };
@@ -3037,7 +3037,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/vnd.api+json": string;
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
             };
@@ -3107,7 +3107,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/vnd.api+json": string;
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
             };

--- a/go/apiserver/areas.go
+++ b/go/apiserver/areas.go
@@ -29,10 +29,11 @@ type areasAPI struct {
 // @Tags areas
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param page query int false "Page number (default 1)"
 // @Param per_page query int false "Items per page (default 50, max 100)"
 // @Success 200 {object} jsonapi.AreasResponse "OK"
-// @Router /areas [get].
+// @Router /g/{groupSlug}/areas [get].
 func (api *areasAPI) listAreas(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -66,9 +67,10 @@ func (api *areasAPI) listAreas(w http.ResponseWriter, r *http.Request) {
 // @Tags areas
 // @Accept  json-api
 // @Produce  json-api
-// @Param id path string true "Area ID"
+// @Param groupSlug path string true "Group slug"
+// @Param areaID path string true "Area ID"
 // @Success 200 {object} jsonapi.AreaResponse "OK"
-// @Router /areas/{id} [get].
+// @Router /g/{groupSlug}/areas/{areaID} [get].
 func (api *areasAPI) getArea(w http.ResponseWriter, r *http.Request) { //revive:disable-line:get-return
 	area := areaFromContext(r.Context())
 	if area == nil {
@@ -89,11 +91,12 @@ func (api *areasAPI) getArea(w http.ResponseWriter, r *http.Request) { //revive:
 // @Tags areas
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param area body jsonapi.AreaRequest true "Area object"
 // @Success 201 {object} jsonapi.AreaResponse "Area created"
 // @Failure 404 {object} jsonapi.Errors "Area not found"
 // @Failure 422 {object} jsonapi.Errors "User-side request problem"
-// @Router /areas [post].
+// @Router /g/{groupSlug}/areas [post].
 func (api *areasAPI) createArea(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -142,10 +145,11 @@ func (api *areasAPI) createArea(w http.ResponseWriter, r *http.Request) {
 // @Tags areas
 // @Accept  json-api
 // @Produce  json-api
-// @Param id path string true "Area ID"
+// @Param groupSlug path string true "Group slug"
+// @Param areaID path string true "Area ID"
 // @Success 204 "No content"
 // @Failure 404 {object} jsonapi.Errors "Area not found"
-// @Router /areas/{id} [delete].
+// @Router /g/{groupSlug}/areas/{areaID} [delete].
 func (api *areasAPI) deleteArea(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -178,12 +182,13 @@ func (api *areasAPI) deleteArea(w http.ResponseWriter, r *http.Request) {
 // @Tags areas
 // @Accept json-api
 // @Produce json-api
-// @Param id path string true "Area ID"
+// @Param groupSlug path string true "Group slug"
+// @Param areaID path string true "Area ID"
 // @Param area body jsonapi.AreaRequest true "Area object"
 // @Success 200 {object} jsonapi.AreaResponse "OK"
 // @Failure 404 {object} jsonapi.Errors "Area not found"
 // @Failure 422 {object} jsonapi.Errors "User-side request problem"
-// @Router /areas/{id} [put].
+// @Router /g/{groupSlug}/areas/{areaID} [put].
 func (api *areasAPI) updateArea(w http.ResponseWriter, r *http.Request) {
 	area := areaFromContext(r.Context())
 	if area == nil {

--- a/go/apiserver/commodities.go
+++ b/go/apiserver/commodities.go
@@ -28,6 +28,7 @@ type commoditiesAPI struct {
 // @Tags commodities
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param page query int false "Page number (default 1)"
 // @Param per_page query int false "Items per page (default 50, max 100)"
 // @Param type query []string false "Filter by commodity type; repeat to OR" collectionFormat(multi)
@@ -37,7 +38,7 @@ type commoditiesAPI struct {
 // @Param include_inactive query bool false "Include drafts and non-in_use commodities (default false hides them)"
 // @Param sort query string false "Sort field — name|registered_date|purchase_date|current_price|original_price|count, prefix with '-' for descending"
 // @Success 200 {object} jsonapi.CommoditiesResponse "OK"
-// @Router /commodities [get].
+// @Router /g/{groupSlug}/commodities [get].
 func (api *commoditiesAPI) listCommodities(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	regSet := RegistrySetFromContext(r.Context())
@@ -112,9 +113,10 @@ func parseCommodityListOptions(q url.Values) registry.CommodityListOptions {
 // @Tags commodities
 // @Accept  json-api
 // @Produce  json-api
-// @Param id path string true "Commodity ID"
+// @Param groupSlug path string true "Group slug"
+// @Param commodityID path string true "Commodity ID"
 // @Success 200 {object} jsonapi.CommodityResponse "OK"
-// @Router /commodities/{id} [get].
+// @Router /g/{groupSlug}/commodities/{commodityID} [get].
 func (api *commoditiesAPI) getCommodity(w http.ResponseWriter, r *http.Request) { //revive:disable-line:get-return
 	commodity := commodityFromContext(r.Context())
 	if commodity == nil {
@@ -136,10 +138,11 @@ func (api *commoditiesAPI) getCommodity(w http.ResponseWriter, r *http.Request) 
 // @Tags commodities
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param commodity body jsonapi.CommodityRequest true "Commodity object"
 // @Success 201 {object} jsonapi.CommodityResponse "Commodity created"
 // @Failure 422 {object} jsonapi.Errors "User-side request problem"
-// @Router /commodities [post].
+// @Router /g/{groupSlug}/commodities [post].
 func (api *commoditiesAPI) createCommodity(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -213,10 +216,11 @@ func (api *commoditiesAPI) createCommodity(w http.ResponseWriter, r *http.Reques
 // @Tags commodities
 // @Accept  json-api
 // @Produce  json-api
-// @Param id path string true "Commodity ID"
+// @Param groupSlug path string true "Group slug"
+// @Param commodityID path string true "Commodity ID"
 // @Success 204 "No content"
 // @Failure 404 {object} jsonapi.Errors "Commodity not found"
-// @Router /commodities/{id} [delete].
+// @Router /g/{groupSlug}/commodities/{commodityID} [delete].
 func (api *commoditiesAPI) deleteCommodity(w http.ResponseWriter, r *http.Request) {
 	commodity := commodityFromContext(r.Context())
 	if commodity == nil {
@@ -239,12 +243,13 @@ func (api *commoditiesAPI) deleteCommodity(w http.ResponseWriter, r *http.Reques
 // @Tags commodities
 // @Accept json-api
 // @Produce json-api
-// @Param id path string true "Commodity ID"
+// @Param groupSlug path string true "Group slug"
+// @Param commodityID path string true "Commodity ID"
 // @Param commodity body jsonapi.CommodityRequest true "Commodity object"
 // @Success 200 {object} jsonapi.CommodityResponse "OK"
 // @Failure 404 {object} jsonapi.Errors "Commodity not found"
 // @Failure 422 {object} jsonapi.Errors "User-side request problem"
-// @Router /commodities/{id} [put].
+// @Router /g/{groupSlug}/commodities/{commodityID} [put].
 func (api *commoditiesAPI) updateCommodity(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -332,10 +337,11 @@ func (api *commoditiesAPI) updateCommodity(w http.ResponseWriter, r *http.Reques
 // @Tags commodities
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param body body jsonapi.BulkIDsRequest true "List of commodity IDs to delete"
 // @Success 200 {object} jsonapi.BulkResultResponse "Per-id outcome"
 // @Failure 422 {object} jsonapi.Errors "Bad request body"
-// @Router /commodities/bulk-delete [post].
+// @Router /g/{groupSlug}/commodities/bulk-delete [post].
 func (api *commoditiesAPI) bulkDeleteCommodities(w http.ResponseWriter, r *http.Request) {
 	var input jsonapi.BulkIDsRequest
 	if err := render.Bind(r, &input); err != nil {
@@ -367,10 +373,11 @@ func (api *commoditiesAPI) bulkDeleteCommodities(w http.ResponseWriter, r *http.
 // @Tags commodities
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param body body jsonapi.BulkMoveRequest true "List of commodity IDs and the destination area_id"
 // @Success 200 {object} jsonapi.BulkResultResponse "Per-id outcome"
 // @Failure 422 {object} jsonapi.Errors "Bad request body"
-// @Router /commodities/bulk-move [post].
+// @Router /g/{groupSlug}/commodities/bulk-move [post].
 func (api *commoditiesAPI) bulkMoveCommodities(w http.ResponseWriter, r *http.Request) {
 	registrySet := RegistrySetFromContext(r.Context())
 	if registrySet == nil {

--- a/go/apiserver/export_restores.go
+++ b/go/apiserver/export_restores.go
@@ -21,9 +21,10 @@ type exportRestoresAPI struct {
 // @Tags exports
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param id path string true "Export ID"
 // @Success 200 {object} jsonapi.RestoreOperationsResponse "OK"
-// @Router /exports/{id}/restores [get].
+// @Router /g/{groupSlug}/exports/{id}/restores [get].
 func (api *exportRestoresAPI) listExportRestores(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -67,11 +68,12 @@ func (api *exportRestoresAPI) listExportRestores(w http.ResponseWriter, r *http.
 // @Tags exports
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param id path string true "Export ID"
 // @Param restoreId path string true "Restore Operation ID"
 // @Success 200 {object} jsonapi.RestoreOperationResponse "OK"
 // @Failure 404 {object} jsonapi.Errors "Not found"
-// @Router /exports/{id}/restores/{restoreId} [get].
+// @Router /g/{groupSlug}/exports/{id}/restores/{restoreId} [get].
 func (api *exportRestoresAPI) apiGetExportRestore(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -141,12 +143,13 @@ func (api *exportRestoresAPI) apiGetExportRestore(w http.ResponseWriter, r *http
 // @Tags exports
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param id path string true "Export ID"
 // @Param request body jsonapi.RestoreOperationCreateRequest true "Restore operation data"
 // @Success 201 {object} jsonapi.RestoreOperationResponse "Created"
 // @Failure 400 {object} jsonapi.Errors "Bad request"
 // @Failure 404 {object} jsonapi.Errors "Not found"
-// @Router /exports/{id}/restores [post].
+// @Router /g/{groupSlug}/exports/{id}/restores [post].
 func (api *exportRestoresAPI) createExportRestore(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -228,11 +231,12 @@ func (api *exportRestoresAPI) createExportRestore(w http.ResponseWriter, r *http
 // @Tags exports
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param id path string true "Export ID"
 // @Param restoreId path string true "Restore Operation ID"
 // @Success 204 "No Content"
 // @Failure 404 {object} jsonapi.Errors "Not found"
-// @Router /exports/{id}/restores/{restoreId} [delete].
+// @Router /g/{groupSlug}/exports/{id}/restores/{restoreId} [delete].
 func (api *exportRestoresAPI) deleteExportRestore(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())

--- a/go/apiserver/exports.go
+++ b/go/apiserver/exports.go
@@ -41,9 +41,10 @@ type exportsAPI struct {
 // @Tags exports
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param include_deleted query bool false "Include deleted exports"
 // @Success 200 {object} jsonapi.ExportsResponse "OK"
-// @Router /exports [get].
+// @Router /g/{groupSlug}/exports [get].
 func (api *exportsAPI) listExports(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -83,10 +84,11 @@ func (api *exportsAPI) listExports(w http.ResponseWriter, r *http.Request) {
 // @Tags exports
 // @Accept  json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param id path string true "Export ID"
 // @Success 200 {object} jsonapi.ExportResponse "OK"
 // @Failure 404 {object} jsonapi.Errors "Not Found"
-// @Router /exports/{id} [get].
+// @Router /g/{groupSlug}/exports/{id} [get].
 func (api *exportsAPI) apiGetExport(w http.ResponseWriter, r *http.Request) {
 	err := appctx.ValidateUserContext(r.Context())
 	if err != nil {
@@ -112,10 +114,11 @@ func (api *exportsAPI) apiGetExport(w http.ResponseWriter, r *http.Request) {
 // @Tags exports
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param export body jsonapi.ExportCreateRequest true "Export"
 // @Success 201 {object} jsonapi.ExportResponse "Created"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity"
-// @Router /exports [post].
+// @Router /g/{groupSlug}/exports [post].
 func (api *exportsAPI) createExport(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -159,10 +162,11 @@ func (api *exportsAPI) createExport(w http.ResponseWriter, r *http.Request) {
 // @Tags exports
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param id path string true "Export ID"
 // @Success 204 "No Content"
 // @Failure 404 {object} jsonapi.Errors "Not Found"
-// @Router /exports/{id} [delete].
+// @Router /g/{groupSlug}/exports/{id} [delete].
 func (api *exportsAPI) deleteExport(w http.ResponseWriter, r *http.Request) {
 	err := appctx.ValidateUserContext(r.Context())
 	if err != nil {
@@ -192,10 +196,11 @@ func (api *exportsAPI) deleteExport(w http.ResponseWriter, r *http.Request) {
 // @Tags exports
 // @Accept octet-stream
 // @Produce octet-stream
+// @Param groupSlug path string true "Group slug"
 // @Param id path string true "Export ID"
 // @Success 200 {file} application/xml "Export file"
 // @Failure 404 {object} jsonapi.Errors "Not Found"
-// @Router /exports/{id}/download [get].
+// @Router /g/{groupSlug}/exports/{id}/download [get].
 func (api *exportsAPI) downloadExport(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -312,11 +317,12 @@ func (api *exportsAPI) downloadExport(w http.ResponseWriter, r *http.Request) {
 // @Tags exports
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param data body jsonapi.ImportExportRequest true "Import request data"
 // @Success 201 {object} jsonapi.ExportResponse "Created"
 // @Failure 400 {object} jsonapi.Errors "Bad Request"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity"
-// @Router /exports/import [post].
+// @Router /g/{groupSlug}/exports/import [post].
 func (api *exportsAPI) importExport(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -635,7 +635,7 @@ func Files(params Params) func(r chi.Router) {
 // @Param fileID path string true "File ID"
 // @Success 200 {file} binary "File content"
 // @Failure 404 {object} jsonapi.Errors "Not Found"
-// @Failure 500 {string} string "Internal Server Error"
+// @Failure 500 {object} jsonapi.Errors "Internal Server Error"
 // @Router /files/download/files/{fileID} [get]
 func (api *filesAPI) downloadOriginalFile(w http.ResponseWriter, r *http.Request) {
 	fileID := chi.URLParam(r, "fileID")
@@ -681,7 +681,7 @@ func (api *filesAPI) downloadOriginalFile(w http.ResponseWriter, r *http.Request
 // @Param size path string true "Thumbnail size" Enums(small, medium)
 // @Success 200 {file} binary "Thumbnail image"
 // @Failure 404 {object} jsonapi.Errors "Not Found"
-// @Failure 500 {string} string "Internal Server Error"
+// @Failure 500 {object} jsonapi.Errors "Internal Server Error"
 // @Router /files/download/thumbnails/{fileID}/{size} [get]
 func (api *filesAPI) downloadThumbnail(w http.ResponseWriter, r *http.Request) {
 	fileID := chi.URLParam(r, "fileID")

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -62,6 +62,7 @@ func parseFileCategoryParam(values []string) (*models.FileCategory, error) {
 // @Tags files
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param type query string false "Filter by file type" Enums(image,document,video,audio,archive,other)
 // @Param category query string false "Filter by file category" Enums(photos,invoices,documents,other)
 // @Param search query string false "Search in title, description, and file paths"
@@ -72,7 +73,7 @@ func parseFileCategoryParam(values []string) (*models.FileCategory, error) {
 // @Param limit query int false "Items per page" default(20)
 // @Success 200 {object} jsonapi.FilesResponse "OK"
 // @Failure 400 {object} jsonapi.Errors "Invalid query parameter"
-// @Router /files [get].
+// @Router /g/{groupSlug}/files [get].
 func (api *filesAPI) listFiles(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -216,10 +217,11 @@ func (api *filesAPI) generateSignedURLsForFiles(ctx context.Context, files []*mo
 // @Tags files
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param file body jsonapi.FileRequest true "File metadata"
 // @Success 201 {object} jsonapi.FileResponse "Created"
 // @Failure 422 {object} jsonapi.Errors "Validation error"
-// @Router /files [post].
+// @Router /g/{groupSlug}/files [post].
 func (api *filesAPI) createFile(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -295,10 +297,11 @@ func (api *filesAPI) createFile(w http.ResponseWriter, r *http.Request) {
 // @Tags files
 // @Accept json-api
 // @Produce json-api
-// @Param id path string true "File ID"
+// @Param groupSlug path string true "Group slug"
+// @Param fileID path string true "File ID"
 // @Success 200 {object} jsonapi.FileResponse "OK"
 // @Failure 404 {object} jsonapi.Errors "File not found"
-// @Router /files/{id} [get].
+// @Router /g/{groupSlug}/files/{fileID} [get].
 func (api *filesAPI) apiGetFile(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -333,12 +336,13 @@ func (api *filesAPI) apiGetFile(w http.ResponseWriter, r *http.Request) {
 // @Tags files
 // @Accept json-api
 // @Produce json-api
-// @Param id path string true "File ID"
+// @Param groupSlug path string true "Group slug"
+// @Param fileID path string true "File ID"
 // @Param file body jsonapi.FileUpdateRequest true "File update data"
 // @Success 200 {object} jsonapi.FileResponse "OK"
 // @Failure 404 {object} jsonapi.Errors "File not found"
 // @Failure 422 {object} jsonapi.Errors "Validation error"
-// @Router /files/{id} [put].
+// @Router /g/{groupSlug}/files/{fileID} [put].
 func (api *filesAPI) updateFile(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -426,10 +430,11 @@ func (api *filesAPI) updateFile(w http.ResponseWriter, r *http.Request) {
 // @Tags files
 // @Accept json-api
 // @Produce json-api
-// @Param id path string true "File ID"
+// @Param groupSlug path string true "Group slug"
+// @Param fileID path string true "File ID"
 // @Success 204 "No Content"
 // @Failure 404 {object} jsonapi.Errors "File not found"
-// @Router /files/{id} [delete].
+// @Router /g/{groupSlug}/files/{fileID} [delete].
 func (api *filesAPI) deleteFile(w http.ResponseWriter, r *http.Request) {
 	fileID := chi.URLParam(r, "fileID")
 
@@ -447,10 +452,11 @@ func (api *filesAPI) deleteFile(w http.ResponseWriter, r *http.Request) {
 // @Summary Generate signed URL for file download
 // @Description Generate a secure signed URL for downloading a file
 // @Tags files
-// @Param id path string true "File ID"
+// @Param groupSlug path string true "Group slug"
+// @Param fileID path string true "File ID"
 // @Success 200 {object} jsonapi.SignedFileURLResponse "Signed URL"
 // @Failure 404 {object} jsonapi.Errors "File not found"
-// @Router /files/{id}/signed-url [post].
+// @Router /g/{groupSlug}/files/{fileID}/signed-url [post].
 func (api *filesAPI) generateSignedURL(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -507,11 +513,12 @@ func (api *filesAPI) generateSignedURL(w http.ResponseWriter, r *http.Request) {
 // @Tags files
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param type query string false "Filter by file type" Enums(image,document,video,audio,archive,other)
 // @Param search query string false "Search in title, description, and file paths"
 // @Param tags query string false "Filter by tags (comma-separated)"
 // @Success 200 {object} jsonapi.FileCategoryCountsResponse "OK"
-// @Router /files/category-counts [get].
+// @Router /g/{groupSlug}/files/category-counts [get].
 func (api *filesAPI) listCategoryCounts(w http.ResponseWriter, r *http.Request) {
 	registrySet := RegistrySetFromContext(r.Context())
 	if registrySet == nil {
@@ -561,10 +568,11 @@ func (api *filesAPI) listCategoryCounts(w http.ResponseWriter, r *http.Request) 
 // @Tags files
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param body body jsonapi.BulkIDsRequest true "List of file IDs to delete"
 // @Success 200 {object} jsonapi.BulkResultResponse "Per-id outcome"
 // @Failure 422 {object} jsonapi.Errors "Bad request body"
-// @Router /files/bulk-delete [post].
+// @Router /g/{groupSlug}/files/bulk-delete [post].
 func (api *filesAPI) bulkDeleteFiles(w http.ResponseWriter, r *http.Request) {
 	var input jsonapi.BulkIDsRequest
 	if err := render.Bind(r, &input); err != nil {

--- a/go/apiserver/locations.go
+++ b/go/apiserver/locations.go
@@ -18,10 +18,11 @@ type locationsAPI struct{}
 // @Tags locations
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param page query int false "Page number (default 1)"
 // @Param per_page query int false "Items per page (default 50, max 100)"
 // @Success 200 {object} jsonapi.LocationsResponse "OK"
-// @Router /locations [get].
+// @Router /g/{groupSlug}/locations [get].
 func (api *locationsAPI) listLocations(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -55,9 +56,10 @@ func (api *locationsAPI) listLocations(w http.ResponseWriter, r *http.Request) {
 // @Tags locations
 // @Accept  json-api
 // @Produce  json-api
-// @Param id path string true "Location ID"
+// @Param groupSlug path string true "Group slug"
+// @Param locationID path string true "Location ID"
 // @Success 200 {object} jsonapi.LocationResponse "OK"
-// @Router /locations/{id} [get].
+// @Router /g/{groupSlug}/locations/{locationID} [get].
 func (api *locationsAPI) getLocation(w http.ResponseWriter, r *http.Request) { //revive:disable-line:get-return
 	// Get user-aware registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -96,11 +98,12 @@ func (api *locationsAPI) getLocation(w http.ResponseWriter, r *http.Request) { /
 // @Tags locations
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param location body jsonapi.LocationRequest true "Location object"
 // @Success 201 {object} jsonapi.LocationResponse "Location created"
 // @Failure 404 {object} jsonapi.Errors "Location not found"
 // @Failure 422 {object} jsonapi.Errors "User-side request problem"
-// @Router /locations [post].
+// @Router /g/{groupSlug}/locations [post].
 func (api *locationsAPI) createLocation(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -160,10 +163,11 @@ func (api *locationsAPI) createLocation(w http.ResponseWriter, r *http.Request) 
 // @Tags locations
 // @Accept  json-api
 // @Produce  json-api
-// @Param id path string true "Location ID"
+// @Param groupSlug path string true "Group slug"
+// @Param locationID path string true "Location ID"
 // @Success 204 "No content"
 // @Failure 404 {object} jsonapi.Errors "Location not found"
-// @Router /locations/{id} [delete].
+// @Router /g/{groupSlug}/locations/{locationID} [delete].
 func (api *locationsAPI) deleteLocation(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -195,12 +199,13 @@ func (api *locationsAPI) deleteLocation(w http.ResponseWriter, r *http.Request) 
 // @Tags locations
 // @Accept json-api
 // @Produce json-api
-// @Param id path string true "Location ID"
+// @Param groupSlug path string true "Group slug"
+// @Param locationID path string true "Location ID"
 // @Param location body jsonapi.LocationRequest true "Location object"
 // @Success 200 {object} jsonapi.LocationResponse "OK"
 // @Failure 404 {object} jsonapi.Errors "Location not found"
 // @Failure 422 {object} jsonapi.Errors "User-side request problem"
-// @Router /locations/{id} [put].
+// @Router /g/{groupSlug}/locations/{locationID} [put].
 func (api *locationsAPI) updateLocation(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware registry from context
 	registrySet := RegistrySetFromContext(r.Context())

--- a/go/apiserver/search.go
+++ b/go/apiserver/search.go
@@ -24,6 +24,7 @@ type searchAPI struct {
 // @Tags search
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param q query string true "Search query"
 // @Param type query string false "Entity type to search" Enums(commodities,files,areas,locations)
 // @Param limit query int false "Maximum number of results" default(20)
@@ -31,7 +32,7 @@ type searchAPI struct {
 // @Param tags query string false "Filter by tags (comma-separated)"
 // @Param operator query string false "Tag operator" Enums(AND,OR) default(OR)
 // @Success 200 {object} jsonapi.SearchResponse "Search results"
-// @Router /search [get]
+// @Router /g/{groupSlug}/search [get]
 func (api *searchAPI) search(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query().Get("q")
 	if query == "" {

--- a/go/apiserver/settings.go
+++ b/go/apiserver/settings.go
@@ -79,8 +79,9 @@ type PatchSettingRequest struct {
 // @Tags settings
 // @Accept  json
 // @Produce  json
+// @Param groupSlug path string true "Group slug"
 // @Success 200 {object} models.SettingsObject "OK"
-// @Router /settings [get]
+// @Router /g/{groupSlug}/settings [get]
 func (api *settingsAPI) getSettings(w http.ResponseWriter, r *http.Request) { //revive:disable-line:get-return
 	// Get user-aware settings registry from context
 	registrySet, err := registrySetFromContext(r.Context())
@@ -115,10 +116,11 @@ func (api *settingsAPI) getSettings(w http.ResponseWriter, r *http.Request) { //
 // @Tags settings
 // @Accept  json
 // @Produce  json
+// @Param groupSlug path string true "Group slug"
 // @Param   settings body SettingsUpdateRequest true "Settings object with documented snake_case field names"
 // @Success 200 {object} models.SettingsObject "OK"
 // @Failure 400 {string} string "Bad Request"
-// @Router /settings [put]
+// @Router /g/{groupSlug}/settings [put]
 func (api *settingsAPI) updateSettings(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet, err := registrySetFromContext(r.Context())
@@ -167,11 +169,12 @@ func (api *settingsAPI) updateSettings(w http.ResponseWriter, r *http.Request) {
 // @Tags settings
 // @Accept  json
 // @Produce  json
+// @Param groupSlug path string true "Group slug"
 // @Param   field path string true "Setting field path (e.g., uiconfig.theme)"
 // @Param   value body PatchSettingRequest true "Setting value envelope with required value."
 // @Success 200 {object} models.SettingsObject "OK"
 // @Failure 400 {string} string "Bad Request"
-// @Router /settings/{field} [patch]
+// @Router /g/{groupSlug}/settings/{field} [patch]
 func (api *settingsAPI) patchSetting(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet, err := registrySetFromContext(r.Context())

--- a/go/apiserver/swagger_route_coverage_test.go
+++ b/go/apiserver/swagger_route_coverage_test.go
@@ -1,0 +1,129 @@
+package apiserver_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/denisvmedia/inventario/apiserver"
+)
+
+// TestSwaggerRouteCoverage walks the chi router that APIServer returns and
+// asserts every /api/v1/... route has a matching swagger operation in
+// docs/swagger.json — and conversely, that no documented operation
+// references a path that isn't registered. The shape comes from the
+// prototype originally drafted on feat/1422-openapi-drift-ci and embedded
+// in #1442.
+func TestSwaggerRouteCoverage(t *testing.T) {
+	t.Parallel()
+
+	params, _, _ := newParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	router, ok := handler.(chi.Router)
+	if !ok {
+		t.Fatalf("APIServer should return a chi.Router-typed handler, got %T", handler)
+	}
+
+	registered, err := walkAPIRoutes(router)
+	if err != nil {
+		t.Fatalf("walk routes: %v", err)
+	}
+	documented, err := loadSwaggerOperations()
+	if err != nil {
+		t.Fatalf("load swagger.json: %v", err)
+	}
+
+	var missing, stale []string
+	for _, op := range registered {
+		if _, ok := documented[op]; !ok {
+			missing = append(missing, op.String())
+		}
+	}
+	for op := range documented {
+		if !slices.Contains(registered, op) {
+			stale = append(stale, op.String())
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(stale)
+
+	if len(missing) > 0 {
+		t.Errorf("\n%d route(s) under /api/v1 are not documented in docs/swagger.json:\n  %s\n\nAdd a swag-style annotation to the handler and run `make swagger`.", len(missing), strings.Join(missing, "\n  "))
+	}
+	if len(stale) > 0 {
+		t.Errorf("\n%d swagger operation(s) reference paths that are no longer registered:\n  %s\n\nEither restore the route or remove the stale annotation, then run `make swagger`.", len(stale), strings.Join(stale, "\n  "))
+	}
+}
+
+type routeOp struct {
+	Method string
+	Path   string
+}
+
+func (r routeOp) String() string { return r.Method + " " + r.Path }
+
+func walkAPIRoutes(router chi.Router) ([]routeOp, error) {
+	const apiPrefix = "/api/v1"
+	var ops []routeOp
+	walker := func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		if !strings.HasPrefix(route, apiPrefix) {
+			return nil
+		}
+		if strings.HasSuffix(route, "/*") {
+			return nil
+		}
+		switch method {
+		case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		default:
+			return nil
+		}
+		stripped := strings.TrimPrefix(route, apiPrefix)
+		if stripped != "/" {
+			stripped = strings.TrimRight(stripped, "/")
+		}
+		if stripped == "" {
+			stripped = "/"
+		}
+		ops = append(ops, routeOp{Method: method, Path: stripped})
+		return nil
+	}
+	if err := chi.Walk(router, walker); err != nil {
+		return nil, fmt.Errorf("chi.Walk: %w", err)
+	}
+	return ops, nil
+}
+
+func loadSwaggerOperations() (map[routeOp]struct{}, error) {
+	path := filepath.Join("..", "docs", "swagger.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var doc struct {
+		BasePath string                    `json:"basePath"`
+		Paths    map[string]map[string]any `json:"paths"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("decode swagger.json: %w", err)
+	}
+	ops := make(map[routeOp]struct{}, len(doc.Paths))
+	for p, methods := range doc.Paths {
+		for method := range methods {
+			switch strings.ToLower(method) {
+			case "get", "post", "put", "patch", "delete":
+			default:
+				continue
+			}
+			ops[routeOp{Method: strings.ToUpper(method), Path: p}] = struct{}{}
+		}
+	}
+	return ops, nil
+}

--- a/go/apiserver/tags.go
+++ b/go/apiserver/tags.go
@@ -58,6 +58,7 @@ type tagsAPI struct {
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param q query string false "Search by label or slug"
 // @Param sort query string false "Sort field (label, created_at, usage)" Enums(label,created_at,usage)
 // @Param order query string false "Sort direction (asc, desc)" default(asc)
@@ -65,7 +66,7 @@ type tagsAPI struct {
 // @Param per_page query int false "Items per page" default(50)
 // @Param include query string false "Comma-separated extras. 'usage' attaches per-row meta.usage." Enums(usage)
 // @Success 200 {object} jsonapi.TagsResponse "OK"
-// @Router /tags [get].
+// @Router /g/{groupSlug}/tags [get].
 func (api *tagsAPI) listTags(w http.ResponseWriter, r *http.Request) {
 	regSet := RegistrySetFromContext(r.Context())
 	if regSet == nil {
@@ -116,8 +117,9 @@ func (api *tagsAPI) listTags(w http.ResponseWriter, r *http.Request) {
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Success 200 {object} jsonapi.TagStatsResponse "OK"
-// @Router /tags/stats [get].
+// @Router /g/{groupSlug}/tags/stats [get].
 func (api *tagsAPI) getTagStats(w http.ResponseWriter, r *http.Request) {
 	regSet := RegistrySetFromContext(r.Context())
 	if regSet == nil {
@@ -158,10 +160,11 @@ func includeHasToken(raw, token string) bool {
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param q query string false "Substring match against label and slug"
 // @Param limit query int false "Maximum suggestions returned" default(10)
 // @Success 200 {object} jsonapi.TagAutocompleteResponse "OK"
-// @Router /tags/autocomplete [get].
+// @Router /g/{groupSlug}/tags/autocomplete [get].
 func (api *tagsAPI) autocompleteTags(w http.ResponseWriter, r *http.Request) {
 	regSet := RegistrySetFromContext(r.Context())
 	if regSet == nil {
@@ -193,10 +196,11 @@ func (api *tagsAPI) autocompleteTags(w http.ResponseWriter, r *http.Request) {
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
-// @Param id path string true "Tag ID"
+// @Param groupSlug path string true "Group slug"
+// @Param tagID path string true "Tag ID"
 // @Success 200 {object} jsonapi.TagResponse "OK"
 // @Failure 404 {object} jsonapi.Errors "Tag not found"
-// @Router /tags/{id} [get].
+// @Router /g/{groupSlug}/tags/{tagID} [get].
 func (api *tagsAPI) getTag(w http.ResponseWriter, r *http.Request) { //revive:disable-line:get-return
 	tag := tagFromContext(r.Context())
 	if tag == nil {
@@ -227,10 +231,11 @@ func (api *tagsAPI) getTag(w http.ResponseWriter, r *http.Request) { //revive:di
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param tag body jsonapi.TagRequest true "Tag object"
 // @Success 201 {object} jsonapi.TagResponse "Tag created"
 // @Failure 422 {object} jsonapi.Errors "User-side request problem"
-// @Router /tags [post].
+// @Router /g/{groupSlug}/tags [post].
 func (api *tagsAPI) createTag(w http.ResponseWriter, r *http.Request) {
 	regSet := RegistrySetFromContext(r.Context())
 	if regSet == nil {
@@ -267,13 +272,14 @@ func (api *tagsAPI) createTag(w http.ResponseWriter, r *http.Request) {
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
-// @Param id path string true "Tag ID"
+// @Param groupSlug path string true "Group slug"
+// @Param tagID path string true "Tag ID"
 // @Param tag body jsonapi.TagUpdateRequest true "Tag patch payload"
 // @Success 200 {object} jsonapi.TagResponse "OK"
 // @Failure 404 {object} jsonapi.Errors "Tag not found"
 // @Failure 409 {object} jsonapi.Errors "Slug already in use"
 // @Failure 422 {object} jsonapi.Errors "User-side request problem"
-// @Router /tags/{id} [patch].
+// @Router /g/{groupSlug}/tags/{tagID} [patch].
 func (api *tagsAPI) updateTag(w http.ResponseWriter, r *http.Request) {
 	tag := tagFromContext(r.Context())
 	if tag == nil {
@@ -315,12 +321,13 @@ func (api *tagsAPI) updateTag(w http.ResponseWriter, r *http.Request) {
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
-// @Param id path string true "Tag ID"
+// @Param groupSlug path string true "Group slug"
+// @Param tagID path string true "Tag ID"
 // @Param force query bool false "Strip JSONB references then delete"
 // @Success 204 "No content"
 // @Failure 404 {object} jsonapi.Errors "Tag not found"
 // @Failure 409 {object} jsonapi.Errors "Tag is in use; pass force=true to strip references"
-// @Router /tags/{id} [delete].
+// @Router /g/{groupSlug}/tags/{tagID} [delete].
 func (api *tagsAPI) deleteTag(w http.ResponseWriter, r *http.Request) {
 	tag := tagFromContext(r.Context())
 	if tag == nil {

--- a/go/apiserver/upload_slots.go
+++ b/go/apiserver/upload_slots.go
@@ -23,12 +23,13 @@ type uploadSlotsAPI struct {
 // @Tags upload-slots
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param operation query string true "Operation name" example(image_upload)
 // @Success 200 {object} jsonapi.UploadStatusResponse "Upload capacity available"
 // @Failure 400 {object} jsonapi.Errors "Bad request"
 // @Failure 401 {object} jsonapi.Errors "Unauthorized"
 // @Failure 429 {object} jsonapi.Errors "Too many concurrent uploads"
-// @Router /upload-slots/check [get]
+// @Router /g/{groupSlug}/upload-slots/check [get]
 func (api *uploadSlotsAPI) checkUploadCapacity(w http.ResponseWriter, r *http.Request) {
 	// Get operation name from query parameter
 	operationName := r.URL.Query().Get("operation")
@@ -72,11 +73,12 @@ func (api *uploadSlotsAPI) checkUploadCapacity(w http.ResponseWriter, r *http.Re
 // @Tags upload-slots
 // @Accept json-api
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param operation query string true "Operation name" example(image_upload)
 // @Success 200 {object} jsonapi.UploadStatusResponse "Upload status retrieved successfully"
 // @Failure 400 {object} jsonapi.Errors "Bad request"
 // @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Router /upload-slots/status [get]
+// @Router /g/{groupSlug}/upload-slots/status [get]
 func (api *uploadSlotsAPI) getUploadStatus(w http.ResponseWriter, r *http.Request) {
 	// Get operation name from query parameter
 	operationName := r.URL.Query().Get("operation")

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -81,7 +81,7 @@ type uploadsAPI struct {
 // @Param file formData file true "File to upload"
 // @Success 201 {object} jsonapi.FileResponse "Created"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity"
-// @Failure 500 {string} string "Internal Server Error"
+// @Failure 500 {object} jsonapi.Errors "Internal Server Error"
 // @Router /g/{groupSlug}/uploads/file [post]
 func (api *uploadsAPI) handleFileUpload(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
@@ -194,7 +194,7 @@ func (api *uploadsAPI) handleFileUpload(w http.ResponseWriter, r *http.Request) 
 // @Param file formData file true "XML backup file to upload"
 // @Success 200 {object} jsonapi.UploadResponse "OK"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity"
-// @Failure 500 {string} string "Internal Server Error"
+// @Failure 500 {object} jsonapi.Errors "Internal Server Error"
 // @Router /g/{groupSlug}/uploads/restores [post]
 func (api *uploadsAPI) handleRestoreUpload(w http.ResponseWriter, r *http.Request) {
 	uploadedFiles := uploadedFilesFromContext(r.Context())

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -77,11 +77,12 @@ type uploadsAPI struct {
 // @Tags uploads
 // @Accept multipart/form-data
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param file formData file true "File to upload"
 // @Success 201 {object} jsonapi.FileResponse "Created"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity"
 // @Failure 500 {string} string "Internal Server Error"
-// @Router /uploads/file [post]
+// @Router /g/{groupSlug}/uploads/file [post]
 func (api *uploadsAPI) handleFileUpload(w http.ResponseWriter, r *http.Request) {
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())
@@ -189,11 +190,12 @@ func (api *uploadsAPI) handleFileUpload(w http.ResponseWriter, r *http.Request) 
 // @Tags uploads
 // @Accept multipart/form-data
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Param file formData file true "XML backup file to upload"
 // @Success 200 {object} jsonapi.UploadResponse "OK"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity"
 // @Failure 500 {string} string "Internal Server Error"
-// @Router /uploads/restores [post]
+// @Router /g/{groupSlug}/uploads/restores [post]
 func (api *uploadsAPI) handleRestoreUpload(w http.ResponseWriter, r *http.Request) {
 	uploadedFiles := uploadedFilesFromContext(r.Context())
 	if len(uploadedFiles) == 0 {

--- a/go/apiserver/values.go
+++ b/go/apiserver/values.go
@@ -21,8 +21,9 @@ type valuesAPI struct {
 // @Tags commodities
 // @Accept json
 // @Produce json-api
+// @Param groupSlug path string true "Group slug"
 // @Success 200 {object} jsonapi.ValueResponse "OK"
-// @Router /commodities/values [get]
+// @Router /g/{groupSlug}/commodities/values [get]
 func (api *valuesAPI) getValues(w http.ResponseWriter, r *http.Request) { //revive:disable-line:get-return
 	// Get user-aware settings registry from context
 	registrySet := RegistrySetFromContext(r.Context())

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -22,203 +22,6 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/areas": {
-            "get": {
-                "description": "get areas",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "areas"
-                ],
-                "summary": "List areas",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number (default 1)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Items per page (default 50, max 100)",
-                        "name": "per_page",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreasResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "add by area data",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "areas"
-                ],
-                "summary": "Create a new area",
-                "parameters": [
-                    {
-                        "description": "Area object",
-                        "name": "area",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreaRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Area created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreaResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Area not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/areas/{id}": {
-            "get": {
-                "description": "get area by ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "areas"
-                ],
-                "summary": "Get an area",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Area ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreaResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "description": "Update by area data",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "areas"
-                ],
-                "summary": "Update a area",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Area ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Area object",
-                        "name": "area",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreaRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreaResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Area not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Delete by area ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "areas"
-                ],
-                "summary": "Delete an area",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Area ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "404": {
-                        "description": "Area not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
         "/auth/change-password": {
             "post": {
                 "description": "Change the authenticated user's password. All existing sessions are invalidated on success.",
@@ -448,344 +251,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/commodities": {
-            "get": {
-                "description": "get commodities",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "List commodities",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number (default 1)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Items per page (default 50, max 100)",
-                        "name": "per_page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "collectionFormat": "multi",
-                        "description": "Filter by commodity type; repeat to OR",
-                        "name": "type",
-                        "in": "query"
-                    },
-                    {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "collectionFormat": "multi",
-                        "description": "Filter by status (in_use, sold, lost, disposed, written_off); repeat to OR",
-                        "name": "status",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by exact area ID",
-                        "name": "area_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Case-insensitive substring match on name + short_name",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Include drafts and non-in_use commodities (default false hides them)",
-                        "name": "include_inactive",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort field — name|registered_date|purchase_date|current_price|original_price|count, prefix with '-' for descending",
-                        "name": "sort",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommoditiesResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "Add a new commodity",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Create a new commodity",
-                "parameters": [
-                    {
-                        "description": "Commodity object",
-                        "name": "commodity",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommodityRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Commodity created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommodityResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/commodities/bulk-delete": {
-            "post": {
-                "description": "Delete every commodity whose id appears in the body. The\nresponse lists succeeded vs. failed ids so the frontend\ncan render partial-failure UX without parsing per-id HTTP\nstatuses.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Bulk-delete commodities",
-                "parameters": [
-                    {
-                        "description": "List of commodity IDs to delete",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkIDsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Per-id outcome",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Bad request body",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/commodities/bulk-move": {
-            "post": {
-                "description": "Update every commodity whose id appears in the body to\nbelong to the supplied area_id.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Bulk-move commodities to a new area",
-                "parameters": [
-                    {
-                        "description": "List of commodity IDs and the destination area_id",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkMoveRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Per-id outcome",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Bad request body",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/commodities/values": {
-            "get": {
-                "description": "Get the total value of commodities globally, by location, and by area",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Get total value of commodities",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ValueResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/commodities/{id}": {
-            "get": {
-                "description": "get commodity by ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Get a commodity",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Commodity ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommodityResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "description": "Update a commodity",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Update a commodity",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Commodity ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Commodity object",
-                        "name": "commodity",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommodityRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommodityResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Commodity not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Delete a commodity by ID and all its linked files",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Delete a commodity",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Commodity ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "404": {
-                        "description": "Commodity not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
         "/currencies": {
             "get": {
                 "description": "get list of supported currencies",
@@ -830,622 +295,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/debug.Info"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports": {
-            "get": {
-                "description": "get exports",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "List exports",
-                "parameters": [
-                    {
-                        "type": "boolean",
-                        "description": "Include deleted exports",
-                        "name": "include_deleted",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ExportsResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "create a new export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Create an export",
-                "parameters": [
-                    {
-                        "description": "Export",
-                        "name": "export",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ExportCreateRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ExportResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports/import": {
-            "post": {
-                "description": "Import an uploaded XML export file and create an export record",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Import XML export",
-                "parameters": [
-                    {
-                        "description": "Import request data",
-                        "name": "data",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ImportExportRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ExportResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports/{id}": {
-            "get": {
-                "description": "get export by ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Get an export",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ExportResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "delete an export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Delete an export",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports/{id}/download": {
-            "get": {
-                "description": "Download an export XML file",
-                "consumes": [
-                    "application/octet-stream"
-                ],
-                "produces": [
-                    "application/octet-stream"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Download an export file",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "file"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports/{id}/restores": {
-            "get": {
-                "description": "get restore operations for an export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "List export restore operations",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.RestoreOperationsResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "create a new restore operation for an export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Create export restore operation",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Restore operation data",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.RestoreOperationCreateRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.RestoreOperationResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "404": {
-                        "description": "Not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports/{id}/restores/{restoreId}": {
-            "get": {
-                "description": "get restore operation by ID for an export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Get export restore operation",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Restore Operation ID",
-                        "name": "restoreId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.RestoreOperationResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "delete a restore operation for an export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Delete export restore operation",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Restore Operation ID",
-                        "name": "restoreId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/files": {
-            "get": {
-                "description": "get files with optional filtering",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "files"
-                ],
-                "summary": "List files",
-                "parameters": [
-                    {
-                        "enum": [
-                            "image",
-                            "document",
-                            "video",
-                            "audio",
-                            "archive",
-                            "other"
-                        ],
-                        "type": "string",
-                        "description": "Filter by file type",
-                        "name": "type",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "photos",
-                            "invoices",
-                            "documents",
-                            "other"
-                        ],
-                        "type": "string",
-                        "description": "Filter by file category",
-                        "name": "category",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Search in title, description, and file paths",
-                        "name": "search",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by tags (comma-separated)",
-                        "name": "tags",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by linked entity type (e.g. commodity, location, export). Must be supplied together with linked_entity_id.",
-                        "name": "linked_entity_type",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by linked entity id. Must be supplied together with linked_entity_type.",
-                        "name": "linked_entity_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 1,
-                        "description": "Page number (1-based)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 20,
-                        "description": "Items per page",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.FilesResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid query parameter",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "create a new file entity with metadata (file upload handled separately)",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "files"
-                ],
-                "summary": "Create a file entity",
-                "parameters": [
-                    {
-                        "description": "File metadata",
-                        "name": "file",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.FileRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.FileResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Validation error",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/files/bulk-delete": {
-            "post": {
-                "description": "Delete every file whose id appears in the body, including\nthe physical blob. The response lists succeeded vs.\nfailed ids so the frontend can render partial-failure UX\nwithout parsing per-id HTTP statuses.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "files"
-                ],
-                "summary": "Bulk-delete files",
-                "parameters": [
-                    {
-                        "description": "List of file IDs to delete",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkIDsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Per-id outcome",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Bad request body",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/files/category-counts": {
-            "get": {
-                "description": "Per-category file counts, respecting the same filters as GET /files",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "files"
-                ],
-                "summary": "File category counts",
-                "parameters": [
-                    {
-                        "enum": [
-                            "image",
-                            "document",
-                            "video",
-                            "audio",
-                            "archive",
-                            "other"
-                        ],
-                        "type": "string",
-                        "description": "Filter by file type",
-                        "name": "type",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Search in title, description, and file paths",
-                        "name": "search",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by tags (comma-separated)",
-                        "name": "tags",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.FileCategoryCountsResponse"
                         }
                     }
                 }
@@ -1544,7 +393,1398 @@ const docTemplate = `{
                 }
             }
         },
-        "/files/{id}": {
+        "/forgot-password": {
+            "post": {
+                "description": "Send a password-reset link to the given email address. Always returns 200 to prevent email enumeration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Request a password reset",
+                "parameters": [
+                    {
+                        "description": "Email address",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.ForgotPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/areas": {
+            "get": {
+                "description": "get areas",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "areas"
+                ],
+                "summary": "List areas",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (default 50, max 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreasResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "add by area data",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "areas"
+                ],
+                "summary": "Create a new area",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Area object",
+                        "name": "area",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreaRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Area created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreaResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Area not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/areas/{areaID}": {
+            "get": {
+                "description": "get area by ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "areas"
+                ],
+                "summary": "Get an area",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Area ID",
+                        "name": "areaID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreaResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update by area data",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "areas"
+                ],
+                "summary": "Update a area",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Area ID",
+                        "name": "areaID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Area object",
+                        "name": "area",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreaRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreaResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Area not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete by area ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "areas"
+                ],
+                "summary": "Delete an area",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Area ID",
+                        "name": "areaID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "404": {
+                        "description": "Area not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/commodities": {
+            "get": {
+                "description": "get commodities",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "List commodities",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (default 50, max 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Filter by commodity type; repeat to OR",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Filter by status (in_use, sold, lost, disposed, written_off); repeat to OR",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by exact area ID",
+                        "name": "area_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Case-insensitive substring match on name + short_name",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include drafts and non-in_use commodities (default false hides them)",
+                        "name": "include_inactive",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort field — name|registered_date|purchase_date|current_price|original_price|count, prefix with '-' for descending",
+                        "name": "sort",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommoditiesResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Add a new commodity",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Create a new commodity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Commodity object",
+                        "name": "commodity",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommodityRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Commodity created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommodityResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/commodities/bulk-delete": {
+            "post": {
+                "description": "Delete every commodity whose id appears in the body. The\nresponse lists succeeded vs. failed ids so the frontend\ncan render partial-failure UX without parsing per-id HTTP\nstatuses.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Bulk-delete commodities",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "List of commodity IDs to delete",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkIDsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Per-id outcome",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Bad request body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/commodities/bulk-move": {
+            "post": {
+                "description": "Update every commodity whose id appears in the body to\nbelong to the supplied area_id.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Bulk-move commodities to a new area",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "List of commodity IDs and the destination area_id",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkMoveRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Per-id outcome",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Bad request body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/commodities/values": {
+            "get": {
+                "description": "Get the total value of commodities globally, by location, and by area",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Get total value of commodities",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ValueResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/commodities/{commodityID}": {
+            "get": {
+                "description": "get commodity by ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Get a commodity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Commodity ID",
+                        "name": "commodityID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommodityResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update a commodity",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Update a commodity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Commodity ID",
+                        "name": "commodityID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Commodity object",
+                        "name": "commodity",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommodityRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommodityResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Commodity not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a commodity by ID and all its linked files",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Delete a commodity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Commodity ID",
+                        "name": "commodityID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "404": {
+                        "description": "Commodity not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports": {
+            "get": {
+                "description": "get exports",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "List exports",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include deleted exports",
+                        "name": "include_deleted",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ExportsResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "create a new export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Create an export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Export",
+                        "name": "export",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ExportCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ExportResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports/import": {
+            "post": {
+                "description": "Import an uploaded XML export file and create an export record",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Import XML export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Import request data",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ImportExportRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ExportResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports/{id}": {
+            "get": {
+                "description": "get export by ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Get an export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ExportResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "delete an export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Delete an export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports/{id}/download": {
+            "get": {
+                "description": "Download an export XML file",
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Download an export file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports/{id}/restores": {
+            "get": {
+                "description": "get restore operations for an export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "List export restore operations",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.RestoreOperationsResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "create a new restore operation for an export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Create export restore operation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Restore operation data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.RestoreOperationCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.RestoreOperationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports/{id}/restores/{restoreId}": {
+            "get": {
+                "description": "get restore operation by ID for an export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Get export restore operation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Restore Operation ID",
+                        "name": "restoreId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.RestoreOperationResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "delete a restore operation for an export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Delete export restore operation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Restore Operation ID",
+                        "name": "restoreId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/files": {
+            "get": {
+                "description": "get files with optional filtering",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "files"
+                ],
+                "summary": "List files",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "image",
+                            "document",
+                            "video",
+                            "audio",
+                            "archive",
+                            "other"
+                        ],
+                        "type": "string",
+                        "description": "Filter by file type",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "photos",
+                            "invoices",
+                            "documents",
+                            "other"
+                        ],
+                        "type": "string",
+                        "description": "Filter by file category",
+                        "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search in title, description, and file paths",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tags (comma-separated)",
+                        "name": "tags",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by linked entity type (e.g. commodity, location, export). Must be supplied together with linked_entity_id.",
+                        "name": "linked_entity_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by linked entity id. Must be supplied together with linked_entity_type.",
+                        "name": "linked_entity_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number (1-based)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FilesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "create a new file entity with metadata (file upload handled separately)",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "files"
+                ],
+                "summary": "Create a file entity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "File metadata",
+                        "name": "file",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/files/bulk-delete": {
+            "post": {
+                "description": "Delete every file whose id appears in the body, including\nthe physical blob. The response lists succeeded vs.\nfailed ids so the frontend can render partial-failure UX\nwithout parsing per-id HTTP statuses.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "files"
+                ],
+                "summary": "Bulk-delete files",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "List of file IDs to delete",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkIDsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Per-id outcome",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Bad request body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/files/category-counts": {
+            "get": {
+                "description": "Per-category file counts, respecting the same filters as GET /files",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "files"
+                ],
+                "summary": "File category counts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "image",
+                            "document",
+                            "video",
+                            "audio",
+                            "archive",
+                            "other"
+                        ],
+                        "type": "string",
+                        "description": "Filter by file type",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search in title, description, and file paths",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tags (comma-separated)",
+                        "name": "tags",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileCategoryCountsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/files/{fileID}": {
             "get": {
                 "description": "get file by ID",
                 "consumes": [
@@ -1560,8 +1800,15 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "File ID",
-                        "name": "id",
+                        "name": "fileID",
                         "in": "path",
                         "required": true
                     }
@@ -1596,8 +1843,15 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "File ID",
-                        "name": "id",
+                        "name": "fileID",
                         "in": "path",
                         "required": true
                     },
@@ -1647,8 +1901,15 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "File ID",
-                        "name": "id",
+                        "name": "fileID",
                         "in": "path",
                         "required": true
                     }
@@ -1666,7 +1927,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/files/{id}/signed-url": {
+        "/g/{groupSlug}/files/{fileID}/signed-url": {
             "post": {
                 "description": "Generate a secure signed URL for downloading a file",
                 "tags": [
@@ -1676,8 +1937,15 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "File ID",
-                        "name": "id",
+                        "name": "fileID",
                         "in": "path",
                         "required": true
                     }
@@ -1698,27 +1966,173 @@ const docTemplate = `{
                 }
             }
         },
-        "/forgot-password": {
-            "post": {
-                "description": "Send a password-reset link to the given email address. Always returns 200 to prevent email enumeration.",
+        "/g/{groupSlug}/locations": {
+            "get": {
+                "description": "get locations",
                 "consumes": [
-                    "application/json"
+                    "application/vnd.api+json"
                 ],
                 "produces": [
-                    "application/json"
+                    "application/vnd.api+json"
                 ],
                 "tags": [
-                    "auth"
+                    "locations"
                 ],
-                "summary": "Request a password reset",
+                "summary": "List locations",
                 "parameters": [
                     {
-                        "description": "Email address",
-                        "name": "data",
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (default 50, max 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.LocationsResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "add by location data",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "locations"
+                ],
+                "summary": "Create a new location",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Location object",
+                        "name": "location",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/apiserver.ForgotPasswordRequest"
+                            "$ref": "#/definitions/jsonapi.LocationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Location created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.LocationResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Location not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/locations/{locationID}": {
+            "get": {
+                "description": "get location by ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "locations"
+                ],
+                "summary": "Get a location",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Location ID",
+                        "name": "locationID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.LocationResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update by location data",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "locations"
+                ],
+                "summary": "Update a location",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Location ID",
+                        "name": "locationID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Location object",
+                        "name": "location",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.LocationRequest"
                         }
                     }
                 ],
@@ -1726,10 +2140,212 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/jsonapi.LocationResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Location not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete by location ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "locations"
+                ],
+                "summary": "Delete a location",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Location ID",
+                        "name": "locationID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "404": {
+                        "description": "Location not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/search": {
+            "get": {
+                "description": "Perform advanced search across commodities, files, and other entities",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "search"
+                ],
+                "summary": "Advanced search",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "commodities",
+                            "files",
+                            "areas",
+                            "locations"
+                        ],
+                        "type": "string",
+                        "description": "Entity type to search",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Maximum number of results",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Number of results to skip",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tags (comma-separated)",
+                        "name": "tags",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "AND",
+                            "OR"
+                        ],
+                        "type": "string",
+                        "default": "OR",
+                        "description": "Tag operator",
+                        "name": "operator",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Search results",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.SearchResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/settings": {
+            "get": {
+                "description": "get current settings",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "settings"
+                ],
+                "summary": "Get current settings",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.SettingsObject"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "update entire settings object",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "settings"
+                ],
+                "summary": "Update settings",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Settings object with documented snake_case field names",
+                        "name": "settings",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.SettingsUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.SettingsObject"
                         }
                     },
                     "400": {
@@ -1737,9 +2353,631 @@ const docTemplate = `{
                         "schema": {
                             "type": "string"
                         }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/settings/{field}": {
+            "patch": {
+                "description": "update a specific setting field.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "settings"
+                ],
+                "summary": "Patch setting",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Setting field path (e.g., uiconfig.theme)",
+                        "name": "field",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Setting value envelope with required value.",
+                        "name": "value",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.PatchSettingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.SettingsObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/tags": {
+            "get": {
+                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "List tags",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search by label or slug",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "label",
+                            "created_at",
+                            "usage"
+                        ],
+                        "type": "string",
+                        "description": "Sort field (label, created_at, usage)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "asc",
+                        "description": "Sort direction (asc, desc)",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number (1-based)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Items per page",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "usage"
+                        ],
+                        "type": "string",
+                        "description": "Comma-separated extras. 'usage' attaches per-row meta.usage.",
+                        "name": "include",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagsResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "add a tag with slug, label, color",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Create a new tag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Tag object",
+                        "name": "tag",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Tag created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/tags/autocomplete": {
+            "get": {
+                "description": "Top-N tags matching the query, ranked by usage desc + created_at desc.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Autocomplete tag suggestions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Substring match against label and slug",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Maximum suggestions returned",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagAutocompleteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/tags/stats": {
+            "get": {
+                "description": "Returns total tags, plus tagged/untagged counts on commodities and files for the current group.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Tag adoption stats",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagStatsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/tags/{tagID}": {
+            "get": {
+                "description": "get tag by ID with usage breakdown",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Get a tag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag ID",
+                        "name": "tagID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Tag not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete tag by ID. Returns 409 with usage breakdown when in use; pass ?force=true to strip references.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Delete a tag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag ID",
+                        "name": "tagID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Strip JSONB references then delete",
+                        "name": "force",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "404": {
+                        "description": "Tag not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "409": {
+                        "description": "Tag is in use; pass force=true to strip references",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Patch label/color/slug. Slug change rewrites JSONB references.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Update a tag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag ID",
+                        "name": "tagID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Tag patch payload",
+                        "name": "tag",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Tag not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "409": {
+                        "description": "Slug already in use",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/upload-slots/check": {
+            "get": {
+                "description": "Check if user can start an upload for a specific operation",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "upload-slots"
+                ],
+                "summary": "Check upload capacity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "image_upload",
+                        "description": "Operation name",
+                        "name": "operation",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Upload capacity available",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.UploadStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
                     },
                     "429": {
-                        "description": "Too Many Requests",
+                        "description": "Too many concurrent uploads",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/upload-slots/status": {
+            "get": {
+                "description": "Get current upload status for a specific operation",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "upload-slots"
+                ],
+                "summary": "Get upload status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "image_upload",
+                        "description": "Operation name",
+                        "name": "operation",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Upload status retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.UploadStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/uploads/file": {
+            "post": {
+                "description": "Upload a single file of any type. The file is stored and a file entity is created without a linked entity.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "uploads"
+                ],
+                "summary": "Upload a file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "File to upload",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/uploads/restores": {
+            "post": {
+                "description": "Upload an XML backup file to be used for a restore operation.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "uploads"
+                ],
+                "summary": "Upload restore file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "XML backup file to upload",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.UploadResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }
@@ -2367,203 +3605,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/locations": {
-            "get": {
-                "description": "get locations",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "locations"
-                ],
-                "summary": "List locations",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number (default 1)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Items per page (default 50, max 100)",
-                        "name": "per_page",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationsResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "add by location data",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "locations"
-                ],
-                "summary": "Create a new location",
-                "parameters": [
-                    {
-                        "description": "Location object",
-                        "name": "location",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Location created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Location not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/locations/{id}": {
-            "get": {
-                "description": "get location by ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "locations"
-                ],
-                "summary": "Get a location",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Location ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "description": "Update by location data",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "locations"
-                ],
-                "summary": "Update a location",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Location ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Location object",
-                        "name": "location",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Location not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Delete by location ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "locations"
-                ],
-                "summary": "Delete a location",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Location ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "404": {
-                        "description": "Location not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
         "/register": {
             "post": {
                 "description": "Create a user. Valid invite_token: account active, no email verification (caller still POSTs /invites/{token}/accept after login). Without an invite: mode decides (open, approval, or 403 closed).",
@@ -2717,81 +3758,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/search": {
-            "get": {
-                "description": "Perform advanced search across commodities, files, and other entities",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "search"
-                ],
-                "summary": "Advanced search",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Search query",
-                        "name": "q",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "enum": [
-                            "commodities",
-                            "files",
-                            "areas",
-                            "locations"
-                        ],
-                        "type": "string",
-                        "description": "Entity type to search",
-                        "name": "type",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 20,
-                        "description": "Maximum number of results",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 0,
-                        "description": "Number of results to skip",
-                        "name": "offset",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by tags (comma-separated)",
-                        "name": "tags",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "AND",
-                            "OR"
-                        ],
-                        "type": "string",
-                        "default": "OR",
-                        "description": "Tag operator",
-                        "name": "operator",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Search results",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.SearchResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/seed": {
             "post": {
                 "description": "Seed the database with example data. Optionally specify user_email and tenant_slug in request body.",
@@ -2828,114 +3794,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/settings": {
-            "get": {
-                "description": "get current settings",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "settings"
-                ],
-                "summary": "Get current settings",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.SettingsObject"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "description": "update entire settings object",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "settings"
-                ],
-                "summary": "Update settings",
-                "parameters": [
-                    {
-                        "description": "Settings object with documented snake_case field names",
-                        "name": "settings",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/apiserver.SettingsUpdateRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.SettingsObject"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/settings/{field}": {
-            "patch": {
-                "description": "update a specific setting field.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "settings"
-                ],
-                "summary": "Patch setting",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Setting field path (e.g., uiconfig.theme)",
-                        "name": "field",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Setting value envelope with required value.",
-                        "name": "value",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/apiserver.PatchSettingRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.SettingsObject"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
         "/system": {
             "get": {
                 "description": "get comprehensive system information including version, runtime metrics, and settings",
@@ -2954,501 +3812,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/apiserver.SystemInfo"
-                        }
-                    }
-                }
-            }
-        },
-        "/tags": {
-            "get": {
-                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "List tags",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Search by label or slug",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "label",
-                            "created_at",
-                            "usage"
-                        ],
-                        "type": "string",
-                        "description": "Sort field (label, created_at, usage)",
-                        "name": "sort",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "asc",
-                        "description": "Sort direction (asc, desc)",
-                        "name": "order",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 1,
-                        "description": "Page number (1-based)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 50,
-                        "description": "Items per page",
-                        "name": "per_page",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "usage"
-                        ],
-                        "type": "string",
-                        "description": "Comma-separated extras. 'usage' attaches per-row meta.usage.",
-                        "name": "include",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagsResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "add a tag with slug, label, color",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Create a new tag",
-                "parameters": [
-                    {
-                        "description": "Tag object",
-                        "name": "tag",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Tag created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/tags/autocomplete": {
-            "get": {
-                "description": "Top-N tags matching the query, ranked by usage desc + created_at desc.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Autocomplete tag suggestions",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Substring match against label and slug",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 10,
-                        "description": "Maximum suggestions returned",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagAutocompleteResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/tags/stats": {
-            "get": {
-                "description": "Returns total tags, plus tagged/untagged counts on commodities and files for the current group.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Tag adoption stats",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagStatsResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/tags/{id}": {
-            "get": {
-                "description": "get tag by ID with usage breakdown",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Get a tag",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Tag ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Tag not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Delete tag by ID. Returns 409 with usage breakdown when in use; pass ?force=true to strip references.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Delete a tag",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Tag ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Strip JSONB references then delete",
-                        "name": "force",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "404": {
-                        "description": "Tag not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "409": {
-                        "description": "Tag is in use; pass force=true to strip references",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "description": "Patch label/color/slug. Slug change rewrites JSONB references.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Update a tag",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Tag ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Tag patch payload",
-                        "name": "tag",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagUpdateRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Tag not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "409": {
-                        "description": "Slug already in use",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/upload-slots/check": {
-            "get": {
-                "description": "Check if user can start an upload for a specific operation",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "upload-slots"
-                ],
-                "summary": "Check upload capacity",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "image_upload",
-                        "description": "Operation name",
-                        "name": "operation",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Upload capacity available",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.UploadStatusResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "429": {
-                        "description": "Too many concurrent uploads",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/upload-slots/status": {
-            "get": {
-                "description": "Get current upload status for a specific operation",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "upload-slots"
-                ],
-                "summary": "Get upload status",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "image_upload",
-                        "description": "Operation name",
-                        "name": "operation",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Upload status retrieved successfully",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.UploadStatusResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/uploads/file": {
-            "post": {
-                "description": "Upload a single file of any type. The file is stored and a file entity is created without a linked entity.",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "uploads"
-                ],
-                "summary": "Upload a file",
-                "parameters": [
-                    {
-                        "type": "file",
-                        "description": "File to upload",
-                        "name": "file",
-                        "in": "formData",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.FileResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/uploads/restores": {
-            "post": {
-                "description": "Upload an XML backup file to be used for a restore operation.",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "uploads"
-                ],
-                "summary": "Upload restore file",
-                "parameters": [
-                    {
-                        "type": "file",
-                        "description": "XML backup file to upload",
-                        "name": "file",
-                        "in": "formData",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.UploadResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
                         }
                     }
                 }

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -335,7 +335,7 @@ const docTemplate = `{
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }
@@ -387,7 +387,7 @@ const docTemplate = `{
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }
@@ -2928,7 +2928,7 @@ const docTemplate = `{
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }
@@ -2979,7 +2979,7 @@ const docTemplate = `{
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -15,203 +15,6 @@
     },
     "basePath": "/api/v1",
     "paths": {
-        "/areas": {
-            "get": {
-                "description": "get areas",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "areas"
-                ],
-                "summary": "List areas",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number (default 1)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Items per page (default 50, max 100)",
-                        "name": "per_page",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreasResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "add by area data",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "areas"
-                ],
-                "summary": "Create a new area",
-                "parameters": [
-                    {
-                        "description": "Area object",
-                        "name": "area",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreaRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Area created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreaResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Area not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/areas/{id}": {
-            "get": {
-                "description": "get area by ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "areas"
-                ],
-                "summary": "Get an area",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Area ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreaResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "description": "Update by area data",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "areas"
-                ],
-                "summary": "Update a area",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Area ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Area object",
-                        "name": "area",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreaRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.AreaResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Area not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Delete by area ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "areas"
-                ],
-                "summary": "Delete an area",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Area ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "404": {
-                        "description": "Area not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
         "/auth/change-password": {
             "post": {
                 "description": "Change the authenticated user's password. All existing sessions are invalidated on success.",
@@ -441,344 +244,6 @@
                 }
             }
         },
-        "/commodities": {
-            "get": {
-                "description": "get commodities",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "List commodities",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number (default 1)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Items per page (default 50, max 100)",
-                        "name": "per_page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "collectionFormat": "multi",
-                        "description": "Filter by commodity type; repeat to OR",
-                        "name": "type",
-                        "in": "query"
-                    },
-                    {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "collectionFormat": "multi",
-                        "description": "Filter by status (in_use, sold, lost, disposed, written_off); repeat to OR",
-                        "name": "status",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by exact area ID",
-                        "name": "area_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Case-insensitive substring match on name + short_name",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Include drafts and non-in_use commodities (default false hides them)",
-                        "name": "include_inactive",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort field — name|registered_date|purchase_date|current_price|original_price|count, prefix with '-' for descending",
-                        "name": "sort",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommoditiesResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "Add a new commodity",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Create a new commodity",
-                "parameters": [
-                    {
-                        "description": "Commodity object",
-                        "name": "commodity",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommodityRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Commodity created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommodityResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/commodities/bulk-delete": {
-            "post": {
-                "description": "Delete every commodity whose id appears in the body. The\nresponse lists succeeded vs. failed ids so the frontend\ncan render partial-failure UX without parsing per-id HTTP\nstatuses.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Bulk-delete commodities",
-                "parameters": [
-                    {
-                        "description": "List of commodity IDs to delete",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkIDsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Per-id outcome",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Bad request body",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/commodities/bulk-move": {
-            "post": {
-                "description": "Update every commodity whose id appears in the body to\nbelong to the supplied area_id.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Bulk-move commodities to a new area",
-                "parameters": [
-                    {
-                        "description": "List of commodity IDs and the destination area_id",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkMoveRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Per-id outcome",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Bad request body",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/commodities/values": {
-            "get": {
-                "description": "Get the total value of commodities globally, by location, and by area",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Get total value of commodities",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ValueResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/commodities/{id}": {
-            "get": {
-                "description": "get commodity by ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Get a commodity",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Commodity ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommodityResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "description": "Update a commodity",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Update a commodity",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Commodity ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Commodity object",
-                        "name": "commodity",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommodityRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.CommodityResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Commodity not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Delete a commodity by ID and all its linked files",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "commodities"
-                ],
-                "summary": "Delete a commodity",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Commodity ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "404": {
-                        "description": "Commodity not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
         "/currencies": {
             "get": {
                 "description": "get list of supported currencies",
@@ -823,622 +288,6 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/debug.Info"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports": {
-            "get": {
-                "description": "get exports",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "List exports",
-                "parameters": [
-                    {
-                        "type": "boolean",
-                        "description": "Include deleted exports",
-                        "name": "include_deleted",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ExportsResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "create a new export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Create an export",
-                "parameters": [
-                    {
-                        "description": "Export",
-                        "name": "export",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ExportCreateRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ExportResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports/import": {
-            "post": {
-                "description": "Import an uploaded XML export file and create an export record",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Import XML export",
-                "parameters": [
-                    {
-                        "description": "Import request data",
-                        "name": "data",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ImportExportRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ExportResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports/{id}": {
-            "get": {
-                "description": "get export by ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Get an export",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.ExportResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "delete an export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Delete an export",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports/{id}/download": {
-            "get": {
-                "description": "Download an export XML file",
-                "consumes": [
-                    "application/octet-stream"
-                ],
-                "produces": [
-                    "application/octet-stream"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Download an export file",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "file"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports/{id}/restores": {
-            "get": {
-                "description": "get restore operations for an export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "List export restore operations",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.RestoreOperationsResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "create a new restore operation for an export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Create export restore operation",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Restore operation data",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.RestoreOperationCreateRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.RestoreOperationResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "404": {
-                        "description": "Not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/exports/{id}/restores/{restoreId}": {
-            "get": {
-                "description": "get restore operation by ID for an export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Get export restore operation",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Restore Operation ID",
-                        "name": "restoreId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.RestoreOperationResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "delete a restore operation for an export",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "exports"
-                ],
-                "summary": "Delete export restore operation",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Export ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Restore Operation ID",
-                        "name": "restoreId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/files": {
-            "get": {
-                "description": "get files with optional filtering",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "files"
-                ],
-                "summary": "List files",
-                "parameters": [
-                    {
-                        "enum": [
-                            "image",
-                            "document",
-                            "video",
-                            "audio",
-                            "archive",
-                            "other"
-                        ],
-                        "type": "string",
-                        "description": "Filter by file type",
-                        "name": "type",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "photos",
-                            "invoices",
-                            "documents",
-                            "other"
-                        ],
-                        "type": "string",
-                        "description": "Filter by file category",
-                        "name": "category",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Search in title, description, and file paths",
-                        "name": "search",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by tags (comma-separated)",
-                        "name": "tags",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by linked entity type (e.g. commodity, location, export). Must be supplied together with linked_entity_id.",
-                        "name": "linked_entity_type",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by linked entity id. Must be supplied together with linked_entity_type.",
-                        "name": "linked_entity_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 1,
-                        "description": "Page number (1-based)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 20,
-                        "description": "Items per page",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.FilesResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid query parameter",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "create a new file entity with metadata (file upload handled separately)",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "files"
-                ],
-                "summary": "Create a file entity",
-                "parameters": [
-                    {
-                        "description": "File metadata",
-                        "name": "file",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.FileRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.FileResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Validation error",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/files/bulk-delete": {
-            "post": {
-                "description": "Delete every file whose id appears in the body, including\nthe physical blob. The response lists succeeded vs.\nfailed ids so the frontend can render partial-failure UX\nwithout parsing per-id HTTP statuses.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "files"
-                ],
-                "summary": "Bulk-delete files",
-                "parameters": [
-                    {
-                        "description": "List of file IDs to delete",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkIDsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Per-id outcome",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Bad request body",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/files/category-counts": {
-            "get": {
-                "description": "Per-category file counts, respecting the same filters as GET /files",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "files"
-                ],
-                "summary": "File category counts",
-                "parameters": [
-                    {
-                        "enum": [
-                            "image",
-                            "document",
-                            "video",
-                            "audio",
-                            "archive",
-                            "other"
-                        ],
-                        "type": "string",
-                        "description": "Filter by file type",
-                        "name": "type",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Search in title, description, and file paths",
-                        "name": "search",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by tags (comma-separated)",
-                        "name": "tags",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.FileCategoryCountsResponse"
                         }
                     }
                 }
@@ -1537,7 +386,1398 @@
                 }
             }
         },
-        "/files/{id}": {
+        "/forgot-password": {
+            "post": {
+                "description": "Send a password-reset link to the given email address. Always returns 200 to prevent email enumeration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Request a password reset",
+                "parameters": [
+                    {
+                        "description": "Email address",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.ForgotPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/areas": {
+            "get": {
+                "description": "get areas",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "areas"
+                ],
+                "summary": "List areas",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (default 50, max 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreasResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "add by area data",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "areas"
+                ],
+                "summary": "Create a new area",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Area object",
+                        "name": "area",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreaRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Area created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreaResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Area not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/areas/{areaID}": {
+            "get": {
+                "description": "get area by ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "areas"
+                ],
+                "summary": "Get an area",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Area ID",
+                        "name": "areaID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreaResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update by area data",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "areas"
+                ],
+                "summary": "Update a area",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Area ID",
+                        "name": "areaID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Area object",
+                        "name": "area",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreaRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AreaResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Area not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete by area ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "areas"
+                ],
+                "summary": "Delete an area",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Area ID",
+                        "name": "areaID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "404": {
+                        "description": "Area not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/commodities": {
+            "get": {
+                "description": "get commodities",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "List commodities",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (default 50, max 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Filter by commodity type; repeat to OR",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Filter by status (in_use, sold, lost, disposed, written_off); repeat to OR",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by exact area ID",
+                        "name": "area_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Case-insensitive substring match on name + short_name",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include drafts and non-in_use commodities (default false hides them)",
+                        "name": "include_inactive",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort field — name|registered_date|purchase_date|current_price|original_price|count, prefix with '-' for descending",
+                        "name": "sort",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommoditiesResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Add a new commodity",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Create a new commodity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Commodity object",
+                        "name": "commodity",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommodityRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Commodity created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommodityResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/commodities/bulk-delete": {
+            "post": {
+                "description": "Delete every commodity whose id appears in the body. The\nresponse lists succeeded vs. failed ids so the frontend\ncan render partial-failure UX without parsing per-id HTTP\nstatuses.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Bulk-delete commodities",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "List of commodity IDs to delete",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkIDsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Per-id outcome",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Bad request body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/commodities/bulk-move": {
+            "post": {
+                "description": "Update every commodity whose id appears in the body to\nbelong to the supplied area_id.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Bulk-move commodities to a new area",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "List of commodity IDs and the destination area_id",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkMoveRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Per-id outcome",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Bad request body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/commodities/values": {
+            "get": {
+                "description": "Get the total value of commodities globally, by location, and by area",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Get total value of commodities",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ValueResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/commodities/{commodityID}": {
+            "get": {
+                "description": "get commodity by ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Get a commodity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Commodity ID",
+                        "name": "commodityID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommodityResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update a commodity",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Update a commodity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Commodity ID",
+                        "name": "commodityID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Commodity object",
+                        "name": "commodity",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommodityRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CommodityResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Commodity not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a commodity by ID and all its linked files",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "commodities"
+                ],
+                "summary": "Delete a commodity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Commodity ID",
+                        "name": "commodityID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "404": {
+                        "description": "Commodity not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports": {
+            "get": {
+                "description": "get exports",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "List exports",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include deleted exports",
+                        "name": "include_deleted",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ExportsResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "create a new export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Create an export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Export",
+                        "name": "export",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ExportCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ExportResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports/import": {
+            "post": {
+                "description": "Import an uploaded XML export file and create an export record",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Import XML export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Import request data",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ImportExportRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ExportResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports/{id}": {
+            "get": {
+                "description": "get export by ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Get an export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.ExportResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "delete an export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Delete an export",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports/{id}/download": {
+            "get": {
+                "description": "Download an export XML file",
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Download an export file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports/{id}/restores": {
+            "get": {
+                "description": "get restore operations for an export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "List export restore operations",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.RestoreOperationsResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "create a new restore operation for an export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Create export restore operation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Restore operation data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.RestoreOperationCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.RestoreOperationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/exports/{id}/restores/{restoreId}": {
+            "get": {
+                "description": "get restore operation by ID for an export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Get export restore operation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Restore Operation ID",
+                        "name": "restoreId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.RestoreOperationResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "delete a restore operation for an export",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Delete export restore operation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Restore Operation ID",
+                        "name": "restoreId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/files": {
+            "get": {
+                "description": "get files with optional filtering",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "files"
+                ],
+                "summary": "List files",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "image",
+                            "document",
+                            "video",
+                            "audio",
+                            "archive",
+                            "other"
+                        ],
+                        "type": "string",
+                        "description": "Filter by file type",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "photos",
+                            "invoices",
+                            "documents",
+                            "other"
+                        ],
+                        "type": "string",
+                        "description": "Filter by file category",
+                        "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search in title, description, and file paths",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tags (comma-separated)",
+                        "name": "tags",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by linked entity type (e.g. commodity, location, export). Must be supplied together with linked_entity_id.",
+                        "name": "linked_entity_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by linked entity id. Must be supplied together with linked_entity_type.",
+                        "name": "linked_entity_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number (1-based)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FilesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "create a new file entity with metadata (file upload handled separately)",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "files"
+                ],
+                "summary": "Create a file entity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "File metadata",
+                        "name": "file",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/files/bulk-delete": {
+            "post": {
+                "description": "Delete every file whose id appears in the body, including\nthe physical blob. The response lists succeeded vs.\nfailed ids so the frontend can render partial-failure UX\nwithout parsing per-id HTTP statuses.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "files"
+                ],
+                "summary": "Bulk-delete files",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "List of file IDs to delete",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkIDsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Per-id outcome",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.BulkResultResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Bad request body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/files/category-counts": {
+            "get": {
+                "description": "Per-category file counts, respecting the same filters as GET /files",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "files"
+                ],
+                "summary": "File category counts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "image",
+                            "document",
+                            "video",
+                            "audio",
+                            "archive",
+                            "other"
+                        ],
+                        "type": "string",
+                        "description": "Filter by file type",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search in title, description, and file paths",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tags (comma-separated)",
+                        "name": "tags",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileCategoryCountsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/files/{fileID}": {
             "get": {
                 "description": "get file by ID",
                 "consumes": [
@@ -1553,8 +1793,15 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "File ID",
-                        "name": "id",
+                        "name": "fileID",
                         "in": "path",
                         "required": true
                     }
@@ -1589,8 +1836,15 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "File ID",
-                        "name": "id",
+                        "name": "fileID",
                         "in": "path",
                         "required": true
                     },
@@ -1640,8 +1894,15 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "File ID",
-                        "name": "id",
+                        "name": "fileID",
                         "in": "path",
                         "required": true
                     }
@@ -1659,7 +1920,7 @@
                 }
             }
         },
-        "/files/{id}/signed-url": {
+        "/g/{groupSlug}/files/{fileID}/signed-url": {
             "post": {
                 "description": "Generate a secure signed URL for downloading a file",
                 "tags": [
@@ -1669,8 +1930,15 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "File ID",
-                        "name": "id",
+                        "name": "fileID",
                         "in": "path",
                         "required": true
                     }
@@ -1691,27 +1959,173 @@
                 }
             }
         },
-        "/forgot-password": {
-            "post": {
-                "description": "Send a password-reset link to the given email address. Always returns 200 to prevent email enumeration.",
+        "/g/{groupSlug}/locations": {
+            "get": {
+                "description": "get locations",
                 "consumes": [
-                    "application/json"
+                    "application/vnd.api+json"
                 ],
                 "produces": [
-                    "application/json"
+                    "application/vnd.api+json"
                 ],
                 "tags": [
-                    "auth"
+                    "locations"
                 ],
-                "summary": "Request a password reset",
+                "summary": "List locations",
                 "parameters": [
                     {
-                        "description": "Email address",
-                        "name": "data",
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (default 50, max 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.LocationsResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "add by location data",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "locations"
+                ],
+                "summary": "Create a new location",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Location object",
+                        "name": "location",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/apiserver.ForgotPasswordRequest"
+                            "$ref": "#/definitions/jsonapi.LocationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Location created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.LocationResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Location not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/locations/{locationID}": {
+            "get": {
+                "description": "get location by ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "locations"
+                ],
+                "summary": "Get a location",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Location ID",
+                        "name": "locationID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.LocationResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update by location data",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "locations"
+                ],
+                "summary": "Update a location",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Location ID",
+                        "name": "locationID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Location object",
+                        "name": "location",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.LocationRequest"
                         }
                     }
                 ],
@@ -1719,10 +2133,212 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/jsonapi.LocationResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Location not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete by location ID",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "locations"
+                ],
+                "summary": "Delete a location",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Location ID",
+                        "name": "locationID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "404": {
+                        "description": "Location not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/search": {
+            "get": {
+                "description": "Perform advanced search across commodities, files, and other entities",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "search"
+                ],
+                "summary": "Advanced search",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "commodities",
+                            "files",
+                            "areas",
+                            "locations"
+                        ],
+                        "type": "string",
+                        "description": "Entity type to search",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Maximum number of results",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Number of results to skip",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tags (comma-separated)",
+                        "name": "tags",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "AND",
+                            "OR"
+                        ],
+                        "type": "string",
+                        "default": "OR",
+                        "description": "Tag operator",
+                        "name": "operator",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Search results",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.SearchResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/settings": {
+            "get": {
+                "description": "get current settings",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "settings"
+                ],
+                "summary": "Get current settings",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.SettingsObject"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "update entire settings object",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "settings"
+                ],
+                "summary": "Update settings",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Settings object with documented snake_case field names",
+                        "name": "settings",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.SettingsUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.SettingsObject"
                         }
                     },
                     "400": {
@@ -1730,9 +2346,631 @@
                         "schema": {
                             "type": "string"
                         }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/settings/{field}": {
+            "patch": {
+                "description": "update a specific setting field.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "settings"
+                ],
+                "summary": "Patch setting",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Setting field path (e.g., uiconfig.theme)",
+                        "name": "field",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Setting value envelope with required value.",
+                        "name": "value",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.PatchSettingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.SettingsObject"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/tags": {
+            "get": {
+                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "List tags",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search by label or slug",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "label",
+                            "created_at",
+                            "usage"
+                        ],
+                        "type": "string",
+                        "description": "Sort field (label, created_at, usage)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "asc",
+                        "description": "Sort direction (asc, desc)",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number (1-based)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Items per page",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "usage"
+                        ],
+                        "type": "string",
+                        "description": "Comma-separated extras. 'usage' attaches per-row meta.usage.",
+                        "name": "include",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagsResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "add a tag with slug, label, color",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Create a new tag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Tag object",
+                        "name": "tag",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Tag created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/tags/autocomplete": {
+            "get": {
+                "description": "Top-N tags matching the query, ranked by usage desc + created_at desc.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Autocomplete tag suggestions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Substring match against label and slug",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Maximum suggestions returned",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagAutocompleteResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/tags/stats": {
+            "get": {
+                "description": "Returns total tags, plus tagged/untagged counts on commodities and files for the current group.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Tag adoption stats",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagStatsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/tags/{tagID}": {
+            "get": {
+                "description": "get tag by ID with usage breakdown",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Get a tag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag ID",
+                        "name": "tagID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Tag not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete tag by ID. Returns 409 with usage breakdown when in use; pass ?force=true to strip references.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Delete a tag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag ID",
+                        "name": "tagID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Strip JSONB references then delete",
+                        "name": "force",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "404": {
+                        "description": "Tag not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "409": {
+                        "description": "Tag is in use; pass force=true to strip references",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Patch label/color/slug. Slug change rewrites JSONB references.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "Update a tag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag ID",
+                        "name": "tagID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Tag patch payload",
+                        "name": "tag",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.TagResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Tag not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "409": {
+                        "description": "Slug already in use",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "User-side request problem",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/upload-slots/check": {
+            "get": {
+                "description": "Check if user can start an upload for a specific operation",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "upload-slots"
+                ],
+                "summary": "Check upload capacity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "image_upload",
+                        "description": "Operation name",
+                        "name": "operation",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Upload capacity available",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.UploadStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
                     },
                     "429": {
-                        "description": "Too Many Requests",
+                        "description": "Too many concurrent uploads",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/upload-slots/status": {
+            "get": {
+                "description": "Get current upload status for a specific operation",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "upload-slots"
+                ],
+                "summary": "Get upload status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "example": "image_upload",
+                        "description": "Operation name",
+                        "name": "operation",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Upload status retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.UploadStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/uploads/file": {
+            "post": {
+                "description": "Upload a single file of any type. The file is stored and a file entity is created without a linked entity.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "uploads"
+                ],
+                "summary": "Upload a file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "File to upload",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.FileResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/uploads/restores": {
+            "post": {
+                "description": "Upload an XML backup file to be used for a restore operation.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "uploads"
+                ],
+                "summary": "Upload restore file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "XML backup file to upload",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.UploadResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }
@@ -2360,203 +3598,6 @@
                 }
             }
         },
-        "/locations": {
-            "get": {
-                "description": "get locations",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "locations"
-                ],
-                "summary": "List locations",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number (default 1)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Items per page (default 50, max 100)",
-                        "name": "per_page",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationsResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "add by location data",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "locations"
-                ],
-                "summary": "Create a new location",
-                "parameters": [
-                    {
-                        "description": "Location object",
-                        "name": "location",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Location created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Location not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/locations/{id}": {
-            "get": {
-                "description": "get location by ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "locations"
-                ],
-                "summary": "Get a location",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Location ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "description": "Update by location data",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "locations"
-                ],
-                "summary": "Update a location",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Location ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Location object",
-                        "name": "location",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.LocationResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Location not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Delete by location ID",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "locations"
-                ],
-                "summary": "Delete a location",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Location ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "404": {
-                        "description": "Location not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
         "/register": {
             "post": {
                 "description": "Create a user. Valid invite_token: account active, no email verification (caller still POSTs /invites/{token}/accept after login). Without an invite: mode decides (open, approval, or 403 closed).",
@@ -2710,81 +3751,6 @@
                 }
             }
         },
-        "/search": {
-            "get": {
-                "description": "Perform advanced search across commodities, files, and other entities",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "search"
-                ],
-                "summary": "Advanced search",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Search query",
-                        "name": "q",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "enum": [
-                            "commodities",
-                            "files",
-                            "areas",
-                            "locations"
-                        ],
-                        "type": "string",
-                        "description": "Entity type to search",
-                        "name": "type",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 20,
-                        "description": "Maximum number of results",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 0,
-                        "description": "Number of results to skip",
-                        "name": "offset",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by tags (comma-separated)",
-                        "name": "tags",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "AND",
-                            "OR"
-                        ],
-                        "type": "string",
-                        "default": "OR",
-                        "description": "Tag operator",
-                        "name": "operator",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Search results",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.SearchResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/seed": {
             "post": {
                 "description": "Seed the database with example data. Optionally specify user_email and tenant_slug in request body.",
@@ -2821,114 +3787,6 @@
                 }
             }
         },
-        "/settings": {
-            "get": {
-                "description": "get current settings",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "settings"
-                ],
-                "summary": "Get current settings",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.SettingsObject"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "description": "update entire settings object",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "settings"
-                ],
-                "summary": "Update settings",
-                "parameters": [
-                    {
-                        "description": "Settings object with documented snake_case field names",
-                        "name": "settings",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/apiserver.SettingsUpdateRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.SettingsObject"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/settings/{field}": {
-            "patch": {
-                "description": "update a specific setting field.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "settings"
-                ],
-                "summary": "Patch setting",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Setting field path (e.g., uiconfig.theme)",
-                        "name": "field",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Setting value envelope with required value.",
-                        "name": "value",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/apiserver.PatchSettingRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.SettingsObject"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
         "/system": {
             "get": {
                 "description": "get comprehensive system information including version, runtime metrics, and settings",
@@ -2947,501 +3805,6 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/apiserver.SystemInfo"
-                        }
-                    }
-                }
-            }
-        },
-        "/tags": {
-            "get": {
-                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "List tags",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Search by label or slug",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "label",
-                            "created_at",
-                            "usage"
-                        ],
-                        "type": "string",
-                        "description": "Sort field (label, created_at, usage)",
-                        "name": "sort",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "default": "asc",
-                        "description": "Sort direction (asc, desc)",
-                        "name": "order",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 1,
-                        "description": "Page number (1-based)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 50,
-                        "description": "Items per page",
-                        "name": "per_page",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "usage"
-                        ],
-                        "type": "string",
-                        "description": "Comma-separated extras. 'usage' attaches per-row meta.usage.",
-                        "name": "include",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagsResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "add a tag with slug, label, color",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Create a new tag",
-                "parameters": [
-                    {
-                        "description": "Tag object",
-                        "name": "tag",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Tag created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/tags/autocomplete": {
-            "get": {
-                "description": "Top-N tags matching the query, ranked by usage desc + created_at desc.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Autocomplete tag suggestions",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Substring match against label and slug",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "default": 10,
-                        "description": "Maximum suggestions returned",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagAutocompleteResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/tags/stats": {
-            "get": {
-                "description": "Returns total tags, plus tagged/untagged counts on commodities and files for the current group.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Tag adoption stats",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagStatsResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/tags/{id}": {
-            "get": {
-                "description": "get tag by ID with usage breakdown",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Get a tag",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Tag ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Tag not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Delete tag by ID. Returns 409 with usage breakdown when in use; pass ?force=true to strip references.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Delete a tag",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Tag ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Strip JSONB references then delete",
-                        "name": "force",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "404": {
-                        "description": "Tag not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "409": {
-                        "description": "Tag is in use; pass force=true to strip references",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "description": "Patch label/color/slug. Slug change rewrites JSONB references.",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "tags"
-                ],
-                "summary": "Update a tag",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Tag ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Tag patch payload",
-                        "name": "tag",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagUpdateRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.TagResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Tag not found",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "409": {
-                        "description": "Slug already in use",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "422": {
-                        "description": "User-side request problem",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/upload-slots/check": {
-            "get": {
-                "description": "Check if user can start an upload for a specific operation",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "upload-slots"
-                ],
-                "summary": "Check upload capacity",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "image_upload",
-                        "description": "Operation name",
-                        "name": "operation",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Upload capacity available",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.UploadStatusResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "429": {
-                        "description": "Too many concurrent uploads",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/upload-slots/status": {
-            "get": {
-                "description": "Get current upload status for a specific operation",
-                "consumes": [
-                    "application/vnd.api+json"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "upload-slots"
-                ],
-                "summary": "Get upload status",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "example": "image_upload",
-                        "description": "Operation name",
-                        "name": "operation",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Upload status retrieved successfully",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.UploadStatusResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    }
-                }
-            }
-        },
-        "/uploads/file": {
-            "post": {
-                "description": "Upload a single file of any type. The file is stored and a file entity is created without a linked entity.",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "uploads"
-                ],
-                "summary": "Upload a file",
-                "parameters": [
-                    {
-                        "type": "file",
-                        "description": "File to upload",
-                        "name": "file",
-                        "in": "formData",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.FileResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/uploads/restores": {
-            "post": {
-                "description": "Upload an XML backup file to be used for a restore operation.",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "produces": [
-                    "application/vnd.api+json"
-                ],
-                "tags": [
-                    "uploads"
-                ],
-                "summary": "Upload restore file",
-                "parameters": [
-                    {
-                        "type": "file",
-                        "description": "XML backup file to upload",
-                        "name": "file",
-                        "in": "formData",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.UploadResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
                         }
                     }
                 }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -328,7 +328,7 @@
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }
@@ -380,7 +380,7 @@
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }
@@ -2921,7 +2921,7 @@
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }
@@ -2972,7 +2972,7 @@
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1840,136 +1840,6 @@ info:
   title: Inventario API
   version: "1.0"
 paths:
-  /areas:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get areas
-      parameters:
-      - description: Page number (default 1)
-        in: query
-        name: page
-        type: integer
-      - description: Items per page (default 50, max 100)
-        in: query
-        name: per_page
-        type: integer
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.AreasResponse'
-      summary: List areas
-      tags:
-      - areas
-    post:
-      consumes:
-      - application/vnd.api+json
-      description: add by area data
-      parameters:
-      - description: Area object
-        in: body
-        name: area
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.AreaRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "201":
-          description: Area created
-          schema:
-            $ref: '#/definitions/jsonapi.AreaResponse'
-        "404":
-          description: Area not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "422":
-          description: User-side request problem
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Create a new area
-      tags:
-      - areas
-  /areas/{id}:
-    delete:
-      consumes:
-      - application/vnd.api+json
-      description: Delete by area ID
-      parameters:
-      - description: Area ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "204":
-          description: No content
-        "404":
-          description: Area not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Delete an area
-      tags:
-      - areas
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get area by ID
-      parameters:
-      - description: Area ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.AreaResponse'
-      summary: Get an area
-      tags:
-      - areas
-    put:
-      consumes:
-      - application/vnd.api+json
-      description: Update by area data
-      parameters:
-      - description: Area ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Area object
-        in: body
-        name: area
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.AreaRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.AreaResponse'
-        "404":
-          description: Area not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "422":
-          description: User-side request problem
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Update a area
-      tags:
-      - areas
   /auth/change-password:
     post:
       consumes:
@@ -2129,239 +1999,6 @@ paths:
       summary: Refresh access token
       tags:
       - auth
-  /commodities:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get commodities
-      parameters:
-      - description: Page number (default 1)
-        in: query
-        name: page
-        type: integer
-      - description: Items per page (default 50, max 100)
-        in: query
-        name: per_page
-        type: integer
-      - collectionFormat: multi
-        description: Filter by commodity type; repeat to OR
-        in: query
-        items:
-          type: string
-        name: type
-        type: array
-      - collectionFormat: multi
-        description: Filter by status (in_use, sold, lost, disposed, written_off);
-          repeat to OR
-        in: query
-        items:
-          type: string
-        name: status
-        type: array
-      - description: Filter by exact area ID
-        in: query
-        name: area_id
-        type: string
-      - description: Case-insensitive substring match on name + short_name
-        in: query
-        name: q
-        type: string
-      - description: Include drafts and non-in_use commodities (default false hides
-          them)
-        in: query
-        name: include_inactive
-        type: boolean
-      - description: Sort field — name|registered_date|purchase_date|current_price|original_price|count,
-          prefix with '-' for descending
-        in: query
-        name: sort
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.CommoditiesResponse'
-      summary: List commodities
-      tags:
-      - commodities
-    post:
-      consumes:
-      - application/vnd.api+json
-      description: Add a new commodity
-      parameters:
-      - description: Commodity object
-        in: body
-        name: commodity
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.CommodityRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "201":
-          description: Commodity created
-          schema:
-            $ref: '#/definitions/jsonapi.CommodityResponse'
-        "422":
-          description: User-side request problem
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Create a new commodity
-      tags:
-      - commodities
-  /commodities/{id}:
-    delete:
-      consumes:
-      - application/vnd.api+json
-      description: Delete a commodity by ID and all its linked files
-      parameters:
-      - description: Commodity ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "204":
-          description: No content
-        "404":
-          description: Commodity not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Delete a commodity
-      tags:
-      - commodities
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get commodity by ID
-      parameters:
-      - description: Commodity ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.CommodityResponse'
-      summary: Get a commodity
-      tags:
-      - commodities
-    put:
-      consumes:
-      - application/vnd.api+json
-      description: Update a commodity
-      parameters:
-      - description: Commodity ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Commodity object
-        in: body
-        name: commodity
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.CommodityRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.CommodityResponse'
-        "404":
-          description: Commodity not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "422":
-          description: User-side request problem
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Update a commodity
-      tags:
-      - commodities
-  /commodities/bulk-delete:
-    post:
-      consumes:
-      - application/vnd.api+json
-      description: |-
-        Delete every commodity whose id appears in the body. The
-        response lists succeeded vs. failed ids so the frontend
-        can render partial-failure UX without parsing per-id HTTP
-        statuses.
-      parameters:
-      - description: List of commodity IDs to delete
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.BulkIDsRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: Per-id outcome
-          schema:
-            $ref: '#/definitions/jsonapi.BulkResultResponse'
-        "422":
-          description: Bad request body
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Bulk-delete commodities
-      tags:
-      - commodities
-  /commodities/bulk-move:
-    post:
-      consumes:
-      - application/vnd.api+json
-      description: |-
-        Update every commodity whose id appears in the body to
-        belong to the supplied area_id.
-      parameters:
-      - description: List of commodity IDs and the destination area_id
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.BulkMoveRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: Per-id outcome
-          schema:
-            $ref: '#/definitions/jsonapi.BulkResultResponse'
-        "422":
-          description: Bad request body
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Bulk-move commodities to a new area
-      tags:
-      - commodities
-  /commodities/values:
-    get:
-      consumes:
-      - application/json
-      description: Get the total value of commodities globally, by location, and by
-        area
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.ValueResponse'
-      summary: Get total value of commodities
-      tags:
-      - commodities
   /currencies:
     get:
       consumes:
@@ -2395,524 +2032,6 @@ paths:
       summary: Get debug information
       tags:
       - debug
-  /exports:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get exports
-      parameters:
-      - description: Include deleted exports
-        in: query
-        name: include_deleted
-        type: boolean
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.ExportsResponse'
-      summary: List exports
-      tags:
-      - exports
-    post:
-      consumes:
-      - application/vnd.api+json
-      description: create a new export
-      parameters:
-      - description: Export
-        in: body
-        name: export
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.ExportCreateRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/jsonapi.ExportResponse'
-        "422":
-          description: Unprocessable Entity
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Create an export
-      tags:
-      - exports
-  /exports/{id}:
-    delete:
-      consumes:
-      - application/vnd.api+json
-      description: delete an export
-      parameters:
-      - description: Export ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "204":
-          description: No Content
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Delete an export
-      tags:
-      - exports
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get export by ID
-      parameters:
-      - description: Export ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.ExportResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Get an export
-      tags:
-      - exports
-  /exports/{id}/download:
-    get:
-      consumes:
-      - application/octet-stream
-      description: Download an export XML file
-      parameters:
-      - description: Export ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/octet-stream
-      responses:
-        "200":
-          description: OK
-          schema:
-            type: file
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Download an export file
-      tags:
-      - exports
-  /exports/{id}/restores:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get restore operations for an export
-      parameters:
-      - description: Export ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.RestoreOperationsResponse'
-      summary: List export restore operations
-      tags:
-      - exports
-    post:
-      consumes:
-      - application/vnd.api+json
-      description: create a new restore operation for an export
-      parameters:
-      - description: Export ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Restore operation data
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.RestoreOperationCreateRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/jsonapi.RestoreOperationResponse'
-        "400":
-          description: Bad request
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "404":
-          description: Not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Create export restore operation
-      tags:
-      - exports
-  /exports/{id}/restores/{restoreId}:
-    delete:
-      consumes:
-      - application/vnd.api+json
-      description: delete a restore operation for an export
-      parameters:
-      - description: Export ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Restore Operation ID
-        in: path
-        name: restoreId
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "204":
-          description: No Content
-        "404":
-          description: Not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Delete export restore operation
-      tags:
-      - exports
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get restore operation by ID for an export
-      parameters:
-      - description: Export ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Restore Operation ID
-        in: path
-        name: restoreId
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.RestoreOperationResponse'
-        "404":
-          description: Not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Get export restore operation
-      tags:
-      - exports
-  /exports/import:
-    post:
-      consumes:
-      - application/vnd.api+json
-      description: Import an uploaded XML export file and create an export record
-      parameters:
-      - description: Import request data
-        in: body
-        name: data
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.ImportExportRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/jsonapi.ExportResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "422":
-          description: Unprocessable Entity
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Import XML export
-      tags:
-      - exports
-  /files:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get files with optional filtering
-      parameters:
-      - description: Filter by file type
-        enum:
-        - image
-        - document
-        - video
-        - audio
-        - archive
-        - other
-        in: query
-        name: type
-        type: string
-      - description: Filter by file category
-        enum:
-        - photos
-        - invoices
-        - documents
-        - other
-        in: query
-        name: category
-        type: string
-      - description: Search in title, description, and file paths
-        in: query
-        name: search
-        type: string
-      - description: Filter by tags (comma-separated)
-        in: query
-        name: tags
-        type: string
-      - description: Filter by linked entity type (e.g. commodity, location, export).
-          Must be supplied together with linked_entity_id.
-        in: query
-        name: linked_entity_type
-        type: string
-      - description: Filter by linked entity id. Must be supplied together with linked_entity_type.
-        in: query
-        name: linked_entity_id
-        type: string
-      - default: 1
-        description: Page number (1-based)
-        in: query
-        name: page
-        type: integer
-      - default: 20
-        description: Items per page
-        in: query
-        name: limit
-        type: integer
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.FilesResponse'
-        "400":
-          description: Invalid query parameter
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: List files
-      tags:
-      - files
-    post:
-      consumes:
-      - application/vnd.api+json
-      description: create a new file entity with metadata (file upload handled separately)
-      parameters:
-      - description: File metadata
-        in: body
-        name: file
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.FileRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/jsonapi.FileResponse'
-        "422":
-          description: Validation error
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Create a file entity
-      tags:
-      - files
-  /files/{id}:
-    delete:
-      consumes:
-      - application/vnd.api+json
-      description: delete file and its associated file
-      parameters:
-      - description: File ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "204":
-          description: No Content
-        "404":
-          description: File not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Delete a file
-      tags:
-      - files
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get file by ID
-      parameters:
-      - description: File ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.FileResponse'
-        "404":
-          description: File not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Get a file
-      tags:
-      - files
-    put:
-      consumes:
-      - application/vnd.api+json
-      description: update file metadata
-      parameters:
-      - description: File ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: File update data
-        in: body
-        name: file
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.FileUpdateRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.FileResponse'
-        "404":
-          description: File not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "422":
-          description: Validation error
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Update a file
-      tags:
-      - files
-  /files/{id}/signed-url:
-    post:
-      description: Generate a secure signed URL for downloading a file
-      parameters:
-      - description: File ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: Signed URL
-          schema:
-            $ref: '#/definitions/jsonapi.SignedFileURLResponse'
-        "404":
-          description: File not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Generate signed URL for file download
-      tags:
-      - files
-  /files/bulk-delete:
-    post:
-      consumes:
-      - application/vnd.api+json
-      description: |-
-        Delete every file whose id appears in the body, including
-        the physical blob. The response lists succeeded vs.
-        failed ids so the frontend can render partial-failure UX
-        without parsing per-id HTTP statuses.
-      parameters:
-      - description: List of file IDs to delete
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.BulkIDsRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: Per-id outcome
-          schema:
-            $ref: '#/definitions/jsonapi.BulkResultResponse'
-        "422":
-          description: Bad request body
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Bulk-delete files
-      tags:
-      - files
-  /files/category-counts:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: Per-category file counts, respecting the same filters as GET /files
-      parameters:
-      - description: Filter by file type
-        enum:
-        - image
-        - document
-        - video
-        - audio
-        - archive
-        - other
-        in: query
-        name: type
-        type: string
-      - description: Search in title, description, and file paths
-        in: query
-        name: search
-        type: string
-      - description: Filter by tags (comma-separated)
-        in: query
-        name: tags
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.FileCategoryCountsResponse'
-      summary: File category counts
-      tags:
-      - files
   /files/download/files/{fileID}:
     get:
       description: Download the original file content by file ID. Requires a valid
@@ -3010,6 +2129,1732 @@ paths:
       summary: Request a password reset
       tags:
       - auth
+  /g/{groupSlug}/areas:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get areas
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Page number (default 1)
+        in: query
+        name: page
+        type: integer
+      - description: Items per page (default 50, max 100)
+        in: query
+        name: per_page
+        type: integer
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.AreasResponse'
+      summary: List areas
+      tags:
+      - areas
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: add by area data
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Area object
+        in: body
+        name: area
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.AreaRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Area created
+          schema:
+            $ref: '#/definitions/jsonapi.AreaResponse'
+        "404":
+          description: Area not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: User-side request problem
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Create a new area
+      tags:
+      - areas
+  /g/{groupSlug}/areas/{areaID}:
+    delete:
+      consumes:
+      - application/vnd.api+json
+      description: Delete by area ID
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Area ID
+        in: path
+        name: areaID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "204":
+          description: No content
+        "404":
+          description: Area not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Delete an area
+      tags:
+      - areas
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get area by ID
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Area ID
+        in: path
+        name: areaID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.AreaResponse'
+      summary: Get an area
+      tags:
+      - areas
+    put:
+      consumes:
+      - application/vnd.api+json
+      description: Update by area data
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Area ID
+        in: path
+        name: areaID
+        required: true
+        type: string
+      - description: Area object
+        in: body
+        name: area
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.AreaRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.AreaResponse'
+        "404":
+          description: Area not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: User-side request problem
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Update a area
+      tags:
+      - areas
+  /g/{groupSlug}/commodities:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get commodities
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Page number (default 1)
+        in: query
+        name: page
+        type: integer
+      - description: Items per page (default 50, max 100)
+        in: query
+        name: per_page
+        type: integer
+      - collectionFormat: multi
+        description: Filter by commodity type; repeat to OR
+        in: query
+        items:
+          type: string
+        name: type
+        type: array
+      - collectionFormat: multi
+        description: Filter by status (in_use, sold, lost, disposed, written_off);
+          repeat to OR
+        in: query
+        items:
+          type: string
+        name: status
+        type: array
+      - description: Filter by exact area ID
+        in: query
+        name: area_id
+        type: string
+      - description: Case-insensitive substring match on name + short_name
+        in: query
+        name: q
+        type: string
+      - description: Include drafts and non-in_use commodities (default false hides
+          them)
+        in: query
+        name: include_inactive
+        type: boolean
+      - description: Sort field — name|registered_date|purchase_date|current_price|original_price|count,
+          prefix with '-' for descending
+        in: query
+        name: sort
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.CommoditiesResponse'
+      summary: List commodities
+      tags:
+      - commodities
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: Add a new commodity
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Commodity object
+        in: body
+        name: commodity
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.CommodityRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Commodity created
+          schema:
+            $ref: '#/definitions/jsonapi.CommodityResponse'
+        "422":
+          description: User-side request problem
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Create a new commodity
+      tags:
+      - commodities
+  /g/{groupSlug}/commodities/{commodityID}:
+    delete:
+      consumes:
+      - application/vnd.api+json
+      description: Delete a commodity by ID and all its linked files
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Commodity ID
+        in: path
+        name: commodityID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "204":
+          description: No content
+        "404":
+          description: Commodity not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Delete a commodity
+      tags:
+      - commodities
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get commodity by ID
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Commodity ID
+        in: path
+        name: commodityID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.CommodityResponse'
+      summary: Get a commodity
+      tags:
+      - commodities
+    put:
+      consumes:
+      - application/vnd.api+json
+      description: Update a commodity
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Commodity ID
+        in: path
+        name: commodityID
+        required: true
+        type: string
+      - description: Commodity object
+        in: body
+        name: commodity
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.CommodityRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.CommodityResponse'
+        "404":
+          description: Commodity not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: User-side request problem
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Update a commodity
+      tags:
+      - commodities
+  /g/{groupSlug}/commodities/bulk-delete:
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: |-
+        Delete every commodity whose id appears in the body. The
+        response lists succeeded vs. failed ids so the frontend
+        can render partial-failure UX without parsing per-id HTTP
+        statuses.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: List of commodity IDs to delete
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.BulkIDsRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: Per-id outcome
+          schema:
+            $ref: '#/definitions/jsonapi.BulkResultResponse'
+        "422":
+          description: Bad request body
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Bulk-delete commodities
+      tags:
+      - commodities
+  /g/{groupSlug}/commodities/bulk-move:
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: |-
+        Update every commodity whose id appears in the body to
+        belong to the supplied area_id.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: List of commodity IDs and the destination area_id
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.BulkMoveRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: Per-id outcome
+          schema:
+            $ref: '#/definitions/jsonapi.BulkResultResponse'
+        "422":
+          description: Bad request body
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Bulk-move commodities to a new area
+      tags:
+      - commodities
+  /g/{groupSlug}/commodities/values:
+    get:
+      consumes:
+      - application/json
+      description: Get the total value of commodities globally, by location, and by
+        area
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.ValueResponse'
+      summary: Get total value of commodities
+      tags:
+      - commodities
+  /g/{groupSlug}/exports:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get exports
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Include deleted exports
+        in: query
+        name: include_deleted
+        type: boolean
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.ExportsResponse'
+      summary: List exports
+      tags:
+      - exports
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: create a new export
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Export
+        in: body
+        name: export
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.ExportCreateRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/jsonapi.ExportResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Create an export
+      tags:
+      - exports
+  /g/{groupSlug}/exports/{id}:
+    delete:
+      consumes:
+      - application/vnd.api+json
+      description: delete an export
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Export ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Delete an export
+      tags:
+      - exports
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get export by ID
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Export ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.ExportResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Get an export
+      tags:
+      - exports
+  /g/{groupSlug}/exports/{id}/download:
+    get:
+      consumes:
+      - application/octet-stream
+      description: Download an export XML file
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Export ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/octet-stream
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Download an export file
+      tags:
+      - exports
+  /g/{groupSlug}/exports/{id}/restores:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get restore operations for an export
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Export ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.RestoreOperationsResponse'
+      summary: List export restore operations
+      tags:
+      - exports
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: create a new restore operation for an export
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Export ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Restore operation data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.RestoreOperationCreateRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/jsonapi.RestoreOperationResponse'
+        "400":
+          description: Bad request
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Create export restore operation
+      tags:
+      - exports
+  /g/{groupSlug}/exports/{id}/restores/{restoreId}:
+    delete:
+      consumes:
+      - application/vnd.api+json
+      description: delete a restore operation for an export
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Export ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Restore Operation ID
+        in: path
+        name: restoreId
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Delete export restore operation
+      tags:
+      - exports
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get restore operation by ID for an export
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Export ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Restore Operation ID
+        in: path
+        name: restoreId
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.RestoreOperationResponse'
+        "404":
+          description: Not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Get export restore operation
+      tags:
+      - exports
+  /g/{groupSlug}/exports/import:
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: Import an uploaded XML export file and create an export record
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Import request data
+        in: body
+        name: data
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.ImportExportRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/jsonapi.ExportResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Import XML export
+      tags:
+      - exports
+  /g/{groupSlug}/files:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get files with optional filtering
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Filter by file type
+        enum:
+        - image
+        - document
+        - video
+        - audio
+        - archive
+        - other
+        in: query
+        name: type
+        type: string
+      - description: Filter by file category
+        enum:
+        - photos
+        - invoices
+        - documents
+        - other
+        in: query
+        name: category
+        type: string
+      - description: Search in title, description, and file paths
+        in: query
+        name: search
+        type: string
+      - description: Filter by tags (comma-separated)
+        in: query
+        name: tags
+        type: string
+      - description: Filter by linked entity type (e.g. commodity, location, export).
+          Must be supplied together with linked_entity_id.
+        in: query
+        name: linked_entity_type
+        type: string
+      - description: Filter by linked entity id. Must be supplied together with linked_entity_type.
+        in: query
+        name: linked_entity_id
+        type: string
+      - default: 1
+        description: Page number (1-based)
+        in: query
+        name: page
+        type: integer
+      - default: 20
+        description: Items per page
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.FilesResponse'
+        "400":
+          description: Invalid query parameter
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: List files
+      tags:
+      - files
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: create a new file entity with metadata (file upload handled separately)
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: File metadata
+        in: body
+        name: file
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.FileRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/jsonapi.FileResponse'
+        "422":
+          description: Validation error
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Create a file entity
+      tags:
+      - files
+  /g/{groupSlug}/files/{fileID}:
+    delete:
+      consumes:
+      - application/vnd.api+json
+      description: delete file and its associated file
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: File ID
+        in: path
+        name: fileID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: File not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Delete a file
+      tags:
+      - files
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get file by ID
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: File ID
+        in: path
+        name: fileID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.FileResponse'
+        "404":
+          description: File not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Get a file
+      tags:
+      - files
+    put:
+      consumes:
+      - application/vnd.api+json
+      description: update file metadata
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: File ID
+        in: path
+        name: fileID
+        required: true
+        type: string
+      - description: File update data
+        in: body
+        name: file
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.FileUpdateRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.FileResponse'
+        "404":
+          description: File not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Validation error
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Update a file
+      tags:
+      - files
+  /g/{groupSlug}/files/{fileID}/signed-url:
+    post:
+      description: Generate a secure signed URL for downloading a file
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: File ID
+        in: path
+        name: fileID
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Signed URL
+          schema:
+            $ref: '#/definitions/jsonapi.SignedFileURLResponse'
+        "404":
+          description: File not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Generate signed URL for file download
+      tags:
+      - files
+  /g/{groupSlug}/files/bulk-delete:
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: |-
+        Delete every file whose id appears in the body, including
+        the physical blob. The response lists succeeded vs.
+        failed ids so the frontend can render partial-failure UX
+        without parsing per-id HTTP statuses.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: List of file IDs to delete
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.BulkIDsRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: Per-id outcome
+          schema:
+            $ref: '#/definitions/jsonapi.BulkResultResponse'
+        "422":
+          description: Bad request body
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Bulk-delete files
+      tags:
+      - files
+  /g/{groupSlug}/files/category-counts:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: Per-category file counts, respecting the same filters as GET /files
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Filter by file type
+        enum:
+        - image
+        - document
+        - video
+        - audio
+        - archive
+        - other
+        in: query
+        name: type
+        type: string
+      - description: Search in title, description, and file paths
+        in: query
+        name: search
+        type: string
+      - description: Filter by tags (comma-separated)
+        in: query
+        name: tags
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.FileCategoryCountsResponse'
+      summary: File category counts
+      tags:
+      - files
+  /g/{groupSlug}/locations:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get locations
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Page number (default 1)
+        in: query
+        name: page
+        type: integer
+      - description: Items per page (default 50, max 100)
+        in: query
+        name: per_page
+        type: integer
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.LocationsResponse'
+      summary: List locations
+      tags:
+      - locations
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: add by location data
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Location object
+        in: body
+        name: location
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.LocationRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Location created
+          schema:
+            $ref: '#/definitions/jsonapi.LocationResponse'
+        "404":
+          description: Location not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: User-side request problem
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Create a new location
+      tags:
+      - locations
+  /g/{groupSlug}/locations/{locationID}:
+    delete:
+      consumes:
+      - application/vnd.api+json
+      description: Delete by location ID
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Location ID
+        in: path
+        name: locationID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "204":
+          description: No content
+        "404":
+          description: Location not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Delete a location
+      tags:
+      - locations
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get location by ID
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Location ID
+        in: path
+        name: locationID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.LocationResponse'
+      summary: Get a location
+      tags:
+      - locations
+    put:
+      consumes:
+      - application/vnd.api+json
+      description: Update by location data
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Location ID
+        in: path
+        name: locationID
+        required: true
+        type: string
+      - description: Location object
+        in: body
+        name: location
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.LocationRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.LocationResponse'
+        "404":
+          description: Location not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: User-side request problem
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Update a location
+      tags:
+      - locations
+  /g/{groupSlug}/search:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: Perform advanced search across commodities, files, and other entities
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Search query
+        in: query
+        name: q
+        required: true
+        type: string
+      - description: Entity type to search
+        enum:
+        - commodities
+        - files
+        - areas
+        - locations
+        in: query
+        name: type
+        type: string
+      - default: 20
+        description: Maximum number of results
+        in: query
+        name: limit
+        type: integer
+      - default: 0
+        description: Number of results to skip
+        in: query
+        name: offset
+        type: integer
+      - description: Filter by tags (comma-separated)
+        in: query
+        name: tags
+        type: string
+      - default: OR
+        description: Tag operator
+        enum:
+        - AND
+        - OR
+        in: query
+        name: operator
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: Search results
+          schema:
+            $ref: '#/definitions/jsonapi.SearchResponse'
+      summary: Advanced search
+      tags:
+      - search
+  /g/{groupSlug}/settings:
+    get:
+      consumes:
+      - application/json
+      description: get current settings
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.SettingsObject'
+      summary: Get current settings
+      tags:
+      - settings
+    put:
+      consumes:
+      - application/json
+      description: update entire settings object
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Settings object with documented snake_case field names
+        in: body
+        name: settings
+        required: true
+        schema:
+          $ref: '#/definitions/apiserver.SettingsUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.SettingsObject'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+      summary: Update settings
+      tags:
+      - settings
+  /g/{groupSlug}/settings/{field}:
+    patch:
+      consumes:
+      - application/json
+      description: update a specific setting field.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Setting field path (e.g., uiconfig.theme)
+        in: path
+        name: field
+        required: true
+        type: string
+      - description: Setting value envelope with required value.
+        in: body
+        name: value
+        required: true
+        schema:
+          $ref: '#/definitions/apiserver.PatchSettingRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.SettingsObject'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+      summary: Patch setting
+      tags:
+      - settings
+  /g/{groupSlug}/tags:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get tags with optional filtering. Pass include=usage to attach
+        a per-row meta.usage block.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Search by label or slug
+        in: query
+        name: q
+        type: string
+      - description: Sort field (label, created_at, usage)
+        enum:
+        - label
+        - created_at
+        - usage
+        in: query
+        name: sort
+        type: string
+      - default: asc
+        description: Sort direction (asc, desc)
+        in: query
+        name: order
+        type: string
+      - default: 1
+        description: Page number (1-based)
+        in: query
+        name: page
+        type: integer
+      - default: 50
+        description: Items per page
+        in: query
+        name: per_page
+        type: integer
+      - description: Comma-separated extras. 'usage' attaches per-row meta.usage.
+        enum:
+        - usage
+        in: query
+        name: include
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.TagsResponse'
+      summary: List tags
+      tags:
+      - tags
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: add a tag with slug, label, color
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Tag object
+        in: body
+        name: tag
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.TagRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Tag created
+          schema:
+            $ref: '#/definitions/jsonapi.TagResponse'
+        "422":
+          description: User-side request problem
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Create a new tag
+      tags:
+      - tags
+  /g/{groupSlug}/tags/{tagID}:
+    delete:
+      consumes:
+      - application/vnd.api+json
+      description: Delete tag by ID. Returns 409 with usage breakdown when in use;
+        pass ?force=true to strip references.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Tag ID
+        in: path
+        name: tagID
+        required: true
+        type: string
+      - description: Strip JSONB references then delete
+        in: query
+        name: force
+        type: boolean
+      produces:
+      - application/vnd.api+json
+      responses:
+        "204":
+          description: No content
+        "404":
+          description: Tag not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "409":
+          description: Tag is in use; pass force=true to strip references
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Delete a tag
+      tags:
+      - tags
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: get tag by ID with usage breakdown
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Tag ID
+        in: path
+        name: tagID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.TagResponse'
+        "404":
+          description: Tag not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Get a tag
+      tags:
+      - tags
+    patch:
+      consumes:
+      - application/vnd.api+json
+      description: Patch label/color/slug. Slug change rewrites JSONB references.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Tag ID
+        in: path
+        name: tagID
+        required: true
+        type: string
+      - description: Tag patch payload
+        in: body
+        name: tag
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.TagUpdateRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.TagResponse'
+        "404":
+          description: Tag not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "409":
+          description: Slug already in use
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: User-side request problem
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Update a tag
+      tags:
+      - tags
+  /g/{groupSlug}/tags/autocomplete:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: Top-N tags matching the query, ranked by usage desc + created_at
+        desc.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Substring match against label and slug
+        in: query
+        name: q
+        type: string
+      - default: 10
+        description: Maximum suggestions returned
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.TagAutocompleteResponse'
+      summary: Autocomplete tag suggestions
+      tags:
+      - tags
+  /g/{groupSlug}/tags/stats:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: Returns total tags, plus tagged/untagged counts on commodities
+        and files for the current group.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.TagStatsResponse'
+      summary: Tag adoption stats
+      tags:
+      - tags
+  /g/{groupSlug}/upload-slots/check:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: Check if user can start an upload for a specific operation
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Operation name
+        example: image_upload
+        in: query
+        name: operation
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: Upload capacity available
+          schema:
+            $ref: '#/definitions/jsonapi.UploadStatusResponse'
+        "400":
+          description: Bad request
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "429":
+          description: Too many concurrent uploads
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Check upload capacity
+      tags:
+      - upload-slots
+  /g/{groupSlug}/upload-slots/status:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: Get current upload status for a specific operation
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Operation name
+        example: image_upload
+        in: query
+        name: operation
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: Upload status retrieved successfully
+          schema:
+            $ref: '#/definitions/jsonapi.UploadStatusResponse'
+        "400":
+          description: Bad request
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Get upload status
+      tags:
+      - upload-slots
+  /g/{groupSlug}/uploads/file:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Upload a single file of any type. The file is stored and a file
+        entity is created without a linked entity.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: File to upload
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/jsonapi.FileResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Upload a file
+      tags:
+      - uploads
+  /g/{groupSlug}/uploads/restores:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Upload an XML backup file to be used for a restore operation.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: XML backup file to upload
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.UploadResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Upload restore file
+      tags:
+      - uploads
   /groups:
     get:
       consumes:
@@ -3436,136 +4281,6 @@ paths:
       summary: Accept invite
       tags:
       - invites
-  /locations:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get locations
-      parameters:
-      - description: Page number (default 1)
-        in: query
-        name: page
-        type: integer
-      - description: Items per page (default 50, max 100)
-        in: query
-        name: per_page
-        type: integer
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.LocationsResponse'
-      summary: List locations
-      tags:
-      - locations
-    post:
-      consumes:
-      - application/vnd.api+json
-      description: add by location data
-      parameters:
-      - description: Location object
-        in: body
-        name: location
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.LocationRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "201":
-          description: Location created
-          schema:
-            $ref: '#/definitions/jsonapi.LocationResponse'
-        "404":
-          description: Location not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "422":
-          description: User-side request problem
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Create a new location
-      tags:
-      - locations
-  /locations/{id}:
-    delete:
-      consumes:
-      - application/vnd.api+json
-      description: Delete by location ID
-      parameters:
-      - description: Location ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "204":
-          description: No content
-        "404":
-          description: Location not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Delete a location
-      tags:
-      - locations
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get location by ID
-      parameters:
-      - description: Location ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.LocationResponse'
-      summary: Get a location
-      tags:
-      - locations
-    put:
-      consumes:
-      - application/vnd.api+json
-      description: Update by location data
-      parameters:
-      - description: Location ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Location object
-        in: body
-        name: location
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.LocationRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.LocationResponse'
-        "404":
-          description: Location not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "422":
-          description: User-side request problem
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Update a location
-      tags:
-      - locations
   /register:
     post:
       consumes:
@@ -3673,58 +4388,6 @@ paths:
       summary: Reset password using a token
       tags:
       - auth
-  /search:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: Perform advanced search across commodities, files, and other entities
-      parameters:
-      - description: Search query
-        in: query
-        name: q
-        required: true
-        type: string
-      - description: Entity type to search
-        enum:
-        - commodities
-        - files
-        - areas
-        - locations
-        in: query
-        name: type
-        type: string
-      - default: 20
-        description: Maximum number of results
-        in: query
-        name: limit
-        type: integer
-      - default: 0
-        description: Number of results to skip
-        in: query
-        name: offset
-        type: integer
-      - description: Filter by tags (comma-separated)
-        in: query
-        name: tags
-        type: string
-      - default: OR
-        description: Tag operator
-        enum:
-        - AND
-        - OR
-        in: query
-        name: operator
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: Search results
-          schema:
-            $ref: '#/definitions/jsonapi.SearchResponse'
-      summary: Advanced search
-      tags:
-      - search
   /seed:
     post:
       consumes:
@@ -3749,77 +4412,6 @@ paths:
       summary: Seed database
       tags:
       - admin
-  /settings:
-    get:
-      consumes:
-      - application/json
-      description: get current settings
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/models.SettingsObject'
-      summary: Get current settings
-      tags:
-      - settings
-    put:
-      consumes:
-      - application/json
-      description: update entire settings object
-      parameters:
-      - description: Settings object with documented snake_case field names
-        in: body
-        name: settings
-        required: true
-        schema:
-          $ref: '#/definitions/apiserver.SettingsUpdateRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/models.SettingsObject'
-        "400":
-          description: Bad Request
-          schema:
-            type: string
-      summary: Update settings
-      tags:
-      - settings
-  /settings/{field}:
-    patch:
-      consumes:
-      - application/json
-      description: update a specific setting field.
-      parameters:
-      - description: Setting field path (e.g., uiconfig.theme)
-        in: path
-        name: field
-        required: true
-        type: string
-      - description: Setting value envelope with required value.
-        in: body
-        name: value
-        required: true
-        schema:
-          $ref: '#/definitions/apiserver.PatchSettingRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/models.SettingsObject'
-        "400":
-          description: Bad Request
-          schema:
-            type: string
-      summary: Patch setting
-      tags:
-      - settings
   /system:
     get:
       consumes:
@@ -3836,340 +4428,6 @@ paths:
       summary: Get system information
       tags:
       - system
-  /tags:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get tags with optional filtering. Pass include=usage to attach
-        a per-row meta.usage block.
-      parameters:
-      - description: Search by label or slug
-        in: query
-        name: q
-        type: string
-      - description: Sort field (label, created_at, usage)
-        enum:
-        - label
-        - created_at
-        - usage
-        in: query
-        name: sort
-        type: string
-      - default: asc
-        description: Sort direction (asc, desc)
-        in: query
-        name: order
-        type: string
-      - default: 1
-        description: Page number (1-based)
-        in: query
-        name: page
-        type: integer
-      - default: 50
-        description: Items per page
-        in: query
-        name: per_page
-        type: integer
-      - description: Comma-separated extras. 'usage' attaches per-row meta.usage.
-        enum:
-        - usage
-        in: query
-        name: include
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.TagsResponse'
-      summary: List tags
-      tags:
-      - tags
-    post:
-      consumes:
-      - application/vnd.api+json
-      description: add a tag with slug, label, color
-      parameters:
-      - description: Tag object
-        in: body
-        name: tag
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.TagRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "201":
-          description: Tag created
-          schema:
-            $ref: '#/definitions/jsonapi.TagResponse'
-        "422":
-          description: User-side request problem
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Create a new tag
-      tags:
-      - tags
-  /tags/{id}:
-    delete:
-      consumes:
-      - application/vnd.api+json
-      description: Delete tag by ID. Returns 409 with usage breakdown when in use;
-        pass ?force=true to strip references.
-      parameters:
-      - description: Tag ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Strip JSONB references then delete
-        in: query
-        name: force
-        type: boolean
-      produces:
-      - application/vnd.api+json
-      responses:
-        "204":
-          description: No content
-        "404":
-          description: Tag not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "409":
-          description: Tag is in use; pass force=true to strip references
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Delete a tag
-      tags:
-      - tags
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: get tag by ID with usage breakdown
-      parameters:
-      - description: Tag ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.TagResponse'
-        "404":
-          description: Tag not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Get a tag
-      tags:
-      - tags
-    patch:
-      consumes:
-      - application/vnd.api+json
-      description: Patch label/color/slug. Slug change rewrites JSONB references.
-      parameters:
-      - description: Tag ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Tag patch payload
-        in: body
-        name: tag
-        required: true
-        schema:
-          $ref: '#/definitions/jsonapi.TagUpdateRequest'
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.TagResponse'
-        "404":
-          description: Tag not found
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "409":
-          description: Slug already in use
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "422":
-          description: User-side request problem
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Update a tag
-      tags:
-      - tags
-  /tags/autocomplete:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: Top-N tags matching the query, ranked by usage desc + created_at
-        desc.
-      parameters:
-      - description: Substring match against label and slug
-        in: query
-        name: q
-        type: string
-      - default: 10
-        description: Maximum suggestions returned
-        in: query
-        name: limit
-        type: integer
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.TagAutocompleteResponse'
-      summary: Autocomplete tag suggestions
-      tags:
-      - tags
-  /tags/stats:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: Returns total tags, plus tagged/untagged counts on commodities
-        and files for the current group.
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.TagStatsResponse'
-      summary: Tag adoption stats
-      tags:
-      - tags
-  /upload-slots/check:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: Check if user can start an upload for a specific operation
-      parameters:
-      - description: Operation name
-        example: image_upload
-        in: query
-        name: operation
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: Upload capacity available
-          schema:
-            $ref: '#/definitions/jsonapi.UploadStatusResponse'
-        "400":
-          description: Bad request
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "429":
-          description: Too many concurrent uploads
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Check upload capacity
-      tags:
-      - upload-slots
-  /upload-slots/status:
-    get:
-      consumes:
-      - application/vnd.api+json
-      description: Get current upload status for a specific operation
-      parameters:
-      - description: Operation name
-        example: image_upload
-        in: query
-        name: operation
-        required: true
-        type: string
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: Upload status retrieved successfully
-          schema:
-            $ref: '#/definitions/jsonapi.UploadStatusResponse'
-        "400":
-          description: Bad request
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-      summary: Get upload status
-      tags:
-      - upload-slots
-  /uploads/file:
-    post:
-      consumes:
-      - multipart/form-data
-      description: Upload a single file of any type. The file is stored and a file
-        entity is created without a linked entity.
-      parameters:
-      - description: File to upload
-        in: formData
-        name: file
-        required: true
-        type: file
-      produces:
-      - application/vnd.api+json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/jsonapi.FileResponse'
-        "422":
-          description: Unprocessable Entity
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "500":
-          description: Internal Server Error
-          schema:
-            type: string
-      summary: Upload a file
-      tags:
-      - uploads
-  /uploads/restores:
-    post:
-      consumes:
-      - multipart/form-data
-      description: Upload an XML backup file to be used for a restore operation.
-      parameters:
-      - description: XML backup file to upload
-        in: formData
-        name: file
-        required: true
-        type: file
-      produces:
-      - application/vnd.api+json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/jsonapi.UploadResponse'
-        "422":
-          description: Unprocessable Entity
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "500":
-          description: Internal Server Error
-          schema:
-            type: string
-      summary: Upload restore file
-      tags:
-      - uploads
   /verify-email:
     get:
       description: Activate a user account using the verification token sent by email.

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -2056,7 +2056,7 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            type: string
+            $ref: '#/definitions/jsonapi.Errors'
       summary: Download original file
       tags:
       - files
@@ -2092,7 +2092,7 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            type: string
+            $ref: '#/definitions/jsonapi.Errors'
       summary: Download file thumbnail
       tags:
       - files
@@ -3817,7 +3817,7 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            type: string
+            $ref: '#/definitions/jsonapi.Errors'
       summary: Upload a file
       tags:
       - uploads
@@ -3851,7 +3851,7 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            type: string
+            $ref: '#/definitions/jsonapi.Errors'
       summary: Upload restore file
       tags:
       - uploads


### PR DESCRIPTION
## Summary

- Reconciles every swag `@Router` / `@Param` block on group-scoped handlers (`areas`, `commodities`, `files`, `locations`, `tags`, `exports`, `export_restores`, `settings`, `search`, `values`, `upload_slots`, `uploads`) with the live chi router shape — `/api/v1/g/{groupSlug}/...` and the `{areaID}` / `{commodityID}` / `{fileID}` / `{locationID}` / `{tagID}` path-param names — closing the 51-route gap between annotations and the actual surface.
- Adds `TestSwaggerRouteCoverage` (`go/apiserver/swagger_route_coverage_test.go`) which walks the chi router returned by `apiserver.APIServer(...)`, decodes `docs/swagger.json`, and asserts a strict bidirectional match. Wired into `.github/workflows/go-swagger-docs.yml` right after the existing drift step.
- Regenerated `go/docs/{swagger.yaml,swagger.json,docs.go}` and `frontend/src/types/api.d.ts` via `make swagger`. FE typecheck + lint clean.
- `devdocs/backend/openapi.md` rewritten: dropped the “What's NOT yet checked” section and documented the new coverage gate plus the group-scoped annotation conventions.

Big-bang variant of the two paths in the issue — the diff is large but the change pattern is uniform (prefix + groupSlug param + entity-id rename), so a single review surface beats carrying a baseline file PR-by-PR.

Closes #1442. Follow-up to #1422. Parent epic #1397.

## Test plan

- [x] `make swagger-backend` produces a clean diff on a second run (no further drift).
- [x] `cd go && go test ./apiserver -count=1` passes — full suite including the new `TestSwaggerRouteCoverage`.
- [x] `cd go && go build ./...` succeeds.
- [x] `cd frontend && npm run codegen:check` reports `up to date`.
- [x] `cd frontend && npm run typecheck` clean.
- [x] `cd frontend && npm run lint` clean.
- [ ] CI green on the PR (Swagger Docs Sync incl. new coverage step + Frontend Codegen Drift + Go tests + e2e).