### PR TITLE
[#1473] Areas listing: filter by location_id

### DIFF
--- a/e2e/tests/includes/user-isolation-auth.ts
+++ b/e2e/tests/includes/user-isolation-auth.ts
@@ -272,10 +272,15 @@ export async function createCommodityAsUser(user: TestUser, commodityName: strin
   }
 
   // Reuse an existing area inside that location, otherwise create one.
-  // Areas are flat at the group level (`GET /areas`), not nested under
-  // a location — the location_id lives on each row's attributes.
+  // The flat `/areas` endpoint accepts `?location_id=` to scope the
+  // result to a single location (#1473) — without it we'd over-fetch
+  // every area in the group and have to filter by `location_id`
+  // attribute client-side.
   let areaId: string;
-  const areasResp = await user.page.request.get(`${apiBase}/areas`, { headers: apiHeaders });
+  const areasResp = await user.page.request.get(
+    `${apiBase}/areas?location_id=${encodeURIComponent(locationId)}`,
+    { headers: apiHeaders },
+  );
   const areasText = await areasResp.text();
   let areasBody: { data?: Array<{ id: string }> };
   try { areasBody = JSON.parse(areasText); }

--- a/frontend/src/features/areas/api.ts
+++ b/frontend/src/features/areas/api.ts
@@ -30,10 +30,14 @@ function envelope(attrs: Partial<Area>) {
 }
 
 export async function listAreas(
-  options: { perPage?: number; signal?: AbortSignal } = {}
+  options: { perPage?: number; locationId?: string; signal?: AbortSignal } = {}
 ): Promise<Area[]> {
   const params = new URLSearchParams()
   if (options.perPage !== undefined) params.set("per_page", String(options.perPage))
+  // `?location_id=` (#1473) restricts the result to a single location;
+  // unknown / cross-tenant ids return an empty list, not a 4xx, so callers
+  // don't need to special-case errors here.
+  if (options.locationId) params.set("location_id", options.locationId)
   const qs = params.toString()
   const path = qs ? `/areas?${qs}` : "/areas"
   const body = await http.get<AreasListResponse>(path, { signal: options.signal })

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -612,11 +612,13 @@ export type paths = {
         };
         /**
          * List areas
-         * @description get areas
+         * @description get areas, optionally filtered to a single location.
          */
         get: {
             parameters: {
                 query?: {
+                    /** @description Restrict the result to areas inside the given location ID. Unknown / cross-tenant IDs return an empty list rather than 4xx. */
+                    location_id?: string;
                     /** @description Page number (default 1) */
                     page?: number;
                     /** @description Items per page (default 50, max 100) */

--- a/go/apiserver/areas.go
+++ b/go/apiserver/areas.go
@@ -3,6 +3,7 @@ package apiserver
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -10,6 +11,7 @@ import (
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/jsonapi"
 	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
 )
 
 func areaFromContext(ctx context.Context) *models.Area {
@@ -25,11 +27,12 @@ type areasAPI struct {
 
 // listAreas lists all areas with pagination.
 // @Summary List areas
-// @Description get areas
+// @Description get areas, optionally filtered to a single location.
 // @Tags areas
 // @Accept json-api
 // @Produce json-api
 // @Param groupSlug path string true "Group slug"
+// @Param location_id query string false "Restrict the result to areas inside the given location ID. Unknown / cross-tenant IDs return an empty list rather than 4xx."
 // @Param page query int false "Page number (default 1)"
 // @Param per_page query int false "Items per page (default 50, max 100)"
 // @Success 200 {object} jsonapi.AreasResponse "OK"
@@ -46,8 +49,12 @@ func (api *areasAPI) listAreas(w http.ResponseWriter, r *http.Request) {
 	page, perPage := parsePagination(q.Get("page"), q.Get("per_page"))
 	offset := (page - 1) * perPage
 
+	opts := registry.AreaListOptions{
+		LocationID: strings.TrimSpace(q.Get("location_id")),
+	}
+
 	areaRegistry := registrySet.AreaRegistry
-	areas, total, err := areaRegistry.ListPaginated(r.Context(), offset, perPage)
+	areas, total, err := areaRegistry.ListPaginated(r.Context(), offset, perPage, opts)
 	if err != nil {
 		renderEntityError(w, r, err)
 		return

--- a/go/apiserver/areas_test.go
+++ b/go/apiserver/areas_test.go
@@ -57,6 +57,54 @@ func TestAreasList(t *testing.T) {
 	c.Assert(body, checkers.JSONPathEquals("$.data[1].attributes.location_id"), expectedAreas[1].LocationID)
 }
 
+// TestAreasList_FilterByLocationID covers #1473 — clients used to have to
+// fetch every area in the group and filter by `location_id` client-side.
+// The filterable-flat contract (`?location_id=…`) returns the same shape,
+// scoped to a single location, and an unknown ID is an empty list rather
+// than a 4xx so the FE doesn't have to special-case errors here.
+func TestAreasList_FilterByLocationID(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	ctx := createTestUserContext(testUser.ID, testUser.TenantID)
+	registrySet := must.Must(params.FactorySet.CreateUserRegistrySet(ctx))
+
+	locations := must.Must(registrySet.LocationRegistry.List(context.Background()))
+	c.Assert(locations, qt.HasLen, 2)
+	loc1 := locations[0]
+	loc2 := locations[1]
+
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	handler := apiserver.APIServer(params, mockRestoreWorker)
+
+	doGET := func(query string) *httptest.ResponseRecorder {
+		req, err := http.NewRequest("GET", "/api/v1/g/"+testGroup.Slug+"/areas"+query, nil)
+		c.Assert(err, qt.IsNil)
+		addTestUserAuthHeader(req, testUser.ID)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr
+	}
+
+	// Location 1 holds both seeded areas — every returned row carries its id.
+	rr := doGET("?location_id=" + loc1.ID)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	body := rr.Body.Bytes()
+	c.Assert(body, checkers.JSONPathMatches("$.data", qt.HasLen), 2)
+	c.Assert(body, checkers.JSONPathEquals("$.data[0].attributes.location_id"), loc1.ID)
+	c.Assert(body, checkers.JSONPathEquals("$.data[1].attributes.location_id"), loc1.ID)
+
+	// Location 2 has no seeded areas — empty collection, 200.
+	rr = doGET("?location_id=" + loc2.ID)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathMatches("$.data", qt.HasLen), 0)
+
+	// Unknown / cross-tenant id is also empty — see AreaListOptions doc.
+	rr = doGET("?location_id=does-not-exist")
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathMatches("$.data", qt.HasLen), 0)
+}
+
 func TestAreasGet(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -444,7 +444,7 @@ const docTemplate = `{
         },
         "/g/{groupSlug}/areas": {
             "get": {
-                "description": "get areas",
+                "description": "get areas, optionally filtered to a single location.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -462,6 +462,12 @@ const docTemplate = `{
                         "name": "groupSlug",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Restrict the result to areas inside the given location ID. Unknown / cross-tenant IDs return an empty list rather than 4xx.",
+                        "name": "location_id",
+                        "in": "query"
                     },
                     {
                         "type": "integer",

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -437,7 +437,7 @@
         },
         "/g/{groupSlug}/areas": {
             "get": {
-                "description": "get areas",
+                "description": "get areas, optionally filtered to a single location.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -455,6 +455,12 @@
                         "name": "groupSlug",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Restrict the result to areas inside the given location ID. Unknown / cross-tenant IDs return an empty list rather than 4xx.",
+                        "name": "location_id",
+                        "in": "query"
                     },
                     {
                         "type": "integer",

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -2817,12 +2817,17 @@ paths:
     get:
       consumes:
       - application/vnd.api+json
-      description: get areas
+      description: get areas, optionally filtered to a single location.
       parameters:
       - description: Group slug
         in: path
         name: groupSlug
         required: true
+        type: string
+      - description: Restrict the result to areas inside the given location ID. Unknown
+          / cross-tenant IDs return an empty list rather than 4xx.
+        in: query
+        name: location_id
         type: string
       - description: Page number (default 1)
         in: query

--- a/go/registry/memory/areas.go
+++ b/go/registry/memory/areas.go
@@ -209,11 +209,23 @@ func (r *AreaRegistry) DeleteCommodity(_ context.Context, areaID, commodityID st
 	return nil
 }
 
-// ListPaginated returns a paginated list of areas along with the total count.
-func (r *AreaRegistry) ListPaginated(ctx context.Context, offset, limit int) ([]*models.Area, int, error) {
+// ListPaginated returns a paginated list of areas along with the total
+// count, optionally narrowed by opts — see registry.AreaListOptions for the
+// field-by-field semantics.
+func (r *AreaRegistry) ListPaginated(ctx context.Context, offset, limit int, opts registry.AreaListOptions) ([]*models.Area, int, error) {
 	all, err := r.List(ctx)
 	if err != nil {
 		return nil, 0, err
+	}
+
+	if opts.LocationID != "" {
+		filtered := make([]*models.Area, 0, len(all))
+		for _, area := range all {
+			if area.LocationID == opts.LocationID {
+				filtered = append(filtered, area)
+			}
+		}
+		all = filtered
 	}
 
 	if offset < 0 {

--- a/go/registry/postgres/areas.go
+++ b/go/registry/postgres/areas.go
@@ -107,8 +107,10 @@ func (r *AreaRegistry) Count(ctx context.Context) (int, error) {
 	return cnt, nil
 }
 
-// ListPaginated returns a paginated list of areas along with the total count.
-func (r *AreaRegistry) ListPaginated(ctx context.Context, offset, limit int) ([]*models.Area, int, error) {
+// ListPaginated returns a paginated list of areas along with the total
+// count, optionally narrowed by opts — see registry.AreaListOptions for the
+// field-by-field semantics.
+func (r *AreaRegistry) ListPaginated(ctx context.Context, offset, limit int, opts registry.AreaListOptions) ([]*models.Area, int, error) {
 	// Normalize pagination parameters to prevent negative SQL OFFSET/LIMIT errors.
 	if offset < 0 {
 		offset = 0
@@ -120,19 +122,27 @@ func (r *AreaRegistry) ListPaginated(ctx context.Context, offset, limit int) ([]
 	var areas []*models.Area
 	var total int
 
+	whereClause, whereArgs := buildAreaWhere(opts)
+
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		countQuery := fmt.Sprintf(`SELECT COUNT(*) FROM %s`, r.tableNames.Areas())
-		if err := tx.QueryRowContext(ctx, countQuery).Scan(&total); err != nil {
+		countQuery := fmt.Sprintf(`SELECT COUNT(*) FROM %s%s`, r.tableNames.Areas(), whereClause)
+		if err := tx.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&total); err != nil {
 			return errxtrace.Wrap("failed to count areas", err)
 		}
 
+		// LIMIT/OFFSET placeholders follow the WHERE arguments so a
+		// non-empty filter shifts them to $2/$3 rather than colliding
+		// with $1.
+		limitPlaceholder := fmt.Sprintf("$%d", len(whereArgs)+1)
+		offsetPlaceholder := fmt.Sprintf("$%d", len(whereArgs)+2)
 		dataQuery := fmt.Sprintf(`
-			SELECT * FROM %s
+			SELECT * FROM %s%s
 			ORDER BY name, id
-			LIMIT $1 OFFSET $2`, r.tableNames.Areas())
+			LIMIT %s OFFSET %s`, r.tableNames.Areas(), whereClause, limitPlaceholder, offsetPlaceholder)
 
-		rows, err := tx.QueryxContext(ctx, dataQuery, limit, offset)
+		dataArgs := append(append([]any{}, whereArgs...), limit, offset)
+		rows, err := tx.QueryxContext(ctx, dataQuery, dataArgs...)
 		if err != nil {
 			return errxtrace.Wrap("failed to list paginated areas", err)
 		}
@@ -153,6 +163,22 @@ func (r *AreaRegistry) ListPaginated(ctx context.Context, offset, limit int) ([]
 	}
 
 	return areas, total, nil
+}
+
+// buildAreaWhere converts opts into a WHERE clause + positional args. The
+// returned clause already starts with a leading space (or is empty) so it
+// can be concatenated directly after the table name.
+func buildAreaWhere(opts registry.AreaListOptions) (string, []any) {
+	var conditions []string
+	var args []any
+	if opts.LocationID != "" {
+		conditions = append(conditions, fmt.Sprintf("location_id = $%d", len(args)+1))
+		args = append(args, opts.LocationID)
+	}
+	if len(conditions) == 0 {
+		return "", nil
+	}
+	return " WHERE " + strings.Join(conditions, " AND "), args
 }
 
 func (r *AreaRegistry) Create(ctx context.Context, area models.Area) (*models.Area, error) {

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -60,8 +60,22 @@ type AreaRegistry interface {
 
 	GetCommodities(ctx context.Context, areaID string) ([]string, error)
 
-	// ListPaginated returns a paginated list of areas along with the total count.
-	ListPaginated(ctx context.Context, offset, limit int) ([]*models.Area, int, error)
+	// ListPaginated returns a paginated list of areas along with the total
+	// count, optionally filtered via opts. Pass a zero AreaListOptions for
+	// the unfiltered shape the old `(ctx, offset, limit)` form returned.
+	ListPaginated(ctx context.Context, offset, limit int, opts AreaListOptions) ([]*models.Area, int, error)
+}
+
+// AreaListOptions narrows the result of AreaRegistry.ListPaginated. Empty
+// fields mean "no filter" — the zero value yields the same shape as an
+// unfiltered listing.
+type AreaListOptions struct {
+	// LocationID, when non-empty, restricts the result to areas inside a
+	// single location. Use "" to disable the filter (rather than a sentinel
+	// like "*"). An unknown ID matches nothing — RLS already group-scopes
+	// the query, so a cross-tenant ID returns the empty list rather than a
+	// 4xx.
+	LocationID string
 }
 
 // CommoditySortField names the columns the commodities list endpoint


### PR DESCRIPTION
Closes #1473.

## Summary
- Adds `?location_id=` filter to `GET /api/v1/g/{slug}/areas` so clients no longer have to fetch every area in the group and filter by `location_id` attribute on the FE side.
- Picks the **filterable-flat** contract from the issue's two acceptance options — matches the wider project style established in #1421 (legacy nested `/locations/{id}/files` was removed in favor of `/files?linked_entity_type=…&linked_entity_id=…`). The flat `/areas` endpoint stays useful for "everything I have access to" lists.
- Updates the e2e helper at `e2e/tests/includes/user-isolation-auth.ts` to use the proper filter instead of the over-fetch + client-side match dance it was doing.

## Behavior
- `GET /areas?location_id=<id>` returns the JSON:API collection scoped to that location, paginated like the unfiltered listing.
- Unknown / cross-tenant `location_id` returns an empty list (200), not a 4xx — RLS already group-scopes the query, and this matches `CommodityListOptions.AreaID` semantics. Callers don't have to special-case errors.
- No filter = same shape the unfiltered call returned before.

## Files
- **registry**: `AreaListOptions{LocationID}` + extended `ListPaginated` signature in interface, postgres impl (WHERE-clause builder shifts `LIMIT`/`OFFSET` placeholders), memory impl.
- **apiserver**: parse `location_id` query, pass through; swagger annotation regenerated via `make swagger-backend`.
- **frontend**: optional `locationId` param on `listAreas` — additive, no callsite changes.
- **e2e helper**: switched to `?location_id=`.
- **tests**: `TestAreasList_FilterByLocationID` covers match / empty-on-empty-location / unknown-id.

## Test plan
- [x] `go build ./...`
- [x] `go test ./apiserver/ -short` (all pass; new `TestAreasList_FilterByLocationID` included)
- [x] `go test ./registry/...` (memory pass; postgres skipped without DSN)
- [x] `go vet ./apiserver/... ./registry/...`
- [x] `gofmt -l` clean
- [ ] Postgres-backed tests via `make docker-test-go-postgres`
- [ ] Frontend typecheck + lint (`make lint-frontend`)
- [ ] `make lint-go`
- [ ] Playwright e2e (the helper change is exercised by `user-isolation-auth.spec.ts` and friends)

via [Happy](https://happy.engineering)