### PR TITLE
[#1006] generate-migration.sh: use dynamic host port

### DIFF
--- a/scripts/generate-migration.sh
+++ b/scripts/generate-migration.sh
@@ -12,7 +12,7 @@
 # Prerequisites: docker, go
 #
 # The script:
-#   1. Spins up a fresh postgres container on a fixed high port (15432; see issue #1006 to make it dynamic)
+#   1. Spins up a fresh postgres container on a Docker-assigned random host port
 #   2. Builds inventool from source
 #   3. Runs bootstrap to create required roles and extensions
 #   4. Applies all existing migrations (so the generator can diff)
@@ -38,11 +38,11 @@ MIGRATIONS_DIR="${GO_DIR}/schema/migrations/_sqldata"
 # Ephemeral Postgres settings
 # ---------------------------------------------------------------------------
 CONTAINER_NAME="inventario-migrate-gen-$$"
-POSTGRES_PORT=15432   # high port — avoids clashing with any local postgres
 POSTGRES_USER=inventario_gen
 POSTGRES_PASSWORD=inventario_gen_pw
 POSTGRES_DB=inventario_gen
-DSN="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable"
+# POSTGRES_PORT and DSN are populated after the container starts (Docker
+# assigns a free host port automatically — see step 1).
 
 # ---------------------------------------------------------------------------
 # Cleanup — runs on EXIT so the container is always removed
@@ -63,9 +63,20 @@ docker run -d \
     -e      POSTGRES_USER="${POSTGRES_USER}" \
     -e      POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
     -e      POSTGRES_DB="${POSTGRES_DB}" \
-    -p      "${POSTGRES_PORT}:5432" \
+    -p      "5432" \
     postgres:17-alpine \
     >/dev/null
+
+# Read the host port Docker assigned to container port 5432/tcp.
+POSTGRES_PORT="$(docker inspect \
+    --format='{{(index (index .NetworkSettings.Ports "5432/tcp") 0).HostPort}}' \
+    "${CONTAINER_NAME}")"
+if [ -z "${POSTGRES_PORT}" ]; then
+    echo "❌  Failed to determine host port for ${CONTAINER_NAME}"
+    exit 1
+fi
+DSN="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable"
+echo "🔌  PostgreSQL listening on host port ${POSTGRES_PORT}"
 
 # ---------------------------------------------------------------------------
 # 2. Wait for postgres to accept connections

--- a/scripts/generate-migration.sh
+++ b/scripts/generate-migration.sh
@@ -63,14 +63,19 @@ docker run -d \
     -e      POSTGRES_USER="${POSTGRES_USER}" \
     -e      POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
     -e      POSTGRES_DB="${POSTGRES_DB}" \
-    -p      "5432" \
+    -p      "127.0.0.1::5432" \
     postgres:17-alpine \
     >/dev/null
 
 # Read the host port Docker assigned to container port 5432/tcp.
+# - Binding to 127.0.0.1 above keeps the random port off other interfaces.
+# - The `with ... end` template produces empty output if the port mapping is
+#   missing rather than the literal "<no value>" Docker emits otherwise.
+# - `|| true` keeps `set -e` from killing the script before our explicit
+#   non-empty check below runs (e.g. if `docker inspect` itself errors).
 POSTGRES_PORT="$(docker inspect \
-    --format='{{(index (index .NetworkSettings.Ports "5432/tcp") 0).HostPort}}' \
-    "${CONTAINER_NAME}")"
+    --format='{{with index .NetworkSettings.Ports "5432/tcp"}}{{(index . 0).HostPort}}{{end}}' \
+    "${CONTAINER_NAME}" 2>/dev/null || true)"
 if [ -z "${POSTGRES_PORT}" ]; then
     echo "❌  Failed to determine host port for ${CONTAINER_NAME}"
     exit 1


### PR DESCRIPTION
## Summary

Closes #1006.

`scripts/generate-migration.sh` previously published the ephemeral postgres on a hardcoded host port `15432`. If the port was occupied (concurrent migration generation, a local service, or — per prior memory — the e2e postgres in some workflows) the script aborted with a connection error.

This PR switches to Docker's automatic port allocation: the container is published with `-p 5432` (no host part), and the assigned host port is read back via `docker inspect` once the container is running. The DSN is then built from that port. A defensive guard fails fast with a clear message if `docker inspect` returns an empty port for any reason.

## Changes

- `scripts/generate-migration.sh`: drop fixed `POSTGRES_PORT=15432`; ask Docker for a free port; resolve the assigned port from `docker inspect`; build the DSN after container start; print the chosen port for visibility.
- Updated header comment and removed the inline `see issue #1006` TODO.

## Test plan

- [x] `bash -n scripts/generate-migration.sh` — syntax OK.
- [x] Smoke-tested the `docker run -p 5432` + `docker inspect` format on this host (got a valid high port; container cleaned up).
- [ ] Run `./scripts/generate-migration.sh test_dynamic_port` end-to-end with no occupant on 15432 (expected: works as before, prints assigned port).
- [ ] Run two invocations concurrently (expected: both succeed; previously the second would fail on port conflict).