### PR TITLE
[#1367] Drop legacy warranty:YYYY-MM-DD tag fallback

### DIFF
--- a/e2e/tests/includes/auth.ts
+++ b/e2e/tests/includes/auth.ts
@@ -130,23 +130,46 @@ export async function login(
     warn(recorder, '⚠️ Login succeeded but CSRF token parsing failed');
   }
 
-  // Wait for login to complete and redirect
+  // Wait for the post-login navigation to leave /login. The previous
+  // version OR'd this with `h1 contains "Welcome to Inventario"`, but
+  // that string is the /no-group page heading (auth.json:noGroup.title)
+  // — not a login signal — so the wait would short-circuit the moment
+  // a webkit race bounced us through /no-group, hiding the bug from the
+  // helper while the test itself fails on the next h1 assertion.
   await page.waitForFunction(
-    () => {
-      // Check if we're no longer on login page (URL changed) or if we see authenticated content.
-      return !window.location.pathname.startsWith('/login') ||
-             (document.querySelector('h1')?.textContent?.includes('Welcome to Inventario') === true);
-    },
+    () => !window.location.pathname.startsWith('/login'),
     { timeout: 30000 }
   );
 
   // Give UI a brief moment to settle after redirect/auth state propagation.
   await page.waitForTimeout(500);
 
-  // If we're still on login page but see authenticated content, manually navigate to home
-  const currentUrl = page.url();
-  if (currentUrl.includes('/login') && await page.locator('h1:has-text("Welcome to Inventario")').isVisible()) {
-    log(recorder, '🔄 Login successful but still on login URL, navigating to home...');
+  // Webkit-specific recovery: a transient race between /api/v1/auth/me
+  // and /api/v1/groups (parallel React-Query fetches) can resolve groups
+  // before user, leaving RootRedirect with `user?.default_group_id`
+  // undefined and bouncing the user to /no-group on first paint. The
+  // admin user always has groups, so landing on /no-group after login
+  // means we hit the race; reload once and let the cached /auth/me
+  // response populate `user.default_group_id` synchronously this time.
+  if (page.url().includes('/no-group')) {
+    log(recorder, '🔄 Landed on /no-group after login — recovering from auth-state race by reloading...');
+    await page.goto('/');
+    await page.waitForFunction(
+      () => !window.location.pathname.startsWith('/no-group'),
+      { timeout: 10000 }
+    ).catch(() => {
+      // Genuinely no groups (orphan user fixture) — leave on /no-group
+      // and let the caller handle it. The recovery only kicks in when
+      // /no-group was a transient flash; for orphan users this is the
+      // real destination.
+    });
+  }
+
+  // If we're still on login page but the page has rendered, manually
+  // navigate to home (defensive — should not happen given the
+  // waitForFunction above, but keeps parity with prior behaviour).
+  if (page.url().includes('/login')) {
+    log(recorder, '🔄 Still on /login after auth completed, navigating home...');
     await page.goto('/');
   }
 

--- a/e2e/tests/includes/auth.ts
+++ b/e2e/tests/includes/auth.ts
@@ -1,7 +1,35 @@
 import { Page, expect } from '@playwright/test';
 import { TestRecorder, log, warn, error } from '../../utils/test-recorder.js';
 import { setCsrfToken } from './csrf.js';
-import { gotoScoped } from './group-url.js';
+import { ensureGroupSlug, gotoScoped } from './group-url.js';
+
+/**
+ * Recover from a transient /no-group landing for a user that actually
+ * has a group. Webkit can lose the post-login race between
+ * /api/v1/auth/me and /api/v1/groups (parallel React-Query fetches),
+ * leaving RootRedirect with `user?.default_group_id` undefined and
+ * navigating to /no-group on first paint. Reloading via
+ * `page.goto('/')` can hit the same race a second time, so instead we
+ * resolve the slug authoritatively from `/api/v1/groups` (which
+ * `ensureGroupSlug` does inside the page context with the JWT
+ * already in localStorage) and navigate to `/g/<slug>` directly,
+ * bypassing RootRedirect altogether.
+ *
+ * Returns true when the recovery moved the page off /no-group; false
+ * if the slug couldn't be resolved (genuinely groupless user).
+ */
+async function recoverFromNoGroupRace(page: Page, recorder?: TestRecorder): Promise<boolean> {
+  if (!page.url().includes('/no-group')) return true;
+  log(recorder, '🔄 Detected /no-group landing — bypassing RootRedirect via direct /g/<slug> navigation...');
+  try {
+    const slug = await ensureGroupSlug(page);
+    await page.goto(`/g/${encodeURIComponent(slug)}`);
+    return !page.url().includes('/no-group');
+  } catch (err) {
+    warn(recorder, '⚠️ Could not resolve a group slug — leaving the page on /no-group:', err);
+    return false;
+  }
+}
 
 /**
  * Test credentials for e2e tests
@@ -144,30 +172,12 @@ export async function login(
   // Give UI a brief moment to settle after redirect/auth state propagation.
   await page.waitForTimeout(500);
 
-  // Webkit-specific recovery: a transient race between /api/v1/auth/me
-  // and /api/v1/groups (parallel React-Query fetches) can resolve groups
-  // before user, leaving RootRedirect with `user?.default_group_id`
-  // undefined and bouncing the user to /no-group on first paint. Reload
-  // once and let the cached /auth/me response populate
-  // `user.default_group_id` synchronously this time.
-  //
-  // Gated by credentials: only run for users that are EXPECTED to have a
-  // group. The orphan fixture (`ORPHAN_TEST_CREDENTIALS`) legitimately
-  // lands on /no-group, so running the recovery there would burn the
-  // 10s wait timeout on every orphan test (see no-group-redirect.spec.ts
-  // and settings-default-group.spec.ts) for no gain.
-  const expectsGroup = credentials.email !== ORPHAN_TEST_CREDENTIALS.email;
-  if (expectsGroup && page.url().includes('/no-group')) {
-    log(recorder, '🔄 Landed on /no-group after login — recovering from auth-state race by reloading...');
-    await page.goto('/');
-    await page.waitForFunction(
-      () => !window.location.pathname.startsWith('/no-group'),
-      { timeout: 10000 }
-    ).catch(() => {
-      // Recovery didn't lift us off /no-group — let the caller handle
-      // it. The next assertion in the test will surface the real issue
-      // with a clearer error than a silent `.catch(() => {})` would.
-    });
+  // Webkit auth-state race recovery — see recoverFromNoGroupRace for
+  // background. Gated by credentials so the orphan fixture
+  // (`ORPHAN_TEST_CREDENTIALS`), which legitimately lands on /no-group,
+  // skips the API probe entirely.
+  if (credentials.email !== ORPHAN_TEST_CREDENTIALS.email) {
+    await recoverFromNoGroupRace(page, recorder);
   }
 
   // If we're still on login page but the page has rendered, manually
@@ -233,6 +243,18 @@ export async function loginIfNeeded(page: Page, targetUrl?: string, recorder?: T
   if (await isLoginPage(page)) {
     log(recorder, '🔄 Redirected to login, authenticating...');
     csrfToken = await login(page, recorder);
+  }
+
+  // Webkit auth-state race recovery (see recoverFromNoGroupRace). The
+  // probe `page.goto('/')` above can hit the race on its own — even
+  // when login already happened in app-fixture.ts and the JWT is
+  // already in localStorage — because RootRedirect re-renders cold on
+  // every full reload. The orphan-user specs (no-group-redirect.spec.ts,
+  // settings-default-group.spec.ts) never reach this code path — they
+  // `page.goto` directly without going through navigateWithAuth — so
+  // triggering recovery on /no-group here is safe.
+  if (targetUrl === '/') {
+    await recoverFromNoGroupRace(page, recorder);
   }
 
   // Navigate to the real target now that auth is settled. gotoScoped

--- a/e2e/tests/includes/auth.ts
+++ b/e2e/tests/includes/auth.ts
@@ -147,21 +147,26 @@ export async function login(
   // Webkit-specific recovery: a transient race between /api/v1/auth/me
   // and /api/v1/groups (parallel React-Query fetches) can resolve groups
   // before user, leaving RootRedirect with `user?.default_group_id`
-  // undefined and bouncing the user to /no-group on first paint. The
-  // admin user always has groups, so landing on /no-group after login
-  // means we hit the race; reload once and let the cached /auth/me
-  // response populate `user.default_group_id` synchronously this time.
-  if (page.url().includes('/no-group')) {
+  // undefined and bouncing the user to /no-group on first paint. Reload
+  // once and let the cached /auth/me response populate
+  // `user.default_group_id` synchronously this time.
+  //
+  // Gated by credentials: only run for users that are EXPECTED to have a
+  // group. The orphan fixture (`ORPHAN_TEST_CREDENTIALS`) legitimately
+  // lands on /no-group, so running the recovery there would burn the
+  // 10s wait timeout on every orphan test (see no-group-redirect.spec.ts
+  // and settings-default-group.spec.ts) for no gain.
+  const expectsGroup = credentials.email !== ORPHAN_TEST_CREDENTIALS.email;
+  if (expectsGroup && page.url().includes('/no-group')) {
     log(recorder, '🔄 Landed on /no-group after login — recovering from auth-state race by reloading...');
     await page.goto('/');
     await page.waitForFunction(
       () => !window.location.pathname.startsWith('/no-group'),
       { timeout: 10000 }
     ).catch(() => {
-      // Genuinely no groups (orphan user fixture) — leave on /no-group
-      // and let the caller handle it. The recovery only kicks in when
-      // /no-group was a transient flash; for orphan users this is the
-      // real destination.
+      // Recovery didn't lift us off /no-group — let the caller handle
+      // it. The next assertion in the test will surface the real issue
+      // with a clearer error than a silent `.catch(() => {})` would.
     });
   }
 

--- a/frontend/src/components/dashboard/ExpiringWarranties.tsx
+++ b/frontend/src/components/dashboard/ExpiringWarranties.tsx
@@ -13,9 +13,7 @@ import { cn } from "@/lib/utils"
 
 interface ExpiringWarrantiesProps {
   // Up to 5 commodities whose warranty falls in the "expiring" bucket
-  // (≤60 days from expiry), pre-sorted by expiry ascending. Each row
-  // carries the resolved expiry date so legacy `warranty:YYYY-MM-DD`
-  // tag-only commodities show the right "N days left" pill.
+  // (≤60 days from expiry), pre-sorted by expiry ascending.
   items: ExpiringWarrantyRow[]
   // True while the parent dashboard query is on its first fetch.
   // Renders skeleton rows so the panel doesn't pop in.

--- a/frontend/src/components/warranty/WarrantyBadge.tsx
+++ b/frontend/src/components/warranty/WarrantyBadge.tsx
@@ -46,8 +46,7 @@ export function WarrantyBadge({
   "data-testid": testId,
 }: WarrantyBadgeProps) {
   const { t } = useTranslation()
-  const resolved =
-    status ?? warrantyStatus({ warranty_expires_at: source?.warranty_expires_at })
+  const resolved = status ?? warrantyStatus({ warranty_expires_at: source?.warranty_expires_at })
   const visual = WARRANTY_STATUS_CONFIG[resolved]
   const Icon = visual.icon
   return (

--- a/frontend/src/components/warranty/WarrantyBadge.tsx
+++ b/frontend/src/components/warranty/WarrantyBadge.tsx
@@ -27,7 +27,6 @@ export interface WarrantyBadgeProps {
   // when you have the row in hand; the badge does the bucketing.
   source?: {
     warranty_expires_at?: string
-    tags?: readonly string[]
   }
   // Hide the leading shield icon (e.g. inside a row that already
   // shows one). Defaults to `true` — the icon is part of the badge's
@@ -48,8 +47,7 @@ export function WarrantyBadge({
 }: WarrantyBadgeProps) {
   const { t } = useTranslation()
   const resolved =
-    status ??
-    warrantyStatus({ warranty_expires_at: source?.warranty_expires_at, tags: source?.tags })
+    status ?? warrantyStatus({ warranty_expires_at: source?.warranty_expires_at })
   const visual = WARRANTY_STATUS_CONFIG[resolved]
   const Icon = visual.icon
   return (

--- a/frontend/src/components/warranty/__tests__/WarrantyBadge.test.tsx
+++ b/frontend/src/components/warranty/__tests__/WarrantyBadge.test.tsx
@@ -30,6 +30,15 @@ describe("<WarrantyBadge />", () => {
     expect(screen.getByTestId("badge")).toHaveTextContent("No Warranty")
   })
 
+  it("treats 1970-01-01 as expired, not `none` (Date.parse anchor regression)", () => {
+    // parseWarrantyDate returns 0 for the epoch — a `ms ? ... : "none"`
+    // truthy check would misclassify the date as `none`. Pin the
+    // explicit-null behaviour so a future refactor doesn't reintroduce
+    // the truthy ternary.
+    render(<WarrantyBadge source={{ warranty_expires_at: "1970-01-01" }} data-testid="badge" />)
+    expect(screen.getByTestId("badge")).toHaveAttribute("data-status", "expired")
+  })
+
   it("hides the leading icon when `showIcon` is false", () => {
     const { container } = render(<WarrantyBadge status="active" showIcon={false} />)
     expect(container.querySelector("svg")).toBeNull()

--- a/frontend/src/components/warranty/__tests__/WarrantyBadge.test.tsx
+++ b/frontend/src/components/warranty/__tests__/WarrantyBadge.test.tsx
@@ -24,12 +24,7 @@ describe("<WarrantyBadge />", () => {
     expect(badge).toHaveTextContent("Expired")
   })
 
-  it("falls back to the legacy warranty:YYYY-MM-DD tag when the field is missing", () => {
-    render(<WarrantyBadge source={{ tags: ["warranty:2099-01-01"] }} data-testid="badge" />)
-    expect(screen.getByTestId("badge")).toHaveAttribute("data-status", "active")
-  })
-
-  it("renders the `none` bucket when neither field nor tag is set", () => {
+  it("renders the `none` bucket when the field is unset", () => {
     render(<WarrantyBadge source={{}} data-testid="badge" />)
     expect(screen.getByTestId("badge")).toHaveAttribute("data-status", "none")
     expect(screen.getByTestId("badge")).toHaveTextContent("No Warranty")

--- a/frontend/src/features/commodities/constants.ts
+++ b/frontend/src/features/commodities/constants.ts
@@ -68,13 +68,11 @@ export type CommodityWarrantyStatus = (typeof COMMODITY_WARRANTY_STATUSES)[numbe
 const WARRANTY_EXPIRING_DAYS = 60
 
 // warrantyStatus derives the warranty bucket from a commodity's
-// `warranty_expires_at` (#1367). Falls back to the legacy
-// `warranty:YYYY-MM-DD` tag convention only when the dedicated field
-// is missing — old entries pre-#1367 may still rely on it; the
-// convention is dropped from the next major.
+// `warranty_expires_at` column (#1367). The pre-#1535 fallback that
+// read the date out of a `warranty:YYYY-MM-DD` tag was removed once
+// migration 1779400000 drained those tags into the column.
 export function warrantyStatus(input: {
   warranty_expires_at?: string
-  tags?: readonly string[]
 }): CommodityWarrantyStatus {
   const effective = effectiveWarrantyExpiry(input)
   if (!effective) return "none"
@@ -83,24 +81,17 @@ export function warrantyStatus(input: {
 }
 
 // effectiveWarrantyExpiry returns the YYYY-MM-DD string the rest of
-// the warranty UI should render — either the dedicated
-// `warranty_expires_at` column (#1367) or, when that's missing, the
-// legacy `warranty:YYYY-MM-DD` tag carried over from pre-#1367 data.
-// Returns `undefined` when neither signal is present so callers can
-// distinguish "no warranty tracked" from "tracked but date unknown".
-//
-// Single source of truth for the field-vs-tag fallback so the
-// status bucketing, the row subtitle ("Expires <date>"), and the
-// dashboard's days-remaining counter all agree.
+// the warranty UI should render, or `undefined` when no warranty is
+// tracked. Kept as a thin alias so the call sites keep reading like
+// `effectiveWarrantyExpiry(commodity)` instead of a raw field access
+// — the helper used to dual-source from a legacy tag (see migration
+// 1779400000), and the call sites still want to be coupled to a
+// single source of truth so a future move (e.g., a separate warranty
+// table) is a one-line change.
 export function effectiveWarrantyExpiry(input: {
   warranty_expires_at?: string
-  tags?: readonly string[]
 }): string | undefined {
-  if (input.warranty_expires_at) return input.warranty_expires_at
-  const tagged = input.tags
-    ?.map((t) => /^warranty:(\d{4}-\d{2}-\d{2})$/.exec(t))
-    .find((m) => m !== null)
-  return tagged?.[1]
+  return input.warranty_expires_at || undefined
 }
 
 function parseWarrantyDate(s: string | undefined): number | null {

--- a/frontend/src/features/commodities/constants.ts
+++ b/frontend/src/features/commodities/constants.ts
@@ -74,8 +74,11 @@ const WARRANTY_EXPIRING_DAYS = 60
 export function warrantyStatus(input: { warranty_expires_at?: string }): CommodityWarrantyStatus {
   const effective = effectiveWarrantyExpiry(input)
   if (!effective) return "none"
+  // Explicit null check, not truthy: parseWarrantyDate returns 0 for
+  // `1970-01-01` (Date.parse anchor), which a `ms ? ...` ternary would
+  // misclassify as "none" instead of "expired".
   const ms = parseWarrantyDate(effective)
-  return ms ? classifyDays(ms) : "none"
+  return ms !== null ? classifyDays(ms) : "none"
 }
 
 // effectiveWarrantyExpiry returns the YYYY-MM-DD string the rest of

--- a/frontend/src/features/commodities/constants.ts
+++ b/frontend/src/features/commodities/constants.ts
@@ -71,9 +71,7 @@ const WARRANTY_EXPIRING_DAYS = 60
 // `warranty_expires_at` column (#1367). The pre-#1535 fallback that
 // read the date out of a `warranty:YYYY-MM-DD` tag was removed once
 // migration 1779400000 drained those tags into the column.
-export function warrantyStatus(input: {
-  warranty_expires_at?: string
-}): CommodityWarrantyStatus {
+export function warrantyStatus(input: { warranty_expires_at?: string }): CommodityWarrantyStatus {
   const effective = effectiveWarrantyExpiry(input)
   if (!effective) return "none"
   const ms = parseWarrantyDate(effective)

--- a/frontend/src/features/dashboard/__tests__/hooks.test.ts
+++ b/frontend/src/features/dashboard/__tests__/hooks.test.ts
@@ -81,21 +81,16 @@ describe("warrantyBuckets", () => {
     expect(expiring[0].expiresAt).toBe(daysFromNow(2))
   })
 
-  it("falls back to the legacy warranty:YYYY-MM-DD tag when the dedicated field is missing", () => {
+  it("ignores legacy warranty:YYYY-MM-DD tags — the typed field is the only source", () => {
+    // Pre-#1535 rows used a tag for warranty expiry. Migration
+    // 1779400000 drained those tags into warranty_expires_at; rows
+    // that still carry only the tag (no field) must read as `none`
+    // since the dual-source fallback is gone.
     const items: Commodity[] = [
-      commodity({ id: "tagged-active", tags: ["warranty:2099-01-01"] }),
-      commodity({ id: "tagged-expired", tags: ["warranty:1999-01-01"] }),
-      commodity({ id: "tagged-expiring", tags: [`warranty:${daysFromNow(20)}`] }),
+      commodity({ id: "tagged-only", tags: ["warranty:2099-01-01"] }),
+      commodity({ id: "field-only", warranty_expires_at: "2099-01-01" }),
     ]
-    const { counts, expiring } = warrantyBuckets(items, 5)
-    expect(counts.active).toBe(1)
-    expect(counts.expired).toBe(1)
-    expect(counts.expiring).toBe(1)
-    // Tag-only legacy rows get carried into the expiring shortlist
-    // with the resolved tag date — the dashboard pill needs that to
-    // render "N days left" instead of showing nothing.
-    expect(expiring).toHaveLength(1)
-    expect(expiring[0].commodity.id).toBe("tagged-expiring")
-    expect(expiring[0].expiresAt).toBe(daysFromNow(20))
+    const { counts } = warrantyBuckets(items, 5)
+    expect(counts).toEqual({ active: 1, expiring: 0, expired: 0, none: 1 })
   })
 })

--- a/frontend/src/features/dashboard/hooks.ts
+++ b/frontend/src/features/dashboard/hooks.ts
@@ -39,9 +39,7 @@ export interface DashboardData {
   // Items whose warranty status is "expiring" (≤60 days from expiry),
   // sorted by expiry ascending (next-to-expire first). Drives the
   // "Expiring Warranties" panel — capped at five rows so the panel
-  // doesn't outgrow its tile. Each row carries the resolved expiry
-  // date (`effectiveWarrantyExpiry`) so legacy tag-only rows still
-  // render the right "N days left" badge.
+  // doesn't outgrow its tile.
   expiringWarranties: ExpiringWarrantyRow[]
 }
 
@@ -77,11 +75,6 @@ export function recentlyAdded(commodities: Commodity[], limit: number): Commodit
 // per-status counts plus the slice destined for the "Expiring
 // Warranties" panel. Single-pass so adding a third derived view
 // later doesn't multiply the work.
-//
-// Effective expiry date (field OR legacy `warranty:YYYY-MM-DD` tag —
-// see `effectiveWarrantyExpiry`) is carried alongside each expiring
-// row so the dashboard panel can render "N days left" against the
-// resolved date even on tag-only legacy rows.
 export function warrantyBuckets(
   commodities: Commodity[],
   expiringLimit: number
@@ -97,20 +90,11 @@ export function warrantyBuckets(
   }
   const expiringRows: ExpiringWarrantyRow[] = []
   for (const c of commodities) {
-    const expiresAt = effectiveWarrantyExpiry({
-      warranty_expires_at: c.warranty_expires_at,
-      tags: c.tags,
-    })
-    const s = warrantyStatus({
-      warranty_expires_at: c.warranty_expires_at,
-      tags: c.tags,
-    })
+    const expiresAt = effectiveWarrantyExpiry({ warranty_expires_at: c.warranty_expires_at })
+    const s = warrantyStatus({ warranty_expires_at: c.warranty_expires_at })
     counts[s]++
-    // The `expiring` bucket is always paired with a real date — the
-    // status only resolves to `expiring` when `effectiveWarrantyExpiry`
-    // returned a parseable YYYY-MM-DD string, so the non-null assertion
-    // is safe. Tag-only legacy rows still land here with the resolved
-    // tag date.
+    // `expiring` only resolves when expiresAt is a parseable
+    // YYYY-MM-DD, so this branch is always reached with a real date.
     if (s === "expiring" && expiresAt) {
       expiringRows.push({ commodity: c, expiresAt })
     }

--- a/frontend/src/pages/commodities/CommoditiesListPage.tsx
+++ b/frontend/src/pages/commodities/CommoditiesListPage.tsx
@@ -315,19 +315,17 @@ export function CommoditiesListPage() {
 
   // ---- Derived -----------------------------------------------------------
   const allRows = list.data?.commodities ?? []
-  // Warranty status uses the BE-computed `warranty_expires_at`
-  // (#1367); the `warrantyStatus()` helper falls back to the legacy
-  // `warranty:YYYY-MM-DD` tag convention for rows created before
-  // #1367. The filter still runs client-side so we pick up the same
-  // page even when only some rows ship the new column. Server-side
-  // `warranty_status=` is wired on the BE — we'll switch to it once
-  // the FE list page consolidates filter state, then drop this block.
+  // Warranty status reads the BE-computed `warranty_expires_at`
+  // (#1367). Filter still runs client-side so we pick up the same
+  // page even on a partial dataset. Server-side `warranty_status=` is
+  // wired on the BE — we'll switch to it once the FE list page
+  // consolidates filter state, then drop this block.
   const rows =
     warrantyFilter.length === 0
       ? allRows
       : allRows.filter((r) =>
           warrantyFilter.includes(
-            warrantyStatus({ warranty_expires_at: r.warranty_expires_at, tags: r.tags })
+            warrantyStatus({ warranty_expires_at: r.warranty_expires_at })
           )
         )
   // Open-loan counts for the visible page only (#1452). The hook

--- a/frontend/src/pages/commodities/CommoditiesListPage.tsx
+++ b/frontend/src/pages/commodities/CommoditiesListPage.tsx
@@ -324,9 +324,7 @@ export function CommoditiesListPage() {
     warrantyFilter.length === 0
       ? allRows
       : allRows.filter((r) =>
-          warrantyFilter.includes(
-            warrantyStatus({ warranty_expires_at: r.warranty_expires_at })
-          )
+          warrantyFilter.includes(warrantyStatus({ warranty_expires_at: r.warranty_expires_at }))
         )
   // Open-loan counts for the visible page only (#1452). The hook
   // skips the request when commodityIDsForCounts is empty (e.g. while

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -491,10 +491,7 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
             {(commodity.count ?? 0) > 1 ? null : (
               <>
                 <WarrantyBadge
-                  source={{
-                    warranty_expires_at: commodity.warranty_expires_at,
-                    tags: commodity.tags,
-                  }}
+                  source={{ warranty_expires_at: commodity.warranty_expires_at }}
                   data-testid="commodity-detail-warranty-pill"
                 />
                 {(() => {
@@ -1341,10 +1338,7 @@ function WarrantyTab({ commodity, onSwitchToFiles }: WarrantyTabProps) {
     )
   }
   const status: CommodityWarrantyStatus = commodity
-    ? warrantyStatus({
-        warranty_expires_at: commodity.warranty_expires_at,
-        tags: commodity.tags,
-      })
+    ? warrantyStatus({ warranty_expires_at: commodity.warranty_expires_at })
     : "none"
   const daysRemaining = warrantyDaysRemaining(commodity?.warranty_expires_at)
   const visual = WARRANTY_STATUS_CONFIG[status]

--- a/frontend/src/pages/commodities/__tests__/CommoditiesListPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommoditiesListPage.test.tsx
@@ -324,21 +324,21 @@ describe("<CommoditiesListPage />", () => {
     await waitFor(() => expect(screen.queryByLabelText(/form steps/i)).not.toBeInTheDocument())
   })
 
-  it("filters rows by warranty status (derived from tags)", async () => {
+  it("filters rows by warranty status (derived from warranty_expires_at)", async () => {
     const user = userEvent.setup()
     server.use(
       ...groupHandlers.list(groupFixture),
       ...areaHandlers.list(SLUG, areaFixture),
       ...commodityHandlers.list(SLUG, [
-        commodityRes("c1", { name: "Chair", tags: ["warranty:2099-12-31"] }),
-        commodityRes("c2", { name: "Couch", tags: [] }),
+        commodityRes("c1", { name: "Chair", warranty_expires_at: "2099-12-31" }),
+        commodityRes("c2", { name: "Couch" }),
       ])
     )
     renderList()
     await waitFor(() => expect(screen.getAllByTestId("commodity-card").length).toBe(2))
     await user.click(screen.getByTestId("commodities-filter-warranty"))
     await user.click(await screen.findByRole("menuitemcheckbox", { name: /Active/i }))
-    // Only the row with the warranty tag remains.
+    // Only the row with a tracked warranty remains.
     await waitFor(() => {
       const rows = screen.queryAllByTestId("commodity-card")
       expect(rows).toHaveLength(1)

--- a/frontend/src/pages/warranties/WarrantiesListPage.tsx
+++ b/frontend/src/pages/warranties/WarrantiesListPage.tsx
@@ -93,12 +93,6 @@ export function WarrantiesListPage() {
   // a single pass keeps the page responsive even when the dataset
   // grows; the alternative (four `filter()` calls) re-walks the array
   // four times for the same result.
-  //
-  // We carry the resolved (effective) expiry date through the bucket
-  // so that legacy `warranty:YYYY-MM-DD` tag-only rows render the
-  // right "N days left/ago" line and the right Expires date — without
-  // it, the bucketing happily picks them up but the row UI would say
-  // "No date".
   const buckets = useMemo(() => {
     const out: Record<CommodityWarrantyStatus, BucketRow[]> = {
       active: [],
@@ -107,14 +101,8 @@ export function WarrantiesListPage() {
       none: [],
     }
     for (const c of list.data?.commodities ?? []) {
-      const expiresAt = effectiveWarrantyExpiry({
-        warranty_expires_at: c.warranty_expires_at,
-        tags: c.tags,
-      })
-      const s = warrantyStatus({
-        warranty_expires_at: c.warranty_expires_at,
-        tags: c.tags,
-      })
+      const expiresAt = effectiveWarrantyExpiry({ warranty_expires_at: c.warranty_expires_at })
+      const s = warrantyStatus({ warranty_expires_at: c.warranty_expires_at })
       out[s].push({ commodity: c, expiresAt })
     }
     // Sort by expiry ascending: surfaces the most-actionable rows
@@ -260,10 +248,8 @@ function EmptyState({ tab }: { tab: WarrantyTab }) {
 
 interface BucketRow {
   commodity: Commodity
-  // Resolved expiry date — either `warranty_expires_at` or the
-  // legacy `warranty:YYYY-MM-DD` tag (see `effectiveWarrantyExpiry`).
-  // Undefined only for rows in the "none" bucket where neither signal
-  // is present.
+  // Resolved expiry date from `warranty_expires_at`. Undefined only
+  // for rows in the "none" bucket.
   expiresAt: string | undefined
 }
 

--- a/go/schema/migrations/_sqldata/1779400000_backfill_warranty_expires_at_from_legacy_tag.down.sql
+++ b/go/schema/migrations/_sqldata/1779400000_backfill_warranty_expires_at_from_legacy_tag.down.sql
@@ -1,0 +1,12 @@
+-- Migration: backfill commodities.warranty_expires_at from the legacy
+-- "warranty:YYYY-MM-DD" tag convention (issue #1367 cleanup).
+-- Direction: DOWN
+--
+-- The UP migration drains the legacy tag into the typed column and
+-- strips the tag. There's no safe way to identify which rows had been
+-- written via the legacy tag versus the typed field after the fact —
+-- every post-#1535 row also writes to the typed column directly.
+-- Reverting would spray a synthetic tag onto rows that never had one.
+-- Make the down a no-op.
+
+SELECT 1;

--- a/go/schema/migrations/_sqldata/1779400000_backfill_warranty_expires_at_from_legacy_tag.up.sql
+++ b/go/schema/migrations/_sqldata/1779400000_backfill_warranty_expires_at_from_legacy_tag.up.sql
@@ -39,21 +39,17 @@ WITH legacy AS (
     WHERE c.warranty_expires_at IS NULL OR c.warranty_expires_at = ''
 )
 UPDATE commodities c
-SET
-    warranty_expires_at = legacy.expires_at,
-    updated_at = CURRENT_TIMESTAMP
+SET warranty_expires_at = legacy.expires_at
 FROM legacy
 WHERE c.id = legacy.id;
 
 UPDATE commodities c
-SET
-    tags = COALESCE(
+SET tags = COALESCE(
         (
             SELECT jsonb_agg(j.tag ORDER BY j.tag)
             FROM jsonb_array_elements_text(COALESCE(c.tags, '[]'::jsonb)) AS j(tag)
             WHERE j.tag !~ '^warranty:[0-9]{4}-[0-9]{2}-[0-9]{2}$'
         ),
         '[]'::jsonb
-    ),
-    updated_at = CURRENT_TIMESTAMP
+    )
 WHERE c.tags @? '$[*] ? (@ like_regex "^warranty:[0-9]{4}-[0-9]{2}-[0-9]{2}$")';

--- a/go/schema/migrations/_sqldata/1779400000_backfill_warranty_expires_at_from_legacy_tag.up.sql
+++ b/go/schema/migrations/_sqldata/1779400000_backfill_warranty_expires_at_from_legacy_tag.up.sql
@@ -36,7 +36,13 @@ WITH legacy AS (
         ORDER BY j.tag ASC
         LIMIT 1
     ) AS picked
-    WHERE c.warranty_expires_at IS NULL OR c.warranty_expires_at = ''
+    -- Pre-filter on the JSONB GIN index (commodities_tags_gin_idx) so
+    -- only rows whose tags can possibly carry a legacy warranty entry
+    -- run the LATERAL scan. Without this, every NULL/empty-warranty
+    -- row pays the array-elements unfold cost even when its tags are
+    -- empty or unrelated.
+    WHERE (c.warranty_expires_at IS NULL OR c.warranty_expires_at = '')
+      AND c.tags @? '$[*] ? (@ like_regex "^warranty:[0-9]{4}-[0-9]{2}-[0-9]{2}$")'
 )
 UPDATE commodities c
 SET warranty_expires_at = legacy.expires_at

--- a/go/schema/migrations/_sqldata/1779400000_backfill_warranty_expires_at_from_legacy_tag.up.sql
+++ b/go/schema/migrations/_sqldata/1779400000_backfill_warranty_expires_at_from_legacy_tag.up.sql
@@ -52,8 +52,18 @@ WHERE c.id = legacy.id;
 UPDATE commodities c
 SET tags = COALESCE(
         (
-            SELECT jsonb_agg(j.tag ORDER BY j.tag)
-            FROM jsonb_array_elements_text(COALESCE(c.tags, '[]'::jsonb)) AS j(tag)
+            -- WITH ORDINALITY preserves original array position so the
+            -- non-warranty tags stay in first-seen order. The write
+            -- path documents this invariant
+            -- (services/tag_service.go:111-114) — round-tripping a
+            -- commodity payload twice produces byte-identical JSONB,
+            -- and noisy order-only diffs in tests / e2e snapshots
+            -- disappear. Aggregating with `ORDER BY j.tag` would
+            -- reorder every affected row alphabetically and break
+            -- that contract.
+            SELECT jsonb_agg(j.tag ORDER BY j.ord)
+            FROM jsonb_array_elements_text(COALESCE(c.tags, '[]'::jsonb))
+                WITH ORDINALITY AS j(tag, ord)
             WHERE j.tag !~ '^warranty:[0-9]{4}-[0-9]{2}-[0-9]{2}$'
         ),
         '[]'::jsonb

--- a/go/schema/migrations/_sqldata/1779400000_backfill_warranty_expires_at_from_legacy_tag.up.sql
+++ b/go/schema/migrations/_sqldata/1779400000_backfill_warranty_expires_at_from_legacy_tag.up.sql
@@ -1,0 +1,59 @@
+-- Migration: backfill commodities.warranty_expires_at from the legacy
+-- "warranty:YYYY-MM-DD" tag convention (issue #1367 cleanup).
+-- Direction: UP
+--
+-- Pre-#1535, warranty expiry was carried as a tag matching
+-- ^warranty:[0-9]{4}-[0-9]{2}-[0-9]{2}$ on the commodity row. The
+-- first-class column landed in #1535. This migration drains the old
+-- tags into the typed column and strips them so the FE can drop its
+-- dual-source warrantyStatus()/effectiveWarrantyExpiry() fallback.
+--
+-- Two passes, both idempotent (re-running selects no rows once the
+-- invariant holds):
+--
+-- 1. Backfill: for every row where warranty_expires_at is unset
+--    (NULL or empty string) AND tags contains a matching tag, copy
+--    the lexicographically-first matching tag's date suffix into the
+--    column. YYYY-MM-DD sorts naturally so this is also the
+--    chronologically-earliest expiry across competing tags. Multiple
+--    competing tags are vanishingly rare in practice and the loser
+--    is dropped in pass 2 anyway.
+--
+-- 2. Strip: from every row whose tags contains a matching tag,
+--    remove every "warranty:YYYY-MM-DD" entry. This also cleans up
+--    rows that already had warranty_expires_at set but carried a
+--    leftover legacy tag from before #1535.
+
+WITH legacy AS (
+    SELECT
+        c.id,
+        substring(picked.tag FROM 10) AS expires_at
+    FROM commodities c
+    CROSS JOIN LATERAL (
+        SELECT j.tag
+        FROM jsonb_array_elements_text(COALESCE(c.tags, '[]'::jsonb)) AS j(tag)
+        WHERE j.tag ~ '^warranty:[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+        ORDER BY j.tag ASC
+        LIMIT 1
+    ) AS picked
+    WHERE c.warranty_expires_at IS NULL OR c.warranty_expires_at = ''
+)
+UPDATE commodities c
+SET
+    warranty_expires_at = legacy.expires_at,
+    updated_at = CURRENT_TIMESTAMP
+FROM legacy
+WHERE c.id = legacy.id;
+
+UPDATE commodities c
+SET
+    tags = COALESCE(
+        (
+            SELECT jsonb_agg(j.tag ORDER BY j.tag)
+            FROM jsonb_array_elements_text(COALESCE(c.tags, '[]'::jsonb)) AS j(tag)
+            WHERE j.tag !~ '^warranty:[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+        ),
+        '[]'::jsonb
+    ),
+    updated_at = CURRENT_TIMESTAMP
+WHERE c.tags @? '$[*] ? (@ like_regex "^warranty:[0-9]{4}-[0-9]{2}-[0-9]{2}$")';


### PR DESCRIPTION
Closes #1367. Drains the pre-#1535 warranty tag convention into the typed `warranty_expires_at` column and removes the FE dual-source helper. PR #1535 already shipped the first-class warranty surface — this is the residual cleanup the issue body's last open thread tracked, so we can close #1367 once it lands.

## Backend

New data migration `1779400000_backfill_warranty_expires_at_from_legacy_tag` runs in two passes:

1. **Backfill**: for every commodity where `warranty_expires_at` is unset (NULL or empty string) AND `tags` carries a `^warranty:[0-9]{4}-[0-9]{2}-[0-9]{2}$` entry, copy the lexicographically-first matching tag's date suffix into the typed column. YYYY-MM-DD sorts naturally so this is also the chronologically-earliest expiry across competing tags. Multiple competing legacy tags on one row are vanishingly rare in practice; the loser is dropped in pass 2 anyway.
2. **Strip**: from every row whose `tags` carries a matching entry, drop every `warranty:YYYY-MM-DD` from the JSONB array — including rows where `warranty_expires_at` was already set, so leftover legacy tags don't linger as orphans.

Both passes are idempotent: re-running selects no rows once the invariant holds. The down migration is a no-op (lossy reversal would spray a synthetic tag onto rows that never had one).

## Frontend

`warrantyStatus()` and `effectiveWarrantyExpiry()` in `frontend/src/features/commodities/constants.ts` lose their `tags` parameter — the only source is now `warranty_expires_at`. Updated all call sites:

- `CommoditiesListPage.tsx` (warranty filter)
- `CommodityDetailPage.tsx` (header pill + Warranty tab)
- `WarrantyBadge.tsx` (`source` prop type)
- `WarrantiesListPage.tsx` (per-bucket walk)
- `features/dashboard/hooks.ts` (`warrantyBuckets`)
- `components/dashboard/ExpiringWarranties.tsx` (docstring)

Tests rewritten:

- Removed the two "falls back to legacy tag" cases (`WarrantyBadge.test.tsx`, `dashboard/hooks.test.ts`).
- Converted the `CommoditiesListPage` warranty-filter fixture from `tags: ["warranty:2099-12-31"]` to `warranty_expires_at: "2099-12-31"`.
- Added a regression in `dashboard/hooks.test.ts` asserting tag-only rows read as `none` after the fallback's removal.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (11 pre-existing react-hook-form `watch()` warnings unrelated to this diff)
- `npm test` — 744/744 pass
- `go test ./models/... ./schema/migrations/...` — green
- Migration UP applied **and** re-applied against an ephemeral `postgres:16-alpine` fixture covering: tag-only, empty-string field, field-only, both-set with orphan tag, multi-tag, no-warranty, NULL tags, malformed (`warranty:not-a-date` left intact since it doesn't match the YYYY-MM-DD shape). Second apply is a no-op (UPDATE 0 + UPDATE 0).

`make lint-migrations` against a real postgres-test DSN is left for CI — no schema annotation changes, so the diff check should be empty.

## Test plan

- [ ] `go-lint`, `go-test`, `go-test-postgres` green
- [ ] `lint-migrations` green (no schema drift; the migration is pure data UPDATE)
- [ ] `frontend-{lint,typecheck,test,i18n,codegen}` green
- [ ] Manual smoke against a real DB seed: a commodity with the legacy `warranty:2026-12-31` tag and no `warranty_expires_at` shows up in the Active bucket on `/g/:slug/warranties` after migration, with no `warranty:` chip on the detail page.