### PR TITLE
fix(e2e): wait for group-selector to settle past the placeholder

### DIFF
--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -828,9 +828,18 @@ test.describe('Group selection persistence (#1262 / #1300)', () => {
       await page.goto('/');
       await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
 
-      const displayedName = await page.locator('.group-selector__name').textContent();
-      expect(displayedName).not.toBe('Select Group');
-      expect(displayedName?.trim().length ?? 0).toBeGreaterThan(0);
+      // The trigger button mounts immediately and renders the
+      // common:shell.noActiveGroup placeholder ("Select a group") while the
+      // groupStore is still resolving the cold-start fallback. Reading
+      // textContent() right after waitForSelector is racy — the test was
+      // failing on Firefox (slower hydration) by reading the placeholder.
+      // Use auto-retrying not.toHaveText to wait for the real group name
+      // to land before sampling it.
+      const nameLocator = page.locator('.group-selector__name');
+      await expect(nameLocator).not.toHaveText(/^\s*Select a group\s*$/i, { timeout: 10000 });
+
+      const displayedName = (await nameLocator.textContent())?.trim() ?? '';
+      expect(displayedName.length).toBeGreaterThan(0);
 
       // Cross-check with the API: the resolved group really belongs to
       // the user. Guards against a bug where fallback picks a bogus


### PR DESCRIPTION
## Summary

Stabilises a chronic Firefox-only flake in `e2e/tests/groups.spec.ts` —
"Group selection persistence (#1262 / #1300) › cold start on / with no
preference falls back to an available group". Same assertion was failing
on PR #1514 (twice on Firefox-only) **and on master** (run 25329414814 on
commit c44903d):

```
Error: expect(received).toContain(expected)
  Expected value: "Select a group"
  Received array: ["Default"]
  at e2e/tests/groups.spec.ts:846 (now :855)
```

## Root cause

Two latent bugs in the test interacted:

1. `await page.waitForSelector('.group-selector', { state: 'visible' })`
   returns as soon as the trigger button mounts. But the button renders
   the `common:shell.noActiveGroup` placeholder — the literal string
   `"Select a group"` — until `groupStore` finishes resolving the
   cold-start fallback (i.e. picks the first-available group when
   `default_group_id` is null). Visibility ≠ hydrated. Firefox is just
   slow enough at hydrating that it loses the race more often;
   Chromium / WebKit happen to win it almost every time.
2. The defensive `expect(displayedName).not.toBe('Select Group')` on the
   following line had wrong casing (the actual placeholder is `"Select a
   group"`) so it never caught the placeholder state — the test relied
   on the cross-check on the next line to do the failing for it, which
   it duly did.

## Fix

Replace the synchronous `textContent()` read with an auto-retrying
`expect(locator).not.toHaveText(/^\s*Select a group\s*$/i, { timeout: 10000 })`,
which gives us a deterministic synchronisation point past hydration. Drop
the dead-string assertion. Sample `displayedName` only after the
placeholder has gone.

```ts
const nameLocator = page.locator('.group-selector__name');
await expect(nameLocator).not.toHaveText(/^\s*Select a group\s*$/i, { timeout: 10000 });

const displayedName = (await nameLocator.textContent())?.trim() ?? '';
expect(displayedName.length).toBeGreaterThan(0);
```

## Impact

- No app code change. `e2e/tests/groups.spec.ts` only.
- Behavioural guarantee being asserted is unchanged: cold-start fallback
  must still resolve to a real user group, not the placeholder. The fix
  just waits for it to actually finish doing so before reading.

## Test plan

- [ ] CI E2E green on chromium / firefox / webkit on this PR.
- [ ] No master-side firefox flake recurrence on this test post-merge
      (track over the next few merges).