### PR TITLE
scripts: add kind-stack.sh dev helper + sync kind-smoke-repro.sh

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -154,6 +154,33 @@ kubectl -n inventario-dev port-forward service/inventario 3333:3333
 After port-forwarding, the app is available on `http://127.0.0.1:3333`.
 The dev baseline seeds example data and uses the default admin email from `k8s/dev/inventario/configmap.yaml` with the password from `k8s/dev/inventario/secret.yaml`.
 
+## Local kind stack helper (for development)
+
+For repeated, interactive use against a local kind cluster, prefer
+`scripts/kind-stack.sh` over typing the kubectl commands above by hand.
+It mirrors what the CI smoke workflow does — same manifests, same apply
+order — but is built around a persistent cluster you can tear up, hack
+on, and tear down at will:
+
+```sh
+scripts/kind-stack.sh up           # build image, create cluster, apply manifests
+scripts/kind-stack.sh smoke        # the same checks CI runs
+scripts/kind-stack.sh logs inventario   # follow logs
+scripts/kind-stack.sh reload       # rebuild image + restart deployment
+scripts/kind-stack.sh psql         # open psql in the postgres pod
+scripts/kind-stack.sh shell        # /bin/sh inside the inventario pod
+scripts/kind-stack.sh down         # delete the cluster
+```
+
+The default cluster name is `inventario-dev`, the namespace is
+`inventario-dev`, and the port-forward listens on `:3333`. All knobs
+are env-var overridable — pass `KIND_CLUSTER_NAME=foo APP_IMAGE=bar:tag`
+to run side-by-side with another stack. State (port-forward PID + log)
+lives under `~/.local/state/inventario-kind-stack/<cluster>/`.
+
+For the **single-shot CI repro** (cluster created, smoke run, cluster
+deleted), use `scripts/kind-smoke-repro.sh` instead.
+
 ## CI kind smoke workflow
 
 - Workflow entry point: `.github/workflows/kind-smoke-test.yml`

--- a/k8s/dev/inventario/configmap.yaml
+++ b/k8s/dev/inventario/configmap.yaml
@@ -12,7 +12,15 @@ metadata:
 data:
   INVENTARIO_RUN_ADDR: ":3333"
   INVENTARIO_RUN_PUBLIC_URL: "http://inventario.inventario-dev.svc.cluster.local:3333"
-  INVENTARIO_RUN_UPLOAD_LOCATION: "s3://inventario?prefix=uploads/&region=us-east-1&endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true"
+  # gocloud.dev v2 spelling: `disable_https` (not `disableSSL`) and
+  # `use_path_style` (not `s3ForcePathStyle`). The endpoint must include
+  # an explicit `http://` scheme — without it AWS SDK v2 prepends
+  # `https://` and the connection to MinIO fails. The legacy `disableSSL`
+  # / `s3ForcePathStyle` keys aren't recognised by gocloud's V2 URL
+  # parameter parser and surface as
+  #   `failed to open bucket: unknown query parameter "disableSSL"`
+  # → 500 on every /api/v1/g/.../uploads/file POST.
+  INVENTARIO_RUN_UPLOAD_LOCATION: "s3://inventario?prefix=uploads/&region=us-east-1&endpoint=http://minio:9000&disable_https=true&use_path_style=true"
   INVENTARIO_RUN_FILE_URL_EXPIRATION: "15m"
   INVENTARIO_RUN_MAX_CONCURRENT_EXPORTS: "3"
   INVENTARIO_RUN_MAX_CONCURRENT_IMPORTS: "1"

--- a/scripts/kind-smoke-repro.sh
+++ b/scripts/kind-smoke-repro.sh
@@ -385,7 +385,17 @@ run_smoke_checks() {
     -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}")"
   access_token="$(printf '%s' "$login_response" | jq -r '.access_token')"
   csrf_token="$(printf '%s' "$login_response" | jq -r '.csrf_token')"
-  [ -n "$access_token" ] && [ "$access_token" != "null" ]
+  if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
+    redacted_login="$(printf '%s' "$login_response" \
+      | jq '.access_token = (.access_token // null | if . == null then null else "<redacted>" end) | .csrf_token = (.csrf_token // null | if . == null then null else "<redacted>" end)' 2>/dev/null || printf '%s' "$login_response")"
+    log "Login response (tokens redacted): $redacted_login"
+    echo "Login failed: empty or null access_token" >&2
+    exit 1
+  fi
+  if [ -z "$csrf_token" ] || [ "$csrf_token" = "null" ]; then
+    echo "Login response missing csrf_token; group creation below would fail with an opaque curl error" >&2
+    exit 1
+  fi
 
   # Locations endpoints are group-scoped after the multi-group rollout —
   # mirrors what kind-smoke-test.yml does. Seed a group if the user

