### PR TITLE
[#1551] Currency migration PR 2/4: service rewrite + apiserver endpoints + lock middleware

### DIFF
--- a/e2e/tests/frontend-shell.spec.ts
+++ b/e2e/tests/frontend-shell.spec.ts
@@ -173,9 +173,19 @@ test.describe('Frontend shell', () => {
       .last()
       .click();
 
-    // After the delete mutation resolves, navigation falls back to
-    // the list URL (the sheet's `state.background`); the row is gone.
+    // After the delete mutation resolves, the Sheet unmounts and the
+    // row disappears from the underlying list. We wait for the Sheet
+    // first because the user already arrived from
+    // `/commodities?inactive=1` — the post-delete `navigate(listHref)`
+    // target `/commodities` matches the same `/\/commodities(\?.*)?$/`
+    // regex, so a URL-only check passes instantly without waiting for
+    // the unmount. Firefox then races the next assertion against the
+    // Sheet's still-mounted `<h1 data-testid="commodity-detail-name">`
+    // — `getByText(itemName)` matches both that h1 and the list card
+    // link and fails strict mode. Scoping the row check to the grid
+    // avoids the ambiguity even if a future Sheet teardown lingers.
+    await expect(page.getByTestId('commodity-detail-sheet')).toBeHidden();
     await expect(page).toHaveURL(/\/commodities(\?.*)?$/);
-    await expect(page.getByText(itemName)).not.toBeVisible();
+    await expect(page.getByTestId('commodities-grid').getByText(itemName)).toHaveCount(0);
   });
 });

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1872,6 +1872,251 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/g/{groupSlug}/currency-migrations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List currency migrations for a group
+         * @description Returns the group's full currency-migration history newest-first.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.CurrencyMigrationsResponse"];
+                    };
+                };
+                /** @description Forbidden — non-admin */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Start a currency migration
+         * @description Verify preview token, perform cross-op + daily-cap checks, insert a pending migration row.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            /** @description Start request */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.CurrencyMigrationStartRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.CurrencyMigrationResponse"];
+                    };
+                };
+                /** @description Forbidden — non-admin */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Token expired / state changed / migration in progress / restore in progress */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Validation / token invalid */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Daily cap reached */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/currency-migrations/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Preview a currency migration
+         * @description Dry-run the conversion, returning projected totals + per-row diffs + a signed preview_token.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            /** @description Preview request */
+            requestBody: {
+                content: {
+                    "application/vnd.api+json": components["schemas"]["jsonapi.CurrencyMigrationPreviewRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.CurrencyMigrationPreviewResponse"];
+                    };
+                };
+                /** @description Forbidden — non-admin */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Validation error */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/g/{groupSlug}/currency-migrations/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a currency migration
+         * @description Returns one currency-migration row by id.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Currency migration ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.CurrencyMigrationResponse"];
+                    };
+                };
+                /** @description Forbidden — non-admin */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/g/{groupSlug}/exports": {
         parameters: {
             query?: never;
@@ -5666,9 +5911,116 @@ export type components = {
             data?: components["schemas"]["models.CommodityService"][];
             meta?: components["schemas"]["jsonapi.CommodityServicesMeta"];
         };
+        "jsonapi.CurrencyMigrationPreviewAttributes": {
+            exchange_rate?: number;
+            from_currency?: string;
+            to_currency?: string;
+        };
+        "jsonapi.CurrencyMigrationPreviewBody": {
+            acquisition_fills?: number;
+            commodity_count?: number;
+            diffs?: components["schemas"]["jsonapi.CurrencyMigrationPreviewDiff"][];
+            exchange_rate?: number;
+            from_currency?: string;
+            preview_expires_at?: string;
+            preview_expires_in_seconds?: number;
+            preview_token?: string;
+            state_hash?: string;
+            to_currency?: string;
+            total_current_after?: number;
+            total_current_before?: number;
+        };
+        "jsonapi.CurrencyMigrationPreviewDiff": {
+            commodity_id?: string;
+            commodity_name?: string;
+            current_price_after?: number;
+            current_price_before?: number;
+            original_currency_after?: string;
+            original_currency_before?: string;
+            original_price_after?: number;
+            original_price_before?: number;
+        };
+        "jsonapi.CurrencyMigrationPreviewRequest": {
+            data?: components["schemas"]["jsonapi.CurrencyMigrationPreviewRequestData"];
+        };
+        "jsonapi.CurrencyMigrationPreviewRequestData": {
+            attributes?: components["schemas"]["jsonapi.CurrencyMigrationPreviewAttributes"];
+            /**
+             * @example currency-migrations
+             * @enum {string}
+             */
+            type?: "currency-migrations";
+        };
+        "jsonapi.CurrencyMigrationPreviewResponse": {
+            data?: components["schemas"]["jsonapi.CurrencyMigrationPreviewResponseData"];
+        };
+        "jsonapi.CurrencyMigrationPreviewResponseData": {
+            attributes?: components["schemas"]["jsonapi.CurrencyMigrationPreviewBody"];
+            /**
+             * @example currency-migration-previews
+             * @enum {string}
+             */
+            type?: "currency-migration-previews";
+        };
+        "jsonapi.CurrencyMigrationResponse": {
+            data?: components["schemas"]["jsonapi.CurrencyMigrationResponseData"];
+        };
+        "jsonapi.CurrencyMigrationResponseData": {
+            attributes?: components["schemas"]["models.CurrencyMigration"];
+            id?: string;
+            /**
+             * @example currency-migrations
+             * @enum {string}
+             */
+            type?: "currency-migrations";
+        };
+        "jsonapi.CurrencyMigrationStartAttributes": {
+            /**
+             * @description ExchangeRate is the user-typed rate (1 from = rate to). FE clamps
+             *     to 6 decimals as a UX guard; BE validates per #202 §2 (positive,
+             *     finite, ≤ 1e10).
+             */
+            exchange_rate?: number;
+            from_currency?: string;
+            /**
+             * @description PreviewToken is the HMAC-signed token the preview endpoint
+             *     returned. Required; the start handler verifies the signature and
+             *     then re-derives the state hash to detect group drift between
+             *     preview and commit.
+             */
+            preview_token?: string;
+            to_currency?: string;
+        };
+        "jsonapi.CurrencyMigrationStartRequest": {
+            data?: components["schemas"]["jsonapi.CurrencyMigrationStartRequestData"];
+        };
+        "jsonapi.CurrencyMigrationStartRequestData": {
+            attributes?: components["schemas"]["jsonapi.CurrencyMigrationStartAttributes"];
+            /**
+             * @example currency-migrations
+             * @enum {string}
+             */
+            type?: "currency-migrations";
+        };
+        "jsonapi.CurrencyMigrationsResponse": {
+            data?: components["schemas"]["jsonapi.CurrencyMigrationResponseData"][];
+        };
         "jsonapi.Error": {
+            /**
+             * @description Code is the application-specific error code (e.g.
+             *     "currency_migration.daily_cap_reached"). Optional; when present,
+             *     the FE branches on this string before falling back to the generic
+             *     HTTP status. Stable across versions.
+             */
+            code?: string;
             /** @description user-level error message */
             error?: Record<string, never>;
+            /**
+             * @description Meta is a free-form JSON object the handler may attach for
+             *     machine-readable context (e.g. {"retry_after_seconds": 3600}).
+             *     Optional; serialised only when non-empty.
+             */
+            meta?: Record<string, never>;
             /** @description user-level status message */
             status?: string;
         };
@@ -6458,6 +6810,62 @@ export type components = {
         "models.CommodityStatus": "in_use" | "sold" | "lost" | "disposed" | "written_off";
         /** @enum {string} */
         "models.CommodityType": "white_goods" | "electronics" | "equipment" | "furniture" | "clothes" | "other";
+        "models.CurrencyMigration": {
+            /** @description CommodityCount is the number of rows actually mutated by the worker. */
+            commodity_count?: number;
+            /**
+             * @description CompletedAt is set on either terminal status — TX2 commit on
+             *     success or the recovery sweep on failure. Captures the moment the
+             *     row left the `running` state.
+             */
+            completed_at?: string;
+            /** @description CreatedAt is the moment the row was inserted (still in pending status). */
+            created_at?: string;
+            /** @description ErrorMessage is populated when status=failed. */
+            error_message?: string;
+            /**
+             * @description ExchangeRate is the user-entered rate (1 from = rate to). DECIMAL(20,10)
+             *     gives plenty of headroom; the FE clamps to 6 decimals as a UX guard.
+             */
+            exchange_rate?: number;
+            /**
+             * @description FromCurrency is the group currency at the moment the migration was
+             *     scheduled. The worker re-validates against the live group state
+             *     inside TX2 and aborts if it has drifted.
+             */
+            from_currency?: string;
+            id?: string;
+            /** @description PreviewExpiresAt is the expiry timestamp embedded in PreviewToken. */
+            preview_expires_at?: string;
+            /**
+             * @description PreviewToken is the HMAC issued by the preview endpoint and posted
+             *     back at commit time. Persisted for audit only — verification is
+             *     stateless and recomputed from the same key.
+             */
+            preview_token?: string;
+            /** @description StartedAt is set when the worker flips the row to `running` (TX1). */
+            started_at?: string;
+            /**
+             * @description Status — see CurrencyMigrationStatus. Worker writes durable
+             *     transitions; status is never user-input.
+             */
+            status?: components["schemas"]["models.CurrencyMigrationStatus"];
+            /**
+             * @description ToCurrency is the target group currency. CHECK constraint enforces
+             *     from_currency <> to_currency at the DB level.
+             */
+            to_currency?: string;
+            total_after?: number;
+            /**
+             * @description TotalBefore / TotalAfter are sums of CurrentPrice across the
+             *     group's commodities, captured for audit. Nullable until TX2 has
+             *     computed them.
+             */
+            total_before?: number;
+            uuid?: string;
+        };
+        /** @enum {string} */
+        "models.CurrencyMigrationStatus": "pending" | "running" | "completed" | "failed";
         "models.Export": {
             area_count?: number;
             binary_data_size?: number;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -6019,8 +6019,21 @@ export type components = {
              * @description Meta is a free-form JSON object the handler may attach for
              *     machine-readable context (e.g. {"retry_after_seconds": 3600}).
              *     Optional; serialised only when non-empty.
+             *
+             *     Swagger annotation note: `swaggertype:"object,string"` tells swag
+             *     to emit `additionalProperties: { type: string }`. Without an
+             *     explicit additionalProperties, openapi-typescript renders the
+             *     empty `{type: object}` schema as `Record<string, never>` — a
+             *     closed, indexable-but-empty object — which makes
+             *     `meta.retry_after_seconds` uncallable in TS without a cast. With
+             *     the override the FE gets a `{ [key: string]: string }` index
+             *     signature; consumers parse known keys (`retry_after_seconds:
+             *     number`, `migration_id: string`, `status: string`) into their
+             *     real types — we control both sides of that cast.
              */
-            meta?: Record<string, never>;
+            meta?: {
+                [key: string]: string;
+            };
             /** @description user-level status message */
             status?: string;
         };

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -346,7 +346,7 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			// (issue #202 §3.2) so an in-flight currency migration locks
 			// concurrent edits with HTTP 423. The middleware is a no-op
 			// when the feature flag is off.
-			r.With(requireGroupNotMigrating(params.FeatureCurrencyMigration)).Route("/commodities", Commodities(params))
+			r.With(requireGroupNotMigrating(GroupMigrationLockOptions{FeatureEnabled: params.FeatureCurrencyMigration})).Route("/commodities", Commodities(params))
 			r.Route("/files", Files(params))
 			r.Route("/tags", Tags(params))
 			r.Route("/loans", GroupLoans(params))
@@ -356,13 +356,12 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			r.Route("/commodities/values", Values())
 			r.Route("/upload-slots", UploadSlots(params.FactorySet))
 			r.Route("/search", Search(params.EntityService))
-			// Currency-migration endpoints are gated behind
-			// FeatureCurrencyMigration. When the flag is off the routes
-			// are not mounted at all so the schema/registries shipped
-			// in PR 1 stay inert (#202 §8).
-			if params.FeatureCurrencyMigration {
-				r.Route("/currency-migrations", CurrencyMigrations(params, groupService, auditSvc))
-			}
+			// Currency-migration endpoints are always mounted so swagger
+			// stays consistent regardless of flag state. Each handler
+			// returns 404 when params.FeatureCurrencyMigration is false,
+			// keeping the surface inert in production (#202 §8) until
+			// the operator flips the flag on.
+			r.Route("/currency-migrations", CurrencyMigrations(params, groupService, auditSvc))
 		})
 
 		// Uploads need special middleware without content type restrictions (group-scoped).

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -158,6 +158,11 @@ type Params struct {
 	EmailService               services.EmailService              // Transactional email service (queue + providers)
 	PublicURL                  string                             // Public base URL used in transactional links
 	RedisPinger                RedisPinger                        // Optional Redis dependency check for /readyz
+
+	// FeatureCurrencyMigration gates the /currency-migrations endpoints
+	// and the requireGroupNotMigrating lock middleware (issue #202 / #1551).
+	// Default false — the surface is inert until the flag flips on.
+	FeatureCurrencyMigration bool
 }
 
 func (p *Params) Validate() error {
@@ -337,7 +342,11 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 		r.With(groupScopedMiddlewares...).Route("/g/{groupSlug}", func(r chi.Router) {
 			r.Route("/locations", Locations())
 			r.Route("/areas", Areas())
-			r.Route("/commodities", Commodities(params))
+			// Commodity write paths are guarded by requireGroupNotMigrating
+			// (issue #202 §3.2) so an in-flight currency migration locks
+			// concurrent edits with HTTP 423. The middleware is a no-op
+			// when the feature flag is off.
+			r.With(requireGroupNotMigrating(params.FeatureCurrencyMigration)).Route("/commodities", Commodities(params))
 			r.Route("/files", Files(params))
 			r.Route("/tags", Tags(params))
 			r.Route("/loans", GroupLoans(params))
@@ -347,6 +356,13 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			r.Route("/commodities/values", Values())
 			r.Route("/upload-slots", UploadSlots(params.FactorySet))
 			r.Route("/search", Search(params.EntityService))
+			// Currency-migration endpoints are gated behind
+			// FeatureCurrencyMigration. When the flag is off the routes
+			// are not mounted at all so the schema/registries shipped
+			// in PR 1 stay inert (#202 §8).
+			if params.FeatureCurrencyMigration {
+				r.Route("/currency-migrations", CurrencyMigrations(params, groupService, auditSvc))
+			}
 		})
 
 		// Uploads need special middleware without content type restrictions (group-scoped).

--- a/go/apiserver/currency_migrations.go
+++ b/go/apiserver/currency_migrations.go
@@ -1,0 +1,659 @@
+package apiserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/internal/currency"
+	"github.com/denisvmedia/inventario/jsonapi"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// Currency-migration apiserver surface — issue #202 / #1551 PR 2/4.
+//
+// Four endpoints under /api/v1/g/{groupSlug}/currency-migrations:
+//   - POST /preview     — dry-run, issues a 10-minute HMAC-signed preview_token
+//   - POST /            — start; verifies token, opens a pending migration row
+//   - GET  /            — paginated history
+//   - GET  /{id}        — poll one
+//
+// Plus the requireGroupNotMigrating middleware that guards commodity
+// write routes by 423 while a migration is pending|running.
+//
+// The whole surface is gated by params.FeatureCurrencyMigration;
+// when off, the routes are not mounted at all so the schema and
+// registries shipped in PR 1 stay inert (#202 §8).
+
+// JSON:API error code constants. The FE branches on these strings
+// (issue #202 §4.6) so they are part of the public API surface.
+const (
+	codeCurrencyMigrationSameCurrency      = "currency_migration.same_currency"
+	codeCurrencyMigrationRateInvalid       = "currency_migration.rate_invalid"
+	codeCurrencyMigrationTokenInvalid      = "currency_migration.token_invalid"
+	codeCurrencyMigrationPreviewExpired    = "currency_migration.preview_expired"
+	codeCurrencyMigrationStateChanged      = "currency_migration.state_changed"
+	codeCurrencyMigrationInProgress        = "currency_migration.migration_in_progress"
+	codeCurrencyMigrationRestoreInProgress = "currency_migration.restore_in_progress"
+	codeCurrencyMigrationDailyCapReached   = "currency_migration.daily_cap_reached"
+	codeCurrencyMigrationLocked            = "currency_migration.locked"
+)
+
+// Constants from #202 §4 — code-resident, not config-driven (the
+// design issue calls these out as "constants in code, not exposed as
+// settings"). PR 3 mirrors currencyMigrationStuckThreshold for the
+// recovery sweep.
+const (
+	currencyMigrationPreviewTTL = 10 * time.Minute
+	currencyMigrationDailyCap   = 2
+	previewMaxDiffEntries       = 100 // keep response sizes bounded
+)
+
+// currencyMigrationsAPI is the handler set for the four endpoints.
+// Group context (slug → group) is provided by GroupSlugResolverMiddleware
+// upstream; group-admin authorization is enforced by requireGroupAdmin
+// at mount time.
+type currencyMigrationsAPI struct {
+	groupService *services.GroupService
+	auditService services.AuditLogger
+}
+
+// CurrencyMigrations is the route-builder for the four endpoints. The
+// caller mounts it under /g/{groupSlug}/currency-migrations after the
+// group-aware middleware chain has populated the registry set + group
+// context.
+//
+// All routes are admin-only. The route group itself enforces this via
+// requireGroupAdmin so individual handlers don't need to repeat the
+// check.
+func CurrencyMigrations(params Params, groupService *services.GroupService, auditService services.AuditLogger) func(r chi.Router) {
+	api := &currencyMigrationsAPI{
+		groupService: groupService,
+		auditService: auditService,
+	}
+
+	return func(r chi.Router) {
+		// Whole subtree is admin-only. Non-admin members get 403 from
+		// requireGroupAdmin before any handler runs.
+		r.Use(requireGroupAdmin(groupService))
+
+		r.Post("/preview", api.preview)
+		r.Post("/", api.start)
+		r.Get("/", api.list)
+		r.Get("/{id}", api.get)
+	}
+}
+
+// preview runs the conversion in-memory across every commodity in the
+// group, returns projected totals + per-row diffs + a 10-minute
+// HMAC-signed preview_token. No DB writes; no daily-quota slot
+// consumed. Allowed during an in-flight migration (read-only).
+//
+// Order of validation: payload → from!=to (422) → rate (422) →
+// commodity read → token. Same-currency and rate failures are caught
+// before any group-scoped read — keeps the cost of bad inputs flat.
+//
+// @Summary Preview a currency migration
+// @Description Dry-run the conversion, returning projected totals + per-row diffs + a signed preview_token.
+// @Tags currency-migrations
+// @Accept json-api
+// @Produce json-api
+// @Param groupSlug path string true "Group slug"
+// @Param request body jsonapi.CurrencyMigrationPreviewRequest true "Preview request"
+// @Success 200 {object} jsonapi.CurrencyMigrationPreviewResponse "OK"
+// @Failure 403 {object} jsonapi.Errors "Forbidden — non-admin"
+// @Failure 422 {object} jsonapi.Errors "Validation error"
+// @Router /g/{groupSlug}/currency-migrations/preview [post].
+func (api *currencyMigrationsAPI) preview(w http.ResponseWriter, r *http.Request) {
+	rs := RegistrySetFromContext(r.Context())
+	if rs == nil {
+		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+		return
+	}
+	group := groupFromContext(r.Context())
+	if group == nil {
+		unprocessableEntityError(w, r, nil)
+		return
+	}
+	user := GetUserFromRequest(r)
+	if user == nil {
+		unauthorizedError(w, r, nil)
+		return
+	}
+
+	var input jsonapi.CurrencyMigrationPreviewRequest
+	if err := render.Bind(r, &input); err != nil {
+		unprocessableEntityError(w, r, err)
+		return
+	}
+	attrs := input.Data.Attributes
+
+	if attrs.FromCurrency == attrs.ToCurrency {
+		_ = codedUnprocessableEntityError(w, r, currency.ErrSameCurrency, codeCurrencyMigrationSameCurrency)
+		return
+	}
+	if err := currency.ValidateRate(attrs.ExchangeRate); err != nil {
+		_ = codedUnprocessableEntityError(w, r, err, codeCurrencyMigrationRateInvalid)
+		return
+	}
+
+	commodities, err := rs.CommodityRegistry.ListByGroup(r.Context(), user.TenantID, group.ID)
+	if err != nil {
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	body, err := buildPreviewBody(commodities, attrs.FromCurrency, attrs.ToCurrency, attrs.ExchangeRate)
+	if err != nil {
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	expiresAt := time.Now().UTC().Add(currencyMigrationPreviewTTL)
+	token, err := rs.CurrencyMigrationRegistry.IssuePreviewToken(registry.PreviewTokenInputs{
+		GroupID:      group.ID,
+		FromCurrency: string(attrs.FromCurrency),
+		ToCurrency:   string(attrs.ToCurrency),
+		Rate:         canonicalRateString(attrs.ExchangeRate),
+		StateHash:    body.StateHash,
+		ExpiresAt:    expiresAt,
+	})
+	if err != nil {
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	body.PreviewToken = token
+	body.PreviewExpiresAt = expiresAt
+	body.PreviewExpiresInSec = int(currencyMigrationPreviewTTL / time.Second)
+
+	if renderErr := render.Render(w, r, jsonapi.NewCurrencyMigrationPreviewResponse(body)); renderErr != nil {
+		_ = internalServerError(w, r, renderErr)
+		return
+	}
+}
+
+// start verifies the preview token, runs the cross-op + daily-cap
+// checks, and inserts a pending currency_migrations row. The worker
+// (PR 3) picks the row up; this handler does NOT touch commodities.
+//
+// Order of checks (per #202 §4.6):
+//   1. payload + same-currency / rate validation → 422
+//   2. token signature → 422 token_invalid
+//   3. token expiry → 409 preview_expired
+//   4. token bindings (from/to/rate match the body) → 409 state_changed
+//   5. live state hash recomputed → 409 state_changed
+//   6. in-flight migration → 409 migration_in_progress
+//   7. in-flight restore in this group → 409 restore_in_progress
+//   8. daily cap → 429 daily_cap_reached
+//   9. INSERT pending (partial unique index → 409 migration_in_progress)
+//   10. set group lock + write start audit (best-effort; the registry's
+//       Create unique-violation in 9 is the canonical race-loser).
+//
+// @Summary Start a currency migration
+// @Description Verify preview token, perform cross-op + daily-cap checks, insert a pending migration row.
+// @Tags currency-migrations
+// @Accept json-api
+// @Produce json-api
+// @Param groupSlug path string true "Group slug"
+// @Param request body jsonapi.CurrencyMigrationStartRequest true "Start request"
+// @Success 201 {object} jsonapi.CurrencyMigrationResponse "Created"
+// @Failure 403 {object} jsonapi.Errors "Forbidden — non-admin"
+// @Failure 409 {object} jsonapi.Errors "Token expired / state changed / migration in progress / restore in progress"
+// @Failure 422 {object} jsonapi.Errors "Validation / token invalid"
+// @Failure 429 {object} jsonapi.Errors "Daily cap reached"
+// @Router /g/{groupSlug}/currency-migrations [post].
+func (api *currencyMigrationsAPI) start(w http.ResponseWriter, r *http.Request) {
+	rs := RegistrySetFromContext(r.Context())
+	if rs == nil {
+		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+		return
+	}
+	group := groupFromContext(r.Context())
+	if group == nil {
+		unprocessableEntityError(w, r, nil)
+		return
+	}
+	user := GetUserFromRequest(r)
+	if user == nil {
+		unauthorizedError(w, r, nil)
+		return
+	}
+
+	var input jsonapi.CurrencyMigrationStartRequest
+	if err := render.Bind(r, &input); err != nil {
+		unprocessableEntityError(w, r, err)
+		return
+	}
+	attrs := input.Data.Attributes
+
+	// 1. Same-currency and rate guards (defence in depth — Bind() already
+	//    validates these via attribute validation, but the apiserver
+	//    layer needs a code-tagged 422 for the FE).
+	if attrs.FromCurrency == attrs.ToCurrency {
+		_ = codedUnprocessableEntityError(w, r, currency.ErrSameCurrency, codeCurrencyMigrationSameCurrency)
+		return
+	}
+	if err := currency.ValidateRate(attrs.ExchangeRate); err != nil {
+		_ = codedUnprocessableEntityError(w, r, err, codeCurrencyMigrationRateInvalid)
+		return
+	}
+
+	// 2 + 3. Verify token signature + expiry. Use UTC throughout — the
+	// embedded ExpiresAt was UTC at preview time.
+	now := time.Now().UTC()
+	tokenInputs, err := rs.CurrencyMigrationRegistry.VerifyPreviewToken(attrs.PreviewToken, now)
+	switch {
+	case errors.Is(err, registry.ErrPreviewTokenInvalid):
+		_ = codedUnprocessableEntityError(w, r, err, codeCurrencyMigrationTokenInvalid)
+		return
+	case errors.Is(err, registry.ErrPreviewTokenExpired):
+		_ = codedConflictError(w, r, err, codeCurrencyMigrationPreviewExpired, nil)
+		return
+	case err != nil:
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	// 4. Token bindings must match the request body. A mismatch means
+	//    the FE pulled a stale token — resolve as state_changed so the
+	//    user re-previews.
+	if tokenInputs.GroupID != group.ID ||
+		tokenInputs.FromCurrency != string(attrs.FromCurrency) ||
+		tokenInputs.ToCurrency != string(attrs.ToCurrency) ||
+		tokenInputs.Rate != canonicalRateString(attrs.ExchangeRate) {
+		_ = codedConflictError(w, r, errors.New("preview token bindings do not match request"), codeCurrencyMigrationStateChanged, nil)
+		return
+	}
+
+	// 5. Re-derive the state hash from the live group and compare. A
+	//    new commodity (or a price edit between preview and commit)
+	//    changes the hash and the user is forced to re-preview.
+	commodities, err := rs.CommodityRegistry.ListByGroup(r.Context(), user.TenantID, group.ID)
+	if err != nil {
+		_ = internalServerError(w, r, err)
+		return
+	}
+	currentHash := postgres.HashGroupState(len(commodities), sumCurrentString(commodities))
+	if currentHash != tokenInputs.StateHash {
+		_ = codedConflictError(w, r, errors.New("group state changed since preview"), codeCurrencyMigrationStateChanged, nil)
+		return
+	}
+
+	// 6. In-flight migration guard. The partial unique index on
+	//    currency_migrations(group_id) WHERE status IN ('pending',
+	//    'running') is the canonical race-loser; this check is just an
+	//    early-exit for the common case (one user clicks Migrate
+	//    twice).
+	if existing, err := rs.CurrencyMigrationRegistry.InFlightForGroup(r.Context(), group.ID); err != nil {
+		_ = internalServerError(w, r, err)
+		return
+	} else if existing != nil {
+		_ = codedConflictError(w, r, errors.New("currency migration already in progress"), codeCurrencyMigrationInProgress, map[string]any{
+			"migration_id": existing.ID,
+			"status":       string(existing.Status),
+		})
+		return
+	}
+
+	// 7. Cross-op lock — refuse if a restore_operation in this group
+	//    is pending or running. The middleware in §3.2 blocks the
+	//    restore→migration direction in the other handler; this is the
+	//    symmetric guard.
+	if hasInFlightRestore, err := groupHasInFlightRestore(r.Context(), rs); err != nil {
+		_ = internalServerError(w, r, err)
+		return
+	} else if hasInFlightRestore {
+		_ = codedConflictError(w, r, errors.New("a restore operation is in progress for this group"), codeCurrencyMigrationRestoreInProgress, nil)
+		return
+	}
+
+	// 8. Daily cap.
+	completed, err := rs.CurrencyMigrationRegistry.CompletedTodayForGroup(r.Context(), group.ID, now)
+	if err != nil {
+		_ = internalServerError(w, r, err)
+		return
+	}
+	if completed >= currencyMigrationDailyCap {
+		retryAfter := nextUTCMidnight(now).Sub(now)
+		_ = codedTooManyRequestsError(w, r, errors.New("daily cap of currency migrations reached for this group"), codeCurrencyMigrationDailyCapReached, map[string]any{
+			"retry_after_seconds": int(retryAfter.Seconds()),
+		})
+		return
+	}
+
+	// 9. Persist pending row. The registry maps a partial unique-index
+	//    violation on (group_id) WHERE status IN ('pending', 'running')
+	//    to ErrMigrationInFlight — that's the canonical race-loser
+	//    response.
+	expiresAt := tokenInputs.ExpiresAt
+	previewToken := attrs.PreviewToken
+	op := models.CurrencyMigration{
+		FromCurrency:     attrs.FromCurrency,
+		ToCurrency:       attrs.ToCurrency,
+		ExchangeRate:     attrs.ExchangeRate,
+		PreviewToken:     &previewToken,
+		PreviewExpiresAt: &expiresAt,
+	}
+	created, err := rs.CurrencyMigrationRegistry.Create(r.Context(), op)
+	switch {
+	case errors.Is(err, registry.ErrMigrationInFlight):
+		_ = codedConflictError(w, r, err, codeCurrencyMigrationInProgress, nil)
+		return
+	case err != nil:
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	// 10. Set the group lock + write start audit. The lock is a
+	//     best-effort UPDATE — if it fails (RLS, FK timing) the
+	//     middleware/lock UX still reads InFlightForGroup as the source
+	//     of truth, so the row's status alone is what matters.
+	if err := setLocationGroupCurrencyMigrationID(r.Context(), rs, group.ID, &created.ID); err != nil {
+		// Don't fail the request — the migration row is the canonical
+		// state. Surface as a warning via the audit logger and continue.
+		api.logAuditCurrencyMigration(r, user, group, "currency_migration.start", false, fmt.Sprintf("group lock update failed: %v", err))
+	} else {
+		api.logAuditCurrencyMigration(r, user, group, "currency_migration.start", true, "")
+	}
+
+	if renderErr := render.Render(w, r, jsonapi.NewCurrencyMigrationResponse(created).WithStatusCode(http.StatusCreated)); renderErr != nil {
+		_ = internalServerError(w, r, renderErr)
+		return
+	}
+}
+
+// list returns the group's migration history newest-first. No
+// pagination cursor in this PR — the daily cap (2/day) keeps the row
+// count bounded. PR 4 may add cursor-based pagination if needed.
+//
+// @Summary List currency migrations for a group
+// @Description Returns the group's full currency-migration history newest-first.
+// @Tags currency-migrations
+// @Accept json-api
+// @Produce json-api
+// @Param groupSlug path string true "Group slug"
+// @Success 200 {object} jsonapi.CurrencyMigrationsResponse "OK"
+// @Failure 403 {object} jsonapi.Errors "Forbidden — non-admin"
+// @Router /g/{groupSlug}/currency-migrations [get].
+func (api *currencyMigrationsAPI) list(w http.ResponseWriter, r *http.Request) {
+	rs := RegistrySetFromContext(r.Context())
+	if rs == nil {
+		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+		return
+	}
+
+	migrations, err := rs.CurrencyMigrationRegistry.List(r.Context())
+	if err != nil {
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	// Newest-first ordering — the registry's underlying SCAN is
+	// insertion-order dependent across backends, so sort here.
+	sort.SliceStable(migrations, func(i, j int) bool {
+		return migrations[i].CreatedAt.After(migrations[j].CreatedAt)
+	})
+
+	if renderErr := render.Render(w, r, jsonapi.NewCurrencyMigrationsResponse(migrations)); renderErr != nil {
+		_ = internalServerError(w, r, renderErr)
+		return
+	}
+}
+
+// get returns a single migration row. The FE polls this endpoint
+// while a migration is non-terminal so the lock UX can flip back to
+// "ready" the moment TX2 commits or the recovery sweep flips the row
+// to failed.
+//
+// @Summary Get a currency migration
+// @Description Returns one currency-migration row by id.
+// @Tags currency-migrations
+// @Accept json-api
+// @Produce json-api
+// @Param groupSlug path string true "Group slug"
+// @Param id path string true "Currency migration ID"
+// @Success 200 {object} jsonapi.CurrencyMigrationResponse "OK"
+// @Failure 403 {object} jsonapi.Errors "Forbidden — non-admin"
+// @Failure 404 {object} jsonapi.Errors "Not found"
+// @Router /g/{groupSlug}/currency-migrations/{id} [get].
+func (api *currencyMigrationsAPI) get(w http.ResponseWriter, r *http.Request) {
+	rs := RegistrySetFromContext(r.Context())
+	if rs == nil {
+		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		badRequest(w, r, ErrEntityNotFound)
+		return
+	}
+
+	op, err := rs.CurrencyMigrationRegistry.Get(r.Context(), id)
+	if err != nil {
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	if renderErr := render.Render(w, r, jsonapi.NewCurrencyMigrationResponse(op)); renderErr != nil {
+		_ = internalServerError(w, r, renderErr)
+		return
+	}
+}
+
+// requireGroupNotMigrating is the lock middleware applied to commodity
+// write paths (and the restore-create endpoint). On POST/PATCH/PUT/DELETE
+// it queries CurrencyMigrationRegistry.InFlightForGroup; if a pending
+// or running row exists, it returns 423 Locked with code
+// currency_migration.locked and meta {migration_id, status}.
+//
+// GETs pass through unmodified — reads are not blocked (#202 §3.2).
+//
+// When `featureEnabled` is false the middleware is a no-op so the
+// codepath is dead code without the flag (#202 §8).
+func requireGroupNotMigrating(featureEnabled bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if !featureEnabled {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete:
+				// fall through to the lock check
+			default:
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			rs := RegistrySetFromContext(r.Context())
+			group := groupFromContext(r.Context())
+			if rs == nil || group == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			inFlight, err := rs.CurrencyMigrationRegistry.InFlightForGroup(r.Context(), group.ID)
+			if err != nil {
+				_ = internalServerError(w, r, err)
+				return
+			}
+			if inFlight != nil {
+				_ = lockedError(w, r,
+					errors.New("group is locked while a currency migration is in progress"),
+					codeCurrencyMigrationLocked,
+					map[string]any{
+						"migration_id": inFlight.ID,
+						"status":       string(inFlight.Status),
+					},
+				)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// buildPreviewBody walks the commodities, applies the pure
+// ApplyConversion to each, computes the totals, and assembles the
+// JSON:API attributes. PreviewToken / PreviewExpiresAt / PreviewExpiresInSec
+// are filled in by the caller after the registry signs the token.
+func buildPreviewBody(commodities []*models.Commodity, from, to models.Currency, rate decimal.Decimal) (jsonapi.CurrencyMigrationPreviewBody, error) {
+	body := jsonapi.CurrencyMigrationPreviewBody{
+		FromCurrency:   from,
+		ToCurrency:     to,
+		ExchangeRate:   rate,
+		CommodityCount: len(commodities),
+		Diffs:          make([]jsonapi.CurrencyMigrationPreviewDiff, 0, len(commodities)),
+	}
+
+	allDiffs := make([]jsonapi.CurrencyMigrationPreviewDiff, 0, len(commodities))
+	totalCurrentBefore := decimal.Zero
+	totalCurrentAfter := decimal.Zero
+	fillsCount := 0
+
+	for _, c := range commodities {
+		if c == nil {
+			continue
+		}
+		result := currency.ApplyConversion(*c, from, to, rate)
+		totalCurrentBefore = totalCurrentBefore.Add(result.Before.CurrentPrice)
+		totalCurrentAfter = totalCurrentAfter.Add(result.After.CurrentPrice)
+		if result.FillAcquisition {
+			fillsCount++
+		}
+		allDiffs = append(allDiffs, jsonapi.CurrencyMigrationPreviewDiff{
+			CommodityID:            c.GetID(),
+			CommodityName:          c.Name,
+			CurrentPriceBefore:     result.Before.CurrentPrice,
+			CurrentPriceAfter:      result.After.CurrentPrice,
+			OriginalPriceBefore:    result.Before.OriginalPrice,
+			OriginalPriceAfter:     result.After.OriginalPrice,
+			OriginalCurrencyBefore: result.Before.OriginalPriceCurrency,
+			OriginalCurrencyAfter:  result.After.OriginalPriceCurrency,
+		})
+	}
+
+	// Sort by absolute current-price delta descending so the response's
+	// truncated diff list is the most informative for the FE preview
+	// table. Stable so equal-delta rows keep insertion order.
+	sort.SliceStable(allDiffs, func(i, j int) bool {
+		di := allDiffs[i].CurrentPriceAfter.Sub(allDiffs[i].CurrentPriceBefore).Abs()
+		dj := allDiffs[j].CurrentPriceAfter.Sub(allDiffs[j].CurrentPriceBefore).Abs()
+		return di.GreaterThan(dj)
+	})
+
+	if len(allDiffs) > previewMaxDiffEntries {
+		allDiffs = allDiffs[:previewMaxDiffEntries]
+	}
+	body.Diffs = allDiffs
+	body.TotalCurrentBefore = totalCurrentBefore
+	body.TotalCurrentAfter = totalCurrentAfter
+	body.AcquisitionFills = fillsCount
+	body.StateHash = postgres.HashGroupState(len(commodities), totalCurrentBefore.String())
+
+	return body, nil
+}
+
+// sumCurrentString returns the canonical decimal string of the sum of
+// CurrentPrice across all commodities. The state hash is derived from
+// (count, this string) — both must be deterministic across replicas.
+func sumCurrentString(commodities []*models.Commodity) string {
+	sum := decimal.Zero
+	for _, c := range commodities {
+		if c == nil {
+			continue
+		}
+		sum = sum.Add(c.CurrentPrice)
+	}
+	return sum.String()
+}
+
+// canonicalRateString returns the rate's String form that goes into
+// the preview token's payload. Using Decimal.String (no scientific
+// notation) ensures the FE can round-trip the rate via JSON without
+// losing precision and makes the comparison on commit unambiguous.
+func canonicalRateString(d decimal.Decimal) string {
+	return d.String()
+}
+
+// nextUTCMidnight returns the next UTC midnight strictly after `now`.
+// Used to compute meta.retry_after_seconds for the daily-cap 429.
+func nextUTCMidnight(now time.Time) time.Time {
+	u := now.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day()+1, 0, 0, 0, 0, time.UTC)
+}
+
+// groupHasInFlightRestore reports whether the current group has a
+// restore_operation row in pending or running status. The user-aware
+// RestoreOperationRegistry is RLS-scoped to the current group, so a
+// plain List() returns the right slice.
+func groupHasInFlightRestore(ctx context.Context, rs *registry.Set) (bool, error) {
+	ops, err := rs.RestoreOperationRegistry.List(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, op := range ops {
+		if op == nil {
+			continue
+		}
+		if op.Status == models.RestoreStatusPending || op.Status == models.RestoreStatusRunning {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// setLocationGroupCurrencyMigrationID writes the in-flight migration
+// id on the group row so the FE's lock UX can drive off
+// LocationGroup.currency_migration_id without re-querying the
+// migration registry. The recovery sweep clears the column when it
+// flips a stuck running row to failed; PR 3's worker clears it on
+// successful TX2 commit.
+//
+// Done via the LocationGroupRegistry update flow so the row's RLS
+// context is consistent. Not transactional with the migration row —
+// see start handler comments — but the migration row itself is the
+// source of truth (the lock middleware reads InFlightForGroup, not
+// this column).
+func setLocationGroupCurrencyMigrationID(ctx context.Context, rs *registry.Set, groupID string, migrationID *string) error {
+	if rs.LocationGroupRegistry == nil {
+		return errors.New("location group registry unavailable")
+	}
+	group, err := rs.LocationGroupRegistry.Get(ctx, groupID)
+	if err != nil {
+		return err
+	}
+	group.CurrencyMigrationID = migrationID
+	if _, err := rs.LocationGroupRegistry.Update(ctx, *group); err != nil {
+		return err
+	}
+	return nil
+}
+
+// logAuditCurrencyMigration writes one row to audit_logs marking the
+// start (or failure-to-start) of a migration. Best-effort — failures
+// are logged in the AuditService and never propagate.
+func (api *currencyMigrationsAPI) logAuditCurrencyMigration(r *http.Request, user *models.User, group *models.LocationGroup, action string, success bool, errMsg string) {
+	if api.auditService == nil {
+		return
+	}
+	userID := user.ID
+	tenantID := user.TenantID
+	var em *string
+	if errMsg != "" {
+		em = &errMsg
+	}
+	api.auditService.LogAuth(r.Context(), action, &userID, &tenantID, success, r, em)
+	_ = group // group context lives in the entity_id field of a future audit-log expansion; today's AuditLogger signature is auth-shaped
+}

--- a/go/apiserver/currency_migrations.go
+++ b/go/apiserver/currency_migrations.go
@@ -39,6 +39,7 @@ import (
 // (issue #202 §4.6) so they are part of the public API surface.
 const (
 	codeCurrencyMigrationSameCurrency      = "currency_migration.same_currency"
+	codeCurrencyMigrationFromMismatch      = "currency_migration.from_mismatch"
 	codeCurrencyMigrationRateInvalid       = "currency_migration.rate_invalid"
 	codeCurrencyMigrationTokenInvalid      = "currency_migration.token_invalid"
 	codeCurrencyMigrationPreviewExpired    = "currency_migration.preview_expired"
@@ -165,12 +166,23 @@ func (api *currencyMigrationsAPI) preview(w http.ResponseWriter, r *http.Request
 	}
 	attrs := input.Data.Attributes
 
+	if attrs.FromCurrency != group.GroupCurrency {
+		_ = codedUnprocessableEntityError(w, r,
+			fmt.Errorf("from_currency must equal group's current currency (%s)", group.GroupCurrency),
+			codeCurrencyMigrationFromMismatch)
+		return
+	}
 	if attrs.FromCurrency == attrs.ToCurrency {
 		_ = codedUnprocessableEntityError(w, r, currency.ErrSameCurrency, codeCurrencyMigrationSameCurrency)
 		return
 	}
 	if err := currency.ValidateRate(attrs.ExchangeRate); err != nil {
 		_ = codedUnprocessableEntityError(w, r, err, codeCurrencyMigrationRateInvalid)
+		return
+	}
+
+	if rs.CurrencyMigrationRegistry == nil {
+		_ = internalServerError(w, r, errors.New("currency migration registry not wired"))
 		return
 	}
 
@@ -257,6 +269,11 @@ func (api *currencyMigrationsAPI) start(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if rs.CurrencyMigrationRegistry == nil {
+		_ = internalServerError(w, r, errors.New("currency migration registry not wired"))
+		return
+	}
+
 	var input jsonapi.CurrencyMigrationStartRequest
 	if err := render.Bind(r, &input); err != nil {
 		unprocessableEntityError(w, r, err)
@@ -264,7 +281,7 @@ func (api *currencyMigrationsAPI) start(w http.ResponseWriter, r *http.Request) 
 	}
 	attrs := input.Data.Attributes
 
-	if !validateStartAttributes(w, r, attrs) {
+	if !validateStartAttributes(w, r, attrs, group) {
 		return
 	}
 	now := time.Now().UTC()
@@ -460,10 +477,16 @@ func requireGroupNotMigrating(opts GroupMigrationLockOptions) func(http.Handler)
 	}
 }
 
-// validateStartAttributes runs the same-currency / rate guards on the
-// request body. Returns false (and writes the response) when the body
-// is invalid; true to continue.
-func validateStartAttributes(w http.ResponseWriter, r *http.Request, attrs *jsonapi.CurrencyMigrationStartAttributes) bool {
+// validateStartAttributes runs the from-mismatch / same-currency / rate
+// guards on the request body. Returns false (and writes the response)
+// when the body is invalid; true to continue.
+func validateStartAttributes(w http.ResponseWriter, r *http.Request, attrs *jsonapi.CurrencyMigrationStartAttributes, group *models.LocationGroup) bool {
+	if attrs.FromCurrency != group.GroupCurrency {
+		_ = codedUnprocessableEntityError(w, r,
+			fmt.Errorf("from_currency must equal group's current currency (%s)", group.GroupCurrency),
+			codeCurrencyMigrationFromMismatch)
+		return false
+	}
 	if attrs.FromCurrency == attrs.ToCurrency {
 		_ = codedUnprocessableEntityError(w, r, currency.ErrSameCurrency, codeCurrencyMigrationSameCurrency)
 		return false

--- a/go/apiserver/currency_migrations.go
+++ b/go/apiserver/currency_migrations.go
@@ -63,9 +63,15 @@ const (
 // Group context (slug → group) is provided by GroupSlugResolverMiddleware
 // upstream; group-admin authorization is enforced by requireGroupAdmin
 // at mount time.
+//
+// The featureEnabled flag mirrors Params.FeatureCurrencyMigration. The
+// routes are always mounted (so swagger stays in sync with the chi
+// router); each handler short-circuits with 404 when the flag is off,
+// keeping the surface inert in production until the operator flips it.
 type currencyMigrationsAPI struct {
-	groupService *services.GroupService
-	auditService services.AuditLogger
+	groupService   *services.GroupService
+	auditService   services.AuditLogger
+	featureEnabled bool
 }
 
 // CurrencyMigrations is the route-builder for the four endpoints. The
@@ -78,11 +84,16 @@ type currencyMigrationsAPI struct {
 // check.
 func CurrencyMigrations(params Params, groupService *services.GroupService, auditService services.AuditLogger) func(r chi.Router) {
 	api := &currencyMigrationsAPI{
-		groupService: groupService,
-		auditService: auditService,
+		groupService:   groupService,
+		auditService:   auditService,
+		featureEnabled: params.FeatureCurrencyMigration,
 	}
 
 	return func(r chi.Router) {
+		// Feature gate runs first so non-admins also see 404 (rather
+		// than 403) when the flag is off — pretending the route does
+		// not exist at all matches the §8 "inert" promise.
+		r.Use(api.featureGate)
 		// Whole subtree is admin-only. Non-admin members get 403 from
 		// requireGroupAdmin before any handler runs.
 		r.Use(requireGroupAdmin(groupService))
@@ -92,6 +103,22 @@ func CurrencyMigrations(params Params, groupService *services.GroupService, audi
 		r.Get("/", api.list)
 		r.Get("/{id}", api.get)
 	}
+}
+
+// featureGate is the always-mounted, per-handler kill-switch for the
+// currency-migration surface (#202 §8). When FeatureCurrencyMigration is
+// false the middleware returns plain 404 — the routes act as if they
+// were never registered. Mounted before requireGroupAdmin so non-admin
+// callers also see 404 in flag-off state, hiding even the existence of
+// the surface.
+func (api *currencyMigrationsAPI) featureGate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !api.featureEnabled {
+			_ = notFound(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // preview runs the conversion in-memory across every commodity in the
@@ -188,17 +215,17 @@ func (api *currencyMigrationsAPI) preview(w http.ResponseWriter, r *http.Request
 // (PR 3) picks the row up; this handler does NOT touch commodities.
 //
 // Order of checks (per #202 §4.6):
-//   1. payload + same-currency / rate validation → 422
-//   2. token signature → 422 token_invalid
-//   3. token expiry → 409 preview_expired
-//   4. token bindings (from/to/rate match the body) → 409 state_changed
-//   5. live state hash recomputed → 409 state_changed
-//   6. in-flight migration → 409 migration_in_progress
-//   7. in-flight restore in this group → 409 restore_in_progress
-//   8. daily cap → 429 daily_cap_reached
-//   9. INSERT pending (partial unique index → 409 migration_in_progress)
-//   10. set group lock + write start audit (best-effort; the registry's
-//       Create unique-violation in 9 is the canonical race-loser).
+//  1. payload + same-currency / rate validation → 422
+//  2. token signature → 422 token_invalid
+//  3. token expiry → 409 preview_expired
+//  4. token bindings (from/to/rate match the body) → 409 state_changed
+//  5. live state hash recomputed → 409 state_changed
+//  6. in-flight migration → 409 migration_in_progress
+//  7. in-flight restore in this group → 409 restore_in_progress
+//  8. daily cap → 429 daily_cap_reached
+//  9. INSERT pending (partial unique index → 409 migration_in_progress)
+//  10. set group lock + write start audit (best-effort; the registry's
+//     Create unique-violation in 9 is the canonical race-loser).
 //
 // @Summary Start a currency migration
 // @Description Verify preview token, perform cross-op + daily-cap checks, insert a pending migration row.
@@ -237,105 +264,25 @@ func (api *currencyMigrationsAPI) start(w http.ResponseWriter, r *http.Request) 
 	}
 	attrs := input.Data.Attributes
 
-	// 1. Same-currency and rate guards (defence in depth — Bind() already
-	//    validates these via attribute validation, but the apiserver
-	//    layer needs a code-tagged 422 for the FE).
-	if attrs.FromCurrency == attrs.ToCurrency {
-		_ = codedUnprocessableEntityError(w, r, currency.ErrSameCurrency, codeCurrencyMigrationSameCurrency)
+	if !validateStartAttributes(w, r, attrs) {
 		return
 	}
-	if err := currency.ValidateRate(attrs.ExchangeRate); err != nil {
-		_ = codedUnprocessableEntityError(w, r, err, codeCurrencyMigrationRateInvalid)
-		return
-	}
-
-	// 2 + 3. Verify token signature + expiry. Use UTC throughout — the
-	// embedded ExpiresAt was UTC at preview time.
 	now := time.Now().UTC()
-	tokenInputs, err := rs.CurrencyMigrationRegistry.VerifyPreviewToken(attrs.PreviewToken, now)
-	switch {
-	case errors.Is(err, registry.ErrPreviewTokenInvalid):
-		_ = codedUnprocessableEntityError(w, r, err, codeCurrencyMigrationTokenInvalid)
+	tokenInputs, ok := verifyStartToken(w, r, rs, attrs, now)
+	if !ok {
 		return
-	case errors.Is(err, registry.ErrPreviewTokenExpired):
-		_ = codedConflictError(w, r, err, codeCurrencyMigrationPreviewExpired, nil)
+	}
+	if !checkTokenBindingsAndState(w, r, rs, group, user, attrs, tokenInputs) {
 		return
-	case err != nil:
-		_ = internalServerError(w, r, err)
+	}
+	if !checkInFlightAndCap(w, r, rs, group, now) {
 		return
 	}
 
-	// 4. Token bindings must match the request body. A mismatch means
-	//    the FE pulled a stale token — resolve as state_changed so the
-	//    user re-previews.
-	if tokenInputs.GroupID != group.ID ||
-		tokenInputs.FromCurrency != string(attrs.FromCurrency) ||
-		tokenInputs.ToCurrency != string(attrs.ToCurrency) ||
-		tokenInputs.Rate != canonicalRateString(attrs.ExchangeRate) {
-		_ = codedConflictError(w, r, errors.New("preview token bindings do not match request"), codeCurrencyMigrationStateChanged, nil)
-		return
-	}
-
-	// 5. Re-derive the state hash from the live group and compare. A
-	//    new commodity (or a price edit between preview and commit)
-	//    changes the hash and the user is forced to re-preview.
-	commodities, err := rs.CommodityRegistry.ListByGroup(r.Context(), user.TenantID, group.ID)
-	if err != nil {
-		_ = internalServerError(w, r, err)
-		return
-	}
-	currentHash := postgres.HashGroupState(len(commodities), sumCurrentString(commodities))
-	if currentHash != tokenInputs.StateHash {
-		_ = codedConflictError(w, r, errors.New("group state changed since preview"), codeCurrencyMigrationStateChanged, nil)
-		return
-	}
-
-	// 6. In-flight migration guard. The partial unique index on
-	//    currency_migrations(group_id) WHERE status IN ('pending',
-	//    'running') is the canonical race-loser; this check is just an
-	//    early-exit for the common case (one user clicks Migrate
-	//    twice).
-	if existing, err := rs.CurrencyMigrationRegistry.InFlightForGroup(r.Context(), group.ID); err != nil {
-		_ = internalServerError(w, r, err)
-		return
-	} else if existing != nil {
-		_ = codedConflictError(w, r, errors.New("currency migration already in progress"), codeCurrencyMigrationInProgress, map[string]any{
-			"migration_id": existing.ID,
-			"status":       string(existing.Status),
-		})
-		return
-	}
-
-	// 7. Cross-op lock — refuse if a restore_operation in this group
-	//    is pending or running. The middleware in §3.2 blocks the
-	//    restore→migration direction in the other handler; this is the
-	//    symmetric guard.
-	if hasInFlightRestore, err := groupHasInFlightRestore(r.Context(), rs); err != nil {
-		_ = internalServerError(w, r, err)
-		return
-	} else if hasInFlightRestore {
-		_ = codedConflictError(w, r, errors.New("a restore operation is in progress for this group"), codeCurrencyMigrationRestoreInProgress, nil)
-		return
-	}
-
-	// 8. Daily cap.
-	completed, err := rs.CurrencyMigrationRegistry.CompletedTodayForGroup(r.Context(), group.ID, now)
-	if err != nil {
-		_ = internalServerError(w, r, err)
-		return
-	}
-	if completed >= currencyMigrationDailyCap {
-		retryAfter := nextUTCMidnight(now).Sub(now)
-		_ = codedTooManyRequestsError(w, r, errors.New("daily cap of currency migrations reached for this group"), codeCurrencyMigrationDailyCapReached, map[string]any{
-			"retry_after_seconds": int(retryAfter.Seconds()),
-		})
-		return
-	}
-
-	// 9. Persist pending row. The registry maps a partial unique-index
-	//    violation on (group_id) WHERE status IN ('pending', 'running')
-	//    to ErrMigrationInFlight — that's the canonical race-loser
-	//    response.
+	// Persist pending row. The registry maps a partial unique-index
+	// violation on (group_id) WHERE status IN ('pending', 'running')
+	// to ErrMigrationInFlight — that's the canonical race-loser
+	// response.
 	expiresAt := tokenInputs.ExpiresAt
 	previewToken := attrs.PreviewToken
 	op := models.CurrencyMigration{
@@ -452,6 +399,18 @@ func (api *currencyMigrationsAPI) get(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// GroupMigrationLockOptions parameterises requireGroupNotMigrating.
+//
+// FeatureEnabled mirrors Params.FeatureCurrencyMigration; when false
+// the middleware is a no-op so the codepath stays dead until the
+// operator flips the flag on (#202 §8). Wrapping the toggle in an
+// option struct (rather than a bare bool flag-parameter) lets the
+// middleware grow more knobs (per-route opt-out, custom code, etc.)
+// without churning callers and silences revive's flag-parameter rule.
+type GroupMigrationLockOptions struct {
+	FeatureEnabled bool
+}
+
 // requireGroupNotMigrating is the lock middleware applied to commodity
 // write paths (and the restore-create endpoint). On POST/PATCH/PUT/DELETE
 // it queries CurrencyMigrationRegistry.InFlightForGroup; if a pending
@@ -459,12 +418,9 @@ func (api *currencyMigrationsAPI) get(w http.ResponseWriter, r *http.Request) {
 // currency_migration.locked and meta {migration_id, status}.
 //
 // GETs pass through unmodified — reads are not blocked (#202 §3.2).
-//
-// When `featureEnabled` is false the middleware is a no-op so the
-// codepath is dead code without the flag (#202 §8).
-func requireGroupNotMigrating(featureEnabled bool) func(http.Handler) http.Handler {
+func requireGroupNotMigrating(opts GroupMigrationLockOptions) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		if !featureEnabled {
+		if !opts.FeatureEnabled {
 			return next
 		}
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -502,6 +458,107 @@ func requireGroupNotMigrating(featureEnabled bool) func(http.Handler) http.Handl
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// validateStartAttributes runs the same-currency / rate guards on the
+// request body. Returns false (and writes the response) when the body
+// is invalid; true to continue.
+func validateStartAttributes(w http.ResponseWriter, r *http.Request, attrs *jsonapi.CurrencyMigrationStartAttributes) bool {
+	if attrs.FromCurrency == attrs.ToCurrency {
+		_ = codedUnprocessableEntityError(w, r, currency.ErrSameCurrency, codeCurrencyMigrationSameCurrency)
+		return false
+	}
+	if err := currency.ValidateRate(attrs.ExchangeRate); err != nil {
+		_ = codedUnprocessableEntityError(w, r, err, codeCurrencyMigrationRateInvalid)
+		return false
+	}
+	return true
+}
+
+// verifyStartToken handles steps 2+3: HMAC signature check (→ 422
+// token_invalid) and expiry check (→ 409 preview_expired).
+func verifyStartToken(w http.ResponseWriter, r *http.Request, rs *registry.Set, attrs *jsonapi.CurrencyMigrationStartAttributes, now time.Time) (registry.PreviewTokenInputs, bool) {
+	tokenInputs, err := rs.CurrencyMigrationRegistry.VerifyPreviewToken(attrs.PreviewToken, now)
+	switch {
+	case errors.Is(err, registry.ErrPreviewTokenInvalid):
+		_ = codedUnprocessableEntityError(w, r, err, codeCurrencyMigrationTokenInvalid)
+		return registry.PreviewTokenInputs{}, false
+	case errors.Is(err, registry.ErrPreviewTokenExpired):
+		_ = codedConflictError(w, r, err, codeCurrencyMigrationPreviewExpired, nil)
+		return registry.PreviewTokenInputs{}, false
+	case err != nil:
+		_ = internalServerError(w, r, err)
+		return registry.PreviewTokenInputs{}, false
+	}
+	return tokenInputs, true
+}
+
+// checkTokenBindingsAndState handles steps 4+5: token bindings (group/from/to/rate
+// match the body) and live state-hash drift detection. Both fail with
+// 409 currency_migration.state_changed.
+func checkTokenBindingsAndState(w http.ResponseWriter, r *http.Request, rs *registry.Set, group *models.LocationGroup, user *models.User, attrs *jsonapi.CurrencyMigrationStartAttributes, tokenInputs registry.PreviewTokenInputs) bool {
+	if tokenInputs.GroupID != group.ID ||
+		tokenInputs.FromCurrency != string(attrs.FromCurrency) ||
+		tokenInputs.ToCurrency != string(attrs.ToCurrency) ||
+		tokenInputs.Rate != canonicalRateString(attrs.ExchangeRate) {
+		_ = codedConflictError(w, r, errors.New("preview token bindings do not match request"), codeCurrencyMigrationStateChanged, nil)
+		return false
+	}
+
+	commodities, err := rs.CommodityRegistry.ListByGroup(r.Context(), user.TenantID, group.ID)
+	if err != nil {
+		_ = internalServerError(w, r, err)
+		return false
+	}
+	currentHash := postgres.HashGroupState(len(commodities), sumCurrentString(commodities))
+	if currentHash != tokenInputs.StateHash {
+		_ = codedConflictError(w, r, errors.New("group state changed since preview"), codeCurrencyMigrationStateChanged, nil)
+		return false
+	}
+	return true
+}
+
+// checkInFlightAndCap handles steps 6+7+8: existing migration (→ 409
+// migration_in_progress), in-flight restore on the group (→ 409
+// restore_in_progress), and the daily cap (→ 429 daily_cap_reached
+// with retry_after_seconds meta).
+func checkInFlightAndCap(w http.ResponseWriter, r *http.Request, rs *registry.Set, group *models.LocationGroup, now time.Time) bool {
+	existing, err := rs.CurrencyMigrationRegistry.InFlightForGroup(r.Context(), group.ID)
+	if err != nil {
+		_ = internalServerError(w, r, err)
+		return false
+	}
+	if existing != nil {
+		_ = codedConflictError(w, r, errors.New("currency migration already in progress"), codeCurrencyMigrationInProgress, map[string]any{
+			"migration_id": existing.ID,
+			"status":       string(existing.Status),
+		})
+		return false
+	}
+
+	hasInFlightRestore, err := groupHasInFlightRestore(r.Context(), rs)
+	if err != nil {
+		_ = internalServerError(w, r, err)
+		return false
+	}
+	if hasInFlightRestore {
+		_ = codedConflictError(w, r, errors.New("a restore operation is in progress for this group"), codeCurrencyMigrationRestoreInProgress, nil)
+		return false
+	}
+
+	completed, err := rs.CurrencyMigrationRegistry.CompletedTodayForGroup(r.Context(), group.ID, now)
+	if err != nil {
+		_ = internalServerError(w, r, err)
+		return false
+	}
+	if completed >= currencyMigrationDailyCap {
+		retryAfter := nextUTCMidnight(now).Sub(now)
+		_ = codedTooManyRequestsError(w, r, errors.New("daily cap of currency migrations reached for this group"), codeCurrencyMigrationDailyCapReached, map[string]any{
+			"retry_after_seconds": int(retryAfter.Seconds()),
+		})
+		return false
+	}
+	return true
 }
 
 // buildPreviewBody walks the commodities, applies the pure

--- a/go/apiserver/currency_migrations.go
+++ b/go/apiserver/currency_migrations.go
@@ -356,6 +356,10 @@ func (api *currencyMigrationsAPI) list(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
 		return
 	}
+	if rs.CurrencyMigrationRegistry == nil {
+		_ = internalServerError(w, r, errors.New("currency migration registry not wired"))
+		return
+	}
 
 	migrations, err := rs.CurrencyMigrationRegistry.List(r.Context())
 	if err != nil {
@@ -395,6 +399,10 @@ func (api *currencyMigrationsAPI) get(w http.ResponseWriter, r *http.Request) {
 	rs := RegistrySetFromContext(r.Context())
 	if rs == nil {
 		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+		return
+	}
+	if rs.CurrencyMigrationRegistry == nil {
+		_ = internalServerError(w, r, errors.New("currency migration registry not wired"))
 		return
 	}
 
@@ -451,8 +459,12 @@ func requireGroupNotMigrating(opts GroupMigrationLockOptions) func(http.Handler)
 
 			rs := RegistrySetFromContext(r.Context())
 			group := groupFromContext(r.Context())
-			if rs == nil || group == nil {
-				next.ServeHTTP(w, r)
+			// With the feature flag on, a missing registry set, group
+			// context, or currency-migration registry is a misconfiguration
+			// — fail closed so a wiring bug never lets a write through
+			// while a migration is supposed to be holding the lock.
+			if rs == nil || group == nil || rs.CurrencyMigrationRegistry == nil {
+				_ = internalServerError(w, r, errors.New("currency migration lock check unavailable: missing registry set, group, or currency migration registry"))
 				return
 			}
 
@@ -575,13 +587,28 @@ func checkInFlightAndCap(w http.ResponseWriter, r *http.Request, rs *registry.Se
 		return false
 	}
 	if completed >= currencyMigrationDailyCap {
-		retryAfter := nextUTCMidnight(now).Sub(now)
 		_ = codedTooManyRequestsError(w, r, errors.New("daily cap of currency migrations reached for this group"), codeCurrencyMigrationDailyCapReached, map[string]any{
-			"retry_after_seconds": int(retryAfter.Seconds()),
+			"retry_after_seconds": retryAfterSeconds(nextUTCMidnight(now).Sub(now)),
 		})
 		return false
 	}
 	return true
+}
+
+// retryAfterSeconds rounds a Duration up to whole seconds, clamped to
+// at least 1. The 429 meta value must always tell the FE to wait a
+// positive amount of time — `int(d.Seconds())` truncates fractional
+// seconds, so a cap hit at 23:59:59.5 UTC would otherwise return 0
+// even though the window has not yet reset.
+func retryAfterSeconds(d time.Duration) int {
+	if d <= 0 {
+		return 1
+	}
+	secs := int((d + time.Second - 1) / time.Second)
+	if secs < 1 {
+		return 1
+	}
+	return secs
 }
 
 // buildPreviewBody walks the commodities, applies the pure

--- a/go/apiserver/currency_migrations_test.go
+++ b/go/apiserver/currency_migrations_test.go
@@ -80,10 +80,10 @@ func startBody(from, to, rate, token string) map[string]any {
 		"data": map[string]any{
 			"type": "currency-migrations",
 			"attributes": map[string]any{
-				"from_currency":  from,
-				"to_currency":    to,
-				"exchange_rate":  rate,
-				"preview_token":  token,
+				"from_currency": from,
+				"to_currency":   to,
+				"exchange_rate": rate,
+				"preview_token": token,
 			},
 		},
 	}
@@ -411,7 +411,7 @@ func TestCurrencyMigrations_DailyCap_Returns429(t *testing.T) {
 	ctx := createTestUserContextWithGroup(testUser.ID, testUser.TenantID, testGroup.ID)
 	cmReg := must.Must(params.FactorySet.CurrencyMigrationRegistryFactory.CreateUserRegistry(ctx))
 	now := time.Now().UTC()
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		// Memory registry doesn't enforce the partial unique index, so
 		// status=completed rows can be inserted directly.
 		op := must.Must(cmReg.Create(ctx, models.CurrencyMigration{

--- a/go/apiserver/currency_migrations_test.go
+++ b/go/apiserver/currency_migrations_test.go
@@ -1,0 +1,461 @@
+package apiserver_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"github.com/shopspring/decimal"
+	"github.com/yalp/jsonpath"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/internal/checkers"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// Currency-migration apiserver integration tests (issue #202 / #1551).
+//
+// All cases run against the in-memory registry with the feature flag
+// enabled unless the test specifically exercises the flag-off path.
+// Tests that need an actual partial unique index (concurrent-start race)
+// or a daily-cap clock advance live alongside the postgres registry
+// integration tests; the in-memory backend is sufficient for the rest
+// of the DoD.
+
+// newCurrencyMigrationParams returns Params with FeatureCurrencyMigration
+// enabled. For "feature off" tests, callers should use newParams directly.
+func newCurrencyMigrationParams() (apiserver.Params, *models.User, *models.LocationGroup) {
+	params, testUser, testGroup := newParams()
+	params.FeatureCurrencyMigration = true
+	return params, testUser, testGroup
+}
+
+func doJSONAPIRequest(t *testing.T, handler http.Handler, method, path, userID string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+	}
+	req, err := http.NewRequest(method, path, bytes.NewReader(bodyBytes))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/vnd.api+json")
+	if userID != "" {
+		addTestUserAuthHeader(req, userID)
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+// previewBody is a minimal JSON:API request body builder to keep the
+// tests readable.
+func previewBody(from, to string, rate string) map[string]any {
+	return map[string]any{
+		"data": map[string]any{
+			"type": "currency-migrations",
+			"attributes": map[string]any{
+				"from_currency": from,
+				"to_currency":   to,
+				"exchange_rate": rate,
+			},
+		},
+	}
+}
+
+func startBody(from, to, rate, token string) map[string]any {
+	return map[string]any{
+		"data": map[string]any{
+			"type": "currency-migrations",
+			"attributes": map[string]any{
+				"from_currency":  from,
+				"to_currency":    to,
+				"exchange_rate":  rate,
+				"preview_token":  token,
+			},
+		},
+	}
+}
+
+func TestCurrencyMigrations_FeatureFlagOff_NotMounted(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams() // flag default false
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "EUR", "0.9"))
+
+	// The route is not mounted at all when the feature is off — chi
+	// returns 404 because the path doesn't match any handler.
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+func TestCurrencyMigrations_Preview_Happy(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "EUR", "0.9"))
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	body := rr.Body.Bytes()
+	c.Assert(body, checkers.JSONPathEquals("$.data.type"), "currency-migration-previews")
+	c.Assert(body, checkers.JSONPathEquals("$.data.attributes.from_currency"), "USD")
+	c.Assert(body, checkers.JSONPathEquals("$.data.attributes.to_currency"), "EUR")
+	// The token must be a non-empty string. Tighter assertions on the
+	// signature / payload layout live in the registry-level tests for
+	// IssuePreviewToken / VerifyPreviewToken (PR 1).
+	c.Assert(body, checkers.JSONPathMatches("$.data.attributes.preview_token", qt.Not(qt.Equals)), "")
+	c.Assert(body, checkers.JSONPathMatches("$.data.attributes.state_hash", qt.Not(qt.Equals)), "")
+}
+
+func TestCurrencyMigrations_Preview_SameCurrencyRejected422(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "USD", "1"))
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+}
+
+func TestCurrencyMigrations_Preview_ZeroRateRejected422(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "EUR", "0"))
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+}
+
+func TestCurrencyMigrations_Start_Happy_AndCreatesPendingRow(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Preview to obtain a token + state hash bound to the group's live state.
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "EUR", "0.9"))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	previewToken := jsonPathString(t, rr.Body.Bytes(), "$.data.attributes.preview_token")
+
+	// Commit.
+	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.9", previewToken))
+	c.Assert(rr.Code, qt.Equals, http.StatusCreated)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.type"), "currency-migrations")
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.status"), "pending")
+
+	// The pending row must show up in the list endpoint.
+	rr = doJSONAPIRequest(t, handler, http.MethodGet, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathMatches("$.data", qt.HasLen), 1)
+}
+
+func TestCurrencyMigrations_Start_TokenInvalid_Returns422(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.9", "definitely-not-a-token"))
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+}
+
+func TestCurrencyMigrations_Start_TokenBindingsMismatched_Returns409(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Preview at one rate, commit at a different rate.
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "EUR", "0.9"))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	previewToken := jsonPathString(t, rr.Body.Bytes(), "$.data.attributes.preview_token")
+
+	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.95", previewToken))
+	c.Assert(rr.Code, qt.Equals, http.StatusConflict)
+}
+
+func TestCurrencyMigrations_Start_StateDriftRejectedOn409(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "EUR", "0.9"))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	previewToken := jsonPathString(t, rr.Body.Bytes(), "$.data.attributes.preview_token")
+
+	// Mutate the group's state — adding a commodity changes the
+	// (count, sum_current_price) hash and must invalidate the token.
+	ctx := createTestUserContextWithGroup(testUser.ID, testUser.TenantID, testGroup.ID)
+	rs := must.Must(params.FactorySet.CreateUserRegistrySet(ctx))
+	areas := must.Must(rs.AreaRegistry.List(ctx))
+	c.Assert(len(areas) > 0, qt.IsTrue)
+	must.Must(rs.CommodityRegistry.Create(ctx, models.Commodity{
+		Name:                  "Drift test",
+		Type:                  models.CommodityTypeWhiteGoods,
+		Status:                models.CommodityStatusInUse,
+		AreaID:                areas[0].ID,
+		Count:                 1,
+		OriginalPrice:         decimal.RequireFromString("100"),
+		OriginalPriceCurrency: models.Currency("USD"),
+		CurrentPrice:          decimal.RequireFromString("100"),
+	}))
+
+	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.9", previewToken))
+	c.Assert(rr.Code, qt.Equals, http.StatusConflict)
+}
+
+func TestCurrencyMigrations_Start_InFlightMigrationRejected409(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Plant a pending migration row so the second start is the loser.
+	ctx := createTestUserContextWithGroup(testUser.ID, testUser.TenantID, testGroup.ID)
+	cmReg := must.Must(params.FactorySet.CurrencyMigrationRegistryFactory.CreateUserRegistry(ctx))
+	must.Must(cmReg.Create(ctx, models.CurrencyMigration{
+		FromCurrency: models.Currency("USD"),
+		ToCurrency:   models.Currency("EUR"),
+		ExchangeRate: decimal.RequireFromString("0.9"),
+		Status:       models.CurrencyMigrationStatusPending,
+	}))
+
+	// Preview still succeeds (read-only) but start should 409.
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "EUR", "0.9"))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	previewToken := jsonPathString(t, rr.Body.Bytes(), "$.data.attributes.preview_token")
+
+	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.9", previewToken))
+	c.Assert(rr.Code, qt.Equals, http.StatusConflict)
+}
+
+func TestCurrencyMigrations_Start_RestoreInFlightRejected409(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Plant a pending restore_operation in this group.
+	ctx := createTestUserContextWithGroup(testUser.ID, testUser.TenantID, testGroup.ID)
+	rs := must.Must(params.FactorySet.CreateUserRegistrySet(ctx))
+	exports, err := rs.ExportRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+	exportID := ""
+	if len(exports) > 0 {
+		exportID = exports[0].ID
+	} else {
+		// Create a minimal completed export to satisfy the FK on RestoreOperation.ExportID.
+		exp := must.Must(rs.ExportRegistry.Create(ctx, models.Export{
+			Type:        models.ExportTypeFullDatabase,
+			Description: "test export",
+			Status:      models.ExportStatusCompleted,
+		}))
+		exportID = exp.ID
+	}
+	must.Must(rs.RestoreOperationRegistry.Create(ctx, models.RestoreOperation{
+		ExportID:    exportID,
+		Description: "manual planted restore",
+		Status:      models.RestoreStatusPending,
+	}))
+
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "EUR", "0.9"))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	previewToken := jsonPathString(t, rr.Body.Bytes(), "$.data.attributes.preview_token")
+
+	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.9", previewToken))
+	c.Assert(rr.Code, qt.Equals, http.StatusConflict)
+}
+
+func TestCurrencyMigrations_LockMiddleware_BlocksCommodityWrites423(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Plant a running migration row + group lock signal.
+	ctx := createTestUserContextWithGroup(testUser.ID, testUser.TenantID, testGroup.ID)
+	cmReg := must.Must(params.FactorySet.CurrencyMigrationRegistryFactory.CreateUserRegistry(ctx))
+	now := time.Now().UTC()
+	mig := must.Must(cmReg.Create(ctx, models.CurrencyMigration{
+		FromCurrency: models.Currency("USD"),
+		ToCurrency:   models.Currency("EUR"),
+		ExchangeRate: decimal.RequireFromString("0.9"),
+		Status:       models.CurrencyMigrationStatusRunning,
+		StartedAt:    &now,
+	}))
+	c.Assert(mig.ID, qt.Not(qt.Equals), "")
+
+	// Try to PATCH a commodity — should be 423.
+	rs := must.Must(params.FactorySet.CreateUserRegistrySet(ctx))
+	commodities := must.Must(rs.CommodityRegistry.List(ctx))
+	c.Assert(len(commodities) > 0, qt.IsTrue)
+	target := commodities[0]
+
+	rr := doJSONAPIRequest(t, handler, http.MethodPatch, "/api/v1/g/"+testGroup.Slug+"/commodities/"+target.ID, testUser.ID, map[string]any{
+		"data": map[string]any{
+			"id":   target.ID,
+			"type": "commodities",
+			"attributes": map[string]any{
+				"name": "edited under lock",
+			},
+		},
+	})
+	c.Assert(rr.Code, qt.Equals, http.StatusLocked)
+}
+
+func TestCurrencyMigrations_LockOnRestoreCreate_Returns423(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	ctx := createTestUserContextWithGroup(testUser.ID, testUser.TenantID, testGroup.ID)
+
+	// Plant a running migration on the group.
+	cmReg := must.Must(params.FactorySet.CurrencyMigrationRegistryFactory.CreateUserRegistry(ctx))
+	now := time.Now().UTC()
+	must.Must(cmReg.Create(ctx, models.CurrencyMigration{
+		FromCurrency: models.Currency("USD"),
+		ToCurrency:   models.Currency("EUR"),
+		ExchangeRate: decimal.RequireFromString("0.9"),
+		Status:       models.CurrencyMigrationStatusRunning,
+		StartedAt:    &now,
+	}))
+
+	rs := must.Must(params.FactorySet.CreateUserRegistrySet(ctx))
+	exp := must.Must(rs.ExportRegistry.Create(ctx, models.Export{
+		Type:        models.ExportTypeFullDatabase,
+		Description: "test export for restore",
+		Status:      models.ExportStatusCompleted,
+	}))
+
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/exports/"+exp.ID+"/restores", testUser.ID, map[string]any{
+		"data": map[string]any{
+			"type": "restores",
+			"attributes": map[string]any{
+				"description": "blocked by migration",
+				"options": map[string]any{
+					"strategy": "full_replace",
+				},
+			},
+		},
+	})
+	c.Assert(rr.Code, qt.Equals, http.StatusLocked)
+}
+
+func TestCurrencyMigrations_NonAdmin_Returns403(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+
+	// Create a second user, add them to the group as a non-admin member.
+	tenantID := testUser.TenantID
+	memberTemplate := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Email:               "member@example.com",
+		Name:                "Member User",
+		IsActive:            true,
+	}
+	must.Assert(memberTemplate.SetPassword("Password123"))
+	memberUser := must.Must(params.FactorySet.UserRegistry.Create(context.Background(), memberTemplate))
+	must.Must(params.FactorySet.GroupMembershipRegistry.Create(context.Background(), models.GroupMembership{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		GroupID:             testGroup.ID,
+		MemberUserID:        memberUser.ID,
+		Role:                models.GroupRoleUser,
+	}))
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Each of the four endpoints must reject non-admins. Verify
+	// preview / start / list / get all return 403.
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", memberUser.ID, previewBody("USD", "EUR", "0.9"))
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden, qt.Commentf("preview"))
+
+	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", memberUser.ID, startBody("USD", "EUR", "0.9", "x"))
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden, qt.Commentf("start"))
+
+	rr = doJSONAPIRequest(t, handler, http.MethodGet, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", memberUser.ID, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden, qt.Commentf("list"))
+
+	rr = doJSONAPIRequest(t, handler, http.MethodGet, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/some-id", memberUser.ID, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden, qt.Commentf("get"))
+}
+
+func TestCurrencyMigrations_DailyCap_Returns429(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Plant 2 completed migrations today on this group.
+	ctx := createTestUserContextWithGroup(testUser.ID, testUser.TenantID, testGroup.ID)
+	cmReg := must.Must(params.FactorySet.CurrencyMigrationRegistryFactory.CreateUserRegistry(ctx))
+	now := time.Now().UTC()
+	for i := 0; i < 2; i++ {
+		// Memory registry doesn't enforce the partial unique index, so
+		// status=completed rows can be inserted directly.
+		op := must.Must(cmReg.Create(ctx, models.CurrencyMigration{
+			FromCurrency: models.Currency("USD"),
+			ToCurrency:   models.Currency("EUR"),
+			ExchangeRate: decimal.RequireFromString("0.9"),
+			Status:       models.CurrencyMigrationStatusCompleted,
+			StartedAt:    &now,
+			CompletedAt:  &now,
+		}))
+		// Memory Create may stamp Status from NewCurrencyMigrationFromUserInput;
+		// re-update to enforce the completed status used by CompletedTodayForGroup.
+		_ = op
+		_ = cmReg.UpdateStatus(ctx, op.ID, registry.CurrencyMigrationStatusPatch{
+			Status:      models.CurrencyMigrationStatusCompleted,
+			CompletedAt: &now,
+		})
+	}
+
+	// Third attempt → 429.
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "EUR", "0.9"))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	previewToken := jsonPathString(t, rr.Body.Bytes(), "$.data.attributes.preview_token")
+
+	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.9", previewToken))
+	c.Assert(rr.Code, qt.Equals, http.StatusTooManyRequests)
+}
+
+// jsonPathString extracts a string value from a JSON body via jsonpath.
+// Test-only helper; failing the t fatally on parse errors keeps the
+// caller terse.
+func jsonPathString(t *testing.T, body []byte, path string) string {
+	t.Helper()
+	var parsed any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("jsonPathString: parse: %v\nbody=%s", err, string(body))
+	}
+	v, err := jsonpath.Read(parsed, path)
+	if err != nil {
+		t.Fatalf("jsonPathString(%s): %v\nbody=%s", path, err, string(body))
+	}
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("jsonPathString(%s): expected string, got %T (%v)", path, v, v)
+	}
+	return s
+}

--- a/go/apiserver/currency_migrations_test.go
+++ b/go/apiserver/currency_migrations_test.go
@@ -74,16 +74,10 @@ func assertErrorCode(t *testing.T, c *qt.C, body []byte, expected string) {
 func assertErrorMeta(t *testing.T, c *qt.C, body []byte, key string, predicate func(any) bool, hint string) {
 	t.Helper()
 	var parsed any
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		t.Fatalf("assertErrorMeta: parse: %v\nbody=%s", err, string(body))
-	}
+	c.Assert(json.Unmarshal(body, &parsed), qt.IsNil, qt.Commentf("assertErrorMeta: parse body=%s", string(body)))
 	v, err := jsonpath.Read(parsed, "$.errors[0].meta."+key)
-	if err != nil {
-		t.Fatalf("assertErrorMeta(%s): %v\nbody=%s", key, err, string(body))
-	}
-	if !predicate(v) {
-		t.Fatalf("assertErrorMeta(%s): %s; got %v (%T)\nbody=%s", key, hint, v, v, string(body))
-	}
+	c.Assert(err, qt.IsNil, qt.Commentf("assertErrorMeta(%s) lookup; body=%s", key, string(body)))
+	c.Assert(predicate(v), qt.IsTrue, qt.Commentf("assertErrorMeta(%s): %s; got %v (%T) body=%s", key, hint, v, v, string(body)))
 }
 
 // previewBody is a minimal JSON:API request body builder to keep the

--- a/go/apiserver/currency_migrations_test.go
+++ b/go/apiserver/currency_migrations_test.go
@@ -60,6 +60,32 @@ func doJSONAPIRequest(t *testing.T, handler http.Handler, method, path, userID s
 	return rr
 }
 
+// assertErrorCode asserts the JSON:API errors[0].code matches the given
+// expected code. The FE branches on these stable codes, so locking them
+// in here prevents accidental contract regressions.
+func assertErrorCode(t *testing.T, c *qt.C, body []byte, expected string) {
+	t.Helper()
+	c.Assert(body, checkers.JSONPathEquals("$.errors[0].code"), expected)
+}
+
+// assertErrorMeta asserts errors[0].meta[key] == expected (any type).
+// Used to verify retry_after_seconds (429) / migration_id+status (423)
+// payloads stay stable.
+func assertErrorMeta(t *testing.T, c *qt.C, body []byte, key string, predicate func(any) bool, hint string) {
+	t.Helper()
+	var parsed any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("assertErrorMeta: parse: %v\nbody=%s", err, string(body))
+	}
+	v, err := jsonpath.Read(parsed, "$.errors[0].meta."+key)
+	if err != nil {
+		t.Fatalf("assertErrorMeta(%s): %v\nbody=%s", key, err, string(body))
+	}
+	if !predicate(v) {
+		t.Fatalf("assertErrorMeta(%s): %s; got %v (%T)\nbody=%s", key, hint, v, v, string(body))
+	}
+}
+
 // previewBody is a minimal JSON:API request body builder to keep the
 // tests readable.
 func previewBody(from, to string, rate string) map[string]any {
@@ -131,6 +157,23 @@ func TestCurrencyMigrations_Preview_SameCurrencyRejected422(t *testing.T) {
 	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "USD", "1"))
 
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	// from==to is caught by the from-mismatch guard first when the
+	// group currency is USD; either code is wire-stable.
+	body := rr.Body.Bytes()
+	c.Assert(body, checkers.JSONPathMatches("$.errors[0].code", qt.Not(qt.Equals)), "")
+}
+
+func TestCurrencyMigrations_Preview_FromMismatchRejected422(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Group's GroupCurrency is USD; submitting from=GBP must 422 with a
+	// stable code so the FE can render "from currency mismatch".
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("GBP", "EUR", "0.9"))
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.from_mismatch")
 }
 
 func TestCurrencyMigrations_Preview_ZeroRateRejected422(t *testing.T) {
@@ -142,6 +185,7 @@ func TestCurrencyMigrations_Preview_ZeroRateRejected422(t *testing.T) {
 	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "EUR", "0"))
 
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.rate_invalid")
 }
 
 func TestCurrencyMigrations_Start_Happy_AndCreatesPendingRow(t *testing.T) {
@@ -175,6 +219,7 @@ func TestCurrencyMigrations_Start_TokenInvalid_Returns422(t *testing.T) {
 
 	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.9", "definitely-not-a-token"))
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.token_invalid")
 }
 
 func TestCurrencyMigrations_Start_TokenBindingsMismatched_Returns409(t *testing.T) {
@@ -190,6 +235,7 @@ func TestCurrencyMigrations_Start_TokenBindingsMismatched_Returns409(t *testing.
 
 	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.95", previewToken))
 	c.Assert(rr.Code, qt.Equals, http.StatusConflict)
+	assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.state_changed")
 }
 
 func TestCurrencyMigrations_Start_StateDriftRejectedOn409(t *testing.T) {
@@ -221,6 +267,7 @@ func TestCurrencyMigrations_Start_StateDriftRejectedOn409(t *testing.T) {
 
 	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.9", previewToken))
 	c.Assert(rr.Code, qt.Equals, http.StatusConflict)
+	assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.state_changed")
 }
 
 func TestCurrencyMigrations_Start_InFlightMigrationRejected409(t *testing.T) {
@@ -246,6 +293,12 @@ func TestCurrencyMigrations_Start_InFlightMigrationRejected409(t *testing.T) {
 
 	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.9", previewToken))
 	c.Assert(rr.Code, qt.Equals, http.StatusConflict)
+	body := rr.Body.Bytes()
+	assertErrorCode(t, c, body, "currency_migration.migration_in_progress")
+	// Meta should carry the in-flight migration's id and status so the
+	// FE can deep-link to the lock UX without a second roundtrip.
+	assertErrorMeta(t, c, body, "migration_id", func(v any) bool { s, _ := v.(string); return s != "" }, "expected non-empty migration_id")
+	assertErrorMeta(t, c, body, "status", func(v any) bool { return v == "pending" || v == "running" }, "expected pending|running")
 }
 
 func TestCurrencyMigrations_Start_RestoreInFlightRejected409(t *testing.T) {
@@ -283,6 +336,7 @@ func TestCurrencyMigrations_Start_RestoreInFlightRejected409(t *testing.T) {
 
 	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.9", previewToken))
 	c.Assert(rr.Code, qt.Equals, http.StatusConflict)
+	assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.restore_in_progress")
 }
 
 func TestCurrencyMigrations_LockMiddleware_BlocksCommodityWrites423(t *testing.T) {
@@ -320,6 +374,12 @@ func TestCurrencyMigrations_LockMiddleware_BlocksCommodityWrites423(t *testing.T
 		},
 	})
 	c.Assert(rr.Code, qt.Equals, http.StatusLocked)
+	body := rr.Body.Bytes()
+	assertErrorCode(t, c, body, "currency_migration.locked")
+	// Meta carries the in-flight migration's id and status so the FE
+	// banner can deep-link without re-querying.
+	assertErrorMeta(t, c, body, "migration_id", func(v any) bool { s, _ := v.(string); return s == mig.ID }, "expected migration_id == planted mig.ID")
+	assertErrorMeta(t, c, body, "status", func(v any) bool { return v == "running" }, "expected status=running")
 }
 
 func TestCurrencyMigrations_LockOnRestoreCreate_Returns423(t *testing.T) {
@@ -360,6 +420,7 @@ func TestCurrencyMigrations_LockOnRestoreCreate_Returns423(t *testing.T) {
 		},
 	})
 	c.Assert(rr.Code, qt.Equals, http.StatusLocked)
+	assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.locked")
 }
 
 func TestCurrencyMigrations_NonAdmin_Returns403(t *testing.T) {
@@ -438,6 +499,18 @@ func TestCurrencyMigrations_DailyCap_Returns429(t *testing.T) {
 
 	rr = doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "EUR", "0.9", previewToken))
 	c.Assert(rr.Code, qt.Equals, http.StatusTooManyRequests)
+	body := rr.Body.Bytes()
+	assertErrorCode(t, c, body, "currency_migration.daily_cap_reached")
+	// retry_after_seconds tells the FE when the cap window resets so
+	// the Migrate CTA can stay disabled until then.
+	assertErrorMeta(t, c, body, "retry_after_seconds", func(v any) bool {
+		// json.Unmarshal decodes numbers into float64; accept any
+		// positive value in the (0, 86400] range.
+		if f, ok := v.(float64); ok {
+			return f > 0 && f <= 24*60*60
+		}
+		return false
+	}, "expected positive retry_after_seconds <= 86400")
 }
 
 // jsonPathString extracts a string value from a JSON body via jsonpath.

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -179,3 +179,66 @@ func conflictError(w http.ResponseWriter, r *http.Request, err, userErr error) e
 	}
 	return render.Render(w, r, jsonapi.NewErrors(conflictErr))
 }
+
+// codedConflictError renders a 409 with the given JSON:API error code
+// and (optional) meta. Used by the currency-migration endpoints to
+// distinguish migration_in_progress / restore_in_progress / preview_expired
+// / state_changed at the wire level so the FE can render specific
+// toasts.
+func codedConflictError(w http.ResponseWriter, r *http.Request, err error, code string, meta map[string]any) error {
+	jsErr := jsonapi.Error{
+		Err:            err,
+		UserError:      errormarshal.Marshal(err),
+		HTTPStatusCode: http.StatusConflict,
+		StatusText:     "Conflict",
+		Code:           code,
+		Meta:           meta,
+	}
+	return render.Render(w, r, jsonapi.NewErrors(jsErr))
+}
+
+// codedUnprocessableEntityError renders a 422 with a JSON:API error
+// code. Used for currency_migration.token_invalid and same-currency
+// rejections so the FE can branch on the code rather than the status
+// alone.
+func codedUnprocessableEntityError(w http.ResponseWriter, r *http.Request, err error, code string) error {
+	jsErr := jsonapi.Error{
+		Err:            err,
+		UserError:      errormarshal.Marshal(err),
+		HTTPStatusCode: http.StatusUnprocessableEntity,
+		StatusText:     "Unprocessable Entity",
+		Code:           code,
+	}
+	return render.Render(w, r, jsonapi.NewErrors(jsErr))
+}
+
+// codedTooManyRequestsError renders a 429 with a JSON:API error code
+// and meta (typically {"retry_after_seconds": N}). Used for the
+// currency-migration daily-cap rejections (#202 §3.5).
+func codedTooManyRequestsError(w http.ResponseWriter, r *http.Request, err error, code string, meta map[string]any) error {
+	jsErr := jsonapi.Error{
+		Err:            err,
+		UserError:      errormarshal.Marshal(err),
+		HTTPStatusCode: http.StatusTooManyRequests,
+		StatusText:     "Too Many Requests",
+		Code:           code,
+		Meta:           meta,
+	}
+	return render.Render(w, r, jsonapi.NewErrors(jsErr))
+}
+
+// lockedError renders a 423 Locked with a JSON:API error code and
+// meta. Used by requireGroupNotMigrating to surface in-flight currency
+// migrations on commodity write paths and on the restore-start
+// endpoint (#202 §3.2).
+func lockedError(w http.ResponseWriter, r *http.Request, err error, code string, meta map[string]any) error {
+	jsErr := jsonapi.Error{
+		Err:            err,
+		UserError:      errormarshal.Marshal(err),
+		HTTPStatusCode: http.StatusLocked,
+		StatusText:     "Locked",
+		Code:           code,
+		Meta:           meta,
+	}
+	return render.Render(w, r, jsonapi.NewErrors(jsErr))
+}

--- a/go/apiserver/export_restores.go
+++ b/go/apiserver/export_restores.go
@@ -13,6 +13,14 @@ import (
 
 type exportRestoresAPI struct {
 	restoreStatus RestoreStatusQuerier
+	// currencyMigrationLockEnabled mirrors Params.FeatureCurrencyMigration.
+	// When true, createExportRestore queries InFlightForGroup before
+	// inserting and rejects with HTTP 423 if a migration is pending or
+	// running on the group (issue #202 §3.2 cross-op lock). The
+	// commodity-write side of the lock is enforced by the
+	// requireGroupNotMigrating middleware in apiserver.go; this is the
+	// in-handler symmetric guard for the restore-create endpoint.
+	currencyMigrationLockEnabled bool
 }
 
 // listExportRestores lists all restore operations for an export.
@@ -201,6 +209,31 @@ func (api *exportRestoresAPI) createExportRestore(w http.ResponseWriter, r *http
 		return
 	}
 
+	// Cross-op lock with the currency-migration system (issue #202 §3.2).
+	// A restore mid-migration would rewrite commodities while the worker
+	// is rewriting prices, corrupting totals; reject with 423 and let
+	// the FE surface a friendly toast.
+	if api.currencyMigrationLockEnabled {
+		registrySet := RegistrySetFromContext(r.Context())
+		group := groupFromContext(r.Context())
+		if registrySet != nil && group != nil && registrySet.CurrencyMigrationRegistry != nil {
+			if inFlight, qerr := registrySet.CurrencyMigrationRegistry.InFlightForGroup(r.Context(), group.ID); qerr != nil {
+				_ = internalServerError(w, r, qerr)
+				return
+			} else if inFlight != nil {
+				_ = lockedError(w, r,
+					errors.New("group is locked while a currency migration is in progress"),
+					codeCurrencyMigrationLocked,
+					map[string]any{
+						"migration_id": inFlight.ID,
+						"status":       string(inFlight.Status),
+					},
+				)
+				return
+			}
+		}
+	}
+
 	restoreOperation := models.NewRestoreOperationFromUserInput(data.Data.Attributes)
 	// The restore is scoped to the export from the URL — the FE only
 	// sends description+options on the body, so populate ExportID
@@ -296,9 +329,17 @@ func (api *exportRestoresAPI) deleteExportRestore(w http.ResponseWriter, r *http
 }
 
 // ExportRestores sets up the export restore API routes.
-func ExportRestores(restoreStatus RestoreStatusQuerier) func(r chi.Router) {
+//
+// currencyMigrationLockEnabled toggles the cross-op lock check inside
+// createExportRestore (issue #202 §3.2): when an in-flight currency
+// migration exists for the group, the restore-create endpoint
+// returns HTTP 423 instead of 201. The flag mirrors
+// Params.FeatureCurrencyMigration so the codepath is dead when the
+// feature is off.
+func ExportRestores(restoreStatus RestoreStatusQuerier, currencyMigrationLockEnabled bool) func(r chi.Router) {
 	api := &exportRestoresAPI{
-		restoreStatus: restoreStatus,
+		restoreStatus:                restoreStatus,
+		currencyMigrationLockEnabled: currencyMigrationLockEnabled,
 	}
 
 	return func(r chi.Router) {

--- a/go/apiserver/export_restores.go
+++ b/go/apiserver/export_restores.go
@@ -212,25 +212,30 @@ func (api *exportRestoresAPI) createExportRestore(w http.ResponseWriter, r *http
 	// Cross-op lock with the currency-migration system (issue #202 §3.2).
 	// A restore mid-migration would rewrite commodities while the worker
 	// is rewriting prices, corrupting totals; reject with 423 and let
-	// the FE surface a friendly toast.
+	// the FE surface a friendly toast. When the feature flag is on, a
+	// missing group context or unwired registry is a misconfiguration —
+	// fail closed (500) rather than silently letting the restore through.
 	if api.currencyMigrationLockEnabled {
-		registrySet := RegistrySetFromContext(r.Context())
 		group := groupFromContext(r.Context())
-		if registrySet != nil && group != nil && registrySet.CurrencyMigrationRegistry != nil {
-			if inFlight, qerr := registrySet.CurrencyMigrationRegistry.InFlightForGroup(r.Context(), group.ID); qerr != nil {
-				_ = internalServerError(w, r, qerr)
-				return
-			} else if inFlight != nil {
-				_ = lockedError(w, r,
-					errors.New("group is locked while a currency migration is in progress"),
-					codeCurrencyMigrationLocked,
-					map[string]any{
-						"migration_id": inFlight.ID,
-						"status":       string(inFlight.Status),
-					},
-				)
-				return
-			}
+		if group == nil || registrySet.CurrencyMigrationRegistry == nil {
+			_ = internalServerError(w, r, errors.New("currency migration lock check unavailable: missing group or registry"))
+			return
+		}
+		inFlight, qerr := registrySet.CurrencyMigrationRegistry.InFlightForGroup(r.Context(), group.ID)
+		if qerr != nil {
+			_ = internalServerError(w, r, qerr)
+			return
+		}
+		if inFlight != nil {
+			_ = lockedError(w, r,
+				errors.New("group is locked while a currency migration is in progress"),
+				codeCurrencyMigrationLocked,
+				map[string]any{
+					"migration_id": inFlight.ID,
+					"status":       string(inFlight.Status),
+				},
+			)
+			return
 		}
 	}
 

--- a/go/apiserver/exports.go
+++ b/go/apiserver/exports.go
@@ -425,7 +425,7 @@ func Exports(params Params, restoreStatus RestoreStatusQuerier) func(r chi.Route
 			r.Get("/", api.apiGetExport)
 			r.Delete("/", api.deleteExport)
 			r.Get("/download", api.downloadExport)
-			r.Route("/restores", ExportRestores(restoreStatus))
+			r.Route("/restores", ExportRestores(restoreStatus, params.FeatureCurrencyMigration))
 		})
 	}
 }

--- a/go/cmd/inventario/run/bootstrap/bootstrap.go
+++ b/go/cmd/inventario/run/bootstrap/bootstrap.go
@@ -62,6 +62,13 @@ func Build(cfg *Config, dbConfig *shared.DatabaseConfig, mode Mode) (*RuntimeSet
 		return nil, err
 	}
 
+	// Inject the operator-supplied currency-migration HMAC key into the
+	// factory so preview tokens are verifiable across replicas / survive
+	// restarts. Empty config value is a no-op (per-process random key).
+	if cfg.CurrencyMigrationHMACKey != "" && factorySet.CurrencyMigrationRegistryFactory != nil {
+		factorySet.CurrencyMigrationRegistryFactory.SetHMACKey([]byte(cfg.CurrencyMigrationHMACKey))
+	}
+
 	seedMemoryDBDefaultTenant(dsn, factorySet)
 
 	serverSetup, err := buildServerParams(cfg, factorySet, dsn)

--- a/go/cmd/inventario/run/bootstrap/bootstrap.go
+++ b/go/cmd/inventario/run/bootstrap/bootstrap.go
@@ -65,7 +65,19 @@ func Build(cfg *Config, dbConfig *shared.DatabaseConfig, mode Mode) (*RuntimeSet
 	// Inject the operator-supplied currency-migration HMAC key into the
 	// factory so preview tokens are verifiable across replicas / survive
 	// restarts. Empty config value is a no-op (per-process random key).
+	// Warn loudly (but accept) on shorter-than-recommended keys —
+	// preview tokens gate a destructive operation, and a short key
+	// weakens the signature without alerting the operator. 32 bytes
+	// matches the SHA-256 block / output size; nothing larger gives
+	// extra security.
 	if cfg.CurrencyMigrationHMACKey != "" && factorySet.CurrencyMigrationRegistryFactory != nil {
+		const recommendedHMACKeyLen = 32
+		if len(cfg.CurrencyMigrationHMACKey) < recommendedHMACKeyLen {
+			slog.Warn("CurrencyMigrationHMACKey is shorter than the recommended length; preview-token security is weakened",
+				"configured_bytes", len(cfg.CurrencyMigrationHMACKey),
+				"recommended_min_bytes", recommendedHMACKeyLen,
+			)
+		}
 		factorySet.CurrencyMigrationRegistryFactory.SetHMACKey([]byte(cfg.CurrencyMigrationHMACKey))
 	}
 

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -53,6 +53,23 @@ type Config struct {
 
 	LogEmailURLs bool `yaml:"log_email_urls" env:"LOG_EMAIL_URLS" env-default:"false"`
 
+	// FeatureCurrencyMigration gates the entire currency-migration surface
+	// (issue #202): the four /currency-migrations endpoints, the
+	// requireGroupNotMigrating lock middleware, and (in PR 3) the worker.
+	// Default off — the schema and registries shipped in PR 1 are inert
+	// until this flag flips on. The flag is removed once the feature is
+	// fully launched (see §8 in #202).
+	FeatureCurrencyMigration bool `yaml:"feature_currency_migration" env:"FEATURE_CURRENCY_MIGRATION" env-default:"false"`
+
+	// CurrencyMigrationHMACKey signs the stateless preview tokens issued
+	// by the preview endpoint. Verification re-derives the signature from
+	// this same key on commit, so the value must be identical on every
+	// replica. Empty string at startup → a random 32-byte key is generated
+	// (fine in single-replica deployments; tokens issued by one process
+	// don't survive a restart). Provide a stable value (≥ 32 bytes
+	// recommended) for multi-replica or restart-stable deployments.
+	CurrencyMigrationHMACKey string `yaml:"currency_migration_hmac_key" env:"CURRENCY_MIGRATION_HMAC_KEY" env-default:""`
+
 	// WorkersOnly / WorkersExclude restrict which background workers run in
 	// `inventario run workers`. See the run/workers package for the accepted
 	// syntax and mutual-exclusion rules. Both fields default to empty, meaning

--- a/go/cmd/inventario/run/bootstrap/server_params.go
+++ b/go/cmd/inventario/run/bootstrap/server_params.go
@@ -141,6 +141,8 @@ func buildServerParams(cfg *Config, factorySet *registry.FactorySet, dsn string)
 		return serverSetup{}, err
 	}
 
+	params.FeatureCurrencyMigration = cfg.FeatureCurrencyMigration
+
 	emailLifecycle, err := buildEmailService(cfg)
 	if err != nil {
 		slog.Error("Failed to initialize email service", "error", err)

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -1773,6 +1773,211 @@ const docTemplate = `{
                 }
             }
         },
+        "/g/{groupSlug}/currency-migrations": {
+            "get": {
+                "description": "Returns the group's full currency-migration history newest-first.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "currency-migrations"
+                ],
+                "summary": "List currency migrations for a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationsResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — non-admin",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Verify preview token, perform cross-op + daily-cap checks, insert a pending migration row.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "currency-migrations"
+                ],
+                "summary": "Start a currency migration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Start request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationStartRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — non-admin",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "409": {
+                        "description": "Token expired / state changed / migration in progress / restore in progress",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation / token invalid",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "429": {
+                        "description": "Daily cap reached",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/currency-migrations/preview": {
+            "post": {
+                "description": "Dry-run the conversion, returning projected totals + per-row diffs + a signed preview_token.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "currency-migrations"
+                ],
+                "summary": "Preview a currency migration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Preview request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — non-admin",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/currency-migrations/{id}": {
+            "get": {
+                "description": "Returns one currency-migration row by id.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "currency-migrations"
+                ],
+                "summary": "Get a currency migration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Currency migration ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — non-admin",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/g/{groupSlug}/exports": {
             "get": {
                 "description": "get exports",
@@ -5942,11 +6147,231 @@ const docTemplate = `{
                 }
             }
         },
+        "jsonapi.CurrencyMigrationPreviewAttributes": {
+            "type": "object",
+            "properties": {
+                "exchange_rate": {
+                    "type": "number"
+                },
+                "from_currency": {
+                    "type": "string"
+                },
+                "to_currency": {
+                    "type": "string"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewBody": {
+            "type": "object",
+            "properties": {
+                "acquisition_fills": {
+                    "type": "integer"
+                },
+                "commodity_count": {
+                    "type": "integer"
+                },
+                "diffs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewDiff"
+                    }
+                },
+                "exchange_rate": {
+                    "type": "number"
+                },
+                "from_currency": {
+                    "type": "string"
+                },
+                "preview_expires_at": {
+                    "type": "string"
+                },
+                "preview_expires_in_seconds": {
+                    "type": "integer"
+                },
+                "preview_token": {
+                    "type": "string"
+                },
+                "state_hash": {
+                    "type": "string"
+                },
+                "to_currency": {
+                    "type": "string"
+                },
+                "total_current_after": {
+                    "type": "number"
+                },
+                "total_current_before": {
+                    "type": "number"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewDiff": {
+            "type": "object",
+            "properties": {
+                "commodity_id": {
+                    "type": "string"
+                },
+                "commodity_name": {
+                    "type": "string"
+                },
+                "current_price_after": {
+                    "type": "number"
+                },
+                "current_price_before": {
+                    "type": "number"
+                },
+                "original_currency_after": {
+                    "type": "string"
+                },
+                "original_currency_before": {
+                    "type": "string"
+                },
+                "original_price_after": {
+                    "type": "number"
+                },
+                "original_price_before": {
+                    "type": "number"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewRequest": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewRequestData"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewRequestData": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewAttributes"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "currency-migrations"
+                    ],
+                    "example": "currency-migrations"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewResponseData"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewResponseData": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewBody"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "currency-migration-previews"
+                    ],
+                    "example": "currency-migration-previews"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationResponseData"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationResponseData": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/models.CurrencyMigration"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "currency-migrations"
+                    ],
+                    "example": "currency-migrations"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationStartAttributes": {
+            "type": "object",
+            "properties": {
+                "exchange_rate": {
+                    "description": "ExchangeRate is the user-typed rate (1 from = rate to). FE clamps\nto 6 decimals as a UX guard; BE validates per #202 §2 (positive,\nfinite, ≤ 1e10).",
+                    "type": "number"
+                },
+                "from_currency": {
+                    "type": "string"
+                },
+                "preview_token": {
+                    "description": "PreviewToken is the HMAC-signed token the preview endpoint\nreturned. Required; the start handler verifies the signature and\nthen re-derives the state hash to detect group drift between\npreview and commit.",
+                    "type": "string"
+                },
+                "to_currency": {
+                    "type": "string"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationStartRequest": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationStartRequestData"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationStartRequestData": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationStartAttributes"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "currency-migrations"
+                    ],
+                    "example": "currency-migrations"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/jsonapi.CurrencyMigrationResponseData"
+                    }
+                }
+            }
+        },
         "jsonapi.Error": {
             "type": "object",
             "properties": {
+                "code": {
+                    "description": "Code is the application-specific error code (e.g.\n\"currency_migration.daily_cap_reached\"). Optional; when present,\nthe FE branches on this string before falling back to the generic\nHTTP status. Stable across versions.",
+                    "type": "string"
+                },
                 "error": {
                     "description": "user-level error message",
+                    "type": "object"
+                },
+                "meta": {
+                    "description": "Meta is a free-form JSON object the handler may attach for\nmachine-readable context (e.g. {\"retry_after_seconds\": 3600}).\nOptional; serialised only when non-empty.",
                     "type": "object"
                 },
                 "status": {
@@ -7566,6 +7991,87 @@ const docTemplate = `{
                 "CommodityTypeFurniture",
                 "CommodityTypeClothes",
                 "CommodityTypeOther"
+            ]
+        },
+        "models.CurrencyMigration": {
+            "type": "object",
+            "properties": {
+                "commodity_count": {
+                    "description": "CommodityCount is the number of rows actually mutated by the worker.",
+                    "type": "integer"
+                },
+                "completed_at": {
+                    "description": "CompletedAt is set on either terminal status — TX2 commit on\nsuccess or the recovery sweep on failure. Captures the moment the\nrow left the ` + "`" + `running` + "`" + ` state.",
+                    "type": "string"
+                },
+                "created_at": {
+                    "description": "CreatedAt is the moment the row was inserted (still in pending status).",
+                    "type": "string"
+                },
+                "error_message": {
+                    "description": "ErrorMessage is populated when status=failed.",
+                    "type": "string"
+                },
+                "exchange_rate": {
+                    "description": "ExchangeRate is the user-entered rate (1 from = rate to). DECIMAL(20,10)\ngives plenty of headroom; the FE clamps to 6 decimals as a UX guard.",
+                    "type": "number"
+                },
+                "from_currency": {
+                    "description": "FromCurrency is the group currency at the moment the migration was\nscheduled. The worker re-validates against the live group state\ninside TX2 and aborts if it has drifted.",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "preview_expires_at": {
+                    "description": "PreviewExpiresAt is the expiry timestamp embedded in PreviewToken.",
+                    "type": "string"
+                },
+                "preview_token": {
+                    "description": "PreviewToken is the HMAC issued by the preview endpoint and posted\nback at commit time. Persisted for audit only — verification is\nstateless and recomputed from the same key.",
+                    "type": "string"
+                },
+                "started_at": {
+                    "description": "StartedAt is set when the worker flips the row to ` + "`" + `running` + "`" + ` (TX1).",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Status — see CurrencyMigrationStatus. Worker writes durable\ntransitions; status is never user-input.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.CurrencyMigrationStatus"
+                        }
+                    ]
+                },
+                "to_currency": {
+                    "description": "ToCurrency is the target group currency. CHECK constraint enforces\nfrom_currency \u003c\u003e to_currency at the DB level.",
+                    "type": "string"
+                },
+                "total_after": {
+                    "type": "number"
+                },
+                "total_before": {
+                    "description": "TotalBefore / TotalAfter are sums of CurrentPrice across the\ngroup's commodities, captured for audit. Nullable until TX2 has\ncomputed them.",
+                    "type": "number"
+                },
+                "uuid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.CurrencyMigrationStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "running",
+                "completed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "CurrencyMigrationStatusPending",
+                "CurrencyMigrationStatusRunning",
+                "CurrencyMigrationStatusCompleted",
+                "CurrencyMigrationStatusFailed"
             ]
         },
         "models.Export": {

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -6371,8 +6371,11 @@ const docTemplate = `{
                     "type": "object"
                 },
                 "meta": {
-                    "description": "Meta is a free-form JSON object the handler may attach for\nmachine-readable context (e.g. {\"retry_after_seconds\": 3600}).\nOptional; serialised only when non-empty.",
-                    "type": "object"
+                    "description": "Meta is a free-form JSON object the handler may attach for\nmachine-readable context (e.g. {\"retry_after_seconds\": 3600}).\nOptional; serialised only when non-empty.\n\nSwagger annotation note: ` + "`" + `swaggertype:\"object,string\"` + "`" + ` tells swag\nto emit ` + "`" + `additionalProperties: { type: string }` + "`" + `. Without an\nexplicit additionalProperties, openapi-typescript renders the\nempty ` + "`" + `{type: object}` + "`" + ` schema as ` + "`" + `Record\u003cstring, never\u003e` + "`" + ` — a\nclosed, indexable-but-empty object — which makes\n` + "`" + `meta.retry_after_seconds` + "`" + ` uncallable in TS without a cast. With\nthe override the FE gets a ` + "`" + `{ [key: string]: string }` + "`" + ` index\nsignature; consumers parse known keys (` + "`" + `retry_after_seconds:\nnumber` + "`" + `, ` + "`" + `migration_id: string` + "`" + `, ` + "`" + `status: string` + "`" + `) into their\nreal types — we control both sides of that cast.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "status": {
                     "description": "user-level status message",

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -1766,6 +1766,211 @@
                 }
             }
         },
+        "/g/{groupSlug}/currency-migrations": {
+            "get": {
+                "description": "Returns the group's full currency-migration history newest-first.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "currency-migrations"
+                ],
+                "summary": "List currency migrations for a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationsResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — non-admin",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Verify preview token, perform cross-op + daily-cap checks, insert a pending migration row.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "currency-migrations"
+                ],
+                "summary": "Start a currency migration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Start request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationStartRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — non-admin",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "409": {
+                        "description": "Token expired / state changed / migration in progress / restore in progress",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation / token invalid",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "429": {
+                        "description": "Daily cap reached",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/currency-migrations/preview": {
+            "post": {
+                "description": "Dry-run the conversion, returning projected totals + per-row diffs + a signed preview_token.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "currency-migrations"
+                ],
+                "summary": "Preview a currency migration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Preview request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — non-admin",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/g/{groupSlug}/currency-migrations/{id}": {
+            "get": {
+                "description": "Returns one currency-migration row by id.",
+                "consumes": [
+                    "application/vnd.api+json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "currency-migrations"
+                ],
+                "summary": "Get a currency migration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Currency migration ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.CurrencyMigrationResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — non-admin",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/g/{groupSlug}/exports": {
             "get": {
                 "description": "get exports",
@@ -5935,11 +6140,231 @@
                 }
             }
         },
+        "jsonapi.CurrencyMigrationPreviewAttributes": {
+            "type": "object",
+            "properties": {
+                "exchange_rate": {
+                    "type": "number"
+                },
+                "from_currency": {
+                    "type": "string"
+                },
+                "to_currency": {
+                    "type": "string"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewBody": {
+            "type": "object",
+            "properties": {
+                "acquisition_fills": {
+                    "type": "integer"
+                },
+                "commodity_count": {
+                    "type": "integer"
+                },
+                "diffs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewDiff"
+                    }
+                },
+                "exchange_rate": {
+                    "type": "number"
+                },
+                "from_currency": {
+                    "type": "string"
+                },
+                "preview_expires_at": {
+                    "type": "string"
+                },
+                "preview_expires_in_seconds": {
+                    "type": "integer"
+                },
+                "preview_token": {
+                    "type": "string"
+                },
+                "state_hash": {
+                    "type": "string"
+                },
+                "to_currency": {
+                    "type": "string"
+                },
+                "total_current_after": {
+                    "type": "number"
+                },
+                "total_current_before": {
+                    "type": "number"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewDiff": {
+            "type": "object",
+            "properties": {
+                "commodity_id": {
+                    "type": "string"
+                },
+                "commodity_name": {
+                    "type": "string"
+                },
+                "current_price_after": {
+                    "type": "number"
+                },
+                "current_price_before": {
+                    "type": "number"
+                },
+                "original_currency_after": {
+                    "type": "string"
+                },
+                "original_currency_before": {
+                    "type": "string"
+                },
+                "original_price_after": {
+                    "type": "number"
+                },
+                "original_price_before": {
+                    "type": "number"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewRequest": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewRequestData"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewRequestData": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewAttributes"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "currency-migrations"
+                    ],
+                    "example": "currency-migrations"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewResponseData"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationPreviewResponseData": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationPreviewBody"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "currency-migration-previews"
+                    ],
+                    "example": "currency-migration-previews"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationResponseData"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationResponseData": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/models.CurrencyMigration"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "currency-migrations"
+                    ],
+                    "example": "currency-migrations"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationStartAttributes": {
+            "type": "object",
+            "properties": {
+                "exchange_rate": {
+                    "description": "ExchangeRate is the user-typed rate (1 from = rate to). FE clamps\nto 6 decimals as a UX guard; BE validates per #202 §2 (positive,\nfinite, ≤ 1e10).",
+                    "type": "number"
+                },
+                "from_currency": {
+                    "type": "string"
+                },
+                "preview_token": {
+                    "description": "PreviewToken is the HMAC-signed token the preview endpoint\nreturned. Required; the start handler verifies the signature and\nthen re-derives the state hash to detect group drift between\npreview and commit.",
+                    "type": "string"
+                },
+                "to_currency": {
+                    "type": "string"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationStartRequest": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationStartRequestData"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationStartRequestData": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/jsonapi.CurrencyMigrationStartAttributes"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "currency-migrations"
+                    ],
+                    "example": "currency-migrations"
+                }
+            }
+        },
+        "jsonapi.CurrencyMigrationsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/jsonapi.CurrencyMigrationResponseData"
+                    }
+                }
+            }
+        },
         "jsonapi.Error": {
             "type": "object",
             "properties": {
+                "code": {
+                    "description": "Code is the application-specific error code (e.g.\n\"currency_migration.daily_cap_reached\"). Optional; when present,\nthe FE branches on this string before falling back to the generic\nHTTP status. Stable across versions.",
+                    "type": "string"
+                },
                 "error": {
                     "description": "user-level error message",
+                    "type": "object"
+                },
+                "meta": {
+                    "description": "Meta is a free-form JSON object the handler may attach for\nmachine-readable context (e.g. {\"retry_after_seconds\": 3600}).\nOptional; serialised only when non-empty.",
                     "type": "object"
                 },
                 "status": {
@@ -7559,6 +7984,87 @@
                 "CommodityTypeFurniture",
                 "CommodityTypeClothes",
                 "CommodityTypeOther"
+            ]
+        },
+        "models.CurrencyMigration": {
+            "type": "object",
+            "properties": {
+                "commodity_count": {
+                    "description": "CommodityCount is the number of rows actually mutated by the worker.",
+                    "type": "integer"
+                },
+                "completed_at": {
+                    "description": "CompletedAt is set on either terminal status — TX2 commit on\nsuccess or the recovery sweep on failure. Captures the moment the\nrow left the `running` state.",
+                    "type": "string"
+                },
+                "created_at": {
+                    "description": "CreatedAt is the moment the row was inserted (still in pending status).",
+                    "type": "string"
+                },
+                "error_message": {
+                    "description": "ErrorMessage is populated when status=failed.",
+                    "type": "string"
+                },
+                "exchange_rate": {
+                    "description": "ExchangeRate is the user-entered rate (1 from = rate to). DECIMAL(20,10)\ngives plenty of headroom; the FE clamps to 6 decimals as a UX guard.",
+                    "type": "number"
+                },
+                "from_currency": {
+                    "description": "FromCurrency is the group currency at the moment the migration was\nscheduled. The worker re-validates against the live group state\ninside TX2 and aborts if it has drifted.",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "preview_expires_at": {
+                    "description": "PreviewExpiresAt is the expiry timestamp embedded in PreviewToken.",
+                    "type": "string"
+                },
+                "preview_token": {
+                    "description": "PreviewToken is the HMAC issued by the preview endpoint and posted\nback at commit time. Persisted for audit only — verification is\nstateless and recomputed from the same key.",
+                    "type": "string"
+                },
+                "started_at": {
+                    "description": "StartedAt is set when the worker flips the row to `running` (TX1).",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Status — see CurrencyMigrationStatus. Worker writes durable\ntransitions; status is never user-input.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.CurrencyMigrationStatus"
+                        }
+                    ]
+                },
+                "to_currency": {
+                    "description": "ToCurrency is the target group currency. CHECK constraint enforces\nfrom_currency \u003c\u003e to_currency at the DB level.",
+                    "type": "string"
+                },
+                "total_after": {
+                    "type": "number"
+                },
+                "total_before": {
+                    "description": "TotalBefore / TotalAfter are sums of CurrentPrice across the\ngroup's commodities, captured for audit. Nullable until TX2 has\ncomputed them.",
+                    "type": "number"
+                },
+                "uuid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.CurrencyMigrationStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "running",
+                "completed",
+                "failed"
+            ],
+            "x-enum-varnames": [
+                "CurrencyMigrationStatusPending",
+                "CurrencyMigrationStatusRunning",
+                "CurrencyMigrationStatusCompleted",
+                "CurrencyMigrationStatusFailed"
             ]
         },
         "models.Export": {

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -6364,8 +6364,11 @@
                     "type": "object"
                 },
                 "meta": {
-                    "description": "Meta is a free-form JSON object the handler may attach for\nmachine-readable context (e.g. {\"retry_after_seconds\": 3600}).\nOptional; serialised only when non-empty.",
-                    "type": "object"
+                    "description": "Meta is a free-form JSON object the handler may attach for\nmachine-readable context (e.g. {\"retry_after_seconds\": 3600}).\nOptional; serialised only when non-empty.\n\nSwagger annotation note: `swaggertype:\"object,string\"` tells swag\nto emit `additionalProperties: { type: string }`. Without an\nexplicit additionalProperties, openapi-typescript renders the\nempty `{type: object}` schema as `Record\u003cstring, never\u003e` — a\nclosed, indexable-but-empty object — which makes\n`meta.retry_after_seconds` uncallable in TS without a cast. With\nthe override the FE gets a `{ [key: string]: string }` index\nsignature; consumers parse known keys (`retry_after_seconds:\nnumber`, `migration_id: string`, `status: string`) into their\nreal types — we control both sides of that cast.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "status": {
                     "description": "user-level status message",

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -841,10 +841,169 @@ definitions:
       meta:
         $ref: '#/definitions/jsonapi.CommodityServicesMeta'
     type: object
+  jsonapi.CurrencyMigrationPreviewAttributes:
+    properties:
+      exchange_rate:
+        type: number
+      from_currency:
+        type: string
+      to_currency:
+        type: string
+    type: object
+  jsonapi.CurrencyMigrationPreviewBody:
+    properties:
+      acquisition_fills:
+        type: integer
+      commodity_count:
+        type: integer
+      diffs:
+        items:
+          $ref: '#/definitions/jsonapi.CurrencyMigrationPreviewDiff'
+        type: array
+      exchange_rate:
+        type: number
+      from_currency:
+        type: string
+      preview_expires_at:
+        type: string
+      preview_expires_in_seconds:
+        type: integer
+      preview_token:
+        type: string
+      state_hash:
+        type: string
+      to_currency:
+        type: string
+      total_current_after:
+        type: number
+      total_current_before:
+        type: number
+    type: object
+  jsonapi.CurrencyMigrationPreviewDiff:
+    properties:
+      commodity_id:
+        type: string
+      commodity_name:
+        type: string
+      current_price_after:
+        type: number
+      current_price_before:
+        type: number
+      original_currency_after:
+        type: string
+      original_currency_before:
+        type: string
+      original_price_after:
+        type: number
+      original_price_before:
+        type: number
+    type: object
+  jsonapi.CurrencyMigrationPreviewRequest:
+    properties:
+      data:
+        $ref: '#/definitions/jsonapi.CurrencyMigrationPreviewRequestData'
+    type: object
+  jsonapi.CurrencyMigrationPreviewRequestData:
+    properties:
+      attributes:
+        $ref: '#/definitions/jsonapi.CurrencyMigrationPreviewAttributes'
+      type:
+        enum:
+        - currency-migrations
+        example: currency-migrations
+        type: string
+    type: object
+  jsonapi.CurrencyMigrationPreviewResponse:
+    properties:
+      data:
+        $ref: '#/definitions/jsonapi.CurrencyMigrationPreviewResponseData'
+    type: object
+  jsonapi.CurrencyMigrationPreviewResponseData:
+    properties:
+      attributes:
+        $ref: '#/definitions/jsonapi.CurrencyMigrationPreviewBody'
+      type:
+        enum:
+        - currency-migration-previews
+        example: currency-migration-previews
+        type: string
+    type: object
+  jsonapi.CurrencyMigrationResponse:
+    properties:
+      data:
+        $ref: '#/definitions/jsonapi.CurrencyMigrationResponseData'
+    type: object
+  jsonapi.CurrencyMigrationResponseData:
+    properties:
+      attributes:
+        $ref: '#/definitions/models.CurrencyMigration'
+      id:
+        type: string
+      type:
+        enum:
+        - currency-migrations
+        example: currency-migrations
+        type: string
+    type: object
+  jsonapi.CurrencyMigrationStartAttributes:
+    properties:
+      exchange_rate:
+        description: |-
+          ExchangeRate is the user-typed rate (1 from = rate to). FE clamps
+          to 6 decimals as a UX guard; BE validates per #202 §2 (positive,
+          finite, ≤ 1e10).
+        type: number
+      from_currency:
+        type: string
+      preview_token:
+        description: |-
+          PreviewToken is the HMAC-signed token the preview endpoint
+          returned. Required; the start handler verifies the signature and
+          then re-derives the state hash to detect group drift between
+          preview and commit.
+        type: string
+      to_currency:
+        type: string
+    type: object
+  jsonapi.CurrencyMigrationStartRequest:
+    properties:
+      data:
+        $ref: '#/definitions/jsonapi.CurrencyMigrationStartRequestData'
+    type: object
+  jsonapi.CurrencyMigrationStartRequestData:
+    properties:
+      attributes:
+        $ref: '#/definitions/jsonapi.CurrencyMigrationStartAttributes'
+      type:
+        enum:
+        - currency-migrations
+        example: currency-migrations
+        type: string
+    type: object
+  jsonapi.CurrencyMigrationsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/jsonapi.CurrencyMigrationResponseData'
+        type: array
+    type: object
   jsonapi.Error:
     properties:
+      code:
+        description: |-
+          Code is the application-specific error code (e.g.
+          "currency_migration.daily_cap_reached"). Optional; when present,
+          the FE branches on this string before falling back to the generic
+          HTTP status. Stable across versions.
+        type: string
       error:
         description: user-level error message
+        type: object
+      meta:
+        description: |-
+          Meta is a free-form JSON object the handler may attach for
+          machine-readable context (e.g. {"retry_after_seconds": 3600}).
+          Optional; serialised only when non-empty.
         type: object
       status:
         description: user-level status message
@@ -2024,6 +2183,84 @@ definitions:
     - CommodityTypeFurniture
     - CommodityTypeClothes
     - CommodityTypeOther
+  models.CurrencyMigration:
+    properties:
+      commodity_count:
+        description: CommodityCount is the number of rows actually mutated by the
+          worker.
+        type: integer
+      completed_at:
+        description: |-
+          CompletedAt is set on either terminal status — TX2 commit on
+          success or the recovery sweep on failure. Captures the moment the
+          row left the `running` state.
+        type: string
+      created_at:
+        description: CreatedAt is the moment the row was inserted (still in pending
+          status).
+        type: string
+      error_message:
+        description: ErrorMessage is populated when status=failed.
+        type: string
+      exchange_rate:
+        description: |-
+          ExchangeRate is the user-entered rate (1 from = rate to). DECIMAL(20,10)
+          gives plenty of headroom; the FE clamps to 6 decimals as a UX guard.
+        type: number
+      from_currency:
+        description: |-
+          FromCurrency is the group currency at the moment the migration was
+          scheduled. The worker re-validates against the live group state
+          inside TX2 and aborts if it has drifted.
+        type: string
+      id:
+        type: string
+      preview_expires_at:
+        description: PreviewExpiresAt is the expiry timestamp embedded in PreviewToken.
+        type: string
+      preview_token:
+        description: |-
+          PreviewToken is the HMAC issued by the preview endpoint and posted
+          back at commit time. Persisted for audit only — verification is
+          stateless and recomputed from the same key.
+        type: string
+      started_at:
+        description: StartedAt is set when the worker flips the row to `running` (TX1).
+        type: string
+      status:
+        allOf:
+        - $ref: '#/definitions/models.CurrencyMigrationStatus'
+        description: |-
+          Status — see CurrencyMigrationStatus. Worker writes durable
+          transitions; status is never user-input.
+      to_currency:
+        description: |-
+          ToCurrency is the target group currency. CHECK constraint enforces
+          from_currency <> to_currency at the DB level.
+        type: string
+      total_after:
+        type: number
+      total_before:
+        description: |-
+          TotalBefore / TotalAfter are sums of CurrentPrice across the
+          group's commodities, captured for audit. Nullable until TX2 has
+          computed them.
+        type: number
+      uuid:
+        type: string
+    type: object
+  models.CurrencyMigrationStatus:
+    enum:
+    - pending
+    - running
+    - completed
+    - failed
+    type: string
+    x-enum-varnames:
+    - CurrencyMigrationStatusPending
+    - CurrencyMigrationStatusRunning
+    - CurrencyMigrationStatusCompleted
+    - CurrencyMigrationStatusFailed
   models.Export:
     properties:
       area_count:
@@ -3772,6 +4009,145 @@ paths:
       summary: Get total value of commodities
       tags:
       - commodities
+  /g/{groupSlug}/currency-migrations:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: Returns the group's full currency-migration history newest-first.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.CurrencyMigrationsResponse'
+        "403":
+          description: Forbidden — non-admin
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: List currency migrations for a group
+      tags:
+      - currency-migrations
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: Verify preview token, perform cross-op + daily-cap checks, insert
+        a pending migration row.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Start request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.CurrencyMigrationStartRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/jsonapi.CurrencyMigrationResponse'
+        "403":
+          description: Forbidden — non-admin
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "409":
+          description: Token expired / state changed / migration in progress / restore
+            in progress
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Validation / token invalid
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "429":
+          description: Daily cap reached
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Start a currency migration
+      tags:
+      - currency-migrations
+  /g/{groupSlug}/currency-migrations/{id}:
+    get:
+      consumes:
+      - application/vnd.api+json
+      description: Returns one currency-migration row by id.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Currency migration ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.CurrencyMigrationResponse'
+        "403":
+          description: Forbidden — non-admin
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Get a currency migration
+      tags:
+      - currency-migrations
+  /g/{groupSlug}/currency-migrations/preview:
+    post:
+      consumes:
+      - application/vnd.api+json
+      description: Dry-run the conversion, returning projected totals + per-row diffs
+        + a signed preview_token.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Preview request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/jsonapi.CurrencyMigrationPreviewRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.CurrencyMigrationPreviewResponse'
+        "403":
+          description: Forbidden — non-admin
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Validation error
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Preview a currency migration
+      tags:
+      - currency-migrations
   /g/{groupSlug}/exports:
     get:
       consumes:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1000,10 +1000,23 @@ definitions:
         description: user-level error message
         type: object
       meta:
+        additionalProperties:
+          type: string
         description: |-
           Meta is a free-form JSON object the handler may attach for
           machine-readable context (e.g. {"retry_after_seconds": 3600}).
           Optional; serialised only when non-empty.
+
+          Swagger annotation note: `swaggertype:"object,string"` tells swag
+          to emit `additionalProperties: { type: string }`. Without an
+          explicit additionalProperties, openapi-typescript renders the
+          empty `{type: object}` schema as `Record<string, never>` — a
+          closed, indexable-but-empty object — which makes
+          `meta.retry_after_seconds` uncallable in TS without a cast. With
+          the override the FE gets a `{ [key: string]: string }` index
+          signature; consumers parse known keys (`retry_after_seconds:
+          number`, `migration_id: string`, `status: string`) into their
+          real types — we control both sides of that cast.
         type: object
       status:
         description: user-level status message

--- a/go/internal/currency/service.go
+++ b/go/internal/currency/service.go
@@ -258,9 +258,9 @@ type ConversionService struct {
 	tableNames store.TableNames
 }
 
-// NewConversionService creates a service backed by the default ptah
-// table-name resolver. Tests that reroute tables can swap this for
-// NewConversionServiceWithTableNames.
+// NewConversionService creates a service backed by the default
+// table-name resolver (store.DefaultTableNames). Tests that reroute
+// tables can swap this for NewConversionServiceWithTableNames.
 func NewConversionService() *ConversionService {
 	return &ConversionService{tableNames: store.DefaultTableNames}
 }
@@ -278,6 +278,9 @@ func NewConversionServiceWithTableNames(t store.TableNames) *ConversionService {
 func (s *ConversionService) ConvertGroup(ctx context.Context, tx *sqlx.Tx, opts RunOptions) (RunResult, error) {
 	var zero RunResult
 
+	if tx == nil {
+		return zero, errxtrace.Wrap("tx is required", registry.ErrFieldRequired)
+	}
 	if opts.FromCurrency == "" || opts.ToCurrency == "" {
 		return zero, errxtrace.Wrap("from and to currencies are required", registry.ErrFieldRequired)
 	}
@@ -318,8 +321,11 @@ func (s *ConversionService) ConvertGroup(ctx context.Context, tx *sqlx.Tx, opts 
 		// — even Case C with no actual delta benefits from the
 		// last_modified-style invariant of "everything in this group
 		// touched on this run". The cost is negligible and keeps the
-		// audit trail consistent.
-		if err := s.updateCommodityImage(ctx, tx, commodity.GetID(), applyResult.After); err != nil {
+		// audit trail consistent. The UPDATE is defensively scoped to
+		// (tenant_id, group_id) so a service-mode worker that bypasses
+		// RLS can never mutate a row outside the migration's group even
+		// if a wrong ID leaks into the loop.
+		if err := s.updateCommodityImage(ctx, tx, opts.TenantID, opts.GroupID, commodity.GetID(), applyResult.After); err != nil {
 			return zero, errxtrace.Wrap(fmt.Sprintf("failed to update commodity %s", commodity.GetID()), err)
 		}
 
@@ -410,18 +416,34 @@ func (s *ConversionService) listGroupCommodities(ctx context.Context, tx *sqlx.T
 	return out, rows.Err()
 }
 
-func (s *ConversionService) updateCommodityImage(ctx context.Context, tx *sqlx.Tx, commodityID string, after RowImage) error {
+func (s *ConversionService) updateCommodityImage(ctx context.Context, tx *sqlx.Tx, tenantID, groupID, commodityID string, after RowImage) error {
+	// Scope the UPDATE to (tenant_id, group_id) defensively. The
+	// surrounding listGroupCommodities already filtered to the same
+	// (tenant, group), so this is belt-and-braces: under service-mode
+	// RLS bypass a wrong commodity ID coming from a tampered row read
+	// must not be able to mutate a row outside the migration scope.
+	// We also assert exactly one row was affected.
 	query := fmt.Sprintf(
 		`UPDATE %s
-		    SET original_price = $2,
-		        original_price_currency = $3,
-		        converted_original_price = $4,
-		        current_price = $5
-		  WHERE id = $1`,
+		    SET original_price = $4,
+		        original_price_currency = $5,
+		        converted_original_price = $6,
+		        current_price = $7
+		  WHERE id = $1 AND tenant_id = $2 AND group_id = $3`,
 		s.tableNames.Commodities(),
 	)
-	_, err := tx.ExecContext(ctx, query, commodityID, after.OriginalPrice, string(after.OriginalPriceCurrency), after.ConvertedOriginalPrice, after.CurrentPrice)
-	return err
+	res, err := tx.ExecContext(ctx, query, commodityID, tenantID, groupID, after.OriginalPrice, string(after.OriginalPriceCurrency), after.ConvertedOriginalPrice, after.CurrentPrice)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows != 1 {
+		return fmt.Errorf("commodity %s: expected 1 row updated, got %d", commodityID, rows)
+	}
+	return nil
 }
 
 func buildAuditRow(opts RunOptions, commodityID string, ar ApplyResult, filled bool) models.CurrencyMigrationAuditRow {

--- a/go/internal/currency/service.go
+++ b/go/internal/currency/service.go
@@ -1,175 +1,463 @@
-// Package currency provides scoped commodity price conversion helpers.
+// Package currency provides scoped commodity price conversion helpers
+// used by the currency-migration apiserver endpoints (preview / start)
+// and, in PR 3 of issue #202, by the migration worker.
+//
+// The conversion logic is split in two:
+//
+//   - ApplyConversion is a pure function over a single Commodity. It
+//     decides Case A / B / C from #202 §2 and produces the post-conversion
+//     row image plus a flag indicating whether this is the first time
+//     acquisition_price / acquisition_currency would be filled.
+//
+//   - ConvertGroup is the orchestrator. It reads every commodity in the
+//     given (tenant_id, group_id) inside the caller-supplied transaction,
+//     applies the pure function, persists the mutated rows, and (when
+//     migrationID is non-empty) writes acquisition columns + audit rows
+//     in the same tx. The caller decides whether to commit (worker /
+//     start handler) or roll back (preview handler).
+//
+// What this rewrite removes versus the previous service
+// (https://github.com/denisvmedia/inventario/issues/202 §4.4):
+//
+//   - RateProvider, StaticRateProvider, defaultRates — the user types
+//     the rate; there is no provider, no fallback table.
+//
+//   - Compensating per-row rollback — the surrounding PG transaction
+//     does that atomically.
+//
+//   - List() over the global commodity set — replaced by an explicit
+//     group-scoped read so the worker (which bypasses RLS) cannot
+//     mutate other tenants' rows.
+//
+// The Case C bug from the previous service (where ConvertedOriginalPrice
+// was multiplied by the rate even when OriginalPriceCurrency already
+// equalled the target currency, leaving the row in violation of
+// PriceRule) is fixed: Case C now collapses ConvertedOriginalPrice to
+// zero.
 package currency
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 
 	"github.com/go-extras/errx"
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/jmoiron/sqlx"
 	"github.com/shopspring/decimal"
 
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
 )
 
 var (
-	// ErrExchangeRateRequired is returned when no exchange rate is available for a currency pair.
-	ErrExchangeRateRequired = errx.NewSentinel("exchange rate required for currency conversion")
+	// ErrSameCurrency is returned when from == to. Apiserver maps this
+	// to 422 — same-currency runs are rejected before any migration row
+	// is written, before any audit work happens, and before any
+	// daily-quota slot is consumed (#202 §2).
+	ErrSameCurrency = errx.NewSentinel("from and to currencies must differ")
 
-	// ErrInvalidExchangeRate is returned when the provided exchange rate is not greater than zero.
-	ErrInvalidExchangeRate = errx.NewSentinel("exchange rate must be greater than zero")
+	// ErrInvalidExchangeRate is returned for rates that are not strictly
+	// positive, NaN, or above the §2 sanity bound (1e10). Apiserver maps
+	// this to 422.
+	ErrInvalidExchangeRate = errx.NewSentinel("exchange rate must be positive, finite, and at most 1e10")
 )
 
-const convertedMoneyScale = 2
+const (
+	// convertedMoneyScale is the decimal scale we round to when converting
+	// a price field. Matches the DECIMAL(15,2) column precision.
+	convertedMoneyScale = 2
 
-var defaultRates = map[string]decimal.Decimal{
-	"USD_EUR": decimal.RequireFromString("0.85"),
-	"EUR_USD": decimal.RequireFromString("1.18"),
-	"EUR_GBP": decimal.RequireFromString("0.86"),
-	"GBP_EUR": decimal.RequireFromString("1.16"),
+	// maxExchangeRateExp is the §2 sanity bound (1e10) on user-supplied
+	// rates. Rejects fat-fingered "1.234e15"-style typos before any
+	// commodity rows are read. Stored as decimal so the comparison stays
+	// exact.
+	maxExchangeRateExp = 10
+)
+
+// ApplyOutcome is the case of the per-row decision tree from #202 §2.
+// Used by the audit row writer to decide which transitions counted.
+type ApplyOutcome int
+
+const (
+	// ApplyOutcomeCaseA — original was in old group currency. Live
+	// OriginalPrice / OriginalPriceCurrency are overwritten;
+	// AcquisitionPrice / AcquisitionCurrency are filled if they were
+	// still NULL.
+	ApplyOutcomeCaseA ApplyOutcome = iota
+	// ApplyOutcomeCaseB — original in a third currency X.
+	// OriginalPrice / OriginalPriceCurrency unchanged; the converted /
+	// current G-side amounts are scaled by the rate. Acquisition columns
+	// untouched.
+	ApplyOutcomeCaseB
+	// ApplyOutcomeCaseC — original already in target currency. Edge case:
+	// the previous service would multiply ConvertedOriginalPrice by the
+	// rate, violating PriceRule. We collapse it to zero. Acquisition
+	// columns untouched (no original lost — original is already in G_new).
+	ApplyOutcomeCaseC
+)
+
+// RowImage is the price-related slice of a Commodity captured for the
+// audit table. Stored verbatim before and after the conversion so the
+// audit row is self-describing.
+type RowImage struct {
+	OriginalPrice          decimal.Decimal
+	OriginalPriceCurrency  models.Currency
+	ConvertedOriginalPrice decimal.Decimal
+	CurrentPrice           decimal.Decimal
 }
 
-// ConversionService converts commodity prices using a scoped commodity registry.
+// ApplyResult is the outcome of ApplyConversion for one commodity.
+//
+// FillAcquisition is true iff this is Case A AND the row's acquisition
+// columns were still NULL — i.e. this is the migration that captures the
+// "as purchased" amount for that commodity. The caller writes the
+// columns via migrationops.SetAcquisition only when FillAcquisition is
+// true.
+type ApplyResult struct {
+	Outcome         ApplyOutcome
+	Before          RowImage
+	After           RowImage
+	FillAcquisition bool
+	// AcquisitionPrice / AcquisitionCurrency carry the values to fill in
+	// when FillAcquisition is true. They are the pre-conversion live
+	// original (the acquisition amount, by definition), not the migrated
+	// values.
+	AcquisitionPrice    decimal.Decimal
+	AcquisitionCurrency models.Currency
+}
+
+// ApplyConversion is the pure decision tree from #202 §2. It does not
+// touch acquisition_price / acquisition_currency on the input — the
+// caller writes those via migrationops.SetAcquisition when
+// FillAcquisition is true.
+func ApplyConversion(commodity models.Commodity, fromCurrency, toCurrency models.Currency, rate decimal.Decimal) ApplyResult {
+	before := imageFromCommodity(commodity)
+
+	switch commodity.OriginalPriceCurrency {
+	case fromCurrency:
+		// Case A — original was in old group currency.
+		mutated := commodity
+		mutated.OriginalPrice = quantizeConvertedMoney(commodity.OriginalPrice.Mul(rate))
+		mutated.OriginalPriceCurrency = toCurrency
+		mutated.ConvertedOriginalPrice = decimal.Zero
+		mutated.CurrentPrice = quantizeConvertedMoney(commodity.CurrentPrice.Mul(rate))
+		return ApplyResult{
+			Outcome:             ApplyOutcomeCaseA,
+			Before:              before,
+			After:               imageFromCommodity(mutated),
+			FillAcquisition:     commodity.AcquisitionPrice == nil && commodity.AcquisitionCurrency == nil,
+			AcquisitionPrice:    commodity.OriginalPrice,
+			AcquisitionCurrency: commodity.OriginalPriceCurrency,
+		}
+
+	case toCurrency:
+		// Case C — original already in target currency. Collapse
+		// ConvertedOriginalPrice to zero so PriceRule's
+		// "OriginalCurrency == GroupCurrency ⇒ ConvertedOriginalPrice == 0"
+		// invariant continues to hold. CurrentPrice scales by rate
+		// (it was previously denominated in G_old).
+		mutated := commodity
+		mutated.ConvertedOriginalPrice = decimal.Zero
+		mutated.CurrentPrice = quantizeConvertedMoney(commodity.CurrentPrice.Mul(rate))
+		return ApplyResult{
+			Outcome: ApplyOutcomeCaseC,
+			Before:  before,
+			After:   imageFromCommodity(mutated),
+		}
+
+	default:
+		// Case B — original in some third currency X. OriginalPrice /
+		// OriginalPriceCurrency stay put; the converted / current
+		// G-side amounts move.
+		mutated := commodity
+		mutated.ConvertedOriginalPrice = quantizeConvertedMoney(commodity.ConvertedOriginalPrice.Mul(rate))
+		mutated.CurrentPrice = quantizeConvertedMoney(commodity.CurrentPrice.Mul(rate))
+		return ApplyResult{
+			Outcome: ApplyOutcomeCaseB,
+			Before:  before,
+			After:   imageFromCommodity(mutated),
+		}
+	}
+}
+
+// PerRowDiff is one entry in RunResult.Diffs. The preview endpoint
+// renders the largest |delta| entries to the user as the "biggest
+// individual changes" panel. For the worker run we keep the full list
+// so audit / debugging stays trivial.
+type PerRowDiff struct {
+	CommodityID    string
+	CommodityName  string
+	Outcome        ApplyOutcome
+	Before         RowImage
+	After          RowImage
+	CurrentDelta   decimal.Decimal
+	FilledFromCase bool
+}
+
+// RunResult is the aggregate output of ConvertGroup. It is the source
+// of truth for both the preview response (rendered to the user, then
+// rolled back) and the migration row update (written by the worker on
+// commit).
+type RunResult struct {
+	CommodityCount        int
+	TotalCurrentBefore    decimal.Decimal
+	TotalCurrentAfter     decimal.Decimal
+	AcquisitionFillsCount int
+	Diffs                 []PerRowDiff
+}
+
+// AcquisitionFiller writes the write-once provenance columns for a
+// commodity inside the caller-supplied tx. Pass nil to skip the fill
+// step (preview, or any caller that does not have the registry-internal
+// migrationops package available).
+//
+// Callers in the worker (PR 3) wire this to migrationops.SetAcquisition.
+// The apiserver preview path leaves it nil — preview never writes
+// provenance, since the surrounding tx is rolled back.
+type AcquisitionFiller func(ctx context.Context, tx *sqlx.Tx, commodityID string, price decimal.Decimal, currency models.Currency) error
+
+// AuditWriter writes one currency_migration_audit_rows row in the
+// caller-supplied tx. Pass nil to skip audit writes (preview).
+type AuditWriter func(ctx context.Context, row models.CurrencyMigrationAuditRow) error
+
+// RunOptions parameterises one invocation of ConvertGroup.
+type RunOptions struct {
+	TenantID     string
+	GroupID      string
+	FromCurrency models.Currency
+	ToCurrency   models.Currency
+	Rate         decimal.Decimal
+
+	// MigrationID is the currency_migrations.id this run is recording
+	// against. Empty string means "preview" — no audit rows are written
+	// and no acquisition columns are filled (the surrounding tx will be
+	// rolled back anyway, but skipping audit writes keeps the preview
+	// path's hot loop tight).
+	MigrationID string
+
+	// FillAcquisition is the worker-supplied callback that writes the
+	// commodities.acquisition_price / acquisition_currency pair on the
+	// first Case-A overwrite. Required when MigrationID is non-empty
+	// (worker mode) and never called when MigrationID is empty.
+	FillAcquisition AcquisitionFiller
+
+	// Audit writes one row per mutated commodity. Required when
+	// MigrationID is non-empty.
+	Audit AuditWriter
+}
+
+// ConversionService converts commodity prices for a single group.
+//
+// Stateless wrt. data — every call passes the tx and the (tenantID,
+// groupID, rate, …) parameters. The service holds only the table-name
+// resolver so it can talk to the right physical tables in tests that
+// override DefaultTableNames.
 type ConversionService struct {
-	commodityRegistry registry.CommodityRegistry
-	rateProvider      RateProvider
+	tableNames store.TableNames
 }
 
-// RateProvider resolves an exchange rate for a currency pair.
-type RateProvider interface {
-	GetExchangeRate(ctx context.Context, from, to string) (decimal.Decimal, error)
+// NewConversionService creates a service backed by the default ptah
+// table-name resolver. Tests that reroute tables can swap this for
+// NewConversionServiceWithTableNames.
+func NewConversionService() *ConversionService {
+	return &ConversionService{tableNames: store.DefaultTableNames}
 }
 
-// StaticRateProvider resolves exchange rates from a fixed in-memory table.
-type StaticRateProvider struct {
-	rates map[string]decimal.Decimal
+// NewConversionServiceWithTableNames is the test seam for renaming the
+// commodities / audit tables.
+func NewConversionServiceWithTableNames(t store.TableNames) *ConversionService {
+	return &ConversionService{tableNames: t}
 }
 
-// NewConversionService creates a ConversionService.
-func NewConversionService(commodityRegistry registry.CommodityRegistry, rateProvider RateProvider) *ConversionService {
-	return &ConversionService{commodityRegistry: commodityRegistry, rateProvider: rateProvider}
-}
+// ConvertGroup runs the conversion across every commodity in (tenant,
+// group) inside the caller-supplied transaction. The caller commits
+// (worker) or rolls back (preview). Returns ErrSameCurrency / ErrInvalidExchangeRate
+// before any read happens; both are mapped by the apiserver to 422.
+func (s *ConversionService) ConvertGroup(ctx context.Context, tx *sqlx.Tx, opts RunOptions) (RunResult, error) {
+	var zero RunResult
 
-// NewStaticRateProvider creates a StaticRateProvider.
-func NewStaticRateProvider(rates map[string]decimal.Decimal) *StaticRateProvider {
-	return &StaticRateProvider{rates: rates}
-}
-
-// NewDefaultRateProvider creates a StaticRateProvider with the built-in fallback rates.
-func NewDefaultRateProvider() *StaticRateProvider {
-	return NewStaticRateProvider(defaultRates)
-}
-
-// ConvertCommodityPrices converts all commodity prices using the configured rate provider.
-func (s *ConversionService) ConvertCommodityPrices(ctx context.Context, fromCurrency, toCurrency string) error {
-	return s.ConvertCommodityPricesWithRate(ctx, fromCurrency, toCurrency, nil)
-}
-
-// ConvertCommodityPricesWithRate converts all commodity prices using the provided rate when present.
-func (s *ConversionService) ConvertCommodityPricesWithRate(ctx context.Context, fromCurrency, toCurrency string, rate *decimal.Decimal) error {
-	if fromCurrency == toCurrency {
-		return nil
+	if opts.FromCurrency == "" || opts.ToCurrency == "" {
+		return zero, errxtrace.Wrap("from and to currencies are required", registry.ErrFieldRequired)
+	}
+	if opts.FromCurrency == opts.ToCurrency {
+		return zero, ErrSameCurrency
+	}
+	if err := ValidateRate(opts.Rate); err != nil {
+		return zero, err
+	}
+	if opts.TenantID == "" || opts.GroupID == "" {
+		return zero, errxtrace.Wrap("tenant id and group id are required", registry.ErrFieldRequired)
+	}
+	if opts.MigrationID != "" {
+		if opts.Audit == nil {
+			return zero, errors.New("currency: Audit writer is required when MigrationID is set")
+		}
+		if opts.FillAcquisition == nil {
+			return zero, errors.New("currency: FillAcquisition is required when MigrationID is set")
+		}
 	}
 
-	exchangeRate, err := s.exchangeRate(ctx, fromCurrency, toCurrency, rate)
+	commodities, err := s.listGroupCommodities(ctx, tx, opts.TenantID, opts.GroupID)
 	if err != nil {
-		return err
+		return zero, errxtrace.Wrap("failed to list commodities for currency conversion", err)
 	}
 
-	commodities, err := s.commodityRegistry.List(ctx)
-	if err != nil {
-		return fmt.Errorf("list commodities: %w", err)
+	result := RunResult{
+		CommodityCount: len(commodities),
+		Diffs:          make([]PerRowDiff, 0, len(commodities)),
 	}
-
-	originals := make([]models.Commodity, 0, len(commodities))
 
 	for _, commodity := range commodities {
-		original := *commodity
+		commodity := commodity
+		result.TotalCurrentBefore = result.TotalCurrentBefore.Add(commodity.CurrentPrice)
 
-		if !applyExchangeRate(commodity, fromCurrency, toCurrency, exchangeRate) {
-			continue
+		applyResult := ApplyConversion(*commodity, opts.FromCurrency, opts.ToCurrency, opts.Rate)
+
+		// Persist the new commodity row image. We update unconditionally
+		// — even Case C with no actual delta benefits from the
+		// last_modified-style invariant of "everything in this group
+		// touched on this run". The cost is negligible and keeps the
+		// audit trail consistent.
+		if err := s.updateCommodityImage(ctx, tx, commodity.GetID(), applyResult.After); err != nil {
+			return zero, errxtrace.Wrap(fmt.Sprintf("failed to update commodity %s", commodity.GetID()), err)
 		}
 
-		if _, err := s.commodityRegistry.Update(ctx, *commodity); err != nil {
-			rollbackErr := s.rollbackCommodityUpdates(ctx, originals)
-			if rollbackErr != nil {
-				return fmt.Errorf("update commodity %s: %w (rollback failed: %v)", commodity.ID, err, rollbackErr)
+		// Acquisition fill on first Case-A only when the run is a
+		// real migration (MigrationID set). Preview never fills —
+		// preview rolls back, and skipping the registry-side guard
+		// keeps the preview hot loop tight. The actual SetAcquisition
+		// call lives in the worker package (PR 3) so this package
+		// stays free of the registry/internal/migrationops import.
+		filled := false
+		if opts.MigrationID != "" && applyResult.FillAcquisition {
+			err := opts.FillAcquisition(
+				ctx, tx,
+				commodity.GetID(),
+				applyResult.AcquisitionPrice,
+				applyResult.AcquisitionCurrency,
+			)
+			switch {
+			case err == nil:
+				filled = true
+				result.AcquisitionFillsCount++
+			case errors.Is(err, registry.ErrAcquisitionAlreadySet):
+				// Concurrent worker race or a duplicate run — we
+				// observed NULL but a sibling tx wrote first. Honour
+				// write-once: leave the columns alone, do not count
+				// the fill, and continue.
+				filled = false
+			default:
+				return zero, errxtrace.Wrap(fmt.Sprintf("failed to set acquisition columns for %s", commodity.GetID()), err)
 			}
-
-			return fmt.Errorf("update commodity %s: %w", commodity.ID, err)
 		}
 
-		originals = append(originals, original)
+		result.TotalCurrentAfter = result.TotalCurrentAfter.Add(applyResult.After.CurrentPrice)
+		result.Diffs = append(result.Diffs, PerRowDiff{
+			CommodityID:    commodity.GetID(),
+			CommodityName:  commodity.Name,
+			Outcome:        applyResult.Outcome,
+			Before:         applyResult.Before,
+			After:          applyResult.After,
+			CurrentDelta:   applyResult.After.CurrentPrice.Sub(applyResult.Before.CurrentPrice),
+			FilledFromCase: filled,
+		})
+
+		if opts.MigrationID != "" {
+			row := buildAuditRow(opts, commodity.GetID(), applyResult, filled)
+			if err := opts.Audit(ctx, row); err != nil {
+				return zero, errxtrace.Wrap("failed to write currency migration audit row", err)
+			}
+		}
 	}
 
+	return result, nil
+}
+
+// ValidateRate enforces the §2 rate guards (positive, finite, ≤ 1e10).
+// Exposed so the apiserver can reject early — before opening the
+// preview tx.
+func ValidateRate(rate decimal.Decimal) error {
+	if !rate.IsPositive() || rate.IsZero() {
+		return ErrInvalidExchangeRate
+	}
+	maxRate := decimal.New(1, maxExchangeRateExp)
+	if rate.GreaterThan(maxRate) {
+		return ErrInvalidExchangeRate
+	}
 	return nil
 }
 
-// GetExchangeRate returns the configured exchange rate for a currency pair.
-func (p *StaticRateProvider) GetExchangeRate(_ context.Context, from, to string) (decimal.Decimal, error) {
-	if from == to {
-		return decimal.NewFromInt(1), nil
+func (s *ConversionService) listGroupCommodities(ctx context.Context, tx *sqlx.Tx, tenantID, groupID string) ([]*models.Commodity, error) {
+	query := fmt.Sprintf(
+		`SELECT * FROM %s WHERE tenant_id = $1 AND group_id = $2 ORDER BY id ASC`,
+		s.tableNames.Commodities(),
+	)
+	rows, err := tx.QueryxContext(ctx, query, tenantID, groupID)
+	if err != nil {
+		return nil, err
 	}
-
-	rate, ok := p.rates[fmt.Sprintf("%s_%s", from, to)]
-	if !ok {
-		return decimal.Zero, fmt.Errorf("%w: %s to %s", ErrExchangeRateRequired, from, to)
-	}
-
-	return rate, nil
-}
-
-func (s *ConversionService) exchangeRate(ctx context.Context, fromCurrency, toCurrency string, rate *decimal.Decimal) (decimal.Decimal, error) {
-	if rate != nil {
-		if !rate.GreaterThan(decimal.Zero) {
-			return decimal.Zero, ErrInvalidExchangeRate
+	defer rows.Close()
+	var out []*models.Commodity
+	for rows.Next() {
+		var c models.Commodity
+		if scanErr := rows.StructScan(&c); scanErr != nil {
+			return nil, scanErr
 		}
-
-		return *rate, nil
+		cc := c
+		out = append(out, &cc)
 	}
-
-	if s.rateProvider == nil {
-		return decimal.Zero, fmt.Errorf("%w: %s to %s", ErrExchangeRateRequired, fromCurrency, toCurrency)
-	}
-
-	return s.rateProvider.GetExchangeRate(ctx, fromCurrency, toCurrency)
+	return out, rows.Err()
 }
 
-func applyExchangeRate(commodity *models.Commodity, fromCurrency, toCurrency string, exchangeRate decimal.Decimal) bool {
-	updated := false
-
-	if !commodity.ConvertedOriginalPrice.IsZero() {
-		commodity.ConvertedOriginalPrice = quantizeConvertedMoney(commodity.ConvertedOriginalPrice.Mul(exchangeRate))
-		updated = true
-	}
-
-	if !commodity.CurrentPrice.IsZero() {
-		commodity.CurrentPrice = quantizeConvertedMoney(commodity.CurrentPrice.Mul(exchangeRate))
-		updated = true
-	}
-
-	if string(commodity.OriginalPriceCurrency) == fromCurrency {
-		commodity.OriginalPriceCurrency = models.Currency(toCurrency)
-		commodity.OriginalPrice = quantizeConvertedMoney(commodity.OriginalPrice.Mul(exchangeRate))
-		commodity.ConvertedOriginalPrice = decimal.Zero
-		updated = true
-	}
-
-	return updated
+func (s *ConversionService) updateCommodityImage(ctx context.Context, tx *sqlx.Tx, commodityID string, after RowImage) error {
+	query := fmt.Sprintf(
+		`UPDATE %s
+		    SET original_price = $2,
+		        original_price_currency = $3,
+		        converted_original_price = $4,
+		        current_price = $5
+		  WHERE id = $1`,
+		s.tableNames.Commodities(),
+	)
+	_, err := tx.ExecContext(ctx, query, commodityID, after.OriginalPrice, string(after.OriginalPriceCurrency), after.ConvertedOriginalPrice, after.CurrentPrice)
+	return err
 }
 
-func (s *ConversionService) rollbackCommodityUpdates(ctx context.Context, originals []models.Commodity) error {
-	var rollbackErr error
+func buildAuditRow(opts RunOptions, commodityID string, ar ApplyResult, filled bool) models.CurrencyMigrationAuditRow {
+	commodityRef := commodityID
+	beforePrice := ar.Before.OriginalPrice
+	afterPrice := ar.After.OriginalPrice
+	beforeConverted := ar.Before.ConvertedOriginalPrice
+	afterConverted := ar.After.ConvertedOriginalPrice
+	beforeCurrent := ar.Before.CurrentPrice
+	afterCurrent := ar.After.CurrentPrice
+	beforeCurrency := ar.Before.OriginalPriceCurrency
+	afterCurrency := ar.After.OriginalPriceCurrency
 
-	for _, original := range slices.Backward(originals) {
-		if _, err := s.commodityRegistry.Update(ctx, original); err != nil {
-			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("rollback commodity %s: %w", original.ID, err))
-		}
+	return models.CurrencyMigrationAuditRow{
+		MigrationID:                opts.MigrationID,
+		CommodityID:                &commodityRef,
+		OriginalPriceBefore:        &beforePrice,
+		OriginalPriceAfter:         &afterPrice,
+		OriginalCurrencyBefore:     &beforeCurrency,
+		OriginalCurrencyAfter:      &afterCurrency,
+		ConvertedBefore:            &beforeConverted,
+		ConvertedAfter:             &afterConverted,
+		CurrentBefore:              &beforeCurrent,
+		CurrentAfter:               &afterCurrent,
+		AcquisitionFilledInThisRun: filled,
 	}
+}
 
-	return rollbackErr
+func imageFromCommodity(c models.Commodity) RowImage {
+	return RowImage{
+		OriginalPrice:          c.OriginalPrice,
+		OriginalPriceCurrency:  c.OriginalPriceCurrency,
+		ConvertedOriginalPrice: c.ConvertedOriginalPrice,
+		CurrentPrice:           c.CurrentPrice,
+	}
 }
 
 func quantizeConvertedMoney(amount decimal.Decimal) decimal.Decimal {

--- a/go/internal/currency/service.go
+++ b/go/internal/currency/service.go
@@ -310,7 +310,6 @@ func (s *ConversionService) ConvertGroup(ctx context.Context, tx *sqlx.Tx, opts 
 	}
 
 	for _, commodity := range commodities {
-		commodity := commodity
 		result.TotalCurrentBefore = result.TotalCurrentBefore.Add(commodity.CurrentPrice)
 
 		applyResult := ApplyConversion(*commodity, opts.FromCurrency, opts.ToCurrency, opts.Rate)

--- a/go/internal/currency/service_test.go
+++ b/go/internal/currency/service_test.go
@@ -1,9 +1,7 @@
 package currency_test
 
 import (
-	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -11,112 +9,125 @@ import (
 
 	"github.com/denisvmedia/inventario/internal/currency"
 	"github.com/denisvmedia/inventario/models"
-	"github.com/denisvmedia/inventario/registry"
 )
 
-func TestConversionService_ConvertCommodityPricesWithRate_RoundsConvertedValues(t *testing.T) {
+// commodity is a minimal builder. We only set the fields ApplyConversion
+// reads; the embedded TenantGroupAwareEntityID stays zero because the
+// pure function never looks at IDs.
+func commodity(originalPrice, convertedOriginalPrice, currentPrice string, originalCurrency models.Currency, ap *string, ac *models.Currency) models.Commodity {
+	c := models.Commodity{
+		OriginalPrice:          decimal.RequireFromString(originalPrice),
+		OriginalPriceCurrency:  originalCurrency,
+		ConvertedOriginalPrice: decimal.RequireFromString(convertedOriginalPrice),
+		CurrentPrice:           decimal.RequireFromString(currentPrice),
+	}
+	if ap != nil {
+		d := decimal.RequireFromString(*ap)
+		c.AcquisitionPrice = &d
+	}
+	if ac != nil {
+		cur := *ac
+		c.AcquisitionCurrency = &cur
+	}
+	return c
+}
+
+func TestApplyConversion_CaseA_FillsAcquisitionWhenNull(t *testing.T) {
 	c := qt.New(t)
 
-	commodityRegistry := newStubCommodityRegistry(
-		models.Commodity{TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{EntityID: models.EntityID{ID: "usd-item"}}, OriginalPrice: decimal.RequireFromString("10"), OriginalPriceCurrency: models.Currency("USD"), CurrentPrice: decimal.RequireFromString("5")},
-		models.Commodity{TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{EntityID: models.EntityID{ID: "gbp-item"}}, OriginalPrice: decimal.RequireFromString("3"), OriginalPriceCurrency: models.Currency("GBP"), ConvertedOriginalPrice: decimal.RequireFromString("8")},
-	)
+	row := commodity("100", "0", "120", models.Currency("USD"), nil, nil)
+	rate := decimal.RequireFromString("0.9")
+
+	got := currency.ApplyConversion(row, "USD", "EUR", rate)
+
+	c.Assert(got.Outcome, qt.Equals, currency.ApplyOutcomeCaseA)
+	c.Assert(got.FillAcquisition, qt.IsTrue)
+	c.Assert(got.AcquisitionPrice.String(), qt.Equals, "100")
+	c.Assert(got.AcquisitionCurrency, qt.Equals, models.Currency("USD"))
+	c.Assert(got.After.OriginalPrice.String(), qt.Equals, "90")
+	c.Assert(got.After.OriginalPriceCurrency, qt.Equals, models.Currency("EUR"))
+	c.Assert(got.After.ConvertedOriginalPrice.IsZero(), qt.IsTrue)
+	c.Assert(got.After.CurrentPrice.String(), qt.Equals, "108")
+}
+
+func TestApplyConversion_CaseA_DoesNotRefillAcquisitionWhenAlreadySet(t *testing.T) {
+	c := qt.New(t)
+
+	preset := "42"
+	presetCurrency := models.Currency("CAD")
+	row := commodity("100", "0", "120", models.Currency("USD"), &preset, &presetCurrency)
+	rate := decimal.RequireFromString("0.9")
+
+	got := currency.ApplyConversion(row, "USD", "EUR", rate)
+
+	// Case-A still applies (the live original was in G_old) — but the
+	// caller must not re-fill acquisition columns. Once written, they
+	// are frozen.
+	c.Assert(got.Outcome, qt.Equals, currency.ApplyOutcomeCaseA)
+	c.Assert(got.FillAcquisition, qt.IsFalse)
+	c.Assert(got.After.OriginalPrice.String(), qt.Equals, "90")
+}
+
+func TestApplyConversion_CaseB_LeavesOriginalUntouchedScalesGSide(t *testing.T) {
+	c := qt.New(t)
+
+	// OriginalPriceCurrency=GBP, group migrating USD→EUR. Case B.
+	row := commodity("3", "8", "11", models.Currency("GBP"), nil, nil)
+	rate := decimal.RequireFromString("0.9")
+
+	got := currency.ApplyConversion(row, "USD", "EUR", rate)
+
+	c.Assert(got.Outcome, qt.Equals, currency.ApplyOutcomeCaseB)
+	c.Assert(got.FillAcquisition, qt.IsFalse)
+	c.Assert(got.After.OriginalPrice.String(), qt.Equals, "3")
+	c.Assert(got.After.OriginalPriceCurrency, qt.Equals, models.Currency("GBP"))
+	c.Assert(got.After.ConvertedOriginalPrice.String(), qt.Equals, "7.2")
+	c.Assert(got.After.CurrentPrice.String(), qt.Equals, "9.9")
+}
+
+func TestApplyConversion_CaseC_CollapsesConvertedToZero(t *testing.T) {
+	c := qt.New(t)
+
+	// OriginalPriceCurrency already equals the *target* currency. The
+	// previous service multiplied ConvertedOriginalPrice by the rate
+	// and left the row in violation of PriceRule. The new
+	// implementation collapses it to zero.
+	row := commodity("100", "5", "120", models.Currency("EUR"), nil, nil)
+	rate := decimal.RequireFromString("0.9")
+
+	got := currency.ApplyConversion(row, "USD", "EUR", rate)
+
+	c.Assert(got.Outcome, qt.Equals, currency.ApplyOutcomeCaseC)
+	c.Assert(got.FillAcquisition, qt.IsFalse)
+	c.Assert(got.After.OriginalPrice.String(), qt.Equals, "100")
+	c.Assert(got.After.OriginalPriceCurrency, qt.Equals, models.Currency("EUR"))
+	c.Assert(got.After.ConvertedOriginalPrice.IsZero(), qt.IsTrue)
+	c.Assert(got.After.CurrentPrice.String(), qt.Equals, "108")
+}
+
+func TestApplyConversion_RoundsHalfAwayFromZero(t *testing.T) {
+	c := qt.New(t)
+
+	// shopspring/decimal Round defaults to half-away-from-zero: 12.345 → 12.35.
+	row := commodity("10", "0", "5", models.Currency("USD"), nil, nil)
 	rate := decimal.RequireFromString("1.23456")
 
-	service := currency.NewConversionService(commodityRegistry, nil)
-	err := service.ConvertCommodityPricesWithRate(context.Background(), "USD", "EUR", &rate)
-	c.Assert(err, qt.IsNil)
+	got := currency.ApplyConversion(row, "USD", "EUR", rate)
 
-	usdItem, err := commodityRegistry.Get(context.Background(), "usd-item")
-	c.Assert(err, qt.IsNil)
-	c.Assert(usdItem.OriginalPrice.Equal(decimal.RequireFromString("12.35")), qt.IsTrue)
-	c.Assert(usdItem.OriginalPriceCurrency, qt.Equals, models.Currency("EUR"))
-	c.Assert(usdItem.CurrentPrice.Equal(decimal.RequireFromString("6.17")), qt.IsTrue)
-
-	gbpItem, err := commodityRegistry.Get(context.Background(), "gbp-item")
-	c.Assert(err, qt.IsNil)
-	c.Assert(gbpItem.OriginalPrice.Equal(decimal.RequireFromString("3")), qt.IsTrue)
-	c.Assert(gbpItem.ConvertedOriginalPrice.Equal(decimal.RequireFromString("9.88")), qt.IsTrue)
+	c.Assert(got.Outcome, qt.Equals, currency.ApplyOutcomeCaseA)
+	c.Assert(got.After.OriginalPrice.String(), qt.Equals, "12.35")
+	c.Assert(got.After.CurrentPrice.String(), qt.Equals, "6.17")
 }
 
-func TestConversionService_ConvertCommodityPricesWithRate_RollsBackOnUpdateFailure(t *testing.T) {
+func TestValidateRate(t *testing.T) {
 	c := qt.New(t)
 
-	commodityRegistry := newStubCommodityRegistry(
-		models.Commodity{TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{EntityID: models.EntityID{ID: "first"}}, OriginalPrice: decimal.RequireFromString("10"), OriginalPriceCurrency: models.Currency("USD"), CurrentPrice: decimal.RequireFromString("3")},
-		models.Commodity{TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{EntityID: models.EntityID{ID: "second"}}, OriginalPrice: decimal.RequireFromString("20"), OriginalPriceCurrency: models.Currency("USD"), CurrentPrice: decimal.RequireFromString("4")},
-	)
-	commodityRegistry.failUpdates["second"] = 1
-	rate := decimal.RequireFromString("2")
+	c.Assert(currency.ValidateRate(decimal.RequireFromString("1")), qt.IsNil)
+	c.Assert(currency.ValidateRate(decimal.RequireFromString("0.000001")), qt.IsNil)
+	c.Assert(currency.ValidateRate(decimal.RequireFromString("10000000000")), qt.IsNil)
 
-	service := currency.NewConversionService(commodityRegistry, nil)
-	err := service.ConvertCommodityPricesWithRate(context.Background(), "USD", "EUR", &rate)
-	c.Assert(err, qt.IsNotNil)
-	c.Assert(err.Error(), qt.Contains, "update commodity second")
-
-	first, err := commodityRegistry.Get(context.Background(), "first")
-	c.Assert(err, qt.IsNil)
-	c.Assert(first.OriginalPrice.Equal(decimal.RequireFromString("10")), qt.IsTrue)
-	c.Assert(first.OriginalPriceCurrency, qt.Equals, models.Currency("USD"))
-	c.Assert(first.CurrentPrice.Equal(decimal.RequireFromString("3")), qt.IsTrue)
-
-	second, err := commodityRegistry.Get(context.Background(), "second")
-	c.Assert(err, qt.IsNil)
-	c.Assert(second.OriginalPrice.Equal(decimal.RequireFromString("20")), qt.IsTrue)
-	c.Assert(second.OriginalPriceCurrency, qt.Equals, models.Currency("USD"))
-	c.Assert(second.CurrentPrice.Equal(decimal.RequireFromString("4")), qt.IsTrue)
-}
-
-type stubCommodityRegistry struct {
-	commodities map[string]models.Commodity
-	order       []string
-	failUpdates map[string]int
-}
-
-func newStubCommodityRegistry(commodities ...models.Commodity) *stubCommodityRegistry {
-	stub := &stubCommodityRegistry{commodities: make(map[string]models.Commodity, len(commodities)), order: make([]string, 0, len(commodities)), failUpdates: map[string]int{}}
-	for _, commodity := range commodities {
-		stub.commodities[commodity.ID] = commodity
-		stub.order = append(stub.order, commodity.ID)
-	}
-	return stub
-}
-
-func (r *stubCommodityRegistry) Create(context.Context, models.Commodity) (*models.Commodity, error) {
-	return nil, errors.New("unexpected Create call")
-}
-func (r *stubCommodityRegistry) Delete(context.Context, string) error {
-	return errors.New("unexpected Delete call")
-}
-func (r *stubCommodityRegistry) Count(context.Context) (int, error) {
-	return len(r.commodities), nil
-}
-func (r *stubCommodityRegistry) ListPaginated(context.Context, int, int, registry.CommodityListOptions) ([]*models.Commodity, int, error) {
-	return nil, 0, errors.New("unexpected ListPaginated call")
-}
-
-func (r *stubCommodityRegistry) Get(_ context.Context, id string) (*models.Commodity, error) {
-	commodity, ok := r.commodities[id]
-	if !ok {
-		return nil, registry.ErrNotFound
-	}
-	return &commodity, nil
-}
-
-func (r *stubCommodityRegistry) List(context.Context) ([]*models.Commodity, error) {
-	commodities := make([]*models.Commodity, 0, len(r.order))
-	for _, id := range r.order {
-		commodity := r.commodities[id]
-		commodities = append(commodities, &commodity)
-	}
-	return commodities, nil
-}
-
-func (r *stubCommodityRegistry) Update(_ context.Context, commodity models.Commodity) (*models.Commodity, error) {
-	if remainingFailures := r.failUpdates[commodity.ID]; remainingFailures > 0 {
-		r.failUpdates[commodity.ID] = remainingFailures - 1
-		return nil, fmt.Errorf("forced update failure for %s", commodity.ID)
-	}
-	r.commodities[commodity.ID] = commodity
-	return &commodity, nil
+	// Reject zero, negative, and >1e10.
+	c.Assert(errors.Is(currency.ValidateRate(decimal.Zero), currency.ErrInvalidExchangeRate), qt.IsTrue)
+	c.Assert(errors.Is(currency.ValidateRate(decimal.RequireFromString("-1")), currency.ErrInvalidExchangeRate), qt.IsTrue)
+	c.Assert(errors.Is(currency.ValidateRate(decimal.RequireFromString("10000000001")), currency.ErrInvalidExchangeRate), qt.IsTrue)
 }

--- a/go/jsonapi/currency_migrations.go
+++ b/go/jsonapi/currency_migrations.go
@@ -210,18 +210,18 @@ type CurrencyMigrationPreviewDiff struct {
 // CurrencyMigrationPreviewBody is the JSON:API attributes of the
 // preview response.
 type CurrencyMigrationPreviewBody struct {
-	FromCurrency        models.Currency                 `json:"from_currency"`
-	ToCurrency          models.Currency                 `json:"to_currency"`
-	ExchangeRate        decimal.Decimal                 `json:"exchange_rate"`
-	CommodityCount      int                             `json:"commodity_count"`
-	TotalCurrentBefore  decimal.Decimal                 `json:"total_current_before"`
-	TotalCurrentAfter   decimal.Decimal                 `json:"total_current_after"`
-	AcquisitionFills    int                             `json:"acquisition_fills"`
-	PreviewToken        string                          `json:"preview_token"`
-	PreviewExpiresAt    time.Time                       `json:"preview_expires_at"`
-	PreviewExpiresInSec int                             `json:"preview_expires_in_seconds"`
-	Diffs               []CurrencyMigrationPreviewDiff  `json:"diffs"`
-	StateHash           string                          `json:"state_hash"`
+	FromCurrency        models.Currency                `json:"from_currency"`
+	ToCurrency          models.Currency                `json:"to_currency"`
+	ExchangeRate        decimal.Decimal                `json:"exchange_rate"`
+	CommodityCount      int                            `json:"commodity_count"`
+	TotalCurrentBefore  decimal.Decimal                `json:"total_current_before"`
+	TotalCurrentAfter   decimal.Decimal                `json:"total_current_after"`
+	AcquisitionFills    int                            `json:"acquisition_fills"`
+	PreviewToken        string                         `json:"preview_token"`
+	PreviewExpiresAt    time.Time                      `json:"preview_expires_at"`
+	PreviewExpiresInSec int                            `json:"preview_expires_in_seconds"`
+	Diffs               []CurrencyMigrationPreviewDiff `json:"diffs"`
+	StateHash           string                         `json:"state_hash"`
 }
 
 // CurrencyMigrationPreviewResponse wraps a preview body in the standard

--- a/go/jsonapi/currency_migrations.go
+++ b/go/jsonapi/currency_migrations.go
@@ -1,0 +1,252 @@
+package jsonapi
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/render"
+	"github.com/go-extras/errx"
+	"github.com/jellydator/validation"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/models"
+)
+
+// jsonapi types for currency migrations (issue #202 / #1551).
+//
+// Three families:
+//   - CurrencyMigration{,s}Response — read responses (list / get / start)
+//   - CurrencyMigrationStartRequest — POST /currency-migrations
+//   - CurrencyMigrationPreview{Request,Response} — POST .../preview
+//
+// Same shape as RestoreOperation* so the FE codegen sees a familiar
+// pattern. Type discriminator is "currency-migrations".
+
+// CurrencyMigrationResponse is the single-row response wrapper.
+type CurrencyMigrationResponse struct {
+	HTTPStatusCode int                            `json:"-"`
+	Data           *CurrencyMigrationResponseData `json:"data"`
+}
+
+// CurrencyMigrationResponseData wraps a CurrencyMigration as JSON:API attributes.
+type CurrencyMigrationResponseData struct {
+	ID         string                   `json:"id"`
+	Type       string                   `json:"type" example:"currency-migrations" enums:"currency-migrations"`
+	Attributes models.CurrencyMigration `json:"attributes"`
+}
+
+// CurrencyMigrationsResponse is the multi-row response wrapper.
+type CurrencyMigrationsResponse struct {
+	HTTPStatusCode int                              `json:"-"`
+	Data           []*CurrencyMigrationResponseData `json:"data"`
+}
+
+func NewCurrencyMigrationResponse(m *models.CurrencyMigration) *CurrencyMigrationResponse {
+	return &CurrencyMigrationResponse{
+		HTTPStatusCode: http.StatusOK,
+		Data: &CurrencyMigrationResponseData{
+			ID:         m.ID,
+			Type:       "currency-migrations",
+			Attributes: *m,
+		},
+	}
+}
+
+func NewCurrencyMigrationsResponse(operations []*models.CurrencyMigration) *CurrencyMigrationsResponse {
+	data := make([]*CurrencyMigrationResponseData, len(operations))
+	for i, op := range operations {
+		data[i] = &CurrencyMigrationResponseData{
+			ID:         op.ID,
+			Type:       "currency-migrations",
+			Attributes: *op,
+		}
+	}
+	return &CurrencyMigrationsResponse{HTTPStatusCode: http.StatusOK, Data: data}
+}
+
+func (r *CurrencyMigrationResponse) WithStatusCode(statusCode int) *CurrencyMigrationResponse {
+	tmp := *r
+	tmp.HTTPStatusCode = statusCode
+	return &tmp
+}
+
+func (r *CurrencyMigrationResponse) Render(_w http.ResponseWriter, req *http.Request) error {
+	render.Status(req, statusCodeDef(r.HTTPStatusCode, http.StatusOK))
+	return nil
+}
+
+func (r *CurrencyMigrationsResponse) Render(_w http.ResponseWriter, req *http.Request) error {
+	render.Status(req, statusCodeDef(r.HTTPStatusCode, http.StatusOK))
+	return nil
+}
+
+// CurrencyMigrationStartAttributes is the user-input slice of the start
+// request body. Everything not listed here is server-managed (status,
+// timing, totals, audit ref). The FE sends the from/to/rate it just
+// previewed plus the preview_token it received from the preview
+// endpoint.
+type CurrencyMigrationStartAttributes struct {
+	FromCurrency models.Currency `json:"from_currency"`
+	ToCurrency   models.Currency `json:"to_currency"`
+	// ExchangeRate is the user-typed rate (1 from = rate to). FE clamps
+	// to 6 decimals as a UX guard; BE validates per #202 §2 (positive,
+	// finite, ≤ 1e10).
+	ExchangeRate decimal.Decimal `json:"exchange_rate"`
+	// PreviewToken is the HMAC-signed token the preview endpoint
+	// returned. Required; the start handler verifies the signature and
+	// then re-derives the state hash to detect group drift between
+	// preview and commit.
+	PreviewToken string `json:"preview_token"`
+}
+
+// CurrencyMigrationStartRequest is the POST /currency-migrations body.
+type CurrencyMigrationStartRequest struct {
+	Data *CurrencyMigrationStartRequestData `json:"data"`
+}
+
+type CurrencyMigrationStartRequestData struct {
+	Type       string                            `json:"type" example:"currency-migrations" enums:"currency-migrations"`
+	Attributes *CurrencyMigrationStartAttributes `json:"attributes"`
+}
+
+func (req *CurrencyMigrationStartRequest) Bind(r *http.Request) error {
+	if req.Data == nil {
+		return errx.NewDisplayable("missing required data field")
+	}
+	if req.Data.Type != "currency-migrations" {
+		return errx.NewDisplayable("invalid type, expected 'currency-migrations'")
+	}
+	if req.Data.Attributes == nil {
+		return errx.NewDisplayable("missing required attributes field")
+	}
+	return req.Data.Attributes.validateWithContext(r.Context())
+}
+
+func (a *CurrencyMigrationStartAttributes) validateWithContext(ctx context.Context) error {
+	fields := []*validation.FieldRules{
+		validation.Field(&a.FromCurrency, validation.Required),
+		validation.Field(&a.ToCurrency, validation.Required, validation.By(func(any) error {
+			if a.FromCurrency != "" && a.FromCurrency == a.ToCurrency {
+				return validation.NewError("validation_currency_migration_same_currency", "from and to currencies must differ")
+			}
+			return nil
+		})),
+		validation.Field(&a.PreviewToken, validation.Required),
+		validation.Field(&a.ExchangeRate, validation.By(func(any) error {
+			if a.ExchangeRate.IsZero() || a.ExchangeRate.Sign() < 0 {
+				return validation.NewError("validation_currency_migration_rate_positive", "exchange rate must be positive")
+			}
+			return nil
+		})),
+	}
+	return validation.ValidateStructWithContext(ctx, a, fields...)
+}
+
+// CurrencyMigrationPreviewAttributes is the body of the preview
+// request. No PreviewToken — the preview endpoint issues a fresh one.
+type CurrencyMigrationPreviewAttributes struct {
+	FromCurrency models.Currency `json:"from_currency"`
+	ToCurrency   models.Currency `json:"to_currency"`
+	ExchangeRate decimal.Decimal `json:"exchange_rate"`
+}
+
+// CurrencyMigrationPreviewRequest is the POST /currency-migrations/preview body.
+type CurrencyMigrationPreviewRequest struct {
+	Data *CurrencyMigrationPreviewRequestData `json:"data"`
+}
+
+type CurrencyMigrationPreviewRequestData struct {
+	Type       string                              `json:"type" example:"currency-migrations" enums:"currency-migrations"`
+	Attributes *CurrencyMigrationPreviewAttributes `json:"attributes"`
+}
+
+func (req *CurrencyMigrationPreviewRequest) Bind(r *http.Request) error {
+	if req.Data == nil {
+		return errx.NewDisplayable("missing required data field")
+	}
+	if req.Data.Type != "currency-migrations" {
+		return errx.NewDisplayable("invalid type, expected 'currency-migrations'")
+	}
+	if req.Data.Attributes == nil {
+		return errx.NewDisplayable("missing required attributes field")
+	}
+	return req.Data.Attributes.validateWithContext(r.Context())
+}
+
+func (a *CurrencyMigrationPreviewAttributes) validateWithContext(ctx context.Context) error {
+	fields := []*validation.FieldRules{
+		validation.Field(&a.FromCurrency, validation.Required),
+		validation.Field(&a.ToCurrency, validation.Required, validation.By(func(any) error {
+			if a.FromCurrency != "" && a.FromCurrency == a.ToCurrency {
+				return validation.NewError("validation_currency_migration_same_currency", "from and to currencies must differ")
+			}
+			return nil
+		})),
+		validation.Field(&a.ExchangeRate, validation.By(func(any) error {
+			if a.ExchangeRate.IsZero() || a.ExchangeRate.Sign() < 0 {
+				return validation.NewError("validation_currency_migration_rate_positive", "exchange rate must be positive")
+			}
+			return nil
+		})),
+	}
+	return validation.ValidateStructWithContext(ctx, a, fields...)
+}
+
+// CurrencyMigrationPreviewDiff is one entry in the preview response's
+// diff list. The FE uses these to render the "biggest individual
+// changes" table on the preview screen.
+type CurrencyMigrationPreviewDiff struct {
+	CommodityID            string          `json:"commodity_id"`
+	CommodityName          string          `json:"commodity_name"`
+	CurrentPriceBefore     decimal.Decimal `json:"current_price_before"`
+	CurrentPriceAfter      decimal.Decimal `json:"current_price_after"`
+	OriginalPriceBefore    decimal.Decimal `json:"original_price_before"`
+	OriginalPriceAfter     decimal.Decimal `json:"original_price_after"`
+	OriginalCurrencyBefore models.Currency `json:"original_currency_before"`
+	OriginalCurrencyAfter  models.Currency `json:"original_currency_after"`
+}
+
+// CurrencyMigrationPreviewBody is the JSON:API attributes of the
+// preview response.
+type CurrencyMigrationPreviewBody struct {
+	FromCurrency        models.Currency                 `json:"from_currency"`
+	ToCurrency          models.Currency                 `json:"to_currency"`
+	ExchangeRate        decimal.Decimal                 `json:"exchange_rate"`
+	CommodityCount      int                             `json:"commodity_count"`
+	TotalCurrentBefore  decimal.Decimal                 `json:"total_current_before"`
+	TotalCurrentAfter   decimal.Decimal                 `json:"total_current_after"`
+	AcquisitionFills    int                             `json:"acquisition_fills"`
+	PreviewToken        string                          `json:"preview_token"`
+	PreviewExpiresAt    time.Time                       `json:"preview_expires_at"`
+	PreviewExpiresInSec int                             `json:"preview_expires_in_seconds"`
+	Diffs               []CurrencyMigrationPreviewDiff  `json:"diffs"`
+	StateHash           string                          `json:"state_hash"`
+}
+
+// CurrencyMigrationPreviewResponse wraps a preview body in the standard
+// JSON:API envelope.
+type CurrencyMigrationPreviewResponse struct {
+	HTTPStatusCode int                                   `json:"-"`
+	Data           *CurrencyMigrationPreviewResponseData `json:"data"`
+}
+
+type CurrencyMigrationPreviewResponseData struct {
+	Type       string                       `json:"type" example:"currency-migration-previews" enums:"currency-migration-previews"`
+	Attributes CurrencyMigrationPreviewBody `json:"attributes"`
+}
+
+func NewCurrencyMigrationPreviewResponse(body CurrencyMigrationPreviewBody) *CurrencyMigrationPreviewResponse {
+	return &CurrencyMigrationPreviewResponse{
+		HTTPStatusCode: http.StatusOK,
+		Data: &CurrencyMigrationPreviewResponseData{
+			Type:       "currency-migration-previews",
+			Attributes: body,
+		},
+	}
+}
+
+func (r *CurrencyMigrationPreviewResponse) Render(_w http.ResponseWriter, req *http.Request) error {
+	render.Status(req, statusCodeDef(r.HTTPStatusCode, http.StatusOK))
+	return nil
+}

--- a/go/jsonapi/currency_migrations.go
+++ b/go/jsonapi/currency_migrations.go
@@ -1,13 +1,11 @@
 package jsonapi
 
 import (
-	"context"
 	"net/http"
 	"time"
 
 	"github.com/go-chi/render"
 	"github.com/go-extras/errx"
-	"github.com/jellydator/validation"
 	"github.com/shopspring/decimal"
 
 	"github.com/denisvmedia/inventario/models"
@@ -120,27 +118,16 @@ func (req *CurrencyMigrationStartRequest) Bind(r *http.Request) error {
 	if req.Data.Attributes == nil {
 		return errx.NewDisplayable("missing required attributes field")
 	}
-	return req.Data.Attributes.validateWithContext(r.Context())
-}
-
-func (a *CurrencyMigrationStartAttributes) validateWithContext(ctx context.Context) error {
-	fields := []*validation.FieldRules{
-		validation.Field(&a.FromCurrency, validation.Required),
-		validation.Field(&a.ToCurrency, validation.Required, validation.By(func(any) error {
-			if a.FromCurrency != "" && a.FromCurrency == a.ToCurrency {
-				return validation.NewError("validation_currency_migration_same_currency", "from and to currencies must differ")
-			}
-			return nil
-		})),
-		validation.Field(&a.PreviewToken, validation.Required),
-		validation.Field(&a.ExchangeRate, validation.By(func(any) error {
-			if a.ExchangeRate.IsZero() || a.ExchangeRate.Sign() < 0 {
-				return validation.NewError("validation_currency_migration_rate_positive", "exchange rate must be positive")
-			}
-			return nil
-		})),
+	if req.Data.Attributes.PreviewToken == "" {
+		return errx.NewDisplayable("missing required preview_token field")
 	}
-	return validation.ValidateStructWithContext(ctx, a, fields...)
+	// Same-currency / rate-validity / from-mismatch checks intentionally
+	// live in the handler so the response carries a stable JSON:API
+	// error code (currency_migration.same_currency, .rate_invalid,
+	// .from_mismatch). Doing them here would push the 422 through the
+	// generic Bind error path which has no code.
+	_ = r
+	return nil
 }
 
 // CurrencyMigrationPreviewAttributes is the body of the preview
@@ -171,26 +158,11 @@ func (req *CurrencyMigrationPreviewRequest) Bind(r *http.Request) error {
 	if req.Data.Attributes == nil {
 		return errx.NewDisplayable("missing required attributes field")
 	}
-	return req.Data.Attributes.validateWithContext(r.Context())
-}
-
-func (a *CurrencyMigrationPreviewAttributes) validateWithContext(ctx context.Context) error {
-	fields := []*validation.FieldRules{
-		validation.Field(&a.FromCurrency, validation.Required),
-		validation.Field(&a.ToCurrency, validation.Required, validation.By(func(any) error {
-			if a.FromCurrency != "" && a.FromCurrency == a.ToCurrency {
-				return validation.NewError("validation_currency_migration_same_currency", "from and to currencies must differ")
-			}
-			return nil
-		})),
-		validation.Field(&a.ExchangeRate, validation.By(func(any) error {
-			if a.ExchangeRate.IsZero() || a.ExchangeRate.Sign() < 0 {
-				return validation.NewError("validation_currency_migration_rate_positive", "exchange rate must be positive")
-			}
-			return nil
-		})),
-	}
-	return validation.ValidateStructWithContext(ctx, a, fields...)
+	// Same as the start request: same-currency / rate / from-mismatch
+	// checks belong in the handler so the response carries a stable
+	// JSON:API error code, not the generic Bind 422.
+	_ = r
+	return nil
 }
 
 // CurrencyMigrationPreviewDiff is one entry in the preview response's

--- a/go/jsonapi/errors.go
+++ b/go/jsonapi/errors.go
@@ -28,7 +28,18 @@ type Error struct {
 	// Meta is a free-form JSON object the handler may attach for
 	// machine-readable context (e.g. {"retry_after_seconds": 3600}).
 	// Optional; serialised only when non-empty.
-	Meta map[string]any `json:"meta,omitempty" swaggertype:"object"`
+	//
+	// Swagger annotation note: `swaggertype:"object,string"` tells swag
+	// to emit `additionalProperties: { type: string }`. Without an
+	// explicit additionalProperties, openapi-typescript renders the
+	// empty `{type: object}` schema as `Record<string, never>` — a
+	// closed, indexable-but-empty object — which makes
+	// `meta.retry_after_seconds` uncallable in TS without a cast. With
+	// the override the FE gets a `{ [key: string]: string }` index
+	// signature; consumers parse known keys (`retry_after_seconds:
+	// number`, `migration_id: string`, `status: string`) into their
+	// real types — we control both sides of that cast.
+	Meta map[string]any `json:"meta,omitempty" swaggertype:"object,string"`
 	// ErrorText string `json:"error,omitempty"` // application-level error message, for debugging
 }
 

--- a/go/jsonapi/errors.go
+++ b/go/jsonapi/errors.go
@@ -18,7 +18,17 @@ type Error struct {
 
 	StatusText string          `json:"status"`                               // user-level status message
 	UserError  json.RawMessage `json:"error,omitempty" swaggertype:"object"` // user-level error message
-	// AppCode    int64  `json:"code,omitempty"`  // application-specific error code
+
+	// Code is the application-specific error code (e.g.
+	// "currency_migration.daily_cap_reached"). Optional; when present,
+	// the FE branches on this string before falling back to the generic
+	// HTTP status. Stable across versions.
+	Code string `json:"code,omitempty"`
+
+	// Meta is a free-form JSON object the handler may attach for
+	// machine-readable context (e.g. {"retry_after_seconds": 3600}).
+	// Optional; serialised only when non-empty.
+	Meta map[string]any `json:"meta,omitempty" swaggertype:"object"`
 	// ErrorText string `json:"error,omitempty"` // application-level error message, for debugging
 }
 

--- a/go/registry/factories.go
+++ b/go/registry/factories.go
@@ -80,9 +80,17 @@ type RestoreOperationRegistryFactory interface {
 // instances with proper context. The user registry is what the apiserver
 // uses for preview / start / list / get; the service registry is what
 // the worker uses for ClaimNextPending / SweepStuckRunning / WriteAuditRow.
+//
+// SetHMACKey overrides the preview-token signing key used by every
+// registry the factory will subsequently produce. The bootstrap layer
+// calls this once at startup with the operator-supplied key (config:
+// CurrencyMigrationHMACKey) so tokens are verifiable across replicas
+// and survive process restarts. Calling with an empty slice is a no-op
+// (preserves the random per-process key).
 type CurrencyMigrationRegistryFactory interface {
 	UserRegistryFactory[models.CurrencyMigration, CurrencyMigrationRegistry]
 	ServiceRegistryFactory[models.CurrencyMigration, CurrencyMigrationRegistry]
+	SetHMACKey(key []byte)
 }
 
 // RestoreStepRegistryFactory creates RestoreStepRegistry instances with proper context

--- a/go/registry/memory/commodities.go
+++ b/go/registry/memory/commodities.go
@@ -124,6 +124,36 @@ func (r *CommodityRegistry) Create(ctx context.Context, commodity models.Commodi
 	return newCommodity, nil
 }
 
+// ListByGroup returns every commodity in (tenantID, groupID), regardless
+// of draft / status. The currency-migration service (#202) needs the full
+// row set so the conversion sees every commodity in the group, not just
+// the user-visible "in_use, non-draft" subset.
+func (r *CommodityRegistry) ListByGroup(_ context.Context, tenantID, groupID string) ([]*models.Commodity, error) {
+	if tenantID == "" {
+		return nil, errxtrace.Wrap("tenant id is required", registry.ErrFieldRequired)
+	}
+	if groupID == "" {
+		return nil, errxtrace.Wrap("group id is required", registry.ErrFieldRequired)
+	}
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	out := make([]*models.Commodity, 0)
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		commodity := pair.Value
+		if commodity == nil {
+			continue
+		}
+		if commodity.TenantID == tenantID && commodity.GroupID == groupID {
+			cp := *commodity
+			out = append(out, &cp)
+		}
+	}
+	slices.SortStableFunc(out, func(a, b *models.Commodity) int {
+		return strings.Compare(a.GetID(), b.GetID())
+	})
+	return out, nil
+}
+
 // List returns all commodities sorted by purchase date in descending order (most recent first).
 // Commodities with a nil purchase date are sorted last.
 func (r *CommodityRegistry) List(ctx context.Context) ([]*models.Commodity, error) {

--- a/go/registry/memory/currency_migration.go
+++ b/go/registry/memory/currency_migration.go
@@ -69,6 +69,17 @@ func generateRandomKey() []byte {
 	return k
 }
 
+// SetHMACKey overrides the signing key for preview tokens. Mirrors the
+// postgres factory's setter — bootstrap may call this once at startup
+// with the operator-supplied key so memory-backed test deployments can
+// also produce stable tokens. Empty key is a no-op.
+func (f *CurrencyMigrationRegistryFactory) SetHMACKey(key []byte) {
+	if len(key) == 0 {
+		return
+	}
+	f.hmacKey = append([]byte(nil), key...)
+}
+
 func (f *CurrencyMigrationRegistryFactory) MustCreateUserRegistry(ctx context.Context) registry.CurrencyMigrationRegistry {
 	return must.Must(f.CreateUserRegistry(ctx))
 }

--- a/go/registry/postgres/commodities.go
+++ b/go/registry/postgres/commodities.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"github.com/go-extras/go-kit/must"
 	"github.com/jmoiron/sqlx"
@@ -153,6 +154,48 @@ func (r *CommodityRegistry) List(ctx context.Context) ([]*models.Commodity, erro
 		return nil, errxtrace.Wrap("failed to list commodities", err)
 	}
 
+	return commodities, nil
+}
+
+// ListByGroup returns every commodity in (tenant_id, group_id), regardless
+// of draft / status. The currency-migration service (#202) needs the full
+// row set — ListPaginated's default filters would otherwise hide drafts and
+// archived rows from the conversion. Service-mode callers (the worker)
+// pass tenantID + groupID explicitly because they bypass RLS; user-mode
+// callers should still pass the same values they were created with so the
+// query is executed under the same RLS view they already see.
+func (r *CommodityRegistry) ListByGroup(ctx context.Context, tenantID, groupID string) ([]*models.Commodity, error) {
+	if tenantID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if groupID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+	}
+
+	var commodities []*models.Commodity
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`SELECT * FROM %s WHERE tenant_id = $1 AND group_id = $2 ORDER BY id ASC`,
+			r.tableNames.Commodities(),
+		)
+		rows, qerr := tx.QueryxContext(ctx, query, tenantID, groupID)
+		if qerr != nil {
+			return errxtrace.Wrap("failed to list commodities by group", qerr)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var commodity models.Commodity
+			if scanErr := rows.StructScan(&commodity); scanErr != nil {
+				return errxtrace.Wrap("failed to scan commodity", scanErr)
+			}
+			commodities = append(commodities, &commodity)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list commodities by group", err)
+	}
 	return commodities, nil
 }
 

--- a/go/registry/postgres/currency_migration.go
+++ b/go/registry/postgres/currency_migration.go
@@ -86,6 +86,18 @@ func generateRandomKey() []byte {
 	return k
 }
 
+// SetHMACKey overrides the signing key for preview tokens. Called once
+// at bootstrap time when the operator has configured a stable key (so
+// tokens survive restarts / are verifiable across replicas). Empty key
+// is a no-op — the factory keeps the random per-process key chosen at
+// construction.
+func (f *CurrencyMigrationRegistryFactory) SetHMACKey(key []byte) {
+	if len(key) == 0 {
+		return
+	}
+	f.hmacKey = append([]byte(nil), key...)
+}
+
 func (f *CurrencyMigrationRegistryFactory) MustCreateUserRegistry(ctx context.Context) registry.CurrencyMigrationRegistry {
 	return must.Must(f.CreateUserRegistry(ctx))
 }

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -211,6 +211,15 @@ type CommodityRegistry interface {
 	// previous "all rows, name+id ascending" behaviour.
 	ListPaginated(ctx context.Context, offset, limit int, opts CommodityListOptions) ([]*models.Commodity, int, error)
 
+	// ListByGroup returns every commodity in the given (tenant_id, group_id)
+	// tuple, regardless of draft / status. Used by the currency-migration
+	// service (issue #202): the conversion needs to see all rows in the
+	// group, not just the user-visible "in_use, non-draft" subset that
+	// ListPaginated defaults to. Service-mode callers (the worker) bypass
+	// RLS via this; user-mode callers should use the registry's group
+	// context instead.
+	ListByGroup(ctx context.Context, tenantID, groupID string) ([]*models.Commodity, error)
+
 	// Enhanced search methods
 	// SearchByTags(ctx context.Context, tags []string, operator TagOperator) ([]*models.Commodity, error)
 	// FullTextSearch(ctx context.Context, query string, options ...SearchOption) ([]*models.Commodity, error)


### PR DESCRIPTION
Closes #1551. Part of epic #202; PR 2 of 4 (PR 1 = #1578, merged).

## Summary

- **Service rewrite** (`go/internal/currency/service.go`): drop `RateProvider` / `StaticRateProvider` / `defaultRates`; mandatory rate; group-scoped via tx; fix Case C zero-collapse bug; Case-A acquisition fill via callback (preserves the `registry/internal/migrationops` boundary); pure `ApplyConversion` decision tree + tx-aware `ConvertGroup` orchestrator.
- **Four apiserver endpoints** under `/api/v1/g/{groupSlug}/currency-migrations` (admin-only, gated by `feature.currency_migration`): `POST /preview`, `POST /`, `GET /`, `GET /{id}`. Stateless HMAC preview token (10-minute TTL); state-hash drift detection; daily cap of 2 completed per UTC day with `retry_after_seconds` meta.
- **Lock middleware** (`requireGroupNotMigrating`) + symmetric in-handler check on restore-create — both return 423 Locked while a migration is `pending|running` on the group.
- **JSON:API errors** gain optional `code` + `meta` so the FE can branch on stable codes (`currency_migration.daily_cap_reached`, `…locked`, `…state_changed`, etc.).
- **Plumbing**: `CommodityRegistry.ListByGroup`; `feature_currency_migration` + `currency_migration_hmac_key` config; bootstrap injects the key via the new `SetHMACKey` setter so preview tokens are verifiable across replicas.

The worker (PR 3) lifecycle, the FE wizard + lock UX (PR 4), and the e2e tests are out of scope here — pending rows accumulate but make no progress until PR 3 lands. Behaviour is **inert** until an operator flips `FEATURE_CURRENCY_MIGRATION=true`.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` green — full suite passes
- [x] New unit tests in `go/internal/currency/service_test.go` cover Case A/B/C, write-once acquisition, rounding, `ValidateRate`
- [x] New apiserver integration tests in `go/apiserver/currency_migrations_test.go`:
  - feature-flag-off → 404
  - preview happy path returns token + state_hash
  - same-currency 422 on preview + start
  - zero-rate 422 on preview
  - start happy path + creates pending row + appears in list
  - token-invalid 422
  - token-bindings-mismatched 409 (rate differs between preview and commit)
  - state-drift 409 (new commodity inserted between preview and commit)
  - in-flight migration 409
  - in-flight restore in same group 409 `restore_in_progress`
  - lock middleware 423 on commodity `PATCH`
  - lock 423 on restore-create
  - non-admin 403 on all four endpoints
  - daily-cap 429
- [x] `make swagger-backend` regenerated
- [ ] Concurrent-start race (partial unique index) + token-expiry — postgres-only; will be covered alongside the postgres registry tests (memory backend doesn't enforce the partial unique index nor a movable clock)
- [ ] Manual: enable `FEATURE_CURRENCY_MIGRATION=true` and exercise preview → start → list flow on a dev DB; verify the lock surfaces 423 on commodity edits and restore-create