### PR TITLE
[#1519] Strip pgxpool params from DSN before pq/pgx.Connect

### DIFF
--- a/go/schema/bootstrap/bootstrap.go
+++ b/go/schema/bootstrap/bootstrap.go
@@ -12,6 +12,8 @@ import (
 	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"github.com/jackc/pgx/v5"
+
+	"github.com/denisvmedia/inventario/schema/dsnutil"
 )
 
 //go:embed _sqldata/*.sql
@@ -78,8 +80,11 @@ func (m *Migrator) Apply(ctx context.Context, args ApplyArgs) error {
 		return m.dryRun(files, args.Template)
 	}
 
-	// Connect to database
-	conn, err := pgx.Connect(ctx, args.DSN)
+	// Connect to database. pgx.Connect (unlike pgxpool.ParseConfig) does not
+	// strip pool_* keys from the DSN, so callers passing a pgxpool-shaped DSN
+	// (e.g. POSTGRES_TEST_DSN) would otherwise have those params forwarded
+	// to the server as unknown startup parameters. See dsnutil.StripPGXPoolParams.
+	conn, err := pgx.Connect(ctx, dsnutil.StripPGXPoolParams(args.DSN))
 	if err != nil {
 		return errxtrace.Wrap("failed to connect to database", err)
 	}

--- a/go/schema/dsnutil/dsnutil.go
+++ b/go/schema/dsnutil/dsnutil.go
@@ -1,0 +1,42 @@
+// Package dsnutil contains small helpers for normalising PostgreSQL DSNs
+// across the inventario schema layer (migrator, bootstrap).
+package dsnutil
+
+import (
+	"net/url"
+	"strings"
+)
+
+// StripPGXPoolParams removes pgxpool-specific query parameters from a
+// PostgreSQL DSN. pgx accepts pool_* keys (pool_max_conns, pool_min_conns,
+// pool_max_conn_lifetime, …) only via pgxpool.ParseConfig, which discards
+// them before opening the underlying connection. lib/pq and pgx.Connect /
+// pgconn.ParseConfig do NOT strip them; they forward every unrecognised
+// query param to the server as a startup_message parameter, and the server
+// rejects pool_* with `42704 unrecognized configuration parameter`.
+//
+// Schema-layer code (migrator, bootstrap) opens connections via pq and
+// pgx.Connect, so it must be handed a DSN free of pool_* keys. Stripping
+// here lets callers pass the same DSN they use for pgxpool without each
+// schema-layer entrypoint having to know which driver it ultimately uses.
+//
+// If the input is unparseable as a URL, it is returned unchanged.
+func StripPGXPoolParams(dbURL string) string {
+	parsed, err := url.Parse(dbURL)
+	if err != nil {
+		return dbURL
+	}
+	q := parsed.Query()
+	stripped := false
+	for k := range q {
+		if strings.HasPrefix(k, "pool_") {
+			q.Del(k)
+			stripped = true
+		}
+	}
+	if !stripped {
+		return dbURL
+	}
+	parsed.RawQuery = q.Encode()
+	return parsed.String()
+}

--- a/go/schema/dsnutil/dsnutil_test.go
+++ b/go/schema/dsnutil/dsnutil_test.go
@@ -1,0 +1,61 @@
+package dsnutil_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/schema/dsnutil"
+)
+
+func TestStripPGXPoolParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "removes pool_max_conns and pool_min_conns",
+			input:    "postgres://user:pass@localhost:5432/db?sslmode=disable&pool_max_conns=1&pool_min_conns=1",
+			expected: "postgres://user:pass@localhost:5432/db?sslmode=disable",
+		},
+		{
+			name:     "removes other pool_ prefixed params",
+			input:    "postgres://user:pass@localhost:5432/db?pool_max_conn_lifetime=1h&pool_health_check_period=30s",
+			expected: "postgres://user:pass@localhost:5432/db",
+		},
+		{
+			name:     "preserves DSN with no pool_ params",
+			input:    "postgres://user:pass@localhost:5432/db?sslmode=disable",
+			expected: "postgres://user:pass@localhost:5432/db?sslmode=disable",
+		},
+		{
+			name:     "preserves DSN with no query string",
+			input:    "postgres://user:pass@localhost:5432/db",
+			expected: "postgres://user:pass@localhost:5432/db",
+		},
+		{
+			name:     "preserves non-pool params alongside stripped pool params",
+			input:    "postgres://u:p@h:5432/db?sslmode=disable&application_name=app&pool_max_conns=4",
+			expected: "postgres://u:p@h:5432/db?application_name=app&sslmode=disable",
+		},
+		{
+			name:     "preserves postgresql scheme",
+			input:    "postgresql://u:p@h:5432/db?sslmode=disable&pool_max_conns=4",
+			expected: "postgresql://u:p@h:5432/db?sslmode=disable",
+		},
+		{
+			name:     "returns input unchanged when URL is unparseable",
+			input:    "::not-a-url",
+			expected: "::not-a-url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := dsnutil.StripPGXPoolParams(tt.input)
+			c.Assert(got, qt.Equals, tt.expected)
+		})
+	}
+}

--- a/go/schema/migrations/migrator/migrator.go
+++ b/go/schema/migrations/migrator/migrator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
 
+	"github.com/denisvmedia/inventario/schema/dsnutil"
 	"github.com/denisvmedia/inventario/schema/migrations"
 )
 
