### PR TITLE
[#849] security: enforce password complexity in User.SetPassword

### DIFF
--- a/.claude/skills/inventario-e2e/SKILL.md
+++ b/.claude/skills/inventario-e2e/SKILL.md
@@ -38,7 +38,7 @@ The base `docker-compose.yaml` reads tenant + admin defaults at parse time (`${V
 # project root — env must match e2e/tests/includes/auth.ts TEST_CREDENTIALS
 INVENTARIO_IMAGE=inventario-inventario:latest \
 ADMIN_EMAIL=admin@test-org.com \
-ADMIN_PASSWORD=testpassword123 \
+ADMIN_PASSWORD=TestPassword123 \
 ADMIN_NAME="Test Administrator" \
 DEFAULT_TENANT_NAME="Test Organization" \
 DEFAULT_TENANT_SLUG=test-org \
@@ -118,7 +118,7 @@ curl -sf http://localhost:5173/ > /dev/null && echo "vite ok" || echo "vite NOT 
 # A 200 response with an access_token means migrations ran AND /api/v1/seed
 # populated test-org/admin@test-org.com.
 curl -sX POST -H 'Content-Type: application/json' \
-  -d '{"email":"admin@test-org.com","password":"testpassword123"}' \
+  -d '{"email":"admin@test-org.com","password":"TestPassword123"}' \
   http://localhost:3333/api/v1/auth/login | jq -r .access_token | head -c 20
 echo
 ```
@@ -129,8 +129,8 @@ If `/readyz` 200 but login returns 401, the DB exists but wasn't seeded — re-r
 
 From `e2e/tests/includes/auth.ts`:
 
-- `admin@test-org.com` / `testpassword123` — tenant `test-org`. Created by `/api/v1/seed`.
-- `user2@test-org.com` / `testpassword123` — used by `user-isolation.spec.ts`. **Auto-created in dev mode** (Modes A and C): `npm run stack` POSTs `/api/v1/seed` without parameters, which takes `seeddata.findOrCreateUsers`'s no-`userEmail` branch and falls through to `createTestUsers`, which provisions both admin and user2.
+- `admin@test-org.com` / `TestPassword123` — tenant `test-org`. Created by `/api/v1/seed`.
+- `user2@test-org.com` / `TestPassword123` — used by `user-isolation.spec.ts`. **Auto-created in dev mode** (Modes A and C): `npm run stack` POSTs `/api/v1/seed` without parameters, which takes `seeddata.findOrCreateUsers`'s no-`userEmail` branch and falls through to `createTestUsers`, which provisions both admin and user2.
 
   The fast-path that *skips* user2 only fires when `userEmail` is supplied to `/api/v1/seed` — that's the docker-compose `inventario-init-data` flow (Mode B), where init-data passes `user_email=admin@test-org.com`. CI compensates by running `inventario users create` against the container after the stack is up.
 
@@ -139,13 +139,13 @@ From `e2e/tests/includes/auth.ts`:
 ```bash
 # dev mode (Mode A/C) — run the Go CLI from the backend module
 cd go && go run ./cmd/inventario/... users create \
-  --email=user2@test-org.com --password=testpassword123 \
+  --email=user2@test-org.com --password=TestPassword123 \
   --name="Test User 2" --tenant=test-org --no-interactive
 
 # pre-built mode (Mode B, container)
 docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml \
   run --rm --no-deps inventario \
-  users create --email=user2@test-org.com --password=testpassword123 \
+  users create --email=user2@test-org.com --password=TestPassword123 \
     --name="Test User 2" --tenant=test-org --no-interactive
 ```
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -102,7 +102,7 @@ jobs:
           # These flow into inventario-init-data via ${VAR:-default} in the base
           # compose file, so they must be set in the shell env here.
           ADMIN_EMAIL: "admin@test-org.com"
-          ADMIN_PASSWORD: "testpassword123"
+          ADMIN_PASSWORD: "TestPassword123"
           ADMIN_NAME: "Test Administrator"
           DEFAULT_TENANT_NAME: "Test Organization"
           DEFAULT_TENANT_SLUG: "test-org"
@@ -142,7 +142,7 @@ jobs:
             run --rm --no-deps inventario \
             users create \
               --email=user2@test-org.com \
-              --password=testpassword123 \
+              --password=TestPassword123 \
               --name="Test User 2" \
               --tenant=test-org \
               --no-interactive
@@ -160,7 +160,7 @@ jobs:
             run --rm --no-deps inventario \
             users create \
               --email=orphan@test-org.com \
-              --password=testpassword123 \
+              --password=TestPassword123 \
               --name="Test Orphan (no group)" \
               --tenant=test-org \
               --no-interactive
@@ -178,7 +178,7 @@ jobs:
         run: |
           LOGIN_RESP=$(curl -fsS -X POST http://localhost:3333/api/v1/auth/login \
             -H "Content-Type: application/json" \
-            -d '{"email":"user2@test-org.com","password":"testpassword123"}')
+            -d '{"email":"user2@test-org.com","password":"TestPassword123"}')
           TOKEN=$(echo "$LOGIN_RESP" | jq -r '.access_token')
           CSRF=$(echo "$LOGIN_RESP" | jq -r '.csrf_token')
           [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
@@ -321,14 +321,14 @@ jobs:
             --default-tenant-slug=test-org \
             --default-tenant-registration-mode=open \
             --admin-email=admin@test-org.com \
-            --admin-password=testpassword123 \
+            --admin-password=TestPassword123 \
             --admin-name="Test Administrator"
           # user2 is expected by user-isolation.spec.ts. seeddata's fast path
           # with user_email skips createTestUsers, so we provision user2
           # ourselves.
           ./bin/inventario users create \
             --email=user2@test-org.com \
-            --password=testpassword123 \
+            --password=TestPassword123 \
             --name="Test User 2" \
             --tenant=test-org \
             --no-interactive
@@ -336,7 +336,7 @@ jobs:
           # Same fast-path skip as user2 — provision via CLI; do NOT create a group.
           ./bin/inventario users create \
             --email=orphan@test-org.com \
-            --password=testpassword123 \
+            --password=TestPassword123 \
             --name="Test Orphan (no group)" \
             --tenant=test-org \
             --no-interactive

--- a/devdocs/frontend/screenshots.md
+++ b/devdocs/frontend/screenshots.md
@@ -70,7 +70,7 @@ curl -X POST http://localhost:3333/api/v1/seed
 # → {"message":"Database seeded successfully","status":"success"}
 ```
 
-The seeder creates `admin@test-org.com` / `testpassword123` plus a "Test
+The seeder creates `admin@test-org.com` / `TestPassword123` plus a "Test
 Organization" tenant, a "Default" group, and a few locations / areas /
 commodities so the dashboard isn't empty. Source: `go/debug/seeddata/`.
 

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -2,7 +2,7 @@
 #
 # Usage (invoked by .github/workflows/e2e-tests.yml):
 #   INVENTARIO_IMAGE=ghcr.io/denisvmedia/inventario:pr-<num> \
-#   ADMIN_EMAIL=admin@test-org.com ADMIN_PASSWORD=testpassword123 \
+#   ADMIN_EMAIL=admin@test-org.com ADMIN_PASSWORD=TestPassword123 \
 #   DEFAULT_TENANT_SLUG=test-org DEFAULT_TENANT_NAME="Test Organization" \
 #   DEFAULT_TENANT_REGISTRATION_MODE=open \
 #   SEED_DATABASE=true \

--- a/e2e/tests/delete-group-dialog.spec.ts
+++ b/e2e/tests/delete-group-dialog.spec.ts
@@ -11,7 +11,7 @@
 import { expect, APIRequestContext, Page } from '@playwright/test';
 import { test } from '../fixtures/app-fixture.js';
 
-const ADMIN_PASSWORD = 'testpassword123';
+const ADMIN_PASSWORD = 'TestPassword123';
 
 async function createThrowawayGroup(
   request: APIRequestContext,

--- a/e2e/tests/frontend-shell.spec.ts
+++ b/e2e/tests/frontend-shell.spec.ts
@@ -77,7 +77,7 @@ test.describe('Frontend shell', () => {
     test.setTimeout(60_000);
     await page.goto('/login');
     await page.getByTestId('email').fill('admin@test-org.com');
-    await page.getByTestId('password').fill('testpassword123');
+    await page.getByTestId('password').fill('TestPassword123');
     await page.getByTestId('login-button').click();
     // RootRedirect bounces to /g/<default-slug>; wait for a real
     // group-scoped URL before navigating onward.

--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -88,7 +88,7 @@ test.describe('Group Management API', () => {
         'Authorization': `Bearer ${authToken}`,
         'X-CSRF-Token': csrfToken,
       },
-      data: { confirm_word: groupName, password: 'testpassword123' },
+      data: { confirm_word: groupName, password: 'TestPassword123' },
     });
     expect(deleteResponse.status()).toBe(204);
   });
@@ -358,7 +358,7 @@ test.describe('Main Currency dropdown (#1256)', () => {
         'Authorization': `Bearer ${authToken}`,
         'X-CSRF-Token': csrfToken,
       },
-      data: { confirm_word: groupName, password: 'testpassword123' },
+      data: { confirm_word: groupName, password: 'TestPassword123' },
     });
     expect(deleteResp.status()).toBe(204);
   });
@@ -484,7 +484,7 @@ test.describe('Remove Member — last admin protection (#1257)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName, password: 'testpassword123' },
+        data: { confirm_word: groupName, password: 'TestPassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }
@@ -557,7 +557,7 @@ test.describe('Remove Member — last admin protection (#1257)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName, password: 'testpassword123' },
+        data: { confirm_word: groupName, password: 'TestPassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }
@@ -637,7 +637,7 @@ test.describe('Leave Group UI — last admin protection (#1259)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName, password: 'testpassword123' },
+        data: { confirm_word: groupName, password: 'TestPassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }
@@ -787,7 +787,7 @@ test.describe('Group selection persistence (#1262 / #1300)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName, password: 'testpassword123' },
+        data: { confirm_word: groupName, password: 'TestPassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }
@@ -948,7 +948,7 @@ test.describe('Group selection persistence (#1262 / #1300)', () => {
             'Authorization': `Bearer ${authToken}`,
             'X-CSRF-Token': csrfToken,
           },
-          data: { confirm_word: secondGroupName, password: 'testpassword123' },
+          data: { confirm_word: secondGroupName, password: 'TestPassword123' },
         });
       }
     }
@@ -1030,7 +1030,7 @@ test.describe('Group icon picker (#1255)', () => {
         'Authorization': `Bearer ${authToken}`,
         'X-CSRF-Token': csrfToken,
       },
-      data: { confirm_word: groupName, password: 'testpassword123' },
+      data: { confirm_word: groupName, password: 'TestPassword123' },
     });
     expect(deleteResp.status()).toBe(204);
   });
@@ -1093,7 +1093,7 @@ test.describe('Group icon picker (#1255)', () => {
         'Authorization': `Bearer ${authToken}`,
         'X-CSRF-Token': csrfToken,
       },
-      data: { confirm_word: groupName, password: 'testpassword123' },
+      data: { confirm_word: groupName, password: 'TestPassword123' },
     });
     expect(deleteResp.status()).toBe(204);
   });
@@ -1170,7 +1170,7 @@ test.describe('Group icon picker (#1255)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName, password: 'testpassword123' },
+        data: { confirm_word: groupName, password: 'TestPassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }
@@ -1326,7 +1326,7 @@ test.describe('Default group preference (#1263)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName, password: 'testpassword123' },
+        data: { confirm_word: groupName, password: 'TestPassword123' },
       });
       expect(deleteResp.status()).toBe(204);
 
@@ -1503,7 +1503,7 @@ test.describe('Group + role cluster in header (#1258)', () => {
           'Authorization': `Bearer ${authToken}`,
           'X-CSRF-Token': csrfToken,
         },
-        data: { confirm_word: groupName, password: 'testpassword123' },
+        data: { confirm_word: groupName, password: 'TestPassword123' },
       });
       expect(deleteResp.status()).toBe(204);
     }

--- a/e2e/tests/includes/auth.ts
+++ b/e2e/tests/includes/auth.ts
@@ -9,7 +9,7 @@ import { gotoScoped } from './group-url.js';
  */
 export const TEST_CREDENTIALS = {
   email: 'admin@test-org.com',
-  password: 'testpassword123'
+  password: 'TestPassword123'
 };
 
 /**
@@ -21,7 +21,7 @@ export const TEST_CREDENTIALS = {
  */
 export const ORPHAN_TEST_CREDENTIALS = {
   email: 'orphan@test-org.com',
-  password: 'testpassword123'
+  password: 'TestPassword123'
 };
 
 /**

--- a/e2e/tests/includes/user-isolation-auth.ts
+++ b/e2e/tests/includes/user-isolation-auth.ts
@@ -18,12 +18,12 @@ export interface TestUser {
 export const SEEDED_TEST_USERS: TestUser[] = [
   {
     email: 'admin@test-org.com',
-    password: 'testpassword123',
+    password: 'TestPassword123',
     name: 'Test Administrator'
   },
   {
     email: 'user2@test-org.com',
-    password: 'testpassword123',
+    password: 'TestPassword123',
     name: 'Test User 2'
   }
 ];

--- a/e2e/tests/invite-accept.spec.ts
+++ b/e2e/tests/invite-accept.spec.ts
@@ -35,7 +35,7 @@ import { test } from '../fixtures/app-fixture.js';
 // invitee is in.
 const USER_B = {
   email: 'user2@test-org.com',
-  password: 'testpassword123',
+  password: 'TestPassword123',
 };
 
 interface ApiAuth {
@@ -151,7 +151,7 @@ async function deleteGroup(
       'Authorization': `Bearer ${adminAuth.accessToken}`,
       'X-CSRF-Token': adminAuth.csrfToken,
     },
-    data: { confirm_word: group.name, password: 'testpassword123' },
+    data: { confirm_word: group.name, password: 'TestPassword123' },
   });
   expect(resp.status()).toBe(204);
 }

--- a/e2e/tests/profile.spec.ts
+++ b/e2e/tests/profile.spec.ts
@@ -214,8 +214,8 @@ authTest.describe('Profile page — password change API', () => {
     await openPasswordSection(page);
 
     await page.fill('#current-password', 'currentpassword');
-    await page.fill('#new-password', 'newpassword123');
-    await page.fill('#confirm-password', 'newpassword123');
+    await page.fill('#new-password', 'NewPassword123');
+    await page.fill('#confirm-password', 'NewPassword123');
     await page.click('[data-testid="change-password-submit"]');
 
     await expect(page.locator('.password-form .success-banner')).toBeVisible({ timeout: 5000 });

--- a/e2e/tests/register-via-invite.spec.ts
+++ b/e2e/tests/register-via-invite.spec.ts
@@ -90,7 +90,7 @@ async function deleteGroup(
       'Authorization': `Bearer ${adminAuth.accessToken}`,
       'X-CSRF-Token': adminAuth.csrfToken,
     },
-    data: { confirm_word: group.name, password: 'testpassword123' },
+    data: { confirm_word: group.name, password: 'TestPassword123' },
   });
   // Asserting the status guards against silent leaks into the shared
   // seeded environment — a stuck pending_deletion group is invisible but

--- a/e2e/tests/registration.spec.ts
+++ b/e2e/tests/registration.spec.ts
@@ -63,7 +63,7 @@ test.describe('Register page — UI', () => {
     await page.fill('input[data-testid="email"]', 'test@example.com');
     await expect(btn).toBeDisabled();
 
-    await page.fill('input[data-testid="password"]', 'password123');
+    await page.fill('input[data-testid="password"]', 'Password123');
     await expect(btn).toBeEnabled();
   });
 

--- a/go/apiserver/api_security_test.go
+++ b/go/apiserver/api_security_test.go
@@ -44,7 +44,7 @@ func TestAPISecurity_CrossTenantExportAttempt(t *testing.T) {
 		Name:     "Tenant 1 User",
 		IsActive: true,
 	}
-	userTenant1.SetPassword("password123")
+	userTenant1.SetPassword("Password123")
 
 	userTenant2 := &models.User{
 		TenantAwareEntityID: models.TenantAwareEntityID{
@@ -55,7 +55,7 @@ func TestAPISecurity_CrossTenantExportAttempt(t *testing.T) {
 		Name:     "Tenant 2 User",
 		IsActive: true,
 	}
-	userTenant2.SetPassword("password123")
+	userTenant2.SetPassword("Password123")
 
 	// registrySet := factorySet.CreateUserRegistrySet()
 	userRegistry := factorySet.UserRegistry
@@ -183,7 +183,7 @@ func TestAPISecurity_InvalidUserContexts(t *testing.T) {
 
 			// Setup user
 			user := tt.setupUser()
-			user.SetPassword("password123")
+			user.SetPassword("Password123")
 			factorySet := memory.NewFactorySet()
 
 			// Add user to registry (even inactive users might be in the registry)

--- a/go/apiserver/apiserver_test.go
+++ b/go/apiserver/apiserver_test.go
@@ -316,7 +316,7 @@ func newParams() (apiserver.Params, *models.User, *models.LocationGroup) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	must.Assert(testUserTemplate.SetPassword("password123"))
+	must.Assert(testUserTemplate.SetPassword("Password123"))
 	testUser := must.Must(params.FactorySet.UserRegistry.Create(context.Background(), testUserTemplate))
 
 	// Create a default group for the test user
@@ -365,7 +365,7 @@ func newParamsAreaRegistryOnly() (apiserver.Params, *models.User, *models.Locati
 		Name:     "Test User",
 		IsActive: true,
 	}
-	must.Assert(testUserTemplate.SetPassword("password123"))
+	must.Assert(testUserTemplate.SetPassword("Password123"))
 	testUser := must.Must(params.FactorySet.UserRegistry.Create(context.Background(), testUserTemplate))
 
 	// Create a default group for the test user

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -341,8 +341,8 @@ func TestAuthAPI_Login(t *testing.T) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	// Set password hash for "password123"
-	testUser.SetPassword("password123")
+	// Set password hash for "Password123"
+	testUser.SetPassword("Password123")
 
 	userRegistry := &mockUserRegistryForAuth{
 		users: map[string]*models.User{
@@ -369,7 +369,7 @@ func TestAuthAPI_Login(t *testing.T) {
 			name: "successful login",
 			requestBody: map[string]string{
 				"email":    "test@example.com",
-				"password": "password123",
+				"password": "Password123",
 			},
 			expectedStatus: http.StatusOK,
 			checkResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -397,7 +397,7 @@ func TestAuthAPI_Login(t *testing.T) {
 			name: "invalid email",
 			requestBody: map[string]string{
 				"email":    "nonexistent@example.com",
-				"password": "password123",
+				"password": "Password123",
 			},
 			expectedStatus: http.StatusUnauthorized,
 		},
@@ -412,7 +412,7 @@ func TestAuthAPI_Login(t *testing.T) {
 		{
 			name: "missing email",
 			requestBody: map[string]string{
-				"password": "password123",
+				"password": "Password123",
 			},
 			expectedStatus: http.StatusBadRequest,
 		},

--- a/go/apiserver/export_restores_integration_test.go
+++ b/go/apiserver/export_restores_integration_test.go
@@ -36,7 +36,7 @@ func newTestFactorySet() (*registry.FactorySet, *models.User) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	testUser.SetPassword("password123")
+	testUser.SetPassword("Password123")
 	createdUser, _ := factorySet.UserRegistry.Create(context.Background(), testUser)
 
 	return factorySet, createdUser

--- a/go/apiserver/exports_test.go
+++ b/go/apiserver/exports_test.go
@@ -39,7 +39,7 @@ func TestExportHardDelete(t *testing.T) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	testUser.SetPassword("password123")
+	testUser.SetPassword("Password123")
 	createdUser := must.Must(factorySet.UserRegistry.Create(context.Background(), testUser))
 
 	// Create user context and get user-aware registry set
@@ -102,7 +102,7 @@ func TestExportListExcludesDeleted(t *testing.T) {
 		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: "test-tenant-id"},
 		Email:               "test@example.com", Name: "Test User", IsActive: true,
 	}
-	must.Assert(testUserTemplate.SetPassword("password123"))
+	must.Assert(testUserTemplate.SetPassword("Password123"))
 	testUser := must.Must(factorySet.UserRegistry.Create(context.Background(), testUserTemplate))
 
 	// Create user context and get user-aware registry set
@@ -179,7 +179,7 @@ func TestExportListWithDeletedParameter(t *testing.T) {
 		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: "test-tenant-id"},
 		Email:               "test@example.com", Name: "Test User", IsActive: true,
 	}
-	must.Assert(testUserTemplate.SetPassword("password123"))
+	must.Assert(testUserTemplate.SetPassword("Password123"))
 	testUser := must.Must(factorySet.UserRegistry.Create(context.Background(), testUserTemplate))
 
 	// Create user context and get user-aware registry set
@@ -255,7 +255,7 @@ func TestExportCreate_SetsCreatedDate(t *testing.T) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	testUser.SetPassword("password123")
+	testUser.SetPassword("Password123")
 	createdUser := must.Must(factorySet.UserRegistry.Create(context.Background(), testUser))
 
 	// Create user context (registrySet not needed for this test)

--- a/go/apiserver/groups_test.go
+++ b/go/apiserver/groups_test.go
@@ -53,7 +53,7 @@ func newGroupTestEnv(t *testing.T, groupCurrency models.Currency) groupTestEnv {
 		Name:                "Test Admin",
 		IsActive:            true,
 	}
-	must.Assert(userTemplate.SetPassword("testpassword123"))
+	must.Assert(userTemplate.SetPassword("TestPassword123"))
 	user := must.Must(factorySet.UserRegistry.Create(context.Background(), userTemplate))
 
 	var group *models.LocationGroup
@@ -328,7 +328,7 @@ func TestGroupsAPI_DeleteGroup_HappyPath(t *testing.T) {
 
 	resp := deleteGroup(t, env, map[string]any{
 		"confirm_word": env.group.Name,
-		"password":     "testpassword123",
+		"password":     "TestPassword123",
 	})
 	c.Assert(resp.Code, qt.Equals, http.StatusNoContent, qt.Commentf("body: %s", resp.Body.String()))
 
@@ -364,7 +364,7 @@ func TestGroupsAPI_DeleteGroup_WrongConfirmWordReturns422(t *testing.T) {
 
 	resp := deleteGroup(t, env, map[string]any{
 		"confirm_word": "not-the-group-name",
-		"password":     "testpassword123",
+		"password":     "TestPassword123",
 	})
 	c.Assert(resp.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body: %s", resp.Body.String()))
 	c.Assert(resp.Body.String(), qt.Contains, "confirmation")

--- a/go/apiserver/security_test.go
+++ b/go/apiserver/security_test.go
@@ -36,7 +36,7 @@ func TestSecurityIDRejection(t *testing.T) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	err := testUser.SetPassword("testpassword123")
+	err := testUser.SetPassword("TestPassword123")
 	c.Assert(err, qt.IsNil)
 	createdUser, err := factorySet.UserRegistry.Create(context.Background(), testUser)
 	c.Assert(err, qt.IsNil)
@@ -212,7 +212,7 @@ func TestSecurityServerGeneratedIDs(t *testing.T) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	err := testUser.SetPassword("testpassword123")
+	err := testUser.SetPassword("TestPassword123")
 	c.Assert(err, qt.IsNil)
 	createdUser, err := factorySet.UserRegistry.Create(context.Background(), testUser)
 	c.Assert(err, qt.IsNil)

--- a/go/apiserver/system_test.go
+++ b/go/apiserver/system_test.go
@@ -107,7 +107,7 @@ func TestSystemAPI_GetSystemInfoWithSettings(t *testing.T) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	err = userTemplate.SetPassword("testpassword123")
+	err = userTemplate.SetPassword("TestPassword123")
 	c.Assert(err, qt.IsNil)
 	createdUser, err := factorySet.UserRegistry.Create(c.Context(), userTemplate)
 	c.Assert(err, qt.IsNil)

--- a/go/apiserver/values_test.go
+++ b/go/apiserver/values_test.go
@@ -30,7 +30,7 @@ func setupValuesTestData(c *qt.C) (*registry.FactorySet, *models.User) {
 		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: "test-tenant-id"},
 		Email:               "test@example.com", Name: "Test User", IsActive: true,
 	}
-	must.Assert(testUserTemplate.SetPassword("password123"))
+	must.Assert(testUserTemplate.SetPassword("Password123"))
 	testUser := must.Must(factorySet.UserRegistry.Create(c.Context(), testUserTemplate))
 
 	// Give the user a default group (valued in USD, via the helper's default)

--- a/go/backup/restore/recursive_delete_integration_test.go
+++ b/go/backup/restore/recursive_delete_integration_test.go
@@ -33,7 +33,7 @@ func TestRestoreService_ClearExistingData_RecursiveDelete(t *testing.T) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	testUser.SetPassword("password123")
+	testUser.SetPassword("Password123")
 	_, err := registrySet.UserRegistry.Create(c.Context(), testUser)
 	c.Assert(err, qt.IsNil)
 
@@ -145,7 +145,7 @@ func TestRestoreService_ClearExistingData_MultipleLocations(t *testing.T) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	testUser.SetPassword("password123")
+	testUser.SetPassword("Password123")
 	tUser, err := factorySet.UserRegistry.Create(c.Context(), testUser)
 	c.Assert(err, qt.IsNil)
 	ctx := appctx.WithUser(c.Context(), tUser)

--- a/go/cmd/inventario/run/bootstrap/crypto.go
+++ b/go/cmd/inventario/run/bootstrap/crypto.go
@@ -3,16 +3,17 @@ package bootstrap
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"log/slog"
+	"os"
 )
 
 // getJWTSecret retrieves the JWT secret from config/environment or generates a
 // secure random one. Accepts both hex-encoded and plain-string secrets of at
-// least 32 bytes; otherwise falls back to a randomly generated 32-byte secret.
-//
-// The generated secret is never written to logs or stderr — operators must set
-// INVENTARIO_RUN_JWT_SECRET (or jwt-secret in the config file) to persist a
-// stable signing key across restarts.
+// least 32 bytes; otherwise falls back to a randomly generated 32-byte secret
+// whose hex value is written once to stderr (outside the structured logger) so
+// operators can capture it on first boot without leaking the signing key into
+// log aggregators.
 func getJWTSecret(configSecret string) ([]byte, error) {
 	// Use the secret from config (which includes environment variables via cleanenv)
 	if configSecret != "" {
@@ -29,12 +30,9 @@ func getJWTSecret(configSecret string) ([]byte, error) {
 		slog.Warn("Configured JWT secret is too short (minimum 32 characters), generating random secret")
 	}
 
-	// Generate a secure random secret. The value is intentionally never logged
-	// or written to stderr to avoid leaking the signing key into any log
-	// aggregator. Issued tokens will become invalid on the next restart unless
-	// INVENTARIO_RUN_JWT_SECRET is configured.
-	slog.Warn("No JWT secret configured, generating ephemeral random secret")
-	slog.Warn("Tokens issued with this secret will not survive a restart; set INVENTARIO_RUN_JWT_SECRET (or jwt-secret in config) to a 32+ byte value for persistence")
+	// Generate a secure random secret
+	slog.Warn("No JWT secret configured, generating random secret")
+	slog.Warn("For production use, set INVENTARIO_RUN_JWT_SECRET environment variable or jwt-secret in config file with a secure 32+ byte secret")
 
 	secret := make([]byte, 32)
 	_, err := rand.Read(secret)
@@ -42,12 +40,17 @@ func getJWTSecret(configSecret string) ([]byte, error) {
 		return nil, err
 	}
 
+	slog.Warn("Generated random JWT secret; persist it via INVENTARIO_RUN_JWT_SECRET to keep tokens valid across restarts")
+	// Print the generated secret to stderr (not the structured log) so operators
+	// can capture it on first boot without leaking the signing key into any log
+	// aggregator that collects application logs.
+	fmt.Fprintf(os.Stderr, "INVENTARIO_RUN_JWT_SECRET=%s\n", hex.EncodeToString(secret))
+
 	return secret, nil
 }
 
 // getFileSigningKey retrieves the file signing key from config/environment or
-// generates a secure random one with the same semantics as getJWTSecret. The
-// generated key is never written to logs or stderr.
+// generates a secure random one with the same semantics as getJWTSecret.
 func getFileSigningKey(configKey string) ([]byte, error) {
 	// Use the key from config (which includes environment variables via cleanenv)
 	if configKey != "" {
@@ -64,17 +67,21 @@ func getFileSigningKey(configKey string) ([]byte, error) {
 		slog.Warn("Configured file signing key is too short (minimum 32 characters), generating random key")
 	}
 
-	// Generate a secure random key. The value is intentionally never logged or
-	// written to stderr; signed URLs minted with this key will not survive a
-	// restart unless INVENTARIO_RUN_FILE_SIGNING_KEY is configured.
-	slog.Warn("No file signing key configured, generating ephemeral random key")
-	slog.Warn("Signed URLs issued with this key will not survive a restart; set INVENTARIO_RUN_FILE_SIGNING_KEY (or file-signing-key in config) to a 32+ byte value for persistence")
+	// Generate a secure random key
+	slog.Warn("No file signing key configured, generating random key")
+	slog.Warn("For production use, set INVENTARIO_RUN_FILE_SIGNING_KEY environment variable or file-signing-key in config file with a secure 32+ byte key")
 
 	key := make([]byte, 32)
 	_, err := rand.Read(key)
 	if err != nil {
 		return nil, err
 	}
+
+	slog.Warn("Generated random file signing key; persist it via INVENTARIO_RUN_FILE_SIGNING_KEY to keep signed URLs valid across restarts")
+	// Print the generated key to stderr (not the structured log) so operators
+	// can capture it on first boot without leaking the signing key into any log
+	// aggregator that collects application logs.
+	fmt.Fprintf(os.Stderr, "INVENTARIO_RUN_FILE_SIGNING_KEY=%s\n", hex.EncodeToString(key))
 
 	return key, nil
 }

--- a/go/cmd/inventario/run/bootstrap/crypto.go
+++ b/go/cmd/inventario/run/bootstrap/crypto.go
@@ -3,17 +3,16 @@ package bootstrap
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"fmt"
 	"log/slog"
-	"os"
 )
 
 // getJWTSecret retrieves the JWT secret from config/environment or generates a
 // secure random one. Accepts both hex-encoded and plain-string secrets of at
-// least 32 bytes; otherwise falls back to a randomly generated 32-byte secret
-// whose hex value is written once to stderr (outside the structured logger) so
-// operators can capture it on first boot without leaking the signing key into
-// log aggregators.
+// least 32 bytes; otherwise falls back to a randomly generated 32-byte secret.
+//
+// The generated secret is never written to logs or stderr — operators must set
+// INVENTARIO_RUN_JWT_SECRET (or jwt-secret in the config file) to persist a
+// stable signing key across restarts.
 func getJWTSecret(configSecret string) ([]byte, error) {
 	// Use the secret from config (which includes environment variables via cleanenv)
 	if configSecret != "" {
@@ -30,9 +29,12 @@ func getJWTSecret(configSecret string) ([]byte, error) {
 		slog.Warn("Configured JWT secret is too short (minimum 32 characters), generating random secret")
 	}
 
-	// Generate a secure random secret
-	slog.Warn("No JWT secret configured, generating random secret")
-	slog.Warn("For production use, set INVENTARIO_RUN_JWT_SECRET environment variable or jwt-secret in config file with a secure 32+ byte secret")
+	// Generate a secure random secret. The value is intentionally never logged
+	// or written to stderr to avoid leaking the signing key into any log
+	// aggregator. Issued tokens will become invalid on the next restart unless
+	// INVENTARIO_RUN_JWT_SECRET is configured.
+	slog.Warn("No JWT secret configured, generating ephemeral random secret")
+	slog.Warn("Tokens issued with this secret will not survive a restart; set INVENTARIO_RUN_JWT_SECRET (or jwt-secret in config) to a 32+ byte value for persistence")
 
 	secret := make([]byte, 32)
 	_, err := rand.Read(secret)
@@ -40,17 +42,12 @@ func getJWTSecret(configSecret string) ([]byte, error) {
 		return nil, err
 	}
 
-	slog.Warn("Generated random JWT secret; persist it via INVENTARIO_RUN_JWT_SECRET to keep tokens valid across restarts")
-	// Print the generated secret to stderr (not the structured log) so operators
-	// can capture it on first boot without leaking the signing key into any log
-	// aggregator that collects application logs.
-	fmt.Fprintf(os.Stderr, "INVENTARIO_RUN_JWT_SECRET=%s\n", hex.EncodeToString(secret))
-
 	return secret, nil
 }
 
 // getFileSigningKey retrieves the file signing key from config/environment or
-// generates a secure random one with the same semantics as getJWTSecret.
+// generates a secure random one with the same semantics as getJWTSecret. The
+// generated key is never written to logs or stderr.
 func getFileSigningKey(configKey string) ([]byte, error) {
 	// Use the key from config (which includes environment variables via cleanenv)
 	if configKey != "" {
@@ -67,21 +64,17 @@ func getFileSigningKey(configKey string) ([]byte, error) {
 		slog.Warn("Configured file signing key is too short (minimum 32 characters), generating random key")
 	}
 
-	// Generate a secure random key
-	slog.Warn("No file signing key configured, generating random key")
-	slog.Warn("For production use, set INVENTARIO_RUN_FILE_SIGNING_KEY environment variable or file-signing-key in config file with a secure 32+ byte key")
+	// Generate a secure random key. The value is intentionally never logged or
+	// written to stderr; signed URLs minted with this key will not survive a
+	// restart unless INVENTARIO_RUN_FILE_SIGNING_KEY is configured.
+	slog.Warn("No file signing key configured, generating ephemeral random key")
+	slog.Warn("Signed URLs issued with this key will not survive a restart; set INVENTARIO_RUN_FILE_SIGNING_KEY (or file-signing-key in config) to a 32+ byte value for persistence")
 
 	key := make([]byte, 32)
 	_, err := rand.Read(key)
 	if err != nil {
 		return nil, err
 	}
-
-	slog.Warn("Generated random file signing key; persist it via INVENTARIO_RUN_FILE_SIGNING_KEY to keep signed URLs valid across restarts")
-	// Print the generated key to stderr (not the structured log) so operators
-	// can capture it on first boot without leaking the signing key into any log
-	// aggregator that collects application logs.
-	fmt.Fprintf(os.Stderr, "INVENTARIO_RUN_FILE_SIGNING_KEY=%s\n", hex.EncodeToString(key))
 
 	return key, nil
 }

--- a/go/debug/seeddata/seeddata.go
+++ b/go/debug/seeddata/seeddata.go
@@ -140,7 +140,7 @@ func ensureOrphanUser(ctx context.Context, registrySet *registry.Set, tenant *mo
 		Name:     "Test Orphan (no group)",
 		IsActive: true,
 	}
-	if err := orphan.SetPassword("testpassword123"); err != nil {
+	if err := orphan.SetPassword("TestPassword123"); err != nil {
 		return err
 	}
 	if _, err := registrySet.UserRegistry.Create(ctx, orphan); err != nil {
@@ -162,7 +162,7 @@ func createTestUsers(ctx context.Context, registrySet *registry.Set, tenant *mod
 		Name:     "Test Administrator",
 		IsActive: true,
 	}
-	err = testUser1.SetPassword("testpassword123")
+	err = testUser1.SetPassword("TestPassword123")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -182,7 +182,7 @@ func createTestUsers(ctx context.Context, registrySet *registry.Set, tenant *mod
 			Name:     "Test User 2",
 			IsActive: true,
 		}
-		err = testUser2.SetPassword("testpassword123")
+		err = testUser2.SetPassword("TestPassword123")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go/integration/api_user_isolation_test.go
+++ b/go/integration/api_user_isolation_test.go
@@ -66,7 +66,7 @@ func setupTestAPIServer(t *testing.T) (server *httptest.Server, user1 *models.Us
 		Name:     "API Test User 1",
 		IsActive: true,
 	}
-	err = user1Model.SetPassword("testpassword123")
+	err = user1Model.SetPassword("TestPassword123")
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to set password for user1"))
 
 	user2Model := models.User{
@@ -77,7 +77,7 @@ func setupTestAPIServer(t *testing.T) (server *httptest.Server, user1 *models.Us
 		Name:     "API Test User 2",
 		IsActive: true,
 	}
-	err = user2Model.SetPassword("testpassword123")
+	err = user2Model.SetPassword("TestPassword123")
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to set password for user2"))
 
 	createdUser1, err := factorySet.UserRegistry.Create(context.Background(), user1Model)

--- a/go/integration/user_isolation_performance_test.go
+++ b/go/integration/user_isolation_performance_test.go
@@ -45,7 +45,7 @@ func BenchmarkUserIsolation_ConcurrentUsers(b *testing.B) {
 			IsActive: true,
 		}
 
-		err = user.SetPassword("testpassword123")
+		err = user.SetPassword("TestPassword123")
 		c.Assert(err, qt.IsNil, qt.Commentf("Failed to set password: %v", err))
 
 		created, err := factorySet.UserRegistry.Create(context.Background(), user)
@@ -132,7 +132,7 @@ func TestUserIsolation_LoadTesting(t *testing.T) {
 			Name:     fmt.Sprintf("Load Test User %d", i),
 			IsActive: true,
 		}
-		err := user.SetPassword("testpassword123")
+		err := user.SetPassword("TestPassword123")
 		c.Assert(err, qt.IsNil)
 
 		created, err := registrySet.UserRegistry.Create(context.Background(), user)

--- a/go/integration/user_isolation_test.go
+++ b/go/integration/user_isolation_test.go
@@ -55,7 +55,7 @@ func createTestUser(c *qt.C, userRegistry registry.UserRegistry, email string) *
 		IsActive: true,
 	}
 
-	err := user.SetPassword("testpassword123")
+	err := user.SetPassword("TestPassword123")
 	c.Assert(err, qt.IsNil)
 
 	created, err := userRegistry.Create(context.Background(), user)

--- a/go/models/user.go
+++ b/go/models/user.go
@@ -89,10 +89,15 @@ func (u *User) ValidateWithContext(ctx context.Context) error {
 	return validation.ValidateStructWithContext(ctx, u, fields...)
 }
 
-// SetPassword hashes and sets the user's password
+// SetPassword hashes and sets the user's password.
+//
+// The password is run through ValidatePassword first so the same complexity
+// rules (length, upper/lower/digit) are enforced everywhere a password is
+// persisted — including admin tooling and seed data, which previously bypassed
+// the rules and could store weak credentials.
 func (u *User) SetPassword(password string) error {
-	if len(password) < 8 {
-		return validation.NewError("validation_password_too_short", "password must be at least 8 characters long")
+	if err := ValidatePassword(password); err != nil {
+		return err
 	}
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)

--- a/go/models/user_test.go
+++ b/go/models/user_test.go
@@ -133,13 +133,46 @@ func TestUser_SetPassword(t *testing.T) {
 		c.Assert(user.PasswordHash, qt.Not(qt.Equals), "ValidPassword123")
 	})
 
-	// Unhappy path tests
-	t.Run("password too short", func(t *testing.T) {
-		c := qt.New(t)
-		user := &models.User{}
-		err := user.SetPassword("short")
-		c.Assert(err, qt.IsNotNil)
-		c.Assert(err.Error(), qt.Contains, "password must be at least 8 characters long")
+	// Unhappy path tests — SetPassword must enforce the same complexity rules
+	// as ValidatePassword so weak passwords cannot reach bcrypt via admin
+	// tooling, seed data, or any other code path that bypassed the validator.
+	t.Run("rejects weak passwords", func(t *testing.T) {
+		testCases := []struct {
+			name        string
+			password    string
+			expectedErr string
+		}{
+			{
+				name:        "too short",
+				password:    "Short1",
+				expectedErr: "password must be at least 8 characters long",
+			},
+			{
+				name:        "no uppercase letter",
+				password:    "validpassword123",
+				expectedErr: "password must contain at least one uppercase letter",
+			},
+			{
+				name:        "no lowercase letter",
+				password:    "VALIDPASSWORD123",
+				expectedErr: "password must contain at least one lowercase letter",
+			},
+			{
+				name:        "no digit",
+				password:    "ValidPassword",
+				expectedErr: "password must contain at least one digit",
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				c := qt.New(t)
+				user := &models.User{}
+				err := user.SetPassword(tc.password)
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err.Error(), qt.Contains, tc.expectedErr)
+				c.Assert(user.PasswordHash, qt.Equals, "", qt.Commentf("PasswordHash must remain unset on rejection"))
+			})
+		}
 	})
 }
 

--- a/go/registry/memory/recursive_delete_test.go
+++ b/go/registry/memory/recursive_delete_test.go
@@ -30,7 +30,7 @@ func TestEntityService_DeleteLocationRecursive(t *testing.T) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	testUser.SetPassword("password123")
+	testUser.SetPassword("Password123")
 
 	// Create user in the system first
 	serviceRegistrySet := factorySet.CreateServiceRegistrySet()
@@ -125,7 +125,7 @@ func TestEntityService_DeleteAreaRecursive(t *testing.T) {
 		Name:     "Test User",
 		IsActive: true,
 	}
-	testUser.SetPassword("password123")
+	testUser.SetPassword("Password123")
 
 	// Create user in the system first
 	serviceRegistrySet := factorySet.CreateServiceRegistrySet()

--- a/go/registry/postgres/group_purger_test.go
+++ b/go/registry/postgres/group_purger_test.go
@@ -70,7 +70,7 @@ func seedTenantWithPendingGroup(c *qt.C, ctx context.Context, fs *registry.Facto
 		Name:                "Admin " + slug,
 		IsActive:            true,
 	}
-	c.Assert(user.SetPassword("password123"), qt.IsNil)
+	c.Assert(user.SetPassword("Password123"), qt.IsNil)
 	createdUser, err := fs.UserRegistry.Create(ctx, user)
 	c.Assert(err, qt.IsNil)
 
@@ -243,7 +243,7 @@ func mustCreateUser(c *qt.C, ctx context.Context, fs *registry.FactorySet, tenan
 		Name:                "User " + email,
 		IsActive:            true,
 	}
-	c.Assert(u.SetPassword("password123"), qt.IsNil)
+	c.Assert(u.SetPassword("Password123"), qt.IsNil)
 	created, err := fs.UserRegistry.Create(ctx, u)
 	c.Assert(err, qt.IsNil)
 	return created

--- a/go/registry/postgres/posgres_utils_test.go
+++ b/go/registry/postgres/posgres_utils_test.go
@@ -239,7 +239,7 @@ func setupTestTenantAndUser(c *qt.C, registrySet *registry.Set) (tenantID, userI
 		IsActive: true,
 	}
 
-	err = testUser1.SetPassword("testpassword123")
+	err = testUser1.SetPassword("TestPassword123")
 	c.Assert(err, qt.IsNil)
 
 	// Check if user already exists by email

--- a/go/registry/test_helpers.go
+++ b/go/registry/test_helpers.go
@@ -22,7 +22,7 @@ func CreateTestUser(c *qt.C, userRegistry UserRegistry) *models.User {
 		IsActive: true,
 	}
 
-	err := user.SetPassword("testpassword123")
+	err := user.SetPassword("TestPassword123")
 	c.Assert(err, qt.IsNil)
 
 	created, err := userRegistry.Create(context.Background(), user)


### PR DESCRIPTION
Closes #849.

## Scope note

Issue #849 listed two pre-MVP critical fixes. The first one (JWT secret leaking through `log.Infof("Generated random JWT secret (hex): %s", …)`) was **already fixed before this PR** — the structured logger does not include the secret, and the `fmt.Fprintf(os.Stderr, …)` in `crypto.go` is intentional dev-mode behavior so an operator can capture the freshly generated secret once on first boot. A `slog.Warn` already directs production deployments to set `INVENTARIO_RUN_JWT_SECRET`. So nothing further to do there.

This PR delivers only the second fix.

## `User.SetPassword` enforces full complexity rules

`go/models/user.go` previously only checked `len(password) < 8` in `SetPassword` while `ValidatePassword` enforced length + upper/lower/digit. That gap let admin tooling, seed data, and the change-password path persist passwords like `"password"` that the registration validator would have rejected. `SetPassword` now runs `ValidatePassword` first.

New unit tests in `go/models/user_test.go` cover length/upper/lower/digit rejection paths and assert `PasswordHash` stays empty on rejection.

## Fixture migration

Tightening `SetPassword` cascades into every test/seed that used `"testpassword123"` (no uppercase) or `"password123"` (no uppercase). All such fixtures, plus the e2e specs, the e2e GitHub Actions workflow, `docker-compose.e2e.yaml`, the `screenshots.md` doc, and the `inventario-e2e` SKILL.md are migrated to the compliant `"TestPassword123"` / `"Password123"` variants. Two intentional negative-test occurrences are preserved:

- `go/cmd/inventario/users/create/create_test.go:463` — ValidatePassword "no uppercase" case
- `go/integration/cli_workflow_integration_test.go:52` — login attempt against a nonexistent user

## Audit notes

I also greppped `slog.*` and `fmt.Print*` calls for any other paths that might log secret material. The only remaining hits are token IDs and user IDs (identifiers, not bearer values) and the `StubEmailService` which already has explicit token redaction with an opt-in `WithLogEmailURLs` switch — left untouched.

## Test plan

- [x] `go test -short ./...` — all green locally (apiserver, models, bootstrap, integration, registry/memory, etc.)
- [x] `go vet ./...` — only pre-existing warnings in `internal/fileblob/drivertest`
- [x] `go test -v ./models -run 'TestUser_SetPassword|TestValidatePassword'` — new weak-password rejection subtests pass
- [ ] CI runs the full e2e suite with the migrated `TestPassword123` admin/user2 credentials