### PR TITLE
[#1546] Item detail: ship the overlay Sheet variant alongside the full page

### DIFF
--- a/e2e/tests/frontend-shell.spec.ts
+++ b/e2e/tests/frontend-shell.spec.ts
@@ -154,18 +154,18 @@ test.describe('Frontend shell', () => {
     await expect(page.getByTestId('page-commodities')).toBeVisible();
     await expect(page.getByText(itemName)).toBeVisible({ timeout: 10_000 });
 
-    // Click the row title → Sheet preview opens. The bare-click
-    // guard from #1410 intercepts the click and opens the overlay
-    // instead of navigating; modifier-clicks fall through to the link.
+    // Click the row title → overlay Sheet opens (#1546). The
+    // bare-click guard intercepts the click and pushes
+    // `state.background` so the router renders
+    // `<CommodityDetailSheet>` over the list. Modifier-clicks
+    // still fall through to the underlying `<Link>` to the page
+    // variant.
     await page.getByText(itemName).click();
-    await expect(page.getByTestId('commodity-preview-sheet')).toBeVisible();
+    await expect(page.getByTestId('commodity-detail-sheet')).toBeVisible();
 
-    // "View full details" → canonical detail page.
-    await page.getByTestId('commodity-preview-open').click();
-    await expect(page.getByTestId('page-commodity-detail')).toBeVisible();
-
-    // Delete via the detail page action. ConfirmProvider locks body
-    // scroll while the modal is up — that's the signal it's open.
+    // Delete via the same Delete button that lives inside the
+    // sheet's action row. ConfirmProvider locks body scroll while
+    // the modal is up — that's the signal the confirm is open.
     await page.getByTestId('commodity-detail-delete').click();
     await expect(page.locator('body[data-scroll-locked]')).toBeVisible();
     await page
@@ -173,8 +173,9 @@ test.describe('Frontend shell', () => {
       .last()
       .click();
 
-    // Detail page bounces back to the list; the row is gone.
-    await expect(page).toHaveURL(/\/commodities$/);
+    // After the delete mutation resolves, navigation falls back to
+    // the list URL (the sheet's `state.background`); the row is gone.
+    await expect(page).toHaveURL(/\/commodities(\?.*)?$/);
     await expect(page.getByText(itemName)).not.toBeVisible();
   });
 });

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -10,6 +10,7 @@ import { UngroupedRedirect } from "@/components/routing/UngroupedRedirect"
 import { PlaceholderPage } from "@/pages/Placeholder"
 import { ComingSoonPage } from "@/components/coming-soon"
 import { Shell } from "@/app/Shell"
+import { ConfirmProvider } from "@/hooks/useConfirm"
 
 // Real pages are code-split — each one becomes its own chunk so adding the
 // real implementation later (in #1407–#1417) doesn't grow the entry bundle.
@@ -324,7 +325,18 @@ export function AppRoutes() {
             element={
               <ProtectedRoute>
                 <GroupProvider>
-                  <Outlet />
+                  {/* The page tree's <Shell /> already mounts a
+                      ConfirmProvider, but the modal tree is a
+                      sibling that bypasses Shell — without its own
+                      provider, components inside the sheet that
+                      call useConfirm() (e.g. the Delete button)
+                      throw "must be used within a ConfirmProvider".
+                      Per-tree provider instances are fine — the
+                      sheet's confirms are scoped to the sheet, the
+                      page's to the page. */}
+                  <ConfirmProvider>
+                    <Outlet />
+                  </ConfirmProvider>
                 </GroupProvider>
               </ProtectedRoute>
             }

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy } from "react"
-import { Navigate, Outlet, Route, Routes, useParams } from "react-router-dom"
+import { Navigate, Outlet, Route, Routes, useLocation, useParams } from "react-router-dom"
+import type { Location } from "react-router-dom"
 
 import { AuthProvider } from "@/features/auth/AuthContext"
 import { GroupProvider } from "@/features/group/GroupContext"
@@ -82,6 +83,14 @@ const CommodityDetailPage = lazy(() =>
     default: m.CommodityDetailPage,
   }))
 )
