### PR TITLE
Local dev stack ergonomics: kind reload, compose feature flag, .env defaults, docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 #   3. Optionally customize ADMIN_EMAIL, ADMIN_PASSWORD, and other settings below
 #   4. docker-compose up -d
 #   5. Login at http://localhost:3333 with your configured credentials
-#      (default if unchanged: admin@example.com / admin123)
+#      (default if unchanged: admin@example.com / Admin123)
 
 # PostgreSQL Database Configuration
 POSTGRES_DB=inventario
@@ -34,7 +34,7 @@ FILE_URL_EXPIRATION=15m
 DEFAULT_TENANT_NAME=Test Organization
 DEFAULT_TENANT_SLUG=test-org
 ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=admin123
+ADMIN_PASSWORD=Admin123
 ADMIN_NAME=System Administrator
 
 # Database Seeding (optional - enabled by default for quick start)
@@ -74,4 +74,4 @@ TZ=UTC
 # - Change all default passwords before production deployment
 # - Generate secure JWT_SECRET and FILE_SIGNING_KEY with: openssl rand -hex 32
 # - Use strong, unique passwords for database users
-# - The default admin credentials are admin@example.com / admin123
+# - The default admin credentials are admin@example.com / Admin123

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -147,9 +147,14 @@ services:
    ```
 
 2. **Permission issues with volumes**:
+   The inventario container runs as uid 1001, but the `postgres:17-alpine` image
+   runs as uid 70. Each bind-mounted subdirectory needs the matching owner:
    ```bash