@@ -37,7 +38,7 @@ type Migrator struct {
 //   - dbURL:    PostgreSQL database connection string
 func New(dbURL string, migFS fs.FS) *Migrator {
 	return &Migrator{
-		dbURL:  dbURL,
+		dbURL:  dsnutil.StripPGXPoolParams(dbURL),
 		logger: slog.Default(),
 		migFS:  migFS,
 	}

--- a/go/schema/migrations/migrator/migrator_internal_test.go
+++ b/go/schema/migrations/migrator/migrator_internal_test.go
@@ -1,0 +1,30 @@
+package migrator
+
+import (
+	"net/url"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestNew_StripsPGXPoolParamsFromStoredDSN guards the integration between the
+// migrator and dsnutil: a DSN carrying pgxpool-only params (as compose hands
+// us in POSTGRES_TEST_DSN) must arrive sanitised at every sql.Open("postgres",
+// …) call inside this package, otherwise lib/pq forwards them to the server
+// and the migrator dies on `42704 unrecognized configuration parameter`. We
+// reach into the unexported field on purpose so this test still catches a
+// future refactor that "forgets" to strip.
+func TestNew_StripsPGXPoolParamsFromStoredDSN(t *testing.T) {
+	c := qt.New(t)
+
+	dsn := "postgres://user:pass@localhost:5432/db?sslmode=disable&pool_max_conns=1&pool_min_conns=1"
+	m := New(dsn, nil)
+
+	parsed, err := url.Parse(m.dbURL)
+	c.Assert(err, qt.IsNil)
+
+	q := parsed.Query()
+	c.Assert(q.Has("pool_max_conns"), qt.IsFalse, qt.Commentf("pool_max_conns must be stripped to keep lib/pq happy"))
+	c.Assert(q.Has("pool_min_conns"), qt.IsFalse, qt.Commentf("pool_min_conns must be stripped to keep lib/pq happy"))
+	c.Assert(q.Get("sslmode"), qt.Equals, "disable", qt.Commentf("non-pool params must be preserved"))
+}


### PR DESCRIPTION
Fixes #1519.

## Summary

- Add `go/schema/dsnutil.StripPGXPoolParams` and apply it at the migrator constructor and `bootstrap.Apply`'s `pgx.Connect` call.
- `make docker-test-go-postgres` (and any other code path that hands the schema layer a pgxpool-shaped DSN) now actually runs the postgres test suite instead of dying on `42704 unrecognized configuration parameter "pool_max_conns"`.

## Why

The schema layer opens admin connections via two drivers:

- **lib/pq** — `migrator.DropTables` (`sql.Open("postgres", m.dbURL)`) and `migrator.DropDatabase` (admin DSN derived from `m.dbURL`).
- **pgx.Connect** — `bootstrap.Apply`.

Neither strips pgxpool-only query params (`pool_max_conns`, `pool_min_conns`, …). Only `pgxpool.ParseConfig` does — so anything else forwards them to the server as startup parameters and the server rejects with `42704 unrecognized configuration parameter`.

`POSTGRES_TEST_DSN` in `docker-compose.yaml` carries `?sslmode=disable&pool_max_conns=1&pool_min_conns=1`, so every postgres registry test going through `setupTestRegistrySet → migrateUp → DropTables` died before its body ran. `migrator.MigrateUp` was unaffected because `dbschema.ConnectToDatabase` (ptah) already strips internally — that's why `inventario-test-migrate` exits 0 in compose.

The issue's option (1) ("strip in the migrator before opening pq") covers `DropTables/DropDatabase`. Empirically the next failure after that fix is `bootstrap.Apply`'s `pgx.Connect`, which has the same drug-of-choice problem, so the helper lives in a small shared package and both schema-layer entrypoints call it.

## Changes

- `go/schema/dsnutil/dsnutil.go` (new) — `StripPGXPoolParams` (URL-parses, drops every `pool_*` query key, re-encodes; returns the input unchanged if unparseable or already clean).
- `go/schema/dsnutil/dsnutil_test.go` — table-driven coverage including pool/non-pool param mixes, no-query DSNs, and unparseable input.
- `go/schema/migrations/migrator/migrator.go` — sanitise `dbURL` at `New(...)` so every internal `sql.Open("postgres", …)` and the admin DSN built by `parsePostgreSQLDSN` get a pq-safe URL.
- `go/schema/migrations/migrator/migrator_internal_test.go` (new, whitebox `package migrator`) — guards that `New` strips pool params from the stored DSN. The test has to peek at the unexported `m.dbURL`; that's intentional, so a future refactor that "forgets" to strip still trips it.
- `go/schema/bootstrap/bootstrap.go` — strip at the `pgx.Connect` site.

## Test plan

- [x] `go test ./schema/dsnutil/... ./schema/migrations/migrator/... ./schema/bootstrap/...` — green.
- [x] `go vet ./schema/... ./cmd/...` — clean.
- [x] End-to-end repro of the original failure: spun up only `postgres-test` (compose), ran `POSTGRES_TEST_DSN='postgres://inventario_test:test_password@localhost:5433/inventario_test?sslmode=disable&pool_max_conns=1&pool_min_conns=1' go test -timeout 15m -count=1 -p 1 ./registry/postgres/...`. Without the fix: 13 fails in `setupTestRegistrySet`. With the fix: `ok ... 101.100s` for `registry/postgres` and `ok` for `registry/postgres/store`.
- [ ] `make docker-test-go-postgres` end-to-end (full image build) — not run locally; the host-side run above exercises the same `setupTestRegistrySet → DropTables → bootstrap.Apply → MigrateUp` chain with the same DSN, so the docker path should follow.

## Out of scope

- Adding a CI job for `make docker-test-go-postgres` (issue lists this as a follow-up).
- Touching the pgx-driver-name vs `sqlx.NewDb(sqlDB, "pgx")` story.