### PR TITLE
[#1507] Loan→audit-timeline integration

### DIFF
--- a/e2e/tests/loans.spec.ts
+++ b/e2e/tests/loans.spec.ts
@@ -129,6 +129,18 @@ test.describe('Commodity loans — lend out + return round-trip', () => {
       await expect(
         page.locator('[data-testid^="lent-row-"]', { hasText: commodityName }),
       ).toHaveCount(0, { timeout: 15000 })
+
+      // 7) Audit timeline (#1507): the History card on the Details
+      //    tab must show both the lent_out and returned events emitted
+      //    by the loan service. Order is newest-first, so `returned`
+      //    comes before `lent_out`.
+      await page.goto(
+        `/g/${encodeURIComponent(group.slug)}/commodities/${encodeURIComponent(commodityID)}`,
+      )
+      await page.getByRole('tab', { name: /^Details$/ }).click()
+      await expect(page.getByTestId('commodity-detail-history')).toBeVisible()
+      await expect(page.getByTestId('history-row-lent_out')).toContainText(borrowerName)
+      await expect(page.getByTestId('history-row-returned')).toContainText(/Marked returned/i)
     } finally {
       await cleanup()
     }

--- a/e2e/utils/axe.ts
+++ b/e2e/utils/axe.ts
@@ -28,6 +28,41 @@ interface AxeAuditOptions {
 }
 
 /**
+ * Wait for every CSS animation / transition currently running on the
+ * document to finish before letting axe sample colors. Capped to keep a
+ * runaway animation from hanging the suite — anything that takes more
+ * than 1s to settle is a real bug worth catching another way.
+ *
+ * Why this matters: webkit reports color-contrast violations on Radix
+ * dropdowns when axe runs while the menu is mid-fade-in (the items'
+ * effective foreground is `rgba(text, ~0.2)`, which composites against
+ * the background to ~#cdcbc8 / #cfcecd → 1.56:1 contrast, well below
+ * AA's 4.5:1). Chromium and Firefox happen to schedule axe AFTER the
+ * fade completes; webkit lands inside the animation. Pre-existing flake
+ * across multiple specs (commodity-bulk-and-filter type-filter +
+ * sort-by-registered-date, see CI run 25370390043 on PR #1515) — the
+ * earlier `data-state="open"` scope tightening covered the close-edge
+ * but not the open-edge. Fix the root cause once, in the shared utility.
+ */
+async function waitForAnimations(page: Page, timeoutMs = 1000): Promise<void> {
+  await page.evaluate(
+    (timeout) =>
+      new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, timeout);
+        Promise.all(
+          document
+            .getAnimations()
+            .map((a) => a.finished.catch(() => undefined)),
+        ).then(() => {
+          clearTimeout(timer);
+          resolve();
+        });
+      }),
+    timeoutMs,
+  );
+}
+
+/**
  * Run an axe audit against the current page and assert no violations of
  * the configured severity. Wire this into every page-level spec — `@axe`
  * is part of the issue #1419 acceptance criteria. The default severity
@@ -37,6 +72,10 @@ interface AxeAuditOptions {
  */
 export async function axeAudit(page: Page, options: AxeAuditOptions = {}): Promise<void> {
   const failOnImpact = options.failOnImpact ?? ['serious', 'critical'];
+
+  // Settle CSS animations / transitions before sampling colors — see
+  // waitForAnimations comment for the webkit dropdown background.
+  await waitForAnimations(page);
 
   let builder = new AxeBuilder({ page });
   if (options.include) {

--- a/frontend/i18next.config.ts
+++ b/frontend/i18next.config.ts
@@ -101,6 +101,13 @@ export default defineConfig({
       "commodities:status.*",
       "commodities:sort.*",
       "commodities:warranty.*",
+      // commodities:detail.historyEvent.loanField.* — built from
+      //   `t(\`commodities:detail.historyEvent.loanField.${key}\`)` over
+      //   the four mutable loan fields (borrower_name, borrower_contact,
+      //   borrower_note, due_back_at) that snapshotLoanDiff persists
+      //   in the BE event payload. Dynamic keys; the extractor can't
+      //   see the literals.
+      "commodities:detail.historyEvent.loanField.*",
       // commodities:bulk.{deleteTitle,deleteDescription,selected,
       //   bulkDeleted,bulkMoved,moveTitle,moveDescription,subtitle}_one /
       //   _other — i18next pluralization suffixes. The list/dialog code

--- a/frontend/src/features/commodities/CommodityHistoryTimeline.tsx
+++ b/frontend/src/features/commodities/CommodityHistoryTimeline.tsx
@@ -278,9 +278,7 @@ function labelFor(
         return t("commodities:detail.historyEvent.loanUpdatedLabel")
       }
       const labels = fields
-        .map((key) =>
-          t(`commodities:detail.historyEvent.loanField.${key}`, { defaultValue: key })
-        )
+        .map((key) => t(`commodities:detail.historyEvent.loanField.${key}`, { defaultValue: key }))
         .join(", ")
       return t("commodities:detail.historyEvent.loanUpdatedLabelFields", {
         fields: labels,
@@ -294,9 +292,10 @@ function labelFor(
 }
 
 // changedLoanFields lists the keys whose values differ between a
-// loan_updated event's before and after payloads. Order matches
-// snapshotLoanDiff on the BE so the rendered list is stable across
-// kinds and locales.
+// loan_updated event's before and after payloads. The fixed `keys`
+// array fixes the rendered order — the BE payload is a Go map (no
+// guaranteed key order), so we anchor stability here rather than
+// relying on insertion order on the wire.
 function changedLoanFields(
   before: Record<string, unknown> | undefined,
   after: Record<string, unknown> | undefined

--- a/frontend/src/features/commodities/CommodityHistoryTimeline.tsx
+++ b/frontend/src/features/commodities/CommodityHistoryTimeline.tsx
@@ -10,7 +10,18 @@
 
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { CheckCircle2, CircleDot, ImagePlus, MapPin, Pencil, Plus, Tag, Trash2 } from "lucide-react"
+import {
+  CheckCircle2,
+  CircleDot,
+  HandHelping,
+  ImagePlus,
+  MapPin,
+  PackageCheck,
+  Pencil,
+  Plus,
+  Tag,
+  Trash2,
+} from "lucide-react"
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -175,6 +186,12 @@ function iconFor(kind: CommodityEventKind) {
       return Tag
     case "cover_changed":
       return ImagePlus
+    case "lent_out":
+      return HandHelping
+    case "returned":
+      return PackageCheck
+    case "loan_updated":
+      return Pencil
     case "updated":
       return Pencil
     default:
@@ -229,11 +246,68 @@ function labelFor(
         ? t("commodities:detail.historyEvent.coverChangedLabelSet")
         : t("commodities:detail.historyEvent.coverChangedLabelCleared")
     }
+    case "lent_out": {
+      const borrower = stringField(ev.after, "borrower_name")
+      const dueBack = stringField(ev.after, "due_back_at")
+      if (borrower && dueBack) {
+        return t("commodities:detail.historyEvent.lentOutLabelDue", {
+          borrower,
+          dueBack,
+        })
+      }
+      if (borrower) {
+        return t("commodities:detail.historyEvent.lentOutLabel", { borrower })
+      }
+      return t("commodities:detail.historyEvent.lentOutLabelGeneric")
+    }
+    case "returned": {
+      const returnedAt = stringField(ev.after, "returned_at")
+      if (returnedAt) {
+        return t("commodities:detail.historyEvent.returnedLabelOn", {
+          returnedAt,
+        })
+      }
+      return t("commodities:detail.historyEvent.returnedLabel")
+    }
+    case "loan_updated": {
+      const fields = changedLoanFields(ev.before, ev.after)
+      if (fields.length === 0) {
+        // Defensive: BE skips no-op patches, but if a row sneaks
+        // through (older client / hand-edited DB), show the generic
+        // copy rather than an empty diff.
+        return t("commodities:detail.historyEvent.loanUpdatedLabel")
+      }
+      const labels = fields
+        .map((key) =>
+          t(`commodities:detail.historyEvent.loanField.${key}`, { defaultValue: key })
+        )
+        .join(", ")
+      return t("commodities:detail.historyEvent.loanUpdatedLabelFields", {
+        fields: labels,
+      })
+    }
     case "updated":
       return t("commodities:detail.historyEvent.updatedLabel")
     default:
       return t("commodities:detail.historyEvent.updatedLabel")
   }
+}
+
+// changedLoanFields lists the keys whose values differ between a
+// loan_updated event's before and after payloads. Order matches
+// snapshotLoanDiff on the BE so the rendered list is stable across
+// kinds and locales.
+function changedLoanFields(
+  before: Record<string, unknown> | undefined,
+  after: Record<string, unknown> | undefined
+): string[] {
+  if (!before || !after) return []
+  const keys = ["borrower_name", "borrower_contact", "borrower_note", "due_back_at"]
+  const out: string[] = []
+  for (const k of keys) {
+    if (before[k] !== after[k]) out.push(k)
+  }
+  return out
 }
 
 // stringField pulls a string-typed field from a sparse before/after

--- a/frontend/src/features/commodities/__tests__/CommodityHistoryTimeline.test.tsx
+++ b/frontend/src/features/commodities/__tests__/CommodityHistoryTimeline.test.tsx
@@ -219,7 +219,9 @@ describe("<CommodityHistoryTimeline />", () => {
       /Loan updated:.*borrower contact.*borrower note/i
     )
     // returned shows the returned_at date.
-    expect(screen.getByTestId("history-row-returned")).toHaveTextContent(/Marked returned on 2026-05-20/i)
+    expect(screen.getByTestId("history-row-returned")).toHaveTextContent(
+      /Marked returned on 2026-05-20/i
+    )
   })
 
   it("renders cover-changed cleared label when after.cover_file_id is empty", async () => {

--- a/frontend/src/features/commodities/__tests__/CommodityHistoryTimeline.test.tsx
+++ b/frontend/src/features/commodities/__tests__/CommodityHistoryTimeline.test.tsx
@@ -151,6 +151,77 @@ describe("<CommodityHistoryTimeline />", () => {
     )
   })
 
+  it("renders kind-aware copy for loan lifecycle events", async () => {
+    const rows: CommodityEventFixture[] = [
+      {
+        id: "l1",
+        kind: "lent_out",
+        occurred_at: "2026-05-01T10:30:00Z",
+        after: {
+          loan_id: "ln1",
+          borrower_name: "Alice",
+          lent_at: "2026-05-01",
+          due_back_at: "2026-06-01",
+        },
+        meta: { actor },
+      },
+      {
+        id: "l2",
+        kind: "lent_out",
+        occurred_at: "2026-04-15T10:00:00Z",
+        // No due_back_at — open-ended loan path.
+        after: { loan_id: "ln2", borrower_name: "Bob", lent_at: "2026-04-15" },
+        meta: { actor },
+      },
+      {
+        id: "l3",
+        kind: "loan_updated",
+        occurred_at: "2026-05-10T10:00:00Z",
+        before: {
+          loan_id: "ln1",
+          borrower_name: "Alice",
+          borrower_contact: "alice@old.example.com",
+          borrower_note: "",
+          due_back_at: "2026-06-01",
+        },
+        after: {
+          loan_id: "ln1",
+          borrower_name: "Alice",
+          borrower_contact: "alice@new.example.com",
+          borrower_note: "back office",
+          due_back_at: "2026-06-01",
+        },
+        meta: { actor },
+      },
+      {
+        id: "l4",
+        kind: "returned",
+        occurred_at: "2026-05-20T10:00:00Z",
+        after: { loan_id: "ln1", returned_at: "2026-05-20" },
+        meta: { actor },
+      },
+    ]
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.events(SLUG, COMMODITY_ID, rows)
+    )
+
+    renderTimeline()
+    // First lent_out row carries borrower + due-back date.
+    const lentOutRows = await screen.findAllByTestId("history-row-lent_out")
+    expect(lentOutRows[0]).toHaveTextContent(/Lent out to Alice \(due back 2026-06-01\)/i)
+    // Second lent_out row (open-ended) renders just the borrower name.
+    expect(lentOutRows[1]).toHaveTextContent(/Lent out to Bob/i)
+    expect(lentOutRows[1]).not.toHaveTextContent(/due back/i)
+    // loan_updated lists the changed field labels.
+    expect(screen.getByTestId("history-row-loan_updated")).toHaveTextContent(
+      /Loan updated:.*borrower contact.*borrower note/i
+    )
+    // returned shows the returned_at date.
+    expect(screen.getByTestId("history-row-returned")).toHaveTextContent(/Marked returned on 2026-05-20/i)
+  })
+
   it("renders cover-changed cleared label when after.cover_file_id is empty", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),

--- a/frontend/src/features/commodities/api.ts
+++ b/frontend/src/features/commodities/api.ts
@@ -254,9 +254,10 @@ export async function setCommodityCover(
   }
 }
 
-// CommodityEventKind mirrors the BE enum (issue #1450). Keep in sync with
-// `models.CommodityEventKind` — the FE renders kind-aware copy off this
-// union and unknown kinds fall through to a generic "updated" line.
+// CommodityEventKind mirrors the BE enum (issues #1450 + #1507). Keep in
+// sync with `models.CommodityEventKind` — the FE renders kind-aware copy
+// off this union and unknown kinds fall through to a generic "updated"
+// line.
 export type CommodityEventKind =
   | "created"
   | "updated"
@@ -264,6 +265,9 @@ export type CommodityEventKind =
   | "moved"
   | "price_changed"
   | "cover_changed"
+  | "lent_out"
+  | "returned"
+  | "loan_updated"
   | "deleted"
 
 export interface CommodityEventActor {

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -58,8 +58,21 @@
       "coverChangedLabelSet": "Set cover photo",
       "createdLabel": "Added this item",
       "deletedLabel": "Deleted this item",
+      "lentOutLabel": "Lent out to {{borrower}}",
+      "lentOutLabelDue": "Lent out to {{borrower}} (due back {{dueBack}})",
+      "lentOutLabelGeneric": "Lent out",
+      "loanField": {
+        "borrower_contact": "borrower contact",
+        "borrower_name": "borrower name",
+        "borrower_note": "borrower note",
+        "due_back_at": "due back date"
+      },
+      "loanUpdatedLabel": "Loan updated",
+      "loanUpdatedLabelFields": "Loan updated: {{fields}}",
       "movedLabel": "Moved to a new area",
       "priceChangedLabel": "Price changed",
+      "returnedLabel": "Marked returned",
+      "returnedLabelOn": "Marked returned on {{returnedAt}}",
       "statusChangedFromLabel": "Status: {{from}} → {{to}}",
       "statusChangedLabel": "Marked as {{to}}",
       "updatedLabel": "Edited this item"

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -5784,7 +5784,7 @@ export type components = {
             uuid?: string;
         };
         /** @enum {string} */
-        "models.CommodityEventKind": "created" | "updated" | "status_changed" | "moved" | "price_changed" | "cover_changed" | "deleted";
+        "models.CommodityEventKind": "created" | "updated" | "status_changed" | "moved" | "price_changed" | "cover_changed" | "lent_out" | "returned" | "loan_updated" | "deleted";
         "models.CommodityEventPayload": {
             [key: string]: unknown;
         };

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -6688,6 +6688,9 @@ const docTemplate = `{
                 "moved",
                 "price_changed",
                 "cover_changed",
+                "lent_out",
+                "returned",
+                "loan_updated",
                 "deleted"
             ],
             "x-enum-varnames": [
@@ -6697,6 +6700,9 @@ const docTemplate = `{
                 "CommodityEventKindMoved",
                 "CommodityEventKindPriceChanged",
                 "CommodityEventKindCoverChanged",
+                "CommodityEventKindLentOut",
+                "CommodityEventKindReturned",
+                "CommodityEventKindLoanUpdated",
                 "CommodityEventKindDeleted"
             ]
         },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -6681,6 +6681,9 @@
                 "moved",
                 "price_changed",
                 "cover_changed",
+                "lent_out",
+                "returned",
+                "loan_updated",
                 "deleted"
             ],
             "x-enum-varnames": [
@@ -6690,6 +6693,9 @@
                 "CommodityEventKindMoved",
                 "CommodityEventKindPriceChanged",
                 "CommodityEventKindCoverChanged",
+                "CommodityEventKindLentOut",
+                "CommodityEventKindReturned",
+                "CommodityEventKindLoanUpdated",
                 "CommodityEventKindDeleted"
             ]
         },

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1591,6 +1591,9 @@ definitions:
     - moved
     - price_changed
     - cover_changed
+    - lent_out
+    - returned
+    - loan_updated
     - deleted
     type: string
     x-enum-varnames:
@@ -1600,6 +1603,9 @@ definitions:
     - CommodityEventKindMoved
     - CommodityEventKindPriceChanged
     - CommodityEventKindCoverChanged
+    - CommodityEventKindLentOut
+    - CommodityEventKindReturned
+    - CommodityEventKindLoanUpdated
     - CommodityEventKindDeleted
   models.CommodityEventPayload:
     additionalProperties: {}

--- a/go/models/commodity_event.go
+++ b/go/models/commodity_event.go
@@ -34,6 +34,19 @@ const (
 	// CommodityEventKindCoverChanged is emitted when the cover_file_id override
 	// is set or cleared.
 	CommodityEventKindCoverChanged CommodityEventKind = "cover_changed"
+	// CommodityEventKindLentOut is emitted when a commodity is lent out
+	// (a new commodity_loans row is created with returned_at NULL). After
+	// holds the borrower-facing fields; before is null. See #1507.
+	CommodityEventKindLentOut CommodityEventKind = "lent_out"
+	// CommodityEventKindReturned is emitted when an open loan closes
+	// (returned_at flips from null to a date). Carries the loan id and
+	// the returned_at date for kind-aware FE copy.
+	CommodityEventKindReturned CommodityEventKind = "returned"
+	// CommodityEventKindLoanUpdated is emitted when a loan's mutable
+	// fields change (borrower_contact / borrower_note / due_back_at). The
+	// service skips no-op patches so this event only lands when something
+	// actually changed — same gate as EmitUpdated for commodities.
+	CommodityEventKindLoanUpdated CommodityEventKind = "loan_updated"
 	// CommodityEventKindDeleted is emitted right before a commodity is deleted.
 	// Persisted so the event row is still in the table when the commodity row
 	// is removed in the same transaction; ON DELETE CASCADE then drops it. The
@@ -50,6 +63,9 @@ func (k CommodityEventKind) IsValid() bool {
 		CommodityEventKindMoved,
 		CommodityEventKindPriceChanged,
 		CommodityEventKindCoverChanged,
+		CommodityEventKindLentOut,
+		CommodityEventKindReturned,
+		CommodityEventKindLoanUpdated,
 		CommodityEventKindDeleted:
 		return true
 	}

--- a/go/models/commodity_event_test.go
+++ b/go/models/commodity_event_test.go
@@ -1,0 +1,50 @@
+package models_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+)
+
+func TestCommodityEventKind_IsValid(t *testing.T) {
+	// Locks the IsValid switch against future enum additions: a new
+	// constant added without an entry in the switch will fail this
+	// table because IsValid would return false.
+	cases := []struct {
+		kind models.CommodityEventKind
+		want bool
+	}{
+		{models.CommodityEventKindCreated, true},
+		{models.CommodityEventKindUpdated, true},
+		{models.CommodityEventKindStatusChanged, true},
+		{models.CommodityEventKindMoved, true},
+		{models.CommodityEventKindPriceChanged, true},
+		{models.CommodityEventKindCoverChanged, true},
+		{models.CommodityEventKindLentOut, true},
+		{models.CommodityEventKindReturned, true},
+		{models.CommodityEventKindLoanUpdated, true},
+		{models.CommodityEventKindDeleted, true},
+		{"", false},
+		{"unknown", false},
+		{"LENT_OUT", false}, // case-sensitive — wire format is lowercase
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(tc.kind.IsValid(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestCommodityEventKind_Validate(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(models.CommodityEventKindLentOut.Validate(), qt.IsNil)
+	c.Assert(models.CommodityEventKindReturned.Validate(), qt.IsNil)
+	c.Assert(models.CommodityEventKindLoanUpdated.Validate(), qt.IsNil)
+
+	err := models.CommodityEventKind("nope").Validate()
+	c.Assert(err, qt.IsNotNil)
+}

--- a/go/services/commodity_event_service.go
+++ b/go/services/commodity_event_service.go
@@ -131,6 +131,58 @@ func (s *CommodityEventService) EmitDeleted(ctx context.Context, before *models.
 	s.emit(ctx, before.ID, models.CommodityEventKindDeleted, snapshotCreated(before), nil)
 }
 
+// EmitLoanStarted records a "lent_out" event when a new loan opens. The
+// after payload carries the borrower-facing fields the timeline UI
+// renders ("Lent out to X on Y, due back Z"); before is null since this
+// is the first observation of the loan.
+func (s *CommodityEventService) EmitLoanStarted(ctx context.Context, loan *models.CommodityLoan) {
+	if s == nil || loan == nil {
+		return
+	}
+	s.emit(ctx, loan.CommodityID, models.CommodityEventKindLentOut,
+		nil,
+		snapshotLoanLifecycle(loan),
+	)
+}
+
+// EmitLoanReturned records a "returned" event when an open loan closes.
+// after carries the returned_at + identifying fields so the timeline can
+// render "Marked returned on Z" without joining back to commodity_loans.
+// before is null on this kind — the loan's identity hasn't changed,
+// only its terminal state, and surfacing a sparse diff would just be
+// noise.
+func (s *CommodityEventService) EmitLoanReturned(ctx context.Context, loan *models.CommodityLoan) {
+	if s == nil || loan == nil {
+		return
+	}
+	s.emit(ctx, loan.CommodityID, models.CommodityEventKindReturned,
+		nil,
+		snapshotLoanLifecycle(loan),
+	)
+}
+
+// EmitLoanUpdated records a "loan_updated" event when one or more
+// mutable loan fields change (borrower_contact / borrower_note /
+// due_back_at). When nothing actually changed the call is a no-op —
+// same gate as EmitUpdated for commodities, so idempotent PATCHes don't
+// pollute the timeline.
+//
+// borrower_name is included in the snapshot for traceability even
+// though the service rejects renames; that way the FE can render a
+// human-readable "X's loan updated" line without a join.
+func (s *CommodityEventService) EmitLoanUpdated(ctx context.Context, before, after *models.CommodityLoan) {
+	if s == nil || before == nil || after == nil {
+		return
+	}
+	if !loanFieldsChanged(before, after) {
+		return
+	}
+	s.emit(ctx, after.CommodityID, models.CommodityEventKindLoanUpdated,
+		snapshotLoanDiff(before),
+		snapshotLoanDiff(after),
+	)
+}
+
 // emit is the shared write path. Construction of the registry per-call is
 // cheap (it's just a wrapper around the shared dbx) and keeps the call
 // fully RLS-scoped to the current request's tenant + group + user.
@@ -280,6 +332,63 @@ func sliceStringsEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// snapshotLoanLifecycle captures the loan fields the timeline renders
+// for `lent_out` and `returned` events. Sparse on purpose — the FE only
+// formats the listed keys, and storing more would invite a schema-rev
+// trap (an unused key sticks in JSONB forever). Empty-string optionals
+// are dropped so the JSON object stays minimal.
+func snapshotLoanLifecycle(l *models.CommodityLoan) models.CommodityEventPayload {
+	p := models.CommodityEventPayload{
+		"loan_id":       l.ID,
+		"borrower_name": l.BorrowerName,
+		"lent_at":       string(l.LentAt),
+	}
+	if l.BorrowerContact != "" {
+		p["borrower_contact"] = l.BorrowerContact
+	}
+	if l.BorrowerNote != "" {
+		p["borrower_note"] = l.BorrowerNote
+	}
+	if l.DueBackAt != nil && *l.DueBackAt != "" {
+		p["due_back_at"] = string(*l.DueBackAt)
+	}
+	if l.ReturnedAt != nil && *l.ReturnedAt != "" {
+		p["returned_at"] = string(*l.ReturnedAt)
+	}
+	return p
+}
+
+// snapshotLoanDiff captures the fields the timeline renders for a
+// `loan_updated` diff. borrower_name is preserved so the FE can build
+// "X's loan updated" copy without a separate join, even though the
+// service rejects rename mutations.
+func snapshotLoanDiff(l *models.CommodityLoan) models.CommodityEventPayload {
+	p := models.CommodityEventPayload{
+		"loan_id":          l.ID,
+		"borrower_name":    l.BorrowerName,
+		"borrower_contact": l.BorrowerContact,
+		"borrower_note":    l.BorrowerNote,
+	}
+	if l.DueBackAt != nil {
+		p["due_back_at"] = string(*l.DueBackAt)
+	} else {
+		p["due_back_at"] = ""
+	}
+	return p
+}
+
+// loanFieldsChanged reports whether any of the mutable loan fields
+// shifted between before and after. Mirrors the EmitUpdated diff gate
+// for commodities — saves a no-op PATCH from polluting the timeline.
+func loanFieldsChanged(before, after *models.CommodityLoan) bool {
+	if before.BorrowerName != after.BorrowerName ||
+		before.BorrowerContact != after.BorrowerContact ||
+		before.BorrowerNote != after.BorrowerNote {
+		return true
+	}
+	return !equalPDate(before.DueBackAt, after.DueBackAt)
 }
 
 // urlsEqual compares two URL slices by their string forms — the order

--- a/go/services/commodity_event_service.go
+++ b/go/services/commodity_event_service.go
@@ -161,15 +161,12 @@ func (s *CommodityEventService) EmitLoanReturned(ctx context.Context, loan *mode
 	)
 }
 
-// EmitLoanUpdated records a "loan_updated" event when one or more
-// mutable loan fields change (borrower_contact / borrower_note /
-// due_back_at). When nothing actually changed the call is a no-op —
-// same gate as EmitUpdated for commodities, so idempotent PATCHes don't
-// pollute the timeline.
-//
-// borrower_name is included in the snapshot for traceability even
-// though the service rejects renames; that way the FE can render a
-// human-readable "X's loan updated" line without a join.
+// EmitLoanUpdated records a "loan_updated" event when one or more of
+// the patch-mutable loan fields change (borrower_name /
+// borrower_contact / borrower_note / due_back_at — see LoanUpdate in
+// commodity_loan_service.go). When nothing actually changed the call
+// is a no-op — same gate as EmitUpdated for commodities, so idempotent
+// PATCHes don't pollute the timeline.
 func (s *CommodityEventService) EmitLoanUpdated(ctx context.Context, before, after *models.CommodityLoan) {
 	if s == nil || before == nil || after == nil {
 		return
@@ -361,20 +358,31 @@ func snapshotLoanLifecycle(l *models.CommodityLoan) models.CommodityEventPayload
 }
 
 // snapshotLoanDiff captures the fields the timeline renders for a
-// `loan_updated` diff. borrower_name is preserved so the FE can build
-// "X's loan updated" copy without a separate join, even though the
-// service rejects rename mutations.
+// `loan_updated` diff. Sparse — empty-string optionals and nil
+// due_back_at are omitted, matching snapshotLoanLifecycle's "absent
+// key means unset" semantics. The FE's changedLoanFields uses `!==`
+// against a fixed key list so missing-vs-present and present-vs-empty
+// both register as a diff.
+//
+// loan_id and borrower_name are always present: loan_id keys the
+// event back to the source row, and borrower_name lets the FE render
+// "X's loan updated" copy without a join. borrower_name being empty
+// would itself be a meaningful change (the service permits it via
+// PATCH today) — but the registry rejects it on validation, so the
+// "always present" guarantee holds in practice.
 func snapshotLoanDiff(l *models.CommodityLoan) models.CommodityEventPayload {
 	p := models.CommodityEventPayload{
-		"loan_id":          l.ID,
-		"borrower_name":    l.BorrowerName,
-		"borrower_contact": l.BorrowerContact,
-		"borrower_note":    l.BorrowerNote,
+		"loan_id":       l.ID,
+		"borrower_name": l.BorrowerName,
 	}
-	if l.DueBackAt != nil {
+	if l.BorrowerContact != "" {
+		p["borrower_contact"] = l.BorrowerContact
+	}
+	if l.BorrowerNote != "" {
+		p["borrower_note"] = l.BorrowerNote
+	}
+	if l.DueBackAt != nil && *l.DueBackAt != "" {
 		p["due_back_at"] = string(*l.DueBackAt)
-	} else {
-		p["due_back_at"] = ""
 	}
 	return p
 }

--- a/go/services/commodity_event_service_test.go
+++ b/go/services/commodity_event_service_test.go
@@ -172,6 +172,146 @@ func TestCommodityEventService_EmitUpdated_GenericUpdate(t *testing.T) {
 	c.Assert(events[0].Kind, qt.Equals, models.CommodityEventKindUpdated)
 }
 
+func makeLoan(id, commodityID string, mutators ...func(*models.CommodityLoan)) *models.CommodityLoan {
+	due := models.Date("2026-06-01")
+	l := &models.CommodityLoan{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			EntityID: models.EntityID{ID: id},
+			TenantID: "tenant-1",
+			GroupID:  "group-1",
+		},
+		CommodityID:     commodityID,
+		BorrowerName:    "Alice",
+		BorrowerContact: "alice@example.com",
+		LentAt:          models.Date("2026-05-01"),
+		DueBackAt:       &due,
+	}
+	for _, m := range mutators {
+		m(l)
+	}
+	return l
+}
+
+func TestCommodityEventService_EmitLoanStarted(t *testing.T) {
+	c := qt.New(t)
+	ctx, svc, reg := newEventTestContext(c)
+
+	loan := makeLoan("loan-1", "c1")
+	svc.EmitLoanStarted(ctx, loan)
+
+	events, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 1)
+	c.Assert(events[0].Kind, qt.Equals, models.CommodityEventKindLentOut)
+	c.Assert(events[0].CommodityID, qt.Equals, "c1")
+	c.Assert(events[0].Before, qt.IsNil)
+	c.Assert(events[0].After["loan_id"], qt.Equals, "loan-1")
+	c.Assert(events[0].After["borrower_name"], qt.Equals, "Alice")
+	c.Assert(events[0].After["lent_at"], qt.Equals, "2026-05-01")
+	c.Assert(events[0].After["due_back_at"], qt.Equals, "2026-06-01")
+	c.Assert(events[0].After["borrower_contact"], qt.Equals, "alice@example.com")
+}
+
+func TestCommodityEventService_EmitLoanStarted_DropsEmptyOptionals(t *testing.T) {
+	// Empty-string contact / note / nil due-back must not appear in the
+	// JSONB payload — keeps the row minimal and avoids "" sneaking into
+	// FE conditionals that test for presence.
+	c := qt.New(t)
+	ctx, svc, reg := newEventTestContext(c)
+
+	loan := makeLoan("loan-1", "c1", func(l *models.CommodityLoan) {
+		l.BorrowerContact = ""
+		l.BorrowerNote = ""
+		l.DueBackAt = nil
+	})
+	svc.EmitLoanStarted(ctx, loan)
+
+	events, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 1)
+	_, hasContact := events[0].After["borrower_contact"]
+	_, hasNote := events[0].After["borrower_note"]
+	_, hasDue := events[0].After["due_back_at"]
+	c.Assert(hasContact, qt.IsFalse)
+	c.Assert(hasNote, qt.IsFalse)
+	c.Assert(hasDue, qt.IsFalse)
+}
+
+func TestCommodityEventService_EmitLoanReturned(t *testing.T) {
+	c := qt.New(t)
+	ctx, svc, reg := newEventTestContext(c)
+
+	returned := models.Date("2026-05-15")
+	loan := makeLoan("loan-1", "c1", func(l *models.CommodityLoan) {
+		l.ReturnedAt = &returned
+	})
+	svc.EmitLoanReturned(ctx, loan)
+
+	events, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 1)
+	c.Assert(events[0].Kind, qt.Equals, models.CommodityEventKindReturned)
+	c.Assert(events[0].After["loan_id"], qt.Equals, "loan-1")
+	c.Assert(events[0].After["returned_at"], qt.Equals, "2026-05-15")
+	c.Assert(events[0].Before, qt.IsNil)
+}
+
+func TestCommodityEventService_EmitLoanUpdated_NoChange(t *testing.T) {
+	// Saving a loan with the same field values must not emit — same
+	// idempotency gate as commodity EmitUpdated.
+	c := qt.New(t)
+	ctx, svc, reg := newEventTestContext(c)
+
+	before := makeLoan("loan-1", "c1")
+	after := makeLoan("loan-1", "c1")
+	svc.EmitLoanUpdated(ctx, before, after)
+
+	events, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 0)
+}
+
+func TestCommodityEventService_EmitLoanUpdated_FieldChange(t *testing.T) {
+	c := qt.New(t)
+	ctx, svc, reg := newEventTestContext(c)
+
+	before := makeLoan("loan-1", "c1")
+	after := makeLoan("loan-1", "c1", func(l *models.CommodityLoan) {
+		l.BorrowerContact = "alice@new.example.com"
+		l.BorrowerNote = "back office"
+	})
+	svc.EmitLoanUpdated(ctx, before, after)
+
+	events, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 1)
+	c.Assert(events[0].Kind, qt.Equals, models.CommodityEventKindLoanUpdated)
+	c.Assert(events[0].Before["borrower_contact"], qt.Equals, "alice@example.com")
+	c.Assert(events[0].After["borrower_contact"], qt.Equals, "alice@new.example.com")
+	c.Assert(events[0].After["borrower_note"], qt.Equals, "back office")
+}
+
+func TestCommodityEventService_EmitLoanUpdated_DueBackChange(t *testing.T) {
+	// due_back_at shifting between two non-nil dates must trigger an
+	// event — covers the equalPDate path used by loanFieldsChanged.
+	c := qt.New(t)
+	ctx, svc, reg := newEventTestContext(c)
+
+	before := makeLoan("loan-1", "c1")
+	newDue := models.Date("2026-07-01")
+	after := makeLoan("loan-1", "c1", func(l *models.CommodityLoan) {
+		l.DueBackAt = &newDue
+	})
+	svc.EmitLoanUpdated(ctx, before, after)
+
+	events, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 1)
+	c.Assert(events[0].Kind, qt.Equals, models.CommodityEventKindLoanUpdated)
+	c.Assert(events[0].Before["due_back_at"], qt.Equals, "2026-06-01")
+	c.Assert(events[0].After["due_back_at"], qt.Equals, "2026-07-01")
+}
+
 func TestCommodityEventService_EmitUpdated_CoverChangedTakesPrecedence(t *testing.T) {
 	// Cover-only edits emit a `cover_changed` row, not a generic update.
 	c := qt.New(t)

--- a/go/services/commodity_event_service_test.go
+++ b/go/services/commodity_event_service_test.go
@@ -291,6 +291,45 @@ func TestCommodityEventService_EmitLoanUpdated_FieldChange(t *testing.T) {
 	c.Assert(events[0].After["borrower_note"], qt.Equals, "back office")
 }
 
+func TestCommodityEventService_EmitLoanUpdated_DropsEmptyOptionals(t *testing.T) {
+	// Sparse-payload guarantee: empty borrower_contact / borrower_note
+	// and nil due_back_at must NOT appear as keys on either side of
+	// the diff. Same shape as snapshotLoanLifecycle so the FE's
+	// "key in payload" semantics stay consistent across kinds.
+	c := qt.New(t)
+	ctx, svc, reg := newEventTestContext(c)
+
+	before := makeLoan("loan-1", "c1", func(l *models.CommodityLoan) {
+		l.BorrowerContact = ""
+		l.BorrowerNote = ""
+		l.DueBackAt = nil
+	})
+	after := makeLoan("loan-1", "c1", func(l *models.CommodityLoan) {
+		l.BorrowerContact = ""
+		l.BorrowerNote = "back office"
+		l.DueBackAt = nil
+	})
+	svc.EmitLoanUpdated(ctx, before, after)
+
+	events, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 1)
+
+	_, beforeHasContact := events[0].Before["borrower_contact"]
+	_, beforeHasNote := events[0].Before["borrower_note"]
+	_, beforeHasDue := events[0].Before["due_back_at"]
+	c.Assert(beforeHasContact, qt.IsFalse)
+	c.Assert(beforeHasNote, qt.IsFalse)
+	c.Assert(beforeHasDue, qt.IsFalse)
+
+	_, afterHasContact := events[0].After["borrower_contact"]
+	_, afterHasDue := events[0].After["due_back_at"]
+	c.Assert(afterHasContact, qt.IsFalse)
+	c.Assert(afterHasDue, qt.IsFalse)
+	// borrower_note is non-empty on the `after` side and must be present.
+	c.Assert(events[0].After["borrower_note"], qt.Equals, "back office")
+}
+
 func TestCommodityEventService_EmitLoanUpdated_DueBackChange(t *testing.T) {
 	// due_back_at shifting between two non-nil dates must trigger an
 	// event — covers the equalPDate path used by loanFieldsChanged.

--- a/go/services/commodity_loan_service.go
+++ b/go/services/commodity_loan_service.go
@@ -43,10 +43,18 @@ var (
 // endpoint, agentic flow), revisit this.
 type CommodityLoanService struct {
 	factorySet *registry.FactorySet
+	// eventService writes lent_out / returned / loan_updated audit
+	// events into the per-commodity timeline (#1507). The event service
+	// is best-effort internally — a failed event write logs but does not
+	// roll back the loan operation.
+	eventService *CommodityEventService
 }
 
 func NewCommodityLoanService(factorySet *registry.FactorySet) *CommodityLoanService {
-	return &CommodityLoanService{factorySet: factorySet}
+	return &CommodityLoanService{
+		factorySet:   factorySet,
+		eventService: NewCommodityEventService(factorySet),
+	}
 }
 
 // StartLoan records a new open loan for the commodity.
@@ -94,6 +102,7 @@ func (s *CommodityLoanService) StartLoan(ctx context.Context, loan models.Commod
 	if err != nil {
 		return nil, nil, errxtrace.Wrap("failed to create loan", err)
 	}
+	s.eventService.EmitLoanStarted(ctx, created)
 	return created, nil, nil
 }
 
@@ -156,6 +165,7 @@ func (s *CommodityLoanService) UpdateLoan(ctx context.Context, id string, patch 
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to update loan", err)
 	}
+	s.eventService.EmitLoanUpdated(ctx, current, final)
 	return final, nil
 }
 
@@ -188,5 +198,6 @@ func (s *CommodityLoanService) MarkReturned(ctx context.Context, id string, retu
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to mark loan returned", err)
 	}
+	s.eventService.EmitLoanReturned(ctx, final)
 	return final, nil
 }

