### PR TITLE
[#1554] Disallow lend / service / warranty on commodities with quantity > 1

### DIFF
--- a/e2e/tests/frontend-shell.spec.ts
+++ b/e2e/tests/frontend-shell.spec.ts
@@ -173,9 +173,19 @@ test.describe('Frontend shell', () => {
       .last()
       .click();
 
-    // After the delete mutation resolves, navigation falls back to
-    // the list URL (the sheet's `state.background`); the row is gone.
+    // After the delete mutation resolves, the Sheet unmounts and the
+    // row disappears from the underlying list. We wait for the Sheet
+    // first because the user already arrived from
+    // `/commodities?inactive=1` — the post-delete `navigate(listHref)`
+    // target `/commodities` matches the same `/\/commodities(\?.*)?$/`
+    // regex, so a URL-only check passes instantly without waiting for
+    // the unmount. Firefox then races the next assertion against the
+    // Sheet's still-mounted `<h1 data-testid="commodity-detail-name">`
+    // — `getByText(itemName)` matches both that h1 and the list card
+    // link and fails strict mode. Scoping the row check to the grid
+    // avoids the ambiguity even if a future Sheet teardown lingers.
+    await expect(page.getByTestId('commodity-detail-sheet')).toBeHidden();
     await expect(page).toHaveURL(/\/commodities(\?.*)?$/);
-    await expect(page.getByText(itemName)).not.toBeVisible();
+    await expect(page.getByTestId('commodities-grid').getByText(itemName)).toHaveCount(0);
   });
 });

