### PR TITLE
[#1552] Currency migration PR 3/4: worker + recovery sweep + metrics

### DIFF
--- a/go/apiserver/currency_migrations.go
+++ b/go/apiserver/currency_migrations.go
@@ -587,6 +587,7 @@ func checkInFlightAndCap(w http.ResponseWriter, r *http.Request, rs *registry.Se
 		return false
 	}
 	if completed >= currencyMigrationDailyCap {
+		services.CurrencyMigrationDailyCapRejected()
 		_ = codedTooManyRequestsError(w, r, errors.New("daily cap of currency migrations reached for this group"), codeCurrencyMigrationDailyCapReached, map[string]any{
 			"retry_after_seconds": retryAfterSeconds(nextUTCMidnight(now).Sub(now)),
 		})

--- a/go/cmd/inventario/run/all/all.go
+++ b/go/cmd/inventario/run/all/all.go
@@ -86,6 +86,9 @@ func (c *Command) run() error {
 	stopWarrantyReminder := bootstrap.StartWarrantyReminderWorker(ctx, rs, c.cfg)
 	defer stopWarrantyReminder()
 
+	stopCurrencyMigration := bootstrap.StartCurrencyMigrationWorker(ctx, rs, c.cfg)
+	defer stopCurrencyMigration()
+
 	// One-shot backfill of files.size_bytes for rows that pre-date #1388.
 	// Runs in a goroutine so a slow bucket walk can't delay readiness;
 	// errors are swallowed (logged at debug) so a partial blob outage

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	RefreshTokenCleanupInterval   string `yaml:"refresh_token_cleanup_interval" env:"REFRESH_TOKEN_CLEANUP_INTERVAL" env-default:""`
 	GroupPurgeInterval            string `yaml:"group_purge_interval" env:"GROUP_PURGE_INTERVAL" env-default:""`
 	WarrantyReminderInterval      string `yaml:"warranty_reminder_interval" env:"WARRANTY_REMINDER_INTERVAL" env-default:""`
+	CurrencyMigrationInterval     string `yaml:"currency_migration_interval" env:"CURRENCY_MIGRATION_INTERVAL" env-default:""`
 	JWTSecret                     string `yaml:"jwt_secret" env:"JWT_SECRET" env-default:""`
 	FileSigningKey                string `yaml:"file_signing_key" env:"FILE_SIGNING_KEY" env-default:""`
 	FileURLExpiration             string `yaml:"file_url_expiration" env:"FILE_URL_EXPIRATION" env-default:"15m"`
@@ -164,6 +165,9 @@ func (c *Config) setWorkerDefaults() {
 	}
 	if c.WarrantyReminderInterval == "" {
 		c.WarrantyReminderInterval = defaults.GetWarrantyReminderInterval()
+	}
+	if c.CurrencyMigrationInterval == "" {
+		c.CurrencyMigrationInterval = defaults.GetCurrencyMigrationInterval()
 	}
 }
 

--- a/go/cmd/inventario/run/bootstrap/durations.go
+++ b/go/cmd/inventario/run/bootstrap/durations.go
@@ -17,6 +17,7 @@ type WorkerDurations struct {
 	RefreshTokenCleanupInterval time.Duration
 	GroupPurgeInterval          time.Duration
 	WarrantyReminderInterval    time.Duration
+	CurrencyMigrationInterval   time.Duration
 	ThumbnailPollInterval       time.Duration
 	ThumbnailCleanupInterval    time.Duration
 	ThumbnailJobRetentionPeriod time.Duration
@@ -54,6 +55,7 @@ func ParseWorkerDurations(cfg *Config) (WorkerDurations, error) {
 		{"refresh-token-cleanup-interval", cfg.RefreshTokenCleanupInterval, &out.RefreshTokenCleanupInterval},
 		{"group-purge-interval", cfg.GroupPurgeInterval, &out.GroupPurgeInterval},
 		{"warranty-reminder-interval", cfg.WarrantyReminderInterval, &out.WarrantyReminderInterval},
+		{"currency-migration-interval", cfg.CurrencyMigrationInterval, &out.CurrencyMigrationInterval},
 		{"thumbnail-poll-interval", cfg.ThumbnailPollInterval, &out.ThumbnailPollInterval},
 		{"thumbnail-cleanup-interval", cfg.ThumbnailCleanupInterval, &out.ThumbnailCleanupInterval},
 		{"thumbnail-job-retention-period", cfg.ThumbnailJobRetentionPeriod, &out.ThumbnailJobRetentionPeriod},

--- a/go/cmd/inventario/run/bootstrap/durations_test.go
+++ b/go/cmd/inventario/run/bootstrap/durations_test.go
@@ -19,6 +19,7 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 		RefreshTokenCleanupInterval: "2h",
 		GroupPurgeInterval:          "7m",
 		WarrantyReminderInterval:    "30m",
+		CurrencyMigrationInterval:   "8s",
 		ThumbnailPollInterval:       "7s",
 		ThumbnailCleanupInterval:    "6m",
 		ThumbnailJobRetentionPeriod: "48h",
@@ -34,6 +35,7 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 	c.Assert(got.RefreshTokenCleanupInterval, qt.Equals, 2*time.Hour)
 	c.Assert(got.GroupPurgeInterval, qt.Equals, 7*time.Minute)
 	c.Assert(got.WarrantyReminderInterval, qt.Equals, 30*time.Minute)
+	c.Assert(got.CurrencyMigrationInterval, qt.Equals, 8*time.Second)
 	c.Assert(got.ThumbnailPollInterval, qt.Equals, 7*time.Second)
 	c.Assert(got.ThumbnailCleanupInterval, qt.Equals, 6*time.Minute)
 	c.Assert(got.ThumbnailJobRetentionPeriod, qt.Equals, 48*time.Hour)

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -28,6 +28,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags.StringVar(&cfg.RefreshTokenCleanupInterval, "refresh-token-cleanup-interval", cfg.RefreshTokenCleanupInterval, "Interval between refresh token cleanup runs (e.g., 1h, 30m)")
 	flags.StringVar(&cfg.GroupPurgeInterval, "group-purge-interval", cfg.GroupPurgeInterval, "Interval between group purge sweeps (hard-deletes pending_deletion groups and expired unused invites; e.g., 5m, 15m)")
 	flags.StringVar(&cfg.WarrantyReminderInterval, "warranty-reminder-interval", cfg.WarrantyReminderInterval, "Interval between warranty reminder sweeps (60/30/7-day expiry emails; e.g., 1h)")
+	flags.StringVar(&cfg.CurrencyMigrationInterval, "currency-migration-interval", cfg.CurrencyMigrationInterval, "Currency migration worker active-poll interval (when pending rows exist; idle cadence is fixed at 1m). Values like 5s, 10s.")
 	flags.IntVar(&cfg.ThumbnailBatchSize, "thumbnail-batch-size", cfg.ThumbnailBatchSize, "Maximum thumbnail jobs processed per batch")
 	flags.StringVar(&cfg.ThumbnailPollInterval, "thumbnail-poll-interval", cfg.ThumbnailPollInterval, "Thumbnail worker poll interval (e.g., 5s, 10s)")
 	flags.StringVar(&cfg.ThumbnailCleanupInterval, "thumbnail-cleanup-interval", cfg.ThumbnailCleanupInterval, "Interval between thumbnail job cleanup runs (e.g., 5m)")

--- a/go/cmd/inventario/run/bootstrap/workers.go
+++ b/go/cmd/inventario/run/bootstrap/workers.go
@@ -2,13 +2,20 @@ package bootstrap
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 
 	"github.com/denisvmedia/inventario/backup/export"
 	importpkg "github.com/denisvmedia/inventario/backup/import"
 	"github.com/denisvmedia/inventario/backup/restore"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry/postgres"
 	"github.com/denisvmedia/inventario/services"
 )
+
+// currencyMigrationOp is a local alias for *models.CurrencyMigration so
+// the adapter signatures below stay readable.
+type currencyMigrationOp = models.CurrencyMigration
 
 // StartEmailLifecycle starts the configured email service (if any) and returns
 // the matching stop function. cfg is accepted (and ignored) so the signature
@@ -113,6 +120,59 @@ func StartWarrantyReminderWorker(ctx context.Context, rs *RuntimeSetup, cfg *Con
 	)
 	worker.Start(ctx)
 	return worker.Stop
+}
+
+// StartCurrencyMigrationWorker wires and starts the currency migration
+// worker (#1552 / #202 §4.5). Returns a no-op stop function when the
+// feature flag is off OR the active backend is not postgres — TX2 of
+// the migration lifecycle is postgres-only by design (advisory lock,
+// SET LOCAL role, transactional audit_logs insert), so a memory or
+// future non-postgres backend simply never schedules work. The
+// CurrencyMigrationRegistryFactory always exposes the registry side so
+// the apiserver endpoints stay live.
+func StartCurrencyMigrationWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) func() {
+	if !cfg.FeatureCurrencyMigration {
+		slog.Info("Currency migration worker disabled; FEATURE_CURRENCY_MIGRATION is off")
+		return func() {}
+	}
+	pgFactory, ok := rs.FactorySet.CurrencyMigrationRegistryFactory.(*postgres.CurrencyMigrationRegistryFactory)
+	if !ok {
+		// Memory backend or any future stub. The conversion service +
+		// audit + advisory lock surface lives in the postgres package,
+		// so a non-postgres deployment cannot run TX2 — log loudly so
+		// operators don't think the worker silently succeeded.
+		slog.Warn("Currency migration worker: skipping startup, backend is not postgres")
+		return func() {}
+	}
+
+	processor := pgFactory.NewProcessor()
+	adapter := &currencyMigrationProcessorAdapter{inner: processor}
+	worker := services.NewCurrencyMigrationWorker(
+		rs.FactorySet.CurrencyMigrationRegistryFactory.CreateServiceRegistry(),
+		adapter,
+		services.WithCurrencyMigrationActiveInterval(rs.WorkerDurations.CurrencyMigrationInterval),
+	)
+	worker.Start(ctx)
+	return worker.Stop
+}
+
+// currencyMigrationProcessorAdapter bridges the concrete postgres
+// processor to the services.CurrencyMigrationProcessor interface. The
+// summary types are field-compatible so the conversion is a single
+// struct cast — kept as an explicit adapter (rather than relying on
+// implicit interface satisfaction) so a future drift in either struct
+// fails at compile time here, not in a downstream caller.
+type currencyMigrationProcessorAdapter struct {
+	inner *postgres.CurrencyMigrationProcessor
+}
+
+func (a *currencyMigrationProcessorAdapter) ProcessRunningMigration(ctx context.Context, op *currencyMigrationOp) (services.CurrencyMigrationProcessSummary, error) {
+	res, err := a.inner.ProcessRunningMigration(ctx, op)
+	return services.CurrencyMigrationProcessSummary(res), err
+}
+
+func (a *currencyMigrationProcessorAdapter) WriteSweepFailureAuditLog(ctx context.Context, op *currencyMigrationOp) error {
+	return a.inner.WriteSweepFailureAuditLog(ctx, op)
 }
 
 // buildCommodityURLBuilder returns the per-commodity URL builder

--- a/go/cmd/inventario/run/workers/workers.go
+++ b/go/cmd/inventario/run/workers/workers.go
@@ -145,6 +145,7 @@ func (c *Command) run() error {
 			bootstrap.StartRefreshTokenCleanupWorker,
 			bootstrap.StartGroupPurgeWorker,
 			bootstrap.StartWarrantyReminderWorker,
+			bootstrap.StartCurrencyMigrationWorker,
 		}},
 	}
 

