### PR TITLE
[#1529] Warranty UI overhaul: canonical badge + dashboard panels + WarrantiesView polish

### DIFF
--- a/e2e/tests/warranties.spec.ts
+++ b/e2e/tests/warranties.spec.ts
@@ -97,15 +97,21 @@ test.describe('Warranties — list view + detail surface', () => {
       )
       seededIDs.push(expiredId)
 
-      // 1) /warranties (default "All" tab) shows every seeded row.
+      // 1) /warranties default tab is "Expiring" (#1529 polish — the
+      //    "all" tab was dropped). Only the expiring row is visible
+      //    on first paint; the active + expired rows live behind their
+      //    own tabs which the next steps walk.
       await page.goto(`/g/${encodeURIComponent(group.slug)}/warranties`)
       await expect(page.getByTestId('page-warranties')).toBeVisible()
-      const allRowActive = page.locator(`[data-testid="warranties-row-${activeId}"]`)
-      const allRowExpiring = page.locator(`[data-testid="warranties-row-${expiringId}"]`)
-      const allRowExpired = page.locator(`[data-testid="warranties-row-${expiredId}"]`)
-      await expect(allRowActive).toBeVisible({ timeout: 15000 })
-      await expect(allRowExpiring).toBeVisible()
-      await expect(allRowExpired).toBeVisible()
+      await expect(page.getByTestId('warranties-tab-expiring')).toHaveAttribute(
+        'aria-selected',
+        'true',
+      )
+      await expect(page.getByTestId(`warranties-row-${expiringId}`)).toBeVisible({
+        timeout: 15000,
+      })
+      await expect(page.locator(`[data-testid="warranties-row-${activeId}"]`)).toHaveCount(0)
+      await expect(page.locator(`[data-testid="warranties-row-${expiredId}"]`)).toHaveCount(0)
 
       // 2) "Active" tab — hits the BE `warranty_status=active` filter.
       await page.getByTestId('warranties-tab-active').click()
@@ -113,23 +119,18 @@ test.describe('Warranties — list view + detail surface', () => {
       await expect(page.locator(`[data-testid="warranties-row-${expiringId}"]`)).toHaveCount(0)
       await expect(page.locator(`[data-testid="warranties-row-${expiredId}"]`)).toHaveCount(0)
 
-      // 3) "Expiring soon" tab — hits warranty_status=expiring.
-      await page.getByTestId('warranties-tab-expiring').click()
-      await expect(page.getByTestId(`warranties-row-${expiringId}`)).toBeVisible({ timeout: 15000 })
-      await expect(page.locator(`[data-testid="warranties-row-${activeId}"]`)).toHaveCount(0)
-      await expect(page.locator(`[data-testid="warranties-row-${expiredId}"]`)).toHaveCount(0)
-
-      // 4) "Expired" tab — hits warranty_status=expired.
+      // 3) "Expired" tab — hits warranty_status=expired.
       await page.getByTestId('warranties-tab-expired').click()
       await expect(page.getByTestId(`warranties-row-${expiredId}`)).toBeVisible({ timeout: 15000 })
       await expect(page.locator(`[data-testid="warranties-row-${activeId}"]`)).toHaveCount(0)
       await expect(page.locator(`[data-testid="warranties-row-${expiringId}"]`)).toHaveCount(0)
 
-      // 5) Detail page — Warranty tab shows the computed pill.
+      // 4) Detail page — Warranty tab shows the computed pill. Use the
+      //    new `?tab=warranty` deep-link path (#1545) so we exercise
+      //    that surface end-to-end as well.
       await page.goto(
-        `/g/${encodeURIComponent(group.slug)}/commodities/${encodeURIComponent(expiringId)}`,
+        `/g/${encodeURIComponent(group.slug)}/commodities/${encodeURIComponent(expiringId)}?tab=warranty`,
       )
-      await page.getByRole('tab', { name: /^Warranty$/ }).click()
       await expect(page.getByTestId('commodity-detail-warranty')).toBeVisible()
       await expect(page.getByTestId('commodity-detail-warranty-status')).toContainText(
         /Expiring soon/i,

--- a/frontend/src/components/dashboard/ExpiringWarranties.tsx
+++ b/frontend/src/components/dashboard/ExpiringWarranties.tsx
@@ -1,0 +1,122 @@
+import { Link } from "react-router-dom"
+import { ShieldAlert } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
+import { WARRANTY_STATUS_CONFIG } from "@/components/warranty/config"
+import type { Commodity } from "@/features/commodities/api"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { cn } from "@/lib/utils"
+
+interface ExpiringWarrantiesProps {
+  // Up to 5 commodities whose warranty falls in the "expiring" bucket
+  // (≤60 days from expiry), pre-sorted by expiry ascending. Empty
+  // array renders an "all clear" line.
+  items: Commodity[]
+  // True while the parent dashboard query is on its first fetch.
+  // Renders skeleton rows so the panel doesn't pop in.
+  isLoading?: boolean
+}
+
+function daysUntil(dateStr: string | undefined): number | null {
+  if (!dateStr) return null
+  const t = Date.parse(`${dateStr}T00:00:00Z`)
+  if (Number.isNaN(t)) return null
+  const now = new Date()
+  const todayUTC = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  return Math.round((t - todayUTC) / (1000 * 60 * 60 * 24))
+}
+
+// ExpiringWarranties is the dashboard's left-hand panel above the
+// Warranty Health card. Mirrors the design mock's "Expiring Warranties"
+// list — each row shows item name, optional short-name secondary line,
+// and a status-coloured "N days left" pill on the right. Rows are
+// links so click + keyboard activation drill into the item's detail
+// page (Warranty tab preselected).
+export function ExpiringWarranties({ items, isLoading = false }: ExpiringWarrantiesProps) {
+  const { t } = useTranslation()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  const visual = WARRANTY_STATUS_CONFIG.expiring
+  return (
+    <Card data-testid="dashboard-expiring-warranties">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <ShieldAlert aria-hidden="true" className={cn("size-4", visual.text)} />
+          {t("dashboard:expiringWarranties.title")}
+        </CardTitle>
+        <CardDescription>{t("dashboard:expiringWarranties.description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        {isLoading ? (
+          <ul aria-busy="true">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <li key={i}>
+                {i > 0 ? <Separator /> : null}
+                <div className="flex items-center justify-between gap-4 px-6 py-3.5">
+                  <div className="flex-1 space-y-1.5">
+                    <Skeleton className="h-3 w-32" />
+                    <Skeleton className="h-3 w-20" />
+                  </div>
+                  <Skeleton className="h-5 w-20" />
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : items.length === 0 ? (
+          <p
+            className="px-6 pb-6 text-sm text-muted-foreground"
+            data-testid="dashboard-expiring-warranties-empty"
+          >
+            {t("dashboard:expiringWarranties.empty")}
+          </p>
+        ) : (
+          <ul>
+            {items.map((item, i) => {
+              const days = daysUntil(item.warranty_expires_at)
+              const id = item.id ?? ""
+              const subtitle =
+                item.short_name && item.short_name !== item.name ? item.short_name : null
+              return (
+                <li key={id || i}>
+                  {i > 0 ? <Separator /> : null}
+                  <Link
+                    to={
+                      id && slug
+                        ? `/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}?tab=warranty`
+                        : "#"
+                    }
+                    className="flex w-full items-center justify-between px-6 py-3.5 text-left transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 outline-none"
+                    data-testid="dashboard-expiring-warranty-row"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">
+                        {item.name ?? t("dashboard:recentlyAdded.untitled")}
+                      </p>
+                      {subtitle ? (
+                        <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
+                      ) : null}
+                    </div>
+                    {days !== null ? (
+                      <Badge
+                        variant="outline"
+                        className={cn("shrink-0 ml-4", visual.text, visual.bg, visual.border)}
+                      >
+                        {days >= 0
+                          ? t("dashboard:expiringWarranties.daysLeft", { count: days })
+                          : t("dashboard:expiringWarranties.daysAgo", { count: -days })}
+                      </Badge>
+                    ) : null}
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/dashboard/ExpiringWarranties.tsx
+++ b/frontend/src/components/dashboard/ExpiringWarranties.tsx
@@ -7,15 +7,16 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { WARRANTY_STATUS_CONFIG } from "@/components/warranty/config"
-import type { Commodity } from "@/features/commodities/api"
+import type { ExpiringWarrantyRow } from "@/features/dashboard/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { cn } from "@/lib/utils"
 
 interface ExpiringWarrantiesProps {
   // Up to 5 commodities whose warranty falls in the "expiring" bucket
-  // (≤60 days from expiry), pre-sorted by expiry ascending. Empty
-  // array renders an "all clear" line.
-  items: Commodity[]
+  // (≤60 days from expiry), pre-sorted by expiry ascending. Each row
+  // carries the resolved expiry date so legacy `warranty:YYYY-MM-DD`
+  // tag-only commodities show the right "N days left" pill.
+  items: ExpiringWarrantyRow[]
   // True while the parent dashboard query is on its first fetch.
   // Renders skeleton rows so the panel doesn't pop in.
   isLoading?: boolean
@@ -75,11 +76,13 @@ export function ExpiringWarranties({ items, isLoading = false }: ExpiringWarrant
           </p>
         ) : (
           <ul>
-            {items.map((item, i) => {
-              const days = daysUntil(item.warranty_expires_at)
-              const id = item.id ?? ""
+            {items.map(({ commodity, expiresAt }, i) => {
+              const days = daysUntil(expiresAt)
+              const id = commodity.id ?? ""
               const subtitle =
-                item.short_name && item.short_name !== item.name ? item.short_name : null
+                commodity.short_name && commodity.short_name !== commodity.name
+                  ? commodity.short_name
+                  : null
               return (
                 <li key={id || i}>
                   {i > 0 ? <Separator /> : null}
@@ -94,7 +97,7 @@ export function ExpiringWarranties({ items, isLoading = false }: ExpiringWarrant
                   >
                     <div className="min-w-0">
                       <p className="truncate text-sm font-medium">
-                        {item.name ?? t("dashboard:recentlyAdded.untitled")}
+                        {commodity.name ?? t("dashboard:recentlyAdded.untitled")}
                       </p>
                       {subtitle ? (
                         <p className="truncate text-xs text-muted-foreground">{subtitle}</p>

--- a/frontend/src/components/dashboard/WarrantyHealth.tsx
+++ b/frontend/src/components/dashboard/WarrantyHealth.tsx
@@ -1,0 +1,89 @@
+import { useTranslation } from "react-i18next"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { WARRANTY_STATUS_CONFIG } from "@/components/warranty/config"
+import {
+  COMMODITY_WARRANTY_STATUSES,
+  type CommodityWarrantyStatus,
+} from "@/features/commodities/constants"
+import { cn } from "@/lib/utils"
+
+interface WarrantyHealthProps {
+  // Per-status counts across the loaded commodities slice. The widths
+  // are computed against `total` rather than the page's visible total
+  // so a future per-tab variant of the dashboard reads the same way.
+  counts: Record<CommodityWarrantyStatus, number>
+  isLoading?: boolean
+}
+
+// WarrantyHealth is the dashboard's "status distribution across all
+// items" card. Four horizontal rows (one per status), each with a
+// label, a proportional bar (`bgSolid` from `WARRANTY_STATUS_CONFIG`),
+// and the absolute count right-aligned. Mirrors the design mock's
+// `<Card>` at the bottom of `DashboardView.tsx`.
+export function WarrantyHealth({ counts, isLoading = false }: WarrantyHealthProps) {
+  const { t } = useTranslation()
+  const total = counts.active + counts.expiring + counts.expired + counts.none
+  return (
+    <Card data-testid="dashboard-warranty-health">
+      <CardHeader>
+        <CardTitle className="text-base">{t("dashboard:warrantyHealth.title")}</CardTitle>
+        <CardDescription>{t("dashboard:warrantyHealth.description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <ul className="space-y-3" aria-busy="true">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <li key={i} className="flex items-center gap-3">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-2 flex-1 rounded-full" />
+                <Skeleton className="h-3 w-6" />
+              </li>
+            ))}
+          </ul>
+        ) : total === 0 ? (
+          <p
+            className="text-sm text-muted-foreground"
+            data-testid="dashboard-warranty-health-empty"
+          >
+            {t("dashboard:warrantyHealth.empty")}
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {COMMODITY_WARRANTY_STATUSES.map((status) => {
+              const visual = WARRANTY_STATUS_CONFIG[status]
+              const count = counts[status]
+              const pct = total > 0 ? Math.round((count / total) * 100) : 0
+              return (
+                <li
+                  key={status}
+                  className="flex items-center gap-3"
+                  data-testid={`dashboard-warranty-health-${status}`}
+                >
+                  <span className={cn("w-24 text-xs font-medium", visual.text)}>
+                    {t(visual.i18nKey)}
+                  </span>
+                  <div
+                    className="flex-1 h-2 rounded-full bg-muted overflow-hidden"
+                    role="progressbar"
+                    aria-valuemin={0}
+                    aria-valuemax={total}
+                    aria-valuenow={count}
+                    aria-label={t(visual.i18nKey)}
+                  >
+                    <div
+                      className={cn("h-full rounded-full transition-all", visual.bgSolid)}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                  <span className="w-8 text-right text-xs text-muted-foreground">{count}</span>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -23,11 +23,11 @@ import {
   COMMODITY_STATUSES,
   COMMODITY_TYPES,
   COMMODITY_TYPE_ICONS,
-  COMMODITY_WARRANTY_TONES,
   warrantyStatus,
   type CommodityStatusValue,
   type CommodityTypeValue,
 } from "@/features/commodities/constants"
+import { WarrantyBadge } from "@/components/warranty/WarrantyBadge"
 import { commoditySchema, type CommodityFormInput } from "@/features/commodities/schemas"
 import type {
   Commodity,
@@ -554,15 +554,11 @@ function WarrantyStep(props: any) {
         <FieldError error={errors.warranty_expires_at} />
       </div>
       {status !== "none" ? (
-        <div
-          className={cn(
-            "inline-flex w-fit items-center rounded-md border px-2 py-1 text-xs font-medium",
-            COMMODITY_WARRANTY_TONES[status]
-          )}
+        <WarrantyBadge
+          status={status}
+          className="w-fit"
           data-testid="commodity-form-warranty-status"
-        >
-          {t(`commodities:warrantyStatus.${status}`)}
-        </div>
+        />
       ) : null}
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="commodity-warranty-notes">{t("commodities:fields.warrantyNotes")}</Label>

--- a/frontend/src/components/warranty/WarrantyBadge.tsx
+++ b/frontend/src/components/warranty/WarrantyBadge.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import { warrantyStatus, type CommodityWarrantyStatus } from "@/features/commodities/constants"
+
+import { WARRANTY_STATUS_CONFIG } from "./config"
+
+// WarrantyBadge is the only place a warranty status pill is rendered.
+// Callers either hand it a precomputed status (`status`) or the raw
+// commodity slice (`source`) and the component derives the bucket via
+// the shared `warrantyStatus()` helper. The badge picks colour, icon,
+// and i18n label from `WARRANTY_STATUS_CONFIG` so the four design
+// tokens (`--status-active|expiring|expired|none`) stay the canonical
+// colour binding.
+//
+// Intentional non-features (deferred to follow-ups):
+// - No size variants. Every consumer renders the badge inline next to
+//   text at the default badge height; if a smaller pill is needed
+//   later (e.g. dense tables), add a `size` prop.
+// - No "live update" of the status as the day rolls over. The status
+//   is computed from the commodity payload at render time.
+export interface WarrantyBadgeProps {
+  // Either pass an already-classified status, or…
+  status?: CommodityWarrantyStatus
+  // …a raw commodity slice carrying the warranty fields. Convenient
+  // when you have the row in hand; the badge does the bucketing.
+  source?: {
+    warranty_expires_at?: string
+    tags?: readonly string[]
+  }
+  // Hide the leading shield icon (e.g. inside a row that already
+  // shows one). Defaults to `true` — the icon is part of the badge's
+  // identity and dropping it should be a deliberate per-call choice.
+  showIcon?: boolean
+  className?: string
+  // Optional test selector. Pass when the badge needs to be located
+  // independently of its parent row.
+  "data-testid"?: string
+}
+
+export function WarrantyBadge({
+  status,
+  source,
+  showIcon = true,
+  className,
+  "data-testid": testId,
+}: WarrantyBadgeProps) {
+  const { t } = useTranslation()
+  const resolved =
+    status ??
+    warrantyStatus({ warranty_expires_at: source?.warranty_expires_at, tags: source?.tags })
+  const visual = WARRANTY_STATUS_CONFIG[resolved]
+  const Icon = visual.icon
+  return (
+    <Badge
+      variant="outline"
+      className={cn("gap-1 font-medium", visual.text, visual.bg, visual.border, className)}
+      data-testid={testId}
+      data-status={resolved}
+    >
+      {showIcon ? <Icon className="size-3" aria-hidden="true" /> : null}
+      {t(visual.i18nKey)}
+    </Badge>
+  )
+}

--- a/frontend/src/components/warranty/__tests__/WarrantyBadge.test.tsx
+++ b/frontend/src/components/warranty/__tests__/WarrantyBadge.test.tsx
@@ -1,0 +1,42 @@
+import { beforeAll, describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+import { WarrantyBadge } from "@/components/warranty/WarrantyBadge"
+import { initI18n } from "@/i18n"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+describe("<WarrantyBadge />", () => {
+  it("renders the i18n label for the precomputed status", () => {
+    render(<WarrantyBadge status="active" data-testid="badge" />)
+    const badge = screen.getByTestId("badge")
+    expect(badge).toHaveTextContent("Active")
+    expect(badge).toHaveAttribute("data-status", "active")
+    expect(badge).toHaveClass("text-status-active")
+  })
+
+  it("derives the status from a raw commodity slice when `source` is given", () => {
+    render(<WarrantyBadge source={{ warranty_expires_at: "1999-01-01" }} data-testid="badge" />)
+    const badge = screen.getByTestId("badge")
+    expect(badge).toHaveAttribute("data-status", "expired")
+    expect(badge).toHaveTextContent("Expired")
+  })
+
+  it("falls back to the legacy warranty:YYYY-MM-DD tag when the field is missing", () => {
+    render(<WarrantyBadge source={{ tags: ["warranty:2099-01-01"] }} data-testid="badge" />)
+    expect(screen.getByTestId("badge")).toHaveAttribute("data-status", "active")
+  })
+
+  it("renders the `none` bucket when neither field nor tag is set", () => {
+    render(<WarrantyBadge source={{}} data-testid="badge" />)
+    expect(screen.getByTestId("badge")).toHaveAttribute("data-status", "none")
+    expect(screen.getByTestId("badge")).toHaveTextContent("No warranty")
+  })
+
+  it("hides the leading icon when `showIcon` is false", () => {
+    const { container } = render(<WarrantyBadge status="active" showIcon={false} />)
+    expect(container.querySelector("svg")).toBeNull()
+  })
+})

--- a/frontend/src/components/warranty/config.ts
+++ b/frontend/src/components/warranty/config.ts
@@ -1,0 +1,70 @@
+// WARRANTY_STATUS_CONFIG is the single source of truth for the
+// per-status colour binding + icon used by every warranty surface
+// (badge, list rows, dashboard panel, item-detail tab). Pulled out of
+// `features/commodities/constants.ts` so non-commodity surfaces can
+// import from a stable path without dragging the list-page filter
+// helpers along. Class strings reference the design tokens declared
+// in src/index.css (`--status-active`, `--status-expiring`,
+// `--status-expired`, `--status-none`); `bgSolid` is the unbordered
+// background variant the dashboard's progress bar fills with — the
+// regular `bg` is the tinted card surface.
+import { Shield, ShieldAlert, ShieldCheck, ShieldOff, type LucideIcon } from "lucide-react"
+
+import type { CommodityWarrantyStatus } from "@/features/commodities/constants"
+
+export interface WarrantyStatusVisual {
+  // i18n key that resolves to the short human label (e.g. "Active",
+  // "Expiring soon"). The `commodities:warranty.*` namespace already
+  // ships the short forms — `warrantyStatus.*` exists too but its
+  // values are sentence-y ("Warranty active") which reads off inside
+  // a chip.
+  i18nKey: `commodities:warranty.${CommodityWarrantyStatus}`
+  // Lucide icon for the status — shield variants per the mock.
+  icon: LucideIcon
+  // Foreground colour class. `text-status-*` tokens already live in
+  // index.css for both light + dark themes.
+  text: string
+  // Tinted background class used by cards / chip backdrops.
+  bg: string
+  // Solid `bg-status-*` (no /N opacity). Used by the dashboard's
+  // proportional progress bars where a tinted background reads as
+  // washed-out.
+  bgSolid: string
+  // Border colour class for outlined badges.
+  border: string
+}
+
+export const WARRANTY_STATUS_CONFIG: Record<CommodityWarrantyStatus, WarrantyStatusVisual> = {
+  active: {
+    i18nKey: "commodities:warranty.active",
+    icon: ShieldCheck,
+    text: "text-status-active",
+    bg: "bg-status-active/10",
+    bgSolid: "bg-status-active",
+    border: "border-status-active/30",
+  },
+  expiring: {
+    i18nKey: "commodities:warranty.expiring",
+    icon: ShieldAlert,
+    text: "text-status-expiring",
+    bg: "bg-status-expiring/10",
+    bgSolid: "bg-status-expiring",
+    border: "border-status-expiring/30",
+  },
+  expired: {
+    i18nKey: "commodities:warranty.expired",
+    icon: ShieldOff,
+    text: "text-status-expired",
+    bg: "bg-status-expired/10",
+    bgSolid: "bg-status-expired",
+    border: "border-status-expired/30",
+  },
+  none: {
+    i18nKey: "commodities:warranty.none",
+    icon: Shield,
+    text: "text-status-none",
+    bg: "bg-status-none/10",
+    bgSolid: "bg-status-none",
+    border: "border-status-none/30",
+  },
+}

--- a/frontend/src/features/commodities/constants.ts
+++ b/frontend/src/features/commodities/constants.ts
@@ -109,13 +109,8 @@ function classifyDays(expiresAt: number): CommodityWarrantyStatus {
   return "active"
 }
 
-// Tone classes for the warranty pill — same pattern as the status
-// pills (text/border/bg derived from the design tokens). Used by
-// future detail-page warranty surfaces; the filter dropdown itself
-// shows plain labels.
-export const COMMODITY_WARRANTY_TONES: Record<CommodityWarrantyStatus, string> = {
-  active: "text-status-active border-status-active/30 bg-status-active/10",
-  expiring: "text-status-expiring border-status-expiring/30 bg-status-expiring/10",
-  expired: "text-status-expired border-status-expired/30 bg-status-expired/10",
-  none: "text-muted-foreground border-border bg-muted",
-}
+// Tone classes for the warranty pill used to live here as
+// `COMMODITY_WARRANTY_TONES`. Per #1529 the canonical rendering surface
+// is `<WarrantyBadge>` (frontend/src/components/warranty/) which reads
+// `WARRANTY_STATUS_CONFIG`; importing tones from here is no longer
+// supported. New code: render `<WarrantyBadge status={...} />` instead.

--- a/frontend/src/features/commodities/constants.ts
+++ b/frontend/src/features/commodities/constants.ts
@@ -76,16 +76,31 @@ export function warrantyStatus(input: {
   warranty_expires_at?: string
   tags?: readonly string[]
 }): CommodityWarrantyStatus {
-  const direct = parseWarrantyDate(input.warranty_expires_at)
-  if (direct) return classifyDays(direct)
+  const effective = effectiveWarrantyExpiry(input)
+  if (!effective) return "none"
+  const ms = parseWarrantyDate(effective)
+  return ms ? classifyDays(ms) : "none"
+}
+
+// effectiveWarrantyExpiry returns the YYYY-MM-DD string the rest of
+// the warranty UI should render — either the dedicated
+// `warranty_expires_at` column (#1367) or, when that's missing, the
+// legacy `warranty:YYYY-MM-DD` tag carried over from pre-#1367 data.
+// Returns `undefined` when neither signal is present so callers can
+// distinguish "no warranty tracked" from "tracked but date unknown".
+//
+// Single source of truth for the field-vs-tag fallback so the
+// status bucketing, the row subtitle ("Expires <date>"), and the
+// dashboard's days-remaining counter all agree.
+export function effectiveWarrantyExpiry(input: {
+  warranty_expires_at?: string
+  tags?: readonly string[]
+}): string | undefined {
+  if (input.warranty_expires_at) return input.warranty_expires_at
   const tagged = input.tags
     ?.map((t) => /^warranty:(\d{4}-\d{2}-\d{2})$/.exec(t))
     .find((m) => m !== null)
-  if (tagged) {
-    const fromTag = parseWarrantyDate(tagged[1])
-    if (fromTag) return classifyDays(fromTag)
-  }
-  return "none"
+  return tagged?.[1]
 }
 
 function parseWarrantyDate(s: string | undefined): number | null {

--- a/frontend/src/features/dashboard/__tests__/hooks.test.ts
+++ b/frontend/src/features/dashboard/__tests__/hooks.test.ts
@@ -67,7 +67,7 @@ describe("warrantyBuckets", () => {
     expect(counts).toEqual({ active: 1, expiring: 2, expired: 1, none: 1 })
   })
 
-  it("returns up to N expiring rows sorted by expiry ascending", () => {
+  it("returns up to N expiring rows sorted by expiry ascending with the resolved date", () => {
     const items: Commodity[] = [
       commodity({ id: "later", warranty_expires_at: daysFromNow(45) }),
       commodity({ id: "soonest", warranty_expires_at: daysFromNow(2) }),
@@ -75,16 +75,27 @@ describe("warrantyBuckets", () => {
       commodity({ id: "limit-out", warranty_expires_at: daysFromNow(50) }),
     ]
     const { expiring } = warrantyBuckets(items, 2)
-    expect(expiring.map((c) => c.id)).toEqual(["soonest", "middle"])
+    expect(expiring.map((r) => r.commodity.id)).toEqual(["soonest", "middle"])
+    // Each row must carry the resolved date — used by the dashboard
+    // panel's "N days left" pill.
+    expect(expiring[0].expiresAt).toBe(daysFromNow(2))
   })
 
   it("falls back to the legacy warranty:YYYY-MM-DD tag when the dedicated field is missing", () => {
     const items: Commodity[] = [
       commodity({ id: "tagged-active", tags: ["warranty:2099-01-01"] }),
       commodity({ id: "tagged-expired", tags: ["warranty:1999-01-01"] }),
+      commodity({ id: "tagged-expiring", tags: [`warranty:${daysFromNow(20)}`] }),
     ]
-    const { counts } = warrantyBuckets(items, 5)
+    const { counts, expiring } = warrantyBuckets(items, 5)
     expect(counts.active).toBe(1)
     expect(counts.expired).toBe(1)
+    expect(counts.expiring).toBe(1)
+    // Tag-only legacy rows get carried into the expiring shortlist
+    // with the resolved tag date — the dashboard pill needs that to
+    // render "N days left" instead of showing nothing.
+    expect(expiring).toHaveLength(1)
+    expect(expiring[0].commodity.id).toBe("tagged-expiring")
+    expect(expiring[0].expiresAt).toBe(daysFromNow(20))
   })
 })

--- a/frontend/src/features/dashboard/__tests__/hooks.test.ts
+++ b/frontend/src/features/dashboard/__tests__/hooks.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest"
 
-import { recentlyAdded } from "@/features/dashboard/hooks"
+import { recentlyAdded, warrantyBuckets } from "@/features/dashboard/hooks"
 import type { Commodity } from "@/features/commodities/api"
 
 function commodity(over: Partial<Commodity>): Commodity {
   return { id: "c", name: "Item", ...over }
+}
+
+function daysFromNow(days: number): string {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
 }
 
 describe("recentlyAdded", () => {
@@ -47,5 +51,40 @@ describe("recentlyAdded", () => {
     const snapshot = items.map((c) => c.id)
     recentlyAdded(items, 5)
     expect(items.map((c) => c.id)).toEqual(snapshot)
+  })
+})
+
+describe("warrantyBuckets", () => {
+  it("counts each commodity into the right warranty bucket", () => {
+    const items: Commodity[] = [
+      commodity({ id: "a", warranty_expires_at: "2099-01-01" }),
+      commodity({ id: "b", warranty_expires_at: daysFromNow(30) }),
+      commodity({ id: "c", warranty_expires_at: "1999-01-01" }),
+      commodity({ id: "d" }),
+      commodity({ id: "e", warranty_expires_at: daysFromNow(10) }),
+    ]
+    const { counts } = warrantyBuckets(items, 5)
+    expect(counts).toEqual({ active: 1, expiring: 2, expired: 1, none: 1 })
+  })
+
+  it("returns up to N expiring rows sorted by expiry ascending", () => {
+    const items: Commodity[] = [
+      commodity({ id: "later", warranty_expires_at: daysFromNow(45) }),
+      commodity({ id: "soonest", warranty_expires_at: daysFromNow(2) }),
+      commodity({ id: "middle", warranty_expires_at: daysFromNow(20) }),
+      commodity({ id: "limit-out", warranty_expires_at: daysFromNow(50) }),
+    ]
+    const { expiring } = warrantyBuckets(items, 2)
+    expect(expiring.map((c) => c.id)).toEqual(["soonest", "middle"])
+  })
+
+  it("falls back to the legacy warranty:YYYY-MM-DD tag when the dedicated field is missing", () => {
+    const items: Commodity[] = [
+      commodity({ id: "tagged-active", tags: ["warranty:2099-01-01"] }),
+      commodity({ id: "tagged-expired", tags: ["warranty:1999-01-01"] }),
+    ]
+    const { counts } = warrantyBuckets(items, 5)
+    expect(counts.active).toBe(1)
+    expect(counts.expired).toBe(1)
   })
 })

--- a/frontend/src/features/dashboard/hooks.ts
+++ b/frontend/src/features/dashboard/hooks.ts
@@ -2,13 +2,14 @@ import { useMemo } from "react"
 
 import { useCommodities, useCommoditiesValue } from "@/features/commodities/hooks"
 import type { Commodity } from "@/features/commodities/api"
+import { warrantyStatus, type CommodityWarrantyStatus } from "@/features/commodities/constants"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 
 // What the Dashboard page renders. Aggregates two upstream queries
 // (commodities list + values endpoint) into a single shape so the page
-// component stays dumb. Warranty status counts are stubbed at zero
-// today — first-class warranties land in #1367; until then the cards
-// surface a "Coming soon" affordance instead of derived numbers.
+// component stays dumb. Warranty status counts ship now (#1367 / #1529)
+// — both `warrantyStatusCounts` and `expiringWarranties` are derived
+// from the same commodities list query, no extra round-trip.
 export interface DashboardData {
   // True while either upstream query is on its first fetch. `isLoading`
   // (not `isFetching`) so a stale-while-revalidate refetch doesn't
@@ -27,6 +28,15 @@ export interface DashboardData {
   // descending (falling back to last_modified_date if registered_date
   // is missing). The list is what the "Recently Added" card renders.
   recent: Commodity[]
+  // Warranty bucket counts (active / expiring / expired / none) over
+  // the loaded commodities slice. Drives the "Warranty Health" panel
+  // bars + the upper bound for the bar widths.
+  warrantyStatusCounts: Record<CommodityWarrantyStatus, number>
+  // Items whose warranty status is "expiring" (≤60 days from expiry),
+  // sorted by expiry ascending (next-to-expire first). Drives the
+  // "Expiring Warranties" panel — capped at five rows so the panel
+  // doesn't outgrow its tile.
+  expiringWarranties: Commodity[]
 }
 
 // Date string ↦ Unix epoch (ms). Returns 0 for missing/unparseable
@@ -52,6 +62,38 @@ export function recentlyAdded(commodities: Commodity[], limit: number): Commodit
     .slice(0, limit)
 }
 
+// warrantyBuckets walks the commodity list once and returns the
+// per-status counts plus the slice destined for the "Expiring
+// Warranties" panel. Single-pass so adding a third derived view
+// later doesn't multiply the work.
+export function warrantyBuckets(
+  commodities: Commodity[],
+  expiringLimit: number
+): {
+  counts: Record<CommodityWarrantyStatus, number>
+  expiring: Commodity[]
+} {
+  const counts: Record<CommodityWarrantyStatus, number> = {
+    active: 0,
+    expiring: 0,
+    expired: 0,
+    none: 0,
+  }
+  const expiringRows: Commodity[] = []
+  for (const c of commodities) {
+    const s = warrantyStatus({
+      warranty_expires_at: c.warranty_expires_at,
+      tags: c.tags,
+    })
+    counts[s]++
+    if (s === "expiring") expiringRows.push(c)
+  }
+  expiringRows.sort((a, b) =>
+    (a.warranty_expires_at ?? "").localeCompare(b.warranty_expires_at ?? "")
+  )
+  return { counts, expiring: expiringRows.slice(0, expiringLimit) }
+}
+
 // useDashboardData composes the two upstream queries the page needs.
 // Returning a single object keeps Dashboard.tsx free of TanStack
 // machinery — it just renders against a plain shape.
@@ -75,6 +117,7 @@ export function useDashboardData(): DashboardData {
 
   return useMemo<DashboardData>(() => {
     const list = commodities.data?.commodities ?? []
+    const { counts, expiring } = warrantyBuckets(list, 5)
     return {
       // Treat "waiting for group" as still-loading so the page renders
       // skeletons rather than an empty state.
@@ -83,6 +126,8 @@ export function useDashboardData(): DashboardData {
       totalItems: commodities.data?.total ?? list.length,
       totalValue: values.data?.globalTotal ?? 0,
       recent: recentlyAdded(list, 5),
+      warrantyStatusCounts: counts,
+      expiringWarranties: expiring,
     }
   }, [
     enabled,

--- a/frontend/src/features/dashboard/hooks.ts
+++ b/frontend/src/features/dashboard/hooks.ts
@@ -2,7 +2,11 @@ import { useMemo } from "react"
 
 import { useCommodities, useCommoditiesValue } from "@/features/commodities/hooks"
 import type { Commodity } from "@/features/commodities/api"
-import { warrantyStatus, type CommodityWarrantyStatus } from "@/features/commodities/constants"
+import {
+  effectiveWarrantyExpiry,
+  warrantyStatus,
+  type CommodityWarrantyStatus,
+} from "@/features/commodities/constants"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 
 // What the Dashboard page renders. Aggregates two upstream queries
@@ -35,8 +39,15 @@ export interface DashboardData {
   // Items whose warranty status is "expiring" (≤60 days from expiry),
   // sorted by expiry ascending (next-to-expire first). Drives the
   // "Expiring Warranties" panel — capped at five rows so the panel
-  // doesn't outgrow its tile.
-  expiringWarranties: Commodity[]
+  // doesn't outgrow its tile. Each row carries the resolved expiry
+  // date (`effectiveWarrantyExpiry`) so legacy tag-only rows still
+  // render the right "N days left" badge.
+  expiringWarranties: ExpiringWarrantyRow[]
+}
+
+export interface ExpiringWarrantyRow {
+  commodity: Commodity
+  expiresAt: string
 }
 
 // Date string ↦ Unix epoch (ms). Returns 0 for missing/unparseable
@@ -66,12 +77,17 @@ export function recentlyAdded(commodities: Commodity[], limit: number): Commodit
 // per-status counts plus the slice destined for the "Expiring
 // Warranties" panel. Single-pass so adding a third derived view
 // later doesn't multiply the work.
+//
+// Effective expiry date (field OR legacy `warranty:YYYY-MM-DD` tag —
+// see `effectiveWarrantyExpiry`) is carried alongside each expiring
+// row so the dashboard panel can render "N days left" against the
+// resolved date even on tag-only legacy rows.
 export function warrantyBuckets(
   commodities: Commodity[],
   expiringLimit: number
 ): {
   counts: Record<CommodityWarrantyStatus, number>
-  expiring: Commodity[]
+  expiring: ExpiringWarrantyRow[]
 } {
   const counts: Record<CommodityWarrantyStatus, number> = {
     active: 0,
@@ -79,18 +95,27 @@ export function warrantyBuckets(
     expired: 0,
     none: 0,
   }
-  const expiringRows: Commodity[] = []
+  const expiringRows: ExpiringWarrantyRow[] = []
   for (const c of commodities) {
+    const expiresAt = effectiveWarrantyExpiry({
+      warranty_expires_at: c.warranty_expires_at,
+      tags: c.tags,
+    })
     const s = warrantyStatus({
       warranty_expires_at: c.warranty_expires_at,
       tags: c.tags,
     })
     counts[s]++
-    if (s === "expiring") expiringRows.push(c)
+    // The `expiring` bucket is always paired with a real date — the
+    // status only resolves to `expiring` when `effectiveWarrantyExpiry`
+    // returned a parseable YYYY-MM-DD string, so the non-null assertion
+    // is safe. Tag-only legacy rows still land here with the resolved
+    // tag date.
+    if (s === "expiring" && expiresAt) {
+      expiringRows.push({ commodity: c, expiresAt })
+    }
   }
-  expiringRows.sort((a, b) =>
-    (a.warranty_expires_at ?? "").localeCompare(b.warranty_expires_at ?? "")
-  )
+  expiringRows.sort((a, b) => a.expiresAt.localeCompare(b.expiresAt))
   return { counts, expiring: expiringRows.slice(0, expiringLimit) }
 }
 

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -113,10 +113,16 @@
       "emptyState": "No warranty tracked yet. Edit the item to add an expiry date.",
       "expiredAgo_one": "Expired {{count}} day ago",
       "expiredAgo_other": "Expired {{count}} days ago",
+      "expiredOnAgo_one": "Expired {{date}} — {{count}} day ago",
+      "expiredOnAgo_other": "Expired {{date}} — {{count}} days ago",
       "expiresOn": "Expires {{date}}",
+      "expiresOnIn_one": "Expires {{date}} — {{count}} day from now",
+      "expiresOnIn_other": "Expires {{date}} — {{count}} days from now",
       "expiresToday": "Expires today",
+      "noneInline": "No warranty information recorded for this item.",
       "notesLabel": "Notes",
-      "title": "Warranty"
+      "title": "Warranty",
+      "uploadReceipt": "Upload Receipt"
     }
   },
   "fields": {

--- a/frontend/src/i18n/locales/en/dashboard.json
+++ b/frontend/src/i18n/locales/en/dashboard.json
@@ -4,6 +4,15 @@
     "description": "We couldn't load your inventory summary. Refresh the page to retry, or contact support if the problem keeps happening.",
     "title": "Unable to load dashboard"
   },
+  "expiringWarranties": {
+    "daysAgo_one": "{{count}} day ago",
+    "daysAgo_other": "{{count}} days ago",
+    "daysLeft_one": "{{count}} day left",
+    "daysLeft_other": "{{count}} days left",
+    "description": "Warranties expiring within 60 days.",
+    "empty": "All clear — no warranties expiring soon.",
+    "title": "Expiring warranties"
+  },
   "heading": "Overview",
   "recentlyAdded": {
     "description": "Your latest inventory entries.",
@@ -34,8 +43,9 @@
     "description": "A breakdown of inventory value across your locations.",
     "title": "Value by location"
   },
-  "warrantyPanel": {
-    "description": "Track per-item warranty terms, expiry, and renewals.",
+  "warrantyHealth": {
+    "description": "Status distribution across all items.",
+    "empty": "No items yet. Warranty distribution lights up once you start tracking inventory.",
     "title": "Warranty health"
   }
 }

--- a/frontend/src/i18n/locales/en/warranties.json
+++ b/frontend/src/i18n/locales/en/warranties.json
@@ -2,21 +2,23 @@
   "list": {
     "empty": {
       "active": "No items currently under active warranty.",
-      "all": "Add a warranty expiry date to any item and it will show up here.",
       "expired": "Nothing has expired recently.",
       "expiring": "No warranties are expiring in the next 60 days.",
       "none": "Every tracked item already has a warranty date set."
     },
-    "headerExpires": "Expires",
-    "headerItem": "Item",
-    "headerStatus": "Status",
+    "row": {
+      "daysAgo_one": "{{count}} day ago",
+      "daysAgo_other": "{{count}} days ago",
+      "daysLeft_one": "{{count}} day left",
+      "daysLeft_other": "{{count}} days left",
+      "noDate": "No date"
+    },
     "subtitle": "Track manufacturer and seller warranties at a glance. Reminder emails fire 60, 30, and 7 days before expiry.",
     "tab": {
       "active": "Active",
-      "all": "All",
       "expired": "Expired",
-      "expiring": "Expiring soon",
-      "none": "No date"
+      "expiring": "Expiring",
+      "none": "No Warranty"
     },
     "title": "Warranties"
   }

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -135,9 +135,7 @@ describe("<DashboardPage />", () => {
     // The card mounts during the loading-skeleton phase too, so wait
     // for one of its inner status rows (which only render once data
     // resolves) before asserting counts.
-    expect(
-      await screen.findByTestId("dashboard-warranty-health-active")
-    ).toHaveTextContent("1")
+    expect(await screen.findByTestId("dashboard-warranty-health-active")).toHaveTextContent("1")
     expect(screen.getByTestId("dashboard-warranty-health-expiring")).toHaveTextContent("1")
     expect(screen.getByTestId("dashboard-warranty-health-expired")).toHaveTextContent("1")
     expect(screen.getByTestId("dashboard-warranty-health-none")).toHaveTextContent("1")

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -119,18 +119,61 @@ describe("<DashboardPage />", () => {
     )
   })
 
-  it("renders the warranty 'Coming soon' banner referencing #1367", async () => {
+  it("renders the Warranty Health bars + counts (#1529)", async () => {
+    const todayPlus30 = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
     server.use(
       ...groupHandlers.list(groupFixture),
-      ...commodityHandlers.list(SLUG, []),
-      ...commodityHandlers.values(SLUG, {})
+      ...commodityHandlers.list(SLUG, [
+        commodityResource("c-active", { name: "Fridge", warranty_expires_at: "2099-01-01" }),
+        commodityResource("c-expiring", { name: "Kettle", warranty_expires_at: todayPlus30 }),
+        commodityResource("c-expired", { name: "Toaster", warranty_expires_at: "1999-01-01" }),
+        commodityResource("c-none", { name: "Lamp" }),
+      ]),
+      ...commodityHandlers.values(SLUG, { globalTotal: 0 })
     )
     renderDashboard()
-    // Multiple "warranties" surfaces ship now (the warranty card + the
-    // value-by-location/area placeholder cards each render one); proving at
-    // least one is mounted is enough for the #1367 contract this test guards.
-    const banners = await screen.findAllByTestId("coming-soon-banner-warranties")
-    expect(banners.length).toBeGreaterThan(0)
+    // The card mounts during the loading-skeleton phase too, so wait
+    // for one of its inner status rows (which only render once data
+    // resolves) before asserting counts.
+    expect(
+      await screen.findByTestId("dashboard-warranty-health-active")
+    ).toHaveTextContent("1")
+    expect(screen.getByTestId("dashboard-warranty-health-expiring")).toHaveTextContent("1")
+    expect(screen.getByTestId("dashboard-warranty-health-expired")).toHaveTextContent("1")
+    expect(screen.getByTestId("dashboard-warranty-health-none")).toHaveTextContent("1")
+  })
+
+  it("renders the Expiring Warranties panel with one row per expiring item", async () => {
+    const todayPlus10 = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+    const todayPlus40 = new Date(Date.now() + 40 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...commodityHandlers.list(SLUG, [
+        commodityResource("c-soon", { name: "Kettle", warranty_expires_at: todayPlus10 }),
+        commodityResource("c-later", { name: "Mixer", warranty_expires_at: todayPlus40 }),
+      ]),
+      ...commodityHandlers.values(SLUG, { globalTotal: 0 })
+    )
+    renderDashboard()
+    // findAllByTestId polls until at least one row is present, which
+    // guarantees the loading skeleton has resolved into the real list.
+    const rows = await screen.findAllByTestId("dashboard-expiring-warranty-row")
+    expect(rows).toHaveLength(2)
+    // Sorted by expiry ascending — Kettle (10d) ahead of Mixer (40d).
+    expect(rows[0]).toHaveTextContent("Kettle")
+    expect(rows[1]).toHaveTextContent("Mixer")
+  })
+
+  it("shows the Expiring Warranties empty state when nothing is expiring", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...commodityHandlers.list(SLUG, [
+        commodityResource("c-active", { name: "Fridge", warranty_expires_at: "2099-01-01" }),
+      ]),
+      ...commodityHandlers.values(SLUG, { globalTotal: 0 })
+    )
+    renderDashboard()
+    expect(await screen.findByTestId("dashboard-expiring-warranties-empty")).toBeInTheDocument()
   })
 
   it("renders an error alert when an upstream query fails", async () => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,9 +1,11 @@
 import { useTranslation } from "react-i18next"
-import { FolderOpen, MapPin, Package, Pin, ShieldAlert, TrendingUp } from "lucide-react"
+import { FolderOpen, MapPin, Package, Pin, TrendingUp } from "lucide-react"
 
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { StatCard } from "@/components/dashboard/StatCard"
 import { RecentlyAdded } from "@/components/dashboard/RecentlyAdded"
+import { ExpiringWarranties } from "@/components/dashboard/ExpiringWarranties"
+import { WarrantyHealth } from "@/components/dashboard/WarrantyHealth"
 import { ComingSoonBanner } from "@/components/coming-soon/ComingSoonBanner"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -17,19 +19,16 @@ import { formatCurrency } from "@/lib/intl"
 // DashboardPage is the user's group landing at /g/:slug. Layout:
 //
 //   1. Heading + tagline.
-//   2. Four stat cards (totals + warranties + value).
-//   3. Two-up grid: warranty placeholder (left) + recently added (right).
+//   2. Two stat-card rows (totals + value, then locations / areas / files).
+//   3. Two-up grid of value-by-location/area placeholders (still gated
+//      on a future per-place value endpoint — those panels keep their
+//      `ComingSoonBanner`).
+//   4. Two-up grid: ExpiringWarranties (left) + RecentlyAdded (right).
+//   5. Full-width WarrantyHealth card.
 //
-// Warranty status is currently a tag-based concept (#1367); the two
-// warranty stat cards render placeholder dashes ("—") + a "Coming soon"
-// affordance rather than guessing at counts. The placeholder card on
-// the lower half (`ComingSoonBanner` with `surface="warranties"`)
-// tracks #1367 directly so reviewers can find the issue from the UI.
-//
-// Stat cards link to /g/:slug/commodities — the items list (#1410)
-// will eventually accept query-string filters (`?status=expiring`)
-// that the warranty cards point at; today they all link to the same
-// list because there's nothing to filter on yet.
+// Warranty data lights up via #1367 / #1529: counts + the expiring
+// shortlist come from `useDashboardData`'s warrantyBuckets() pass over
+// the same commodities query the page already runs.
 //
 // Slugs are passed through `encodeURIComponent` (matching the rest of
 // the navigation surface) so a slug that ever contains a `/` or `?`
@@ -167,21 +166,11 @@ export function DashboardPage() {
             </div>
 
             <div className="grid gap-6 lg:grid-cols-2">
-              <Card data-testid="dashboard-warranty-placeholder">
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    <ShieldAlert aria-hidden="true" className="size-4 text-muted-foreground" />
-                    {t("dashboard:warrantyPanel.title")}
-                  </CardTitle>
-                  <CardDescription>{t("dashboard:warrantyPanel.description")}</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <ComingSoonBanner surface="warranties" />
-                </CardContent>
-              </Card>
-
+              <ExpiringWarranties items={data.expiringWarranties} isLoading={data.isLoading} />
               <RecentlyAdded items={data.recent} isLoading={data.isLoading} />
             </div>
+
+            <WarrantyHealth counts={data.warrantyStatusCounts} isLoading={data.isLoading} />
           </>
         )}
       </div>

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { Link, useMatch, useNavigate, useParams } from "react-router-dom"
+import { Link, useMatch, useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import {
   ArrowLeft,
@@ -56,6 +56,12 @@ import { cn } from "@/lib/utils"
 
 type TabKey = "details" | "warranty" | "files" | "lend" | "service"
 
+const TAB_KEYS = ["details", "warranty", "files", "lend", "service"] as const
+
+function parseTab(raw: string | null): TabKey {
+  return (TAB_KEYS as readonly string[]).includes(raw ?? "") ? (raw as TabKey) : "details"
+}
+
 // /commodities/:id — full-page detail. The design mock renders this as
 // a Sheet overlay over the list; that variant is deferred to a follow-up
 // because the deep-link case (a shared link or back-button reload) needs
@@ -81,7 +87,18 @@ export function CommodityDetailPage() {
   const toast = useAppToast()
   const confirm = useConfirm()
 
-  const [tab, setTab] = useState<TabKey>("details")
+  // Tab selection is mirrored in the `?tab=` query string so deep
+  // links from the warranties list / dashboard expiring panel land on
+  // the right tab. `?tab=details` is the default — we strip the param
+  // when switching back so the URL stays clean.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const tab = parseTab(searchParams.get("tab"))
+  function setTab(next: TabKey) {
+    const params = new URLSearchParams(searchParams)
+    if (next === "details") params.delete("tab")
+    else params.set("tab", next)
+    setSearchParams(params, { replace: true })
+  }
   // /commodities/:id/edit deep-link: open the edit dialog immediately.
   // Closing the dialog navigates back to /commodities/:id (sans /edit)
   // so the URL stays meaningful.

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -5,6 +5,7 @@ import {
   ArrowLeft,
   Calendar,
   ExternalLink,
+  FileText,
   Hash,
   MapPin,
   Package,
@@ -39,12 +40,13 @@ import {
 } from "@/features/commodities/hooks"
 import {
   COMMODITY_STATUS_TONES,
-  COMMODITY_WARRANTY_TONES,
   warrantyStatus,
   type CommodityStatusValue,
   type CommodityTypeValue,
   type CommodityWarrantyStatus,
 } from "@/features/commodities/constants"
+import { WarrantyBadge } from "@/components/warranty/WarrantyBadge"
+import { WARRANTY_STATUS_CONFIG } from "@/components/warranty/config"
 import type { Commodity } from "@/features/commodities/api"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
@@ -323,7 +325,7 @@ export function CommodityDetailPage() {
             {commodity.id ? <CommodityHistoryTimeline commodityId={commodity.id} /> : null}
           </>
         ) : tab === "warranty" ? (
-          <WarrantyTab commodity={commodity} />
+          <WarrantyTab commodity={commodity} onSwitchToFiles={() => setTab("files")} />
         ) : tab === "lend" ? (
           <LendTab commodityId={commodity?.id ?? id} />
         ) : tab === "service" ? (
@@ -676,14 +678,24 @@ function FilesTab({
 
 interface WarrantyTabProps {
   commodity?: Commodity
+  // Optional. When provided, renders an "Upload Receipt" CTA that
+  // jumps to the Files tab so the user can drop the warranty PDF
+  // there instead of inventing a per-commodity upload widget.
+  onSwitchToFiles?: () => void
 }
 
 // WarrantyTab renders the first-class warranty surface (#1367):
-// status pill + expiry date + days-remaining + free-form notes. When
-// no expiry is set the tab shows an empty-state nudge that points at
-// the edit dialog — the inputs themselves live in the form's
-// Warranty step, not here, to keep the detail page read-only.
-function WarrantyTab({ commodity }: WarrantyTabProps) {
+// status-coloured card + expiry-with-days-remaining line + notes block
+// + an "Upload Receipt" CTA pointing at the Files tab. Layout mirrors
+// the design mock (`inventario-design/src/components/ItemDetail.tsx`,
+// `<TabsContent value="warranty">`); the design mock CLAUDE.md
+// requires that warranty status colours go through the canonical
+// WarrantyBadge / `WARRANTY_STATUS_CONFIG` so all four surfaces
+// (badge, list rows, dashboard panel, this tab) read the same tokens.
+//
+// The form inputs themselves live in the commodity edit dialog's
+// Warranty step — this tab stays read-only.
+function WarrantyTab({ commodity, onSwitchToFiles }: WarrantyTabProps) {
   const { t } = useTranslation()
   const status: CommodityWarrantyStatus = commodity
     ? warrantyStatus({
@@ -692,6 +704,8 @@ function WarrantyTab({ commodity }: WarrantyTabProps) {
       })
     : "none"
   const daysRemaining = warrantyDaysRemaining(commodity?.warranty_expires_at)
+  const visual = WARRANTY_STATUS_CONFIG[status]
+  const StatusIcon = visual.icon
   return (
     <Card data-testid="commodity-detail-warranty">
       <CardHeader>
@@ -699,37 +713,44 @@ function WarrantyTab({ commodity }: WarrantyTabProps) {
         <CardDescription>{t("commodities:detail.warranty.description")}</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
-        <div className="flex items-center gap-3">
-          <span
-            className={cn(
-              "inline-flex items-center rounded-md border px-2 py-1 text-xs font-medium",
-              COMMODITY_WARRANTY_TONES[status]
-            )}
-            data-testid="commodity-detail-warranty-status"
-          >
-            {t(`commodities:warrantyStatus.${status}`)}
-          </span>
-          {commodity?.warranty_expires_at ? (
-            <span className="text-sm text-muted-foreground">
-              {t("commodities:detail.warranty.expiresOn", {
-                date: formatDate(commodity.warranty_expires_at),
-              })}
-            </span>
+        <div className={cn("flex flex-col gap-2 rounded-lg border p-4", visual.bg, visual.border)}>
+          <div className="flex items-center gap-2">
+            <StatusIcon className={cn("size-4", visual.text)} aria-hidden="true" />
+            <WarrantyBadge
+              status={status}
+              showIcon={false}
+              data-testid="commodity-detail-warranty-status"
+            />
+          </div>
+          {commodity?.warranty_expires_at && daysRemaining !== null ? (
+            <p className={cn("text-sm", visual.text)}>
+              {daysRemaining > 0
+                ? t("commodities:detail.warranty.expiresOnIn", {
+                    date: formatDate(commodity.warranty_expires_at),
+                    count: daysRemaining,
+                  })
+                : daysRemaining === 0
+                  ? t("commodities:detail.warranty.expiresToday")
+                  : t("commodities:detail.warranty.expiredOnAgo", {
+                      date: formatDate(commodity.warranty_expires_at),
+                      count: -daysRemaining,
+                    })}
+            </p>
+          ) : status === "none" ? (
+            <p className="text-sm text-muted-foreground">
+              {t("commodities:detail.warranty.noneInline")}
+            </p>
           ) : null}
         </div>
-        {daysRemaining !== null ? (
-          <p className="text-sm text-muted-foreground">
-            {daysRemaining === 0
-              ? t("commodities:detail.warranty.expiresToday")
-              : daysRemaining > 0
-                ? t("commodities:detail.warranty.daysRemaining", { count: daysRemaining })
-                : t("commodities:detail.warranty.expiredAgo", { count: -daysRemaining })}
-          </p>
-        ) : null}
         {commodity?.warranty_notes ? (
-          <div className="flex flex-col gap-1.5" data-testid="commodity-detail-warranty-notes">
-            <p className="text-sm font-medium">{t("commodities:detail.warranty.notesLabel")}</p>
-            <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+          <div
+            className="rounded-lg border border-border bg-muted/30 p-3"
+            data-testid="commodity-detail-warranty-notes"
+          >
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {t("commodities:detail.warranty.notesLabel")}
+            </p>
+            <p className="mt-1 text-sm text-foreground whitespace-pre-wrap">
               {commodity.warranty_notes}
             </p>
           </div>
@@ -738,6 +759,19 @@ function WarrantyTab({ commodity }: WarrantyTabProps) {
           <p className="text-sm text-muted-foreground">
             {t("commodities:detail.warranty.emptyState")}
           </p>
+        ) : null}
+        {onSwitchToFiles ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-fit gap-1.5"
+            onClick={onSwitchToFiles}
+            data-testid="commodity-detail-warranty-upload-receipt"
+          >
+            <FileText className="size-3.5" aria-hidden="true" />
+            {t("commodities:detail.warranty.uploadReceipt")}
+          </Button>
         ) : null}
       </CardContent>
     </Card>

--- a/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
@@ -124,6 +124,19 @@ describe("<CommodityDetailPage />", () => {
     expect(await screen.findByTestId("commodity-detail-files")).toBeInTheDocument()
   })
 
+  it("preselects the Warranty tab when the URL has ?tab=warranty (#1529)", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.detail(SLUG, ID, commodityFixture)
+    )
+    renderDetail(`/g/${SLUG}/commodities/${ID}?tab=warranty`)
+    // Warranty tab should already be active without any user click —
+    // the warranty list / dashboard expiring panel both deep-link in
+    // through this query string.
+    expect(await screen.findByTestId("commodity-detail-warranty")).toBeInTheDocument()
+  })
+
   it("opens the edit dialog when the Edit button is clicked", async () => {
     const user = userEvent.setup()
     server.use(

--- a/frontend/src/pages/warranties/WarrantiesListPage.tsx
+++ b/frontend/src/pages/warranties/WarrantiesListPage.tsx
@@ -11,6 +11,7 @@ import { useAreas } from "@/features/areas/hooks"
 import { useCommodities } from "@/features/commodities/hooks"
 import {
   COMMODITY_WARRANTY_STATUSES,
+  effectiveWarrantyExpiry,
   warrantyStatus,
   type CommodityWarrantyStatus,
 } from "@/features/commodities/constants"
@@ -71,8 +72,14 @@ export function WarrantiesListPage() {
   // groups; if a user blows past that we'd add server-side pagination
   // here, but the BE's `warranty_status=` filter still works either way
   // since the tab partitioning happens client-side from this dataset.
-  const list = useCommodities({ perPage: 200, includeInactive: true })
-  const areas = useAreas()
+  //
+  // Both queries are gated on `currentGroup` because the http client
+  // rewrites /commodities → /g/{slug}/commodities only after the
+  // GroupProvider's useEffect has populated the slug slot (same
+  // pattern useDashboardData uses). Firing before that would 404.
+  const enabled = !!currentGroup
+  const list = useCommodities({ perPage: 200, includeInactive: true }, { enabled })
+  const areas = useAreas({ enabled })
   const areaName = useMemo(() => {
     const map = new Map<string, string>()
     for (const a of areas.data ?? []) {
@@ -86,29 +93,39 @@ export function WarrantiesListPage() {
   // a single pass keeps the page responsive even when the dataset
   // grows; the alternative (four `filter()` calls) re-walks the array
   // four times for the same result.
+  //
+  // We carry the resolved (effective) expiry date through the bucket
+  // so that legacy `warranty:YYYY-MM-DD` tag-only rows render the
+  // right "N days left/ago" line and the right Expires date — without
+  // it, the bucketing happily picks them up but the row UI would say
+  // "No date".
   const buckets = useMemo(() => {
-    const out: Record<CommodityWarrantyStatus, Commodity[]> = {
+    const out: Record<CommodityWarrantyStatus, BucketRow[]> = {
       active: [],
       expiring: [],
       expired: [],
       none: [],
     }
     for (const c of list.data?.commodities ?? []) {
+      const expiresAt = effectiveWarrantyExpiry({
+        warranty_expires_at: c.warranty_expires_at,
+        tags: c.tags,
+      })
       const s = warrantyStatus({
         warranty_expires_at: c.warranty_expires_at,
         tags: c.tags,
       })
-      out[s].push(c)
+      out[s].push({ commodity: c, expiresAt })
     }
-    // Sort each bucket by expiry ascending so the most-actionable rows
-    // surface first inside Expiring; the same order is fine for
-    // Active (oldest to expire shows up first) and Expired (most
-    // recently lapsed first when reversed).
-    for (const bucket of Object.values(out)) {
-      bucket.sort((a, b) =>
-        (a.warranty_expires_at ?? "").localeCompare(b.warranty_expires_at ?? "")
-      )
+    // Sort by expiry ascending: surfaces the most-actionable rows
+    // first inside Expiring (next to lapse on top), and Active (next
+    // to enter the expiring window on top). Expired is reversed so
+    // the *most recently* lapsed rows are on top — those are the
+    // ones the user is most likely to act on (renew / replace).
+    for (const status of COMMODITY_WARRANTY_STATUSES) {
+      out[status].sort((a, b) => (a.expiresAt ?? "").localeCompare(b.expiresAt ?? ""))
     }
+    out.expired.reverse()
     return out
   }, [list.data?.commodities])
 
@@ -207,14 +224,15 @@ export function WarrantiesListPage() {
       ) : (
         <Card className="overflow-hidden p-0" data-testid="warranties-list">
           <ul>
-            {rows.map((c, i) => (
-              <li key={c.id ?? `idx-${i}`}>
+            {rows.map(({ commodity, expiresAt }, i) => (
+              <li key={commodity.id ?? `idx-${i}`}>
                 {i > 0 ? <Separator /> : null}
                 <WarrantyRow
-                  commodity={c}
+                  commodity={commodity}
+                  expiresAt={expiresAt}
                   slug={slug}
                   status={tab}
-                  areaName={areaName(c.area_id)}
+                  areaName={areaName(commodity.area_id)}
                 />
               </li>
             ))}
@@ -240,18 +258,26 @@ function EmptyState({ tab }: { tab: WarrantyTab }) {
   )
 }
 
-interface WarrantyRowProps {
+interface BucketRow {
   commodity: Commodity
+  // Resolved expiry date — either `warranty_expires_at` or the
+  // legacy `warranty:YYYY-MM-DD` tag (see `effectiveWarrantyExpiry`).
+  // Undefined only for rows in the "none" bucket where neither signal
+  // is present.
+  expiresAt: string | undefined
+}
+
+interface WarrantyRowProps extends BucketRow {
   slug: string
   status: WarrantyTab
   areaName: string
 }
 
-function WarrantyRow({ commodity, slug, status, areaName }: WarrantyRowProps) {
+function WarrantyRow({ commodity, expiresAt, slug, status, areaName }: WarrantyRowProps) {
   const { t } = useTranslation(["warranties", "commodities"])
   const visual = WARRANTY_STATUS_CONFIG[status]
   const Icon = visual.icon
-  const days = daysUntil(commodity.warranty_expires_at)
+  const days = daysUntil(expiresAt)
   const id = commodity.id ?? ""
   const subtitle = [
     commodity.short_name && commodity.short_name !== commodity.name ? commodity.short_name : null,
@@ -259,25 +285,22 @@ function WarrantyRow({ commodity, slug, status, areaName }: WarrantyRowProps) {
   ]
     .filter((part): part is string => Boolean(part && part.length > 0))
     .join(" · ")
-  const href = id
-    ? `/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}?tab=warranty`
-    : undefined
-  const Container = href ? Link : "div"
-  return (
-    <Container
-      to={href!}
-      className="flex w-full items-center gap-4 px-5 py-4 text-left transition-colors hover:bg-muted/50"
-      data-testid={`warranties-row-${id}`}
-    >
+  // `Container` was previously a polymorphic Link|div, which leaked
+  // the `to` prop onto a div. Render the two branches explicitly so
+  // each tag carries only its own props.
+  const className =
+    "flex w-full items-center gap-4 px-5 py-4 text-left transition-colors hover:bg-muted/50"
+  const inner = (
+    <>
       <Icon className={cn("size-5 shrink-0", visual.text)} aria-hidden="true" />
       <div className="flex-1 min-w-0">
         <p className="truncate text-sm font-medium">{commodity.name}</p>
         {subtitle ? <p className="text-xs text-muted-foreground">{subtitle}</p> : null}
       </div>
       <div className="text-right shrink-0">
-        {commodity.warranty_expires_at ? (
+        {expiresAt ? (
           <>
-            <p className="text-sm font-medium">{formatDate(commodity.warranty_expires_at)}</p>
+            <p className="text-sm font-medium">{formatDate(expiresAt)}</p>
             {days !== null ? (
               <p className={cn("text-xs", visual.text)}>
                 {days >= 0
@@ -290,6 +313,22 @@ function WarrantyRow({ commodity, slug, status, areaName }: WarrantyRowProps) {
           <p className="text-xs text-muted-foreground">{t("warranties:list.row.noDate")}</p>
         )}
       </div>
-    </Container>
+    </>
+  )
+  if (id) {
+    return (
+      <Link
+        to={`/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}?tab=warranty`}
+        className={className}
+        data-testid={`warranties-row-${id}`}
+      >
+        {inner}
+      </Link>
+    )
+  }
+  return (
+    <div className={className} data-testid="warranties-row-unknown">
+      {inner}
+    </div>
   )
 }

--- a/frontend/src/pages/warranties/WarrantiesListPage.tsx
+++ b/frontend/src/pages/warranties/WarrantiesListPage.tsx
@@ -1,38 +1,65 @@
+import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useSearchParams } from "react-router-dom"
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
+import { WARRANTY_STATUS_CONFIG } from "@/components/warranty/config"
+import { useAreas } from "@/features/areas/hooks"
 import { useCommodities } from "@/features/commodities/hooks"
 import {
   COMMODITY_WARRANTY_STATUSES,
-  COMMODITY_WARRANTY_TONES,
   warrantyStatus,
   type CommodityWarrantyStatus,
 } from "@/features/commodities/constants"
+import type { Commodity } from "@/features/commodities/api"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { formatDate } from "@/lib/intl"
 import { cn } from "@/lib/utils"
 
-// VALID_TABS includes the "all" sentinel at the head — it does not map
-// to a server-side filter, just renders every commodity that owns a
-// `warranty_expires_at` (or a legacy tag). The other entries map 1:1
-// to `warranty_status=` on the BE.
-const VALID_TABS = ["all", ...COMMODITY_WARRANTY_STATUSES] as const
+// Tabs map 1:1 to the BE `warranty_status=` filter; "all" is intentionally
+// dropped — the four summary cards above the tabs already give the
+// aggregate view. The default tab is "expiring" (the most actionable
+// bucket); the URL omits ?tab when on the default so a fresh load looks
+// the same with or without the param.
+const VALID_TABS = COMMODITY_WARRANTY_STATUSES
 type WarrantyTab = (typeof VALID_TABS)[number]
 
+const DEFAULT_TAB: WarrantyTab = "expiring"
+// Tabs that show a counter Badge next to the label. "none" intentionally
+// omits the badge per the design mock — that bucket is the catch-all
+// rather than something the user is monitoring, so the count would
+// just be visual noise.
+const TAB_COUNTERS: ReadonlySet<WarrantyTab> = new Set(["expiring", "active", "expired"])
+
 function parseTab(raw: string | null): WarrantyTab {
-  return (VALID_TABS as readonly string[]).includes(raw ?? "") ? (raw as WarrantyTab) : "all"
+  return (VALID_TABS as readonly string[]).includes(raw ?? "") ? (raw as WarrantyTab) : DEFAULT_TAB
+}
+
+function daysUntil(dateStr: string | undefined): number | null {
+  if (!dateStr) return null
+  const t = Date.parse(`${dateStr}T00:00:00Z`)
+  if (Number.isNaN(t)) return null
+  const now = new Date()
+  const todayUTC = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  return Math.round((t - todayUTC) / (1000 * 60 * 60 * 24))
 }
 
 // WarrantiesListPage is the dedicated `/g/:slug/warranties` surface
-// (#1367). Group-wide list of commodities partitioned by warranty
-// status with tabs for All / Active / Expiring / Expired / None.
+// (#1367, polish #1529). Group-wide list of commodities partitioned by
+// warranty status with four tabs (Expiring / Active / Expired / No
+// Warranty), four tinted summary cards above, and a row layout that
+// surfaces the next-action ("N days left" or "N days ago") in the
+// status colour. The status pill itself is the canonical
+// `WarrantyBadge` so all four warranty surfaces (badge / list rows /
+// dashboard / item-detail tab) read the same `--status-*` tokens.
 //
-// The status pill itself is computed client-side via warrantyStatus()
-// — the BE pre-filters via `warranty_status=` so the page is what
-// the server returned, and pill rendering doesn't need a second
-// round-trip.
+// Counts: the per-tab badges + summary cards are computed from the
+// "all rows" query — a single perPage=200 fetch — rather than four
+// concurrent filtered queries, so the badges stay accurate when the
+// user moves between tabs without a refetch.
 export function WarrantiesListPage() {
   const { t } = useTranslation(["warranties", "commodities", "common"])
   const { currentGroup } = useCurrentGroup()
@@ -40,145 +67,229 @@ export function WarrantiesListPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const tab = parseTab(searchParams.get("tab"))
 
-  // Default view (All) shows every commodity with a tracked warranty,
-  // sorted by purchase_date desc. The status tabs each request a
-  // single status from the BE — the BE filter is documented in
-  // models.ComputeWarrantyStatus and the worker emits emails on the
-  // same boundary.
-  const list = useCommodities({
-    perPage: 100,
-    includeInactive: true,
-    warrantyStatuses: tab === "all" ? undefined : [tab],
-  })
+  // Single fetch for everything. perPage=200 covers all but the largest
+  // groups; if a user blows past that we'd add server-side pagination
+  // here, but the BE's `warranty_status=` filter still works either way
+  // since the tab partitioning happens client-side from this dataset.
+  const list = useCommodities({ perPage: 200, includeInactive: true })
+  const areas = useAreas()
+  const areaName = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const a of areas.data ?? []) {
+      if (a.id && a.name) map.set(a.id, a.name)
+    }
+    return (id: string | undefined) => (id ? (map.get(id) ?? "") : "")
+  }, [areas.data])
+
+  // Bucket every commodity into one of the four warranty statuses.
+  // Used both for the per-tab counters and the active-tab list. Using
+  // a single pass keeps the page responsive even when the dataset
+  // grows; the alternative (four `filter()` calls) re-walks the array
+  // four times for the same result.
+  const buckets = useMemo(() => {
+    const out: Record<CommodityWarrantyStatus, Commodity[]> = {
+      active: [],
+      expiring: [],
+      expired: [],
+      none: [],
+    }
+    for (const c of list.data?.commodities ?? []) {
+      const s = warrantyStatus({
+        warranty_expires_at: c.warranty_expires_at,
+        tags: c.tags,
+      })
+      out[s].push(c)
+    }
+    // Sort each bucket by expiry ascending so the most-actionable rows
+    // surface first inside Expiring; the same order is fine for
+    // Active (oldest to expire shows up first) and Expired (most
+    // recently lapsed first when reversed).
+    for (const bucket of Object.values(out)) {
+      bucket.sort((a, b) =>
+        (a.warranty_expires_at ?? "").localeCompare(b.warranty_expires_at ?? "")
+      )
+    }
+    return out
+  }, [list.data?.commodities])
+
+  const counts: Record<CommodityWarrantyStatus, number> = {
+    active: buckets.active.length,
+    expiring: buckets.expiring.length,
+    expired: buckets.expired.length,
+    none: buckets.none.length,
+  }
 
   function setTab(next: WarrantyTab) {
     const params = new URLSearchParams(searchParams)
-    if (next === "all") params.delete("tab")
+    if (next === DEFAULT_TAB) params.delete("tab")
     else params.set("tab", next)
     setSearchParams(params, { replace: true })
   }
 
-  const rows =
-    tab === "all"
-      ? // "All" lists every commodity that has any tracked warranty
-        // signal — either the dedicated `warranty_expires_at` field
-        // or the legacy `warranty:YYYY-MM-DD` tag fallback. Items
-        // without ANY warranty signal live under the "No date" tab,
-        // not here, so this filter strips them out. Same
-        // warrantyStatus() helper the per-row pill uses, keeping
-        // counted vs rendered consistent.
-        (list.data?.commodities.filter((c) => {
-          const s = warrantyStatus({
-            warranty_expires_at: c.warranty_expires_at,
-            tags: c.tags,
-          })
-          return s !== "none" || !!c.warranty_expires_at
-        }) ?? [])
-      : (list.data?.commodities ?? [])
+  const rows = buckets[tab]
 
   return (
-    <div className="flex flex-col gap-6 p-6" data-testid="page-warranties">
+    <div className="flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full" data-testid="page-warranties">
       <header className="flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold">{t("warranties:list.title")}</h1>
-        <p className="text-sm text-muted-foreground">{t("warranties:list.subtitle")}</p>
+        <h1 className="text-3xl font-semibold tracking-tight">{t("warranties:list.title")}</h1>
+        <p className="text-muted-foreground">{t("warranties:list.subtitle")}</p>
       </header>
+
+      {/* Status summary cards — counts mirror the per-tab badges. */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4" data-testid="warranties-summary">
+        {VALID_TABS.map((status) => {
+          const visual = WARRANTY_STATUS_CONFIG[status]
+          const Icon = visual.icon
+          return (
+            <Card
+              key={status}
+              className={cn("gap-3 border", visual.bg, visual.border)}
+              data-testid={`warranties-summary-${status}`}
+            >
+              <CardHeader className="pb-1">
+                <Icon className={cn("size-5", visual.text)} aria-hidden="true" />
+              </CardHeader>
+              <CardContent>
+                <p className={cn("text-2xl font-bold", visual.text)}>{counts[status]}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">{t(visual.i18nKey)}</p>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
 
       <div
         role="tablist"
         className="flex gap-1 border-b border-border"
         data-testid="warranties-tabs"
       >
-        {VALID_TABS.map((s) => (
-          <button
-            key={s}
-            role="tab"
-            type="button"
-            aria-selected={tab === s}
-            onClick={() => setTab(s)}
-            data-testid={`warranties-tab-${s}`}
-            className={cn(
-              "px-3 py-2 text-sm border-b-2 -mb-px",
-              tab === s
-                ? "border-primary text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground"
-            )}
-          >
-            {t(`warranties:list.tab.${s}`)}
-          </button>
-        ))}
+        {VALID_TABS.map((s) => {
+          const visual = WARRANTY_STATUS_CONFIG[s]
+          const showCounter = TAB_COUNTERS.has(s) && counts[s] > 0
+          return (
+            <button
+              key={s}
+              role="tab"
+              type="button"
+              aria-selected={tab === s}
+              onClick={() => setTab(s)}
+              data-testid={`warranties-tab-${s}`}
+              className={cn(
+                "inline-flex items-center gap-1.5 px-3 py-2 text-sm border-b-2 -mb-px",
+                tab === s
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {t(`warranties:list.tab.${s}`)}
+              {showCounter ? (
+                <Badge
+                  variant="outline"
+                  className={cn("h-4 px-1 text-[10px]", visual.text, visual.border)}
+                  data-testid={`warranties-tab-${s}-count`}
+                >
+                  {counts[s]}
+                </Badge>
+              ) : null}
+            </button>
+          )
+        })}
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="sr-only">{t("warranties:list.title")}</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {list.isLoading ? (
-            <div className="flex flex-col gap-2" data-testid="warranties-loading">
-              <Skeleton className="h-10" />
-              <Skeleton className="h-10" />
-              <Skeleton className="h-10" />
-            </div>
-          ) : rows.length === 0 ? (
-            <p className="text-sm text-muted-foreground" data-testid="warranties-empty">
-              {t(`warranties:list.empty.${tab}`)}
-            </p>
-          ) : (
-            <table className="w-full text-sm" data-testid="warranties-table">
-              <thead className="text-left text-xs text-muted-foreground">
-                <tr>
-                  <th className="px-2 py-2 font-medium">{t("warranties:list.headerItem")}</th>
-                  <th className="px-2 py-2 font-medium">{t("warranties:list.headerExpires")}</th>
-                  <th className="px-2 py-2 font-medium">{t("warranties:list.headerStatus")}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((c) => {
-                  const status: CommodityWarrantyStatus = warrantyStatus({
-                    warranty_expires_at: c.warranty_expires_at,
-                    tags: c.tags,
-                  })
-                  const id = c.id ?? ""
-                  return (
-                    <tr
-                      key={id}
-                      className="border-t border-border"
-                      data-testid={`warranties-row-${id}`}
-                    >
-                      <td className="px-2 py-2">
-                        {id ? (
-                          <Link
-                            to={`/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}?tab=warranty`}
-                            className="font-medium hover:underline"
-                          >
-                            {c.name}
-                          </Link>
-                        ) : (
-                          <span className="font-medium">{c.name}</span>
-                        )}
-                      </td>
-                      <td className="px-2 py-2 text-muted-foreground">
-                        {c.warranty_expires_at ? formatDate(c.warranty_expires_at) : "—"}
-                      </td>
-                      <td className="px-2 py-2">
-                        <span
-                          className={cn(
-                            "inline-flex items-center rounded-md border px-2 py-1 text-xs font-medium",
-                            COMMODITY_WARRANTY_TONES[status]
-                          )}
-                          data-testid={`warranties-status-${id}`}
-                        >
-                          {t(`commodities:warrantyStatus.${status}`)}
-                        </span>
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-          )}
-        </CardContent>
-      </Card>
+      {list.isLoading || areas.isLoading ? (
+        <div className="flex flex-col gap-2" data-testid="warranties-loading">
+          <Skeleton className="h-14" />
+          <Skeleton className="h-14" />
+          <Skeleton className="h-14" />
+        </div>
+      ) : rows.length === 0 ? (
+        <EmptyState tab={tab} />
+      ) : (
+        <Card className="overflow-hidden p-0" data-testid="warranties-list">
+          <ul>
+            {rows.map((c, i) => (
+              <li key={c.id ?? `idx-${i}`}>
+                {i > 0 ? <Separator /> : null}
+                <WarrantyRow
+                  commodity={c}
+                  slug={slug}
+                  status={tab}
+                  areaName={areaName(c.area_id)}
+                />
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
     </div>
+  )
+}
+
+function EmptyState({ tab }: { tab: WarrantyTab }) {
+  const { t } = useTranslation(["warranties"])
+  const visual = WARRANTY_STATUS_CONFIG[tab]
+  const Icon = visual.icon
+  return (
+    <div
+      className="flex flex-col items-center gap-2 py-12 text-center"
+      data-testid="warranties-empty"
+    >
+      <Icon className="size-8 text-muted-foreground/30" aria-hidden="true" />
+      <p className="text-sm text-muted-foreground">{t(`warranties:list.empty.${tab}`)}</p>
+    </div>
+  )
+}
+
+interface WarrantyRowProps {
+  commodity: Commodity
+  slug: string
+  status: WarrantyTab
+  areaName: string
+}
+
+function WarrantyRow({ commodity, slug, status, areaName }: WarrantyRowProps) {
+  const { t } = useTranslation(["warranties", "commodities"])
+  const visual = WARRANTY_STATUS_CONFIG[status]
+  const Icon = visual.icon
+  const days = daysUntil(commodity.warranty_expires_at)
+  const id = commodity.id ?? ""
+  const subtitle = [
+    commodity.short_name && commodity.short_name !== commodity.name ? commodity.short_name : null,
+    areaName,
+  ]
+    .filter((part): part is string => Boolean(part && part.length > 0))
+    .join(" · ")
+  const href = id
+    ? `/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}?tab=warranty`
+    : undefined
+  const Container = href ? Link : "div"
+  return (
+    <Container
+      to={href!}
+      className="flex w-full items-center gap-4 px-5 py-4 text-left transition-colors hover:bg-muted/50"
+      data-testid={`warranties-row-${id}`}
+    >
+      <Icon className={cn("size-5 shrink-0", visual.text)} aria-hidden="true" />
+      <div className="flex-1 min-w-0">
+        <p className="truncate text-sm font-medium">{commodity.name}</p>
+        {subtitle ? <p className="text-xs text-muted-foreground">{subtitle}</p> : null}
+      </div>
+      <div className="text-right shrink-0">
+        {commodity.warranty_expires_at ? (
+          <>
+            <p className="text-sm font-medium">{formatDate(commodity.warranty_expires_at)}</p>
+            {days !== null ? (
+              <p className={cn("text-xs", visual.text)}>
+                {days >= 0
+                  ? t("warranties:list.row.daysLeft", { count: days })
+                  : t("warranties:list.row.daysAgo", { count: -days })}
+              </p>
+            ) : null}
+          </>
+        ) : (
+          <p className="text-xs text-muted-foreground">{t("warranties:list.row.noDate")}</p>
+        )}
+      </div>
+    </Container>
   )
 }

--- a/frontend/src/pages/warranties/__tests__/WarrantiesListPage.test.tsx
+++ b/frontend/src/pages/warranties/__tests__/WarrantiesListPage.test.tsx
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { Route } from "react-router-dom"
-import { screen, waitFor } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import { WarrantiesListPage } from "@/pages/warranties/WarrantiesListPage"
@@ -61,14 +61,15 @@ beforeEach(() => {
 })
 
 describe("<WarrantiesListPage />", () => {
-  it("renders an empty-state message when no commodities own a warranty", async () => {
+  it("defaults to the Expiring tab and shows an empty state when nothing is expiring", async () => {
     server.use(...groupHandlers.list(groupFixture), ...commodityHandlers.list(SLUG, []))
     renderPage()
     expect(await screen.findByTestId("warranties-empty")).toBeInTheDocument()
-    expect(screen.queryByTestId("warranties-table")).toBeNull()
+    expect(screen.queryByTestId("warranties-list")).toBeNull()
+    expect(screen.getByTestId("warranties-tab-expiring")).toHaveAttribute("aria-selected", "true")
   })
 
-  it("renders one row per commodity with a warranty + the computed status pill", async () => {
+  it("renders one row per commodity bucketed into the active tab + summary counts", async () => {
     // 2099-01-01 → active; <today>+30d → expiring; 1999-01-01 → expired.
     const todayPlus30 = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
     server.use(
@@ -80,19 +81,40 @@ describe("<WarrantiesListPage />", () => {
       ])
     )
     renderPage()
-    await waitFor(() => expect(screen.getByTestId("warranties-table")).toBeInTheDocument())
-    expect(screen.getByTestId("warranties-row-c-active")).toHaveTextContent("Fridge")
+    await waitFor(() => expect(screen.getByTestId("warranties-list")).toBeInTheDocument())
+    // Only the Expiring bucket is on screen (default tab).
     expect(screen.getByTestId("warranties-row-c-expiring")).toHaveTextContent("Kettle")
-    expect(screen.getByTestId("warranties-row-c-expired")).toHaveTextContent("Toaster")
+    expect(screen.queryByTestId("warranties-row-c-active")).toBeNull()
+    expect(screen.queryByTestId("warranties-row-c-expired")).toBeNull()
+    // Summary cards still know about everything else.
+    expect(
+      within(screen.getByTestId("warranties-summary-active")).getByText("1")
+    ).toBeInTheDocument()
+    expect(
+      within(screen.getByTestId("warranties-summary-expiring")).getByText("1")
+    ).toBeInTheDocument()
+    expect(
+      within(screen.getByTestId("warranties-summary-expired")).getByText("1")
+    ).toBeInTheDocument()
+    // Per-tab counter shows for Expiring (the default + the populated bucket).
+    expect(screen.getByTestId("warranties-tab-expiring-count")).toHaveTextContent("1")
   })
 
-  it("updates the URL state when a tab is clicked", async () => {
-    server.use(...groupHandlers.list(groupFixture), ...commodityHandlers.list(SLUG, []))
+  it("switches buckets when a tab is clicked", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...commodityHandlers.list(SLUG, [
+        commodityRes("c-active", { name: "Fridge", warranty_expires_at: "2099-01-01" }),
+      ])
+    )
     const user = userEvent.setup()
     renderPage()
+    // Expiring is the default, so the Active row only shows after the
+    // user switches tabs.
     await screen.findByTestId("warranties-empty")
-    await user.click(screen.getByTestId("warranties-tab-expiring"))
-    expect(screen.getByTestId("warranties-tab-expiring")).toHaveAttribute("aria-selected", "true")
+    await user.click(screen.getByTestId("warranties-tab-active"))
+    expect(screen.getByTestId("warranties-tab-active")).toHaveAttribute("aria-selected", "true")
+    expect(await screen.findByTestId("warranties-row-c-active")).toHaveTextContent("Fridge")
   })
 
   it("preselects the tab matching ?tab=expired", async () => {


### PR DESCRIPTION
Closes #1529.

The mock at [`denisvmedia/inventario-design`](https://github.com/denisvmedia/inventario-design) ships a fully realised warranty UI; the four umbrella items in #1529 are landed here. PR #1535 (the warranty backend + base FE) is already merged on master, so this PR is the design-mock alignment pass on top.

## What's in

### 1. Canonical `WarrantyBadge` + `WARRANTY_STATUS_CONFIG`
- `frontend/src/components/warranty/{WarrantyBadge.tsx,config.ts}` — single component, single config map (icon, text/bg/bgSolid/border classes, i18n key) that every warranty surface reads. Bound to the existing `--status-active|expiring|expired|none` design tokens in `index.css`.
- Removed ad-hoc `COMMODITY_WARRANTY_TONES` from `features/commodities/constants.ts`. The three call sites — `WarrantiesListPage`, `CommodityDetailPage` Warranty tab, `CommodityFormDialog` warranty step preview — now render `<WarrantyBadge>` instead of an inline pill.

### 2. `WarrantiesView` polished against the mock
- Four tinted **status summary cards** above the tabs (Active / Expiring / Expired / No Warranty).
- Tabs reduced to four (no "All"); default is **Expiring** — the actionable view.
- Per-tab **counter badges** on Expiring / Active / Expired (No Warranty intentionally omitted per mock).
- List rendered as a single Card with status-coloured row icons + "N days left/ago" text in the matching tone.
- Single-pass `warrantyBuckets` over a perPage=200 fetch — counts + active list both come from one query.

### 3. Item detail Warranty tab
- Replaced the plain pill+lines with a status-coloured card (`bg-status-*/10` + matching border), an inline `WarrantyBadge`, the matching shield icon, and an "Expires {date} — N days from now" line.
- Notes block rendered in a muted-bg card.
- New "Upload Receipt" CTA jumps to the Files tab (uses the existing files surface — no new upload widget).

### 4. Dashboard `Warranty Health` + `Expiring Warranties`
- Removed the `dashboard-warranty-placeholder` `<ComingSoonBanner />`.
- New `<ExpiringWarranties>` (left of the dashboard's lower row) — up to 5 items inside the 60-day window, sorted by expiry asc, each row links to `/g/:slug/commodities/:id?tab=warranty`.
- New `<WarrantyHealth>` (full-width below) — four horizontal bars, one per status, proportional widths via `bg-status-*` solid fills, absolute counts right-aligned, `role=progressbar` for screen readers.
- `useDashboardData` exposes `warrantyStatusCounts` + `expiringWarranties` from a single-pass `warrantyBuckets()` over the same commodities query the page already runs — no new round-trip.

## Out of scope

- The dashboard's two `dashboard-value-by-{location,area}` placeholders still mount `surface="warranties"` (mislabelled — they're not warranty UI). Tracked separately; cleaning that up needs a real per-place value endpoint and a new surface key in the coming-soon registry.
- Dropping the legacy `warranty:YYYY-MM-DD` tag fallback in `warrantyStatus()` is still gated on a data migration (carried over from #1535).

## Test plan
- [x] `npm run typecheck && npm run lint && npm run format:check` — clean
- [x] `npx vitest run` — **99 files / 641 tests pass**
- [x] `npm run i18n:check` — clean (extractor reports "No files were updated")
- [x] New unit tests: `WarrantyBadge.test.tsx` (5 cases), Dashboard Warranty Health + Expiring Warranties cases, updated WarrantiesListPage tests, new `warrantyBuckets` cases in dashboard hooks.