--- a/scripts/kind-smoke-repro.sh
+++ b/scripts/kind-smoke-repro.sh
@@ -13,7 +13,9 @@ KIND_CACHE_DIR="${KIND_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/inventario-kin
 KEEP_CLUSTER="${KEEP_CLUSTER:-false}"
 DELETE_EXISTING_CLUSTER="${DELETE_EXISTING_CLUSTER:-true}"
 ADMIN_EMAIL="${ADMIN_EMAIL:-admin@example.com}"
-ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin123}"
+# Must match k8s/dev/inventario/secret.yaml's INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD —
+# bumped from `admin123` after #1577 added password complexity rules.
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-Admin123}"
 EXPECTED_LOCATION_NAME="${EXPECTED_LOCATION_NAME:-Home}"
 
 PORT_FORWARD_LOG="$ARTIFACTS_DIR/inventario-port-forward.log"
@@ -382,10 +384,29 @@ run_smoke_checks() {
     -H 'Content-Type: application/json' \
     -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}")"
   access_token="$(printf '%s' "$login_response" | jq -r '.access_token')"
+  csrf_token="$(printf '%s' "$login_response" | jq -r '.csrf_token')"
   [ -n "$access_token" ] && [ "$access_token" != "null" ]
 
-  log "Checking seeded locations"
-  locations_response="$(curl -fsS "$base_url/api/v1/locations" \
+  # Locations endpoints are group-scoped after the multi-group rollout —
+  # mirrors what kind-smoke-test.yml does. Seed a group if the user
+  # doesn't already have one.
+  log "Resolving group slug"
+  groups_response="$(curl -fsS "$base_url/api/v1/groups" \
+    -H "Authorization: Bearer $access_token" \
+    -H 'Accept: application/vnd.api+json')"
+  group_slug="$(printf '%s' "$groups_response" | jq -r '.data[0].attributes.slug // empty')"
+  if [ -z "$group_slug" ]; then
+    log "No group yet; creating one"
+    create_resp="$(curl -fsS -X POST "$base_url/api/v1/groups" \
+      -H "Authorization: Bearer $access_token" \
+      -H 'Content-Type: application/vnd.api+json' \
+      -H "X-CSRF-Token: $csrf_token" \
+      -d '{"data":{"type":"groups","attributes":{"name":"Smoke Test"}}}')"
+    group_slug="$(printf '%s' "$create_resp" | jq -r '.data.attributes.slug')"
+  fi
+
+  log "Checking seeded locations under group $group_slug"
+  locations_response="$(curl -fsS "$base_url/api/v1/g/$group_slug/locations" \
     -H "Authorization: Bearer $access_token")"
   printf '%s' "$locations_response" | jq -e --arg expected_name "$EXPECTED_LOCATION_NAME" 'any(.data[]?; .attributes.name == $expected_name)' >/dev/null
 }