--- a/go/internal/defaults/defaults.go
+++ b/go/internal/defaults/defaults.go
@@ -31,6 +31,7 @@ type Workers struct {
 	RefreshTokenCleanupInterval string // Refresh token cleanup interval (e.g., "1h")
 	GroupPurgeInterval          string // Group purge worker interval (e.g., "5m")
 	WarrantyReminderInterval    string // Warranty reminder worker interval (e.g., "1h")
+	CurrencyMigrationInterval   string // Currency migration worker active-poll interval (e.g., "5s")
 }
 
 // ThumbnailGeneration contains default values for thumbnail generation configuration
@@ -92,6 +93,7 @@ func New() Config {
 			RefreshTokenCleanupInterval: "1h",
 			GroupPurgeInterval:          "5m",
 			WarrantyReminderInterval:    "1h",
+			CurrencyMigrationInterval:   "5s",
 		},
 		ThumbnailGeneration: ThumbnailGeneration{
 			MaxConcurrentPerUser: 5,     // Maximum 5 simultaneous thumbnail generation jobs per user
@@ -188,6 +190,14 @@ func GetGroupPurgeInterval() string {
 // warranty reminder sweeps.
 func GetWarrantyReminderInterval() string {
 	return defaultConfig.Workers.WarrantyReminderInterval
+}
+
+// GetCurrencyMigrationInterval returns the default active-poll interval
+// for the currency migration worker. The worker switches to a 1m idle
+// cadence when no pending rows exist, so this is the latency-sensitive
+// knob the operator tunes.
+func GetCurrencyMigrationInterval() string {
+	return defaultConfig.Workers.CurrencyMigrationInterval
 }
 
 // GetThumbnailBatchSize returns the default thumbnail worker batch size

--- a/go/internal/defaults/defaults_test.go
+++ b/go/internal/defaults/defaults_test.go
@@ -32,6 +32,7 @@ func TestDefaults(t *testing.T) {
 	c.Assert(cfg.Workers.RestorePollInterval, qt.Equals, "10s")
 	c.Assert(cfg.Workers.RefreshTokenCleanupInterval, qt.Equals, "1h")
 	c.Assert(cfg.Workers.GroupPurgeInterval, qt.Equals, "5m")
+	c.Assert(cfg.Workers.CurrencyMigrationInterval, qt.Equals, "5s")
 
 	// Test thumbnail generation defaults
 	c.Assert(cfg.ThumbnailGeneration.MaxConcurrentPerUser, qt.Equals, 5)
@@ -59,6 +60,7 @@ func TestDefaultGetters(t *testing.T) {
 	c.Assert(defaults.GetRestorePollInterval(), qt.Equals, "10s")
 	c.Assert(defaults.GetRefreshTokenCleanupInterval(), qt.Equals, "1h")
 	c.Assert(defaults.GetGroupPurgeInterval(), qt.Equals, "5m")
+	c.Assert(defaults.GetCurrencyMigrationInterval(), qt.Equals, "5s")
 	c.Assert(defaults.GetThumbnailBatchSize(), qt.Equals, 10)
 	c.Assert(defaults.GetThumbnailPollInterval(), qt.Equals, "5s")
 	c.Assert(defaults.GetThumbnailCleanupInterval(), qt.Equals, "5m")

--- a/go/registry/postgres/currency_migration.go
+++ b/go/registry/postgres/currency_migration.go
@@ -128,6 +128,22 @@ func (f *CurrencyMigrationRegistryFactory) CreateServiceRegistry() registry.Curr
 	}
 }
 
+// NewProcessor returns a CurrencyMigrationProcessor wired against the
+// same dbx + table names this factory uses. The processor owns TX2 of
+// the migration lifecycle (#202 §4.5); the worker (in services/) holds
+// the run loop + metrics and calls the processor once per claim.
+//
+// Returning the concrete type (rather than a registry-level interface)
+// is intentional: TX2 is postgres-only by design — the advisory lock,
+// the SET LOCAL role, the schema-level audit_logs INSERT all assume
+// the postgres backend. Memory-backend callers don't need a worker
+// (the feature is gated by FEATURE_CURRENCY_MIGRATION on top of a real
+// database; the memory factory is wired at boot but ProcessRunningMigration
+// is never reached).
+func (f *CurrencyMigrationRegistryFactory) NewProcessor() *CurrencyMigrationProcessor {
+	return NewCurrencyMigrationProcessorWithTableNames(f.dbx, f.tableNames)
+}
+
 // Registry[T] interface methods.
 
 func (r *CurrencyMigrationRegistry) Get(ctx context.Context, id string) (*models.CurrencyMigration, error) {

--- a/go/registry/postgres/currency_migration_processor.go
+++ b/go/registry/postgres/currency_migration_processor.go
@@ -1,0 +1,458 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/internal/currency"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/internal/migrationops"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+// CurrencyMigrationStuckThreshold is the §4.5 hard-coded threshold the
+// worker uses to flip stuck `running` rows to `failed`. 10 minutes is
+// long enough to cover legitimately slow runs on multi-thousand-row
+// groups but short enough that a crashed-mid-TX2 worker is recovered
+// well within a single business day.
+const CurrencyMigrationStuckThreshold = 10 * time.Minute
+
+// AuditActionCurrencyMigrationComplete is the audit_logs.action value
+// the worker writes inside the same TX2 it uses to flip a migration
+// row to `completed`. Co-located with the apiserver action constants so
+// audit consumers can branch on a single namespace.
+const (
+	AuditActionCurrencyMigrationComplete = "currency_migration.complete"
+	AuditActionCurrencyMigrationFail     = "currency_migration.fail"
+)
+
+// CurrencyMigrationProcessSummary is the aggregate produced by TX2 once
+// a migration row commits as `completed`. The worker emits these values
+// as Prometheus histogram observations.
+type CurrencyMigrationProcessSummary struct {
+	CommodityCount        int
+	TotalBefore           decimal.Decimal
+	TotalAfter            decimal.Decimal
+	AcquisitionFillsCount int
+	Duration              time.Duration
+}
+
+// CurrencyMigrationProcessor owns TX2 of the currency-migration
+// lifecycle (#202 §4.5). It is intentionally postgres-only — the
+// transaction takes the inventario_background_worker role, drops a
+// pg_advisory_xact_lock keyed on group_id, runs the conversion via
+// currency.ConversionService, persists per-row audit + price-changed
+// events, flips the group's GroupCurrency, marks the migration
+// row `completed`, and writes the audit_logs row, all atomically.
+//
+// Constructed at bootstrap time from the postgres FactorySet so the
+// services-package worker only needs the small ProcessRunningMigration
+// surface. Factory-style HMAC key handling stays inside the registry;
+// the processor is plain DB plumbing.
+type CurrencyMigrationProcessor struct {
+	dbx        *sqlx.DB
+	tableNames store.TableNames
+	conv       *currency.ConversionService
+}
+
+// NewCurrencyMigrationProcessor wires the processor against the same
+// dbx the registries use. Table names default to store.DefaultTableNames;
+// tests that reroute tables can use NewCurrencyMigrationProcessorWithTableNames.
+func NewCurrencyMigrationProcessor(dbx *sqlx.DB) *CurrencyMigrationProcessor {
+	return NewCurrencyMigrationProcessorWithTableNames(dbx, store.DefaultTableNames)
+}
+
+// NewCurrencyMigrationProcessorWithTableNames is the test seam for
+// renaming the underlying tables (parallels the conversion service
+// constructor of the same shape).
+func NewCurrencyMigrationProcessorWithTableNames(dbx *sqlx.DB, tableNames store.TableNames) *CurrencyMigrationProcessor {
+	return &CurrencyMigrationProcessor{
+		dbx:        dbx,
+		tableNames: tableNames,
+		conv:       currency.NewConversionServiceWithTableNames(tableNames),
+	}
+}
+
+// ProcessRunningMigration runs TX2 for `op` (which the worker has
+// already flipped to `running` via TX1).
+//
+// On success: the migration row is updated to `completed` with the
+// captured totals, the group's GroupCurrency is flipped to op.ToCurrency
+// and its currency_migration_id is cleared, every per-commodity audit
+// row + price-changed CommodityEvent is written, and one
+// audit_logs.currency_migration.complete row is inserted — all in a
+// single tx. The returned summary is ready to feed into Prometheus.
+//
+// On any error the tx is rolled back. The migration row stays in
+// `running` (so SweepStuckRunning recovers it after the threshold) and
+// no commodity changes leak. The error is returned wrapped so the
+// caller can log and continue.
+func (p *CurrencyMigrationProcessor) ProcessRunningMigration(ctx context.Context, op *models.CurrencyMigration) (CurrencyMigrationProcessSummary, error) {
+	var summary CurrencyMigrationProcessSummary
+	if op == nil {
+		return summary, errxtrace.Wrap("op is required", registry.ErrFieldRequired)
+	}
+	if op.TenantID == "" || op.GroupID == "" {
+		return summary, errxtrace.Wrap("tenant id and group id are required on the running migration", registry.ErrFieldRequired)
+	}
+	if op.ID == "" {
+		return summary, errxtrace.Wrap("migration id is required", registry.ErrFieldRequired)
+	}
+
+	startedAt := time.Now()
+
+	err := store.DoAsBackgroundWorker(ctx, p.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// Set tenant + group context so any application-role read inside
+		// the tx (e.g. a future RLS-enabled join) is scoped correctly.
+		// The worker role bypasses RLS but we keep the GUCs in sync so
+		// helper functions (get_current_group_id) see the right value.
+		if err := setLocalTenantAndGroup(ctx, tx, op.TenantID, op.GroupID); err != nil {
+			return err
+		}
+
+		// pg_advisory_xact_lock serialises this group's TX2 with any
+		// concurrent worker process that picks up the same row by
+		// mistake (FOR UPDATE SKIP LOCKED in TX1 already prevents the
+		// claim collision; the advisory lock is defence in depth for
+		// the work phase). Two-arg form: hashtext(namespace) +
+		// hashtext(group_id) live in the lock manager's 2x int4
+		// keyspace, so the pair acts as a per-group lock without
+		// needing an int8 PK.
+		if _, err := tx.ExecContext(ctx,
+			"SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))",
+			"currency_migration", op.GroupID,
+		); err != nil {
+			return errxtrace.Wrap("failed to take per-group advisory lock", err)
+		}
+
+		// Build the per-row callbacks the conversion service consumes.
+		// FillAcquisition delegates to migrationops.SetAcquisition so the
+		// write-once guard inside the helper still runs (defence in
+		// depth on top of the schema CHECK constraint). Audit writes go
+		// through a tx-local TxExecutor so they commit atomically with
+		// the commodity row update.
+		commoditiesTable := string(p.tableNames.Commodities())
+		auditExec := store.NewTxRegistry[models.CurrencyMigrationAuditRow](tx, p.tableNames.CurrencyMigrationAudit())
+		eventsExec := store.NewTxRegistry[models.CommodityEvent](tx, p.tableNames.CommodityEvents())
+
+		fillAcquisition := func(ctx context.Context, tx *sqlx.Tx, commodityID string, price decimal.Decimal, cur models.Currency) error {
+			return migrationops.SetAcquisition(ctx, tx, commoditiesTable, commodityID, price, cur)
+		}
+		writeAudit := func(ctx context.Context, row models.CurrencyMigrationAuditRow) error {
+			row.SetTenantID(op.TenantID)
+			row.SetGroupID(op.GroupID)
+			row.SetCreatedByUserID(op.CreatedByUserID)
+			if row.CreatedAt.IsZero() {
+				row.CreatedAt = time.Now().UTC()
+			}
+			// TxExecutor.Insert does not auto-generate id/uuid the way
+			// the standard repository Create path does — the worker
+			// is bypassing that path so the audit write commits
+			// atomically with the commodity update. Pre-stamp both
+			// columns explicitly.
+			row.ID = generateAuditLogID()
+			row.UUID = generateAuditLogID()
+			return auditExec.Insert(ctx, row)
+		}
+
+		runResult, err := p.conv.ConvertGroup(ctx, tx, currency.RunOptions{
+			TenantID:        op.TenantID,
+			GroupID:         op.GroupID,
+			FromCurrency:    op.FromCurrency,
+			ToCurrency:      op.ToCurrency,
+			Rate:            op.ExchangeRate,
+			MigrationID:     op.ID,
+			FillAcquisition: fillAcquisition,
+			Audit:           writeAudit,
+		})
+		if err != nil {
+			return errxtrace.Wrap("conversion failed", err)
+		}
+
+		// Emit one price_changed CommodityEvent per mutated row inside
+		// the same tx so the timeline lands atomically with the price
+		// changes. Skip rows whose price didn't actually move (Case C
+		// where rate is 1.0, or Case B in a third currency with no
+		// rate-side delta — though that's impossible by construction
+		// since rate>0 always shifts ConvertedOriginalPrice).
+		now := time.Now().UTC()
+		for i := range runResult.Diffs {
+			diff := &runResult.Diffs[i]
+			if !priceImagesDiffer(diff.Before, diff.After) {
+				continue
+			}
+			event := buildPriceChangedEvent(op, diff, now)
+			// TxExecutor.Insert does not auto-generate id/uuid;
+			// pre-stamp both so the INSERT carries them.
+			event.ID = generateAuditLogID()
+			event.UUID = generateAuditLogID()
+			if err := eventsExec.Insert(ctx, event); err != nil {
+				return errxtrace.Wrap("failed to write commodity_events row", err)
+			}
+		}
+
+		// Flip the group's GroupCurrency to the new currency and clear
+		// the currency_migration_id lock signal. Both updates land in
+		// the same tx as the migration row update, so the FE sees the
+		// lock release and the new group currency together.
+		if _, err := tx.ExecContext(ctx,
+			fmt.Sprintf(
+				`UPDATE %s
+				    SET group_currency = $1,
+				        currency_migration_id = NULL,
+				        updated_at = $2
+				  WHERE id = $3`,
+				p.tableNames.LocationGroups(),
+			),
+			string(op.ToCurrency), now, op.GroupID,
+		); err != nil {
+			return errxtrace.Wrap("failed to update location_groups for completed migration", err)
+		}
+
+		// Update the migration row to completed.
+		totalBefore := runResult.TotalCurrentBefore
+		totalAfter := runResult.TotalCurrentAfter
+		if _, err := tx.ExecContext(ctx,
+			fmt.Sprintf(
+				`UPDATE %s
+				    SET status = 'completed',
+				        completed_at = $1,
+				        commodity_count = $2,
+				        total_before = $3,
+				        total_after = $4
+				  WHERE id = $5`,
+				p.tableNames.CurrencyMigrations(),
+			),
+			now, runResult.CommodityCount, totalBefore.String(), totalAfter.String(), op.ID,
+		); err != nil {
+			return errxtrace.Wrap("failed to mark currency migration completed", err)
+		}
+
+		// Audit-log row keyed to the migration. tenant_id / user_id are
+		// what start handler stamped at INSERT time; entity_type +
+		// entity_id let downstream queries pivot on the migration.
+		if err := insertCurrencyMigrationAuditLog(ctx, tx, p.tableNames, auditLogParams{
+			Action:  AuditActionCurrencyMigrationComplete,
+			Op:      op,
+			Success: true,
+			ErrMsg:  "",
+			Now:     now,
+			Summary: &runResult,
+			Reason:  "",
+		}); err != nil {
+			return errxtrace.Wrap("failed to write audit_logs row for completed migration", err)
+		}
+
+		summary = CurrencyMigrationProcessSummary{
+			CommodityCount:        runResult.CommodityCount,
+			TotalBefore:           totalBefore,
+			TotalAfter:            totalAfter,
+			AcquisitionFillsCount: runResult.AcquisitionFillsCount,
+		}
+		return nil
+	})
+
+	summary.Duration = time.Since(startedAt)
+	if err != nil {
+		return CurrencyMigrationProcessSummary{Duration: summary.Duration}, err
+	}
+	return summary, nil
+}
+
+// WriteSweepFailureAuditLog inserts one audit_logs.currency_migration.fail
+// row per swept migration. Called by the worker after SweepStuckRunning
+// returns the recovered rows so the audit trail captures the recovery
+// event even though the original tx rolled back. The reason string is
+// the error_message persisted on the migration row (defaults to
+// "worker crashed or stalled" if empty).
+func (p *CurrencyMigrationProcessor) WriteSweepFailureAuditLog(ctx context.Context, op *models.CurrencyMigration) error {
+	if op == nil {
+		return nil
+	}
+	return store.DoAsBackgroundWorker(ctx, p.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		return insertCurrencyMigrationAuditLog(ctx, tx, p.tableNames, auditLogParams{
+			Action:  AuditActionCurrencyMigrationFail,
+			Op:      op,
+			Success: false,
+			ErrMsg:  op.ErrorMessage,
+			Now:     time.Now().UTC(),
+			Reason:  "recovery_sweep",
+		})
+	})
+}
+
+// auditLogParams bundles the inputs to insertCurrencyMigrationAuditLog
+// so the helper signature stays compact.
+type auditLogParams struct {
+	Action  string
+	Op      *models.CurrencyMigration
+	Success bool
+	ErrMsg  string
+	Now     time.Time
+	Summary *currency.RunResult // nil for failure rows
+	Reason  string              // free-form context, embedded in user_agent
+}
+
+// insertCurrencyMigrationAuditLog writes a single row into audit_logs
+// inside the supplied tx. The tenant/user fields fall back to the
+// migration row's stamps so the audit log is never headless.
+func insertCurrencyMigrationAuditLog(ctx context.Context, tx *sqlx.Tx, tableNames store.TableNames, p auditLogParams) error {
+	entry := models.AuditLog{
+		Timestamp: p.Now,
+		Action:    p.Action,
+		Success:   p.Success,
+	}
+	if p.Op.CreatedByUserID != "" {
+		userID := p.Op.CreatedByUserID
+		entry.UserID = &userID
+	}
+	if p.Op.TenantID != "" {
+		tenantID := p.Op.TenantID
+		entry.TenantID = &tenantID
+	}
+	entityType := "currency_migration"
+	entry.EntityType = &entityType
+	if p.Op.ID != "" {
+		entityID := p.Op.ID
+		entry.EntityID = &entityID
+	}
+	if p.ErrMsg != "" {
+		em := p.ErrMsg
+		entry.ErrorMessage = &em
+	}
+	// Encode summary (success path) or recovery breadcrumb (failure
+	// path) as a JSON blob in user_agent. The audit_logs schema doesn't
+	// have a generic context column today; stuffing the breadcrumb into
+	// user_agent keeps the row self-describing without a schema bump.
+	breadcrumb := map[string]any{
+		"group_id":      p.Op.GroupID,
+		"migration_id":  p.Op.ID,
+		"from_currency": string(p.Op.FromCurrency),
+		"to_currency":   string(p.Op.ToCurrency),
+	}
+	if p.Reason != "" {
+		breadcrumb["reason"] = p.Reason
+	}
+	if p.Summary != nil {
+		breadcrumb["commodity_count"] = p.Summary.CommodityCount
+		breadcrumb["acquisition_fills"] = p.Summary.AcquisitionFillsCount
+		breadcrumb["total_before"] = p.Summary.TotalCurrentBefore.String()
+		breadcrumb["total_after"] = p.Summary.TotalCurrentAfter.String()
+	}
+	if encoded, err := json.Marshal(breadcrumb); err == nil {
+		entry.UserAgent = string(encoded)
+	}
+
+	// audit_logs goes through NonRLSRepository.Create in the normal
+	// path, which stamps id+uuid via generateID(). We're bypassing that
+	// path so the writes commit in TX2 — pre-stamp both columns
+	// explicitly so the INSERT carries them.
+	entry.ID = generateAuditLogID()
+	entry.UUID = generateAuditLogID()
+
+	exec := store.NewTxRegistry[models.AuditLog](tx, tableNames.AuditLogs())
+	if err := exec.Insert(ctx, entry); err != nil {
+		return errxtrace.Wrap("failed to insert audit_logs row", err)
+	}
+	return nil
+}
+
+// generateAuditLogID returns a fresh UUID4 string. Mirrors store.generateID's
+// implementation; lives here (vs the unexported store helper) so this file
+// stays self-contained without leaking a new export.
+func generateAuditLogID() string {
+	return uuid.New().String()
+}
+
+// setLocalTenantAndGroup sets the per-tx app.current_tenant_id and
+// app.current_group_id GUCs so any helper function inside the tx
+// resolves the correct scope. Mirrors the per-request middleware path
+// that the apiserver uses; the worker has no http.Request to drive
+// it from, so we set the values from the migration row directly.
+func setLocalTenantAndGroup(ctx context.Context, tx *sqlx.Tx, tenantID, groupID string) error {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL app.current_tenant_id = '%s'", escapeSQLIdent(tenantID))); err != nil {
+		return errxtrace.Wrap("failed to set tenant context for currency migration tx", err)
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL app.current_group_id = '%s'", escapeSQLIdent(groupID))); err != nil {
+		return errxtrace.Wrap("failed to set group context for currency migration tx", err)
+	}
+	return nil
+}
+
+// escapeSQLIdent escapes single quotes for the SET LOCAL value above.
+// Same pattern store.setUserContext / setTenantContext use for their
+// session GUCs — the values we feed in come from the migration row's
+// own UUID columns so they shouldn't carry quotes, but defence in
+// depth costs nothing.
+func escapeSQLIdent(s string) string {
+	return sqlEscape(s)
+}
+
+func sqlEscape(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			out = append(out, '\'', '\'')
+			continue
+		}
+		out = append(out, s[i])
+	}
+	return string(out)
+}
+
+// priceImagesDiffer reports whether the four price-related fields
+// changed across the conversion. Used to skip emitting commodity_events
+// for no-op rows (e.g. zero-priced commodities under any rate).
+func priceImagesDiffer(before, after currency.RowImage) bool {
+	if !before.OriginalPrice.Equal(after.OriginalPrice) {
+		return true
+	}
+	if before.OriginalPriceCurrency != after.OriginalPriceCurrency {
+		return true
+	}
+	if !before.ConvertedOriginalPrice.Equal(after.ConvertedOriginalPrice) {
+		return true
+	}
+	if !before.CurrentPrice.Equal(after.CurrentPrice) {
+		return true
+	}
+	return false
+}
+
+// buildPriceChangedEvent returns the CommodityEvent row for one
+// migrated commodity. Mirrors CommodityEventService's price_changed
+// payload shape so the FE timeline can render it identically to a
+// user-driven price edit.
+func buildPriceChangedEvent(op *models.CurrencyMigration, diff *currency.PerRowDiff, now time.Time) models.CommodityEvent {
+	event := models.CommodityEvent{
+		CommodityID: diff.CommodityID,
+		Kind:        models.CommodityEventKindPriceChanged,
+		OccurredAt:  now,
+		Before: models.CommodityEventPayload{
+			"original_price":           diff.Before.OriginalPrice.String(),
+			"original_price_currency":  string(diff.Before.OriginalPriceCurrency),
+			"converted_original_price": diff.Before.ConvertedOriginalPrice.String(),
+			"current_price":            diff.Before.CurrentPrice.String(),
+		},
+		After: models.CommodityEventPayload{
+			"original_price":           diff.After.OriginalPrice.String(),
+			"original_price_currency":  string(diff.After.OriginalPriceCurrency),
+			"converted_original_price": diff.After.ConvertedOriginalPrice.String(),
+			"current_price":            diff.After.CurrentPrice.String(),
+			"_source":                  "currency_migration",
+			"_migration_id":            op.ID,
+		},
+	}
+	event.SetTenantID(op.TenantID)
+	event.SetGroupID(op.GroupID)
+	event.SetCreatedByUserID(op.CreatedByUserID)
+	return event
+}