--- a/go/services/commodity_loan_service_test.go
+++ b/go/services/commodity_loan_service_test.go
@@ -1,0 +1,156 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// loanServiceFixture wires an in-memory FactorySet plus a user/group
+// context so the CommodityLoanService can run end-to-end. The events
+// registry returned alongside is service-mode (no user filter) so the
+// test can poll for whatever the service emitted regardless of who
+// triggered the call.
+type loanServiceFixture struct {
+	ctx     context.Context
+	factory *registry.FactorySet
+	loanSvc *services.CommodityLoanService
+	events  *memory.CommodityEventRegistry
+}
+
+func newLoanServiceFixture(c *qt.C) *loanServiceFixture {
+	c.Helper()
+
+	factorySet := memory.NewFactorySet()
+	user := &models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "user-1"},
+			TenantID: "tenant-1",
+		},
+		Email: "u@example.com",
+		Name:  "Tester",
+	}
+	ctx := appctx.WithUser(context.Background(), user)
+	ctx = appctx.WithGroup(ctx, &models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "group-1"},
+			TenantID: "tenant-1",
+		},
+	})
+
+	eventReg := factorySet.CommodityEventRegistryFactory.CreateServiceRegistry()
+	concrete, ok := eventReg.(*memory.CommodityEventRegistry)
+	c.Assert(ok, qt.IsTrue)
+
+	return &loanServiceFixture{
+		ctx:     ctx,
+		factory: factorySet,
+		loanSvc: services.NewCommodityLoanService(factorySet),
+		events:  concrete,
+	}
+}
+
+func (f *loanServiceFixture) startLoan(c *qt.C) *models.CommodityLoan {
+	c.Helper()
+	loan := models.CommodityLoan{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: "tenant-1",
+			GroupID:  "group-1",
+		},
+		CommodityID:     "c-1",
+		BorrowerName:    "Alice",
+		BorrowerContact: "alice@example.com",
+		LentAt:          models.Date("2026-05-01"),
+	}
+	created, existing, err := f.loanSvc.StartLoan(f.ctx, loan)
+	c.Assert(err, qt.IsNil)
+	c.Assert(existing, qt.IsNil)
+	c.Assert(created, qt.IsNotNil)
+	return created
+}
+
+func TestCommodityLoanService_StartLoan_EmitsLentOut(t *testing.T) {
+	c := qt.New(t)
+	fx := newLoanServiceFixture(c)
+
+	created := fx.startLoan(c)
+
+	events, err := fx.events.List(fx.ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 1)
+	c.Assert(events[0].Kind, qt.Equals, models.CommodityEventKindLentOut)
+	c.Assert(events[0].CommodityID, qt.Equals, "c-1")
+	c.Assert(events[0].After["loan_id"], qt.Equals, created.ID)
+	c.Assert(events[0].After["borrower_name"], qt.Equals, "Alice")
+}
+
+func TestCommodityLoanService_MarkReturned_EmitsReturned(t *testing.T) {
+	c := qt.New(t)
+	fx := newLoanServiceFixture(c)
+
+	created := fx.startLoan(c)
+
+	final, err := fx.loanSvc.MarkReturned(fx.ctx, created.ID, nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.IsOpen(), qt.IsFalse)
+
+	events, err := fx.events.List(fx.ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 2)
+	kinds := []models.CommodityEventKind{events[0].Kind, events[1].Kind}
+	c.Assert(kinds, qt.Contains, models.CommodityEventKindLentOut)
+	c.Assert(kinds, qt.Contains, models.CommodityEventKindReturned)
+}
+
+func TestCommodityLoanService_UpdateLoan_EmitsLoanUpdated(t *testing.T) {
+	c := qt.New(t)
+	fx := newLoanServiceFixture(c)
+
+	created := fx.startLoan(c)
+
+	newContact := "alice@new.example.com"
+	_, err := fx.loanSvc.UpdateLoan(fx.ctx, created.ID, services.LoanUpdate{
+		BorrowerContact: &newContact,
+	})
+	c.Assert(err, qt.IsNil)
+
+	events, err := fx.events.List(fx.ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 2)
+	updates := 0
+	for _, ev := range events {
+		if ev.Kind == models.CommodityEventKindLoanUpdated {
+			updates++
+		}
+	}
+	c.Assert(updates, qt.Equals, 1)
+}
+
+func TestCommodityLoanService_UpdateLoan_NoOpDoesNotEmit(t *testing.T) {
+	// PATCH with no-op (a present pointer that matches the current
+	// value) must not pollute the timeline. Locks the
+	// loanFieldsChanged gate.
+	c := qt.New(t)
+	fx := newLoanServiceFixture(c)
+
+	created := fx.startLoan(c)
+
+	sameContact := created.BorrowerContact
+	_, err := fx.loanSvc.UpdateLoan(fx.ctx, created.ID, services.LoanUpdate{
+		BorrowerContact: &sameContact,
+	})
+	c.Assert(err, qt.IsNil)
+
+	events, err := fx.events.List(fx.ctx)
+	c.Assert(err, qt.IsNil)
+	// Only the original lent_out emit; no loan_updated row.
+	c.Assert(events, qt.HasLen, 1)
+	c.Assert(events[0].Kind, qt.Equals, models.CommodityEventKindLentOut)
+}


