### PR TITLE
[#1538] Files page polish: list/grid toggle, accent tiles, tag pills, footer

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -59,7 +59,14 @@ _None yet._
 
 ### Files & Attachments
 
-_None yet._
+#### 2026-05-09 — Curated tag pills match by lowercase tag name, not opaque tag id
+
+- **Issue/PR**: #1538 (item 3) / PR _pending_
+- **Mock**: [`design-mocks/src/views/FileBrowserView.tsx`](../../design-mocks/src/views/FileBrowserView.tsx) (lines ~645–673) renders six curated tag pills sourced from `FILE_TAGS` in [`design-mocks/src/data/mock.ts`](../../design-mocks/src/data/mock.ts) — each pill is `{ id: "t1", label: "Invoice", color: "text-chart-1" }` and matches `file.tags.includes("t1")`. Files in the mock dataset are tagged with the same opaque ids (`t1`, `t2`, …).
+- **Reality**: The real BE stores `tags` as a free-form `string[]` (no Tags entity yet — that's #1400). The FE's curated pills mirror the mock's six labels (Invoice / Warranty / Manual / Photo / Certificate / Backup) but match against the lowercase tag name (`invoice`, `warranty`, …) so the toolbar pill toggles a recognisable string into `?tags=`. Custom user-supplied tags still render on the file cards/rows but don't appear as toolbar pills, and the freeform `TagsInput` is removed from the toolbar (it stays on the upload/edit forms only, per the issue spec).
+- **Why**: The mock's opaque-id taxonomy doesn't exist on the BE — there's no Tags table to assign ids from. Using the lowercase label as the literal tag string keeps the pill flow round-trippable through `?tags=` and the BE's `tags @> $` filter without inventing an id space the BE doesn't enforce. The discoverability gap for custom tags is a deliberate trade — the issue explicitly notes "Likely coordinates with #1400" — and the curated taxonomy is the canonical surface until that lands.
+- **Approved by**: agent-suggested-then-user-confirmed — issue #1538 §3 specifies replacing the freeform input with curated pills and notes the #1400 coordination.
+- **Reversion plan**: Resolve when #1400 lands a proper Tags entity — pills then match by id again, and the i18n keys become tag-record labels.
 
 ### Forms & Validation
 

--- a/e2e/tests/files.spec.ts
+++ b/e2e/tests/files.spec.ts
@@ -27,7 +27,13 @@ async function gotoFiles(page: Page): Promise<void> {
   // Group-scoped routes are `/g/<slug>/...`; navigateWithAuth stays
   // logged in across the redirect through /no-group / /login bounces
   // that pure page.goto would otherwise expose.
-  await navigateWithAuth(page, '/files')
+  //
+  // `?view=grid` pins the page to the FileCard grid renderer. The
+  // default became `list` under #1538, but every file selector in
+  // this spec is `[data-testid^="file-card-"]` — the grid is the
+  // mode under test here. The list/grid toggle itself is covered by
+  // the FilesListPage vitest cases.
+  await navigateWithAuth(page, '/files?view=grid')
   await expect(page.getByTestId('page-files')).toBeVisible()
 }
 

--- a/frontend/src/components/files/CategoryTiles.tsx
+++ b/frontend/src/components/files/CategoryTiles.tsx
@@ -2,30 +2,10 @@ import { useTranslation } from "react-i18next"
 
 import { Card } from "@/components/ui/card"
 import { FILE_CATEGORY_TILES, type FileCategoryTile } from "@/features/files/constants"
+import { useCategoryLabel } from "@/features/files/labels"
 import type { FileCategoryCounts } from "@/features/files/api"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
-
-// Static label resolver — i18next-cli can't see template-literal keys,
-// so a switch with explicit t() calls keeps the en/files.json catalogue
-// in sync without manual key bookkeeping.
-function useCategoryLabel(): (key: FileCategoryTile) => string {
-  const { t } = useTranslation()
-  return (key) => {
-    switch (key) {
-      case "all":
-        return t("files:categoryAll", { defaultValue: "All" })
-      case "images":
-        return t("files:categoryImages", { defaultValue: "Images" })
-      case "invoices":
-        return t("files:categoryInvoices", { defaultValue: "Invoices" })
-      case "documents":
-        return t("files:categoryDocuments", { defaultValue: "Documents" })
-      case "other":
-        return t("files:categoryOther", { defaultValue: "Other" })
-    }
-  }
-}
 
 // Five tiles row at the top of the Files list. Selecting a tile filters
 // the list to that category (or "all" — synthetic, not part of the BE

--- a/frontend/src/components/files/CategoryTiles.tsx
+++ b/frontend/src/components/files/CategoryTiles.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Card } from "@/components/ui/card"
 import { FILE_CATEGORY_TILES, type FileCategoryTile } from "@/features/files/constants"
 import type { FileCategoryCounts } from "@/features/files/api"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 
 // Static label resolver — i18next-cli can't see template-literal keys,
@@ -29,7 +30,9 @@ function useCategoryLabel(): (key: FileCategoryTile) => string {
 // Five tiles row at the top of the Files list. Selecting a tile filters
 // the list to that category (or "all" — synthetic, not part of the BE
 // enum). Counts come from GET /files/category-counts and respect the
-// active search/tags filters.
+// active search/tags filters. Below the `sm` breakpoint the row collapses
+// into a single full-width <select>; the mock paid for the screen real
+// estate the 2-col grid was eating on phones.
 export interface CategoryTilesProps {
   active: FileCategoryTile
   counts?: FileCategoryCounts
@@ -40,11 +43,39 @@ export interface CategoryTilesProps {
 export function CategoryTiles({ active, counts, loading, onSelect }: CategoryTilesProps) {
   const { t } = useTranslation()
   const labelOf = useCategoryLabel()
+  const isMobile = useIsMobile()
+
+  if (isMobile) {
+    return (
+      <label className="block">
+        <span className="sr-only">
+          {t("files:categoryMobileLabel", { defaultValue: "Category" })}
+        </span>
+        <select
+          data-testid="files-category-select"
+          value={active}
+          onChange={(e) => onSelect(e.target.value as FileCategoryTile)}
+          className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm font-medium shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {FILE_CATEGORY_TILES.map((tile) => {
+            const value = countForKey(tile.key, counts)
+            const display = loading && value === undefined ? "—" : (value ?? 0)
+            return (
+              <option key={tile.key} value={tile.key}>
+                {labelOf(tile.key)} ({display})
+              </option>
+            )
+          })}
+        </select>
+      </label>
+    )
+  }
+
   return (
     <div
       role="tablist"
       aria-label={t("files:title", { defaultValue: "Files" })}
-      className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5"
+      className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5"
     >
       {FILE_CATEGORY_TILES.map((tile) => {
         const Icon = tile.icon
@@ -65,27 +96,39 @@ export function CategoryTiles({ active, counts, loading, onSelect }: CategoryTil
               }
             }}
             className={cn(
-              "flex cursor-pointer items-center gap-3 p-4 transition-colors",
-              "hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              selected && "border-primary bg-primary/5"
+              "group flex cursor-pointer flex-col items-start gap-1.5 p-3 text-left transition-all",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              selected
+                ? "border-primary bg-primary/5 shadow-sm"
+                : "hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-sm"
             )}
           >
             <div
               className={cn(
-                "flex size-10 items-center justify-center rounded-md",
-                selected ? "bg-primary text-primary-foreground" : "bg-muted text-foreground/70"
+                "flex size-7 items-center justify-center rounded-lg transition-colors",
+                selected ? cn(tile.activeBg, tile.activeColor) : "bg-muted text-muted-foreground"
               )}
             >
-              <Icon className="size-5" aria-hidden="true" />
+              <Icon className="size-3.5" aria-hidden="true" />
             </div>
-            <div className="flex min-w-0 flex-col">
-              <span className="text-sm font-medium leading-tight">{labelOf(tile.key)}</span>
-              <span
-                className="text-xs text-muted-foreground"
+            <div className="min-w-0 w-full">
+              <p
+                className={cn(
+                  "truncate text-xs font-semibold",
+                  selected ? "text-foreground" : "text-muted-foreground group-hover:text-foreground"
+                )}
+              >
+                {labelOf(tile.key)}
+              </p>
+              <p
+                className={cn(
+                  "mt-0.5 text-lg font-bold leading-none tabular-nums",
+                  selected ? "text-foreground" : "text-muted-foreground"
+                )}
                 data-testid={`files-tile-count-${tile.key}`}
               >
                 {loading && value === undefined ? "—" : (value ?? 0)}
-              </span>
+              </p>
             </div>
           </Card>
         )

--- a/frontend/src/components/files/FileListRow.tsx
+++ b/frontend/src/components/files/FileListRow.tsx
@@ -1,0 +1,233 @@
+import { useTranslation } from "react-i18next"
+import { File as FileIcon, FileImage, FileText, Receipt } from "lucide-react"
+
+import { Checkbox } from "@/components/ui/checkbox"
+import type { FileEntity } from "@/features/files/api"
+import { FILE_CATEGORY_TILES, FILE_TAG_PILLS } from "@/features/files/constants"
+import { formatBytes, formatDate } from "@/lib/intl"
+import { cn } from "@/lib/utils"
+
+// One row in the Files list-view (the table-style alternate to the
+// FileCard grid). Mirrors design-mocks/src/views/FileBrowserView.tsx
+// rows ~700–765: 5-column desktop layout (icon / Name+meta / Category
+// badge / Uploaded / Size) and a mobile card-style collapse.
+//
+// Activating the row (click or Enter/Space) opens the detail sheet via
+// `onOpen`. The checkbox sits behind a `data-row-checkbox` boundary so
+// its clicks don't bubble into the row activation handler.
+export interface FileListRowProps {
+  file: FileEntity & { id: string }
+  selected: boolean
+  onToggleSelect: (id: string) => void
+  onOpen: (id: string) => void
+}
+
+export function FileListRow({ file, selected, onToggleSelect, onOpen }: FileListRowProps) {
+  const { t } = useTranslation()
+  const title = file.title?.trim() || file.path?.trim() || file.id
+  const tile = FILE_CATEGORY_TILES.find((c) => c.key === file.category)
+  const categoryIconClass = cn("size-3 shrink-0", tile?.activeColor ?? "text-muted-foreground")
+  const categoryLabelKey = tile?.i18nKey ?? "categoryOther"
+  const categoryLabel = t(`files:${categoryLabelKey}`)
+  const tags = file.tags ?? []
+  // The curated tag pills carry colour metadata; for any tag the user
+  // tagged with (lowercase match) we fall back to the standard text
+  // colour so unknown tags still surface on the row.
+  const matchedTags = tags.map((tag) => {
+    const pill = FILE_TAG_PILLS.find((p) => p.id === tag.toLowerCase())
+    return {
+      id: tag,
+      label: pill ? t(`files:${pill.i18nKey}`) : tag,
+      colorClass: pill?.colorClass ?? "text-muted-foreground",
+    }
+  })
+  const dateStr = file.created_at ? formatDate(file.created_at) : ""
+  const sizeStr = file.size_bytes ? formatBytes(file.size_bytes) : ""
+  const fileTypeIcon = renderFileTypeIcon(file)
+  const openLabel = t("files:list.openDetail", { title, defaultValue: `Open ${title}` })
+
+  return (
+    <li>
+      {/* Desktop row (sm+). The Checkbox lives in column 1 OUTSIDE the
+          activation button so axe doesn't see nested interactive
+          elements; the button covers columns 2–6 which is everything
+          else (icon / Name+meta / Category badge / Uploaded / Size). */}
+      <div
+        className={cn(
+          "hidden grid-cols-[auto_auto_1fr_auto_auto_auto] items-center gap-3 px-3 transition-colors sm:grid",
+          selected ? "bg-accent" : "hover:bg-muted/40"
+        )}
+        data-testid={`file-row-${file.id}`}
+        data-category={file.category}
+      >
+        <Checkbox
+          checked={selected}
+          onCheckedChange={() => onToggleSelect(file.id)}
+          aria-label={t("files:list.selectFile", { title, defaultValue: `Select ${title}` })}
+          data-testid={`file-row-checkbox-${file.id}`}
+        />
+        <button
+          type="button"
+          onClick={() => onOpen(file.id)}
+          aria-label={openLabel}
+          className={cn(
+            "col-span-5 grid cursor-pointer grid-cols-subgrid items-center gap-3 py-2 text-left",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          )}
+        >
+          {fileTypeIcon}
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium" title={title}>
+              {title}
+            </p>
+            {(file.linked_entity_id || matchedTags.length > 0) && (
+              <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                {file.linked_entity_id ? (
+                  <span className="truncate text-xs text-muted-foreground">
+                    {file.linked_entity_type ?? ""}
+                  </span>
+                ) : null}
+                {matchedTags.slice(0, 4).map((tag) => (
+                  <span
+                    key={tag.id}
+                    className={cn("text-[10px] font-medium", tag.colorClass)}
+                    data-testid={`file-row-tag-${file.id}-${tag.id.toLowerCase()}`}
+                  >
+                    #{tag.label}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+          <div
+            className={cn(
+              "flex w-24 items-center justify-center gap-1 rounded-full px-2 py-0.5",
+              tile?.activeBg ?? "bg-muted"
+            )}
+          >
+            {renderCategoryIcon(file.category, categoryIconClass)}
+            <span
+              className={cn(
+                "text-[10px] font-medium",
+                tile?.activeColor ?? "text-muted-foreground"
+              )}
+            >
+              {categoryLabel}
+            </span>
+          </div>
+          <span className="w-28 text-right text-xs text-muted-foreground tabular-nums">
+            {dateStr}
+          </span>
+          <span className="w-16 text-right text-xs text-muted-foreground tabular-nums">
+            {sizeStr}
+          </span>
+        </button>
+      </div>
+
+      {/* Mobile row — card-style collapse. Same Checkbox-outside-button
+          structure as the desktop row, just stacked. */}
+      <div
+        className={cn(
+          "flex items-start gap-3 px-3 py-3 transition-colors sm:hidden",
+          selected ? "bg-accent" : "active:bg-muted/40"
+        )}
+      >
+        <Checkbox
+          checked={selected}
+          onCheckedChange={() => onToggleSelect(file.id)}
+          aria-label={t("files:list.selectFile", { title, defaultValue: `Select ${title}` })}
+          className="mt-0.5"
+        />
+        <button
+          type="button"
+          onClick={() => onOpen(file.id)}
+          aria-label={openLabel}
+          className={cn(
+            "flex flex-1 cursor-pointer items-start gap-3 text-left",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          )}
+        >
+          <div
+            className={cn(
+              "mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg",
+              tile?.activeBg ?? "bg-muted"
+            )}
+          >
+            {renderFileTypeIcon(file, cn("size-4", tile?.activeColor ?? "text-muted-foreground"))}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium leading-tight" title={title}>
+              {title}
+            </p>
+            <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5">
+              <span
+                className={cn(
+                  "flex items-center gap-1 rounded-full px-2 py-0.5",
+                  tile?.activeBg ?? "bg-muted"
+                )}
+              >
+                {renderCategoryIcon(
+                  file.category,
+                  cn("size-2.5 shrink-0", tile?.activeColor ?? "text-muted-foreground")
+                )}
+                <span
+                  className={cn(
+                    "text-[10px] font-medium",
+                    tile?.activeColor ?? "text-muted-foreground"
+                  )}
+                >
+                  {categoryLabel}
+                </span>
+              </span>
+              {matchedTags.slice(0, 3).map((tag) => (
+                <span key={tag.id} className={cn("text-[10px] font-medium", tag.colorClass)}>
+                  #{tag.label}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="mt-0.5 flex shrink-0 flex-col items-end gap-0.5">
+            <span className="text-xs text-muted-foreground tabular-nums">{sizeStr}</span>
+            <span className="text-[10px] whitespace-nowrap text-muted-foreground tabular-nums">
+              {dateStr}
+            </span>
+          </div>
+        </button>
+      </div>
+    </li>
+  )
+}
+
+// renderFileTypeIcon resolves the leading file-type icon as JSX. We
+// return JSX (not a component reference) to satisfy react-hooks's
+// "Cannot create components during render" rule, which flags the
+// PascalCase locals coming back from a switch.
+function renderFileTypeIcon(file: FileEntity, className = "size-4 shrink-0 text-muted-foreground") {
+  const mime = file.mime_type ?? ""
+  if (mime.startsWith("image/")) {
+    return <FileImage className={className} aria-hidden="true" />
+  }
+  if (mime === "application/pdf" || file.category === "documents") {
+    return <FileText className={className} aria-hidden="true" />
+  }
+  if (file.category === "invoices") {
+    return <Receipt className={className} aria-hidden="true" />
+  }
+  return <FileIcon className={className} aria-hidden="true" />
+}
+
+function renderCategoryIcon(
+  category: FileEntity["category"],
+  className = "size-3 shrink-0 text-muted-foreground"
+) {
+  switch (category) {
+    case "images":
+      return <FileImage className={className} aria-hidden="true" />
+    case "invoices":
+      return <Receipt className={className} aria-hidden="true" />
+    case "documents":
+      return <FileText className={className} aria-hidden="true" />
+    default:
+      return <FileIcon className={className} aria-hidden="true" />
+  }
+}

--- a/frontend/src/components/files/FileListRow.tsx
+++ b/frontend/src/components/files/FileListRow.tsx
@@ -4,6 +4,7 @@ import { File as FileIcon, FileImage, FileText, Receipt } from "lucide-react"
 import { Checkbox } from "@/components/ui/checkbox"
 import type { FileEntity } from "@/features/files/api"
 import { FILE_CATEGORY_TILES, FILE_TAG_PILLS } from "@/features/files/constants"
+import { useCategoryLabel, useTagPillLabel } from "@/features/files/labels"
 import { formatBytes, formatDate } from "@/lib/intl"
 import { cn } from "@/lib/utils"
 
@@ -24,11 +25,12 @@ export interface FileListRowProps {
 
 export function FileListRow({ file, selected, onToggleSelect, onOpen }: FileListRowProps) {
   const { t } = useTranslation()
+  const labelOf = useCategoryLabel()
+  const tagLabelOf = useTagPillLabel()
   const title = file.title?.trim() || file.path?.trim() || file.id
   const tile = FILE_CATEGORY_TILES.find((c) => c.key === file.category)
   const categoryIconClass = cn("size-3 shrink-0", tile?.activeColor ?? "text-muted-foreground")
-  const categoryLabelKey = tile?.i18nKey ?? "categoryOther"
-  const categoryLabel = t(`files:${categoryLabelKey}`)
+  const categoryLabel = labelOf((tile?.key ?? "other") as Parameters<typeof labelOf>[0])
   const tags = file.tags ?? []
   // The curated tag pills carry colour metadata; for any tag the user
   // tagged with (lowercase match) we fall back to the standard text
@@ -37,7 +39,7 @@ export function FileListRow({ file, selected, onToggleSelect, onOpen }: FileList
     const pill = FILE_TAG_PILLS.find((p) => p.id === tag.toLowerCase())
     return {
       id: tag,
-      label: pill ? t(`files:${pill.i18nKey}`) : tag,
+      label: pill ? tagLabelOf(pill.id) : tag,
       colorClass: pill?.colorClass ?? "text-muted-foreground",
     }
   })

--- a/frontend/src/components/files/__tests__/CategoryTiles.test.tsx
+++ b/frontend/src/components/files/__tests__/CategoryTiles.test.tsx
@@ -76,4 +76,41 @@ describe("<CategoryTiles />", () => {
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })
+
+  it("collapses to a <select> on mobile breakpoints", async () => {
+    const original = window.matchMedia
+    // Force the useIsMobile hook to read mobile=true via a synchronous
+    // matchMedia stub. Restored in afterEach so it doesn't leak.
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      media: query,
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      onchange: null,
+    })) as unknown as typeof window.matchMedia
+    try {
+      const onSelect = vi.fn()
+      render(
+        <CategoryTiles
+          active="images"
+          counts={{ all: 4, images: 2, invoices: 1, documents: 1, other: 0 }}
+          onSelect={onSelect}
+        />
+      )
+      const sel = screen.getByTestId("files-category-select") as HTMLSelectElement
+      expect(sel.value).toBe("images")
+      // Each option carries the count in its label — the mobile fallback
+      // doubles as a quick reference.
+      expect(sel.textContent).toMatch(/Images \(2\)/)
+      expect(sel.textContent).toMatch(/All \(4\)/)
+      const user = userEvent.setup()
+      await user.selectOptions(sel, "invoices")
+      expect(onSelect).toHaveBeenCalledWith("invoices")
+    } finally {
+      window.matchMedia = original
+    }
+  })
 })

--- a/frontend/src/features/files/constants.ts
+++ b/frontend/src/features/files/constants.ts
@@ -14,11 +14,6 @@ export type FileCategoryTile = "all" | FileCategory
 
 export interface CategoryTile {
   key: FileCategoryTile
-  i18nKey: string
-  // i18n key (under the `files:` namespace) for the contextual subtitle
-  // shown below the tile row when this tile is active. Mirrors the mock's
-  // `CATEGORY_TABS[].description`.
-  descriptionI18nKey: string
   icon: ComponentType<SVGProps<SVGSVGElement>>
   // Tailwind utility class for the icon foreground when this tile is
   // active. The whole point is a per-category accent — All=muted, the
@@ -30,43 +25,36 @@ export interface CategoryTile {
   activeBg: string
 }
 
+// Label + description for each tile go through the static helpers in
+// ./labels.ts so the i18next-cli extractor can see literal `t(...)`
+// keys. Keep the labels.ts switch in sync with this list.
 export const FILE_CATEGORY_TILES: CategoryTile[] = [
   {
     key: "all",
-    i18nKey: "categoryAll",
-    descriptionI18nKey: "descriptionAll",
     icon: FilesIcon,
     activeColor: "text-muted-foreground",
     activeBg: "bg-muted",
   },
   {
     key: "images",
-    i18nKey: "categoryImages",
-    descriptionI18nKey: "descriptionImages",
     icon: FileImage,
     activeColor: "text-status-active",
     activeBg: "bg-status-active/10",
   },
   {
     key: "invoices",
-    i18nKey: "categoryInvoices",
-    descriptionI18nKey: "descriptionInvoices",
     icon: Receipt,
     activeColor: "text-chart-1",
     activeBg: "bg-chart-1/10",
   },
   {
     key: "documents",
-    i18nKey: "categoryDocuments",
-    descriptionI18nKey: "descriptionDocuments",
     icon: FileText,
     activeColor: "text-chart-3",
     activeBg: "bg-chart-3/10",
   },
   {
     key: "other",
-    i18nKey: "categoryOther",
-    descriptionI18nKey: "descriptionOther",
     icon: FileIcon,
     activeColor: "text-chart-4",
     activeBg: "bg-chart-4/10",
@@ -79,9 +67,11 @@ export const FILE_CATEGORY_TILES: CategoryTile[] = [
 // entity (#1400) exists, this list is the canonical taxonomy surfaced
 // in the toolbar; arbitrary user-supplied tags still show on cards
 // but aren't reachable via the toolbar — see #1538 design deviation.
+// Label per tag goes through useTagPillLabel in ./labels.ts so the
+// i18next-cli extractor can see literal `t(...)` keys. Keep the
+// labels.ts switch in sync with this list.
 export interface FileTagPill {
-  id: string
-  i18nKey: string
+  id: "invoice" | "warranty" | "manual" | "photo" | "certificate" | "backup"
   // Tailwind text utility for the pill label and the inline tag chip
   // rendered next to a file's title in the list/grid views. Mirrors
   // the mock's `FILE_TAGS[].color`.
@@ -89,12 +79,12 @@ export interface FileTagPill {
 }
 
 export const FILE_TAG_PILLS: FileTagPill[] = [
-  { id: "invoice", i18nKey: "tagInvoice", colorClass: "text-chart-1" },
-  { id: "warranty", i18nKey: "tagWarranty", colorClass: "text-status-active" },
-  { id: "manual", i18nKey: "tagManual", colorClass: "text-chart-3" },
-  { id: "photo", i18nKey: "tagPhoto", colorClass: "text-status-expiring" },
-  { id: "certificate", i18nKey: "tagCertificate", colorClass: "text-chart-2" },
-  { id: "backup", i18nKey: "tagBackup", colorClass: "text-muted-foreground" },
+  { id: "invoice", colorClass: "text-chart-1" },
+  { id: "warranty", colorClass: "text-status-active" },
+  { id: "manual", colorClass: "text-chart-3" },
+  { id: "photo", colorClass: "text-status-expiring" },
+  { id: "certificate", colorClass: "text-chart-2" },
+  { id: "backup", colorClass: "text-muted-foreground" },
 ]
 
 // Mirrors models.FileCategoryFromMIME on the BE — used to suggest a

--- a/frontend/src/features/files/constants.ts
+++ b/frontend/src/features/files/constants.ts
@@ -15,15 +15,86 @@ export type FileCategoryTile = "all" | FileCategory
 export interface CategoryTile {
   key: FileCategoryTile
   i18nKey: string
+  // i18n key (under the `files:` namespace) for the contextual subtitle
+  // shown below the tile row when this tile is active. Mirrors the mock's
+  // `CATEGORY_TABS[].description`.
+  descriptionI18nKey: string
   icon: ComponentType<SVGProps<SVGSVGElement>>
+  // Tailwind utility class for the icon foreground when this tile is
+  // active. The whole point is a per-category accent — All=muted, the
+  // four real buckets each get a distinct hue so the active tile reads
+  // as "this category" at a glance.
+  activeColor: string
+  // Matching tinted background for the icon chip when active (uses the
+  // same hue as `activeColor` at /10 opacity).
+  activeBg: string
 }
 
 export const FILE_CATEGORY_TILES: CategoryTile[] = [
-  { key: "all", i18nKey: "categoryAll", icon: FilesIcon },
-  { key: "images", i18nKey: "categoryImages", icon: FileImage },
-  { key: "invoices", i18nKey: "categoryInvoices", icon: Receipt },
-  { key: "documents", i18nKey: "categoryDocuments", icon: FileText },
-  { key: "other", i18nKey: "categoryOther", icon: FileIcon },
+  {
+    key: "all",
+    i18nKey: "categoryAll",
+    descriptionI18nKey: "descriptionAll",
+    icon: FilesIcon,
+    activeColor: "text-muted-foreground",
+    activeBg: "bg-muted",
+  },
+  {
+    key: "images",
+    i18nKey: "categoryImages",
+    descriptionI18nKey: "descriptionImages",
+    icon: FileImage,
+    activeColor: "text-status-active",
+    activeBg: "bg-status-active/10",
+  },
+  {
+    key: "invoices",
+    i18nKey: "categoryInvoices",
+    descriptionI18nKey: "descriptionInvoices",
+    icon: Receipt,
+    activeColor: "text-chart-1",
+    activeBg: "bg-chart-1/10",
+  },
+  {
+    key: "documents",
+    i18nKey: "categoryDocuments",
+    descriptionI18nKey: "descriptionDocuments",
+    icon: FileText,
+    activeColor: "text-chart-3",
+    activeBg: "bg-chart-3/10",
+  },
+  {
+    key: "other",
+    i18nKey: "categoryOther",
+    descriptionI18nKey: "descriptionOther",
+    icon: FileIcon,
+    activeColor: "text-chart-4",
+    activeBg: "bg-chart-4/10",
+  },
+]
+
+// Curated tag pills shown in the Files toolbar as quick filters. The
+// real BE filters by exact tag string (`tags @> $`), so each pill's
+// `id` is the literal tag value used to match. Until the proper Tags
+// entity (#1400) exists, this list is the canonical taxonomy surfaced
+// in the toolbar; arbitrary user-supplied tags still show on cards
+// but aren't reachable via the toolbar — see #1538 design deviation.
+export interface FileTagPill {
+  id: string
+  i18nKey: string
+  // Tailwind text utility for the pill label and the inline tag chip
+  // rendered next to a file's title in the list/grid views. Mirrors
+  // the mock's `FILE_TAGS[].color`.
+  colorClass: string
+}
+
+export const FILE_TAG_PILLS: FileTagPill[] = [
+  { id: "invoice", i18nKey: "tagInvoice", colorClass: "text-chart-1" },
+  { id: "warranty", i18nKey: "tagWarranty", colorClass: "text-status-active" },
+  { id: "manual", i18nKey: "tagManual", colorClass: "text-chart-3" },
+  { id: "photo", i18nKey: "tagPhoto", colorClass: "text-status-expiring" },
+  { id: "certificate", i18nKey: "tagCertificate", colorClass: "text-chart-2" },
+  { id: "backup", i18nKey: "tagBackup", colorClass: "text-muted-foreground" },
 ]
 
 // Mirrors models.FileCategoryFromMIME on the BE — used to suggest a

--- a/frontend/src/features/files/labels.ts
+++ b/frontend/src/features/files/labels.ts
@@ -1,0 +1,82 @@
+import { useTranslation } from "react-i18next"
+
+import type { FileCategoryTile } from "./constants"
+
+// i18next-cli's static-key extractor can't see template-literal keys
+// like `t(\`files:${tile.descriptionI18nKey}\`)`, so the catalogue
+// drifts every CI run. These helpers shape every dynamic key as an
+// explicit `t()` call inside a switch, mirroring the pre-existing
+// `useCategoryLabel` pattern. Keep new files-page i18n lookups going
+// through these hooks (or add another switch like them) to keep the
+// extractor happy.
+
+export function useCategoryLabel(): (key: FileCategoryTile) => string {
+  const { t } = useTranslation()
+  return (key) => {
+    switch (key) {
+      case "all":
+        return t("files:categoryAll", { defaultValue: "All" })
+      case "images":
+        return t("files:categoryImages", { defaultValue: "Images" })
+      case "invoices":
+        return t("files:categoryInvoices", { defaultValue: "Invoices" })
+      case "documents":
+        return t("files:categoryDocuments", { defaultValue: "Documents" })
+      case "other":
+        return t("files:categoryOther", { defaultValue: "Other" })
+    }
+  }
+}
+
+export function useCategoryDescription(): (key: FileCategoryTile) => string {
+  const { t } = useTranslation()
+  return (key) => {
+    switch (key) {
+      case "all":
+        return t("files:descriptionAll", {
+          defaultValue: "Every file attached to your inventory",
+        })
+      case "images":
+        return t("files:descriptionImages", {
+          defaultValue: "Item photos — shown on cards and in galleries",
+        })
+      case "invoices":
+        return t("files:descriptionInvoices", {
+          defaultValue: "Purchase receipts for insurance and reports",
+        })
+      case "documents":
+        return t("files:descriptionDocuments", {
+          defaultValue: "Manuals, warranties, certificates",
+        })
+      case "other":
+        return t("files:descriptionOther", {
+          defaultValue: "Backups and miscellaneous files",
+        })
+    }
+  }
+}
+
+// Curated tag-pill ids. Mirrors FILE_TAG_PILLS in constants — kept in
+// sync by hand because the static-extractor needs literal keys to find
+// in the source.
+export type FileTagPillId = "invoice" | "warranty" | "manual" | "photo" | "certificate" | "backup"
+
+export function useTagPillLabel(): (id: FileTagPillId) => string {
+  const { t } = useTranslation()
+  return (id) => {
+    switch (id) {
+      case "invoice":
+        return t("files:tagInvoice", { defaultValue: "Invoice" })
+      case "warranty":
+        return t("files:tagWarranty", { defaultValue: "Warranty" })
+      case "manual":
+        return t("files:tagManual", { defaultValue: "Manual" })
+      case "photo":
+        return t("files:tagPhoto", { defaultValue: "Photo" })
+      case "certificate":
+        return t("files:tagCertificate", { defaultValue: "Certificate" })
+      case "backup":
+        return t("files:tagBackup", { defaultValue: "Backup" })
+    }
+  }
+}

--- a/frontend/src/i18n/locales/en/files.json
+++ b/frontend/src/i18n/locales/en/files.json
@@ -22,18 +22,18 @@
   "categoryDocuments": "Documents",
   "categoryImages": "Images",
   "categoryInvoices": "Invoices",
-  "categoryOther": "Other",
   "categoryMobileLabel": "Category",
-  "descriptionAll": "Every file attached to your inventory",
-  "descriptionDocuments": "Manuals, warranties, certificates",
-  "descriptionImages": "Item photos — shown on cards and in galleries",
-  "descriptionInvoices": "Purchase receipts for insurance and reports",
-  "descriptionOther": "Backups and miscellaneous files",
+  "categoryOther": "Other",
   "cover": {
     "clearLabel": "Clear cover",
     "pinLabel": "Pin as cover",
     "setLabel": "Set as cover"
   },
+  "descriptionAll": "Every file attached to your inventory",
+  "descriptionDocuments": "Manuals, warranties, certificates",
+  "descriptionImages": "Item photos — shown on cards and in galleries",
+  "descriptionInvoices": "Purchase receipts for insurance and reports",
+  "descriptionOther": "Backups and miscellaneous files",
   "detail": {
     "category": "Category",
     "delete": "Delete file",
@@ -107,18 +107,13 @@
   },
   "searchPlaceholder": "Search by title, description, or filename",
   "subtitle": "Photos, invoices, documents, and other files attached to your inventory.",
-  "tagsClearAll": "Clear all",
   "tagBackup": "Backup",
   "tagCertificate": "Certificate",
   "tagInvoice": "Invoice",
   "tagManual": "Manual",
   "tagPhoto": "Photo",
+  "tagsClearAll": "Clear all",
   "tagWarranty": "Warranty",
-  "tagsPlaceholder": "Filter by tag",
-  "view": {
-    "grid": "Grid view",
-    "list": "List view"
-  },
   "title": "Files",
   "upload": {
     "attachTitle": "Attach files",
@@ -152,6 +147,10 @@
   "uploadCta": "Upload files",
   "validation": {
     "pathRequired": "Path is required"
+  },
+  "view": {
+    "grid": "Grid view",
+    "list": "List view"
   },
   "viewer": {
     "close": "Close",

--- a/frontend/src/i18n/locales/en/files.json
+++ b/frontend/src/i18n/locales/en/files.json
@@ -23,6 +23,12 @@
   "categoryImages": "Images",
   "categoryInvoices": "Invoices",
   "categoryOther": "Other",
+  "categoryMobileLabel": "Category",
+  "descriptionAll": "Every file attached to your inventory",
+  "descriptionDocuments": "Manuals, warranties, certificates",
+  "descriptionImages": "Item photos — shown on cards and in galleries",
+  "descriptionInvoices": "Purchase receipts for insurance and reports",
+  "descriptionOther": "Backups and miscellaneous files",
   "cover": {
     "clearLabel": "Clear cover",
     "pinLabel": "Pin as cover",
@@ -85,6 +91,12 @@
     "title": "Files"
   },
   "list": {
+    "columnCategory": "Category",
+    "columnName": "Name",
+    "columnSize": "Size",
+    "columnUploaded": "Uploaded",
+    "footerTotal_one": "{{count}} file · {{size}} total",
+    "footerTotal_other": "{{count}} files · {{size}} total",
     "nextPage": "Next page",
     "openDetail": "Open {{title}}",
     "previousPage": "Previous page",
@@ -95,7 +107,18 @@
   },
   "searchPlaceholder": "Search by title, description, or filename",
   "subtitle": "Photos, invoices, documents, and other files attached to your inventory.",
+  "tagsClearAll": "Clear all",
+  "tagBackup": "Backup",
+  "tagCertificate": "Certificate",
+  "tagInvoice": "Invoice",
+  "tagManual": "Manual",
+  "tagPhoto": "Photo",
+  "tagWarranty": "Warranty",
   "tagsPlaceholder": "Filter by tag",
+  "view": {
+    "grid": "Grid view",
+    "list": "List view"
+  },
   "title": "Files",
   "upload": {
     "attachTitle": "Attach files",

--- a/frontend/src/pages/files/FilesListPage.tsx
+++ b/frontend/src/pages/files/FilesListPage.tsx
@@ -1,13 +1,22 @@
 import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate, useParams, useSearchParams } from "react-router-dom"
-import { ChevronLeft, ChevronRight, Search, Trash2, Upload } from "lucide-react"
+import {
+  ChevronLeft,
+  ChevronRight,
+  LayoutGrid,
+  List,
+  Search,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react"
 
 import { CategoryTiles } from "@/components/files/CategoryTiles"
 import { FileCard } from "@/components/files/FileCard"
 import { FileDetailSheet } from "@/components/files/FileDetailSheet"
 import type { GalleryImage } from "@/components/files/ImageViewer"
-import { TagsInput } from "@/components/files/TagsInput"
+import { FileListRow } from "@/components/files/FileListRow"
 import { UploadFilesDialog } from "@/components/files/UploadFilesDialog"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -16,8 +25,12 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Skeleton } from "@/components/ui/skeleton"
-import type { FileCategoryTile } from "@/features/files/constants"
-import type { FileCategory, ListFilesOptions } from "@/features/files/api"
+import {
+  FILE_CATEGORY_TILES,
+  FILE_TAG_PILLS,
+  type FileCategoryTile,
+} from "@/features/files/constants"
+import type { FileCategory, FileCategoryCounts, ListFilesOptions } from "@/features/files/api"
 import {
   useBulkDeleteFiles,
   useBulkReclassifyFiles,
@@ -27,13 +40,21 @@ import {
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
 import { useConfirm } from "@/hooks/useConfirm"
+import { formatBytes } from "@/lib/intl"
+import { cn } from "@/lib/utils"
 
 const PAGE_SIZE = 24
+const VIEW_MODE_KEY = "files:viewMode"
 
-// Files list page — the centrepiece of #1411. Renders five category
-// tiles with live counts (BE: GET /files/category-counts), a search +
-// tag filter row, and a paginated grid of file cards. Selecting a file
-// opens the detail sheet; selecting the checkbox enables bulk delete.
+type ViewMode = "list" | "grid"
+
+// Files list page — the centrepiece of #1411, polished under #1538.
+// Renders five category tiles with live counts (BE: GET
+// /files/category-counts), a contextual subtitle row + view-mode
+// toggle, search + curated tag pills, and a paginated grid OR table of
+// files. Selecting a file opens the detail sheet; selecting checkboxes
+// enables bulk delete / move. The grid/list toggle persists per-user
+// via localStorage and is also URL-syncable for shareable links.
 export function FilesListPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -47,6 +68,16 @@ export function FilesListPage() {
   const search = searchParams.get("q") ?? ""
   const tags = useMemo(() => splitTags(searchParams.get("tags")), [searchParams])
   const page = parsePageParam(searchParams.get("page"))
+  // View mode: URL `?view=` overrides; otherwise the user's localStorage
+  // pick survives across refreshes; otherwise default = list (per the
+  // #1538 mock).
+  const urlView = searchParams.get("view") as ViewMode | null
+  const [storedView, setStoredView] = useState<ViewMode>(() => {
+    if (typeof window === "undefined") return "list"
+    const raw = window.localStorage.getItem(VIEW_MODE_KEY)
+    return raw === "grid" || raw === "list" ? raw : "list"
+  })
+  const viewMode: ViewMode = urlView === "grid" || urlView === "list" ? urlView : storedView
 
   const [pendingSearch, setPendingSearch] = useState(search)
   // Re-seed input when URL search param changes (back/forward).
@@ -102,16 +133,16 @@ export function FilesListPage() {
     [items]
   )
 
-  // Unique tag list from the current page's files — feeds the
-  // toolbar's tag-filter datalist suggestions until #1400 lands a
-  // proper tags entity. Sorted for stable rendering across renders.
-  const tagSuggestions = useMemo(() => {
-    const set = new Set<string>()
-    for (const it of items) {
-      for (const tag of it.file.tags ?? []) set.add(tag)
-    }
-    return [...set].sort()
-  }, [items])
+  const activeTileMeta =
+    FILE_CATEGORY_TILES.find((c) => c.key === activeTile) ?? FILE_CATEGORY_TILES[0]
+  const ActiveIcon = activeTileMeta.icon
+  // Cumulative footer numbers: when the user is on the synthetic "All"
+  // tile we want the sum across categories (counts.all / counts.bytes.all);
+  // otherwise the bucket totals for the active category. Both are
+  // already scoped to the active search/tag filters by the BE.
+  const counts = countsQuery.data
+  const cumulativeBytes = counts ? bytesForKey(activeTile, counts) : undefined
+  const cumulativeCount = counts ? countForKey(activeTile, counts) : total
 
   function patchParams(next: Record<string, string | null>) {
     setSearchParams((prev) => {
@@ -121,10 +152,32 @@ export function FilesListPage() {
         else out.set(k, v)
       }
       // Resetting filters / category implicitly resets pagination.
-      if (Object.keys(next).some((k) => k !== "page")) out.delete("page")
+      // `view` is presentation-only and never resets the page.
+      if (Object.keys(next).some((k) => k !== "page" && k !== "view")) out.delete("page")
       return out
     })
     setSelected(new Set())
+  }
+
+  function setViewMode(mode: ViewMode) {
+    setStoredView(mode)
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(VIEW_MODE_KEY, mode)
+    }
+    setSearchParams((prev) => {
+      const out = new URLSearchParams(prev)
+      out.set("view", mode)
+      return out
+    })
+  }
+
+  function toggleTagPill(tag: string) {
+    const next = tags.includes(tag) ? tags.filter((x) => x !== tag) : [...tags, tag]
+    patchParams({ tags: next.length ? next.join(",") : null })
+  }
+
+  function clearTagPills() {
+    patchParams({ tags: null })
   }
 
   function toggleOne(id: string) {
@@ -238,40 +291,112 @@ export function FilesListPage() {
         onSelect={(key) => patchParams({ category: key === "all" ? null : key })}
       />
 
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+      {/* Per-category contextual subtitle row + view-mode toggle. The
+          active tile's accent colour tints the mini-icon on the left so
+          the row doubles as a visual reminder of which bucket is on. */}
+      <div className="flex items-center gap-2" data-testid="files-category-subtitle">
+        <div
+          className={cn(
+            "flex size-5 shrink-0 items-center justify-center rounded-md",
+            activeTileMeta.activeBg
+          )}
+        >
+          <ActiveIcon className={cn("size-3", activeTileMeta.activeColor)} aria-hidden="true" />
+        </div>
+        <p className="flex-1 text-xs text-muted-foreground">
+          {t(`files:${activeTileMeta.descriptionI18nKey}`)}
+        </p>
+        <div className="flex gap-1">
+          <Button
+            variant={viewMode === "list" ? "secondary" : "ghost"}
+            size="icon"
+            className="size-8"
+            onClick={() => setViewMode("list")}
+            aria-label={t("files:view.list", { defaultValue: "List view" })}
+            aria-pressed={viewMode === "list"}
+            data-testid="files-view-list"
+          >
+            <List className="size-4" aria-hidden="true" />
+          </Button>
+          <Button
+            variant={viewMode === "grid" ? "secondary" : "ghost"}
+            size="icon"
+            className="size-8"
+            onClick={() => setViewMode("grid")}
+            aria-label={t("files:view.grid", { defaultValue: "Grid view" })}
+            aria-pressed={viewMode === "grid"}
+            data-testid="files-view-grid"
+          >
+            <LayoutGrid className="size-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
         <form
-          className="flex flex-1 items-center gap-2"
+          className="relative"
           onSubmit={(e) => {
             e.preventDefault()
             patchParams({ q: pendingSearch.trim() || null })
           }}
         >
-          <div className="relative flex-1">
-            <Search
-              className="absolute left-2 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
-              aria-hidden="true"
-            />
-            <Input
-              type="search"
-              value={pendingSearch}
-              onChange={(e) => setPendingSearch(e.target.value)}
-              placeholder={t("files:searchPlaceholder")}
-              className="pl-8"
-              data-testid="files-search-input"
-            />
-          </div>
-          <Button type="submit" variant="outline">
-            {t("common:nav.search")}
-          </Button>
-        </form>
-        <div className="lg:w-72">
-          <TagsInput
-            placeholder={t("files:tagsPlaceholder")}
-            values={tags}
-            onChange={(next) => patchParams({ tags: next.length ? next.join(",") : null })}
-            testId="files-tag-filter"
-            suggestions={tagSuggestions}
+          <Search
+            className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
           />
+          <Input
+            type="search"
+            value={pendingSearch}
+            onChange={(e) => setPendingSearch(e.target.value)}
+            placeholder={t("files:searchPlaceholder")}
+            className="pl-8"
+            data-testid="files-search-input"
+          />
+          {/* Submit-on-Enter only; the bare input keeps the toolbar
+              compact like the mock. */}
+          <button type="submit" className="sr-only">
+            {t("common:nav.search")}
+          </button>
+        </form>
+
+        {/* Curated tag-filter pills. Until #1400 lands a proper Tags
+            entity these are the canonical taxonomy surfaced in the
+            toolbar; arbitrary user-supplied tags still appear on
+            individual files but aren't reachable here. */}
+        <div className="flex flex-wrap items-center gap-1.5" data-testid="files-tag-pills">
+          {FILE_TAG_PILLS.map((pill) => {
+            const isActive = tags.includes(pill.id)
+            const label = t(`files:${pill.i18nKey}`)
+            return (
+              <button
+                key={pill.id}
+                type="button"
+                onClick={() => toggleTagPill(pill.id)}
+                aria-pressed={isActive}
+                data-testid={`files-tag-pill-${pill.id}`}
+                className={cn(
+                  "flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-all",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  isActive
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-card text-muted-foreground hover:border-foreground/30 hover:text-foreground"
+                )}
+              >
+                {label}
+                {isActive ? <X className="size-3" aria-hidden="true" /> : null}
+              </button>
+            )
+          })}
+          {tags.length > 0 ? (
+            <button
+              type="button"
+              onClick={clearTagPills}
+              className="ml-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              data-testid="files-tag-clear"
+            >
+              {t("files:tagsClearAll", { defaultValue: "Clear all" })}
+            </button>
+          ) : null}
         </div>
       </div>
 
@@ -309,16 +434,10 @@ export function FilesListPage() {
               <option value="" disabled>
                 {t("files:bulk.move")}
               </option>
-              <option value="images">
-                {t("files:categoryImages", { defaultValue: "Images" })}
-              </option>
-              <option value="invoices">
-                {t("files:categoryInvoices", { defaultValue: "Invoices" })}
-              </option>
-              <option value="documents">
-                {t("files:categoryDocuments", { defaultValue: "Documents" })}
-              </option>
-              <option value="other">{t("files:categoryOther", { defaultValue: "Other" })}</option>
+              <option value="images">{t("files:categoryImages")}</option>
+              <option value="invoices">{t("files:categoryInvoices")}</option>
+              <option value="documents">{t("files:categoryDocuments")}</option>
+              <option value="other">{t("files:categoryOther")}</option>
             </select>
             <Button
               variant="destructive"
@@ -344,11 +463,19 @@ export function FilesListPage() {
       ) : null}
 
       {filesQuery.isLoading ? (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <Skeleton key={i} className="aspect-[4/3] w-full" />
-          ))}
-        </div>
+        viewMode === "grid" ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="aspect-[4/3] w-full" />
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-12 w-full" />
+            ))}
+          </div>
+        )
       ) : items.length === 0 ? (
         <div
           className="flex flex-col items-center justify-center gap-3 rounded-md border border-dashed p-12 text-center"
@@ -367,7 +494,7 @@ export function FilesListPage() {
             </Button>
           ) : null}
         </div>
-      ) : (
+      ) : viewMode === "grid" ? (
         <div
           className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4"
           data-testid="files-grid"
@@ -382,6 +509,44 @@ export function FilesListPage() {
               onOpen={(id) => navigate(filesUrl(groupSlug, id))}
             />
           ))}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border bg-card" data-testid="files-list">
+          {/* Desktop header row — hidden on mobile (rows collapse). */}
+          <div className="hidden grid-cols-[auto_auto_1fr_auto_auto_auto] gap-3 border-b bg-muted/50 px-3 py-2 sm:grid">
+            <div>
+              <Checkbox
+                checked={allSelectedOnPage}
+                onCheckedChange={toggleAllOnPage}
+                aria-label={t("files:list.selectAll")}
+                data-testid="files-list-select-all"
+              />
+            </div>
+            <span className="size-4" aria-hidden="true" />
+            <span className="text-xs font-medium text-muted-foreground">
+              {t("files:list.columnName", { defaultValue: "Name" })}
+            </span>
+            <span className="w-24 text-center text-xs font-medium text-muted-foreground">
+              {t("files:list.columnCategory", { defaultValue: "Category" })}
+            </span>
+            <span className="w-28 text-right text-xs font-medium text-muted-foreground">
+              {t("files:list.columnUploaded", { defaultValue: "Uploaded" })}
+            </span>
+            <span className="w-16 text-right text-xs font-medium text-muted-foreground">
+              {t("files:list.columnSize", { defaultValue: "Size" })}
+            </span>
+          </div>
+          <ul className="divide-y">
+            {items.map(({ file }) => (
+              <FileListRow
+                key={file.id}
+                file={file}
+                selected={selected.has(file.id)}
+                onToggleSelect={toggleOne}
+                onOpen={(id) => navigate(filesUrl(groupSlug, id))}
+              />
+            ))}
+          </ul>
         </div>
       )}
 
@@ -422,6 +587,20 @@ export function FilesListPage() {
             </Button>
           </div>
         </nav>
+      ) : null}
+
+      {/* Cumulative footer — "{N} files · {Y} total". Only shown when
+          we have at least one file in the active filter set so empty
+          buckets don't get a useless "0 files · 0 B total" tail. */}
+      {items.length > 0 && counts && cumulativeBytes !== undefined ? (
+        <p className="text-xs text-muted-foreground" data-testid="files-cumulative-footer">
+          {t("files:list.footerTotal", {
+            count: cumulativeCount ?? items.length,
+            size: formatBytes(cumulativeBytes),
+            defaultValue_one: "{{count}} file · {{size}} total",
+            defaultValue_other: "{{count}} files · {{size}} total",
+          })}
+        </p>
       ) : null}
 
       <FileDetailSheet
@@ -475,4 +654,36 @@ function filesUrl(slug: string, id?: string, suffix?: "edit"): string {
   if (!id) return base
   const url = `${base}/${encodeURIComponent(id)}`
   return suffix ? `${url}/${suffix}` : url
+}
+
+function countForKey(key: FileCategoryTile, counts: FileCategoryCounts): number {
+  switch (key) {
+    case "all":
+      return counts.all ?? 0
+    case "images":
+      return counts.images ?? 0
+    case "invoices":
+      return counts.invoices ?? 0
+    case "documents":
+      return counts.documents ?? 0
+    case "other":
+      return counts.other ?? 0
+  }
+}
+
+function bytesForKey(key: FileCategoryTile, counts: FileCategoryCounts): number {
+  const bytes = counts.bytes
+  if (!bytes) return 0
+  switch (key) {
+    case "all":
+      return bytes.all ?? 0
+    case "images":
+      return bytes.images ?? 0
+    case "invoices":
+      return bytes.invoices ?? 0
+    case "documents":
+      return bytes.documents ?? 0
+    case "other":
+      return bytes.other ?? 0
+  }
 }

--- a/frontend/src/pages/files/FilesListPage.tsx
+++ b/frontend/src/pages/files/FilesListPage.tsx
@@ -30,6 +30,7 @@ import {
   FILE_TAG_PILLS,
   type FileCategoryTile,
 } from "@/features/files/constants"
+import { useCategoryDescription, useTagPillLabel } from "@/features/files/labels"
 import type { FileCategory, FileCategoryCounts, ListFilesOptions } from "@/features/files/api"
 import {
   useBulkDeleteFiles,
@@ -62,6 +63,8 @@ export function FilesListPage() {
   const groupSlug = currentGroup?.slug ?? ""
   const toast = useAppToast()
   const confirm = useConfirm()
+  const descriptionOf = useCategoryDescription()
+  const tagPillLabelOf = useTagPillLabel()
 
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTile = parseTileParam(searchParams.get("category"))
@@ -303,9 +306,7 @@ export function FilesListPage() {
         >
           <ActiveIcon className={cn("size-3", activeTileMeta.activeColor)} aria-hidden="true" />
         </div>
-        <p className="flex-1 text-xs text-muted-foreground">
-          {t(`files:${activeTileMeta.descriptionI18nKey}`)}
-        </p>
+        <p className="flex-1 text-xs text-muted-foreground">{descriptionOf(activeTile)}</p>
         <div className="flex gap-1">
           <Button
             variant={viewMode === "list" ? "secondary" : "ghost"}
@@ -366,7 +367,7 @@ export function FilesListPage() {
         <div className="flex flex-wrap items-center gap-1.5" data-testid="files-tag-pills">
           {FILE_TAG_PILLS.map((pill) => {
             const isActive = tags.includes(pill.id)
-            const label = t(`files:${pill.i18nKey}`)
+            const label = tagPillLabelOf(pill.id)
             return (
               <button
                 key={pill.id}
@@ -671,9 +672,13 @@ function countForKey(key: FileCategoryTile, counts: FileCategoryCounts): number 
   }
 }
 
-function bytesForKey(key: FileCategoryTile, counts: FileCategoryCounts): number {
+function bytesForKey(key: FileCategoryTile, counts: FileCategoryCounts): number | undefined {
+  // Returning `undefined` (not `0`) when the BE didn't ship a `bytes`
+  // sub-object — the footer's render gate checks
+  // `cumulativeBytes !== undefined`, so dropping a `0` here would
+  // surface a misleading "0 B total" against an unknown total.
   const bytes = counts.bytes
-  if (!bytes) return 0
+  if (!bytes) return undefined
   switch (key) {
     case "all":
       return bytes.all ?? 0

--- a/frontend/src/pages/files/__tests__/FilesListPage.test.tsx
+++ b/frontend/src/pages/files/__tests__/FilesListPage.test.tsx
@@ -87,16 +87,28 @@ describe("<FilesListPage />", () => {
     expect(await screen.findByTestId("files-empty")).toBeInTheDocument()
   })
 
-  it("lists files returned from the BE and renders them as cards", async () => {
+  it("lists files returned from the BE and renders them as list rows by default", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),
       ...fileHandlers.list(SLUG, [fileRow("f1"), fileRow("f2")]),
       ...fileHandlers.counts(SLUG, { all: 2, images: 2 })
     )
     renderPage()
+    // List view is the default per the #1538 mock — files render as
+    // table rows. The grid renderer is exercised by the view-toggle test.
+    expect(await screen.findByTestId("file-row-f1")).toBeInTheDocument()
+    expect(screen.getByTestId("file-row-f2")).toBeInTheDocument()
+    expect(screen.getAllByText("File f1").length).toBeGreaterThan(0)
+  })
+
+  it("renders the FileCard grid when ?view=grid is set in the URL", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...fileHandlers.list(SLUG, [fileRow("f1")]),
+      ...fileHandlers.counts(SLUG, { all: 1, images: 1 })
+    )
+    renderPage(`/g/${SLUG}/files?view=grid`)
     expect(await screen.findByTestId("file-card-f1")).toBeInTheDocument()
-    expect(screen.getByTestId("file-card-f2")).toBeInTheDocument()
-    expect(screen.getByText("File f1")).toBeInTheDocument()
   })
 
   it("renders the four category tiles with counts from the counts endpoint", async () => {
@@ -134,7 +146,7 @@ describe("<FilesListPage />", () => {
     expect(screen.getByTestId("files-tile-all")).toHaveAttribute("aria-selected", "false")
   })
 
-  it("opens the bulk-delete bar when a card is selected", async () => {
+  it("opens the bulk-delete bar when a list row checkbox is selected", async () => {
     const user = userEvent.setup()
     server.use(
       ...groupHandlers.list(groupFixture),
@@ -142,8 +154,11 @@ describe("<FilesListPage />", () => {
       ...fileHandlers.counts(SLUG, { all: 1 })
     )
     renderPage()
-    await screen.findByTestId("file-card-f1")
-    await user.click(screen.getByTestId("file-card-checkbox-f1"))
+    await screen.findByTestId("file-row-f1")
+    // The desktop row checkbox is the visible-by-default branch in
+    // jsdom (matchMedia stub returns matches=false → desktop).
+    const checkboxes = screen.getAllByLabelText(/select file f1/i)
+    await user.click(checkboxes[0])
     expect(await screen.findByTestId("files-bulk-bar")).toBeInTheDocument()
   })
 
@@ -154,7 +169,7 @@ describe("<FilesListPage />", () => {
       ...fileHandlers.counts(SLUG, { all: 1, images: 1 })
     )
     const { container } = renderPage()
-    await screen.findByTestId("file-card-f1")
+    await screen.findByTestId("file-row-f1")
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })
@@ -212,8 +227,9 @@ describe("<FilesListPage />", () => {
       ...fileHandlers.update(SLUG, "f1", { id: "f1", category: "documents" })
     )
     renderPage()
-    await screen.findByTestId("file-card-f1")
-    await user.click(screen.getByTestId("file-card-checkbox-f1"))
+    await screen.findByTestId("file-row-f1")
+    const checkboxes = screen.getAllByLabelText(/select file f1/i)
+    await user.click(checkboxes[0])
     await screen.findByTestId("files-bulk-bar")
     const moveSelect = screen.getByTestId("files-bulk-move") as HTMLSelectElement
     await user.selectOptions(moveSelect, "documents")
@@ -221,19 +237,76 @@ describe("<FilesListPage />", () => {
     await waitFor(() => expect(screen.queryByTestId("files-bulk-bar")).not.toBeInTheDocument())
   })
 
-  it("preserves the active tag filter from the URL query", async () => {
+  it("reflects the active tag filter from the URL on the matching pill", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),
-      ...fileHandlers.list(SLUG, [fileRow("f1", { tags: ["receipt"] })]),
+      ...fileHandlers.list(SLUG, [fileRow("f1", { tags: ["invoice"] })]),
       ...fileHandlers.counts(SLUG, { all: 1 })
     )
-    renderPage(`/g/${SLUG}/files?tags=receipt,important`)
-    await screen.findByTestId("file-card-f1")
-    // Both tags persist as chips in the toolbar's tag-filter input.
-    const chips = screen.getAllByTestId("files-tag-filter-chip")
-    const labels = chips.map((c) => c.textContent?.trim())
-    expect(labels).toContain("receipt")
-    expect(labels).toContain("important")
+    renderPage(`/g/${SLUG}/files?tags=invoice`)
+    await screen.findByTestId("file-row-f1")
+    // The curated pill matching the URL tag is pressed; the others are
+    // not. Custom tags (not in FILE_TAG_PILLS) don't render as pills.
+    expect(screen.getByTestId("files-tag-pill-invoice")).toHaveAttribute("aria-pressed", "true")
+    expect(screen.getByTestId("files-tag-pill-warranty")).toHaveAttribute("aria-pressed", "false")
+  })
+
+  it("toggles a curated tag pill — flips aria-pressed and reveals Clear all", async () => {
+    const user = userEvent.setup()
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...fileHandlers.list(SLUG, []),
+      ...fileHandlers.counts(SLUG, { all: 0 })
+    )
+    renderPage()
+    const pill = await screen.findByTestId("files-tag-pill-warranty")
+    expect(pill).toHaveAttribute("aria-pressed", "false")
+    expect(screen.queryByTestId("files-tag-clear")).not.toBeInTheDocument()
+    await user.click(pill)
+    await waitFor(() =>
+      expect(screen.getByTestId("files-tag-pill-warranty")).toHaveAttribute("aria-pressed", "true")
+    )
+    expect(screen.getByTestId("files-tag-clear")).toBeInTheDocument()
+  })
+
+  it("toggles between list and grid views via the toolbar buttons", async () => {
+    const user = userEvent.setup()
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...fileHandlers.list(SLUG, [fileRow("f1")]),
+      ...fileHandlers.counts(SLUG, { all: 1, images: 1 })
+    )
+    renderPage()
+    // Default = list view (per the #1538 mock).
+    expect(await screen.findByTestId("files-list")).toBeInTheDocument()
+    expect(screen.getByTestId("file-row-f1")).toBeInTheDocument()
+    expect(screen.queryByTestId("files-grid")).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId("files-view-grid"))
+    expect(await screen.findByTestId("files-grid")).toBeInTheDocument()
+    expect(screen.getByTestId("file-card-f1")).toBeInTheDocument()
+    expect(screen.queryByTestId("files-list")).not.toBeInTheDocument()
+  })
+
+  it("renders the cumulative footer with humanised total bytes", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...fileHandlers.list(SLUG, [fileRow("f1")]),
+      ...fileHandlers.counts(SLUG, {
+        all: 1,
+        images: 1,
+        bytes: { images: 1024, all: 1024 },
+      })
+    )
+    renderPage()
+    const footer = await screen.findByTestId("files-cumulative-footer")
+    // Shape of "{N} file · {Y} total" — formatBytes() emits binary
+    // units (KiB / MiB / …) per ECMAScript Intl conventions; the
+    // assertion is loose on the unit so locale shifts don't fail the
+    // test.
+    expect(footer.textContent).toMatch(/1\s*file/i)
+    expect(footer.textContent).toMatch(/total/i)
+    expect(footer.textContent).toMatch(/[KMG]i?B/i)
   })
 
   it("opens the file detail sheet when navigating to /files/:id directly", async () => {
@@ -266,7 +339,7 @@ describe("<FilesListPage />", () => {
       ...fileHandlers.counts(SLUG, { all: 50 })
     )
     renderPage()
-    await screen.findByTestId("file-card-f0")
+    await screen.findByTestId("file-row-f0")
     expect(screen.getByTestId("files-pagination")).toBeInTheDocument()
   })
 
@@ -278,10 +351,9 @@ describe("<FilesListPage />", () => {
       ...fileHandlers.counts(SLUG, { all: 1 })
     )
     renderPage()
-    await screen.findByTestId("file-card-f1")
+    await screen.findByTestId("file-row-f1")
     const input = screen.getByTestId("files-search-input") as HTMLInputElement
-    await user.type(input, "invoice")
-    await user.click(screen.getByRole("button", { name: /^search$/i }))
+    await user.type(input, "invoice{Enter}")
     // The toolbar pendingSearch state was committed to URL params; the
     // input retains the typed value through the rerender.
     await waitFor(() => expect(input.value).toBe("invoice"))

--- a/frontend/src/test/handlers/files.ts
+++ b/frontend/src/test/handlers/files.ts
@@ -32,7 +32,20 @@ export function list(
 
 export function counts(
   slug: string,
-  data: { images?: number; invoices?: number; documents?: number; other?: number; all?: number }
+  data: {
+    images?: number
+    invoices?: number
+    documents?: number
+    other?: number
+    all?: number
+    bytes?: {
+      images?: number
+      invoices?: number
+      documents?: number
+      other?: number
+      all?: number
+    }
+  }
 ) {
   return [
     http.get(apiUrl(`/g/${encodeURIComponent(slug)}/files/category-counts`), () =>
@@ -43,6 +56,7 @@ export function counts(
           documents: 0,
           other: 0,
           all: 0,
+          bytes: { images: 0, invoices: 0, documents: 0, other: 0, all: 0 },
           ...data,
         },
       })

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -6140,12 +6140,40 @@ export type components = {
             data?: components["schemas"]["jsonapi.ExportResponseData"][];
             meta?: components["schemas"]["jsonapi.ExportsMeta"];
         };
+        "jsonapi.FileCategoryBytes": {
+            /**
+             * Format: int64
+             * @example 1966080
+             */
+            all?: number;
+            /**
+             * Format: int64
+             * @example 262144
+             */
+            documents?: number;
+            /**
+             * Format: int64
+             * @example 1048576
+             */
+            images?: number;
+            /**
+             * Format: int64
+             * @example 524288
+             */
+            invoices?: number;
+            /**
+             * Format: int64
+             * @example 131072
+             */
+            other?: number;
+        };
         "jsonapi.FileCategoryCounts": {
             /**
              * Format: int64
              * @example 11
              */
             all?: number;
+            bytes?: components["schemas"]["jsonapi.FileCategoryBytes"];
             /**
              * Format: int64
              * @example 1

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -544,13 +544,13 @@ func (api *filesAPI) listCategoryCounts(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	counts, err := registrySet.FileRegistry.CountByCategory(r.Context(), searchParam, fileType, tags)
+	counts, bytes, err := registrySet.FileRegistry.CountByCategory(r.Context(), searchParam, fileType, tags)
 	if err != nil {
 		renderEntityError(w, r, err)
 		return
 	}
 
-	response := jsonapi.NewFileCategoryCountsResponse(counts)
+	response := jsonapi.NewFileCategoryCountsResponse(counts, bytes)
 	if err := render.Render(w, r, response); err != nil {
 		internalServerError(w, r, err)
 		return

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -6510,6 +6510,36 @@ const docTemplate = `{
                 }
             }
         },
+        "jsonapi.FileCategoryBytes": {
+            "type": "object",
+            "properties": {
+                "all": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 1966080
+                },
+                "documents": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 262144
+                },
+                "images": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 1048576
+                },
+                "invoices": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 524288
+                },
+                "other": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 131072
+                }
+            }
+        },
         "jsonapi.FileCategoryCounts": {
             "type": "object",
             "properties": {
@@ -6517,6 +6547,9 @@ const docTemplate = `{
                     "type": "integer",
                     "format": "int64",
                     "example": 11
+                },
+                "bytes": {
+                    "$ref": "#/definitions/jsonapi.FileCategoryBytes"
                 },
                 "documents": {
                     "type": "integer",

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -6503,6 +6503,36 @@
                 }
             }
         },
+        "jsonapi.FileCategoryBytes": {
+            "type": "object",
+            "properties": {
+                "all": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 1966080
+                },
+                "documents": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 262144
+                },
+                "images": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 1048576
+                },
+                "invoices": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 524288
+                },
+                "other": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 131072
+                }
+            }
+        },
         "jsonapi.FileCategoryCounts": {
             "type": "object",
             "properties": {
@@ -6510,6 +6540,9 @@
                     "type": "integer",
                     "format": "int64",
                     "example": 11
+                },
+                "bytes": {
+                    "$ref": "#/definitions/jsonapi.FileCategoryBytes"
                 },
                 "documents": {
                     "type": "integer",

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1082,12 +1082,37 @@ definitions:
       meta:
         $ref: '#/definitions/jsonapi.ExportsMeta'
     type: object
+  jsonapi.FileCategoryBytes:
+    properties:
+      all:
+        example: 1966080
+        format: int64
+        type: integer
+      documents:
+        example: 262144
+        format: int64
+        type: integer
+      images:
+        example: 1048576
+        format: int64
+        type: integer
+      invoices:
+        example: 524288
+        format: int64
+        type: integer
+      other:
+        example: 131072
+        format: int64
+        type: integer
+    type: object
   jsonapi.FileCategoryCounts:
     properties:
       all:
         example: 11
         format: int64
         type: integer
+      bytes:
+        $ref: '#/definitions/jsonapi.FileCategoryBytes'
       documents:
         example: 1
         format: int64

--- a/go/jsonapi/files.go
+++ b/go/jsonapi/files.go
@@ -87,13 +87,28 @@ func NewFilesResponse(files []*models.FileEntity, total int) *FilesResponse {
 
 // FileCategoryCounts is the per-category count payload for the four UI tiles.
 // `All` is the sum across the four buckets, scoped to the same filters as the
-// containing GET /files/category-counts request.
+// containing GET /files/category-counts request. `Bytes` carries the same
+// shape but with per-category byte totals so the Files page can render the
+// cumulative "{N} files · {Y} total" footer without a second round-trip.
 type FileCategoryCounts struct {
-	Images    int `json:"images" example:"3" format:"int64"`
-	Invoices  int `json:"invoices" example:"5" format:"int64"`
-	Documents int `json:"documents" example:"1" format:"int64"`
-	Other     int `json:"other" example:"2" format:"int64"`
-	All       int `json:"all" example:"11" format:"int64"`
+	Images    int                `json:"images" example:"3" format:"int64"`
+	Invoices  int                `json:"invoices" example:"5" format:"int64"`
+	Documents int                `json:"documents" example:"1" format:"int64"`
+	Other     int                `json:"other" example:"2" format:"int64"`
+	All       int                `json:"all" example:"11" format:"int64"`
+	Bytes     FileCategoryBytes  `json:"bytes"`
+}
+
+// FileCategoryBytes is the per-category byte-total payload, mirroring
+// FileCategoryCounts. `All` is the sum across the four buckets so the FE can
+// pick the right number based on the active tile (and read All when the user
+// is on the synthetic "All" filter).
+type FileCategoryBytes struct {
+	Images    int64 `json:"images" example:"1048576" format:"int64"`
+	Invoices  int64 `json:"invoices" example:"524288" format:"int64"`
+	Documents int64 `json:"documents" example:"262144" format:"int64"`
+	Other     int64 `json:"other" example:"131072" format:"int64"`
+	All       int64 `json:"all" example:"1966080" format:"int64"`
 }
 
 // FileCategoryCountsResponse is the JSON:API envelope for category counts.
@@ -101,17 +116,24 @@ type FileCategoryCountsResponse struct {
 	Data FileCategoryCounts `json:"data"`
 }
 
-// NewFileCategoryCountsResponse fills the four buckets from the registry map
-// and computes `All` so callers don't have to. Missing buckets are treated as
-// zero, matching the registry contract.
-func NewFileCategoryCountsResponse(counts map[models.FileCategory]int) *FileCategoryCountsResponse {
+// NewFileCategoryCountsResponse fills the four buckets from the registry maps
+// and computes `All` (both count and bytes) so callers don't have to. Missing
+// buckets are treated as zero, matching the registry contract.
+func NewFileCategoryCountsResponse(counts map[models.FileCategory]int, bytes map[models.FileCategory]int64) *FileCategoryCountsResponse {
 	data := FileCategoryCounts{
 		Images:    counts[models.FileCategoryImages],
 		Invoices:  counts[models.FileCategoryInvoices],
 		Documents: counts[models.FileCategoryDocuments],
 		Other:     counts[models.FileCategoryOther],
+		Bytes: FileCategoryBytes{
+			Images:    bytes[models.FileCategoryImages],
+			Invoices:  bytes[models.FileCategoryInvoices],
+			Documents: bytes[models.FileCategoryDocuments],
+			Other:     bytes[models.FileCategoryOther],
+		},
 	}
 	data.All = data.Images + data.Invoices + data.Documents + data.Other
+	data.Bytes.All = data.Bytes.Images + data.Bytes.Invoices + data.Bytes.Documents + data.Bytes.Other
 	return &FileCategoryCountsResponse{Data: data}
 }
 

--- a/go/jsonapi/files.go
+++ b/go/jsonapi/files.go
@@ -91,12 +91,12 @@ func NewFilesResponse(files []*models.FileEntity, total int) *FilesResponse {
 // shape but with per-category byte totals so the Files page can render the
 // cumulative "{N} files · {Y} total" footer without a second round-trip.
 type FileCategoryCounts struct {
-	Images    int                `json:"images" example:"3" format:"int64"`
-	Invoices  int                `json:"invoices" example:"5" format:"int64"`
-	Documents int                `json:"documents" example:"1" format:"int64"`
-	Other     int                `json:"other" example:"2" format:"int64"`
-	All       int                `json:"all" example:"11" format:"int64"`
-	Bytes     FileCategoryBytes  `json:"bytes"`
+	Images    int               `json:"images" example:"3" format:"int64"`
+	Invoices  int               `json:"invoices" example:"5" format:"int64"`
+	Documents int               `json:"documents" example:"1" format:"int64"`
+	Other     int               `json:"other" example:"2" format:"int64"`
+	All       int               `json:"all" example:"11" format:"int64"`
+	Bytes     FileCategoryBytes `json:"bytes"`
 }
 
 // FileCategoryBytes is the per-category byte-total payload, mirroring

--- a/go/jsonapi/files_category_test.go
+++ b/go/jsonapi/files_category_test.go
@@ -77,11 +77,11 @@ func TestNewFileCategoryCountsResponse(t *testing.T) {
 
 		var parsed struct {
 			Data struct {
-				Images    int   `json:"images"`
-				Invoices  int   `json:"invoices"`
-				Documents int   `json:"documents"`
-				Other     int   `json:"other"`
-				All       int   `json:"all"`
+				Images    int `json:"images"`
+				Invoices  int `json:"invoices"`
+				Documents int `json:"documents"`
+				Other     int `json:"other"`
+				All       int `json:"all"`
 				Bytes     struct {
 					Images    int64 `json:"images"`
 					Invoices  int64 `json:"invoices"`

--- a/go/jsonapi/files_category_test.go
+++ b/go/jsonapi/files_category_test.go
@@ -20,44 +20,86 @@ func TestNewFileCategoryCountsResponse(t *testing.T) {
 			models.FileCategoryDocuments: 1,
 			models.FileCategoryOther:     2,
 		}
-		resp := jsonapi.NewFileCategoryCountsResponse(counts)
+		bytes := map[models.FileCategory]int64{
+			models.FileCategoryImages:    1024,
+			models.FileCategoryInvoices:  2048,
+			models.FileCategoryDocuments: 4096,
+			models.FileCategoryOther:     8192,
+		}
+		resp := jsonapi.NewFileCategoryCountsResponse(counts, bytes)
 		c.Assert(resp.Data.Images, qt.Equals, 3)
 		c.Assert(resp.Data.Invoices, qt.Equals, 5)
 		c.Assert(resp.Data.Documents, qt.Equals, 1)
 		c.Assert(resp.Data.Other, qt.Equals, 2)
 		c.Assert(resp.Data.All, qt.Equals, 11)
+		c.Assert(resp.Data.Bytes.Images, qt.Equals, int64(1024))
+		c.Assert(resp.Data.Bytes.Invoices, qt.Equals, int64(2048))
+		c.Assert(resp.Data.Bytes.Documents, qt.Equals, int64(4096))
+		c.Assert(resp.Data.Bytes.Other, qt.Equals, int64(8192))
+		c.Assert(resp.Data.Bytes.All, qt.Equals, int64(1024+2048+4096+8192))
 	})
 
 	t.Run("missing buckets default to zero", func(t *testing.T) {
 		c := qt.New(t)
 
-		resp := jsonapi.NewFileCategoryCountsResponse(map[models.FileCategory]int{
-			models.FileCategoryImages: 4,
-		})
+		resp := jsonapi.NewFileCategoryCountsResponse(
+			map[models.FileCategory]int{
+				models.FileCategoryImages: 4,
+			},
+			map[models.FileCategory]int64{
+				models.FileCategoryImages: 1024,
+			},
+		)
 		c.Assert(resp.Data.Images, qt.Equals, 4)
 		c.Assert(resp.Data.Invoices, qt.Equals, 0)
 		c.Assert(resp.Data.Documents, qt.Equals, 0)
 		c.Assert(resp.Data.Other, qt.Equals, 0)
 		c.Assert(resp.Data.All, qt.Equals, 4)
+		c.Assert(resp.Data.Bytes.Images, qt.Equals, int64(1024))
+		c.Assert(resp.Data.Bytes.All, qt.Equals, int64(1024))
 	})
 
 	t.Run("JSON shape matches the FE tile renderer contract", func(t *testing.T) {
 		c := qt.New(t)
 
-		resp := jsonapi.NewFileCategoryCountsResponse(map[models.FileCategory]int{
-			models.FileCategoryImages:   1,
-			models.FileCategoryInvoices: 2,
-		})
+		resp := jsonapi.NewFileCategoryCountsResponse(
+			map[models.FileCategory]int{
+				models.FileCategoryImages:   1,
+				models.FileCategoryInvoices: 2,
+			},
+			map[models.FileCategory]int64{
+				models.FileCategoryImages:   100,
+				models.FileCategoryInvoices: 200,
+			},
+		)
 		raw, err := json.Marshal(resp)
 		c.Assert(err, qt.IsNil)
 
-		var parsed map[string]map[string]int
+		var parsed struct {
+			Data struct {
+				Images    int   `json:"images"`
+				Invoices  int   `json:"invoices"`
+				Documents int   `json:"documents"`
+				Other     int   `json:"other"`
+				All       int   `json:"all"`
+				Bytes     struct {
+					Images    int64 `json:"images"`
+					Invoices  int64 `json:"invoices"`
+					Documents int64 `json:"documents"`
+					Other     int64 `json:"other"`
+					All       int64 `json:"all"`
+				} `json:"bytes"`
+			} `json:"data"`
+		}
 		err = json.Unmarshal(raw, &parsed)
 		c.Assert(err, qt.IsNil)
-		c.Assert(parsed["data"]["images"], qt.Equals, 1)
-		c.Assert(parsed["data"]["invoices"], qt.Equals, 2)
-		c.Assert(parsed["data"]["documents"], qt.Equals, 0)
-		c.Assert(parsed["data"]["other"], qt.Equals, 0)
-		c.Assert(parsed["data"]["all"], qt.Equals, 3)
+		c.Assert(parsed.Data.Images, qt.Equals, 1)
+		c.Assert(parsed.Data.Invoices, qt.Equals, 2)
+		c.Assert(parsed.Data.Documents, qt.Equals, 0)
+		c.Assert(parsed.Data.Other, qt.Equals, 0)
+		c.Assert(parsed.Data.All, qt.Equals, 3)
+		c.Assert(parsed.Data.Bytes.Images, qt.Equals, int64(100))
+		c.Assert(parsed.Data.Bytes.Invoices, qt.Equals, int64(200))
+		c.Assert(parsed.Data.Bytes.All, qt.Equals, int64(300))
 	})
 }

--- a/go/registry/memory/files.go
+++ b/go/registry/memory/files.go
@@ -199,11 +199,13 @@ func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fil
 
 // CountByCategory aggregates files matching the same filters as Search,
 // grouped by Category. Always returns all four buckets (zero-filled),
-// keeping the response shape stable for the FE tile renderer.
-func (r *FileRegistry) CountByCategory(ctx context.Context, query string, fileType *models.FileType, tags []string) (map[models.FileCategory]int, error) {
+// keeping the response shape stable for the FE tile renderer. The second
+// returned map carries per-category byte totals (sum of size_bytes); the
+// FE uses it to render the cumulative "{N} files · {Y} total" footer.
+func (r *FileRegistry) CountByCategory(ctx context.Context, query string, fileType *models.FileType, tags []string) (map[models.FileCategory]int, map[models.FileCategory]int64, error) {
 	files, err := r.Search(ctx, query, fileType, nil, tags, nil, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	counts := map[models.FileCategory]int{
@@ -212,10 +214,17 @@ func (r *FileRegistry) CountByCategory(ctx context.Context, query string, fileTy
 		models.FileCategoryDocuments: 0,
 		models.FileCategoryOther:     0,
 	}
+	bytes := map[models.FileCategory]int64{
+		models.FileCategoryImages:    0,
+		models.FileCategoryInvoices:  0,
+		models.FileCategoryDocuments: 0,
+		models.FileCategoryOther:     0,
+	}
 	for _, file := range files {
 		counts[file.Category]++
+		bytes[file.Category] += file.SizeBytes
 	}
-	return counts, nil
+	return counts, bytes, nil
 }
 
 // ListPendingSizeBackfill mirrors the postgres method — returns up to

--- a/go/registry/memory/files_category_test.go
+++ b/go/registry/memory/files_category_test.go
@@ -66,23 +66,28 @@ func TestFileRegistry_Memory_FilterByCategory(t *testing.T) {
 
 	t.Run("CountByCategory returns all four buckets", func(t *testing.T) {
 		c := qt.New(t)
-		counts, err := reg.CountByCategory(ctx, "", nil, nil)
+		counts, bytes, err := reg.CountByCategory(ctx, "", nil, nil)
 		c.Assert(err, qt.IsNil)
 		c.Assert(counts, qt.HasLen, 4)
 		c.Assert(counts[models.FileCategoryImages], qt.Equals, 2)
 		c.Assert(counts[models.FileCategoryInvoices], qt.Equals, 1)
 		c.Assert(counts[models.FileCategoryDocuments], qt.Equals, 1)
 		c.Assert(counts[models.FileCategoryOther], qt.Equals, 1)
+		// Seed rows have SizeBytes==0; the bytes map is still always
+		// populated with the four buckets so callers don't NPE.
+		c.Assert(bytes, qt.HasLen, 4)
+		c.Assert(bytes[models.FileCategoryImages], qt.Equals, int64(0))
 	})
 
 	t.Run("CountByCategory respects tag filter", func(t *testing.T) {
 		c := qt.New(t)
-		counts, err := reg.CountByCategory(ctx, "", nil, []string{"manual"})
+		counts, bytes, err := reg.CountByCategory(ctx, "", nil, []string{"manual"})
 		c.Assert(err, qt.IsNil)
 		c.Assert(counts[models.FileCategoryImages], qt.Equals, 0)
 		c.Assert(counts[models.FileCategoryDocuments], qt.Equals, 1)
 		c.Assert(counts[models.FileCategoryInvoices], qt.Equals, 0)
 		c.Assert(counts[models.FileCategoryOther], qt.Equals, 0)
+		c.Assert(bytes[models.FileCategoryDocuments], qt.Equals, int64(0))
 	})
 }
 
@@ -238,6 +243,62 @@ func categoryTestFiles() []models.FileEntity {
 		mk("manual-1", "application/pdf", ".pdf", models.FileCategoryDocuments, "manual"),
 		mk("clip-1", "video/mp4", ".mp4", models.FileCategoryOther),
 	}
+}
+
+// TestFileRegistry_Memory_CountByCategory_Bytes asserts the per-category
+// byte totals returned by CountByCategory aggregate SizeBytes correctly.
+// Used by the Files page's cumulative "{N} files · {Y} total" footer.
+func TestFileRegistry_Memory_CountByCategory_Bytes(t *testing.T) {
+	c := qt.New(t)
+
+	ctx := appctx.WithUser(c.Context(), &models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "user-1"},
+			TenantID: "tenant-1",
+		},
+	})
+	ctx = appctx.WithGroup(ctx, &models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "group-1"},
+			TenantID: "tenant-1",
+		},
+		Slug: "g1",
+	})
+
+	reg := memory.NewFileRegistryFactory().MustCreateUserRegistry(ctx)
+
+	mk := func(name, mime, ext string, cat models.FileCategory, size int64) models.FileEntity {
+		return models.FileEntity{
+			Title:    name,
+			Type:     models.FileTypeFromMIME(mime),
+			Category: cat,
+			File: &models.File{
+				Path:         name,
+				OriginalPath: name + ext,
+				Ext:          ext,
+				MIMEType:     mime,
+				SizeBytes:    size,
+			},
+		}
+	}
+	for _, fe := range []models.FileEntity{
+		mk("photo-1", "image/jpeg", ".jpg", models.FileCategoryImages, 1024),
+		mk("photo-2", "image/png", ".png", models.FileCategoryImages, 2048),
+		mk("invoice-1", "application/pdf", ".pdf", models.FileCategoryInvoices, 4096),
+		mk("manual-1", "application/pdf", ".pdf", models.FileCategoryDocuments, 8192),
+		mk("clip-1", "video/mp4", ".mp4", models.FileCategoryOther, 16384),
+	} {
+		_, err := reg.Create(ctx, fe)
+		c.Assert(err, qt.IsNil)
+	}
+
+	counts, bytes, err := reg.CountByCategory(ctx, "", nil, nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(counts[models.FileCategoryImages], qt.Equals, 2)
+	c.Assert(bytes[models.FileCategoryImages], qt.Equals, int64(1024+2048))
+	c.Assert(bytes[models.FileCategoryInvoices], qt.Equals, int64(4096))
+	c.Assert(bytes[models.FileCategoryDocuments], qt.Equals, int64(8192))
+	c.Assert(bytes[models.FileCategoryOther], qt.Equals, int64(16384))
 }
 
 // TestFileRegistry_Memory_SumSizeBreakdown checks the per-bucket byte

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -437,9 +437,17 @@ func (r *FileRegistry) ListPaginated(ctx context.Context, offset, limit int, fil
 // CountByCategory aggregates files matching the same filters as Search,
 // grouped by Category. The four buckets are always present in the result
 // (zero-filled when missing) so the FE tile renderer can rely on a stable
-// shape.
-func (r *FileRegistry) CountByCategory(ctx context.Context, query string, fileType *models.FileType, tags []string) (map[models.FileCategory]int, error) {
+// shape. The second returned map carries the per-category sum of
+// size_bytes — the FE consumes it to render the cumulative
+// "{N} files · {Y} total" footer alongside the tile counts.
+func (r *FileRegistry) CountByCategory(ctx context.Context, query string, fileType *models.FileType, tags []string) (map[models.FileCategory]int, map[models.FileCategory]int64, error) {
 	counts := map[models.FileCategory]int{
+		models.FileCategoryImages:    0,
+		models.FileCategoryInvoices:  0,
+		models.FileCategoryDocuments: 0,
+		models.FileCategoryOther:     0,
+	}
+	bytes := map[models.FileCategory]int64{
 		models.FileCategoryImages:    0,
 		models.FileCategoryInvoices:  0,
 		models.FileCategoryDocuments: 0,
@@ -455,8 +463,10 @@ func (r *FileRegistry) CountByCategory(ctx context.Context, query string, fileTy
 			whereClause = "WHERE " + strings.Join(conditions, " AND ")
 		}
 
+		// COALESCE keeps NULL sums (an entirely empty bucket on this
+		// scoped query) from blowing up the int64 scan.
 		sqlQuery := fmt.Sprintf(`
-			SELECT category, COUNT(*) FROM %s
+			SELECT category, COUNT(*), COALESCE(SUM(size_bytes), 0) FROM %s
 			%s
 			GROUP BY category`, r.tableNames.Files(), whereClause)
 
@@ -469,19 +479,21 @@ func (r *FileRegistry) CountByCategory(ctx context.Context, query string, fileTy
 		for rows.Next() {
 			var category models.FileCategory
 			var count int
-			if err := rows.Scan(&category, &count); err != nil {
+			var sizeBytes int64
+			if err := rows.Scan(&category, &count, &sizeBytes); err != nil {
 				return errxtrace.Wrap("failed to scan category count", err)
 			}
 			counts[category] = count
+			bytes[category] = sizeBytes
 		}
 
 		return rows.Err()
 	})
 	if err != nil {
-		return nil, errxtrace.Wrap("failed to count files by category", err)
+		return nil, nil, errxtrace.Wrap("failed to count files by category", err)
 	}
 
-	return counts, nil
+	return counts, bytes, nil
 }
 
 // ListPendingSizeBackfill returns up to limit file rows whose

--- a/go/registry/postgres/files_category_test.go
+++ b/go/registry/postgres/files_category_test.go
@@ -59,18 +59,22 @@ func TestFileRegistry_Postgres_CategoryFilter(t *testing.T) {
 
 	t.Run("CountByCategory returns all four buckets, even empty ones", func(t *testing.T) {
 		c := qt.New(t)
-		counts, err := registrySet.FileRegistry.CountByCategory(ctx, "", nil, nil)
+		counts, bytes, err := registrySet.FileRegistry.CountByCategory(ctx, "", nil, nil)
 		c.Assert(err, qt.IsNil)
 		c.Assert(counts, qt.HasLen, 4)
 		c.Assert(counts[models.FileCategoryImages], qt.Equals, 2)
 		c.Assert(counts[models.FileCategoryInvoices], qt.Equals, 1)
 		c.Assert(counts[models.FileCategoryDocuments], qt.Equals, 1)
 		c.Assert(counts[models.FileCategoryOther], qt.Equals, 1)
+		// SUM(size_bytes) is COALESCEd to 0 — buckets that match no rows
+		// don't appear in GROUP BY output, so the four-bucket guarantee is
+		// the registry method, not SQL.
+		c.Assert(bytes, qt.HasLen, 4)
 	})
 
 	t.Run("CountByCategory respects search filter", func(t *testing.T) {
 		c := qt.New(t)
-		counts, err := registrySet.FileRegistry.CountByCategory(ctx, "manual", nil, nil)
+		counts, _, err := registrySet.FileRegistry.CountByCategory(ctx, "manual", nil, nil)
 		c.Assert(err, qt.IsNil)
 		c.Assert(counts[models.FileCategoryDocuments], qt.Equals, 1)
 		c.Assert(counts[models.FileCategoryImages], qt.Equals, 0)

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -298,11 +298,12 @@ type FileRegistry interface {
 	//     specific commodity/location/export (both required together).
 	ListPaginated(ctx context.Context, offset, limit int, fileType *models.FileType, fileCategory *models.FileCategory, linkedEntityType, linkedEntityID *string) ([]*models.FileEntity, int, error)
 
-	// CountByCategory returns the per-category file count, scoped to the
-	// current group via RLS and constrained by the same filters as Search
-	// (text query, file type, tags). Backs the GET /files/category-counts
-	// endpoint that drives the four-tile UI on the Files page.
-	CountByCategory(ctx context.Context, query string, fileType *models.FileType, tags []string) (map[models.FileCategory]int, error)
+	// CountByCategory returns the per-category file count and total byte
+	// size, scoped to the current group via RLS and constrained by the
+	// same filters as Search (text query, file type, tags). Backs the GET
+	// /files/category-counts endpoint that drives the four-tile UI and the
+	// cumulative footer on the Files page.
+	CountByCategory(ctx context.Context, query string, fileType *models.FileType, tags []string) (map[models.FileCategory]int, map[models.FileCategory]int64, error)
 
 	// SumSizeBreakdown returns per-bucket byte totals for the current
 	// (tenant, group) scope. Backs GET /g/{slug}/storage-usage (#1388).

--- a/go/services/storage_usage_service_test.go
+++ b/go/services/storage_usage_service_test.go
@@ -63,7 +63,7 @@ func (s *stubFileRegistry) Search(context.Context, string, *models.FileType, *mo
 func (s *stubFileRegistry) ListPaginated(context.Context, int, int, *models.FileType, *models.FileCategory, *string, *string) ([]*models.FileEntity, int, error) {
 	panic("not implemented")
 }
-func (s *stubFileRegistry) CountByCategory(context.Context, string, *models.FileType, []string) (map[models.FileCategory]int, error) {
+func (s *stubFileRegistry) CountByCategory(context.Context, string, *models.FileType, []string) (map[models.FileCategory]int, map[models.FileCategory]int64, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
## Summary

Six design-audit follow-ups on the global Files page (umbrella issue #1538), bundled into one PR per the prior #1527/#1529/#1581 pattern.

1. **List/grid view-mode toggle** with `localStorage` (`files:viewMode`) + `?view=list|grid` URL sync. Default = list (per the mock). New `FileListRow` component renders the table-style row (icon / Name+meta / Category badge / Uploaded / Size on desktop, card-style stack on mobile). Selection persists across the toggle.
2. **Per-category contextual subtitle row** under the tiles, with a tinted mini-icon in the active category's accent colour and the i18n description for that bucket ("Every file attached to your inventory" / "Item photos — shown on cards and in galleries" / etc.).
3. **Curated clickable tag-filter pills** (Invoice / Warranty / Manual / Photo / Certificate / Backup) replacing the freeform `TagsInput` in the toolbar. Pills match by lowercase tag name (deviation logged in `devdocs/frontend/design-deviations.md` — coordinates with #1400 once a Tags entity exists).
4. **`CategoryTiles` redesigned** as accent-coloured stat cards (icon chip on top, label, count as `text-lg font-bold`). Each bucket gets a distinct hue when active (Photos→`status-active`, Invoices→`chart-1`, Documents→`chart-3`, Other→`chart-4`).
5. **Mobile fallback**: tiles collapse to a single-column native `<select>` below `sm` via `useIsMobile`, so phones don't burn two screen-heights on the 2-col tile grid.
6. **Cumulative footer** "{N} files · {Y} total" below pagination, scoped to the active filter set. **BE**: `FileCategoryCounts` gains a `bytes` sub-object (per-category byte sums + `all`). Postgres adds a `COALESCE(SUM(size_bytes))` to the existing `GROUP BY` query; memory iterates `SizeBytes` alongside the category bucket.

## Related issues

Closes #1538.
Refs #1527 (umbrella audit), #1400 (proper Tags entity — coordination point for the curated pills).

## Test plan

- [x] `make test` (Go) — 22 backend files modified, full suite green
- [x] `make test-frontend` — 735/735 vitest green (14 new/updated cases for default-list, view toggle, tag-pill toggle/URL reflection, cumulative footer, mobile `<select>` fallback)
- [x] `make lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — clean
- [x] swagger + frontend codegen regenerated (`go tool swag init` + `npm run codegen`)
- [ ] `make test-e2e` — n/a for design-audit fidelity polish; existing Playwright specs continue to use `file-card-*` testIds (still emitted in grid view)

## Notes

- Default view-mode flip from grid → list is intentional per the issue spec; existing users on the page will see the list view on first load after the deploy. The toggle persists their preference back to grid via `localStorage` + URL param if they prefer it.
- The `CountByCategory` registry signature changed from `(map[FileCategory]int, error)` to `(map[FileCategory]int, map[FileCategory]int64, error)` — only one production caller (`apiserver/files.go::listCategoryCounts`) and one test stub (`storage_usage_service_test.go`).