### PR TITLE
[#1277] e2e: real zero-group user fixture (orphan@test-org.com)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -147,6 +147,24 @@ jobs:
               --tenant=test-org \
               --no-interactive
 
+      - name: Create orphan user (zero-group fixture for #1277)
+        # no-group-redirect.spec.ts logs in as orphan@test-org.com to exercise
+        # the real `/api/v1/groups` empty-collection backend response. Same
+        # fast-path skip as user2 (init-data's seed call passes user_email),
+        # so we provision it via the CLI and intentionally do NOT create a
+        # group for this user — the spec's premise is "zero memberships".
+        run: |
+          docker compose \
+            -f docker-compose.yaml \
+            -f docker-compose.e2e.yaml \
+            run --rm --no-deps inventario \
+            users create \
+              --email=orphan@test-org.com \
+              --password=testpassword123 \
+              --name="Test Orphan (no group)" \
+              --tenant=test-org \
+              --no-interactive
+
       - name: Create default group for user2
         # Without this, user2 has no group — /api/v1/seed ran inside
         # inventario-init-data BEFORE user2 existed (init-data's seeddata
@@ -312,6 +330,14 @@ jobs:
             --email=user2@test-org.com \
             --password=testpassword123 \
             --name="Test User 2" \
+            --tenant=test-org \
+            --no-interactive
+          # orphan is the zero-group fixture for #1277 (no-group-redirect.spec.ts).
+          # Same fast-path skip as user2 — provision via CLI; do NOT create a group.
+          ./bin/inventario users create \
+            --email=orphan@test-org.com \
+            --password=testpassword123 \
+            --name="Test Orphan (no group)" \
             --tenant=test-org \
             --no-interactive
 

--- a/e2e/tests/includes/auth.ts
+++ b/e2e/tests/includes/auth.ts
@@ -13,6 +13,18 @@ export const TEST_CREDENTIALS = {
 };
 
 /**
+ * Zero-group test user credentials. Seeded by debug/seeddata as an active
+ * user with no group memberships so e2e tests can authenticate against the
+ * real `/api/v1/groups` empty-collection response without intercepting it.
+ * See issue #1277 — admin can't be used because the last-admin invariant
+ * blocks `POST /groups/{id}/leave`.
+ */
+export const ORPHAN_TEST_CREDENTIALS = {
+  email: 'orphan@test-org.com',
+  password: 'testpassword123'
+};
+
+/**
  * Check if the current page is the login page
  */
 export async function isLoginPage(page: Page): Promise<boolean> {
@@ -65,17 +77,23 @@ export async function isAuthenticated(page: Page, recorder?: TestRecorder): Prom
 }
 
 /**
- * Perform login with test credentials and extract CSRF token
+ * Perform login with test credentials and extract CSRF token.
+ * Defaults to the seeded admin credentials; pass `credentials` to log in as
+ * a different seeded user (e.g. ORPHAN_TEST_CREDENTIALS for #1277 tests).
  */
-export async function login(page: Page, recorder?: TestRecorder): Promise<string | null> {
-  log(recorder, '🔐 Performing login with test credentials...');
+export async function login(
+  page: Page,
+  recorder?: TestRecorder,
+  credentials: { email: string; password: string } = TEST_CREDENTIALS,
+): Promise<string | null> {
+  log(recorder, `🔐 Performing login as ${credentials.email}...`);
 
   // Wait for login form to be visible
   await page.waitForSelector('input[type="email"]', { timeout: 10000 });
 
   // Fill in credentials
-  await page.fill('input[type="email"]', TEST_CREDENTIALS.email);
-  await page.fill('input[type="password"]', TEST_CREDENTIALS.password);
+  await page.fill('input[type="email"]', credentials.email);
+  await page.fill('input[type="password"]', credentials.password);
   // Wait for login API response and fail fast on non-200 statuses.
   const loginResponsePromise = page.waitForResponse(
     (response) => response.url().includes('/api/v1/auth/login'),

--- a/e2e/tests/no-group-redirect.spec.ts
+++ b/e2e/tests/no-group-redirect.spec.ts
@@ -3,41 +3,53 @@
  * redirected to the `/no-group` onboarding view from every protected route
  * so they never see broken / 403 pages that assume a selected group.
  *
- * We simulate the zero-group state by intercepting GET /api/v1/groups and
- * returning an empty collection. Actually leaving the seeded admin's only
- * group is not an option: admin is the sole admin, so the leave endpoint
- * rejects the request, and deleting the group would wipe the default seed
- * data that the rest of the E2E suite depends on.
+ * The redirect-path tests authenticate as `orphan@test-org.com`, the seeded
+ * zero-membership user added in #1277. The earlier iteration of this spec
+ * stubbed `GET /api/v1/groups` with `page.route` because the seeded admin
+ * can't leave the default group (last-admin invariant) and a freshly
+ * registered user requires email verification — neither yields a real
+ * zero-group session in the e2e environment. The orphan fixture closes
+ * that gap so the redirect tests now exercise the actual backend response
+ * path.
+ *
+ * The "drives group creation" test is the lone exception: it tests the UI
+ * onboarding flow rather than the backend response, and creating a real
+ * group during a parallel test run would mutate orphan's membership and
+ * race the redirect tests in sibling browser workers (chromium / firefox /
+ * webkit run in parallel against the same backend, so they'd see orphan
+ * with one group and skip the /no-group redirect). It keeps its page.route
+ * mocks for that reason.
  */
-import { expect } from '@playwright/test';
-import { test } from '../fixtures/app-fixture.js';
+import { Page, expect, test } from '@playwright/test';
+import waitOn from 'wait-on';
+import { login, ORPHAN_TEST_CREDENTIALS } from './includes/auth.js';
+import { BASE_URL } from '../setup/urls.js';
 
 const GROUPS_URL_GLOB = '**/api/v1/groups';
 
-async function mockEmptyGroups(page: Parameters<Parameters<typeof test>[2]>[0]['page']) {
-  await page.route(GROUPS_URL_GLOB, (route) => {
-    if (route.request().method() === 'GET') {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/vnd.api+json',
-        body: JSON.stringify({ data: [] }),
-      });
-    }
-    return route.continue();
-  });
+async function loginAsOrphan(page: Page): Promise<void> {
+  await page.goto('/login');
+  await login(page, undefined, ORPHAN_TEST_CREDENTIALS);
+  // Post-login: RootRedirect (no default_group_id, no memberships) routes
+  // through the router guard, which lands the user on /no-group.
 }
 
-test.describe('No-group redirects (#1261)', () => {
-  test.beforeEach(async ({ page }) => {
-    await mockEmptyGroups(page);
+test.describe('No-group redirects (#1261, real fixture #1277)', () => {
+  test.beforeAll(async () => {
+    // global-setup already waits for the stack, but other tests may have
+    // restarted services in between — re-probe so the first goto doesn't
+    // race a still-warming server.
+    await waitOn({
+      resources: [BASE_URL],
+      timeout: 15000,
+      interval: 250,
+      window: 1000,
+      tcpTimeout: 1000,
+    });
+  });
 
-    // After #1300 the groupStore doesn't keep a localStorage snapshot, so
-    // there's nothing to scrub — a reload is enough to force ensureLoaded()
-    // to re-run against the (mocked) empty /api/v1/groups response.
-    await page.reload();
-    // Wait for the post-reload auth + groups bootstrap to finish before the
-    // test-specific navigation, otherwise assertions can race the redirect.
-    await page.waitForLoadState('networkidle');
+  test.beforeEach(async ({ page }) => {
+    await loginAsOrphan(page);
   });
 
   for (const target of ['/', '/locations', '/commodities', '/files', '/exports', '/system']) {
@@ -77,12 +89,15 @@ test.describe('No-group redirects (#1261)', () => {
   });
 
   test('NoGroupView drives group creation and returns the user to /', async ({ page }) => {
+    // This test stays mocked: a real POST /api/v1/groups would mutate
+    // orphan's membership state and race the redirect tests above when the
+    // suite runs across browser projects in parallel (chromium, firefox,
+    // webkit all share the same backend orphan user). The contract this
+    // test guards is "form submit → router takes the user out of /no-group",
+    // which is a frontend reaction that doesn't need a real backend write.
     await page.goto('/');
     await expect(page).toHaveURL(/\/no-group$/);
 
-    // Swap the mock so POST /api/v1/groups "succeeds" and the subsequent GET
-    // returns the newly-created group. After that the router guard sees
-    // hasGroups=true and lets the user through to /.
     const createdGroup = {
       id: 'mock-grp-1261',
       type: 'groups',
@@ -98,7 +113,6 @@ test.describe('No-group redirects (#1261)', () => {
       },
     };
     let createSucceeded = false;
-    await page.unroute(GROUPS_URL_GLOB);
     await page.route(GROUPS_URL_GLOB, (route) => {
       const method = route.request().method();
       if (method === 'POST') {

--- a/go/debug/seeddata/seeddata.go
+++ b/go/debug/seeddata/seeddata.go
@@ -117,6 +117,38 @@ func findExistingUsers(users []*models.User, tenantID string) (primary *models.U
 	return primary, secondary
 }
 
+// ensureOrphanUser idempotently provisions a third active test user with
+// zero group memberships (`orphan@test-org.com`). The seeded admin can't be
+// used for this because admin is the sole admin of the default group and the
+// last-admin invariant blocks `POST /groups/{id}/leave`; e2e tests that need
+// to exercise the backend's zero-group code paths (router-guard redirect,
+// `/api/v1/groups` empty response, etc.) authenticate as this user instead.
+// See issue #1277.
+func ensureOrphanUser(ctx context.Context, registrySet *registry.Set, tenant *models.Tenant, users []*models.User) error {
+	const orphanEmail = "orphan@test-org.com"
+	for _, user := range users {
+		if user.TenantID == tenant.ID && user.Email == orphanEmail {
+			return nil
+		}
+	}
+
+	orphan := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: tenant.ID,
+		},
+		Email:    orphanEmail,
+		Name:     "Test Orphan (no group)",
+		IsActive: true,
+	}
+	if err := orphan.SetPassword("testpassword123"); err != nil {
+		return err
+	}
+	if _, err := registrySet.UserRegistry.Create(ctx, orphan); err != nil {
+		return fmt.Errorf("failed to create orphan test user: %w", err)
+	}
+	return nil
+}
+
 // createTestUsers creates test users
 func createTestUsers(ctx context.Context, registrySet *registry.Set, tenant *models.Tenant, existingUser2 *models.User) (primary *models.User, secondary *models.User, err error) {
 	slog.Info("Creating test users", "tenant", tenant.Slug)
@@ -235,7 +267,7 @@ func findOrCreateDefaultGroup(ctx context.Context, registrySet *registry.Set, us
 }
 
 // SeedData seeds the database with example data.
-func SeedData(factorySet *registry.FactorySet, opts SeedOptions) error { //nolint:funlen,gocyclo // it's a seed function
+func SeedData(factorySet *registry.FactorySet, opts SeedOptions) error { //nolint:funlen,gocyclo,gocognit // it's a seed function
 	slog.Info("Seeding database",
 		"user_email", opts.UserEmail,
 		"tenant_slug", opts.TenantSlug,
@@ -258,6 +290,17 @@ func SeedData(factorySet *registry.FactorySet, opts SeedOptions) error { //nolin
 	user1, user2, err := findOrCreateUsers(ctx, registrySet, tenant, users, opts.UserEmail)
 	if err != nil {
 		return err
+	}
+
+	// On the default e2e/dev seed path (no specific user requested) also
+	// provision a third zero-group test user so e2e tests can authenticate
+	// against the real `/api/v1/groups` empty-collection response. Skipped
+	// when seeding for a specific user — that path is for production-like
+	// per-user provisioning and shouldn't synthesize extra fixture rows.
+	if opts.UserEmail == "" {
+		if err := ensureOrphanUser(ctx, registrySet, tenant, users); err != nil {
+			return err
+		}
 	}
 
 	// Ensure user1 has a default group valued in CZK, then set user+group

--- a/go/debug/seeddata/seeddata.go
+++ b/go/debug/seeddata/seeddata.go
@@ -292,12 +292,15 @@ func SeedData(factorySet *registry.FactorySet, opts SeedOptions) error { //nolin
 		return err
 	}
 
-	// On the default e2e/dev seed path (no specific user requested) also
-	// provision a third zero-group test user so e2e tests can authenticate
-	// against the real `/api/v1/groups` empty-collection response. Skipped
-	// when seeding for a specific user — that path is for production-like
-	// per-user provisioning and shouldn't synthesize extra fixture rows.
-	if opts.UserEmail == "" {
+	// On the default e2e/dev seed path (no specific user requested) and
+	// only inside the well-known `test-org` test tenant, provision a third
+	// zero-group test user so e2e tests can authenticate against the real
+	// `/api/v1/groups` empty-collection response. Skipped on the per-user
+	// provisioning path (UserEmail set) and on any non-test tenant —
+	// otherwise a `/api/v1/seed?tenant_slug=acme` call could plant an
+	// active `orphan@test-org.com` account with a known password in an
+	// arbitrary tenant.
+	if opts.UserEmail == "" && tenant.Slug == "test-org" {
 		if err := ensureOrphanUser(ctx, registrySet, tenant, users); err != nil {
 			return err
 		}

--- a/go/debug/seeddata/seeddata_postgres_test.go
+++ b/go/debug/seeddata/seeddata_postgres_test.go
@@ -35,7 +35,7 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 	cleanupTestData(c, db)
 
 	// Test that seed data creation works without errors
-	err = seeddata.SeedData(factorySet)
+	err = seeddata.SeedData(factorySet, seeddata.SeedOptions{})
 	c.Assert(err, qt.IsNil)
 
 	// Verify that a tenant was created
@@ -59,35 +59,45 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 	// Verify that users were created with the correct tenant ID
 	users, err := registrySet.UserRegistry.List(context.Background())
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(users) >= 2, qt.IsTrue, qt.Commentf("Expected at least 2 users, got %d", len(users)))
+	c.Assert(len(users) >= 3, qt.IsTrue, qt.Commentf("Expected at least 3 users, got %d", len(users)))
 
 	// Find the test users
-	var adminUser, regularUser *models.User
+	var adminUser, regularUser, orphanUser *models.User
 	for _, user := range users {
-		if user.Email == "admin@test-org.com" {
+		switch user.Email {
+		case "admin@test-org.com":
 			adminUser = user
-		} else if user.Email == "user2@test-org.com" {
+		case "user2@test-org.com":
 			regularUser = user
+		case "orphan@test-org.com":
+			orphanUser = user
 		}
 	}
 
 	c.Assert(adminUser, qt.IsNotNil, qt.Commentf("Admin user not found"))
 	c.Assert(adminUser.TenantID, qt.Equals, testTenant.ID)
-	c.Assert(adminUser.UserID, qt.Equals, adminUser.ID) // Self-referencing user ID
 	c.Assert(adminUser.Name, qt.Equals, "Test Administrator")
 	c.Assert(adminUser.IsActive, qt.Equals, true)
 
 	c.Assert(regularUser, qt.IsNotNil, qt.Commentf("Regular user not found"))
 	c.Assert(regularUser.TenantID, qt.Equals, testTenant.ID)
-	c.Assert(regularUser.UserID, qt.Equals, regularUser.ID) // Self-referencing user ID
 	c.Assert(regularUser.Name, qt.Equals, "Test User 2")
 	c.Assert(regularUser.IsActive, qt.Equals, true)
+
+	// Orphan: active so it can authenticate, zero memberships so e2e tests
+	// hit the real `/api/v1/groups` empty-collection response (issue #1277).
+	c.Assert(orphanUser, qt.IsNotNil, qt.Commentf("Orphan user not found"))
+	c.Assert(orphanUser.TenantID, qt.Equals, testTenant.ID)
+	c.Assert(orphanUser.IsActive, qt.Equals, true)
+	memberships, err := registrySet.GroupMembershipRegistry.ListByUser(context.Background(), testTenant.ID, orphanUser.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(memberships, qt.HasLen, 0)
 }
 
 func cleanupTestData(c *qt.C, db *sqlx.DB) {
 	// Clean up in reverse order of dependencies
 	queries := []string{
-		"DELETE FROM users WHERE email IN ('admin@test-org.com', 'user2@test-org.com')",
+		"DELETE FROM users WHERE email IN ('admin@test-org.com', 'user2@test-org.com', 'orphan@test-org.com')",
 		"DELETE FROM tenants WHERE slug = 'test-org'",
 	}
 

--- a/go/debug/seeddata/seeddata_test.go
+++ b/go/debug/seeddata/seeddata_test.go
@@ -35,9 +35,9 @@ func TestSeedData(t *testing.T) {
 	// Verify that users were created with the correct tenant ID
 	users, err := registrySet.UserRegistry.List(context.Background())
 	c.Assert(err, qt.IsNil)
-	c.Assert(users, qt.HasLen, 2)
+	c.Assert(users, qt.HasLen, 3)
 
-	// Check that both users have the correct tenant ID. The legacy
+	// Check that all users have the correct tenant ID. The legacy
 	// users.user_id self-FK was dropped by issue #1289 Gap B — the row's
 	// own id is authoritative, so there is nothing left to assert on a
 	// separate user_id field.
@@ -46,13 +46,15 @@ func TestSeedData(t *testing.T) {
 	}
 
 	// Check specific user details
-	var adminUser, regularUser *models.User
+	var adminUser, regularUser, orphanUser *models.User
 	for _, user := range users {
 		switch user.Email {
 		case "admin@test-org.com":
 			adminUser = user
 		case "user2@test-org.com":
 			regularUser = user
+		case "orphan@test-org.com":
+			orphanUser = user
 		}
 	}
 
@@ -63,6 +65,15 @@ func TestSeedData(t *testing.T) {
 	c.Assert(regularUser, qt.IsNotNil)
 	c.Assert(regularUser.Name, qt.Equals, "Test User 2")
 	c.Assert(regularUser.IsActive, qt.Equals, true)
+
+	// Orphan must be active so it can authenticate, but must hold zero
+	// group memberships so e2e tests exercise the real `/api/v1/groups`
+	// empty-collection response (issue #1277).
+	c.Assert(orphanUser, qt.IsNotNil)
+	c.Assert(orphanUser.IsActive, qt.Equals, true)
+	memberships, err := registrySet.GroupMembershipRegistry.ListByUser(context.Background(), tenant.ID, orphanUser.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(memberships, qt.HasLen, 0)
 }
 
 func TestSeedDataIdempotent(t *testing.T) {
@@ -86,5 +97,5 @@ func TestSeedDataIdempotent(t *testing.T) {
 
 	users, err := registrySet.UserRegistry.List(context.Background())
 	c.Assert(err, qt.IsNil)
-	c.Assert(users, qt.HasLen, 2)
+	c.Assert(users, qt.HasLen, 3)
 }

--- a/go/debug/seeddata/seeddata_test.go
+++ b/go/debug/seeddata/seeddata_test.go
@@ -89,7 +89,9 @@ func TestSeedDataIdempotent(t *testing.T) {
 	err = seeddata.SeedData(factorySet, seeddata.SeedOptions{})
 	c.Assert(err, qt.IsNil)
 
-	// Verify that we still have only one tenant and two users
+	// Verify that we still have only one tenant and three users
+	// (admin + user2 + orphan — the orphan fixture is gated on the
+	// test-org tenant; see SeedData).
 	registrySet := factorySet.CreateServiceRegistrySet()
 	tenants, err := registrySet.TenantRegistry.List(context.Background())
 	c.Assert(err, qt.IsNil)
@@ -98,4 +100,32 @@ func TestSeedDataIdempotent(t *testing.T) {
 	users, err := registrySet.UserRegistry.List(context.Background())
 	c.Assert(err, qt.IsNil)
 	c.Assert(users, qt.HasLen, 3)
+}
+
+// TestSeedDataDoesNotCreateOrphanInNonTestTenant guards the security gate on
+// `ensureOrphanUser`: the orphan fixture has a well-known email and password,
+// so it must never be planted outside the test-org tenant. Seeding into an
+// arbitrary tenant (e.g. `/api/v1/seed?tenant_slug=acme`) must skip the
+// orphan creation entirely.
+func TestSeedDataDoesNotCreateOrphanInNonTestTenant(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+	registrySet := factorySet.CreateServiceRegistrySet()
+
+	_, err := registrySet.TenantRegistry.Create(context.Background(), models.Tenant{
+		Name:   "Acme Corp",
+		Slug:   "acme",
+		Status: models.TenantStatusActive,
+	})
+	c.Assert(err, qt.IsNil)
+
+	err = seeddata.SeedData(factorySet, seeddata.SeedOptions{TenantSlug: "acme"})
+	c.Assert(err, qt.IsNil)
+
+	users, err := registrySet.UserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	for _, u := range users {
+		c.Assert(u.Email, qt.Not(qt.Equals), "orphan@test-org.com")
+	}
 }


### PR DESCRIPTION
Closes #1277.

## Summary

- Seed a third active test user `orphan@test-org.com` with **zero group memberships** so e2e specs can authenticate against the real `/api/v1/groups` empty-collection response.
- Refactor `e2e/tests/no-group-redirect.spec.ts`: the redirect tests now drive the real backend instead of intercepting `GET /api/v1/groups` via `page.route`.
- Drive-by: fix pre-existing breakage in the integration-tagged `seeddata_postgres_test.go` (stale single-arg `SeedData` signature + removed `User.UserID` self-FK assertion).

## Why

`page.route` mocking only verifies the frontend guard reaction — it doesn't catch backend regressions where `/api/v1/groups` starts returning 403 (instead of `{data: []}`) for zero-group users. The seeded admin can't satisfy the test premise (last-admin invariant blocks `POST /groups/{id}/leave`), and registration requires email verification (no automated path in the stdout-stub mail provider). Picked option **(1)** from the issue: smallest surface area, just a seed-data tweak + one credentials constant.

## Implementation notes

- `ensureOrphanUser` is idempotent and only fires when `opts.UserEmail == ""` (the e2e/dev seed path) — production single-user provisioning is unaffected.
- The "drives group creation" test stays mocked. Creating a real group for orphan would mutate that user's membership state and race the redirect tests when the suite runs across browser projects in parallel (chromium / firefox / webkit share one backend). This was caught during cross-browser verification: chromium passed 11/11 alone, but a 3-project run lost 2 tests until the create flow went back to mocks. Comment in the spec explains the trade-off.

## Test plan

- [x] `go test ./debug/seeddata/...` (memory backend) green
- [x] `golangci-lint run ./debug/seeddata/...` clean
- [x] Playwright `tests/no-group-redirect.spec.ts` — **33/33 passed** across chromium + firefox + webkit (32.7s)
- [x] Verified orphan returns to zero active groups after the test (cleanup not even needed since the create flow is mocked)
- [ ] CI green