### PR DESCRIPTION
Closes #1507.

Wire `CommodityLoanService` into `CommodityEventService` so lend / return / loan-edit operations land as `lent_out` / `returned` / `loan_updated` rows on the per-commodity History timeline. Both #1450 and #1452 cross-referenced this integration in their bodies but the wiring between the two PRs (#1505 + #1506) never landed.

## Summary

### Backend
- Extend `CommodityEventKind` with `lent_out` / `returned` / `loan_updated` + `IsValid` switch.
- Add `EmitLoanStarted` / `EmitLoanReturned` / `EmitLoanUpdated` on `CommodityEventService`. Sparse JSONB payloads (loan_id + borrower-facing fields, dropping empty optionals so the row stays minimal and FE conditionals can `key in payload` test cleanly).
- `EmitLoanUpdated` skips no-op patches via `loanFieldsChanged` — same idempotency gate as `EmitUpdated` for commodities, so saving a row with the same field values doesn't pollute the timeline.
- `CommodityLoanService` grows an internal `CommodityEventService` and emits after each successful registry write. Failures stay best-effort inside the event service (the loan write is not rolled back if the audit row hiccups — same discipline as `EmitCreated/Updated/Deleted`).

### Frontend
- Extend the FE `CommodityEventKind` union and `CommodityHistoryTimeline` with kind-aware copy / icons (HandHelping / PackageCheck / Pencil) for `lent_out` / `returned` / `loan_updated`.
- `changedLoanFields()` drives the `loan_updated` label off the diff keys the BE persists, so contact + note + due-back changes read distinctly ("Loan updated: borrower contact, due back date").
- en copy under `detail.historyEvent.*` + `detail.historyEvent.loanField.*`; cs/ru fall back to en (existing convention — both locale files are `{}` placeholders today, populated case-by-case).

