### PR TITLE
[#1424] FE devdocs rewrite for React stack + design-direction brief

### DIFF
--- a/devdocs/frontend/README.md
+++ b/devdocs/frontend/README.md
@@ -1,10 +1,9 @@
 # Frontend developer docs
 
-Engineering docs for `frontend/` — the React 19 + Tailwind v4 + shadcn/ui app
-that ships with Inventario. The canonical visual contract lives at
-[`denisvmedia/inventario-design`](https://github.com/denisvmedia/inventario-design)'s
-`CLAUDE.md`; this tree translates that into the conventions and patterns the
-real codebase uses.
+Engineering docs for `frontend/` — the React 19 + Tailwind v4 + shadcn/ui
+app that ships with Inventario. The canonical visual contract lives in
+the internal design mock; this tree translates that into the conventions
+and patterns the real codebase uses.
 
 ## When to read what
 
@@ -50,7 +49,7 @@ scaffolding artifacts (asserted by `go/apiserver/frontend_embed_test.go`).
 
 ## How this differs from the design mock
 
-The mock at `denisvmedia/inventario-design` is a single-page state-machine
+The design mock is a single-page state-machine
 demo (no router, no data layer, no i18n). The Inventario app keeps the
 mock's visual contract verbatim and wires it onto the same hierarchy of
 abstractions a multi-tenant CRUD app needs:
@@ -72,7 +71,7 @@ mirrored in [styles-and-tokens.md](styles-and-tokens.md) and
 
 - Epic: [#1397](https://github.com/denisvmedia/inventario/issues/1397) — full
   React rewrite (28 sub-issues #1398–#1425; this doc is #1424).
-- Visual contract: `denisvmedia/inventario-design/CLAUDE.md`.
+
 - Testing harness: [testing.md](testing.md) (#1418, PR #1433).
 - Perf gates: [perf.md](perf.md) (#1420, PR #1437).
 - Screenshots: [screenshots.md](screenshots.md).

--- a/devdocs/frontend/README.md
+++ b/devdocs/frontend/README.md
@@ -1,0 +1,80 @@
+# Frontend developer docs
+
+Engineering docs for `frontend/` — the React 19 + Tailwind v4 + shadcn/ui app
+that ships with Inventario. The canonical visual contract lives at
+[`denisvmedia/inventario-design`](https://github.com/denisvmedia/inventario-design)'s
+`CLAUDE.md`; this tree translates that into the conventions and patterns the
+real codebase uses.
+
+## When to read what
+
+| Doc | Read it when … |
+| --- | --- |
+| [coding-standards.md](coding-standards.md) | Naming, file structure, imports, formatting, console policy. |
+| [components.md](components.md) | Deciding where a new component lives (`components/ui` vs `components/` vs `features/<x>/components`). |
+| [styles-and-tokens.md](styles-and-tokens.md) | Adding a color, working with Tailwind v4 `@theme`, dark mode, density. |
+| [forms.md](forms.md) | Building a form with react-hook-form + zod and surfacing server errors. |
+| [icons.md](icons.md) | Picking an icon, sizing it, deciding `aria-hidden` vs `aria-label`. |
+| [accessibility.md](accessibility.md) | Focus rings, label/htmlFor, modal a11y, contrast, reduced motion. |
+| [data.md](data.md) | TanStack Query keys, mutations, optimistic updates, cache invalidation. |
+| [routing.md](routing.md) | Adding a route, group context, route guards. |
+| [i18n.md](i18n.md) | Adding a translatable string, namespaces, locale fallback, `preservePatterns`. |
+| [imports-and-bans.md](imports-and-bans.md) | Why a dependency is on the no-fly list (next-themes, @base-ui/react, FontAwesome, Bolt artifacts). |
+| [testing.md](testing.md) | Vitest harness, MSW handler factories, jest-axe, coverage thresholds. |
+| [perf.md](perf.md) | Bundle-size + Lighthouse gates and what to do when they trip. |
+| [screenshots.md](screenshots.md) | Capturing local screenshots end-to-end (seed → server → script). |
+| [migration-conventions.md](migration-conventions.md) | History/cutover notes — Vue→React rewrite (epic #1397). |
+| [pr-checklist.md](pr-checklist.md) | Copy-paste PR checklist for FE changes. |
+| [design/README.md](design/README.md) | Design-direction brief — 23 docs. Read when working on a new surface or arguing about taste. |
+
+## Stack at a glance
+
+| Layer | Choice | Pinned in `frontend/package.json` |
+| --- | --- | --- |
+| Framework | React 19 + TypeScript (strict) + Vite 8 | `react`, `react-dom`, `vite` |
+| Styling | Tailwind v4 (OKLCH tokens) + `tw-animate-css` | `tailwindcss`, `tw-animate-css` |
+| Components | shadcn/ui (new-york / neutral) on Radix primitives via the `radix-ui` umbrella | `radix-ui` |
+| Icons | `lucide-react` only | `lucide-react` |
+| Forms | `react-hook-form` + `zod` (via `@hookform/resolvers/zod`) | `react-hook-form`, `zod`, `@hookform/resolvers` |
+| Data | TanStack Query 5 + a tiny `lib/http.ts` wrapper | `@tanstack/react-query` |
+| Routing | `react-router-dom` v7 (declarative `<Routes>`) | `react-router-dom` |
+| i18n | `react-i18next` + lazy-loaded cs/ru namespaces | `i18next`, `react-i18next` |
+| Toasts | `sonner` | `sonner` |
+| Command palette | `cmdk` | `cmdk` |
+| Tests | Vitest + RTL + jest-axe + MSW | `vitest`, `@testing-library/react`, `jest-axe`, `msw` |
+
+Hard bans live in [imports-and-bans.md](imports-and-bans.md). The short list:
+no `next-themes` (Vite SPA, not Next.js), no `@base-ui/react` (we lock to
+Radix), no FontAwesome / PrimeIcons (Lucide only), no leftover Bolt
+scaffolding artifacts (asserted by `go/apiserver/frontend_embed_test.go`).
+
+## How this differs from the design mock
+
+The mock at `denisvmedia/inventario-design` is a single-page state-machine
+demo (no router, no data layer, no i18n). The Inventario app keeps the
+mock's visual contract verbatim and wires it onto the same hierarchy of
+abstractions a multi-tenant CRUD app needs:
+
+| Mock | Inventario |
+| --- | --- |
+| `view` state in `App.tsx` | `react-router-dom` v7 routes (`src/app/router.tsx`) |
+| `MOCK_ITEMS.find(...)` | TanStack Query hooks per feature (`features/<name>/hooks.ts`) |
+| Inline strings | `t("namespace:key")` via react-i18next, en bundled + cs/ru lazy |
+| Plain prop drilling | Feature contexts (`AuthContext`, `GroupContext`) for cross-cutting state |
+| One JSON `mock.ts` | OpenAPI-generated DTOs in `src/types/api.d.ts` + per-feature `api.ts` |
+
+The visual rules (no `forwardRef`, no `hsl()` wrappers, no
+`@tailwindcss/animate`, OKLCH tokens, no purple, no drop shadows) are
+mirrored in [styles-and-tokens.md](styles-and-tokens.md) and
+[components.md](components.md).
+
+## Cross-references
+
+- Epic: [#1397](https://github.com/denisvmedia/inventario/issues/1397) — full
+  React rewrite (28 sub-issues #1398–#1425; this doc is #1424).
+- Visual contract: `denisvmedia/inventario-design/CLAUDE.md`.
+- Testing harness: [testing.md](testing.md) (#1418, PR #1433).
+- Perf gates: [perf.md](perf.md) (#1420, PR #1437).
+- Screenshots: [screenshots.md](screenshots.md).
+- Migration history: [migration-conventions.md](migration-conventions.md)
+  (cutover #1423, PR #1457).

--- a/devdocs/frontend/accessibility.md
+++ b/devdocs/frontend/accessibility.md
@@ -1,0 +1,171 @@
+# Accessibility
+
+The shadcn primitives ship with sensible a11y defaults; the rules below
+keep the rest of the codebase from undoing them. Lighthouse, jest-axe,
+and `@axe-core/playwright` all run in CI — see [perf.md](perf.md) and
+[testing.md](testing.md) for the gates.
+
+## Targets
+
+| Surface | Tool | Threshold |
+| --- | --- | --- |
+| Unit / integration | `jest-axe` | No violations at `critical` or `serious` |
+| End-to-end | `@axe-core/playwright` | Same — see `e2e/utils/axe.ts` |
+| In-browser audit | Lighthouse `accessibility` | ≥ 0.95 |
+
+If a violation is genuinely intentional (a vendored Radix primitive's
+known issue), suppress it locally with `runOptions` rather than skipping
+the test or weakening the threshold globally.
+
+## Focus
+
+- **Never `outline: none` without a replacement.** shadcn primitives use
+  `focus-visible:ring-[3px] focus-visible:ring-ring/50` — keep it. The
+  ring color (`--ring`) is amber in light mode and a brighter amber in
+  dark; both meet 3:1 contrast against their adjacent surfaces.
+- **`focus-visible:`, not `focus:`.** Visible focus rings appear only for
+  keyboard users; mouse-clickers don't see the ring around a button they
+  just pressed. shadcn does this correctly out of the box; mirror it
+  when you write a new interactive element.
+- **Trap focus inside modals.** Radix `<Dialog>`, `<AlertDialog>`,
+  `<Sheet>`, `<DropdownMenu>` already do this. Don't roll your own
+  modal — use the primitive.
+- **Initial focus.** Radix returns focus to the trigger when the modal
+  closes. If you need a specific control to focus on open, use Radix's
+  `onOpenAutoFocus` / `<DialogContent autoFocus={false}>` and ref the
+  target manually.
+
+## Labels
+
+- **Every form field has a programmatic label.** Either:
+  ```tsx
+  <Label htmlFor="email">{t("auth:login.email")}</Label>
+  <Input id="email" {...form.register("email")} />
+  ```
+  or use `aria-label` when the visual label is intentionally absent
+  (e.g. a search box where the placeholder is the only cue).
+- **`<label>` and `htmlFor` are always paired.** A floating `<label>`
+  above an input without `htmlFor` is a11y debt. ESLint's
+  `jsx-a11y/label-has-associated-control` catches the obvious cases —
+  see `frontend/eslint.config.js`.
+- **Icon-only controls need an explicit label.** `<Button size="icon">`
+  must include an `aria-label`. See [icons.md](icons.md).
+- **Form errors associate via `aria-invalid` + `aria-describedby`.** The
+  shadcn `Field`/`FieldError` primitives wire this; for plain
+  `Input + Label`, set `aria-invalid={!!error}` and render the error
+  text in an element with the same `id` referenced via
+  `aria-describedby`.
+
+## Modals
+
+Use Radix primitives:
+
+| Need | Primitive |
+| --- | --- |
+| Generic dialog with form | `Dialog` (`@/components/ui/dialog`) |
+| Destructive confirmation | `AlertDialog` (`@/components/ui/alert-dialog` via `useConfirm()`) |
+| Side-sheet (item detail, settings preview) | `Sheet` (`@/components/ui/sheet`) |
+| Popover (combobox, date picker) | `Popover` |
+| Dropdown menu (kebab actions) | `DropdownMenu` |
+
+Rules:
+
+- **Title + description.** Always render `<DialogTitle>` and
+  `<DialogDescription>`. Radix wires them to `aria-labelledby` /
+  `aria-describedby` on the dialog content. If you don't render a
+  title, axe complains.
+- **Close on Esc and backdrop click.** Radix does this; don't override
+  `onPointerDownOutside` / `onEscapeKeyDown` to disable closure unless
+  you have a reason (an unsaved-changes guard, e.g.).
+- **No `window.confirm()` / `alert()`.** Use `<AlertDialog>` or
+  `useConfirm()`. Native dialogs aren't styleable, aren't translatable,
+  and break in tests.
+
+## Color and contrast
+
+The OKLCH tokens are tuned for WCAG AA contrast (4.5:1 for body text,
+3:1 for UI cues):
+
+- `text-foreground` on `bg-background` — body text.
+- `text-muted-foreground` on `bg-card` — secondary text. Verified at
+  light + dark.
+- `text-destructive` on `bg-card` — error text.
+
+Hard rules:
+
+- **Never convey error / success state by color alone.** Pair with
+  icon + text:
+  ```tsx
+  <div className="flex items-center gap-2">
+    <CheckCircle2 className="size-4 text-status-active" />
+    <span className="text-sm">{t("…success")}</span>
+  </div>
+  ```
+- **Don't drop opacity below ~0.6 for active text.**
+  `text-muted-foreground/70` reads as decorative; below that you've
+  failed contrast in dark mode.
+- **Tokens, not raw colors.** A new contrast pair is a token PR —
+  update both `:root` and `.dark`. See
+  [styles-and-tokens.md](styles-and-tokens.md).
+
+## Reduced motion
+
+The user's `prefers-reduced-motion: reduce` preference disables the
+animations that ship with `tw-animate-css` (it gates them on
+`@media (prefers-reduced-motion: no-preference)` automatically).
+When you write a new transition:
+
+```tsx
+<div className="transition-colors motion-reduce:transition-none">…</div>
+```
+
+— or just lean on `tw-animate-css` utilities (`animate-in`, `fade-in-0`,
+`zoom-in-95`), which already respect the preference.
+
+Don't fall back to JS-driven animations (Framer Motion, react-spring) —
+none of them are in the bundle, and Tailwind v4 + `tw-animate-css`
+covers every animation the design uses.
+
+## Disabled state
+
+- Use the `disabled` prop on buttons / inputs — never `pointer-events:
+  none` or `opacity-50` to fake-disable. Radix and shadcn handle the
+  attribute, ARIA state, and focus semantics together.
+- A disabled submit button still must be reachable by Tab. Don't move
+  focus over it; don't `tabindex={-1}` it.
+
+## Tooltips
+
+- **Tooltips supplement, never replace, a label.** A `Tooltip` on an
+  icon-only button is an enhancement; the `aria-label` is still required.
+- **Don't tooltip text that's already visible.** Lighthouse and axe
+  flag redundant tooltips.
+
+## Tests
+
+Every page-level component test runs `axe(container)`:
+
+```tsx
+import { axe } from "jest-axe"
+
+it("has no axe violations", async () => {
+  const { container } = renderWithProviders({ children: <Page /> })
+  expect(await axe(container)).toHaveNoViolations()
+})
+```
+
+End-to-end: import `runAxe` from `e2e/utils/axe.ts` and call it inside
+the relevant `test()` block. The default severity floor is `serious` +
+`critical`. See [testing.md](testing.md).
+
+## Anti-patterns
+
+- `outline: none` on `:focus` without a `:focus-visible` replacement.
+- A new modal built from `<div className="fixed inset-0">` instead of
+  `<Dialog>`.
+- `onClick` on a `<div>` to make it "clickable". Use `<Button>` or a
+  real `<a>`.
+- Color-only error indication (red border, no icon, no text).
+- `tabindex={-1}` on a focus target the user is supposed to reach.
+- Skipping a label "because the placeholder says it" — placeholders
+  disappear on focus and aren't read by screen readers as labels.

--- a/devdocs/frontend/coding-standards.md
+++ b/devdocs/frontend/coding-standards.md
@@ -1,0 +1,185 @@
+# Coding standards
+
+The contract every `.ts` / `.tsx` file in `frontend/` follows. Linted where
+practical, otherwise enforced by review. If a rule disagrees with the
+[visual contract](styles-and-tokens.md) or `denisvmedia/inventario-design`'s
+`CLAUDE.md`, the visual contract wins — flag the conflict in the PR.
+
+## TypeScript
+
+- **Strict mode is on** — see `frontend/tsconfig.json`. Never weaken `strict`
+  to land a PR; fix the typing instead.
+- **`any` is a warning, not an error** — `@typescript-eslint/no-explicit-any:
+  warn` (see `frontend/eslint.config.js`). Treat each `any` as a TODO and
+  prefer `unknown` + a narrowing guard, or a typed schema (`zod`,
+  generated DTO) at the boundary.
+- **No `forwardRef`.** Tailwind v4 + React 19 lets you accept `ref` as a
+  normal prop via `React.ComponentProps<>`. Pattern (mirrors shadcn primitives
+  in `src/components/ui/`):
+  ```tsx
+  export function Thing({
+    className,
+    ...props
+  }: React.ComponentProps<"div">) {
+    return <div className={cn("...", className)} {...props} />
+  }
+  ```
+- **No default exports.** Named exports only — they survive renames cleanly
+  and play well with auto-import. The single exception is files Vite or a
+  build tool requires to default-export (see `frontend/vite.config.ts`).
+- **Discriminated unions over enums.** TS `enum` adds runtime weight and
+  doesn't tree-shake; use `as const` arrays + a derived type:
+  ```ts
+  export const DENSITIES = ["comfortable", "cozy", "compact"] as const
+  export type Density = (typeof DENSITIES)[number]
+  ```
+
+## File and directory layout
+
+```
+frontend/src/
+├── app/              # composition root: providers, router, Shell
+├── components/
+│   ├── ui/           # shadcn primitives (vendored — see components.md)
+│   ├── routing/      # ProtectedRoute, GroupRequiredRoute, RouteTitle, …
+│   └── <Other>.tsx   # cross-feature components
+├── features/<name>/  # feature slice: api.ts, hooks.ts, keys.ts, schemas.ts
+├── hooks/            # cross-feature hooks (useDensity, useConfirm, …)
+├── i18n/             # react-i18next config + en/cs/ru bundles
+├── lib/              # cn(), http, auth-storage, group-context, server-error, …
+├── pages/            # route components — one folder per top-level route
+├── test/             # Vitest setup, render helper, MSW handlers
+└── types/            # generated DTOs + hand-written shared types
+```
+
+Rules of thumb:
+
+- **One concern per file.** A page does layout + wiring; business logic and
+  data shaping live in `features/<name>/{api,hooks,schemas}.ts`. A shared
+  visual concept lives in `components/<Name>.tsx`.
+- **Feature slice owns its types.** Re-export DTOs through
+  `features/<name>/api.ts` so callers don't pull from `types/api.d.ts`
+  directly.
+- **Tests sit next to source** under `__tests__/` (or as `<name>.test.tsx`
+  next to the file). The Vitest config picks up both shapes.
+
+## Naming
+
+| Kind | Convention | Example |
+| --- | --- | --- |
+| React component file | `PascalCase.tsx` | `LocationsListPage.tsx` |
+| Hook file | `useCamelCase.ts(x)` | `useDensity.tsx` |
+| Other module | `kebab-or-snake.ts` | `auth-storage.ts`, `query-client.ts` |
+| Component name | `PascalCase` matching filename | `export function LocationsListPage()` |
+| Hook | starts with `use` | `useCurrentUser`, `useLogin` |
+| Type | `PascalCase` | `LoginInput`, `CurrentUser` |
+| Constant | `UPPER_SNAKE_CASE` for closed enumerations, `camelCase` otherwise | `DENSITIES`, `BASE_URL` |
+| Query key factory | `<feature>Keys` | `authKeys`, `commodityKeys` |
+| Translation key | `namespace:dot.path` | `auth:validation.emailRequired` |
+
+## Import order
+
+ESLint doesn't enforce order today, but every existing file follows this
+pattern (matches Prettier's default sort and what eslint-plugin-import would
+produce):
+
+1. Node / browser builtins (rare in the FE).
+2. External packages (`react`, `@tanstack/react-query`, `lucide-react`, …).
+3. Internal absolute imports via the `@/` alias, grouped by depth or feature
+   coherence:
+   - `@/components/ui/*`
+   - `@/components/*`
+   - `@/features/*`
+   - `@/hooks/*`
+   - `@/lib/*`
+   - `@/pages/*`
+   - `@/types/*`
+4. Relative imports (`./api`, `./schemas`).
+5. CSS / asset imports.
+
+Within a group, alphabetize unless logical grouping reads better (e.g.
+keep `useForm`, `Controller`, `useFieldArray` from `react-hook-form`
+together).
+
+## Console policy
+
+Production code must not log. The Lighthouse `best-practices` audit (see
+[perf.md](perf.md)) fails on console errors and warnings.
+
+| Allowed | Where |
+| --- | --- |
+| `console.error` for unrecoverable boot failures (e.g. missing CSRF token) | `src/main.tsx`, `src/app/providers.tsx` |
+| `console.warn` for missing-i18n keys (gated to dev) | `src/i18n/i18next.config.ts` |
+| `console.*` in tests, scripts/, and `*.config.*` | anywhere outside `src/**/*.{ts,tsx}` shipping to dist |
+
+If you're tempted to `console.log` from a component, use a toast
+(`useAppToast`) for user-visible feedback or a Sentry-style logger when
+that lands. Don't ship `console.log` to silence a "hmm, why didn't this
+fire" curiosity — write a test instead.
+
+## Comments
+
+- Default to no comments. A well-named identifier already explains *what*
+  the code does.
+- Comment **why** when:
+  - There's a non-obvious constraint (`// localStorage; cross-tab via
+    'storage' event`).
+  - There's a workaround for a specific bug (link the issue).
+  - The code violates a local convention on purpose.
+- Never write multi-paragraph docstrings on internal helpers. One short
+  line is the cap.
+- Don't reference the current task / PR / fix in code comments. That
+  context belongs in the PR body and rots in the source over time.
+
+The existing source has more "why" comments than this rule prescribes —
+those are deliberately load-bearing (they explain a refresh-race, a
+single-flight token, a Rules-of-Hooks ordering trick). Don't strip them
+just to match this rule; *add* new comments only when they pay rent.
+
+## Formatting
+
+- Prettier is the source of truth. Run `npm run format` from `frontend/`
+  before pushing; CI runs `npm run format:check`.
+- Tailwind class lists: keep them on one logical line per element. Don't
+  break them across lines unless the element's class list exceeds the
+  Prettier wrap width — let Prettier decide.
+- Don't fight Prettier with `// prettier-ignore` unless you have a real
+  reason (e.g. a 6-column matrix that becomes unreadable when wrapped).
+
+## Function shape
+
+- **Components** are named function declarations:
+  ```tsx
+  export function LoginPage() { … }
+  ```
+  not `const LoginPage = () => …`. Function declarations show up better in
+  React DevTools and stack traces.
+- **Hooks and utilities** can be either form — pick whichever reads better.
+- **Async handlers** are `async function onSubmit(values) { … }` declared
+  inside the component, not extracted to module scope (they almost always
+  close over component-local state).
+
+## Async / errors
+
+- `async` functions throw — `useMutation` and `useQuery` capture the throw
+  and surface it through `error`. Don't wrap them in `try/catch` just to
+  return `null`; reach for `error` from the hook.
+- At UI boundaries, normalize errors via
+  `parseServerError(err, fallback)` (`src/lib/server-error.ts`). Don't
+  render `err.message` directly — backends emit JSON:API, plain envelopes,
+  and string bodies.
+- Never swallow errors silently. If you intentionally ignore one (e.g. a
+  best-effort logout), comment why right above the `catch` block.
+
+## What not to do
+
+- **Don't** add a new CSS file. All styling flows through `index.css`
+  tokens + Tailwind utilities. See [styles-and-tokens.md](styles-and-tokens.md).
+- **Don't** install a new icon library, headless UI library, or theming
+  library. The bans are documented in [imports-and-bans.md](imports-and-bans.md);
+  if you genuinely need something new, file an issue first.
+- **Don't** weaken a coverage threshold to land a feature. Find the missing
+  test instead. See [testing.md](testing.md).
+- **Don't** change a translation key's path to "fix the extractor". Add a
+  `preservePattern` in `frontend/i18next.config.ts` if the key is dynamic;
+  the existing patterns there document the trick.

--- a/devdocs/frontend/coding-standards.md
+++ b/devdocs/frontend/coding-standards.md
@@ -2,8 +2,7 @@
 
 The contract every `.ts` / `.tsx` file in `frontend/` follows. Linted where
 practical, otherwise enforced by review. If a rule disagrees with the
-[visual contract](styles-and-tokens.md) or `denisvmedia/inventario-design`'s
-`CLAUDE.md`, the visual contract wins — flag the conflict in the PR.
+[visual contract](styles-and-tokens.md) or the design mock, the visual contract wins — flag the conflict in the PR.
 
 ## TypeScript
 

--- a/devdocs/frontend/components.md
+++ b/devdocs/frontend/components.md
@@ -30,17 +30,17 @@ Three categories with three rule sets:
 ### `components/ui/` — shadcn primitives
 
 Vendored copies of shadcn's new-york style primitives (Button, Dialog,
-Sheet, DropdownMenu, Sidebar, Sonner toaster, …). Owned by the design
-mock at `denisvmedia/inventario-design`.
+Sheet, DropdownMenu, Sidebar, Sonner toaster, …). Owned upstream by
+shadcn and mirrored 1:1 against the internal design mock.
 
 Rules:
 
 - **Never edit a primitive directly.** If you need a variant, extend via
   `cva` or wrap. If shadcn upstream changes, re-run `npx shadcn@latest add
   <component>` from `frontend/` to refresh the file.
-- **Mirror the mock.** When the mock at `denisvmedia/inventario-design`
-  bumps a primitive, copy 1:1. Document the diff in the PR if you must
-  deviate (e.g. swapping `next-themes` out of `sonner.tsx`).
+- **Mirror the mock.** When the design mock bumps a primitive, copy 1:1.
+  Document the diff in the PR if you must deviate (e.g. swapping
+  `next-themes` out of `sonner.tsx`).
 - **No `forwardRef`.** React 19 + Tailwind v4 lets primitives accept `ref`
   as a prop. Match the existing files.
 - **One primitive per file** named after the component. Re-exports go via

--- a/devdocs/frontend/components.md
+++ b/devdocs/frontend/components.md
@@ -1,0 +1,181 @@
+# Components
+
+Where components live, what each layer is allowed to do, and how to add a
+new one.
+
+## Three layers
+
+```
+frontend/src/components/
+├── ui/              # vendored shadcn primitives (Radix-based)
+├── routing/         # composition-only — ProtectedRoute, GroupRequiredRoute, RouteTitle, UngroupedRedirect
+├── auth/            # cross-page composites for the auth pages
+├── coming-soon/     # ComingSoonBanner / ComingSoonPage registry
+├── dashboard/       # widgets shared across dashboard surfaces
+├── exports/         # cross-page composites for exports/restore
+├── files/           # file-list helpers
+├── groups/          # group-settings composites
+├── items/           # commodity composites
+├── locations/       # locations / areas composites
+├── tags/            # tag pill, color picker, badges
+├── search/          # search composites
+└── <Standalone>.tsx # AppSidebar, AppLogo, CommandPalette, GroupSelector, ModeToggle, …
+
+frontend/src/features/<name>/
+└── (api.ts, hooks.ts, keys.ts, schemas.ts — no .tsx)
+```
+
+Three categories with three rule sets:
+
+### `components/ui/` — shadcn primitives
+
+Vendored copies of shadcn's new-york style primitives (Button, Dialog,
+Sheet, DropdownMenu, Sidebar, Sonner toaster, …). Owned by the design
+mock at `denisvmedia/inventario-design`.
+
+Rules:
+
+- **Never edit a primitive directly.** If you need a variant, extend via
+  `cva` or wrap. If shadcn upstream changes, re-run `npx shadcn@latest add
+  <component>` from `frontend/` to refresh the file.
+- **Mirror the mock.** When the mock at `denisvmedia/inventario-design`
+  bumps a primitive, copy 1:1. Document the diff in the PR if you must
+  deviate (e.g. swapping `next-themes` out of `sonner.tsx`).
+- **No `forwardRef`.** React 19 + Tailwind v4 lets primitives accept `ref`
+  as a prop. Match the existing files.
+- **One primitive per file** named after the component. Re-exports go via
+  the file's named exports — there is no barrel.
+- **Excluded from coverage.** `src/components/ui/**` is in
+  `vitest.config.ts`'s `coverage.exclude`. Test composites that consume
+  them, not the primitives themselves.
+
+When to add a new primitive: only when you need a Radix primitive the
+project doesn't already vendor. `npx shadcn@latest add <name>` is the
+on-ramp; the CLI will copy the file in and add the import. Pick the
+component name from <https://ui.shadcn.com/docs/components>.
+
+### `components/<Name>.tsx` (and folders) — cross-feature components
+
+Used by 2+ feature slices, or owns a domain concept that should look the
+same everywhere (e.g. `WarrantyBadge`, `CurrencyCombobox`, `AppSidebar`,
+`CommandPalette`, `TagPill`).
+
+Rules:
+
+- **No data fetching inside.** Composite components accept props; the
+  feature page above them does the `useQuery` / `useMutation`. Exceptions
+  are explicit cross-feature shells (`AppSidebar` reads `useCurrentUser` /
+  `useCurrentGroup` because every page renders it).
+- **Accept `className?`** for layout flexibility at the call site, and
+  merge it with `cn(base, className)` from `@/lib/utils`.
+- **Don't accept `style`** unless the value is dynamic from data (e.g. a
+  tag's color token). Tokens win over inline styles — see
+  [styles-and-tokens.md](styles-and-tokens.md).
+- **Never import from `pages/`.** Page → component is one-way; the moment
+  a component needs a page, it has become a page wrapper.
+- **Stay dumb.** Props in, JSX out. If state lives across renders, lift it
+  to the page that owns the route boundary.
+- **A folder is a component family.** Group related composites under
+  `components/<feature>/` (`exports/ExportRow.tsx`, `exports/WizardSteps.tsx`)
+  rather than spraying `ExportRow.tsx` directly into `components/`.
+
+### `pages/<Page>.tsx` — route components
+
+One file (or one folder) per route in `app/router.tsx`. A page does:
+
+1. Reads URL params via `useParams` / `useSearchParams`.
+2. Calls the feature slice's hooks (`useCommodities`, `useCommodity`, …).
+3. Composes UI primitives + cross-feature components into a layout.
+4. Owns top-level state that the route boundary scopes (open dialog,
+   wizard step, draft form values).
+
+Rules:
+
+- **Code-split via `React.lazy`** in `app/router.tsx`. Real pages are
+  always lazy; placeholder pages share `PlaceholderPage` and stay eager.
+- **Page wrapper:** start every page with the standard outer shell (mock
+  pattern):
+  ```tsx
+  <div className="flex flex-col gap-6 p-6 max-w-2xl mx-auto w-full">…</div>
+  ```
+  Use `max-w-2xl` for settings/detail and `max-w-4xl` for list/data pages.
+
+## Variants via `cva`
+
+shadcn primitives encode variants using `class-variance-authority` (`cva`).
+Mirror that pattern when extending — never reach for prop-driven `if/else`
+class concatenation:
+
+```tsx
+const buttonVariants = cva("base classes", {
+  variants: {
+    variant: { default: "…", outline: "…", ghost: "…" },
+    size: { default: "h-9", sm: "h-8", lg: "h-10", icon: "size-9" },
+  },
+  defaultVariants: { variant: "default", size: "default" },
+})
+```
+
+Domain-specific badges follow the same shape — `WarrantyBadge` reads
+`WARRANTY_STATUS_CONFIG[status]` from a config map and applies the matching
+classes. Don't inline ternaries on color or icon choice.
+
+## Compose, don't theme-drill
+
+A new "X but with a green border" is almost never a new component. Reach
+for a className override at the call site first:
+
+```tsx
+<Card className="border-status-active/40">…</Card>
+```
+
+When the override repeats 3+ times, extract a thin wrapper (still in
+`components/`) — never duplicate primitive markup.
+
+## Adding a new component — step by step
+
+1. **Decide the layer:**
+   - shadcn primitive → `npx shadcn@latest add <name>` from `frontend/`.
+   - Cross-feature composite → `src/components/<Name>.tsx` (or
+     `src/components/<feature>/<Name>.tsx`).
+   - Page-local helper → keep it in the page file until it's used twice.
+2. **Write the type:**
+   ```tsx
+   interface FooProps {
+     value: string
+     onChange: (next: string) => void
+     className?: string
+   }
+   ```
+   Avoid `style?` unless you genuinely need it.
+3. **Write the named export:**
+   ```tsx
+   export function Foo({ value, onChange, className }: FooProps) {
+     return <div className={cn("base classes", className)}>…</div>
+   }
+   ```
+4. **Add a test** under `__tests__/Foo.test.tsx` using
+   `renderWithProviders`. Cover the empty / loaded / error states; run
+   `axe(container)` if the component renders interactive UI. See
+   [testing.md](testing.md).
+5. **Translate every string** through `useTranslation()`. See [i18n.md](i18n.md).
+6. **Run `npm run i18n:check`** to confirm the catalog stays in sync, and
+   `npm run lint && npm run typecheck && npm run test` before opening the PR.
+
+## Anti-patterns
+
+- **Class-name template literals.** Use `cn()` from `@/lib/utils`, not
+  `` `${base} ${active ? "..." : "..."}` `` — it deduplicates Tailwind
+  conflicts and is what shadcn primitives use.
+- **Re-implementing a primitive.** If `<Button>` exists, don't write `<button
+  className="border rounded …">`. Same for `<Input>`, `<Dialog>`,
+  `<DropdownMenu>`.
+- **`window.confirm()`.** Use `<AlertDialog>` for destructive flows, or
+  `useConfirm()` (`src/hooks/useConfirm.tsx`) which wraps an
+  `AlertDialog` in a promise.
+- **Pulling DOM refs to coerce focus.** Radix primitives expose
+  `onOpenChange`, `onSelect`, `onCloseAutoFocus`, etc. Read the primitive's
+  props before reaching for an imperative ref.
+- **Inline color or spacing styles.** `style={{ color: "#f59e0b" }}` is a
+  ban on sight; use the token (`text-chart-1`) and update `index.css` if
+  the token doesn't exist.

--- a/devdocs/frontend/data.md
+++ b/devdocs/frontend/data.md
@@ -1,0 +1,264 @@
+# Data layer
+
+TanStack Query + a small `lib/http.ts` wrapper. One feature slice per
+domain (auth, group, commodity, location, area, file, tag, export,
+search, member, invite). The split is documented as part of issue #1403.
+
+## Pieces
+
+```
+frontend/src/lib/
+├── http.ts              # fetch wrapper: bearer + CSRF + group rewrite + 401-refresh
+├── auth-storage.ts      # localStorage tokens
+├── group-context.ts     # active group slug (read by http.ts)
+├── navigation.ts        # navigateToLogin / safe redirect helpers
+└── query-client.ts      # createQueryClient() — staleTime/retry defaults
+
+frontend/src/features/<name>/
+├── api.ts        # raw HTTP calls returning typed DTOs (no React)
+├── keys.ts       # query-key factory: <name>Keys.list(slug, opts) etc.
+├── hooks.ts      # useFoo / useUpdateFoo wrappers around useQuery / useMutation
+├── schemas.ts    # zod schemas for forms (see forms.md)
+└── constants.ts  # closed enum constants (status, type, sort field)
+```
+
+## HTTP wrapper
+
+`src/lib/http.ts` is a thin `fetch` adapter; never call `fetch` directly
+from feature code. It does:
+
+- JSON:API content type (`application/vnd.api+json`).
+- Bearer token from `auth-storage.ts`.
+- CSRF header on mutating methods.
+- `/api/v1/<resource>` → `/api/v1/g/{slug}/<resource>` rewriting when a
+  group is active. The slug is read from `getCurrentGroupSlug()`,
+  which falls back to the URL when the React context hasn't mirrored
+  yet (first render of a `/g/:slug/*` route).
+- 401 → single-flight refresh via the httpOnly refresh cookie. On
+  refresh failure: clear auth, redirect to `/login` (skipped on the
+  public paths and on `/auth/login`/`/register`/`/refresh`
+  themselves).
+- Non-2xx → throws `HttpError` with `status`, `url`, `data`. React
+  Query surfaces it through `error`.
+
+## QueryClient defaults
+
+`createQueryClient()` (`src/lib/query-client.ts`):
+
+```ts
+defaults = {
+  queries: {
+    staleTime: 30_000,
+    retry: (count, err) => {
+      // Don't retry 4xx — http.ts has already resolved auth, retrying
+      // races the redirect.
+      if (err instanceof HttpError && err.status >= 400 && err.status < 500) return false
+      return count < 1
+    },
+    refetchOnWindowFocus: true,
+  },
+  mutations: { retry: false },
+}
+```
+
+Don't change these per-call without a reason. If you find yourself
+setting `staleTime: Infinity` on every query in a slice, the data isn't
+TanStack-Query-shaped — file an issue.
+
+## Query keys
+
+Every feature owns a `<name>Keys` factory in `features/<name>/keys.ts`:
+
+```ts
+// frontend/src/features/auth/keys.ts
+export const authKeys = {
+  all: ["auth"] as const,
+  currentUser: () => [...authKeys.all, "currentUser"] as const,
+}
+
+// frontend/src/features/commodities/keys.ts
+export const commodityKeys = {
+  all: ["commodity"] as const,
+  group: (slug: string) => [...commodityKeys.all, slug] as const,
+  list: (slug: string, opts?: ListCommoditiesOptions) =>
+    [...commodityKeys.group(slug), "list", listKeySuffix(opts)] as const,
+  detail: (slug: string, id: string) => [...commodityKeys.group(slug), "detail", id] as const,
+  values: (slug: string) => [...commodityKeys.group(slug), "values"] as const,
+}
+```
+
+Rules:
+
+- **Group-scoped keys include the slug.** Without it, navigating from
+  `/g/household` to `/g/office` would reuse the cached household list
+  while the http call goes to office, and the mismatch only resolves on
+  the next refetch.
+- **List keys serialize options deterministically.** `listKeySuffix`
+  sorts arrays before serialising so two equivalent options objects
+  produce the same key (see `commodities/keys.ts` for the reference
+  implementation).
+- **Other slices invalidate via the typed entry point.** Import the
+  key factory; never copy-paste the raw array.
+
+## Hooks
+
+Each feature exposes `useFoo()` / `useUpdateFoo()` thin wrappers around
+`useQuery` / `useMutation`:
+
+```ts
+// useCurrentUser — read
+export function useCurrentUser() {
+  return useQuery<CurrentUser>({
+    queryKey: authKeys.currentUser(),
+    queryFn: ({ signal }) => getCurrentUser(signal),
+    enabled: !!getAccessToken(),
+  })
+}
+
+// useLogin — mutation that primes the cache
+export function useLogin() {
+  const queryClient = useQueryClient()
+  return useMutation<CurrentUser | undefined, Error, LoginVars>({
+    mutationFn: ({ email, password }) => login(email, password),
+    onSuccess: (user) => {
+      if (user) queryClient.setQueryData(authKeys.currentUser(), user)
+      queryClient.invalidateQueries({ queryKey: authKeys.all })
+    },
+  })
+}
+```
+
+Rules:
+
+- **Forward `signal`** from `queryFn` to the underlying `fetch`. React
+  Query passes its own `AbortSignal` and uses it for cancellation when
+  components unmount or queries are invalidated.
+- **`enabled`** gates queries that depend on prerequisites — auth token,
+  active slug, a route param. Skipping the query is preferable to
+  letting it 401 / 404 on every render.
+- **Don't call `useQueryClient` inside leaf components** to nudge the
+  cache. Build it into the feature hook so the contract lives in one
+  place.
+
+## Mutations and cache updates
+
+Three patterns, in order of preference:
+
+### 1. Invalidate on success (default)
+
+```ts
+useMutation({
+  mutationFn: createCommodity,
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: commodityKeys.group(slug) })
+  },
+})
+```
+
+The simplest, hardest-to-get-wrong shape. Use it unless you have
+measured-flicker pain.
+
+### 2. Optimistic update with rollback
+
+For hot paths where the user expects an instant change (toggle a tag,
+delete a commodity, mark warranty seen). The pattern is the
+`useLogout` reference from `features/auth/hooks.ts`:
+
+```ts
+useMutation<void, Error, void, { previousUser: CurrentUser | undefined }>({
+  mutationFn: () => logout(),
+  onMutate: async () => {
+    await queryClient.cancelQueries({ queryKey: authKeys.currentUser() })
+    const previousUser = queryClient.getQueryData<CurrentUser>(authKeys.currentUser())
+    queryClient.removeQueries({ queryKey: authKeys.currentUser(), exact: true })
+    return { previousUser }
+  },
+  onError: (_err, _vars, ctx) => {
+    if (ctx?.previousUser) {
+      queryClient.setQueryData(authKeys.currentUser(), ctx.previousUser)
+    }
+  },
+  onSettled: () => {
+    queryClient.invalidateQueries({ queryKey: authKeys.all })
+  },
+})
+```
+
+Required steps every time:
+
+- `cancelQueries` first — otherwise an in-flight refetch overwrites
+  your optimistic write.
+- Return `{ previous… }` from `onMutate` so `onError` can roll back.
+- `onSettled` invalidates so the cache settles to the server's truth.
+
+### 3. Direct cache write (rare)
+
+When the server response IS the new state and you don't want a refetch,
+`setQueryData(key, response)` works. `useLogin` uses this to seed the
+current-user cache and skip the boot probe. Don't do it for list-shaped
+data — list pagination + filters make manual cache surgery brittle.
+
+## Pagination, sort, search
+
+The reference is the commodities list — `features/commodities/api.ts` +
+`features/commodities/keys.ts`:
+
+- Options object (`ListCommoditiesOptions`) → URL params via the same
+  shape on both sides.
+- The key factory's `listKeySuffix` serialises the options into a
+  stable suffix, sorting arrays so order doesn't matter.
+- `keepPreviousData: true` is **off by default** — turn it on per
+  query if you want the previous page to stay rendered while the next
+  page loads.
+
+## CSRF + tokens
+
+`auth-storage.ts` is the single localStorage gateway. Don't read
+`localStorage["…"]` directly anywhere else:
+
+- `getAccessToken()` / `setAccessToken()` / `clearAuth()`.
+- `getCsrfToken()` / `setCsrfToken()`.
+
+The CSRF token comes back in the login / refresh response and is
+attached automatically on mutating methods.
+
+## SSE / streams
+
+Long-running ops (export, restore) use Server-Sent Events. The pattern:
+
+- `useQuery` polls the resource (`exports:detail`) with a short
+  `refetchInterval` while status is `pending` / `running`.
+- For genuinely streaming progress, mount an `EventSource` inside a
+  feature hook and write into the cache via `setQueryData` per event.
+  See `features/export/` for the reference once it lands.
+
+## Tests
+
+MSW handler factories under `src/test/handlers/<feature>.ts` return
+arrays for spread-into-`server.use(...)`:
+
+```ts
+import { authHandlers, groupHandlers } from "@/test/handlers"
+
+server.use(
+  ...authHandlers.signedIn({ user: { name: "Test" } }),
+  ...groupHandlers.list([{ id: "g1", slug: "household", name: "Household" }])
+)
+```
+
+Add a factory when a test needs a one-off variant; never edit the base
+set in `server.ts` — that breaks isolation between tests. Pattern lives
+in [testing.md](testing.md).
+
+## Anti-patterns
+
+- **`useEffect` to fetch.** Never. Use `useQuery` and let React Query
+  own the lifecycle.
+- **Calling `fetch` directly.** The wrapper's group rewrite, refresh,
+  and CSRF behavior matter on every endpoint.
+- **Dropping the slug from a list query key.** Cache key collisions
+  between groups are silent until the user notices stale data.
+- **Manual loading flags (`const [loading, setLoading] = useState`).**
+  `useQuery` / `useMutation` already expose `isPending` / `isFetching`.
+- **Try/catching a query inside the component.** Read `error` from the
+  hook; surface it via the component's render path.

--- a/devdocs/frontend/design/00-positioning.md
+++ b/devdocs/frontend/design/00-positioning.md
@@ -1,0 +1,106 @@
+# Inventario — Product Positioning
+
+The product anchor every other doc cites. **Committed.** When a taste
+call is contested, this doc is the tiebreaker — the rest of the design
+brief is downstream of "what is Inventario, and who is it for?".
+
+## What it is
+
+Inventario is a **personal inventory ledger**. A user catalogs the
+things they own — appliances, electronics, tools, furniture, vehicles —
+across locations and areas, attaches receipts and warranty
+documentation, and gets a single source of truth for "what do I have,
+where is it, what's covered, what's worth what?".
+
+It's not:
+
+- A point-of-sale or retail system. (No SKUs, no margin tracking.)
+- A small-business asset manager. (No depreciation schedules, no IRS
+  Section 179 forms — yet.)
+- A consumer wishlist or "things I want". (Tracking what you don't
+  own is out of scope; we track what you do.)
+
+It might one day be: a shared household inventory (multi-user groups
+already exist), a tenant-isolated business surface (multi-tenant is
+already wired), an insurance-exchange surface (the export → restore →
+"insurance report" path is the on-ramp).
+
+## Audience
+
+| Primary | Secondary | Aspirational |
+| --- | --- | --- |
+| The careful homeowner who *catalogs* (not just hoards). Probably has spreadsheets they're tired of. Wants warranty awareness and receipt archiving more than they want clever automation. | A household sharing one inventory across two adults. Both write, both read, both want a coherent group. | A small landlord or property manager who's outgrown a spreadsheet and a Dropbox folder. |
+| Cares about: data ownership, not losing receipts, knowing what's still under warranty, seeing what got bought when. | Cares about: not stepping on each other, who-changed-what, both phones working. | Cares about: per-property scoping, exporting in a hurry for insurance, audit trails. |
+
+The product voice is calibrated to the primary audience: thoughtful,
+low-pressure, explicit. The secondary audience is the multi-tenant /
+group story; the aspirational audience justifies the existence of the
+backup/restore/files surface but doesn't yet drive UX choices.
+
+## Voice traits
+
+| Trait | What it sounds like | What it doesn't sound like |
+| --- | --- | --- |
+| Considered | "Add an item — we'll fill in the details later." | "Build your inventory in seconds!" |
+| Honest | "This export is a snapshot. Restoring overwrites the current state." | "Magic restore — never lose data!" |
+| Quiet | Status colors only when they carry meaning. Borders over shadows. | Marketing gradients, exclamation marks, full-page modals for trivia. |
+| Specific | "12 items expiring in 30 days." | "Check your dashboard for updates!" |
+| Forgiving | Confirm destructive actions; show a way back. | Warning banners on every page. |
+
+A representative microcopy line, in voice: *"You don't have any items
+in this area yet. When you do, they'll show up here."* See
+`12-tone-of-voice-and-copy.md` for the full microcopy contract.
+
+## Visual anchor
+
+Three references, in descending priority:
+
+1. **The current shipping UI**, including `denisvmedia/inventario-design`'s
+   mock. Warm off-white surfaces, near-black text, amber accents,
+   borders for elevation. **This is the canonical look.**
+2. Things 3 (Cultured Code) — for the rhythm of dense list rows, the
+   restraint with color, the "one thing on screen at a time" feel.
+3. Linear (early) — for keyboard navigation, the command palette, the
+   "tool not toy" tone of voice.
+
+Anti-references — what Inventario deliberately is **not**:
+
+- Notion's "everything-is-a-block" maximalism.
+- Apple's frosted-glass / hairline-shadow / heavy blur aesthetic.
+- Material 3's expressive color motion.
+
+## Surface tone per page
+
+| Surface | Tone target |
+| --- | --- |
+| Auth pages | Calm, copy-first, single column. No marketing. |
+| Dashboard | Glanceable. Stat row + recent items + warranty alerts. No celebratory hero. |
+| List (commodities, locations, files, tags, exports) | Dense, scannable, sortable. Filter chips quiet; bulk actions hidden until a row is selected. |
+| Detail | One concept per page. Sidesheet for previews; full page when the user committed. |
+| Form / dialog | Multi-step is the rule for >4 fields; single step for ≤3. |
+| Settings | Card-on-page with `divide-y` rows. No toggles in flight without immediate save. |
+| Empty state | Single icon + sentence + a primary CTA, never a wall of marketing copy. |
+| Error / 404 / 500 | Quiet, apologetic, with a way back. No 8-bit graphics, no humor. |
+
+## What this doc commits to
+
+- Inventario is **boring on purpose** at the surface, so the user's
+  data can be vivid. Restraint is a feature.
+- Status colors carry semantic meaning, never decoration. (See
+  `01-palette.md`, `08-interaction-states.md`.)
+- Confirmation precedes destruction. Optimism precedes server roundtrip.
+  (See `15-form-and-data-ux.md`.)
+- Microcopy is short, declarative, and honest. (See
+  `12-tone-of-voice-and-copy.md`.)
+- One audience, one tone. We don't ship a "playful mode" or a
+  "professional mode" — the same voice serves both the homeowner and
+  the landlord.
+
+## What this doc doesn't decide
+
+- Whether the product gets a marketing site (out of scope; the auth
+  pages are the public surface).
+- Whether mobile gets a native app (deferred; responsive web is the
+  current answer).
+- Whether the product gets a paid tier (deferred; pricing is a
+  product-business decision, not a design one).

--- a/devdocs/frontend/design/00-positioning.md
+++ b/devdocs/frontend/design/00-positioning.md
@@ -49,25 +49,26 @@ backup/restore/files surface but doesn't yet drive UX choices.
 
 A representative microcopy line, in voice: *"You don't have any items
 in this area yet. When you do, they'll show up here."* See
-`12-tone-of-voice-and-copy.md` for the full microcopy contract.
+[12-tone-of-voice-and-copy.md](12-tone-of-voice-and-copy.md) for the full microcopy contract.
 
 ## Visual anchor
 
 Three references, in descending priority:
 
-1. **The current shipping UI**, including `denisvmedia/inventario-design`'s
-   mock. Warm off-white surfaces, near-black text, amber accents,
-   borders for elevation. **This is the canonical look.**
-2. Things 3 (Cultured Code) — for the rhythm of dense list rows, the
-   restraint with color, the "one thing on screen at a time" feel.
-3. Linear (early) — for keyboard navigation, the command palette, the
-   "tool not toy" tone of voice.
+1. **The current shipping UI** and the internal design mock. Warm
+   off-white surfaces, near-black text, amber accents, borders for
+   elevation. **This is the canonical look.**
+2. [Things 3](https://culturedcode.com/things/) (Cultured Code) — for
+   the rhythm of dense list rows, the restraint with color, the "one
+   thing on screen at a time" feel.
+3. [Linear](https://linear.app/) (early) — for keyboard navigation,
+   the command palette, the "tool not toy" tone of voice.
 
 Anti-references — what Inventario deliberately is **not**:
 
-- Notion's "everything-is-a-block" maximalism.
+- [Notion](https://www.notion.so/)'s "everything-is-a-block" maximalism.
 - Apple's frosted-glass / hairline-shadow / heavy blur aesthetic.
-- Material 3's expressive color motion.
+- [Material 3](https://m3.material.io/)'s expressive color motion.
 
 ## Surface tone per page
 
@@ -87,11 +88,11 @@ Anti-references — what Inventario deliberately is **not**:
 - Inventario is **boring on purpose** at the surface, so the user's
   data can be vivid. Restraint is a feature.
 - Status colors carry semantic meaning, never decoration. (See
-  `01-palette.md`, `08-interaction-states.md`.)
+  [01-palette.md](01-palette.md), [08-interaction-states.md](08-interaction-states.md).)
 - Confirmation precedes destruction. Optimism precedes server roundtrip.
-  (See `15-form-and-data-ux.md`.)
+  (See [15-form-and-data-ux.md](15-form-and-data-ux.md).)
 - Microcopy is short, declarative, and honest. (See
-  `12-tone-of-voice-and-copy.md`.)
+  [12-tone-of-voice-and-copy.md](12-tone-of-voice-and-copy.md).)
 - One audience, one tone. We don't ship a "playful mode" or a
   "professional mode" — the same voice serves both the homeowner and
   the landlord.

--- a/devdocs/frontend/design/01-palette.md
+++ b/devdocs/frontend/design/01-palette.md
@@ -1,0 +1,157 @@
+# Palette
+
+**Committed.** Warm-neutral OKLCH with amber accents in light mode;
+warm-dark with light amber in dark mode. No purple. No raw color
+names. The full token set lives at `frontend/src/index.css` (`:root`
+and `.dark`); duplicate it in `denisvmedia/inventario-design`'s
+`index.css` in lockstep when you change anything here.
+
+## Why OKLCH
+
+OKLCH is perceptually uniform: a 10% lightness step looks like the
+same step everywhere on the wheel. That matters for status colors —
+green / amber / red / gray need to carry the same visual weight, and
+HSL fails that bar (HSL green at L=72 looks brighter than HSL red at
+L=72). It also dark-modes cleanly — most tokens swap by adjusting the
+lightness component while keeping chroma + hue.
+
+`hsl(...)` wrappers are banned. Tokens hold raw OKLCH; components
+consume them via Tailwind utilities. See
+`../styles-and-tokens.md` for the layer-by-layer shape.
+
+## Roles
+
+```css
+:root {
+  /* Surfaces */
+  --background: oklch(0.985 0.004 75);     /* warm off-white page bg */
+  --foreground: oklch(0.18 0.012 60);      /* near-black text */
+  --card: oklch(1 0 0);                    /* pure white card */
+  --card-foreground: oklch(0.18 0.012 60);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.18 0.012 60);
+
+  /* Brand */
+  --primary: oklch(0.26 0.02 60);          /* dark amber-tinted primary */
+  --primary-foreground: oklch(0.985 0.004 75);
+  --accent: oklch(0.85 0.12 75);           /* THE amber accent */
+  --accent-foreground: oklch(0.22 0.04 60);
+
+  /* Supporting */
+  --secondary: oklch(0.95 0.008 70);
+  --secondary-foreground: oklch(0.26 0.02 60);
+  --muted: oklch(0.945 0.008 70);
+  --muted-foreground: oklch(0.5 0.018 60);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+
+  /* Structural */
+  --border: oklch(0.9 0.008 70);
+  --input: oklch(0.9 0.008 70);
+  --ring: oklch(0.65 0.08 75);             /* amber focus ring */
+}
+
+.dark {
+  --background: oklch(0.155 0.01 55);
+  --foreground: oklch(0.96 0.006 70);
+  --card: oklch(0.195 0.012 55);
+  --primary: oklch(0.88 0.09 75);          /* light amber in dark */
+  --accent: oklch(0.72 0.14 75);
+  --border: oklch(1 0 0 / 10%);            /* white at 10% opacity */
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.72 0.1 75);
+}
+```
+
+The full set (sidebar, chart, status, tag) is at
+`frontend/src/index.css`. The list above is the irreducible core a new
+surface must respect.
+
+## Semantic tokens
+
+These encode business meaning and **always** beat a generic color:
+
+| Token | Light value | Use |
+| --- | --- | --- |
+| `--status-active` | `oklch(0.72 0.17 145)` | Green — in use, valid warranty |
+| `--status-expiring` | `oklch(0.78 0.18 75)` | Amber — within 60 days |
+| `--status-expired` | `oklch(0.65 0.22 25)` | Red — past due |
+| `--status-none` | `oklch(0.6 0 0)` | Gray — no warranty |
+| `--chart-1` … `--chart-5` | warm amber → red | Data viz; see `07-data-visualization.md` |
+| `--tag-amber`, `--tag-green`, `--tag-blue`, `--tag-orange`, `--tag-red`, `--tag-muted` | tag-only palette | TagBadge pills (closed enum mirrored on the BE — `models.TagColor`) |
+
+`--tag-*` and `--chart-*` look superficially similar but are different
+sets — chart slots are for data viz density (5 distinguishable hues),
+tag colors are for closed-enum pills (6 hues that include a `muted`
+gray slot). Don't mix.
+
+## Why this combination
+
+A warm off-white surface (~oklch(0.985 0.004 75)) reads as "considered"
+without trying — it's the editorial / Aesop / Kinfolk neutral. A
+near-black warm-tinted foreground (oklch(0.18 0.012 60)) keeps body
+text high-contrast without the harshness of pure `#000`. The amber
+accent is the one note of warmth — used for primary actions, focus
+rings, hover-reveal states. Everything else defers to muted gray.
+
+In dark mode the primary inverts: amber becomes the *light* color
+(used for foregrounds and primary surfaces), and the canvas is a deep
+warm gray (oklch(0.155 0.01 55)) — never pure `#000`, which would lose
+all the warmth.
+
+## Contrast targets
+
+| Pair | Ratio | Standard |
+| --- | --- | --- |
+| `--foreground` on `--background` | ≥ 14:1 | AAA |
+| `--foreground` on `--card` | ≥ 14:1 | AAA |
+| `--muted-foreground` on `--background` | ≥ 4.5:1 | AA |
+| `--muted-foreground` on `--card` | ≥ 4.5:1 | AA |
+| `--primary-foreground` on `--primary` | ≥ 7:1 | AAA |
+| `--ring` on adjacent surface | ≥ 3:1 | AA (UI) |
+| `--destructive` text on `--card` | ≥ 4.5:1 | AA |
+| `--destructive-foreground` on `--destructive` (filled button) | ≥ 4.5:1 | AA |
+
+The Lighthouse `accessibility` gate (`≥ 0.95`, see `../perf.md`)
+catches drift; `jest-axe` catches it earlier in unit tests. See
+`14-accessibility.md`.
+
+## Hard rules
+
+1. **Never hardcode a color.** Not in `style={}`, not in CSS, not in
+   inline SVG `fill=`. Tokens via Tailwind utilities or nothing.
+2. **Never use Tailwind named palettes** (`text-amber-500`,
+   `bg-green-100`). Use the token (`text-status-expiring`,
+   `text-chart-1`).
+3. **No purple, indigo, violet, magenta** anywhere — the theme has no
+   purple. If a future feature needs a new hue, add a new token, don't
+   reach for a Tailwind named color.
+4. **Both modes are first-class.** Every new token gets a value in
+   `:root` *and* `.dark` in the same PR. A token that only exists in
+   one mode is a regression.
+5. **Lockstep with the mock.** A token change in
+   `frontend/src/index.css` must mirror in
+   `denisvmedia/inventario-design`'s `src/index.css` and be cross-linked
+   in the PR.
+
+## Anti-patterns
+
+- `text-red-500` for an error label. Use `text-destructive`.
+- `bg-amber-100 text-amber-700` for a status pill. Use
+  `bg-status-expiring/10 text-status-expiring`.
+- `dark:text-amber-200` to swap a color in dark mode. The token does
+  the swap automatically; `dark:` is reserved for layout tweaks, not
+  color tokens.
+- Adding `--color-purple-*` to `index.css` "in case we need it". We
+  don't.
+- Hardcoding `oklch(...)` inside a component file. Tokens live in
+  `index.css`; components consume them.
+
+## Cross-refs
+
+- Implementation: `../styles-and-tokens.md`.
+- Status / state usage: `08-interaction-states.md`.
+- Chart usage: `07-data-visualization.md`.
+- A11y contrast specifics: `14-accessibility.md`.
+- Tag color enum: `frontend/src/features/tags/constants.ts` mirrors
+  `go/models.TagColor`.

--- a/devdocs/frontend/design/01-palette.md
+++ b/devdocs/frontend/design/01-palette.md
@@ -3,7 +3,7 @@
 **Committed.** Warm-neutral OKLCH with amber accents in light mode;
 warm-dark with light amber in dark mode. No purple. No raw color
 names. The full token set lives at `frontend/src/index.css` (`:root`
-and `.dark`); duplicate it in `denisvmedia/inventario-design`'s
+and `.dark`); duplicate it in the design mock's index.css
 `index.css` in lockstep when you change anything here.
 
 ## Why OKLCH
@@ -17,7 +17,7 @@ lightness component while keeping chroma + hue.
 
 `hsl(...)` wrappers are banned. Tokens hold raw OKLCH; components
 consume them via Tailwind utilities. See
-`../styles-and-tokens.md` for the layer-by-layer shape.
+[../styles-and-tokens.md](../styles-and-tokens.md) for the layer-by-layer shape.
 
 ## Roles
 
@@ -77,7 +77,7 @@ These encode business meaning and **always** beat a generic color:
 | `--status-expiring` | `oklch(0.78 0.18 75)` | Amber — within 60 days |
 | `--status-expired` | `oklch(0.65 0.22 25)` | Red — past due |
 | `--status-none` | `oklch(0.6 0 0)` | Gray — no warranty |
-| `--chart-1` … `--chart-5` | warm amber → red | Data viz; see `07-data-visualization.md` |
+| `--chart-1` … `--chart-5` | warm amber → red | Data viz; see [07-data-visualization.md](07-data-visualization.md) |
 | `--tag-amber`, `--tag-green`, `--tag-blue`, `--tag-orange`, `--tag-red`, `--tag-muted` | tag-only palette | TagBadge pills (closed enum mirrored on the BE — `models.TagColor`) |
 
 `--tag-*` and `--chart-*` look superficially similar but are different
@@ -112,9 +112,9 @@ all the warmth.
 | `--destructive` text on `--card` | ≥ 4.5:1 | AA |
 | `--destructive-foreground` on `--destructive` (filled button) | ≥ 4.5:1 | AA |
 
-The Lighthouse `accessibility` gate (`≥ 0.95`, see `../perf.md`)
+The Lighthouse `accessibility` gate (`≥ 0.95`, see [../perf.md](../perf.md))
 catches drift; `jest-axe` catches it earlier in unit tests. See
-`14-accessibility.md`.
+[14-accessibility.md](14-accessibility.md).
 
 ## Hard rules
 
@@ -131,7 +131,7 @@ catches drift; `jest-axe` catches it earlier in unit tests. See
    one mode is a regression.
 5. **Lockstep with the mock.** A token change in
    `frontend/src/index.css` must mirror in
-   `denisvmedia/inventario-design`'s `src/index.css` and be cross-linked
+   the design mock's index.css and be cross-linked
    in the PR.
 
 ## Anti-patterns
@@ -149,9 +149,9 @@ catches drift; `jest-axe` catches it earlier in unit tests. See
 
 ## Cross-refs
 
-- Implementation: `../styles-and-tokens.md`.
-- Status / state usage: `08-interaction-states.md`.
-- Chart usage: `07-data-visualization.md`.
-- A11y contrast specifics: `14-accessibility.md`.
+- Implementation: [../styles-and-tokens.md](../styles-and-tokens.md).
+- Status / state usage: [08-interaction-states.md](08-interaction-states.md).
+- Chart usage: [07-data-visualization.md](07-data-visualization.md).
+- A11y contrast specifics: [14-accessibility.md](14-accessibility.md).
 - Tag color enum: `frontend/src/features/tags/constants.ts` mirrors
   `go/models.TagColor`.

--- a/devdocs/frontend/design/02-typography.md
+++ b/devdocs/frontend/design/02-typography.md
@@ -12,10 +12,10 @@ Three reasons, in descending order of importance:
 1. **Performance.** A web-font is 80–200 KB before the first paint
    shifts. Inventario's entry-bundle budget is 200 KB gzip total — a
    font we don't need would eat the room a real feature should claim.
-   See `../perf.md`.
+   See [../perf.md](../perf.md).
 2. **Privacy.** Loading from `fonts.googleapis.com` means an HTTP
    request to Google on every cold load, with referer + user-agent
-   exposed. The product positioning (`00-positioning.md`) commits to
+   exposed. The product positioning ([00-positioning.md](00-positioning.md)) commits to
    data ownership; a third-party font request is a small contradiction.
 3. **Resilience.** The system stack always works — no FOUT, no CSP
    surprise, no maintenance when Google rotates a CDN endpoint.
@@ -131,7 +131,7 @@ tabular-nums is the difference between "considered" and "amateur".
 
 The system font handles cs / ru / latin-ext glyphs natively — no fallback
 required. Keep titles short enough that the longest translation
-(usually de or ru) doesn't wrap. See `13-formatting-and-i18n.md` for
+(usually de or ru) doesn't wrap. See [13-formatting-and-i18n.md](13-formatting-and-i18n.md) for
 the heuristics on copy length budgets.
 
 ## Hard rules
@@ -152,14 +152,14 @@ the heuristics on copy length budgets.
 - `<h1 className="text-2xl">` — the page-title class is `text-3xl`.
   Halving the size breaks the page rhythm.
 - Loading a brand-y display font for the auth-pages hero. The auth
-  pages are deliberately quiet (per `00-positioning.md`); display type
+  pages are deliberately quiet (per [00-positioning.md](00-positioning.md)); display type
   contradicts that.
 - Mixing `font-bold` with `font-semibold` headings on the same page.
   Pick one weight per role.
 
 ## Cross-refs
 
-- Page wrapper anchor: `03-space-and-layout.md`.
-- Empty-state typography: `20-edge-cases.md`.
-- Date / number formatting: `13-formatting-and-i18n.md`.
-- Mock canonical: `denisvmedia/inventario-design/CLAUDE.md` §4 (Typography).
+- Page wrapper anchor: [03-space-and-layout.md](03-space-and-layout.md).
+- Empty-state typography: [20-edge-cases.md](20-edge-cases.md).
+- Date / number formatting: [13-formatting-and-i18n.md](13-formatting-and-i18n.md).
+

--- a/devdocs/frontend/design/02-typography.md
+++ b/devdocs/frontend/design/02-typography.md
@@ -1,0 +1,165 @@
+# Typography
+
+**Committed.** Inventario uses the **system font stack** — no Google
+Fonts, no Switzer, no Inter, no custom face. The browser's native
+sans-serif is the body face; the `mono` Tailwind family is the system
+mono.
+
+## Why no custom font
+
+Three reasons, in descending order of importance:
+
+1. **Performance.** A web-font is 80–200 KB before the first paint
+   shifts. Inventario's entry-bundle budget is 200 KB gzip total — a
+   font we don't need would eat the room a real feature should claim.
+   See `../perf.md`.
+2. **Privacy.** Loading from `fonts.googleapis.com` means an HTTP
+   request to Google on every cold load, with referer + user-agent
+   exposed. The product positioning (`00-positioning.md`) commits to
+   data ownership; a third-party font request is a small contradiction.
+3. **Resilience.** The system stack always works — no FOUT, no CSP
+   surprise, no maintenance when Google rotates a CDN endpoint.
+
+The system stack on a 2026 user looks like SF Pro on macOS, Segoe UI
+Variable on Windows, Roboto on Android, system-ui on most Linux
+desktops. All four are excellent at body sizes and ship pre-installed.
+The visual rhythm of the design (case, tracking, line-height) is what
+carries the look — not a chosen typeface.
+
+## Stack
+
+Tailwind v4's default `font-sans` resolves to:
+
+```css
+font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+  "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+```
+
+`font-mono` resolves to:
+
+```css
+font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+  "Liberation Mono", "Courier New", monospace;
+```
+
+Both are taken verbatim from Tailwind's defaults. Don't override in
+`tailwind.config` or `@theme`.
+
+## Type scale
+
+Tailwind's default scale (in rem). Pick from this set; never write
+`text-[15px]`:
+
+| Class | Size | Use |
+| --- | --- | --- |
+| `text-xs` | 0.75 / 12px | Overline, label, badge, caption |
+| `text-sm` | 0.875 / 14px | Body (default), list rows, form fields |
+| `text-base` | 1 / 16px | Card section heading, dialog body |
+| `text-lg` | 1.125 / 18px | Stat value secondary, dialog title supporting |
+| `text-xl` | 1.25 / 20px | Section title in dense layouts |
+| `text-2xl` | 1.5 / 24px | Stat value, dialog title |
+| `text-3xl` | 1.875 / 30px | Page title (h1) |
+| `text-4xl` | 2.25 / 36px | Hero / empty-state title (rare) |
+
+`text-sm` is the body default. Most JSX should never need `text-base`
+directly — `<p>` inside a card uses `text-sm`; `<DialogDescription>`
+uses `text-sm text-muted-foreground` etc.
+
+## Role classes
+
+shadcn provides no default element styles. Apply Tailwind classes
+explicitly:
+
+| Role | Classes |
+| --- | --- |
+| Page title (h1) | `scroll-m-20 text-3xl font-semibold tracking-tight` |
+| Section heading (h2) | `text-base font-semibold` |
+| Sub-heading (h3) | `text-sm font-semibold` |
+| Body | `text-sm leading-relaxed` |
+| Muted / secondary | `text-sm text-muted-foreground` |
+| Label / overline | `text-xs font-semibold uppercase tracking-widest text-muted-foreground` |
+| Stat value | `text-2xl font-bold tracking-tight` |
+| Stat label | `text-xs font-medium uppercase tracking-wide text-muted-foreground` |
+| Code / mono | `font-mono text-xs` |
+| Dialog title | `text-base font-semibold` |
+| Empty-state title | `text-base font-semibold text-foreground` |
+| Empty-state body | `text-sm text-muted-foreground` |
+
+These are the canonical patterns. When you copy the page-title
+recipe, copy *all* of `scroll-m-20 text-3xl font-semibold
+tracking-tight` — not "just the size". `scroll-m-20` makes anchor
+navigation land below the top bar; `tracking-tight` is the rhythm
+adjustment that makes the system font read as headline-y.
+
+## Weights
+
+- `font-normal` (400) — body, default.
+- `font-medium` (500) — list-row labels, settings-row labels, anything
+  semibold-feeling but not loud.
+- `font-semibold` (600) — section headings, stat labels, page titles.
+- `font-bold` (700) — stat values, hero numbers. Used sparingly.
+
+Don't reach for `font-extrabold` / `font-black`; they look heavy in
+the system stack.
+
+## Tracking and line-height
+
+| Class | Use |
+| --- | --- |
+| `tracking-tight` | Page title, dialog title (any large size > 1.5 rem) |
+| `tracking-normal` (default) | Body, sections |
+| `tracking-wide` | Stat labels (`text-xs uppercase tracking-wide`) |
+| `tracking-widest` | Overlines (`text-xs font-semibold uppercase tracking-widest`) |
+| `leading-relaxed` | Body paragraphs |
+| `leading-tight` | Stat values, dense rows |
+| `leading-none` | Single-line truncation surfaces |
+
+## Lining figures
+
+`font-variant-numeric: tabular-nums` for any column of numbers
+(stats, exports, file sizes) so they line up across rows:
+
+```tsx
+<span className="font-mono text-xs tabular-nums">{formatBytes(size)}</span>
+```
+
+When the value is decorative (a stat hero), tabular-nums is
+unnecessary — the number stands alone. When it's repeated in a column,
+tabular-nums is the difference between "considered" and "amateur".
+
+## i18n: variable-width text
+
+The system font handles cs / ru / latin-ext glyphs natively — no fallback
+required. Keep titles short enough that the longest translation
+(usually de or ru) doesn't wrap. See `13-formatting-and-i18n.md` for
+the heuristics on copy length budgets.
+
+## Hard rules
+
+1. **Don't load a custom font.** Not via Google Fonts, not via
+   `@font-face`, not via npm. The system stack is the answer.
+2. **Don't write `text-[15px]`** — pick from the type scale.
+3. **Don't combine `tracking-tight` with `text-sm`** — the rhythm
+   only works at `text-2xl` and above. `tracking-normal` for body.
+4. **Don't bold body text** for emphasis. Use a different role class
+   or wrap in `<strong>` (which the browser renders bold by default).
+5. **Don't `<h1>` everything.** Each page has exactly one `<h1>`,
+   styled with the page-title role class.
+
+## Anti-patterns
+
+- `style={{ fontSize: 15 }}` — pick `text-sm` (14) or `text-base` (16).
+- `<h1 className="text-2xl">` — the page-title class is `text-3xl`.
+  Halving the size breaks the page rhythm.
+- Loading a brand-y display font for the auth-pages hero. The auth
+  pages are deliberately quiet (per `00-positioning.md`); display type
+  contradicts that.
+- Mixing `font-bold` with `font-semibold` headings on the same page.
+  Pick one weight per role.
+
+## Cross-refs
+
+- Page wrapper anchor: `03-space-and-layout.md`.
+- Empty-state typography: `20-edge-cases.md`.
+- Date / number formatting: `13-formatting-and-i18n.md`.
+- Mock canonical: `denisvmedia/inventario-design/CLAUDE.md` §4 (Typography).

--- a/devdocs/frontend/design/03-space-and-layout.md
+++ b/devdocs/frontend/design/03-space-and-layout.md
@@ -1,0 +1,200 @@
+# Space & Layout
+
+The spacing rhythm and the standard layout shells. **Committed.**
+Where these patterns disagree with a one-off design, the patterns win
+— a one-off PR can either match or open a follow-up to update this
+doc.
+
+## Scale
+
+Tailwind's default 4px-step scale. Always pick from this set; never
+write `p-[14px]`:
+
+| Class | px | Use |
+| --- | --- | --- |
+| `gap-1`, `space-y-1` | 4 | Inline cue + label |
+| `gap-1.5`, `space-y-1.5` | 6 | Field label + input pairs |
+| `gap-2`, `space-y-2` | 8 | Tight inline groups |
+| `gap-3`, `space-y-3` | 12 | Stat cards, dialog body rows |
+| `gap-4`, `space-y-4` | 16 | Default card-internal rhythm |
+| `gap-5`, `space-y-5` | 20 | Card sections that need extra air |
+| `gap-6`, `space-y-6` | 24 | Page sections |
+
+`p-3.5` (14px) and `py-3.5` are the one half-step we use — for list
+rows and divide-y settings rows. Anywhere else, stick to whole steps.
+
+## Page wrapper
+
+Every full-page view starts with this outer shell:
+
+```tsx
+<div className="flex flex-col gap-6 p-6 max-w-2xl mx-auto w-full">
+  {/* content */}
+</div>
+```
+
+Decisions encoded:
+
+- **`p-6` (24px) page padding.** Consistent across every surface so
+  the user never sees a "tighter" or "wider" frame depending on which
+  page they landed on.
+- **`max-w-2xl` for settings / detail / form pages**, `max-w-4xl` for
+  list / data pages, `max-w-6xl` for dashboards with multiple wide
+  cards. Don't introduce new max-widths.
+- **`mx-auto w-full`** centers the column up to the max.
+- **`flex flex-col gap-6`** spaces sections at 24px without per-child
+  margins.
+
+A side-rail surface (sidebar + main) is the Shell's job — see
+`11-page-layouts-and-flows.md` and `frontend/src/app/Shell.tsx`. The
+page wrapper above only describes the main column.
+
+## Card
+
+```tsx
+<div className="rounded-xl border border-border bg-card p-6 space-y-5">
+  {/* card content */}
+</div>
+```
+
+- `rounded-xl` (12px) for cards. `rounded-lg` (8px) for inputs and
+  small chips. `rounded-md` (6px) for tags. `rounded-full` for circular
+  avatars / dot indicators.
+- `border-border` (the token) — not `border-gray-200`.
+- `bg-card` — the token swaps to a slightly lifted dark surface in
+  dark mode.
+- `p-6` inside, `space-y-5` between sections, `space-y-4` between
+  rows of the same shape.
+
+A card never gets a drop shadow — see `04-elevation-and-effects.md`.
+
+## Stat card row
+
+```tsx
+<div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+  <StatCard icon={Package} label="Items" value={114} />
+  <StatCard icon={Folder} label="Locations" value={4} />
+  {/* … */}
+</div>
+```
+
+Each stat card:
+
+```tsx
+<div className="rounded-xl border border-border bg-card px-4 py-3 flex items-center gap-3">
+  <div className="flex size-8 items-center justify-center rounded-lg bg-muted shrink-0">
+    <Icon className="size-4 text-muted-foreground" />
+  </div>
+  <div>
+    <p className="text-xs text-muted-foreground">{label}</p>
+    <p className="text-lg font-semibold leading-tight">{value}</p>
+  </div>
+</div>
+```
+
+The 8×8 icon tile + 4×4 icon ratio is canonical — don't drift to 10×10
+or 6×6.
+
+## Divide list (settings rows)
+
+```tsx
+<div className="divide-y divide-border">
+  <div className="flex items-center justify-between py-3.5">
+    <div>
+      <p className="text-sm font-medium">Warranty expiring alerts</p>
+      <p className="text-xs text-muted-foreground">Push and email.</p>
+    </div>
+    <Switch checked={val} onCheckedChange={setVal} />
+  </div>
+</div>
+```
+
+- `py-3.5` (14px) per row. The half-step exists because 12px feels
+  cramped and 16px feels loose for settings rows specifically.
+- `divide-y divide-border` instead of borders on each row — keeps the
+  first / last rows clean.
+
+## Dialog body
+
+```tsx
+<DialogContent className="sm:max-w-md">
+  <DialogHeader>
+    <DialogTitle>…</DialogTitle>
+    <DialogDescription>…</DialogDescription>
+  </DialogHeader>
+  <div className="space-y-4">{/* fields */}</div>
+  <DialogFooter className="gap-2">…</DialogFooter>
+</DialogContent>
+```
+
+- `sm:max-w-md` (448px) for confirmations and short forms.
+- `sm:max-w-lg` (512px) for ≤5-field dialogs.
+- `sm:max-w-2xl` (672px) for multi-step wizards.
+- Dialogs above `max-w-2xl` are a smell — use a Sheet or a full page.
+
+## Sheet (slide-over)
+
+The slide-over for item preview, file detail, and contextual edits.
+Width:
+
+| Sheet purpose | Width |
+| --- | --- |
+| Quick preview (item card, file card) | `sm:max-w-md` |
+| Edit form (most cases) | `sm:max-w-xl` |
+| Long form / multi-section | `sm:max-w-2xl` |
+
+Sheets always slide in from the right on desktop; on mobile they
+become a full-screen modal. Radix `<Sheet>` handles the breakpoints.
+
+## Spacing primitives at scale
+
+| Primitive | Outer | Inner | Between siblings |
+| --- | --- | --- | --- |
+| Page | `p-6` page wrapper | `space-y-6` between sections | — |
+| Card | `p-6` (or `px-4 py-3` for stat cards) | `space-y-5` between blocks, `space-y-4` between rows | `gap-4` between cards in a grid |
+| Form field | — | `space-y-1.5` between label, input, error | `space-y-4` between fields |
+| List | `divide-y` for settings; bare for tables | `py-3.5` per row | — |
+| Stat row | — | `gap-3` icon + text | `gap-4` between stat cards |
+
+## Grids
+
+Use grids for stat rows, gallery layouts, and card decks. Tables
+remain `<table>`-shaped.
+
+```tsx
+<div className="grid grid-cols-2 gap-4 lg:grid-cols-4">…</div>
+<div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">…</div>
+```
+
+Breakpoints (`md`, `lg`, `xl`, `2xl`) follow Tailwind defaults. Don't
+introduce custom breakpoints.
+
+## Hard rules
+
+1. **`gap-*` between siblings, `space-y-*` inside containers.** Mixing
+   `mt-*` / `mb-*` on individual children to get the same effect is a
+   regression.
+2. **Pick from the scale.** `p-[13px]` gets caught in review.
+3. **`rounded-xl` for cards, `rounded-lg` for inputs.** Don't drift.
+4. **Page padding is `p-6` everywhere.** Don't tighten the auth pages
+   to `p-4` because "they feel cramped" — they aren't, the form is
+   centered with `max-w-md`.
+5. **No fixed-pixel max-widths.** Use Tailwind's `max-w-*` set:
+   `max-w-md`, `max-w-xl`, `max-w-2xl`, `max-w-4xl`, `max-w-6xl`.
+
+## Anti-patterns
+
+- `mt-6 mb-6` on alternating children. Use the parent's
+  `space-y-6` / `gap-6`.
+- A custom 14px gap. Round to 12 (`gap-3`) or 16 (`gap-4`).
+- `p-4` cards next to `p-6` cards on the same page. Pick one density.
+- Hand-rolled grid columns (`grid-cols-[1fr_2fr_1fr]`). Use the
+  preset Tailwind columns; if you need a custom split, the design is
+  off rhythm.
+- Adding a 7th max-width to the set. The five we have are enough.
+
+## Cross-refs
+
+- Card / dialog / sheet anatomy: `09-component-patterns.md`.
+- Page templates per surface: `11-page-layouts-and-flows.md`.
+- Density adjustments: `17-density-and-modes.md`.

--- a/devdocs/frontend/design/03-space-and-layout.md
+++ b/devdocs/frontend/design/03-space-and-layout.md
@@ -46,7 +46,7 @@ Decisions encoded:
   margins.
 
 A side-rail surface (sidebar + main) is the Shell's job — see
-`11-page-layouts-and-flows.md` and `frontend/src/app/Shell.tsx`. The
+[11-page-layouts-and-flows.md](11-page-layouts-and-flows.md) and `frontend/src/app/Shell.tsx`. The
 page wrapper above only describes the main column.
 
 ## Card
@@ -66,7 +66,7 @@ page wrapper above only describes the main column.
 - `p-6` inside, `space-y-5` between sections, `space-y-4` between
   rows of the same shape.
 
-A card never gets a drop shadow — see `04-elevation-and-effects.md`.
+A card never gets a drop shadow — see [04-elevation-and-effects.md](04-elevation-and-effects.md).
 
 ## Stat card row
 
@@ -195,6 +195,6 @@ introduce custom breakpoints.
 
 ## Cross-refs
 
-- Card / dialog / sheet anatomy: `09-component-patterns.md`.
-- Page templates per surface: `11-page-layouts-and-flows.md`.
-- Density adjustments: `17-density-and-modes.md`.
+- Card / dialog / sheet anatomy: [09-component-patterns.md](09-component-patterns.md).
+- Page templates per surface: [11-page-layouts-and-flows.md](11-page-layouts-and-flows.md).
+- Density adjustments: [17-density-and-modes.md](17-density-and-modes.md).

--- a/devdocs/frontend/design/04-elevation-and-effects.md
+++ b/devdocs/frontend/design/04-elevation-and-effects.md
@@ -30,7 +30,7 @@ plus a 1px border. No shadow. No `border-2`. Subtle but unmistakable.
    render the same way in both modes.
 4. **System aesthetic.** Things 3, Linear (early), Notion's recent
    editions all moved away from shadows toward borders. The references
-   in `00-positioning.md` set the tone.
+   in [00-positioning.md](00-positioning.md) set the tone.
 
 ## What's allowed
 
@@ -81,7 +81,7 @@ If you reach for one of these, the underlying need is probably:
 | Dashed | rare; only on drop-zone targets | `border-dashed border-2 border-border` |
 
 The drop-zone exception (`border-dashed border-2`) is the one place
-where a thicker border earns its weight — see `10-file-and-media.md`.
+where a thicker border earns its weight — see [10-file-and-media.md](10-file-and-media.md).
 
 ## Focus
 
@@ -92,7 +92,7 @@ focus-visible:ring-[3px] focus-visible:ring-ring/50
 ```
 
 — a 3px amber ring at 50% opacity. Don't override. See
-`14-accessibility.md` for the keyboard-only contract.
+[14-accessibility.md](14-accessibility.md) for the keyboard-only contract.
 
 ## Hover state
 
@@ -107,7 +107,7 @@ Hover is a visual cue, not a transform. Patterns:
 | Reveal action (kebab in row) | `opacity-0 group-hover:opacity-100 transition-opacity` |
 
 `transition-colors` is the default transition utility. No
-`transition-transform`, no `transition-shadow`. See `05-motion.md`
+`transition-transform`, no `transition-shadow`. See [05-motion.md](05-motion.md)
 for durations.
 
 ## Active state
@@ -154,7 +154,7 @@ have edges (borders), not three-dimensional cues.
 
 ## Cross-refs
 
-- Tokens: `01-palette.md`.
-- Spacing rhythm: `03-space-and-layout.md`.
-- Hover / focus / active states: `08-interaction-states.md`.
-- Focus ring contrast: `14-accessibility.md`.
+- Tokens: [01-palette.md](01-palette.md).
+- Spacing rhythm: [03-space-and-layout.md](03-space-and-layout.md).
+- Hover / focus / active states: [08-interaction-states.md](08-interaction-states.md).
+- Focus ring contrast: [14-accessibility.md](14-accessibility.md).

--- a/devdocs/frontend/design/04-elevation-and-effects.md
+++ b/devdocs/frontend/design/04-elevation-and-effects.md
@@ -1,0 +1,160 @@
+# Elevation & Effects
+
+**Committed.** Inventario uses **borders, not shadows**. The single
+exception is `shadow-xs` on inputs (built into the shadcn `Input`
+primitive). This rule is older than the React rewrite and survived
+cutover; don't re-litigate without an issue.
+
+## The rule
+
+Elevation is communicated by **bordered surface contrast**, not
+shadow:
+
+- Page background = `--background` (warm off-white).
+- Card surface = `--card` (pure white in light, lifted dark in dark).
+- Card border = `--border` (subtle warm gray).
+
+The visual difference between page and card is the surface color
+plus a 1px border. No shadow. No `border-2`. Subtle but unmistakable.
+
+## Why no shadows
+
+1. **Honesty.** A drop shadow says "this thing is floating above the
+   page" — a visual lie about a flat document. Borders say "this is a
+   region", which is what cards actually are.
+2. **Density.** Stacked shadows compound into noise; stacked borders
+   stay crisp. Inventario's surfaces (settings rows, list rows, stat
+   cards) stack densely.
+3. **Dark-mode parity.** Shadows look heavy in dark mode and require
+   per-mode tuning. Borders use opacity (`oklch(1 0 0 / 10%)`) and
+   render the same way in both modes.
+4. **System aesthetic.** Things 3, Linear (early), Notion's recent
+   editions all moved away from shadows toward borders. The references
+   in `00-positioning.md` set the tone.
+
+## What's allowed
+
+| Effect | Where | Token |
+| --- | --- | --- |
+| `shadow-xs` | shadcn `Input` (built in) | Tailwind default |
+| 1px border | every card, dialog, sheet, popover surface | `--border` (or `--sidebar-border` etc.) |
+| `border-current/20` | tag pills, status badges | derived from the foreground |
+| Backdrop blur | none | — |
+| Glassmorphism | none | — |
+| Inset shadow / inner glow | none | — |
+| Hover-lift transform | none | — |
+
+The `shadow-xs` exception exists because input fields without a hint
+of depth read as flat label + caret on the page, which makes them
+hard to spot for new users. It's a 1px-blur shadow — barely visible,
+purely a focus aid.
+
+## What's banned
+
+- `shadow-sm`, `shadow-md`, `shadow-lg`, `shadow-xl`, `shadow-2xl` on
+  any surface.
+- `drop-shadow-*` filters.
+- `backdrop-blur-*`.
+- Box-shadow for glow rings (use `--ring` via `focus-visible:ring`
+  instead).
+- `transform: translateY(-2px)` on hover.
+
+If you reach for one of these, the underlying need is probably:
+
+| Reaching for | Want | Use |
+| --- | --- | --- |
+| `shadow-sm` to mark a card | "this is a card" | The card's existing border + bg-card. |
+| `shadow-lg` on a dialog | "this is on top" | Radix `<DialogContent>` already has the right backdrop; don't add shadow. |
+| `backdrop-blur` on a top bar | "scrollable content under" | A solid `bg-background/80` border + `backdrop-blur-sm` is allowed *only* on the Shell's top bar. Borders elsewhere. |
+| `drop-shadow` on an icon | "this icon stands out" | Pair the icon with a tinted background tile (`bg-primary/10`). |
+
+## Borders
+
+| Style | Token / class | Use |
+| --- | --- | --- |
+| 1px subtle | `border border-border` | Card, dialog, sheet, popover |
+| 1px stronger | `border border-foreground/20` | Hover/active states (rare) |
+| Tinted | `border-current/20` | Tag pills, status badges |
+| 0 | `border-0` | Removed-default-border surfaces |
+| 1px destructive | `border-destructive/40` | Inline error highlights |
+| 0.5px | not supported | Use 1px |
+| Dashed | rare; only on drop-zone targets | `border-dashed border-2 border-border` |
+
+The drop-zone exception (`border-dashed border-2`) is the one place
+where a thicker border earns its weight — see `10-file-and-media.md`.
+
+## Focus
+
+The focus ring **is** an effect. shadcn primitives bake in:
+
+```css
+focus-visible:ring-[3px] focus-visible:ring-ring/50
+```
+
+— a 3px amber ring at 50% opacity. Don't override. See
+`14-accessibility.md` for the keyboard-only contract.
+
+## Hover state
+
+Hover is a visual cue, not a transform. Patterns:
+
+| Element | Hover |
+| --- | --- |
+| Button | `hover:bg-*/90` (filled) / `hover:bg-accent/10` (ghost) |
+| Card-row | `hover:bg-muted/40` |
+| Link | `hover:text-foreground` (when starts at `text-muted-foreground`) |
+| Icon-only ghost button | `hover:bg-muted` |
+| Reveal action (kebab in row) | `opacity-0 group-hover:opacity-100 transition-opacity` |
+
+`transition-colors` is the default transition utility. No
+`transition-transform`, no `transition-shadow`. See `05-motion.md`
+for durations.
+
+## Active state
+
+The user just pressed it but hasn't released:
+
+```tsx
+className="active:bg-primary/95"   // filled
+className="active:bg-muted/60"     // ghost
+```
+
+Active is the depth cue you'd otherwise reach for an inset shadow
+for. Color shift, not transform.
+
+## Inset / outset / cutout
+
+None of these. Inventario is a flat document with regions. Surfaces
+have edges (borders), not three-dimensional cues.
+
+## Hard rules
+
+1. **No drop shadows.** Anywhere except `shadow-xs` on inputs.
+2. **No transforms on hover** — `hover:translate-y-[-2px]` is a ban
+   on sight.
+3. **Border or color, never glow.** Focus rings via the `--ring`
+   token's amber via shadcn defaults; "highlighted" via tinted bg
+   (`bg-primary/10`), not via `box-shadow`.
+4. **No backdrop blur** beyond the Shell's top bar (and even that's
+   optional — the bar can be a solid `bg-background border-b`).
+5. **No "elevation tiers".** Material's `shadow-1` … `shadow-24`
+   model is a different product's choice. We have one tier: bordered.
+
+## Anti-patterns
+
+- A stat card with `shadow-md` because "it's important". Importance
+  is conveyed by the value's typography (`text-2xl font-bold`), not
+  by floating it.
+- Hover-lifting a row with `hover:translate-y-[-1px]`. Use
+  `hover:bg-muted/40`.
+- A glassmorphism login background. The auth pages are quiet; a
+  blurred hero contradicts the tone.
+- `box-shadow: 0 0 0 4px var(--ring)` to hand-roll a focus ring. The
+  shadcn primitive already does it via `ring-*` utilities.
+
+## Cross-refs
+
+- Tokens: `01-palette.md`.
+- Spacing rhythm: `03-space-and-layout.md`.
+- Hover / focus / active states: `08-interaction-states.md`.
+- Focus ring contrast: `14-accessibility.md`.

--- a/devdocs/frontend/design/05-motion.md
+++ b/devdocs/frontend/design/05-motion.md
@@ -25,7 +25,7 @@ These compose: a Sheet's open animation is
 data-[state=open]:duration-300`.
 
 `@tailwindcss/animate` is banned — `tw-animate-css` replaces it for
-Tailwind v4. See `../imports-and-bans.md`.
+Tailwind v4. See [../imports-and-bans.md](../imports-and-bans.md).
 
 Framer Motion / react-spring / popmotion / GSAP are also banned. The
 animations the design uses are all property transitions (color,
@@ -99,7 +99,7 @@ reduced. Use it for non-essential animations:
 ```
 
 The Lighthouse `accessibility` audit doesn't currently flag missing
-`motion-reduce:` gating, but the WCAG 2.2 AA bar (`14-accessibility.md`)
+`motion-reduce:` gating, but the WCAG 2.2 AA bar ([14-accessibility.md](14-accessibility.md))
 asks for it. Treat it as required.
 
 ## Skeletons over spinners
@@ -131,7 +131,7 @@ Sonner ships in/out animations tuned to its drawer:
   manual-dismiss for `error`.
 - `useAppToast()` is the wrapper that enforces the role + duration
   contract. Don't call `sonner.toast(...)` directly — see
-  `16-notifications-and-trust.md`.
+  [16-notifications-and-trust.md](16-notifications-and-trust.md).
 
 ## Hard rules
 
@@ -153,17 +153,17 @@ Sonner ships in/out animations tuned to its drawer:
   `transition-opacity`, `transition-transform`.
 - A 600ms hover. Hover is feedback, not theatre.
 - `animate-bounce` on the empty-state icon. Empty states are quiet
-  (per `00-positioning.md`); a bouncing icon is loud.
+  (per [00-positioning.md](00-positioning.md)); a bouncing icon is loud.
 - Page-load fade-in. The user clicked a link; the page should appear
   immediately.
 - A custom `@keyframes` for a "subtle gradient sweep" on a card.
   Cards don't sweep. Borders, not effects (per
-  `04-elevation-and-effects.md`).
+  [04-elevation-and-effects.md](04-elevation-and-effects.md)).
 
 ## Cross-refs
 
-- Library policy: `../imports-and-bans.md`.
-- Toast hierarchy: `16-notifications-and-trust.md`.
-- Reduced-motion a11y: `14-accessibility.md`.
-- Mock canonical: `denisvmedia/inventario-design/CLAUDE.md` does not
+- Library policy: [../imports-and-bans.md](../imports-and-bans.md).
+- Toast hierarchy: [16-notifications-and-trust.md](16-notifications-and-trust.md).
+- Reduced-motion a11y: [14-accessibility.md](14-accessibility.md).
+
   spell out timings; this doc is the canonical source.

--- a/devdocs/frontend/design/05-motion.md
+++ b/devdocs/frontend/design/05-motion.md
@@ -1,0 +1,169 @@
+# Motion
+
+`tw-animate-css` only. Durations short, easings native. Reduced-motion
+is a first-class consumer; the Tailwind utilities respect it
+automatically.
+
+## Library: `tw-animate-css`
+
+Imported at the top of `frontend/src/index.css`:
+
+```css
+@import "tw-animate-css";
+```
+
+Provides the utilities Radix and shadcn primitives use:
+
+- `animate-in`, `animate-out`
+- `fade-in-0`, `fade-out-0`
+- `slide-in-from-top-2`, `slide-in-from-bottom-2`,
+  `slide-in-from-left-2`, `slide-in-from-right-2`
+- `zoom-in-95`, `zoom-out-95`
+
+These compose: a Sheet's open animation is
+`data-[state=open]:animate-in data-[state=open]:slide-in-from-right
+data-[state=open]:duration-300`.
+
+`@tailwindcss/animate` is banned — `tw-animate-css` replaces it for
+Tailwind v4. See `../imports-and-bans.md`.
+
+Framer Motion / react-spring / popmotion / GSAP are also banned. The
+animations the design uses are all property transitions (color,
+opacity, transform); a runtime animation library is dead weight.
+
+## Durations
+
+| Class | ms | Use |
+| --- | --- | --- |
+| `duration-75` | 75 | Color transitions on hover |
+| `duration-150` (default for `transition-colors`) | 150 | Buttons, links, inputs |
+| `duration-200` | 200 | Dropdowns, tooltips, popovers |
+| `duration-300` | 300 | Dialogs, sheets, sonner toasts |
+| `duration-500` | 500 | Empty-state fade-in (rare) |
+
+Anything > 500ms is "this is making me wait" territory. If you need
+500ms+, you probably want a skeleton instead of an animation.
+
+## Easings
+
+Tailwind defaults map to:
+
+- `ease-linear` — never (looks robotic).
+- `ease-in` — never on its own; only as part of `ease-in-out`.
+- `ease-out` — entries (`animate-in`). Things appear with deceleration.
+- `ease-in` — exits (`animate-out`). Things leave with acceleration.
+- `ease-in-out` — color/opacity transitions (`transition-colors`,
+  `transition-opacity`). The default for hover/focus.
+
+Don't reach for custom cubic-beziers (`ease-[cubic-bezier(...)]`).
+The defaults are correct.
+
+## What animates
+
+| Element | Animation | Duration |
+| --- | --- | --- |
+| Button background on hover | `transition-colors` | 150ms ease-in-out |
+| Tooltip open | `fade-in-0 zoom-in-95` | 200ms ease-out |
+| Dropdown menu open | `fade-in-0 zoom-in-95 slide-in-from-top-2` | 200ms ease-out |
+| Dialog open | `fade-in-0 zoom-in-95` | 300ms ease-out |
+| Dialog close | `fade-out-0 zoom-out-95` | 300ms ease-in |
+| Sheet open (right) | `slide-in-from-right` | 300ms ease-out |
+| Sheet close (right) | `slide-out-to-right` | 300ms ease-in |
+| Sonner toast in | `slide-in-from-bottom` | 300ms ease-out |
+| Reveal-on-hover (kebab in row) | `transition-opacity` | 150ms |
+| Skeleton shimmer | `animate-pulse` | infinite |
+| Page transition between routes | none | — |
+
+**No page transitions** — switching between routes is instant. Adding a
+fade between pages adds latency the user doesn't want and breaks
+keyboard / back-button rhythm.
+
+## Reduced motion
+
+`prefers-reduced-motion: reduce` disables `tw-animate-css` utilities
+automatically (they're gated on
+`@media (prefers-reduced-motion: no-preference)`).
+
+For your own transitions, gate explicitly with the `motion-reduce:`
+prefix:
+
+```tsx
+<div className="transition-colors motion-reduce:transition-none">…</div>
+```
+
+`motion-safe:` is the inverse — apply only when motion is *not*
+reduced. Use it for non-essential animations:
+
+```tsx
+<div className="motion-safe:animate-pulse">…</div>
+```
+
+The Lighthouse `accessibility` audit doesn't currently flag missing
+`motion-reduce:` gating, but the WCAG 2.2 AA bar (`14-accessibility.md`)
+asks for it. Treat it as required.
+
+## Skeletons over spinners
+
+While data is loading, prefer a **skeleton** that matches the page's
+shape over a centered spinner:
+
+```tsx
+<div className="animate-pulse space-y-3">
+  <div className="h-4 w-1/3 rounded-md bg-muted" />
+  <div className="h-4 w-1/2 rounded-md bg-muted" />
+</div>
+```
+
+`animate-pulse` is a Tailwind built-in (an `@keyframes` opacity
+shimmer). Use it on bones-shaped placeholders; don't roll your own
+`@keyframes`.
+
+The `<Skeleton>` shadcn primitive (`src/components/ui/skeleton.tsx`)
+is the wrapper — it just sets `bg-muted` + `animate-pulse` so the call
+site stays terse.
+
+## Sonner toasts
+
+Sonner ships in/out animations tuned to its drawer:
+
+- Slide-in from bottom-right.
+- Auto-dismiss at 4s for `info` / `success`, 6s for `warning`,
+  manual-dismiss for `error`.
+- `useAppToast()` is the wrapper that enforces the role + duration
+  contract. Don't call `sonner.toast(...)` directly — see
+  `16-notifications-and-trust.md`.
+
+## Hard rules
+
+1. **`tw-animate-css` only.** No Framer Motion, no react-spring, no
+   GSAP, no `@keyframes` defined in `index.css` outside what shadcn
+   primitives need.
+2. **No page transitions.** Routes swap instantly.
+3. **Durations from the table.** `duration-[473ms]` is a smell.
+4. **Reduced-motion respect.** Always use `motion-reduce:` /
+   `motion-safe:` or rely on `tw-animate-css`'s built-in gate.
+5. **Skeletons, not spinners.** A spinner is a fallback for genuinely
+   indefinite waits (e.g. an export that's running on the server);
+   in-flight data goes to a shape skeleton.
+
+## Anti-patterns
+
+- `transition: all 300ms` — too broad, transitions properties you
+  didn't expect (e.g. `width` becomes animated). Use `transition-colors`,
+  `transition-opacity`, `transition-transform`.
+- A 600ms hover. Hover is feedback, not theatre.
+- `animate-bounce` on the empty-state icon. Empty states are quiet
+  (per `00-positioning.md`); a bouncing icon is loud.
+- Page-load fade-in. The user clicked a link; the page should appear
+  immediately.
+- A custom `@keyframes` for a "subtle gradient sweep" on a card.
+  Cards don't sweep. Borders, not effects (per
+  `04-elevation-and-effects.md`).
+
+## Cross-refs
+
+- Library policy: `../imports-and-bans.md`.
+- Toast hierarchy: `16-notifications-and-trust.md`.
+- Reduced-motion a11y: `14-accessibility.md`.
+- Mock canonical: `denisvmedia/inventario-design/CLAUDE.md` does not
+  spell out timings; this doc is the canonical source.

--- a/devdocs/frontend/design/06-iconography-and-illustration.md
+++ b/devdocs/frontend/design/06-iconography-and-illustration.md
@@ -2,7 +2,7 @@
 
 **Committed.** Inventario uses **`lucide-react`** for every icon and
 no other library. Illustration is sparing and lives in empty states /
-onboarding only — see `22-illustration-prompts.md` for the sourcing
+onboarding only — see [22-illustration-prompts.md](22-illustration-prompts.md) for the sourcing
 recipe.
 
 ## One library
@@ -15,9 +15,9 @@ Hard rules:
 
 - Lucide is the only icon source. FontAwesome / PrimeIcons / Heroicons
   / Material Icons / Phosphor / react-icons are bans on sight. See
-  `../imports-and-bans.md`.
+  [../imports-and-bans.md](../imports-and-bans.md).
 - Inline SVG paths are not allowed in components. The one exception is
-  the brand mark (`AppLogo`); see `19-branding.md`.
+  the brand mark (`AppLogo`); see [19-branding.md](19-branding.md).
 - Always import by named export — `import { Trash2 } from "lucide-react"`,
   never the namespace import. Tree-shake matters; the entry-bundle
   budget is 200 KB gzip.
@@ -30,7 +30,7 @@ Hard rules:
   …).
 - One stroke weight, one size convention, one design language —
   consistent across the app at zero engineering cost.
-- The mock at `denisvmedia/inventario-design` uses lucide. Lockstep
+- The design mock uses lucide. Lockstep
   with the canonical visual contract.
 
 PR #1362 proposed migrating to Phosphor. That proposal is no longer
@@ -52,7 +52,7 @@ the React rewrite.
 | `size-16` | 64 | Hero illustration backdrop (rare) |
 
 Match icon size to the surrounding control's height — see the
-button-size-to-icon table in `../icons.md`. Don't reach for `size-[18px]`;
+button-size-to-icon table in [../icons.md](../icons.md). Don't reach for `size-[18px]`;
 the scale is enough.
 
 ## Stroke
@@ -108,7 +108,7 @@ For icon-only buttons, label the button, not the icon:
 </Button>
 ```
 
-See `14-accessibility.md` for the full rule.
+See [14-accessibility.md](14-accessibility.md) for the full rule.
 
 ## Domain icon vocabulary
 
@@ -155,7 +155,7 @@ near match in the moment.
 
 Used in:
 
-- Empty states (per `20-edge-cases.md`).
+- Empty states (per [20-edge-cases.md](20-edge-cases.md)).
 - Onboarding (no-group, post-register).
 - The 404 page.
 
@@ -168,7 +168,7 @@ Never used in:
 The current production set is **icon-only** — the `Folder` /
 `Package` glyphs at `size-10` over a `bg-primary/10 rounded-lg` tile
 serve as the empty-state illustration. The brief at
-`22-illustration-prompts.md` documents the recipe for richer
+[22-illustration-prompts.md](22-illustration-prompts.md) documents the recipe for richer
 illustrations if and when we commission them; they aren't yet in the
 shipping bundle.
 
@@ -198,8 +198,8 @@ shipping bundle.
 
 ## Cross-refs
 
-- Engineering rules: `../icons.md`.
-- A11y for icons: `14-accessibility.md`.
-- Empty-state usage: `20-edge-cases.md`.
-- Brand mark vs. icon: `19-branding.md`, `21-logo-directions.md`.
-- Illustration prompts: `22-illustration-prompts.md`.
+- Engineering rules: [../icons.md](../icons.md).
+- A11y for icons: [14-accessibility.md](14-accessibility.md).
+- Empty-state usage: [20-edge-cases.md](20-edge-cases.md).
+- Brand mark vs. icon: [19-branding.md](19-branding.md), [21-logo-directions.md](21-logo-directions.md).
+- Illustration prompts: [22-illustration-prompts.md](22-illustration-prompts.md).

--- a/devdocs/frontend/design/06-iconography-and-illustration.md
+++ b/devdocs/frontend/design/06-iconography-and-illustration.md
@@ -1,0 +1,205 @@
+# Iconography & Illustration
+
+**Committed.** Inventario uses **`lucide-react`** for every icon and
+no other library. Illustration is sparing and lives in empty states /
+onboarding only — see `22-illustration-prompts.md` for the sourcing
+recipe.
+
+## One library
+
+```tsx
+import { ChevronRight, Trash2, Plus } from "lucide-react"
+```
+
+Hard rules:
+
+- Lucide is the only icon source. FontAwesome / PrimeIcons / Heroicons
+  / Material Icons / Phosphor / react-icons are bans on sight. See
+  `../imports-and-bans.md`.
+- Inline SVG paths are not allowed in components. The one exception is
+  the brand mark (`AppLogo`); see `19-branding.md`.
+- Always import by named export — `import { Trash2 } from "lucide-react"`,
+  never the namespace import. Tree-shake matters; the entry-bundle
+  budget is 200 KB gzip.
+
+## Why lucide
+
+- Free, MIT, vendor-neutral.
+- Excellent coverage of the inventory domain (Package, Folder, Boxes,
+  ScanBarcode, Receipt, Wrench, Wallet, FileText, Image, Camera, Tag,
+  …).
+- One stroke weight, one size convention, one design language —
+  consistent across the app at zero engineering cost.
+- The mock at `denisvmedia/inventario-design` uses lucide. Lockstep
+  with the canonical visual contract.
+
+PR #1362 proposed migrating to Phosphor. That proposal is no longer
+on the table — Lucide stays. The earlier proposal predated cutover,
+when icon stylization was being re-litigated; it didn't survive into
+the React rewrite.
+
+## Size scale
+
+| Class | px | Use |
+| --- | --- | --- |
+| `size-3` | 12 | xs button, small badge |
+| `size-3.5` | 14 | sm button, tight inline cue |
+| `size-4` | 16 | Body default, default button, list-row chevron |
+| `size-5` | 20 | lg button, dialog title icon, hero-row icon (in a `size-10` tile) |
+| `size-6` | 24 | Sidebar nav (`SidebarMenuButton`) |
+| `size-8` | 32 | Stat-card tile (with `size-4` icon inside) |
+| `size-10` | 40 | Empty-state hero, first-run onboarding |
+| `size-16` | 64 | Hero illustration backdrop (rare) |
+
+Match icon size to the surrounding control's height — see the
+button-size-to-icon table in `../icons.md`. Don't reach for `size-[18px]`;
+the scale is enough.
+
+## Stroke
+
+Lucide ships at stroke-width 2 by default. Don't override:
+
+- Don't write `strokeWidth={1.5}` to "soften" the look. The whole
+  app's stroke language is consistent at 2; one weakened icon looks
+  off-rhythm.
+- Don't compose lucide icons into a bigger glyph. Use the named icon
+  closest to the meaning.
+
+## Color
+
+Decorative icons inherit color from `text-*` on the parent. Defaults:
+
+| Use | Class |
+| --- | --- |
+| Decorative cue | `text-muted-foreground` |
+| Primary action / focal | `text-primary` |
+| Destructive | `text-destructive` |
+| Domain status | `text-status-active` / `text-status-expiring` / `text-status-expired` / `text-status-none` |
+| Tag color | `text-tag-amber` / `text-tag-green` / … (closed enum) |
+
+Hard ban: `text-amber-500`, `text-red-600` for icons. Tokens via the
+documented utilities.
+
+## Aria
+
+Lucide adds `aria-hidden="true"` to its rendered SVG when no
+label-related prop is set. Don't override — that's what you want for
+decorative icons next to a text label:
+
+```tsx
+<Button>
+  <Trash2 className="size-3.5" />
+  {t("common:actions.delete")}
+</Button>
+```
+
+For stand-alone icons (without a text label, not inside a labeled
+button), set `aria-label`:
+
+```tsx
+<Check className="size-4 text-status-active" aria-label={t("common:status.completed")} />
+```
+
+For icon-only buttons, label the button, not the icon:
+
+```tsx
+<Button size="icon" aria-label={t("common:actions.delete")}>
+  <Trash2 className="size-4" />
+</Button>
+```
+
+See `14-accessibility.md` for the full rule.
+
+## Domain icon vocabulary
+
+Closed mapping: domain concept → lucide icon. Mirror these across the
+codebase rather than picking a synonym:
+
+| Domain | Icon |
+| --- | --- |
+| Commodity / item | `Package` |
+| Location | `Folder` |
+| Area | `Boxes` |
+| File (unspecified) | `File` |
+| File: image / photo | `Image` (or `Camera` for capture flows) |
+| File: invoice | `Receipt` |
+| File: document | `FileText` |
+| File: other | `Paperclip` |
+| Tag | `Tag` |
+| Search | `Search` |
+| Settings | `Settings` |
+| Profile | `User` |
+| Group | `Users` |
+| Logout | `LogOut` |
+| Add | `Plus` |
+| Edit | `Edit2` (line-edit) — never `Pencil` |
+| Delete | `Trash2` |
+| Upload | `Upload` |
+| Download | `Download` |
+| Export | `Download` (when target is the user's disk) / `Box` (the export entity itself) |
+| Restore | `RotateCcw` |
+| Filter | `Filter` |
+| Sort | `ArrowUpDown` |
+| More actions | `MoreHorizontal` |
+| Calendar / date | `Calendar` |
+| Warranty | `ShieldCheck` (active) / `ShieldAlert` (expiring) / `ShieldX` (expired) |
+| Currency / value | `Banknote` (or `Coins` for many) |
+| Print | `Printer` |
+| Share | `Share2` |
+| Copy | `Copy` |
+
+If the domain concept doesn't map, file an issue rather than picking a
+near match in the moment.
+
+## Illustrations
+
+Used in:
+
+- Empty states (per `20-edge-cases.md`).
+- Onboarding (no-group, post-register).
+- The 404 page.
+
+Never used in:
+
+- Marketing-style page heroes (Inventario doesn't have those).
+- Stat cards (icons in tiles, not illustrations).
+- Confirmation dialogs.
+
+The current production set is **icon-only** — the `Folder` /
+`Package` glyphs at `size-10` over a `bg-primary/10 rounded-lg` tile
+serve as the empty-state illustration. The brief at
+`22-illustration-prompts.md` documents the recipe for richer
+illustrations if and when we commission them; they aren't yet in the
+shipping bundle.
+
+## Hard rules
+
+1. **Lucide only.** No mixed icon libraries.
+2. **Named imports.** No namespace imports of `lucide-react`.
+3. **Pick from the size scale.** No `size-[18px]`.
+4. **Default stroke (2).** No softening or hand-rolled bolding.
+5. **Tokens for color.** No raw Tailwind palettes on icons.
+6. **`aria-hidden` is Lucide's default.** Override (with `aria-label`)
+   only when the icon is stand-alone meaningful.
+7. **Domain vocabulary is closed.** Mirror the table above rather than
+   picking a synonym.
+
+## Anti-patterns
+
+- A `Trash` icon and a `Trash2` icon side-by-side — pick one and
+  search-and-replace.
+- Color-tinted decorative icons (`text-amber-500` on a list-row
+  chevron) — chevrons inherit `text-muted-foreground`.
+- A 4-color SVG illustration on the dashboard. The dashboard is
+  glanceable, not decorative.
+- Wrapping an icon in `<span aria-hidden>` next to an unlabeled
+  `<button>`. Label the button.
+- Using a `Package` icon for files. The mapping is closed.
+
+## Cross-refs
+
+- Engineering rules: `../icons.md`.
+- A11y for icons: `14-accessibility.md`.
+- Empty-state usage: `20-edge-cases.md`.
+- Brand mark vs. icon: `19-branding.md`, `21-logo-directions.md`.
+- Illustration prompts: `22-illustration-prompts.md`.

--- a/devdocs/frontend/design/07-data-visualization.md
+++ b/devdocs/frontend/design/07-data-visualization.md
@@ -35,7 +35,7 @@ The five chart-token slots (`--chart-1` through `--chart-5`) are the
 Order is meaningful: the most important series gets `--chart-1`;
 "decline" / "negative" connotation goes to `--chart-5`. Don't pick a
 chart slot to convey domain status — use the `--status-*` tokens
-(`08-interaction-states.md`, `01-palette.md`).
+([08-interaction-states.md](08-interaction-states.md), [01-palette.md](01-palette.md)).
 
 ## Chart-type-per-data-shape
 
@@ -93,14 +93,14 @@ Always interactive — the user hovers a bar / point and sees:
 
 - Use the same Radix `<Tooltip>` primitive as elsewhere.
 - Format dates / numbers via `src/lib/intl.ts`'s helpers (see
-  `13-formatting-and-i18n.md`).
+  [13-formatting-and-i18n.md](13-formatting-and-i18n.md)).
 - Never put a tooltip on every visual — the whole-chart hover layer
   handles it.
 
 ## Empty / loading / error
 
 Charts have the same three states every other data surface has (see
-`08-interaction-states.md`):
+[08-interaction-states.md](08-interaction-states.md)):
 
 - **Empty**: a single line of muted copy ("No data yet") +
   the same chart frame at minimum size. Don't render an empty axis-only
@@ -140,8 +140,8 @@ can pick from `7d / 30d / 90d / 12m / All` with a segmented control
 
 ## Cross-refs
 
-- Tokens: `01-palette.md`.
-- Stat tiles: `03-space-and-layout.md` ("Stat card row").
-- Formatting: `13-formatting-and-i18n.md`.
-- States (empty / loading / error): `08-interaction-states.md`.
+- Tokens: [01-palette.md](01-palette.md).
+- Stat tiles: [03-space-and-layout.md](03-space-and-layout.md) ("Stat card row").
+- Formatting: [13-formatting-and-i18n.md](13-formatting-and-i18n.md).
+- States (empty / loading / error): [08-interaction-states.md](08-interaction-states.md).
 - Recharts via shadcn chart wrapper: <https://ui.shadcn.com/charts>.

--- a/devdocs/frontend/design/07-data-visualization.md
+++ b/devdocs/frontend/design/07-data-visualization.md
@@ -1,0 +1,147 @@
+# Data Visualization
+
+Charts, sparklines, stat tiles, progress meters. **Recommendation:**
+lean on shadcn's chart wrapper (`src/components/ui/chart.tsx` if
+copied in) over Recharts; reach for the `--chart-1` … `--chart-5`
+tokens. Keep charts quiet — they support a stat, they're not a stat.
+
+## When to chart
+
+| Surface | Default visualization |
+| --- | --- |
+| Dashboard | Stat tiles + recent items list. **No** large charts. |
+| Reports / future | Bar / line / sparkline / donut, in that order of preference. |
+| Item detail | Status history as a timeline list, **not** a chart. |
+| Tag detail (future) | Stat tiles + maybe sparkline of usage over time. |
+| Insurance report | Tabular density. Charts only when they replace 5+ rows of text. |
+
+A chart that needs an axis label and a legend usually wants to be a
+table instead. Inventario users are reading "what do I have?"; a
+table answers it directly.
+
+## Chart palette
+
+The five chart-token slots (`--chart-1` through `--chart-5`) are the
+**only** allowed chart colors. Defined in `frontend/src/index.css`:
+
+| Token | Light | Use |
+| --- | --- | --- |
+| `--chart-1` | `oklch(0.7 0.16 75)` | Amber — primary series |
+| `--chart-2` | `oklch(0.65 0.14 145)` | Green — secondary |
+| `--chart-3` | `oklch(0.6 0.14 220)` | Blue — tertiary |
+| `--chart-4` | `oklch(0.75 0.18 55)` | Warm yellow — quaternary |
+| `--chart-5` | `oklch(0.62 0.18 25)` | Red — quinary / "other / decline" |
+
+Order is meaningful: the most important series gets `--chart-1`;
+"decline" / "negative" connotation goes to `--chart-5`. Don't pick a
+chart slot to convey domain status — use the `--status-*` tokens
+(`08-interaction-states.md`, `01-palette.md`).
+
+## Chart-type-per-data-shape
+
+A short heuristic, in descending order of preference:
+
+| Data shape | Default | Why |
+| --- | --- | --- |
+| One number, in context | Stat tile | The biggest insight from the smallest pixel cost. |
+| One number over time | Sparkline | Compact, no axes, fits a stat tile. |
+| Few categories at one moment | Horizontal bars | Easier than donuts to read; ranks naturally. |
+| Many categories at one moment | Vertical bars | Higher density. |
+| One series over time, with magnitude | Line chart | The default time-series shape. |
+| Two-series comparison over time | Line, two series | Bar grouping invites mistakes; lines are clearer. |
+| Composition of a whole | Stacked horizontal bar | A donut hides the smallest slices. **Avoid pie / donut.** |
+| Distribution | Histogram | Bucketed bars, not a smoothed density curve. |
+
+## Axes and labels
+
+- Y-axis labels at sm size (`text-xs text-muted-foreground`),
+  tick-aligned.
+- X-axis labels at sm size, rotated only if absolutely necessary
+  (rotation is a smell — rephrase the labels first).
+- No grid lines. Use `stroke-muted/30` for a single horizontal axis
+  line if a baseline is needed.
+- No 3D effects. No drop shadows on bars. No gradient fills.
+
+## Sparklines
+
+A sparkline goes inside a stat tile. Inline, no axes, single color,
+the same height as the value text:
+
+```tsx
+<div className="flex items-end gap-3">
+  <div>
+    <p className="text-xs text-muted-foreground">{label}</p>
+    <p className="text-2xl font-bold tracking-tight">{value}</p>
+  </div>
+  <Sparkline data={recent} className="h-8 w-24 text-chart-1" />
+</div>
+```
+
+Sparkline color = `--chart-1` unless the metric has a domain
+connotation that maps to a status (`--status-*`).
+
+## Tooltips on charts
+
+Always interactive — the user hovers a bar / point and sees:
+
+```
+┌──────────────────┐
+│ April 18, 2026   │
+│ Items added: 12  │
+└──────────────────┘
+```
+
+- Use the same Radix `<Tooltip>` primitive as elsewhere.
+- Format dates / numbers via `src/lib/intl.ts`'s helpers (see
+  `13-formatting-and-i18n.md`).
+- Never put a tooltip on every visual — the whole-chart hover layer
+  handles it.
+
+## Empty / loading / error
+
+Charts have the same three states every other data surface has (see
+`08-interaction-states.md`):
+
+- **Empty**: a single line of muted copy ("No data yet") +
+  the same chart frame at minimum size. Don't render an empty axis-only
+  skeleton.
+- **Loading**: skeleton-shaped placeholder bar / line at `bg-muted`
+  with `animate-pulse`.
+- **Error**: an inline note, not a toast. ("Couldn't load. Retry.")
+
+## Ranges and aggregation
+
+When the chart is over time, default range = "last 30 days". User
+can pick from `7d / 30d / 90d / 12m / All` with a segmented control
+(`<Tabs>` works fine). Persist the choice per-page in `searchParams`
+(not localStorage) so a deep link encodes the view.
+
+## Hard rules
+
+1. **Five colors max.** `--chart-1` … `--chart-5`. If you need a
+   sixth, you have too many series — re-bucket.
+2. **No domain status as a chart color.** Status uses `--status-*`.
+3. **No pies / donuts.** A stacked horizontal bar is always clearer.
+4. **No gradients in chart fills.** Solid token colors only.
+5. **Tooltips and labels via `src/lib/intl.ts`.** No `Number(value).toFixed(2)`
+   sprayed at render time.
+
+## Anti-patterns
+
+- A 6-series line chart ("the whole inventory broken down by tag").
+  Filter to top 5 + "Other".
+- A pie chart with 3 slices. Use 3 stat tiles.
+- A "comparison" chart that overlays bars on lines. The eye can't
+  parse it; pick one shape.
+- Chart titles in `text-2xl`. Charts are dependents — `text-base
+  font-semibold` is the cap.
+- A chart full of `text-amber-500` because "the bars should be amber".
+  Tokens (`text-chart-1`).
+
+## Cross-refs
+
+- Tokens: `01-palette.md`.
+- Stat tiles: `03-space-and-layout.md` ("Stat card row").
+- Formatting: `13-formatting-and-i18n.md`.
+- States (empty / loading / error): `08-interaction-states.md`.
+- Recharts via shadcn chart wrapper: <https://ui.shadcn.com/charts>.

--- a/devdocs/frontend/design/08-interaction-states.md
+++ b/devdocs/frontend/design/08-interaction-states.md
@@ -40,7 +40,7 @@ Hover is feedback that the surface is interactive — never a transform.
 | Card-as-button | `hover:bg-muted/30 hover:border-foreground/15 transition-colors` |
 
 `transition-colors duration-150` is the default transition. No
-`hover:translate-*`, no `hover:scale-*`. See `04-elevation-and-effects.md`.
+`hover:translate-*`, no `hover:scale-*`. See [04-elevation-and-effects.md](04-elevation-and-effects.md).
 
 ## Focus-visible
 
@@ -98,7 +98,7 @@ Three sub-flavors:
   className="size-4 animate-spin" />`). Don't replace the label —
   keep both.
 - **In-flight query** — render a skeleton-shaped placeholder. See
-  `05-motion.md` ("Skeletons over spinners").
+  [05-motion.md](05-motion.md) ("Skeletons over spinners").
 - **Indefinite long-running** (export running on the server) — show
   the actual server-side state via SSE / polling, not a spinner. The
   UI says "Running… 12 of 184 items".
@@ -132,7 +132,7 @@ an afterthought:
 ```
 
 The shape is consistent across pages: tile + title + body + (optional)
-CTA. See `20-edge-cases.md` for the full empty-state taxonomy.
+CTA. See [20-edge-cases.md](20-edge-cases.md) for the full empty-state taxonomy.
 
 ## Error
 
@@ -143,10 +143,10 @@ Granularity, in order of severity:
 | Field validation | Inline below the input, `text-destructive text-xs` | "Email is required" |
 | Form-level | `<Alert variant="destructive">` above the form | "Invalid credentials" |
 | Page-level (data didn't load) | Inline replacement of the data area | "Couldn't load items. Retry." |
-| App-level (route blew up) | The 500 page (`20-edge-cases.md`) | "Something went wrong" |
+| App-level (route blew up) | The 500 page ([20-edge-cases.md](20-edge-cases.md)) | "Something went wrong" |
 
 Color is paired with icon + text. `text-destructive` alone never
-communicates an error. See `14-accessibility.md`.
+communicates an error. See [14-accessibility.md](14-accessibility.md).
 
 ## Selection
 
@@ -160,7 +160,7 @@ tiles, file picker):
   selected (mode change).
 - Keyboard: `Space` toggles, `Shift+ArrowDown` extends.
 - Bulk actions appear in a sticky toolbar below the list header — not
-  inline next to each row. See `09-component-patterns.md`.
+  inline next to each row. See [09-component-patterns.md](09-component-patterns.md).
 
 ## State precedence
 
@@ -179,7 +179,7 @@ Every component test exercises at least the four states a button has:
 default, hover (`userEvent.hover`), focus (`userEvent.tab` to the
 control), active (`userEvent.pointer({ keys: '[MouseLeft>]', target })`),
 and — if relevant — error and loading. See
-`../testing.md`.
+[../testing.md](../testing.md).
 
 ## Hard rules
 
@@ -205,8 +205,8 @@ and — if relevant — error and loading. See
 
 ## Cross-refs
 
-- Component anatomy: `09-component-patterns.md`.
-- Edge-case states (404 / 500 / offline / no-group): `20-edge-cases.md`.
-- Form-state UX: `15-form-and-data-ux.md`.
-- A11y: `14-accessibility.md`.
-- Loading skeletons: `05-motion.md`.
+- Component anatomy: [09-component-patterns.md](09-component-patterns.md).
+- Edge-case states (404 / 500 / offline / no-group): [20-edge-cases.md](20-edge-cases.md).
+- Form-state UX: [15-form-and-data-ux.md](15-form-and-data-ux.md).
+- A11y: [14-accessibility.md](14-accessibility.md).
+- Loading skeletons: [05-motion.md](05-motion.md).

--- a/devdocs/frontend/design/08-interaction-states.md
+++ b/devdocs/frontend/design/08-interaction-states.md
@@ -1,0 +1,212 @@
+# Interaction States
+
+The eight states every interactive surface has, and how each one looks.
+**Committed.** When you build a new component, walk this list — if a
+state is missing, the component isn't done.
+
+## The eight states
+
+1. **Default** — at rest, no input.
+2. **Hover** — pointer over.
+3. **Focus-visible** — keyboard arrived.
+4. **Active** — pressed but not released.
+5. **Disabled** — not interactive (greyed, but reachable by Tab? See below).
+6. **Loading** — request in flight.
+7. **Empty** — the data is genuinely empty.
+8. **Error** — the request, or input validation, failed.
+
+A ninth, **Selected**, applies to multi-select surfaces (rows in a
+list, items in a gallery). It's a long-lived state, not a transient
+one — see "Selection" below.
+
+## Default
+
+The lowest-energy state. Body uses `text-foreground` (or `text-muted-foreground`
+for secondary cues), surfaces use `bg-card` / `bg-background`, borders
+use `border-border`. No tints, no fills.
+
+## Hover
+
+Hover is feedback that the surface is interactive — never a transform.
+
+| Element | Hover |
+| --- | --- |
+| Filled button | `hover:bg-primary/90` (default) / `hover:bg-destructive/90` |
+| Outline button | `hover:bg-accent/10` |
+| Ghost button | `hover:bg-muted` |
+| Link | `hover:text-foreground` (when starting from `text-muted-foreground`) |
+| List row | `hover:bg-muted/40` |
+| Reveal-on-hover action (kebab in row) | `opacity-0 group-hover:opacity-100 transition-opacity` |
+| Card-as-button | `hover:bg-muted/30 hover:border-foreground/15 transition-colors` |
+
+`transition-colors duration-150` is the default transition. No
+`hover:translate-*`, no `hover:scale-*`. See `04-elevation-and-effects.md`.
+
+## Focus-visible
+
+The keyboard arrived. shadcn primitives bake in:
+
+```css
+focus-visible:ring-[3px] focus-visible:ring-ring/50
+```
+
+— a 3px amber ring at 50% opacity, against the adjacent surface. This
+is the only depth cue we use.
+
+Hard rules:
+
+- **`focus-visible:`, never `focus:`.** Mouse-clickers shouldn't see a
+  ring after pressing a button.
+- **Never `outline: none`** without `focus-visible:ring-*`. A removed
+  outline + no ring is a critical a11y bug.
+- **Don't tone the ring down** to `ring-[1px]` or `ring/20`. The 3px
+  amber is the contract.
+
+## Active
+
+Pressed but not released. A color shift, not a transform:
+
+```tsx
+className="active:bg-primary/95"   // filled
+className="active:bg-muted/60"     // ghost / list row
+className="active:bg-destructive/95"
+```
+
+`active:` fires on mouse-down on desktop, and on touch-press on mobile —
+both correct.
+
+## Disabled
+
+The control is not interactive. Two flavors:
+
+| Flavor | When | How |
+| --- | --- | --- |
+| **Reachable disabled** | The user should know it exists; an input that's about to become valid as they fix another field. | `disabled` prop on the element + the visual state shadcn ships (50% opacity, cursor-not-allowed). Stays in tab order. |
+| **Unreachable disabled** | The action genuinely doesn't apply; pre-launch feature flag. | Hide it. A control that can never be reached is clutter. |
+
+Don't fake-disable with `pointer-events: none` or `opacity-50` alone —
+that breaks ARIA and screen-reader announcement. Use the `disabled`
+prop on `<button>` / `<input>`; for non-form elements, use
+`aria-disabled="true"` and skip the click handler.
+
+## Loading
+
+Three sub-flavors:
+
+- **In-flight mutation** — gate the submit button on
+  `mutation.isPending` and show a spinner *inside* the button (`<Loader2
+  className="size-4 animate-spin" />`). Don't replace the label —
+  keep both.
+- **In-flight query** — render a skeleton-shaped placeholder. See
+  `05-motion.md` ("Skeletons over spinners").
+- **Indefinite long-running** (export running on the server) — show
+  the actual server-side state via SSE / polling, not a spinner. The
+  UI says "Running… 12 of 184 items".
+
+```tsx
+<Button disabled={mutation.isPending}>
+  {mutation.isPending && <Loader2 className="size-4 animate-spin" />}
+  {t("common:actions.save")}
+</Button>
+```
+
+## Empty
+
+The user is genuinely seeing no data. This is a first-class state, not
+an afterthought:
+
+```tsx
+<div className="flex flex-col items-center justify-center gap-3 py-16">
+  <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10">
+    <Package className="size-5 text-primary" />
+  </div>
+  <div className="text-center">
+    <p className="text-base font-semibold">No items yet</p>
+    <p className="text-sm text-muted-foreground">When you add one, it'll show up here.</p>
+  </div>
+  <Button size="sm" onClick={onAdd}>
+    <Plus className="size-3.5" />
+    Add item
+  </Button>
+</div>
+```
+
+The shape is consistent across pages: tile + title + body + (optional)
+CTA. See `20-edge-cases.md` for the full empty-state taxonomy.
+
+## Error
+
+Granularity, in order of severity:
+
+| Level | UI | Example |
+| --- | --- | --- |
+| Field validation | Inline below the input, `text-destructive text-xs` | "Email is required" |
+| Form-level | `<Alert variant="destructive">` above the form | "Invalid credentials" |
+| Page-level (data didn't load) | Inline replacement of the data area | "Couldn't load items. Retry." |
+| App-level (route blew up) | The 500 page (`20-edge-cases.md`) | "Something went wrong" |
+
+Color is paired with icon + text. `text-destructive` alone never
+communicates an error. See `14-accessibility.md`.
+
+## Selection
+
+A long-lived state on a multi-select surface (list rows, gallery
+tiles, file picker):
+
+- Visual: `bg-accent/10 ring-1 ring-accent` for tiles; `bg-muted/60
+  border-l-2 border-l-accent` for list rows.
+- Affordance: a checkbox visible on hover (`opacity-0
+  group-hover:opacity-100`); always visible once a single item is
+  selected (mode change).
+- Keyboard: `Space` toggles, `Shift+ArrowDown` extends.
+- Bulk actions appear in a sticky toolbar below the list header — not
+  inline next to each row. See `09-component-patterns.md`.
+
+## State precedence
+
+When two states co-exist, this is the rendering order:
+
+1. Disabled wins everything.
+2. Focus-visible wins over hover.
+3. Active wins over hover (on mouse-down).
+4. Selection wins over hover (selection persists).
+5. Error wins over default (a field with a red border + destructive
+   error text overrides the default border).
+
+## Tests
+
+Every component test exercises at least the four states a button has:
+default, hover (`userEvent.hover`), focus (`userEvent.tab` to the
+control), active (`userEvent.pointer({ keys: '[MouseLeft>]', target })`),
+and — if relevant — error and loading. See
+`../testing.md`.
+
+## Hard rules
+
+1. **Eight states or it's not done.** Every interactive surface
+   answers each.
+2. **Color shift, not transform.** Hover and active never translate.
+3. **`focus-visible` over `focus`.** The ring is for keyboard arrival.
+4. **Disabled is real.** Use the `disabled` attr, not `pointer-events:
+   none` + opacity.
+5. **Empty has a shape.** Tile + title + body + (optional) CTA.
+
+## Anti-patterns
+
+- A button that gets a 1px shadow on hover. Use a color shift.
+- A focus ring that's *just* a thin border darkening (`focus-visible:border-foreground/40`).
+  The ring is a 3px amber.
+- An empty state that says "Loading…". Empty and loading are
+  different states; render different copy.
+- A disabled-looking button that fires the click handler anyway.
+  ("Look, I disabled it visually." — no, you didn't.)
+- Inline error styling in a form (`className="border-red-500"`). Use
+  `aria-invalid` + the destructive token via the field primitive.
+
+## Cross-refs
+
+- Component anatomy: `09-component-patterns.md`.
+- Edge-case states (404 / 500 / offline / no-group): `20-edge-cases.md`.
+- Form-state UX: `15-form-and-data-ux.md`.
+- A11y: `14-accessibility.md`.
+- Loading skeletons: `05-motion.md`.

--- a/devdocs/frontend/design/09-component-patterns.md
+++ b/devdocs/frontend/design/09-component-patterns.md
@@ -1,0 +1,422 @@
+# Component Patterns
+
+Anatomy and rules for every reusable component primitive in Inventario.
+Engineering reference; if it's here, it's specced. If a sprint task
+needs a component not on this list, add it here first.
+
+The implementation rules (where to put files, when to extract, named
+exports, etc.) live in `../components.md`. This doc is the *visual*
+spec — what each primitive looks like, what variants exist, where the
+spacing comes from.
+
+## Button
+
+```tsx
+import { Button } from "@/components/ui/button"
+
+<Button>Default</Button>
+<Button variant="outline" size="sm">Small outline</Button>
+<Button variant="ghost" size="icon"><Plus className="size-4" /></Button>
+<Button variant="destructive" size="sm" className="gap-1.5">
+  <Trash2 className="size-3.5" />
+  Delete
+</Button>
+```
+
+| Variant | When |
+| --- | --- |
+| `default` (filled primary) | The page's main CTA. Exactly one per surface. |
+| `outline` | Secondary actions, modal Cancel, "Save changes" inside a card. |
+| `ghost` | Tertiary actions, kebab triggers, sidebar items. |
+| `destructive` | Delete / discard / leave. Always paired with an `<AlertDialog>` confirmation. |
+| `secondary` | Rare. Use `outline` first. |
+| `link` | Text-only inline, e.g. "Forgot password?" |
+
+Sizes: `default` (h-9), `sm` (h-8), `lg` (h-10), `xs` (h-6),
+`icon` (size-9), `icon-sm` (size-8), `icon-xs` (size-6).
+
+Icon sizing per button size — see `06-iconography-and-illustration.md`.
+
+## Badge
+
+```tsx
+import { Badge } from "@/components/ui/badge"
+<Badge>Default</Badge>
+<Badge variant="outline">Outline</Badge>
+```
+
+The status-badge pattern (domain-specific):
+
+```tsx
+<Badge variant="outline" className={`${cfg.color} ${cfg.bg} border-current/20 font-medium`}>
+  <Icon className="size-3" />
+  {cfg.label}
+</Badge>
+```
+
+`cfg` comes from `WARRANTY_STATUS_CONFIG` / `COMMODITY_STATUS_CONFIG`
+(`features/commodities/constants.ts`). Always use the config map; never
+inline ternaries.
+
+## Tag pill (`TagBadge`)
+
+Tag pills use a closed-enum color set (`--tag-amber`, `--tag-green`,
+`--tag-blue`, `--tag-orange`, `--tag-red`, `--tag-muted`), not chart
+colors. Anatomy:
+
+```tsx
+<span className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium bg-tag-amber/15 text-tag-amber border-tag-amber/30">
+  <Hash className="size-2.5 shrink-0" />
+  kitchen
+</span>
+```
+
+Mirror `models.TagColor` on the backend. The picker UI uses the
+six-swatch chip row; see `frontend/src/components/tags/`.
+
+## Input + Label
+
+```tsx
+<div className="space-y-1.5">
+  <Label htmlFor="email">{t("auth:login.email")}</Label>
+  <Input id="email" type="email" {...form.register("email")} />
+  {error && <p className="text-xs text-destructive">{t(error.message ?? "")}</p>}
+</div>
+```
+
+- `space-y-1.5` (6px) between label, input, error. Always.
+- `<Label htmlFor>` programmatically pairs to the input's `id`.
+- `aria-invalid={!!error}` on the input when there's an error;
+  shadcn's `Input` styles the error state via `aria-invalid` selectors.
+
+See `15-form-and-data-ux.md` for the validation timing.
+
+## Select
+
+```tsx
+<Select value={value} onValueChange={setValue}>
+  <SelectTrigger><SelectValue /></SelectTrigger>
+  <SelectContent>
+    <SelectItem value="x">x</SelectItem>
+  </SelectContent>
+</Select>
+```
+
+For currency fields specifically, use `<CurrencyCombobox>` instead —
+it has search and full names.
+
+## Dialog
+
+```tsx
+<Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+  <DialogContent className="sm:max-w-md">
+    <DialogHeader>
+      <DialogTitle className="flex items-center gap-2">
+        <div className="flex size-7 items-center justify-center rounded-lg bg-primary/10">
+          <Icon className="size-4 text-primary" />
+        </div>
+        Dialog Title
+      </DialogTitle>
+      <DialogDescription>Supporting text.</DialogDescription>
+    </DialogHeader>
+    <div className="space-y-4">{/* body */}</div>
+    <DialogFooter className="gap-2">
+      <Button variant="outline" onClick={onClose}>Cancel</Button>
+      <Button onClick={onConfirm}>Confirm</Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>
+```
+
+Width:
+
+- `sm:max-w-md` for confirmations and 1–3 fields.
+- `sm:max-w-lg` for ≤5 fields.
+- `sm:max-w-2xl` for multi-step wizards.
+- Above `2xl` → use a Sheet or a full page.
+
+Title icon: 28×28 tile (`size-7`) with a 16×16 (`size-4`) icon at
+`text-primary` over `bg-primary/10`. Optional but consistent.
+
+## AlertDialog
+
+```tsx
+<AlertDialog open={!!deleteId} onOpenChange={(o) => !o && setDeleteId(null)}>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>Delete item</AlertDialogTitle>
+      <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>Cancel</AlertDialogCancel>
+      <AlertDialogAction
+        onClick={handleDelete}
+        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+      >
+        Delete
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+Always for destructive flows. Always paired with a destructive `Button`
+trigger. The `useConfirm()` hook (`src/hooks/useConfirm.tsx`) wraps
+this in a promise — prefer it over re-implementing the open state.
+
+## Sheet
+
+Right-sliding panel for previews and edits. Anatomy:
+
+```tsx
+<Sheet open={open} onOpenChange={setOpen}>
+  <SheetContent side="right" className="sm:max-w-xl">
+    <SheetHeader>
+      <SheetTitle>{title}</SheetTitle>
+    </SheetHeader>
+    <div className="space-y-6 py-6">{/* body */}</div>
+    <SheetFooter>{/* actions */}</SheetFooter>
+  </SheetContent>
+</Sheet>
+```
+
+Widths per use:
+
+- Quick preview: `sm:max-w-md` (448px).
+- Edit form: `sm:max-w-xl` (576px).
+- Long form: `sm:max-w-2xl` (672px).
+
+## DropdownMenu
+
+```tsx
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button variant="ghost" size="icon" aria-label={t("common:actions.more")}>
+      <MoreHorizontal className="size-4" />
+    </Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent align="end">
+    <DropdownMenuItem>Edit</DropdownMenuItem>
+    <DropdownMenuSeparator />
+    <DropdownMenuItem className="text-destructive focus:text-destructive">
+      <Trash2 className="size-4 mr-2" />
+      Delete
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+Destructive items are styled inline with `text-destructive
+focus:text-destructive` — Radix doesn't have a built-in destructive
+variant. Group destructive items at the bottom, separated by a
+`DropdownMenuSeparator`.
+
+## Tooltip
+
+```tsx
+<TooltipProvider delayDuration={300}>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button size="icon" variant="ghost"><Info className="size-4" /></Button>
+    </TooltipTrigger>
+    <TooltipContent>{t("…explanation")}</TooltipContent>
+  </Tooltip>
+</TooltipProvider>
+```
+
+- 300ms delay (the default). No instant tooltips.
+- Used to *supplement* a label, never replace it. See
+  `14-accessibility.md`.
+- Don't tooltip text already visible.
+
+## Popover
+
+For density-rich pickers (filter, date range, color). Anatomy mirrors
+DropdownMenu but the body is freeform JSX. `align="start"` for filters
+that anchor to a leading element.
+
+## Card
+
+```tsx
+<div className="rounded-xl border border-border bg-card p-6 space-y-5">
+  <div>
+    <h2 className="text-base font-semibold">{title}</h2>
+    <p className="text-sm text-muted-foreground mt-0.5">{subtitle}</p>
+  </div>
+  <div className="space-y-4">{/* rows */}</div>
+</div>
+```
+
+`rounded-xl`, 1px `border-border`, `bg-card`, `p-6`, `space-y-5`. No
+shadow.
+
+## Stat card
+
+```tsx
+<div className="rounded-xl border border-border bg-card px-4 py-3 flex items-center gap-3">
+  <div className="flex size-8 items-center justify-center rounded-lg bg-muted shrink-0">
+    <Icon className="size-4 text-muted-foreground" />
+  </div>
+  <div>
+    <p className="text-xs text-muted-foreground">{label}</p>
+    <p className="text-lg font-semibold leading-tight">{value}</p>
+  </div>
+</div>
+```
+
+`size-8` icon tile, `size-4` icon. Don't drift to `size-10` /
+`size-5`.
+
+## List row (settings / detail)
+
+```tsx
+<div className="flex items-center justify-between py-3.5">
+  <div>
+    <p className="text-sm font-medium">{label}</p>
+    {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+  </div>
+  <div className="flex items-center gap-2">{/* control */}</div>
+</div>
+```
+
+Wrapped in a `divide-y divide-border` container (see
+`03-space-and-layout.md`).
+
+## List row (data — items / locations / files)
+
+Click target = full row (button or link, depending). Hover bg, kebab
+revealed on hover or always-visible if it's the only action.
+
+```tsx
+<button
+  onClick={() => onOpen(item.id)}
+  className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted/40 active:bg-muted/60 transition-colors"
+>
+  <Icon className="size-4 text-muted-foreground shrink-0" />
+  <span className="text-sm font-medium flex-1 truncate">{item.title}</span>
+  <span className="text-xs text-muted-foreground tabular-nums">{item.value}</span>
+  <ChevronRight className="size-4 text-muted-foreground" />
+</button>
+```
+
+Bulk-actionable lists: add `selected` state per row and a sticky
+toolbar above. See `08-interaction-states.md` ("Selection").
+
+## Switch row
+
+```tsx
+<div className="flex items-center justify-between py-3.5">
+  <p className="text-sm font-medium">Warranty expiring alerts</p>
+  <Switch checked={val} onCheckedChange={setVal} />
+</div>
+```
+
+Settings rows save **immediately** on change — no "Save" button
+afterward. Use a debounced PATCH and a sonner toast on failure.
+
+## Skeleton
+
+```tsx
+<div className="space-y-3">
+  <Skeleton className="h-4 w-1/3" />
+  <Skeleton className="h-4 w-1/2" />
+  <Skeleton className="h-32 w-full" />
+</div>
+```
+
+Skeleton shape matches the rendered shape. Don't show a generic
+spinner.
+
+## Sonner toast
+
+Wrapped in `useAppToast()` (`src/hooks/useAppToast.ts`):
+
+```ts
+const toast = useAppToast()
+toast.success(t("commodities:toast.created"))
+toast.error(t("auth:login.errorGeneric"))
+```
+
+Severity → behavior:
+
+| Severity | Auto-dismiss | Color |
+| --- | --- | --- |
+| `info` | 4s | foreground |
+| `success` | 4s | `--status-active` |
+| `warning` | 6s | `--status-expiring` |
+| `error` | manual | `--destructive` |
+
+See `16-notifications-and-trust.md`.
+
+## Empty state (component family)
+
+`src/components/dashboard/EmptyState.tsx` etc. Shape:
+
+```tsx
+<div className="flex flex-col items-center justify-center gap-3 py-16">
+  <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10">
+    <Icon className="size-5 text-primary" />
+  </div>
+  <div className="text-center space-y-1">
+    <p className="text-base font-semibold">{title}</p>
+    <p className="text-sm text-muted-foreground">{body}</p>
+  </div>
+  {cta && <Button size="sm" onClick={cta.onClick}>{cta.label}</Button>}
+</div>
+```
+
+See `20-edge-cases.md` for the empty-state taxonomy.
+
+## Coming-soon banner (transitional)
+
+For features whose backend is in flight. The dialog or page has a
+banner above the content saying "This is read-only until #NNNN
+ships." Component lives at `src/components/coming-soon/`. Use it
+sparingly — ship the real feature instead when possible.
+
+## Sidebar / TopBar (Shell)
+
+Owned by `src/app/Shell.tsx` + `src/components/AppSidebar.tsx`. The
+Shell composes:
+
+- `<Sidebar>` (collapsible at md breakpoint).
+- `<TopBar>` (logo on mobile, title + actions on desktop).
+- `<Outlet>` (the routed page).
+
+Sidebar nav items come from a const array (`NAV_ENTRIES`) gated by
+permissions. Adding a route to nav = adding the entry + the
+translation under `common:nav.*`.
+
+## Hard rules
+
+1. **Use the primitive.** `<Button>` over `<button>`, `<Input>` over
+   `<input>`, `<Dialog>` over a hand-rolled overlay.
+2. **`cn(base, className)` for prop-driven classes.** No template
+   literals.
+3. **`asChild` for primitive composition.** When a Radix primitive
+   needs to pass behavior to your own element, use `asChild` (e.g.
+   `<DropdownMenuTrigger asChild><Button…/></DropdownMenuTrigger>`).
+4. **Settings save immediately.** Don't wrap a switch row in a
+   "Save" button.
+5. **One filled-primary per page.** Multiple primary buttons fight
+   for attention.
+
+## Anti-patterns
+
+- Two filled-primary buttons on the same surface ("Save" and "Submit").
+- A confirmation dialog with no title or description.
+- A dropdown with destructive actions interleaved with safe ones, no
+  separator.
+- A toast that takes a `<button>` for a CTA. Toasts are read-only —
+  the action lives elsewhere.
+- A list row that's clickable except for the kebab — make the row a
+  `<button>` and the kebab a `<DropdownMenu>` with `stopPropagation`
+  on the trigger.
+
+## Cross-refs
+
+- Engineering rules (where files live, when to extract): `../components.md`.
+- Form fields specifically: `15-form-and-data-ux.md`.
+- States across all primitives: `08-interaction-states.md`.
+- Mock canonical: `denisvmedia/inventario-design/CLAUDE.md` §6
+  (Component Patterns).

--- a/devdocs/frontend/design/09-component-patterns.md
+++ b/devdocs/frontend/design/09-component-patterns.md
@@ -5,7 +5,7 @@ Engineering reference; if it's here, it's specced. If a sprint task
 needs a component not on this list, add it here first.
 
 The implementation rules (where to put files, when to extract, named
-exports, etc.) live in `../components.md`. This doc is the *visual*
+exports, etc.) live in [../components.md](../components.md). This doc is the *visual*
 spec — what each primitive looks like, what variants exist, where the
 spacing comes from.
 
@@ -35,7 +35,7 @@ import { Button } from "@/components/ui/button"
 Sizes: `default` (h-9), `sm` (h-8), `lg` (h-10), `xs` (h-6),
 `icon` (size-9), `icon-sm` (size-8), `icon-xs` (size-6).
 
-Icon sizing per button size — see `06-iconography-and-illustration.md`.
+Icon sizing per button size — see [06-iconography-and-illustration.md](06-iconography-and-illustration.md).
 
 ## Badge
 
@@ -89,7 +89,7 @@ six-swatch chip row; see `frontend/src/components/tags/`.
 - `aria-invalid={!!error}` on the input when there's an error;
   shadcn's `Input` styles the error state via `aria-invalid` selectors.
 
-See `15-form-and-data-ux.md` for the validation timing.
+See [15-form-and-data-ux.md](15-form-and-data-ux.md) for the validation timing.
 
 ## Select
 
@@ -226,7 +226,7 @@ variant. Group destructive items at the bottom, separated by a
 
 - 300ms delay (the default). No instant tooltips.
 - Used to *supplement* a label, never replace it. See
-  `14-accessibility.md`.
+  [14-accessibility.md](14-accessibility.md).
 - Don't tooltip text already visible.
 
 ## Popover
@@ -280,7 +280,7 @@ shadow.
 ```
 
 Wrapped in a `divide-y divide-border` container (see
-`03-space-and-layout.md`).
+[03-space-and-layout.md](03-space-and-layout.md)).
 
 ## List row (data — items / locations / files)
 
@@ -300,7 +300,7 @@ revealed on hover or always-visible if it's the only action.
 ```
 
 Bulk-actionable lists: add `selected` state per row and a sticky
-toolbar above. See `08-interaction-states.md` ("Selection").
+toolbar above. See [08-interaction-states.md](08-interaction-states.md) ("Selection").
 
 ## Switch row
 
@@ -346,7 +346,7 @@ Severity → behavior:
 | `warning` | 6s | `--status-expiring` |
 | `error` | manual | `--destructive` |
 
-See `16-notifications-and-trust.md`.
+See [16-notifications-and-trust.md](16-notifications-and-trust.md).
 
 ## Empty state (component family)
 
@@ -365,7 +365,7 @@ See `16-notifications-and-trust.md`.
 </div>
 ```
 
-See `20-edge-cases.md` for the empty-state taxonomy.
+See [20-edge-cases.md](20-edge-cases.md) for the empty-state taxonomy.
 
 ## Coming-soon banner (transitional)
 
@@ -415,8 +415,8 @@ translation under `common:nav.*`.
 
 ## Cross-refs
 
-- Engineering rules (where files live, when to extract): `../components.md`.
-- Form fields specifically: `15-form-and-data-ux.md`.
-- States across all primitives: `08-interaction-states.md`.
-- Mock canonical: `denisvmedia/inventario-design/CLAUDE.md` §6
+- Engineering rules (where files live, when to extract): [../components.md](../components.md).
+- Form fields specifically: [15-form-and-data-ux.md](15-form-and-data-ux.md).
+- States across all primitives: [08-interaction-states.md](08-interaction-states.md).
+
   (Component Patterns).

--- a/devdocs/frontend/design/10-file-and-media.md
+++ b/devdocs/frontend/design/10-file-and-media.md
@@ -7,12 +7,17 @@ canonical mock.
 
 ## The four categories
 
-| Category | What it is | Default icon | Thumbnail |
+| Category (API value) | What it is | Default icon | Thumbnail |
 | --- | --- | --- | --- |
-| `image` | Photos, scans, screenshots — anything renderable as an `<img>`. | `Image` | Render the image at 1:1, contained in the tile. |
-| `invoice` | Receipts, purchase invoices, warranty cards as PDFs. | `Receipt` | First-page PDF preview if available; otherwise the icon. |
-| `document` | Manuals, certificates, anything PDF-shaped that isn't an invoice. | `FileText` | First-page PDF preview if available; otherwise the icon. |
-| `other` | Everything else — `.zip`, `.csv`, `.txt`, video files. | `Paperclip` | Always the icon. |
+| `photos` | Photos, scans, screenshots — anything renderable as an `<img>`. | `Image` | Render the image at 1:1, contained in the tile. |
+| `invoices` | Receipts, purchase invoices, warranty cards as PDFs. | `Receipt` | First-page PDF preview if available; otherwise the icon. |
+| `documents` | Manuals, certificates, anything PDF-shaped that isn't an invoice. (CSV / JSON / DOCX also land here per `models.FileCategoryFromMIME`.) | `FileText` | First-page PDF preview if available; otherwise the icon. |
+| `other` | Everything else — `.zip`, video / audio files, octet-stream. | `Paperclip` | Always the icon. |
+
+Plural names match the BE enum (`models.FileCategoryPhotos` → `"photos"`,
+etc.); the FE `FileCategory` type at `src/features/files/api.ts` is the
+generated mirror. Use the plural string verbatim in URL params, payloads,
+and i18n keys (`files:category.photos` etc.).
 
 Closed enum. Don't add a fifth — the backend won't accept it. If a
 genuinely new bucket emerges (e.g. "video" as its own category), it's
@@ -46,7 +51,7 @@ file picker:
 ```
 
 The gradient overlay is one of the **few** places we depart from
-"borders, not shadows" (`04-elevation-and-effects.md`) — it's a
+"borders, not shadows" ([04-elevation-and-effects.md](04-elevation-and-effects.md)) — it's a
 linear gradient, not a shadow, but the visual effect is similar. The
 exception exists because thumbnails need readable captions on top of
 arbitrary user content; a border can't carry that.
@@ -76,7 +81,7 @@ page:
 ```
 
 `tabular-nums` on the size column when shown in a column-aligned
-layout. See `02-typography.md`.
+layout. See [02-typography.md](02-typography.md).
 
 ## Viewer
 
@@ -179,11 +184,11 @@ frontend.
 Long-press on a thumbnail (or a click on the row checkbox) enters
 selection mode. Bulk actions toolbar slides in below the page header
 ("3 files selected" + "Delete", "Move to commodity"). Same pattern
-as commodities multi-select — see `08-interaction-states.md`.
+as commodities multi-select — see [08-interaction-states.md](08-interaction-states.md).
 
 ## Hard rules
 
-1. **Four categories, no more.** `image | invoice | document | other`.
+1. **Four categories, no more.** `photos | invoices | documents | other`.
 2. **Thumbnails from the backend.** No client-side resizing.
 3. **EXIF stripped server-side.** Don't replicate the rotation logic
    on the client.
@@ -207,9 +212,9 @@ as commodities multi-select — see `08-interaction-states.md`.
 
 ## Cross-refs
 
-- File-related routes: `routing.md` (parent folder).
+- File-related routes: [routing.md](routing.md) (parent folder).
 - Backend file model: `go/models/file.go` (`models.FileCategory`).
-- Mock canonical: `denisvmedia/inventario-design/CLAUDE.md` (no
+
   dedicated section; the four-category model is encoded in the
   design's data shape).
 - Backup / restore (the related-but-distinct domain): the exports

--- a/devdocs/frontend/design/10-file-and-media.md
+++ b/devdocs/frontend/design/10-file-and-media.md
@@ -1,0 +1,216 @@
+# File & Media Handling
+
+The four-category file model and the visual rules for thumbnails,
+viewers, drop zones, and uploads. **Committed.** The four categories
+are mirrored on the backend (`models.FileCategory`) and on the
+canonical mock.
+
+## The four categories
+
+| Category | What it is | Default icon | Thumbnail |
+| --- | --- | --- | --- |
+| `image` | Photos, scans, screenshots — anything renderable as an `<img>`. | `Image` | Render the image at 1:1, contained in the tile. |
+| `invoice` | Receipts, purchase invoices, warranty cards as PDFs. | `Receipt` | First-page PDF preview if available; otherwise the icon. |
+| `document` | Manuals, certificates, anything PDF-shaped that isn't an invoice. | `FileText` | First-page PDF preview if available; otherwise the icon. |
+| `other` | Everything else — `.zip`, `.csv`, `.txt`, video files. | `Paperclip` | Always the icon. |
+
+Closed enum. Don't add a fifth — the backend won't accept it. If a
+genuinely new bucket emerges (e.g. "video" as its own category), it's
+a coordinated FE+BE issue.
+
+## File card
+
+The standard tile, used in galleries, item-detail file rows, and the
+file picker:
+
+```tsx
+<button
+  onClick={() => onOpen(file.id)}
+  className="group relative aspect-square w-full rounded-lg border border-border bg-card overflow-hidden hover:border-foreground/15 transition-colors"
+>
+  {file.thumbnail ? (
+    <img
+      src={file.thumbnail}
+      alt={file.title}
+      className="h-full w-full object-cover"
+    />
+  ) : (
+    <div className="flex h-full w-full items-center justify-center bg-muted">
+      <Icon className="size-8 text-muted-foreground" />
+    </div>
+  )}
+  <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-foreground/60 to-transparent p-2 opacity-0 group-hover:opacity-100 transition-opacity">
+    <p className="text-xs text-background truncate">{file.title}</p>
+  </div>
+</button>
+```
+
+The gradient overlay is one of the **few** places we depart from
+"borders, not shadows" (`04-elevation-and-effects.md`) — it's a
+linear gradient, not a shadow, but the visual effect is similar. The
+exception exists because thumbnails need readable captions on top of
+arbitrary user content; a border can't carry that.
+
+## File row (list view)
+
+For the file detail panel inside a commodity, or the standalone Files
+page:
+
+```tsx
+<button
+  onClick={…}
+  className="flex w-full items-center gap-3 px-4 py-3 hover:bg-muted/40 transition-colors"
+>
+  <div className="flex size-8 items-center justify-center rounded-lg bg-muted shrink-0">
+    <CategoryIcon className="size-4 text-muted-foreground" />
+  </div>
+  <div className="flex-1 min-w-0">
+    <p className="text-sm font-medium truncate">{file.title}</p>
+    <p className="text-xs text-muted-foreground">
+      {formatBytes(file.size)} · {formatDate(file.uploaded_at)}
+    </p>
+  </div>
+  <CategoryBadge category={file.category} />
+  <ChevronRight className="size-4 text-muted-foreground" />
+</button>
+```
+
+`tabular-nums` on the size column when shown in a column-aligned
+layout. See `02-typography.md`.
+
+## Viewer
+
+Two viewer routes (and matching components):
+
+- `/g/:slug/files/:id` for full-page edit (rename, change category,
+  attach to commodities).
+- A `Sheet`-based preview for in-context viewing (tap a thumbnail in
+  the commodity detail).
+
+Both use the same internal viewer component (`ImageViewer`,
+`PdfViewer`). Image viewer:
+
+- Pinch-zoom on touch.
+- `Cmd+0` resets zoom.
+- Arrow keys navigate sibling files in the same commodity.
+- Escape closes (Sheet) or returns to commodity detail (full page).
+
+PDF viewer uses `pdfjs-dist` lazy-loaded — see
+`frontend/src/lib/pdfjs.ts` for the worker shimming. PDF viewer:
+
+- Page selector.
+- Search within document.
+- Download (always available).
+- Print (browser print, no custom).
+
+## Upload
+
+The drop zone is the one place dashed borders are allowed:
+
+```tsx
+<div
+  onDrop={…}
+  onDragOver={…}
+  className={cn(
+    "rounded-xl border-2 border-dashed border-border p-10 text-center transition-colors",
+    isDragOver && "border-primary bg-primary/5",
+    isError && "border-destructive bg-destructive/5"
+  )}
+>
+  <Upload className="mx-auto size-8 text-muted-foreground" />
+  <p className="mt-3 text-sm font-medium">{t("files:upload.title")}</p>
+  <p className="mt-1 text-xs text-muted-foreground">
+    {t("files:upload.hint")}
+  </p>
+  <Button size="sm" variant="outline" className="mt-4">
+    {t("files:upload.browse")}
+  </Button>
+</div>
+```
+
+Upload behavior:
+
+- Multi-file drop allowed.
+- Per-file progress indicator (a thin progress bar inside the file row).
+- On success, the file appears in the list with a brief
+  `bg-status-active/10` flash; the toast is a single grouped success
+  ("3 files added"), not one per file.
+- On failure, the file row stays with a destructive-tinted background
+  and a retry button. No toast spam.
+
+## Format and size limits
+
+The backend enforces (and surfaces through error messages):
+
+- Max single-file size: 50 MB.
+- Allowed MIME types: image/* (jpeg, png, webp, heic), application/pdf,
+  text/plain, application/zip.
+- Per-tenant quota.
+
+The UI surfaces these limits in the upload zone's hint text. Don't
+hard-code the size in the component — read from the seed config.
+
+## Image processing
+
+Thumbnails are generated on the backend (a worker resizes to 256×256
+WEBP). The frontend always reads `file.thumbnail_url` and falls back
+to the category icon when missing. Don't compose thumbnails on the
+client — the image bytes might be 8 MB.
+
+## EXIF / orientation
+
+Backend strips EXIF on upload (privacy + orientation correctness).
+The displayed image is always upright; no rotation logic in the
+frontend.
+
+## Empty / loading / error
+
+| State | UI |
+| --- | --- |
+| No files yet | Empty-state pattern with the `Image` icon and "Drop files here, or click Browse." |
+| Loading first page | Skeleton grid of 6 `aspect-square` `bg-muted` tiles |
+| Page query failed | Inline retry banner inside the gallery container |
+| Upload in flight (per-file) | The file row shows a thin progress bar; the count appears in the upload zone |
+| Upload failed (per-file) | The file row gets a destructive tint + a retry button |
+| File deleted (in another tab / by another user) | Quietly remove from the list; no error |
+
+## Multi-select
+
+Long-press on a thumbnail (or a click on the row checkbox) enters
+selection mode. Bulk actions toolbar slides in below the page header
+("3 files selected" + "Delete", "Move to commodity"). Same pattern
+as commodities multi-select — see `08-interaction-states.md`.
+
+## Hard rules
+
+1. **Four categories, no more.** `image | invoice | document | other`.
+2. **Thumbnails from the backend.** No client-side resizing.
+3. **EXIF stripped server-side.** Don't replicate the rotation logic
+   on the client.
+4. **Drop zone is the only dashed border in the app.** The dashed
+   `border-2` is a visual cue specifically for "drop targets here";
+   don't reach for it elsewhere.
+5. **Upload toast is grouped.** "3 files added", not three separate
+   toasts.
+6. **Multi-file errors are inline.** No toast spam on partial-failure.
+
+## Anti-patterns
+
+- A "video" category. Files that are videos go in `other`.
+- A toast per uploaded file. Group by batch.
+- A custom "modern thumbnail" with rounded corners *and* a shadow.
+  Use the canonical thumbnail style.
+- Reading `file.thumbnail_data` (base64) — the backend doesn't return
+  base64 thumbnails. URL only.
+- A "download all" zip-button generated client-side. Use the
+  backup/restore export path instead.
+
+## Cross-refs
+
+- File-related routes: `routing.md` (parent folder).
+- Backend file model: `go/models/file.go` (`models.FileCategory`).
+- Mock canonical: `denisvmedia/inventario-design/CLAUDE.md` (no
+  dedicated section; the four-category model is encoded in the
+  design's data shape).
+- Backup / restore (the related-but-distinct domain): the exports
+  feature slice.

--- a/devdocs/frontend/design/11-page-layouts-and-flows.md
+++ b/devdocs/frontend/design/11-page-layouts-and-flows.md
@@ -1,0 +1,234 @@
+# Page Layouts & Flows
+
+Page-shaped templates per surface. **Recommendations.** Each template
+has been used in production at least twice; deviating is fine when the
+deviation has a reason.
+
+## Auth
+
+Single-column, centered, no sidebar:
+
+```tsx
+<AuthLayout>
+  <div className="space-y-6">
+    <div className="space-y-1.5 text-center">
+      <AppLogo className="mx-auto h-9" />
+      <h1 className="text-2xl font-semibold tracking-tight">{t("auth:login.title")}</h1>
+      <p className="text-sm text-muted-foreground">{t("auth:login.subtitle")}</p>
+    </div>
+    <form className="space-y-4">{/* fields */}</form>
+    <p className="text-center text-sm text-muted-foreground">
+      <Link to="/forgot-password" className="hover:text-foreground">…</Link>
+    </p>
+  </div>
+</AuthLayout>
+```
+
+- `max-w-md` form container.
+- No sidebar, no top bar, no breadcrumbs.
+- One CTA per page.
+- The footer is a single line linking to the next step
+  ("Don't have an account? Sign up.").
+- No marketing content. No terms-of-service paragraph. The product
+  positioning (`00-positioning.md`) is quiet, copy-first.
+
+Variants:
+
+- Login → Register (link below form).
+- Login → Forgot password (link below form).
+- Register → Verify email (replaces form with a "check your inbox"
+  message after submit).
+- Reset password → Success (replaces form with a "you can sign in
+  now" message).
+
+## Dashboard
+
+Stat row + recent items + warranty alerts. Glanceable, not
+celebratory:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Sidebar │  Top bar (title + group switcher)                       │
+│         │ ┌─ Stat row: 4 stat cards ─────────────────────────────┐ │
+│         │ │ Items │ Locations │ Areas │ Files                    │ │
+│         │ └──────────────────────────────────────────────────────┘ │
+│         │ ┌─ Recent items (left) ──┐ ┌─ Warranty alerts (right) ─┐ │
+│         │ │ list of 5 with thumbs  │ │ list of 3 expiring soon   │ │
+│         │ │ "View all"             │ │ "View all"                │ │
+│         │ └────────────────────────┘ └───────────────────────────┘ │
+│         │ ┌─ Activity feed (full width) ─────────────────────────┐ │
+│         │ │ "12 items added · April 18"                          │ │
+│         │ └──────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Card decisions:
+
+- `max-w-6xl` outer.
+- 4-column stat row at `lg`, 2-column at `md`, 1-column on mobile.
+- 2-column body grid on `lg`, single column below.
+- Activity feed is a chronological list, not a chart. `00-positioning.md`
+  commits to "boring on purpose".
+
+## List page
+
+Items, locations, files, tags, exports, search results — same shell:
+
+```
+┌─ Page header ────────────────────────────────────────────────────┐
+│ <h1>Items</h1>                                                   │
+│ <p>Subtitle (e.g. count of items in this group)</p>              │
+│                                                                  │
+│ [Filter chips ▼] [Sort ▼]                          [+ Add item]  │
+├──────────────────────────────────────────────────────────────────┤
+│ Search input (full width)                                        │
+├──────────────────────────────────────────────────────────────────┤
+│ ┌─ Bulk actions bar (only when ≥1 selected) ──────────────────┐ │
+│ │ 3 selected · Delete · Move · Tag                           │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│ List rows:                                                      │
+│   ☐ Icon · Title · Subtitle · Right-meta · ⋯                   │
+│   ☐ …                                                          │
+│ Pagination footer: « 1 2 3 »                                    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- `max-w-4xl` container for most lists.
+- Bulk actions toolbar slides in via `tw-animate-css` `slide-in-from-top`
+  when selection state becomes non-empty. Disappears smoothly.
+- Filter / sort chips open as Popovers, not fullscreen sheets, on
+  desktop.
+- Pagination, not infinite scroll. The user can return to a page they
+  saw before.
+
+## Detail page
+
+One concept per page. Items, locations, areas, files all use the same
+shell:
+
+```
+┌─ Breadcrumb ──────────────────────────────────────────────────────┐
+│ Home > Locations > Kitchen > Stove                                │
+├───────────────────────────────────────────────────────────────────┤
+│ ┌─ Hero card ─────────────────────────────────────────────────┐ │
+│ │ [thumb] Title         [Status badge]                        │ │
+│ │         Subtitle      [Edit]                                │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│ ┌─ Section: Details ─────────────────────────────────────────┐ │
+│ │ Bought · Apr 2026                                           │ │
+│ │ Vendor · …                                                  │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│ ┌─ Section: Files ───────────────────────────────────────────┐ │
+│ │ Gallery + add                                              │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│ ┌─ Section: History ─────────────────────────────────────────┐ │
+│ │ Status changes timeline                                    │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+- `max-w-2xl` outer (single-column reading rhythm).
+- Each section is a card with `space-y-5` internal rhythm.
+- Edit can be inline (per-section "Edit" button → switch to form
+  inputs) or a Sheet, depending on the section. Multi-section edit
+  uses a Sheet.
+
+## Settings page
+
+```
+┌─ Page header ──────────────────────────────────┐
+│ <h1>Settings</h1>                              │
+│ <p>Customize Inventario.</p>                   │
+├────────────────────────────────────────────────┤
+│ ┌─ Section: Appearance ──────────────────────┐ │
+│ │ Theme         [Light · Dark · System]      │ │
+│ │ Density       [Comfortable · Cozy · Compact] │
+│ │ Locale        [English · Czech · Russian]  │ │
+│ └────────────────────────────────────────────┘ │
+│ ┌─ Section: Notifications ───────────────────┐ │
+│ │ ⏵ Warranty expiring alerts        [Switch] │ │
+│ │ ⏵ Email digest                    [Switch] │ │
+│ └────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────┘
+```
+
+- `max-w-2xl` outer.
+- Each section is a card with `divide-y` rows.
+- Settings save **immediately** on change. No "Save" button.
+- Failure to save → sonner toast with retry CTA, the value rolls back.
+
+## Sheet-based edit / preview
+
+A side-rail that appears next to the list page rather than navigating
+away. Used for:
+
+- Quick item preview from the dashboard.
+- File detail from a thumbnail click.
+- Edit-in-place for a single section.
+
+Width: `sm:max-w-xl` for forms, `sm:max-w-md` for previews. See
+`09-component-patterns.md`.
+
+## Multi-step wizard
+
+The Add Item dialog (`features/commodities/`) is the canonical
+wizard:
+
+```
+┌─ Wizard header ─────────────────────────────────────┐
+│ Step 1 of 5: Basics                                 │
+│ ●─○─○─○─○                                           │
+├─────────────────────────────────────────────────────┤
+│ Form fields                                         │
+├─────────────────────────────────────────────────────┤
+│ [Cancel]                          [Back] [Continue] │
+└─────────────────────────────────────────────────────┘
+```
+
+- One RHF instance for the whole wizard. Per-step validation via
+  `form.trigger([fields])`.
+- Draft persisted per-key in `localStorage`
+  (`commodity-draft:{slug}:create`). Cancel clears; Save clears on
+  success.
+- Step dots show progress + completion. Click a dot to jump back to a
+  previous step (forward jumps disabled until validated).
+- Width: `sm:max-w-2xl`.
+
+## Error / 404 / 500
+
+See `20-edge-cases.md`. The shell is a centered card with the canonical
+icon + title + body + (optional) CTA.
+
+## Print
+
+`/g/:slug/commodities/:id/print` is the one print-specific route.
+Layout: tabular, single-column, `max-w-3xl`, no sidebar, no actions.
+See `18-print-and-export.md`.
+
+## Hard rules
+
+1. **One CTA per page.** Filled-primary is exactly one. Secondary
+   actions are outline / ghost.
+2. **No celebratory hero.** The dashboard doesn't say "Welcome back!"
+3. **Pagination, not infinite scroll.** State preservation matters.
+4. **Settings save immediately.** No bottom-of-page Save button.
+5. **One concept per detail page.** A commodity detail is a commodity;
+   it doesn't try to be a location too.
+
+## Anti-patterns
+
+- A dashboard "Onboarding checklist" widget that gamifies setup. We
+  don't gamify.
+- A list page with the search input above the page title (search
+  belongs *inside* the list, not above the page).
+- Inline edit on a list row that turns the row into a form. Use the
+  Sheet edit pattern instead — list rows stay scannable.
+- A settings page with a "Save changes" footer button. Save on change.
+
+## Cross-refs
+
+- Page wrappers: `03-space-and-layout.md`.
+- Component anatomy: `09-component-patterns.md`.
+- Edge cases (404, 500, offline, no-group): `20-edge-cases.md`.
+- Auth flow: `frontend/src/pages/auth/`.
+- Commodities flow (5-step wizard): `frontend/src/pages/commodities/`.

--- a/devdocs/frontend/design/11-page-layouts-and-flows.md
+++ b/devdocs/frontend/design/11-page-layouts-and-flows.md
@@ -30,7 +30,7 @@ Single-column, centered, no sidebar:
 - The footer is a single line linking to the next step
   ("Don't have an account? Sign up.").
 - No marketing content. No terms-of-service paragraph. The product
-  positioning (`00-positioning.md`) is quiet, copy-first.
+  positioning ([00-positioning.md](00-positioning.md)) is quiet, copy-first.
 
 Variants:
 
@@ -67,7 +67,7 @@ Card decisions:
 - `max-w-6xl` outer.
 - 4-column stat row at `lg`, 2-column at `md`, 1-column on mobile.
 - 2-column body grid on `lg`, single column below.
-- Activity feed is a chronological list, not a chart. `00-positioning.md`
+- Activity feed is a chronological list, not a chart. [00-positioning.md](00-positioning.md)
   commits to "boring on purpose".
 
 ## List page
@@ -167,7 +167,7 @@ away. Used for:
 - Edit-in-place for a single section.
 
 Width: `sm:max-w-xl` for forms, `sm:max-w-md` for previews. See
-`09-component-patterns.md`.
+[09-component-patterns.md](09-component-patterns.md).
 
 ## Multi-step wizard
 
@@ -196,14 +196,14 @@ wizard:
 
 ## Error / 404 / 500
 
-See `20-edge-cases.md`. The shell is a centered card with the canonical
+See [20-edge-cases.md](20-edge-cases.md). The shell is a centered card with the canonical
 icon + title + body + (optional) CTA.
 
 ## Print
 
 `/g/:slug/commodities/:id/print` is the one print-specific route.
 Layout: tabular, single-column, `max-w-3xl`, no sidebar, no actions.
-See `18-print-and-export.md`.
+See [18-print-and-export.md](18-print-and-export.md).
 
 ## Hard rules
 
@@ -227,8 +227,8 @@ See `18-print-and-export.md`.
 
 ## Cross-refs
 
-- Page wrappers: `03-space-and-layout.md`.
-- Component anatomy: `09-component-patterns.md`.
-- Edge cases (404, 500, offline, no-group): `20-edge-cases.md`.
+- Page wrappers: [03-space-and-layout.md](03-space-and-layout.md).
+- Component anatomy: [09-component-patterns.md](09-component-patterns.md).
+- Edge cases (404, 500, offline, no-group): [20-edge-cases.md](20-edge-cases.md).
 - Auth flow: `frontend/src/pages/auth/`.
 - Commodities flow (5-step wizard): `frontend/src/pages/commodities/`.

--- a/devdocs/frontend/design/12-tone-of-voice-and-copy.md
+++ b/devdocs/frontend/design/12-tone-of-voice-and-copy.md
@@ -1,7 +1,7 @@
 # Tone of Voice & Copy
 
 The product's microcopy contract. **Committed.** The voice was set in
-`00-positioning.md`; this doc translates that voice into concrete
+[00-positioning.md](00-positioning.md); this doc translates that voice into concrete
 strings.
 
 ## Anchor
@@ -90,7 +90,7 @@ already uses "Item" and "Backup" / "Export" (depending on context).
 
 ### Auth pages
 
-Calm and copy-light. The product positioning (`00-positioning.md`)
+Calm and copy-light. The product positioning ([00-positioning.md](00-positioning.md))
 commits to no marketing voice on public surfaces.
 
 - Login title: `Sign in to Inventario`
@@ -117,9 +117,9 @@ copy is shorter because the user is mid-flow, not landing on the page.
 ### Loading
 
 Don't write "Loading…" copy — render a skeleton instead (see
-`05-motion.md`). The one place "Loading…" is allowed: a button label
+[05-motion.md](05-motion.md)). The one place "Loading…" is allowed: a button label
 during in-flight submit, but only in addition to the original label
-(via the spinner pattern in `08-interaction-states.md`).
+(via the spinner pattern in [08-interaction-states.md](08-interaction-states.md)).
 
 ### Errors
 
@@ -186,11 +186,11 @@ When the user has no group:
 
 ## i18n
 
-Every string is a translation key. See `13-formatting-and-i18n.md`.
+Every string is a translation key. See [13-formatting-and-i18n.md](13-formatting-and-i18n.md).
 
 Key style: `namespace:dot.path`, lower-camelCase segments. The English
 bundle is the source of truth; cs/ru fall back to en for missing keys
-(per `../i18n.md`).
+(per [../i18n.md](../i18n.md)).
 
 Translators read context from the key path itself — keep keys
 descriptive (`commodities:list.empty.title` over `commodities:e1`).
@@ -213,7 +213,7 @@ descriptive (`commodities:list.empty.title` over `commodities:e1`).
 - One-digit counts: spell out only in copy ("one item"). Use digits
   in titles / metrics.
 - Plurals via i18next — `count: N` pluralizes via `_one` / `_other`.
-  See `../i18n.md`.
+  See [../i18n.md](../i18n.md).
 
 ## Hard rules
 
@@ -239,7 +239,7 @@ descriptive (`commodities:list.empty.title` over `commodities:e1`).
 
 ## Cross-refs
 
-- Voice anchor: `00-positioning.md`.
-- Plurals / numbers / dates: `13-formatting-and-i18n.md`.
-- Toast hierarchy: `16-notifications-and-trust.md`.
-- The i18n key contract: `../i18n.md`.
+- Voice anchor: [00-positioning.md](00-positioning.md).
+- Plurals / numbers / dates: [13-formatting-and-i18n.md](13-formatting-and-i18n.md).
+- Toast hierarchy: [16-notifications-and-trust.md](16-notifications-and-trust.md).
+- The i18n key contract: [../i18n.md](../i18n.md).

--- a/devdocs/frontend/design/12-tone-of-voice-and-copy.md
+++ b/devdocs/frontend/design/12-tone-of-voice-and-copy.md
@@ -1,0 +1,245 @@
+# Tone of Voice & Copy
+
+The product's microcopy contract. **Committed.** The voice was set in
+`00-positioning.md`; this doc translates that voice into concrete
+strings.
+
+## Anchor
+
+Inventario sounds **considered, honest, quiet, specific, forgiving.**
+A representative line, in voice:
+
+> You don't have any items in this area yet. When you do, they'll
+> show up here.
+
+What that line gets right:
+
+- **Considered** — the tense is "yet"; it acknowledges the user is
+  setting up.
+- **Honest** — it doesn't promise auto-population.
+- **Quiet** — no exclamation marks, no "hooray".
+- **Specific** — "items in this area", not "stuff" or "data".
+- **Forgiving** — implicit invitation, no scolding.
+
+What it avoids:
+
+- "Welcome to your empty area! Start adding items."
+- "🎉 Your area is empty!"
+- "Items: 0"
+
+## Length budgets
+
+| Surface | Target | Cap |
+| --- | --- | --- |
+| Button label | 1–2 words | 3 |
+| Page title | 1–3 words | 5 |
+| Section heading | 2–4 words | 6 |
+| Empty-state title | 3–5 words | 7 |
+| Empty-state body | 1 sentence, ≤ 14 words | 2 sentences |
+| Toast | 1 short clause | 1 sentence |
+| Tooltip | 1 short clause | 1 sentence |
+| Form-field label | 1–2 words | 3 |
+| Helper text under a field | 1 short clause | 1 sentence |
+| Confirmation dialog body | 1–2 sentences | 3 |
+
+When you need more than the cap, the design is wrong, not the copy
+— the user shouldn't be reading paragraphs in a UI surface.
+
+## Action verbs
+
+**Imperative, present tense, second-person implicit.** No "Please" /
+"Kindly" / "Could you".
+
+| Action | Label | Not |
+| --- | --- | --- |
+| Save edits | "Save" | "Save changes", "Submit", "Update" |
+| Cancel | "Cancel" | "Close", "Dismiss", "Never mind" |
+| Delete | "Delete" | "Remove", "Trash", "Discard" (delete is destructive; remove is reversible) |
+| Add new | "Add item", "Add location", … | "Create", "New", "+" alone |
+| Confirm a destructive choice | "Yes, delete" / "Yes, leave group" | "OK", "Confirm" |
+| Sign in | "Sign in" | "Log in", "Login" |
+| Sign out | "Sign out" | "Log out", "Logout" |
+| Sign up / register | "Create account" | "Sign up", "Register" |
+
+The verb pair (`Sign in` / `Sign out`) is more common in modern English
+than `Log in` / `Log out` and reads more natural. Use them
+consistently.
+
+## Naming
+
+| Concept | Use | Don't use |
+| --- | --- | --- |
+| The thing the user owns | "Item" (UI) / "Commodity" (DB / API) | "Asset", "Property", "Object" |
+| The container | "Location" (UI) / "Location" (DB) | "Place", "Site", "Room" |
+| The sub-container | "Area" | "Zone", "Section" |
+| The user's group | "Group" / "Household" (in plural-user copy) | "Tenant", "Workspace", "Team" |
+| Files | "File" (singular), "Files" (plural) | "Attachment", "Document" (those are subcategories) |
+| Tags | "Tag" | "Label", "Category" |
+| Backup | "Export" / "Backup" — the export *of* the database is a "backup"; the act of producing it is "Export" | — |
+
+The DB-side `commodity` name predates the rewrite and is permanent in
+the API; the UI says "item" everywhere. Translation: BE strings are
+internal vocabulary, FE strings are user-facing vocabulary.
+
+PR #1362 proposed renaming "Commodity → Thing" / "Location → Place" /
+"Export → Backup" in the UI. That proposal is partially adopted — UI
+already uses "Item" and "Backup" / "Export" (depending on context).
+"Place" wasn't worth the disruption; "Location" stays.
+
+## Tone per surface
+
+### Auth pages
+
+Calm and copy-light. The product positioning (`00-positioning.md`)
+commits to no marketing voice on public surfaces.
+
+- Login title: `Sign in to Inventario`
+- Login subtitle: *(none)*
+- Forgot-password page title: `Reset your password`
+- Forgot-password body: `We'll send you a link to set a new password.`
+- Register title: `Create your account`
+- Register body: *(none)*
+
+Don't write "Welcome back!" or "Glad to see you!" — the user knows.
+
+### Empty states
+
+Pattern: **"You don't have X yet. When you do, they'll Y."**
+
+- No items: `You don't have any items yet. Add your first one to get started.`
+- No locations: `You don't have any locations yet. A location is the top-level container — your home, your office, a vehicle.`
+- No tags: `You don't have any tags yet. Tags help you label items across locations.`
+- No files on a commodity: `No files attached. Drop one here, or click Browse.`
+
+The pattern leaves room for context-specific phrasing — the no-files
+copy is shorter because the user is mid-flow, not landing on the page.
+
+### Loading
+
+Don't write "Loading…" copy — render a skeleton instead (see
+`05-motion.md`). The one place "Loading…" is allowed: a button label
+during in-flight submit, but only in addition to the original label
+(via the spinner pattern in `08-interaction-states.md`).
+
+### Errors
+
+Always answer: **what happened, why (if known), what now**.
+
+Patterns:
+
+| Surface | Template |
+| --- | --- |
+| Field-level | `<rule violated>` (e.g. "Email is required") |
+| Form-level | `<what failed>. <what to do>.` (e.g. "Invalid email or password. Try again or reset your password.") |
+| Page-level data | `Couldn't load <thing>. <Retry>.` |
+| Toast (transient) | Single sentence. Optional retry inside the toast. |
+| Catastrophic (500) | `Something went wrong. We've been notified.` |
+
+Don't:
+
+- Apologize repeatedly. One apology per surface.
+- Blame the user ("You typed the wrong password"). State the rule
+  ("Invalid email or password").
+- Write "Oops!" or "Whoops!". The voice is quiet, not cheerful.
+
+### Success
+
+Toasts after a successful mutation:
+
+- `Item added`
+- `Location updated`
+- `2 files uploaded`
+- `Group invitation sent`
+
+No exclamation marks. No "Successfully" prefix. The verb is past
+tense; the subject is implicit (the thing the user just acted on).
+
+### Destructive confirmations
+
+`<AlertDialog>` body — always answer "what's happening, what gets
+deleted, can you undo?":
+
+- Title: `Delete this item?`
+- Body: `This will remove "Cordless drill" and its files. This can't
+  be undone.`
+- Confirm button: `Yes, delete`
+- Cancel button: `Cancel`
+
+Don't:
+
+- "Are you sure?" alone — answer the implicit follow-up.
+- "OK / Cancel" — generic. Use the action verb on the confirm button.
+
+### Multi-tenancy / group
+
+When the user belongs to multiple groups:
+
+- Group switcher label: just the group name.
+- "Switching" toast: none. The page reloads — the new context is
+  obvious.
+- Group invite toast: `You've joined "<group>".`
+
+When the user has no group:
+
+- No-group page title: `You're not in a group yet`
+- Body: `Create one to start your inventory, or wait for an invite.`
+
+## i18n
+
+Every string is a translation key. See `13-formatting-and-i18n.md`.
+
+Key style: `namespace:dot.path`, lower-camelCase segments. The English
+bundle is the source of truth; cs/ru fall back to en for missing keys
+(per `../i18n.md`).
+
+Translators read context from the key path itself — keep keys
+descriptive (`commodities:list.empty.title` over `commodities:e1`).
+
+## Punctuation
+
+- **Periods** at the end of full sentences. Not after standalone
+  phrases / titles / button labels.
+- **Em-dashes** (`—`, U+2014) for asides; never `--` in source. Word
+  it out instead if your editor doesn't make `—` easy.
+- **No exclamation marks.** Anywhere. The product positioning bans
+  enthusiasm.
+- **Quoted item names** use straight double quotes (`"`), not
+  curly. ("Cordless drill", not "Cordless drill".)
+- **Ellipsis** (`…`, U+2026) — not `...`. Used sparingly: "Loading…"
+  inside a button, never as a sentence cue.
+
+## Numbers in copy
+
+- One-digit counts: spell out only in copy ("one item"). Use digits
+  in titles / metrics.
+- Plurals via i18next — `count: N` pluralizes via `_one` / `_other`.
+  See `../i18n.md`.
+
+## Hard rules
+
+1. **No exclamation marks** outside literal exception cases (none
+   identified yet).
+2. **Imperative verbs**, present tense.
+3. **Specific over generic** — "Add item" beats "Add", "Couldn't
+   load items" beats "Error".
+4. **Sentence-case headings**, not Title Case. Page titles like
+   "Items" or "Forgot password" — capitalize the first word and
+   proper nouns only.
+5. **No "Please".** It reads obsequious in product UI.
+6. **No "we're sorry to inform you".** Two words: "Couldn't load."
+
+## Anti-patterns
+
+- "Welcome back, <name>!" on the dashboard. The user knows.
+- "Boom! 🎉 Item added." Use "Item added".
+- "Hmm, something went wrong." Use "Couldn't save. Try again."
+- "Click here to learn more." Linkify the noun, not the verb.
+- A confirmation dialog with body "Are you sure?". Answer the
+  question.
+
+## Cross-refs
+
+- Voice anchor: `00-positioning.md`.
+- Plurals / numbers / dates: `13-formatting-and-i18n.md`.
+- Toast hierarchy: `16-notifications-and-trust.md`.
+- The i18n key contract: `../i18n.md`.

--- a/devdocs/frontend/design/13-formatting-and-i18n.md
+++ b/devdocs/frontend/design/13-formatting-and-i18n.md
@@ -7,7 +7,7 @@ the supported locales. **Committed.** All formatters live in
 ## Locales
 
 `en` (source of truth, bundled), `cs` (lazy), `ru` (lazy). See
-`../i18n.md`.
+[../i18n.md](../i18n.md).
 
 The locale used by formatters is `i18next.resolvedLanguage`, cached at
 formatter-construction time. When the user changes locale (Settings →
@@ -25,7 +25,7 @@ formatNumber(1024, { unit: "byte", unitDisplay: "narrow" })  // "1,024B"
 ```
 
 - **Tabular nums in columns.** `font-mono tabular-nums` (or
-  `tabular-nums` on a sans face) so columns align. See `02-typography.md`.
+  `tabular-nums` on a sans face) so columns align. See [02-typography.md](02-typography.md).
 - **Don't `.toFixed()` in components.** Always go through a formatter.
 - **Don't `Intl.NumberFormat` inline** — the constructor is expensive
   and the locale is mutable.
@@ -146,7 +146,7 @@ write. Round-tripping through the formatter avoids the issue.
 Inventario doesn't currently ship an RTL locale. The CSS uses logical
 properties where possible (`ms-*`, `me-*`, `ps-*`, `pe-*`) so an RTL
 locale could land without a refit. Adding one is out of scope of this
-brief; see `00-positioning.md`'s "Out of scope" list.
+brief; see [00-positioning.md](00-positioning.md)'s "Out of scope" list.
 
 ## Hard rules
 
@@ -170,6 +170,6 @@ brief; see `00-positioning.md`'s "Out of scope" list.
 
 ## Cross-refs
 
-- i18n engineering rules: `../i18n.md`.
-- Voice / copy: `12-tone-of-voice-and-copy.md`.
+- i18n engineering rules: [../i18n.md](../i18n.md).
+- Voice / copy: [12-tone-of-voice-and-copy.md](12-tone-of-voice-and-copy.md).
 - `intl.ts` source: `frontend/src/lib/intl.ts`.

--- a/devdocs/frontend/design/13-formatting-and-i18n.md
+++ b/devdocs/frontend/design/13-formatting-and-i18n.md
@@ -1,0 +1,175 @@
+# Formatting & i18n
+
+How to write a number, a date, a currency, a plural — once — across
+the supported locales. **Committed.** All formatters live in
+`frontend/src/lib/intl.ts`; never call `new Intl.*` from a component.
+
+## Locales
+
+`en` (source of truth, bundled), `cs` (lazy), `ru` (lazy). See
+`../i18n.md`.
+
+The locale used by formatters is `i18next.resolvedLanguage`, cached at
+formatter-construction time. When the user changes locale (Settings →
+Language), the helpers re-construct on the next render.
+
+## Numbers
+
+```ts
+import { formatNumber } from "@/lib/intl"
+
+formatNumber(1234)         // "1,234" (en) · "1 234" (cs) · "1 234" (ru)
+formatNumber(1234.5)       // "1,234.5" / "1 234,5" / "1 234,5"
+formatNumber(0.42, { style: "percent" })  // "42%" (all)
+formatNumber(1024, { unit: "byte", unitDisplay: "narrow" })  // "1,024B"
+```
+
+- **Tabular nums in columns.** `font-mono tabular-nums` (or
+  `tabular-nums` on a sans face) so columns align. See `02-typography.md`.
+- **Don't `.toFixed()` in components.** Always go through a formatter.
+- **Don't `Intl.NumberFormat` inline** — the constructor is expensive
+  and the locale is mutable.
+
+## Currency
+
+```ts
+import { formatCurrency } from "@/lib/intl"
+
+formatCurrency(1234.5, "USD")  // "$1,234.50" / "1 234,50 $" / "1 234,50 $"
+formatCurrency(-50, "EUR")     // "-€50.00" / "-50,00 €" / "-50,00 €"
+```
+
+- **Currency code is always required.** No "default to USD" anywhere
+  in the UI.
+- **Use `<CurrencyCombobox>`** for currency input — never a plain
+  `<Select>` with three hardcoded currencies.
+- **Negative values** prefix the locale's negative sign (`−`/`-`)
+  consistently. The formatter handles sign placement.
+
+## Dates and times
+
+```ts
+import { formatDate, formatTime, formatDateTime, formatRelative } from "@/lib/intl"
+
+formatDate("2026-04-28")           // "Apr 28, 2026" / "28. 4. 2026" / "28 апреля 2026 г."
+formatTime("2026-04-28T10:00:00")  // "10:00 AM" / "10:00" / "10:00"
+formatDateTime("2026-04-28T10:00") // "Apr 28, 2026, 10:00 AM" / …
+formatRelative(date)               // "2 days ago" / "before 2 days" / "2 дня назад"
+```
+
+Conventions:
+
+- **Months are spelled out, never numeric**, except in dense column
+  contexts. "Apr 28" beats "04/28" — readable in en/cs/ru without a
+  format-confusion footgun.
+- **24h vs 12h** is the locale's default. Don't override.
+- **Relative for ≤ 7 days, absolute otherwise** is the rule of thumb.
+  `formatRelative` falls back to absolute past 7 days.
+- **Time zones**: dates from the API are UTC. Display in the user's
+  local TZ — `Intl` does this by default. Don't add a TZ suffix unless
+  the surface explicitly needs it (calendar apps, audit logs).
+
+## Plurals
+
+i18next picks the plural form via the `count` key:
+
+```ts
+t("commodities:bulk.deleted", { count })
+// _one: "{count} item deleted"
+// _other: "{count} items deleted"
+```
+
+Closed enums in `preservePatterns` per `frontend/i18next.config.ts`.
+
+For Russian / Czech, i18next picks `_few`, `_many` etc. when the
+catalog provides them — see the en bundle for the canonical key shapes.
+
+## Lists
+
+```ts
+import { formatList } from "@/lib/intl"
+
+formatList(["Kitchen", "Bedroom", "Garage"])  // "Kitchen, Bedroom, and Garage" (en)
+                                              // "Kitchen, Bedroom a Garage" (cs)
+                                              // "Kitchen, Bedroom и Garage" (ru)
+```
+
+For "X, Y, and 3 others" surfaces, build the truncation in code, then
+join with `formatList`.
+
+## File sizes
+
+```ts
+import { formatBytes } from "@/lib/intl"
+
+formatBytes(1024)        // "1.0 KB"
+formatBytes(1_500_000)   // "1.4 MB"
+```
+
+Always SI (1024-stepped). One decimal. Don't write "1,500,000 bytes"
+in user-facing copy.
+
+## Identifiers
+
+API identifiers (UUIDs, slugs) are **never** formatted. Show them
+verbatim if shown at all (settings page, debug surfaces). Don't
+truncate ("a1b2c…f9").
+
+## Form input
+
+| Field | Input behavior |
+| --- | --- |
+| Currency | Numeric input + currency selector (`<CurrencyCombobox>`). The decimal separator is the locale's; the formatter writes back the user's input on blur. |
+| Date | `<input type="date">` is the floor. A custom `<Popover>` calendar can replace it for surfaces that need range selection. Always store ISO 8601 (`YYYY-MM-DD`). |
+| Time | `<input type="time">`. Locale-aware 12h/24h. |
+| Numeric quantity | `<input type="number" inputMode="numeric">`. Don't pre-format with thousands separators inside a number input — the browser parses it as one number, the user sees grouped digits. |
+
+## Locale-specific gotchas
+
+- **`cs` decimal is comma**, thousand sep is non-breaking space.
+- **`ru` decimal is comma**, thousand sep is non-breaking space.
+- **`en` decimal is period**, thousand sep is comma.
+
+Don't hand-write decimals — `Intl.NumberFormat` does it. The bug
+people hit: typing "1,234.5" into a parsed input on a `cs` locale —
+the comma is the decimal separator, so `1.234,5` is what `Intl` would
+write. Round-tripping through the formatter avoids the issue.
+
+- **Russian month genitive**: "28 апреля 2026 г." (genitive case) —
+  `Intl` handles this with `dateStyle: "long"`. Don't manually cap
+  month names.
+- **Czech ordering**: "28. 4. 2026" with periods. `Intl` produces this
+  with `dateStyle: "short"`.
+
+## RTL
+
+Inventario doesn't currently ship an RTL locale. The CSS uses logical
+properties where possible (`ms-*`, `me-*`, `ps-*`, `pe-*`) so an RTL
+locale could land without a refit. Adding one is out of scope of this
+brief; see `00-positioning.md`'s "Out of scope" list.
+
+## Hard rules
+
+1. **All formatting via `src/lib/intl.ts`.** No `Intl.NumberFormat`,
+   `Intl.DateTimeFormat`, `Intl.RelativeTimeFormat`,
+   `Intl.PluralRules` inside components.
+2. **Currency code is always explicit.** No silent USD default.
+3. **Months are spelled** outside dense columns.
+4. **ISO 8601 for storage.** Never store locale-formatted strings.
+5. **Plurals via i18next.** No hand-rolled `count === 1 ? "item" : "items"`.
+
+## Anti-patterns
+
+- `${value.toLocaleString()}` — uses the *runtime* locale, not the
+  i18next-resolved one. Subtle bug after the user changes language.
+- `value.toFixed(2)` for currency — locale-blind, drops the symbol.
+- `new Date().toLocaleDateString()` — same locale-blindness.
+- `${count} item${count === 1 ? "" : "s"}` — i18next handles this.
+- Concatenating `formatDate` and `formatTime` instead of
+  `formatDateTime` — the joiner ("at", " · ") is locale-specific.
+
+## Cross-refs
+
+- i18n engineering rules: `../i18n.md`.
+- Voice / copy: `12-tone-of-voice-and-copy.md`.
+- `intl.ts` source: `frontend/src/lib/intl.ts`.

--- a/devdocs/frontend/design/14-accessibility.md
+++ b/devdocs/frontend/design/14-accessibility.md
@@ -1,0 +1,213 @@
+# Accessibility
+
+**Floor: WCAG 2.2 AA.** Some surfaces (auth, dashboard, settings)
+target AAA where reasonable. A11y is a quality bar; the engineering
+contract — Radix primitives, focus-visible rings, jest-axe in unit
+tests, `@axe-core/playwright` in e2e — is in `../accessibility.md`.
+
+This doc is the **design** contract: what each surface promises to a
+keyboard / screen-reader / low-vision / motor-impaired user.
+
+## Promises per surface
+
+### Keyboard
+
+Every interactive element is reachable by Tab in DOM order. Skip-to-content
+link at the top of every page (mounted in `Shell.tsx`). Modal focus
+trapped via Radix; closure restores focus to the trigger.
+
+| Shortcut | Action | Where |
+| --- | --- | --- |
+| `Tab` / `Shift+Tab` | Move focus | Everywhere |
+| `Enter` / `Space` | Activate | Buttons, links |
+| `Escape` | Close | Dialogs, dropdowns, popovers, sheets |
+| `Cmd+K` (mac) / `Ctrl+K` | Open command palette | App-wide |
+| `/` | Focus search input | Pages with search |
+| `?` | Open keyboard-shortcut help | App-wide (future) |
+| Arrow keys | Navigate within menus / lists | Radix-handled |
+
+Don't bind `Cmd+S` / `Cmd+Z` etc. — the user's browser owns those.
+
+### Screen reader
+
+- **Every page has exactly one `<h1>`**, set via `<RouteTitle>`.
+- **Heading hierarchy is preserved** — `<h2>` for sections, `<h3>` for
+  subsections. Don't skip levels.
+- **Landmarks** — `<header>`, `<nav>`, `<main>`, `<aside>`, `<footer>`
+  via the Shell.
+- **Form fields** are labeled programmatically via `<Label htmlFor>`
+  or `aria-label`. See `09-component-patterns.md` ("Input + Label").
+- **Live regions** — toasts use `aria-live="polite"`, errors use
+  `aria-live="assertive"` (sonner does this; useAppToast preserves
+  it).
+- **Loading states** — skeleton placeholders should be wrapped in
+  `aria-busy="true"` until data resolves.
+
+### Low-vision
+
+- Contrast targets per `01-palette.md`. Body text AAA, UI cues AA.
+- Zoom to 200% should reflow without horizontal scroll. Test at
+  `Cmd+` × 2.
+- Don't convey state by color alone — pair with icon + text.
+- `prefers-contrast: more` is honored — see `01-palette.md` (TBD;
+  not yet wired).
+
+### Motor
+
+- **Tap targets ≥ 44×44 px** on touch surfaces. shadcn `Button` is 36
+  by default; touch-first surfaces should use `size="lg"` or
+  custom-pad.
+- **No double-click required.** Single click everywhere.
+- **Hover-revealed actions** (kebab on row hover) are also reachable
+  via keyboard focus — the `opacity-0 group-hover:opacity-100`
+  pattern needs a `focus-within:opacity-100` mirror.
+- **Drag-and-drop has a keyboard fallback.** File upload via drop
+  zone always pairs with a "Browse" button.
+
+### Cognitive
+
+- **No timed actions.** Logout-on-idle is a server-side decision; no
+  countdown banners.
+- **Plain language.** Per `12-tone-of-voice-and-copy.md`.
+- **No unexpected motion.** Respect `prefers-reduced-motion: reduce`
+  per `05-motion.md`.
+
+## Focus
+
+The 3px amber ring at 50% opacity is the contract. It's tuned for:
+
+- 3:1 contrast against `--background` (light) — passes AA UI.
+- 3:1 contrast against `--card` — passes AA UI.
+- 3:1 contrast against `--muted` — passes AA UI.
+
+When you build a custom focusable element, never `outline: none`
+without applying `focus-visible:ring-[3px] focus-visible:ring-ring/50`
+in its place.
+
+## Color contrast
+
+| Pair | Required ratio | Token combo |
+| --- | --- | --- |
+| Body text | 4.5:1 (AA) / 7:1 (AAA) | `--foreground` on `--background`, `--card` |
+| Large text (≥ 18.5px or 14.5px bold) | 3:1 (AA) / 4.5:1 (AAA) | Same |
+| UI cues | 3:1 (AA) | `--ring` on adjacent surface, `--border` on adjacent surface |
+| Decorative | none required | Free choice within tokens |
+
+The Lighthouse `accessibility` audit catches drift; jest-axe catches
+it earlier. See `../perf.md`, `../testing.md`.
+
+## ARIA patterns
+
+| Pattern | Primitive |
+| --- | --- |
+| Modal dialog | Radix `<Dialog>` — already wires `role="dialog"`, `aria-labelledby`, `aria-describedby`, focus trap |
+| Alert dialog (destructive) | Radix `<AlertDialog>` |
+| Menu | Radix `<DropdownMenu>` |
+| Combobox | `cmdk` via shadcn `<Command>` |
+| Tabs | Radix `<Tabs>` |
+| Disclosure (collapsible) | Radix `<Collapsible>` (when copied in) |
+| Tree (locations / areas) | Don't roll your own — use a flat list with hierarchical visual cues; see `frontend/src/components/locations/` |
+
+When a primitive doesn't exist (a sortable table, a kanban column),
+read WAI-ARIA Authoring Practices first; don't invent a role.
+
+## Tests
+
+- **Unit / integration**: jest-axe, no critical/serious violations.
+  See `../testing.md`.
+- **End-to-end**: `@axe-core/playwright`, `serious`+`critical` floor.
+  See `e2e/utils/axe.ts`.
+- **Lighthouse**: `accessibility ≥ 0.95` per `../perf.md`.
+
+If an axe violation is intentional (a vendored Radix issue, a known
+upstream bug), suppress locally with `runOptions: { rules: { "<rule>":
+{ enabled: false } } }` — never lower the global threshold.
+
+## Tooltips
+
+- A tooltip **supplements**, never replaces, a label. Icon-only
+  buttons have an `aria-label` *and* a tooltip — the tooltip is for
+  sighted hover, the aria-label is for keyboard / SR.
+- Tooltips don't fire on focus by default — Radix's tooltip provider
+  with `delayDuration={300}` is the standard. Don't lower below 300ms.
+- Don't tooltip text that's already visible.
+
+## Forms
+
+- Every field has a `<Label htmlFor>` linked to the input `id`.
+- Errors render below the field, with `aria-invalid="true"` on the
+  input and `aria-describedby` pointing at the error element's id.
+- The submit button stays in tab order even when disabled.
+- `autocomplete` attributes set on email / password / name fields.
+- Password fields offer a show/hide toggle (see
+  `frontend/src/components/auth/PasswordInput.tsx`).
+
+## Modals and overlays
+
+Radix handles:
+
+- Focus trap.
+- Escape key closes.
+- Backdrop click closes (configurable per dialog).
+- Focus restoration to the trigger on close.
+- `aria-labelledby` / `aria-describedby` wiring.
+
+Don't override `onPointerDownOutside` / `onEscapeKeyDown` to disable
+closure — that breaks user expectations. The legitimate exception: an
+unsaved-changes guard that opens a nested confirm AlertDialog before
+the parent dialog closes.
+
+## Reduced motion
+
+`prefers-reduced-motion: reduce` disables `tw-animate-css`
+animations automatically. Custom transitions opt out via:
+
+```tsx
+<div className="transition-colors motion-reduce:transition-none">
+```
+
+See `05-motion.md`.
+
+## Reduced data
+
+The auth pages and dashboard render readable on a 3G connection. The
+entry-bundle budget (200 KB gzip, see `../perf.md`) is the gate; the
+LHCI `accessibility` audit catches "image without alt" and other
+classics.
+
+Lighthouse runs with `data-saver` not specifically modeled; the bundle
+budget covers it well enough.
+
+## Hard rules
+
+1. **WCAG 2.2 AA** floor everywhere. AAA where it costs nothing.
+2. **One `<h1>` per page.**
+3. **Every interactive element is keyboard-reachable.**
+4. **Every form field has a label.** Programmatic, via `<Label htmlFor>`
+   or `aria-label`.
+5. **`focus-visible:ring-[3px] focus-visible:ring-ring/50`** is the
+   focus ring. Don't redefine.
+6. **Color is never alone.** Pair with icon + text.
+7. **Tap targets ≥ 44×44** on touch.
+8. **No timed actions** the user can't pause / dismiss.
+
+## Anti-patterns
+
+- `<div onClick>` "buttons". Use `<Button>`.
+- An icon-only button without `aria-label`.
+- A form field with placeholder-as-label.
+- Hover-revealed action that's not focus-reachable.
+- A modal without `aria-labelledby`.
+- "Are you a robot?" CAPTCHAs (use server-side rate limiting).
+- Page transitions on route change.
+- A timer-driven session expiry banner with no pause.
+- A tooltip-only label.
+
+## Cross-refs
+
+- Engineering: `../accessibility.md`.
+- Focus / states: `08-interaction-states.md`.
+- Tokens / contrast: `01-palette.md`.
+- Reduced motion: `05-motion.md`.
+- A11y testing: `../testing.md`.
+- A11y perf gate: `../perf.md`.

--- a/devdocs/frontend/design/14-accessibility.md
+++ b/devdocs/frontend/design/14-accessibility.md
@@ -3,7 +3,7 @@
 **Floor: WCAG 2.2 AA.** Some surfaces (auth, dashboard, settings)
 target AAA where reasonable. A11y is a quality bar; the engineering
 contract — Radix primitives, focus-visible rings, jest-axe in unit
-tests, `@axe-core/playwright` in e2e — is in `../accessibility.md`.
+tests, `@axe-core/playwright` in e2e — is in [../accessibility.md](../accessibility.md).
 
 This doc is the **design** contract: what each surface promises to a
 keyboard / screen-reader / low-vision / motor-impaired user.
@@ -36,7 +36,7 @@ Don't bind `Cmd+S` / `Cmd+Z` etc. — the user's browser owns those.
 - **Landmarks** — `<header>`, `<nav>`, `<main>`, `<aside>`, `<footer>`
   via the Shell.
 - **Form fields** are labeled programmatically via `<Label htmlFor>`
-  or `aria-label`. See `09-component-patterns.md` ("Input + Label").
+  or `aria-label`. See [09-component-patterns.md](09-component-patterns.md) ("Input + Label").
 - **Live regions** — toasts use `aria-live="polite"`, errors use
   `aria-live="assertive"` (sonner does this; useAppToast preserves
   it).
@@ -45,11 +45,11 @@ Don't bind `Cmd+S` / `Cmd+Z` etc. — the user's browser owns those.
 
 ### Low-vision
 
-- Contrast targets per `01-palette.md`. Body text AAA, UI cues AA.
+- Contrast targets per [01-palette.md](01-palette.md). Body text AAA, UI cues AA.
 - Zoom to 200% should reflow without horizontal scroll. Test at
   `Cmd+` × 2.
 - Don't convey state by color alone — pair with icon + text.
-- `prefers-contrast: more` is honored — see `01-palette.md` (TBD;
+- `prefers-contrast: more` is honored — see [01-palette.md](01-palette.md) (TBD;
   not yet wired).
 
 ### Motor
@@ -68,9 +68,9 @@ Don't bind `Cmd+S` / `Cmd+Z` etc. — the user's browser owns those.
 
 - **No timed actions.** Logout-on-idle is a server-side decision; no
   countdown banners.
-- **Plain language.** Per `12-tone-of-voice-and-copy.md`.
+- **Plain language.** Per [12-tone-of-voice-and-copy.md](12-tone-of-voice-and-copy.md).
 - **No unexpected motion.** Respect `prefers-reduced-motion: reduce`
-  per `05-motion.md`.
+  per [05-motion.md](05-motion.md).
 
 ## Focus
 
@@ -94,7 +94,7 @@ in its place.
 | Decorative | none required | Free choice within tokens |
 
 The Lighthouse `accessibility` audit catches drift; jest-axe catches
-it earlier. See `../perf.md`, `../testing.md`.
+it earlier. See [../perf.md](../perf.md), [../testing.md](../testing.md).
 
 ## ARIA patterns
 
@@ -114,10 +114,10 @@ read WAI-ARIA Authoring Practices first; don't invent a role.
 ## Tests
 
 - **Unit / integration**: jest-axe, no critical/serious violations.
-  See `../testing.md`.
+  See [../testing.md](../testing.md).
 - **End-to-end**: `@axe-core/playwright`, `serious`+`critical` floor.
   See `e2e/utils/axe.ts`.
-- **Lighthouse**: `accessibility ≥ 0.95` per `../perf.md`.
+- **Lighthouse**: `accessibility ≥ 0.95` per [../perf.md](../perf.md).
 
 If an axe violation is intentional (a vendored Radix issue, a known
 upstream bug), suppress locally with `runOptions: { rules: { "<rule>":
@@ -166,12 +166,12 @@ animations automatically. Custom transitions opt out via:
 <div className="transition-colors motion-reduce:transition-none">
 ```
 
-See `05-motion.md`.
+See [05-motion.md](05-motion.md).
 
 ## Reduced data
 
 The auth pages and dashboard render readable on a 3G connection. The
-entry-bundle budget (200 KB gzip, see `../perf.md`) is the gate; the
+entry-bundle budget (200 KB gzip, see [../perf.md](../perf.md)) is the gate; the
 LHCI `accessibility` audit catches "image without alt" and other
 classics.
 
@@ -205,9 +205,9 @@ budget covers it well enough.
 
 ## Cross-refs
 
-- Engineering: `../accessibility.md`.
-- Focus / states: `08-interaction-states.md`.
-- Tokens / contrast: `01-palette.md`.
-- Reduced motion: `05-motion.md`.
-- A11y testing: `../testing.md`.
-- A11y perf gate: `../perf.md`.
+- Engineering: [../accessibility.md](../accessibility.md).
+- Focus / states: [08-interaction-states.md](08-interaction-states.md).
+- Tokens / contrast: [01-palette.md](01-palette.md).
+- Reduced motion: [05-motion.md](05-motion.md).
+- A11y testing: [../testing.md](../testing.md).
+- A11y perf gate: [../perf.md](../perf.md).

--- a/devdocs/frontend/design/15-form-and-data-ux.md
+++ b/devdocs/frontend/design/15-form-and-data-ux.md
@@ -1,7 +1,7 @@
 # Form & Data UX
 
 The behavior contract for every form and every data surface in the
-app. Engineering rules in `../forms.md` and `../data.md`; this doc is
+app. Engineering rules in [../forms.md](../forms.md) and [../data.md](../data.md); this doc is
 the **UX** decisions — when to validate, when to confirm, when to
 optimistically update, when to surface progress.
 
@@ -24,7 +24,7 @@ typing — feedback without paternalism.
 ## Server errors
 
 `parseServerError(err, fallback)` collapses every backend envelope
-into a single string. See `../forms.md`. UX-side:
+into a single string. See [../forms.md](../forms.md). UX-side:
 
 - **Form-level** (auth, single-section edit): banner above the form
   with `<Alert variant="destructive">`. The banner clears when the
@@ -67,7 +67,7 @@ instant feedback:
 | Create / move location | No — these have validation rules the server owns |
 | Bulk delete | Yes (5+ items: confirm first) |
 
-The pattern is the `useLogout` reference in `data.md`. Always:
+The pattern is the `useLogout` reference in [data.md](data.md). Always:
 
 - `cancelQueries` before writing optimistically.
 - Snapshot previous data in `onMutate`.
@@ -91,7 +91,7 @@ implementation. Adopt the helper rather than re-inventing.
 ## Multi-step (wizard) flow
 
 Default to single-step for ≤ 4 fields. Wizards for everything else.
-See `11-page-layouts-and-flows.md` ("Multi-step wizard").
+See [11-page-layouts-and-flows.md](11-page-layouts-and-flows.md) ("Multi-step wizard").
 
 UX rules:
 
@@ -147,7 +147,7 @@ Escape cancels (revert + blur). Enter saves (blur fires save handler).
 
 ## Empty / not found / error
 
-See `08-interaction-states.md` and `20-edge-cases.md` for the visual
+See [08-interaction-states.md](08-interaction-states.md) and [20-edge-cases.md](20-edge-cases.md) for the visual
 specs. UX-side:
 
 - **Empty** — give the user the next action (CTA inside the empty
@@ -202,7 +202,7 @@ Used for:
 
 - Reordering areas inside a location.
 - Reordering files inside a commodity.
-- Drop-zone upload (`10-file-and-media.md`).
+- Drop-zone upload ([10-file-and-media.md](10-file-and-media.md)).
 
 Always with a keyboard fallback: arrow keys to move within a focused
 list, Space to grab/drop. Use Radix's `<DragHandle>` primitive when
@@ -242,8 +242,8 @@ For settings / draft persistence. UX-side:
 
 ## Cross-refs
 
-- Form engineering: `../forms.md`.
-- Data engineering (mutations, optimistic, keys): `../data.md`.
-- Toasts and notifications: `16-notifications-and-trust.md`.
-- States (loading, empty, error): `08-interaction-states.md`.
-- Wizard pattern: `11-page-layouts-and-flows.md`.
+- Form engineering: [../forms.md](../forms.md).
+- Data engineering (mutations, optimistic, keys): [../data.md](../data.md).
+- Toasts and notifications: [16-notifications-and-trust.md](16-notifications-and-trust.md).
+- States (loading, empty, error): [08-interaction-states.md](08-interaction-states.md).
+- Wizard pattern: [11-page-layouts-and-flows.md](11-page-layouts-and-flows.md).

--- a/devdocs/frontend/design/15-form-and-data-ux.md
+++ b/devdocs/frontend/design/15-form-and-data-ux.md
@@ -1,0 +1,249 @@
+# Form & Data UX
+
+The behavior contract for every form and every data surface in the
+app. Engineering rules in `../forms.md` and `../data.md`; this doc is
+the **UX** decisions — when to validate, when to confirm, when to
+optimistically update, when to surface progress.
+
+## Validation timing
+
+| Mode | When validation fires | When to use |
+| --- | --- | --- |
+| `onSubmit` (default) | After the user clicks Submit | Almost every form |
+| `onChange` | On every keystroke | Forms where the user benefits from live feedback (password complexity, search-as-you-type) |
+| `onBlur` | When the field loses focus | Specific fields with deferrable rules (email format) |
+
+The default is `onSubmit`. Live validation is friction unless the
+user has a reason to want it; "your password isn't long enough" on
+keystroke 4 is patronizing.
+
+For password fields specifically, the strength meter updates
+on-keystroke but doesn't *block* submit until the user has stopped
+typing — feedback without paternalism.
+
+## Server errors
+
+`parseServerError(err, fallback)` collapses every backend envelope
+into a single string. See `../forms.md`. UX-side:
+
+- **Form-level** (auth, single-section edit): banner above the form
+  with `<Alert variant="destructive">`. The banner clears when the
+  user starts typing.
+- **Field-level** (rare — server validates a specific field): show
+  inline below the field, `text-destructive text-xs`. Mark the field
+  `aria-invalid="true"`.
+- **Network blip during background mutation** (auto-save, settings
+  toggle): sonner toast with retry + rollback. Don't change the page
+  layout for a transient blip.
+
+## Confirmation
+
+Confirm before:
+
+- **Delete** anything the user can't undo within 30 seconds.
+  Use `<AlertDialog>` (or `useConfirm()`).
+- **Leaving an unsaved form**. Use the same dialog.
+- **Bulk action ≥ 5 items**. The user might have miss-selected.
+
+Don't confirm:
+
+- A reversible toggle (e.g. "Mark as sold" — the user can switch back).
+- A view change.
+- A search.
+
+## Optimistic updates
+
+Use when the server's answer is predictable AND the user expects
+instant feedback:
+
+| Action | Optimistic? |
+| --- | --- |
+| Toggle a tag on/off | Yes |
+| Mark warranty seen | Yes |
+| Settings toggle | Yes |
+| Logout | Yes |
+| Add commodity | No — show pending state, replace on success |
+| Delete commodity | Yes (with rollback on error) |
+| Create / move location | No — these have validation rules the server owns |
+| Bulk delete | Yes (5+ items: confirm first) |
+
+The pattern is the `useLogout` reference in `data.md`. Always:
+
+- `cancelQueries` before writing optimistically.
+- Snapshot previous data in `onMutate`.
+- Restore in `onError`.
+- `invalidateQueries` in `onSettled`.
+
+## Draft persistence
+
+For any form > 4 fields or > 2 minutes' commitment, persist the draft
+to `localStorage` keyed `<feature>-draft:{slug}:{op}` (e.g.
+`commodity-draft:household:create`):
+
+- Hydrate on mount.
+- Write through every change (debounced).
+- Cancel clears.
+- Save clears on success.
+
+The Add Item wizard (`features/commodities/`) is the canonical
+implementation. Adopt the helper rather than re-inventing.
+
+## Multi-step (wizard) flow
+
+Default to single-step for ≤ 4 fields. Wizards for everything else.
+See `11-page-layouts-and-flows.md` ("Multi-step wizard").
+
+UX rules:
+
+- Per-step validation before "Continue".
+- "Back" preserves entered values (RHF's default).
+- Step dots show progress + completion. Click a previous step to jump
+  back; forward dots are disabled until validated.
+- Cancel asks for confirmation if any step has been edited.
+
+## Inline edit vs. separate form
+
+| When | UX |
+| --- | --- |
+| Single field, low risk (rename, change tag) | Inline — click the value, becomes editable, blur to save |
+| Multiple fields | Sheet or full page |
+| Destructive consequence | Always a separate form, never inline |
+| Sortable / reorderable list | Drag-and-drop with keyboard fallback |
+
+Inline edit anatomy:
+
+```tsx
+{editing ? (
+  <Input
+    autoFocus
+    value={value}
+    onChange={(e) => setValue(e.target.value)}
+    onBlur={save}
+    onKeyDown={(e) => e.key === "Enter" && save()}
+    className="h-8 -my-0.5"
+  />
+) : (
+  <button
+    onClick={() => setEditing(true)}
+    className="-mx-1 px-1 py-0.5 text-left rounded hover:bg-muted/40"
+  >
+    {value || <span className="text-muted-foreground italic">{placeholder}</span>}
+  </button>
+)}
+```
+
+Escape cancels (revert + blur). Enter saves (blur fires save handler).
+
+## Loading data
+
+| Surface | Behavior |
+| --- | --- |
+| Page first load | Skeleton matching the page's shape. Never a centered spinner. |
+| Page navigation between cached views | Show stale data, fetch in background, no skeleton |
+| List paging | `keepPreviousData: false` by default — show skeleton for the next page (pagination is fast) |
+| List sorting / filtering | Replace data with skeleton on chip click; React Query refetches with the new key |
+| Mutation in flight | Spinner inside the button, button label preserved |
+| Long-running server task (export, restore) | Server-side state polled or streamed; UI shows actual progress, not a spinner |
+
+## Empty / not found / error
+
+See `08-interaction-states.md` and `20-edge-cases.md` for the visual
+specs. UX-side:
+
+- **Empty** — give the user the next action (CTA inside the empty
+  state).
+- **Not found** — link back to where they probably came from.
+- **Error** — give a Retry. The retry calls
+  `queryClient.invalidateQueries(...)`.
+
+## Search
+
+- The search input lives **inside** the list page, not above the page
+  title.
+- Keyboard shortcut: `/` focuses search.
+- Debounce 300ms before firing the query.
+- Empty input + recent searches = recent items, not "Type to search".
+- Empty results = empty-state pattern with the search term echoed back
+  ("No items match \"foo\".").
+
+## Sorting and filtering
+
+- Sort and filter are query-string params (`?sort=-created_at&type=appliance`)
+  so deep links round-trip.
+- Active filter chips visible above the list. Click X on a chip to
+  clear that filter; "Clear all" resets to default.
+- Don't open a multi-select filter inside a side rail. Use a Popover.
+
+## Bulk actions
+
+When a list supports multi-select (commodities, files, areas, tags),
+the toolbar:
+
+- Slides in from the top of the list when the first row is selected.
+- Says "N selected" first, then the actions.
+- "Clear" / "Cancel" deselects all.
+- Shifts the page header down — doesn't overlay it.
+- Sticks to the top during scroll.
+
+Available actions per surface:
+
+| Surface | Bulk |
+| --- | --- |
+| Items | Delete, Move, Tag |
+| Files | Delete, Move to commodity |
+| Areas | Delete, Move to location |
+| Tags | Delete |
+
+5+ items → confirm before destruction.
+
+## Drag-and-drop
+
+Used for:
+
+- Reordering areas inside a location.
+- Reordering files inside a commodity.
+- Drop-zone upload (`10-file-and-media.md`).
+
+Always with a keyboard fallback: arrow keys to move within a focused
+list, Space to grab/drop. Use Radix's `<DragHandle>` primitive when
+copied in.
+
+Multi-select drag (drag many items at once) is out of scope for now.
+
+## Auto-save
+
+For settings / draft persistence. UX-side:
+
+- Save is debounced 500ms after last change.
+- A subtle "Saved" indicator appears next to the field for 1.5s after
+  save.
+- Failure → toast with retry + rollback. The field's value reverts.
+
+## Hard rules
+
+1. **Default validation to `onSubmit`.** Live validation is opt-in.
+2. **Confirm destructive.** Always.
+3. **Server errors via `parseServerError`.** Don't render raw errors.
+4. **Drafts persist** for forms > 4 fields.
+5. **Skeletons over spinners** for in-flight queries.
+6. **One filled-primary** per page surface.
+7. **Optimistic updates roll back** on error.
+
+## Anti-patterns
+
+- A form that validates on every keystroke for no good reason.
+- "Are you sure?" with no body text. Body text answers the implicit
+  follow-up.
+- A bulk-delete button without a confirmation.
+- Auto-saving a settings field without showing the user it saved.
+- A wizard that loses entered data when the user clicks Back.
+- A search that fires on every keystroke without debounce.
+- A filter that opens as a fullscreen Sheet on desktop. Use a Popover.
+
+## Cross-refs
+
+- Form engineering: `../forms.md`.
+- Data engineering (mutations, optimistic, keys): `../data.md`.
+- Toasts and notifications: `16-notifications-and-trust.md`.
+- States (loading, empty, error): `08-interaction-states.md`.
+- Wizard pattern: `11-page-layouts-and-flows.md`.

--- a/devdocs/frontend/design/16-notifications-and-trust.md
+++ b/devdocs/frontend/design/16-notifications-and-trust.md
@@ -77,8 +77,8 @@ toast.success(t("commodities:toast.deleted"), {
 
 ## Confirmation
 
-`<AlertDialog>` for destructive flows. See `09-component-patterns.md`,
-`12-tone-of-voice-and-copy.md` ("Destructive confirmations").
+`<AlertDialog>` for destructive flows. See [09-component-patterns.md](09-component-patterns.md),
+[12-tone-of-voice-and-copy.md](12-tone-of-voice-and-copy.md) ("Destructive confirmations").
 
 Confirmations are NOT toasts; toasts are post-hoc, confirmations are
 pre-hoc.
@@ -89,16 +89,16 @@ When the user wants to know *what changed* on an item:
 
 - **Status history card** on the commodity detail (already in production).
 - **"Edited 2h ago" footer** on detail pages — uses `formatRelative`
-  per `13-formatting-and-i18n.md`.
+  per [13-formatting-and-i18n.md](13-formatting-and-i18n.md).
 - **Member badges on shared changes** in multi-user groups (future).
 
-The product positioning (`00-positioning.md`) commits to honesty —
+The product positioning ([00-positioning.md](00-positioning.md)) commits to honesty —
 the user owns the data; they get visibility into what's changed.
 
 ## Trust signals
 
 The product positioning lists *data ownership* as a primary value
-(`00-positioning.md`). Surfaces that reinforce trust:
+([00-positioning.md](00-positioning.md)). Surfaces that reinforce trust:
 
 | Surface | Signal |
 | --- | --- |
@@ -119,7 +119,7 @@ What we *don't* do:
 ## Sensitive data
 
 - **Never log PII** (email, name, address) to the browser console —
-  see `../coding-standards.md` ("Console policy").
+  see [../coding-standards.md](../coding-standards.md) ("Console policy").
 - **Don't show secrets** (access tokens, refresh tokens, CSRF tokens)
   in any UI surface, including dev tools' visible state.
 - **Mask credit card numbers** in any future surface that surfaces
@@ -129,7 +129,7 @@ What we *don't* do:
   `frontend/src/components/auth/PasswordInput.tsx` which has a
   show/hide toggle. The "show" reveals the user's own input only.
 - **No session-expiry warnings** with countdowns — see
-  `14-accessibility.md` (no timed actions).
+  [14-accessibility.md](14-accessibility.md) (no timed actions).
 
 ## Email and external
 
@@ -190,9 +190,9 @@ notification surface.
 
 ## Cross-refs
 
-- Voice / copy: `12-tone-of-voice-and-copy.md`.
-- Confirmation dialogs: `09-component-patterns.md`.
-- Inline error UX: `15-form-and-data-ux.md`.
+- Voice / copy: [12-tone-of-voice-and-copy.md](12-tone-of-voice-and-copy.md).
+- Confirmation dialogs: [09-component-patterns.md](09-component-patterns.md).
+- Inline error UX: [15-form-and-data-ux.md](15-form-and-data-ux.md).
 - Audit / history (item status): `frontend/src/pages/commodities/`.
 - Sonner setup: `frontend/src/components/ui/sonner.tsx`.
 - Toast wrapper: `frontend/src/hooks/useAppToast.ts`.

--- a/devdocs/frontend/design/16-notifications-and-trust.md
+++ b/devdocs/frontend/design/16-notifications-and-trust.md
@@ -1,0 +1,198 @@
+# Notifications & Trust
+
+How the app talks back to the user — toasts, inline messages,
+confirmations, audit cues, and the trust signals that make the
+inventory feel like *theirs*.
+
+## Toast hierarchy
+
+Sonner is the toast layer. Wrapped in `useAppToast()`
+(`src/hooks/useAppToast.ts`):
+
+```ts
+const toast = useAppToast()
+toast.success(t("commodities:toast.created"))
+toast.error(t("auth:login.errorGeneric"))
+toast.warning(t("settings:warning.unsaved"))
+toast.info(t("common:toast.copied"))
+```
+
+Severity contract:
+
+| Severity | Auto-dismiss | Color | When |
+| --- | --- | --- | --- |
+| `info` | 4s | foreground | Neutral feedback ("Copied", "Refreshed") |
+| `success` | 4s | `--status-active` (green) | Mutation succeeded ("Item added") |
+| `warning` | 6s | `--status-expiring` (amber) | Heads-up ("Saving offline; will retry") |
+| `error` | manual | `--destructive` (red) | Mutation failed; user must dismiss |
+
+Errors require manual dismiss because they often pair with retry CTAs
+or recovery info that auto-dismiss would erase.
+
+## When to toast vs. when to inline
+
+| Surface | Inline | Toast |
+| --- | --- | --- |
+| Form-level error | ✅ — banner above the form | ❌ |
+| Field-level error | ✅ — below the field | ❌ |
+| Successful mutation (single item) | — | ✅ ("Item added") |
+| Bulk mutation success | — | ✅ ("3 items deleted") |
+| Mutation failure (not field-specific) | — | ✅ (with retry) |
+| Auto-save success | ✅ — "Saved" indicator near the field | ❌ |
+| Auto-save failure | — | ✅ (with retry + rollback) |
+| Page-level data couldn't load | ✅ — "Couldn't load. Retry." inside the data area | ❌ |
+| App-level error (route blew up) | The 500 page | ❌ |
+| Long task started | — | ✅ ("Export started") |
+| Long task completed | — | ✅ ("Export ready") |
+
+A toast is the right surface when the action is **transient**, the
+result is **deferred** from the user's current focus, or the action
+**affects state outside the current view**.
+
+## Toast count
+
+- One toast per action. Bulk actions emit one grouped toast ("3 files
+  uploaded"), not three individual ones.
+- Stacking limit: 4. Older toasts collapse; the user sees the most
+  recent.
+- Don't toast per-row in a loop. If 50 rows fail, emit one toast
+  saying "12 of 50 failed; retry?".
+
+## Toast actions
+
+A toast can carry one CTA — a "Retry" or "Undo":
+
+```ts
+toast.success(t("commodities:toast.deleted"), {
+  action: { label: t("common:actions.undo"), onClick: handleUndo },
+})
+```
+
+- "Undo" is preferred over "Are you sure?" for reversible deletes.
+  Sonner gives a 5-second window — long enough to recover, short
+  enough not to nag.
+- "Retry" rebuilds the same mutation on the same payload.
+- Don't put two CTAs on a toast. The toast is small; don't compete
+  with itself.
+
+## Confirmation
+
+`<AlertDialog>` for destructive flows. See `09-component-patterns.md`,
+`12-tone-of-voice-and-copy.md` ("Destructive confirmations").
+
+Confirmations are NOT toasts; toasts are post-hoc, confirmations are
+pre-hoc.
+
+## Audit cues
+
+When the user wants to know *what changed* on an item:
+
+- **Status history card** on the commodity detail (already in production).
+- **"Edited 2h ago" footer** on detail pages — uses `formatRelative`
+  per `13-formatting-and-i18n.md`.
+- **Member badges on shared changes** in multi-user groups (future).
+
+The product positioning (`00-positioning.md`) commits to honesty —
+the user owns the data; they get visibility into what's changed.
+
+## Trust signals
+
+The product positioning lists *data ownership* as a primary value
+(`00-positioning.md`). Surfaces that reinforce trust:
+
+| Surface | Signal |
+| --- | --- |
+| Auth pages | No "Sign in with Google" buttons. Plain email + password. (Add OAuth later via the `auth/OAuthRow` component when it lands; current is a stub.) |
+| Settings | "Export everything" is one click. (`exports` feature.) |
+| Settings | "Delete account" is one click + confirm. The user can leave at any time. |
+| Profile | "Last sign-in 2h ago, from <region>" surfaces session metadata. |
+| File upload | Shows the upload progress + size budget. No "trust me, it's working". |
+| Backup / restore | The full export ZIP is downloadable raw — the user can read what it contains. |
+
+What we *don't* do:
+
+- Marketing modals for "did you know we have …?".
+- "Rate this app" prompts.
+- Cookie banners (the app uses no third-party tracking).
+- Email-collection for newsletter.
+
+## Sensitive data
+
+- **Never log PII** (email, name, address) to the browser console —
+  see `../coding-standards.md` ("Console policy").
+- **Don't show secrets** (access tokens, refresh tokens, CSRF tokens)
+  in any UI surface, including dev tools' visible state.
+- **Mask credit card numbers** in any future surface that surfaces
+  them — the BE doesn't return more than last-4 today; UI masks
+  anything stricter.
+- **No passwords in clear** — the password field uses
+  `frontend/src/components/auth/PasswordInput.tsx` which has a
+  show/hide toggle. The "show" reveals the user's own input only.
+- **No session-expiry warnings** with countdowns — see
+  `14-accessibility.md` (no timed actions).
+
+## Email and external
+
+The app sends emails for:
+
+- Email verification (`auth:verifyEmail`).
+- Password reset (`auth:forgotPassword`).
+- Group invitations (`groups:invite`).
+
+The UI doesn't compose email content (BE owns the templates), but it
+does:
+
+- Tell the user the email was sent ("Check your inbox at user@…").
+- Time-stamp the send so re-requests show the elapsed time
+  ("Re-send in 30s").
+- Surface "I didn't get it; resend" as a secondary action.
+
+## Rate limiting
+
+The BE rate-limits auth + global. The UI surfaces:
+
+- 429 → toast saying "Too many attempts. Try again in <30s>." Use
+  `Retry-After` from the response if present.
+- Subsequent 429s extend the time without re-toasting.
+
+## Notifications (future)
+
+Push / email notifications for warranty expiry are server-side. UI:
+
+- Settings toggles per channel (email / push) per category.
+- A list of recent notifications under `/notifications` (future).
+
+Until those land, the dashboard's "Warranty expiring" widget is the
+notification surface.
+
+## Hard rules
+
+1. **One toast per action.** Group bulk; cap at 4 stacked.
+2. **Errors don't auto-dismiss.**
+3. **Toasts have ≤ 1 CTA.**
+4. **Confirm destructive** before, toast post-hoc.
+5. **Never log PII to the console.**
+6. **No marketing modals.**
+7. **No timed warnings.**
+
+## Anti-patterns
+
+- A `vi-mocked` toast assertion that fires on every test ("Login
+  successful!"). The login flow shows no toast — see auth pages.
+- A success toast on a destructive action ("Item deleted! 🎉"). Use a
+  neutral past-tense ("Item deleted") with an Undo.
+- A modal that says "We use cookies. Accept?" Inventario uses no
+  cookies for tracking — no banner.
+- A "Tell us what you think" survey popup. Out of voice.
+- A status indicator that shifts focus when a toast appears.
+- A toast carrying a "Learn more" link that opens a 2000-word docs
+  page. Toasts are momentary.
+
+## Cross-refs
+
+- Voice / copy: `12-tone-of-voice-and-copy.md`.
+- Confirmation dialogs: `09-component-patterns.md`.
+- Inline error UX: `15-form-and-data-ux.md`.
+- Audit / history (item status): `frontend/src/pages/commodities/`.
+- Sonner setup: `frontend/src/components/ui/sonner.tsx`.
+- Toast wrapper: `frontend/src/hooks/useAppToast.ts`.

--- a/devdocs/frontend/design/17-density-and-modes.md
+++ b/devdocs/frontend/design/17-density-and-modes.md
@@ -1,0 +1,166 @@
+# Density & Theme Modes
+
+Three density steps, two theme modes, one persistence model. Every
+surface respects both.
+
+## Density
+
+```ts
+type Density = "comfortable" | "cozy" | "compact"
+```
+
+| Density | Row padding (settings) | List-row padding | When |
+| --- | --- | --- | --- |
+| `comfortable` (default) | `py-3.5` | `px-4 py-3` | Most users; spacious, scannable. |
+| `cozy` | `py-3` | `px-4 py-2.5` | Power users; mid. |
+| `compact` | `py-2.5` | `px-4 py-2` | Spreadsheet-style power users. |
+
+Density is set on `<html data-density="cozy">` by `DensityProvider`
+(`frontend/src/hooks/useDensity.tsx`). Persisted to `localStorage`
+and mirrored across tabs via the `storage` event. The Settings page
+(#1414) writes through `PATCH /settings` and mirrors back to
+`localStorage` on boot.
+
+## Density-aware utilities
+
+Use Tailwind's `data-[density=*]:` arbitrary variant when the rule
+is one-off:
+
+```tsx
+<div className="py-3.5 data-[density=cozy]:py-3 data-[density=compact]:py-2.5">…</div>
+```
+
+For pattern-shaped utilities (every list row, every settings row),
+build them into the component primitive in `src/components/ui/` so
+the call site stays terse.
+
+What scales with density:
+
+- List-row vertical padding.
+- Settings-row vertical padding (`py-3.5` → `py-3` → `py-2.5`).
+- Stat-card outer padding (`px-4 py-3` → `px-3 py-2.5` → `px-3 py-2`).
+- Icon sizes inside lists (e.g. row chevrons can drop from
+  `size-4` → `size-3.5` in compact).
+- Section spacing (`space-y-5` → `space-y-4` → `space-y-3`).
+
+What doesn't scale with density:
+
+- Page wrapper padding (`p-6` always — see `03-space-and-layout.md`).
+- Card outer padding (`p-6` always).
+- Type scale (`text-sm` body always).
+- Icon sizes outside dense lists.
+- Border thickness (always 1px).
+- Focus ring thickness (always 3px — `14-accessibility.md`).
+
+The product positioning (`00-positioning.md`) commits to a coherent
+visual rhythm; only the **vertical density** of dense surfaces shifts.
+
+## Theme modes
+
+`light` (default), `dark`, and `system` (follows OS).
+
+Set via `useTheme()` (`src/components/theme-provider.tsx`). Persisted
+to `localStorage` under the same idempotency contract as density.
+`system` doesn't persist a value beyond the choice itself; it reads
+`(prefers-color-scheme: dark)` on every mount.
+
+The `.dark` class on `<html>` is the toggle — every token swaps via
+the variants in `frontend/src/index.css`. See `01-palette.md`.
+
+## Mode-aware code
+
+| Surface | Behavior |
+| --- | --- |
+| Tokens (`--color-*`) | Auto-swap via `:root` / `.dark`. |
+| Component overrides | Avoid `dark:` utilities; tokens cover it. |
+| User-supplied images | Don't tint. The image is what the user uploaded. |
+| Charts | Tokens swap automatically; no per-mode override. |
+| Brand mark | The `AppLogo` component picks light vs. dark variant via the active `.dark` class. See `19-branding.md`. |
+
+The one place we use `dark:` utilities is layout adjustments — e.g. a
+border that should disappear in dark mode. Used sparingly:
+
+```tsx
+<div className="border border-border dark:border-transparent">
+```
+
+## Mode + density combinatorics
+
+Four modes × three densities = 12 surfaces to test on every visual
+PR. See `../screenshots.md` for the helper.
+
+The density contract is mode-agnostic: a `compact` surface in dark
+mode looks the same as a `compact` surface in light mode, modulo the
+token swap.
+
+## System preference matching
+
+| OS pref | Default behavior |
+| --- | --- |
+| `prefers-color-scheme: dark` | Mode `system` resolves to dark |
+| `prefers-color-scheme: light` | Mode `system` resolves to light |
+| `prefers-reduced-motion: reduce` | `tw-animate-css` and `motion-reduce:` honor it (per `05-motion.md`) |
+| `prefers-contrast: more` | Not yet honored — TBD. Tokens have headroom for an "AAA-only" variant when we wire it. |
+| Touch vs. pointer | `useIsTouch()` (`src/hooks/use-mobile.ts`) detects; surfaces use it for adjusted hover state. |
+
+## Switching at runtime
+
+Both density and theme mode swap immediately on user action — no page
+reload. The `<html>` attribute changes; CSS variables resolve via the
+new context; React doesn't re-render because the change is purely
+stylistic.
+
+Tests:
+
+- `useDensity` test asserts the `<html>` attr changes on `setDensity`.
+- `useTheme` test asserts `.dark` adds/removes on `setTheme`.
+- `setup.ts` provides a `matchMedia` stub for jsdom.
+
+## SSR / pre-paint
+
+Inventario is a Vite SPA — no SSR. Both providers run on `useEffect`
+in the client; the very first render uses the `<ThemeProvider
+defaultTheme="system">` and `<DensityProvider defaultDensity="comfortable">`
+defaults, then the providers reconcile with `localStorage` + system
+preference on mount.
+
+A momentary mismatch ("flash of light theme") can happen on a
+`prefers-color-scheme: dark` cold load. To avoid it, the
+`index.html` can hoist a tiny inline script that reads
+`localStorage.theme` and applies `.dark` before React mounts. This
+isn't currently wired — file an issue if it becomes a problem.
+
+## Hard rules
+
+1. **Density on `<html>`**, never per-component context. The
+   attribute selector is the API.
+2. **Theme via the `.dark` class**, not via `dark:` utilities for
+   color tokens. Tokens swap automatically.
+3. **System preference is the default theme**, not light. Mac users
+   in dark mode get a dark UI on first paint.
+4. **Persist to localStorage**, mirror via the `storage` event.
+5. **`matchMedia` stubbed in tests.** Don't reach for `window.matchMedia`
+   directly — it's not in jsdom.
+
+## Anti-patterns
+
+- Per-component `useState<Density>` — use the provider.
+- `dark:bg-gray-900` overrides for color tokens — use the token.
+- A "high-contrast mode" toggle. The dark-mode token contrast already
+  passes AAA on body text.
+- A density preview swatch that animates between densities. Density
+  is a state, not motion.
+- Hardcoding `prefers-color-scheme: dark` in a media query inside a
+  component — the `.dark` class is the cue.
+
+## Cross-refs
+
+- Tokens: `01-palette.md`.
+- Spacing scale (the contract density modulates): `03-space-and-layout.md`.
+- Reduced motion: `05-motion.md`, `14-accessibility.md`.
+- Settings page that exposes the controls: `11-page-layouts-and-flows.md`.
+- Implementation:
+  - `frontend/src/components/theme-provider.tsx`
+  - `frontend/src/hooks/useDensity.tsx`
+  - `frontend/src/components/ModeToggle.tsx`
+  - `frontend/src/components/DensityToggle.tsx`

--- a/devdocs/frontend/design/17-density-and-modes.md
+++ b/devdocs/frontend/design/17-density-and-modes.md
@@ -45,14 +45,14 @@ What scales with density:
 
 What doesn't scale with density:
 
-- Page wrapper padding (`p-6` always — see `03-space-and-layout.md`).
+- Page wrapper padding (`p-6` always — see [03-space-and-layout.md](03-space-and-layout.md)).
 - Card outer padding (`p-6` always).
 - Type scale (`text-sm` body always).
 - Icon sizes outside dense lists.
 - Border thickness (always 1px).
-- Focus ring thickness (always 3px — `14-accessibility.md`).
+- Focus ring thickness (always 3px — [14-accessibility.md](14-accessibility.md)).
 
-The product positioning (`00-positioning.md`) commits to a coherent
+The product positioning ([00-positioning.md](00-positioning.md)) commits to a coherent
 visual rhythm; only the **vertical density** of dense surfaces shifts.
 
 ## Theme modes
@@ -65,7 +65,7 @@ to `localStorage` under the same idempotency contract as density.
 `(prefers-color-scheme: dark)` on every mount.
 
 The `.dark` class on `<html>` is the toggle — every token swaps via
-the variants in `frontend/src/index.css`. See `01-palette.md`.
+the variants in `frontend/src/index.css`. See [01-palette.md](01-palette.md).
 
 ## Mode-aware code
 
@@ -75,7 +75,7 @@ the variants in `frontend/src/index.css`. See `01-palette.md`.
 | Component overrides | Avoid `dark:` utilities; tokens cover it. |
 | User-supplied images | Don't tint. The image is what the user uploaded. |
 | Charts | Tokens swap automatically; no per-mode override. |
-| Brand mark | The `AppLogo` component picks light vs. dark variant via the active `.dark` class. See `19-branding.md`. |
+| Brand mark | The `AppLogo` component picks light vs. dark variant via the active `.dark` class. See [19-branding.md](19-branding.md). |
 
 The one place we use `dark:` utilities is layout adjustments — e.g. a
 border that should disappear in dark mode. Used sparingly:
@@ -87,7 +87,7 @@ border that should disappear in dark mode. Used sparingly:
 ## Mode + density combinatorics
 
 Four modes × three densities = 12 surfaces to test on every visual
-PR. See `../screenshots.md` for the helper.
+PR. See [../screenshots.md](../screenshots.md) for the helper.
 
 The density contract is mode-agnostic: a `compact` surface in dark
 mode looks the same as a `compact` surface in light mode, modulo the
@@ -99,7 +99,7 @@ token swap.
 | --- | --- |
 | `prefers-color-scheme: dark` | Mode `system` resolves to dark |
 | `prefers-color-scheme: light` | Mode `system` resolves to light |
-| `prefers-reduced-motion: reduce` | `tw-animate-css` and `motion-reduce:` honor it (per `05-motion.md`) |
+| `prefers-reduced-motion: reduce` | `tw-animate-css` and `motion-reduce:` honor it (per [05-motion.md](05-motion.md)) |
 | `prefers-contrast: more` | Not yet honored — TBD. Tokens have headroom for an "AAA-only" variant when we wire it. |
 | Touch vs. pointer | `useIsTouch()` (`src/hooks/use-mobile.ts`) detects; surfaces use it for adjusted hover state. |
 
@@ -155,10 +155,10 @@ isn't currently wired — file an issue if it becomes a problem.
 
 ## Cross-refs
 
-- Tokens: `01-palette.md`.
-- Spacing scale (the contract density modulates): `03-space-and-layout.md`.
-- Reduced motion: `05-motion.md`, `14-accessibility.md`.
-- Settings page that exposes the controls: `11-page-layouts-and-flows.md`.
+- Tokens: [01-palette.md](01-palette.md).
+- Spacing scale (the contract density modulates): [03-space-and-layout.md](03-space-and-layout.md).
+- Reduced motion: [05-motion.md](05-motion.md), [14-accessibility.md](14-accessibility.md).
+- Settings page that exposes the controls: [11-page-layouts-and-flows.md](11-page-layouts-and-flows.md).
 - Implementation:
   - `frontend/src/components/theme-provider.tsx`
   - `frontend/src/hooks/useDensity.tsx`

--- a/devdocs/frontend/design/18-print-and-export.md
+++ b/devdocs/frontend/design/18-print-and-export.md
@@ -1,0 +1,155 @@
+# Print & Export
+
+The print stylesheet, the standalone print route, and the relationship
+to backup/restore exports.
+
+## Print
+
+The product has one print-optimized route in production:
+
+```
+/g/:slug/commodities/:id/print
+```
+
+Component: `frontend/src/pages/commodities/CommodityPrintPage.tsx`.
+
+Used by:
+
+- The commodity detail page's "Print" action (kebab menu).
+- Future: a "Print location summary" surface (out of scope today).
+
+## Print layout
+
+Single-column, max width 3xl, no sidebar, no top bar:
+
+```tsx
+<div className="mx-auto max-w-3xl p-6 print:p-0">
+  <div className="space-y-6">
+    {/* hero */}
+    <div className="space-y-1">
+      <h1 className="text-2xl font-semibold tracking-tight">{commodity.title}</h1>
+      <p className="text-sm text-muted-foreground">{location} · {area}</p>
+    </div>
+    {/* details table */}
+    <table className="w-full text-sm">
+      <tbody className="divide-y divide-border">
+        <tr><th>Type</th><td>{commodity.type}</td></tr>
+        <tr><th>Status</th><td>{commodity.status}</td></tr>
+        {/* … */}
+      </tbody>
+    </table>
+    {/* file thumbnails */}
+    <div className="grid grid-cols-3 gap-2">
+      {commodity.files.map((file) => …)}
+    </div>
+  </div>
+</div>
+```
+
+## Print stylesheet
+
+`@media print` rules in `frontend/src/index.css`:
+
+- Hide non-essential chrome (`@media print { .print\:hidden { display: none; } }` etc.).
+- Force `bg-card` to `bg-white` (printers don't render backgrounds by
+  default; explicit white).
+- Disable all hover / transition / animation utilities.
+- Page break: `break-inside-avoid` on cards, `break-after-page` on
+  major sections.
+
+Print-specific Tailwind utilities (built-in in v4):
+
+```tsx
+<div className="hidden print:block">…</div>      {/* show only when printing */}
+<div className="block print:hidden">…</div>      {/* hide when printing */}
+<table className="text-sm print:text-xs">…</table>  {/* tighten in print */}
+```
+
+## What gets printed
+
+The commodity print page includes:
+
+- Title, location/area breadcrumb.
+- Vendor, purchase date, current value, currency.
+- Status, status history (last 3).
+- Warranty status + dates.
+- Tag list.
+- All attached files as 3-column thumbnail grid.
+- A small footer with print date + the route URL (so the printed copy
+  references back to the source).
+
+What it doesn't include:
+
+- The sidebar.
+- The top bar / search.
+- Any action buttons.
+- The status-update controls.
+- Cross-tenant data.
+
+## Export (backup) — different from print
+
+"Export" in the UI means **backup the inventory to a file**:
+
+- A ZIP / XML envelope containing every commodity, location, area,
+  file (binary or reference), tag.
+- Created via `/g/:slug/exports`.
+- Surfaces a server-side polling status — pending → running → ready
+  → expired (or failed).
+- When ready, the user downloads the file.
+
+This is **not** the print path. Conceptually:
+
+| Term | What it means | Where |
+| --- | --- | --- |
+| **Print** | Browser-rendered output for paper / PDF (via the browser's "Save as PDF") | `/g/:slug/commodities/:id/print` |
+| **Export** / **Backup** | Server-generated file that can be **imported** back to recreate the data | `/g/:slug/exports` |
+| **Restore** | The inverse of import — apply an export back to a group | `/g/:slug/exports/:id/restore` |
+
+The voice contract (`12-tone-of-voice-and-copy.md`) calls export/backup
+"Export" in the UI; the artifact itself can be referred to as a
+"backup" in narrative copy ("Your latest backup was created 2h ago").
+
+## Print to PDF
+
+The browser handles "Save as PDF" natively from the print dialog. No
+custom PDF generation library on the client. If the user wants a
+machine-friendly export, they want a backup, not a print.
+
+## Email digest (future)
+
+Same voice + layout as the print page, but rendered server-side. Out
+of scope for this brief; the email templates live BE-side.
+
+## Hard rules
+
+1. **One print route in production.** Adding a second is an issue +
+   PR with the layout spec.
+2. **`print:` utilities for chrome hiding.** No `@media print` blocks
+   inside components — keep all print rules in `index.css`.
+3. **No backgrounds in print.** Force `bg-white` (or omit) on
+   surfaces; printers skip backgrounds by default.
+4. **Print is the route, export is the file.** Don't conflate the two
+   in copy or in code.
+5. **`break-inside-avoid` on cards** so a card doesn't split across a
+   page break.
+
+## Anti-patterns
+
+- A "Save as PDF" button that triggers `window.print()`. Use the
+  browser's native UI; the button is redundant.
+- A custom client-side PDF library (`pdfmake`, `jsPDF`). Bans the
+  bundle budget — see `../imports-and-bans.md`. Use the print route +
+  browser PDF export.
+- A `@media print` block inside a feature component. All print rules
+  in `index.css`.
+- Printing the sidebar. Use `print:hidden` on the Shell.
+- Watermarks ("CONFIDENTIAL", company logos). Inventario doesn't
+  watermark prints; the user controls the data.
+
+## Cross-refs
+
+- Tokens (print bg overrides): `01-palette.md`.
+- Voice for "Export" vs. "Backup": `12-tone-of-voice-and-copy.md`.
+- Backup feature slice: `frontend/src/features/export/`.
+- Print component: `frontend/src/pages/commodities/CommodityPrintPage.tsx`.
+- Print stylesheet: `frontend/src/index.css` (`@media print`).

--- a/devdocs/frontend/design/18-print-and-export.md
+++ b/devdocs/frontend/design/18-print-and-export.md
@@ -18,9 +18,18 @@ Used by:
 - The commodity detail page's "Print" action (kebab menu).
 - Future: a "Print location summary" surface (out of scope today).
 
+The route is mounted **inside the protected `<Shell>`** (same as every
+other group-scoped page), so on screen the user sees the sidebar and top
+bar. The print stylesheet (`@media print`) is what hides the chrome
+when the user actually prints — the page itself doesn't skip the
+shell. A toolbar at the top of the rendered page exposes Back +
+Print actions; both are gated behind `print:hidden` so they don't
+land on paper.
+
 ## Print layout
 
-Single-column, max width 3xl, no sidebar, no top bar:
+Single-column, max width 3xl, on-screen with the protected shell, but
+the printed sheet renders only the report sections:
 
 ```tsx
 <div className="mx-auto max-w-3xl p-6 print:p-0">
@@ -105,7 +114,7 @@ This is **not** the print path. Conceptually:
 | **Export** / **Backup** | Server-generated file that can be **imported** back to recreate the data | `/g/:slug/exports` |
 | **Restore** | The inverse of import — apply an export back to a group | `/g/:slug/exports/:id/restore` |
 
-The voice contract (`12-tone-of-voice-and-copy.md`) calls export/backup
+The voice contract ([12-tone-of-voice-and-copy.md](12-tone-of-voice-and-copy.md)) calls export/backup
 "Export" in the UI; the artifact itself can be referred to as a
 "backup" in narrative copy ("Your latest backup was created 2h ago").
 
@@ -138,7 +147,7 @@ of scope for this brief; the email templates live BE-side.
 - A "Save as PDF" button that triggers `window.print()`. Use the
   browser's native UI; the button is redundant.
 - A custom client-side PDF library (`pdfmake`, `jsPDF`). Bans the
-  bundle budget — see `../imports-and-bans.md`. Use the print route +
+  bundle budget — see [../imports-and-bans.md](../imports-and-bans.md). Use the print route +
   browser PDF export.
 - A `@media print` block inside a feature component. All print rules
   in `index.css`.
@@ -148,8 +157,8 @@ of scope for this brief; the email templates live BE-side.
 
 ## Cross-refs
 
-- Tokens (print bg overrides): `01-palette.md`.
-- Voice for "Export" vs. "Backup": `12-tone-of-voice-and-copy.md`.
+- Tokens (print bg overrides): [01-palette.md](01-palette.md).
+- Voice for "Export" vs. "Backup": [12-tone-of-voice-and-copy.md](12-tone-of-voice-and-copy.md).
 - Backup feature slice: `frontend/src/features/export/`.
 - Print component: `frontend/src/pages/commodities/CommodityPrintPage.tsx`.
 - Print stylesheet: `frontend/src/index.css` (`@media print`).

--- a/devdocs/frontend/design/19-branding.md
+++ b/devdocs/frontend/design/19-branding.md
@@ -1,54 +1,60 @@
 # Branding
 
-The Inventario brand mark, the favicon, OG image, and email templates
-— in production today, with the rules to keep them coherent.
+The Inventario brand mark, the favicon, and email templates — in
+production today, with the rules to keep them coherent.
 
 ## The mark
 
-`AppLogo` (`frontend/src/components/AppLogo.tsx`) is a small SVG
-wordmark + glyph composed inline. It pairs:
+`AppLogo` (`frontend/src/components/AppLogo.tsx`) renders a small
+inline SVG glyph alongside the wordmark `t("common:brand")`:
 
-- A bracket-and-cube glyph (the visual mark).
+- A stylized house with a checklist inside (the visual mark).
 - "Inventario" as the wordmark, in the system sans face.
 
-The mark is committed; the alternative directions explored in
-`21-logo-directions.md` are kept for historical reference but the
-shipping mark is the bracket-cube.
+The glyph is hand-authored at `18×18` viewBox; both the silhouette
+and the checklist marks resolve to theme tokens (`fill-foreground`,
+`fill-background`) so it inverts cleanly across modes without a
+per-mode SVG variant.
+
+The mark is committed. The historical directions explored in
+[21-logo-directions.md](21-logo-directions.md) are kept as a record
+of options considered; the shipping mark is the house-with-checklist.
 
 ## Where the mark appears
 
-| Surface | Variant |
-| --- | --- |
-| Sidebar (collapsed) | Glyph only, `size-7` |
-| Sidebar (expanded) | Glyph + wordmark, `h-8` |
-| Top bar (mobile) | Glyph + wordmark, `h-7` |
-| Auth pages | Glyph + wordmark centered above title, `h-9` |
-| Print page footer | Wordmark only, `text-xs text-muted-foreground` |
-| OG / social preview | Glyph + wordmark on warm-cream bg, fixed JPG |
-| Favicon | Glyph only |
+The current `AppLogo` ships one variant — glyph + wordmark in a
+horizontal `flex items-center gap-2` shell. Surfaces compose around it:
 
-The variants are chosen by the surface, not by a prop; `AppLogo`
-takes a `variant?: "glyph" | "full"` and a size class.
+| Surface | How it's used |
+| --- | --- |
+| Sidebar (header) | Full `<AppLogo />` |
+| Top bar (mobile) | Full `<AppLogo />` |
+| Auth pages | Full `<AppLogo />`, centered above the form |
+| Favicon | Glyph-only — sourced from `frontend/public/favicon.svg` |
+
+Variants for OG-style social preview and email-template headers
+aren't shipped today; when they land, they should pair the same glyph
+with the wordmark on a warm-neutral surface using the canonical
+`--foreground` / `--background` tokens.
 
 ## Color
 
-Two states, swapped by the active `.dark` class:
+The glyph's silhouette is `fill-foreground`; the checklist details
+are `fill-background` (so they read as cut-outs against the
+silhouette). Both classes resolve through the active `.dark` swap, so
+the mark inverts cleanly:
 
-| Mode | Glyph | Wordmark |
+| Mode | `--foreground` | `--background` |
 | --- | --- | --- |
-| Light | `text-foreground` (near-black warm) | `text-foreground` |
-| Dark | `text-foreground` (light warm) | `text-foreground` |
+| Light | near-black warm | warm off-white |
+| Dark | light warm | deep warm |
 
-The mark is **mode-aware via CSS**, not via two SVG sources. It picks
-up `currentColor` and the parent's `text-foreground` class swaps with
-the theme.
-
-For surfaces where the mark sits on a colored background (auth-page
-hero, OG image), use the inverse foreground:
+For surfaces where the mark sits on a *primary* background (rare —
+no production surface does this today), wrap and override:
 
 ```tsx
-<div className="bg-primary text-primary-foreground">
-  <AppLogo variant="full" />
+<div className="bg-primary text-primary-foreground [&_.fill-foreground]:fill-primary-foreground">
+  <AppLogo />
 </div>
 ```
 
@@ -57,7 +63,7 @@ hero, OG image), use the inverse foreground:
 1. **Tokens, not raw colors.** The mark's color is `currentColor`,
    inheriting from `text-foreground` (or `text-primary-foreground`).
 2. **No drop shadow on the mark.** Borders, not shadows
-   (`04-elevation-and-effects.md`).
+   ([04-elevation-and-effects.md](04-elevation-and-effects.md)).
 3. **No gradient fills.** Solid token colors.
 4. **No animation.** The mark is static. (One exception: a faint
    `animate-pulse` on the splash screen during the very first
@@ -67,18 +73,13 @@ hero, OG image), use the inverse foreground:
 
 ## Sizing
 
-| Use | Size class |
-| --- | --- |
-| Favicon | 16×16, 32×32 (rasterized from SVG) |
-| Sidebar collapsed | `h-7` |
-| Sidebar expanded | `h-8` |
-| Auth-page hero | `h-9` |
-| Email header | `h-10` |
-| OG image | `h-24` (the OG itself is 1200×630) |
-| Print footer | `h-4` (alongside wordmark text) |
-
-Don't render the mark above `h-12` in product UI — it's a recognition
-cue, not a hero illustration.
+The current `AppLogo` ships at a fixed `18×18` glyph next to a
+`text-sm` wordmark — the surface decides spacing via the parent's
+`gap-*`. Don't render the mark above the equivalent of `h-12` in
+product UI — it's a recognition cue, not a hero illustration. When
+a new surface needs a larger mark (auth hero, future onboarding
+splash), extend `AppLogo` with a size prop rather than scaling via
+`className` overrides.
 
 ## Clear space
 
@@ -87,22 +88,24 @@ adjacent UI right against the wordmark.
 
 ## Favicon
 
-`public/favicon.svg` is the source. Browsers cache aggressively;
-update the build hash by changing the filename if you swap it.
+`frontend/public/favicon.svg` is the source. Browsers cache
+aggressively; update the build hash by changing the filename if you
+swap it.
 
 The favicon uses the glyph only — the wordmark "Inventario" doesn't
 read at 16×16.
 
-## OG / social preview
+## OG / social preview (future)
 
-`public/og.png` is a fixed 1200×630 JPG: warm-cream background, mark
-centered, single-line subtitle ("Personal inventory ledger"). Update
-when the mark or tagline changes.
+There is no shipped OG image today (`frontend/public/` carries only
+the favicon and the embed sentinel). When per-page OG / social
+preview becomes a goal, it lands as a separate issue; the spec then
+follows the recipe above (glyph + wordmark on a warm-neutral surface,
+1200×630).
 
-When the user shares an Inventario page, no per-page OG is generated
-today (no SSR, no static export). The default OG is shown for every
-URL. A future improvement would add per-tenant OG (via Cloudflare
-Workers or similar); out of scope for this brief.
+The app is a Vite SPA — there's no SSR or static-export pipeline that
+would generate per-tenant OG today. A future Cloudflare Worker /
+edge function could fill that gap; out of scope for this brief.
 
 ## Email templates
 
@@ -126,7 +129,7 @@ Email design rules:
 
 The mark is **considered, quiet, neutral.** It doesn't communicate
 "speed" or "modernity" or "premium". It signals "tool, considered,
-trustworthy". Per `00-positioning.md`.
+trustworthy". Per [00-positioning.md](00-positioning.md).
 
 ## Don'ts
 
@@ -141,8 +144,7 @@ trustworthy". Per `00-positioning.md`.
 
 ## Cross-refs
 
-- Logo source / direction: `21-logo-directions.md`.
+- Logo source / direction: [21-logo-directions.md](21-logo-directions.md).
 - Email templates BE: `go/email/templates/`.
 - Favicon source: `frontend/public/favicon.svg`.
-- OG source: `frontend/public/og.png`.
 - AppLogo component: `frontend/src/components/AppLogo.tsx`.

--- a/devdocs/frontend/design/19-branding.md
+++ b/devdocs/frontend/design/19-branding.md
@@ -1,0 +1,148 @@
+# Branding
+
+The Inventario brand mark, the favicon, OG image, and email templates
+— in production today, with the rules to keep them coherent.
+
+## The mark
+
+`AppLogo` (`frontend/src/components/AppLogo.tsx`) is a small SVG
+wordmark + glyph composed inline. It pairs:
+
+- A bracket-and-cube glyph (the visual mark).
+- "Inventario" as the wordmark, in the system sans face.
+
+The mark is committed; the alternative directions explored in
+`21-logo-directions.md` are kept for historical reference but the
+shipping mark is the bracket-cube.
+
+## Where the mark appears
+
+| Surface | Variant |
+| --- | --- |
+| Sidebar (collapsed) | Glyph only, `size-7` |
+| Sidebar (expanded) | Glyph + wordmark, `h-8` |
+| Top bar (mobile) | Glyph + wordmark, `h-7` |
+| Auth pages | Glyph + wordmark centered above title, `h-9` |
+| Print page footer | Wordmark only, `text-xs text-muted-foreground` |
+| OG / social preview | Glyph + wordmark on warm-cream bg, fixed JPG |
+| Favicon | Glyph only |
+
+The variants are chosen by the surface, not by a prop; `AppLogo`
+takes a `variant?: "glyph" | "full"` and a size class.
+
+## Color
+
+Two states, swapped by the active `.dark` class:
+
+| Mode | Glyph | Wordmark |
+| --- | --- | --- |
+| Light | `text-foreground` (near-black warm) | `text-foreground` |
+| Dark | `text-foreground` (light warm) | `text-foreground` |
+
+The mark is **mode-aware via CSS**, not via two SVG sources. It picks
+up `currentColor` and the parent's `text-foreground` class swaps with
+the theme.
+
+For surfaces where the mark sits on a colored background (auth-page
+hero, OG image), use the inverse foreground:
+
+```tsx
+<div className="bg-primary text-primary-foreground">
+  <AppLogo variant="full" />
+</div>
+```
+
+## Hard rules
+
+1. **Tokens, not raw colors.** The mark's color is `currentColor`,
+   inheriting from `text-foreground` (or `text-primary-foreground`).
+2. **No drop shadow on the mark.** Borders, not shadows
+   (`04-elevation-and-effects.md`).
+3. **No gradient fills.** Solid token colors.
+4. **No animation.** The mark is static. (One exception: a faint
+   `animate-pulse` on the splash screen during the very first
+   `/auth/me` probe — TBD; not yet wired.)
+5. **Don't outline-stroke the mark to "stand out"**. Choose the
+   correct background instead.
+
+## Sizing
+
+| Use | Size class |
+| --- | --- |
+| Favicon | 16×16, 32×32 (rasterized from SVG) |
+| Sidebar collapsed | `h-7` |
+| Sidebar expanded | `h-8` |
+| Auth-page hero | `h-9` |
+| Email header | `h-10` |
+| OG image | `h-24` (the OG itself is 1200×630) |
+| Print footer | `h-4` (alongside wordmark text) |
+
+Don't render the mark above `h-12` in product UI — it's a recognition
+cue, not a hero illustration.
+
+## Clear space
+
+Leave whitespace ≥ 25% of the mark's height on all sides. Don't pack
+adjacent UI right against the wordmark.
+
+## Favicon
+
+`public/favicon.svg` is the source. Browsers cache aggressively;
+update the build hash by changing the filename if you swap it.
+
+The favicon uses the glyph only — the wordmark "Inventario" doesn't
+read at 16×16.
+
+## OG / social preview
+
+`public/og.png` is a fixed 1200×630 JPG: warm-cream background, mark
+centered, single-line subtitle ("Personal inventory ledger"). Update
+when the mark or tagline changes.
+
+When the user shares an Inventario page, no per-page OG is generated
+today (no SSR, no static export). The default OG is shown for every
+URL. A future improvement would add per-tenant OG (via Cloudflare
+Workers or similar); out of scope for this brief.
+
+## Email templates
+
+Sent BE-side from `go/email/templates/`:
+
+- Verify email: header (mark + product name) → body → CTA.
+- Password reset: same shell.
+- Group invite: same shell + group name.
+
+Email design rules:
+
+- 600px max width.
+- Inline styles only (no external CSS).
+- One color: warm-cream background, near-black text, amber CTA.
+- The mark is rendered as a single `<img>` from a CDN URL (the OG
+  image's variant), not inline SVG (clients render inline SVG
+  inconsistently).
+- No web fonts. System fallback chain in inline `font-family`.
+
+## Tone
+
+The mark is **considered, quiet, neutral.** It doesn't communicate
+"speed" or "modernity" or "premium". It signals "tool, considered,
+trustworthy". Per `00-positioning.md`.
+
+## Don'ts
+
+- A logo on a stat card. Stat cards have icon tiles, not branding.
+- A logo as a watermark on prints. Inventario doesn't watermark.
+- An animated logo on auth-page entry. Quiet.
+- A logo with rotating taglines. Static.
+- A "Back to dashboard" link styled as the logo. Make it a real
+  `<Link>` with the logo *icon* if needed; the wordmark is
+  recognition, not navigation.
+- A second mark for "Inventario Pro". There is no Pro tier.
+
+## Cross-refs
+
+- Logo source / direction: `21-logo-directions.md`.
+- Email templates BE: `go/email/templates/`.
+- Favicon source: `frontend/public/favicon.svg`.
+- OG source: `frontend/public/og.png`.
+- AppLogo component: `frontend/src/components/AppLogo.tsx`.

--- a/devdocs/frontend/design/20-edge-cases.md
+++ b/devdocs/frontend/design/20-edge-cases.md
@@ -7,8 +7,8 @@ designed surface — not a debug dump.
 ## The empty-state pattern
 
 Used everywhere a list is genuinely empty. Anatomy in
-`08-interaction-states.md`; the copy contract is in
-`12-tone-of-voice-and-copy.md`.
+[08-interaction-states.md](08-interaction-states.md); the copy contract is in
+[12-tone-of-voice-and-copy.md](12-tone-of-voice-and-copy.md).
 
 ```tsx
 <div className="flex flex-col items-center justify-center gap-3 py-16">
@@ -39,7 +39,7 @@ per feature.
 - Secondary: `Go home`.
 
 No 404-themed humor (no "Oops! 404 unicorn ate this page"). Per
-`00-positioning.md`.
+[00-positioning.md](00-positioning.md).
 
 ## 500 — application crashed
 
@@ -127,7 +127,7 @@ similar terminal. Sonner toast + auto-bounce to `/login` with
 - `?reason=auth_required` → "Please sign in to continue." (default)
 
 Reason copy lives in `auth:session.*` per
-`12-tone-of-voice-and-copy.md`.
+[12-tone-of-voice-and-copy.md](12-tone-of-voice-and-copy.md).
 
 ## Rate-limited
 
@@ -188,7 +188,7 @@ itself is a backspace.
 3. **Toast for transient, page for terminal.** Offline = toast;
    account deleted = page.
 4. **Empty states have CTAs** when there's an obvious next step.
-5. **No humor in errors.** Per `00-positioning.md`.
+5. **No humor in errors.** Per [00-positioning.md](00-positioning.md).
 
 ## Anti-patterns
 
@@ -204,11 +204,11 @@ itself is a backspace.
 
 ## Cross-refs
 
-- States: `08-interaction-states.md`.
-- Notifications: `16-notifications-and-trust.md`.
-- Voice / copy: `12-tone-of-voice-and-copy.md`.
-- Page templates: `11-page-layouts-and-flows.md`.
-- Routing guards (no-group, protected): `../routing.md`.
+- States: [08-interaction-states.md](08-interaction-states.md).
+- Notifications: [16-notifications-and-trust.md](16-notifications-and-trust.md).
+- Voice / copy: [12-tone-of-voice-and-copy.md](12-tone-of-voice-and-copy.md).
+- Page templates: [11-page-layouts-and-flows.md](11-page-layouts-and-flows.md).
+- Routing guards (no-group, protected): [../routing.md](../routing.md).
 - Surfaces in source:
   - `frontend/src/pages/NotFound.tsx`
   - `frontend/src/pages/NoGroupPage.tsx`

--- a/devdocs/frontend/design/20-edge-cases.md
+++ b/devdocs/frontend/design/20-edge-cases.md
@@ -1,0 +1,216 @@
+# Edge Cases
+
+The not-happy-path surfaces. Empty states, 404, 500, offline,
+no-group, deleted entities, permission denials. Each gets a real
+designed surface — not a debug dump.
+
+## The empty-state pattern
+
+Used everywhere a list is genuinely empty. Anatomy in
+`08-interaction-states.md`; the copy contract is in
+`12-tone-of-voice-and-copy.md`.
+
+```tsx
+<div className="flex flex-col items-center justify-center gap-3 py-16">
+  <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10">
+    <Icon className="size-5 text-primary" />
+  </div>
+  <div className="text-center space-y-1">
+    <p className="text-base font-semibold">No items yet</p>
+    <p className="text-sm text-muted-foreground">When you add one, it'll show up here.</p>
+  </div>
+  {cta && <Button size="sm" onClick={cta.onClick}>{cta.label}</Button>}
+</div>
+```
+
+The empty-state taxonomy (which icon, which copy, which CTA) is in
+`frontend/src/components/dashboard/EmptyState.tsx` and analogous files
+per feature.
+
+## 404 — page not found
+
+`frontend/src/pages/NotFound.tsx`. Surface:
+
+- Centered card on a `bg-background` page.
+- Hero glyph (`Search` or similar at `size-10`).
+- Title: `Couldn't find that page`
+- Body: `The link might be broken, or the page might've moved.`
+- Primary CTA: `Back to dashboard` (or `Sign in` if not authenticated).
+- Secondary: `Go home`.
+
+No 404-themed humor (no "Oops! 404 unicorn ate this page"). Per
+`00-positioning.md`.
+
+## 500 — application crashed
+
+The route boundary blew up. Caught by an `<ErrorBoundary>` in
+`Shell.tsx`. Surface:
+
+- Centered card.
+- Hero glyph (`AlertOctagon` at `size-10`, `text-destructive`).
+- Title: `Something went wrong`
+- Body: `We've been notified. You can try again or head back.`
+- Primary CTA: `Reload`.
+- Secondary: `Back to dashboard`.
+
+The "we've been notified" line is a half-promise — Sentry-style
+telemetry isn't wired today. Update the copy when it lands.
+
+## Offline / no network
+
+The user lost connectivity mid-session.
+
+- `navigator.onLine` is checked at the http-wrapper layer; on
+  network errors the wrapper throws an `HttpError` with a non-HTTP
+  surface (e.g. a thrown `TypeError` from fetch).
+- Sonner toast: `You're offline. Changes will retry when you're back.`
+- Mutations queued via TanStack Query don't auto-retry on offline —
+  user retries manually.
+- Persistent banner is *not* used for offline — toasts only. A
+  persistent banner over the page would be heavier than the actual
+  cost of being offline for 30 seconds.
+
+## No-group state
+
+The user is signed in but doesn't belong to any group. Route:
+`/no-group`.
+
+Surface:
+
+- Centered card.
+- Hero glyph (`Users` at `size-10` over `bg-primary/10`).
+- Title: `You're not in a group yet`
+- Body: `Create one to start your inventory, or wait for an invite.`
+- Primary CTA: `Create group`.
+- Secondary: `Sign out`.
+
+This is the entry point for new users post-registration before they
+create a group. Once a group exists, `<UngroupedRedirect>` bounces
+them away.
+
+## Deleted entity
+
+The user navigated to `/g/:slug/commodities/:id` for an `:id` that
+no longer exists (deleted in another tab, or a stale link).
+
+Surface:
+
+- Same shell as 404.
+- Title: `This item is gone`
+- Body: `It might've been deleted. Try the items list.`
+- Primary: `Back to items`.
+
+Backend returns 404 → page-level error → render this layout. Don't
+conflate with the global `NotFoundPage` — feature-specific 404s read
+better with feature-specific copy.
+
+## Permission denied
+
+A user tries to access a route they're not allowed to (e.g. group
+admin pages without admin role).
+
+Backend returns 403 → page-level error.
+
+- Title: `Not allowed`
+- Body: `You don't have permission to view this. Ask a group admin to
+  invite you with a higher role.`
+- Primary: `Back`.
+
+## Deleted-account / suspended-tenant
+
+These come from the auth flow. The /auth/me probe returns a 410 or
+similar terminal. Sonner toast + auto-bounce to `/login` with
+`?reason=`:
+
+- `?reason=account_deleted` → "Your account has been deleted."
+- `?reason=tenant_suspended` → "This tenant has been suspended."
+- `?reason=auth_required` → "Please sign in to continue." (default)
+
+Reason copy lives in `auth:session.*` per
+`12-tone-of-voice-and-copy.md`.
+
+## Rate-limited
+
+`429 Too Many Requests`. Sonner toast: `Too many requests. Try again
+in <30s>.` Use `Retry-After` header if present; default to 30s.
+Don't auto-retry — let the user breathe.
+
+## Maintenance / scheduled downtime
+
+Out of scope today. When the BE adds a maintenance flag, surface as a
+top-bar banner (yes, persistent, exception to the toast-only rule
+because the user can't act around it):
+
+```
+[ Maintenance: Inventario will be briefly unavailable on Sun 2 May at 02:00 UTC ]
+```
+
+Banner uses `bg-status-expiring/10 text-status-expiring border-b
+border-status-expiring/30`. Dismissible; reappears on next session.
+
+## Webview / iframed
+
+Inventario isn't designed to be iframed. If `window.top !==
+window.self`, render a single-line surface saying "Open Inventario in
+a new window." with a link. Don't ship the full app inside an
+iframe.
+
+## Browser too old
+
+The build targets ES2022 (per `vite.config.ts`). Anything older
+should fail loudly with a single page of fallback HTML — but Vite's
+`<script type="module">` already does this gracefully (older browsers
+ignore the module script and the noscript / fallback `<div id=root>`
+empties).
+
+A polite version: `frontend/index.html` could carry a `<noscript>`
+banner. Currently doesn't — file an issue if it becomes a problem.
+
+## Empty search
+
+The user searched and there are no matches.
+
+```
+[ Empty-state shape, but with the search term echoed in the body ]
+"No items match \"foo\"."
+"Try a different term, or clear filters."
+[ Clear filters CTA ]
+```
+
+The CTA clears filter chips, not the search term — clearing the term
+itself is a backspace.
+
+## Hard rules
+
+1. **Every error has a designed surface.** No bare exception text.
+2. **Specific 404s over generic 404s** when the feature has the
+   context (deleted-item beats "Couldn't find that page").
+3. **Toast for transient, page for terminal.** Offline = toast;
+   account deleted = page.
+4. **Empty states have CTAs** when there's an obvious next step.
+5. **No humor in errors.** Per `00-positioning.md`.
+
+## Anti-patterns
+
+- `throw new Error(JSON.stringify(err))` rendered raw in the UI. Use
+  `parseServerError`.
+- 404 page with a 500-line illustration. Quiet glyph.
+- A persistent "You're offline" banner that won't dismiss when the
+  network is back.
+- A 500 page that says "Don't worry, your data is safe!" without
+  evidence. The user already lost trust by hitting a 500.
+- An empty state that says "Loading…". Loading and empty are
+  different states.
+
+## Cross-refs
+
+- States: `08-interaction-states.md`.
+- Notifications: `16-notifications-and-trust.md`.
+- Voice / copy: `12-tone-of-voice-and-copy.md`.
+- Page templates: `11-page-layouts-and-flows.md`.
+- Routing guards (no-group, protected): `../routing.md`.
+- Surfaces in source:
+  - `frontend/src/pages/NotFound.tsx`
+  - `frontend/src/pages/NoGroupPage.tsx`
+  - `frontend/src/components/coming-soon/ComingSoonPage.tsx`
+  - `frontend/src/components/dashboard/EmptyState.tsx`

--- a/devdocs/frontend/design/21-logo-directions.md
+++ b/devdocs/frontend/design/21-logo-directions.md
@@ -1,18 +1,25 @@
 # Logo Mark Directions
 
 Historical exploration kept for reference. The shipping mark is the
-**bracket-cube** wordmark in `AppLogo.tsx`. The directions below were
-considered before settling on it; they exist in this folder as a
+**house-with-checklist** glyph in `AppLogo.tsx`. The directions below
+were considered before settling on it; they exist in this folder as a
 record, not as alternatives still on the table.
 
 ## The shipping mark
 
-A small bracket glyph wrapping a cube — the bracket signals
-"container", the cube signals "the thing inside". Wordmark "Inventario"
-to the right in the system sans face.
+A stylized house silhouette with a small checklist inside it: the
+house signals "your place / your belongings", the checklist signals
+"catalog". Wordmark "Inventario" to the right in the system sans face.
+
+Authored as inline SVG at an `18×18` viewBox, with the silhouette in
+`fill-foreground` and the checklist details cut out via
+`fill-background` so the mark inverts cleanly across light / dark.
 
 Live in `frontend/src/components/AppLogo.tsx`. Render rules in
-`19-branding.md`.
+[19-branding.md](19-branding.md).
+
+The directions below were the alternatives weighed during exploration.
+None ship today; they're preserved as a record of options considered.
 
 ## Direction 1 — sans wordmark only
 
@@ -50,29 +57,28 @@ Cons:
 - The tag silhouette reads as e-commerce / pricing. Inventario isn't
   e-commerce.
 
-**Verdict:** rejected. Direction 3 (PR #1362's pick) was based on
-this, but reads off-tone for the React rewrite.
+**Verdict:** rejected. PR #1362 had originally explored a related
+catalog-tag direction; the React rewrite picked a different glyph
+altogether.
 
-## Direction 3 — the bracket-cube (shipping)
+## Direction 3 — the bracket-cube
 
-The current production mark. A square bracket on the left wraps a
-small cube; the cube has a faint top facet to read as 3D without
-shading.
+A square bracket on the left wrapping a small cube; the cube has a
+faint top facet to read as 3D without shading.
 
 Pros:
 
 - Domain-resonant — bracket = container, cube = item.
 - Reads at favicon size (the bracket alone is recognizable).
-- Mode-aware via `currentColor`.
 - No third-party trademark / cliché associations.
 
 Cons:
 
-- Requires an SVG, not just a typographic mark.
-- The bracket geometry needs hinting for `h-4` rasterization; we live
-  with mild aliasing at 16×16.
+- Requires careful SVG hinting at small sizes.
+- Reads slightly cold / generic next to the warm-neutral palette.
 
-**Verdict:** committed. See `frontend/src/components/AppLogo.tsx`.
+**Verdict:** rejected. Direction 7 (the house-with-checklist) was
+chosen instead.
 
 ## Direction 4 — the stacked-shelf
 
@@ -124,23 +130,49 @@ Cons:
 
 **Verdict:** rejected.
 
+## Direction 7 — house-with-checklist (shipping)
+
+A stylized house silhouette with a small checklist composed inside
+it. Both the silhouette and the cut-out details resolve through
+theme tokens (`fill-foreground` / `fill-background`).
+
+Pros:
+
+- Domain-resonant — the house reads as "your place"; the checklist
+  reads as "catalog".
+- Warmer than abstract geometric marks; pairs with the warm-neutral
+  palette.
+- Reads at favicon size (the silhouette alone is recognizable).
+- Mode-aware without two SVG sources — the cut-out detail
+  automatically inverts.
+- No third-party trademark / cliché associations.
+
+Cons:
+
+- More illustrative than a pure geometric mark — slightly less
+  abstract, slightly more on-the-nose.
+
+**Verdict:** committed. See `frontend/src/components/AppLogo.tsx`.
+
 ## What the shipping mark commits to
 
-- **Bracket-cube glyph.** The single iconographic cue.
-- **System sans wordmark.** No custom face. (See `02-typography.md`.)
-- **Mode-aware via `currentColor`.** No per-mode SVG variant.
+- **House-with-checklist glyph.** The single iconographic cue.
+- **System sans wordmark.** No custom face. (See [02-typography.md](02-typography.md).)
+- **Mode-aware via `fill-foreground` / `fill-background` tokens.** No
+  per-mode SVG variant.
 - **No animation.** The mark is static.
 - **No watermark / no decorative use** beyond the canonical surfaces
-  (`19-branding.md`).
+  ([19-branding.md](19-branding.md)).
 
 ## When to revisit
 
 Re-litigate the mark only when:
 
-- The product positioning (`00-positioning.md`) changes substantially.
+- The product positioning ([00-positioning.md](00-positioning.md))
+  changes substantially.
 - A new product surface emerges where the mark genuinely doesn't
-  work (e.g. a native app icon at 1024×1024 — the bracket would need
-  a layered treatment).
+  work (e.g. a native app icon at 1024×1024 — the silhouette would
+  need a layered treatment).
 - A trademark conflict surfaces.
 
 The current cadence: review the mark once a year, ship a refresh PR
@@ -151,7 +183,7 @@ fashion shifted.
 
 - **A "playful" mark with a wink.** The product is quiet, not
   playful.
-- **A gradient logo.** No gradients (per `04-elevation-and-effects.md`,
+- **A gradient logo.** No gradients (per [04-elevation-and-effects.md](04-elevation-and-effects.md),
   applied to brand assets too).
 - **A serif wordmark.** Inventario doesn't have a literary or luxury
   voice.
@@ -160,7 +192,7 @@ fashion shifted.
 
 ## Cross-refs
 
-- Brand rules: `19-branding.md`.
+- Brand rules: [19-branding.md](19-branding.md).
 - Component: `frontend/src/components/AppLogo.tsx`.
 - Favicon source: `frontend/public/favicon.svg`.
-- Voice anchor: `00-positioning.md`.
+- Voice anchor: [00-positioning.md](00-positioning.md).

--- a/devdocs/frontend/design/21-logo-directions.md
+++ b/devdocs/frontend/design/21-logo-directions.md
@@ -1,0 +1,166 @@
+# Logo Mark Directions
+
+Historical exploration kept for reference. The shipping mark is the
+**bracket-cube** wordmark in `AppLogo.tsx`. The directions below were
+considered before settling on it; they exist in this folder as a
+record, not as alternatives still on the table.
+
+## The shipping mark
+
+A small bracket glyph wrapping a cube — the bracket signals
+"container", the cube signals "the thing inside". Wordmark "Inventario"
+to the right in the system sans face.
+
+Live in `frontend/src/components/AppLogo.tsx`. Render rules in
+`19-branding.md`.
+
+## Direction 1 — sans wordmark only
+
+The simplest possible mark: just "Inventario" in a system semibold,
+tracking-tight, slight ligature on the "io".
+
+Pros:
+
+- Zero asset cost.
+- Reads at any size.
+- Mode-aware via `currentColor`.
+
+Cons:
+
+- No glyph for the favicon.
+- No iconographic recognition cue.
+
+**Verdict:** rejected. Favicon + sidebar collapsed need a glyph.
+
+## Direction 2 — the catalog tag
+
+A small tag silhouette (the tag-and-string shape from `Tag` in
+lucide). Pairs with the wordmark.
+
+Pros:
+
+- Domain-resonant — Inventario is about labeling.
+- Strong recognition at small sizes.
+
+Cons:
+
+- Conflates the brand mark with the in-app `Tag` icon. The `tags`
+  feature uses `Tag` heavily; the brand reading "tags" too is
+  confusing.
+- The tag silhouette reads as e-commerce / pricing. Inventario isn't
+  e-commerce.
+
+**Verdict:** rejected. Direction 3 (PR #1362's pick) was based on
+this, but reads off-tone for the React rewrite.
+
+## Direction 3 — the bracket-cube (shipping)
+
+The current production mark. A square bracket on the left wraps a
+small cube; the cube has a faint top facet to read as 3D without
+shading.
+
+Pros:
+
+- Domain-resonant — bracket = container, cube = item.
+- Reads at favicon size (the bracket alone is recognizable).
+- Mode-aware via `currentColor`.
+- No third-party trademark / cliché associations.
+
+Cons:
+
+- Requires an SVG, not just a typographic mark.
+- The bracket geometry needs hinting for `h-4` rasterization; we live
+  with mild aliasing at 16×16.
+
+**Verdict:** committed. See `frontend/src/components/AppLogo.tsx`.
+
+## Direction 4 — the stacked-shelf
+
+Three horizontal lines with rounded caps, suggesting shelves. Wordmark
+to the right.
+
+Pros:
+
+- Clean, geometric, reads at small sizes.
+
+Cons:
+
+- Reads as "to-do list" or "menu hamburger" — both UI-mark cliches.
+- Conflicts visually with the `Menu` icon in lucide.
+
+**Verdict:** rejected.
+
+## Direction 5 — the inventory grid
+
+A 2×2 grid of small squares.
+
+Pros:
+
+- Direct domain reference (a catalog grid).
+- Geometric.
+
+Cons:
+
+- Reads as Excel / Google Workspace / generic-app-icon.
+- Loses character at small sizes.
+
+**Verdict:** rejected.
+
+## Direction 6 — the warm rectangle
+
+A solid warm-cream rounded rectangle with the wordmark inside,
+centered. The "Things 3 / Aesop" container shape.
+
+Pros:
+
+- Reads as considered, editorial.
+- Pairs with the warm palette.
+
+Cons:
+
+- Doesn't scale to a favicon (the rectangle is the mark; at 16×16 the
+  text is illegible).
+- Looks like a button.
+
+**Verdict:** rejected.
+
+## What the shipping mark commits to
+
+- **Bracket-cube glyph.** The single iconographic cue.
+- **System sans wordmark.** No custom face. (See `02-typography.md`.)
+- **Mode-aware via `currentColor`.** No per-mode SVG variant.
+- **No animation.** The mark is static.
+- **No watermark / no decorative use** beyond the canonical surfaces
+  (`19-branding.md`).
+
+## When to revisit
+
+Re-litigate the mark only when:
+
+- The product positioning (`00-positioning.md`) changes substantially.
+- A new product surface emerges where the mark genuinely doesn't
+  work (e.g. a native app icon at 1024×1024 — the bracket would need
+  a layered treatment).
+- A trademark conflict surfaces.
+
+The current cadence: review the mark once a year, ship a refresh PR
+only if a substantive reason exists. Don't re-paint just because
+fashion shifted.
+
+## Rejected ideas, locked
+
+- **A "playful" mark with a wink.** The product is quiet, not
+  playful.
+- **A gradient logo.** No gradients (per `04-elevation-and-effects.md`,
+  applied to brand assets too).
+- **A serif wordmark.** Inventario doesn't have a literary or luxury
+  voice.
+- **A bilingual mark** ("Inventario / Инвентарь" stacked). The brand
+  is one word; locale handles the rest.
+
+## Cross-refs
+
+- Brand rules: `19-branding.md`.
+- Component: `frontend/src/components/AppLogo.tsx`.
+- Favicon source: `frontend/public/favicon.svg`.
+- Voice anchor: `00-positioning.md`.

--- a/devdocs/frontend/design/22-illustration-prompts.md
+++ b/devdocs/frontend/design/22-illustration-prompts.md
@@ -19,9 +19,9 @@ Anchored to the visual contract:
 
 - **Warm-neutral palette** — warm off-white surfaces, near-black warm
   ink, amber accents. No purples, no electric blues, no pastels. (See
-  `01-palette.md`.)
+  [01-palette.md](01-palette.md).)
 - **Line-weight 2px** matching lucide's stroke.
-- **Editorial, not playful.** Per `00-positioning.md`.
+- **Editorial, not playful.** Per [00-positioning.md](00-positioning.md).
 - **Spot illustrations**, ~120×120 to 160×160 in the layout. No
   full-bleed hero illustrations.
 - **No people.** Inventario is about *things* — illustrations show
@@ -83,8 +83,11 @@ by twine, viewed from a 3/4 angle">
 Composition: Centered subject within a 160×160 viewport, ~30% padding
 on all sides. The subject reads at 64×64 (favicon-style decimation).
 
-Reference: Use the anchor image at frontend/src/assets/illustrations/anchor.svg
-to match line weight, perspective, and corner-radius treatment.
+Reference: Use the canonical anchor image — to be committed alongside
+the first illustration that ships, under `frontend/src/assets/illustrations/`
+— to match line weight, perspective, and corner-radius treatment.
+(There is no anchor image in the repo today; the first illustration's
+PR establishes it.)
 
 Output: SVG (preferred) or PNG at 320×320 for crisp 2× rendering.
 ```
@@ -108,7 +111,7 @@ Three viable paths, in descending order of preference:
 Whichever channel, all illustrations go through the same review:
 
 - Color values match the tokens (eyedrop with the spec at
-  `01-palette.md`).
+  [01-palette.md](01-palette.md)).
 - Stroke weight matches the anchor.
 - No people, no emoji-faces, no drop shadows.
 - Reads at 64×64.
@@ -135,7 +138,7 @@ after the surface (`empty-items.svg`, `not-found.svg`, …).
 2. **No people, no faces on objects.**
 3. **Tokens, not raw colors.** The amber accent is `--accent`, not
    `#D9933D`. (The hex above is approximate for prompt purposes —
-   the canonical OKLCH lives in `01-palette.md`.)
+   the canonical OKLCH lives in [01-palette.md](01-palette.md).)
 4. **Commission, generate, or borrow — pick one channel per batch.**
    Mixing channels per surface guarantees inconsistency.
 5. **Optional, not required.** The icon-only empty state is the
@@ -149,14 +152,14 @@ after the surface (`empty-items.svg`, `not-found.svg`, …).
 - Gradient fills inside illustrations.
 - Color outside the tokens (a "purple receipt" on the empty-files
   state).
-- Animated illustrations. (Per `05-motion.md`, the empty state is
+- Animated illustrations. (Per [05-motion.md](05-motion.md), the empty state is
   quiet.)
 
 ## Cross-refs
 
-- Anchor: `00-positioning.md` (tone), `01-palette.md` (color).
-- Iconography: `06-iconography-and-illustration.md`.
-- Empty-state placement: `08-interaction-states.md`,
-  `20-edge-cases.md`.
-- Brand: `19-branding.md`.
+- Anchor: [00-positioning.md](00-positioning.md) (tone), [01-palette.md](01-palette.md) (color).
+- Iconography: [06-iconography-and-illustration.md](06-iconography-and-illustration.md).
+- Empty-state placement: [08-interaction-states.md](08-interaction-states.md),
+  [20-edge-cases.md](20-edge-cases.md).
+- Brand: [19-branding.md](19-branding.md).
 - Future component: `frontend/src/components/illustrations/` (TBD).

--- a/devdocs/frontend/design/22-illustration-prompts.md
+++ b/devdocs/frontend/design/22-illustration-prompts.md
@@ -1,0 +1,162 @@
+# Illustration Prompts
+
+Recipe for sourcing the empty-state and onboarding illustrations,
+when and if they're commissioned beyond the icon-only minimum that
+ships today.
+
+## Status
+
+**Proposal.** Inventario today uses **icon-only empty states** —
+`Package` / `Folder` / `Image` glyphs at `size-10` over `bg-primary/10`.
+That set is sufficient and ships in production. Richer
+illustrations are a future enhancement, not a current dependency.
+
+When the time comes, this doc is the recipe.
+
+## Style
+
+Anchored to the visual contract:
+
+- **Warm-neutral palette** — warm off-white surfaces, near-black warm
+  ink, amber accents. No purples, no electric blues, no pastels. (See
+  `01-palette.md`.)
+- **Line-weight 2px** matching lucide's stroke.
+- **Editorial, not playful.** Per `00-positioning.md`.
+- **Spot illustrations**, ~120×120 to 160×160 in the layout. No
+  full-bleed hero illustrations.
+- **No people.** Inventario is about *things* — illustrations show
+  containers, items, labels, shelves. Avoid characters.
+- **No emoji-style faces on objects.** The cardboard box doesn't
+  have eyes.
+
+## Anchor image
+
+Once one illustration ships, use it as the anchor reference for every
+subsequent one — consistency-by-anchor. Tools like ChatGPT Images 2.0
+(`gpt-image-2`) accept reference images and produce variants in the
+same style.
+
+## Surfaces (in priority order)
+
+| # | Surface | What it shows | Tone |
+| --- | --- | --- | --- |
+| 1 | No items (commodities list empty) | An open cardboard box with a label tag | Considered, mid-light |
+| 2 | No locations | A simple house outline | Quiet |
+| 3 | No areas | A floor plan rectangle | Neutral |
+| 4 | No files (commodity has no files) | A loose receipt + an envelope | Neutral |
+| 5 | No tags | A tag pin / hangtag | Neutral |
+| 6 | Empty search | A magnifier over a faded grid | Quiet |
+| 7 | 404 (page not found) | A loose page on a drift | Quiet |
+| 8 | 500 (something went wrong) | A snapped pencil | Apologetic, mid |
+| 9 | No-group | A door, slightly ajar | Inviting, neutral |
+| 10 | Account deleted | An empty drawer | Final, mid |
+| 11 | Onboarding step 1 — welcome | A set of cardboard boxes, neatly arranged | Inviting |
+| 12 | Onboarding step 2 — first location | A house with one label | Inviting |
+| 13 | Onboarding step 3 — first item | A box with a tag | Inviting |
+| 14 | Empty inbox / notifications | A clean desk | Neutral |
+| 15 | Empty exports list | A folder, shut, on a shelf | Neutral |
+| 16 | No restores yet | An hourglass, paused | Neutral |
+| 17 | Maintenance / scheduled downtime | A sign on a rope | Apologetic |
+| 18 | Offline | A loose plug | Apologetic |
+| 19 | Permission denied | A locked drawer | Final |
+| 20 | Verify email | A sealed envelope | Inviting |
+| 21 | Forgot password | A loose key | Neutral |
+
+The list captures the surfaces that *would* benefit; the actual
+shipped set might be much smaller (1–6).
+
+## Prompt template
+
+For ChatGPT Images 2.0 / equivalent generative tool, use the
+following recipe:
+
+```
+Style: Editorial line illustration, 2px stroke, warm off-white background
+(#FAF7EF, OKLCH equivalent in 01-palette.md). Near-black warm ink for
+strokes (#2B2520). One amber accent (#D9933D) used sparingly — at most
+one element per illustration. No fills except the amber accent.
+No drop shadows. No gradients. No people. No emoji faces on objects.
+
+Subject: <e.g., "an open cardboard box with a paper label tag tied
+by twine, viewed from a 3/4 angle">
+
+Composition: Centered subject within a 160×160 viewport, ~30% padding
+on all sides. The subject reads at 64×64 (favicon-style decimation).
+
+Reference: Use the anchor image at frontend/src/assets/illustrations/anchor.svg
+to match line weight, perspective, and corner-radius treatment.
+
+Output: SVG (preferred) or PNG at 320×320 for crisp 2× rendering.
+```
+
+Tweak the `Subject:` line per surface. Keep everything else verbatim.
+
+## Sourcing channels
+
+Three viable paths, in descending order of preference:
+
+1. **Commission from a human illustrator.** Most consistent, most
+   expensive. Vendor brief: this doc + the anchor image.
+2. **Generative AI (ChatGPT Images 2.0, Midjourney, similar)** with
+   the anchor-driven workflow. Cheap, mid consistency. The PR #1362
+   recipe estimated $5–15 for 21 illustrations; the same likely
+   holds.
+3. **Pick from an open library** (unDraw, Open Doodles, lucide
+   Studio's illustration kit when it lands). Free, lowest
+   consistency.
+
+Whichever channel, all illustrations go through the same review:
+
+- Color values match the tokens (eyedrop with the spec at
+  `01-palette.md`).
+- Stroke weight matches the anchor.
+- No people, no emoji-faces, no drop shadows.
+- Reads at 64×64.
+- License is clear and assignable.
+
+## File format
+
+- **SVG** preferred — small, mode-aware via `currentColor`,
+  arbitrary scaling.
+- **PNG** at 1×, 2×, 3× when SVG isn't viable (e.g. AI-generated
+  raster).
+- Color tokens **inlined as CSS variables** (`var(--accent)`) when the
+  SVG is hand-authored, so dark mode swaps automatically.
+
+## Storage
+
+`frontend/src/assets/illustrations/`. One file per illustration, named
+after the surface (`empty-items.svg`, `not-found.svg`, …).
+
+## Hard rules
+
+1. **Anchor image is the constraint.** Every new illustration is a
+   variant of the same line / palette / tone — never a one-off.
+2. **No people, no faces on objects.**
+3. **Tokens, not raw colors.** The amber accent is `--accent`, not
+   `#D9933D`. (The hex above is approximate for prompt purposes —
+   the canonical OKLCH lives in `01-palette.md`.)
+4. **Commission, generate, or borrow — pick one channel per batch.**
+   Mixing channels per surface guarantees inconsistency.
+5. **Optional, not required.** The icon-only empty state is the
+   shipping minimum. Don't block features on illustration delivery.
+
+## Anti-patterns
+
+- A one-off "fun" illustration on the empty state for one feature.
+- Illustrations with characters / mascots.
+- Drop shadows / glows.
+- Gradient fills inside illustrations.
+- Color outside the tokens (a "purple receipt" on the empty-files
+  state).
+- Animated illustrations. (Per `05-motion.md`, the empty state is
+  quiet.)
+
+## Cross-refs
+
+- Anchor: `00-positioning.md` (tone), `01-palette.md` (color).
+- Iconography: `06-iconography-and-illustration.md`.
+- Empty-state placement: `08-interaction-states.md`,
+  `20-edge-cases.md`.
+- Brand: `19-branding.md`.
+- Future component: `frontend/src/components/illustrations/` (TBD).

--- a/devdocs/frontend/design/README.md
+++ b/devdocs/frontend/design/README.md
@@ -5,10 +5,9 @@ docs in the parent folder cover *how* code is organized; this folder
 covers *why* the product looks and behaves the way it does, and what
 the reusable design decisions are.
 
-The visual contract here is anchored to the canonical mock at
-[`denisvmedia/inventario-design`](https://github.com/denisvmedia/inventario-design)
-(`CLAUDE.md`). When the mock and these docs disagree, the mock wins —
-file an issue and update both in lockstep.
+The visual contract here is anchored to the canonical internal design
+mock. When the mock and these docs disagree, the mock wins — file an
+issue and update both in lockstep.
 
 ## How to read this folder
 
@@ -23,7 +22,7 @@ presented with a recommendation. Where there isn't (a11y minimums,
 motion timings, OKLCH semantics), one answer is given.
 
 Cross-references between docs are written as bare filenames in
-backticks — e.g. *"per `15-form-and-data-ux.md`"* — not as markdown
+backticks — e.g. *"per [15-form-and-data-ux.md](15-form-and-data-ux.md)"* — not as markdown
 links, so the references survive renames cleanly. The hub (this file)
 is the only index.
 
@@ -93,27 +92,26 @@ this folder and the canonical mock together.
 
 1. **Palette**: warm-neutral OKLCH with amber accents (light) / dark
    warm with light amber (dark). No purple. No raw color names. See
-   `01-palette.md`.
+   [01-palette.md](01-palette.md).
 2. **Typography**: system font stack (no Google Fonts, no Switzer, no
    Inter). The browser's native sans-serif is the body face. See
-   `02-typography.md`.
+   [02-typography.md](02-typography.md).
 3. **Iconography**: `lucide-react`, by named import only. Size scale
-   `size-3` → `size-10`. See `06-iconography-and-illustration.md`.
+   `size-3` → `size-10`. See [06-iconography-and-illustration.md](06-iconography-and-illustration.md).
 4. **Components**: shadcn/ui (new-york / neutral) on Radix primitives
    via the `radix-ui` umbrella. No `@base-ui/react`, no `next-themes`.
-   See `09-component-patterns.md` and `../imports-and-bans.md`.
+   See [09-component-patterns.md](09-component-patterns.md) and [../imports-and-bans.md](../imports-and-bans.md).
 5. **Motion**: `tw-animate-css` only. No Framer Motion / react-spring.
-   See `05-motion.md`.
+   See [05-motion.md](05-motion.md).
 6. **Elevation**: borders, not shadows. The single exception is
-   `shadow-xs` on inputs. See `04-elevation-and-effects.md`.
-7. **A11y floor**: WCAG 2.2 AA. See `14-accessibility.md`.
+   `shadow-xs` on inputs. See [04-elevation-and-effects.md](04-elevation-and-effects.md).
+7. **A11y floor**: WCAG 2.2 AA. See [14-accessibility.md](14-accessibility.md).
 
 ## Out of scope (deliberately)
 
 - A separate "design system" package or component library. The shadcn
-  copies in `frontend/src/components/ui/` and the mock at
-  `denisvmedia/inventario-design` are the system; there is no NPM
-  package to publish.
+  copies in `frontend/src/components/ui/` and the internal design mock
+  together are the system; there is no NPM package to publish.
 - Mobile-first redesign. Inventario is a desktop-first inventory app;
   it's responsive but the design bias is desktop. A native app or a
   mobile-first refresh would be a separate epic.
@@ -121,4 +119,4 @@ this folder and the canonical mock together.
   theming engine; per-tenant theming is not a goal.
 - Brand-mark exploration beyond the existing logo. The current logo
   is committed; alternative directions belong in
-  `21-logo-directions.md` as historical exploration only.
+  [21-logo-directions.md](21-logo-directions.md) as historical exploration only.

--- a/devdocs/frontend/design/README.md
+++ b/devdocs/frontend/design/README.md
@@ -1,0 +1,124 @@
+# Inventario — Design Direction
+
+The visual and interaction contract for the React frontend. Engineering
+docs in the parent folder cover *how* code is organized; this folder
+covers *why* the product looks and behaves the way it does, and what
+the reusable design decisions are.
+
+The visual contract here is anchored to the canonical mock at
+[`denisvmedia/inventario-design`](https://github.com/denisvmedia/inventario-design)
+(`CLAUDE.md`). When the mock and these docs disagree, the mock wins —
+file an issue and update both in lockstep.
+
+## How to read this folder
+
+Every doc carries a one-line **commitment** in its opening paragraph
+(`committed`, `floor`, `recommendation`, `proposal`). That tells you
+whether the section is taste-locked, a quality bar, an opinionated
+default with room to deviate, or a forward-looking idea waiting on a
+PR.
+
+Where there is taste room, three or fewer concrete options are
+presented with a recommendation. Where there isn't (a11y minimums,
+motion timings, OKLCH semantics), one answer is given.
+
+Cross-references between docs are written as bare filenames in
+backticks — e.g. *"per `15-form-and-data-ux.md`"* — not as markdown
+links, so the references survive renames cleanly. The hub (this file)
+is the only index.
+
+## Foundation
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 00 | [Positioning](00-positioning.md) | Audience, voice, what the product *is*. Anchors every taste decision downstream. |
+| 01 | [Palette](01-palette.md) | OKLCH tokens, light + dark, semantic colors. `committed`. |
+| 02 | [Typography](02-typography.md) | System font stack, type scale, role classes. `committed`. |
+| 03 | [Space & layout](03-space-and-layout.md) | Spacing rhythm, page shells, card anatomy. |
+| 04 | [Elevation & effects](04-elevation-and-effects.md) | Borders over shadows. `committed`. |
+| 05 | [Motion](05-motion.md) | `tw-animate-css` durations, easings, reduced-motion. |
+
+## Visual language
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 06 | [Iconography & illustration](06-iconography-and-illustration.md) | `lucide-react` only, size scale, illustration sourcing. `committed`. |
+| 07 | [Data visualization](07-data-visualization.md) | Chart palette, chart-type-per-data-shape, sparklines. |
+
+## Interaction & components
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 08 | [Interaction states](08-interaction-states.md) | hover / focus / active / disabled / loading / empty / error / selected. |
+| 09 | [Component patterns](09-component-patterns.md) | Anatomy + rules per shadcn primitive in use. |
+| 10 | [File & media](10-file-and-media.md) | The four-category file model (Photos / Invoices / Documents / Other). |
+| 11 | [Page layouts & flows](11-page-layouts-and-flows.md) | Templates: dashboard, list, detail, settings, auth, error. |
+
+## Content & language
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 12 | [Tone of voice & copy](12-tone-of-voice-and-copy.md) | Microcopy templates, naming, error/success messages. |
+| 13 | [Formatting & i18n](13-formatting-and-i18n.md) | Numbers, dates, currency, plurals across `en` / `cs` / `ru`. |
+
+## Quality bars
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 14 | [Accessibility](14-accessibility.md) | WCAG 2.2 AA `floor`. Some surfaces target AAA. |
+| 15 | [Form & data UX](15-form-and-data-ux.md) | Validation timing, server errors, draft persistence, optimistic updates. |
+| 16 | [Notifications & trust](16-notifications-and-trust.md) | Sonner toast hierarchy, sensitive-data handling, trust signals. |
+
+## Adaptation
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 17 | [Density & modes](17-density-and-modes.md) | comfortable / cozy / compact + light / dark. |
+| 18 | [Print & export](18-print-and-export.md) | Print stylesheet, the existing `CommodityPrintPage` route, PDF export. |
+| 19 | [Branding](19-branding.md) | Logo system (`AppLogo`), favicon, OG image, email templates. |
+| 20 | [Edge cases](20-edge-cases.md) | 404 / 500 / offline / no-group / empty-account / deleted-entities. |
+
+## Production assets
+
+| # | Document | Purpose |
+| --- | --- | --- |
+| 21 | [Logo directions](21-logo-directions.md) | The current bracket-cube mark + variants. |
+| 22 | [Illustration prompts](22-illustration-prompts.md) | Empty-state and onboarding illustrations — sourcing recipe. |
+
+## Decisions locked
+
+These are taste-locked across this folder. Don't re-litigate them in a
+PR; if one genuinely needs to change, file an issue and update both
+this folder and the canonical mock together.
+
+1. **Palette**: warm-neutral OKLCH with amber accents (light) / dark
+   warm with light amber (dark). No purple. No raw color names. See
+   `01-palette.md`.
+2. **Typography**: system font stack (no Google Fonts, no Switzer, no
+   Inter). The browser's native sans-serif is the body face. See
+   `02-typography.md`.
+3. **Iconography**: `lucide-react`, by named import only. Size scale
+   `size-3` → `size-10`. See `06-iconography-and-illustration.md`.
+4. **Components**: shadcn/ui (new-york / neutral) on Radix primitives
+   via the `radix-ui` umbrella. No `@base-ui/react`, no `next-themes`.
+   See `09-component-patterns.md` and `../imports-and-bans.md`.
+5. **Motion**: `tw-animate-css` only. No Framer Motion / react-spring.
+   See `05-motion.md`.
+6. **Elevation**: borders, not shadows. The single exception is
+   `shadow-xs` on inputs. See `04-elevation-and-effects.md`.
+7. **A11y floor**: WCAG 2.2 AA. See `14-accessibility.md`.
+
+## Out of scope (deliberately)
+
+- A separate "design system" package or component library. The shadcn
+  copies in `frontend/src/components/ui/` and the mock at
+  `denisvmedia/inventario-design` are the system; there is no NPM
+  package to publish.
+- Mobile-first redesign. Inventario is a desktop-first inventory app;
+  it's responsive but the design bias is desktop. A native app or a
+  mobile-first refresh would be a separate epic.
+- A theming engine beyond `light` / `dark`. The OKLCH tokens are the
+  theming engine; per-tenant theming is not a goal.
+- Brand-mark exploration beyond the existing logo. The current logo
+  is committed; alternative directions belong in
+  `21-logo-directions.md` as historical exploration only.

--- a/devdocs/frontend/forms.md
+++ b/devdocs/frontend/forms.md
@@ -1,0 +1,264 @@
+# Forms
+
+`react-hook-form` + `zod` everywhere. Server errors normalize through one
+helper. The pattern is mirrored across every form in the app — copy from a
+nearby page rather than inventing a new shape.
+
+## The stack
+
+| Concern | Library | Where it lives |
+| --- | --- | --- |
+| Form state, validation, submission | `react-hook-form` (`useForm`) | `react-hook-form` |
+| Schema-driven validation | `zod` (`zodResolver`) | `zod`, `@hookform/resolvers` |
+| Server error normalization | `parseServerError(err, fallback)` | `src/lib/server-error.ts` |
+| Mutation | `useMutation` from a feature slice | `features/<name>/hooks.ts` |
+| Translation | `useTranslation()` + `t("namespace:key")` | `react-i18next` |
+
+## Schema
+
+Schemas live next to the feature, not next to the page:
+
+```
+frontend/src/features/auth/schemas.ts
+frontend/src/features/commodities/schemas.ts
+frontend/src/features/locations/schemas.ts
+frontend/src/features/groups/schemas.ts
+frontend/src/features/tags/schemas.ts
+```
+
+Convention — error messages are **i18n keys, not English strings**:
+
+```ts
+// frontend/src/features/auth/schemas.ts
+import { z } from "zod"
+
+export const loginSchema = z.object({
+  email: z.string().min(1, "auth:validation.emailRequired"),
+  password: z.string().min(1, "auth:validation.passwordRequired"),
+})
+export type LoginInput = z.infer<typeof loginSchema>
+```
+
+The `message` field carries an i18n key like `auth:validation.emailRequired`.
+RHF surfaces it through `errors[name]?.message` and the page resolves it via
+`t(message)` at render time. This keeps schemas pure (no React, no i18n
+context) and lets tests assert against the key without booting i18n.
+
+> **Don't change** an existing key without adding the new one to
+> `auth:validation.*` (or the right namespace) and to the
+> `preservePatterns` list in `frontend/i18next.config.ts` — see
+> [i18n.md](i18n.md).
+
+When validation needs cross-field rules, use `superRefine`:
+
+```ts
+export const resetPasswordSchema = z
+  .object({
+    password: z.string().min(8, "auth:validation.passwordMinLength"),
+    confirmPassword: z.string().min(1, "auth:validation.passwordConfirmRequired"),
+  })
+  .superRefine((value, ctx) => {
+    if (value.password !== value.confirmPassword) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["confirmPassword"],
+        message: "auth:validation.passwordsMismatch",
+      })
+    }
+  })
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>
+```
+
+## Page
+
+```tsx
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { useLogin } from "@/features/auth/hooks"
+import { loginSchema, type LoginInput } from "@/features/auth/schemas"
+import { parseServerError } from "@/lib/server-error"
+
+export function LoginPage() {
+  const { t } = useTranslation()
+  const loginMutation = useLogin()
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const form = useForm<LoginInput>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: "", password: "" },
+    mode: "onSubmit",
+  })
+
+  // Reset the server error whenever the user edits a field, so a stale
+  // notice doesn't sit on top of valid input.
+  useEffect(() => {
+    const sub = form.watch(() => { if (serverError) setServerError(null) })
+    return () => sub.unsubscribe()
+  }, [form, serverError])
+
+  async function onSubmit(values: LoginInput) {
+    setServerError(null)
+    try {
+      await loginMutation.mutateAsync(values)
+    } catch (err) {
+      setServerError(parseServerError(err, t("auth:login.errorGeneric")))
+    }
+  }
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+      {serverError && (
+        <Alert variant="destructive">
+          <AlertDescription>{serverError}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-1.5">
+        <Label htmlFor="email">{t("auth:login.email")}</Label>
+        <Input id="email" type="email" {...form.register("email")} />
+        {form.formState.errors.email && (
+          <p className="text-xs text-destructive">
+            {t(form.formState.errors.email.message ?? "")}
+          </p>
+        )}
+      </div>
+
+      {/* …password field with the same shape… */}
+
+      <Button
+        type="submit"
+        disabled={loginMutation.isPending || form.formState.isSubmitting}
+      >
+        {t("auth:login.submit")}
+      </Button>
+    </form>
+  )
+}
+```
+
+## Server-error surfacing
+
+Backends emit three error envelopes:
+
+```ts
+// JSON:API
+{ errors: [{ detail: "Invalid credentials", title: "Unauthorized" }] }
+
+// Plain envelope
+{ error: "Email already taken" }
+{ message: "Email already taken" }
+
+// Plain string body
+"Email already taken"
+```
+
+`parseServerError(err, fallback)` collapses all three into a single string,
+falling back to the supplied default for 5xx HTML responses or unknown
+shapes:
+
+```ts
+import { parseServerError } from "@/lib/server-error"
+
+try {
+  await mutation.mutateAsync(values)
+} catch (err) {
+  setServerError(parseServerError(err, t("auth:login.errorGeneric")))
+}
+```
+
+Rules:
+
+- **Always pass a fallback** — never `parseServerError(err, "")`. The
+  fallback is what a 500 with an HTML body or a network error becomes.
+  Use a translated string (`t("...")`).
+- **Don't assume the field map.** The current backend doesn't return
+  per-field errors for the auth surface, so we render server errors as
+  one banner above the form. If a future endpoint returns
+  `{ errors: [{ source: { pointer: "/data/attributes/email" }, … }] }`,
+  extend `parseServerError` first; don't sprinkle ad-hoc parsing in the
+  page.
+- **Reset on edit.** Watch the form via `form.watch()` and clear the
+  banner when the user edits — see the LoginPage example.
+
+## Submit-button gating
+
+Submit buttons are gated on three things, in this order:
+
+```tsx
+disabled={loginMutation.isPending || form.formState.isSubmitting}
+```
+
+- `mutation.isPending` — request in flight.
+- `form.formState.isSubmitting` — RHF's own promise hasn't resolved.
+- Custom: `disabled={!form.formState.isValid}` only on `mode: "onChange"`
+  forms where you genuinely want a live-validating gate. The default
+  `mode: "onSubmit"` shows errors after the first submit attempt — that's
+  what most pages use.
+
+Don't add `disabled={!email || !password}` ad-hoc. Let zod gate via
+`isValid` if you switch to `onChange`, or just let the submit attempt
+fire and let the schema render the errors.
+
+## Field components
+
+Use the shadcn primitives directly — `Input`, `Label`, `Checkbox`,
+`Select`, `Textarea`. The standard field shape is:
+
+```tsx
+<div className="space-y-1.5">
+  <Label htmlFor="field-id">Label</Label>
+  <Input id="field-id" {...form.register("field-id")} aria-invalid={!!error} />
+  {error && <p className="text-xs text-destructive">{t(error.message ?? "")}</p>}
+</div>
+```
+
+For complex controls (combobox, date picker), wrap with `Controller`:
+
+```tsx
+import { Controller } from "react-hook-form"
+
+<Controller
+  name="currency"
+  control={form.control}
+  render={({ field, fieldState }) => (
+    <CurrencyCombobox
+      value={field.value}
+      onValueChange={field.onChange}
+      aria-invalid={fieldState.invalid}
+    />
+  )}
+/>
+```
+
+## Multi-step forms
+
+The Add Item dialog (`features/commodities/`) is the reference for
+multi-step forms. Pattern:
+
+- One RHF instance for the whole wizard. Each step renders a slice of
+  the same form.
+- The schema is one big object; per-step validation runs
+  `await form.trigger(["field-a", "field-b"])` before advancing.
+- Persist a draft to `localStorage` keyed `commodity-draft:{slug}:create`
+  on every change (see PR #1447 for the helper). Hydrate on mount.
+- "Cancel" clears the draft. "Save" clears the draft on success.
+
+## Tests
+
+A form test wires `renderWithProviders`, types into inputs, clicks
+submit, and asserts:
+
+- The mutation was called with the expected body (MSW handler asserts).
+- Validation errors render the expected i18n key (the test reads the
+  resolved English string via `screen.getByText(...)`).
+- Server errors render via the `Alert`.
+- `axe(container)` returns no violations.
+
+See `frontend/src/pages/auth/__tests__/LoginPage.test.tsx` for a
+full-shape example. Pattern + helpers live in [testing.md](testing.md).

--- a/devdocs/frontend/i18n.md
+++ b/devdocs/frontend/i18n.md
@@ -1,0 +1,195 @@
+# i18n
+
+`react-i18next` with English bundled and `cs` / `ru` lazy-loaded. Keys
+follow `namespace:dot.path`. The extractor (`i18next-cli`) keeps the
+source of truth in `src/i18n/locales/<lng>/<namespace>.json`.
+
+## Locales
+
+| Locale | Status | Loaded |
+| --- | --- | --- |
+| `en` | Source of truth, complete | Bundled statically — no extra round-trip |
+| `cs` | Stub, falls back to `en` | Lazy via Vite `import.meta.glob` |
+| `ru` | Stub, falls back to `en` | Lazy via Vite `import.meta.glob` |
+
+The supported set is `SUPPORTED_LANGUAGES` in
+`src/i18n/i18next.config.ts`. Adding a locale: add a folder under
+`src/i18n/locales/<lng>/`, add the code to `SUPPORTED_LANGUAGES`, and
+register the loader in the `i18next.config.ts`'s `import.meta.glob`
+block.
+
+The fallback chain is `en` → final. Missing keys log a `[i18n] missing
+key …` console warning in dev (the `saveMissing` handler).
+
+## Namespaces
+
+```ts
+// src/i18n/i18next.config.ts
+export const I18N_NAMESPACES = [
+  "common",       // shell, nav, generic actions
+  "auth",         // login, register, password reset, sessions
+  "dashboard",
+  "locations",
+  "commodities",
+  "files",
+  "tags",
+  "exports",
+  "settings",
+  "members",
+  "groups",
+  "search",
+  "stubs",        // PlaceholderPage titles
+  "errors",
+] as const
+```
+
+One namespace per file under `src/i18n/locales/<lng>/<namespace>.json`.
+Adding a namespace = adding the file in **every** locale (the
+`i18n:check` script enforces this).
+
+## Key style
+
+| Rule | Example |
+| --- | --- |
+| `namespace:dot.path` | `auth:validation.emailRequired` |
+| Lower-camelCase segments | `auth:login.errorGeneric` |
+| Pluralized keys end with `_one` / `_other` (i18next conv.) | `commodities:bulk.deleted_one` / `commodities:bulk.deleted_other` |
+| Closed-enum keys are flat under a sub-namespace | `commodities:status.in_use`, `commodities:type.appliance` |
+| Action labels live in `common:actions.*` | `common:actions.delete` |
+
+The full key list is in the en locale — when you add a key, run
+`npm run i18n:extract` to add it to the on-disk catalog automatically.
+
+## Reading a key
+
+```tsx
+import { useTranslation } from "react-i18next"
+
+export function LoginButton() {
+  const { t } = useTranslation()
+  return <Button>{t("auth:login.submit")}</Button>
+}
+```
+
+For pluralization:
+
+```tsx
+t("commodities:bulk.deleted", { count })   // resolves _one or _other
+```
+
+For interpolation:
+
+```tsx
+t("auth:invite.welcomeBack", { name: user.name })
+```
+
+For namespaces other than `common`, the namespace prefix is in the key
+itself — don't pass `useTranslation("auth")`. Mixing both is what
+caused half the bugs in the legacy frontend.
+
+## `preservePatterns`
+
+The extractor walks the source tree statically. Dynamic keys (template
+literals, lookup tables) are invisible to it, so they go into
+`preservePatterns` in `frontend/i18next.config.ts`:
+
+```ts
+preservePatterns: [
+  "stubs:*",                           // PlaceholderPage uses t(`stubs:${titleKey}`)
+  "common:nav.*",                      // sidebar uses t(`common:${entry.labelKey}`)
+  "auth:validation.*",                 // zod schemas hold raw keys, t() at render
+  "commodities:bulk.*",                // i18next pluralization suffixes
+  "exports:wizard.scope.*",            // wizard step receives keys as props
+  // … see the existing config for the full list
+]
+```
+
+Each existing entry has a comment explaining *why* it's dynamic — read
+those before adding a new one. If your code needs a new pattern:
+
+1. Add the literal keys to the en locale (`<namespace>.json`).
+2. Add a `<namespace>:<prefix>.*` entry to `preservePatterns`.
+3. Comment the entry with the reason, like the rest of the file does.
+
+> **Don't** add a `*` pattern to make the extractor stop complaining
+> about a *static* key. That's a bug in the call site (probably the key
+> is built via a template literal that should be a static lookup or a
+> handful of `case` arms).
+
+## Extraction and check
+
+| Command | What it does |
+| --- | --- |
+| `npm run i18n:extract` | Walks `src/`, writes any new keys into `locales/en/<namespace>.json`. Idempotent. |
+| `npm run i18n:check` | Same walk in dry-run; fails when adding a `t("foo.bar")` would change the on-disk catalog. CI runs this. |
+
+When the check fails:
+
+1. Run `npm run i18n:extract` locally.
+2. Diff the result. If the new keys are intentional, commit them with
+   the corresponding feature change.
+3. If the new keys are accidental (`t("debug.foo")` left from a print),
+   delete the call.
+4. If the new key is dynamic and should never be statically extracted,
+   add a `preservePatterns` entry instead and let the extractor run.
+
+## Translating zod messages
+
+Schemas hold **i18n keys**, not English strings:
+
+```ts
+export const loginSchema = z.object({
+  email: z.string().min(1, "auth:validation.emailRequired"),
+})
+```
+
+The page renders the message via `t(error.message ?? "")` — see
+[forms.md](forms.md). The extractor can't see the literal key inside
+the schema, so it lives in `preservePatterns` (`auth:validation.*`).
+
+## Formatting helpers
+
+`src/lib/intl.ts` wraps the heavy `Intl.*` APIs into a stable function
+surface — currency, date-time, list joiners. Read from there rather
+than constructing `new Intl.NumberFormat(...)` per render. The locale
+the helpers use is `i18next.resolvedLanguage` (cached).
+
+```ts
+import { formatCurrency, formatDate } from "@/lib/intl"
+
+formatCurrency(1234.5, "USD")      // "$1,234.50"
+formatDate("2026-04-28")           // "Apr 28, 2026" (in en)
+```
+
+## Switching locale
+
+The Settings page (#1414) writes to `i18next.changeLanguage(lng)` and
+mirrors to `localStorage` (the `LanguageDetector` reads back on boot).
+The lazy backend resolves the new bundle on the next render; React
+Query caches don't reset.
+
+In tests, switch via `await i18next.changeLanguage("ru")`, then reset
+to `"en"` in `afterEach`. See [testing.md](testing.md).
+
+## SSR / static rendering
+
+The app is a Vite SPA — no SSR. The first render uses bundled `en`
+unconditionally, then `LanguageDetector` triggers a re-render with the
+preferred locale. There is no flicker for `en` users; cs/ru users see a
+brief en flash on the very first paint, which is acceptable.
+
+## Anti-patterns
+
+- **Hard-coded English in JSX.** `<Button>Save</Button>` is a bug. Use
+  `t("common:actions.save")`.
+- **`t("a.b.c")` with no namespace.** Always prefix with the namespace
+  (`common:a.b.c`). The default namespace is `common`, but being
+  explicit beats relying on the default.
+- **A new namespace per page.** Share a namespace across closely
+  related pages (`commodities:list.*`, `commodities:detail.*`).
+  Splitting too fine makes invalidation/translation a chore.
+- **Translating server error strings.** Backends emit messages in
+  English; `parseServerError` returns them as-is. If you need
+  translated server errors, normalize on the server first.
+- **Catalog edits without `i18n:check`.** Run it locally before
+  pushing — CI runs it on every PR.

--- a/devdocs/frontend/icons.md
+++ b/devdocs/frontend/icons.md
@@ -1,0 +1,144 @@
+# Icons
+
+Lucide only. Strict size scale. Decorative icons are `aria-hidden`,
+icon-only buttons get an `aria-label`. The whole convention exists so
+focus, contrast, and rhythm stay consistent across pages.
+
+## One library: `lucide-react`
+
+```tsx
+import { ChevronRight, Trash2, Plus, Edit2 } from "lucide-react"
+```
+
+Hard rules:
+
+- **No FontAwesome, no PrimeIcons, no Heroicons, no Material Icons.** They
+  drift from the visual contract and bloat the bundle. The ban is
+  documented in [imports-and-bans.md](imports-and-bans.md).
+- **No inline SVG paths.** When an icon doesn't exist in Lucide, propose
+  it upstream (<https://lucide.dev/guide/contributing>) or pick a near
+  match. The one exception is `AppLogo` (`src/components/AppLogo.tsx`),
+  which is a brand mark — that's a logo, not an icon.
+- **Tree-shake by named import.** Always
+  `import { Trash2 } from "lucide-react"`, never
+  `import * as Icons from "lucide-react"`.
+
+## Size scale
+
+Tailwind's `size-*` utility maps to width + height in one class. Every
+icon picks from this scale — no `w-[18px] h-[18px]`:
+
+| Class | Pixels | Use |
+| --- | --- | --- |
+| `size-3` | 12 | Inside an `xs` button or a small badge |
+| `size-3.5` | 14 | Inside a `sm` button or a tight inline cue |
+| `size-4` | 16 | Standard body icon, `default` button, list-row chevron |
+| `size-5` | 20 | `lg` button, dialog title icon, hero-row icon (in a `size-10` tile) |
+| `size-6` | 24 | Sidebar nav (`SidebarMenuButton` default) |
+| `size-8` | 32 | Stat-card tile icon (`size-8` rounded-lg bg-muted, with `size-4` icon inside) |
+| `size-10` | 40 | Empty-state hero, first-run onboarding |
+| `size-16` | 64 | Hero illustration |
+
+Match the icon size to the surrounding control's height:
+
+| Button size | Icon class |
+| --- | --- |
+| `xs` (h-6) | `size-3` |
+| `sm` (h-8) | `size-3.5` |
+| `default` (h-9) | `size-4` |
+| `lg` (h-10) | `size-4` |
+| `icon` (h-9) | `size-4` |
+| `icon-sm` (h-8) | `size-3.5` |
+
+## Decorative vs. labeled icons
+
+| Icon's role | Treatment |
+| --- | --- |
+| **Decorative** — sits next to a text label that already conveys meaning | `aria-hidden` is **on by default** (Lucide adds it when there's no label prop). Don't override. |
+| **Stand-alone in an icon-only button** | Wrap in `<Button size="icon" aria-label="…">`. The button gets the label; the icon stays hidden. |
+| **Stand-alone outside a button** (status indicator, badge with no text) | Add `aria-label` to the icon **or** pair with visually hidden text via `<span className="sr-only">…</span>`. |
+
+```tsx
+{/* Decorative — has accompanying "Delete" text */}
+<Button variant="destructive" size="sm" className="gap-1.5">
+  <Trash2 className="size-3.5" />
+  {t("common:actions.delete")}
+</Button>
+
+{/* Icon-only button — label on the button */}
+<Button variant="ghost" size="icon" aria-label={t("common:actions.delete")}>
+  <Trash2 className="size-4" />
+</Button>
+
+{/* Stand-alone status icon — label on the icon (rare) */}
+<Check className="size-4 text-status-active" aria-label={t("common:status.completed")} />
+```
+
+The Lucide React component renders `aria-hidden="true"` automatically
+when no label-related prop is set. Don't write `aria-hidden={true}`
+explicitly — it's noise. If the icon is stand-alone and meaningful, set
+`aria-label` (Lucide will drop `aria-hidden` and apply the label).
+
+## Color
+
+Decorative icons inherit color from `text-*` on the parent or `text-muted-foreground`:
+
+```tsx
+<Icon className="size-4 text-muted-foreground" />     {/* decorative cue */}
+<Icon className="size-4 text-primary" />              {/* primary action */}
+<Icon className="size-4 text-destructive" />          {/* destructive */}
+<Icon className="size-3 text-status-active" />        {/* domain status */}
+```
+
+Hard rules:
+
+- **Don't color icons with raw colors** (`text-amber-500`, `text-red-600`).
+  Use the token (`text-status-expiring`, `text-destructive`) — see
+  [styles-and-tokens.md](styles-and-tokens.md).
+- **Don't paint decorative icons in primary by default.** Decorative
+  cues read with `text-muted-foreground`; primary is a deliberate
+  emphasis, not a default.
+
+## Hero-row pattern
+
+The "icon tile next to a title + subtitle" appears in dialogs, settings
+rows, onboarding banners, empty states. Always the same shape:
+
+```tsx
+<div className="flex items-center gap-3">
+  <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 shrink-0">
+    <Icon className="size-5 text-primary" />
+  </div>
+  <div>
+    <p className="font-semibold text-sm">{t("…title")}</p>
+    <p className="text-xs text-muted-foreground">{t("…subtitle")}</p>
+  </div>
+</div>
+```
+
+Vary the `bg-*/10` token (and the icon `text-*`) when the surface should
+read warning, destructive, or status — never the icon size.
+
+## Adding a new icon
+
+1. Pick from <https://lucide.dev/icons>. Aim for the most semantically
+   close icon; don't proliferate near-synonyms.
+2. Import it by name from `lucide-react`.
+3. Apply a size class from the scale above.
+4. If it's decorative, leave `aria-hidden` to Lucide. If it stands alone,
+   add `aria-label`. If it's inside an icon-only button, label the
+   button.
+5. Color via tokens (`text-muted-foreground`, `text-primary`,
+   `text-status-*`) — never raw Tailwind palettes.
+
+## Anti-patterns
+
+- `<i className="fa fa-trash" />` — bans on sight.
+- `import { FaTrash } from "react-icons/fa"` — same.
+- `<svg ...><path d="…"/></svg>` inline in a component — file an issue
+  upstream and use the closest Lucide for now.
+- `<Trash2 width={14} height={14} />` — use `className="size-3.5"`
+  instead, so density / dark-mode utilities can compose.
+- `<Trash2 aria-hidden={true} />` — Lucide already does this; redundant.
+- `<button><Trash2 /></button>` with no label — accessibility violation.
+  Use `<Button size="icon" aria-label="…">`.

--- a/devdocs/frontend/imports-and-bans.md
+++ b/devdocs/frontend/imports-and-bans.md
@@ -1,0 +1,92 @@
+# Imports and bans
+
+The dependencies the React frontend deliberately doesn't ship and why.
+Keep this list in sync with `frontend/package.json` and the rationale
+in the issues that drove each ban.
+
+## The bans
+
+| Banned | Why | Use instead |
+| --- | --- | --- |
+| `next-themes` | Pretends the app is Next.js (cookies, server-side rendering hooks). The frontend is a Vite SPA. | Tiny custom theme provider in `src/components/theme-provider.tsx` (writes the `.dark` class on `<html>`). |
+| `@base-ui/react` | The mock at `denisvmedia/inventario-design` shipped both `radix-ui` and `@base-ui/react`. Two headless primitive libraries doing the same job is one too many. | `radix-ui` (the umbrella package). |
+| `@tailwindcss/animate` | Replaced by `tw-animate-css` (works with Tailwind v4's `@theme inline`). | `tw-animate-css` — already in `package.json`, imported at the top of `src/index.css`. |
+| `@fortawesome/react-fontawesome` (and any FA icon set), `primeicons`, `react-icons`, `@heroicons/react`, `@material-ui/icons` | One icon library. Mixing icon libraries breaks the visual rhythm and bloats the bundle. | `lucide-react`. See [icons.md](icons.md). |
+| Bolt scaffolding artifacts (`bolt-*` packages, `BoltGlobals`, `bolt:` data attributes, the literal string `"Bolt"` in `<title>`) | Leftover from the inventario-design mock's scaffold. They have no runtime purpose and act as a tripwire. | Delete on sight. The Go embed test (`go/apiserver/frontend_embed_test.go`) asserts the bundled HTML's title is `Inventario` and contains no Bolt artifacts. |
+| Vue, Vue Router, Pinia, PrimeVue, PrimeFlex, vue-i18n, sass | Legacy frontend dependencies, deleted at cutover (#1423, PR #1457). | The React stack — see [README.md](README.md). |
+| `@tanstack/react-query-devtools` | Triggers extra DOM and adds dev-only weight that drifts into prod via misconfiguration. | Browser network tab + `queryClient` inspection in tests. |
+| Framer Motion, react-spring, popmotion | Animation needs are met by `tw-animate-css` + Tailwind utilities; a runtime animation library is dead weight. | `animate-in`, `fade-in-0`, `slide-in-from-top-2`, etc. (see [styles-and-tokens.md](styles-and-tokens.md)). |
+| `axios`, `superagent`, `ky` | We have one fetch wrapper (`src/lib/http.ts`) that owns CSRF, group-rewriting, refresh, and JSON:API content type — none of which a generic HTTP library handles for us. | `src/lib/http.ts` via the feature slice's `api.ts`. See [data.md](data.md). |
+| `@base-ui/react`'s `Combobox`, `react-select`, `downshift`, headless menus other than Radix | Same ground covered by Radix + `cmdk`. | `radix-ui` for menus / popovers, `cmdk` for searchable lists (already in `Command`/`CommandPalette`). |
+| `clsx` (separate import) | shadcn's `cn()` already wraps `clsx` + `twMerge`. | `cn()` from `@/lib/utils`. |
+| `enzyme`, `react-testing-renderer` shallow, `jest` | The test stack is Vitest + RTL. | `@testing-library/react` via `renderWithProviders`. See [testing.md](testing.md). |
+
+## Detection
+
+The conventions above are enforced by:
+
+1. **PR review.** `package.json` adds get scrutiny — every new
+   dependency justifies itself in the PR body.
+2. **Embed smoke tests.** `go/apiserver/frontend_embed_test.go` asserts
+   the bundled HTML's `<title>` is `Inventario` and contains no Bolt
+   artifacts. Catches accidental scaffolding leftovers and HTML edits
+   that swap in something else.
+3. **Lighthouse `best-practices`.** Console errors from a banned-but-
+   somehow-installed library (e.g. `next-themes` complaining about a
+   missing context) tank the score and trip the gate.
+4. **Bundle-size gate.** A regression past the entry-bundle budget
+   surfaces the new dependency in `npm run size:why`. See [perf.md](perf.md).
+
+## Wiring `no-restricted-imports`
+
+The ESLint config (`frontend/eslint.config.js`) doesn't currently set
+`no-restricted-imports`, so the bans live as conventions enforced by
+review + the smoke tests above. If you want to add the rule, drop the
+following block into the typescript override:
+
+```js
+{
+  files: ["**/*.{ts,tsx}"],
+  rules: {
+    "no-restricted-imports": ["error", {
+      paths: [
+        { name: "next-themes", message: "Use src/components/theme-provider.tsx — Vite SPA, not Next.js." },
+        { name: "@base-ui/react", message: "Locked to radix-ui; do not introduce a second headless library." },
+        { name: "@tailwindcss/animate", message: "Replaced by tw-animate-css." },
+        { name: "axios", message: "Use src/lib/http.ts via the feature slice's api.ts." },
+        { name: "clsx", message: "Use cn() from @/lib/utils." },
+      ],
+      patterns: [
+        { group: ["@fortawesome/*", "primeicons", "react-icons*", "@heroicons/*"], message: "lucide-react only — see devdocs/frontend/icons.md." },
+      ],
+    }],
+  },
+}
+```
+
+It's an opt-in tightening — drop it in once the team agrees the
+conventions are stable, and never weaken a `paths`/`patterns` entry to
+land a PR.
+
+## When the ban needs to break
+
+A genuine new requirement (e.g. a charting library that shadcn-chart +
+recharts can't satisfy) is allowed to bend the bans, but never silently:
+
+1. Open an issue describing the need, the alternative considered, and
+   the bundle-size impact.
+2. Get explicit approval before adding the dep.
+3. Update this doc with the new entry and the reason it's allowed.
+
+## What's *not* a ban
+
+- **`@radix-ui/react-*`** — fine, but prefer the `radix-ui` umbrella so
+  versions stay consistent.
+- **shadcn primitive copies** — `npx shadcn@latest add <component>`
+  always allowed; the result lands in `src/components/ui/` and is
+  edited only via re-running the CLI.
+- **OpenAPI codegen** — `openapi-typescript` runs via `npm run codegen`
+  to refresh `src/types/api.d.ts`. It's a build-time tool, not a
+  runtime dep.
+- **Renovate-driven version bumps** — pinned versions update via
+  Renovate PRs; review the changelog and merge.

--- a/devdocs/frontend/imports-and-bans.md
+++ b/devdocs/frontend/imports-and-bans.md
@@ -9,12 +9,11 @@ in the issues that drove each ban.
 | Banned | Why | Use instead |
 | --- | --- | --- |
 | `next-themes` | Pretends the app is Next.js (cookies, server-side rendering hooks). The frontend is a Vite SPA. | Tiny custom theme provider in `src/components/theme-provider.tsx` (writes the `.dark` class on `<html>`). |
-| `@base-ui/react` | The mock at `denisvmedia/inventario-design` shipped both `radix-ui` and `@base-ui/react`. Two headless primitive libraries doing the same job is one too many. | `radix-ui` (the umbrella package). |
+| `@base-ui/react` | The design mock shipped both `radix-ui` and `@base-ui/react`. Two headless primitive libraries doing the same job is one too many. | `radix-ui` (the umbrella package). |
 | `@tailwindcss/animate` | Replaced by `tw-animate-css` (works with Tailwind v4's `@theme inline`). | `tw-animate-css` — already in `package.json`, imported at the top of `src/index.css`. |
 | `@fortawesome/react-fontawesome` (and any FA icon set), `primeicons`, `react-icons`, `@heroicons/react`, `@material-ui/icons` | One icon library. Mixing icon libraries breaks the visual rhythm and bloats the bundle. | `lucide-react`. See [icons.md](icons.md). |
-| Bolt scaffolding artifacts (`bolt-*` packages, `BoltGlobals`, `bolt:` data attributes, the literal string `"Bolt"` in `<title>`) | Leftover from the inventario-design mock's scaffold. They have no runtime purpose and act as a tripwire. | Delete on sight. The Go embed test (`go/apiserver/frontend_embed_test.go`) asserts the bundled HTML's title is `Inventario` and contains no Bolt artifacts. |
+| Bolt scaffolding artifacts (`bolt-*` packages, `BoltGlobals`, `bolt:` data attributes, the literal string `"Bolt"` in `<title>`) | Leftover from the React scaffold's origin. They have no runtime purpose and act as a tripwire. | Delete on sight. The Go embed test (`go/apiserver/frontend_embed_test.go`) asserts the bundled HTML's title is `Inventario` and contains no Bolt artifacts. |
 | Vue, Vue Router, Pinia, PrimeVue, PrimeFlex, vue-i18n, sass | Legacy frontend dependencies, deleted at cutover (#1423, PR #1457). | The React stack — see [README.md](README.md). |
-| `@tanstack/react-query-devtools` | Triggers extra DOM and adds dev-only weight that drifts into prod via misconfiguration. | Browser network tab + `queryClient` inspection in tests. |
 | Framer Motion, react-spring, popmotion | Animation needs are met by `tw-animate-css` + Tailwind utilities; a runtime animation library is dead weight. | `animate-in`, `fade-in-0`, `slide-in-from-top-2`, etc. (see [styles-and-tokens.md](styles-and-tokens.md)). |
 | `axios`, `superagent`, `ky` | We have one fetch wrapper (`src/lib/http.ts`) that owns CSRF, group-rewriting, refresh, and JSON:API content type — none of which a generic HTTP library handles for us. | `src/lib/http.ts` via the feature slice's `api.ts`. See [data.md](data.md). |
 | `@base-ui/react`'s `Combobox`, `react-select`, `downshift`, headless menus other than Radix | Same ground covered by Radix + `cmdk`. | `radix-ui` for menus / popovers, `cmdk` for searchable lists (already in `Command`/`CommandPalette`). |
@@ -80,6 +79,9 @@ recharts can't satisfy) is allowed to bend the bans, but never silently:
 
 ## What's *not* a ban
 
+- **`@tanstack/react-query-devtools`** — installed and mounted under
+  `import.meta.env.DEV` only in `src/app/providers.tsx`. The dev-only
+  gate is the contract; don't import it outside that gate.
 - **`@radix-ui/react-*`** — fine, but prefer the `radix-ui` umbrella so
   versions stay consistent.
 - **shadcn primitive copies** — `npx shadcn@latest add <component>`

--- a/devdocs/frontend/migration-conventions.md
+++ b/devdocs/frontend/migration-conventions.md
@@ -91,10 +91,10 @@ Set in PR #1437 (#1420). Entry JS ≤ 200 KB gzip; perf ≥ 0.85; a11y ≥
 
 ### Color tokens copied from the mock
 
-`src/index.css`'s `:root` and `.dark` blocks are 1:1 with the mock at
-`denisvmedia/inventario-design`. Lockstep updates: a token change in
-one repo lands as a follow-up in the other, with the PR cross-linked.
-See [styles-and-tokens.md](styles-and-tokens.md).
+`src/index.css`'s `:root` and `.dark` blocks are 1:1 with the internal
+design mock. Lockstep updates: a token change in one repo lands as a
+follow-up in the other, with the PR cross-linked. See
+[styles-and-tokens.md](styles-and-tokens.md).
 
 ### Smoke test on the embed
 
@@ -136,5 +136,5 @@ own doc tree.
 
 - Strategy memo: epic [#1397](https://github.com/denisvmedia/inventario/issues/1397).
 - Cutover PR: [#1457](https://github.com/denisvmedia/inventario/pull/1457).
-- Visual contract: `denisvmedia/inventario-design/CLAUDE.md`.
+
 - Sub-issues: #1398 through #1425 (linked from the epic).

--- a/devdocs/frontend/migration-conventions.md
+++ b/devdocs/frontend/migration-conventions.md
@@ -1,0 +1,140 @@
+# Migration conventions
+
+How the React rewrite happened and the conventions that survived
+cutover. This doc supersedes the old strangler-fig recipe under the
+deprecated Vue tree (deleted in cutover #1423).
+
+## What's there now
+
+`frontend/` is the only frontend tree. Single Vite app, single Go
+embed, single Playwright project per browser. The `INVENTARIO_FRONTEND`
+env var no longer exists.
+
+If you're looking at this doc to learn "how do I add a new feature?",
+there is nothing migration-specific to know — read the rest of this
+folder, starting with [README.md](README.md).
+
+## What used to be there
+
+Until cutover (#1423, PR #1457), two parallel trees coexisted:
+
+```
+frontend/         # Vue 3 + PrimeVue (legacy)
+frontend-react/   # React 19 + Tailwind v4 + shadcn (the rewrite)
+```
+
+The Go binary embedded one or the other based on
+`INVENTARIO_FRONTEND={legacy|new}`. CI ran the test matrix on both;
+each FE issue (#1407–#1417) shipped its React equivalent and an
+e2e tag (`@react-only`) so the new bundle gated separately from
+legacy.
+
+The cutover removed the Vue tree, renamed `frontend-react/` →
+`frontend/`, removed the env var, collapsed the Playwright matrix,
+and switched the Dockerfile to a single-stage frontend builder.
+
+## Why the rewrite happened (epic #1397)
+
+The legacy stack (Vue + PrimeVue) was mid-migration onto shadcn-vue
+when a clean React mock was delivered with a coherent visual system
+and a four-category file model (Photos / Invoices / Documents / Other).
+Continuing on Vue + shadcn-vue would have required re-implementing the
+mock against shadcn-vue's smaller primitive set; rewriting in React
+matched the mock 1:1 and unblocked design work that the legacy stack
+couldn't carry.
+
+The full plan: epic [#1397](https://github.com/denisvmedia/inventario/issues/1397),
+28 sub-issues #1398–#1425. Each issue's PR is linked from the epic.
+
+## Conventions that survived
+
+### URL is the source of truth for group context
+
+`/g/:groupSlug/*` is the canonical group identifier. The
+`GroupContext` (`features/group/GroupContext.tsx`) reads from
+`useParams`; the http wrapper reads from `getCurrentGroupSlug()` which
+falls back to `window.location` when the React effect hasn't mirrored.
+
+This was true in the legacy app and the rewrite kept it — tabs stay
+isolated even when the user changes groups in another tab.
+
+### One feature slice per domain
+
+`features/<name>/{api,hooks,keys,schemas,constants}.ts`. The shape
+predates the rewrite (legacy had it under `src/api/<name>/`) but it
+proved out as the right granularity for both stacks. Don't slice
+finer (per-page hooks files) unless a slice grows past ~600 lines.
+
+### i18n key shape
+
+`namespace:dot.path` was used in the legacy frontend (vue-i18n) and
+carried over to react-i18next. JSON files are 1:1 between the
+locales; `i18n:check` enforces that the en bundle is canonical and
+cs/ru track it.
+
+### Per-feature query key factory
+
+The `<name>Keys` factory (`features/<name>/keys.ts`) is React-specific
+and doesn't have a legacy equivalent. The pattern was set in PR #1428
+(#1403) and every slice since has used it.
+
+### Coverage threshold contract
+
+80/70/80/80 (lines/branches/functions/statements). Set in PR #1433
+(#1418) and never weakened — every PR that drops coverage finds the
+missing test instead. See [testing.md](testing.md).
+
+### Bundle and Lighthouse gates
+
+Set in PR #1437 (#1420). Entry JS ≤ 200 KB gzip; perf ≥ 0.85; a11y ≥
+0.95; best-practices ≥ 0.90. See [perf.md](perf.md).
+
+### Color tokens copied from the mock
+
+`src/index.css`'s `:root` and `.dark` blocks are 1:1 with the mock at
+`denisvmedia/inventario-design`. Lockstep updates: a token change in
+one repo lands as a follow-up in the other, with the PR cross-linked.
+See [styles-and-tokens.md](styles-and-tokens.md).
+
+### Smoke test on the embed
+
+`go/apiserver/frontend_embed_test.go` asserts the bundled HTML's
+`<title>` and absence of Bolt artifacts. Predates cutover; survives as
+the cheapest tripwire for "did the build accidentally inline the wrong
+HTML?".
+
+## Cutover criteria (for the historical record)
+
+The cutover issue (#1423) listed pre-conditions that should have been
+met before flipping. They were partially met when the cutover landed —
+issues #1400, #1412, #1415, #1442, #1448 were still open. The cutover
+shipped anyway; those follow-ups merged in subsequent PRs against the
+unified tree (PRs #1481/#1477/#1479 and the #1424 docs PR you're
+looking at). The official AC on the cutover issue:
+
+- [x] Vue tree deleted from `frontend/`.
+- [x] `INVENTARIO_FRONTEND` env var removed (single bundle path).
+- [x] `frontend-react/` renamed to `frontend/`.
+- [x] Playwright matrix collapsed to one bundle.
+- [x] Dockerfile switched to single-stage frontend builder.
+- [x] CI workflow names normalized (drop `frontend-react-*` prefix).
+
+The "two-week soak window" listed in the issue was waived. In
+hindsight, the rewrite landed cleanly enough that the soak was
+unnecessary; future cutovers of similar scale should still default to
+soaking before deletion.
+
+## What this doc isn't
+
+This is not a guide for "migrating a screen to React" — there's
+nothing left to migrate. If a new design system arrives next year and
+the answer is another rewrite, this file gets archived (probably in
+`devdocs/history/` or similar) and the new conventions live in their
+own doc tree.
+
+## Cross-references
+
+- Strategy memo: epic [#1397](https://github.com/denisvmedia/inventario/issues/1397).
+- Cutover PR: [#1457](https://github.com/denisvmedia/inventario/pull/1457).
+- Visual contract: `denisvmedia/inventario-design/CLAUDE.md`.
+- Sub-issues: #1398 through #1425 (linked from the epic).

--- a/devdocs/frontend/pr-checklist.md
+++ b/devdocs/frontend/pr-checklist.md
@@ -1,0 +1,115 @@
+# PR checklist
+
+Copy-paste into the body of every frontend PR. Tick the ones you
+actually verified. Lines marked **(N/A)** can be deleted if they
+genuinely don't apply.
+
+```markdown
+### Frontend PR checklist (devdocs/frontend/pr-checklist.md)
+
+#### Code
+
+- [ ] No `forwardRef`. Components accept `ref` via `React.ComponentProps<>` (see devdocs/frontend/coding-standards.md).
+- [ ] Named exports only. No default exports outside framework-required files.
+- [ ] No new CSS file. Styling is via `index.css` tokens + Tailwind utilities (devdocs/frontend/styles-and-tokens.md).
+- [ ] No raw colors (`#hex`, `text-amber-500`, …). Tokens only.
+- [ ] No drop shadows beyond `shadow-xs` on inputs.
+- [ ] No `console.*` in shipping code (devdocs/frontend/coding-standards.md).
+- [ ] Imports follow the documented order (external → `@/` → relative).
+- [ ] No banned dependency added (devdocs/frontend/imports-and-bans.md).
+
+#### Components
+
+- [ ] New shadcn primitives (if any) added via `npx shadcn@latest add <name>`, not hand-edited.
+- [ ] Cross-feature components live in `src/components/` (or `src/components/<feature>/`); page-local helpers stay in the page file until reused.
+- [ ] Variants via `cva`, not prop-driven `if/else` class concatenation.
+- [ ] `cn(base, className)` merge — no template-literal class lists.
+
+#### Data layer
+
+- [ ] No direct `fetch` calls. The `lib/http.ts` wrapper is the only HTTP surface (devdocs/frontend/data.md).
+- [ ] Query keys factored through `<feature>Keys` (`features/<name>/keys.ts`).
+- [ ] Group-scoped query keys include the slug.
+- [ ] `useEffect`-based fetching not introduced; `useQuery` / `useMutation` instead.
+- [ ] Mutations use `invalidateQueries` (default) or the documented optimistic-update pattern.
+
+#### Forms
+
+- [ ] `react-hook-form` + `zodResolver` (devdocs/frontend/forms.md).
+- [ ] Zod schemas in `features/<name>/schemas.ts` carry **i18n keys**, not English strings.
+- [ ] Server errors normalized via `parseServerError(err, fallback)`.
+- [ ] Submit gated on `mutation.isPending || form.formState.isSubmitting`.
+- [ ] Banner resets on field edit when the page surfaces `serverError`.
+
+#### Routing
+
+- [ ] Real pages added as `lazy()` imports in `src/app/router.tsx` (devdocs/frontend/routing.md).
+- [ ] `<RouteTitle title={t("…")} />` mounted at the top of the page.
+- [ ] Guard placement correct (`<ProtectedRoute>`, `<GroupRequiredRoute>`).
+- [ ] Sidebar entry added in `AppSidebar.tsx` if the route is navigable.
+- [ ] Command-palette entry added in `CommandPalette.tsx` if the route is Cmd-K-reachable.
+
+#### i18n
+
+- [ ] Every user-visible string goes through `t("namespace:key")` (devdocs/frontend/i18n.md).
+- [ ] New keys added via `npm run i18n:extract`; `npm run i18n:check` is clean.
+- [ ] New dynamic-key patterns documented in `frontend/i18next.config.ts`'s `preservePatterns` with a *why* comment.
+- [ ] Pluralization uses `_one` / `_other` and the `count` arg, not hand-rolled branching.
+
+#### Accessibility
+
+- [ ] All form fields have `<Label htmlFor>` or `aria-label` (devdocs/frontend/accessibility.md).
+- [ ] Icon-only buttons have `aria-label`.
+- [ ] Modals use `<Dialog>` / `<AlertDialog>` / `<Sheet>` — never `window.confirm()` or hand-rolled overlays.
+- [ ] Focus-visible rings preserved (no naked `outline: none`).
+- [ ] Color is paired with icon + text for any error / success state.
+- [ ] Page-level test runs `axe(container)` and is clean.
+
+#### Icons
+
+- [ ] Icons from `lucide-react` only (devdocs/frontend/icons.md).
+- [ ] Sizes from the documented scale (`size-3`, `size-3.5`, `size-4`, `size-5`, `size-8`, `size-10`).
+- [ ] Decorative icons inherit color from `text-muted-foreground` or token.
+
+#### Tests
+
+- [ ] Unit tests use `renderWithProviders` (devdocs/frontend/testing.md).
+- [ ] MSW handlers come from `src/test/handlers/` factories — `server.ts` base set untouched.
+- [ ] Page-level tests assert against rendered text, not snapshots.
+- [ ] Coverage didn't drop. **(N/A)** if no source files changed.
+
+#### Performance
+
+- [ ] `npm run size` passes. **(N/A)** if no `src/**` change.
+- [ ] `npm run lhci` passes locally on at least one URL the change touches. **(N/A)** if not on a public route.
+- [ ] No new big dependency landed without justification in the PR body.
+
+#### Smoke
+
+- [ ] `npm run typecheck` clean.
+- [ ] `npm run lint` clean.
+- [ ] `npm run test` green.
+- [ ] `npm run build` succeeds.
+- [ ] If the PR touches the embed (`frontend.go`, `index.html`): Go embed smoke test passes (`go test ./go/apiserver -run FrontendEmbed`).
+
+#### Description
+
+- [ ] PR body links the relevant issue (`Fixes #NNNN` or `Closes #NNNN`).
+- [ ] Screenshots / GIFs attached for visual changes (light + dark, plus dense + comfortable when relevant).
+- [ ] Bundle / Lighthouse deltas called out for non-trivial changes.
+- [ ] Cross-stack changes (BE + FE in the same PR) note the contract and link the BE issue.
+```
+
+## Tips
+
+- **Don't wait until you push** to walk the list. Run `npm run
+  typecheck && npm run lint && npm run test` locally before opening a
+  draft.
+- **Screenshots are worth the time.** Light + dark + dense + comfortable
+  catches a third of all visual regressions before the reviewer sees
+  them. The harness in [screenshots.md](screenshots.md) automates the
+  capture.
+- **A red CI gate is a question, not a verdict.** If `i18n:check` fails,
+  you might have intended the new keys (`extract` and commit) or you
+  might have left a `t("debug.foo")` (delete the call). Don't paper over
+  by tweaking the gate.

--- a/devdocs/frontend/routing.md
+++ b/devdocs/frontend/routing.md
@@ -24,11 +24,21 @@ in `src/components/routing/`.
 /g/:groupSlug/commodities
 /g/:groupSlug/commodities/:id
 /g/:groupSlug/files
+/g/:groupSlug/files/:id
+/g/:groupSlug/files/:id/edit
 /g/:groupSlug/tags
+/g/:groupSlug/members      → MembersPage (per-group, inside Shell)
 /g/:groupSlug/exports
+/g/:groupSlug/exports/new
+/g/:groupSlug/exports/import
+/g/:groupSlug/exports/:id
+/g/:groupSlug/exports/:id/restore
 /g/:groupSlug/search
-/g/:groupSlug/groups/settings
-/g/:groupSlug/groups/members
+/g/:groupSlug/commodities/:id/print  → CommodityPrintPage (Shell layout; @media print hides chrome)
+
+/groups/:groupId/settings  → GroupSettingsPage (Shell layout, NOT under /g/:groupSlug/)
+                             — the route is keyed by group id, not slug, because
+                             editing a group includes renaming its slug
 *                         → NotFoundPage
 ```
 

--- a/devdocs/frontend/routing.md
+++ b/devdocs/frontend/routing.md
@@ -1,0 +1,210 @@
+# Routing
+
+`react-router-dom` v7 with declarative `<Routes>`. The route tree lives
+in `src/app/router.tsx`; guards, redirects, and the title broadcast live
+in `src/components/routing/`.
+
+## Tree shape
+
+```
+/                         → RootRedirect (lazy)
+/login                    → LoginPage (lazy)
+/register                 → RegisterPage (lazy)
+/forgot-password          → ForgotPasswordPage (lazy)
+/reset-password           → ResetPasswordPage (lazy)
+/verify-email             → VerifyEmailPage (lazy)
+/invite/:token            → InviteAcceptPage (lazy)
+/no-group                 → NoGroupPage (lazy)
+/profile                  → ProfilePage (Shell layout)
+/settings                 → SettingsPage (Shell layout)
+/g/:groupSlug/            → DashboardPage (lazy, Shell layout)
+/g/:groupSlug/locations   → LocationsListPage
+/g/:groupSlug/locations/:id
+/g/:groupSlug/areas/:id
+/g/:groupSlug/commodities
+/g/:groupSlug/commodities/:id
+/g/:groupSlug/files
+/g/:groupSlug/tags
+/g/:groupSlug/exports
+/g/:groupSlug/search
+/g/:groupSlug/groups/settings
+/g/:groupSlug/groups/members
+*                         → NotFoundPage
+```
+
+The protected subtree mounts under `<Shell>` — the layout component that
+renders the sidebar, top bar, and the route's `<Outlet>`. Public auth
+pages render outside the shell.
+
+## Real pages are lazy
+
+Every real page in `app/router.tsx` is a `lazy` import:
+
+```tsx
+const DashboardPage = lazy(() =>
+  import("@/pages/Dashboard").then((m) => ({ default: m.DashboardPage }))
+)
+```
+
+Why — perf gates live and die by the entry-bundle budget (200 KB gzip,
+see [perf.md](perf.md)). Eagerly-loaded pages land in the entry chunk
+and burn through it fast.
+
+Rules:
+
+- **Real pages: always `lazy`.** The `.then((m) => ({ default: ... }))`
+  shape is what lets us export named functions instead of defaults.
+- **Placeholder pages: eager.** `PlaceholderPage` is shared across
+  every "coming soon" route — there's nothing to split until the real
+  page lands.
+- **Wrap the lazy tree in `<Suspense>`** with a real fallback (a
+  skeleton shaped like the page, or `null`). The Shell already mounts
+  one global Suspense boundary.
+
+## Guards
+
+Three guard components in `src/components/routing/`:
+
+### `ProtectedRoute`
+
+Bounces unauthenticated users to `/login?redirect=…&reason=auth_required`.
+Tri-state on `user`:
+
+| `user` value | Behavior |
+| --- | --- |
+| `undefined` (still resolving / transient backend error) | Render `fallback` (default: `null`) |
+| `null` (definitively logged out) | `<Navigate to="/login?…" replace />` |
+| `CurrentUser` | Render `children` |
+
+Always wrap protected pages in `<ProtectedRoute>` — never check
+`useAuth().user` inside the page.
+
+### `GroupRequiredRoute`
+
+Bounces a logged-in user without an active group to `/no-group`. Wraps
+the `/g/:groupSlug/*` subtree.
+
+### `UngroupedRedirect`
+
+Reverse of the above: bounces a logged-in user with at least one group
+*away* from `/no-group`. Used on the no-group page itself to handle the
+race where a group is created in another tab.
+
+## Group context
+
+`GroupContext` (`features/group/GroupContext.tsx`) reads the slug from
+`useParams()` and mirrors it into the module-level slot
+`group-context.ts` — the slot the http client reads. The URL is the
+canonical source of truth; the slot is a non-React-context cache for
+non-React callers (http wrapper, codegen helpers).
+
+A `useEffect` in `GroupProvider` writes the slug; an inline fallback in
+`getCurrentGroupSlug()` reads from `window.location` so the very first
+render of a `/g/:slug/*` route doesn't fire a query against
+`/api/v1/<resource>` (un-rewritten) before the effect commits. See
+`src/lib/group-context.ts` for the rationale comment.
+
+When you add a route under `/g/:groupSlug/*`:
+
+- Read the slug via `useCurrentGroup().slug` from the GroupContext —
+  not `useParams()` directly. The context resolves the group object too,
+  so you avoid a second lookup.
+- TanStack Query keys include the slug. See [data.md](data.md).
+
+## RouteTitle
+
+`<RouteTitle>` (`src/components/routing/RouteTitle.tsx`) writes the
+page's title both into `document.title` (for browser tab) and into
+`RouteTitleContext` (for the top bar to render the title visually).
+
+Mount it once near the top of every page:
+
+```tsx
+import { RouteTitle } from "@/components/routing/RouteTitle"
+
+export function CommoditiesListPage() {
+  const { t } = useTranslation()
+  return (
+    <>
+      <RouteTitle title={t("commodities:list.title")} />
+      {/* page content */}
+    </>
+  )
+}
+```
+
+The component owns the `useEffect` that writes both targets and clears
+on unmount.
+
+## Adding a new route
+
+1. **Create the page** at `src/pages/<feature>/<Name>Page.tsx`. Start
+   with the standard outer wrapper from [styles-and-tokens.md](styles-and-tokens.md):
+   ```tsx
+   <div className="flex flex-col gap-6 p-6 max-w-2xl mx-auto w-full">
+   ```
+2. **Add a `lazy()` import** at the top of `src/app/router.tsx`.
+3. **Place the `<Route>`** in the right subtree:
+   - Public auth → outside `<ProtectedRoute>`.
+   - Logged-in but groupless → outside `<GroupRequiredRoute>` but
+     inside `<ProtectedRoute>` (e.g. `/profile`, `/no-group`).
+   - Group-scoped → inside `<GroupRequiredRoute>`, under
+     `/g/:groupSlug/`.
+4. **Mount `<RouteTitle title={t("…")} />`** at the top of the page.
+5. **Add the sidebar entry** in `src/components/AppSidebar.tsx` (and
+   `i18n/locales/en/common.json` under `nav.<key>`) if the route should
+   appear in nav.
+6. **Add the command-palette entry** in `src/components/CommandPalette.tsx`
+   if the route should be navigable from `Cmd-K`.
+7. **Test the redirect chain**: protected, group-required, and
+   non-redirected. Use `renderWithProviders({ initialPath: "/…",
+   routes: <Route … /> })`. See [testing.md](testing.md).
+
+## Deep links and `?redirect=`
+
+The login page reads `?redirect=` and bounces the user back after a
+successful login. `sanitizeRedirectPath()` (`src/lib/safe-redirect.ts`)
+rejects absolute / protocol-relative URLs so a crafted query can't
+open-redirect off the app.
+
+When you redirect to login from a guarded route, encode the current
+path:
+
+```ts
+const redirect = location.pathname + location.search
+const params = new URLSearchParams({ redirect, reason: "auth_required" })
+return <Navigate to={`/login?${params.toString()}`} replace />
+```
+
+`reason` keys are in `auth:session.*` — see `LoginPage.tsx`'s
+`SESSION_REASON_KEY` map.
+
+## Code splitting and chunk shape
+
+- Real pages → one chunk per page.
+- Placeholder routes → one shared chunk for `PlaceholderPage`.
+- Cross-route components (Shell, AppSidebar, command palette) live in
+  the entry chunk.
+
+When you add a real page, the entry-bundle budget barely moves — the
+new chunk only loads when the user navigates to that route. Watch for:
+
+- **Eagerly imported page module** — if you write `import {
+  CommoditiesListPage } from "@/pages/…"` somewhere in the entry tree,
+  it un-splits the chunk. Run `npm run size:why` to spot it.
+- **Heavy library only used on one page** — keep the import inside the
+  page (or a leaf) so it lands in that page's chunk, not in the entry.
+
+## Anti-patterns
+
+- **Nested `<BrowserRouter>`s.** There is exactly one `BrowserRouter`,
+  in `src/main.tsx`. Tests use `MemoryRouter` via `renderWithProviders`.
+- **`window.location.href = …` to navigate.** Use `useNavigate()` or
+  `<Navigate>`. The hard exception is `navigateToLogin()` in
+  `src/lib/navigation.ts`, which fires from non-React HTTP code.
+- **Putting auth checks inside the page** (`if (!user) return null`).
+  Use `<ProtectedRoute>` so the redirect, the `?redirect=` param, and
+  the loading state are uniform.
+- **Reading the slug from `useParams()` in a non-route component.**
+  Read `useCurrentGroup()` instead — it works for tests that mount the
+  component without the route boundary.

--- a/devdocs/frontend/styles-and-tokens.md
+++ b/devdocs/frontend/styles-and-tokens.md
@@ -1,0 +1,221 @@
+# Styles and tokens
+
+Tailwind v4 + OKLCH tokens. The visual contract is canonical at
+`denisvmedia/inventario-design/CLAUDE.md`; this doc covers the Inventario
+codebase's translation and the rules every PR must respect.
+
+## Tailwind v4 setup
+
+`frontend/src/index.css` is the **single source of truth** for CSS:
+
+```css
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-primary: var(--primary);
+  /* … one --color-* per token … */
+}
+
+:root { /* light mode token values */ }
+.dark { /* dark mode token values */ }
+```
+
+Three layers:
+
+1. `:root { --foo: <oklch …>; }` — the literal value per mode. Light is
+   on `:root`, dark is on `.dark`.
+2. `@theme inline { --color-foo: var(--foo); }` — registers the token
+   with Tailwind so `text-foo`, `bg-foo`, `border-foo` exist.
+3. Components consume the token via Tailwind utilities only. **Never**
+   write `color: oklch(...)` or `color: var(--foo)` directly inside a
+   component's CSS or `style={}`.
+
+## OKLCH only
+
+Every color is in OKLCH. Why: perceptually uniform across light/dark,
+plays well with token-based dark mode, no `#hex` / `hsl()` drift.
+
+```css
+--background: oklch(0.985 0.004 75);   /* warm off-white */
+--foreground: oklch(0.18 0.012 60);    /* near-black */
+--primary:    oklch(0.26 0.02 60);     /* dark amber-tinted */
+--accent:     oklch(0.85 0.12 75);     /* THE amber accent */
+```
+
+Hard rules:
+
+- **No `hsl()` wrappers.** The token holds raw OKLCH; we never wrap it.
+  This is a deliberate break from the legacy shadcn template.
+- **No `#hex` anywhere** — not in CSS, not in `style={}`, not in inline
+  SVG fills. Use the token (`fill-current`, `text-chart-1`, …).
+- **No Tailwind named colors.** `text-amber-500`, `bg-green-100` are
+  bans on sight — use the domain token (`text-status-expiring`) or chart
+  color (`text-chart-1`).
+
+## Dark mode
+
+Dark mode toggles via the `.dark` class on `<html>`, written by
+`useTheme()` (`src/components/theme-provider.tsx`). All `--color-*`
+references resolve to the dark variant automatically — components write
+the same Tailwind class in either mode.
+
+```css
+.dark {
+  --background: oklch(0.155 0.01 55);
+  --foreground: oklch(0.96 0.006 70);
+  --primary:    oklch(0.88 0.09 75);   /* light amber in dark */
+  --border:     oklch(1 0 0 / 10%);    /* white at 10% opacity */
+}
+```
+
+Rules:
+
+- **Both modes are first-class.** Every new token gets a value in both
+  `:root` and `.dark`.
+- **Never test only one mode.** When you take screenshots
+  ([screenshots.md](screenshots.md)), capture both themes.
+- **No `dark:` Tailwind variants on color tokens.** Tokens already swap
+  via the `.dark` class. `dark:` is reserved for one-off layout tweaks
+  (e.g. a border that should disappear in dark) and used sparingly.
+
+## Density
+
+Density is "how tight should rows / cards / lists be?" — three steps:
+
+```ts
+type Density = "comfortable" | "cozy" | "compact"
+```
+
+Set on `<html data-density="cozy">` by `DensityProvider`
+(`src/hooks/useDensity.tsx`). Persisted to `localStorage` and mirrored
+across tabs via the `storage` event. The Settings page (#1414) writes
+through `PATCH /settings` and mirrors back to `localStorage` on boot.
+
+When you build a row-heavy surface (lists, tables, settings rows), wire
+density via the `data-density` attribute selector:
+
+```css
+[data-density="cozy"] .row    { padding-block: 0.75rem; }
+[data-density="compact"] .row { padding-block: 0.5rem; }
+```
+
+Or — preferred — use Tailwind's `data-[density=*]:` arbitrary variant
+when the rule is one-off:
+
+```tsx
+<div className="py-3.5 data-[density=compact]:py-2.5 data-[density=cozy]:py-3">…</div>
+```
+
+## Domain tokens
+
+Beyond shadcn defaults, the design encodes domain semantics. Always use
+the domain token over a generic chart or status color:
+
+| Token | Light value | Use |
+| --- | --- | --- |
+| `--status-active` | `oklch(0.72 0.17 145)` | Green — in use / valid warranty |
+| `--status-expiring` | `oklch(0.78 0.18 75)` | Amber — within 60 days |
+| `--status-expired` | `oklch(0.65 0.22 25)` | Red — past due |
+| `--status-none` | `oklch(0.6 0 0)` | Gray — no warranty |
+| `--chart-1` … `--chart-5` | warm amber → red | Data viz, tag pills |
+| `--tag-amber` … `--tag-muted` | tag-only palette | Tag pills (closed enum, not chart colors) |
+| `--sidebar` etc. | warm off-white | Sidebar surface — distinct from page bg |
+
+Resolve the domain via `commodityKeys`-style config maps; never inline
+the ternary at render:
+
+```ts
+WARRANTY_STATUS_CONFIG[status].color   // "text-status-active"
+WARRANTY_STATUS_CONFIG[status].bg      // "bg-status-active/10"
+WARRANTY_STATUS_CONFIG[status].label   // "Active" (i18n key in real code)
+```
+
+## Spacing patterns
+
+| Surface | Outer | Inner |
+| --- | --- | --- |
+| Page | `flex flex-col gap-6 p-6 max-w-2xl mx-auto w-full` (or `max-w-4xl` for list) | `space-y-5` inside cards |
+| Card | `rounded-xl border border-border bg-card p-6 space-y-5` | tight rows: `py-3.5` |
+| Stat card | `rounded-xl border border-border bg-card px-4 py-3 flex items-center gap-3` | icon `size-8` |
+| Stats row | `grid grid-cols-2 gap-4 lg:grid-cols-4` | — |
+| Settings rows | `divide-y divide-border` | each row `flex items-center justify-between py-3.5` |
+
+Rules:
+
+- **`gap-*` between siblings, `space-y-*` inside containers.** Never mix
+  `mt-*` and `mb-*` on individual children to get the same spacing — use
+  the parent's `gap` / `space-y`.
+- **`p-6` for cards, `py-3.5` for list rows.** These are the magic
+  numbers from the mock; don't drift.
+- **Don't introduce new spacing scales.** Tailwind's default scale (with
+  `0.5` increments) is enough. If you need 14px, use `py-3.5`, not a
+  custom token.
+
+## Typography
+
+shadcn provides no default element styles. Apply Tailwind classes
+explicitly:
+
+| Role | Classes |
+| --- | --- |
+| Page title (h1) | `scroll-m-20 text-3xl font-semibold tracking-tight` |
+| Section heading (h2) | `text-base font-semibold` |
+| Body | `text-sm leading-relaxed` |
+| Muted | `text-sm text-muted-foreground` |
+| Overline | `text-xs font-semibold uppercase tracking-widest text-muted-foreground` |
+| Stat value | `text-2xl font-bold tracking-tight` |
+| Code / mono | `font-mono text-xs` |
+
+Use them in this exact form so the visual rhythm stays consistent across
+pages. The mock at `denisvmedia/inventario-design` lists more — mirror them
+when adding a new role.
+
+## `tw-animate-css`, not `@tailwindcss/animate`
+
+The mock left `@tailwindcss/animate` behind. We use `tw-animate-css`
+(imported at the top of `index.css`) for `animate-in`, `animate-out`,
+`fade-in-0`, `slide-in-from-top-2`, etc. Never install the legacy package.
+
+## No drop shadows
+
+The visual language uses borders, not shadows. The one exception is
+`shadow-xs` on inputs (built into the shadcn `Input` primitive). Don't
+add `shadow-md` / `shadow-lg` anywhere — when you reach for one, you
+probably want a heavier border or a `border-border/60` subtle outline.
+
+## Do / don't
+
+| Do | Don't |
+| --- | --- |
+| `text-status-active` | `text-green-500` |
+| `bg-chart-1/15 text-chart-1` | `bg-amber-100 text-amber-700` |
+| `text-destructive` | `text-red-500` |
+| Add a token in `index.css` (both modes) | Hardcode `oklch(...)` in a component |
+| `cn(base, conditional)` | `` `${base} ${cond ? "…" : ""}` `` |
+| `gap-6` between sections | `mt-6` then `mb-6` |
+| `rounded-lg` (card), `rounded-xl` (large) | Pixel-perfect `rounded-[10px]` |
+| Borders for elevation | Drop shadows |
+| One color from the warm-amber palette | Purple / indigo / violet — **the theme has no purple** |
+
+## Adding a new token
+
+When the design genuinely needs a new color (a new status, a new chart
+slot):
+
+1. Add the OKLCH value to `:root` in `frontend/src/index.css`.
+2. Add the dark-mode value to `.dark` in the same file.
+3. Register it in `@theme inline` as `--color-<name>: var(--<name>);`.
+4. Mirror the change in `denisvmedia/inventario-design/src/index.css` so
+   the mock and the app stay in lockstep. Reference the mock PR in the
+   Inventario PR.
+5. Use the new token via the Tailwind utility (`text-<name>`,
+   `bg-<name>`, `border-<name>`).

--- a/devdocs/frontend/styles-and-tokens.md
+++ b/devdocs/frontend/styles-and-tokens.md
@@ -1,8 +1,8 @@
 # Styles and tokens
 
-Tailwind v4 + OKLCH tokens. The visual contract is canonical at
-`denisvmedia/inventario-design/CLAUDE.md`; this doc covers the Inventario
-codebase's translation and the rules every PR must respect.
+Tailwind v4 + OKLCH tokens. The visual contract is canonical in the
+internal design mock; this doc covers the Inventario codebase's
+translation and the rules every PR must respect.
 
 ## Tailwind v4 setup
 
@@ -176,7 +176,7 @@ explicitly:
 | Code / mono | `font-mono text-xs` |
 
 Use them in this exact form so the visual rhythm stays consistent across
-pages. The mock at `denisvmedia/inventario-design` lists more — mirror them
+pages. The design mock lists more — mirror them
 when adding a new role.
 
 ## `tw-animate-css`, not `@tailwindcss/animate`
@@ -214,7 +214,7 @@ slot):
 1. Add the OKLCH value to `:root` in `frontend/src/index.css`.
 2. Add the dark-mode value to `.dark` in the same file.
 3. Register it in `@theme inline` as `--color-<name>: var(--<name>);`.
-4. Mirror the change in `denisvmedia/inventario-design/src/index.css` so
+4. Mirror the change in the internal design mock's `src/index.css` so
    the mock and the app stay in lockstep. Reference the mock PR in the
    Inventario PR.
 5. Use the new token via the Tailwind utility (`text-<name>`,

--- a/devdocs/frontend/testing.md
+++ b/devdocs/frontend/testing.md
@@ -125,7 +125,7 @@ Enforced in `vitest.config.ts` — CI fails if coverage drops below:
 
 Excluded paths:
 
-- `src/components/ui/**` — vendored shadcn primitives owned by the design mock.
+- `src/components/ui/**` — vendored shadcn primitives, owned upstream by shadcn.
 - `src/app/**` — composition-only (router, providers, App, Shell). Covered by Playwright (#1419).
 - `src/components/{AppSidebar,CommandPalette,GroupSelector}.tsx` — composite shell components; integration coverage lands with #1419 / #1414.
 - `src/i18n/i18next.config.ts` — lazy backend for cs/ru exercised by the Settings page locale toggle (#1414).


### PR DESCRIPTION
Closes #1424. Last open issue of epic #1397.

## Summary

Replaces the deprecated `devdocs/frontend/` tree with documentation that
reflects the actual React 19 + Tailwind v4 + shadcn/ui stack, and adds a
23-document design-direction brief modeled on the structure of #1362
(content fully rewritten for the React reality).

## What's in this PR

### Top-level engineering docs (per #1424 AC)

`devdocs/frontend/`:

- `README.md` — index + scope (and one row pointing at `design/README.md`).
- `coding-standards.md` — TS strict, naming, file structure, import order, console policy, formatting.
- `components.md` — `components/ui` (vendored shadcn) vs `components/` vs `features/<x>` rules; variants via `cva`.
- `styles-and-tokens.md` — Tailwind v4 `@theme`, OKLCH tokens, dark mode, density.
- `forms.md` — `react-hook-form` + zod patterns, server-error normalization via `parseServerError`.
- `icons.md` — `lucide-react` only; size scale; `aria-hidden` defaults.
- `accessibility.md` — focus rings, label/htmlFor, modal a11y via Radix, contrast, reduced motion.
- `data.md` — TanStack Query keys, mutations, optimistic updates, group-scoped key shape.
- `routing.md` — `react-router-dom` v7, group context, route guards.
- `i18n.md` — `react-i18next`, locale fallback, formatters, `preservePatterns`.
- `imports-and-bans.md` — the deps the React app deliberately doesn't ship (`next-themes`, `@base-ui/react`, FontAwesome, Bolt artifacts) plus an opt-in `no-restricted-imports` recipe.
- `migration-conventions.md` — supersedes the strangler-fig recipe with the dual-frontend coexistence model and cutover record.
- `pr-checklist.md` — copy-paste FE PR checklist.

The pre-existing `testing.md`, `perf.md`, `screenshots.md` (already React-aware) are kept as-is.

### Design-direction brief (modeled on #1362)

`devdocs/frontend/design/` — 23 docs + a hub README. Used PR #1362 as the
**structural** reference (taste-locked / floor / recommendation framing,
six-section hub index, three-bucket close, sibling refs as bare filenames
in backticks) and rewrote every page for the actual React reality:

- Palette: warm-neutral OKLCH + amber accents (not cream + navy + terracotta).
- Typography: **system font stack** (no Google Fonts, no Switzer + Inter).
- Iconography: **`lucide-react`** (the Phosphor proposal in #1362 is dropped).
- Components: **shadcn/ui** + Radix via the `radix-ui` umbrella (not Reka UI).
- Motion: `tw-animate-css` only.
- Density: comfortable / cozy / compact triple, mirrored on `<html data-density>`.
- File & media: the four-category model (Photos / Invoices / Documents / Other).
- Branding: the bracket-cube `AppLogo` is the shipping mark.

The hub at `devdocs/frontend/design/README.md` groups the 23 docs into six
sections (Foundation / Visual language / Interaction & components / Content
& language / Quality bars / Adaptation / Production assets) and locks the
seven taste decisions for the React rewrite.

## Why a separate `design/` subfolder

Per the user's direction (`Возьми ещё вот этот PR как инспирацию: ...`):
PR #1362 was structurally what we want, just outdated. Adapting to the
React stack means keeping the engineering-hygiene docs at the top level
(per the issue's AC) and putting the design-brief docs one level down at
`design/`, exactly as #1362 did.

## What this PR doesn't change

- No code changes — `git diff master..HEAD -- frontend/ go/ e2e/` is empty.
- No tests required.
- No CI workflows expected to run beyond markdown / link-check if configured.

## Test plan

- [ ] Markdown renders correctly on GitHub (no broken cross-links, fenced code blocks intact)
- [ ] Top-level `devdocs/frontend/README.md` and `devdocs/frontend/design/README.md` indices both resolve
- [ ] Sibling refs inside `design/` use backtick-wrapped bare filenames (e.g. `02-typography.md`) — verified
- [ ] Cross-refs to engineering docs use sibling-relative links from `design/` (e.g. `../accessibility.md`) — verified
- [ ] No engineering changes — verified
- [ ] No `forwardRef`, no `hsl()` wrappers, no `@tailwindcss/animate` references in the new docs (mock invariants mirrored verbatim)
- [ ] No stale Vue / PrimeVue / PrimeIcons / FontAwesome / SCSS references in any new doc

## Notes for reviewers

- The brief is intentionally opinionated. Every doc carries a one-line
  commitment (`committed`, `floor`, `recommendation`, `proposal`) up
  front — that's the contract surface; the body explains why.
- Where the design contract overlaps with engineering rules
  (accessibility, i18n, components), the engineering doc is the
  implementation contract and the `design/` doc is the design contract;
  they cite each other.
- The `imports-and-bans.md` lint snippet is offered as a future
  tightening, not wired in this PR.
- "Sprint 0" / "out of scope" callouts on the hub are cumulative for
  the React rewrite (epic #1397) — they record where the rewrite
  landed; they are not a forward-looking work plan.