--- a/scripts/kind-stack.sh
+++ b/scripts/kind-stack.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+#
+# kind-stack.sh — bring the full Inventario stack up in a local kind cluster
+# for development and debugging. Mirrors the pods CI runs but is intended for
+# repeated, interactive use rather than one-shot CI reproduction.
+#
+# Subcommands:
+#   up           Build image, create cluster (if absent), load image, apply
+#                manifests, wait for ready, start port-forward
+#   down         Delete the cluster (and stop port-forward)
+#   restart      down + up
+#   status       Show cluster + pods + services in the namespace
+#   logs <comp>  Tail logs for a component
+#                  (inventario | postgres | redis | minio | setup | bucket)
+#   reload       Rebuild the inventario image, reload into kind, restart the
+#                inventario deployment in-place. Fast iteration for code
+#                changes — leaves postgres/redis/minio data intact.
+#   port-forward Re-create the background svc/inventario port-forward
+#   smoke        Hit healthz/readyz/login/locations (same checks CI runs)
+#   psql         Open `psql` inside the postgres pod
+#   shell        Exec /bin/sh inside the inventario pod
+#   help         Print this help
+#
+# Use `-h`/`--help` or `help` for usage. Most knobs are env vars (see top).
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-inventario-dev}"
+K8S_NAMESPACE="${K8S_NAMESPACE:-inventario-dev}"
+APP_IMAGE="${APP_IMAGE:-inventario:kind-dev}"
+KIND_VERSION="${KIND_VERSION:-v0.29.0}"
+KIND_CACHE_DIR="${KIND_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/inventario-kind-stack}"
+PORT_FORWARD_PORT="${PORT_FORWARD_PORT:-3333}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-admin@example.com}"
+# Must match k8s/dev/inventario/secret.yaml's INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD.
+# Bumped from `admin123` after #1577 added password complexity rules.
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-Admin123}"
+EXPECTED_LOCATION_NAME="${EXPECTED_LOCATION_NAME:-Home}"
+
+STATE_DIR="${STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/inventario-kind-stack/$KIND_CLUSTER_NAME}"
+PORT_FORWARD_LOG="$STATE_DIR/port-forward.log"
+PORT_FORWARD_PID_FILE="$STATE_DIR/port-forward.pid"
+
+KUBECTL_CONTEXT="kind-$KIND_CLUSTER_NAME"
+KIND_BIN="${KIND_BIN:-}"
+
+mkdir -p "$STATE_DIR"
+
+usage() {
+  # Print the comment header (lines 3..first blank line), stripping the leading "# ".
+  awk 'NR>=3 { if ($0 == "") exit; sub(/^# ?/, ""); print }' "${BASH_SOURCE[0]}"
+  cat <<EOF
+
+Environment overrides (current values shown):
+  KIND_CLUSTER_NAME       $KIND_CLUSTER_NAME
+  K8S_NAMESPACE           $K8S_NAMESPACE
+  APP_IMAGE               $APP_IMAGE
+  PORT_FORWARD_PORT       $PORT_FORWARD_PORT
+  ADMIN_EMAIL             $ADMIN_EMAIL
+  ADMIN_PASSWORD          (hidden — defaults to Admin123)
+  KIND_VERSION            $KIND_VERSION (auto-downloaded if kind missing)
+  STATE_DIR               $STATE_DIR
+
+Examples:
+  scripts/kind-stack.sh up
+  scripts/kind-stack.sh logs inventario
+  scripts/kind-stack.sh reload     # iterate on backend code
+  scripts/kind-stack.sh smoke
+  scripts/kind-stack.sh down
+EOF
+}
+
+log() { printf '\n[%s] %s\n' "$(date '+%H:%M:%S')" "$*"; }
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+# ---------- kind helpers (download to cache dir if missing) -------------------
+
+resolve_kind_bin() {
+  if [ -n "$KIND_BIN" ] && [ -x "$KIND_BIN" ]; then printf '%s\n' "$KIND_BIN"; return 0; fi
+  if command -v kind >/dev/null 2>&1; then command -v kind; return 0; fi
+  return 1
+}
+
+kind_cmd() {
+  local bin
+  bin="$(resolve_kind_bin)" || fail "kind not available; run 'kind-stack.sh up' to auto-download"
+  "$bin" "$@"
+}
+
+kubectl_cmd() { kubectl --context "$KUBECTL_CONTEXT" "$@"; }
+
+ensure_kind() {
+  if resolve_kind_bin >/dev/null 2>&1; then
+    KIND_BIN="$(resolve_kind_bin)"
+    return 0
+  fi
+
+  local os arch
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+  case "$arch" in x86_64|amd64) arch=amd64 ;; arm64|aarch64) arch=arm64 ;; *) fail "unsupported arch $arch" ;; esac
+  case "$os" in linux|darwin) ;; *) fail "unsupported OS $os" ;; esac
+
+  mkdir -p "$KIND_CACHE_DIR"
+  local url="https://kind.sigs.k8s.io/dl/$KIND_VERSION/kind-$os-$arch"
+  local path="$KIND_CACHE_DIR/kind-$KIND_VERSION-$os-$arch"
+
+  if [ ! -x "$path" ]; then
+    log "downloading kind $KIND_VERSION → $path"
+    curl -fsSL -o "$path" "$url"
+    curl -fsSL -o "$path.sha256sum" "$url.sha256sum"
+    local expected actual
+    expected="$(awk '{print $1}' "$path.sha256sum")"
+    if command -v sha256sum >/dev/null 2>&1; then
+      actual="$(sha256sum "$path" | awk '{print $1}')"
+    else
+      actual="$(shasum -a 256 "$path" | awk '{print $1}')"
+    fi
+    [ "$actual" = "$expected" ] || fail "kind checksum mismatch ($actual vs $expected)"
+    chmod +x "$path"
+  fi
+
+  KIND_BIN="$path"
+}
+
+require_prereqs() {
+  local missing=""
+  for t in bash docker kubectl curl jq perl; do
+    command -v "$t" >/dev/null 2>&1 || missing="$missing $t"
+  done
+  [ -z "$missing" ] || fail "missing required tools:$missing"
+  docker info >/dev/null 2>&1 || fail "docker daemon is not reachable"
+}
+
+cluster_exists() {
+  resolve_kind_bin >/dev/null 2>&1 || return 1
+  kind_cmd get clusters 2>/dev/null | grep -Fxq "$KIND_CLUSTER_NAME"
+}
+
+# ---------- manifest preparation (mirrors kind-smoke-test.yml) ----------------
+
+prepare_manifests() {
+  local out="$STATE_DIR/manifests"
+  rm -rf "$out"
+  mkdir -p "$out"
+  cp -R "$REPO_ROOT/k8s/dev/." "$out/"
+  perl -0pi -e "s#ghcr.io/denisvmedia/inventario:latest#$APP_IMAGE#g" \
+    "$out/inventario/job-setup.yaml" \
+    "$out/inventario/deployment.yaml"
+  printf '%s' "$out"
+}
+
+apply_manifests() {
+  local mdir="$1"
+  for manifest in \
+    "$mdir/namespace.yaml" \
+    "$mdir/postgres/secret.yaml" \
+    "$mdir/postgres/configmap.yaml" \
+    "$mdir/postgres/pvc.yaml" \
+    "$mdir/postgres/service.yaml" \
+    "$mdir/postgres/deployment.yaml" \
+    "$mdir/redis/service.yaml" \
+    "$mdir/redis/deployment.yaml" \
+    "$mdir/minio/secret.yaml" \
+    "$mdir/minio/pvc.yaml" \
+    "$mdir/minio/service.yaml" \
+    "$mdir/minio/deployment.yaml" \
+    "$mdir/minio/job.yaml" \
+    "$mdir/inventario/configmap.yaml" \
+    "$mdir/inventario/secret.yaml" \
+    "$mdir/inventario/job-setup.yaml"; do
+    log "apply ${manifest#"$mdir"/}"
+    kubectl_cmd apply -f "$manifest"
+  done
+}
+
+wait_for_endpoint() {
+  local svc="$1" attempt=1 ip
+  while [ "$attempt" -le 60 ]; do
+    ip="$(kubectl_cmd get endpoints "$svc" -n "$K8S_NAMESPACE" -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null || true)"
+    if [ -n "$ip" ]; then log "service/$svc has endpoint $ip"; return 0; fi
+    log "waiting for service/$svc... ($attempt/60)"
+    attempt=$((attempt + 1))
+    sleep 2
+  done
+  fail "timed out waiting for service/$svc"
+}
+
+wait_for_ready() {
+  local mdir="$1"
+  log "waiting for postgres rollout"
+  kubectl_cmd rollout status deployment/postgres -n "$K8S_NAMESPACE" --timeout=180s
+  log "waiting for redis rollout"
+  kubectl_cmd rollout status deployment/redis -n "$K8S_NAMESPACE" --timeout=180s
+  log "waiting for minio rollout"
+  kubectl_cmd rollout status deployment/minio -n "$K8S_NAMESPACE" --timeout=180s
+  wait_for_endpoint postgres
+  wait_for_endpoint redis
+  wait_for_endpoint minio
+  log "waiting for minio-create-bucket job"
+  kubectl_cmd wait --for=condition=complete job/minio-create-bucket -n "$K8S_NAMESPACE" --timeout=180s
+  log "waiting for inventario-setup job"
+  kubectl_cmd wait --for=condition=complete job/inventario-setup -n "$K8S_NAMESPACE" --timeout=300s
+
+  log "applying inventario service + deployment"
+  kubectl_cmd apply -f "$mdir/inventario/service.yaml"
+  kubectl_cmd apply -f "$mdir/inventario/deployment.yaml"
+
+  log "waiting for inventario rollout"
+  kubectl_cmd rollout status deployment/inventario -n "$K8S_NAMESPACE" --timeout=300s
+  wait_for_endpoint inventario
+}
+
+build_image() {
+  log "building $APP_IMAGE (this can take a few minutes the first time)"
+  ( cd "$REPO_ROOT" && docker build --target production -t "$APP_IMAGE" . )
+}
+
+load_image() {
+  log "loading $APP_IMAGE into kind cluster $KIND_CLUSTER_NAME"
+  kind_cmd load docker-image "$APP_IMAGE" --name "$KIND_CLUSTER_NAME"
+}
+
+# ---------- port-forward (background) -----------------------------------------
+
+stop_port_forward() {
+  if [ -f "$PORT_FORWARD_PID_FILE" ]; then
+    local pid
+    pid="$(cat "$PORT_FORWARD_PID_FILE")"
+    if kill -0 "$pid" 2>/dev/null; then
+      log "stopping port-forward (pid $pid)"
+      kill "$pid" 2>/dev/null || true
+    fi
+    rm -f "$PORT_FORWARD_PID_FILE"
+  fi
+}
+
+start_port_forward() {
+  stop_port_forward
+  log "starting port-forward on :$PORT_FORWARD_PORT (logs: $PORT_FORWARD_LOG)"
+  : > "$PORT_FORWARD_LOG"
+  nohup kubectl --context "$KUBECTL_CONTEXT" port-forward \
+    -n "$K8S_NAMESPACE" "svc/inventario" "$PORT_FORWARD_PORT:3333" \
+    > "$PORT_FORWARD_LOG" 2>&1 &
+  echo $! > "$PORT_FORWARD_PID_FILE"
+
+  local attempt=1
+  while [ "$attempt" -le 30 ]; do
+    if curl -fsS "http://127.0.0.1:$PORT_FORWARD_PORT/healthz" >/dev/null 2>&1; then
+      log "port-forward is ready: http://127.0.0.1:$PORT_FORWARD_PORT"
+      return 0
+    fi
+    if ! kill -0 "$(cat "$PORT_FORWARD_PID_FILE")" 2>/dev/null; then
+      cat "$PORT_FORWARD_LOG" >&2
+      fail "port-forward exited unexpectedly"
+    fi
+    sleep 2
+    attempt=$((attempt + 1))
+  done
+  cat "$PORT_FORWARD_LOG" >&2
+  fail "timed out waiting for port-forward"
+}
+
+# ---------- subcommands -------------------------------------------------------
+
+cmd_up() {
+  require_prereqs
+  ensure_kind
+
+  if ! cluster_exists; then
+    log "creating kind cluster $KIND_CLUSTER_NAME"
+    kind_cmd create cluster --name "$KIND_CLUSTER_NAME" --wait 120s
+    kubectl_cmd cluster-info
+  else
+    log "kind cluster $KIND_CLUSTER_NAME already exists; reusing"
+  fi
+
+  build_image
+  load_image
+
+  local mdir
+  mdir="$(prepare_manifests)"
+  apply_manifests "$mdir"
+  wait_for_ready "$mdir"
+  start_port_forward
+
+  cat <<EOF
+
+Stack is up.
+  url:      http://127.0.0.1:$PORT_FORWARD_PORT
+  login:    $ADMIN_EMAIL / $ADMIN_PASSWORD
+  cluster:  $KIND_CLUSTER_NAME
+  context:  $KUBECTL_CONTEXT
+  ns:       $K8S_NAMESPACE
+
+Try:
+  scripts/kind-stack.sh smoke      # verify endpoints
+  scripts/kind-stack.sh logs inventario
+  scripts/kind-stack.sh reload     # rebuild image + restart deployment
+  scripts/kind-stack.sh down       # delete the cluster
+EOF
+}
+
+cmd_down() {
+  ensure_kind || true
+  stop_port_forward
+  if cluster_exists; then
+    log "deleting kind cluster $KIND_CLUSTER_NAME"
+    kind_cmd delete cluster --name "$KIND_CLUSTER_NAME"
+  else
+    log "no kind cluster $KIND_CLUSTER_NAME to delete"
+  fi
+}
+
+cmd_restart() { cmd_down; cmd_up; }
+
+cmd_status() {
+  ensure_kind
+  cluster_exists || fail "cluster $KIND_CLUSTER_NAME does not exist; run 'kind-stack.sh up' first"
+  kubectl_cmd get all,jobs,pvc -n "$K8S_NAMESPACE" -o wide
+  echo
+  if [ -f "$PORT_FORWARD_PID_FILE" ] && kill -0 "$(cat "$PORT_FORWARD_PID_FILE")" 2>/dev/null; then
+    echo "port-forward: running on :$PORT_FORWARD_PORT (pid $(cat "$PORT_FORWARD_PID_FILE"))"
+  else
+    echo "port-forward: not running"
+  fi
+}
+
+cmd_logs() {
+  local component="${1:-inventario}"
+  case "$component" in
+    inventario) kubectl_cmd logs -n "$K8S_NAMESPACE" -l app.kubernetes.io/name=inventario,app.kubernetes.io/component=web --all-containers=true --tail=200 -f ;;
+    postgres)   kubectl_cmd logs -n "$K8S_NAMESPACE" deployment/postgres --tail=200 -f ;;
+    redis)      kubectl_cmd logs -n "$K8S_NAMESPACE" deployment/redis --tail=200 -f ;;
+    minio)      kubectl_cmd logs -n "$K8S_NAMESPACE" deployment/minio --tail=200 -f ;;
+    setup)      kubectl_cmd logs -n "$K8S_NAMESPACE" job/inventario-setup --all-containers=true --tail=500 ;;
+    bucket)     kubectl_cmd logs -n "$K8S_NAMESPACE" job/minio-create-bucket --tail=500 ;;
+    *) fail "unknown component '$component'; expected one of: inventario postgres redis minio setup bucket" ;;
+  esac
+}
+
+cmd_reload() {
+  ensure_kind
+  cluster_exists || fail "cluster $KIND_CLUSTER_NAME does not exist; run 'kind-stack.sh up' first"
+  build_image
+  load_image
+  log "rolling inventario deployment"
+  # Forces pods to restart even though the image tag is the same — kubectl
+  # recognises the env-var bump as a spec change.
+  kubectl_cmd patch deployment/inventario -n "$K8S_NAMESPACE" \
+    -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kind-stack.sh/reload\":\"$(date +%s)\"}}}}}"
+  kubectl_cmd rollout status deployment/inventario -n "$K8S_NAMESPACE" --timeout=300s
+  log "reload complete"
+}
+
+cmd_port_forward() {
+  ensure_kind
+  cluster_exists || fail "cluster $KIND_CLUSTER_NAME does not exist; run 'kind-stack.sh up' first"
+  start_port_forward
+}
+
+cmd_smoke() {
+  local base="http://127.0.0.1:$PORT_FORWARD_PORT"
+  log "GET $base/healthz"
+  curl -fsS "$base/healthz" | jq -e '.status == "alive"' >/dev/null
+  log "GET $base/readyz"
+  curl -fsS "$base/readyz" | jq -e '.status == "ready" and .checks.database.status == "ok" and .checks.redis.status == "ok"' >/dev/null
+  log "POST $base/api/v1/auth/login as $ADMIN_EMAIL"
+  local login access csrf
+  login="$(curl -fsS -X POST "$base/api/v1/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}")"
+  access="$(printf '%s' "$login" | jq -r '.access_token')"
+  csrf="$(printf '%s' "$login" | jq -r '.csrf_token')"
+  [ -n "$access" ] && [ "$access" != "null" ] || fail "login failed"
+
+  log "GET $base/api/v1/groups"
+  local groups slug
+  groups="$(curl -fsS "$base/api/v1/groups" \
+    -H "Authorization: Bearer $access" \
+    -H "Accept: application/vnd.api+json")"
+  slug="$(printf '%s' "$groups" | jq -r '.data[0].attributes.slug // empty')"
+  if [ -z "$slug" ]; then
+    log "no group yet; creating one"
+    local create
+    create="$(curl -fsS -X POST "$base/api/v1/groups" \
+      -H "Authorization: Bearer $access" \
+      -H "Content-Type: application/vnd.api+json" \
+      -H "X-CSRF-Token: $csrf" \
+      -d '{"data":{"type":"groups","attributes":{"name":"Local Stack"}}}')"
+    slug="$(printf '%s' "$create" | jq -r '.data.attributes.slug')"
+  fi
+
+  log "GET $base/api/v1/g/$slug/locations"
+  curl -fsS "$base/api/v1/g/$slug/locations" \
+    -H "Authorization: Bearer $access" \
+    | jq -e --arg name "$EXPECTED_LOCATION_NAME" 'any(.data[]?; .attributes.name == $name)' >/dev/null
+
+  log "smoke checks passed"
+}
+
+cmd_psql() {
+  ensure_kind
+  cluster_exists || fail "cluster $KIND_CLUSTER_NAME does not exist; run 'kind-stack.sh up' first"
+  exec kubectl_cmd exec -it deployment/postgres -n "$K8S_NAMESPACE" -- \
+    psql -U inventario -d inventario "$@"
+}
+
+cmd_shell() {
+  ensure_kind
+  cluster_exists || fail "cluster $KIND_CLUSTER_NAME does not exist; run 'kind-stack.sh up' first"
+  local pod
+  pod="$(kubectl_cmd get pod -n "$K8S_NAMESPACE" -l app.kubernetes.io/name=inventario,app.kubernetes.io/component=web -o jsonpath='{.items[0].metadata.name}')"
+  [ -n "$pod" ] || fail "no inventario pod found"
+  exec kubectl --context "$KUBECTL_CONTEXT" exec -it -n "$K8S_NAMESPACE" "$pod" -- /bin/sh
+}
+
+# ---------- entry point -------------------------------------------------------
+
+main() {
+  case "${1:-help}" in
+    up)            shift; cmd_up "$@" ;;
+    down)          shift; cmd_down "$@" ;;
+    restart)       shift; cmd_restart "$@" ;;
+    status)        shift; cmd_status "$@" ;;
+    logs)          shift; cmd_logs "$@" ;;
+    reload)        shift; cmd_reload "$@" ;;
+    port-forward)  shift; cmd_port_forward "$@" ;;
+    smoke)         shift; cmd_smoke "$@" ;;
+    psql)          shift; cmd_psql "$@" ;;
+    shell)         shift; cmd_shell "$@" ;;
+    -h|--help|help) usage ;;
+    *) usage; fail "unknown subcommand '${1:-}'" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/kind-stack.sh
+++ b/scripts/kind-stack.sh
@@ -225,17 +225,45 @@ load_image() {
 }
 
 # ---------- port-forward (background) -----------------------------------------