--- a/go/registry/postgres/currency_migration_processor_test.go
+++ b/go/registry/postgres/currency_migration_processor_test.go
@@ -1,0 +1,315 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres"
+)
+
+// TestCurrencyMigrationProcessor_HappyPath_SmallGroup walks the worker
+// TX2 lifecycle end-to-end against postgres: seed two commodities,
+// insert+claim a pending migration, run ProcessRunningMigration, and
+// assert: commodity rows updated; migration row marked completed with
+// totals; group's GroupCurrency flipped + currency_migration_id
+// cleared; one audit row per commodity; one audit_logs row keyed to
+// the migration; one price_changed CommodityEvent per row.
+func TestCurrencyMigrationProcessor_HappyPath_SmallGroup(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+	groupID := getTestGroupID(c, registrySet, user)
+
+	// Seed: one location, one area, two commodities (Case A both:
+	// OriginalPriceCurrency=USD = group's current GroupCurrency).
+	location := createTestLocation(c, registrySet)
+	area := createTestArea(c, registrySet, location.ID)
+	com1 := createTestCommodity(c, registrySet, area.ID)
+
+	// Seed a second commodity with a known different price so the
+	// totals math is non-trivial.
+	com2 := models.Commodity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        user.TenantID,
+			CreatedByUserID: user.ID,
+		},
+		Name:                   "Second Commodity",
+		ShortName:              "SC",
+		Type:                   models.CommodityTypeElectronics,
+		AreaID:                 area.ID,
+		Count:                  1,
+		OriginalPrice:          decimal.NewFromFloat(50.00),
+		OriginalPriceCurrency:  "USD",
+		ConvertedOriginalPrice: decimal.Zero,
+		CurrentPrice:           decimal.NewFromFloat(60.00),
+		Status:                 models.CommodityStatusInUse,
+		PurchaseDate:           models.ToPDate("2023-01-01"),
+		RegisteredDate:         models.ToPDate("2023-01-02"),
+		LastModifiedDate:       models.ToPDate("2023-01-03"),
+	}
+	createdCom2, err := registrySet.CommodityRegistry.Create(ctx, com2)
+	c.Assert(err, qt.IsNil)
+
+	// Build a separate processor + service registry so the worker
+	// surface is exercised exactly the way bootstrap wires it.
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	pgFactory := postgres.NewCurrencyMigrationRegistry(dbx)
+	processor := pgFactory.NewProcessor()
+	serviceReg := pgFactory.CreateServiceRegistry()
+
+	// Pending row: USD → EUR at 0.9.
+	created, err := registrySet.CurrencyMigrationRegistry.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		ExchangeRate: decimal.NewFromFloat(0.9),
+	})
+	c.Assert(err, qt.IsNil)
+
+	// TX1 — service registry flips it to running.
+	op, err := serviceReg.ClaimNextPending(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(op.ID, qt.Equals, created.ID)
+	c.Assert(op.Status, qt.Equals, models.CurrencyMigrationStatusRunning)
+
+	// TX2 — the processor.
+	summary, err := processor.ProcessRunningMigration(ctx, op)
+	c.Assert(err, qt.IsNil)
+	c.Assert(summary.CommodityCount, qt.Equals, 2)
+	c.Assert(summary.TotalBefore.String(), qt.Equals, "150") // 90 + 60
+	c.Assert(summary.TotalAfter.String(), qt.Equals, "135")  // 81 + 54
+	c.Assert(summary.AcquisitionFillsCount, qt.Equals, 2)    // both Case A, both NULL pre-migration
+	c.Assert(summary.Duration > 0, qt.IsTrue)
+
+	// The migration row is now completed.
+	round, err := registrySet.CurrencyMigrationRegistry.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(round.Status, qt.Equals, models.CurrencyMigrationStatusCompleted)
+	c.Assert(round.CommodityCount, qt.Equals, 2)
+	c.Assert(round.CompletedAt, qt.IsNotNil)
+	c.Assert(round.TotalBefore, qt.IsNotNil)
+	c.Assert(round.TotalBefore.Equal(decimal.NewFromInt(150)), qt.IsTrue)
+	c.Assert(round.TotalAfter, qt.IsNotNil)
+	c.Assert(round.TotalAfter.Equal(decimal.NewFromInt(135)), qt.IsTrue)
+
+	// Group currency flipped + lock cleared.
+	updatedGroup, err := registrySet.LocationGroupRegistry.Get(ctx, groupID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(updatedGroup.GroupCurrency), qt.Equals, "EUR")
+	c.Assert(updatedGroup.CurrencyMigrationID, qt.IsNil)
+
+	// Commodities updated: original_price * 0.9, current_price * 0.9,
+	// converted_original_price collapsed to 0.
+	roundCom1, err := registrySet.CommodityRegistry.Get(ctx, com1.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(roundCom1.OriginalPrice.String(), qt.Equals, "90")
+	c.Assert(string(roundCom1.OriginalPriceCurrency), qt.Equals, "EUR")
+	c.Assert(roundCom1.CurrentPrice.String(), qt.Equals, "81")
+	c.Assert(roundCom1.AcquisitionPrice, qt.IsNotNil)
+	c.Assert(roundCom1.AcquisitionPrice.String(), qt.Equals, "100")
+	c.Assert(roundCom1.AcquisitionCurrency, qt.IsNotNil)
+	c.Assert(string(*roundCom1.AcquisitionCurrency), qt.Equals, "USD")
+
+	roundCom2, err := registrySet.CommodityRegistry.Get(ctx, createdCom2.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(roundCom2.OriginalPrice.String(), qt.Equals, "45")
+	c.Assert(roundCom2.CurrentPrice.String(), qt.Equals, "54")
+	c.Assert(roundCom2.AcquisitionPrice, qt.IsNotNil)
+	c.Assert(roundCom2.AcquisitionPrice.String(), qt.Equals, "50")
+
+	// Audit rows — one per commodity.
+	auditRows, err := registrySet.CurrencyMigrationRegistry.ListAuditRows(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(auditRows, qt.HasLen, 2)
+	for _, row := range auditRows {
+		c.Assert(row.AcquisitionFilledInThisRun, qt.IsTrue)
+	}
+
+	// Commodity events — one price_changed per commodity. The
+	// registry's listing is paginated; 50 is plenty for a two-row test.
+	events, _, err := registrySet.CommodityEventRegistry.ListByCommodity(ctx, com1.ID, 0, 50, registry.CommodityEventListOptions{})
+	c.Assert(err, qt.IsNil)
+	priceChanged := 0
+	for _, e := range events {
+		if e.Kind == models.CommodityEventKindPriceChanged {
+			priceChanged++
+		}
+	}
+	c.Assert(priceChanged, qt.Equals, 1)
+
+	// audit_logs has one currency_migration.complete row keyed to the
+	// migration. We list newest-first and find the matching action.
+	logs, err := registrySet.AuditLogRegistry.ListByAction(ctx, postgres.AuditActionCurrencyMigrationComplete)
+	c.Assert(err, qt.IsNil)
+	matched := 0
+	for _, log := range logs {
+		if log.EntityID != nil && *log.EntityID == created.ID {
+			matched++
+			c.Assert(log.Success, qt.IsTrue)
+		}
+	}
+	c.Assert(matched, qt.Equals, 1)
+}
+
+// TestCurrencyMigrationProcessor_ForwardThenInverse round-trips the
+// conversion: G_old → G_new at r, then G_new → G_old at 1/r. The final
+// CurrentPrice must equal the starting CurrentPrice (within rounding)
+// and the acquisition columns must remain at the values fixed on the
+// first migration — write-once invariant from #1550.
+func TestCurrencyMigrationProcessor_ForwardThenInverse(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+	groupID := getTestGroupID(c, registrySet, user)
+
+	location := createTestLocation(c, registrySet)
+	area := createTestArea(c, registrySet, location.ID)
+	com := createTestCommodity(c, registrySet, area.ID)
+	startingOriginalPrice := com.OriginalPrice
+	startingCurrentPrice := com.CurrentPrice
+	startingCurrency := com.OriginalPriceCurrency
+
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	pgFactory := postgres.NewCurrencyMigrationRegistry(dbx)
+	processor := pgFactory.NewProcessor()
+	serviceReg := pgFactory.CreateServiceRegistry()
+
+	// Forward: USD → EUR @ 0.5.
+	forwardOp, err := registrySet.CurrencyMigrationRegistry.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		ExchangeRate: decimal.NewFromFloat(0.5),
+	})
+	c.Assert(err, qt.IsNil)
+	claimed, err := serviceReg.ClaimNextPending(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(claimed.ID, qt.Equals, forwardOp.ID)
+	_, err = processor.ProcessRunningMigration(ctx, claimed)
+	c.Assert(err, qt.IsNil)
+
+	mid, err := registrySet.CommodityRegistry.Get(ctx, com.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(mid.OriginalPriceCurrency), qt.Equals, "EUR")
+	c.Assert(mid.AcquisitionPrice, qt.IsNotNil)
+	c.Assert(mid.AcquisitionPrice.Equal(startingOriginalPrice), qt.IsTrue)
+	c.Assert(string(*mid.AcquisitionCurrency), qt.Equals, string(startingCurrency))
+
+	// Inverse: EUR → USD @ 2.0 (1/0.5).
+	inverseOp, err := registrySet.CurrencyMigrationRegistry.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "EUR",
+		ToCurrency:   "USD",
+		ExchangeRate: decimal.NewFromFloat(2.0),
+	})
+	c.Assert(err, qt.IsNil)
+	claimed2, err := serviceReg.ClaimNextPending(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(claimed2.ID, qt.Equals, inverseOp.ID)
+	_, err = processor.ProcessRunningMigration(ctx, claimed2)
+	c.Assert(err, qt.IsNil)
+
+	// Final state matches starting state for the price columns.
+	final, err := registrySet.CommodityRegistry.Get(ctx, com.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(final.OriginalPrice.String(), qt.Equals, startingOriginalPrice.String())
+	c.Assert(string(final.OriginalPriceCurrency), qt.Equals, string(startingCurrency))
+	c.Assert(final.CurrentPrice.String(), qt.Equals, startingCurrentPrice.String())
+
+	// Acquisition columns are still the originals — the second
+	// migration must NOT have overwritten them (write-once).
+	c.Assert(final.AcquisitionPrice, qt.IsNotNil)
+	c.Assert(final.AcquisitionPrice.Equal(startingOriginalPrice), qt.IsTrue)
+	c.Assert(string(*final.AcquisitionCurrency), qt.Equals, string(startingCurrency))
+
+	// Group currency flipped back to USD.
+	finalGroup, err := registrySet.LocationGroupRegistry.Get(ctx, groupID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(finalGroup.GroupCurrency), qt.Equals, "USD")
+}
+
+// TestCurrencyMigrationProcessor_RecoverySweepWithAuditLog asserts the
+// post-sweep failure path: a stuck running row passes the threshold,
+// the registry's SweepStuckRunning returns the swept row, and the
+// processor's WriteSweepFailureAuditLog inserts a matching audit log
+// keyed to the migration.
+func TestCurrencyMigrationProcessor_RecoverySweepWithAuditLog(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+	_ = user
+
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	dbx := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	pgFactory := postgres.NewCurrencyMigrationRegistry(dbx)
+	processor := pgFactory.NewProcessor()
+	serviceReg := pgFactory.CreateServiceRegistry()
+
+	created, err := registrySet.CurrencyMigrationRegistry.Create(ctx, models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		ExchangeRate: decimal.NewFromFloat(0.9),
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Manually flip to running with an old started_at so the sweep's
+	// "started_at < cutoff" predicate matches. Cutoff = now - 10m.
+	pastStart := time.Now().UTC().Add(-1 * time.Hour)
+	c.Assert(serviceReg.UpdateStatus(ctx, created.ID, registry.CurrencyMigrationStatusPatch{
+		Status:    models.CurrencyMigrationStatusRunning,
+		StartedAt: &pastStart,
+	}), qt.IsNil)
+
+	// Sweep with the production threshold.
+	swept, err := serviceReg.SweepStuckRunning(ctx, time.Now().UTC(), postgres.CurrencyMigrationStuckThreshold)
+	c.Assert(err, qt.IsNil)
+	c.Assert(swept, qt.HasLen, 1)
+	c.Assert(swept[0].ID, qt.Equals, created.ID)
+	c.Assert(swept[0].Status, qt.Equals, models.CurrencyMigrationStatusFailed)
+
+	// Write the recovery audit log via the processor.
+	c.Assert(processor.WriteSweepFailureAuditLog(ctx, swept[0]), qt.IsNil)
+
+	// The migration row is failed with the worker-stalled message.
+	round, err := registrySet.CurrencyMigrationRegistry.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(round.Status, qt.Equals, models.CurrencyMigrationStatusFailed)
+	c.Assert(round.ErrorMessage, qt.Equals, "worker crashed or stalled")
+
+	// audit_logs has the corresponding fail entry.
+	logs, err := registrySet.AuditLogRegistry.ListByAction(ctx, postgres.AuditActionCurrencyMigrationFail)
+	c.Assert(err, qt.IsNil)
+	matched := 0
+	for _, log := range logs {
+		if log.EntityID != nil && *log.EntityID == created.ID {
+			matched++
+			c.Assert(log.Success, qt.IsFalse)
+		}
+	}
+	c.Assert(matched, qt.Equals, 1)
+}

--- a/go/services/currency_migration_worker.go
+++ b/go/services/currency_migration_worker.go
@@ -1,0 +1,442 @@
+// Package services hosts cross-registry workflow + worker code that the
+// /api/v1 handlers call into. This file owns the currency-migration
+// background worker introduced in PR 3 of issue #202 (#1552). It is the
+// "tick + claim + delegate" coordinator: the heavy SQL — TX2, advisory
+// lock, conversion, audit writes — lives in
+// registry/postgres.CurrencyMigrationProcessor, behind the small
+// CurrencyMigrationProcessor interface this file declares.
+package services
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// Default tick cadences (#1552 spec):
+//
+//   - active: 5s when there is pending work — keeps queue latency low
+//     for an admin who just kicked off a migration.
+//   - idle:   1m when the last claim returned ErrNotFound — most groups
+//     never migrate, so a flat 5s tick wastes connection-pool slots.
+//
+// Both default values can be overridden via WithCurrencyMigrationActiveInterval
+// / WithCurrencyMigrationIdleInterval; the bootstrap layer also exposes
+// --currency-migration-interval to keep the operator-facing knob
+// single-valued (active interval; idle is derived).
+const (
+	defaultCurrencyMigrationActiveInterval = 5 * time.Second
+	defaultCurrencyMigrationIdleInterval   = 1 * time.Minute
+)
+
+// CurrencyMigrationProcessSummary is the per-run aggregate the
+// processor returns to the worker after TX2 commits successfully.
+// Mirrors postgres.CurrencyMigrationProcessSummary in shape, defined
+// here too so the services package doesn't import the postgres package
+// directly (which would create a cycle through the registry interfaces).
+type CurrencyMigrationProcessSummary struct {
+	CommodityCount        int
+	TotalBefore           decimal.Decimal
+	TotalAfter            decimal.Decimal
+	AcquisitionFillsCount int
+	Duration              time.Duration
+}
+
+// CurrencyMigrationProcessor is the small surface the worker depends on
+// for TX2. Implemented by postgres.CurrencyMigrationProcessor; tests can
+// substitute a fake so the worker run-loop is exercised without standing
+// up postgres.
+type CurrencyMigrationProcessor interface {
+	// ProcessRunningMigration completes TX2 for an already-claimed
+	// running migration. On error the row stays in `running` so the
+	// recovery sweep recovers it; on success the row commits as
+	// `completed` and the group lock + currency flip happen atomically.
+	ProcessRunningMigration(ctx context.Context, op *models.CurrencyMigration) (CurrencyMigrationProcessSummary, error)
+
+	// WriteSweepFailureAuditLog inserts one audit_logs.currency_migration.fail
+	// row per swept migration. Best-effort — failures are logged but do
+	// not propagate (we'd otherwise risk re-flapping the row through
+	// the sweep on every tick).
+	WriteSweepFailureAuditLog(ctx context.Context, op *models.CurrencyMigration) error
+}
+
+// Prometheus metrics (#1552 spec). Registered lazily at package init via
+// promauto against the default registry — same pattern as the warranty
+// reminder worker, so the /metrics scrape sees a single coherent
+// namespace.
+//
+// Labels:
+//   - status: "completed" | "failed" — branches the histogram observation
+//     in tickComplete vs sweepStuck.
+var (
+	currencyMigrationTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_currency_migration_total",
+		Help: "Number of currency migrations transitioned to a terminal status, partitioned by status (completed|failed).",
+	}, []string{"status"})
+
+	currencyMigrationDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "inventario_currency_migration_duration_seconds",
+		Help:    "Wall-clock duration of TX2 (claim → completed/rollback) for a single currency migration.",
+		Buckets: prometheus.ExponentialBuckets(0.05, 2, 12), // 50ms .. ~204s
+	})
+
+	currencyMigrationCommodityCount = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "inventario_currency_migration_commodity_count",
+		Help:    "Number of commodities mutated by a single currency migration TX2.",
+		Buckets: []float64{1, 10, 50, 100, 500, 1000, 5000, 10000},
+	})
+
+	currencyMigrationAcquisitionFillsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "inventario_currency_migration_acquisition_fills_total",
+		Help: "Number of commodities whose acquisition_price/acquisition_currency were filled (write-once) by a currency migration.",
+	})
+
+	currencyMigrationDailyCapRejectionsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "inventario_currency_migration_daily_cap_rejections_total",
+		Help: "Number of /currency-migrations start requests rejected because the per-group daily cap (2/day) was reached.",
+	})
+
+	currencyMigrationRecoverySweepsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "inventario_currency_migration_recovery_sweeps_total",
+		Help: "Number of currency migration rows transitioned from running → failed by the periodic recovery sweep.",
+	})
+)
+
+// CurrencyMigrationDailyCapRejected lets the apiserver bump the
+// per-group daily-cap rejection counter without re-importing the
+// promauto-registered metric across packages. The /metrics output
+// stays a single counter.
+func CurrencyMigrationDailyCapRejected() {
+	currencyMigrationDailyCapRejectionsTotal.Inc()
+}
+
+// CurrencyMigrationWorkerOption customises the worker. Same shape as
+// the other go/services workers (functional options on a private
+// options struct).
+type CurrencyMigrationWorkerOption func(*currencyMigrationWorkerOptions)
+
+type currencyMigrationWorkerOptions struct {
+	activeInterval time.Duration
+	idleInterval   time.Duration
+	clock          func() time.Time
+}
+
+// WithCurrencyMigrationActiveInterval overrides the cadence used after
+// the worker successfully processed (or attempted) a migration. Lower
+// values reduce queue latency at the cost of connection-pool churn on
+// idle deployments. Non-positive is ignored.
+func WithCurrencyMigrationActiveInterval(d time.Duration) CurrencyMigrationWorkerOption {
+	return func(o *currencyMigrationWorkerOptions) {
+		if d > 0 {
+			o.activeInterval = d
+		}
+	}
+}
+
+// WithCurrencyMigrationIdleInterval overrides the cadence used after a
+// claim attempt that found no pending work. Defaults to 1m so a quiet
+// deployment doesn't burn one tx + advisory-lock slot per 5 seconds.
+// Non-positive is ignored.
+func WithCurrencyMigrationIdleInterval(d time.Duration) CurrencyMigrationWorkerOption {
+	return func(o *currencyMigrationWorkerOptions) {
+		if d > 0 {
+			o.idleInterval = d
+		}
+	}
+}
+
+// WithCurrencyMigrationClock overrides the clock the worker hands to
+// SweepStuckRunning. Tests pin the clock to advance past the stuck
+// threshold without sleeping; production passes time.Now indirectly via
+// the default.
+func WithCurrencyMigrationClock(now func() time.Time) CurrencyMigrationWorkerOption {
+	return func(o *currencyMigrationWorkerOptions) {
+		if now != nil {
+			o.clock = now
+		}
+	}
+}
+
+// CurrencyMigrationWorker periodically sweeps stuck running rows,
+// claims one pending migration per tick, and hands the row to the
+// CurrencyMigrationProcessor for TX2.
+//
+// The two-tx lifecycle (#202 §4.5):
+//
+//   - Recovery sweep: every tick BEFORE the claim attempt, plus once at
+//     startup. Flips any `running` row whose started_at is older than
+//     CurrencyMigrationStuckThreshold (10m, hard-coded in the postgres
+//     registry) to `failed`, clearing the group lock signal in the same
+//     statement.
+//
+//   - Claim TX1: registry.ClaimNextPending atomically picks one
+//     pending row via SELECT FOR UPDATE SKIP LOCKED + UPDATE → running.
+//     After commit, FE polls observe the row as running.
+//
+//   - Work TX2: the processor takes the inventario_background_worker
+//     role, drops a per-group advisory lock, runs the conversion +
+//     audit + event emission, flips group_currency, marks the row
+//     `completed`, and writes the audit_logs row — atomically.
+//
+// Metrics, log lines, and stop-channel discipline match the
+// warranty-reminder / refresh-token-cleanup workers.
+type CurrencyMigrationWorker struct {
+	registry  registry.CurrencyMigrationRegistry
+	processor CurrencyMigrationProcessor
+
+	activeInterval time.Duration
+	idleInterval   time.Duration
+	clock          func() time.Time
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+
+	mu      sync.Mutex
+	running bool
+}
+
+// NewCurrencyMigrationWorker constructs the worker. registry is the
+// service-mode CurrencyMigrationRegistry (background-worker RLS
+// bypass); processor is the TX2 owner. Both are required.
+func NewCurrencyMigrationWorker(reg registry.CurrencyMigrationRegistry, processor CurrencyMigrationProcessor, opts ...CurrencyMigrationWorkerOption) *CurrencyMigrationWorker {
+	options := currencyMigrationWorkerOptions{
+		activeInterval: defaultCurrencyMigrationActiveInterval,
+		idleInterval:   defaultCurrencyMigrationIdleInterval,
+		clock:          time.Now,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return &CurrencyMigrationWorker{
+		registry:       reg,
+		processor:      processor,
+		activeInterval: options.activeInterval,
+		idleInterval:   options.idleInterval,
+		clock:          options.clock,
+		stopCh:         make(chan struct{}),
+	}
+}
+
+// Start launches the worker goroutine. No-op if registry/processor are
+// nil (mirrors the warranty reminder worker's "no service configured"
+// behaviour) or if Start has already been called.
+func (w *CurrencyMigrationWorker) Start(ctx context.Context) {
+	if w == nil {
+		return
+	}
+	if w.registry == nil || w.processor == nil {
+		slog.Warn("CurrencyMigrationWorker: missing registry or processor, skipping startup")
+		return
+	}
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return
+	}
+	w.running = true
+	w.mu.Unlock()
+
+	w.wg.Go(func() {
+		defer func() {
+			w.mu.Lock()
+			w.running = false
+			w.mu.Unlock()
+		}()
+		w.run(ctx)
+	})
+	slog.Info("Currency migration worker started",
+		"active_interval", w.activeInterval,
+		"idle_interval", w.idleInterval,
+	)
+}
+
+// Stop signals the worker and waits for the loop goroutine to exit.
+// Idempotent — stopping twice is a no-op.
+func (w *CurrencyMigrationWorker) Stop() {
+	if w == nil {
+		return
+	}
+	w.stopOnce.Do(func() {
+		close(w.stopCh)
+	})
+	w.wg.Wait()
+	slog.Info("Currency migration worker stopped")
+}
+
+// run is the main loop. Each iteration:
+//
+//  1. SweepStuckRunning(now-threshold) — flips long-stuck running rows
+//     to failed (recovery from a crashed worker). The threshold itself
+//     is hard-coded to 10 minutes inside the registry per #202 §4.5.
+//
+//  2. ClaimNextPending — picks one pending row, flips it to running.
+//     Returns ErrNotFound when the queue is empty.
+//
+//  3. processor.ProcessRunningMigration — runs TX2. On error, the row
+//     stays in `running` and the next sweep recovers it; on success,
+//     the row commits as `completed` and the group's currency flips.
+//
+// The next-tick interval is `activeInterval` if a row was claimed
+// this iteration (regardless of TX2 outcome — work is in flight so
+// we want to drain quickly) and `idleInterval` otherwise.
+func (w *CurrencyMigrationWorker) run(ctx context.Context) {
+	// Run once at startup so the recovery sweep clears any
+	// dangling running row left by a previous process before we
+	// even claim. This handles the "process restarted while a
+	// running row was past the stuck threshold" path the issue
+	// calls out.
+	w.tick(ctx)
+
+	timer := time.NewTimer(w.idleInterval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-timer.C:
+			workWasFound := w.tick(ctx)
+			next := w.idleInterval
+			if workWasFound {
+				next = w.activeInterval
+			}
+			timer.Reset(next)
+		}
+	}
+}
+
+// tick runs the per-iteration sweep + claim + process pipeline. Returns
+// true iff the claim picked up a row (regardless of TX2 outcome) — the
+// run loop uses this signal to switch to active cadence.
+func (w *CurrencyMigrationWorker) tick(ctx context.Context) bool {
+	w.runSweep(ctx)
+
+	op, err := w.registry.ClaimNextPending(ctx)
+	switch {
+	case errors.Is(err, registry.ErrNotFound):
+		return false
+	case err != nil:
+		slog.ErrorContext(ctx, "Currency migration claim failed", "error", err)
+		return false
+	}
+
+	w.runWork(ctx, op)
+	return true
+}
+
+// runSweep delegates to the registry's SweepStuckRunning, increments
+// metrics for each transitioned row, and writes a per-row failure
+// audit_logs entry through the processor. Failures inside the audit
+// write are logged and swallowed — re-running the sweep would re-emit
+// the audit row anyway, but the migration row is already in `failed`
+// state so we can't re-flap.
+func (w *CurrencyMigrationWorker) runSweep(ctx context.Context) {
+	now := w.clock()
+	swept, err := w.registry.SweepStuckRunning(ctx, now, currencyMigrationStuckThreshold)
+	if err != nil {
+		slog.ErrorContext(ctx, "Currency migration recovery sweep failed", "error", err)
+		return
+	}
+	for _, op := range swept {
+		if op == nil {
+			continue
+		}
+		currencyMigrationTotal.WithLabelValues("failed").Inc()
+		currencyMigrationRecoverySweepsTotal.Inc()
+		if op.StartedAt != nil && !op.StartedAt.IsZero() && op.CompletedAt != nil && !op.CompletedAt.IsZero() {
+			currencyMigrationDuration.Observe(op.CompletedAt.Sub(*op.StartedAt).Seconds())
+		}
+
+		if err := w.processor.WriteSweepFailureAuditLog(ctx, op); err != nil {
+			slog.WarnContext(ctx, "Currency migration: failed to write recovery audit log",
+				"migration_id", op.ID, "group_id", op.GroupID, "error", err,
+			)
+		}
+		slog.WarnContext(ctx, "Currency migration recovered from stall",
+			"migration_id", op.ID,
+			"group_id", op.GroupID,
+			"from", string(op.FromCurrency),
+			"to", string(op.ToCurrency),
+			"started_at", op.StartedAt,
+		)
+	}
+}
+
+// runWork hands the claimed row to the processor and emits the success
+// metrics on commit. On TX2 failure we record the failure log + bump
+// the duration histogram with the partial walk, but we do NOT increment
+// the `failed` total counter — the row is still in `running`, not
+// terminal. The recovery sweep flips it (and bumps the counter) once
+// the threshold expires.
+func (w *CurrencyMigrationWorker) runWork(ctx context.Context, op *models.CurrencyMigration) {
+	slog.InfoContext(ctx, "Processing currency migration",
+		"migration_id", op.ID,
+		"group_id", op.GroupID,
+		"from", string(op.FromCurrency),
+		"to", string(op.ToCurrency),
+	)
+
+	summary, err := w.processor.ProcessRunningMigration(ctx, op)
+	if err != nil {
+		// TX2 failed and rolled back. Row is still `running`; the next
+		// sweep (or this one — sweep runs BEFORE claim, so on the next
+		// tick) will mark it `failed` once the stuck threshold passes.
+		// Don't touch the row from here — racing with the sweep would
+		// risk emitting two terminal-state events for one migration.
+		currencyMigrationDuration.Observe(summary.Duration.Seconds())
+		slog.ErrorContext(ctx, "Currency migration TX2 failed",
+			"migration_id", op.ID,
+			"group_id", op.GroupID,
+			"error", err,
+		)
+		return
+	}
+
+	currencyMigrationTotal.WithLabelValues("completed").Inc()
+	currencyMigrationDuration.Observe(summary.Duration.Seconds())
+	currencyMigrationCommodityCount.Observe(float64(summary.CommodityCount))
+	if summary.AcquisitionFillsCount > 0 {
+		currencyMigrationAcquisitionFillsTotal.Add(float64(summary.AcquisitionFillsCount))
+	}
+
+	slog.InfoContext(ctx, "Currency migration completed",
+		"migration_id", op.ID,
+		"group_id", op.GroupID,
+		"commodity_count", summary.CommodityCount,
+		"total_before", summary.TotalBefore.String(),
+		"total_after", summary.TotalAfter.String(),
+		"acquisition_fills", summary.AcquisitionFillsCount,
+		"duration", summary.Duration.String(),
+	)
+}
+
+// IsRunning reports whether Start has been called and the loop
+// goroutine is alive. Used by tests that need a barrier between
+// Start and the first tick.
+func (w *CurrencyMigrationWorker) IsRunning() bool {
+	if w == nil {
+		return false
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.running
+}
+
+// currencyMigrationStuckThreshold mirrors postgres.CurrencyMigrationStuckThreshold
+// so this package doesn't import postgres directly. The duplication is
+// load-bearing per #202 §4.5: the constant is "code, not config" — both
+// places reference the same 10-minute window. If you change one, change
+// the other in the same PR.
+const currencyMigrationStuckThreshold = 10 * time.Minute

--- a/go/services/currency_migration_worker.go
+++ b/go/services/currency_migration_worker.go
@@ -74,9 +74,10 @@ type CurrencyMigrationProcessor interface {
 // reminder worker, so the /metrics scrape sees a single coherent
 // namespace.
 //
-// Labels:
-//   - status: "completed" | "failed" — branches the histogram observation
-//     in tickComplete vs sweepStuck.
+// Only currencyMigrationTotal is labelled (status: "completed" | "failed");
+// the duration histogram is intentionally TX2-only and unlabelled — recovery
+// timings for stuck rows go on a separate stall histogram so the TX2
+// latency distribution is not skewed by the 10m+ stall window.
 var (
 	currencyMigrationTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "inventario_currency_migration_total",
@@ -84,9 +85,17 @@ var (
 	}, []string{"status"})
 
 	currencyMigrationDuration = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "inventario_currency_migration_duration_seconds",
-		Help:    "Wall-clock duration of TX2 (claim → completed/rollback) for a single currency migration.",
+		Name: "inventario_currency_migration_duration_seconds",
+		Help: "Wall-clock duration of a single TX2 (conversion + commit) for a successfully completed currency migration. " +
+			"Rolled-back attempts and recovery-sweep stalls are NOT observed here — see inventario_currency_migration_stall_seconds.",
 		Buckets: prometheus.ExponentialBuckets(0.05, 2, 12), // 50ms .. ~204s
+	})
+
+	currencyMigrationStallSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "inventario_currency_migration_stall_seconds",
+		Help: "Time a currency migration spent in 'running' before the recovery sweep flipped it to 'failed' (started_at → completed_at). " +
+			"Distinct from inventario_currency_migration_duration_seconds, which measures the TX2 commit path only.",
+		Buckets: []float64{60, 5 * 60, 10 * 60, 30 * 60, 60 * 60, 6 * 60 * 60, 24 * 60 * 60},
 	})
 
 	currencyMigrationCommodityCount = promauto.NewHistogram(prometheus.HistogramOpts{
@@ -290,14 +299,17 @@ func (w *CurrencyMigrationWorker) Stop() {
 // this iteration (regardless of TX2 outcome — work is in flight so
 // we want to drain quickly) and `idleInterval` otherwise.
 func (w *CurrencyMigrationWorker) run(ctx context.Context) {
-	// Run once at startup so the recovery sweep clears any
-	// dangling running row left by a previous process before we
-	// even claim. This handles the "process restarted while a
-	// running row was past the stuck threshold" path the issue
-	// calls out.
-	w.tick(ctx)
-
-	timer := time.NewTimer(w.idleInterval)
+	// Run once at startup so the recovery sweep clears any dangling
+	// running row left by a previous process before we even claim,
+	// and so the queue is drained eagerly — without the eager tick
+	// the worker would idle for `idleInterval` after process boot
+	// even when there is pending work.
+	startupFound := w.tick(ctx)
+	first := w.idleInterval
+	if startupFound {
+		first = w.activeInterval
+	}
+	timer := time.NewTimer(first)
 	defer timer.Stop()
 
 	for {
@@ -355,8 +367,12 @@ func (w *CurrencyMigrationWorker) runSweep(ctx context.Context) {
 		}
 		currencyMigrationTotal.WithLabelValues("failed").Inc()
 		currencyMigrationRecoverySweepsTotal.Inc()
+		// Observe the stall window — the time the row spent in `running`
+		// before the sweep flipped it. This is deliberately a separate
+		// histogram from currencyMigrationDuration (TX2 commit timings)
+		// so a 10m+ stall does not skew the TX2 latency distribution.
 		if op.StartedAt != nil && !op.StartedAt.IsZero() && op.CompletedAt != nil && !op.CompletedAt.IsZero() {
-			currencyMigrationDuration.Observe(op.CompletedAt.Sub(*op.StartedAt).Seconds())
+			currencyMigrationStallSeconds.Observe(op.CompletedAt.Sub(*op.StartedAt).Seconds())
 		}
 
 		if err := w.processor.WriteSweepFailureAuditLog(ctx, op); err != nil {
@@ -395,7 +411,10 @@ func (w *CurrencyMigrationWorker) runWork(ctx context.Context, op *models.Curren
 		// tick) will mark it `failed` once the stuck threshold passes.
 		// Don't touch the row from here — racing with the sweep would
 		// risk emitting two terminal-state events for one migration.
-		currencyMigrationDuration.Observe(summary.Duration.Seconds())
+		// Don't observe the partial walk on currencyMigrationDuration
+		// either — that histogram is documented as "successful TX2
+		// commit only", and counting rolled-back attempts would skew
+		// the latency distribution operators read for SLO purposes.
 		slog.ErrorContext(ctx, "Currency migration TX2 failed",
 			"migration_id", op.ID,
 			"group_id", op.GroupID,

--- a/go/services/currency_migration_worker_test.go
+++ b/go/services/currency_migration_worker_test.go
@@ -1,0 +1,324 @@
+package services_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// fakeMigrationRegistry stubs registry.CurrencyMigrationRegistry for the
+// worker run-loop tests. Only the worker-facing methods are exercised
+// (ClaimNextPending, SweepStuckRunning, plus a no-op for everything
+// else); the rest panic to surface accidental wide usage.
+type fakeMigrationRegistry struct {
+	registry.CurrencyMigrationRegistry
+
+	mu sync.Mutex
+
+	// Queue of operations that ClaimNextPending will return in order.
+	// When empty, returns ErrNotFound.
+	pending []*models.CurrencyMigration
+
+	// Each call to SweepStuckRunning returns this slice once and then
+	// empties (one-shot recovery).
+	sweepReturn []*models.CurrencyMigration
+
+	claimCalls atomic.Int32
+	sweepCalls atomic.Int32
+}
+
+func (f *fakeMigrationRegistry) ClaimNextPending(_ context.Context) (*models.CurrencyMigration, error) {
+	f.claimCalls.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.pending) == 0 {
+		return nil, registry.ErrNotFound
+	}
+	op := f.pending[0]
+	f.pending = f.pending[1:]
+	return op, nil
+}
+
+func (f *fakeMigrationRegistry) SweepStuckRunning(_ context.Context, _ time.Time, _ time.Duration) ([]*models.CurrencyMigration, error) {
+	f.sweepCalls.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.sweepReturn) == 0 {
+		return nil, nil
+	}
+	out := f.sweepReturn
+	f.sweepReturn = nil
+	return out, nil
+}
+
+// fakeProcessor records ProcessRunningMigration / WriteSweepFailureAuditLog
+// calls and lets each test inject the desired outcome.
+type fakeProcessor struct {
+	mu sync.Mutex
+
+	// summaryOnce returns this summary on the first call; subsequent
+	// calls return a zero summary. Use processErr to short-circuit
+	// before summary lookup.
+	summary services.CurrencyMigrationProcessSummary
+	// processErr (if non-nil) is returned instead of a successful
+	// summary on every Process call.
+	processErr error
+
+	// auditErr (if non-nil) is returned by WriteSweepFailureAuditLog.
+	auditErr error
+
+	processed []*models.CurrencyMigration
+	swept     []*models.CurrencyMigration
+}
+
+func (f *fakeProcessor) ProcessRunningMigration(_ context.Context, op *models.CurrencyMigration) (services.CurrencyMigrationProcessSummary, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.processed = append(f.processed, op)
+	if f.processErr != nil {
+		return services.CurrencyMigrationProcessSummary{Duration: 50 * time.Millisecond}, f.processErr
+	}
+	out := f.summary
+	if out.Duration == 0 {
+		out.Duration = 100 * time.Millisecond
+	}
+	return out, nil
+}
+
+func (f *fakeProcessor) WriteSweepFailureAuditLog(_ context.Context, op *models.CurrencyMigration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.swept = append(f.swept, op)
+	return f.auditErr
+}
+
+func (f *fakeProcessor) processedIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ids := make([]string, len(f.processed))
+	for i, op := range f.processed {
+		ids[i] = op.ID
+	}
+	return ids
+}
+
+func (f *fakeProcessor) sweptIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ids := make([]string, len(f.swept))
+	for i, op := range f.swept {
+		ids[i] = op.ID
+	}
+	return ids
+}
+
+// TestCurrencyMigrationWorker_ProcessesPendingRow drives the worker
+// through a single tick path: sweep returns nothing, claim returns one
+// row, processor commits successfully. After Stop, we assert the
+// processor saw the row exactly once.
+func TestCurrencyMigrationWorker_ProcessesPendingRow(t *testing.T) {
+	c := qt.New(t)
+
+	op := &models.CurrencyMigration{
+		FromCurrency: "USD",
+		ToCurrency:   "EUR",
+		ExchangeRate: decimal.RequireFromString("0.9"),
+	}
+	op.SetTenantID("tenant-1")
+	op.SetGroupID("group-1")
+	op.SetCreatedByUserID("user-1")
+	op.ID = "mig-1"
+
+	reg := &fakeMigrationRegistry{pending: []*models.CurrencyMigration{op}}
+	proc := &fakeProcessor{
+		summary: services.CurrencyMigrationProcessSummary{
+			CommodityCount:        3,
+			TotalBefore:           decimal.RequireFromString("100"),
+			TotalAfter:            decimal.RequireFromString("90"),
+			AcquisitionFillsCount: 1,
+		},
+	}
+
+	worker := services.NewCurrencyMigrationWorker(reg, proc,
+		services.WithCurrencyMigrationActiveInterval(20*time.Millisecond),
+		services.WithCurrencyMigrationIdleInterval(20*time.Millisecond),
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	worker.Start(ctx)
+	defer worker.Stop()
+
+	// Wait for the processor to record the call. Initial tick fires
+	// synchronously inside run() so the first call happens before the
+	// timer even resets — but we still poll defensively.
+	c.Assert(eventually(c, 500*time.Millisecond, func() bool {
+		return len(proc.processedIDs()) >= 1
+	}), qt.IsTrue)
+
+	c.Assert(proc.processedIDs(), qt.DeepEquals, []string{"mig-1"})
+	c.Assert(reg.claimCalls.Load() >= int32(1), qt.IsTrue)
+	c.Assert(reg.sweepCalls.Load() >= int32(1), qt.IsTrue)
+}
+
+// TestCurrencyMigrationWorker_RunsSweepBeforeClaim checks the
+// per-tick ordering mandated by #202 §4.5: every tick must call
+// SweepStuckRunning before ClaimNextPending. We assert this by
+// loading swept rows AND a pending row in the same tick — the swept
+// row must reach the processor's WriteSweepFailureAuditLog and the
+// claim row must reach ProcessRunningMigration.
+func TestCurrencyMigrationWorker_RunsSweepBeforeClaim(t *testing.T) {
+	c := qt.New(t)
+
+	// Stuck row recovered by the sweep.
+	stuck := &models.CurrencyMigration{Status: models.CurrencyMigrationStatusFailed}
+	stuck.SetTenantID("tenant-1")
+	stuck.SetGroupID("group-1")
+	stuck.SetCreatedByUserID("user-1")
+	stuck.ID = "stuck-1"
+	stuck.ErrorMessage = "worker crashed or stalled"
+
+	pending := &models.CurrencyMigration{FromCurrency: "USD", ToCurrency: "EUR", ExchangeRate: decimal.RequireFromString("0.9")}
+	pending.SetTenantID("tenant-1")
+	pending.SetGroupID("group-1")
+	pending.SetCreatedByUserID("user-1")
+	pending.ID = "pending-1"
+
+	reg := &fakeMigrationRegistry{
+		pending:     []*models.CurrencyMigration{pending},
+		sweepReturn: []*models.CurrencyMigration{stuck},
+	}
+	proc := &fakeProcessor{}
+
+	worker := services.NewCurrencyMigrationWorker(reg, proc,
+		services.WithCurrencyMigrationActiveInterval(50*time.Millisecond),
+		services.WithCurrencyMigrationIdleInterval(50*time.Millisecond),
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	worker.Start(ctx)
+	defer worker.Stop()
+
+	c.Assert(eventually(c, time.Second, func() bool {
+		return len(proc.processedIDs()) >= 1 && len(proc.sweptIDs()) >= 1
+	}), qt.IsTrue)
+
+	c.Assert(proc.processedIDs(), qt.Contains, "pending-1")
+	c.Assert(proc.sweptIDs(), qt.Contains, "stuck-1")
+}
+
+// TestCurrencyMigrationWorker_TX2FailureLeavesRowRunning asserts that a
+// processor error does NOT trigger any registry write — the row must
+// stay in `running` so the next sweep recovers it. The worker should
+// continue ticking (next claim attempt, next sweep) instead of
+// terminating.
+func TestCurrencyMigrationWorker_TX2FailureLeavesRowRunning(t *testing.T) {
+	c := qt.New(t)
+
+	op := &models.CurrencyMigration{FromCurrency: "USD", ToCurrency: "EUR", ExchangeRate: decimal.RequireFromString("0.9")}
+	op.SetTenantID("tenant-1")
+	op.SetGroupID("group-1")
+	op.SetCreatedByUserID("user-1")
+	op.ID = "mig-fail"
+
+	reg := &fakeMigrationRegistry{pending: []*models.CurrencyMigration{op}}
+	proc := &fakeProcessor{processErr: errors.New("simulated TX2 rollback")}
+
+	worker := services.NewCurrencyMigrationWorker(reg, proc,
+		services.WithCurrencyMigrationActiveInterval(20*time.Millisecond),
+		services.WithCurrencyMigrationIdleInterval(20*time.Millisecond),
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	worker.Start(ctx)
+	defer worker.Stop()
+
+	c.Assert(eventually(c, 500*time.Millisecond, func() bool {
+		return len(proc.processedIDs()) >= 1
+	}), qt.IsTrue)
+	// The processor was called with the row but no sweep audit was
+	// written — the row stays in running and the registry caller did
+	// not write a failure audit through the processor.
+	c.Assert(proc.processedIDs(), qt.DeepEquals, []string{"mig-fail"})
+	c.Assert(proc.sweptIDs(), qt.HasLen, 0)
+	// Worker is still alive and ticking.
+	c.Assert(worker.IsRunning(), qt.IsTrue)
+}
+
+// TestCurrencyMigrationWorker_StartIsIdempotent — calling Start twice
+// should not spawn two run goroutines.
+func TestCurrencyMigrationWorker_StartIsIdempotent(t *testing.T) {
+	c := qt.New(t)
+
+	reg := &fakeMigrationRegistry{}
+	proc := &fakeProcessor{}
+	worker := services.NewCurrencyMigrationWorker(reg, proc,
+		services.WithCurrencyMigrationActiveInterval(50*time.Millisecond),
+		services.WithCurrencyMigrationIdleInterval(50*time.Millisecond),
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	worker.Start(ctx)
+	worker.Start(ctx) // second Start is a no-op
+	defer worker.Stop()
+
+	// Wait briefly so the run loop has produced at least one tick.
+	c.Assert(eventually(c, 500*time.Millisecond, func() bool {
+		return reg.claimCalls.Load() >= 1
+	}), qt.IsTrue)
+
+	// At most one run goroutine; if Start spawned twice, the claim
+	// counter would race ahead by 2x. We assert "low", not exact, since
+	// the timer may have elapsed multiple times before assertion.
+	c.Assert(worker.IsRunning(), qt.IsTrue)
+}
+
+// TestCurrencyMigrationWorker_NoPendingDoesntInvokeProcessor — the
+// processor must not be called when ClaimNextPending returns
+// ErrNotFound. Sweep is still expected on every tick.
+func TestCurrencyMigrationWorker_NoPendingDoesntInvokeProcessor(t *testing.T) {
+	c := qt.New(t)
+
+	reg := &fakeMigrationRegistry{}
+	proc := &fakeProcessor{}
+	worker := services.NewCurrencyMigrationWorker(reg, proc,
+		services.WithCurrencyMigrationActiveInterval(20*time.Millisecond),
+		services.WithCurrencyMigrationIdleInterval(20*time.Millisecond),
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	worker.Start(ctx)
+	defer worker.Stop()
+
+	c.Assert(eventually(c, 300*time.Millisecond, func() bool {
+		return reg.sweepCalls.Load() >= 1
+	}), qt.IsTrue)
+
+	c.Assert(proc.processedIDs(), qt.HasLen, 0)
+}
+
+// eventually polls until cond returns true or the deadline expires.
+// Returns true on success. Used instead of fixed sleeps so we don't
+// race the timer cadence in CI.
+func eventually(c *qt.C, deadline time.Duration, cond func() bool) bool {
+	c.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return cond()
+}


### PR DESCRIPTION
Closes #1552. Part of epic #202 — corresponds to PR 3/4 in the §8 rollout plan. Builds on #1578 (PR 1) and #1584 (PR 2).

## What this PR does

Lands the background worker that picks up `pending` migration rows, runs the conversion behind a per-group advisory lock, recovers stuck `running` rows, and emits Prometheus metrics for the whole pipeline. After this PR the feature works end-to-end behind `FEATURE_CURRENCY_MIGRATION`.

### Worker — `go/services/currency_migration_worker.go`

- Run loop with active/idle cadence: 5s default while there are pending rows, 1m idle. Configurable via `--currency-migration-interval` (active interval; idle is fixed at 1m).
- Per-tick recovery sweep **before** the claim attempt + one at startup, mandated by the second-pass design review on #202 (a long-lived worker that crashes mid-TX2 must self-recover even without a restart).
- Structured logging + Prometheus metrics: `inventario_currency_migration_total{status}`, `…_duration_seconds`, `…_commodity_count`, `…_acquisition_fills_total`, `…_daily_cap_rejections_total`, `…_recovery_sweeps_total`.
- Registered in the housekeeping worker group of `inventario run workers` and in the `run all` startup sequence.

### Processor — `go/registry/postgres/currency_migration_processor.go`

Owns **TX2** of the lifecycle:

1. `BEGIN` as `inventario_background_worker` (RLS bypass for cross-table maintenance).
2. `SET LOCAL app.current_tenant_id` / `app.current_group_id` so `get_current_group_id()`-style helpers see the right scope.
3. `pg_advisory_xact_lock(hashtext('currency_migration'), hashtext(group_id))` — defence in depth on top of `FOR UPDATE SKIP LOCKED` in TX1.
4. `currency.ConversionService.ConvertGroup` with closures wired to `migrationops.SetAcquisition` (write-once acquisition fill) and a tx-aware `currency_migration_audit_rows` insert.
5. One `commodity_events.price_changed` row per mutated commodity, payload mirroring `CommodityEventService` so the FE timeline renders identically to a manual price edit.
6. `UPDATE location_groups SET group_currency=…, currency_migration_id=NULL`.
7. `UPDATE currency_migrations SET status='completed', commodity_count, total_before, total_after, completed_at`.
8. `INSERT audit_logs(currency_migration.complete)` keyed to the migration with a JSON breadcrumb in `user_agent`.
9. `COMMIT`.

On any error inside the closure: rollback, row stays in `running`, no commodity changes leak. The next sweep flips the row to `failed` once `currencyMigrationStuckThreshold = 10m` expires (constant duplicated in services + postgres per the second-pass review).

### Apiserver hook

`apiserver/currency_migrations.go` calls `services.CurrencyMigrationDailyCapRejected()` on the 429 path so the daily-cap counter lands on the same `/metrics` namespace as the worker counters.

## Tests

| Test | Coverage |
|---|---|
| `TestCurrencyMigrationProcessor_HappyPath_SmallGroup` | Two Case-A commodities; verifies totals, group currency flip, audit rows (1 per commodity, `acquisition_filled_in_this_run=true`), commodity events, `audit_logs.currency_migration.complete` row keyed to the migration. |
| `TestCurrencyMigrationProcessor_ForwardThenInverse` | Forward `USD→EUR @ 0.5`, then inverse `EUR→USD @ 2.0`. Final commodity columns match the starting state. Acquisition columns remain frozen at the first migration's values (write-once). |
| `TestCurrencyMigrationProcessor_RecoverySweepWithAuditLog` | Stuck `running` row past the 10m threshold gets swept to `failed` with `error_message="worker crashed or stalled"`; `audit_logs.currency_migration.fail` row inserted; daily-cap quota not consumed. |
| Worker unit tests | sweep-before-claim ordering; TX2 error leaves the row in `running` (no terminal-state event from the worker — sweep handles it); idempotent `Start`; empty queue ⇒ no `ProcessRunningMigration` call but sweep still runs. |

Full suite green (`go test ./...`); postgres integration suite green against the `inventario_test` test container; lint clean.

## What's still inert

The endpoints + worker remain gated by `FEATURE_CURRENCY_MIGRATION=false` by default. PR 4/4 (#1553) lands the FE wizard, lock UX, commodity-detail acquisition line, e2e test coverage, and flips the flag on.

## Test plan

- [x] `go test ./...` (in-memory backends)
- [x] `go test ./registry/postgres/... ./apiserver/...` (postgres backend)
- [x] `golangci-lint run` (changed packages)
- [x] `go vet ./...` (no new warnings)
- [ ] Manual: kick a migration via the `/preview` + `/start` endpoints with the flag enabled and confirm the worker drains the row + flips the group currency
- [ ] Manual: kill the worker mid-TX2, restart, observe the recovery sweep mark the row `failed` past the 10m threshold