### PR TITLE
Skeleton bg-muted (kill amber flash) + URL-wins-over-stale-slot (fix dashboard 404 race)

### DIFF
--- a/design-mocks/src/components/ui/skeleton.tsx
+++ b/design-mocks/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-accent", className)}
+      className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
   )

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-accent", className)}
+      className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
   )

--- a/frontend/src/lib/__tests__/http.test.ts
+++ b/frontend/src/lib/__tests__/http.test.ts
@@ -124,6 +124,38 @@ describe("group-scoped URL rewriting", () => {
     await http.request("/commodities", { skipGroupRewrite: true })
     expect(captured).toBe("/api/v1/commodities")
   })
+
+  it("URL slug wins over a stale slot when path is /g/:slug/*", async () => {
+    // Models the URL-shape-reconciliation race: the slot still holds the
+    // old slug from the previous mirror effect, but window.location has
+    // already replaced to the corrected slug. The http client must read
+    // the URL, not the stale slot — otherwise the request 404s against
+    // the wrong group (see GroupContext.tsx URL-shape reconciliation).
+    const original = window.location
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { ...original, pathname: "/g/right-slug/dashboard" },
+    })
+    try {
+      setCurrentGroupSlug("stale-slug")
+      let captured: string | null = null
+      server.use(
+        msw.get(/.*/, ({ request }) => {
+          captured = new URL(request.url).pathname
+          return HttpResponse.json({ ok: true })
+        })
+      )
+      await http.get("/commodities")
+      expect(captured).toBe("/api/v1/g/right-slug/commodities")
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        writable: true,
+        value: original,
+      })
+    }
+  })
 })
 
 describe("auth + CSRF headers", () => {

--- a/frontend/src/lib/group-context.ts
+++ b/frontend/src/lib/group-context.ts
@@ -7,22 +7,40 @@
 // (the http client, codegen helpers) can read it without subscribing.
 let currentGroupSlug: string | null = null
 
-// Extract the active group slug from the current URL. Used as a fallback for
-// the slot when a group-scoped query fires before GroupProvider's mirroring
-// effect has had a chance to run — which can happen on the very first render
-// of a /g/:slug/* route, since useEffect commits run after the same render's
-// child queries register their fetches. Per the GroupProvider docstring, the
-// URL is the canonical source of truth; reading it here closes the gap
-// without reordering effect timing.
+// Extract the active group slug from the current URL. Per the GroupProvider
+// docstring the URL is the canonical source of truth; the module-level slot
+// is just a non-React mirror that gets written from a useEffect.
 function readSlugFromUrl(): string | null {
   if (typeof window === "undefined") return null
   const match = window.location.pathname.match(/^\/g\/([^/]+)(?:\/|$)/)
   return match ? decodeURIComponent(match[1]) : null
 }
 
+// URL wins over the slot whenever the path carries a /g/:slug/* prefix. Two
+// effect-timing races are closed by this preference:
+//
+//  1. First render of /g/:slug/* — useEffect commits run after the same
+//     render's child queries register their fetches, so a query firing in
+//     render N may read a slot that hasn't been mirrored yet.
+//
+//  2. URL-shape reconciliation — when GroupProvider navigate()s away from a
+//     slug the user isn't a member of (URL /g/<wrong>/* → replace to
+//     /g/<right>/*), `replaceState` updates window.location synchronously,
+//     but the slot still holds the OLD slug from the previous mirror
+//     effect. A query that fires in the same effect tick (e.g. React-Query
+//     refetch triggered by `enabled` flipping false→true once `currentGroup`
+//     resolves) reads the stale slot and 404s against the wrong group.
+//     Preferring the URL closes the gap because window.location is already
+//     authoritative by the time the query fires.
+//
+// On routes whose path doesn't carry a slug (/profile, /settings,
+// /groups/:id/*) the URL fallback returns null and the slot wins — that's
+// the only case where the slot is load-bearing (it carries the active group
+// pinned via `?g=<slug>` or via `currentGroup.slug` for id-keyed routes).
 export function getCurrentGroupSlug(): string | null {
-  if (currentGroupSlug) return currentGroupSlug
-  return readSlugFromUrl()
+  const fromUrl = readSlugFromUrl()
+  if (fromUrl) return fromUrl
+  return currentGroupSlug
 }
 
 export function setCurrentGroupSlug(slug: string | null): void {


### PR DESCRIPTION
Two independent bugs surfaced in one investigation. The amber-flash report led to compose-bring-up to verify visually, which surfaced a separate "Unable to load dashboard" first-load error — both fixed here.

---

## 1. Skeleton: `bg-muted` instead of `bg-accent`

`--accent` in this theme is the saturated brand amber (`oklch(0.85 0.12 75)` light / `oklch(0.72 0.14 75)` dark), explicitly documented in [`design-mocks/CLAUDE.md`](../blob/master/design-mocks/CLAUDE.md):

> the amber accent is reserved for moments that matter — primary actions, focus states, active highlights.

A loading placeholder is the opposite. `Skeleton` was a 1:1 copy from shadcn upstream (which assumes `--accent` is the stock near-neutral light gray), so every skeleton mount pulses brand amber — visible as a brief orange flash on every page that fetches data (Dashboard stat cards, Commodities/Files/Locations/Areas/Tags/Exports lists, Search results, sidebar menu, …).

```diff
- className={cn("animate-pulse rounded-md bg-accent", className)}
+ className={cn("animate-pulse rounded-md bg-muted", className)}
```

`bg-muted` resolves to `oklch(0.945 0.008 70)` light / `oklch(0.255 0.012 55)` dark — same warm-gray used for empty-state chips and inactive tile backgrounds.

### No `design-deviations.md` entry

The same bug exists upstream in `denisvmedia/inventario-design` (`design-mocks/` is a 1:1 mirror). This is a **port-correction** of an upstream copy-paste oversight, not an intentional divergence — the fix actually *aligns* frontend with the design system's own stated rule. Companion PR opened against `inventario-design`: denisvmedia/inventario-design#13.

Other shadcn primitives that read `bg-accent` / `text-accent-foreground` (button outline/ghost hover, dropdown-menu/command focus, dialog close `data-state=open`, badge link-hover) are interactive states where amber-pop is correct; left alone.

---

## 2. `getCurrentGroupSlug`: URL wins over stale slot (dashboard 404 race)

Surfaced while clicking through the orange-flash fix — first load *often* renders the destructive "Unable to load dashboard" alert. Server logs show the dashboard's queries firing against a slug the user is not a member of:

```
17:40:32 GET /g/Z0jzFbraXkwj7u8FOEp93Q                            → 200 (SPA shell — stale URL)
17:40:37 POST /api/v1/auth/login                                   → 200
17:40:37 GET  /api/v1/groups                                       → 200 (user has 1 group: Qk4dp71a5oVUqpJC3gT5hg)
17:40:38 GET  /api/v1/g/Z0jzFbraXkwj7u8FOEp93Q/locations           → 404
17:40:38 GET  /api/v1/g/Z0jzFbraXkwj7u8FOEp93Q/areas               → 404
17:40:38 GET  /api/v1/g/Z0jzFbraXkwj7u8FOEp93Q/files               → 404
17:40:38 GET  /api/v1/g/Z0jzFbraXkwj7u8FOEp93Q/commodities         → 404
17:40:38 GET  /api/v1/g/Z0jzFbraXkwj7u8FOEp93Q/commodities/values  → 404
```

User opens an `/g/<wrong-slug>/...` URL (browser autocomplete, stale tab, copy-paste). `GroupProvider` detects the slug isn't in the user's groups and `navigate()`s via `replaceState` to `/g/<right-slug>/...`. Two effect ticks happen back-to-back:

1. Re-render where `currentGroup` resolves to the user's real group → React-Query's `enabled` flips false→true → refetch all dashboard queries.
2. `setCurrentGroupSlug` effect mirrors the new URL slug into the module-level slot.

Effect ordering between the two is not guaranteed. When RQ's refetch fires before the slot mirror, the http client reads the **old** slug from the slot, request goes to `/api/v1/g/<wrong-slug>/...` and 404s. `useDashboardData`'s `isError` flips true and the page renders the destructive alert. Refresh masks the race.

Fix: prefer URL pathname over the slot in `getCurrentGroupSlug`:

```diff
 export function getCurrentGroupSlug(): string | null {
-  if (currentGroupSlug) return currentGroupSlug
-  return readSlugFromUrl()
+  const fromUrl = readSlugFromUrl()
+  if (fromUrl) return fromUrl
+  return currentGroupSlug
 }
```

`window.location.pathname` is updated synchronously by `replaceState`, so by the time RQ's refetch runs the URL is already authoritative. The slot remains the fallback for routes whose path doesn't carry a slug (`/profile`, `/settings`, `/groups/:id/*` — populated from `?g=` query or from the resolved `currentGroup.slug`).

Regression test added in `src/lib/__tests__/http.test.ts` that fakes the race (stale slot + mismatched `window.location.pathname`) and asserts the http client rewrites against the URL slug. Verified to fail on the pre-fix code and pass on the fix. Full http + GroupContext suites green (45/45).

---

## Test plan

- [ ] `npm test` — http + GroupContext suites pass
- [ ] Click through Dashboard → Commodities → Files → Locations → Areas → Tags → Exports → Search; verify no amber pulse on the loading skeletons
- [ ] Toggle dark mode; verify dark-mode skeletons remain subtle
- [ ] Confirm interactive amber states still work: hover an outline/ghost button, focus a dropdown item, open the command palette
- [ ] Reproduce the dashboard race manually: open `/g/<wrong-slug>/dashboard` with auth, verify dashboard loads correctly (not the "Unable to load" alert)