### PR TITLE
[#250] Add searchable filter to export SelectedItemsPicker

### DIFF
--- a/frontend/src/components/exports/SelectedItemsPicker.tsx
+++ b/frontend/src/components/exports/SelectedItemsPicker.tsx
@@ -1,5 +1,8 @@
+import { Search } from "lucide-react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
+import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import type { ExportSelectedItem } from "@/features/export/api"
 import { useLocations } from "@/features/locations/hooks"
@@ -24,8 +27,28 @@ export interface SelectedItemsPickerProps {
 export function SelectedItemsPicker({ value, onChange, errorMessage }: SelectedItemsPickerProps) {
   const { t } = useTranslation(["exports"])
   const locationsQuery = useLocations()
-  const locations = locationsQuery.data ?? []
-  const pickedIds = new Set(value.map((item) => item.id).filter((id): id is string => !!id))
+  const locations = useMemo(() => locationsQuery.data ?? [], [locationsQuery.data])
+  const pickedIds = useMemo(
+    () => new Set(value.map((item) => item.id).filter((id): id is string => !!id)),
+    [value]
+  )
+
+  const [query, setQuery] = useState("")
+
+  // Already-picked rows stay visible even when they don't match the
+  // query, so the user doesn't lose track of what they have selected
+  // while narrowing the list.
+  const visibleLocations = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return locations
+    return locations.filter((loc) => {
+      const id = loc.id ?? ""
+      if (pickedIds.has(id)) return true
+      if ((loc.name ?? "").toLowerCase().includes(q)) return true
+      if ((loc.address ?? "").toLowerCase().includes(q)) return true
+      return false
+    })
+  }, [locations, pickedIds, query])
 
   function toggle(locationId: string, locationName: string) {
     if (pickedIds.has(locationId)) {
@@ -48,44 +71,75 @@ export function SelectedItemsPicker({ value, onChange, errorMessage }: SelectedI
     )
   }
 
+  const hasLocations = locations.length > 0
+  const showSearchEmpty = hasLocations && visibleLocations.length === 0
+
   return (
     <div className="flex flex-col gap-2" data-testid="selected-items-picker">
-      {locations.length === 0 ? (
+      {!hasLocations ? (
         <p className="text-sm text-muted-foreground" data-testid="selected-items-picker-empty">
           {t("exports:wizard.scopePicker.empty")}
         </p>
       ) : (
-        <ul className="flex flex-col gap-1.5">
-          {locations.map((loc) => {
-            const id = loc.id ?? ""
-            const checked = pickedIds.has(id)
-            return (
-              <li key={id}>
-                <label
-                  className={cn(
-                    "flex cursor-pointer items-center justify-between gap-3 rounded-md border bg-card px-3 py-2 text-sm",
-                    checked && "border-primary/40 bg-primary/5"
-                  )}
-                  data-testid={`selected-items-picker-row-${id}`}
-                >
-                  <span className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      className="size-4"
-                      checked={checked}
-                      onChange={() => toggle(id, loc.name ?? "")}
-                      aria-label={loc.name ?? id}
-                    />
-                    <span className="font-medium">{loc.name ?? id}</span>
-                  </span>
-                  {loc.address && (
-                    <span className="truncate text-xs text-muted-foreground">{loc.address}</span>
-                  )}
-                </label>
-              </li>
-            )
-          })}
-        </ul>
+        <>
+          <div className="relative">
+            <Search
+              className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <Input
+              type="search"
+              placeholder={t("exports:wizard.scopePicker.searchPlaceholder")}
+              aria-label={t("exports:wizard.scopePicker.searchPlaceholder")}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="pl-9"
+              data-testid="selected-items-picker-search"
+            />
+          </div>
+          {showSearchEmpty ? (
+            <p
+              className="text-sm text-muted-foreground"
+              data-testid="selected-items-picker-search-empty"
+            >
+              {t("exports:wizard.scopePicker.searchEmpty", { query: query.trim() })}
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-1.5">
+              {visibleLocations.map((loc) => {
+                const id = loc.id ?? ""
+                const checked = pickedIds.has(id)
+                return (
+                  <li key={id}>
+                    <label
+                      className={cn(
+                        "flex cursor-pointer items-center justify-between gap-3 rounded-md border bg-card px-3 py-2 text-sm",
+                        checked && "border-primary/40 bg-primary/5"
+                      )}
+                      data-testid={`selected-items-picker-row-${id}`}
+                    >
+                      <span className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          className="size-4"
+                          checked={checked}
+                          onChange={() => toggle(id, loc.name ?? "")}
+                          aria-label={loc.name ?? id}
+                        />
+                        <span className="font-medium">{loc.name ?? id}</span>
+                      </span>
+                      {loc.address && (
+                        <span className="truncate text-xs text-muted-foreground">
+                          {loc.address}
+                        </span>
+                      )}
+                    </label>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </>
       )}
       {errorMessage && (
         <p

--- a/frontend/src/components/exports/SelectedItemsPicker.tsx
+++ b/frontend/src/components/exports/SelectedItemsPicker.tsx
@@ -71,8 +71,34 @@ export function SelectedItemsPicker({ value, onChange, errorMessage }: SelectedI
     )
   }
 
+  // Distinguish a load failure from an actually-empty list: react-query
+  // returns `data: undefined` when `isError` is true, which would
+  // otherwise fall through to the same empty-state copy.
+  if (locationsQuery.isError) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="selected-items-picker">
+        <p
+          className="text-sm text-destructive"
+          role="alert"
+          data-testid="selected-items-picker-load-error"
+        >
+          {t("exports:wizard.scopePicker.loadError")}
+        </p>
+      </div>
+    )
+  }
+
   const hasLocations = locations.length > 0
-  const showSearchEmpty = hasLocations && visibleLocations.length === 0
+  const trimmedQuery = query.trim()
+  // Three explicit conditions, so the rule reads the same way the issue
+  // describes it: search-empty fires only when the user has typed
+  // something AND there are no picks AND no rows match. Without the
+  // `pickedIds.size === 0` gate, a picked id that's no longer present in
+  // `locations` (e.g., the location was deleted server-side) would
+  // wrongly trigger the "no matches" copy even though the user's
+  // selection is non-empty.
+  const showSearchEmpty =
+    hasLocations && trimmedQuery.length > 0 && pickedIds.size === 0 && visibleLocations.length === 0
 
   return (
     <div className="flex flex-col gap-2" data-testid="selected-items-picker">
@@ -102,7 +128,7 @@ export function SelectedItemsPicker({ value, onChange, errorMessage }: SelectedI
               className="text-sm text-muted-foreground"
               data-testid="selected-items-picker-search-empty"
             >
-              {t("exports:wizard.scopePicker.searchEmpty", { query: query.trim() })}
+              {t("exports:wizard.scopePicker.searchEmpty", { query: trimmedQuery })}
             </p>
           ) : (
             <ul className="flex flex-col gap-1.5">

--- a/frontend/src/components/exports/__tests__/SelectedItemsPicker.test.tsx
+++ b/frontend/src/components/exports/__tests__/SelectedItemsPicker.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { http, HttpResponse } from "msw"
 import { Outlet, Route } from "react-router-dom"
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -10,7 +11,7 @@ import { initI18n } from "@/i18n"
 import { clearAuth, setAccessToken } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
-import { groupHandlers, locationHandlers } from "@/test/handlers"
+import { apiUrl, groupHandlers, locationHandlers } from "@/test/handlers"
 import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
 
@@ -168,6 +169,55 @@ describe("<SelectedItemsPicker />", () => {
     await waitFor(() => {
       expect(screen.getByTestId("selected-items-picker-empty")).toBeVisible()
     })
+    expect(screen.queryByTestId("selected-items-picker-search")).not.toBeInTheDocument()
+  })
+
+  it("does NOT render the search-empty message when picked rows aren't in the loaded list", async () => {
+    // Edge case: a previously-picked location got deleted server-side
+    // (or was never returned). `pickedIds` is non-empty but `value`'s
+    // ids don't intersect `locations`. The search-empty banner must
+    // stay hidden because the user's selection is still non-empty.
+    const user = userEvent.setup()
+    renderPicker({
+      locations: [{ id: "loc-1", name: "Main House" }],
+      initialValue: [{ type: "location", id: "ghost", name: "Ghost", include_all: true }],
+    })
+    const search = await screen.findByTestId("selected-items-picker-search")
+    await user.type(search, "zzz")
+    expect(screen.queryByTestId("selected-items-picker-search-empty")).not.toBeInTheDocument()
+  })
+
+  it("renders an explicit error state when the locations query fails", async () => {
+    server.use(
+      http.get(apiUrl(`/g/${SLUG}/locations`), () =>
+        HttpResponse.json({ error: "boom" }, { status: 500 })
+      )
+    )
+    renderWithProviders({
+      initialPath: `/g/${SLUG}/exports/new`,
+      routes: (
+        <Route
+          path="/g/:groupSlug"
+          element={
+            <GroupProvider>
+              <main>
+                <Outlet />
+              </main>
+            </GroupProvider>
+          }
+        >
+          <Route
+            path="exports/new"
+            element={<SelectedItemsPicker value={[]} onChange={vi.fn()} />}
+          />
+        </Route>
+      ),
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-items-picker-load-error")).toBeVisible()
+    })
+    // The error branch shouldn't masquerade as the no-locations empty state.
+    expect(screen.queryByTestId("selected-items-picker-empty")).not.toBeInTheDocument()
     expect(screen.queryByTestId("selected-items-picker-search")).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/exports/__tests__/SelectedItemsPicker.test.tsx
+++ b/frontend/src/components/exports/__tests__/SelectedItemsPicker.test.tsx
@@ -1,0 +1,173 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { Outlet, Route } from "react-router-dom"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SelectedItemsPicker } from "@/components/exports/SelectedItemsPicker"
+import type { ExportSelectedItem } from "@/features/export/api"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { initI18n } from "@/i18n"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { groupHandlers, locationHandlers } from "@/test/handlers"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+
+const SLUG = "household"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+  server.use(...groupHandlers.list([{ id: "g1", slug: SLUG, name: "Household" }]))
+})
+
+interface LocationFixture {
+  id: string
+  name: string
+  address?: string
+}
+
+function toResource(loc: LocationFixture) {
+  return {
+    id: loc.id,
+    type: "locations",
+    attributes: { name: loc.name, address: loc.address ?? "" },
+  }
+}
+
+function renderPicker(options: {
+  locations: LocationFixture[]
+  initialValue?: ExportSelectedItem[]
+  onChange?: (next: ExportSelectedItem[]) => void
+}) {
+  server.use(...locationHandlers.list(SLUG, options.locations.map(toResource)))
+  const onChange = options.onChange ?? vi.fn()
+  return renderWithProviders({
+    initialPath: `/g/${SLUG}/exports/new`,
+    routes: (
+      <Route
+        path="/g/:groupSlug"
+        element={
+          <GroupProvider>
+            <main>
+              <Outlet />
+            </main>
+          </GroupProvider>
+        }
+      >
+        <Route
+          path="exports/new"
+          element={<SelectedItemsPicker value={options.initialValue ?? []} onChange={onChange} />}
+        />
+      </Route>
+    ),
+  })
+}
+
+describe("<SelectedItemsPicker />", () => {
+  it("renders the search input above the list once locations have loaded", async () => {
+    renderPicker({
+      locations: [
+        { id: "loc-1", name: "Main House" },
+        { id: "loc-2", name: "Garage" },
+      ],
+    })
+    expect(await screen.findByTestId("selected-items-picker-search")).toBeVisible()
+    expect(screen.getByTestId("selected-items-picker-row-loc-1")).toBeVisible()
+    expect(screen.getByTestId("selected-items-picker-row-loc-2")).toBeVisible()
+  })
+
+  it("filters the list by name as the user types (case-insensitive)", async () => {
+    const user = userEvent.setup()
+    renderPicker({
+      locations: [
+        { id: "loc-1", name: "Main House" },
+        { id: "loc-2", name: "Garage" },
+        { id: "loc-3", name: "Cottage" },
+      ],
+    })
+    const search = await screen.findByTestId("selected-items-picker-search")
+    await user.type(search, "gar")
+    await waitFor(() =>
+      expect(screen.queryByTestId("selected-items-picker-row-loc-1")).not.toBeInTheDocument()
+    )
+    expect(screen.getByTestId("selected-items-picker-row-loc-2")).toBeVisible()
+    expect(screen.queryByTestId("selected-items-picker-row-loc-3")).not.toBeInTheDocument()
+  })
+
+  it("matches against the address as well as the name", async () => {
+    const user = userEvent.setup()
+    renderPicker({
+      locations: [
+        { id: "loc-1", name: "Main House", address: "12 Elm Street" },
+        { id: "loc-2", name: "Garage", address: "Backyard" },
+      ],
+    })
+    const search = await screen.findByTestId("selected-items-picker-search")
+    await user.type(search, "elm")
+    await waitFor(() =>
+      expect(screen.queryByTestId("selected-items-picker-row-loc-2")).not.toBeInTheDocument()
+    )
+    expect(screen.getByTestId("selected-items-picker-row-loc-1")).toBeVisible()
+  })
+
+  it("keeps already-picked rows visible even when they don't match the query", async () => {
+    const user = userEvent.setup()
+    renderPicker({
+      locations: [
+        { id: "loc-1", name: "Main House" },
+        { id: "loc-2", name: "Garage" },
+        { id: "loc-3", name: "Cottage" },
+      ],
+      initialValue: [{ type: "location", id: "loc-1", name: "Main House", include_all: true }],
+    })
+    const search = await screen.findByTestId("selected-items-picker-search")
+    await user.type(search, "gar")
+    // loc-1 is picked → stays visible despite not matching "gar".
+    expect(screen.getByTestId("selected-items-picker-row-loc-1")).toBeVisible()
+    expect(screen.getByTestId("selected-items-picker-row-loc-2")).toBeVisible()
+    expect(screen.queryByTestId("selected-items-picker-row-loc-3")).not.toBeInTheDocument()
+  })
+
+  it("renders the search-empty message when nothing matches and nothing is picked", async () => {
+    const user = userEvent.setup()
+    renderPicker({
+      locations: [
+        { id: "loc-1", name: "Main House" },
+        { id: "loc-2", name: "Garage" },
+      ],
+    })
+    const search = await screen.findByTestId("selected-items-picker-search")
+    await user.type(search, "zzz")
+    expect(await screen.findByTestId("selected-items-picker-search-empty")).toBeVisible()
+    expect(screen.queryByTestId("selected-items-picker-row-loc-1")).not.toBeInTheDocument()
+  })
+
+  it("does NOT render the search-empty message when a picked row keeps the list non-empty", async () => {
+    const user = userEvent.setup()
+    renderPicker({
+      locations: [{ id: "loc-1", name: "Main House" }],
+      initialValue: [{ type: "location", id: "loc-1", name: "Main House", include_all: true }],
+    })
+    const search = await screen.findByTestId("selected-items-picker-search")
+    await user.type(search, "zzz")
+    // Picked row keeps the list non-empty → no search-empty banner.
+    expect(screen.queryByTestId("selected-items-picker-search-empty")).not.toBeInTheDocument()
+    expect(screen.getByTestId("selected-items-picker-row-loc-1")).toBeVisible()
+  })
+
+  it("does not render the search input when there are no locations at all", async () => {
+    renderPicker({ locations: [] })
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-items-picker-empty")).toBeVisible()
+    })
+    expect(screen.queryByTestId("selected-items-picker-search")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/i18n/locales/en/exports.json
+++ b/frontend/src/i18n/locales/en/exports.json
@@ -135,6 +135,7 @@
     },
     "scopePicker": {
       "empty": "No locations available — create one first.",
+      "loadError": "Could not load locations. Refresh the page to retry.",
       "searchEmpty": "No locations match \"{{query}}\".",
       "searchPlaceholder": "Search locations…",
       "title": "Selected items"

--- a/frontend/src/i18n/locales/en/exports.json
+++ b/frontend/src/i18n/locales/en/exports.json
@@ -135,6 +135,8 @@
     },
     "scopePicker": {
       "empty": "No locations available — create one first.",
+      "searchEmpty": "No locations match \"{{query}}\".",
+      "searchPlaceholder": "Search locations…",
       "title": "Selected items"
     },
     "step1Title": "What to export",


### PR DESCRIPTION
Closes #250.

## Summary

- The location list in the New Export wizard's **Selected items** scope was unfiltered — slow to scan once a group has more than a handful of locations. Added a client-side text filter above the list (case-insensitive substring match against `name` and `address`).
- Already-picked rows stay visible regardless of the query, so the user can't lose track of what they've selected.
- An empty-filter message renders only when the query has no matches **and** nothing is picked.
- Search-input markup mirrors the existing pattern from `LocationsListPage` (lucide `<Search />` icon + `<Input type="search" className="pl-9">`) for visual consistency.

## Files

- `frontend/src/components/exports/SelectedItemsPicker.tsx` — search input, filter logic, search-empty state.
- `frontend/src/i18n/locales/en/exports.json` — `wizard.scopePicker.searchPlaceholder` and `searchEmpty` keys.
- `frontend/src/components/exports/__tests__/SelectedItemsPicker.test.tsx` — 7 new tests covering filter behavior, picked-rows-survive-query rule, empty-filter states, and the no-search-input-when-zero-locations case.

cs/ru `exports.json` left as the existing `{}` stubs — that matches the namespace's current convention (en-only with fallback), same as `warranties.json` and other newer namespaces.

## Out of scope

- Area / commodity granularity in the picker — tracked separately, per the existing comment in `SelectedItemsPicker.tsx`.
- Server-side search and virtualization — list is loaded in full today; client-side filter is sufficient for foreseeable group sizes.

## Test plan

- [x] `vitest run src/components/exports src/pages/exports` → 25 passed
- [x] `eslint` on changed files → clean
- [x] `tsc --noEmit` → clean
- [x] `prettier --check` → clean
- [x] `node scripts/i18n-check.mjs` → catalogs in sync
- [ ] Manual smoke: open New Export wizard, switch scope to "Selected items", type into the search box, confirm the list narrows; pick a row, type a query that excludes it, confirm it stays visible.