+#
+# When the script crashes mid-run, the OS may eventually reuse the PID stored
+# in PORT_FORWARD_PID_FILE for an unrelated process. To avoid killing or
+# observing the wrong PID, we stamp the cmdline at start time and only act
+# on it if it still belongs to a kubectl port-forward process.
+
+# port_forward_alive reports whether the PID in $PORT_FORWARD_PID_FILE still
+# names a `kubectl port-forward` process (and not some unrelated re-use).
+# Returns 0 iff the file exists, the PID is alive, AND its cmdline matches.
+port_forward_alive() {
+  [ -f "$PORT_FORWARD_PID_FILE" ] || return 1
+  local pid
+  pid="$(cat "$PORT_FORWARD_PID_FILE" 2>/dev/null || true)"
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+
+  # /proc is the cheapest reliable check on Linux; ps -p ... -o args= is the
+  # macOS / non-Linux fallback. cmdline arguments are NUL-separated; turn
+  # those into spaces before grepping so the pattern stays simple.
+  local cmd=""
+  if [ -r "/proc/$pid/cmdline" ]; then
+    cmd="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
+  elif command -v ps >/dev/null 2>&1; then
+    cmd="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+  fi
+  case "$cmd" in
+    *kubectl*port-forward*svc/inventario*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 stop_port_forward() {
-  if [ -f "$PORT_FORWARD_PID_FILE" ]; then
+  if port_forward_alive; then
     local pid
     pid="$(cat "$PORT_FORWARD_PID_FILE")"
-    if kill -0 "$pid" 2>/dev/null; then
-      log "stopping port-forward (pid $pid)"
-      kill "$pid" 2>/dev/null || true
-    fi
-    rm -f "$PORT_FORWARD_PID_FILE"
+    log "stopping port-forward (pid $pid)"
+    kill "$pid" 2>/dev/null || true
   fi
+  rm -f "$PORT_FORWARD_PID_FILE"
 }
 
 start_port_forward() {
@@ -253,7 +281,7 @@ start_port_forward() {
       log "port-forward is ready: http://127.0.0.1:$PORT_FORWARD_PORT"
       return 0
     fi
-    if ! kill -0 "$(cat "$PORT_FORWARD_PID_FILE")" 2>/dev/null; then
+    if ! port_forward_alive; then
       cat "$PORT_FORWARD_LOG" >&2
       fail "port-forward exited unexpectedly"
     fi
@@ -291,7 +319,8 @@ cmd_up() {
 
 Stack is up.
   url:      http://127.0.0.1:$PORT_FORWARD_PORT
-  login:    $ADMIN_EMAIL / $ADMIN_PASSWORD
+  email:    $ADMIN_EMAIL
+  password: (default Admin123 from k8s/dev/inventario/secret.yaml; override via ADMIN_PASSWORD)
   cluster:  $KIND_CLUSTER_NAME
   context:  $KUBECTL_CONTEXT
   ns:       $K8S_NAMESPACE
@@ -322,7 +351,7 @@ cmd_status() {
   cluster_exists || fail "cluster $KIND_CLUSTER_NAME does not exist; run 'kind-stack.sh up' first"
   kubectl_cmd get all,jobs,pvc -n "$K8S_NAMESPACE" -o wide
   echo
-  if [ -f "$PORT_FORWARD_PID_FILE" ] && kill -0 "$(cat "$PORT_FORWARD_PID_FILE")" 2>/dev/null; then
+  if port_forward_alive; then
     echo "port-forward: running on :$PORT_FORWARD_PORT (pid $(cat "$PORT_FORWARD_PID_FILE"))"
   else
     echo "port-forward: not running"
@@ -375,7 +404,14 @@ cmd_smoke() {
     -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}")"
   access="$(printf '%s' "$login" | jq -r '.access_token')"
   csrf="$(printf '%s' "$login" | jq -r '.csrf_token')"
-  [ -n "$access" ] && [ "$access" != "null" ] || fail "login failed"
+  if [ -z "$access" ] || [ "$access" = "null" ]; then
+    printf 'login response (token field redacted):\n%s\n' \
+      "$(printf '%s' "$login" | jq '.access_token = (.access_token // null | if . == null then null else "<redacted>" end) | .csrf_token = (.csrf_token // null | if . == null then null else "<redacted>" end)' 2>/dev/null || printf '%s' "$login")" >&2
+    fail "login failed: empty or null access_token"
+  fi
+  if [ -z "$csrf" ] || [ "$csrf" = "null" ]; then
+    fail "login response missing csrf_token; the group-create call below cannot succeed without it"
+  fi
 
   log "GET $base/api/v1/groups"
   local groups slug


### PR DESCRIPTION
## Summary

A new `scripts/kind-stack.sh` helper for running the **full** Inventario stack (postgres, redis, minio, inventario) inside a local kind cluster — interactively, persistently, with a small docker-compose-style command surface so reloads, log tails, psql shells and smoke checks are one short command each. Mirrors the manifests + apply order from `.github/workflows/kind-smoke-test.yml` so the local stack and CI stay aligned.

## What's in the script

```sh
scripts/kind-stack.sh up           # build image, create cluster, apply manifests, port-forward
scripts/kind-stack.sh smoke        # the same healthz/readyz/login/locations CI runs
scripts/kind-stack.sh logs inventario   # tail (also: postgres|redis|minio|setup|bucket)
scripts/kind-stack.sh reload       # rebuild image + roll inventario deployment in-place
scripts/kind-stack.sh psql         # psql inside the postgres pod
scripts/kind-stack.sh shell        # /bin/sh inside the inventario pod
scripts/kind-stack.sh status       # kubectl get all,jobs,pvc + port-forward state
scripts/kind-stack.sh port-forward # restart the background svc/inventario forward
scripts/kind-stack.sh restart      # down + up
scripts/kind-stack.sh down         # delete the cluster
```

Defaults:

| knob | value |
|---|---|
| cluster name | `inventario-dev` |
| namespace | `inventario-dev` |
| image tag | `inventario:kind-dev` |
| port | `3333` |
| admin login | `admin@example.com` / `Admin123` (matches `k8s/dev/inventario/secret.yaml`) |

All overridable via env vars (`KIND_CLUSTER_NAME`, `APP_IMAGE`, `PORT_FORWARD_PORT`, etc.) so multiple stacks can run side-by-side. kind itself is auto-downloaded into `~/.cache/inventario-kind-stack/` if absent (pinned to `v0.29.0`, same as CI). State (port-forward PID + log) lives under `~/.local/state/inventario-kind-stack/<cluster>/`.

The cluster is **kept** by default — opposite of the one-shot `kind-smoke-repro.sh`. `reload` is the fast path: rebuilds the image, `kind load`s it, and patches a timestamp annotation onto the deployment to force a rolling restart while leaving postgres/redis/minio data intact.

## Drift-fix in `kind-smoke-repro.sh`

The existing one-shot CI repro had two stale references that would fail every run on master:

1. `ADMIN_PASSWORD` default was still `admin123`. After PR #1577 added password complexity rules (`≥8 chars, ≥1 upper, ≥1 lower, ≥1 digit`), the dev bootstrap rejects it — the same regression that hung Kind Smoke Test in CI before `Admin123` was rolled into `k8s/dev/inventario/secret.yaml`. Bumped to `Admin123`.
2. The smoke check hit `GET /api/v1/locations` — that endpoint was retired during the multi-group rollout. Now it resolves (or creates) a group slug first, then hits `/api/v1/g/<slug>/locations`. Same shape `.github/workflows/kind-smoke-test.yml` already uses.

## Docs

`k8s/README.md` gets a new "Local kind stack helper" section pointing at the new script with the subcommand cheat sheet, plus a one-liner saying `kind-smoke-repro.sh` is still the right tool for one-shot CI reproduction.

## Test plan

- [x] `bash -n` passes on both scripts.
- [x] `scripts/kind-stack.sh --help` renders cleanly.
- [x] Error paths (`status` without cluster, `logs banana`, unknown subcommand) print actionable messages.
- [x] `prepare_manifests` rewrites `inventario:latest` → `inventario:kind-dev` in the right two manifests (verified by hand against `k8s/dev/`).
- [ ] End-to-end `up` → `smoke` → `down` was **not** runnable on my local host (kernel `7.0.0-15-generic` causes `kubeadm init` to hang in `create-kubelet-cgroup-v2.sh`; mainline-Ubuntu / CI-runner kernel 6.x is fine). Whoever picks this up first on a regular host should run through the cycle and confirm.