### Tests
- `commodity_event_service_test.go`: cover `EmitLoanStarted` (full payload + empty-optional drop), `EmitLoanReturned`, `EmitLoanUpdated` (no-op skip + field-change + due-back-only path through `equalPDate`).
- `commodity_loan_service_test.go` (new): integration test through the in-memory FactorySet — `StartLoan` emits `lent_out`, `MarkReturned` emits `returned`, `UpdateLoan` emits `loan_updated`, no-op PATCH (present pointer matching the current value) does NOT emit.
- `CommodityHistoryTimeline.test.tsx`: cover `lent_out` (with + without due-back), `loan_updated` (lists changed fields), `returned` (with returned_at). Plus the existing axe-clean assertion still applies.
- `e2e/tests/loans.spec.ts`: after the existing lend → return roundtrip, switch to the Details tab and assert the History card shows both `history-row-lent_out` and `history-row-returned`. Locks the wire-up end-to-end against a real BE.

## Tradeoffs

- **`loan_updated` vs reusing `updated`**: chose a distinct kind because the FE renders kind-aware copy and the loan payload schema is meaningfully different from a commodity payload (loan_id, borrower_*, due_back_at). Mixing into `updated` would force the renderer to introspect payload keys to decide what kind of "edit" happened.
- **`audit_logs` vs `commodity_events`**: kept loans in `commodity_events`. `audit_logs` is reserved for security events (login, logout, password change). Loans are a domain event and belong on the per-commodity History tab.
- **Retroactive audit trail**: not in scope. Loans created before this PR have no events. The FE timeline already tolerates missing rows — old loans simply don't show audit entries.

## Test plan

- [ ] `go test ./services/ ./registry/memory/ -count=1` — green.
- [ ] `npx vitest run src/features/commodities src/components/loans` — green.
- [ ] `npx tsc --noEmit` — clean.
- [ ] `e2e/tests/loans.spec.ts` after deploy — lend → return → History tab shows both rows.
- [ ] Manual: open an existing commodity (no loan history), lend it out, confirm History card lists "Lent out to X (due back Y)"; mark returned, refresh, confirm "Marked returned on Z" appears as the newest row.