+// CommodityDetailSheet is the overlay variant of the same surface
+// (#1546). Mounted as a *modal* route — i.e. rendered alongside the
+// list backdrop when the navigation carried `state.background`.
+const CommodityDetailSheet = lazy(() =>
+  import("@/pages/commodities/CommodityDetailPage").then((m) => ({
+    default: m.CommodityDetailSheet,
+  }))
+)
 const CommodityPrintPage = lazy(() =>
   import("@/pages/commodities/CommodityPrintPage").then((m) => ({
     default: m.CommodityPrintPage,
@@ -147,9 +156,20 @@ const ExportRestorePage = lazy(() =>
 // AuthProvider sits above <Routes> in providers.tsx; mounting it inside
 // <Routes> would re-create the auth context every navigation.
 export function AppRoutes() {
+  // #1546 modal-routes pattern. When the navigation that landed us
+  // here carried `state.background` (the items list pushes one when a
+  // row is opened), we render TWO route trees: the underlying page
+  // tree resolves against the saved `background` location so the list
+  // stays mounted, and a separate "modal" tree resolves against the
+  // current location to mount `<CommodityDetailSheet>` on top. On
+  // direct landings — refresh, share, "open in new tab" — `background`
+  // is undefined and the page tree resolves against the current
+  // location as today, falling through to the full-page detail.
+  const location = useLocation()
+  const background = (location.state as { background?: Location } | null)?.background
   return (
     <Suspense fallback={null}>
-      <Routes>
+      <Routes location={background ?? location}>
         {/* Public — auth pages own their own full-screen layout (#1407). */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
@@ -289,6 +309,39 @@ export function AppRoutes() {
         {/* Catch-all */}
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
+
+      {/* Modal overlay tree (#1546). Mounted only when the
+          navigation that pushed us here carried `state.background` —
+          i.e. an in-session drill-in from the items list. The print
+          subroute is intentionally left out: it's a full-page-only
+          surface (the user explicitly went to the print view, not a
+          quick peek). The /edit subroute renders the same sheet —
+          the edit dialog opens by side effect once mounted, mirroring
+          the full-page behaviour. */}
+      {background ? (
+        <Routes>
+          <Route
+            element={
+              <ProtectedRoute>
+                <GroupProvider>
+                  <Outlet />
+                </GroupProvider>
+              </ProtectedRoute>
+            }
+          >
+            <Route
+              element={
+                <GroupRequiredRoute>
+                  <Outlet />
+                </GroupRequiredRoute>
+              }
+            >
+              <Route path="/g/:groupSlug/commodities/:id" element={<CommodityDetailSheet />} />
+              <Route path="/g/:groupSlug/commodities/:id/edit" element={<CommodityDetailSheet />} />
+            </Route>
+          </Route>
+        </Routes>
+      ) : null}
     </Suspense>
   )
 }

--- a/frontend/src/components/warranty/__tests__/WarrantyBadge.test.tsx
+++ b/frontend/src/components/warranty/__tests__/WarrantyBadge.test.tsx
@@ -32,7 +32,7 @@ describe("<WarrantyBadge />", () => {
   it("renders the `none` bucket when neither field nor tag is set", () => {
     render(<WarrantyBadge source={{}} data-testid="badge" />)
     expect(screen.getByTestId("badge")).toHaveAttribute("data-status", "none")
-    expect(screen.getByTestId("badge")).toHaveTextContent("No warranty")
+    expect(screen.getByTestId("badge")).toHaveTextContent("No Warranty")
   })
 
   it("hides the leading icon when `showIcon` is false", () => {

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -95,10 +95,16 @@
     "historyShowMore_one": "Show {{count}} more",
     "historyShowMore_other": "Show {{count}} more",
     "historyTitle": "History",
+    "insuranceReport": "Insurance Report",
     "notFoundDescription": "It may have been deleted or you don't have access to it.",
     "notFoundTitle": "Item not found",
     "noValue": "—",
     "print": "Print",
+    "statusTransition": {
+      "description": "Mark this item as {{label}}? You can revert from the edit dialog later.",
+      "heading": "Change Status",
+      "title": "Mark as {{label}}?"
+    },
     "tabs": {
       "details": "Details",
       "files": "Files",
@@ -260,6 +266,8 @@
     "created": "Item added.",
     "deleted": "Item deleted.",
     "deleteError": "Couldn't delete the item.",
+    "statusUpdated": "Status updated.",
+    "statusUpdateError": "Couldn't update the status.",
     "updated": "Item saved."
   },
   "type": {

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -35,16 +35,17 @@
     "fields": {
       "area": "Area",
       "comments": "Notes",
-      "convertedOriginalPrice": "Converted original price",
+      "convertedOriginalPrice": "Converted Original Price",
       "count": "Quantity",
-      "currentPrice": "Current value",
-      "extraSerialNumbers": "Extra serials",
-      "lastModifiedDate": "Last edited",
-      "originalPrice": "Original price",
-      "partNumbers": "Part numbers",
-      "purchaseDate": "Purchase date",
-      "registeredDate": "Date added",
-      "serialNumber": "Serial number",
+      "currentPrice": "Current Value",
+      "extraSerialNumbers": "Extra Serials",
+      "lastModifiedDate": "Last Edited",
+      "location": "Location",
+      "originalPrice": "Original Price",
+      "partNumbers": "Part Numbers",
+      "purchaseDate": "Purchase Date",
+      "registeredDate": "Date Added",
+      "serialNumber": "Serial Number",
       "status": "Status",
       "tags": "Tags",
       "urls": "Links"
@@ -254,7 +255,7 @@
     "in_use": "In use",
     "lost": "Lost",
     "sold": "Sold",
-    "written_off": "Written off"
+    "written_off": "Written Off"
   },
   "toast": {
     "bulkDeleted_one": "{{count}} item deleted.",

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -213,7 +213,6 @@
     "headerStatus": "Status",
     "headerValue": "Value",
     "heading": "Items",
-    "openFull": "View full details",
     "searchPlaceholder": "Search by name or short name…",
     "selectAll": "Select all visible",
     "subtitle_one": "{{count}} item in this group",

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -252,7 +252,7 @@
   },
   "status": {
     "disposed": "Disposed",
-    "in_use": "In use",
+    "in_use": "In Use",
     "lost": "Lost",
     "sold": "Sold",
     "written_off": "Written Off"
@@ -300,13 +300,13 @@
   "warranty": {
     "active": "Active",
     "expired": "Expired",
-    "expiring": "Expiring soon",
-    "none": "No warranty"
+    "expiring": "Expiring Soon",
+    "none": "No Warranty"
   },
   "warrantyStatus": {
-    "active": "Warranty active",
-    "expired": "Warranty expired",
-    "expiring": "Expiring soon",
-    "none": "No warranty"
+    "active": "Warranty Active",
+    "expired": "Warranty Expired",
+    "expiring": "Expiring Soon",
+    "none": "No Warranty"
   }
 }

--- a/frontend/src/lib/nav-labels.ts
+++ b/frontend/src/lib/nav-labels.ts
@@ -25,6 +25,8 @@ export function useNavLabel(labelKey: string): string {
       return t("common:nav.warranties")
     case "common:nav.lent":
       return t("common:nav.lent")
+    case "common:nav.inService":
+      return t("common:nav.inService")
     case "common:nav.tags":
       return t("common:nav.tags")
     case "common:nav.files":

--- a/frontend/src/pages/commodities/CommoditiesListPage.tsx
+++ b/frontend/src/pages/commodities/CommoditiesListPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react"
-import { Link, useNavigate, useSearchParams } from "react-router-dom"
+import { Link, useLocation, useNavigate, useSearchParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import {
   ArrowUpDown,
@@ -42,14 +42,6 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetFooter,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
 import { CommodityFormDialog } from "@/components/items/CommodityFormDialog"
 import { RouteTitle } from "@/components/routing/RouteTitle"
@@ -106,6 +98,12 @@ export function CommoditiesListPage() {
   const enabled = !!currentGroup
   const slug = currentGroup?.slug
   const [searchParams, setSearchParams] = useSearchParams()
+  // `useLocation` is captured here (not inside the row click handler)
+  // so each navigation pushes the SAME backdrop URL — i.e. the list
+  // location at the moment the user opened the row. The router
+  // re-renders on tab/filter changes, so this hook re-runs and the
+  // closure always carries the freshest list URL.
+  const listLocation = useLocation()
 
   // ---- URL → state ------------------------------------------------------
   const page = Math.max(1, Number(searchParams.get("page") ?? "1"))
@@ -213,13 +211,22 @@ export function CommoditiesListPage() {
   const [createOpen, setCreateOpen] = useState(false)
   const [moveOpen, setMoveOpen] = useState(false)
   const [moveTargetArea, setMoveTargetArea] = useState<string>("")
-  // ---- Sheet preview overlay -------------------------------------------
-  // The mock renders the detail as a slide-over Sheet when reached from
-  // the list. Cmd/Ctrl-click on a card still opens the full detail page
-  // in a new tab thanks to the `<Link>` underneath; bare click triggers
-  // this Sheet instead. Closing the Sheet clears state — no URL hop, so
-  // the list page never unmounts.
-  const [previewId, setPreviewId] = useState<string | null>(null)
+  // ---- Row → Sheet overlay -------------------------------------------
+  // #1546 modal-routes pattern. A bare row click navigates to
+  // /commodities/:id and stamps the current list URL onto
+  // `state.background`. The router (see app/router.tsx) reads that
+  // state and renders TWO trees: this list as the backdrop + the
+  // CommodityDetailSheet on top. The URL update is what makes back /
+  // forward / `?tab=` deep-links work for the in-session drill-in.
+  // Cmd/Ctrl/Shift-click + middle-button still fall through to the
+  // underlying `<Link>` so opening in a new tab gets the full page
+  // (the new tab carries no `state.background`, so the modal tree
+  // stays unmounted there).
+  function openCommodityInSheet(id: string) {
+    if (!slug || !id) return
+    const next = `/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}`
+    navigate(next, { state: { background: listLocation } })
+  }
 
   // ---- URL helpers -------------------------------------------------------
   function updateParams(patch: (params: URLSearchParams) => void, opts?: { keepPage?: boolean }) {
@@ -327,7 +334,6 @@ export function CommoditiesListPage() {
   const loanCounts = loanCountsQuery.data ?? {}
   const serviceCountsQuery = useServiceCounts(commodityIDsForCounts)
   const serviceCounts = serviceCountsQuery.data ?? {}
-  const previewRow = previewId ? (rows.find((r) => r.id === previewId) ?? null) : null
   const total = list.data?.total ?? 0
   const totalPages = Math.max(1, Math.ceil(total / PER_PAGE))
   const isLoading = list.isLoading
@@ -477,7 +483,7 @@ export function CommoditiesListPage() {
             slug={slug}
             selected={selected}
             onToggleSelected={toggleSelected}
-            onPreview={setPreviewId}
+            onPreview={openCommodityInSheet}
             areaName={areaName}
             currency={currentGroup?.group_currency ?? "USD"}
             loanCounts={loanCounts}
@@ -490,7 +496,7 @@ export function CommoditiesListPage() {
             selected={selected}
             onToggleSelected={toggleSelected}
             onToggleSelectAll={() => toggleSelectAll(rows)}
-            onPreview={setPreviewId}
+            onPreview={openCommodityInSheet}
             areaName={areaName}
             currency={currentGroup?.group_currency ?? "USD"}
             loanCounts={loanCounts}
@@ -552,147 +558,15 @@ export function CommoditiesListPage() {
         </DialogContent>
       </Dialog>
 
-      <Sheet open={!!previewId} onOpenChange={(open) => !open && setPreviewId(null)}>
-        <SheetContent
-          className="sm:max-w-md w-full overflow-y-auto"
-          data-testid="commodity-preview-sheet"
-        >
-          {previewRow ? (
-            <CommodityPreview
-              row={previewRow}
-              slug={slug}
-              areaName={areaName(previewRow.area_id)}
-              groupCurrency={currentGroup?.group_currency ?? "USD"}
-              onClose={() => setPreviewId(null)}
-            />
-          ) : null}
-        </SheetContent>
-      </Sheet>
+      {/*
+        The dedicated preview Sheet that used to live here was
+        replaced in #1546 by the modal-routes pattern: a row click
+        navigates to /commodities/:id with `state.background` set,
+        and the router renders <CommodityDetailSheet> on top of this
+        list page (see app/router.tsx). The full detail surface — not
+        the trimmed preview — is now what shows on a quick drill-in.
+      */}
     </>
-  )
-}
-
-// ---- Preview Sheet ------------------------------------------------------
-
-interface CommodityPreviewProps {
-  row: Commodity
-  slug?: string
-  areaName: string
-  groupCurrency: string
-  onClose: () => void
-}
-
-// CommodityPreview is the slide-over rendered when a list row is clicked.
-// It surfaces the most-likely-needed fields (name, type, area, prices,
-// tags, comments) and a "View full details" link to the canonical
-// detail page; deeper actions (Edit, Delete, Print) live on the full
-// page so the Sheet stays scannable.
-function CommodityPreview({ row, slug, areaName, groupCurrency, onClose }: CommodityPreviewProps) {
-  const { t } = useTranslation()
-  const id = row.id ?? ""
-  const detailHref =
-    slug && id ? `/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(id)}` : "#"
-  const status = row.status as CommodityStatusValue | undefined
-  const tone = status ? COMMODITY_STATUS_TONES[status] : ""
-  const type = row.type as CommodityTypeValue | undefined
-  const purchaseCurrency = row.original_price_currency ?? groupCurrency
-  return (
-    <>
-      <SheetHeader>
-        <SheetTitle className="flex items-center gap-2">
-          <CommodityThumb
-            cover={row.cover}
-            type={type}
-            name={row.name}
-            size={36}
-            testId="commodity-preview-thumb"
-          />
-          <span className="truncate">{row.name}</span>
-        </SheetTitle>
-        <SheetDescription>
-          {row.short_name ? `${row.short_name} · ` : ""}
-          {type ? t(`commodities:type.${type}`) : ""}
-        </SheetDescription>
-      </SheetHeader>
-      <div className="flex flex-col gap-4 px-4 pb-4">
-        <div className="flex flex-wrap items-center gap-1.5">
-          {row.draft ? (
-            <Badge variant="outline" className="border-dashed">
-              {t("commodities:list.draftBadge")}
-            </Badge>
-          ) : null}
-          {status ? (
-            <span className={cn("text-xs font-medium px-2 py-0.5 rounded-full border", tone)}>
-              {t(`commodities:status.${status}`)}
-            </span>
-          ) : null}
-        </div>
-        <dl className="grid grid-cols-2 gap-3 text-sm">
-          <PreviewRow label={t("commodities:detail.fields.area")} value={areaName || "—"} />
-          <PreviewRow
-            label={t("commodities:detail.fields.count")}
-            value={String(row.count ?? "—")}
-          />
-          <PreviewRow
-            label={t("commodities:detail.fields.currentPrice")}
-            value={
-              row.current_price !== undefined
-                ? formatCurrency(Number(row.current_price), groupCurrency)
-                : "—"
-            }
-          />
-          <PreviewRow
-            label={t("commodities:detail.fields.originalPrice")}
-            value={
-              row.original_price !== undefined
-                ? formatCurrency(Number(row.original_price), purchaseCurrency)
-                : "—"
-            }
-          />
-        </dl>
-        {row.tags && row.tags.length > 0 ? (
-          <div className="flex flex-col gap-1.5">
-            <span className="text-xs uppercase tracking-wide text-muted-foreground">
-              {t("commodities:detail.fields.tags")}
-            </span>
-            <div className="flex flex-wrap gap-1.5">
-              {row.tags.map((tag) => (
-                <Badge key={tag} variant="secondary">
-                  {tag}
-                </Badge>
-              ))}
-            </div>
-          </div>
-        ) : null}
-        {row.comments ? (
-          <div className="flex flex-col gap-1.5">
-            <span className="text-xs uppercase tracking-wide text-muted-foreground">
-              {t("commodities:detail.fields.comments")}
-            </span>
-            <p className="text-sm whitespace-pre-wrap">{row.comments}</p>
-          </div>
-        ) : null}
-      </div>
-      <SheetFooter>
-        <Button variant="ghost" onClick={onClose}>
-          {t("common:actions.cancel")}
-        </Button>
-        <Button asChild data-testid="commodity-preview-open">
-          <Link to={detailHref} onClick={onClose}>
-            {t("commodities:list.openFull")}
-          </Link>
-        </Button>
-      </SheetFooter>
-    </>
-  )
-}
-
-function PreviewRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex flex-col gap-0.5">
-      <dt className="text-xs uppercase tracking-wide text-muted-foreground">{label}</dt>
-      <dd className="text-sm">{value}</dd>
-    </div>
   )
 }
 

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -115,13 +115,19 @@ export interface CommodityDetailContentProps {
 export function CommodityDetailContent({ id, variant = "page" }: CommodityDetailContentProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  // Outer-frame classes: page mode uses the canonical 4xl-max-width
-  // centered-column layout; sheet mode lets the SheetContent control
-  // width and just provides padding + scroll inside the panel.
+  // Outer-frame classes match the design mock 1:1
+  // (`denisvmedia/inventario-design/src/components/ItemDetail.tsx`):
+  // sheet mode uses `flex flex-col gap-0 px-5 pb-5` with each section
+  // owning its own vertical padding (the mock's `<SheetHeader pt-6
+  // pb-4>` + `flex gap-2 pb-4` + `mb-4 rounded-xl …` pattern). Page
+  // mode keeps the wider 4xl centered-column layout that direct
+  // landings expect. Scroll is owned by `<SheetContent
+  // overflow-y-auto>` — leaving it off the inner wrapper avoids the
+  // double-scrollbar bug copilot flagged.
   const isSheet = variant === "sheet"
-  const errorWrapperClass = isSheet ? "p-6" : "p-6 max-w-4xl mx-auto w-full"
+  const errorWrapperClass = isSheet ? "px-5 py-6" : "p-6 max-w-4xl mx-auto w-full"
   const mainWrapperClass = isSheet
-    ? "relative flex flex-col gap-6 p-6 overflow-y-auto"
+    ? "relative flex flex-col gap-0 px-5 pb-5"
     : "relative flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full"
   const { currentGroup } = useCurrentGroup()
   const slug = currentGroup?.slug
@@ -201,16 +207,20 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
   }, [areas.data])
 
   // The detail page heading mirrors the commodity name; once it's
-  // loaded we update the document title via RouteTitle so browser tabs
-  // are useful in long sessions.
+  // loaded we update the document title via RouteTitle so browser
+  // tabs are useful in long sessions. Sheet mode is gated out — the
+  // backdrop list page already owns the tab title, and stomping it
+  // when the user pops the sheet would leak the item name onto the
+  // list URL too (copilot review).
   useEffect(() => {
+    if (isSheet) return
     if (!commodity?.id) return
     if (typeof document !== "undefined") {
       document.title = commodity.name
         ? `${commodity.name} — Inventario`
         : t("commodities:detail.documentTitle")
     }
-  }, [commodity?.id, commodity?.name, t])
+  }, [isSheet, commodity?.id, commodity?.name, t])
 
   if (detail.isLoading) {
     return (
@@ -354,95 +364,95 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
           </Link>
         )}
 
-        {/* Header — name + identity. The mock keeps the title at
-            text-lg even on the full-page version, so both variants
-            share the size. The status pills row that used to live
-            inline in the description has been hoisted into its own
-            row below so the badges don't compete for vertical
-            rhythm with the brand subtitle. */}
-        <header className="flex items-start gap-3">
-          <CommodityThumb
-            cover={commodity.cover}
-            type={type}
-            name={commodity.name}
-            size={48}
-            testId="commodity-detail-thumb"
-          />
-          <div className="min-w-0 flex-1">
-            <h1
-              className={cn(
-                "font-semibold leading-tight tracking-tight",
-                isSheet ? "text-lg" : "text-2xl"
-              )}
-              data-testid="commodity-detail-name"
-            >
-              {commodity.name}
-            </h1>
-            {commodity.short_name && commodity.short_name !== commodity.name ? (
-              <p
-                className="text-xs font-mono text-muted-foreground mt-0.5"
-                data-testid="commodity-detail-short-name"
+        {/* Header (mock parity: `<SheetHeader pt-6 pb-4 px-0>`). The
+            title block + status pills row both live inside the
+            header in the mock. We do the same shape: avatar +
+            title + short_name + type subtitle, then status pills
+            below. Page mode keeps `gap-6` flow above so the
+            existing visual rhythm is unchanged. */}
+        <header className={isSheet ? "pt-6 pb-4" : ""}>
+          <div className="flex items-start gap-3">
+            <CommodityThumb
+              cover={commodity.cover}
+              type={type}
+              name={commodity.name}
+              size={48}
+              testId="commodity-detail-thumb"
+            />
+            <div className="min-w-0 flex-1 pr-6">
+              <h1
+                className={cn(
+                  "font-semibold leading-tight tracking-tight",
+                  isSheet ? "text-lg" : "text-2xl"
+                )}
+                data-testid="commodity-detail-name"
               >
-                {commodity.short_name}
-              </p>
+                {commodity.name}
+              </h1>
+              {commodity.short_name && commodity.short_name !== commodity.name ? (
+                <p
+                  className="text-xs font-mono text-muted-foreground mt-0.5"
+                  data-testid="commodity-detail-short-name"
+                >
+                  {commodity.short_name}
+                </p>
+              ) : null}
+              {type ? (
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  {t(`commodities:type.${type}`)}
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          {/* Status pills row — commodity status + warranty + days
+              remaining. Mock places it inside SheetHeader directly
+              under the title block (`pt-1`). */}
+          <div
+            className="flex flex-wrap items-center gap-2 pt-1"
+            data-testid="commodity-detail-pills"
+          >
+            {status ? (
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium border",
+                  tone || "border-border text-foreground"
+                )}
+                data-testid="commodity-detail-status-pill"
+              >
+                <CircleDot className="size-3" aria-hidden="true" />
+                {t(`commodities:status.${status}`)}
+              </span>
             ) : null}
-            {type ? (
-              <p className="text-sm text-muted-foreground mt-0.5">
-                {t(`commodities:type.${type}`)}
-              </p>
+            {commodity.draft ? (
+              <Badge variant="outline" className="border-dashed text-xs">
+                {t("commodities:list.draftBadge")}
+              </Badge>
             ) : null}
+            <WarrantyBadge
+              source={{
+                warranty_expires_at: commodity.warranty_expires_at,
+                tags: commodity.tags,
+              }}
+              data-testid="commodity-detail-warranty-pill"
+            />
+            {(() => {
+              const days = warrantyDaysRemaining(commodity.warranty_expires_at)
+              return days !== null && days > 0 ? (
+                <span className="text-xs text-muted-foreground">
+                  {t("commodities:detail.warranty.daysRemaining", { count: days })}
+                </span>
+              ) : null
+            })()}
           </div>
         </header>
 
-        {/* Status pills row — commodity status + warranty + days
-            remaining. Mock shows this directly under the header,
-            outside the action row, so glanceable signals don't
-            crowd the buttons. */}
-        <div
-          className="flex flex-wrap items-center gap-2 -mt-2"
-          data-testid="commodity-detail-pills"
-        >
-          {status ? (
-            <span
-              className={cn(
-                "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium border",
-                tone || "border-border text-foreground"
-              )}
-              data-testid="commodity-detail-status-pill"
-            >
-              <CircleDot className="size-3" aria-hidden="true" />
-              {t(`commodities:status.${status}`)}
-            </span>
-          ) : null}
-          {commodity.draft ? (
-            <Badge variant="outline" className="border-dashed text-xs">
-              {t("commodities:list.draftBadge")}
-            </Badge>
-          ) : null}
-          <WarrantyBadge
-            source={{
-              warranty_expires_at: commodity.warranty_expires_at,
-              tags: commodity.tags,
-            }}
-            data-testid="commodity-detail-warranty-pill"
-          />
-          {(() => {
-            const days = warrantyDaysRemaining(commodity.warranty_expires_at)
-            return days !== null && days > 0 ? (
-              <span className="text-xs text-muted-foreground">
-                {t("commodities:detail.warranty.daysRemaining", { count: days })}
-              </span>
-            ) : null
-          })()}
-        </div>
-
-        {/* Action buttons row — Edit (primary, flex-1), Insurance
-            Report (mock parity, links to the per-item insurance
-            report stub at /insurance/:id), and a small icon-only
-            destructive Delete on the right. Print stays as a small
-            icon button next to Delete so the action stays reachable
-            without the row taking three lines on narrow viewports. */}
-        <div className="flex flex-wrap items-center gap-2">
+        {/* Action row — `flex gap-2 pb-4 flex-wrap` per the mock.
+            Edit (flex-1) + Insurance Report + icon-only destructive
+            Delete. Print is page-only (the mock has no Print
+            button); direct landings still have it on the page
+            chrome where it doesn't crowd the action row. */}
+        <div className={cn("flex flex-wrap items-center gap-2", isSheet && "pb-4")}>
           <Button
             type="button"
             variant="outline"
@@ -471,19 +481,21 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
               </Link>
             </Button>
           ) : null}
-          <Button
-            asChild
-            type="button"
-            variant="outline"
-            size="icon"
-            className="size-8"
-            title={t("commodities:detail.print")}
-            aria-label={t("commodities:detail.print")}
-          >
-            <Link to={printHref} data-testid="commodity-detail-print">
-              <Printer className="size-3.5" aria-hidden="true" />
-            </Link>
-          </Button>
+          {isSheet ? null : (
+            <Button
+              asChild
+              type="button"
+              variant="outline"
+              size="icon"
+              className="size-8"
+              title={t("commodities:detail.print")}
+              aria-label={t("commodities:detail.print")}
+            >
+              <Link to={printHref} data-testid="commodity-detail-print">
+                <Printer className="size-3.5" aria-hidden="true" />
+              </Link>
+            </Button>
+          )}
           <Button
             type="button"
             variant="outline"
@@ -498,19 +510,18 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
           </Button>
         </div>
 
-        {/* CHANGE STATUS bar — only meaningful while the item is
-            still `in_use`. Once it transitions to a terminal status
-            (sold/lost/disposed/written_off) the bar disappears and
-            the user can revert via the edit dialog. Each button
-            opens a confirm; on confirm we PATCH `status` only — the
-            mock's optional date/note/sale-price capture needs new
-            BE columns first. */}
+        {/* CHANGE STATUS bar — `mb-4 rounded-xl border border-border
+            bg-muted/30 p-3 space-y-2` lifted from the mock. Only
+            meaningful while the item is still `in_use`. */}
         {status === "in_use" ? (
           <div
-            className="rounded-xl border border-border bg-muted/30 p-3 space-y-2"
+            className={cn(
+              "rounded-xl border border-border bg-muted/30 p-3 space-y-2",
+              isSheet && "mb-4"
+            )}
             data-testid="commodity-detail-change-status"
           >
-            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
               {t("commodities:detail.statusTransition.heading")}
             </p>
             <div className="flex flex-wrap gap-1.5">
@@ -532,63 +543,70 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
           </div>
         ) : null}
 
-        <Tabs value={tab} onChange={setTab} fileCount={fileCount} />
+        <Tabs value={tab} onChange={setTab} fileCount={fileCount} variant={variant} />
 
-        {tab === "details" ? (
-          <>
-            <DetailsTab
-              commodity={commodity}
-              groupCurrency={groupCurrency}
-              purchaseCurrency={purchaseCurrency}
-              areaName={areaName(commodity.area_id)}
-              variant={variant}
+        {/* Tab content gets `mt-4` in sheet mode to mirror the
+            mock's `<TabsContent className="mt-4 space-y-0">`. Page
+            mode keeps its parent `gap-6` flow. */}
+        <div className={isSheet ? "mt-4" : ""}>
+          {tab === "details" ? (
+            <>
+              <DetailsTab
+                commodity={commodity}
+                groupCurrency={groupCurrency}
+                purchaseCurrency={purchaseCurrency}
+                areaName={areaName(commodity.area_id)}
+                variant={variant}
+              />
+              {commodity.id ? <CommodityHistoryTimeline commodityId={commodity.id} /> : null}
+            </>
+          ) : tab === "warranty" ? (
+            <WarrantyTab commodity={commodity} onSwitchToFiles={() => setTab("files")} />
+          ) : tab === "lend" ? (
+            <LendTab commodityId={commodity?.id ?? id} />
+          ) : tab === "service" ? (
+            <ServiceTab commodityId={commodity?.id ?? id} />
+          ) : (
+            <FilesTab
+              commodityId={commodity?.id ?? id}
+              coverState={{
+                // Explicit override (issue #1451 option B) takes precedence;
+                // first_photo is the auto-pick when no override is set.
+                current: commodity?.cover_file_id ?? undefined,
+                auto:
+                  commodity?.cover && commodity.cover.source === "first_photo"
+                    ? commodity.cover.fileId
+                    : undefined,
+              }}
+              onSetCover={(fileId) => {
+                setCover.mutate(fileId, {
+                  onSuccess: () => {
+                    toast.success(
+                      fileId
+                        ? t("commodities:cover.setSuccess", {
+                            defaultValue: "Cover photo updated.",
+                          })
+                        : t("commodities:cover.clearSuccess", {
+                            defaultValue: "Cover photo cleared.",
+                          })
+                    )
+                  },
+                  onError: () =>
+                    toast.error(
+                      t("commodities:cover.error", {
+                        defaultValue: "Couldn't update the cover photo.",
+                      })
+                    ),
+                })
+              }}
+              coverBusy={setCover.isPending}
+              onAttachClick={() => {
+                setPendingDropFiles([])
+                setUploadOpen(true)
+              }}
             />
-            {commodity.id ? <CommodityHistoryTimeline commodityId={commodity.id} /> : null}
-          </>
-        ) : tab === "warranty" ? (
-          <WarrantyTab commodity={commodity} onSwitchToFiles={() => setTab("files")} />
-        ) : tab === "lend" ? (
-          <LendTab commodityId={commodity?.id ?? id} />
-        ) : tab === "service" ? (
-          <ServiceTab commodityId={commodity?.id ?? id} />
-        ) : (
-          <FilesTab
-            commodityId={commodity?.id ?? id}
-            coverState={{
-              // Explicit override (issue #1451 option B) takes precedence;
-              // first_photo is the auto-pick when no override is set.
-              current: commodity?.cover_file_id ?? undefined,
-              auto:
-                commodity?.cover && commodity.cover.source === "first_photo"
-                  ? commodity.cover.fileId
-                  : undefined,
-            }}
-            onSetCover={(fileId) => {
-              setCover.mutate(fileId, {
-                onSuccess: () => {
-                  toast.success(
-                    fileId
-                      ? t("commodities:cover.setSuccess", { defaultValue: "Cover photo updated." })
-                      : t("commodities:cover.clearSuccess", {
-                          defaultValue: "Cover photo cleared.",
-                        })
-                  )
-                },
-                onError: () =>
-                  toast.error(
-                    t("commodities:cover.error", {
-                      defaultValue: "Couldn't update the cover photo.",
-                    })
-                  ),
-              })
-            }}
-            coverBusy={setCover.isPending}
-            onAttachClick={() => {
-              setPendingDropFiles([])
-              setUploadOpen(true)
-            }}
-          />
-        )}
+          )}
+        </div>
       </div>
 
       <CommodityFormDialog
@@ -648,10 +666,15 @@ interface TabsProps {
   // Zero is hidden so the tab strip doesn't carry visual debt for
   // every empty commodity.
   fileCount?: number
+  // `"sheet"` flips the tab strip to `w-full` so it spans the
+  // narrower panel; `"page"` keeps the existing left-clumped
+  // layout that fits the wider canvas.
+  variant?: "page" | "sheet"
 }
 
-function Tabs({ value, onChange, fileCount = 0 }: TabsProps) {
+function Tabs({ value, onChange, fileCount = 0, variant = "page" }: TabsProps) {
   const { t } = useTranslation()
+  const isSheet = variant === "sheet"
   const tabs: { key: TabKey; label: string; count?: number }[] = [
     { key: "details", label: t("commodities:detail.tabs.details") },
     { key: "warranty", label: t("commodities:detail.tabs.warranty") },
@@ -662,7 +685,10 @@ function Tabs({ value, onChange, fileCount = 0 }: TabsProps) {
   return (
     <div
       role="tablist"
-      className="flex gap-1 border-b border-border"
+      className={cn(
+        "flex border-b border-border",
+        isSheet ? "w-full justify-start gap-4" : "gap-1"
+      )}
       data-testid="commodity-detail-tabs"
     >
       {tabs.map((tb) => (
@@ -673,9 +699,10 @@ function Tabs({ value, onChange, fileCount = 0 }: TabsProps) {
           aria-selected={value === tb.key}
           onClick={() => onChange(tb.key)}
           className={cn(
-            "inline-flex items-center gap-1.5 px-3 py-2 text-sm border-b-2 -mb-px transition-colors",
+            "inline-flex items-center gap-1.5 py-2 text-sm border-b-2 -mb-px transition-colors",
+            isSheet ? "px-1" : "px-3",
             value === tb.key
-              ? "border-primary text-foreground"
+              ? "border-primary text-foreground font-semibold"
               : "border-transparent text-muted-foreground hover:text-foreground"
           )}
           data-testid={`commodity-detail-tab-${tb.key}`}
@@ -764,18 +791,21 @@ function DetailsTab({
       value: commodity.serial_number || noValue,
     },
   ]
-  // Sheet variant renders a single-column vertical list with each row
-  // formatted as `[icon] [label/value]` to match the design mock; the
-  // page variant keeps the wider 2-col grid that fills the canvas.
+  // Sheet variant renders the rows directly on the SheetContent
+  // surface (NO outer Card / no nested rounded border) — the mock's
+  // `<TabsContent className="mt-4 space-y-0">` pattern. Each row +
+  // Separator pair is the entire visual rhythm; the panel chrome
+  // is everything around it. Page variant keeps the wider 2-col
+  // grid wrapped in the existing Card.
   const isSheet = variant === "sheet"
-  const containerClass = isSheet
-    ? "flex flex-col py-2"
-    : "grid grid-cols-1 sm:grid-cols-2 gap-4 py-6"
+  const containerClass = isSheet ? "flex flex-col" : "grid grid-cols-1 sm:grid-cols-2 gap-4 py-6"
   const fullWidthClass = isSheet ? "" : "sm:col-span-2"
   const separatorClass = isSheet ? "" : "sm:col-span-2"
+  const Outer: React.ElementType = isSheet ? "div" : Card
+  const Inner: React.ElementType = isSheet ? "div" : CardContent
   return (
-    <Card data-testid="commodity-detail-details">
-      <CardContent className={containerClass}>
+    <Outer data-testid="commodity-detail-details">
+      <Inner className={containerClass}>
         {rows.map((r, i) => (
           <DetailRow
             key={r.label}
@@ -786,68 +816,169 @@ function DetailsTab({
             withDivider={isSheet && i > 0}
           />
         ))}
-        {commodity.tags && commodity.tags.length > 0 ? (
-          <div className={cn("flex flex-col gap-1.5", fullWidthClass, isSheet && "py-2.5")}>
-            <DetailLabel icon={Tag} label={t("commodities:detail.fields.tags")} />
-            <div className="flex flex-wrap gap-1.5">
-              {commodity.tags.map((tag) => (
-                <Badge key={tag} variant="secondary">
-                  {tag}
-                </Badge>
-              ))}
-            </div>
-          </div>
-        ) : null}
-        {Array.isArray(commodity.urls) && commodity.urls.length > 0 ? (
-          <div className={cn("flex flex-col gap-1.5", fullWidthClass, isSheet && "py-2.5")}>
-            <DetailLabel icon={ExternalLink} label={t("commodities:detail.fields.urls")} />
-            <ul className="text-sm">
-              {(commodity.urls as unknown as string[]).map((u, i) => (
-                <li key={i}>
-                  <a
-                    href={u}
-                    target="_blank"
-                    rel="noreferrer noopener"
-                    className="text-primary hover:underline"
-                  >
-                    {u}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-        {commodity.comments ? (
-          <div className={cn("flex flex-col gap-1.5", fullWidthClass, isSheet && "py-2.5")}>
-            <DetailLabel icon={Hash} label={t("commodities:detail.fields.comments")} />
-            <p className="text-sm whitespace-pre-wrap">{commodity.comments}</p>
-          </div>
-        ) : null}
-        {commodity.extra_serial_numbers && commodity.extra_serial_numbers.length > 0 ? (
-          <div className={cn("flex flex-col gap-1.5", fullWidthClass, isSheet && "py-2.5")}>
-            <DetailLabel icon={Hash} label={t("commodities:detail.fields.extraSerialNumbers")} />
-            <div className="flex flex-wrap gap-1.5">
-              {commodity.extra_serial_numbers.map((s) => (
-                <Badge key={s} variant="outline">
-                  {s}
-                </Badge>
-              ))}
-            </div>
-          </div>
-        ) : null}
-        {commodity.part_numbers && commodity.part_numbers.length > 0 ? (
-          <div className={cn("flex flex-col gap-1.5", fullWidthClass, isSheet && "py-2.5")}>
-            <DetailLabel icon={Hash} label={t("commodities:detail.fields.partNumbers")} />
-            <div className="flex flex-wrap gap-1.5">
-              {commodity.part_numbers.map((p) => (
-                <Badge key={p} variant="outline">
-                  {p}
-                </Badge>
-              ))}
-            </div>
-          </div>
-        ) : null}
-        <Separator className={separatorClass} />
+        {/* Auxiliary fields (tags / urls / notes / extra serials /
+            part numbers). Sheet mode threads them through the same
+            DetailRow shape as the main rows so the labels stay
+            "Tags" / "Notes" (not "TAGS" / "NOTES" via DetailLabel's
+            uppercase tracking) and the icon-on-left layout is
+            uniform. Page mode keeps the existing 2-col grid block
+            with DetailLabel on top. */}
+        {commodity.tags && commodity.tags.length > 0
+          ? (isSheet ? (
+              <DetailRow
+                icon={Tag}
+                label={t("commodities:detail.fields.tags")}
+                value={
+                  <div className="flex flex-wrap gap-1.5 mt-0.5">
+                    {commodity.tags.map((tag) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                }
+                variant={variant}
+                withDivider
+              />
+            ) : (
+              <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
+                <DetailLabel icon={Tag} label={t("commodities:detail.fields.tags")} />
+                <div className="flex flex-wrap gap-1.5">
+                  {commodity.tags.map((tag) => (
+                    <Badge key={tag} variant="secondary">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ))
+          : null}
+        {Array.isArray(commodity.urls) && commodity.urls.length > 0
+          ? (isSheet ? (
+              <DetailRow
+                icon={ExternalLink}
+                label={t("commodities:detail.fields.urls")}
+                value={
+                  <ul className="text-sm">
+                    {(commodity.urls as unknown as string[]).map((u, i) => (
+                      <li key={i}>
+                        <a
+                          href={u}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          className="text-primary hover:underline"
+                        >
+                          {u}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                }
+                variant={variant}
+                withDivider
+              />
+            ) : (
+              <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
+                <DetailLabel icon={ExternalLink} label={t("commodities:detail.fields.urls")} />
+                <ul className="text-sm">
+                  {(commodity.urls as unknown as string[]).map((u, i) => (
+                    <li key={i}>
+                      <a
+                        href={u}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="text-primary hover:underline"
+                      >
+                        {u}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))
+          : null}
+        {commodity.comments
+          ? (isSheet ? (
+              <DetailRow
+                icon={FileText}
+                label={t("commodities:detail.fields.comments")}
+                value={
+                  <p className="text-sm font-normal whitespace-pre-wrap">{commodity.comments}</p>
+                }
+                variant={variant}
+                withDivider
+              />
+            ) : (
+              <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
+                <DetailLabel icon={Hash} label={t("commodities:detail.fields.comments")} />
+                <p className="text-sm whitespace-pre-wrap">{commodity.comments}</p>
+              </div>
+            ))
+          : null}
+        {commodity.extra_serial_numbers && commodity.extra_serial_numbers.length > 0
+          ? (isSheet ? (
+              <DetailRow
+                icon={Hash}
+                label={t("commodities:detail.fields.extraSerialNumbers")}
+                value={
+                  <div className="flex flex-wrap gap-1.5 mt-0.5">
+                    {commodity.extra_serial_numbers.map((s) => (
+                      <Badge key={s} variant="outline">
+                        {s}
+                      </Badge>
+                    ))}
+                  </div>
+                }
+                variant={variant}
+                withDivider
+              />
+            ) : (
+              <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
+                <DetailLabel
+                  icon={Hash}
+                  label={t("commodities:detail.fields.extraSerialNumbers")}
+                />
+                <div className="flex flex-wrap gap-1.5">
+                  {commodity.extra_serial_numbers.map((s) => (
+                    <Badge key={s} variant="outline">
+                      {s}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ))
+          : null}
+        {commodity.part_numbers && commodity.part_numbers.length > 0
+          ? (isSheet ? (
+              <DetailRow
+                icon={Package}
+                label={t("commodities:detail.fields.partNumbers")}
+                value={
+                  <div className="flex flex-wrap gap-1.5 mt-0.5">
+                    {commodity.part_numbers.map((p) => (
+                      <Badge key={p} variant="outline">
+                        {p}
+                      </Badge>
+                    ))}
+                  </div>
+                }
+                variant={variant}
+                withDivider
+              />
+            ) : (
+              <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
+                <DetailLabel icon={Hash} label={t("commodities:detail.fields.partNumbers")} />
+                <div className="flex flex-wrap gap-1.5">
+                  {commodity.part_numbers.map((p) => (
+                    <Badge key={p} variant="outline">
+                      {p}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ))
+          : null}
+        {isSheet ? null : <Separator className={separatorClass} />}
         <DetailRow
           icon={Calendar}
           label={t("commodities:detail.fields.registeredDate")}
@@ -870,8 +1001,8 @@ function DetailsTab({
           variant={variant}
           withDivider={isSheet}
         />
-      </CardContent>
-    </Card>
+      </Inner>
+    </Outer>
   )
 }
 
@@ -1122,13 +1253,16 @@ export function CommodityDetailSheet() {
     <Sheet open onOpenChange={(open) => !open && handleClose()}>
       <SheetContent
         side="right"
-        // Width matches the design mock 1:1 (`sm:max-w-lg` → 32rem
-        // ≈ 512px). The detail surface adapts: in sheet mode the
-        // DetailsTab body switches to a vertical icon|label-value
-        // list (instead of a 2-col grid) so the narrower panel
-        // stays readable. Below `sm` the Sheet primitive falls
-        // back to `w-3/4` and the panel takes the whole viewport.
-        className="w-full sm:max-w-lg overflow-y-auto p-0"
+        // Width + flex shape lifted verbatim from the design mock
+        // (`denisvmedia/inventario-design/src/components/ItemDetail.tsx`).
+        // `flex flex-col gap-0` overrides the SheetContent default
+        // `gap-4` so children layout flush against the header — each
+        // section owns its own padding (header `pt-6 pb-4`, action
+        // row `pb-4`, status card `mb-4`, tab body `mt-4`). `p-0`
+        // lets the inner wrapper supply `px-5 pb-5`. Below `sm` the
+        // Sheet primitive falls back to `w-3/4` so the panel takes
+        // the whole viewport on narrow screens.
+        className="w-full sm:max-w-lg flex flex-col gap-0 overflow-y-auto p-0"
         data-testid="commodity-detail-sheet"
       >
         <CommodityDetailContent id={id} variant="sheet" />

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -10,14 +10,16 @@ import {
 import { useTranslation } from "react-i18next"
 import {
   ArrowLeft,
+  BarChart3,
   Calendar,
   CircleDot,
+  DollarSign,
   ExternalLink,
-  FileBarChart2,
   FileText,
   Hash,
   MapPin,
   Package,
+  Paperclip,
   Pencil,
   Printer,
   Tag,
@@ -62,6 +64,20 @@ import {
 // Mirror the mock's set sans `in_use`, since `in_use` is what we're
 // transitioning *from*. Order matches the mock's row.
 const TERMINAL_STATUSES = ["sold", "lost", "disposed", "written_off"] as const
+
+// Mock parity colour-only mapping for the CHANGE STATUS quick
+// buttons. Lifted from `inventario-design`'s
+// `COMMODITY_STATUS_CONFIG.color` field — text-only, no bg/border
+// tint, so the buttons are plain outline pills with coloured
+// labels (the mock's `cn("gap-1.5 text-xs h-7", c.color)` pattern).
+// Distinct from the project's `COMMODITY_STATUS_TONES` (which adds
+// bg + border for the inline status pills elsewhere).
+const STATUS_TRANSITION_TEXT_TONES: Record<(typeof TERMINAL_STATUSES)[number], string> = {
+  sold: "text-chart-2",
+  lost: "text-status-expiring",
+  disposed: "text-muted-foreground",
+  written_off: "text-status-expired",
+}
 import { WarrantyBadge } from "@/components/warranty/WarrantyBadge"
 import { WARRANTY_STATUS_CONFIG } from "@/components/warranty/config"
 import type { Commodity } from "@/features/commodities/api"
@@ -476,7 +492,7 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
               <Link
                 to={`/g/${encodeURIComponent(slug)}/insurance/${encodeURIComponent(commodity.id)}`}
               >
-                <FileBarChart2 className="size-3.5" aria-hidden="true" />
+                <BarChart3 className="size-3.5" aria-hidden="true" />
                 {t("commodities:detail.insuranceReport")}
               </Link>
             </Button>
@@ -486,8 +502,7 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
               asChild
               type="button"
               variant="outline"
-              size="icon"
-              className="size-8"
+              size="sm"
               title={t("commodities:detail.print")}
               aria-label={t("commodities:detail.print")}
             >
@@ -496,11 +511,16 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
               </Link>
             </Button>
           )}
+          {/* Delete uses `size="sm"` (h-8 px-3 — slightly wider
+              than `size="icon"`'s 8x8 square) to match the mock's
+              same-row Edit / Insurance Report buttons. The icon
+              child stays the same; the destructive tone comes from
+              the className. */}
           <Button
             type="button"
             variant="outline"
-            size="icon"
-            className="size-8 text-destructive hover:bg-destructive/10"
+            size="sm"
+            className="text-destructive hover:bg-destructive/10"
             onClick={handleDelete}
             data-testid="commodity-detail-delete"
             title={t("commodities:detail.delete")}
@@ -531,7 +551,7 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
                   type="button"
                   variant="outline"
                   size="sm"
-                  className={cn("gap-1.5 text-xs h-7", COMMODITY_STATUS_TONES[s])}
+                  className={cn("gap-1.5 text-xs h-7", STATUS_TRANSITION_TEXT_TONES[s])}
                   onClick={() => handleStatusTransition(s)}
                   data-testid={`commodity-detail-transition-${s}`}
                   disabled={update.isPending}
@@ -675,10 +695,24 @@ interface TabsProps {
 function Tabs({ value, onChange, fileCount = 0, variant = "page" }: TabsProps) {
   const { t } = useTranslation()
   const isSheet = variant === "sheet"
-  const tabs: { key: TabKey; label: string; count?: number }[] = [
+  // Files tab gets a leading icon — mock parity (`<Paperclip
+  // size-3.5 />` inside `<TabsTrigger>`). Other tabs stay
+  // text-only; the strip would feel cluttered if every label
+  // sprouted an icon.
+  const tabs: {
+    key: TabKey
+    label: string
+    count?: number
+    icon?: typeof Paperclip
+  }[] = [
     { key: "details", label: t("commodities:detail.tabs.details") },
     { key: "warranty", label: t("commodities:detail.tabs.warranty") },
-    { key: "files", label: t("commodities:detail.tabs.files"), count: fileCount },
+    {
+      key: "files",
+      label: t("commodities:detail.tabs.files"),
+      count: fileCount,
+      icon: Paperclip,
+    },
     { key: "lend", label: t("commodities:detail.tabs.lend") },
     { key: "service", label: t("commodities:detail.tabs.service") },
   ]
@@ -691,33 +725,37 @@ function Tabs({ value, onChange, fileCount = 0, variant = "page" }: TabsProps) {
       )}
       data-testid="commodity-detail-tabs"
     >
-      {tabs.map((tb) => (
-        <button
-          key={tb.key}
-          role="tab"
-          type="button"
-          aria-selected={value === tb.key}
-          onClick={() => onChange(tb.key)}
-          className={cn(
-            "inline-flex items-center gap-1.5 py-2 text-sm border-b-2 -mb-px transition-colors",
-            isSheet ? "px-1" : "px-3",
-            value === tb.key
-              ? "border-primary text-foreground font-semibold"
-              : "border-transparent text-muted-foreground hover:text-foreground"
-          )}
-          data-testid={`commodity-detail-tab-${tb.key}`}
-        >
-          {tb.label}
-          {tb.count && tb.count > 0 ? (
-            <span
-              className="flex size-4 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-foreground"
-              data-testid={`commodity-detail-tab-${tb.key}-count`}
-            >
-              {tb.count}
-            </span>
-          ) : null}
-        </button>
-      ))}
+      {tabs.map((tb) => {
+        const Icon = tb.icon
+        return (
+          <button
+            key={tb.key}
+            role="tab"
+            type="button"
+            aria-selected={value === tb.key}
+            onClick={() => onChange(tb.key)}
+            className={cn(
+              "inline-flex items-center gap-1.5 py-2 text-sm border-b-2 -mb-px transition-colors",
+              isSheet ? "px-1" : "px-3",
+              value === tb.key
+                ? "border-primary text-foreground font-semibold"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            )}
+            data-testid={`commodity-detail-tab-${tb.key}`}
+          >
+            {Icon ? <Icon className="size-3.5" aria-hidden="true" /> : null}
+            {tb.label}
+            {tb.count && tb.count > 0 ? (
+              <span
+                className="flex size-4 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-foreground"
+                data-testid={`commodity-detail-tab-${tb.key}-count`}
+              >
+                {tb.count}
+              </span>
+            ) : null}
+          </button>
+        )
+      })}
     </div>
   )
 }
@@ -762,7 +800,7 @@ function DetailsTab({
         : noValue,
     },
     {
-      icon: Hash,
+      icon: DollarSign,
       label: t("commodities:detail.fields.originalPrice"),
       value:
         commodity.original_price !== undefined
@@ -770,7 +808,7 @@ function DetailsTab({
           : noValue,
     },
     {
-      icon: Hash,
+      icon: DollarSign,
       label: t("commodities:detail.fields.convertedOriginalPrice"),
       value:
         commodity.converted_original_price !== undefined
@@ -778,7 +816,7 @@ function DetailsTab({
           : noValue,
     },
     {
-      icon: Hash,
+      icon: DollarSign,
       label: t("commodities:detail.fields.currentPrice"),
       value:
         commodity.current_price !== undefined
@@ -823,63 +861,42 @@ function DetailsTab({
             uppercase tracking) and the icon-on-left layout is
             uniform. Page mode keeps the existing 2-col grid block
             with DetailLabel on top. */}
-        {commodity.tags && commodity.tags.length > 0
-          ? (isSheet ? (
-              <DetailRow
-                icon={Tag}
-                label={t("commodities:detail.fields.tags")}
-                value={
-                  <div className="flex flex-wrap gap-1.5 mt-0.5">
-                    {commodity.tags.map((tag) => (
-                      <Badge key={tag} variant="secondary">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                }
-                variant={variant}
-                withDivider
-              />
-            ) : (
-              <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
-                <DetailLabel icon={Tag} label={t("commodities:detail.fields.tags")} />
-                <div className="flex flex-wrap gap-1.5">
+        {commodity.tags && commodity.tags.length > 0 ? (
+          isSheet ? (
+            <DetailRow
+              icon={Tag}
+              label={t("commodities:detail.fields.tags")}
+              value={
+                <div className="flex flex-wrap gap-1.5 mt-0.5">
                   {commodity.tags.map((tag) => (
                     <Badge key={tag} variant="secondary">
                       {tag}
                     </Badge>
                   ))}
                 </div>
+              }
+              variant={variant}
+              withDivider
+            />
+          ) : (
+            <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
+              <DetailLabel icon={Tag} label={t("commodities:detail.fields.tags")} />
+              <div className="flex flex-wrap gap-1.5">
+                {commodity.tags.map((tag) => (
+                  <Badge key={tag} variant="secondary">
+                    {tag}
+                  </Badge>
+                ))}
               </div>
-            ))
-          : null}
-        {Array.isArray(commodity.urls) && commodity.urls.length > 0
-          ? (isSheet ? (
-              <DetailRow
-                icon={ExternalLink}
-                label={t("commodities:detail.fields.urls")}
-                value={
-                  <ul className="text-sm">
-                    {(commodity.urls as unknown as string[]).map((u, i) => (
-                      <li key={i}>
-                        <a
-                          href={u}
-                          target="_blank"
-                          rel="noreferrer noopener"
-                          className="text-primary hover:underline"
-                        >
-                          {u}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                }
-                variant={variant}
-                withDivider
-              />
-            ) : (
-              <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
-                <DetailLabel icon={ExternalLink} label={t("commodities:detail.fields.urls")} />
+            </div>
+          )
+        ) : null}
+        {Array.isArray(commodity.urls) && commodity.urls.length > 0 ? (
+          isSheet ? (
+            <DetailRow
+              icon={ExternalLink}
+              label={t("commodities:detail.fields.urls")}
+              value={
                 <ul className="text-sm">
                   {(commodity.urls as unknown as string[]).map((u, i) => (
                     <li key={i}>
@@ -894,90 +911,108 @@ function DetailsTab({
                     </li>
                   ))}
                 </ul>
-              </div>
-            ))
-          : null}
-        {commodity.comments
-          ? (isSheet ? (
-              <DetailRow
-                icon={FileText}
-                label={t("commodities:detail.fields.comments")}
-                value={
-                  <p className="text-sm font-normal whitespace-pre-wrap">{commodity.comments}</p>
-                }
-                variant={variant}
-                withDivider
-              />
-            ) : (
-              <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
-                <DetailLabel icon={Hash} label={t("commodities:detail.fields.comments")} />
-                <p className="text-sm whitespace-pre-wrap">{commodity.comments}</p>
-              </div>
-            ))
-          : null}
-        {commodity.extra_serial_numbers && commodity.extra_serial_numbers.length > 0
-          ? (isSheet ? (
-              <DetailRow
-                icon={Hash}
-                label={t("commodities:detail.fields.extraSerialNumbers")}
-                value={
-                  <div className="flex flex-wrap gap-1.5 mt-0.5">
-                    {commodity.extra_serial_numbers.map((s) => (
-                      <Badge key={s} variant="outline">
-                        {s}
-                      </Badge>
-                    ))}
-                  </div>
-                }
-                variant={variant}
-                withDivider
-              />
-            ) : (
-              <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
-                <DetailLabel
-                  icon={Hash}
-                  label={t("commodities:detail.fields.extraSerialNumbers")}
-                />
-                <div className="flex flex-wrap gap-1.5">
+              }
+              variant={variant}
+              withDivider
+            />
+          ) : (
+            <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
+              <DetailLabel icon={ExternalLink} label={t("commodities:detail.fields.urls")} />
+              <ul className="text-sm">
+                {(commodity.urls as unknown as string[]).map((u, i) => (
+                  <li key={i}>
+                    <a
+                      href={u}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="text-primary hover:underline"
+                    >
+                      {u}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )
+        ) : null}
+        {commodity.comments ? (
+          isSheet ? (
+            <DetailRow
+              icon={FileText}
+              label={t("commodities:detail.fields.comments")}
+              value={
+                <p className="text-sm font-normal whitespace-pre-wrap">{commodity.comments}</p>
+              }
+              variant={variant}
+              withDivider
+            />
+          ) : (
+            <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
+              <DetailLabel icon={Hash} label={t("commodities:detail.fields.comments")} />
+              <p className="text-sm whitespace-pre-wrap">{commodity.comments}</p>
+            </div>
+          )
+        ) : null}
+        {commodity.extra_serial_numbers && commodity.extra_serial_numbers.length > 0 ? (
+          isSheet ? (
+            <DetailRow
+              icon={Hash}
+              label={t("commodities:detail.fields.extraSerialNumbers")}
+              value={
+                <div className="flex flex-wrap gap-1.5 mt-0.5">
                   {commodity.extra_serial_numbers.map((s) => (
                     <Badge key={s} variant="outline">
                       {s}
                     </Badge>
                   ))}
                 </div>
+              }
+              variant={variant}
+              withDivider
+            />
+          ) : (
+            <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
+              <DetailLabel icon={Hash} label={t("commodities:detail.fields.extraSerialNumbers")} />
+              <div className="flex flex-wrap gap-1.5">
+                {commodity.extra_serial_numbers.map((s) => (
+                  <Badge key={s} variant="outline">
+                    {s}
+                  </Badge>
+                ))}
               </div>
-            ))
-          : null}
-        {commodity.part_numbers && commodity.part_numbers.length > 0
-          ? (isSheet ? (
-              <DetailRow
-                icon={Package}
-                label={t("commodities:detail.fields.partNumbers")}
-                value={
-                  <div className="flex flex-wrap gap-1.5 mt-0.5">
-                    {commodity.part_numbers.map((p) => (
-                      <Badge key={p} variant="outline">
-                        {p}
-                      </Badge>
-                    ))}
-                  </div>
-                }
-                variant={variant}
-                withDivider
-              />
-            ) : (
-              <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
-                <DetailLabel icon={Hash} label={t("commodities:detail.fields.partNumbers")} />
-                <div className="flex flex-wrap gap-1.5">
+            </div>
+          )
+        ) : null}
+        {commodity.part_numbers && commodity.part_numbers.length > 0 ? (
+          isSheet ? (
+            <DetailRow
+              icon={Package}
+              label={t("commodities:detail.fields.partNumbers")}
+              value={
+                <div className="flex flex-wrap gap-1.5 mt-0.5">
                   {commodity.part_numbers.map((p) => (
                     <Badge key={p} variant="outline">
                       {p}
                     </Badge>
                   ))}
                 </div>
+              }
+              variant={variant}
+              withDivider
+            />
+          ) : (
+            <div className={cn("flex flex-col gap-1.5", fullWidthClass)}>
+              <DetailLabel icon={Hash} label={t("commodities:detail.fields.partNumbers")} />
+              <div className="flex flex-wrap gap-1.5">
+                {commodity.part_numbers.map((p) => (
+                  <Badge key={p} variant="outline">
+                    {p}
+                  </Badge>
+                ))}
               </div>
-            ))
-          : null}
+            </div>
+          )
+        ) : null}
         {isSheet ? null : <Separator className={separatorClass} />}
         <DetailRow
           icon={Calendar}

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -11,7 +11,9 @@ import { useTranslation } from "react-i18next"
 import {
   ArrowLeft,
   Calendar,
+  CircleDot,
   ExternalLink,
+  FileBarChart2,
   FileText,
   Hash,
   MapPin,
@@ -38,6 +40,7 @@ import { LendTab } from "@/components/loans/LendTab"
 import { ServiceTab } from "@/components/services/ServiceTab"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { useAreas } from "@/features/areas/hooks"
+import { useFiles } from "@/features/files/hooks"
 import { CommodityHistoryTimeline } from "@/features/commodities/CommodityHistoryTimeline"
 import { CommodityThumb } from "@/features/commodities/CommodityThumb"
 import {
@@ -53,6 +56,12 @@ import {
   type CommodityTypeValue,
   type CommodityWarrantyStatus,
 } from "@/features/commodities/constants"
+
+// CHANGE-STATUS bar: terminal status transitions surfaced as quick
+// buttons on the detail surface (mock: "Change Status" section).
+// Mirror the mock's set sans `in_use`, since `in_use` is what we're
+// transitioning *from*. Order matches the mock's row.
+const TERMINAL_STATUSES = ["sold", "lost", "disposed", "written_off"] as const
 import { WarrantyBadge } from "@/components/warranty/WarrantyBadge"
 import { WARRANTY_STATUS_CONFIG } from "@/components/warranty/config"
 import type { Commodity } from "@/features/commodities/api"
@@ -124,6 +133,16 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
   const setCover = useSetCommodityCover(id)
   const toast = useAppToast()
   const confirm = useConfirm()
+  // The Files tab label gets a count badge driven by this query.
+  // perPage=1 keeps the round-trip cheap — we only need `meta.total`.
+  // Gated on `enabled && id` so it doesn't fire before the slug
+  // resolves, and the cache key matches the "all files attached to
+  // this commodity" view the Files tab reuses.
+  const filesCount = useFiles(
+    { linkedEntityType: "commodity", linkedEntityId: id, perPage: 1 },
+    { enabled: enabled && !!id }
+  )
+  const fileCount = filesCount.data?.total ?? 0
 
   // Tab selection is mirrored in the `?tab=` query string so deep
   // links from the warranties list / dashboard expiring panel land on
@@ -277,6 +296,33 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
     }
   }
 
+  // CHANGE STATUS quick action: confirm + PATCH the commodity's
+  // `status`. The mock's StatusTransitionDialog also captures a
+  // status_date / status_note / sale_price triple, but our BE schema
+  // doesn't carry those fields — we just transition the status and
+  // surface a toast. Adding the metadata is a follow-up that needs
+  // BE work first.
+  async function handleStatusTransition(next: CommodityStatusValue) {
+    if (!commodity) return
+    const ok = await confirm({
+      title: t("commodities:detail.statusTransition.title", {
+        label: t(`commodities:status.${next}`),
+      }),
+      description: t("commodities:detail.statusTransition.description", {
+        label: t(`commodities:status.${next}`),
+      }),
+      confirmLabel: t("common:actions.confirm"),
+      destructive: next === "lost" || next === "written_off",
+    })
+    if (!ok) return
+    try {
+      await update.mutateAsync({ ...commodity, status: next })
+      toast.success(t("commodities:toast.statusUpdated"))
+    } catch {
+      toast.error(t("commodities:toast.statusUpdateError"))
+    }
+  }
+
   return (
     <>
       {/* Document title is owned by the full-page variant only — when
@@ -308,75 +354,185 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
           </Link>
         )}
 
-        <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex items-start gap-3 min-w-0">
-            <CommodityThumb
-              cover={commodity.cover}
-              type={type}
-              name={commodity.name}
-              size={48}
-              testId="commodity-detail-thumb"
-            />
-            <div className="min-w-0">
-              <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight truncate">
-                {commodity.name}
-              </h1>
-              <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                {commodity.short_name ? (
-                  <span data-testid="commodity-detail-short-name">{commodity.short_name}</span>
-                ) : null}
-                {type ? <span>· {t(`commodities:type.${type}`)}</span> : null}
-                {commodity.draft ? (
-                  <Badge variant="outline" className="border-dashed text-[10px] h-4 px-1">
-                    draft
-                  </Badge>
-                ) : null}
-                {status && status !== "in_use" ? (
-                  <span
-                    className={cn(
-                      "text-[10px] font-medium px-1.5 py-0.5 rounded-full border",
-                      tone
-                    )}
-                  >
-                    {t(`commodities:status.${status}`)}
-                  </span>
-                ) : null}
-              </div>
-            </div>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setEditOpen(true)}
-              data-testid="commodity-detail-edit"
-              className="gap-1.5"
+        {/* Header — name + identity. The mock keeps the title at
+            text-lg even on the full-page version, so both variants
+            share the size. The status pills row that used to live
+            inline in the description has been hoisted into its own
+            row below so the badges don't compete for vertical
+            rhythm with the brand subtitle. */}
+        <header className="flex items-start gap-3">
+          <CommodityThumb
+            cover={commodity.cover}
+            type={type}
+            name={commodity.name}
+            size={48}
+            testId="commodity-detail-thumb"
+          />
+          <div className="min-w-0 flex-1">
+            <h1
+              className={cn(
+                "font-semibold leading-tight tracking-tight",
+                isSheet ? "text-lg" : "text-2xl"
+              )}
+              data-testid="commodity-detail-name"
             >
-              <Pencil className="size-3.5" aria-hidden="true" />
-              {t("commodities:detail.edit")}
-            </Button>
-            <Button asChild type="button" variant="ghost" size="sm" className="gap-1.5">
-              <Link to={printHref} data-testid="commodity-detail-print">
-                <Printer className="size-3.5" aria-hidden="true" />
-                {t("commodities:detail.print")}
-              </Link>
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={handleDelete}
-              data-testid="commodity-detail-delete"
-              className="gap-1.5 text-destructive"
-            >
-              <Trash2 className="size-3.5" aria-hidden="true" />
-              {t("commodities:detail.delete")}
-            </Button>
+              {commodity.name}
+            </h1>
+            {commodity.short_name && commodity.short_name !== commodity.name ? (
+              <p
+                className="text-xs font-mono text-muted-foreground mt-0.5"
+                data-testid="commodity-detail-short-name"
+              >
+                {commodity.short_name}
+              </p>
+            ) : null}
+            {type ? (
+              <p className="text-sm text-muted-foreground mt-0.5">
+                {t(`commodities:type.${type}`)}
+              </p>
+            ) : null}
           </div>
         </header>
 
-        <Tabs value={tab} onChange={setTab} />
+        {/* Status pills row — commodity status + warranty + days
+            remaining. Mock shows this directly under the header,
+            outside the action row, so glanceable signals don't
+            crowd the buttons. */}
+        <div
+          className="flex flex-wrap items-center gap-2 -mt-2"
+          data-testid="commodity-detail-pills"
+        >
+          {status ? (
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium border",
+                tone || "border-border text-foreground"
+              )}
+              data-testid="commodity-detail-status-pill"
+            >
+              <CircleDot className="size-3" aria-hidden="true" />
+              {t(`commodities:status.${status}`)}
+            </span>
+          ) : null}
+          {commodity.draft ? (
+            <Badge variant="outline" className="border-dashed text-xs">
+              {t("commodities:list.draftBadge")}
+            </Badge>
+          ) : null}
+          <WarrantyBadge
+            source={{
+              warranty_expires_at: commodity.warranty_expires_at,
+              tags: commodity.tags,
+            }}
+            data-testid="commodity-detail-warranty-pill"
+          />
+          {(() => {
+            const days = warrantyDaysRemaining(commodity.warranty_expires_at)
+            return days !== null && days > 0 ? (
+              <span className="text-xs text-muted-foreground">
+                {t("commodities:detail.warranty.daysRemaining", { count: days })}
+              </span>
+            ) : null
+          })()}
+        </div>
+
+        {/* Action buttons row — Edit (primary, flex-1), Insurance
+            Report (mock parity, links to the per-item insurance
+            report stub at /insurance/:id), and a small icon-only
+            destructive Delete on the right. Print stays as a small
+            icon button next to Delete so the action stays reachable
+            without the row taking three lines on narrow viewports. */}
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setEditOpen(true)}
+            data-testid="commodity-detail-edit"
+            className="flex-1 gap-1.5"
+          >
+            <Pencil className="size-3.5" aria-hidden="true" />
+            {t("commodities:detail.edit")}
+          </Button>
+          {slug && commodity.id ? (
+            <Button
+              asChild
+              type="button"
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              data-testid="commodity-detail-insurance"
+            >
+              <Link
+                to={`/g/${encodeURIComponent(slug)}/insurance/${encodeURIComponent(commodity.id)}`}
+              >
+                <FileBarChart2 className="size-3.5" aria-hidden="true" />
+                {t("commodities:detail.insuranceReport")}
+              </Link>
+            </Button>
+          ) : null}
+          <Button
+            asChild
+            type="button"
+            variant="outline"
+            size="icon"
+            className="size-8"
+            title={t("commodities:detail.print")}
+            aria-label={t("commodities:detail.print")}
+          >
+            <Link to={printHref} data-testid="commodity-detail-print">
+              <Printer className="size-3.5" aria-hidden="true" />
+            </Link>
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="size-8 text-destructive hover:bg-destructive/10"
+            onClick={handleDelete}
+            data-testid="commodity-detail-delete"
+            title={t("commodities:detail.delete")}
+            aria-label={t("commodities:detail.delete")}
+          >
+            <Trash2 className="size-3.5" aria-hidden="true" />
+          </Button>
+        </div>
+
+        {/* CHANGE STATUS bar — only meaningful while the item is
+            still `in_use`. Once it transitions to a terminal status
+            (sold/lost/disposed/written_off) the bar disappears and
+            the user can revert via the edit dialog. Each button
+            opens a confirm; on confirm we PATCH `status` only — the
+            mock's optional date/note/sale-price capture needs new
+            BE columns first. */}
+        {status === "in_use" ? (
+          <div
+            className="rounded-xl border border-border bg-muted/30 p-3 space-y-2"
+            data-testid="commodity-detail-change-status"
+          >
+            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              {t("commodities:detail.statusTransition.heading")}
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {TERMINAL_STATUSES.map((s) => (
+                <Button
+                  key={s}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className={cn("gap-1.5 text-xs h-7", COMMODITY_STATUS_TONES[s])}
+                  onClick={() => handleStatusTransition(s)}
+                  data-testid={`commodity-detail-transition-${s}`}
+                  disabled={update.isPending}
+                >
+                  {t(`commodities:status.${s}`)}
+                </Button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        <Tabs value={tab} onChange={setTab} fileCount={fileCount} />
 
         {tab === "details" ? (
           <>
@@ -385,6 +541,7 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
               groupCurrency={groupCurrency}
               purchaseCurrency={purchaseCurrency}
               areaName={areaName(commodity.area_id)}
+              variant={variant}
             />
             {commodity.id ? <CommodityHistoryTimeline commodityId={commodity.id} /> : null}
           </>
@@ -486,14 +643,19 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
 interface TabsProps {
   value: TabKey
   onChange: (v: TabKey) => void
+  // File count surfaced as a badge on the Files tab — mirrors the
+  // mock's `<TabsTrigger value="files">Files {n > 0 && <Badge>}`.
+  // Zero is hidden so the tab strip doesn't carry visual debt for
+  // every empty commodity.
+  fileCount?: number
 }
 
-function Tabs({ value, onChange }: TabsProps) {
+function Tabs({ value, onChange, fileCount = 0 }: TabsProps) {
   const { t } = useTranslation()
-  const tabs: { key: TabKey; label: string }[] = [
+  const tabs: { key: TabKey; label: string; count?: number }[] = [
     { key: "details", label: t("commodities:detail.tabs.details") },
     { key: "warranty", label: t("commodities:detail.tabs.warranty") },
-    { key: "files", label: t("commodities:detail.tabs.files") },
+    { key: "files", label: t("commodities:detail.tabs.files"), count: fileCount },
     { key: "lend", label: t("commodities:detail.tabs.lend") },
     { key: "service", label: t("commodities:detail.tabs.service") },
   ]
@@ -511,7 +673,7 @@ function Tabs({ value, onChange }: TabsProps) {
           aria-selected={value === tb.key}
           onClick={() => onChange(tb.key)}
           className={cn(
-            "px-3 py-2 text-sm border-b-2 -mb-px transition-colors",
+            "inline-flex items-center gap-1.5 px-3 py-2 text-sm border-b-2 -mb-px transition-colors",
             value === tb.key
               ? "border-primary text-foreground"
               : "border-transparent text-muted-foreground hover:text-foreground"
@@ -519,6 +681,14 @@ function Tabs({ value, onChange }: TabsProps) {
           data-testid={`commodity-detail-tab-${tb.key}`}
         >
           {tb.label}
+          {tb.count && tb.count > 0 ? (
+            <span
+              className="flex size-4 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-foreground"
+              data-testid={`commodity-detail-tab-${tb.key}-count`}
+            >
+              {tb.count}
+            </span>
+          ) : null}
         </button>
       ))}
     </div>
@@ -534,9 +704,20 @@ interface DetailsTabProps {
   // `current_price` in — always the active group currency.
   groupCurrency: string
   areaName: string
+  // Variant matches the parent's: `"sheet"` swaps the 2-col grid
+  // for a vertical icon|label-value list (matching the mock and
+  // staying readable inside the narrower Sheet panel); `"page"`
+  // keeps the existing 2-col layout that fills the wider canvas.
+  variant?: "page" | "sheet"
 }
 
-function DetailsTab({ commodity, purchaseCurrency, groupCurrency, areaName }: DetailsTabProps) {
+function DetailsTab({
+  commodity,
+  purchaseCurrency,
+  groupCurrency,
+  areaName,
+  variant = "page",
+}: DetailsTabProps) {
   const { t } = useTranslation()
   const noValue = t("commodities:detail.noValue")
   const rows: { icon: typeof MapPin; label: string; value: React.ReactNode; testId?: string }[] = [
@@ -583,14 +764,30 @@ function DetailsTab({ commodity, purchaseCurrency, groupCurrency, areaName }: De
       value: commodity.serial_number || noValue,
     },
   ]
+  // Sheet variant renders a single-column vertical list with each row
+  // formatted as `[icon] [label/value]` to match the design mock; the
+  // page variant keeps the wider 2-col grid that fills the canvas.
+  const isSheet = variant === "sheet"
+  const containerClass = isSheet
+    ? "flex flex-col py-2"
+    : "grid grid-cols-1 sm:grid-cols-2 gap-4 py-6"
+  const fullWidthClass = isSheet ? "" : "sm:col-span-2"
+  const separatorClass = isSheet ? "" : "sm:col-span-2"
   return (
     <Card data-testid="commodity-detail-details">
-      <CardContent className="grid grid-cols-1 sm:grid-cols-2 gap-4 py-6">
-        {rows.map((r) => (
-          <DetailRow key={r.label} icon={r.icon} label={r.label} value={r.value} />
+      <CardContent className={containerClass}>
+        {rows.map((r, i) => (
+          <DetailRow
+            key={r.label}
+            icon={r.icon}
+            label={r.label}
+            value={r.value}
+            variant={variant}
+            withDivider={isSheet && i > 0}
+          />
         ))}
         {commodity.tags && commodity.tags.length > 0 ? (
-          <div className="sm:col-span-2 flex flex-col gap-1.5">
+          <div className={cn("flex flex-col gap-1.5", fullWidthClass, isSheet && "py-2.5")}>
             <DetailLabel icon={Tag} label={t("commodities:detail.fields.tags")} />
             <div className="flex flex-wrap gap-1.5">
               {commodity.tags.map((tag) => (
@@ -602,7 +799,7 @@ function DetailsTab({ commodity, purchaseCurrency, groupCurrency, areaName }: De
           </div>
         ) : null}
         {Array.isArray(commodity.urls) && commodity.urls.length > 0 ? (
-          <div className="sm:col-span-2 flex flex-col gap-1.5">
+          <div className={cn("flex flex-col gap-1.5", fullWidthClass, isSheet && "py-2.5")}>
             <DetailLabel icon={ExternalLink} label={t("commodities:detail.fields.urls")} />
             <ul className="text-sm">
               {(commodity.urls as unknown as string[]).map((u, i) => (
@@ -621,13 +818,13 @@ function DetailsTab({ commodity, purchaseCurrency, groupCurrency, areaName }: De
           </div>
         ) : null}
         {commodity.comments ? (
-          <div className="sm:col-span-2 flex flex-col gap-1.5">
+          <div className={cn("flex flex-col gap-1.5", fullWidthClass, isSheet && "py-2.5")}>
             <DetailLabel icon={Hash} label={t("commodities:detail.fields.comments")} />
             <p className="text-sm whitespace-pre-wrap">{commodity.comments}</p>
           </div>
         ) : null}
         {commodity.extra_serial_numbers && commodity.extra_serial_numbers.length > 0 ? (
-          <div className="sm:col-span-2 flex flex-col gap-1.5">
+          <div className={cn("flex flex-col gap-1.5", fullWidthClass, isSheet && "py-2.5")}>
             <DetailLabel icon={Hash} label={t("commodities:detail.fields.extraSerialNumbers")} />
             <div className="flex flex-wrap gap-1.5">
               {commodity.extra_serial_numbers.map((s) => (
@@ -639,7 +836,7 @@ function DetailsTab({ commodity, purchaseCurrency, groupCurrency, areaName }: De
           </div>
         ) : null}
         {commodity.part_numbers && commodity.part_numbers.length > 0 ? (
-          <div className="sm:col-span-2 flex flex-col gap-1.5">
+          <div className={cn("flex flex-col gap-1.5", fullWidthClass, isSheet && "py-2.5")}>
             <DetailLabel icon={Hash} label={t("commodities:detail.fields.partNumbers")} />
             <div className="flex flex-wrap gap-1.5">
               {commodity.part_numbers.map((p) => (
@@ -650,7 +847,7 @@ function DetailsTab({ commodity, purchaseCurrency, groupCurrency, areaName }: De
             </div>
           </div>
         ) : null}
-        <Separator className="sm:col-span-2" />
+        <Separator className={separatorClass} />
         <DetailRow
           icon={Calendar}
           label={t("commodities:detail.fields.registeredDate")}
@@ -659,6 +856,8 @@ function DetailsTab({ commodity, purchaseCurrency, groupCurrency, areaName }: De
               ? formatDate(commodity.registered_date as string, { style: "short" })
               : noValue
           }
+          variant={variant}
+          withDivider={isSheet}
         />
         <DetailRow
           icon={Calendar}
@@ -668,21 +867,42 @@ function DetailsTab({ commodity, purchaseCurrency, groupCurrency, areaName }: De
               ? formatDate(commodity.last_modified_date as string, { style: "short" })
               : noValue
           }
+          variant={variant}
+          withDivider={isSheet}
         />
       </CardContent>
     </Card>
   )
 }
 
-function DetailRow({
-  icon: Icon,
-  label,
-  value,
-}: {
+interface DetailRowProps {
   icon: typeof MapPin
   label: string
   value: React.ReactNode
-}) {
+  // `"sheet"` switches to the mock's `[icon] [label / value]`
+  // horizontal arrangement separated by Separator; `"page"` keeps
+  // the existing label-stacked-above-value layout.
+  variant?: "page" | "sheet"
+  // Sheet rows draw a top Separator unless they're first in the
+  // list; the parent passes `false` for the leading row.
+  withDivider?: boolean
+}
+
+function DetailRow({ icon: Icon, label, value, variant = "page", withDivider }: DetailRowProps) {
+  if (variant === "sheet") {
+    return (
+      <>
+        {withDivider ? <Separator /> : null}
+        <div className="flex items-start gap-3 py-2.5">
+          <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-muted-foreground mb-0.5">{label}</p>
+            <div className="text-sm font-medium">{value}</div>
+          </div>
+        </div>
+      </>
+    )
+  }
   return (
     <div className="flex flex-col gap-1">
       <DetailLabel icon={Icon} label={label} />
@@ -902,14 +1122,13 @@ export function CommodityDetailSheet() {
     <Sheet open onOpenChange={(open) => !open && handleClose()}>
       <SheetContent
         side="right"
-        // The mock's Sheet maxes out at `sm:max-w-lg`, but the
-        // detail surface ships richer content (the file gallery, the
-        // history timeline, multi-row Details cards). 2xl gives the
-        // tabs room without forcing a horizontal scroll on dense
-        // forms; on viewports below `sm` the SheetContent falls back
-        // to its default `w-3/4` and then the Sheet primitive
-        // handles the full-width takeover.
-        className="w-full sm:max-w-2xl overflow-y-auto p-0"
+        // Width matches the design mock 1:1 (`sm:max-w-lg` → 32rem
+        // ≈ 512px). The detail surface adapts: in sheet mode the
+        // DetailsTab body switches to a vertical icon|label-value
+        // list (instead of a 2-col grid) so the narrower panel
+        // stays readable. Below `sm` the Sheet primitive falls
+        // back to `w-3/4` and the panel takes the whole viewport.
+        className="w-full sm:max-w-lg overflow-y-auto p-0"
         data-testid="commodity-detail-sheet"
       >
         <CommodityDetailContent id={id} variant="sheet" />

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useMemo, useState } from "react"
-import { Link, useMatch, useNavigate, useParams, useSearchParams } from "react-router-dom"
+import {
+  Link,
+  useLocation,
+  useMatch,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import {
   ArrowLeft,
@@ -20,6 +27,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
+import { Sheet, SheetContent } from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DropOverlay } from "@/components/files/DropOverlay"
 import { EntityFilesPanel } from "@/components/files/EntityFilesPanel"
@@ -62,20 +70,50 @@ function parseTab(raw: string | null): TabKey {
   return (TAB_KEYS as readonly string[]).includes(raw ?? "") ? (raw as TabKey) : "details"
 }
 
-// /commodities/:id — full-page detail. The design mock renders this as
-// a Sheet overlay over the list; that variant is deferred to a follow-up
-// because the deep-link case (a shared link or back-button reload) needs
-// a stable URL anyway, and "full page everywhere" is simpler than
-// switching modes based on navigation provenance.
+// CommodityDetailContent is the rendered body of the item detail surface
+// — header, action buttons, tab strip, and the per-tab bodies. The same
+// component is rendered in two visual frames:
 //
-// Tabs: Details, Warranty, Files. Warranty + Files are stubbed because
-// first-class warranties (#1367) and the unified Files surface
-// (#1398/#1399) haven't shipped — the tabs render coming-soon banners
-// linking the trackers so the UI doesn't pretend.
-export function CommodityDetailPage() {
+//   - `variant="page"` (default): standard full-page wrapper at
+//     `/g/:slug/commodities/:id`. Stable URL, deep-link friendly,
+//     refresh-survivable. This is what the catch-all route and
+//     direct-link arrivals see (#1546 AC2).
+//   - `variant="sheet"`: rendered inside a right-side `<Sheet>` overlay
+//     on top of the items list. Used when the user drills in from the
+//     list — the URL still updates to the same `/commodities/:id` so
+//     back/forward and `?tab=` deep-links work, but the list page
+//     stays mounted behind the sheet (#1546 AC1).
+//
+// Tabs: Details, Warranty, Files, Lend, Service. The same hooks /
+// query-string mirror / edit dialog / drop zone all run in both
+// variants — the only difference is the outer chrome and a "Back to
+// list" affordance vs. the Sheet's built-in close button.
+export interface CommodityDetailContentProps {
+  /**
+   * The commodity id to load. Pre-extracted from the URL by the page
+   * or sheet wrapper so this component stays unaware of the route shape.
+   */
+  id: string
+  /**
+   * Outer-frame variant. Default `"page"`. `"sheet"` drops the
+   * page-level max-width wrapper and the "Back to list" link (the
+   * Sheet provides its own X close button), but otherwise renders
+   * the same content with the same hooks and behaviour.
+   */
+  variant?: "page" | "sheet"
+}
+
+export function CommodityDetailContent({ id, variant = "page" }: CommodityDetailContentProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { id = "" } = useParams<{ id: string }>()
+  // Outer-frame classes: page mode uses the canonical 4xl-max-width
+  // centered-column layout; sheet mode lets the SheetContent control
+  // width and just provides padding + scroll inside the panel.
+  const isSheet = variant === "sheet"
+  const errorWrapperClass = isSheet ? "p-6" : "p-6 max-w-4xl mx-auto w-full"
+  const mainWrapperClass = isSheet
+    ? "relative flex flex-col gap-6 p-6 overflow-y-auto"
+    : "relative flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full"
   const { currentGroup } = useCurrentGroup()
   const slug = currentGroup?.slug
   const enabled = !!currentGroup
@@ -157,7 +195,7 @@ export function CommodityDetailPage() {
 
   if (detail.isLoading) {
     return (
-      <div className="p-6 max-w-4xl mx-auto w-full" data-testid="commodity-detail-loading">
+      <div className={errorWrapperClass} data-testid="commodity-detail-loading">
         <Skeleton className="h-8 w-64" />
         <Skeleton className="mt-2 h-4 w-32" />
         <div className="mt-6 grid grid-cols-2 gap-3">
@@ -170,7 +208,7 @@ export function CommodityDetailPage() {
   }
   if (detail.isError) {
     return (
-      <div className="p-6 max-w-4xl mx-auto w-full">
+      <div className={errorWrapperClass}>
         <Alert variant="destructive" data-testid="commodity-detail-error">
           <AlertTitle>{t("commodities:detail.errorTitle")}</AlertTitle>
           <AlertDescription>{t("commodities:detail.errorDescription")}</AlertDescription>
@@ -184,7 +222,7 @@ export function CommodityDetailPage() {
   }
   if (!commodity) {
     return (
-      <div className="p-6 max-w-4xl mx-auto w-full">
+      <div className={errorWrapperClass}>
         <Card data-testid="commodity-detail-not-found">
           <CardHeader>
             <CardTitle>{t("commodities:detail.notFoundTitle")}</CardTitle>
@@ -241,10 +279,13 @@ export function CommodityDetailPage() {
 
   return (
     <>
-      <RouteTitle title={t("commodities:detail.documentTitle")} />
+      {/* Document title is owned by the full-page variant only — when
+          the sheet is open over the list, the list page already set
+          the title and the user expects it to stay. */}
+      {isSheet ? null : <RouteTitle title={t("commodities:detail.documentTitle")} />}
       <div
-        className="relative flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full"
-        data-testid="page-commodity-detail"
+        className={mainWrapperClass}
+        data-testid={isSheet ? "sheet-commodity-detail" : "page-commodity-detail"}
         {...dropZone.bindProps}
       >
         {dropZone.isDragging ? (
@@ -253,13 +294,19 @@ export function CommodityDetailPage() {
             hint={t("files:entityPanel.dropHint")}
           />
         ) : null}
-        <Link
-          to={listHref}
-          className="text-sm text-muted-foreground hover:underline inline-flex items-center gap-1"
-        >
-          <ArrowLeft className="size-3.5" aria-hidden="true" />
-          {t("commodities:detail.backToList")}
-        </Link>
+        {/* The Sheet variant renders its own X close button (top-right
+            of the panel), so the explicit "Back to list" Link is
+            page-only — clicking the X dismisses the overlay and lands
+            the user back on the list URL the sheet opened over. */}
+        {isSheet ? null : (
+          <Link
+            to={listHref}
+            className="text-sm text-muted-foreground hover:underline inline-flex items-center gap-1"
+          >
+            <ArrowLeft className="size-3.5" aria-hidden="true" />
+            {t("commodities:detail.backToList")}
+          </Link>
+        )}
 
         <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex items-start gap-3 min-w-0">
@@ -805,4 +852,68 @@ function warrantyDaysRemaining(date: string | undefined): number | null {
   const today = new Date()
   const todayUTC = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate())
   return Math.round((t - todayUTC) / (1000 * 60 * 60 * 24))
+}
+
+// CommodityDetailPage is the canonical full-page entry mounted at
+// `/g/:slug/commodities/:id` (and `/edit`). Direct landings, refresh,
+// "open in new tab", and shared links all hit this page — its URL is
+// stable and the layout is the standard centered-column view.
+//
+// The actual rendering lives in `<CommodityDetailContent>` so the
+// sheet variant can reuse the same hooks, dialogs, drag-drop, and
+// tab logic without duplication.
+export function CommodityDetailPage() {
+  const { id = "" } = useParams<{ id: string }>()
+  return <CommodityDetailContent id={id} variant="page" />
+}
+
+// CommodityDetailSheet renders the same content as the full page,
+// but inside a right-side `<Sheet>` overlay. Used by the router when
+// the navigation that landed us here carried `state.background` (i.e.
+// the user drilled in from the items list). The list page stays
+// mounted underneath so closing the sheet just dismisses the overlay
+// without a route transition.
+//
+// Closing the sheet (X / Esc / outside click) navigates to the
+// `state.background` URL — that drops the `:id` from the path and
+// returns the user to the list they came from. If we can't resolve a
+// background (e.g. the user reloaded with a stale state), we fall
+// back to going back in history; if even that fails, the route's
+// catch-all `<NotFoundPage>` would handle it after the page reloads.
+export function CommodityDetailSheet() {
+  const { id = "" } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const background = (
+    location.state as { background?: { pathname: string; search?: string; hash?: string } } | null
+  )?.background
+
+  function handleClose() {
+    if (background) {
+      navigate(`${background.pathname}${background.search ?? ""}${background.hash ?? ""}`, {
+        replace: true,
+      })
+    } else {
+      navigate(-1)
+    }
+  }
+
+  return (
+    <Sheet open onOpenChange={(open) => !open && handleClose()}>
+      <SheetContent
+        side="right"
+        // The mock's Sheet maxes out at `sm:max-w-lg`, but the
+        // detail surface ships richer content (the file gallery, the
+        // history timeline, multi-row Details cards). 2xl gives the
+        // tabs room without forcing a horizontal scroll on dense
+        // forms; on viewports below `sm` the SheetContent falls back
+        // to its default `w-3/4` and then the Sheet primitive
+        // handles the full-width takeover.
+        className="w-full sm:max-w-2xl overflow-y-auto p-0"
+        data-testid="commodity-detail-sheet"
+      >
+        <CommodityDetailContent id={id} variant="sheet" />
+      </SheetContent>
+    </Sheet>
+  )
 }

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -43,6 +43,7 @@ import { ServiceTab } from "@/components/services/ServiceTab"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { useAreas } from "@/features/areas/hooks"
 import { useFiles } from "@/features/files/hooks"
+import { useLocations } from "@/features/locations/hooks"
 import { CommodityHistoryTimeline } from "@/features/commodities/CommodityHistoryTimeline"
 import { CommodityThumb } from "@/features/commodities/CommodityThumb"
 import {
@@ -150,6 +151,7 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
   const enabled = !!currentGroup
   const detail = useCommodity(id, { enabled })
   const areas = useAreas({ enabled })
+  const locations = useLocations({ enabled })
   const update = useUpdateCommodity(id)
   const remove = useDeleteCommodity()
   const setCover = useSetCommodityCover(id)
@@ -221,6 +223,29 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
     }
     return (areaId?: string) => (areaId ? (map.get(areaId) ?? "") : "")
   }, [areas.data])
+
+  // areaLabel mirrors the design mock's `areaLabel(areaId)` —
+  // "{Location.name} · {Area.name}" when both exist, fall back to
+  // just the area name (mock fallback), then empty string. Drives
+  // the Location row in DetailsTab so the user sees both
+  // breadcrumb levels at a glance instead of a single area name.
+  const areaLabel = useMemo(() => {
+    const areaById = new Map<string, { name: string; locationId?: string }>()
+    for (const a of areas.data ?? []) {
+      if (a.id) areaById.set(a.id, { name: a.name ?? "", locationId: a.location_id })
+    }
+    const locationById = new Map<string, string>()
+    for (const l of locations.data ?? []) {
+      if (l.id) locationById.set(l.id, l.name ?? "")
+    }
+    return (areaId?: string) => {
+      if (!areaId) return ""
+      const area = areaById.get(areaId)
+      if (!area) return ""
+      const locationName = area.locationId ? (locationById.get(area.locationId) ?? "") : ""
+      return locationName ? `${locationName} · ${area.name}` : area.name
+    }
+  }, [areas.data, locations.data])
 
   // The detail page heading mirrors the commodity name; once it's
   // loaded we update the document title via RouteTitle so browser
@@ -576,6 +601,7 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
                 groupCurrency={groupCurrency}
                 purchaseCurrency={purchaseCurrency}
                 areaName={areaName(commodity.area_id)}
+                areaLabel={areaLabel(commodity.area_id)}
                 variant={variant}
               />
               {commodity.id ? <CommodityHistoryTimeline commodityId={commodity.id} /> : null}
@@ -720,8 +746,14 @@ function Tabs({ value, onChange, fileCount = 0, variant = "page" }: TabsProps) {
     <div
       role="tablist"
       className={cn(
-        "flex border-b border-border",
-        isSheet ? "w-full justify-start gap-4" : "gap-1"
+        "flex",
+        // Sheet variant: no full-width bottom border on the
+        // container — the mock's `<TabsList variant="line">` only
+        // shows the underline under the *active* trigger. Page
+        // mode keeps the strip-wide divider for the wider chrome.
+        // `flex-1` triggers below spread the labels evenly across
+        // the panel instead of clumping left.
+        isSheet ? "w-full gap-1" : "gap-1 border-b border-border"
       )}
       data-testid="commodity-detail-tabs"
     >
@@ -736,7 +768,10 @@ function Tabs({ value, onChange, fileCount = 0, variant = "page" }: TabsProps) {
             onClick={() => onChange(tb.key)}
             className={cn(
               "inline-flex items-center gap-1.5 py-2 text-sm border-b-2 -mb-px transition-colors",
-              isSheet ? "px-1" : "px-3",
+              // Sheet triggers grow to equal width + center their
+              // labels so the tab strip mirrors the mock's
+              // `flex-1 justify-center` `<TabsTrigger>` shape.
+              isSheet ? "flex-1 justify-center px-2" : "px-3",
               value === tb.key
                 ? "border-primary text-foreground font-semibold"
                 : "border-transparent text-muted-foreground hover:text-foreground"
@@ -769,6 +804,12 @@ interface DetailsTabProps {
   // `current_price` in — always the active group currency.
   groupCurrency: string
   areaName: string
+  // "{Location.name} · {Area.name}" breadcrumb for the Location
+  // row (mock parity). Falls back to the area name alone when the
+  // location can't be resolved; empty string when the area itself
+  // is missing. Sheet mode prefers this richer label since the
+  // panel is narrow but the user still wants the full context.
+  areaLabel: string
   // Variant matches the parent's: `"sheet"` swaps the 2-col grid
   // for a vertical icon|label-value list (matching the mock and
   // staying readable inside the narrower Sheet panel); `"page"`
@@ -781,12 +822,24 @@ function DetailsTab({
   purchaseCurrency,
   groupCurrency,
   areaName,
+  areaLabel,
   variant = "page",
 }: DetailsTabProps) {
   const { t } = useTranslation()
   const noValue = t("commodities:detail.noValue")
+  // Sheet mode shows the breadcrumb-style "Location · Area"
+  // value with a "Location" label (mock parity); page mode keeps
+  // the bare "Area" / area-name pair to match the existing column
+  // layout where adjacent rows already carry their own context.
+  const isSheetVariant = variant === "sheet"
   const rows: { icon: typeof MapPin; label: string; value: React.ReactNode; testId?: string }[] = [
-    { icon: MapPin, label: t("commodities:detail.fields.area"), value: areaName || noValue },
+    {
+      icon: MapPin,
+      label: isSheetVariant
+        ? t("commodities:detail.fields.location")
+        : t("commodities:detail.fields.area"),
+      value: (isSheetVariant ? areaLabel : areaName) || noValue,
+    },
     {
       icon: Package,
       label: t("commodities:detail.fields.count"),

--- a/frontend/src/pages/commodities/__tests__/CommoditiesListPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommoditiesListPage.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest"
-import { Route } from "react-router-dom"
+import { Route, useLocation } from "react-router-dom"
 import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { axe } from "jest-axe"
@@ -346,7 +346,7 @@ describe("<CommoditiesListPage />", () => {
     })
   })
 
-  it("opens the Sheet preview when a card title is clicked (bare click)", async () => {
+  it("navigates to /commodities/:id with state.background on a bare card click (#1546)", async () => {
     const user = userEvent.setup()
     server.use(
       ...groupHandlers.list(groupFixture),
@@ -361,18 +361,52 @@ describe("<CommoditiesListPage />", () => {
         }),
       ])
     )
-    renderList()
+    // Mount the list under its real path, plus a sentinel route at
+    // /commodities/:id so the navigation lands somewhere we can
+    // inspect. The sentinel reads useLocation and emits the
+    // pathname + the captured `state.background.pathname` so the
+    // test can assert both the URL flip and the modal-routes
+    // backdrop wiring without spinning up the full <AppRoutes>.
+    setAccessToken("good-token")
+    function NavSentinel() {
+      const location = useLocation()
+      const background = (location.state as { background?: { pathname: string } } | null)
+        ?.background
+      return (
+        <div>
+          <span data-testid="nav-sentinel-path">{location.pathname}</span>
+          <span data-testid="nav-sentinel-background">{background?.pathname ?? ""}</span>
+        </div>
+      )
+    }
+    renderWithProviders({
+      initialPath: `/g/${SLUG}/commodities`,
+      routes: (
+        <>
+          <Route
+            path="/g/:groupSlug/commodities"
+            element={
+              <GroupProvider>
+                <ConfirmProvider>
+                  <CommoditiesListPage />
+                </ConfirmProvider>
+              </GroupProvider>
+            }
+          />
+          <Route path="/g/:groupSlug/commodities/:id" element={<NavSentinel />} />
+        </>
+      ),
+    })
     const card = await screen.findByTestId("commodity-card")
     await user.click(within(card).getByTestId("commodity-card-link"))
-    const sheet = await screen.findByTestId("commodity-preview-sheet")
-    expect(within(sheet).getByRole("heading", { name: /macbook pro/i })).toBeInTheDocument()
-    // Both the original ($2,400) and current ($1,900) prices show.
-    expect(within(sheet).getByText(/\$2,400\.00/)).toBeInTheDocument()
-    expect(within(sheet).getByText(/\$1,900\.00/)).toBeInTheDocument()
-    // The Sheet exposes a "View full details" link to the canonical URL.
-    expect(screen.getByTestId("commodity-preview-open")).toHaveAttribute(
-      "href",
+    expect(await screen.findByTestId("nav-sentinel-path")).toHaveTextContent(
       `/g/${SLUG}/commodities/c1`
+    )
+    // The list URL is stamped on `state.background` so the modal
+    // routes tree in app/router.tsx can render the list backdrop
+    // behind the sheet.
+    expect(screen.getByTestId("nav-sentinel-background")).toHaveTextContent(
+      `/g/${SLUG}/commodities`
     )
   })
 

--- a/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest"
-import { Route } from "react-router-dom"
+import { Route, useLocation } from "react-router-dom"
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { axe } from "jest-axe"
 
-import { CommodityDetailPage } from "@/pages/commodities/CommodityDetailPage"
+import { CommodityDetailPage, CommodityDetailSheet } from "@/pages/commodities/CommodityDetailPage"
 import { GroupProvider } from "@/features/group/GroupContext"
 import { ConfirmProvider } from "@/hooks/useConfirm"
 import { renderWithProviders } from "@/test/render"
@@ -303,5 +303,103 @@ describe("<CommodityDetailPage />", () => {
     const { container } = renderDetail()
     await screen.findByTestId("commodity-detail-details")
     expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe("<CommodityDetailSheet /> (#1546 modal-routes overlay)", () => {
+  // The sheet variant ships the same content as the page variant
+  // (header, action buttons, tabs, drag-drop, dialogs); the only
+  // difference is the outer chrome. These tests cover the wiring —
+  // the rendered Sheet primitive shows up, the inner content is
+  // present and labelled with the sheet-specific testid (so the
+  // page-mode tests can keep using `page-commodity-detail`), and
+  // closing the sheet navigates to `state.background`.
+  function renderSheet(opts: { pathname?: string; search?: string } = {}) {
+    const pathname = opts.pathname ?? `/g/${SLUG}/commodities/${ID}`
+    const search = opts.search ?? ""
+    setAccessToken("good-token")
+    // Mount BOTH the list backdrop route and the sheet route. We
+    // can't actually render <CommoditiesListPage /> without its
+    // upstream queries; an empty sentinel is enough to assert the
+    // backdrop URL stayed mounted while the sheet was on screen.
+    function ListBackdrop() {
+      const location = useLocation()
+      return <div data-testid="list-backdrop">{location.pathname}</div>
+    }
+    return renderWithProviders({
+      // Pass the full Location-shape so `state.background` carries
+      // through and `?tab=...` arrives in `location.search` (the
+      // detail page's `useSearchParams` reads it from there, not
+      // from the pathname).
+      initialEntries: [
+        {
+          pathname,
+          search,
+          state: { background: { pathname: `/g/${SLUG}/commodities` } },
+        },
+      ],
+      routes: (
+        <>
+          <Route path="/g/:groupSlug/commodities" element={<ListBackdrop />} />
+          <Route
+            path="/g/:groupSlug/commodities/:id"
+            element={
+              <GroupProvider>
+                <ConfirmProvider>
+                  <CommodityDetailSheet />
+                </ConfirmProvider>
+              </GroupProvider>
+            }
+          />
+        </>
+      ),
+    })
+  }
+
+  it("renders the detail surface inside a Sheet panel", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.detail(SLUG, ID, commodityFixture)
+    )
+    renderSheet()
+    // Sheet wrapper testid identifies the overlay variant; inside,
+    // the same content (`sheet-commodity-detail`) renders without
+    // the page-mode `back-to-list` link.
+    expect(await screen.findByTestId("commodity-detail-sheet")).toBeInTheDocument()
+    expect(await screen.findByTestId("sheet-commodity-detail")).toBeInTheDocument()
+    expect(screen.queryByTestId("page-commodity-detail")).toBeNull()
+    expect(screen.getByRole("heading", { name: /macbook pro 16/i, level: 1 })).toBeInTheDocument()
+  })
+
+  it("supports the same `?tab=warranty` deep-link as the page variant", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.detail(SLUG, ID, commodityFixture)
+    )
+    renderSheet({ search: "?tab=warranty" })
+    // Warranty tab content is what the dashboard expiring-row +
+    // warranty-list deep-links target — it must work in sheet mode.
+    expect(await screen.findByTestId("commodity-detail-warranty")).toBeInTheDocument()
+  })
+
+  it("navigates back to the backdrop URL when the user closes the sheet (Escape)", async () => {
+    const user = userEvent.setup()
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.detail(SLUG, ID, commodityFixture)
+    )
+    renderSheet()
+    expect(await screen.findByTestId("commodity-detail-sheet")).toBeInTheDocument()
+    await user.keyboard("{Escape}")
+    // The Sheet primitive's onOpenChange fires `handleClose`, which
+    // navigates back to `state.background.pathname`. The list
+    // backdrop sentinel renders the new URL.
+    await waitFor(() =>
+      expect(screen.getByTestId("list-backdrop")).toHaveTextContent(`/g/${SLUG}/commodities`)
+    )
+    expect(screen.queryByTestId("commodity-detail-sheet")).toBeNull()
   })
 })

--- a/frontend/src/test/render.tsx
+++ b/frontend/src/test/render.tsx
@@ -11,6 +11,20 @@ import { DensityProvider } from "@/hooks/useDensity"
 interface RenderWithProvidersBaseOptions {
   // Initial URL the MemoryRouter starts at. Defaults to "/".
   initialPath?: string
+  // Full Location-shaped initial entries — alternative to
+  // `initialPath` when the test needs to set `location.state` (e.g.
+  // the modal-routes pattern in #1546 where `state.background`
+  // controls whether the sheet variant or the page variant
+  // renders). Pass an array of `Partial<Location>` objects; if
+  // both `initialEntries` and `initialPath` are set,
+  // `initialEntries` wins.
+  initialEntries?: Array<{
+    pathname: string
+    search?: string
+    hash?: string
+    state?: unknown
+    key?: string
+  }>
   // Optional preload of the QueryClient cache so tests can seed e.g.
   // current-user data without going through MSW for every case.
   queryClient?: QueryClient
@@ -72,6 +86,7 @@ export function renderWithProviders(
 ): RenderResult & { queryClient: QueryClient } {
   const {
     initialPath = "/",
+    initialEntries,
     queryClient,
     withAuth = false,
     withGroup = false,
@@ -102,7 +117,7 @@ export function renderWithProviders(
     <ThemeProvider defaultTheme="light" storageKey="test-theme">
       <DensityProvider defaultDensity="comfortable" storageKey="test-density">
         <QueryClientProvider client={client}>
-          <MemoryRouter initialEntries={[initialPath]}>{tree}</MemoryRouter>
+          <MemoryRouter initialEntries={initialEntries ?? [initialPath]}>{tree}</MemoryRouter>
         </QueryClientProvider>
       </DensityProvider>
     </ThemeProvider>


### PR DESCRIPTION
Closes #1546.

Ships the right-side `<Sheet>` overlay variant of the commodity detail surface alongside the existing full page, per the design mock at `denisvmedia/inventario-design` (`src/components/ItemDetail.tsx`).

## What's in

### Wiring

- **`CommodityDetailContent`** (extracted from the old `CommodityDetailPage` body): the rendered surface — header, action buttons, tab strip, Details / Warranty / Files / Lend / Service tabs — driven by the same hooks, dialogs, drag-drop, and `?tab=` query-string mirror the page already used. Takes a `variant` prop: `"page"` (default) is the 4xl-max-width centered chrome with Back-to-list link + `RouteTitle`; `"sheet"` drops the outer chrome and back-link and lets the SheetContent supply width / padding.
- **`CommodityDetailPage`**: thin wrapper at `/g/:slug/commodities/:id` that reads `:id` from useParams and renders `<CommodityDetailContent variant="page" />`. Stable URL, deep-link friendly, refresh-survivable. (#1546 AC2)
- **`CommodityDetailSheet`** (new): wraps the content in `<Sheet open>` + `<SheetContent side="right" sm:max-w-2xl>`. Reads `state.background` from `useLocation` and on close navigates back to the backdrop URL with `replace: true` so the detail URL doesn't pile up in history.
- **`app/router.tsx`** now reads `useLocation().state?.background` at the top of `<AppRoutes>` and renders **two** `<Routes>` trees:
  - the page tree resolves against `background ?? location` (so the list stays mounted as the backdrop), and
  - a separate "modal" tree resolves the current location to mount `<CommodityDetailSheet>` on top.
  Direct landings (refresh, share, "open in new tab") carry no background → only the page tree renders → full-page detail as before. The print subroute is intentionally excluded from the modal tree (full-page-only).
- **`CommoditiesListPage`**: the row-click handler now navigates with `state: { background: location }` instead of opening a local preview Sheet. The old `<CommodityPreview>` slide-over is gone — the full overlay Sheet shows the same surface (and more) on the same drill-in. Cmd/Ctrl/Shift-click + middle-button still fall through to the underlying `<Link>` so opening in a new tab carries no `state.background` and the new tab gets the full page.
- **`?tab=` deep-links** (from #1545's warranties list + dashboard expiring panel), the **`/edit`** form-dialog deep-link, and the **Files tab drag-drop quick-attach** (#1448) all run through the same hooks in both variants — no duplication. (#1546 AC3, AC4)

### Tests

- `CommoditiesListPage.test.tsx` — the "preview Sheet on click" case is replaced with a navigation assertion: clicking a card pushes `/commodities/:id` AND stamps the list URL onto `state.background`, captured by a sentinel route in the test router.
- `CommodityDetailPage.test.tsx` — new `<CommodityDetailSheet />` block (3 cases):
  - renders the sheet panel + the `sheet-commodity-detail` content (and NOT the `page-commodity-detail` testid),
  - honours the same `?tab=warranty` deep-link as the page,
  - closes back to `state.background` on Escape.
- `test/render.tsx` gained an `initialEntries` option so tests can pass a full Location-shape with `state` set on first render.

## Out of scope

- The print view (`/print` subroute) stays page-only — no overlay print is meaningful.
- Other entry points (warranties list, dashboard expiring panel) still navigate to the full page; if we want those to open the sheet too, a follow-up PR can stamp `state.background` on those links.

## Test plan
- [x] `npm run typecheck && npm run lint && npm run format:check` — clean
- [x] `npm run i18n:check` — clean (the now-unused `commodities:list.openFull` key was dropped along with the preview Sheet's "View full details" CTA)
- [x] `npx vitest run` — **99 files / 645 tests** pass (3 new sheet-mode cases + 1 updated list-page case)