--- a/e2e/tests/quantity-tracking-restrictions.spec.ts
+++ b/e2e/tests/quantity-tracking-restrictions.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * E2E coverage for issue #1554: a commodity with quantity > 1 is a
+ * bundle of interchangeable units, not a single tracked instance.
+ * The Warranty / Lend / Service tabs swap their bodies for an
+ * empty-state hint that nudges the user to "split into separate
+ * items" instead of letting them open dialogs that the BE would
+ * reject with a 422.
+ *
+ * Locks the visible copy (translation key
+ * `commodities:trackingRestrictions.*`) so future i18n edits don't
+ * silently change the user-facing message.
+ */
+import { expect } from '@playwright/test'
+
+import { test } from '../fixtures/app-fixture.js'
+import {
+  createCommodityViaAPI,
+  deleteCommodityViaAPI,
+  ensureLocationAndArea,
+  extractApiAuth,
+  resolveActiveGroup,
+} from './includes/commodities-api.js'
+
+test.describe('Issue #1554 — bundle commodities hide per-instance affordances', () => {
+  test('Warranty / Lend / Service tabs render the bundle empty-state when count > 1', async ({
+    page,
+    request,
+  }) => {
+    const auth = await extractApiAuth(page)
+    const group = await resolveActiveGroup(request, auth)
+    const { areaId } = await ensureLocationAndArea(request, auth, group.slug)
+
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const seededIDs: string[] = []
+    const cleanup = async () => {
+      for (const id of seededIDs) {
+        await deleteCommodityViaAPI(request, auth, group.slug, id).catch(() => {})
+      }
+    }
+
+    try {
+      const { id: bundleId } = await createCommodityViaAPI(
+        request,
+        auth,
+        group.slug,
+        {
+          name: `Pack of bulbs ${suffix}`,
+          areaId,
+          count: 12,
+        },
+        group.groupCurrency,
+      )
+      seededIDs.push(bundleId)
+
+      // Warranty tab — empty-state hint replaces the live status pill /
+      // notes block. The pill in the page header is hidden too.
+      await page.goto(
+        `/g/${encodeURIComponent(group.slug)}/commodities/${encodeURIComponent(bundleId)}?tab=warranty`,
+      )
+      await expect(page.getByTestId('commodity-detail-warranty')).toBeVisible()
+      await expect(
+        page.getByTestId('commodity-detail-warranty-bundle-empty-state'),
+      ).toContainText(/quantity greater than 1/i)
+      await expect(page.getByTestId('commodity-detail-warranty-pill')).toHaveCount(0)
+
+      // Lend tab — bundle empty-state, no Lend button.
+      await page.getByTestId('commodity-detail-tab-lend').click()
+      await expect(page.getByTestId('lend-bundle-empty-state')).toBeVisible()
+      await expect(page.getByTestId('commodity-detail-lend-button')).toHaveCount(0)
+
+      // Service tab — bundle empty-state, no Send-for-service button.
+      await page.getByTestId('commodity-detail-tab-service').click()
+      await expect(page.getByTestId('service-bundle-empty-state')).toBeVisible()
+      await expect(page.getByTestId('commodity-detail-service-button')).toHaveCount(0)
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -209,7 +209,16 @@ export function CommodityFormDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl" data-testid="commodity-form-dialog">
+      {/* `max-h-[90vh] overflow-y-auto` keeps the whole dialog scrollable
+          inside the viewport. Without it the centered-translate
+          positioning lets a tall variant (e.g. the #1554 bundle banner +
+          the 5-step wizard combined) push the footer below the visible
+          viewport on small CI viewports, and Playwright's actionability
+          check refuses to click an off-viewport Next button. */}
+      <DialogContent
+        className="max-w-2xl max-h-[90vh] overflow-y-auto"
+        data-testid="commodity-form-dialog"
+      >
         <DialogHeader>
           <DialogTitle>
             {mode === "create"
@@ -256,9 +265,7 @@ export function CommodityFormDialog({
           >
             <AlertTriangle className="size-4" aria-hidden="true" />
             <AlertTitle>{t("commodities:trackingRestrictions.bannerTitle")}</AlertTitle>
-            <AlertDescription>
-              {t("commodities:trackingRestrictions.bannerBody")}
-            </AlertDescription>
+            <AlertDescription>{t("commodities:trackingRestrictions.bannerBody")}</AlertDescription>
           </Alert>
         ) : null}
 
@@ -283,12 +290,7 @@ export function CommodityFormDialog({
             <PurchaseStep register={register} errors={errors} watch={watch} />
           ) : null}
           {step === "warranty" ? (
-            <WarrantyStep
-              register={register}
-              errors={errors}
-              watch={watch}
-              disabled={isBundle}
-            />
+            <WarrantyStep register={register} errors={errors} watch={watch} isBundle={isBundle} />
           ) : null}
           {step === "extras" ? (
             <ExtrasStep register={register} errors={errors} watch={watch} setValue={setValue} />
@@ -553,17 +555,30 @@ function PurchaseStep(props: any) {
 // expiry date + notes. Status (active/expiring/expired/none) is
 // computed live from the entered date and shown as a pill preview so
 // the user sees how the row will surface on the list page before
-// saving. When the row is a bundle (#1554, count > 1) the inputs are
-// disabled and a hint replaces the live status pill — the per-row
-// dialog banner already explains why, this step just reflects the
-// constraint at the field level.
+// saving.
+//
+// On bundles (#1554, count > 1) the inputs are disabled ONLY when
+// they're empty — i.e. there's nothing for the user to clean up. Per-
+// field disabling lets a legacy bundle that already carries warranty
+// data (the migration is log-only, so legacy rows pass through
+// unmodified) be cleared from the UI. The same step always renders the
+// "split into separate items" hint so the disabled state never looks
+// like a bug.
 //
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see BasicsStep
 function WarrantyStep(props: any) {
   const { t } = useTranslation()
-  const { register, errors, watch, disabled } = props
+  const { register, errors, watch, isBundle } = props
   const expiresAt = watch("warranty_expires_at") as string | undefined
+  const notes = watch("warranty_notes") as string | undefined
   const status = warrantyStatusFromDate(expiresAt)
+  // Only disable when the field is empty AND the row is a bundle. A
+  // populated input stays editable so the user can clear / fix legacy
+  // data that pre-dates the constraint.
+  const expiresAtEmpty = !expiresAt || expiresAt.trim() === ""
+  const notesEmpty = !notes || notes.trim() === ""
+  const expiresAtDisabled = isBundle && expiresAtEmpty
+  const notesDisabled = isBundle && notesEmpty
   return (
     <div className="flex flex-col gap-4" data-testid="commodity-form-warranty-step">
       <div className="flex flex-col gap-1.5">
@@ -575,17 +590,17 @@ function WarrantyStep(props: any) {
           type="date"
           {...register("warranty_expires_at")}
           aria-invalid={!!errors.warranty_expires_at}
-          disabled={disabled}
+          disabled={expiresAtDisabled}
           data-testid="commodity-form-warranty-expires-at"
         />
         <p className="text-xs text-muted-foreground">
-          {disabled
+          {isBundle
             ? t("commodities:trackingRestrictions.warrantyStepHint")
             : t("commodities:fields.warrantyExpiresAtHelp")}
         </p>
         <FieldError error={errors.warranty_expires_at} />
       </div>
-      {status !== "none" && !disabled ? (
+      {status !== "none" && !isBundle ? (
         <WarrantyBadge
           status={status}
           className="w-fit"
@@ -600,7 +615,7 @@ function WarrantyStep(props: any) {
           {...register("warranty_notes")}
           className="border-input bg-transparent rounded-md border px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           aria-invalid={!!errors.warranty_notes}
-          disabled={disabled}
+          disabled={notesDisabled}
           data-testid="commodity-form-warranty-notes"
         />
         <FieldError error={errors.warranty_notes} />

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -2,8 +2,9 @@ import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Controller, useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { ChevronLeft, ChevronRight, Plus, X } from "lucide-react"
+import { AlertTriangle, ChevronLeft, ChevronRight, Plus, X } from "lucide-react"
 
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -199,6 +200,12 @@ export function CommodityFormDialog({
 
   const stepIndex = STEPS.indexOf(step)
   const isLastStep = stepIndex === STEPS.length - 1
+  // #1554: a count > 1 row is a bundle of identical units and can't
+  // carry warranty / loan / service. Watching the count value lets the
+  // banner show up live as soon as the user types, and lets the
+  // warranty step disable its inputs without waiting for a re-render.
+  const liveCount = Number(watch("count"))
+  const isBundle = Number.isFinite(liveCount) && liveCount > 1
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -241,6 +248,20 @@ export function CommodityFormDialog({
 
         <Separator />
 
+        {isBundle ? (
+          <Alert
+            variant="default"
+            className="border-amber-300 bg-amber-50 text-amber-900 dark:bg-amber-950/30"
+            data-testid="commodity-form-bundle-banner"
+          >
+            <AlertTriangle className="size-4" aria-hidden="true" />
+            <AlertTitle>{t("commodities:trackingRestrictions.bannerTitle")}</AlertTitle>
+            <AlertDescription>
+              {t("commodities:trackingRestrictions.bannerBody")}
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
         <form
           id="commodity-form"
           onSubmit={handleSubmit(submit)}
@@ -262,7 +283,12 @@ export function CommodityFormDialog({
             <PurchaseStep register={register} errors={errors} watch={watch} />
           ) : null}
           {step === "warranty" ? (
-            <WarrantyStep register={register} errors={errors} watch={watch} />
+            <WarrantyStep
+              register={register}
+              errors={errors}
+              watch={watch}
+              disabled={isBundle}
+            />
           ) : null}
           {step === "extras" ? (
             <ExtrasStep register={register} errors={errors} watch={watch} setValue={setValue} />
@@ -527,12 +553,15 @@ function PurchaseStep(props: any) {
 // expiry date + notes. Status (active/expiring/expired/none) is
 // computed live from the entered date and shown as a pill preview so
 // the user sees how the row will surface on the list page before
-// saving.
+// saving. When the row is a bundle (#1554, count > 1) the inputs are
+// disabled and a hint replaces the live status pill — the per-row
+// dialog banner already explains why, this step just reflects the
+// constraint at the field level.
 //
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see BasicsStep
 function WarrantyStep(props: any) {
   const { t } = useTranslation()
-  const { register, errors, watch } = props
+  const { register, errors, watch, disabled } = props
   const expiresAt = watch("warranty_expires_at") as string | undefined
   const status = warrantyStatusFromDate(expiresAt)
   return (
@@ -546,14 +575,17 @@ function WarrantyStep(props: any) {
           type="date"
           {...register("warranty_expires_at")}
           aria-invalid={!!errors.warranty_expires_at}
+          disabled={disabled}
           data-testid="commodity-form-warranty-expires-at"
         />
         <p className="text-xs text-muted-foreground">
-          {t("commodities:fields.warrantyExpiresAtHelp")}
+          {disabled
+            ? t("commodities:trackingRestrictions.warrantyStepHint")
+            : t("commodities:fields.warrantyExpiresAtHelp")}
         </p>
         <FieldError error={errors.warranty_expires_at} />
       </div>
-      {status !== "none" ? (
+      {status !== "none" && !disabled ? (
         <WarrantyBadge
           status={status}
           className="w-fit"
@@ -566,8 +598,9 @@ function WarrantyStep(props: any) {
           id="commodity-warranty-notes"
           rows={3}
           {...register("warranty_notes")}
-          className="border-input bg-transparent rounded-md border px-3 py-2 text-sm"
+          className="border-input bg-transparent rounded-md border px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           aria-invalid={!!errors.warranty_notes}
+          disabled={disabled}
           data-testid="commodity-form-warranty-notes"
         />
         <FieldError error={errors.warranty_notes} />

--- a/frontend/src/components/items/__tests__/CommodityFormDialog.test.tsx
+++ b/frontend/src/components/items/__tests__/CommodityFormDialog.test.tsx
@@ -281,6 +281,67 @@ describe("<CommodityFormDialog />", () => {
     }
   })
 
+  // Issue #1554: bundle commodities (count > 1) cannot carry warranty
+  // / loan / service. The dialog surfaces a banner the moment the
+  // user enters a count > 1, and the Warranty step disables its
+  // inputs.
+  it("shows the bundle banner when count > 1", async () => {
+    const user = userEvent.setup()
+    renderWithProviders({
+      children: (
+        <CommodityFormDialog
+          open
+          onOpenChange={() => {}}
+          mode="create"
+          areas={areas}
+          defaultCurrency="USD"
+          onSubmit={async () => {}}
+        />
+      ),
+    })
+    const countInput = await screen.findByLabelText(/^Quantity$/i)
+    expect(screen.queryByTestId("commodity-form-bundle-banner")).not.toBeInTheDocument()
+    await user.clear(countInput)
+    await user.type(countInput, "12")
+    await waitFor(() =>
+      expect(screen.getByTestId("commodity-form-bundle-banner")).toBeInTheDocument()
+    )
+  })
+
+  it("disables the Warranty step inputs when count > 1", async () => {
+    const user = userEvent.setup()
+    renderWithProviders({
+      children: (
+        <CommodityFormDialog
+          open
+          onOpenChange={() => {}}
+          mode="edit"
+          initialValues={{
+            id: "c1",
+            name: "Pack of bulbs",
+            short_name: "bulbs",
+            type: "other",
+            area_id: "a1",
+            status: "in_use",
+            count: 12,
+            draft: true,
+          }}
+          areas={areas}
+          defaultCurrency="USD"
+          onSubmit={async () => {}}
+        />
+      ),
+    })
+    // Walk to warranty step.
+    await user.click(await screen.findByTestId("commodity-form-next"))
+    await screen.findByLabelText(/Purchase date/i)
+    await user.click(screen.getByTestId("commodity-form-next"))
+    await screen.findByTestId("commodity-form-warranty-step")
+
+    expect(screen.getByTestId("commodity-form-warranty-expires-at")).toBeDisabled()
+    expect(screen.getByTestId("commodity-form-warranty-notes")).toBeDisabled()
+  })
+
   it("has no axe violations", async () => {
     const { container } = renderWithProviders({
       children: (

--- a/frontend/src/components/loans/LendTab.tsx
+++ b/frontend/src/components/loans/LendTab.tsx
@@ -114,6 +114,10 @@ export function LendTab({ commodityId, commodityCount }: LendTabProps) {
     }
   }
 
+  // The bundle hint stays a pure "you can't START a new loan" message —
+  // legacy bundle commodities may already carry loan rows (the
+  // migration only logs, doesn't strip), so the current-loan card and
+  // history list are always rendered. Only the start-loan CTA is gated.
   return (
     <Card data-testid="commodity-detail-lend">
       <CardHeader className="flex-row items-center justify-between gap-4">
@@ -131,15 +135,12 @@ export function LendTab({ commodityId, commodityCount }: LendTabProps) {
       </CardHeader>
       <CardContent className="flex flex-col gap-6">
         {isBundle ? (
-          <p
-            className="text-sm text-muted-foreground"
-            data-testid="lend-bundle-empty-state"
-          >
+          <p className="text-sm text-muted-foreground" data-testid="lend-bundle-empty-state">
             {t("commodities:trackingRestrictions.lendDisabled")}
           </p>
         ) : null}
 
-        {list.isLoading && !isBundle ? (
+        {list.isLoading ? (
           <p className="text-sm text-muted-foreground">{t("common:loading", "Loading...")}</p>
         ) : null}
 
@@ -151,7 +152,7 @@ export function LendTab({ commodityId, commodityCount }: LendTabProps) {
           </Alert>
         ) : null}
 
-        {!isBundle && current ? (
+        {current ? (
           <CurrentLoanCard
             loan={current}
             onReturn={() => handleReturn(current)}
@@ -165,7 +166,7 @@ export function LendTab({ commodityId, commodityCount }: LendTabProps) {
           </p>
         ) : null}
 
-        {!isBundle && history.length > 0 ? (
+        {history.length > 0 ? (
           <div className="flex flex-col gap-2" data-testid="lend-history">
             <h3 className="text-sm font-medium">{t("loans:tab.historyTitle")}</h3>
             <ul className="flex flex-col gap-2">

--- a/frontend/src/components/loans/LendTab.tsx
+++ b/frontend/src/components/loans/LendTab.tsx
@@ -23,18 +23,25 @@ import { LendDialog } from "./LendDialog"
 
 interface LendTabProps {
   commodityId: string
+  // #1554: when the parent commodity has count > 1 the row is a
+  // bundle of interchangeable units, not a single tracked instance.
+  // Lending isn't a meaningful operation in that case (which one
+  // of the 12 bulbs is on loan?). The tab swaps its body for an
+  // empty-state hint and disables the Lend CTA.
+  commodityCount?: number
 }
 
 // LendTab is the lend-out surface on the commodity detail page. It
 // renders the (at most one) currently-open loan as a card with a
 // "mark returned" affordance, plus a history list of closed loans for
 // audit context. The card is bordered amber when overdue.
-export function LendTab({ commodityId }: LendTabProps) {
+export function LendTab({ commodityId, commodityCount }: LendTabProps) {
   const { t } = useTranslation(["loans", "common"])
   const toast = useAppToast()
   const confirm = useConfirm()
   const [open, setOpen] = useState(false)
 
+  const isBundle = (commodityCount ?? 0) > 1
   const list = useLoansForCommodity(commodityId)
   const start = useStartLoan()
   const ret = useReturnLoan()
@@ -111,7 +118,7 @@ export function LendTab({ commodityId }: LendTabProps) {
     <Card data-testid="commodity-detail-lend">
       <CardHeader className="flex-row items-center justify-between gap-4">
         <CardTitle>{t("loans:tab.title")}</CardTitle>
-        {!current && !openService ? (
+        {!current && !openService && !isBundle ? (
           <Button
             type="button"
             size="sm"
@@ -123,11 +130,20 @@ export function LendTab({ commodityId }: LendTabProps) {
         ) : null}
       </CardHeader>
       <CardContent className="flex flex-col gap-6">
-        {list.isLoading ? (
+        {isBundle ? (
+          <p
+            className="text-sm text-muted-foreground"
+            data-testid="lend-bundle-empty-state"
+          >
+            {t("commodities:trackingRestrictions.lendDisabled")}
+          </p>
+        ) : null}
+
+        {list.isLoading && !isBundle ? (
           <p className="text-sm text-muted-foreground">{t("common:loading", "Loading...")}</p>
         ) : null}
 
-        {!current && openService ? (
+        {!current && openService && !isBundle ? (
           <Alert data-testid="lend-blocked-by-service">
             <AlertDescription>
               {t("loans:tab.blockedByService", { provider: openService.provider_name })}
@@ -135,7 +151,7 @@ export function LendTab({ commodityId }: LendTabProps) {
           </Alert>
         ) : null}
 
-        {current ? (
+        {!isBundle && current ? (
           <CurrentLoanCard
             loan={current}
             onReturn={() => handleReturn(current)}
@@ -143,13 +159,13 @@ export function LendTab({ commodityId }: LendTabProps) {
             returning={ret.isPending}
             deleting={remove.isPending}
           />
-        ) : !list.isLoading ? (
+        ) : !isBundle && !list.isLoading ? (
           <p className="text-sm text-muted-foreground" data-testid="lend-empty-state">
             {t("loans:tab.emptyState")}
           </p>
         ) : null}
 
-        {history.length > 0 ? (
+        {!isBundle && history.length > 0 ? (
           <div className="flex flex-col gap-2" data-testid="lend-history">
             <h3 className="text-sm font-medium">{t("loans:tab.historyTitle")}</h3>
             <ul className="flex flex-col gap-2">

--- a/frontend/src/components/loans/__tests__/LendTab.test.tsx
+++ b/frontend/src/components/loans/__tests__/LendTab.test.tsx
@@ -41,7 +41,7 @@ beforeEach(() => {
   setCurrentGroupSlug(SLUG)
 })
 
-function renderTab() {
+function renderTab(commodityCount?: number) {
   return renderWithProviders({
     initialPath: `/g/${SLUG}/commodities/${COMMODITY_ID}`,
     routes: (
@@ -51,7 +51,7 @@ function renderTab() {
           <ConfirmProvider>
             <GroupProvider>
               <main>
-                <LendTab commodityId={COMMODITY_ID} />
+                <LendTab commodityId={COMMODITY_ID} commodityCount={commodityCount} />
               </main>
             </GroupProvider>
           </ConfirmProvider>
@@ -226,6 +226,21 @@ describe("<LendTab />", () => {
     } finally {
       window.fetch = realFetch
     }
+  })
+
+  // Issue #1554: bundle commodities (count > 1) cannot be lent out —
+  // the row models a bag of interchangeable units, not a single
+  // tracked instance. The tab swaps its body for the empty-state hint
+  // and hides the Lend CTA so the user can't even open the dialog.
+  it("renders the bundle empty-state and hides the Lend button when count > 1", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...loanHandlers.listForCommodity(SLUG, COMMODITY_ID, [])
+    )
+    renderTab(12)
+    expect(await screen.findByTestId("lend-bundle-empty-state")).toBeInTheDocument()
+    expect(screen.queryByTestId("commodity-detail-lend-button")).toBeNull()
+    expect(screen.queryByTestId("lend-empty-state")).toBeNull()
   })
 
   it("is axe-clean once data has loaded", async () => {

--- a/frontend/src/components/services/ServiceTab.tsx
+++ b/frontend/src/components/services/ServiceTab.tsx
@@ -23,18 +23,22 @@ import { SendForServiceDialog } from "./SendForServiceDialog"
 
 interface ServiceTabProps {
   commodityId: string
+  // #1554: bundle commodities (count > 1) cannot be sent for service.
+  // Mirror LendTab — render an empty-state hint and hide the CTA.
+  commodityCount?: number
 }
 
 // ServiceTab is the in-service surface on commodity detail. Mirrors
 // LendTab structurally — at most one open service row + a history
 // list — but the copy and icons emphasise repair / workshop semantics
 // instead of borrower semantics.
-export function ServiceTab({ commodityId }: ServiceTabProps) {
+export function ServiceTab({ commodityId, commodityCount }: ServiceTabProps) {
   const { t } = useTranslation(["services", "common"])
   const toast = useAppToast()
   const confirm = useConfirm()
   const [open, setOpen] = useState(false)
 
+  const isBundle = (commodityCount ?? 0) > 1
   const list = useServicesForCommodity(commodityId)
   const start = useStartService()
   const ret = useReturnService()
@@ -115,7 +119,7 @@ export function ServiceTab({ commodityId }: ServiceTabProps) {
     <Card data-testid="commodity-detail-service">
       <CardHeader className="flex-row items-center justify-between gap-4">
         <CardTitle>{t("services:tab.title")}</CardTitle>
-        {!current && !openLoan ? (
+        {!current && !openLoan && !isBundle ? (
           <Button
             type="button"
             size="sm"
@@ -127,11 +131,20 @@ export function ServiceTab({ commodityId }: ServiceTabProps) {
         ) : null}
       </CardHeader>
       <CardContent className="flex flex-col gap-6">
-        {list.isLoading ? (
+        {isBundle ? (
+          <p
+            className="text-sm text-muted-foreground"
+            data-testid="service-bundle-empty-state"
+          >
+            {t("commodities:trackingRestrictions.serviceDisabled")}
+          </p>
+        ) : null}
+
+        {!isBundle && list.isLoading ? (
           <p className="text-sm text-muted-foreground">{t("common:loading", "Loading...")}</p>
         ) : null}
 
-        {!current && openLoan ? (
+        {!isBundle && !current && openLoan ? (
           <Alert data-testid="service-blocked-by-loan">
             <AlertDescription>
               {t("services:tab.blockedByLoan", { borrower: openLoan.borrower_name })}
@@ -139,7 +152,7 @@ export function ServiceTab({ commodityId }: ServiceTabProps) {
           </Alert>
         ) : null}
 
-        {current ? (
+        {!isBundle && current ? (
           <CurrentServiceCard
             service={current}
             onReturn={() => handleReturn(current)}
@@ -147,13 +160,13 @@ export function ServiceTab({ commodityId }: ServiceTabProps) {
             returning={ret.isPending}
             deleting={remove.isPending}
           />
-        ) : !list.isLoading ? (
+        ) : !isBundle && !list.isLoading ? (
           <p className="text-sm text-muted-foreground" data-testid="service-empty-state">
             {t("services:tab.emptyState")}
           </p>
         ) : null}
 
-        {history.length > 0 ? (
+        {!isBundle && history.length > 0 ? (
           <div className="flex flex-col gap-2" data-testid="service-history">
             <h3 className="text-sm font-medium">{t("services:tab.historyTitle")}</h3>
             <ul className="flex flex-col gap-2">

--- a/frontend/src/components/services/ServiceTab.tsx
+++ b/frontend/src/components/services/ServiceTab.tsx
@@ -115,6 +115,10 @@ export function ServiceTab({ commodityId, commodityCount }: ServiceTabProps) {
     }
   }
 
+  // Mirror LendTab: legacy bundle commodities may already carry
+  // service rows; we only gate the START affordance, never hide the
+  // current/history rows. The bundle hint sits above the data so the
+  // user understands why they can't open a new service row.
   return (
     <Card data-testid="commodity-detail-service">
       <CardHeader className="flex-row items-center justify-between gap-4">
@@ -132,19 +136,16 @@ export function ServiceTab({ commodityId, commodityCount }: ServiceTabProps) {
       </CardHeader>
       <CardContent className="flex flex-col gap-6">
         {isBundle ? (
-          <p
-            className="text-sm text-muted-foreground"
-            data-testid="service-bundle-empty-state"
-          >
+          <p className="text-sm text-muted-foreground" data-testid="service-bundle-empty-state">
             {t("commodities:trackingRestrictions.serviceDisabled")}
           </p>
         ) : null}
 
-        {!isBundle && list.isLoading ? (
+        {list.isLoading ? (
           <p className="text-sm text-muted-foreground">{t("common:loading", "Loading...")}</p>
         ) : null}
 
-        {!isBundle && !current && openLoan ? (
+        {!current && openLoan && !isBundle ? (
           <Alert data-testid="service-blocked-by-loan">
             <AlertDescription>
               {t("services:tab.blockedByLoan", { borrower: openLoan.borrower_name })}
@@ -152,7 +153,7 @@ export function ServiceTab({ commodityId, commodityCount }: ServiceTabProps) {
           </Alert>
         ) : null}
 
-        {!isBundle && current ? (
+        {current ? (
           <CurrentServiceCard
             service={current}
             onReturn={() => handleReturn(current)}
@@ -166,7 +167,7 @@ export function ServiceTab({ commodityId, commodityCount }: ServiceTabProps) {
           </p>
         ) : null}
 
-        {!isBundle && history.length > 0 ? (
+        {history.length > 0 ? (
           <div className="flex flex-col gap-2" data-testid="service-history">
             <h3 className="text-sm font-medium">{t("services:tab.historyTitle")}</h3>
             <ul className="flex flex-col gap-2">

--- a/frontend/src/features/commodities/__tests__/schemas.test.ts
+++ b/frontend/src/features/commodities/__tests__/schemas.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+
+import { commoditySchema } from "@/features/commodities/schemas"
+
+// Issue #1554: a count > 1 commodity (a bundle of interchangeable
+// units) cannot carry warranty fields. The schema's superRefine
+// surfaces the same translation key the BE 422 maps to, so the form
+// rejects the pair before the network round-trip.
+describe("commoditySchema — quantity-forbids-warranty (#1554)", () => {
+  const baseValues = {
+    name: "Pack of bulbs",
+    short_name: "bulbs",
+    type: "other",
+    area_id: "a1",
+    status: "in_use",
+    count: "12",
+    original_price: "",
+    original_price_currency: "USD",
+    converted_original_price: "",
+    current_price: "",
+    serial_number: "",
+    extra_serial_numbers: [],
+    part_numbers: [],
+    tags: [],
+    purchase_date: "",
+    urls: [],
+    comments: "",
+    draft: true, // skip purchase / price triad guards
+    warranty_expires_at: "",
+    warranty_notes: "",
+  }
+
+  it("rejects count > 1 with a warranty expiry", () => {
+    const result = commoditySchema.safeParse({
+      ...baseValues,
+      warranty_expires_at: "2027-01-01",
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain("commodities:validation.quantityForbidsWarranty")
+      const paths = result.error.issues.map((i) => i.path.join("."))
+      expect(paths).toContain("warranty_expires_at")
+      expect(paths).toContain("count")
+    }
+  })
+
+  it("rejects count > 1 with warranty notes", () => {
+    const result = commoditySchema.safeParse({
+      ...baseValues,
+      warranty_notes: "covers parts only",
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."))
+      expect(paths).toContain("warranty_notes")
+      expect(paths).toContain("count")
+    }
+  })
+
+  it("accepts count > 1 with no warranty fields", () => {
+    const result = commoditySchema.safeParse(baseValues)
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts count = 1 with warranty fields", () => {
+    const result = commoditySchema.safeParse({
+      ...baseValues,
+      count: "1",
+      warranty_expires_at: "2027-01-01",
+      warranty_notes: "covers parts only",
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/frontend/src/features/commodities/schemas.ts
+++ b/frontend/src/features/commodities/schemas.ts
@@ -27,6 +27,11 @@ const CONVERTED_PRICE_REQUIRED = "commodities:validation.convertedPriceRequired"
 const CURRENT_PRICE_REQUIRED = "commodities:validation.currentPriceRequired"
 const COMMENTS_TOO_LONG = "commodities:validation.commentsTooLong"
 const NOT_A_NUMBER = "commodities:validation.notANumber"
+// #1554: a Count > 1 commodity (a bundle of interchangeable units)
+// can't carry a warranty — it's not a single tracked instance. The
+// schema rejects the pair at submit time so the user sees the same
+// hint the BE 422 would surface, just earlier.
+const QUANTITY_FORBIDS_WARRANTY = "commodities:validation.quantityForbidsWarranty"
 
 // optionalNumberString accepts a number-as-string and refuses anything
 // that isn't blank or numeric. It stays a string in the schema so the
@@ -66,6 +71,36 @@ export const commoditySchema = z
     warranty_notes: z.string().max(1000, COMMENTS_TOO_LONG),
   })
   .superRefine((vals, ctx) => {
+    // #1554: bundle commodities (count > 1) don't carry warranty. Fire
+    // the message on every offending field so RHF surfaces it next to
+    // the bad input regardless of which step the user is on.
+    const count = Number(vals.count)
+    if (count > 1) {
+      if (vals.warranty_expires_at && vals.warranty_expires_at.trim() !== "") {
+        ctx.addIssue({
+          path: ["warranty_expires_at"],
+          code: z.ZodIssueCode.custom,
+          message: QUANTITY_FORBIDS_WARRANTY,
+        })
+        ctx.addIssue({
+          path: ["count"],
+          code: z.ZodIssueCode.custom,
+          message: QUANTITY_FORBIDS_WARRANTY,
+        })
+      }
+      if (vals.warranty_notes && vals.warranty_notes.trim() !== "") {
+        ctx.addIssue({
+          path: ["warranty_notes"],
+          code: z.ZodIssueCode.custom,
+          message: QUANTITY_FORBIDS_WARRANTY,
+        })
+        ctx.addIssue({
+          path: ["count"],
+          code: z.ZodIssueCode.custom,
+          message: QUANTITY_FORBIDS_WARRANTY,
+        })
+      }
+    }
     // Future-date guard. Surface the error on `purchase_date` directly
     // so RHF puts it next to the input.
     if (vals.purchase_date) {

--- a/frontend/src/features/commodities/schemas.ts
+++ b/frontend/src/features/commodities/schemas.ts
@@ -72,34 +72,34 @@ export const commoditySchema = z
   })
   .superRefine((vals, ctx) => {
     // #1554: bundle commodities (count > 1) don't carry warranty. Fire
-    // the message on every offending field so RHF surfaces it next to
-    // the bad input regardless of which step the user is on.
+    // a per-field message so RHF surfaces it next to each offending
+    // input, plus a single `count` issue so the Quantity field is also
+    // highlighted (one count issue total, even when both warranty
+    // fields are populated — multiple identical issues on the same
+    // path would render duplicate error rows).
     const count = Number(vals.count)
-    if (count > 1) {
-      if (vals.warranty_expires_at && vals.warranty_expires_at.trim() !== "") {
+    const hasWarrantyExpiry = !!vals.warranty_expires_at && vals.warranty_expires_at.trim() !== ""
+    const hasWarrantyNotes = !!vals.warranty_notes && vals.warranty_notes.trim() !== ""
+    if (count > 1 && (hasWarrantyExpiry || hasWarrantyNotes)) {
+      if (hasWarrantyExpiry) {
         ctx.addIssue({
           path: ["warranty_expires_at"],
           code: z.ZodIssueCode.custom,
           message: QUANTITY_FORBIDS_WARRANTY,
         })
-        ctx.addIssue({
-          path: ["count"],
-          code: z.ZodIssueCode.custom,
-          message: QUANTITY_FORBIDS_WARRANTY,
-        })
       }
-      if (vals.warranty_notes && vals.warranty_notes.trim() !== "") {
+      if (hasWarrantyNotes) {
         ctx.addIssue({
           path: ["warranty_notes"],
           code: z.ZodIssueCode.custom,
           message: QUANTITY_FORBIDS_WARRANTY,
         })
-        ctx.addIssue({
-          path: ["count"],
-          code: z.ZodIssueCode.custom,
-          message: QUANTITY_FORBIDS_WARRANTY,
-        })
       }
+      ctx.addIssue({
+        path: ["count"],
+        code: z.ZodIssueCode.custom,
+        message: QUANTITY_FORBIDS_WARRANTY,
+      })
     }
     // Future-date guard. Surface the error on `purchase_date` directly
     // so RHF puts it next to the input.

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -271,6 +271,14 @@
     "statusUpdateError": "Couldn't update the status.",
     "updated": "Item saved."
   },
+  "trackingRestrictions": {
+    "bannerBody": "Bundle items don't support warranty, lending, or service tracking. Split into separate items if you need any of those per-unit.",
+    "bannerTitle": "Quantity greater than 1",
+    "lendDisabled": "Lending isn't tracked for items with quantity greater than 1. Split into separate items to lend individual units.",
+    "serviceDisabled": "Service tracking isn't available for items with quantity greater than 1. Split into separate items to send a single unit for repair.",
+    "warrantyDisabled": "Warranty isn't tracked for items with quantity greater than 1. Split into separate items if you need per-unit warranty tracking.",
+    "warrantyStepHint": "Warranty fields are disabled while quantity is greater than 1."
+  },
   "type": {
     "clothes": "Clothes",
     "electronics": "Electronics",
@@ -297,14 +305,6 @@
     "shortNameTooLong": "Short name must be 20 characters or fewer.",
     "statusRequired": "Pick a status.",
     "typeRequired": "Pick a type."
-  },
-  "trackingRestrictions": {
-    "bannerTitle": "Quantity greater than 1",
-    "bannerBody": "Bundle items don't support warranty, lending, or service tracking. Split into separate items if you need any of those per-unit.",
-    "lendDisabled": "Lending isn't tracked for items with quantity greater than 1. Split into separate items to lend individual units.",
-    "serviceDisabled": "Service tracking isn't available for items with quantity greater than 1. Split into separate items to send a single unit for repair.",
-    "warrantyDisabled": "Warranty isn't tracked for items with quantity greater than 1. Split into separate items if you need per-unit warranty tracking.",
-    "warrantyStepHint": "Warranty fields are disabled while quantity is greater than 1."
   },
   "warranty": {
     "active": "Active",

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -292,10 +292,19 @@
     "originalPriceRequired": "Original price is required for non-draft items.",
     "purchaseDateFuture": "Purchase date cannot be in the future.",
     "purchaseDateRequired": "Purchase date is required for non-draft items.",
+    "quantityForbidsWarranty": "Items with quantity greater than 1 don't support warranty tracking. Split into separate items for per-unit tracking.",
     "shortNameRequired": "Short name is required.",
     "shortNameTooLong": "Short name must be 20 characters or fewer.",
     "statusRequired": "Pick a status.",
     "typeRequired": "Pick a type."
+  },
+  "trackingRestrictions": {
+    "bannerTitle": "Quantity greater than 1",
+    "bannerBody": "Bundle items don't support warranty, lending, or service tracking. Split into separate items if you need any of those per-unit.",
+    "lendDisabled": "Lending isn't tracked for items with quantity greater than 1. Split into separate items to lend individual units.",
+    "serviceDisabled": "Service tracking isn't available for items with quantity greater than 1. Split into separate items to send a single unit for repair.",
+    "warrantyDisabled": "Warranty isn't tracked for items with quantity greater than 1. Split into separate items if you need per-unit warranty tracking.",
+    "warrantyStepHint": "Warranty fields are disabled while quantity is greater than 1."
   },
   "warranty": {
     "active": "Active",

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -472,21 +472,29 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
                 {t("commodities:list.draftBadge")}
               </Badge>
             ) : null}
-            <WarrantyBadge
-              source={{
-                warranty_expires_at: commodity.warranty_expires_at,
-                tags: commodity.tags,
-              }}
-              data-testid="commodity-detail-warranty-pill"
-            />
-            {(() => {
-              const days = warrantyDaysRemaining(commodity.warranty_expires_at)
-              return days !== null && days > 0 ? (
-                <span className="text-xs text-muted-foreground">
-                  {t("commodities:detail.warranty.daysRemaining", { count: days })}
-                </span>
-              ) : null
-            })()}
+            {/* #1554: bundles don't carry a warranty — hide the pill
+                + days-remaining row entirely so the header doesn't
+                advertise an attribute the row can't have. The
+                Warranty tab body shows the explanatory empty state. */}
+            {(commodity.count ?? 0) > 1 ? null : (
+              <>
+                <WarrantyBadge
+                  source={{
+                    warranty_expires_at: commodity.warranty_expires_at,
+                    tags: commodity.tags,
+                  }}
+                  data-testid="commodity-detail-warranty-pill"
+                />
+                {(() => {
+                  const days = warrantyDaysRemaining(commodity.warranty_expires_at)
+                  return days !== null && days > 0 ? (
+                    <span className="text-xs text-muted-foreground">
+                      {t("commodities:detail.warranty.daysRemaining", { count: days })}
+                    </span>
+                  ) : null
+                })()}
+              </>
+            )}
           </div>
         </header>
 
@@ -611,9 +619,15 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
           ) : tab === "warranty" ? (
             <WarrantyTab commodity={commodity} onSwitchToFiles={() => setTab("files")} />
           ) : tab === "lend" ? (
-            <LendTab commodityId={commodity?.id ?? id} />
+            <LendTab
+              commodityId={commodity?.id ?? id}
+              commodityCount={commodity?.count ?? undefined}
+            />
           ) : tab === "service" ? (
-            <ServiceTab commodityId={commodity?.id ?? id} />
+            <ServiceTab
+              commodityId={commodity?.id ?? id}
+              commodityCount={commodity?.count ?? undefined}
+            />
           ) : (
             <FilesTab
               commodityId={commodity?.id ?? id}
@@ -1202,6 +1216,30 @@ interface WarrantyTabProps {
 // Warranty step — this tab stays read-only.
 function WarrantyTab({ commodity, onSwitchToFiles }: WarrantyTabProps) {
   const { t } = useTranslation()
+  // #1554: bundle commodities don't carry a warranty — render the
+  // "split into separate items" hint instead of the live pill / notes
+  // block. Doing this here (rather than inside the existing layout)
+  // avoids leaking the upload-receipt CTA + status pill into a row
+  // that can never have either.
+  const isBundle = (commodity?.count ?? 0) > 1
+  if (isBundle) {
+    return (
+      <Card data-testid="commodity-detail-warranty">
+        <CardHeader>
+          <CardTitle>{t("commodities:detail.warranty.title")}</CardTitle>
+          <CardDescription>{t("commodities:detail.warranty.description")}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p
+            className="text-sm text-muted-foreground"
+            data-testid="commodity-detail-warranty-bundle-empty-state"
+          >
+            {t("commodities:trackingRestrictions.warrantyDisabled")}
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
   const status: CommodityWarrantyStatus = commodity
     ? warrantyStatus({
         warranty_expires_at: commodity.warranty_expires_at,

--- a/go/apiserver/commodities.go
+++ b/go/apiserver/commodities.go
@@ -24,6 +24,7 @@ type commoditiesAPI struct {
 	tagService    *services.TagService
 	coverService  *services.CommodityCoverService
 	eventService  *services.CommodityEventService
+	factorySet    *registry.FactorySet
 }
 
 // listCommodities lists all commodities with pagination, filters, and sort.
@@ -401,6 +402,24 @@ func (api *commoditiesAPI) updateCommodity(w http.ResponseWriter, r *http.Reques
 		updateData.Tags = models.ValuerSlice[string](slugs)
 	}
 
+	// #1554: a 1 → >1 quantity bump must be blocked when the row still
+	// carries per-instance state (warranty fields / open loan / open
+	// service). The model-level validation handles a fresh count>1 row
+	// with warranty fields, but the cross-table loan/service check
+	// needs registry access — done here. Returns a multi-error 422 so
+	// the FE can list every blocker on the same submit.
+	if commodity.Count == 1 && updateData.Count > 1 {
+		blockers, berr := services.CheckQuantityBumpBlockers(r.Context(), api.factorySet, commodity)
+		if berr != nil {
+			renderEntityError(w, r, berr)
+			return
+		}
+		if len(blockers) > 0 {
+			renderQuantityBumpBlockers(w, r, blockers)
+			return
+		}
+	}
+
 	// Use UpdateWithUser to ensure proper user context and validation
 	ctx := r.Context()
 	commodityReg := registrySet.CommodityRegistry
@@ -710,6 +729,7 @@ func Commodities(params Params) func(r chi.Router) {
 		tagService:    services.NewTagService(params.FactorySet),
 		coverService:  services.NewCommodityCoverService(fileSigningService),
 		eventService:  services.NewCommodityEventService(params.FactorySet),
+		factorySet:    params.FactorySet,
 	}
 
 	return func(r chi.Router) {

--- a/go/apiserver/commodity_quantity_bump.go
+++ b/go/apiserver/commodity_quantity_bump.go
@@ -1,0 +1,74 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/render"
+
+	"github.com/denisvmedia/inventario/jsonapi"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// quantityBumpBlockerError adapts services.QuantityBumpBlocker to the
+// error / json.Marshaler contract jsonapi.Error expects. Each blocker
+// becomes one entry in the multi-error 422 response: the FE iterates
+// `errors[]` and renders one localised hint per blocker, keyed by
+// `kind` (warranty / loan / service).
+type quantityBumpBlockerError struct {
+	Kind   services.QuantityBumpBlockerKind `json:"kind"`
+	Detail string                           `json:"detail"`
+	// Source mimics the JSON:API source.pointer convention so the FE can
+	// route the message to the right form field (Quantity vs the gated
+	// step) without having to special-case `kind`. Always points at
+	// /data/attributes/count for now since every blocker fires from the
+	// same form input; future blockers might point elsewhere.
+	Source quantityBumpSource `json:"source"`
+}
+
+type quantityBumpSource struct {
+	Pointer string `json:"pointer"`
+}
+
+func (e *quantityBumpBlockerError) Error() string {
+	return string(e.Kind) + ": " + e.Detail
+}
+
+// renderQuantityBumpBlockers emits a JSON:API 422 multi-error envelope —
+// one entry per blocker — when a 1 → >1 quantity bump still has open
+// per-instance state. Mirrors unprocessableEntityError's shape but
+// stacks N errors under `errors[]` so the FE can list every blocker
+// at once.
+func renderQuantityBumpBlockers(w http.ResponseWriter, r *http.Request, blockers []services.QuantityBumpBlocker) {
+	apiErrors := make([]jsonapi.Error, 0, len(blockers))
+	for _, b := range blockers {
+		blocker := &quantityBumpBlockerError{
+			Kind:   b.Kind,
+			Detail: b.Detail,
+			Source: quantityBumpSource{Pointer: "/data/attributes/count"},
+		}
+		apiErrors = append(apiErrors, jsonapi.Error{
+			Err:            blocker,
+			UserError:      json.RawMessage(mustMarshalBlocker(blocker)),
+			HTTPStatusCode: http.StatusUnprocessableEntity,
+			StatusText:     "Unprocessable Entity",
+		})
+	}
+	envelope := jsonapi.NewErrors(apiErrors...)
+	envelope.HTTPStatusCode = http.StatusUnprocessableEntity
+	if err := render.Render(w, r, envelope); err != nil {
+		internalServerError(w, r, err)
+	}
+}
+
+// mustMarshalBlocker is a tiny shim that never fails — the only reason
+// json.Marshal would error here is a programming bug (e.g. a struct
+// loop), which we'd rather see in tests than mask. The fallback returns
+// a minimal payload so the response still validates.
+func mustMarshalBlocker(b *quantityBumpBlockerError) []byte {
+	data, err := json.Marshal(b)
+	if err != nil {
+		return []byte(`{"kind":"unknown","detail":"failed to marshal blocker"}`)
+	}
+	return data
+}

--- a/go/apiserver/commodity_quantity_bump_test.go
+++ b/go/apiserver/commodity_quantity_bump_test.go
@@ -1,0 +1,196 @@
+package apiserver_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/internal/checkers"
+	"github.com/denisvmedia/inventario/jsonapi"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// Issue #1554: locks the four illegal write paths surfaced as 422.
+//
+//   1. POST /commodities — Count > 1 with warranty fields rejected.
+//   2. POST /commodities/{id}/loans — bundle commodity rejected.
+//   3. POST /commodities/{id}/services — bundle commodity rejected.
+//   4. PUT /commodities/{id} — 1 → >1 bump with open per-instance state
+//      rejected with multi-error.
+
+func TestCommodity_Issue1554_CreateRejectsBundleWithWarranty(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	areas := must.Must(registrySet.AreaRegistry.List(context.Background()))
+	area := areas[0]
+
+	expires := models.ToPDate("2027-01-01")
+	obj := &jsonapi.CommodityRequest{
+		Data: &jsonapi.CommodityData{
+			Type: "commodities",
+			Attributes: &models.Commodity{
+				Name:                   "12 light bulbs",
+				ShortName:              "bulbs",
+				AreaID:                 area.ID,
+				Type:                   models.CommodityTypeOther,
+				Status:                 models.CommodityStatusInUse,
+				Count:                  12,
+				OriginalPrice:          must.Must(decimal.NewFromString("20.00")),
+				OriginalPriceCurrency:  models.Currency("USD"),
+				ConvertedOriginalPrice: must.Must(decimal.NewFromString("0")),
+				CurrentPrice:           must.Must(decimal.NewFromString("18.00")),
+				PurchaseDate:           models.ToPDate("2026-01-01"),
+				WarrantyExpiresAt:      expires,
+			},
+		},
+	}
+	data := must.Must(json.Marshal(obj))
+	req := must.Must(http.NewRequest("POST", "/api/v1/g/"+testGroup.Slug+"/commodities", bytes.NewReader(data)))
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	apiserver.APIServer(params, mockRestoreWorker).ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body=%s", rr.Body.String()))
+}
+
+func TestCommodity_Issue1554_LoanRejectsBundle(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	all := must.Must(registrySet.CommodityRegistry.List(context.Background()))
+	// The fixture seeds Commodity 1 with Count=10 (a bundle) — perfect
+	// target for the rejection path. Sanity-check rather than rely on
+	// fixture order.
+	var bundle *models.Commodity
+	for _, c := range all {
+		if c.Count > 1 {
+			bundle = c
+			break
+		}
+	}
+	c.Assert(bundle, qt.IsNotNil, qt.Commentf("expected fixture to seed at least one Count>1 commodity"))
+
+	body := `{"data":{"type":"commodity_loans","attributes":{"borrower_name":"Alice","lent_at":"2026-05-01"}}}`
+	req := must.Must(http.NewRequest("POST",
+		"/api/v1/g/"+testGroup.Slug+"/commodities/"+bundle.ID+"/loans",
+		bytes.NewBufferString(body)))
+	req.Header.Set("Content-Type", "application/vnd.api+json")
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	apiserver.APIServer(params, mockRestoreWorker).ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body=%s", rr.Body.String()))
+}
+
+func TestCommodity_Issue1554_ServiceRejectsBundle(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	all := must.Must(registrySet.CommodityRegistry.List(context.Background()))
+	var bundle *models.Commodity
+	for _, c := range all {
+		if c.Count > 1 {
+			bundle = c
+			break
+		}
+	}
+	c.Assert(bundle, qt.IsNotNil)
+
+	body := `{"data":{"type":"commodity_services","attributes":{"provider_name":"Repair Shop","sent_at":"2026-05-01"}}}`
+	req := must.Must(http.NewRequest("POST",
+		"/api/v1/g/"+testGroup.Slug+"/commodities/"+bundle.ID+"/services",
+		bytes.NewBufferString(body)))
+	req.Header.Set("Content-Type", "application/vnd.api+json")
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	apiserver.APIServer(params, mockRestoreWorker).ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body=%s", rr.Body.String()))
+}
+
+func TestCommodity_Issue1554_BumpRejectsWithOpenLoan(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	areas := must.Must(registrySet.AreaRegistry.List(context.Background()))
+	area := areas[0]
+
+	// Seed a fresh Count=1 commodity so the bump check has a clean
+	// starting state independent of fixture data.
+	commodity := must.Must(registrySet.CommodityRegistry.Create(context.Background(), models.Commodity{
+		Name:                  "Single laptop",
+		ShortName:             "laptop",
+		AreaID:                area.ID,
+		Type:                  models.CommodityTypeElectronics,
+		Status:                models.CommodityStatusInUse,
+		Count:                 1,
+		OriginalPrice:         must.Must(decimal.NewFromString("1000.00")),
+		OriginalPriceCurrency: models.Currency("USD"),
+	}))
+
+	// Open a loan on the Count=1 row — perfectly legal today.
+	loanBody := `{"data":{"type":"commodity_loans","attributes":{"borrower_name":"Alice","lent_at":"2026-05-01"}}}`
+	loanReq := must.Must(http.NewRequest("POST",
+		"/api/v1/g/"+testGroup.Slug+"/commodities/"+commodity.ID+"/loans",
+		bytes.NewBufferString(loanBody)))
+	loanReq.Header.Set("Content-Type", "application/vnd.api+json")
+	addTestUserAuthHeader(loanReq, testUser.ID)
+	loanRR := httptest.NewRecorder()
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	apiserver.APIServer(params, mockRestoreWorker).ServeHTTP(loanRR, loanReq)
+	c.Assert(loanRR.Code, qt.Equals, http.StatusCreated, qt.Commentf("loan body=%s", loanRR.Body.String()))
+
+	// Now try to bump quantity from 1 to 5 — must fail 422 with a
+	// multi-error envelope listing the loan as a blocker.
+	updateObj := &jsonapi.CommodityRequest{
+		Data: &jsonapi.CommodityData{
+			ID:   commodity.ID,
+			Type: "commodities",
+			Attributes: models.WithID(commodity.ID, &models.Commodity{
+				Name:                   "Single laptop",
+				ShortName:              "laptop",
+				AreaID:                 area.ID,
+				Type:                   models.CommodityTypeElectronics,
+				Status:                 models.CommodityStatusInUse,
+				Count:                  5,
+				OriginalPrice:          must.Must(decimal.NewFromString("1000.00")),
+				OriginalPriceCurrency:  models.Currency("USD"),
+				ConvertedOriginalPrice: must.Must(decimal.NewFromString("0")),
+				CurrentPrice:           must.Must(decimal.NewFromString("900.00")),
+				PurchaseDate:           models.ToPDate("2026-01-01"),
+			}),
+		},
+	}
+	data := must.Must(json.Marshal(updateObj))
+	req := must.Must(http.NewRequest("PUT",
+		"/api/v1/g/"+testGroup.Slug+"/commodities/"+commodity.ID,
+		bytes.NewReader(data)))
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+	apiserver.APIServer(params, mockRestoreWorker).ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body=%s", rr.Body.String()))
+	body := rr.Body.Bytes()
+	// The multi-error payload should include at least the loan
+	// blocker. The error envelope's first entry has its own
+	// `error.kind` and `error.source.pointer` fields keyed off the
+	// quantityBumpBlockerError shape.
+	c.Check(body, checkers.JSONPathEquals("$.errors[0].error.kind"), "loan")
+	c.Check(body, checkers.JSONPathEquals("$.errors[0].error.source.pointer"), "/data/attributes/count")
+}

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -115,6 +115,12 @@ func toJSONAPIError(err error) jsonapi.Error {
 		return NewMaskedNotFoundError(err)
 	case errors.Is(err, services.ErrLastAdmin):
 		return NewUnprocessableEntityError(err)
+	case errors.Is(err, services.ErrCommodityNotTrackable):
+		// #1554: a bundle commodity (count > 1) cannot carry a per-
+		// instance event (lend / service / warranty). Surface as 422
+		// so the FE renders the same "split into separate items" hint
+		// the create-form banner uses.
+		return NewUnprocessableEntityError(err)
 	case errors.Is(err, services.ErrInvalidConfirmation),
 		errors.Is(err, services.ErrInvalidPassword):
 		return NewUnprocessableEntityError(err)

--- a/go/models/commodity.go
+++ b/go/models/commodity.go
@@ -342,6 +342,27 @@ func (a *Commodity) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&a.Status, rules.NotEmpty),
 		validation.Field(&a.PurchaseDate, whenNotDraft.WithRules(rules.NotEmpty)),
 		validation.Field(&a.Count, validation.Required, validation.Min(1)),
+		// #1554: Count > 1 is a "bundle of identical units" semantics, not
+		// a single tracked instance. Warranty fields describe a single
+		// instance's manufacturer cover, so a bundle row carrying a
+		// warranty is nonsensical. Reject at write-time; the FE form
+		// disables the inputs and surfaces a banner. Loan / service
+		// records sit on their own tables and are gated in the
+		// per-table service layer (services.EnsureCommodityTrackable).
+		validation.Field(&a.WarrantyExpiresAt, validation.By(func(any) error {
+			if a.Count > 1 && a.WarrantyExpiresAt != nil && string(*a.WarrantyExpiresAt) != "" {
+				return validation.NewError("quantity_forbids_warranty",
+					"warranty cannot be tracked on commodities with quantity > 1")
+			}
+			return nil
+		})),
+		validation.Field(&a.WarrantyNotes, validation.By(func(any) error {
+			if a.Count > 1 && a.WarrantyNotes != "" {
+				return validation.NewError("quantity_forbids_warranty",
+					"warranty notes cannot be set on commodities with quantity > 1")
+			}
+			return nil
+		})),
 		validation.Field(&a.URLs),
 		validation.Field(&a.OriginalPrice, whenNotDraft.WithRules(priceRule, validation.By(func(any) error {
 			v, _ := a.OriginalPrice.Float64()

--- a/go/models/commodity_test.go
+++ b/go/models/commodity_test.go
@@ -648,3 +648,60 @@ func TestCommodity_JSONMarshaling(t *testing.T) {
 	c.Assert(newCommodity.Comments, qt.Equals, commodity.Comments)
 	c.Assert(newCommodity.Draft, qt.Equals, commodity.Draft)
 }
+
+// TestCommodity_ValidateWithContext_QuantityForbidsWarranty locks
+// issue #1554's model-layer invariant: a commodity with Count > 1
+// (a bundle of interchangeable units, not a single tracked instance)
+// cannot carry warranty fields. The check fires both for an explicit
+// expiry date and for the notes — clearing either alone is not a
+// half-fix, the bundle row simply doesn't model a warranty.
+func TestCommodity_ValidateWithContext_QuantityForbidsWarranty(t *testing.T) {
+	c := qt.New(t)
+	ctx := validationctx.WithGroupCurrency(context.Background(), "USD")
+	expires := models.ToPDate("2027-01-01")
+
+	base := models.Commodity{
+		Name:                   "Pack of bulbs",
+		ShortName:              "bulbs",
+		Type:                   models.CommodityTypeOther,
+		AreaID:                 "area1",
+		Count:                  12,
+		OriginalPrice:          decimal.NewFromFloat(20.00),
+		OriginalPriceCurrency:  "USD",
+		ConvertedOriginalPrice: decimal.Zero,
+		CurrentPrice:           decimal.NewFromFloat(18.00),
+		Status:                 models.CommodityStatusInUse,
+		PurchaseDate:           models.ToPDate("2026-01-01"),
+	}
+
+	c.Run("count>1 with warranty expiry rejected", func(c *qt.C) {
+		commodity := base
+		commodity.WarrantyExpiresAt = expires
+		err := commodity.ValidateWithContext(ctx)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, "warranty cannot be tracked")
+	})
+
+	c.Run("count>1 with warranty notes rejected", func(c *qt.C) {
+		commodity := base
+		commodity.WarrantyNotes = "covers parts only"
+		err := commodity.ValidateWithContext(ctx)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, "warranty notes cannot be set")
+	})
+
+	c.Run("count>1 with no warranty fields passes", func(c *qt.C) {
+		commodity := base
+		err := commodity.ValidateWithContext(ctx)
+		c.Assert(err, qt.IsNil)
+	})
+
+	c.Run("count=1 with warranty fields passes", func(c *qt.C) {
+		commodity := base
+		commodity.Count = 1
+		commodity.WarrantyExpiresAt = expires
+		commodity.WarrantyNotes = "covers parts only"
+		err := commodity.ValidateWithContext(ctx)
+		c.Assert(err, qt.IsNil)
+	})
+}

--- a/go/schema/migrations/_sqldata/1779100000_log_quantity_tracking_violators.down.sql
+++ b/go/schema/migrations/_sqldata/1779100000_log_quantity_tracking_violators.down.sql
@@ -1,0 +1,4 @@
+-- Issue #1554: log-only migration — nothing to undo. The up path emits
+-- PostgreSQL NOTICEs and writes no data, so a no-op down keeps the
+-- rollback path consistent without fabricating state.
+SELECT 1;

--- a/go/schema/migrations/_sqldata/1779100000_log_quantity_tracking_violators.up.sql
+++ b/go/schema/migrations/_sqldata/1779100000_log_quantity_tracking_violators.up.sql
@@ -1,0 +1,41 @@
+-- Issue #1554: log (don't auto-strip) commodities that already violate
+-- the new "no per-instance tracking on bundles" constraint. The write-time
+-- guard (model + service layer) blocks every NEW write that would create
+-- such a row, so legacy data is the only source of violations from now
+-- on. We deliberately leave the existing rows alone — splitting a bundle
+-- into per-unit rows is a user decision, not something a migration
+-- should auto-perform.
+--
+-- This is a hand-written data migration (not Ptah-generated). It only
+-- emits PostgreSQL NOTICEs — no DDL, no UPDATE — so it's safe to re-run.
+
+DO $$
+DECLARE
+  warranty_count int;
+  loan_count int;
+  service_count int;
+BEGIN
+  SELECT COUNT(*) INTO warranty_count
+  FROM commodities
+  WHERE count > 1
+    AND (warranty_expires_at IS NOT NULL OR coalesce(warranty_notes, '') <> '');
+  IF warranty_count > 0 THEN
+    RAISE NOTICE '#1554: % commodities have count > 1 with warranty fields set; clear warranty fields or split the row to enable warranty tracking', warranty_count;
+  END IF;
+
+  SELECT COUNT(*) INTO loan_count
+  FROM commodity_loans l
+  JOIN commodities c ON c.id = l.commodity_id
+  WHERE c.count > 1;
+  IF loan_count > 0 THEN
+    RAISE NOTICE '#1554: % loan rows reference a commodity with count > 1; future StartLoan calls will be rejected for those rows', loan_count;
+  END IF;
+
+  SELECT COUNT(*) INTO service_count
+  FROM commodity_services s
+  JOIN commodities c ON c.id = s.commodity_id
+  WHERE c.count > 1;
+  IF service_count > 0 THEN
+    RAISE NOTICE '#1554: % service rows reference a commodity with count > 1; future StartService calls will be rejected for those rows', service_count;
+  END IF;
+END $$;

--- a/go/services/commodity_loan_service.go
+++ b/go/services/commodity_loan_service.go
@@ -85,6 +85,17 @@ func (s *CommodityLoanService) StartLoan(ctx context.Context, loan models.Commod
 		return nil, nil, nil, errxtrace.Wrap("failed to create loan registry", err)
 	}
 
+	// #1554: bundles (Count > 1) cannot be lent — the row models a bag
+	// of interchangeable units, not a single instance with a borrower.
+	// Pre-fetching the commodity here is intentional: it costs one
+	// extra round-trip but the alternative (translating a postgres
+	// CHECK violation) would require a constraint we deliberately
+	// don't ship (legacy rows are left alone per the issue's migration
+	// policy).
+	if err := EnsureCommodityTrackable(ctx, s.factorySet, loan.CommodityID); err != nil {
+		return nil, nil, nil, err
+	}
+
 	// Guard against a second open loan on the same commodity. We do
 	// not pre-validate that the commodity exists / is in this group —
 	// RLS on commodity_loans + the FK on commodity_id (ON DELETE

--- a/go/services/commodity_loan_service_test.go
+++ b/go/services/commodity_loan_service_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -75,6 +76,61 @@ func (f *loanServiceFixture) startLoan(c *qt.C) *models.CommodityLoan {
 	c.Assert(crossHolding, qt.IsNil)
 	c.Assert(created, qt.IsNotNil)
 	return created
+}
+
+// TestCommodityLoanService_StartLoan_RejectsBundle locks the issue
+// #1554 invariant: a commodity with Count > 1 cannot be lent out —
+// the row models a bag of interchangeable units, not a single
+// instance with a borrower. StartLoan must reject with the shared
+// ErrCommodityNotTrackable sentinel before touching the loan
+// registry, so apiserver maps the response to 422.
+func TestCommodityLoanService_StartLoan_RejectsBundle(t *testing.T) {
+	c := qt.New(t)
+	fx := newLoanServiceFixture(c)
+
+	// Seed a Count > 1 commodity through the user registry. Memory
+	// registries don't enforce model validation on Create, which is
+	// what we want here — the legacy "bundle has warranty / loan /
+	// service" rows that #1554's migration deliberately leaves alone
+	// look exactly like this.
+	commodityReg, err := fx.factory.CommodityRegistryFactory.CreateUserRegistry(fx.ctx)
+	c.Assert(err, qt.IsNil)
+	bundle, err := commodityReg.Create(fx.ctx, models.Commodity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			EntityID: models.EntityID{ID: "bundle-1"},
+			TenantID: "tenant-1",
+			GroupID:  "group-1",
+		},
+		Name:      "12 light bulbs",
+		ShortName: "bulbs",
+		Type:      models.CommodityTypeOther,
+		Status:    models.CommodityStatusInUse,
+		Count:     12,
+	})
+	c.Assert(err, qt.IsNil)
+
+	loan := models.CommodityLoan{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: "tenant-1",
+			GroupID:  "group-1",
+		},
+		CommodityID:  bundle.ID,
+		BorrowerName: "Alice",
+		LentAt:       models.Date("2026-05-01"),
+	}
+	created, existing, crossHolding, err := fx.loanSvc.StartLoan(fx.ctx, loan)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.Is(err, services.ErrCommodityNotTrackable), qt.IsTrue,
+		qt.Commentf("StartLoan must reject a Count>1 commodity with the shared sentinel"))
+	c.Assert(created, qt.IsNil)
+	c.Assert(existing, qt.IsNil)
+	c.Assert(crossHolding, qt.IsNil)
+
+	// Audit timeline must stay clean — the loan was rejected before
+	// the registry insert, so no `lent_out` event leaked.
+	events, err := fx.events.List(fx.ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 0)
 }
 
 func TestCommodityLoanService_StartLoan_EmitsLentOut(t *testing.T) {

--- a/go/services/commodity_quantity_guard.go
+++ b/go/services/commodity_quantity_guard.go
@@ -1,0 +1,138 @@
+package services
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-extras/errx"
+	errxtrace "github.com/go-extras/errx/stacktrace"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// ErrCommodityNotTrackable is the cross-cutting sentinel returned when
+// an operation that records per-instance state (lend, send-for-service,
+// or warranty) is attempted against a bundle commodity (Count > 1).
+//
+// Issue #1554: Count > 1 models a bag of interchangeable units, not a
+// single tracked instance. There is no single warranty / borrower /
+// repair to attach to a "box of 12 screws" — the user splits the row
+// into per-unit commodities when those events matter. Apiserver maps
+// this sentinel to 422.
+var ErrCommodityNotTrackable = errx.NewSentinel("commodity quantity > 1 forbids per-instance tracking")
+
+// EnsureCommodityTrackable rejects with ErrCommodityNotTrackable when
+// the referenced commodity has Count > 1. Used by StartLoan and
+// StartService.
+//
+// Reads through the user-context registry so RLS applies — a commodity
+// the caller cannot see (or that doesn't exist) is silently skipped
+// here so the existing downstream error path stays intact: the loan /
+// service create then fails with the canonical FK / not-found error
+// the FE already handles. This mirrors the long-standing comment on
+// CommodityLoanService.StartLoan ("RLS on commodity_loans + the FK on
+// commodity_id handle that path").
+func EnsureCommodityTrackable(ctx context.Context, factorySet *registry.FactorySet, commodityID string) error {
+	reg, err := factorySet.CommodityRegistryFactory.CreateUserRegistry(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to create commodity registry", err)
+	}
+	c, err := reg.Get(ctx, commodityID)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotFound) {
+			// Defer to the downstream FK / RLS error path. If the row is
+			// genuinely missing, the loan / service insert below surfaces
+			// the canonical 4xx; if it's an RLS isolation hit, exposing
+			// "you can't track this" instead would also leak existence.
+			return nil
+		}
+		return errxtrace.Wrap("failed to look up commodity", err)
+	}
+	if c == nil {
+		return nil
+	}
+	if c.Count > 1 {
+		return errxtrace.Wrap("commodity has count > 1", ErrCommodityNotTrackable)
+	}
+	return nil
+}
+
+// QuantityBumpBlockerKind enumerates the per-instance-state kinds that
+// prevent a 1 → >1 quantity bump. Stable strings — they leak into the
+// JSON:API error code field for FE introspection.
+type QuantityBumpBlockerKind string
+
+const (
+	// QuantityBumpBlockerWarranty signals the row carries warranty data
+	// (expiry date and/or notes) that would become meaningless on a
+	// bundle row.
+	QuantityBumpBlockerWarranty QuantityBumpBlockerKind = "warranty"
+	// QuantityBumpBlockerLoan signals the row has an open loan row.
+	QuantityBumpBlockerLoan QuantityBumpBlockerKind = "loan"
+	// QuantityBumpBlockerService signals the row has an open service row.
+	QuantityBumpBlockerService QuantityBumpBlockerKind = "service"
+)
+
+// QuantityBumpBlocker describes one reason a count=1 → count>1 update
+// is being rejected. The `Detail` is a server-rendered message; the
+// FE renders its own translated copy keyed off `Kind`.
+type QuantityBumpBlocker struct {
+	Kind   QuantityBumpBlockerKind
+	Detail string
+}
+
+// CheckQuantityBumpBlockers inspects a count=1 commodity that's about
+// to be bumped to count>1 and returns every per-instance-state record
+// that needs to be cleared/closed first. Empty result means the bump
+// is safe.
+//
+// Callers (apiserver commodity update path) invoke this only when the
+// quantity actually crosses the 1 → >1 boundary; the model-level
+// validator already rejects warranty fields on a fresh count>1 row
+// without needing the cross-table query.
+func CheckQuantityBumpBlockers(ctx context.Context, factorySet *registry.FactorySet, current *models.Commodity) ([]QuantityBumpBlocker, error) {
+	if current == nil {
+		return nil, nil
+	}
+	out := make([]QuantityBumpBlocker, 0, 3)
+
+	if (current.WarrantyExpiresAt != nil && string(*current.WarrantyExpiresAt) != "") || current.WarrantyNotes != "" {
+		out = append(out, QuantityBumpBlocker{
+			Kind:   QuantityBumpBlockerWarranty,
+			Detail: "warranty fields are set; clear them before increasing quantity",
+		})
+	}
+
+	loanReg, err := factorySet.CommodityLoanRegistryFactory.CreateUserRegistry(ctx)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to create loan registry", err)
+	}
+	openLoan, err := loanReg.GetOpenForCommodity(ctx, current.ID)
+	if err != nil && !errors.Is(err, registry.ErrNotFound) {
+		return nil, errxtrace.Wrap("failed to look up open loan", err)
+	}
+	if openLoan != nil {
+		out = append(out, QuantityBumpBlocker{
+			Kind:   QuantityBumpBlockerLoan,
+			Detail: "an open loan exists; mark it returned before increasing quantity",
+		})
+	}
+
+	svcReg, err := factorySet.CommodityServiceRegistryFactory.CreateUserRegistry(ctx)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to create service registry", err)
+	}
+	openSvc, err := svcReg.GetOpenForCommodity(ctx, current.ID)
+	if err != nil && !errors.Is(err, registry.ErrNotFound) {
+		return nil, errxtrace.Wrap("failed to look up open service", err)
+	}
+	if openSvc != nil {
+		out = append(out, QuantityBumpBlocker{
+			Kind:   QuantityBumpBlockerService,
+			Detail: "an open service row exists; mark it returned before increasing quantity",
+		})
+	}
+
+	return out, nil
+}

--- a/go/services/commodity_service_service.go
+++ b/go/services/commodity_service_service.go
@@ -62,6 +62,12 @@ func (s *CommodityServiceService) StartService(ctx context.Context, svc models.C
 		return nil, nil, nil, errxtrace.Wrap("failed to create service registry", err)
 	}
 
+	// #1554: bundles (Count > 1) cannot be sent for service. Same
+	// rationale + tradeoff as CommodityLoanService.StartLoan.
+	if err := EnsureCommodityTrackable(ctx, s.factorySet, svc.CommodityID); err != nil {
+		return nil, nil, nil, err
+	}
+
 	// Same-kind invariant: at most one open service row per commodity.
 	existing, err = svcReg.GetOpenForCommodity(ctx, svc.CommodityID)
 	if err == nil && existing != nil {

--- a/go/services/commodity_service_service_test.go
+++ b/go/services/commodity_service_service_test.go
@@ -78,6 +78,54 @@ func (f *serviceServiceFixture) sendForService(c *qt.C) *models.CommodityService
 	return created
 }
 
+// TestCommodityServiceService_StartService_RejectsBundle locks the
+// issue #1554 invariant for the in-service surface — mirrors the
+// matching loan test. Sending a Count > 1 row for service is
+// nonsensical (which of the 12 bulbs is at the workshop?), so
+// StartService rejects with the shared ErrCommodityNotTrackable
+// sentinel before touching the service registry.
+func TestCommodityServiceService_StartService_RejectsBundle(t *testing.T) {
+	c := qt.New(t)
+	fx := newServiceServiceFixture(c)
+
+	commodityReg, err := fx.factory.CommodityRegistryFactory.CreateUserRegistry(fx.ctx)
+	c.Assert(err, qt.IsNil)
+	bundle, err := commodityReg.Create(fx.ctx, models.Commodity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			EntityID: models.EntityID{ID: "bundle-1"},
+			TenantID: "tenant-1",
+			GroupID:  "group-1",
+		},
+		Name:      "12 cables",
+		ShortName: "cables",
+		Type:      models.CommodityTypeOther,
+		Status:    models.CommodityStatusInUse,
+		Count:     12,
+	})
+	c.Assert(err, qt.IsNil)
+
+	svc := models.CommodityService{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: "tenant-1",
+			GroupID:  "group-1",
+		},
+		CommodityID:  bundle.ID,
+		ProviderName: "Repair Shop",
+		SentAt:       models.Date("2026-05-01"),
+	}
+	created, existing, crossHolding, err := fx.serviceSvc.StartService(fx.ctx, svc)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.Is(err, services.ErrCommodityNotTrackable), qt.IsTrue,
+		qt.Commentf("StartService must reject a Count>1 commodity with the shared sentinel"))
+	c.Assert(created, qt.IsNil)
+	c.Assert(existing, qt.IsNil)
+	c.Assert(crossHolding, qt.IsNil)
+
+	events, err := fx.events.List(fx.ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(events, qt.HasLen, 0)
+}
+
 func TestCommodityServiceService_StartService_EmitsSentForService(t *testing.T) {
 	c := qt.New(t)
 	fx := newServiceServiceFixture(c)

--- a/go/services/warranty_reminder_service.go
+++ b/go/services/warranty_reminder_service.go
@@ -91,6 +91,19 @@ func (s *WarrantyReminderService) RemindOnce(ctx context.Context, now time.Time)
 		if c == nil || c.WarrantyExpiresAt == nil || string(*c.WarrantyExpiresAt) == "" {
 			continue
 		}
+		// #1554: defence-in-depth — a Count > 1 row should not have a
+		// warranty in the first place (model validation rejects it
+		// from the FE / API path), but legacy rows that pre-date the
+		// constraint may still carry one. Skip them so we don't email
+		// a "your bundle's warranty is expiring" reminder that the
+		// user can't act on without splitting the row first.
+		if c.Count > 1 {
+			slog.Warn("warranty reminder: skipping commodity with count > 1",
+				"commodity_id", c.ID,
+				"count", c.Count,
+			)
+			continue
+		}
 		for _, threshold := range matchedThresholds(c.WarrantyExpiresAt, now) {
 			ok, processErr := s.processOne(ctx, c, threshold, now)
 			if processErr != nil {

--- a/go/services/warranty_reminder_service_test.go
+++ b/go/services/warranty_reminder_service_test.go
@@ -209,6 +209,39 @@ func TestWarrantyReminderService_RemindOnce_EnqueueFailureRetries(t *testing.T) 
 	c.Assert(stats.Failed, qt.Equals, 0)
 }
 
+// TestWarrantyReminderService_RemindOnce_SkipsBundle covers the
+// defence-in-depth guard added by issue #1554: a commodity with
+// Count > 1 must not trigger a warranty reminder even if its
+// warranty_expires_at is set (legacy data left alone by the migration).
+// Without the guard the user would get a "your bundle is expiring"
+// email they can't act on without splitting the row first.
+func TestWarrantyReminderService_RemindOnce_SkipsBundle(t *testing.T) {
+	c := qt.New(t)
+	ctx, regSet, areaID, factorySet := newWarrantyServiceFixture(c)
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	d := models.Date(now.AddDate(0, 0, 30).Format("2006-01-02"))
+	_, err := regSet.CommodityRegistry.Create(ctx, models.Commodity{
+		AreaID:            areaID,
+		Name:              "12 light bulbs",
+		ShortName:         "bulbs",
+		Type:              models.CommodityTypeOther,
+		Status:            models.CommodityStatusInUse,
+		Count:             12,
+		WarrantyExpiresAt: &d,
+	})
+	c.Assert(err, qt.IsNil)
+
+	emailSvc := &recordingEmailService{}
+	svc := services.NewWarrantyReminderService(factorySet, emailSvc, nil)
+	stats, err := svc.RemindOnce(ctx, now)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.Sent(), qt.Equals, 0,
+		qt.Commentf("Count>1 commodities must be skipped even with a warranty date set"))
+	c.Assert(stats.Failed, qt.Equals, 0)
+	c.Assert(emailSvc.snapshot(), qt.HasLen, 0)
+}
+
 // TestWarrantyReminderService_RemindOnce_NoExpiryDate confirms a
 // commodity without warranty_expires_at is silently skipped (no
 // thresholds match, no email).


### PR DESCRIPTION
Closes #1554.

## Why

`commodity.count > 1` models a bag of interchangeable units, not a single tracked instance. Warranty, lending, and service rows describe a *single* instance, so they're nonsensical on a bundle commodity. Today the schema lets the user record "the box of 12 screws is on loan" — this PR enforces the constraint at write time across BE + FE.

Legacy rows are left alone per the issue's migration policy; the migration only logs a `NOTICE` per violator class so ops can spot them.

## Backend

- New `ErrCommodityNotTrackable` sentinel + `EnsureCommodityTrackable` / `CheckQuantityBumpBlockers` helpers in `services`.
- `Commodity.ValidateWithContext` rejects warranty fields when `count > 1` (model-level cross-field check).
- `StartLoan` / `StartService` reject bundle commodities **before** the registry insert (no audit-event leak).
- `updateCommodity` blocks `1 → >1` bumps that still have warranty / open loan / open service; returns a JSON:API **multi-error 422** with one entry per blocker (`kind` ∈ {`warranty`, `loan`, `service`}, `source.pointer = /data/attributes/count`).
- `WarrantyReminderService.RemindOnce` skips `count > 1` rows defensively (legacy data shouldn't email "your bundle is expiring").
- Migration `1779100000_log_quantity_tracking_violators` emits PG `NOTICE`s — no DDL, safe to re-run.
- `apiserver` errors map `ErrCommodityNotTrackable` → 422.

## Frontend

- `commoditySchema` `superRefine` rejects `count > 1` + warranty pair, surfacing the error on both `count` and `warranty_*` paths so RHF highlights both inputs.
- `CommodityFormDialog` renders a bundle banner live as soon as `count > 1`; the Warranty step disables date + notes inputs and swaps the helper text for the disabled-step hint.
- `CommodityDetailPage` hides the warranty pill on bundles. The Warranty / Lend / Service tab bodies render a "split into separate items" hint and hide their CTAs (`commodityCount` threaded down to the tabs).
- New i18n keys under `commodities:trackingRestrictions.*` + `commodities:validation.quantityForbidsWarranty` (en — cs/ru remain empty stubs that fall back to en, matching the existing pattern).

## Tests

- **Go unit (models / services):** model validation, `StartLoan` / `StartService` rejection, warranty reminder skip.
- **apiserver:** 422 on the four illegal write paths — create with warranty, POST loan on bundle, POST service on bundle, PUT bump 1→5 with open loan (multi-error envelope shape locked).
- **Vitest:** zod refine for both warranty fields, `CommodityFormDialog` bundle banner + disabled Warranty step, `LendTab` bundle empty-state replaces the Lend CTA.
- **Playwright e2e:** walks the bundle Warranty / Lend / Service tabs and locks the visible empty-state copy.

## Test plan

- [ ] `go test ./...` (run locally — all passing)
- [ ] `npm run test --prefix frontend` (run locally — 661 passing)
- [ ] `npx playwright test e2e/tests/quantity-tracking-restrictions.spec.ts` against the dev stack
- [ ] Manual: open the create dialog, type `count=12`, watch the banner appear; advance to Warranty step, confirm date + notes are disabled
- [ ] Manual: navigate to a bundle commodity's detail page, confirm Warranty / Lend / Service tabs show the "split into separate items" hint and no action buttons
- [ ] Manual: try to PUT a `1 → 5` count change on a commodity that has an open loan; assert 422 with `errors[].error.kind = "loan"`