### PR TITLE
[#1210] Surface HTTP 5xx responses via global toast

### DIFF
--- a/frontend/src/i18n/locales/en/errors.json
+++ b/frontend/src/i18n/locales/en/errors.json
@@ -1,4 +1,7 @@
 {
+  "global": {
+    "server": "Server error. Please try again later."
+  },
   "notFound": {
     "description": "The page you requested doesn’t exist or has been moved.",
     "documentTitle": "Page not found",

--- a/frontend/src/lib/__tests__/global-error-toast.test.ts
+++ b/frontend/src/lib/__tests__/global-error-toast.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("sonner", () => {
+  const error = vi.fn()
+  return {
+    toast: { error },
+  }
+})
+
+import { toast } from "sonner"
+
+import { notifyGlobalServerError } from "@/lib/global-error-toast"
+import { HttpError } from "@/lib/http"
+
+const errorMock = toast.error as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  errorMock.mockReset()
+})
+
+describe("notifyGlobalServerError", () => {
+  it.each([500, 502, 503, 504])("fires a toast for HttpError status %i", (status) => {
+    notifyGlobalServerError(new HttpError("server", status, "/x", null), undefined)
+    expect(errorMock).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([400, 401, 403, 404, 422])("stays quiet for HttpError status %i", (status) => {
+    notifyGlobalServerError(new HttpError("client", status, "/x", null), undefined)
+    expect(errorMock).not.toHaveBeenCalled()
+  })
+
+  it("ignores non-HttpError throwables (network errors, aborts)", () => {
+    notifyGlobalServerError(new TypeError("Failed to fetch"), undefined)
+    notifyGlobalServerError("boom", undefined)
+    expect(errorMock).not.toHaveBeenCalled()
+  })
+
+  it("respects suppressGlobalErrorToast in meta", () => {
+    notifyGlobalServerError(new HttpError("server", 500, "/x", null), {
+      suppressGlobalErrorToast: true,
+    })
+    expect(errorMock).not.toHaveBeenCalled()
+  })
+
+  it("falls back to the generic message when the body has no useful detail", () => {
+    notifyGlobalServerError(
+      new HttpError("server", 500, "/x", { errors: [{ status: "Internal Server UserError" }] }),
+      undefined
+    )
+    expect(errorMock).toHaveBeenCalledWith("Server error. Please try again later.")
+  })
+
+  it("surfaces the JSON:API detail when the BE provides one", () => {
+    notifyGlobalServerError(
+      new HttpError("server", 500, "/x", {
+        errors: [{ detail: "database is on fire" }],
+      }),
+      undefined
+    )
+    expect(errorMock).toHaveBeenCalledWith("database is on fire")
+  })
+})

--- a/frontend/src/lib/__tests__/query-client.test.ts
+++ b/frontend/src/lib/__tests__/query-client.test.ts
@@ -1,7 +1,22 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("sonner", () => {
+  const error = vi.fn()
+  return {
+    toast: { error },
+  }
+})
+
+import { toast } from "sonner"
 
 import { createQueryClient } from "@/lib/query-client"
 import { HttpError } from "@/lib/http"
+
+const errorMock = toast.error as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  errorMock.mockReset()
+})
 
 describe("createQueryClient", () => {
   it("returns a fresh client instance per call", () => {
@@ -37,5 +52,58 @@ describe("createQueryClient", () => {
   it("mutations never retry", () => {
     const client = createQueryClient()
     expect(client.getDefaultOptions().mutations?.retry).toBe(false)
+  })
+
+  it("fires a global toast when a query bubbles an HTTP 500 (issue #1210)", async () => {
+    const client = createQueryClient()
+    await client
+      .fetchQuery({
+        queryKey: ["1210", "query-500"],
+        queryFn: () => Promise.reject(new HttpError("server", 500, "/x", null)),
+        retry: false,
+      })
+      .catch(() => {
+        // expected — we just need the cache's onError to fire.
+      })
+    expect(errorMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("fires a global toast when a mutation bubbles an HTTP 500 (issue #1210)", async () => {
+    const client = createQueryClient()
+    await client
+      .getMutationCache()
+      .build(client, {
+        mutationFn: () => Promise.reject(new HttpError("server", 500, "/x", null)),
+      })
+      .execute(undefined)
+      .catch(() => {
+        // expected — we just need the cache's onError to fire.
+      })
+    expect(errorMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not fire a global toast on a 4xx", async () => {
+    const client = createQueryClient()
+    await client
+      .fetchQuery({
+        queryKey: ["1210", "query-422"],
+        queryFn: () => Promise.reject(new HttpError("validation", 422, "/x", null)),
+        retry: false,
+      })
+      .catch(() => {})
+    expect(errorMock).not.toHaveBeenCalled()
+  })
+
+  it("respects meta.suppressGlobalErrorToast on a 5xx mutation", async () => {
+    const client = createQueryClient()
+    await client
+      .getMutationCache()
+      .build(client, {
+        mutationFn: () => Promise.reject(new HttpError("server", 500, "/x", null)),
+        meta: { suppressGlobalErrorToast: true },
+      })
+      .execute(undefined)
+      .catch(() => {})
+    expect(errorMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/lib/global-error-toast.ts
+++ b/frontend/src/lib/global-error-toast.ts
@@ -14,7 +14,7 @@
 // would just duplicate it.
 import { toast } from "sonner"
 
-import { i18next } from "@/i18n/i18next.config"
+import { i18next } from "@/i18n"
 
 import { HttpError } from "./http"
 import { parseServerError } from "./server-error"

--- a/frontend/src/lib/global-error-toast.ts
+++ b/frontend/src/lib/global-error-toast.ts
@@ -1,0 +1,39 @@
+// Global "something blew up" toast for HTTP 5xx responses (issue #1210). Fires
+// from TanStack Query's QueryCache/MutationCache onError so any silently failed
+// request — query OR mutation — still surfaces a notification, even if the
+// caller didn't wire its own `onError`.
+//
+// 4xx is intentionally ignored: those are application-level (validation,
+// permissions, conflicts) and the call site usually maps them to the right
+// inline message. 401 is handled inside http.ts (refresh + redirect). Network
+// failures show up as a non-HttpError thrown by fetch and are also ignored
+// here so e.g. an aborted request during navigation stays quiet.
+//
+// Per-mutation/per-query opt-out: set `meta: { suppressGlobalErrorToast: true }`
+// when the caller already shows a richer error message and a generic toast
+// would just duplicate it.
+import { toast } from "sonner"
+
+import { i18next } from "@/i18n/i18next.config"
+
+import { HttpError } from "./http"
+import { parseServerError } from "./server-error"
+
+export interface GlobalErrorToastMeta {
+  suppressGlobalErrorToast?: boolean
+}
+
+export function notifyGlobalServerError(error: unknown, meta: unknown): void {
+  if (!(error instanceof HttpError)) return
+  if (error.status < 500) return
+  if (isMetaSuppressed(meta)) return
+  const fallback = i18next.t("errors:global.server", {
+    defaultValue: "Server error. Please try again later.",
+  })
+  toast.error(parseServerError(error, fallback))
+}
+
+function isMetaSuppressed(meta: unknown): boolean {
+  if (!meta || typeof meta !== "object") return false
+  return (meta as GlobalErrorToastMeta).suppressGlobalErrorToast === true
+}

--- a/frontend/src/lib/query-client.ts
+++ b/frontend/src/lib/query-client.ts
@@ -1,13 +1,22 @@
-import { QueryClient } from "@tanstack/react-query"
+import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query"
 
+import { notifyGlobalServerError } from "./global-error-toast"
 import { HttpError } from "./http"
 
 // One QueryClient per app. Defaults match issue #1403:
 //   - 30s staleTime so navigation between pages reuses cached data
 //   - 1 retry, but never on auth or other 4xx (a 401 has already been
 //     resolved or escalated by http.ts; retrying makes the redirect race)
+// QueryCache/MutationCache onError surface 5xx responses globally (#1210)
+// so silently failing requests still show the user something happened.
 export function createQueryClient(): QueryClient {
   return new QueryClient({
+    queryCache: new QueryCache({
+      onError: (error, query) => notifyGlobalServerError(error, query.meta),
+    }),
+    mutationCache: new MutationCache({
+      onError: (error, _vars, _ctx, mutation) => notifyGlobalServerError(error, mutation.meta),
+    }),
     defaultOptions: {
       queries: {
         staleTime: 30_000,


### PR DESCRIPTION
Closes #1210.

## Summary
- Wires `QueryCache` and `MutationCache` `onError` in `createQueryClient` to a new `notifyGlobalServerError` helper. Any `HttpError` with status >= 500 fires a sonner `toast.error`, so silently failing requests (the upload from #1210, list refetches, mutations) now tell the user something happened instead of dying in the DevTools console.
- 4xx is intentionally not toasted — those are application-level (validation, permissions, conflicts) and the call site already maps them to the right inline message; 401 stays handled inside `http.ts` (refresh + redirect). Non-`HttpError` throwables (network errors, aborted requests during navigation) are also left alone.
- Per-call opt-out via `meta: { suppressGlobalErrorToast: true }` for mutations/queries that already render a richer error themselves and would only end up duplicated.
- Toast copy uses `parseServerError(err, fallback)` so a BE-supplied JSON:API `detail` shows up verbatim when present; otherwise a translatable `errors:global.server` ("Server error. Please try again later.") takes over.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test` — 624 tests pass, including 6 new unit tests in `global-error-toast.test.ts` and 4 new wiring tests in `query-client.test.ts` covering 5xx/4xx/network-error/`meta` opt-out paths
- [ ] Manual: attempt an upload that 500s and confirm a toast appears (the original repro from the issue)