### PR TITLE
e2e: stabilize commodity delete assertion in firefox

### DIFF
--- a/e2e/tests/frontend-shell.spec.ts
+++ b/e2e/tests/frontend-shell.spec.ts
@@ -173,9 +173,19 @@ test.describe('Frontend shell', () => {
       .last()
       .click();
 
-    // After the delete mutation resolves, navigation falls back to
-    // the list URL (the sheet's `state.background`); the row is gone.
+    // After the delete mutation resolves, the Sheet unmounts and the
+    // row disappears from the underlying list. We wait for the Sheet
+    // first because the user already arrived from
+    // `/commodities?inactive=1` — the post-delete `navigate(listHref)`
+    // target `/commodities` matches the same `/\/commodities(\?.*)?$/`
+    // regex, so a URL-only check passes instantly without waiting for
+    // the unmount. Firefox then races the next assertion against the
+    // Sheet's still-mounted `<h1 data-testid="commodity-detail-name">`
+    // — `getByText(itemName)` matches both that h1 and the list card
+    // link and fails strict mode. Scoping the row check to the grid
+    // avoids the ambiguity even if a future Sheet teardown lingers.
+    await expect(page.getByTestId('commodity-detail-sheet')).toBeHidden();
     await expect(page).toHaveURL(/\/commodities(\?.*)?$/);
-    await expect(page.getByText(itemName)).not.toBeVisible();
+    await expect(page.getByTestId('commodities-grid').getByText(itemName)).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the firefox E2E flake observed in [run 25514652983 / job 74883157074](https://github.com/denisvmedia/inventario/actions/runs/25514652983/job/74883157074):

```
Error: expect(locator).not.toBeVisible() failed
Locator: getByText('e2e-react-1778179226285')
Expected: not visible
Error: strict mode violation: getByText('e2e-react-1778179226285') resolved to 2 elements:
    1) <a data-testid="commodity-card-link" .../commodities/4aa6...>e2e-react-1778179226285</a>
    2) <h1 data-testid="commodity-detail-name">e2e-react-1778179226285</h1>
   at e2e/tests/frontend-shell.spec.ts:179:48
```

The test (`logged-in user can preview and delete a commodity` in `frontend-shell.spec.ts`) failed all 3 retries on firefox.

## Root cause

The earlier assertion is

```ts
await expect(page).toHaveURL(/\/commodities(\?.*)?$/);
await expect(page.getByText(itemName)).not.toBeVisible();
```

The user arrives at `/g/<slug>/commodities?inactive=1` (line 153). After delete, `handleDelete` in `CommodityDetailPage.tsx` calls `navigate(listHref)` → `/g/<slug>/commodities`. Both URLs match `/\/commodities(\?.*)?$/`, so `toHaveURL` passes **immediately** without waiting for the navigate-away from `/commodities/:id` (the Sheet's route).

Then `getByText(itemName)` runs while the Sheet route is still mounted, finding two elements (the list card link + the detail `<h1>`). Strict mode trips and the assertion fails fast — `.not.toBeVisible()` doesn't get a chance to retry past it.

Firefox is racier than chromium / webkit on the unmount + refetch tail, which is why it was the only browser to fail.

## Fix

- Wait for `commodity-detail-sheet` to be hidden first (this is the actual signal that the post-delete `navigate` happened and the Sheet unmounted).
- Then scope the row check to `commodities-grid` so the assertion is unambiguous even if the Sheet teardown lingers a tick longer.
- Use `toHaveCount(0)` for the row check, which is the semantically correct way to assert "the deleted row is gone from the list".

No frontend code changed — `useDeleteCommodity` already invalidates queries, and `handleDelete` already navigates back to the list. The bug was in the assertion's specificity and ordering.

## Test plan

- [ ] CI green on firefox / chromium / webkit E2E
- [ ] No regression in the rest of `frontend-shell.spec.ts`