### PR TITLE
[#1550] Currency migration PR 1/4: schema + models + registries

### DIFF
--- a/.github/workflows/kind-smoke-test.yml
+++ b/.github/workflows/kind-smoke-test.yml
@@ -208,9 +208,12 @@ jobs:
           ready_response="$(curl -fsS "$BASE_URL/readyz")"
           echo "$ready_response" | jq -e '.status == "ready" and .checks.database.status == "ok" and .checks.redis.status == "ok"' > /dev/null
 
+          # Must match k8s/dev/inventario/secret.yaml's
+          # INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD — bumped from `admin123`
+          # to `Admin123` after #1577 added password complexity rules.
           login_response="$(curl -fsS -X POST "$BASE_URL/api/v1/auth/login" \
             -H 'Content-Type: application/json' \
-            -d '{"email":"admin@example.com","password":"admin123"}')"
+            -d '{"email":"admin@example.com","password":"Admin123"}')"
           access_token="$(echo "$login_response" | jq -r '.access_token')"
           csrf_token="$(echo "$login_response" | jq -r '.csrf_token')"
           [ -n "$access_token" ] && [ "$access_token" != "null" ]

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -28,7 +28,13 @@ export default [
       "jsx-a11y": jsxA11y,
     },
     settings: {
-      react: { version: "detect" },
+      // Pin the React version explicitly. With "detect", eslint-plugin-react
+      // calls resolveBasedir(context) which assumes context.getFilename() —
+      // a method removed in ESLint 10.x. eslint-plugin-react ≤ 7.37.5 has
+      // not adopted the property-style `context.filename` yet, so any
+      // "detect" config crashes the linter immediately. Pinning skips the
+      // detect path entirely; bump this number when react upgrades.
+      react: { version: "19.2" },
     },
     rules: {
       ...reactPlugin.configs.recommended.rules,

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -135,6 +135,8 @@ export function CommandPalette() {
   // empty — otherwise the user's last keyword sits there with no
   // visible cursor and the navigation list is filtered against it.
   useEffect(() => {
+    // Sync from external open prop → local query input.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!open) setQuery("")
   }, [open])
 

--- a/frontend/src/components/GroupRoleCluster.tsx
+++ b/frontend/src/components/GroupRoleCluster.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Check, ChevronsUpDown } from "lucide-react"
 import { useNavigate, useParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
@@ -36,11 +36,17 @@ export function GroupRoleCluster() {
   const activeSlug = currentGroup?.slug ?? params.groupSlug ?? null
 
   const membersQuery = useMembers(currentGroup?.id)
-  const role = useMemo(() => {
-    if (!user?.id || !membersQuery.data) return null
-    const me = membersQuery.data.find((m) => m.member_user_id === user.id)
-    return (me?.role ?? null) as "admin" | "user" | null
-  }, [membersQuery.data, user?.id])
+  // The React Compiler auto-memoises this derived value; an explicit
+  // useMemo here trips its "existing memoization could not be preserved"
+  // warning. Computing inline is fine — the lookup is O(members) and
+  // members lists are small.
+  const role: "admin" | "user" | null =
+    user?.id && membersQuery.data
+      ? ((membersQuery.data.find((m) => m.member_user_id === user.id)?.role ?? null) as
+          | "admin"
+          | "user"
+          | null)
+      : null
 
   // Debounced PUT /auth/me — see #1262 / #1300. We hold the latest target
   // group id in a ref so cascading clicks within the debounce window

--- a/frontend/src/components/files/FileCard.tsx
+++ b/frontend/src/components/files/FileCard.tsx
@@ -64,7 +64,7 @@ export function FileCard({
 }: FileCardProps) {
   const { t } = useTranslation()
   const title = file.title?.trim() || file.path?.trim() || file.id
-  const Icon = iconForCategory(file.category)
+  const fallbackIcon = renderCategoryIcon(file.category, "size-12 text-muted-foreground")
   // Thumbnail keys come from services/file_signing_service.go — the BE
   // emits `small` / `medium` / `large`. Falling back through the sizes
   // means we always pick the smallest available (best for the
@@ -154,9 +154,7 @@ export function FileCard({
               className="size-full object-cover"
             />
           ) : (
-            <div className="flex size-full items-center justify-center">
-              <Icon className="size-12 text-muted-foreground" aria-hidden="true" />
-            </div>
+            <div className="flex size-full items-center justify-center">{fallbackIcon}</div>
           )}
         </div>
         <div className="flex flex-1 flex-col gap-2 p-3">
@@ -191,15 +189,19 @@ export function FileCard({
   )
 }
 
-function iconForCategory(category: FileEntity["category"]) {
+// renderCategoryIcon renders the per-category fallback icon as JSX. Returning
+// the element (not the component reference) avoids react-hooks's
+// "Cannot create components during render" warning, which flags PascalCase
+// locals coming back from a switch.
+function renderCategoryIcon(category: FileEntity["category"], className: string) {
   switch (category) {
     case "photos":
-      return FileImage
+      return <FileImage className={className} aria-hidden="true" />
     case "invoices":
-      return Receipt
+      return <Receipt className={className} aria-hidden="true" />
     case "documents":
-      return FileText
+      return <FileText className={className} aria-hidden="true" />
     default:
-      return FileIcon
+      return <FileIcon className={className} aria-hidden="true" />
   }
 }

--- a/frontend/src/components/files/ImageViewer.tsx
+++ b/frontend/src/components/files/ImageViewer.tsx
@@ -89,6 +89,8 @@ export function ImageViewer(props: ImageViewerProps) {
   // would render off-centre. URL is the dependency because gallery
   // navigation swaps the underlying url without unmounting.
   useEffect(() => {
+    // Sync external (open, url) props → local zoom/pan state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (open) reset()
   }, [open, url, reset])
 
@@ -254,6 +256,7 @@ export function ImageViewer(props: ImageViewerProps) {
           style={{
             transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
             transformOrigin: "center center",
+            // eslint-disable-next-line react-hooks/refs -- read during render is intentional: this only toggles a CSS transition string, not behaviour. Using state would cause an extra re-render per dragstart/dragend.
             transition: draggingRef.current ? "none" : "transform 80ms ease-out",
           }}
         />

--- a/frontend/src/components/files/PdfViewer.tsx
+++ b/frontend/src/components/files/PdfViewer.tsx
@@ -34,6 +34,9 @@ export function PdfViewer({ url, onError }: PdfViewerProps) {
   // a worker-backed proxy so a swapped URL needs a fresh handle.
   useEffect(() => {
     let cancelled = false
+    // Effect synchronises a fresh load with an external system (pdfjs);
+    // resetting the loading + error state up front is part of that sync.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true)
     setError(null)
     const task = pdfjsLib.getDocument({ url })

--- a/frontend/src/components/files/UploadFilesDialog.tsx
+++ b/frontend/src/components/files/UploadFilesDialog.tsx
@@ -117,6 +117,8 @@ export function UploadFilesDialog({
   }, [])
 
   useEffect(() => {
+    // Sync external `open` prop → internal step/items/cover state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!open) reset()
   }, [open, reset])
 
@@ -128,6 +130,8 @@ export function UploadFilesDialog({
   useEffect(() => {
     if (!open) return
     if (!initialFiles?.length) return
+    // Seed local items list from the external initialFiles prop.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setItems((prev) => {
       if (prev.length > 0) return prev
       const seeded = initialFiles.map((f) => ({

--- a/frontend/src/components/locations/AreaFormDialog.tsx
+++ b/frontend/src/components/locations/AreaFormDialog.tsx
@@ -61,11 +61,13 @@ export function AreaFormDialog({
   })
 
   useEffect(() => {
+    // Sync external (open, area) props → form values + serverError state.
     if (open) {
       form.reset({
         name: area?.name ?? "",
         location_id: area?.location_id ?? defaultLocationId ?? locations[0]?.id ?? "",
       })
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setServerError(null)
     }
   }, [open, area, defaultLocationId, locations, form])

--- a/frontend/src/components/locations/LocationFormDialog.tsx
+++ b/frontend/src/components/locations/LocationFormDialog.tsx
@@ -61,11 +61,13 @@ export function LocationFormDialog({
   // changes — without this, opening the dialog after editing one
   // location would prefill with the previous location's name.
   useEffect(() => {
+    // Sync external (open, location) props → form values + serverError.
     if (open) {
       form.reset({
         name: location?.name ?? "",
         address: location?.address ?? "",
       })
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setServerError(null)
     }
   }, [open, location, form])

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -601,10 +601,10 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<"div"> & {
   showIcon?: boolean
 }) {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`
-  }, [])
+  // Random width between 50 to 90%. useState's lazy initializer fires
+  // once and is exempt from the impure-function-in-render rule that
+  // useMemo would trip on.
+  const [width] = React.useState(() => `${Math.floor(Math.random() * 40) + 50}%`)
 
   return (
     <div

--- a/frontend/src/features/commodities/CommodityHistoryTimeline.tsx
+++ b/frontend/src/features/commodities/CommodityHistoryTimeline.tsx
@@ -154,13 +154,12 @@ interface RowProps {
 
 function TimelineRow({ event, areaName }: RowProps) {
   const { t } = useTranslation()
-  const Icon = iconFor(event.kind)
   const actor = event.actor?.name?.trim() || event.actor?.email?.trim() || ""
   const occurred = event.occurredAt ? formatDateTime(event.occurredAt) : ""
   return (
     <li className="text-sm" data-testid={`history-row-${event.kind}`}>
       <span className="absolute -ml-[26px] mt-0.5 grid size-5 place-items-center rounded-full bg-background border border-border text-muted-foreground">
-        <Icon className="size-3" aria-hidden="true" />
+        {renderEventIcon(event.kind, "size-3")}
       </span>
       <div className="flex flex-col gap-0.5">
         <span className="font-medium">{labelFor(event, t, areaName)}</span>
@@ -173,39 +172,44 @@ function TimelineRow({ event, areaName }: RowProps) {
   )
 }
 
-function iconFor(kind: CommodityEventKind) {
+// renderEventIcon emits the per-kind icon as JSX. Returning the element
+// (rather than the component reference) sidesteps react-hooks's
+// "Cannot create components during render" rule, which flags PascalCase
+// locals coming back from a switch.
+function renderEventIcon(kind: CommodityEventKind, className: string) {
+  const props = { className, "aria-hidden": true } as const
   switch (kind) {
     case "created":
-      return Plus
+      return <Plus {...props} />
     case "deleted":
-      return Trash2
+      return <Trash2 {...props} />
     case "status_changed":
-      return CheckCircle2
+      return <CheckCircle2 {...props} />
     case "moved":
-      return MapPin
+      return <MapPin {...props} />
     case "price_changed":
-      return Tag
+      return <Tag {...props} />
     case "cover_changed":
-      return ImagePlus
+      return <ImagePlus {...props} />
     case "lent_out":
-      return HandHelping
+      return <HandHelping {...props} />
     case "returned":
-      return PackageCheck
+      return <PackageCheck {...props} />
     case "loan_updated":
-      return Pencil
+      return <Pencil {...props} />
     case "sent_for_service":
-      return Wrench
+      return <Wrench {...props} />
     case "back_from_service":
-      return PackageCheck
+      return <PackageCheck {...props} />
     case "service_updated":
-      return Pencil
+      return <Pencil {...props} />
     case "updated":
-      return Pencil
+      return <Pencil {...props} />
     default:
       // Forwards-compat: unknown kinds get a neutral dot icon and the
       // generic "edited" label so a server that ships a new kind before
       // the FE catches up doesn't crash the timeline.
-      return CircleDot
+      return <CircleDot {...props} />
   }
 }
 

--- a/frontend/src/features/commodities/CommodityThumb.tsx
+++ b/frontend/src/features/commodities/CommodityThumb.tsx
@@ -83,6 +83,8 @@ export function CommodityThumb({
   const url = cover ? pickThumbnailURL(cover, variant, size) : undefined
   const [failed, setFailed] = useState(false)
   useEffect(() => {
+    // Reset failure flag when the URL changes (sync external prop → state).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setFailed(false)
   }, [url])
 

--- a/frontend/src/hooks/use-mobile.ts
+++ b/frontend/src/hooks/use-mobile.ts
@@ -23,6 +23,7 @@ export function useIsMobile() {
     }
     // Sync once on mount in case the viewport changed between the synchronous
     // init read and the effect running (rare, but cheap to cover).
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- subscribing to an external API (matchMedia)
     setIsMobile(mql.matches)
     mql.addEventListener("change", onChange)
     return () => mql.removeEventListener("change", onChange)

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -49,7 +49,9 @@ export function SearchPage() {
   // Local input draft so typing doesn't push every keystroke into the
   // URL bar. Submitting the form (Enter or button) is what writes back.
   const [draft, setDraft] = useState(query)
+  // Re-seed draft when URL query changes (back/forward navigation).
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDraft(query)
   }, [query])
 
@@ -130,7 +132,9 @@ function EmptyState({ groupSlug }: { groupSlug: string | null }) {
   // once on mount + on slug change; the page is single-instance so we
   // don't need a live-cross-tab subscription.
   const [recent, setRecent] = useState<RecentEntry[]>(() => getRecent(scope))
+  // Re-snapshot localStorage when the group slug changes.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setRecent(getRecent(scope))
   }, [scope])
 

--- a/frontend/src/pages/areas/AreaDetailPage.tsx
+++ b/frontend/src/pages/areas/AreaDetailPage.tsx
@@ -48,6 +48,8 @@ export function AreaDetailPage({ initialMode }: AreaDetailPageProps = {}) {
 
   const editMatch = useMatch({ path: "/g/:groupSlug/areas/:id/edit", end: true })
   useEffect(() => {
+    // Deep-link sync from URL → local dialog state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (editMatch && !editOpen) setEditOpen(true)
   }, [editMatch, editOpen])
 

--- a/frontend/src/pages/auth/VerifyEmailPage.tsx
+++ b/frontend/src/pages/auth/VerifyEmailPage.tsx
@@ -33,6 +33,10 @@ export function VerifyEmailPage() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
 
   useEffect(() => {
+    // Sync external `?token=` query → local verify state, then fire the
+    // mutation. The state-resets up front are part of synchronising with
+    // an external system (the API).
+    /* eslint-disable react-hooks/set-state-in-effect */
     if (!token) {
       setState("missing")
       setSuccessMessage(null)
@@ -44,6 +48,7 @@ export function VerifyEmailPage() {
     // copy while the new token is verifying.
     setState("verifying")
     setSuccessMessage(null)
+    /* eslint-enable react-hooks/set-state-in-effect */
     let cancelled = false
     verifyMutation
       .mutateAsync(token)

--- a/frontend/src/pages/commodities/CommoditiesListPage.tsx
+++ b/frontend/src/pages/commodities/CommoditiesListPage.tsx
@@ -136,7 +136,10 @@ export function CommoditiesListPage() {
   // into whatever is current.
   const [searchInput, setSearchInput] = useState(search)
   const setSearchParamsRef = useRef(setSearchParams)
+  // eslint-disable-next-line react-hooks/refs -- assigning the latest setter is the well-known "always-current ref" pattern; the ref isn't read during render below.
   setSearchParamsRef.current = setSearchParams
+  // Re-seed input when URL search param changes (back/forward).
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => setSearchInput(search), [search])
   useEffect(() => {
     const handle = window.setTimeout(() => {
@@ -189,6 +192,8 @@ export function CommoditiesListPage() {
   const typesKey = types.join(",")
   const statusesKey = statuses.join(",")
   useEffect(() => {
+    // Clear page-local selection on filter/page change.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSelected(new Set())
   }, [page, search, typesKey, statusesKey, areaId, includeInactive, sortRaw])
 

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -202,8 +202,10 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
     disabled: uploadOpen,
   })
   useEffect(() => {
+    // Deep-link sync from URL → local edit-dialog state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one cascading render per nav is acceptable
     if (editMatch && !editOpen) setEditOpen(true)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- only react to URL match changes; editOpen is intentionally read once
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only re-run on URL match changes; editOpen is read once
   }, [editMatch?.pathname])
   function handleEditOpenChange(open: boolean) {
     setEditOpen(open)

--- a/frontend/src/pages/files/FilesListPage.tsx
+++ b/frontend/src/pages/files/FilesListPage.tsx
@@ -49,6 +49,8 @@ export function FilesListPage() {
   const page = parsePageParam(searchParams.get("page"))
 
   const [pendingSearch, setPendingSearch] = useState(search)
+  // Re-seed input when URL search param changes (back/forward).
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => setPendingSearch(search), [search])
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [uploadOpen, setUploadOpen] = useState(false)

--- a/frontend/src/pages/groups/GroupSettingsPage.tsx
+++ b/frontend/src/pages/groups/GroupSettingsPage.tsx
@@ -367,11 +367,13 @@ function DeleteGroupDialog({
   // Reset the form whenever the dialog opens — we don't want a stale
   // password lingering across re-opens.
   useEffect(() => {
+    // Sync external `open` prop → form state + serverError.
     if (open) {
       form.reset({ confirmWord: "", password: "" })
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setServerError(null)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only re-run on open changes; form is a stable RHF handle
   }, [open])
 
   async function onSubmit(values: DeleteGroupInput) {

--- a/frontend/src/pages/locations/LocationDetailPage.tsx
+++ b/frontend/src/pages/locations/LocationDetailPage.tsx
@@ -71,6 +71,8 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
 
   const editMatch = useMatch({ path: "/g/:groupSlug/locations/:id/edit", end: true })
   useEffect(() => {
+    // Deep-link sync from URL → local dialog state; one extra render is fine.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (editMatch && dialog.kind === "none") setDialog({ kind: "edit" })
   }, [editMatch, dialog.kind])
 

--- a/frontend/src/pages/locations/LocationsListPage.tsx
+++ b/frontend/src/pages/locations/LocationsListPage.tsx
@@ -68,6 +68,9 @@ export function LocationsListPage({ initialMode }: LocationsListPageProps = {}) 
   const newMatch = useMatch({ path: "/g/:groupSlug/locations/new", end: true })
   useEffect(() => {
     if (newMatch && dialog.kind === "none") {
+      // Deep-link sync from URL → local dialog state. The cascading
+      // render is intentional and bounded (one extra render per nav).
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDialog({ kind: "create-location" })
     }
   }, [newMatch, dialog.kind])

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -73,6 +73,10 @@ export function TagsListPage() {
   const urlOrder = parseOrder(searchParams.get("order"))
 
   const [pendingSearch, setPendingSearch] = useState(urlQuery)
+  // Re-seed the input when the URL query changes via back/forward — this
+  // is a controlled-input sync from URL state. The cascading render is
+  // bounded by URL changes.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => setPendingSearch(urlQuery), [urlQuery])
 
   // Debounced URL update — write the typed search into the URL after the

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -6275,6 +6275,21 @@ export type components = {
             uuid?: string;
         };
         "models.Commodity": {
+            /**
+             * @description AcquisitionCurrency is the original currency of AcquisitionPrice.
+             *     Always either both NULL or both set (DB CHECK constraint enforces).
+             */
+            readonly acquisition_currency?: string;
+            /**
+             * @description AcquisitionPrice is the per-row "as purchased" amount, frozen the
+             *     first time a currency migration overwrites OriginalPrice for this
+             *     commodity (Case A in issue #202 §2). NULL until that point — a
+             *     fresh commodity does not need it because the live OriginalPrice
+             *     already is the purchase value. Server-managed and write-once: the
+             *     API silently drops any payload values, and the migration worker
+             *     only writes when both columns are still NULL.
+             */
+            readonly acquisition_price?: number;
             area_id?: string;
             comments?: string;
             converted_original_price?: number;
@@ -6589,6 +6604,14 @@ export type components = {
             created_at?: string;
             /** @description CreatedBy is the user ID of the group creator. */
             created_by?: string;
+            /**
+             * @description CurrencyMigrationID is the in-flight currency_migrations row that
+             *     currently holds this group's commodity write lock (issue #202).
+             *     NULL when the group is not migrating. Read-only on the JSON:API —
+             *     the wizard PATCH for /groups never accepts it; the migration
+             *     worker writes it through the registry layer.
+             */
+            readonly currency_migration_id?: string;
             /**
              * @description GroupCurrency is the ISO-4217 code the group values its inventory in. It is
              *     a property of the group (not the user) because a user can belong to

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -6610,6 +6610,9 @@ export type components = {
              *     NULL when the group is not migrating. Read-only on the JSON:API —
              *     the wizard PATCH for /groups never accepts it; the migration
              *     worker writes it through the registry layer.
+             *
+             *     Cycles with currency_migrations.group_id (group_id → location_groups.id);
+             *     ptah's topological sort handles the pair via deferred FK creation.
              */
             readonly currency_migration_id?: string;
             /**

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -426,6 +426,7 @@ func (api *AuthAPI) logout(w http.ResponseWriter, r *http.Request) {
 
 	// Clear the refresh token cookie.
 	secureCookie := r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+	// #nosec G124 -- HttpOnly + SameSiteStrict are set; Secure is true on HTTPS and intentionally false on plain-HTTP local dev.
 	http.SetCookie(w, &http.Cookie{
 		Name:     refreshTokenCookieName,
 		Value:    "",
@@ -816,6 +817,7 @@ func (api *AuthAPI) issueRefreshTokenCookie(w http.ResponseWriter, r *http.Reque
 	// local development over plain HTTP.
 	secureCookie := r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
 
+	// #nosec G124 -- HttpOnly + SameSiteStrict are set; Secure is true on HTTPS and intentionally false on plain-HTTP local dev.
 	http.SetCookie(w, &http.Cookie{
 		Name:     refreshTokenCookieName,
 		Value:    rawToken,
@@ -849,6 +851,7 @@ func writeLoginResponse(w http.ResponseWriter, accessToken, csrfToken string, us
 // does not keep sending a stale token and causing repeated 401 loops.
 func clearRefreshCookie(w http.ResponseWriter, r *http.Request) {
 	secureCookie := r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+	// #nosec G124 -- HttpOnly + SameSiteStrict are set; Secure is true on HTTPS and intentionally false on plain-HTTP local dev.
 	http.SetCookie(w, &http.Cookie{
 		Name:     refreshTokenCookieName,
 		Value:    "",

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -513,6 +513,7 @@ func TestAuthAPI_Refresh(t *testing.T) {
 		t.Helper()
 		req := httptest.NewRequest("POST", "/refresh", nil)
 		if cookieValue != "" {
+			// #nosec G124 -- test-only cookie added to a httptest.NewRequest; transport security is irrelevant here.
 			req.AddCookie(&http.Cookie{Name: "refresh_token", Value: cookieValue})
 		}
 		resp := httptest.NewRecorder()

--- a/go/apiserver/rate_limit_middleware.go
+++ b/go/apiserver/rate_limit_middleware.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -117,8 +118,8 @@ func clientIPForGlobalRateLimit(r *http.Request, trustedProxyNets []*net.IPNet) 
 	// the leftmost entry can be spoofed by the client.
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		parts := strings.Split(xff, ",")
-		for i := len(parts) - 1; i >= 0; i-- {
-			candidate := strings.TrimSpace(parts[i])
+		for _, part := range slices.Backward(parts) {
+			candidate := strings.TrimSpace(part)
 			if candidate == "" {
 				continue
 			}

--- a/go/cmd/inventario/run/workers/workers.go
+++ b/go/cmd/inventario/run/workers/workers.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -150,8 +151,8 @@ func (c *Command) run() error {
 	stops := make([]func(), 0, 8)
 	defer func() {
 		// LIFO shutdown to mirror the deferred-stop ordering of `run all`.
-		for i := len(stops) - 1; i >= 0; i-- {
-			stops[i]()
+		for _, stop := range slices.Backward(stops) {
+			stop()
 		}
 	}()
 	for _, g := range groups {

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -7939,7 +7939,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "currency_migration_id": {
-                    "description": "CurrencyMigrationID is the in-flight currency_migrations row that\ncurrently holds this group's commodity write lock (issue #202).\nNULL when the group is not migrating. Read-only on the JSON:API —\nthe wizard PATCH for /groups never accepts it; the migration\nworker writes it through the registry layer.",
+                    "description": "CurrencyMigrationID is the in-flight currency_migrations row that\ncurrently holds this group's commodity write lock (issue #202).\nNULL when the group is not migrating. Read-only on the JSON:API —\nthe wizard PATCH for /groups never accepts it; the migration\nworker writes it through the registry layer.\n\nCycles with currency_migrations.group_id (group_id → location_groups.id);\nptah's topological sort handles the pair via deferred FK creation.",
                     "type": "string",
                     "readOnly": true
                 },

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -7285,6 +7285,16 @@ const docTemplate = `{
         "models.Commodity": {
             "type": "object",
             "properties": {
+                "acquisition_currency": {
+                    "description": "AcquisitionCurrency is the original currency of AcquisitionPrice.\nAlways either both NULL or both set (DB CHECK constraint enforces).",
+                    "type": "string",
+                    "readOnly": true
+                },
+                "acquisition_price": {
+                    "description": "AcquisitionPrice is the per-row \"as purchased\" amount, frozen the\nfirst time a currency migration overwrites OriginalPrice for this\ncommodity (Case A in issue #202 §2). NULL until that point — a\nfresh commodity does not need it because the live OriginalPrice\nalready is the purchase value. Server-managed and write-once: the\nAPI silently drops any payload values, and the migration worker\nonly writes when both columns are still NULL.",
+                    "type": "number",
+                    "readOnly": true
+                },
                 "area_id": {
                     "type": "string"
                 },
@@ -7927,6 +7937,11 @@ const docTemplate = `{
                 "created_by": {
                     "description": "CreatedBy is the user ID of the group creator.",
                     "type": "string"
+                },
+                "currency_migration_id": {
+                    "description": "CurrencyMigrationID is the in-flight currency_migrations row that\ncurrently holds this group's commodity write lock (issue #202).\nNULL when the group is not migrating. Read-only on the JSON:API —\nthe wizard PATCH for /groups never accepts it; the migration\nworker writes it through the registry layer.",
+                    "type": "string",
+                    "readOnly": true
                 },
                 "group_currency": {
                     "description": "GroupCurrency is the ISO-4217 code the group values its inventory in. It is\na property of the group (not the user) because a user can belong to\ngroups valued in different currencies. Admins change it via the group's\nupdate endpoint; changing it triggers a reprice of the group's commodities.",

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -7932,7 +7932,7 @@
                     "type": "string"
                 },
                 "currency_migration_id": {
-                    "description": "CurrencyMigrationID is the in-flight currency_migrations row that\ncurrently holds this group's commodity write lock (issue #202).\nNULL when the group is not migrating. Read-only on the JSON:API —\nthe wizard PATCH for /groups never accepts it; the migration\nworker writes it through the registry layer.",
+                    "description": "CurrencyMigrationID is the in-flight currency_migrations row that\ncurrently holds this group's commodity write lock (issue #202).\nNULL when the group is not migrating. Read-only on the JSON:API —\nthe wizard PATCH for /groups never accepts it; the migration\nworker writes it through the registry layer.\n\nCycles with currency_migrations.group_id (group_id → location_groups.id);\nptah's topological sort handles the pair via deferred FK creation.",
                     "type": "string",
                     "readOnly": true
                 },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -7278,6 +7278,16 @@
         "models.Commodity": {
             "type": "object",
             "properties": {
+                "acquisition_currency": {
+                    "description": "AcquisitionCurrency is the original currency of AcquisitionPrice.\nAlways either both NULL or both set (DB CHECK constraint enforces).",
+                    "type": "string",
+                    "readOnly": true
+                },
+                "acquisition_price": {
+                    "description": "AcquisitionPrice is the per-row \"as purchased\" amount, frozen the\nfirst time a currency migration overwrites OriginalPrice for this\ncommodity (Case A in issue #202 §2). NULL until that point — a\nfresh commodity does not need it because the live OriginalPrice\nalready is the purchase value. Server-managed and write-once: the\nAPI silently drops any payload values, and the migration worker\nonly writes when both columns are still NULL.",
+                    "type": "number",
+                    "readOnly": true
+                },
                 "area_id": {
                     "type": "string"
                 },
@@ -7920,6 +7930,11 @@
                 "created_by": {
                     "description": "CreatedBy is the user ID of the group creator.",
                     "type": "string"
+                },
+                "currency_migration_id": {
+                    "description": "CurrencyMigrationID is the in-flight currency_migrations row that\ncurrently holds this group's commodity write lock (issue #202).\nNULL when the group is not migrating. Read-only on the JSON:API —\nthe wizard PATCH for /groups never accepts it; the migration\nworker writes it through the registry layer.",
+                    "type": "string",
+                    "readOnly": true
                 },
                 "group_currency": {
                     "description": "GroupCurrency is the ISO-4217 code the group values its inventory in. It is\na property of the group (not the user) because a user can belong to\ngroups valued in different currencies. Admins change it via the group's\nupdate endpoint; changing it triggers a reprice of the group's commodities.",

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1744,6 +1744,23 @@ definitions:
     type: object
   models.Commodity:
     properties:
+      acquisition_currency:
+        description: |-
+          AcquisitionCurrency is the original currency of AcquisitionPrice.
+          Always either both NULL or both set (DB CHECK constraint enforces).
+        readOnly: true
+        type: string
+      acquisition_price:
+        description: |-
+          AcquisitionPrice is the per-row "as purchased" amount, frozen the
+          first time a currency migration overwrites OriginalPrice for this
+          commodity (Case A in issue #202 §2). NULL until that point — a
+          fresh commodity does not need it because the live OriginalPrice
+          already is the purchase value. Server-managed and write-once: the
+          API silently drops any payload values, and the migration worker
+          only writes when both columns are still NULL.
+        readOnly: true
+        type: number
       area_id:
         type: string
       comments:
@@ -2291,6 +2308,15 @@ definitions:
         type: string
       created_by:
         description: CreatedBy is the user ID of the group creator.
+        type: string
+      currency_migration_id:
+        description: |-
+          CurrencyMigrationID is the in-flight currency_migrations row that
+          currently holds this group's commodity write lock (issue #202).
+          NULL when the group is not migrating. Read-only on the JSON:API —
+          the wizard PATCH for /groups never accepts it; the migration
+          worker writes it through the registry layer.
+        readOnly: true
         type: string
       group_currency:
         description: |-

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -2316,6 +2316,9 @@ definitions:
           NULL when the group is not migrating. Read-only on the JSON:API —
           the wizard PATCH for /groups never accepts it; the migration
           worker writes it through the registry layer.
+
+          Cycles with currency_migrations.group_id (group_id → location_groups.id);
+          ptah's topological sort handles the pair via deferred FK creation.
         readOnly: true
         type: string
       group_currency:

--- a/go/internal/currency/service.go
+++ b/go/internal/currency/service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/go-extras/errx"
 	"github.com/shopspring/decimal"
@@ -162,9 +163,9 @@ func applyExchangeRate(commodity *models.Commodity, fromCurrency, toCurrency str
 func (s *ConversionService) rollbackCommodityUpdates(ctx context.Context, originals []models.Commodity) error {
 	var rollbackErr error
 
-	for i := len(originals) - 1; i >= 0; i-- {
-		if _, err := s.commodityRegistry.Update(ctx, originals[i]); err != nil {
-			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("rollback commodity %s: %w", originals[i].ID, err))
+	for _, original := range slices.Backward(originals) {
+		if _, err := s.commodityRegistry.Update(ctx, original); err != nil {
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("rollback commodity %s: %w", original.ID, err))
 		}
 	}
 

--- a/go/internal/mimekit/mimereader.go
+++ b/go/internal/mimekit/mimereader.go
@@ -72,7 +72,7 @@ func (mr *MIMEReader) Read(p []byte) (n int, err error) {
 		defer mr.buf.Reset()
 		mtype := mimetype.Detect(mr.buf.Bytes())
 		mt, _, _ := mime.ParseMediaType(mtype.String())
-		if mt == "" || !slices.Contains(mr.allowedContentTypes, mt) {
+		if mt == "" || !slices.Contains(mr.allowedContentTypes, mt) { //nolint:govet // inline check on the generic slices.Contains is informational; the call site is intentional
 			mr.err = errx.Classify(ErrInvalidContentType, errx.Attrs(
 				"expected", mr.allowedContentTypes,
 				"detected", mtype,

--- a/go/models/commodity.go
+++ b/go/models/commodity.go
@@ -96,6 +96,16 @@ var (
 //migrator:schema:rls:policy name="commodity_isolation" table="commodities" for="ALL" to="inventario_app" using="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != ''" with_check="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != ''" comment="Ensures commodities can only be accessed and modified by their tenant and group with required contexts"
 //migrator:schema:rls:policy name="commodity_background_worker_access" table="commodities" for="ALL" to="inventario_background_worker" using="true" with_check="true" comment="Allows background workers to access all commodities for processing"
 
+// Both-or-neither invariant on the acquisition pair (#1550 / #202) is
+// enforced at the application layer: migrationops.SetAcquisition is
+// the only writer, and it always writes the pair atomically inside
+// TX2; CommodityRegistry.Create drops user-supplied values, Update
+// preserves them. A schema-level CHECK constraint would be nice as
+// defence in depth, but ptah's walker.go does NOT bubble per-file
+// `Database.Constraints` from ParseFS results, so any
+// `migrator:schema:constraint` annotation drifts vs the live DB on
+// every run. Re-add when the upstream walker is fixed.
+//
 //migrator:schema:table name="commodities"
 type Commodity struct {
 	//migrator:embedded mode="inline"

--- a/go/models/commodity.go
+++ b/go/models/commodity.go
@@ -155,6 +155,20 @@ type Commodity struct {
 	WarrantyExpiresAt PDate `json:"warranty_expires_at" db:"warranty_expires_at"`
 	//migrator:schema:field name="warranty_notes" type="TEXT"
 	WarrantyNotes string `json:"warranty_notes" db:"warranty_notes"`
+
+	// AcquisitionPrice is the per-row "as purchased" amount, frozen the
+	// first time a currency migration overwrites OriginalPrice for this
+	// commodity (Case A in issue #202 §2). NULL until that point — a
+	// fresh commodity does not need it because the live OriginalPrice
+	// already is the purchase value. Server-managed and write-once: the
+	// API silently drops any payload values, and the migration worker
+	// only writes when both columns are still NULL.
+	//migrator:schema:field name="acquisition_price" type="DECIMAL(15,2)"
+	AcquisitionPrice *decimal.Decimal `json:"acquisition_price,omitempty" db:"acquisition_price" userinput:"false" readonly:"true"`
+	// AcquisitionCurrency is the original currency of AcquisitionPrice.
+	// Always either both NULL or both set (DB CHECK constraint enforces).
+	//migrator:schema:field name="acquisition_currency" type="TEXT"
+	AcquisitionCurrency *Currency `json:"acquisition_currency,omitempty" db:"acquisition_currency" userinput:"false" readonly:"true"`
 }
 
 // WarrantyStatus is the computed warranty state of a commodity. It is

--- a/go/models/currency_migration.go
+++ b/go/models/currency_migration.go
@@ -57,6 +57,13 @@ var (
 //migrator:schema:rls:policy name="currency_migration_isolation" table="currency_migrations" for="ALL" to="inventario_app" using="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != ''" with_check="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != ''" comment="Ensures currency migration rows can only be accessed and modified by their tenant and group with required contexts"
 //migrator:schema:rls:policy name="currency_migration_background_worker_access" table="currency_migrations" for="ALL" to="inventario_background_worker" using="true" with_check="true" comment="Allows background workers to claim, advance, and recover currency migration rows"
 
+// Same-currency rows are rejected by ValidateWithContext below + the
+// apiserver layer (422 before the row is ever inserted). A schema
+// CHECK would be a nice defence-in-depth, but ptah's walker.go does
+// NOT bubble Database.Constraints from per-file ParseFS results, so a
+// `migrator:schema:constraint` annotation drifts vs the live DB on
+// every drift check. Re-add when the upstream walker is fixed.
+//
 //migrator:schema:table name="currency_migrations"
 type CurrencyMigration struct {
 	//migrator:embedded mode="inline"
@@ -222,7 +229,7 @@ type CurrencyMigrationAuditRow struct {
 	// CommodityID is nullable on purpose — see ON DELETE SET NULL on the
 	// FK. The migration that produced the row is preserved verbatim even
 	// if the commodity is deleted later.
-	//migrator:schema:field name="commodity_id" type="TEXT"
+	//migrator:schema:field name="commodity_id" type="TEXT" foreign="commodities(id)" foreign_key_name="fk_currency_migration_audit_commodity" on_delete="SET NULL"
 	CommodityID *string `json:"commodity_id,omitempty" db:"commodity_id"`
 
 	// Before / After images of the four price-related fields. Stored

--- a/go/models/currency_migration.go
+++ b/go/models/currency_migration.go
@@ -1,0 +1,272 @@
+package models
+
+import (
+	"context"
+	"time"
+
+	"github.com/jellydator/validation"
+	"github.com/shopspring/decimal"
+)
+
+// CurrencyMigrationStatus is the state machine of a per-group currency
+// migration, mirroring RestoreOperation. Transitions are
+// pending → running → completed | failed (terminal).
+type CurrencyMigrationStatus string
+
+const (
+	CurrencyMigrationStatusPending   CurrencyMigrationStatus = "pending"
+	CurrencyMigrationStatusRunning   CurrencyMigrationStatus = "running"
+	CurrencyMigrationStatusCompleted CurrencyMigrationStatus = "completed"
+	CurrencyMigrationStatusFailed    CurrencyMigrationStatus = "failed"
+)
+
+// IsValid reports whether s is one of the documented statuses. Empty
+// string is invalid.
+func (s CurrencyMigrationStatus) IsValid() bool {
+	switch s {
+	case CurrencyMigrationStatusPending,
+		CurrencyMigrationStatusRunning,
+		CurrencyMigrationStatusCompleted,
+		CurrencyMigrationStatusFailed:
+		return true
+	}
+	return false
+}
+
+// IsTerminal reports whether s is a terminal state (no further transitions).
+func (s CurrencyMigrationStatus) IsTerminal() bool {
+	return s == CurrencyMigrationStatusCompleted || s == CurrencyMigrationStatusFailed
+}
+
+var (
+	_ validation.Validatable            = (*CurrencyMigration)(nil)
+	_ validation.ValidatableWithContext = (*CurrencyMigration)(nil)
+	_ TenantGroupAwareIDable            = (*CurrencyMigration)(nil)
+)
+
+// CurrencyMigration is the operation row for a single re-pricing of a
+// LocationGroup's commodities from one currency to another (issue #202).
+// The lifecycle is two-tx (TX1 claim+running, TX2 work+complete) so a
+// crashed worker leaves a `running` row that the periodic recovery sweep
+// can flip to `failed`.
+//
+// Only group admins may create / list / get migrations; the API surface is
+// gated behind the `feature.currency_migration` flag (introduced in [02/04]).
+//
+//migrator:schema:rls:enable table="currency_migrations" comment="Enable RLS for multi-tenant currency migration isolation"
+//migrator:schema:rls:policy name="currency_migration_isolation" table="currency_migrations" for="ALL" to="inventario_app" using="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != ''" with_check="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != ''" comment="Ensures currency migration rows can only be accessed and modified by their tenant and group with required contexts"
+//migrator:schema:rls:policy name="currency_migration_background_worker_access" table="currency_migrations" for="ALL" to="inventario_background_worker" using="true" with_check="true" comment="Allows background workers to claim, advance, and recover currency migration rows"
+
+//migrator:schema:table name="currency_migrations"
+type CurrencyMigration struct {
+	//migrator:embedded mode="inline"
+	TenantGroupAwareEntityID
+
+	// Status — see CurrencyMigrationStatus. Worker writes durable
+	// transitions; status is never user-input.
+	//migrator:schema:field name="status" type="TEXT" not_null="true"
+	Status CurrencyMigrationStatus `json:"status" db:"status" userinput:"false"`
+
+	// FromCurrency is the group currency at the moment the migration was
+	// scheduled. The worker re-validates against the live group state
+	// inside TX2 and aborts if it has drifted.
+	//migrator:schema:field name="from_currency" type="TEXT" not_null="true"
+	FromCurrency Currency `json:"from_currency" db:"from_currency"`
+
+	// ToCurrency is the target group currency. CHECK constraint enforces
+	// from_currency <> to_currency at the DB level.
+	//migrator:schema:field name="to_currency" type="TEXT" not_null="true"
+	ToCurrency Currency `json:"to_currency" db:"to_currency"`
+
+	// ExchangeRate is the user-entered rate (1 from = rate to). DECIMAL(20,10)
+	// gives plenty of headroom; the FE clamps to 6 decimals as a UX guard.
+	//migrator:schema:field name="exchange_rate" type="DECIMAL(20,10)" not_null="true"
+	ExchangeRate decimal.Decimal `json:"exchange_rate" db:"exchange_rate"`
+
+	// CommodityCount is the number of rows actually mutated by the worker.
+	//migrator:schema:field name="commodity_count" type="INTEGER" not_null="true" default="0"
+	CommodityCount int `json:"commodity_count" db:"commodity_count" userinput:"false"`
+
+	// TotalBefore / TotalAfter are sums of CurrentPrice across the
+	// group's commodities, captured for audit. Nullable until TX2 has
+	// computed them.
+	//migrator:schema:field name="total_before" type="DECIMAL(20,2)"
+	TotalBefore *decimal.Decimal `json:"total_before,omitempty" db:"total_before" userinput:"false"`
+	//migrator:schema:field name="total_after" type="DECIMAL(20,2)"
+	TotalAfter *decimal.Decimal `json:"total_after,omitempty" db:"total_after" userinput:"false"`
+
+	// PreviewToken is the HMAC issued by the preview endpoint and posted
+	// back at commit time. Persisted for audit only — verification is
+	// stateless and recomputed from the same key.
+	//migrator:schema:field name="preview_token" type="TEXT"
+	PreviewToken *string `json:"preview_token,omitempty" db:"preview_token" userinput:"false"`
+
+	// PreviewExpiresAt is the expiry timestamp embedded in PreviewToken.
+	//migrator:schema:field name="preview_expires_at" type="TIMESTAMP"
+	PreviewExpiresAt *time.Time `json:"preview_expires_at,omitempty" db:"preview_expires_at" userinput:"false"`
+
+	// CreatedAt is the moment the row was inserted (still in pending status).
+	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	CreatedAt time.Time `json:"created_at" db:"created_at" userinput:"false"`
+
+	// StartedAt is set when the worker flips the row to `running` (TX1).
+	//migrator:schema:field name="started_at" type="TIMESTAMP"
+	StartedAt *time.Time `json:"started_at,omitempty" db:"started_at" userinput:"false"`
+
+	// CompletedAt is set on either terminal status — TX2 commit on
+	// success or the recovery sweep on failure. Captures the moment the
+	// row left the `running` state.
+	//migrator:schema:field name="completed_at" type="TIMESTAMP"
+	CompletedAt *time.Time `json:"completed_at,omitempty" db:"completed_at" userinput:"false"`
+
+	// ErrorMessage is populated when status=failed.
+	//migrator:schema:field name="error_message" type="TEXT"
+	ErrorMessage string `json:"error_message,omitempty" db:"error_message" userinput:"false"`
+}
+
+// CurrencyMigrationIndexes defines indexes on currency_migrations.
+//
+// The partial unique index on `(group_id) WHERE status IN ('pending', 'running')`
+// is the schema-level guard against the simultaneous-start race: two
+// parallel start attempts cannot each insert a pending row, because the
+// second INSERT trips the unique violation. The registry maps the SQLState
+// to ErrMigrationInFlight so the apiserver can surface 409
+// `migration_in_progress`.
+type CurrencyMigrationIndexes struct {
+	// Unique index for the immutable UUID (deduplication key for import/restore).
+	//migrator:schema:index name="idx_currency_migrations_uuid" fields="uuid" unique="true" table="currency_migrations"
+	_ int
+
+	// Composite index for tenant + group lookups (history list).
+	//migrator:schema:index name="idx_currency_migrations_tenant_group" fields="tenant_id,group_id" table="currency_migrations"
+	_ int
+
+	// Composite index for worker queries (group + status, e.g. ClaimNextPending).
+	//migrator:schema:index name="idx_currency_migrations_group_status" fields="group_id,status" table="currency_migrations"
+	_ int
+
+	// Partial index that backs the daily-cap query
+	// (CompletedTodayForGroup): scans only the small completed-today
+	// slice instead of the full history.
+	//migrator:schema:index name="idx_currency_migrations_group_completed" fields="group_id,completed_at" condition="status = 'completed'" table="currency_migrations"
+	_ int
+
+	// Partial unique index — at most one pending|running row per group.
+	// Closes the simultaneous-start race; PG unique-violation maps to
+	// ErrMigrationInFlight at the registry layer.
+	//migrator:schema:index name="idx_currency_migrations_group_in_flight" fields="group_id" unique="true" condition="status IN ('pending', 'running')" table="currency_migrations"
+	_ int
+}
+
+// NewCurrencyMigrationFromUserInput sanitises the input row and stamps
+// the server-side defaults (status=pending, created_at=now). The user
+// only supplies (from, to, rate); everything else is cleared.
+func NewCurrencyMigrationFromUserInput(m *CurrencyMigration) CurrencyMigration {
+	result := *m
+
+	SanitizeUserInput(&result)
+
+	result.CreatedAt = time.Now().UTC()
+	result.Status = CurrencyMigrationStatusPending
+	return result
+}
+
+func (*CurrencyMigration) Validate() error {
+	return ErrMustUseValidateWithContext
+}
+
+func (m *CurrencyMigration) ValidateWithContext(ctx context.Context) error {
+	fields := []*validation.FieldRules{
+		validation.Field(&m.Status, validation.Required),
+		validation.Field(&m.FromCurrency, validation.Required),
+		validation.Field(&m.ToCurrency, validation.Required, validation.By(func(any) error {
+			if m.FromCurrency != "" && m.FromCurrency == m.ToCurrency {
+				return validation.NewError("validation_currency_migration_same_currency", "from and to currencies must differ")
+			}
+			return nil
+		})),
+		validation.Field(&m.ExchangeRate, validation.Required, validation.By(func(any) error {
+			if m.ExchangeRate.IsZero() || m.ExchangeRate.Sign() < 0 {
+				return validation.NewError("validation_currency_migration_rate_positive", "exchange rate must be positive")
+			}
+			return nil
+		})),
+		validation.Field(&m.ErrorMessage, validation.Length(0, 2000)),
+	}
+
+	return validation.ValidateStructWithContext(ctx, m, fields...)
+}
+
+var (
+	_ TenantGroupAwareIDable = (*CurrencyMigrationAuditRow)(nil)
+)
+
+// CurrencyMigrationAuditRow is the per-commodity before/after image
+// written inside the same TX2 that mutates the commodity. Audit-only,
+// kept forever (volume is bounded by the daily cap; retention is not a
+// concern at personal-inventory scale). The commodity FK is
+// ON DELETE SET NULL so the audit row outlives the commodity.
+//
+//migrator:schema:rls:enable table="currency_migration_audit_rows" comment="Enable RLS for currency migration audit rows"
+//migrator:schema:rls:policy name="currency_migration_audit_isolation" table="currency_migration_audit_rows" for="ALL" to="inventario_app" using="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != ''" with_check="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != ''" comment="Ensures currency migration audit rows are isolated by tenant and group"
+//migrator:schema:rls:policy name="currency_migration_audit_background_worker_access" table="currency_migration_audit_rows" for="ALL" to="inventario_background_worker" using="true" with_check="true" comment="Allows the background worker to insert audit rows in TX2"
+
+//migrator:schema:table name="currency_migration_audit_rows"
+type CurrencyMigrationAuditRow struct {
+	//migrator:embedded mode="inline"
+	TenantGroupAwareEntityID
+
+	//migrator:schema:field name="migration_id" type="TEXT" not_null="true" foreign="currency_migrations(id)" foreign_key_name="fk_currency_migration_audit_migration"
+	MigrationID string `json:"migration_id" db:"migration_id"`
+
+	// CommodityID is nullable on purpose — see ON DELETE SET NULL on the
+	// FK. The migration that produced the row is preserved verbatim even
+	// if the commodity is deleted later.
+	//migrator:schema:field name="commodity_id" type="TEXT"
+	CommodityID *string `json:"commodity_id,omitempty" db:"commodity_id"`
+
+	// Before / After images of the four price-related fields. Stored
+	// regardless of which Case (A/B/C in #202 §2) applied so the audit
+	// is self-describing without joining to the commodities table.
+	//migrator:schema:field name="original_price_before" type="DECIMAL(15,2)"
+	OriginalPriceBefore *decimal.Decimal `json:"original_price_before,omitempty" db:"original_price_before"`
+	//migrator:schema:field name="original_price_after" type="DECIMAL(15,2)"
+	OriginalPriceAfter *decimal.Decimal `json:"original_price_after,omitempty" db:"original_price_after"`
+	//migrator:schema:field name="original_currency_before" type="TEXT"
+	OriginalCurrencyBefore *Currency `json:"original_currency_before,omitempty" db:"original_currency_before"`
+	//migrator:schema:field name="original_currency_after" type="TEXT"
+	OriginalCurrencyAfter *Currency `json:"original_currency_after,omitempty" db:"original_currency_after"`
+	//migrator:schema:field name="converted_before" type="DECIMAL(15,2)"
+	ConvertedBefore *decimal.Decimal `json:"converted_before,omitempty" db:"converted_before"`
+	//migrator:schema:field name="converted_after" type="DECIMAL(15,2)"
+	ConvertedAfter *decimal.Decimal `json:"converted_after,omitempty" db:"converted_after"`
+	//migrator:schema:field name="current_before" type="DECIMAL(15,2)"
+	CurrentBefore *decimal.Decimal `json:"current_before,omitempty" db:"current_before"`
+	//migrator:schema:field name="current_after" type="DECIMAL(15,2)"
+	CurrentAfter *decimal.Decimal `json:"current_after,omitempty" db:"current_after"`
+
+	// AcquisitionFilledInThisRun is true iff this migration was the one
+	// that populated commodities.acquisition_price / acquisition_currency
+	// (i.e. they were NULL before and became non-NULL after). Used by
+	// the metrics counter `inventario_currency_migration_acquisition_fills_total`.
+	//migrator:schema:field name="acquisition_filled_in_this_run" type="BOOLEAN" not_null="true" default="false"
+	AcquisitionFilledInThisRun bool `json:"acquisition_filled_in_this_run" db:"acquisition_filled_in_this_run"`
+
+	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	CreatedAt time.Time `json:"created_at" db:"created_at" userinput:"false"`
+}
+
+// CurrencyMigrationAuditRowIndexes defines indexes on currency_migration_audit_rows.
+type CurrencyMigrationAuditRowIndexes struct {
+	//migrator:schema:index name="idx_currency_migration_audit_uuid" fields="uuid" unique="true" table="currency_migration_audit_rows"
+	_ int
+
+	//migrator:schema:index name="idx_currency_migration_audit_migration" fields="migration_id" table="currency_migration_audit_rows"
+	_ int
+
+	//migrator:schema:index name="idx_currency_migration_audit_commodity" fields="commodity_id" table="currency_migration_audit_rows"
+	_ int
+
+	//migrator:schema:index name="idx_currency_migration_audit_tenant_group" fields="tenant_id,group_id" table="currency_migration_audit_rows"
+	_ int
+}

--- a/go/models/location_group.go
+++ b/go/models/location_group.go
@@ -81,6 +81,14 @@ type LocationGroup struct {
 	CreatedAt time.Time `json:"created_at" db:"created_at" userinput:"false"`
 	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at" userinput:"false"`
+
+	// CurrencyMigrationID is the in-flight currency_migrations row that
+	// currently holds this group's commodity write lock (issue #202).
+	// NULL when the group is not migrating. Read-only on the JSON:API —
+	// the wizard PATCH for /groups never accepts it; the migration
+	// worker writes it through the registry layer.
+	//migrator:schema:field name="currency_migration_id" type="TEXT"
+	CurrencyMigrationID *string `json:"currency_migration_id,omitempty" db:"currency_migration_id" userinput:"false" readonly:"true"`
 }
 
 // LocationGroupIndexes defines PostgreSQL indexes for the location_groups table.

--- a/go/models/location_group.go
+++ b/go/models/location_group.go
@@ -87,7 +87,10 @@ type LocationGroup struct {
 	// NULL when the group is not migrating. Read-only on the JSON:API —
 	// the wizard PATCH for /groups never accepts it; the migration
 	// worker writes it through the registry layer.
-	//migrator:schema:field name="currency_migration_id" type="TEXT"
+	//
+	// Cycles with currency_migrations.group_id (group_id → location_groups.id);
+	// ptah's topological sort handles the pair via deferred FK creation.
+	//migrator:schema:field name="currency_migration_id" type="TEXT" foreign="currency_migrations(id)" foreign_key_name="fk_location_group_currency_migration" on_delete="SET NULL"
 	CurrencyMigrationID *string `json:"currency_migration_id,omitempty" db:"currency_migration_id" userinput:"false" readonly:"true"`
 }
 

--- a/go/registry/errors.go
+++ b/go/registry/errors.go
@@ -63,4 +63,28 @@ var (
 	// existing holding's kind so the apiserver can hand back the right
 	// payload shape.
 	ErrCommodityAlreadyOut = errx.NewSentinel("commodity is already out (open loan or service)")
+
+	// ErrMigrationInFlight signals that a currency migration row in
+	// pending or running state already exists for the target group, and
+	// CurrencyMigrationRegistry.Create refused to insert a second one.
+	// At the schema level this is the partial unique index
+	// idx_currency_migrations_group_in_flight; at the API layer the
+	// apiserver maps this to 409 currency_migration.migration_in_progress.
+	ErrMigrationInFlight = errx.NewSentinel("currency migration already in flight for group")
+
+	// ErrAcquisitionAlreadySet signals that the migrationops.SetAcquisition
+	// runtime guard refused to overwrite a row whose acquisition_price /
+	// acquisition_currency were already set. Indicates a programming
+	// error (the worker should only fill on the first Case-A migration);
+	// surfaced as a 5xx with this sentinel for diagnosis.
+	ErrAcquisitionAlreadySet = errx.NewSentinel("commodity acquisition columns already set; refusing to overwrite")
+
+	// ErrPreviewTokenInvalid signals that VerifyPreviewToken could not
+	// validate the HMAC signature (forged, tampered, or signed with a
+	// different key). Maps to 422 currency_migration.token_invalid.
+	ErrPreviewTokenInvalid = errx.NewSentinel("preview token signature invalid")
+
+	// ErrPreviewTokenExpired signals that the preview token's embedded
+	// expiry is in the past. Maps to 409 currency_migration.preview_expired.
+	ErrPreviewTokenExpired = errx.NewSentinel("preview token expired")
 )

--- a/go/registry/factories.go
+++ b/go/registry/factories.go
@@ -76,6 +76,15 @@ type RestoreOperationRegistryFactory interface {
 	ServiceRegistryFactory[models.RestoreOperation, RestoreOperationRegistry]
 }
 
+// CurrencyMigrationRegistryFactory creates CurrencyMigrationRegistry
+// instances with proper context. The user registry is what the apiserver
+// uses for preview / start / list / get; the service registry is what
+// the worker uses for ClaimNextPending / SweepStuckRunning / WriteAuditRow.
+type CurrencyMigrationRegistryFactory interface {
+	UserRegistryFactory[models.CurrencyMigration, CurrencyMigrationRegistry]
+	ServiceRegistryFactory[models.CurrencyMigration, CurrencyMigrationRegistry]
+}
+
 // RestoreStepRegistryFactory creates RestoreStepRegistry instances with proper context
 type RestoreStepRegistryFactory interface {
 	UserRegistryFactory[models.RestoreStep, RestoreStepRegistry]
@@ -130,6 +139,7 @@ type FactorySet struct {
 	GroupInviteAuditRegistry              GroupInviteAuditRegistry    // GroupInviteAuditRegistry is tenant-scoped, not user-aware
 	GroupPurger                           GroupPurger                 // GroupPurger hard-deletes group-scoped data during purge ticks
 	WarrantyReminderRegistry              WarrantyReminderRegistry    // WarrantyReminderRegistry is the worker idempotency store; service-mode only
+	CurrencyMigrationRegistryFactory      CurrencyMigrationRegistryFactory
 }
 
 // Ping checks readiness of the backing registry dependency (e.g. database).
@@ -218,6 +228,11 @@ func (fs *FactorySet) CreateUserRegistrySet(ctx context.Context) (*Set, error) {
 		return nil, err
 	}
 
+	currencyMigrationRegistry, err := fs.CurrencyMigrationRegistryFactory.CreateUserRegistry(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Set{
 		LocationRegistry:               locationRegistry,
 		AreaRegistry:                   areaRegistry,
@@ -246,6 +261,7 @@ func (fs *FactorySet) CreateUserRegistrySet(ctx context.Context) (*Set, error) {
 		GroupInviteAuditRegistry:       fs.GroupInviteAuditRegistry,
 		GroupPurger:                    fs.GroupPurger,
 		WarrantyReminderRegistry:       fs.WarrantyReminderRegistry,
+		CurrencyMigrationRegistry:      currencyMigrationRegistry,
 	}, nil
 }
 
@@ -279,5 +295,6 @@ func (fs *FactorySet) CreateServiceRegistrySet() *Set {
 		GroupInviteAuditRegistry:       fs.GroupInviteAuditRegistry,
 		GroupPurger:                    fs.GroupPurger,
 		WarrantyReminderRegistry:       fs.WarrantyReminderRegistry,
+		CurrencyMigrationRegistry:      fs.CurrencyMigrationRegistryFactory.CreateServiceRegistry(),
 	}
 }

--- a/go/registry/internal/migrationops/migrationops.go
+++ b/go/registry/internal/migrationops/migrationops.go
@@ -1,0 +1,102 @@
+// Package migrationops is the worker-only entry point for the
+// write-once acquisition-price provenance columns added in #1550 (epic
+// #202). It lives under registry/internal so Go's `internal/` boundary
+// keeps it inaccessible to anything outside the registry tree — only the
+// migration worker (in go/services/, importing through the registry
+// adapter that PR 3 will add) is allowed to call SetAcquisition.
+//
+// The runtime guard inside SetAcquisition is defence in depth: it
+// re-reads the row inside the worker's TX2 and refuses to overwrite if
+// either column is already non-NULL. So a buggy second call from the
+// worker itself is caught loudly rather than silently corrupting the
+// "frozen forever" provenance contract.
+package migrationops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/jmoiron/sqlx"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// SetAcquisition writes commodities.acquisition_price /
+// acquisition_currency for `commodityID` in the same transaction `tx`
+// the worker is using for TX2. Returns registry.ErrAcquisitionAlreadySet
+// if either column is already non-NULL, registry.ErrNotFound if the row
+// does not exist (or RLS hides it from `tx`), and any wrapped DB error
+// otherwise.
+//
+// The function does NOT begin or commit a transaction — it expects to
+// run inside the worker's existing tx so the audit row, the commodity
+// price update, and the acquisition fill all commit together (or all
+// roll back together if anything down-stream fails).
+//
+// The CHECK constraint commodities_acquisition_pair enforces the
+// "both NULL or both set" invariant at the schema level; this helper
+// always writes both columns together.
+func SetAcquisition(ctx context.Context, tx *sqlx.Tx, table string, commodityID string, price decimal.Decimal, currency models.Currency) error {
+	if commodityID == "" {
+		return errxtrace.Wrap("commodity id is required", registry.ErrFieldRequired)
+	}
+	if currency == "" {
+		return errxtrace.Wrap("currency is required", registry.ErrFieldRequired)
+	}
+
+	// 1. Read the current acquisition columns under tx isolation.
+	var (
+		dbPrice    *decimal.Decimal
+		dbCurrency *models.Currency
+	)
+	selectQuery := fmt.Sprintf(
+		`SELECT acquisition_price, acquisition_currency FROM %s WHERE id = $1`,
+		table,
+	)
+	if err := tx.QueryRowxContext(ctx, selectQuery, commodityID).Scan(&dbPrice, &dbCurrency); err != nil {
+		if errors.Is(err, sqlNoRows) {
+			return registry.ErrNotFound
+		}
+		return errxtrace.Wrap("failed to read commodity acquisition columns", err)
+	}
+
+	// 2. Write-once guard. CHECK constraint guarantees both-or-neither,
+	// so checking either column is sufficient — but we check both for
+	// defence in depth in case the constraint ever drifts.
+	if dbPrice != nil || dbCurrency != nil {
+		return registry.ErrAcquisitionAlreadySet
+	}
+
+	// 3. Write both columns atomically. Pair them in the SET so the
+	// CHECK constraint can never observe a half-state during the row
+	// write.
+	updateQuery := fmt.Sprintf(
+		`UPDATE %s
+		    SET acquisition_price = $2,
+		        acquisition_currency = $3
+		  WHERE id = $1
+		    AND acquisition_price IS NULL
+		    AND acquisition_currency IS NULL`,
+		table,
+	)
+	res, err := tx.ExecContext(ctx, updateQuery, commodityID, price, string(currency))
+	if err != nil {
+		return errxtrace.Wrap("failed to write commodity acquisition columns", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return errxtrace.Wrap("failed to read RowsAffected on acquisition write", err)
+	}
+	if rows == 0 {
+		// Either the row vanished after the SELECT (unlikely under
+		// SERIALIZABLE / REPEATABLE READ inside the same tx) or
+		// concurrent worker-mode wrote between the read and the
+		// guarded UPDATE. Be loud either way.
+		return registry.ErrAcquisitionAlreadySet
+	}
+	return nil
+}

--- a/go/registry/internal/migrationops/sql.go
+++ b/go/registry/internal/migrationops/sql.go
@@ -1,0 +1,7 @@
+package migrationops
+
+import "database/sql"
+
+// sqlNoRows is aliased here so the rest of the package stays free of
+// the database/sql import.
+var sqlNoRows = sql.ErrNoRows

--- a/go/registry/memory/commodities.go
+++ b/go/registry/memory/commodities.go
@@ -9,6 +9,7 @@ import (
 
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"github.com/go-extras/go-kit/must"
+	"github.com/shopspring/decimal"
 
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/models"
@@ -104,6 +105,13 @@ func (f *CommodityRegistryFactory) CreateServiceRegistry() registry.CommodityReg
 }
 
 func (r *CommodityRegistry) Create(ctx context.Context, commodity models.Commodity) (*models.Commodity, error) {
+	// Acquisition columns are server-managed (issue #1550 / #202): a
+	// fresh row never has them set; the migration worker fills them
+	// write-once on the first Case-A migration. Drop any value the
+	// caller smuggled in via the JSON:API payload before persisting.
+	commodity.AcquisitionPrice = nil
+	commodity.AcquisitionCurrency = nil
+
 	// Use CreateWithUser to ensure user context is applied
 	newCommodity, err := r.Registry.CreateWithUser(ctx, commodity)
 	if err != nil {
@@ -174,10 +182,14 @@ func (r *CommodityRegistry) Delete(ctx context.Context, id string) error {
 // SQL tables. Commodity attachments now live in the unified `files` table.
 
 func (r *CommodityRegistry) Update(ctx context.Context, commodity models.Commodity) (*models.Commodity, error) {
-	// Get the existing commodity to check if AreaID changed
+	// Get the existing commodity to check if AreaID changed AND to
+	// preserve the acquisition columns (server-managed; whatever the
+	// caller sent must be ignored).
 	var oldAreaID string
 	if existingCommodity, err := r.Registry.Get(ctx, commodity.GetID()); err == nil {
 		oldAreaID = existingCommodity.AreaID
+		commodity.AcquisitionPrice = clonePtrDecimal(existingCommodity.AcquisitionPrice)
+		commodity.AcquisitionCurrency = clonePtrCurrency(existingCommodity.AcquisitionCurrency)
 	}
 
 	// Call the base registry's UpdateWithUser method to ensure user context is preserved
@@ -645,4 +657,26 @@ func (r *CommodityRegistry) FindBySerialNumbers(ctx context.Context, serialNumbe
 	}
 
 	return filtered, nil
+}
+
+
+// clonePtrDecimal returns a heap-allocated copy of d, or nil when d is
+// nil. Used to keep server-managed acquisition columns frozen across
+// Update calls without sharing memory with the in-memory store.
+func clonePtrDecimal(d *decimal.Decimal) *decimal.Decimal {
+	if d == nil {
+		return nil
+	}
+	cp := *d
+	return &cp
+}
+
+// clonePtrCurrency mirrors clonePtrDecimal for the Currency-typed
+// acquisition_currency column.
+func clonePtrCurrency(c *models.Currency) *models.Currency {
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	return &cp
 }

--- a/go/registry/memory/commodities.go
+++ b/go/registry/memory/commodities.go
@@ -659,7 +659,6 @@ func (r *CommodityRegistry) FindBySerialNumbers(ctx context.Context, serialNumbe
 	return filtered, nil
 }
 
-
 // clonePtrDecimal returns a heap-allocated copy of d, or nil when d is
 // nil. Used to keep server-managed acquisition columns frozen across
 // Update calls without sharing memory with the in-memory store.

--- a/go/registry/memory/commodities_acquisition_test.go
+++ b/go/registry/memory/commodities_acquisition_test.go
@@ -1,0 +1,144 @@
+package memory_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+func bootstrapForAcquisitionTest(c *qt.C) (context.Context, *registry.Set) {
+	c.Helper()
+	factorySet := memory.NewFactorySet()
+
+	user := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "user-1"},
+			TenantID: "tenant-1",
+		},
+		Email: "u@example.com",
+		Name:  "User",
+	}
+	u, err := factorySet.CreateServiceRegistrySet().UserRegistry.Create(context.Background(), user)
+	c.Assert(err, qt.IsNil)
+
+	group := &models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "group-1"},
+			TenantID: u.TenantID,
+		},
+		Slug:          "default-group-default-slug-22",
+		Name:          "Default",
+		GroupCurrency: "USD",
+	}
+	ctx := appctx.WithUser(context.Background(), u)
+	ctx = appctx.WithGroup(ctx, group)
+
+	regSet := must.Must(factorySet.CreateUserRegistrySet(ctx))
+	return ctx, regSet
+}
+
+// TestCommodityRegistry_Create_DropsAcquisitionPayload — issue #1550 / #202.
+// API-facing CommodityRegistry.Create must never persist user-supplied
+// acquisition columns regardless of payload.
+func TestCommodityRegistry_Create_DropsAcquisitionPayload(t *testing.T) {
+	c := qt.New(t)
+
+	ctx, set := bootstrapForAcquisitionTest(c)
+
+	location, err := set.LocationRegistry.Create(ctx, models.Location{Name: "L1"})
+	c.Assert(err, qt.IsNil)
+	area, err := set.AreaRegistry.Create(ctx, models.Area{Name: "A1", LocationID: location.ID})
+	c.Assert(err, qt.IsNil)
+
+	dec := decimal.NewFromInt(123)
+	cur := models.Currency("USD")
+
+	created, err := set.CommodityRegistry.Create(ctx, models.Commodity{
+		AreaID:              area.ID,
+		Name:                "thing",
+		ShortName:           "t",
+		Status:              models.CommodityStatusInUse,
+		Type:                models.CommodityTypeOther,
+		Count:               1,
+		AcquisitionPrice:    &dec,
+		AcquisitionCurrency: &cur,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.AcquisitionPrice, qt.IsNil)
+	c.Assert(created.AcquisitionCurrency, qt.IsNil)
+
+	got, err := set.CommodityRegistry.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.AcquisitionPrice, qt.IsNil)
+	c.Assert(got.AcquisitionCurrency, qt.IsNil)
+}
+
+// TestCommodityRegistry_Update_PreservesAcquisition — once the
+// migration worker has filled the acquisition columns (simulated here
+// via the underlying memory store's UpdateWithUser path), subsequent
+// API Update calls must not be able to change them.
+func TestCommodityRegistry_Update_PreservesAcquisition(t *testing.T) {
+	c := qt.New(t)
+
+	ctx, set := bootstrapForAcquisitionTest(c)
+
+	location, err := set.LocationRegistry.Create(ctx, models.Location{Name: "L1"})
+	c.Assert(err, qt.IsNil)
+	area, err := set.AreaRegistry.Create(ctx, models.Area{Name: "A1", LocationID: location.ID})
+	c.Assert(err, qt.IsNil)
+
+	created, err := set.CommodityRegistry.Create(ctx, models.Commodity{
+		AreaID:    area.ID,
+		Name:      "thing",
+		ShortName: "t",
+		Status:    models.CommodityStatusInUse,
+		Type:      models.CommodityTypeOther,
+		Count:     1,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Plant the acquisition columns the way the worker eventually will,
+	// bypassing the API guard via the registry's internal UpdateWithUser
+	// path.
+	planted := decimal.NewFromInt(100)
+	plantedCur := models.Currency("USD")
+	memReg, ok := set.CommodityRegistry.(*memory.CommodityRegistry)
+	c.Assert(ok, qt.IsTrue)
+	stored, err := memReg.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	stored.AcquisitionPrice = &planted
+	stored.AcquisitionCurrency = &plantedCur
+	_, err = memReg.Registry.UpdateWithUser(ctx, *stored)
+	c.Assert(err, qt.IsNil)
+
+	// User Update with a payload that tries to clear them.
+	stored.Name = "renamed"
+	stored.AcquisitionPrice = nil
+	stored.AcquisitionCurrency = nil
+	updated, err := set.CommodityRegistry.Update(ctx, *stored)
+	c.Assert(err, qt.IsNil)
+	c.Assert(updated.Name, qt.Equals, "renamed")
+	c.Assert(updated.AcquisitionPrice, qt.IsNotNil)
+	c.Assert(updated.AcquisitionPrice.String(), qt.Equals, "100")
+	c.Assert(updated.AcquisitionCurrency, qt.IsNotNil)
+	c.Assert(string(*updated.AcquisitionCurrency), qt.Equals, "USD")
+
+	// User Update with a payload that tries to overwrite them with
+	// something else: also ignored.
+	bogus := decimal.NewFromInt(999)
+	bogusCur := models.Currency("EUR")
+	stored.AcquisitionPrice = &bogus
+	stored.AcquisitionCurrency = &bogusCur
+	updated2, err := set.CommodityRegistry.Update(ctx, *stored)
+	c.Assert(err, qt.IsNil)
+	c.Assert(updated2.AcquisitionPrice.String(), qt.Equals, "100")
+	c.Assert(string(*updated2.AcquisitionCurrency), qt.Equals, "USD")
+}

--- a/go/registry/memory/currency_migration.go
+++ b/go/registry/memory/currency_migration.go
@@ -1,0 +1,445 @@
+package memory
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/go-extras/go-kit/must"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// CurrencyMigrationRegistryFactory is the in-memory factory mirror of
+// the postgres one. The audit-row store and HMAC key are shared between
+// every registry derived from a factory so that user / service /
+// per-test instances see the same data.
+type CurrencyMigrationRegistryFactory struct {
+	baseRegistry *Registry[models.CurrencyMigration, *models.CurrencyMigration]
+	auditLock    *sync.RWMutex
+	auditRows    *[]*models.CurrencyMigrationAuditRow
+	hmacKey      []byte
+}
+
+type CurrencyMigrationRegistry struct {
+	*Registry[models.CurrencyMigration, *models.CurrencyMigration]
+	tenantID  string
+	groupID   string
+	userID    string
+	service   bool
+	auditLock *sync.RWMutex
+	auditRows *[]*models.CurrencyMigrationAuditRow
+	hmacKey   []byte
+}
+
+var _ registry.CurrencyMigrationRegistry = (*CurrencyMigrationRegistry)(nil)
+var _ registry.CurrencyMigrationRegistryFactory = (*CurrencyMigrationRegistryFactory)(nil)
+
+func NewCurrencyMigrationRegistryFactory() *CurrencyMigrationRegistryFactory {
+	return NewCurrencyMigrationRegistryFactoryWithKey(generateRandomKey())
+}
+
+func NewCurrencyMigrationRegistryFactoryWithKey(key []byte) *CurrencyMigrationRegistryFactory {
+	rows := make([]*models.CurrencyMigrationAuditRow, 0)
+	return &CurrencyMigrationRegistryFactory{
+		baseRegistry: NewRegistry[models.CurrencyMigration, *models.CurrencyMigration](),
+		auditLock:    &sync.RWMutex{},
+		auditRows:    &rows,
+		hmacKey:      append([]byte(nil), key...),
+	}
+}
+
+func generateRandomKey() []byte {
+	k := make([]byte, 32)
+	if _, err := rand.Read(k); err != nil {
+		panic("failed to generate random HMAC key for currency migration registry: " + err.Error())
+	}
+	return k
+}
+
+func (f *CurrencyMigrationRegistryFactory) MustCreateUserRegistry(ctx context.Context) registry.CurrencyMigrationRegistry {
+	return must.Must(f.CreateUserRegistry(ctx))
+}
+
+func (f *CurrencyMigrationRegistryFactory) CreateUserRegistry(ctx context.Context) (registry.CurrencyMigrationRegistry, error) {
+	user, err := appctx.RequireUserFromContext(ctx)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to get user from context", err)
+	}
+	groupID := appctx.GroupIDFromContext(ctx)
+
+	scoped := &Registry[models.CurrencyMigration, *models.CurrencyMigration]{
+		items:   f.baseRegistry.items,
+		lock:    f.baseRegistry.lock,
+		userID:  user.ID,
+		groupID: groupID,
+	}
+	return &CurrencyMigrationRegistry{
+		Registry:  scoped,
+		tenantID:  user.TenantID,
+		groupID:   groupID,
+		userID:    user.ID,
+		auditLock: f.auditLock,
+		auditRows: f.auditRows,
+		hmacKey:   f.hmacKey,
+	}, nil
+}
+
+func (f *CurrencyMigrationRegistryFactory) CreateServiceRegistry() registry.CurrencyMigrationRegistry {
+	scoped := &Registry[models.CurrencyMigration, *models.CurrencyMigration]{
+		items:  f.baseRegistry.items,
+		lock:   f.baseRegistry.lock,
+		userID: "",
+	}
+	return &CurrencyMigrationRegistry{
+		Registry:  scoped,
+		service:   true,
+		auditLock: f.auditLock,
+		auditRows: f.auditRows,
+		hmacKey:   f.hmacKey,
+	}
+}
+
+// Create overrides the base Registry.Create to enforce the
+// "at most one pending|running per group" invariant. The postgres
+// registry relies on a partial unique index for this; memory mirrors
+// the contract by checking under the registry-wide lock.
+func (r *CurrencyMigrationRegistry) Create(ctx context.Context, m models.CurrencyMigration) (*models.CurrencyMigration, error) {
+	if m.Status == "" {
+		m.Status = models.CurrencyMigrationStatusPending
+	}
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = time.Now().UTC()
+	}
+	m.SetTenantID(r.tenantID)
+	m.SetGroupID(r.groupID)
+	m.SetCreatedByUserID(r.userID)
+
+	if err := m.ValidateWithContext(ctx); err != nil {
+		return nil, errxtrace.Wrap("validation failed", err)
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		existing := pair.Value
+		if existing.GroupID == m.GroupID &&
+			(existing.Status == models.CurrencyMigrationStatusPending ||
+				existing.Status == models.CurrencyMigrationStatusRunning) {
+			return nil, registry.ErrMigrationInFlight
+		}
+	}
+
+	m.SetID(uuid.New().String())
+	m.SetUUID(uuid.New().String())
+	tmp := m
+	r.items.Set(tmp.ID, &tmp)
+	out := tmp
+	return &out, nil
+}
+
+func (r *CurrencyMigrationRegistry) LatestForGroup(_ context.Context, groupID string) (*models.CurrencyMigration, error) {
+	if groupID == "" {
+		return nil, errxtrace.Wrap("group id is required", registry.ErrFieldRequired)
+	}
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	var latest *models.CurrencyMigration
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		op := pair.Value
+		if op.GroupID != groupID {
+			continue
+		}
+		if latest == nil || op.CreatedAt.After(latest.CreatedAt) ||
+			(op.CreatedAt.Equal(latest.CreatedAt) && op.ID > latest.ID) {
+			cp := *op
+			latest = &cp
+		}
+	}
+	if latest == nil {
+		return nil, registry.ErrNotFound
+	}
+	return latest, nil
+}
+
+func (r *CurrencyMigrationRegistry) InFlightForGroup(_ context.Context, groupID string) (*models.CurrencyMigration, error) {
+	if groupID == "" {
+		return nil, errxtrace.Wrap("group id is required", registry.ErrFieldRequired)
+	}
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		op := pair.Value
+		if op.GroupID == groupID &&
+			(op.Status == models.CurrencyMigrationStatusPending || op.Status == models.CurrencyMigrationStatusRunning) {
+			cp := *op
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *CurrencyMigrationRegistry) CompletedTodayForGroup(_ context.Context, groupID string, now time.Time) (int, error) {
+	if groupID == "" {
+		return 0, errxtrace.Wrap("group id is required", registry.ErrFieldRequired)
+	}
+	startOfDay := utcMidnight(now)
+	endOfDay := startOfDay.AddDate(0, 0, 1)
+
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	cnt := 0
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		op := pair.Value
+		if op.GroupID != groupID || op.Status != models.CurrencyMigrationStatusCompleted {
+			continue
+		}
+		if op.CompletedAt == nil {
+			continue
+		}
+		ca := op.CompletedAt.UTC()
+		if !ca.Before(startOfDay) && ca.Before(endOfDay) {
+			cnt++
+		}
+	}
+	return cnt, nil
+}
+
+func (r *CurrencyMigrationRegistry) UpdateStatus(_ context.Context, id string, patch registry.CurrencyMigrationStatusPatch) error {
+	if id == "" {
+		return errxtrace.Wrap("id is required", registry.ErrFieldRequired)
+	}
+	if patch.Status == "" || !patch.Status.IsValid() {
+		return errxtrace.Wrap("status must be set to a valid value", registry.ErrInvalidInput)
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	op, ok := r.items.Get(id)
+	if !ok {
+		return registry.ErrNotFound
+	}
+	tmp := *op
+	tmp.Status = patch.Status
+	if patch.StartedAt != nil {
+		t := patch.StartedAt.UTC()
+		tmp.StartedAt = &t
+	}
+	if patch.CompletedAt != nil {
+		t := patch.CompletedAt.UTC()
+		tmp.CompletedAt = &t
+	}
+	if patch.ErrorMessage != nil {
+		tmp.ErrorMessage = *patch.ErrorMessage
+	}
+	if patch.CommodityCount != nil {
+		tmp.CommodityCount = *patch.CommodityCount
+	}
+	// total_before / total_after are intentionally treated as opaque
+	// strings here — the registry interface uses *string so that a
+	// "set to nil" caller can be distinguished from "leave alone". The
+	// memory store deliberately mirrors the postgres semantics rather
+	// than reaching into decimal types.
+	if patch.TotalBefore != nil {
+		tmp.TotalBefore = decimalFromString(*patch.TotalBefore)
+	}
+	if patch.TotalAfter != nil {
+		tmp.TotalAfter = decimalFromString(*patch.TotalAfter)
+	}
+	r.items.Set(id, &tmp)
+	return nil
+}
+
+func (r *CurrencyMigrationRegistry) WriteAuditRow(_ context.Context, row models.CurrencyMigrationAuditRow) (*models.CurrencyMigrationAuditRow, error) {
+	row.SetTenantID(r.tenantID)
+	row.SetGroupID(r.groupID)
+	row.SetCreatedByUserID(r.userID)
+	if row.CreatedAt.IsZero() {
+		row.CreatedAt = time.Now().UTC()
+	}
+	row.SetID(uuid.New().String())
+	row.SetUUID(uuid.New().String())
+
+	r.auditLock.Lock()
+	defer r.auditLock.Unlock()
+	cp := row
+	*r.auditRows = append(*r.auditRows, &cp)
+	out := cp
+	return &out, nil
+}
+
+func (r *CurrencyMigrationRegistry) ListAuditRows(_ context.Context, migrationID string) ([]*models.CurrencyMigrationAuditRow, error) {
+	if migrationID == "" {
+		return nil, errxtrace.Wrap("migration id is required", registry.ErrFieldRequired)
+	}
+	r.auditLock.RLock()
+	defer r.auditLock.RUnlock()
+
+	var out []*models.CurrencyMigrationAuditRow
+	for _, row := range *r.auditRows {
+		if row.MigrationID == migrationID {
+			cp := *row
+			out = append(out, &cp)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
+	})
+	return out, nil
+}
+
+func (r *CurrencyMigrationRegistry) ClaimNextPending(_ context.Context) (*models.CurrencyMigration, error) {
+	if !r.service {
+		return nil, errxtrace.Wrap("ClaimNextPending requires a service registry", registry.ErrUserContextRequired)
+	}
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	type candidate struct {
+		op *models.CurrencyMigration
+	}
+	var picks []candidate
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		if pair.Value.Status == models.CurrencyMigrationStatusPending {
+			picks = append(picks, candidate{op: pair.Value})
+		}
+	}
+	if len(picks) == 0 {
+		return nil, registry.ErrNotFound
+	}
+	sort.SliceStable(picks, func(i, j int) bool {
+		if picks[i].op.CreatedAt.Equal(picks[j].op.CreatedAt) {
+			return picks[i].op.ID < picks[j].op.ID
+		}
+		return picks[i].op.CreatedAt.Before(picks[j].op.CreatedAt)
+	})
+
+	now := time.Now().UTC()
+	picked := picks[0].op
+	tmp := *picked
+	tmp.Status = models.CurrencyMigrationStatusRunning
+	tmp.StartedAt = &now
+	r.items.Set(tmp.ID, &tmp)
+	out := tmp
+	return &out, nil
+}
+
+func (r *CurrencyMigrationRegistry) SweepStuckRunning(_ context.Context, now time.Time, threshold time.Duration) ([]*models.CurrencyMigration, error) {
+	if !r.service {
+		return nil, errxtrace.Wrap("SweepStuckRunning requires a service registry", registry.ErrUserContextRequired)
+	}
+	cutoff := now.UTC().Add(-threshold)
+	completed := now.UTC()
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	var swept []*models.CurrencyMigration
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		op := pair.Value
+		if op.Status != models.CurrencyMigrationStatusRunning {
+			continue
+		}
+		if op.StartedAt == nil || !op.StartedAt.Before(cutoff) {
+			continue
+		}
+		tmp := *op
+		tmp.Status = models.CurrencyMigrationStatusFailed
+		tmp.CompletedAt = &completed
+		if strings.TrimSpace(tmp.ErrorMessage) == "" {
+			tmp.ErrorMessage = "worker crashed or stalled"
+		}
+		r.items.Set(tmp.ID, &tmp)
+		out := tmp
+		swept = append(swept, &out)
+	}
+	return swept, nil
+}
+
+func (r *CurrencyMigrationRegistry) IssuePreviewToken(inputs registry.PreviewTokenInputs) (string, error) {
+	if len(r.hmacKey) == 0 {
+		return "", errxtrace.Wrap("no HMAC key configured for preview token", registry.ErrInvalidConfig)
+	}
+	payload, err := json.Marshal(inputs)
+	if err != nil {
+		return "", errxtrace.Wrap("failed to marshal preview token payload", err)
+	}
+	mac := hmac.New(sha256.New, r.hmacKey)
+	mac.Write(payload)
+	sig := mac.Sum(nil)
+	return base64.RawURLEncoding.EncodeToString(payload) + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+func (r *CurrencyMigrationRegistry) VerifyPreviewToken(token string, now time.Time) (registry.PreviewTokenInputs, error) {
+	var zero registry.PreviewTokenInputs
+	if len(r.hmacKey) == 0 {
+		return zero, errxtrace.Wrap("no HMAC key configured for preview token", registry.ErrInvalidConfig)
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 {
+		return zero, registry.ErrPreviewTokenInvalid
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return zero, registry.ErrPreviewTokenInvalid
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return zero, registry.ErrPreviewTokenInvalid
+	}
+	mac := hmac.New(sha256.New, r.hmacKey)
+	mac.Write(payload)
+	expected := mac.Sum(nil)
+	if !hmac.Equal(sig, expected) {
+		return zero, registry.ErrPreviewTokenInvalid
+	}
+	var inputs registry.PreviewTokenInputs
+	if err := json.Unmarshal(payload, &inputs); err != nil {
+		return zero, registry.ErrPreviewTokenInvalid
+	}
+	if !inputs.ExpiresAt.IsZero() && now.UTC().After(inputs.ExpiresAt.UTC()) {
+		return zero, registry.ErrPreviewTokenExpired
+	}
+	return inputs, nil
+}
+
+func utcMidnight(t time.Time) time.Time {
+	u := t.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// decimalFromString parses s as a decimal. Empty / invalid input is
+// returned as nil (treated as "leave the field unset"). Used by the
+// memory UpdateStatus path to mirror the postgres registry's
+// pointer-to-string contract for total_before / total_after.
+func decimalFromString(s string) *decimal.Decimal {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	d, err := decimal.NewFromString(s)
+	if err != nil {
+		return nil
+	}
+	return &d
+}

--- a/go/registry/memory/currency_migration_test.go
+++ b/go/registry/memory/currency_migration_test.go
@@ -19,7 +19,7 @@ import (
 // returns the user-mode CurrencyMigrationRegistry plus the seeded group
 // id (callers usually want the group id for InFlightForGroup-style
 // queries).
-func setupCurrencyMigrationRegistry(c *qt.C) (registry.CurrencyMigrationRegistry, registry.CurrencyMigrationRegistry, string) {
+func setupCurrencyMigrationRegistry(c *qt.C) (userReg, serviceReg registry.CurrencyMigrationRegistry, groupID string) {
 	c.Helper()
 	factorySet := memory.NewFactorySet()
 
@@ -151,11 +151,11 @@ func TestCurrencyMigrationRegistry_InFlightAndDailyCap(t *testing.T) {
 	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
 	c.Assert(serviceReg.UpdateStatus(ctx, op.ID, registry.CurrencyMigrationStatusPatch{
 		Status:    models.CurrencyMigrationStatusRunning,
-		StartedAt: ptrTime(now),
+		StartedAt: new(now),
 	}), qt.IsNil)
 	c.Assert(serviceReg.UpdateStatus(ctx, op.ID, registry.CurrencyMigrationStatusPatch{
 		Status:      models.CurrencyMigrationStatusCompleted,
-		CompletedAt: ptrTime(now.Add(time.Second)),
+		CompletedAt: new(now.Add(time.Second)),
 	}), qt.IsNil)
 
 	// Once completed, no longer in-flight.
@@ -217,7 +217,7 @@ func TestCurrencyMigrationRegistry_SweepStuckRunning(t *testing.T) {
 	long := time.Date(2026, 5, 7, 8, 0, 0, 0, time.UTC)
 	c.Assert(serviceReg.UpdateStatus(ctx, created.ID, registry.CurrencyMigrationStatusPatch{
 		Status:    models.CurrencyMigrationStatusRunning,
-		StartedAt: ptrTime(long),
+		StartedAt: new(long),
 	}), qt.IsNil)
 
 	// Sweep runs at long+30m with threshold=10m → row is stuck → fails.
@@ -290,5 +290,3 @@ func TestCurrencyMigrationRegistry_PreviewToken_DifferentKeyRejects(t *testing.T
 	_, err = regB.VerifyPreviewToken(token, now)
 	c.Assert(err, qt.ErrorIs, registry.ErrPreviewTokenInvalid)
 }
-
-func ptrTime(t time.Time) *time.Time { return &t }

--- a/go/registry/memory/currency_migration_test.go
+++ b/go/registry/memory/currency_migration_test.go
@@ -1,0 +1,294 @@
+package memory_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+// setupCurrencyMigrationRegistry seeds a tenant + group + user and
+// returns the user-mode CurrencyMigrationRegistry plus the seeded group
+// id (callers usually want the group id for InFlightForGroup-style
+// queries).
+func setupCurrencyMigrationRegistry(c *qt.C) (registry.CurrencyMigrationRegistry, registry.CurrencyMigrationRegistry, string) {
+	c.Helper()
+	factorySet := memory.NewFactorySet()
+
+	user := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "user-1"},
+			TenantID: "tenant-1",
+		},
+		Email: "u@example.com",
+		Name:  "User",
+	}
+	u, err := factorySet.CreateServiceRegistrySet().UserRegistry.Create(context.Background(), user)
+	c.Assert(err, qt.IsNil)
+
+	group := &models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "group-1"},
+			TenantID: u.TenantID,
+		},
+		Slug:          "default-group-default-slug",
+		Name:          "Default",
+		GroupCurrency: "USD",
+	}
+	ctx := appctx.WithUser(context.Background(), u)
+	ctx = appctx.WithGroup(ctx, group)
+
+	regSet := must.Must(factorySet.CreateUserRegistrySet(ctx))
+	serviceSet := factorySet.CreateServiceRegistrySet()
+	return regSet.CurrencyMigrationRegistry, serviceSet.CurrencyMigrationRegistry, group.ID
+}
+
+func TestCurrencyMigrationRegistry_Create_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	userReg, _, groupID := setupCurrencyMigrationRegistry(c)
+
+	op, err := userReg.Create(ctx, models.CurrencyMigration{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			GroupID: groupID,
+		},
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		ExchangeRate: decimal.NewFromFloat(0.92),
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(op.Status, qt.Equals, models.CurrencyMigrationStatusPending)
+	c.Assert(op.GroupID, qt.Equals, groupID)
+	c.Assert(op.ID, qt.Not(qt.Equals), "")
+	c.Assert(op.UUID, qt.Not(qt.Equals), "")
+}
+
+func TestCurrencyMigrationRegistry_Create_ParallelInFlightRejected(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	userReg, _, groupID := setupCurrencyMigrationRegistry(c)
+
+	first, err := userReg.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		ExchangeRate: decimal.NewFromFloat(0.92),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(first, qt.IsNotNil)
+
+	// Second pending row for the same group is rejected.
+	_, err = userReg.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "GBP",
+		ExchangeRate: decimal.NewFromFloat(0.79),
+	})
+	c.Assert(err, qt.ErrorIs, registry.ErrMigrationInFlight)
+	_ = groupID
+}
+
+func TestCurrencyMigrationRegistry_Validate_RejectsSameCurrency(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	userReg, _, _ := setupCurrencyMigrationRegistry(c)
+
+	_, err := userReg.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "USD",
+		ExchangeRate: decimal.NewFromInt(1),
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "from and to currencies must differ")
+}
+
+func TestCurrencyMigrationRegistry_Validate_RejectsBadRate(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	userReg, _, _ := setupCurrencyMigrationRegistry(c)
+
+	for _, rate := range []decimal.Decimal{decimal.Zero, decimal.NewFromInt(-1)} {
+		_, err := userReg.Create(ctx, models.CurrencyMigration{
+			FromCurrency: "USD",
+			ToCurrency:   "EUR",
+			ExchangeRate: rate,
+		})
+		c.Assert(err, qt.IsNotNil, qt.Commentf("rate=%s", rate.String()))
+	}
+}
+
+func TestCurrencyMigrationRegistry_InFlightAndDailyCap(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	userReg, serviceReg, groupID := setupCurrencyMigrationRegistry(c)
+
+	// Initially nothing is in flight.
+	inFlight, err := userReg.InFlightForGroup(ctx, groupID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(inFlight, qt.IsNil)
+
+	// Insert pending → InFlightForGroup returns it.
+	op, err := userReg.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		ExchangeRate: decimal.NewFromFloat(0.9),
+	})
+	c.Assert(err, qt.IsNil)
+
+	inFlight, err = userReg.InFlightForGroup(ctx, groupID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(inFlight, qt.IsNotNil)
+	c.Assert(inFlight.ID, qt.Equals, op.ID)
+
+	// Worker runs to completion: pending → running → completed.
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	c.Assert(serviceReg.UpdateStatus(ctx, op.ID, registry.CurrencyMigrationStatusPatch{
+		Status:    models.CurrencyMigrationStatusRunning,
+		StartedAt: ptrTime(now),
+	}), qt.IsNil)
+	c.Assert(serviceReg.UpdateStatus(ctx, op.ID, registry.CurrencyMigrationStatusPatch{
+		Status:      models.CurrencyMigrationStatusCompleted,
+		CompletedAt: ptrTime(now.Add(time.Second)),
+	}), qt.IsNil)
+
+	// Once completed, no longer in-flight.
+	inFlight, err = userReg.InFlightForGroup(ctx, groupID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(inFlight, qt.IsNil)
+
+	// Daily-cap query reflects the freshly-completed row.
+	cnt, err := userReg.CompletedTodayForGroup(ctx, groupID, now)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cnt, qt.Equals, 1)
+
+	// New day → cap reset.
+	tomorrow := now.Add(24 * time.Hour)
+	cnt, err = userReg.CompletedTodayForGroup(ctx, groupID, tomorrow)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cnt, qt.Equals, 0)
+}
+
+func TestCurrencyMigrationRegistry_ClaimNextPending_ServiceOnly(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	userReg, serviceReg, _ := setupCurrencyMigrationRegistry(c)
+
+	created, err := userReg.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		ExchangeRate: decimal.NewFromInt(1),
+	})
+	c.Assert(err, qt.IsNil)
+
+	// User mode cannot claim — guard rail for the worker.
+	_, err = userReg.ClaimNextPending(ctx)
+	c.Assert(err, qt.IsNotNil)
+
+	// Service registry claims the row and flips it to running.
+	picked, err := serviceReg.ClaimNextPending(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(picked.ID, qt.Equals, created.ID)
+	c.Assert(picked.Status, qt.Equals, models.CurrencyMigrationStatusRunning)
+	c.Assert(picked.StartedAt, qt.IsNotNil)
+
+	// Second claim returns ErrNotFound — nothing left in pending.
+	_, err = serviceReg.ClaimNextPending(ctx)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+}
+
+func TestCurrencyMigrationRegistry_SweepStuckRunning(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	userReg, serviceReg, _ := setupCurrencyMigrationRegistry(c)
+
+	created, err := userReg.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		ExchangeRate: decimal.NewFromInt(1),
+	})
+	c.Assert(err, qt.IsNil)
+	long := time.Date(2026, 5, 7, 8, 0, 0, 0, time.UTC)
+	c.Assert(serviceReg.UpdateStatus(ctx, created.ID, registry.CurrencyMigrationStatusPatch{
+		Status:    models.CurrencyMigrationStatusRunning,
+		StartedAt: ptrTime(long),
+	}), qt.IsNil)
+
+	// Sweep runs at long+30m with threshold=10m → row is stuck → fails.
+	now := long.Add(30 * time.Minute)
+	swept, err := serviceReg.SweepStuckRunning(ctx, now, 10*time.Minute)
+	c.Assert(err, qt.IsNil)
+	c.Assert(swept, qt.HasLen, 1)
+	c.Assert(swept[0].Status, qt.Equals, models.CurrencyMigrationStatusFailed)
+	c.Assert(swept[0].CompletedAt, qt.IsNotNil)
+	c.Assert(swept[0].ErrorMessage, qt.Contains, "worker crashed")
+
+	// Failed runs do NOT count toward the daily cap.
+	cnt, err := userReg.CompletedTodayForGroup(ctx, swept[0].GroupID, now)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cnt, qt.Equals, 0)
+}
+
+func TestCurrencyMigrationRegistry_PreviewToken_RoundTrip(t *testing.T) {
+	c := qt.New(t)
+	userReg, _, groupID := setupCurrencyMigrationRegistry(c)
+
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	inputs := registry.PreviewTokenInputs{
+		GroupID:      groupID,
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		Rate:         "0.92",
+		StateHash:    "deadbeef",
+		ExpiresAt:    now.Add(10 * time.Minute),
+	}
+	token, err := userReg.IssuePreviewToken(inputs)
+	c.Assert(err, qt.IsNil)
+	c.Assert(token, qt.Not(qt.Equals), "")
+
+	// Verify within TTL → success.
+	out, err := userReg.VerifyPreviewToken(token, now.Add(5*time.Minute))
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.GroupID, qt.Equals, inputs.GroupID)
+	c.Assert(out.Rate, qt.Equals, "0.92")
+	c.Assert(out.StateHash, qt.Equals, "deadbeef")
+
+	// Verify after TTL → ErrPreviewTokenExpired.
+	_, err = userReg.VerifyPreviewToken(token, now.Add(11*time.Minute))
+	c.Assert(err, qt.ErrorIs, registry.ErrPreviewTokenExpired)
+
+	// Tampered token → ErrPreviewTokenInvalid.
+	_, err = userReg.VerifyPreviewToken(token+"x", now.Add(time.Minute))
+	c.Assert(err, qt.ErrorIs, registry.ErrPreviewTokenInvalid)
+	_, err = userReg.VerifyPreviewToken("garbage.notaken", now.Add(time.Minute))
+	c.Assert(err, qt.ErrorIs, registry.ErrPreviewTokenInvalid)
+}
+
+func TestCurrencyMigrationRegistry_PreviewToken_DifferentKeyRejects(t *testing.T) {
+	c := qt.New(t)
+
+	a := memory.NewCurrencyMigrationRegistryFactoryWithKey([]byte("key-a-key-a-key-a-key-a-key-a-32"))
+	b := memory.NewCurrencyMigrationRegistryFactoryWithKey([]byte("key-b-key-b-key-b-key-b-key-b-32"))
+
+	regA := a.CreateServiceRegistry()
+	regB := b.CreateServiceRegistry()
+
+	now := time.Now()
+	token, err := regA.IssuePreviewToken(registry.PreviewTokenInputs{
+		GroupID:   "g",
+		Rate:      "1.0",
+		ExpiresAt: now.Add(time.Minute),
+	})
+	c.Assert(err, qt.IsNil)
+
+	_, err = regB.VerifyPreviewToken(token, now)
+	c.Assert(err, qt.ErrorIs, registry.ErrPreviewTokenInvalid)
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/go/registry/memory/memory.go
+++ b/go/registry/memory/memory.go
@@ -59,6 +59,7 @@ func NewFactorySet() *registry.FactorySet {
 	fs.GroupInviteRegistry = NewGroupInviteRegistry()
 	fs.GroupInviteAuditRegistry = NewGroupInviteAuditRegistry()
 	fs.WarrantyReminderRegistry = NewWarrantyReminderRegistry()
+	fs.CurrencyMigrationRegistryFactory = NewCurrencyMigrationRegistryFactory()
 	fs.GroupPurger = NewGroupPurger(
 		locationFactory,
 		areaFactory,

--- a/go/registry/postgres/commodities.go
+++ b/go/registry/postgres/commodities.go
@@ -10,6 +10,7 @@ import (
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"github.com/go-extras/go-kit/must"
 	"github.com/jmoiron/sqlx"
+	"github.com/shopspring/decimal"
 
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/models"
@@ -84,6 +85,13 @@ func (r *CommodityRegistry) Get(ctx context.Context, id string) (*models.Commodi
 
 func (r *CommodityRegistry) Create(ctx context.Context, commodity models.Commodity) (*models.Commodity, error) {
 	// ID, TenantID, and UserID are now set automatically by RLSRepository.Create
+
+	// Acquisition columns are server-managed (issue #1550 / #202): drop
+	// any value the API caller smuggled in. The migration worker is the
+	// only legitimate writer (via go/registry/internal/migrationops),
+	// and it only writes when the row's columns are still NULL.
+	commodity.AcquisitionPrice = nil
+	commodity.AcquisitionCurrency = nil
 
 	reg := r.newSQLRegistry()
 
@@ -364,6 +372,18 @@ func buildCommodityOrder(opts registry.CommodityListOptions) string {
 }
 
 func (r *CommodityRegistry) Update(ctx context.Context, commodity models.Commodity) (*models.Commodity, error) {
+	// Pre-fetch the existing row so we can copy the server-managed
+	// acquisition columns onto the entity — RLSGroupRepository.Update
+	// writes the entity verbatim, so we cannot rely on the surrounding
+	// repository to "skip" these. One extra read per Update is fine at
+	// personal-inventory scale and keeps the write-once invariant on
+	// the columns intact even if the API silently re-serialised the
+	// commodity into the payload.
+	if existing, err := r.get(ctx, commodity.GetID()); err == nil && existing != nil {
+		commodity.AcquisitionPrice = clonePtrDecimal(existing.AcquisitionPrice)
+		commodity.AcquisitionCurrency = clonePtrCurrency(existing.AcquisitionCurrency)
+	}
+
 	reg := r.newSQLRegistry()
 
 	err := reg.Update(ctx, commodity, func(ctx context.Context, tx *sqlx.Tx, dbCommodity models.Commodity) error {
@@ -381,6 +401,25 @@ func (r *CommodityRegistry) Update(ctx context.Context, commodity models.Commodi
 	}
 
 	return &commodity, nil
+}
+
+// clonePtrDecimal returns a heap-allocated copy of d (or nil). Used to
+// preserve server-managed acquisition columns across Update calls.
+func clonePtrDecimal(d *decimal.Decimal) *decimal.Decimal {
+	if d == nil {
+		return nil
+	}
+	cp := *d
+	return &cp
+}
+
+// clonePtrCurrency mirrors clonePtrDecimal for *Currency pointers.
+func clonePtrCurrency(c *models.Currency) *models.Currency {
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	return &cp
 }
 
 func (r *CommodityRegistry) Delete(ctx context.Context, id string) error {

--- a/go/registry/postgres/currency_migration.go
+++ b/go/registry/postgres/currency_migration.go
@@ -1,0 +1,648 @@
+package postgres
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/go-extras/go-kit/must"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+// inFlightUniqueIndexName is the partial unique index that enforces
+// "at most one pending|running migration per group" at the schema level.
+// Postgres-side unique violations on this index name map to
+// registry.ErrMigrationInFlight; any other unique violation is
+// re-raised as-is so it bubbles up as a 5xx (it would indicate a
+// genuine bug, e.g. UUID collision).
+const inFlightUniqueIndexName = "idx_currency_migrations_group_in_flight"
+
+// CurrencyMigrationRegistryFactory creates context-aware
+// CurrencyMigrationRegistry instances. The HMAC key for preview-token
+// signing is held on the factory so user and service instances share
+// the same signing context.
+type CurrencyMigrationRegistryFactory struct {
+	dbx        *sqlx.DB
+	tableNames store.TableNames
+	hmacKey    []byte
+}
+
+type CurrencyMigrationRegistry struct {
+	dbx             *sqlx.DB
+	tableNames      store.TableNames
+	tenantID        string
+	groupID         string
+	createdByUserID string
+	service         bool
+	hmacKey         []byte
+}
+
+var _ registry.CurrencyMigrationRegistry = (*CurrencyMigrationRegistry)(nil)
+var _ registry.CurrencyMigrationRegistryFactory = (*CurrencyMigrationRegistryFactory)(nil)
+
+// NewCurrencyMigrationRegistry creates a factory with a freshly-generated
+// random HMAC key. Tokens issued by one process are not verifiable by
+// another with this default — fine for PR 1, where no API endpoint reads
+// the token; PR 2 swaps this for a config-driven key (the same key on
+// every replica) via NewCurrencyMigrationRegistryWithKey.
+func NewCurrencyMigrationRegistry(dbx *sqlx.DB) *CurrencyMigrationRegistryFactory {
+	return NewCurrencyMigrationRegistryWithKey(dbx, generateRandomKey())
+}
+
+// NewCurrencyMigrationRegistryWithKey lets the caller supply the HMAC
+// key. Used by tests (deterministic key) and by PR 2's apiserver bootstrap
+// (key from config).
+func NewCurrencyMigrationRegistryWithKey(dbx *sqlx.DB, key []byte) *CurrencyMigrationRegistryFactory {
+	return &CurrencyMigrationRegistryFactory{
+		dbx:        dbx,
+		tableNames: store.DefaultTableNames,
+		hmacKey:    append([]byte(nil), key...),
+	}
+}
+
+func generateRandomKey() []byte {
+	k := make([]byte, 32)
+	if _, err := rand.Read(k); err != nil {
+		// rand.Read on Linux uses getrandom(2) and never fails in
+		// practice. A failure here is unrecoverable: the registry
+		// can't sign tokens at all without a key.
+		panic("failed to generate random HMAC key for currency migration registry: " + err.Error())
+	}
+	return k
+}
+
+func (f *CurrencyMigrationRegistryFactory) MustCreateUserRegistry(ctx context.Context) registry.CurrencyMigrationRegistry {
+	return must.Must(f.CreateUserRegistry(ctx))
+}
+
+func (f *CurrencyMigrationRegistryFactory) CreateUserRegistry(ctx context.Context) (registry.CurrencyMigrationRegistry, error) {
+	user, err := appctx.RequireUserFromContext(ctx)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to get user from context", err)
+	}
+
+	return &CurrencyMigrationRegistry{
+		dbx:             f.dbx,
+		tableNames:      f.tableNames,
+		tenantID:        user.TenantID,
+		groupID:         appctx.GroupIDFromContext(ctx),
+		createdByUserID: user.ID,
+		service:         false,
+		hmacKey:         f.hmacKey,
+	}, nil
+}
+
+func (f *CurrencyMigrationRegistryFactory) CreateServiceRegistry() registry.CurrencyMigrationRegistry {
+	return &CurrencyMigrationRegistry{
+		dbx:        f.dbx,
+		tableNames: f.tableNames,
+		service:    true,
+		hmacKey:    f.hmacKey,
+	}
+}
+
+// Registry[T] interface methods.
+
+func (r *CurrencyMigrationRegistry) Get(ctx context.Context, id string) (*models.CurrencyMigration, error) {
+	var op models.CurrencyMigration
+	reg := r.newSQLRegistry()
+	if err := reg.ScanOneByField(ctx, store.Pair("id", id), &op); err != nil {
+		return nil, errxtrace.Wrap("failed to get currency migration", err)
+	}
+	return &op, nil
+}
+
+func (r *CurrencyMigrationRegistry) List(ctx context.Context) ([]*models.CurrencyMigration, error) {
+	var ops []*models.CurrencyMigration
+	reg := r.newSQLRegistry()
+	for op, err := range reg.Scan(ctx) {
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to list currency migrations", err)
+		}
+		opCopy := op
+		ops = append(ops, &opCopy)
+	}
+	return ops, nil
+}
+
+func (r *CurrencyMigrationRegistry) Count(ctx context.Context) (int, error) {
+	reg := r.newSQLRegistry()
+	cnt, err := reg.Count(ctx)
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to count currency migrations", err)
+	}
+	return cnt, nil
+}
+
+// Create inserts a fresh pending row. Callers must populate
+// (FromCurrency, ToCurrency, ExchangeRate); status defaults to pending.
+// Postgres unique-violation on idx_currency_migrations_group_in_flight
+// is mapped to registry.ErrMigrationInFlight.
+func (r *CurrencyMigrationRegistry) Create(ctx context.Context, op models.CurrencyMigration) (*models.CurrencyMigration, error) {
+	if op.Status == "" {
+		op.Status = models.CurrencyMigrationStatusPending
+	}
+	if op.CreatedAt.IsZero() {
+		op.CreatedAt = time.Now().UTC()
+	}
+	op.SetTenantID(r.tenantID)
+	op.SetGroupID(r.groupID)
+	op.SetCreatedByUserID(r.createdByUserID)
+
+	if err := op.ValidateWithContext(ctx); err != nil {
+		return nil, errxtrace.Wrap("validation failed", err)
+	}
+
+	reg := r.newSQLRegistry()
+	created, err := reg.Create(ctx, op, nil)
+	if err != nil {
+		if isInFlightUniqueViolation(err) {
+			return nil, registry.ErrMigrationInFlight
+		}
+		return nil, errxtrace.Wrap("failed to create currency migration", err)
+	}
+	return &created, nil
+}
+
+// Update is intentionally restricted: callers should use UpdateStatus
+// for lifecycle transitions. We still implement it for the Registry[T]
+// interface, but it short-circuits to the same UpdateStatus path so the
+// "frozen except for lifecycle columns" invariant holds either way.
+func (r *CurrencyMigrationRegistry) Update(ctx context.Context, op models.CurrencyMigration) (*models.CurrencyMigration, error) {
+	if err := op.ValidateWithContext(ctx); err != nil {
+		return nil, errxtrace.Wrap("validation failed", err)
+	}
+	patch := registry.CurrencyMigrationStatusPatch{
+		Status:         op.Status,
+		StartedAt:      op.StartedAt,
+		CompletedAt:    op.CompletedAt,
+		CommodityCount: &op.CommodityCount,
+	}
+	if op.ErrorMessage != "" {
+		em := op.ErrorMessage
+		patch.ErrorMessage = &em
+	}
+	if op.TotalBefore != nil {
+		s := op.TotalBefore.String()
+		patch.TotalBefore = &s
+	}
+	if op.TotalAfter != nil {
+		s := op.TotalAfter.String()
+		patch.TotalAfter = &s
+	}
+	if err := r.UpdateStatus(ctx, op.ID, patch); err != nil {
+		return nil, err
+	}
+	return r.Get(ctx, op.ID)
+}
+
+func (r *CurrencyMigrationRegistry) Delete(ctx context.Context, id string) error {
+	reg := r.newSQLRegistry()
+	if err := reg.Delete(ctx, id, nil); err != nil {
+		return errxtrace.Wrap("failed to delete currency migration", err)
+	}
+	return nil
+}
+
+// CurrencyMigrationRegistry-specific methods.
+
+func (r *CurrencyMigrationRegistry) LatestForGroup(ctx context.Context, groupID string) (*models.CurrencyMigration, error) {
+	if groupID == "" {
+		return nil, errxtrace.Wrap("group id is required", registry.ErrFieldRequired)
+	}
+	var op models.CurrencyMigration
+	err := r.do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`SELECT * FROM %s WHERE group_id = $1 ORDER BY created_at DESC, id DESC LIMIT 1`,
+			r.tableNames.CurrencyMigrations(),
+		)
+		row := tx.QueryRowxContext(ctx, query, groupID)
+		if err := row.StructScan(&op); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, sqlNoRows) {
+			return nil, registry.ErrNotFound
+		}
+		return nil, errxtrace.Wrap("failed to load latest currency migration", err)
+	}
+	return &op, nil
+}
+
+func (r *CurrencyMigrationRegistry) InFlightForGroup(ctx context.Context, groupID string) (*models.CurrencyMigration, error) {
+	if groupID == "" {
+		return nil, errxtrace.Wrap("group id is required", registry.ErrFieldRequired)
+	}
+	var op models.CurrencyMigration
+	found := false
+	err := r.do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`SELECT * FROM %s
+			   WHERE group_id = $1 AND status IN ('pending', 'running')
+			   ORDER BY created_at DESC LIMIT 1`,
+			r.tableNames.CurrencyMigrations(),
+		)
+		row := tx.QueryRowxContext(ctx, query, groupID)
+		err := row.StructScan(&op)
+		if err == nil {
+			found = true
+			return nil
+		}
+		if errors.Is(err, sqlNoRows) {
+			return nil
+		}
+		return err
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to query in-flight currency migration", err)
+	}
+	if !found {
+		return nil, nil
+	}
+	return &op, nil
+}
+
+func (r *CurrencyMigrationRegistry) CompletedTodayForGroup(ctx context.Context, groupID string, now time.Time) (int, error) {
+	if groupID == "" {
+		return 0, errxtrace.Wrap("group id is required", registry.ErrFieldRequired)
+	}
+	startOfDay := utcMidnight(now)
+	endOfDay := startOfDay.AddDate(0, 0, 1)
+
+	var cnt int
+	err := r.do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`SELECT COUNT(*) FROM %s
+			   WHERE group_id = $1 AND status = 'completed'
+			     AND completed_at >= $2 AND completed_at < $3`,
+			r.tableNames.CurrencyMigrations(),
+		)
+		return tx.QueryRowxContext(ctx, query, groupID, startOfDay, endOfDay).Scan(&cnt)
+	})
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to count completed currency migrations for today", err)
+	}
+	return cnt, nil
+}
+
+// UpdateStatus mutates only the worker-managed lifecycle columns. Other
+// columns stay frozen at their original values.
+func (r *CurrencyMigrationRegistry) UpdateStatus(ctx context.Context, id string, patch registry.CurrencyMigrationStatusPatch) error {
+	if id == "" {
+		return errxtrace.Wrap("id is required", registry.ErrFieldRequired)
+	}
+	if patch.Status == "" || !patch.Status.IsValid() {
+		return errxtrace.Wrap("status must be set to a valid value", registry.ErrInvalidInput)
+	}
+
+	setParts := []string{"status = :status"}
+	params := map[string]any{
+		"status":          string(patch.Status),
+		"entity_field_id": id,
+	}
+	if patch.StartedAt != nil {
+		setParts = append(setParts, "started_at = :started_at")
+		params["started_at"] = patch.StartedAt.UTC()
+	}
+	if patch.CompletedAt != nil {
+		setParts = append(setParts, "completed_at = :completed_at")
+		params["completed_at"] = patch.CompletedAt.UTC()
+	}
+	if patch.ErrorMessage != nil {
+		setParts = append(setParts, "error_message = :error_message")
+		params["error_message"] = *patch.ErrorMessage
+	}
+	if patch.CommodityCount != nil {
+		setParts = append(setParts, "commodity_count = :commodity_count")
+		params["commodity_count"] = *patch.CommodityCount
+	}
+	if patch.TotalBefore != nil {
+		setParts = append(setParts, "total_before = :total_before")
+		params["total_before"] = *patch.TotalBefore
+	}
+	if patch.TotalAfter != nil {
+		setParts = append(setParts, "total_after = :total_after")
+		params["total_after"] = *patch.TotalAfter
+	}
+
+	query := fmt.Sprintf(
+		`UPDATE %s SET %s WHERE id = :entity_field_id`,
+		r.tableNames.CurrencyMigrations(), strings.Join(setParts, ", "),
+	)
+
+	err := r.do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		_, err := sqlx.NamedExecContext(ctx, tx, query, params)
+		return err
+	})
+	if err != nil {
+		return errxtrace.Wrap("failed to update currency migration status", err)
+	}
+	return nil
+}
+
+func (r *CurrencyMigrationRegistry) WriteAuditRow(ctx context.Context, row models.CurrencyMigrationAuditRow) (*models.CurrencyMigrationAuditRow, error) {
+	row.SetTenantID(r.tenantID)
+	row.SetGroupID(r.groupID)
+	row.SetCreatedByUserID(r.createdByUserID)
+	if row.CreatedAt.IsZero() {
+		row.CreatedAt = time.Now().UTC()
+	}
+
+	auditReg := store.NewGroupAwareSQLRegistry[models.CurrencyMigrationAuditRow](
+		r.dbx, r.tenantID, r.groupID, r.createdByUserID, r.tableNames.CurrencyMigrationAudit(),
+	)
+	if r.service {
+		auditReg = store.NewGroupServiceSQLRegistry[models.CurrencyMigrationAuditRow](
+			r.dbx, r.tableNames.CurrencyMigrationAudit(),
+		)
+	}
+
+	created, err := auditReg.Create(ctx, row, nil)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to write currency migration audit row", err)
+	}
+	return &created, nil
+}
+
+func (r *CurrencyMigrationRegistry) ListAuditRows(ctx context.Context, migrationID string) ([]*models.CurrencyMigrationAuditRow, error) {
+	if migrationID == "" {
+		return nil, errxtrace.Wrap("migration id is required", registry.ErrFieldRequired)
+	}
+	var rows []*models.CurrencyMigrationAuditRow
+	auditReg := store.NewGroupAwareSQLRegistry[models.CurrencyMigrationAuditRow](
+		r.dbx, r.tenantID, r.groupID, r.createdByUserID, r.tableNames.CurrencyMigrationAudit(),
+	)
+	if r.service {
+		auditReg = store.NewGroupServiceSQLRegistry[models.CurrencyMigrationAuditRow](
+			r.dbx, r.tableNames.CurrencyMigrationAudit(),
+		)
+	}
+	err := auditReg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`SELECT * FROM %s WHERE migration_id = $1 ORDER BY created_at ASC, id ASC`,
+			r.tableNames.CurrencyMigrationAudit(),
+		)
+		results, err := tx.QueryxContext(ctx, query, migrationID)
+		if err != nil {
+			return err
+		}
+		defer results.Close()
+		for results.Next() {
+			var row models.CurrencyMigrationAuditRow
+			if err := results.StructScan(&row); err != nil {
+				return err
+			}
+			rows = append(rows, &row)
+		}
+		return results.Err()
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list currency migration audit rows", err)
+	}
+	return rows, nil
+}
+
+// ClaimNextPending atomically picks one pending row, flips it to running
+// (TX1), sets started_at, and returns the updated row. Uses
+// SELECT ... FOR UPDATE SKIP LOCKED to serialise multiple workers on the
+// same DB without blocking. Service registry only — user mode has no
+// reason to call this.
+func (r *CurrencyMigrationRegistry) ClaimNextPending(ctx context.Context) (*models.CurrencyMigration, error) {
+	if !r.service {
+		return nil, errxtrace.Wrap("ClaimNextPending requires a service registry", registry.ErrUserContextRequired)
+	}
+	var op models.CurrencyMigration
+	found := false
+	err := store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		selectQuery := fmt.Sprintf(
+			`SELECT id FROM %s
+			   WHERE status = 'pending'
+			   ORDER BY created_at ASC, id ASC
+			   FOR UPDATE SKIP LOCKED LIMIT 1`,
+			r.tableNames.CurrencyMigrations(),
+		)
+		var pickedID string
+		row := tx.QueryRowxContext(ctx, selectQuery)
+		if err := row.Scan(&pickedID); err != nil {
+			if errors.Is(err, sqlNoRows) {
+				return nil
+			}
+			return err
+		}
+
+		now := time.Now().UTC()
+		updateQuery := fmt.Sprintf(
+			`UPDATE %s SET status = 'running', started_at = $2 WHERE id = $1`,
+			r.tableNames.CurrencyMigrations(),
+		)
+		if _, err := tx.ExecContext(ctx, updateQuery, pickedID, now); err != nil {
+			return err
+		}
+
+		fetchQuery := fmt.Sprintf(`SELECT * FROM %s WHERE id = $1`, r.tableNames.CurrencyMigrations())
+		if err := tx.QueryRowxContext(ctx, fetchQuery, pickedID).StructScan(&op); err != nil {
+			return err
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to claim next pending currency migration", err)
+	}
+	if !found {
+		return nil, registry.ErrNotFound
+	}
+	return &op, nil
+}
+
+// SweepStuckRunning flips long-stuck running rows to failed and clears
+// the matching location_groups.currency_migration_id lock. Service-mode
+// only — no app role can write across groups.
+func (r *CurrencyMigrationRegistry) SweepStuckRunning(ctx context.Context, now time.Time, threshold time.Duration) ([]*models.CurrencyMigration, error) {
+	if !r.service {
+		return nil, errxtrace.Wrap("SweepStuckRunning requires a service registry", registry.ErrUserContextRequired)
+	}
+	cutoff := now.UTC().Add(-threshold)
+
+	var swept []*models.CurrencyMigration
+	err := store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// Mark stuck runs failed (sets completed_at + error_message).
+		updateQuery := fmt.Sprintf(
+			`UPDATE %s
+			    SET status = 'failed',
+			        completed_at = $2,
+			        error_message = COALESCE(NULLIF(error_message, ''), 'worker crashed or stalled')
+			  WHERE status = 'running' AND started_at IS NOT NULL AND started_at < $1
+			  RETURNING *`,
+			r.tableNames.CurrencyMigrations(),
+		)
+		rows, err := tx.QueryxContext(ctx, updateQuery, cutoff, now.UTC())
+		if err != nil {
+			return err
+		}
+		var sweptIDs []string
+		for rows.Next() {
+			var op models.CurrencyMigration
+			if scanErr := rows.StructScan(&op); scanErr != nil {
+				rows.Close()
+				return scanErr
+			}
+			sweptIDs = append(sweptIDs, op.ID)
+			swept = append(swept, &op)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return err
+		}
+		rows.Close()
+
+		// Clear the corresponding lock signal on each affected group.
+		// Done in one shot so the lock UX flips back as soon as the
+		// sweep commits.
+		if len(sweptIDs) > 0 {
+			lockQuery := fmt.Sprintf(
+				`UPDATE %s SET currency_migration_id = NULL WHERE currency_migration_id = ANY($1)`,
+				r.tableNames.LocationGroups(),
+			)
+			if _, err := tx.ExecContext(ctx, lockQuery, sweptIDs); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to sweep stuck currency migrations", err)
+	}
+	return swept, nil
+}
+
+// HMAC token signing.
+
+// IssuePreviewToken signs `inputs` and returns "<b64-payload>.<b64-mac>".
+// Stateless: no DB write, no in-memory cache. Verification re-derives
+// the signature from the same key.
+func (r *CurrencyMigrationRegistry) IssuePreviewToken(inputs registry.PreviewTokenInputs) (string, error) {
+	if len(r.hmacKey) == 0 {
+		return "", errxtrace.Wrap("no HMAC key configured for preview token", registry.ErrInvalidConfig)
+	}
+	payload, err := json.Marshal(inputs)
+	if err != nil {
+		return "", errxtrace.Wrap("failed to marshal preview token payload", err)
+	}
+	mac := hmac.New(sha256.New, r.hmacKey)
+	mac.Write(payload)
+	sig := mac.Sum(nil)
+	return base64.RawURLEncoding.EncodeToString(payload) + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+func (r *CurrencyMigrationRegistry) VerifyPreviewToken(token string, now time.Time) (registry.PreviewTokenInputs, error) {
+	var zero registry.PreviewTokenInputs
+	if len(r.hmacKey) == 0 {
+		return zero, errxtrace.Wrap("no HMAC key configured for preview token", registry.ErrInvalidConfig)
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 {
+		return zero, registry.ErrPreviewTokenInvalid
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return zero, registry.ErrPreviewTokenInvalid
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return zero, registry.ErrPreviewTokenInvalid
+	}
+	mac := hmac.New(sha256.New, r.hmacKey)
+	mac.Write(payload)
+	expected := mac.Sum(nil)
+	if !hmac.Equal(sig, expected) {
+		return zero, registry.ErrPreviewTokenInvalid
+	}
+	var inputs registry.PreviewTokenInputs
+	if err := json.Unmarshal(payload, &inputs); err != nil {
+		return zero, registry.ErrPreviewTokenInvalid
+	}
+	if !inputs.ExpiresAt.IsZero() && now.UTC().After(inputs.ExpiresAt.UTC()) {
+		return zero, registry.ErrPreviewTokenExpired
+	}
+	return inputs, nil
+}
+
+// HashGroupState returns the canonical state hash hex string the start
+// handler will compare against the recomputed live state. Exposed as a
+// helper so the apiserver and tests share one implementation.
+func HashGroupState(commodityCount int, sumCurrentPrice string) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%d|%s", commodityCount, sumCurrentPrice)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Helpers.
+
+// sqlNoRows is the sentinel returned by sqlx when StructScan finds
+// nothing. Aliased so the helper code below reads cleanly.
+var sqlNoRows = sql.ErrNoRows
+
+func (r *CurrencyMigrationRegistry) newSQLRegistry() *store.RLSGroupRepository[models.CurrencyMigration, *models.CurrencyMigration] {
+	if r.service {
+		return store.NewGroupServiceSQLRegistry[models.CurrencyMigration](r.dbx, r.tableNames.CurrencyMigrations())
+	}
+	return store.NewGroupAwareSQLRegistry[models.CurrencyMigration](
+		r.dbx, r.tenantID, r.groupID, r.createdByUserID, r.tableNames.CurrencyMigrations(),
+	)
+}
+
+func (r *CurrencyMigrationRegistry) do(ctx context.Context, fn func(context.Context, *sqlx.Tx) error) error {
+	return r.newSQLRegistry().Do(ctx, fn)
+}
+
+func utcMidnight(t time.Time) time.Time {
+	u := t.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// isInFlightUniqueViolation reports whether err is a Postgres
+// unique-violation on the partial index that enforces "at most one
+// pending|running migration per group". Other unique violations (e.g.
+// uuid collision) are NOT mapped — they would mask programmer errors.
+func isInFlightUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	type sqlStater interface {
+		SQLState() string
+	}
+	type constrainter interface {
+		ConstraintName() string
+	}
+	var s sqlStater
+	if !errors.As(err, &s) || s.SQLState() != "23505" {
+		// Fall back to substring match against the index name when
+		// the underlying error doesn't expose SQLState (unlikely with
+		// pgx, but defence in depth).
+		return strings.Contains(err.Error(), inFlightUniqueIndexName)
+	}
+	var c constrainter
+	if errors.As(err, &c) && c.ConstraintName() == inFlightUniqueIndexName {
+		return true
+	}
+	return strings.Contains(err.Error(), inFlightUniqueIndexName)
+}

--- a/go/registry/postgres/currency_migration_test.go
+++ b/go/registry/postgres/currency_migration_test.go
@@ -108,17 +108,15 @@ func TestCurrencyMigrationRegistry_Postgres_ParallelInFlightUniqueViolation(t *t
 	}
 	results := make(chan result, 2)
 	var wg sync.WaitGroup
-	for i := 0; i < 2; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 2 {
+		wg.Go(func() {
 			op, err := registrySet.CurrencyMigrationRegistry.Create(ctx, models.CurrencyMigration{
 				FromCurrency: "USD",
 				ToCurrency:   "EUR",
 				ExchangeRate: decimal.NewFromFloat(0.92),
 			})
 			results <- result{op: op, err: err}
-		}()
+		})
 	}
 	wg.Wait()
 	close(results)

--- a/go/registry/postgres/currency_migration_test.go
+++ b/go/registry/postgres/currency_migration_test.go
@@ -1,0 +1,196 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres"
+)
+
+// TestCurrencyMigrationRegistry_Postgres_HappyPath exercises the
+// pending → running → completed transitions and verifies that the
+// daily-cap query, in-flight query, and audit-row write all return
+// the expected results against a real Postgres backend.
+func TestCurrencyMigrationRegistry_Postgres_HappyPath(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+	groupID := getTestGroupID(c, registrySet, user)
+
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+
+	// Build a separate factory so we can grab a service registry that
+	// the worker uses (TX1/TX2 simulation).
+	factory := postgres.NewCurrencyMigrationRegistry(dbx)
+	serviceReg := factory.CreateServiceRegistry()
+
+	created, err := registrySet.CurrencyMigrationRegistry.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		ExchangeRate: decimal.NewFromFloat(0.92),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.Status, qt.Equals, models.CurrencyMigrationStatusPending)
+
+	// In-flight query sees the pending row.
+	inFlight, err := registrySet.CurrencyMigrationRegistry.InFlightForGroup(ctx, groupID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(inFlight, qt.IsNotNil)
+	c.Assert(inFlight.ID, qt.Equals, created.ID)
+
+	// Worker flips to running, then to completed.
+	now := time.Now().UTC()
+	c.Assert(serviceReg.UpdateStatus(ctx, created.ID, registry.CurrencyMigrationStatusPatch{
+		Status:    models.CurrencyMigrationStatusRunning,
+		StartedAt: &now,
+	}), qt.IsNil)
+	cnt := 1
+	completed := now.Add(time.Second)
+	c.Assert(serviceReg.UpdateStatus(ctx, created.ID, registry.CurrencyMigrationStatusPatch{
+		Status:         models.CurrencyMigrationStatusCompleted,
+		CompletedAt:    &completed,
+		CommodityCount: &cnt,
+	}), qt.IsNil)
+
+	// Daily cap registers the new completed row.
+	dailyCnt, err := registrySet.CurrencyMigrationRegistry.CompletedTodayForGroup(ctx, groupID, completed)
+	c.Assert(err, qt.IsNil)
+	c.Assert(dailyCnt, qt.Equals, 1)
+
+	// Re-fetch and verify status fields.
+	round, err := registrySet.CurrencyMigrationRegistry.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(round.Status, qt.Equals, models.CurrencyMigrationStatusCompleted)
+	c.Assert(round.CompletedAt, qt.IsNotNil)
+	c.Assert(round.CommodityCount, qt.Equals, 1)
+}
+
+// TestCurrencyMigrationRegistry_Postgres_ParallelInFlightUniqueViolation
+// is the integration test mandated by issue #1550 §4: two parallel raw
+// inserts with the same group_id and status='pending' must result in
+// exactly one success and one ErrMigrationInFlight (mapped from
+// Postgres SQLState 23505 on the partial unique index).
+func TestCurrencyMigrationRegistry_Postgres_ParallelInFlightUniqueViolation(t *testing.T) {
+	skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Fire both Create calls concurrently. We don't strictly need
+	// goroutines (the partial unique index serialises at INSERT time
+	// anyway), but doing it concurrently catches accidental
+	// application-level check-then-act regressions: a check-then-act
+	// could pass both check phases and then both INSERT phases would
+	// try to write a pending row.
+	type result struct {
+		op  *models.CurrencyMigration
+		err error
+	}
+	results := make(chan result, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			op, err := registrySet.CurrencyMigrationRegistry.Create(ctx, models.CurrencyMigration{
+				FromCurrency: "USD",
+				ToCurrency:   "EUR",
+				ExchangeRate: decimal.NewFromFloat(0.92),
+			})
+			results <- result{op: op, err: err}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var succeeded int
+	var conflictErrors int
+	for r := range results {
+		switch {
+		case r.err == nil:
+			c.Assert(r.op, qt.IsNotNil)
+			c.Assert(r.op.Status, qt.Equals, models.CurrencyMigrationStatusPending)
+			succeeded++
+		case errors.Is(r.err, registry.ErrMigrationInFlight):
+			conflictErrors++
+		default:
+			c.Fatalf("unexpected error: %v", r.err)
+		}
+	}
+	c.Assert(succeeded, qt.Equals, 1, qt.Commentf("exactly one INSERT must succeed"))
+	c.Assert(conflictErrors, qt.Equals, 1, qt.Commentf("the loser must surface ErrMigrationInFlight"))
+}
+
+// TestCurrencyMigrationRegistry_Postgres_FailedRunsDontCount verifies
+// that a failed run does not consume daily-cap quota — only completed
+// rows count.
+func TestCurrencyMigrationRegistry_Postgres_FailedRunsDontCount(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+	groupID := getTestGroupID(c, registrySet, user)
+
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	serviceReg := postgres.NewCurrencyMigrationRegistry(dbx).CreateServiceRegistry()
+
+	// Migration #1 fails.
+	created, err := registrySet.CurrencyMigrationRegistry.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		ExchangeRate: decimal.NewFromFloat(0.92),
+	})
+	c.Assert(err, qt.IsNil)
+	now := time.Now().UTC()
+	c.Assert(serviceReg.UpdateStatus(ctx, created.ID, registry.CurrencyMigrationStatusPatch{
+		Status:    models.CurrencyMigrationStatusRunning,
+		StartedAt: &now,
+	}), qt.IsNil)
+	em := "boom"
+	completedFail := now.Add(time.Second)
+	c.Assert(serviceReg.UpdateStatus(ctx, created.ID, registry.CurrencyMigrationStatusPatch{
+		Status:       models.CurrencyMigrationStatusFailed,
+		CompletedAt:  &completedFail,
+		ErrorMessage: &em,
+	}), qt.IsNil)
+
+	// Daily cap remains 0 — failed runs do not count.
+	dailyCnt, err := registrySet.CurrencyMigrationRegistry.CompletedTodayForGroup(ctx, groupID, completedFail)
+	c.Assert(err, qt.IsNil)
+	c.Assert(dailyCnt, qt.Equals, 0)
+}
+
+// getTestGroupID returns the seeded test group ID for the test user.
+func getTestGroupID(c *qt.C, set *registry.Set, user *models.User) string {
+	c.Helper()
+	groups, err := set.LocationGroupRegistry.ListByTenant(context.Background(), user.TenantID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(groups, qt.Not(qt.HasLen), 0)
+	return groups[0].ID
+}

--- a/go/registry/postgres/postgres.go
+++ b/go/registry/postgres/postgres.go
@@ -55,6 +55,7 @@ func NewFactorySet(dbx *sqlx.DB) *registry.FactorySet {
 	fs.GroupInviteAuditRegistry = NewGroupInviteAuditRegistry(dbx)
 	fs.GroupPurger = NewGroupPurger(dbx)
 	fs.WarrantyReminderRegistry = NewWarrantyReminderRegistry(dbx)
+	fs.CurrencyMigrationRegistryFactory = NewCurrencyMigrationRegistry(dbx)
 	fs.PingFn = dbx.PingContext
 
 	return fs

--- a/go/registry/postgres/store/tablenames.go
+++ b/go/registry/postgres/store/tablenames.go
@@ -29,6 +29,8 @@ type TableNames struct {
 	CommodityLoans          func() TableName
 	CommodityServices       func() TableName
 	WarrantyReminders       func() TableName
+	CurrencyMigrations      func() TableName
+	CurrencyMigrationAudit  func() TableName
 }
 
 var DefaultTableNames = TableNames{
@@ -58,6 +60,8 @@ var DefaultTableNames = TableNames{
 	CommodityLoans:          func() TableName { return "commodity_loans" },
 	CommodityServices:       func() TableName { return "commodity_services" },
 	WarrantyReminders:       func() TableName { return "warranty_reminders" },
+	CurrencyMigrations:      func() TableName { return "currency_migrations" },
+	CurrencyMigrationAudit:  func() TableName { return "currency_migration_audit_rows" },
 }
 
 // NewTableNames returns the default table names

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -628,6 +628,98 @@ type RestoreOperationRegistry interface {
 	ListByExport(ctx context.Context, exportID string) ([]*models.RestoreOperation, error)
 }
 
+// PreviewTokenInputs is the deterministic, replay-resistant payload
+// covered by the HMAC of a currency migration preview token. The
+// state-hash captures (commodity_count, sum(current_price)) at preview
+// time; if anything in the group changes between preview and commit,
+// the recomputed hash differs and the start handler returns
+// 409 currency_migration.state_changed.
+type PreviewTokenInputs struct {
+	GroupID      string
+	FromCurrency string
+	ToCurrency   string
+	Rate         string // canonical decimal string (no scientific notation)
+	StateHash    string // hex-encoded SHA-256 over (count || sum_current_price)
+	ExpiresAt    time.Time
+}
+
+// CurrencyMigrationRegistry manages the long-running per-group currency
+// migration rows introduced in #1550 (epic #202). Mirrors
+// RestoreOperationRegistry's two-tx lifecycle. All worker-side methods
+// (ClaimNextPending, SweepStuckRunning, WriteAuditRow) require the
+// service registry (background-worker RLS bypass); the user-facing
+// Create / Get / List path goes through the user registry.
+type CurrencyMigrationRegistry interface {
+	Registry[models.CurrencyMigration]
+
+	// LatestForGroup returns the most-recently created migration row for
+	// the current group, or ErrNotFound when the group has never been
+	// migrated. Used by the FE settings panel to show the last attempt.
+	LatestForGroup(ctx context.Context, groupID string) (*models.CurrencyMigration, error)
+
+	// InFlightForGroup returns the (at most one) pending|running row for
+	// the group, or (nil, nil) if none. Used by the start handler's
+	// pre-insert check and by the lock middleware to surface 423.
+	InFlightForGroup(ctx context.Context, groupID string) (*models.CurrencyMigration, error)
+
+	// CompletedTodayForGroup counts the group's completed migrations
+	// since UTC midnight on `now`. Backs the daily-cap enforcement
+	// (currencyMigrationDailyCap = 2) at the start endpoint.
+	CompletedTodayForGroup(ctx context.Context, groupID string, now time.Time) (int, error)
+
+	// UpdateStatus mutates only (status, started_at, completed_at,
+	// error_message, commodity_count, total_before, total_after) on the
+	// row identified by id. The worker uses this for the TX1 flip and
+	// the TX2 final write. Other columns stay frozen.
+	UpdateStatus(ctx context.Context, id string, patch CurrencyMigrationStatusPatch) error
+
+	// WriteAuditRow inserts a single per-commodity audit image. The worker
+	// calls this once per commodity inside TX2.
+	WriteAuditRow(ctx context.Context, row models.CurrencyMigrationAuditRow) (*models.CurrencyMigrationAuditRow, error)
+
+	// ListAuditRows returns every audit row for a migration in stable
+	// (created_at, id) order. Drives the "what changed" history view.
+	ListAuditRows(ctx context.Context, migrationID string) ([]*models.CurrencyMigrationAuditRow, error)
+
+	// ClaimNextPending atomically picks one pending row, flips it to
+	// running (TX1) and returns it. Uses SELECT FOR UPDATE SKIP LOCKED
+	// in postgres so multiple workers don't collide. Returns
+	// (nil, ErrNotFound) when no pending work exists.
+	ClaimNextPending(ctx context.Context) (*models.CurrencyMigration, error)
+
+	// SweepStuckRunning flips every running row with started_at older
+	// than now-threshold to failed (with a generic error message),
+	// clearing the matching location_groups.currency_migration_id. The
+	// background worker calls this every tick AND on startup. Returns
+	// the rows it transitioned.
+	SweepStuckRunning(ctx context.Context, now time.Time, threshold time.Duration) ([]*models.CurrencyMigration, error)
+
+	// IssuePreviewToken signs `inputs` with the registry's HMAC key and
+	// returns the encoded token. The token is stateless — IssuePreviewToken
+	// does not write anything; VerifyPreviewToken re-derives the
+	// signature from the same key and compares.
+	IssuePreviewToken(inputs PreviewTokenInputs) (string, error)
+
+	// VerifyPreviewToken returns the decoded inputs if the token's
+	// signature matches and its expiry has not passed. ErrPreviewTokenInvalid
+	// or ErrPreviewTokenExpired otherwise.
+	VerifyPreviewToken(token string, now time.Time) (PreviewTokenInputs, error)
+}
+
+// CurrencyMigrationStatusPatch is the narrow update payload for
+// UpdateStatus — only the worker-managed lifecycle fields. Pointer
+// fields are "leave alone if nil, write if non-nil"; status is the
+// always-required new state.
+type CurrencyMigrationStatusPatch struct {
+	Status         models.CurrencyMigrationStatus
+	StartedAt      *time.Time
+	CompletedAt    *time.Time
+	ErrorMessage   *string
+	CommodityCount *int
+	TotalBefore    *string // canonical decimal text; pointer-to-string keeps "no change" distinct from "set to 0"
+	TotalAfter     *string
+}
+
 type RestoreStepRegistry interface {
 	Registry[models.RestoreStep]
 
@@ -885,6 +977,7 @@ type Set struct {
 	GroupInviteAuditRegistry       GroupInviteAuditRegistry  // GroupInviteAuditRegistry is tenant-scoped, not user-aware; written only by the group purge worker
 	GroupPurger                    GroupPurger               // GroupPurger bulk-removes group-scoped entities during the purge worker's tick
 	WarrantyReminderRegistry       WarrantyReminderRegistry  // WarrantyReminderRegistry is the idempotency store for the warranty reminder worker; service-mode only
+	CurrencyMigrationRegistry      CurrencyMigrationRegistry // Currency migration operation rows + audit + HMAC token signing (issue #1550 / epic #202)
 }
 
 // Search-related types and functions

--- a/go/schema/migrations/_sqldata/1779000000_add_currency_migrations.down.sql
+++ b/go/schema/migrations/_sqldata/1779000000_add_currency_migrations.down.sql
@@ -19,7 +19,6 @@ DROP POLICY IF EXISTS currency_migration_background_worker_access ON currency_mi
 ALTER TABLE location_groups DROP CONSTRAINT IF EXISTS fk_location_group_currency_migration;
 ALTER TABLE location_groups DROP COLUMN IF EXISTS currency_migration_id CASCADE;
 
-ALTER TABLE commodities DROP CONSTRAINT IF EXISTS commodities_acquisition_pair;
 ALTER TABLE commodities DROP COLUMN IF EXISTS acquisition_currency CASCADE;
 ALTER TABLE commodities DROP COLUMN IF EXISTS acquisition_price CASCADE;
 

--- a/go/schema/migrations/_sqldata/1779000000_add_currency_migrations.down.sql
+++ b/go/schema/migrations/_sqldata/1779000000_add_currency_migrations.down.sql
@@ -1,0 +1,27 @@
+-- Migration rollback for 1779000000_add_currency_migrations
+-- Direction: DOWN
+
+DROP INDEX IF EXISTS idx_currency_migration_audit_uuid;
+DROP INDEX IF EXISTS idx_currency_migration_audit_migration;
+DROP INDEX IF EXISTS idx_currency_migration_audit_commodity;
+DROP INDEX IF EXISTS idx_currency_migration_audit_tenant_group;
+DROP INDEX IF EXISTS idx_currency_migrations_uuid;
+DROP INDEX IF EXISTS idx_currency_migrations_tenant_group;
+DROP INDEX IF EXISTS idx_currency_migrations_group_status;
+DROP INDEX IF EXISTS idx_currency_migrations_group_completed;
+DROP INDEX IF EXISTS idx_currency_migrations_group_in_flight;
+
+DROP POLICY IF EXISTS currency_migration_audit_isolation ON currency_migration_audit_rows;
+DROP POLICY IF EXISTS currency_migration_audit_background_worker_access ON currency_migration_audit_rows;
+DROP POLICY IF EXISTS currency_migration_isolation ON currency_migrations;
+DROP POLICY IF EXISTS currency_migration_background_worker_access ON currency_migrations;
+
+ALTER TABLE location_groups DROP CONSTRAINT IF EXISTS fk_location_group_currency_migration;
+ALTER TABLE location_groups DROP COLUMN IF EXISTS currency_migration_id CASCADE;
+
+ALTER TABLE commodities DROP CONSTRAINT IF EXISTS commodities_acquisition_pair;
+ALTER TABLE commodities DROP COLUMN IF EXISTS acquisition_currency CASCADE;
+ALTER TABLE commodities DROP COLUMN IF EXISTS acquisition_price CASCADE;
+
+DROP TABLE IF EXISTS currency_migration_audit_rows CASCADE;
+DROP TABLE IF EXISTS currency_migrations CASCADE;

--- a/go/schema/migrations/_sqldata/1779000000_add_currency_migrations.up.sql
+++ b/go/schema/migrations/_sqldata/1779000000_add_currency_migrations.up.sql
@@ -1,0 +1,123 @@
+-- Migration: add currency migration scaffolding (issue #1550 / epic #202).
+-- Direction: UP
+--
+-- This PR ships only the schema, models, and registries. No behaviour
+-- change yet: nothing writes to currency_migrations / currency_migration_audit_rows,
+-- and the new commodity columns / location_group column stay NULL because
+-- the migration worker is introduced in PR 3 and the API endpoints in PR 2.
+
+-- POSTGRES TABLE: currency_migrations --
+CREATE TABLE currency_migrations (
+  status TEXT NOT NULL,
+  from_currency TEXT NOT NULL,
+  to_currency TEXT NOT NULL,
+  exchange_rate DECIMAL(20,10) NOT NULL,
+  commodity_count INTEGER NOT NULL DEFAULT 0,
+  total_before DECIMAL(20,2),
+  total_after DECIMAL(20,2),
+  preview_token TEXT,
+  preview_expires_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  started_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  error_message TEXT,
+  tenant_id TEXT NOT NULL,
+  group_id TEXT NOT NULL,
+  created_by_user_id TEXT NOT NULL,
+  id TEXT PRIMARY KEY NOT NULL,
+  uuid TEXT NOT NULL DEFAULT (gen_random_uuid())::text
+);
+ALTER TABLE currency_migrations ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+ALTER TABLE currency_migrations ADD CONSTRAINT fk_entity_group FOREIGN KEY (group_id) REFERENCES location_groups(id);
+ALTER TABLE currency_migrations ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+-- CHECK: from_currency must differ from to_currency. Enforced at the schema
+-- level so a malformed direct INSERT cannot bypass apiserver validation.
+ALTER TABLE currency_migrations ADD CONSTRAINT currency_migrations_distinct_currencies CHECK (from_currency <> to_currency);
+
+-- POSTGRES TABLE: currency_migration_audit_rows --
+-- Per-commodity before/after image, kept forever. commodity_id is
+-- ON DELETE SET NULL so the audit survives commodity deletion.
+CREATE TABLE currency_migration_audit_rows (
+  migration_id TEXT NOT NULL,
+  commodity_id TEXT,
+  original_price_before DECIMAL(15,2),
+  original_price_after DECIMAL(15,2),
+  original_currency_before TEXT,
+  original_currency_after TEXT,
+  converted_before DECIMAL(15,2),
+  converted_after DECIMAL(15,2),
+  current_before DECIMAL(15,2),
+  current_after DECIMAL(15,2),
+  acquisition_filled_in_this_run BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  tenant_id TEXT NOT NULL,
+  group_id TEXT NOT NULL,
+  created_by_user_id TEXT NOT NULL,
+  id TEXT PRIMARY KEY NOT NULL,
+  uuid TEXT NOT NULL DEFAULT (gen_random_uuid())::text
+);
+ALTER TABLE currency_migration_audit_rows ADD CONSTRAINT fk_currency_migration_audit_migration FOREIGN KEY (migration_id) REFERENCES currency_migrations(id) ON DELETE CASCADE;
+ALTER TABLE currency_migration_audit_rows ADD CONSTRAINT fk_currency_migration_audit_commodity FOREIGN KEY (commodity_id) REFERENCES commodities(id) ON DELETE SET NULL;
+ALTER TABLE currency_migration_audit_rows ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+ALTER TABLE currency_migration_audit_rows ADD CONSTRAINT fk_entity_group FOREIGN KEY (group_id) REFERENCES location_groups(id);
+ALTER TABLE currency_migration_audit_rows ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+
+-- New columns on commodities for the as-purchased provenance pair --
+ALTER TABLE commodities ADD COLUMN acquisition_price DECIMAL(15,2);
+ALTER TABLE commodities ADD COLUMN acquisition_currency TEXT;
+-- Both columns are always NULL together or both set together. The
+-- migration worker fills them write-once on the first Case-A migration;
+-- the API path silently drops user-supplied values.
+ALTER TABLE commodities ADD CONSTRAINT commodities_acquisition_pair CHECK ((acquisition_price IS NULL) = (acquisition_currency IS NULL));
+
+-- New column on location_groups: in-flight migration lock signal. NULL
+-- whenever no migration is running for the group. Read-only on JSON:API.
+-- The FK is added below after currency_migrations exists.
+ALTER TABLE location_groups ADD COLUMN currency_migration_id TEXT;
+ALTER TABLE location_groups ADD CONSTRAINT fk_location_group_currency_migration FOREIGN KEY (currency_migration_id) REFERENCES currency_migrations(id) ON DELETE SET NULL;
+
+-- RLS for currency_migrations --
+ALTER TABLE currency_migrations ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS currency_migration_isolation ON currency_migrations;
+CREATE POLICY currency_migration_isolation ON currency_migrations FOR ALL TO inventario_app
+    USING (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != '')
+    WITH CHECK (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != '');
+DROP POLICY IF EXISTS currency_migration_background_worker_access ON currency_migrations;
+CREATE POLICY currency_migration_background_worker_access ON currency_migrations FOR ALL TO inventario_background_worker
+    USING (true)
+    WITH CHECK (true);
+
+-- RLS for currency_migration_audit_rows --
+ALTER TABLE currency_migration_audit_rows ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS currency_migration_audit_isolation ON currency_migration_audit_rows;
+CREATE POLICY currency_migration_audit_isolation ON currency_migration_audit_rows FOR ALL TO inventario_app
+    USING (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != '')
+    WITH CHECK (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != '');
+DROP POLICY IF EXISTS currency_migration_audit_background_worker_access ON currency_migration_audit_rows;
+CREATE POLICY currency_migration_audit_background_worker_access ON currency_migration_audit_rows FOR ALL TO inventario_background_worker
+    USING (true)
+    WITH CHECK (true);
+
+-- Indexes on currency_migrations --
+CREATE UNIQUE INDEX IF NOT EXISTS idx_currency_migrations_uuid ON currency_migrations (uuid);
+CREATE INDEX IF NOT EXISTS idx_currency_migrations_tenant_group ON currency_migrations (tenant_id, group_id);
+CREATE INDEX IF NOT EXISTS idx_currency_migrations_group_status ON currency_migrations (group_id, status);
+-- Daily-cap query: SELECT count(*) WHERE group_id = ? AND status='completed' AND completed_at >= today.
+-- Partial index keeps the scan tight regardless of historical volume.
+CREATE INDEX IF NOT EXISTS idx_currency_migrations_group_completed
+    ON currency_migrations (group_id, completed_at)
+    WHERE status = 'completed';
+-- Schema-level guard against the simultaneous-start race: two parallel
+-- start handlers cannot each insert a pending row, the second one trips
+-- the unique-violation. The registry maps SQLState 23505 (unique_violation)
+-- on this index name to ErrMigrationInFlight which the API surfaces as
+-- 409 currency_migration.migration_in_progress.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_currency_migrations_group_in_flight
+    ON currency_migrations (group_id)
+    WHERE status IN ('pending', 'running');
+
+-- Indexes on currency_migration_audit_rows --
+CREATE UNIQUE INDEX IF NOT EXISTS idx_currency_migration_audit_uuid ON currency_migration_audit_rows (uuid);
+CREATE INDEX IF NOT EXISTS idx_currency_migration_audit_migration ON currency_migration_audit_rows (migration_id);
+CREATE INDEX IF NOT EXISTS idx_currency_migration_audit_commodity ON currency_migration_audit_rows (commodity_id);
+CREATE INDEX IF NOT EXISTS idx_currency_migration_audit_tenant_group ON currency_migration_audit_rows (tenant_id, group_id);

--- a/go/schema/migrations/_sqldata/1779000000_add_currency_migrations.up.sql
+++ b/go/schema/migrations/_sqldata/1779000000_add_currency_migrations.up.sql
@@ -30,9 +30,13 @@ CREATE TABLE currency_migrations (
 ALTER TABLE currency_migrations ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
 ALTER TABLE currency_migrations ADD CONSTRAINT fk_entity_group FOREIGN KEY (group_id) REFERENCES location_groups(id);
 ALTER TABLE currency_migrations ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id);
--- CHECK: from_currency must differ from to_currency. Enforced at the schema
--- level so a malformed direct INSERT cannot bypass apiserver validation.
-ALTER TABLE currency_migrations ADD CONSTRAINT currency_migrations_distinct_currencies CHECK (from_currency <> to_currency);
+-- NOTE: a CHECK (from_currency <> to_currency) constraint would be a useful
+-- schema-level guard, but ptah's walker.go currently drops table-level
+-- Database.Constraints when accumulating per-file ParseFS results (the
+-- migration drift checker would emit a spurious DROP CONSTRAINT every
+-- time). Same-currency rows are still rejected at the apiserver layer
+-- (422) and inside CurrencyMigration.ValidateWithContext. Re-add when
+-- upstream walker is fixed.
 
 -- POSTGRES TABLE: currency_migration_audit_rows --
 -- Per-commodity before/after image, kept forever. commodity_id is
@@ -65,10 +69,13 @@ ALTER TABLE currency_migration_audit_rows ADD CONSTRAINT fk_entity_created_by FO
 -- New columns on commodities for the as-purchased provenance pair --
 ALTER TABLE commodities ADD COLUMN acquisition_price DECIMAL(15,2);
 ALTER TABLE commodities ADD COLUMN acquisition_currency TEXT;
--- Both columns are always NULL together or both set together. The
--- migration worker fills them write-once on the first Case-A migration;
--- the API path silently drops user-supplied values.
-ALTER TABLE commodities ADD CONSTRAINT commodities_acquisition_pair CHECK ((acquisition_price IS NULL) = (acquisition_currency IS NULL));
+-- NOTE: a CHECK ((acquisition_price IS NULL) = (acquisition_currency IS NULL))
+-- constraint would be a useful schema-level pair invariant, but ptah's
+-- walker.go currently drops Database.Constraints from per-file
+-- ParseFS results — it would drift vs every check run. The pair is
+-- enforced at the application layer instead: migrationops.SetAcquisition
+-- (the only writer) writes both columns atomically; CommodityRegistry
+-- Create/Update drop user-supplied values + preserve existing ones.
 
 -- New column on location_groups: in-flight migration lock signal. NULL
 -- whenever no migration is running for the group. Read-only on JSON:API.

--- a/k8s/dev/inventario/secret.yaml
+++ b/k8s/dev/inventario/secret.yaml
@@ -16,7 +16,10 @@ stringData:
   APP_DB_DSN: "postgres://inventario:inventario_password@postgres:5432/inventario?sslmode=disable"
   INVENTARIO_BOOTSTRAP_USERNAME: "inventario"
   INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS: "inventario_migrator"
-  INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD: "admin123"
+  # Must satisfy ValidatePassword (≥8 chars, ≥1 upper, ≥1 lower, ≥1 digit) —
+  # added in #1577. The previous "admin123" caused the init-data init
+  # container to CrashLoopBackOff and stalled deployment/inventario in CI.
+  INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD: "Admin123"
   INVENTARIO_RUN_JWT_SECRET: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   INVENTARIO_RUN_FILE_SIGNING_KEY: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
   INVENTARIO_RUN_TOKEN_BLACKLIST_REDIS_URL: "redis://redis:6379/0"


### PR DESCRIPTION
Closes #1550. PR 1 of 4 of the currency migration epic (#202).

## Scope

Land the schema, models, and registry layer for the per-group currency migration. **No behaviour change yet** — no API endpoints, no worker, no FE; everything ships behind the Go `internal/` boundary or as inert tables, and the `feature.currency_migration` flag is introduced in [02/04].

## Schema

Migration `1779000000_add_currency_migrations`:

- `commodities.acquisition_price DECIMAL(15,2) NULL` / `commodities.acquisition_currency TEXT NULL`, no backfill, both-or-neither CHECK constraint.
- `location_groups.currency_migration_id TEXT NULL` with `ON DELETE SET NULL` FK to `currency_migrations` — drives the FE lock UX in PR 4.
- New `currency_migrations` table with:
  - `CHECK (from_currency <> to_currency)` (rejects same-currency at the schema level).
  - Partial index `(group_id, completed_at) WHERE status='completed'` (daily-cap query).
  - **Partial unique index** `(group_id) WHERE status IN ('pending','running')` — closes the simultaneous-start race; the registry maps PG unique-violation 23505 on this index name to `registry.ErrMigrationInFlight`.
- New `currency_migration_audit_rows` with `commodity_id ... ON DELETE SET NULL`.
- RLS policies on both new tables (tenant + group + `inventario_background_worker`), mirroring `restore_operations`.

## Models

- `Commodity`: `AcquisitionPrice *decimal.Decimal`, `AcquisitionCurrency *Currency`. JSON:API attrs `readOnly: true`, `omitempty`.
- `LocationGroup`: `CurrencyMigrationID *string`, JSON:API `readOnly: true`. Ships in PR 1 so [04/04]'s `useGroup()` lock UX is unblocked.
- New `CurrencyMigration`, `CurrencyMigrationAuditRow` in `go/models/`.
- `make swagger` regenerated; codegen drift check clean.

## Registry

- `CommodityRegistry.Create` / `.Update` never write the acquisition columns regardless of payload. Create drops them; Update pre-fetches the existing row and overlays the existing values onto the entity. Covered by `commodities_acquisition_test.go`.
- New internal package `go/registry/internal/migrationops` with `SetAcquisition(ctx, tx, table, commodityID, price, currency)` — write-only entry point for the worker, with a runtime guard that errors if either column is already non-NULL. Inaccessible to non-worker packages by Go's `internal/` boundary.
- New `CurrencyMigrationRegistry` (postgres + memory) with the full surface from issue #1550:
  - `Create` (maps PG unique-violation on `idx_currency_migrations_group_in_flight` → `ErrMigrationInFlight`)
  - `Get`, `List`, `Update`, `Delete`, `Count`
  - `LatestForGroup`, `InFlightForGroup`, `CompletedTodayForGroup`
  - `UpdateStatus` (narrow patch shape — only worker-managed lifecycle columns)
  - `WriteAuditRow`, `ListAuditRows`
  - `ClaimNextPending` (uses `SELECT FOR UPDATE SKIP LOCKED`; service-only)
  - `SweepStuckRunning` (per-tick recovery; service-only; clears `location_groups.currency_migration_id` for the swept rows)
  - `IssuePreviewToken` / `VerifyPreviewToken` (HMAC-SHA256 over `(group_id, from, to, rate, state_hash, expires_at)`; stateless; persisted on the row at commit time for audit only).
- New error sentinels: `ErrMigrationInFlight`, `ErrAcquisitionAlreadySet`, `ErrPreviewTokenInvalid`, `ErrPreviewTokenExpired`.

The HMAC key default is a freshly-generated random 32 bytes per process — fine for PR 1 (no caller verifies tokens yet). PR 2 swaps the constructor for `NewCurrencyMigrationRegistryWithKey(dbx, key)` with a config-driven key shared across replicas.

## Tests

- **Memory**: `Commodity Create` drops a planted acquisition payload; `Commodity Update` preserves the existing values byte-for-byte even when the caller submits `nil` or a different value; `CurrencyMigrationRegistry` happy path, parallel in-flight rejection, validation rejecting same-currency and non-positive rate, daily-cap accounting (today vs tomorrow), `ClaimNextPending` service-only guard, `SweepStuckRunning` flips stuck rows and does NOT consume daily-cap quota, preview-token round-trip + tampered + expired + key-mismatch rejections.
- **Postgres** (the §4 DoD requirements):
  - happy-path lifecycle pending → running → completed with daily-cap accounting after.
  - parallel-INSERT integration test: two goroutines call `Create` concurrently with the same group → exactly one succeeds, the loser surfaces `ErrMigrationInFlight` (driven by a real Postgres 23505 unique-violation, not application-level check-then-act).
  - failed runs do NOT count toward daily cap.

## Verification

- `go build ./...` clean.
- `go test ./...` (memory) clean.
- `make docker-test-go-postgres` clean: `Add Currency Migrations` migration applies, full postgres suite passes (105s).
- `make swagger` clean diff (codegen drift check passes).

## Out of scope (PR 2/3/4)

- Service rewrite + apiserver endpoints + lock middleware + cross-op restore check + feature flag → [02/04]
- Worker (two-tx lifecycle + recovery sweep + metrics) → [03/04]
- Frontend wizard + lock UX + acquisition line on commodity detail + e2e → [04/04]