### PR TITLE
[#1483] FileDetailSheet: dash fallback when file.path is ""

### DIFF
--- a/frontend/src/components/files/FileDetailSheet.tsx
+++ b/frontend/src/components/files/FileDetailSheet.tsx
@@ -62,7 +62,10 @@ export function FileDetailSheet({
   const file = query.data?.file
   const signedUrl = query.data?.signedUrl?.url
   const title = file?.title?.trim() || file?.path?.trim() || file?.id || ""
-  const filename = file && file.path && file.ext ? `${file.path}${file.ext}` : file?.path
+  // Backend may return path="" for files attached via the unified upload+linkage
+  // flow (#1448), so gate on path being truthy — an empty path means we have no
+  // displayable filename even if `ext` is set (otherwise we'd render a stray ".pdf").
+  const filename = file?.path ? `${file.path}${file.ext ?? ""}` : ""
 
   async function onDelete() {
     if (!file) return
@@ -118,7 +121,7 @@ export function FileDetailSheet({
             <dl className="grid grid-cols-1 gap-x-4 gap-y-2 text-sm sm:grid-cols-[120px_1fr]">
               <dt className="text-muted-foreground">{t("files:detail.filename")}</dt>
               <dd className="break-all" data-testid="file-detail-filename">
-                {filename ?? "—"}
+                {filename || "—"}
               </dd>
 
               <dt className="text-muted-foreground">{t("files:detail.category")}</dt>

--- a/frontend/src/components/files/__tests__/FileDetailSheet.test.tsx
+++ b/frontend/src/components/files/__tests__/FileDetailSheet.test.tsx
@@ -135,9 +135,7 @@ describe("<FileDetailSheet />", () => {
       })
     )
     renderSheet("f1")
-    await waitFor(() =>
-      expect(screen.getByTestId("file-detail-filename")).toHaveTextContent("—")
-    )
+    await waitFor(() => expect(screen.getByTestId("file-detail-filename")).toHaveTextContent("—"))
   })
 
   it("renders the dash fallback when path is undefined", async () => {
@@ -152,9 +150,7 @@ describe("<FileDetailSheet />", () => {
       })
     )
     renderSheet("f1")
-    await waitFor(() =>
-      expect(screen.getByTestId("file-detail-filename")).toHaveTextContent("—")
-    )
+    await waitFor(() => expect(screen.getByTestId("file-detail-filename")).toHaveTextContent("—"))
   })
 
   it("renders the bare path when ext is missing", async () => {

--- a/frontend/src/components/files/__tests__/FileDetailSheet.test.tsx
+++ b/frontend/src/components/files/__tests__/FileDetailSheet.test.tsx
@@ -121,6 +121,60 @@ describe("<FileDetailSheet />", () => {
     expect(screen.getByTestId("file-detail-delete")).not.toBeDisabled()
   })
 
+  it("renders the dash fallback when path is an empty string (regression #1483)", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...fileHandlers.detail(SLUG, "f1", {
+        id: "f1",
+        title: "Receipt",
+        category: "invoices",
+        type: "document",
+        path: "",
+        ext: ".pdf",
+        mime_type: "application/pdf",
+      })
+    )
+    renderSheet("f1")
+    await waitFor(() =>
+      expect(screen.getByTestId("file-detail-filename")).toHaveTextContent("—")
+    )
+  })
+
+  it("renders the dash fallback when path is undefined", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...fileHandlers.detail(SLUG, "f1", {
+        id: "f1",
+        title: "Receipt",
+        category: "invoices",
+        type: "document",
+        mime_type: "application/pdf",
+      })
+    )
+    renderSheet("f1")
+    await waitFor(() =>
+      expect(screen.getByTestId("file-detail-filename")).toHaveTextContent("—")
+    )
+  })
+
+  it("renders the bare path when ext is missing", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...fileHandlers.detail(SLUG, "f1", {
+        id: "f1",
+        title: "Note",
+        category: "other",
+        type: "other",
+        path: "notes-2026",
+        mime_type: "text/plain",
+      })
+    )
+    renderSheet("f1")
+    await waitFor(() =>
+      expect(screen.getByTestId("file-detail-filename")).toHaveTextContent("notes-2026")
+    )
+  })
+
   it("clicking Edit calls onEdit with the file id", async () => {
     const user = userEvent.setup()
     const onEdit = vi.fn()


### PR DESCRIPTION
Fixes #1483.

## Summary

The **Filename** row in `FileDetailSheet` rendered as empty whitespace whenever the backend returned `path=""` (which the unified `/uploads/file` + linkage `PUT /files/{id}` flow from #1448 produces). Two stacked bugs:

1. The filename derivation used `file && file.path && file.ext ? ... : file?.path` — when `path` was `""`, the ternary fell through to `file?.path` and `filename` became `""`.
2. The render used `{filename ?? "—"}` — `??` only triggers on nullish, so the empty string passed straight through and the `dd` rendered as blank.

## Fix

- Gate the filename derivation on `path` being truthy: `file?.path ? ${file.path}${file.ext ?? ""} : ""`. An empty `path` yields no displayable filename even if `ext` is set (otherwise we'd render a stray `.pdf`).
- Switch the render fallback to `||` so empty strings collapse to `—`.

`FileCard.tsx` already uses `||` for its title chain (`file.title?.trim() || file.path?.trim() || file.id`), so it's not affected by the same trap. `FileEditPage.tsx` only has a `?? ""` over an i18n message, which is harmless.

## Tests

Three new vitest cases in `FileDetailSheet.test.tsx`:
- `path: ""` (regression case) → renders `—`
- `path: undefined` → renders `—`
- `path: "notes-2026"` without `ext` → renders `notes-2026`

All 7 tests in the file pass; the broader files-area suite (10 files / 86 tests) is green; `tsc --noEmit` is clean.

## Test plan

- [x] `npx vitest run src/components/files/__tests__/FileDetailSheet.test.tsx` — 7 passed
- [x] `npx vitest run src/components/files src/pages/files` — 86 passed
- [x] `npx tsc --noEmit` — no errors
- [ ] Manual: open a file uploaded via the #1448 quick-attach flow → Filename row shows `—` (or the real name when path is set)