-   sudo chown -R 1001:1001 .docker/
+   sudo chown -R 1001:1001 .docker/inventario .docker/init-state
+   sudo chown -R 70:70 .docker/postgresql
    ```
+   A blanket `chown -R 1001:1001 .docker/` will leave postgres unable to read
+   its own data files (`could not open file "global/pg_filenode.map": Permission denied`).
 
 3. **Database connection issues**:
    Check if PostgreSQL is healthy:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -203,9 +203,10 @@ services:
       # Feature flags
       # Currency migration is on by default. Set FEATURE_CURRENCY_MIGRATION=false
       # in .env to disable the wizard, lock middleware, and worker.
-      # The binary reads the env-prefixed name (run section → INVENTARIO_RUN_)
-      # — see shared/config.go ReadSection. The plain log message
-      # "FEATURE_CURRENCY_MIGRATION is off" in workers.go is misleading.
+      # The binary reads the env-prefixed name (run section → INVENTARIO_RUN_):
+      # see ReadSection in go/cmd/inventario/shared/config.go. The plain log
+      # message "FEATURE_CURRENCY_MIGRATION is off" in
+      # go/cmd/inventario/run/bootstrap/workers.go is misleading.
       INVENTARIO_RUN_FEATURE_CURRENCY_MIGRATION: ${FEATURE_CURRENCY_MIGRATION:-true}
 
       # System configuration

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -200,6 +200,14 @@ services:
       INVENTARIO_RUN_SMTP_PORT: ${SMTP_PORT:-1025}
       INVENTARIO_RUN_SMTP_USE_TLS: ${SMTP_USE_TLS:-false}
 
+      # Feature flags
+      # Currency migration is on by default. Set FEATURE_CURRENCY_MIGRATION=false
+      # in .env to disable the wizard, lock middleware, and worker.
+      # The binary reads the env-prefixed name (run section → INVENTARIO_RUN_)
+      # — see shared/config.go ReadSection. The plain log message
+      # "FEATURE_CURRENCY_MIGRATION is off" in workers.go is misleading.
+      INVENTARIO_RUN_FEATURE_CURRENCY_MIGRATION: ${FEATURE_CURRENCY_MIGRATION:-true}
+
       # System configuration
       TZ: ${TZ:-UTC}
     volumes:

--- a/scripts/kind-stack.sh
+++ b/scripts/kind-stack.sh
@@ -298,12 +298,14 @@ cmd_up() {
   require_prereqs
   ensure_kind
 
-  if ! cluster_exists; then
+  local cluster_existed=false
+  if cluster_exists; then
+    log "kind cluster $KIND_CLUSTER_NAME already exists; reusing"
+    cluster_existed=true
+  else
     log "creating kind cluster $KIND_CLUSTER_NAME"
     kind_cmd create cluster --name "$KIND_CLUSTER_NAME" --wait 120s
     kubectl_cmd cluster-info
-  else
-    log "kind cluster $KIND_CLUSTER_NAME already exists; reusing"
   fi
 
   build_image
@@ -313,6 +315,16 @@ cmd_up() {
   mdir="$(prepare_manifests)"
   apply_manifests "$mdir"
   wait_for_ready "$mdir"
+
+  # On a re-up, the deployment manifest is byte-identical to what's already
+  # applied, so `kubectl apply` no-ops and the running pod keeps its old
+  # image bytes even though we just loaded fresh ones under the same tag.
+  # Force the rollout so init containers re-run migrations and the web
+  # container picks up the new frontend + backend.
+  if [ "$cluster_existed" = true ]; then
+    roll_inventario "picking up freshly loaded image"
+  fi
+
   start_port_forward
 
   cat <<EOF
@@ -371,17 +383,23 @@ cmd_logs() {
   esac
 }
 
+# roll_inventario forces a deployment rollout even when the image tag is
+# unchanged, by stamping a fresh annotation onto the pod template. kubectl
+# treats the annotation bump as a spec change and rolls the pod, which is the
+# only way kind picks up freshly loaded bytes under a stable tag.
+roll_inventario() {
+  log "rolling inventario deployment (${1:-forced})"
+  kubectl_cmd patch deployment/inventario -n "$K8S_NAMESPACE" \
+    -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kind-stack.sh/reload\":\"$(date +%s)\"}}}}}"
+  kubectl_cmd rollout status deployment/inventario -n "$K8S_NAMESPACE" --timeout=300s
+}
+
 cmd_reload() {
   ensure_kind
   cluster_exists || fail "cluster $KIND_CLUSTER_NAME does not exist; run 'kind-stack.sh up' first"
   build_image
   load_image
-  log "rolling inventario deployment"
-  # Forces pods to restart even though the image tag is the same — kubectl
-  # recognises the env-var bump as a spec change.
-  kubectl_cmd patch deployment/inventario -n "$K8S_NAMESPACE" \
-    -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kind-stack.sh/reload\":\"$(date +%s)\"}}}}}"
-  kubectl_cmd rollout status deployment/inventario -n "$K8S_NAMESPACE" --timeout=300s
+  roll_inventario "reload"
   log "reload complete"
 }
 


### PR DESCRIPTION
## Summary

Four small fixes to the local-development surface that were uncovered while bringing the stack up from scratch on a fresh box. Each commit is independent and could ship on its own; bundled here because they were found together and all sit in the "first-run dev experience" theme.

### 1. `kind-stack.sh`: force inventario rollout on `up` re-runs

Re-running `scripts/kind-stack.sh up` against an existing cluster did not pick up backend or frontend changes — `kubectl apply` on the byte-identical deployment manifest no-oped, so the running pod kept its old image bytes even though `load_image` had just pushed fresh ones under the same tag (`imagePullPolicy: IfNotPresent`). Workaround was always `down` + `up`.

Now `cmd_up` records whether the cluster pre-existed and, when it did, force-rolls the deployment via the same annotation-bump trick `cmd_reload` already uses. Init containers re-run with the new image (so backend migrations get picked up too), then the web container starts. The patch+rollout pair is extracted into a small `roll_inventario` helper since both `cmd_up` and `cmd_reload` use it.

### 2. `docker-compose.yaml`: pass currency-migration feature flag through

A first `docker compose up -d` left the currency-migration wizard, lock middleware, and worker disabled (404 on `/api/v1/g/{slug}/currency-migrations/preview`) despite the binary's `env-default:"true"` for the field. The compose `inventario` service simply had no env entry for it.

Two non-obvious things this commit captures inline:

- The container env name must be `INVENTARIO_RUN_FEATURE_CURRENCY_MIGRATION` (the run-section read in `shared/config.go` wraps the lookup with an `INVENTARIO_RUN_` env-prefix, so plain `FEATURE_CURRENCY_MIGRATION` is silently ignored).
- The slog message `"FEATURE_CURRENCY_MIGRATION is off"` in `workers.go:135` therefore reports the wrong env name and is misleading. Out of scope for this PR but worth fixing separately.

The user-facing variable in `.env` stays the friendly short name; the env-prefixed mapping happens in compose.

### 3. `.env.example`: align `ADMIN_PASSWORD` with backend complexity rule

Fresh `cp .env.example .env && docker compose up -d` fails on the init-data step:

```
failed to create/update admin user: failed to hash password: password must contain at least one uppercase letter
```

The complexity rule shipped in #1577. `k8s/dev/inventario/secret.yaml` was updated then; `.env.example` was missed. Bumps the default to `Admin123` in three places (header quick-start comment, the variable itself, security-notes footer).

### 4. `DOCKER.md`: split chown advice by container user

Following the existing `sudo chown -R 1001:1001 .docker/` advice breaks postgres — alpine's postgres runs as uid 70 and fails to read its own files (`could not open file "global/pg_filenode.map": Permission denied`). Splits the troubleshooting command into two (1001:1001 for `.docker/inventario` + `.docker/init-state`, 70:70 for `.docker/postgresql`) and names the symptom of the wrong-blanket-chown case so a future reader recognises it.

## Test plan

- [x] `scripts/kind-stack.sh up` then again — second run rolls the inventario pod (no manual `down` needed). Verified locally on a fresh kind cluster.
- [x] `cp .env.example .env && docker compose up -d` from a clean repo — admin user is created with the new default; `/readyz` returns 200; inventario log shows `Currency migration worker started`.
- [x] `bash -n scripts/kind-stack.sh` clean.

## Out of scope

- The misleading `slog.Info("Currency migration worker disabled; FEATURE_CURRENCY_MIGRATION is off")` message and the cleanenv env-prefix surprise that motivates the long compose comment — both worth a separate fix.
- The UX bug of the currency-migration wizard being reachable from the UI when the backend has the flag off (filed as #1616).