### PR TITLE
GroupSettingsPage: section-shell + Storage/Export relocation

### DIFF
--- a/design-mocks/src/components/AddItemDialog.tsx
+++ b/design-mocks/src/components/AddItemDialog.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/select"
 import { Upload, X, FileText, Image, File, Plus, Image as ImageIcon, Receipt, BookOpen, Sparkles, Camera, ScanText, CircleCheck as CheckCircle2, CircleAlert as AlertCircle, ChevronDown, TriangleAlert, RefreshCw, ServerCrash } from "lucide-react"
 import { CATEGORIES, MOCK_LOCATIONS, MOCK_AREAS, CURRENCIES, type ItemCategory, type FileCategory } from "@/data/mock"
-import { cn } from "@/lib/utils"
+import { cn, makeId } from "@/lib/utils"
 import { CurrencyCombobox } from "@/components/CurrencyCombobox"
 
 // ─── Brand / model data ───────────────────────────────────────
@@ -385,7 +385,7 @@ export function AddItemDialog({ open, onClose, defaultAreaId }: AddItemDialogPro
 
   function addFilesToList(files: File[], setter: React.Dispatch<React.SetStateAction<AttachedFileDraft[]>>, category: FileCategory) {
     const drafts: AttachedFileDraft[] = files.map((f) => ({
-      id: crypto.randomUUID(),
+      id: makeId(),
       name: f.name,
       size: formatFileSize(f.size),
       mimeType: f.type,
@@ -734,7 +734,7 @@ function AiPhotoStep({ phase, photos, setPhotos, filledName, filledBrand, filled
 }) {
   function handlePhotoFiles(files: File[]) {
     const previews = files.map((f) => ({
-      id: crypto.randomUUID(),
+      id: makeId(),
       name: f.name,
       preview: URL.createObjectURL(f),
     }))
@@ -1312,7 +1312,7 @@ function ExtrasStep({ notes, setNotes, tagInput, setTagInput, tags, setTags, add
           <button
             type="button"
             className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-            onClick={() => setUrls((prev: any[]) => [...prev, { id: crypto.randomUUID(), label: "", url: "" }])}
+            onClick={() => setUrls((prev: any[]) => [...prev, { id: makeId(), label: "", url: "" }])}
           >
             <Plus className="size-3" />Add
           </button>
@@ -1344,7 +1344,7 @@ function ExtrasStep({ notes, setNotes, tagInput, setTagInput, tags, setTags, add
           <button
             type="button"
             className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-            onClick={() => setSupplyLinks((prev: any[]) => [...prev, { id: crypto.randomUUID(), label: "", url: "" }])}
+            onClick={() => setSupplyLinks((prev: any[]) => [...prev, { id: makeId(), label: "", url: "" }])}
           >
             <Plus className="size-3" />Add
           </button>

--- a/design-mocks/src/components/LocationDialog.tsx
+++ b/design-mocks/src/components/LocationDialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog"
-import { cn } from "@/lib/utils"
+import { cn, makeId } from "@/lib/utils"
 import type { Location } from "@/data/mock"
 
 const LOCATION_ICONS = ["🏠", "🏡", "🏢", "🏗️", "🏚️", "🚗", "🌿", "🌊", "⛺", "🏕️", "🔑", "📦"]
@@ -64,7 +64,7 @@ export function LocationDialog({ open, onClose, location, onSave }: LocationDial
 
   function addFiles(files: File[]) {
     const drafts: AttachedFileDraft[] = files.map((f) => ({
-      id: crypto.randomUUID(),
+      id: makeId(),
       name: f.name,
       size: formatSize(f.size),
       mimeType: f.type,

--- a/design-mocks/src/lib/utils.ts
+++ b/design-mocks/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// `crypto.randomUUID` is undefined outside a secure context (HTTPS or
+// `localhost` / `127.0.0.1`). Plain-HTTP dev hosts (e.g. tailscale
+// hostnames) hit the unbounded form and crash on mount. The fallback
+// yields enough entropy for in-memory list keys — these ids never
+// leave the client.
+export function makeId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  return `id-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}

--- a/design-mocks/src/views/FileBrowserView.tsx
+++ b/design-mocks/src/views/FileBrowserView.tsx
@@ -39,7 +39,7 @@ import {
   PaginationEllipsis,
 } from "@/components/ui/pagination"
 import { FileDetailSheet } from "@/components/FileDetail"
-import { cn } from "@/lib/utils"
+import { cn, makeId } from "@/lib/utils"
 import { MOCK_FILES, FILE_TAGS, type AttachedFile, type FileCategory } from "@/data/mock"
 
 const PAGE_SIZE = 12
@@ -180,7 +180,7 @@ function UploadDialog({ open, onClose }: UploadDialogProps) {
     setPendingFiles((prev) => [
       ...prev,
       ...arr.map((f) => ({
-        id: crypto.randomUUID(),
+        id: makeId(),
         file: f,
         name: f.name.replace(/\.[^.]+$/, ""),
         category: guessCategoryFromMime(f.type),

--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -96,6 +96,14 @@ _None yet._
 - **Approved by**: user (explicit) — issue #1553 §"MigrateCurrencyDialog wizard" §5.2 spells out the four steps and the components to use.
 - **Reversion plan**: Permanent. Reconcile if the upstream mock gains a `MigrateCurrencyView` or similar.
 
+#### 2026-05-09 — Group settings split into Info / Members / Data & Storage / Management sub-sections
+
+- **Mock**: [`design-mocks/src/views/GroupSettingsView.tsx`](../../design-mocks/src/views/GroupSettingsView.tsx) is a single flat page: header, then "Plan" / "Group" / "Notifications" / "Data" (members + backup links) / "Danger zone" cards stacked vertically, no sub-navigation.
+- **Reality**: `frontend/src/pages/groups/GroupSettingsPage.tsx` now uses the same two-pane shell as the user Preferences page (`SettingsPage`): a left rail (Info / Members / Data & Storage / Management) + a right content pane that swaps in one section at a time. Each section owns its own card stack — Info has the identity form + currency migration, Members has the members shortcut + leave-group, Data & Storage has `<StorageCard />` + the Export-data CTA (relocated from user Preferences, where they were group-scoped surfaces masquerading as personal ones), Management has the delete-group danger zone.
+- **Why**: The mock predates the storage + exports surfaces and predates the Preferences sub-navigation pattern that ships in `SettingsPage`. Keeping the group page flat while the personal page is sectioned would diverge the two settings hubs from each other for no design payoff. User explicitly asked for the same pattern ("таким же образом, как это сделано в Preferences"). Storage usage and Export data are per-group, so they belong here, not on `/settings`.
+- **Approved by**: user (explicit) — directly requested the four-section layout (Info / Members / Data & Storage / Management) and the relocation of Storage + Export.
+- **Reversion plan**: Permanent until/unless the upstream mock adopts the sub-navigation pattern across both settings surfaces. Reconcile if a future mock revision aligns the two.
+
 #### 2026-05-08 — "Currency migrations" history list inside Danger Zone
 
 - **Issue/PR**: #1553 / PR #1604

--- a/e2e/tests/delete-group-dialog.spec.ts
+++ b/e2e/tests/delete-group-dialog.spec.ts
@@ -63,8 +63,12 @@ async function hardDelete(
 
 async function openDangerZone(page: Page, group: { id: string; slug: string }) {
   // The settings page sits under /groups/:groupId/settings — not the
-  // group-scoped data routes, so no /g/<slug>/ prefix needed.
+  // group-scoped data routes, so no /g/<slug>/ prefix needed. The
+  // page splits into Info / Members / Data / Management sub-sections;
+  // the delete CTA lives behind the Management nav.
   await page.goto(`/groups/${group.id}/settings`);
+  await page.waitForSelector('[data-testid="group-settings-nav-management"]', { timeout: 10000 });
+  await page.click('[data-testid="group-settings-nav-management"]');
   await page.waitForSelector('[data-testid="delete-group-open"]', { timeout: 10000 });
   await page.click('[data-testid="delete-group-open"]');
   await page.waitForSelector('[data-testid="delete-confirm-word"]', { state: 'visible', timeout: 5000 });

--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -604,6 +604,11 @@ test.describe('Leave Group UI — last admin protection (#1259)', () => {
     try {
       await page.goto(`/groups/${groupId}/settings`);
 
+      // The page splits into Info / Members / Data / Management. Leave-group
+      // lives behind the Members nav; Delete Group behind Management.
+      await page.waitForSelector('[data-testid="group-settings-nav-members"]', { timeout: 10000 });
+      await page.click('[data-testid="group-settings-nav-members"]');
+
       // Wait for the Leave Group section to render — loadData() is async and
       // the last-admin branch only appears once the membership list arrives.
       const leaveBtn = page.locator('[data-testid="leave-group-btn"]');
@@ -627,6 +632,7 @@ test.describe('Leave Group UI — last admin protection (#1259)', () => {
 
       // Danger Zone (with Delete Group) must be reachable — the notice
       // tells the user to use it, so it must actually be rendered.
+      await page.click('[data-testid="group-settings-nav-management"]');
       await expect(page.locator('button:has-text("Delete Group")')).toBeVisible();
     } finally {
       // Clean up the test group so repeat runs don't accumulate state.

--- a/frontend/src/i18n/locales/en/groups.json
+++ b/frontend/src/i18n/locales/en/groups.json
@@ -37,6 +37,13 @@
     "currencyLabel": "Group currency",
     "dangerDescription": "Deleting this group permanently removes all locations, items, files, and exports. This cannot be undone.",
     "dangerTitle": "Danger zone",
+    "data": {
+      "exportCta": "Open exports",
+      "exportDescription": "Generate a JSON or CSV snapshot of this group's inventory.",
+      "exportTitle": "Export data",
+      "noGroupSlug": "—",
+      "title": "Data & storage"
+    },
     "deleteCta": "Delete group",
     "deleteDialog": {
       "body": "Type the group name and your current password to confirm. The name guards against accidental clicks; the password against a hijacked session.",
@@ -100,6 +107,12 @@
     "save": "Save changes",
     "saved": "Group saved.",
     "saving": "Saving…",
+    "sections": {
+      "data": "Data & storage",
+      "info": "Info",
+      "management": "Management",
+      "members": "Members"
+    },
     "slugHelp": "Slugs are randomly generated at creation and immutable.",
     "slugLabel": "URL slug",
     "subtitle": "Manage your group's profile, members, and lifecycle.",

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -2,6 +2,14 @@
   "account": {
     "changePassword": "Change password",
     "changePasswordDescription": "Update the password used to sign in to your account.",
+    "dangerZone": {
+      "deleteAccount": "Delete account",
+      "description": "Once your account is deleted, all data is permanently removed.",
+      "deleteUnavailableConfirm": "Got it",
+      "deleteUnavailableDescription": "Self-service account deletion is on the roadmap. For now, contact support to remove your account.",
+      "deleteUnavailableTitle": "Account deletion is not yet available",
+      "title": "Danger zone"
+    },
     "displayName": "Display name",
     "editProfile": "Edit profile",
     "email": "Email address",
@@ -26,18 +34,6 @@
       "system": "System"
     },
     "title": "Appearance"
-  },
-  "data": {
-    "dangerZoneDescription": "Once your account is deleted, all data is permanently removed.",
-    "dangerZoneTitle": "Danger zone",
-    "deleteAccount": "Delete account",
-    "deleteUnavailableConfirm": "Got it",
-    "deleteUnavailableDescription": "Self-service account deletion is on the roadmap. For now, contact support to remove your account.",
-    "deleteUnavailableTitle": "Account deletion is not yet available",
-    "exportCta": "Open exports",
-    "exportDescription": "Generate a JSON or CSV snapshot of your inventory.",
-    "exportTitle": "Export data",
-    "title": "Data & storage"
   },
   "help": {
     "rows": {
@@ -105,7 +101,6 @@
   "sections": {
     "account": "Account",
     "appearance": "Appearance",
-    "data": "Data & storage",
     "help": "Help & support",
     "notifications": "Notifications",
     "privacy": "Privacy & security"

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,8 +8,6 @@ import {
   Check,
   ChevronRight,
   CircleHelp,
-  Database,
-  Download,
   LogOut,
   Monitor,
   Moon,
@@ -22,7 +20,6 @@ import {
 } from "lucide-react"
 
 import { ComingSoonBanner } from "@/components/coming-soon"
-import { StorageCard } from "@/features/storage/StorageCard"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
@@ -40,7 +37,7 @@ import { parseServerError } from "@/lib/server-error"
 import { cn } from "@/lib/utils"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 
-type SectionId = "account" | "appearance" | "notifications" | "privacy" | "data" | "help"
+type SectionId = "account" | "appearance" | "notifications" | "privacy" | "help"
 
 interface SectionMeta {
   id: SectionId
@@ -53,7 +50,6 @@ const SECTIONS: SectionMeta[] = [
   { id: "appearance", icon: Palette },
   { id: "notifications", icon: Bell },
   { id: "privacy", icon: Shield },
-  { id: "data", icon: Database },
   { id: "help", icon: CircleHelp },
 ]
 
@@ -87,7 +83,6 @@ export function SettingsPage() {
             {active === "appearance" ? <AppearanceSection /> : null}
             {active === "notifications" ? <NotificationsSection /> : null}
             {active === "privacy" ? <PrivacySection /> : null}
-            {active === "data" ? <DataSection /> : null}
             {active === "help" ? <HelpSection /> : null}
           </div>
         </div>
@@ -186,9 +181,23 @@ function AccountSection() {
   const { t } = useTranslation()
   const { user } = useAuth()
   const { groups, currentGroup, isLoading } = useCurrentGroup()
+  const confirm = useConfirm()
   const memberSince = user?.created_at
     ? formatDate(user.created_at, { style: "long" })
     : t("settings:account.memberSinceUnknown")
+
+  // Account deletion isn't backend-supported yet; render a danger-zone
+  // panel that opens a confirm dialog explaining the limitation rather
+  // than fake a destructive action that does nothing.
+  async function handleDeleteAccount() {
+    await confirm({
+      title: t("settings:account.dangerZone.deleteUnavailableTitle"),
+      description: t("settings:account.dangerZone.deleteUnavailableDescription"),
+      confirmLabel: t("settings:account.dangerZone.deleteUnavailableConfirm"),
+      cancelLabel: t("settings:profile.edit.cancel"),
+      destructive: false,
+    })
+  }
 
   // Wait for the membership list to load before deciding which surface to
   // render — a `groups === undefined` state would briefly show the empty-
@@ -254,6 +263,25 @@ function AccountSection() {
             </Link>
           </Button>
         </SettingRow>
+      </div>
+
+      <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 space-y-2">
+        <p className="text-sm font-semibold text-destructive">
+          {t("settings:account.dangerZone.title")}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {t("settings:account.dangerZone.description")}
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          className="text-destructive border-destructive/40 hover:bg-destructive/10 gap-1.5"
+          onClick={handleDeleteAccount}
+          data-testid="delete-account-button"
+        >
+          <Trash2 className="size-3.5" aria-hidden="true" />
+          {t("settings:account.dangerZone.deleteAccount")}
+        </Button>
       </div>
     </div>
   )
@@ -490,72 +518,6 @@ function PrivacySection() {
       <ComingSoonBanner surface="activeSessions" />
       <ComingSoonBanner surface="loginHistory" />
       <ComingSoonBanner surface="connectedAccounts" />
-    </div>
-  )
-}
-
-function DataSection() {
-  const { t } = useTranslation()
-  const { currentGroup } = useCurrentGroup()
-  const confirm = useConfirm()
-
-  // Account deletion isn't backend-supported yet; render a danger-zone
-  // panel that opens a confirm dialog explaining the limitation rather
-  // than fake a destructive action that does nothing.
-  async function handleDeleteAccount() {
-    await confirm({
-      title: t("settings:data.deleteUnavailableTitle"),
-      description: t("settings:data.deleteUnavailableDescription"),
-      confirmLabel: t("settings:data.deleteUnavailableConfirm"),
-      cancelLabel: t("settings:profile.edit.cancel"),
-      destructive: false,
-    })
-  }
-
-  return (
-    <div className="space-y-6" data-testid="section-data">
-      <SectionTitle>{t("settings:data.title")}</SectionTitle>
-
-      <div className="rounded-xl border border-border bg-card p-4 space-y-3">
-        <div>
-          <p className="text-sm font-medium">{t("settings:data.exportTitle")}</p>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            {t("settings:data.exportDescription")}
-          </p>
-        </div>
-        {currentGroup?.slug ? (
-          <Button asChild size="sm" variant="outline" className="gap-1.5">
-            <Link
-              to={`/g/${encodeURIComponent(currentGroup.slug)}/exports`}
-              data-testid="settings-open-exports"
-            >
-              <Download className="size-3.5" aria-hidden="true" />
-              {t("settings:data.exportCta")}
-            </Link>
-          </Button>
-        ) : (
-          <p className="text-xs text-muted-foreground">{t("settings:profile.noGroupSet")}</p>
-        )}
-      </div>
-
-      <StorageCard />
-
-      <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 space-y-2">
-        <p className="text-sm font-semibold text-destructive">
-          {t("settings:data.dangerZoneTitle")}
-        </p>
-        <p className="text-xs text-muted-foreground">{t("settings:data.dangerZoneDescription")}</p>
-        <Button
-          variant="outline"
-          size="sm"
-          className="text-destructive border-destructive/40 hover:bg-destructive/10 gap-1.5"
-          onClick={handleDeleteAccount}
-          data-testid="delete-account-button"
-        >
-          <Trash2 className="size-3.5" aria-hidden="true" />
-          {t("settings:data.deleteAccount")}
-        </Button>
-      </div>
     </div>
   )
 }

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -74,15 +74,17 @@ const baseHandlers = [
 ]
 
 describe("<SettingsPage />", () => {
-  it("renders the section nav with all 6 entries", async () => {
+  it("renders the section nav with all 5 entries", async () => {
     server.use(...baseHandlers)
     renderSettings()
     expect(await screen.findByTestId("settings-nav-account")).toBeInTheDocument()
     expect(screen.getByTestId("settings-nav-appearance")).toBeInTheDocument()
     expect(screen.getByTestId("settings-nav-notifications")).toBeInTheDocument()
     expect(screen.getByTestId("settings-nav-privacy")).toBeInTheDocument()
-    expect(screen.getByTestId("settings-nav-data")).toBeInTheDocument()
     expect(screen.getByTestId("settings-nav-help")).toBeInTheDocument()
+    // Storage usage and Export data moved to /groups/:id/settings → no
+    // "data" nav entry on user Preferences anymore.
+    expect(screen.queryByTestId("settings-nav-data")).not.toBeInTheDocument()
   })
 
   it("appearance section is the default and shows theme/density/locale controls", async () => {
@@ -124,11 +126,11 @@ describe("<SettingsPage />", () => {
     expect(screen.getByTestId("coming-soon-banner-connectedAccounts")).toBeInTheDocument()
   })
 
-  it("data section's delete button opens a confirm dialog explaining unavailability", async () => {
+  it("account danger zone's delete button opens a confirm dialog explaining unavailability", async () => {
     server.use(...baseHandlers)
     const user = userEvent.setup()
     renderSettings()
-    await user.click(await screen.findByTestId("settings-nav-data"))
+    await user.click(await screen.findByTestId("settings-nav-account"))
     await user.click(screen.getByTestId("delete-account-button"))
     expect(await screen.findByText(/account deletion is not yet available/i)).toBeInTheDocument()
   })

--- a/frontend/src/pages/groups/GroupSettingsPage.tsx
+++ b/frontend/src/pages/groups/GroupSettingsPage.tsx
@@ -1,9 +1,22 @@
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useState, type ReactNode } from "react"
 import { useForm, Controller } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useTranslation } from "react-i18next"
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom"
-import { ArrowLeft, ArrowRight, ArrowRightLeft, History, LogOut, Trash2, Users } from "lucide-react"
+import {
+  ArrowLeft,
+  ArrowRight,
+  ArrowRightLeft,
+  ChevronRight,
+  Database,
+  Download,
+  History,
+  Info,
+  LogOut,
+  ShieldAlert,
+  Trash2,
+  Users,
+} from "lucide-react"
 
 import { CurrencyMigrationsList } from "@/components/groups/CurrencyMigrationsList"
 import { IconPicker } from "@/components/groups/IconPicker"
@@ -27,6 +40,7 @@ import {
 } from "@/components/ui/sheet"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { StorageCard } from "@/features/storage/StorageCard"
 import { useAuth } from "@/features/auth/AuthContext"
 import { useCurrencyMigrations } from "@/features/currency-migration/hooks"
 import {
@@ -45,16 +59,34 @@ import {
 import { useAppToast } from "@/hooks/useAppToast"
 import { HttpError } from "@/lib/http"
 import { parseServerError } from "@/lib/server-error"
+import { cn } from "@/lib/utils"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 
-// /groups/:groupId/settings — admin panel: rename / icon, currency
-// (read-only, immutable), members link, leave-group, danger-zone
-// delete with typed confirm-word + password.
+type SectionId = "info" | "members" | "data" | "management"
+
+interface SectionMeta {
+  id: SectionId
+  icon: typeof Info
+}
+
+const SECTIONS: SectionMeta[] = [
+  { id: "info", icon: Info },
+  { id: "members", icon: Users },
+  { id: "data", icon: Database },
+  { id: "management", icon: ShieldAlert },
+]
+
+// /groups/:groupId/settings — group admin panel split across four
+// sub-sections behind a left rail (mirrors the user Preferences pattern
+// at /settings):
+//   - Info        identity (name, icon, slug, currency + migrate)
+//   - Members     members link + leave-group panel
+//   - Data        per-group storage usage + exports shortcut
+//   - Management  destructive actions (delete group)
 //
 // Group `id` (UUID) is the path key here, not the slug — slugs are
-// random and not in URLs that admin tools reach for. The members
-// section lives at /g/{slug}/members so we link there using the
-// group's slug.
+// random and not in URLs that admin tools reach for. Sub-pages that
+// need the slug (members, exports) compose it from the loaded group.
 export function GroupSettingsPage() {
   const { groupId } = useParams<{ groupId: string }>()
   if (!groupId) return <Navigate to="/no-group" replace />
@@ -67,11 +99,138 @@ function GroupSettingsBody({ groupId }: { groupId: string }) {
   const { user } = useAuth()
   const groupQuery = useGroup(groupId)
   const membersQuery = useMembers(groupId)
+  const [active, setActive] = useState<SectionId>("info")
+
+  const myMembership = useMemo(
+    () => membersQuery.data?.find((m) => m.member_user_id === user?.id),
+    [membersQuery.data, user?.id]
+  )
+  const isAdmin = myMembership?.role === "admin"
+  const adminCount = useMemo(
+    () => membersQuery.data?.filter((m) => m.role === "admin").length ?? 0,
+    [membersQuery.data]
+  )
+  const isLastAdmin = isAdmin && adminCount === 1
+
+  if (groupQuery.isLoading) {
+    return <div className="text-sm text-muted-foreground p-6">{t("groups:settings.title")}…</div>
+  }
+  if (groupQuery.isError || !groupQuery.data) {
+    return (
+      <Alert variant="destructive" className="max-w-xl mx-auto mt-6">
+        <AlertDescription>{t("groups:settings.errorGeneric")}</AlertDescription>
+      </Alert>
+    )
+  }
+
+  const group = groupQuery.data
+
+  return (
+    <>
+      <RouteTitle title={t("groups:settings.title")} />
+      <div
+        className="mx-auto flex w-full max-w-4xl flex-col gap-8"
+        data-testid="group-settings-page"
+      >
+        <header className="space-y-1">
+          {/* Back returns to the previous location rather than hard-coding
+              /profile or /no-group: this page is reachable from the
+              GroupSelector dropdown, the members page, and onboarding;
+              any single destination would be wrong for some of them. */}
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            data-testid="group-settings-back"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="size-4" aria-hidden="true" />
+            {t("common:actions.back")}
+          </button>
+          <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">
+            {group.icon ? <span aria-hidden="true">{group.icon} </span> : null}
+            {group.name}
+          </h1>
+          <p className="text-sm text-muted-foreground">{t("groups:settings.subtitle")}</p>
+        </header>
+
+        <div className="flex flex-col gap-6 md:flex-row">
+          <GroupSettingsNav active={active} onSelect={setActive} />
+          <div className="min-w-0 flex-1">
+            {active === "info" ? <InfoSection groupId={groupId} isAdmin={isAdmin} /> : null}
+            {active === "members" ? (
+              <MembersSection
+                groupId={groupId}
+                groupSlug={group.slug ?? null}
+                isLastAdmin={isLastAdmin}
+                membersLoading={membersQuery.isLoading}
+              />
+            ) : null}
+            {active === "data" ? <DataSection groupSlug={group.slug ?? null} /> : null}
+            {active === "management" ? (
+              <ManagementSection
+                groupId={groupId}
+                groupName={group.name ?? ""}
+                isAdmin={isAdmin}
+              />
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+function GroupSettingsNav({
+  active,
+  onSelect,
+}: {
+  active: SectionId
+  onSelect: (id: SectionId) => void
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <aside className="md:w-48 md:shrink-0">
+      <nav className="space-y-0.5" aria-label={t("groups:settings.title")}>
+        {SECTIONS.map(({ id, icon: Icon }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onSelect(id)}
+            data-testid={`group-settings-nav-${id}`}
+            data-active={active === id ? "true" : undefined}
+            className={cn(
+              "flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors",
+              active === id
+                ? "bg-accent text-accent-foreground font-medium"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground"
+            )}
+            aria-current={active === id ? "page" : undefined}
+          >
+            <Icon className="size-4 shrink-0" aria-hidden="true" />
+            {t(`groups:settings.sections.${id}`)}
+            {active === id ? (
+              <ChevronRight className="ml-auto size-3.5" aria-hidden="true" />
+            ) : null}
+          </button>
+        ))}
+      </nav>
+    </aside>
+  )
+}
+
+function SectionTitle({ children }: { children: ReactNode }) {
+  return <h2 className="mb-4 text-base font-semibold">{children}</h2>
+}
+
+// InfoSection — identity (name, icon, slug, currency) + currency
+// migration controls. Admin-only; non-admins see a read-only summary.
+function InfoSection({ groupId, isAdmin }: { groupId: string; isAdmin: boolean }) {
+  const { t } = useTranslation()
+  const groupQuery = useGroup(groupId)
   const updateMutation = useUpdateGroup()
-  const leaveMutation = useLeaveGroup()
   const toast = useAppToast()
   const [serverError, setServerError] = useState<string | null>(null)
-  const [deleteOpen, setDeleteOpen] = useState(false)
   const [migrateOpen, setMigrateOpen] = useState(false)
   const [historyOpen, setHistoryOpen] = useState(false)
   // Migrations list: only fetch when a group is loaded. The group's
@@ -85,17 +244,6 @@ function GroupSettingsBody({ groupId }: { groupId: string }) {
   })
   const migrations = migrationsQuery.data?.migrations ?? []
   const migrationInFlightId = groupQuery.data?.currency_migration_id
-
-  const myMembership = useMemo(
-    () => membersQuery.data?.find((m) => m.member_user_id === user?.id),
-    [membersQuery.data, user?.id]
-  )
-  const isAdmin = myMembership?.role === "admin"
-  const adminCount = useMemo(
-    () => membersQuery.data?.filter((m) => m.role === "admin").length ?? 0,
-    [membersQuery.data]
-  )
-  const isLastAdmin = isAdmin && adminCount === 1
 
   const form = useForm<UpdateGroupInput>({
     resolver: zodResolver(updateGroupSchema),
@@ -120,17 +268,7 @@ function GroupSettingsBody({ groupId }: { groupId: string }) {
     return () => sub.unsubscribe()
   }, [form, serverError])
 
-  if (groupQuery.isLoading) {
-    return <div className="text-sm text-muted-foreground p-6">{t("groups:settings.title")}…</div>
-  }
-  if (groupQuery.isError || !groupQuery.data) {
-    return (
-      <Alert variant="destructive" className="max-w-xl mx-auto mt-6">
-        <AlertDescription>{t("groups:settings.errorGeneric")}</AlertDescription>
-      </Alert>
-    )
-  }
-
+  if (!groupQuery.data) return null
   const group = groupQuery.data
 
   async function onSave(values: UpdateGroupInput) {
@@ -146,6 +284,198 @@ function GroupSettingsBody({ groupId }: { groupId: string }) {
     }
   }
 
+  if (!isAdmin) {
+    return (
+      <div className="space-y-6" data-testid="group-section-info">
+        <SectionTitle>{t("groups:settings.sections.info")}</SectionTitle>
+        <div className="rounded-xl border border-border bg-muted/30 p-5 text-sm text-muted-foreground">
+          {t("members:adminOnlyHelp")}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6" data-testid="group-section-info">
+      <SectionTitle>{t("groups:settings.sections.info")}</SectionTitle>
+
+      <form
+        className="space-y-4 rounded-xl border border-border bg-card p-5"
+        onSubmit={form.handleSubmit(onSave)}
+        noValidate
+      >
+        <div className="space-y-1.5">
+          <Label htmlFor="settings-group-name">{t("groups:settings.nameLabel")}</Label>
+          <Input
+            id="settings-group-name"
+            maxLength={100}
+            disabled={updateMutation.isPending}
+            aria-invalid={!!form.formState.errors.name}
+            data-testid="settings-name-input"
+            {...form.register("name")}
+          />
+          {form.formState.errors.name ? (
+            <p className="text-xs text-destructive" data-testid="settings-name-error">
+              {t(form.formState.errors.name.message ?? "")}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>{t("groups:settings.iconLabel")}</Label>
+          <Controller
+            control={form.control}
+            name="icon"
+            render={({ field }) => (
+              <IconPicker
+                value={field.value}
+                onChange={field.onChange}
+                disabled={updateMutation.isPending}
+                testId="group-settings-icon-picker"
+              />
+            )}
+          />
+          {form.formState.errors.icon ? (
+            <p className="text-xs text-destructive" data-testid="settings-icon-error">
+              {t(form.formState.errors.icon.message ?? "")}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="settings-group-slug">{t("groups:settings.slugLabel")}</Label>
+          <Input
+            id="settings-group-slug"
+            value={group.slug ?? ""}
+            readOnly
+            disabled
+            className="font-mono text-xs"
+          />
+          <p className="text-[11px] text-muted-foreground">{t("groups:settings.slugHelp")}</p>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="settings-group-currency">{t("groups:settings.currencyLabel")}</Label>
+          <div className="flex gap-2">
+            <Input
+              id="settings-group-currency"
+              value={group.group_currency ?? "—"}
+              readOnly
+              disabled
+              className="font-mono uppercase"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0 gap-1.5"
+              // The BE blocks a second migration on the same group at the
+              // start handler with 409 migration_in_progress. We mirror
+              // that as a disabled CTA driven by the group's own
+              // currency_migration_id (read-only on JSON:API; the
+              // migration registry sets it). The 409 is the safety net
+              // for the race between this read and the click.
+              disabled={!!migrationInFlightId}
+              title={migrationInFlightId ? t("errors:lockedDuringMigration") : undefined}
+              aria-disabled={!!migrationInFlightId || undefined}
+              onClick={() => setMigrateOpen(true)}
+              data-testid="migrate-currency-open"
+            >
+              <ArrowRightLeft className="size-3.5" aria-hidden="true" />
+              {t("groups:settings.migrateCurrency")}
+            </Button>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-2 pt-0.5">
+            <p className="text-[11px] text-muted-foreground">
+              {t("groups:settings.migrateCurrencyHelp")}
+            </p>
+            {/* History link mounts only after at least one migration
+                has been started — there's nothing useful behind it
+                on a fresh group. Opens a right-side Sheet instead
+                of inlining the list, since this is reference data
+                a user opens occasionally, not the primary content
+                of the page. */}
+            {migrations.length > 0 ? (
+              <button
+                type="button"
+                onClick={() => setHistoryOpen(true)}
+                className="inline-flex items-center gap-1 text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline transition-colors"
+                data-testid="migrations-history-open"
+              >
+                <History className="size-3" aria-hidden="true" />
+                {t("groups:settings.migrationsHistoryCta", {
+                  count: migrations.length,
+                })}
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        {serverError ? (
+          <Alert variant="destructive" data-testid="settings-server-error">
+            <AlertDescription>{serverError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="flex justify-end pt-2">
+          <Button
+            type="submit"
+            className="gap-2"
+            disabled={updateMutation.isPending}
+            data-testid="settings-save"
+          >
+            {updateMutation.isPending ? t("groups:settings.saving") : t("groups:settings.save")}
+            {!updateMutation.isPending ? <ArrowRight className="size-4" /> : null}
+          </Button>
+        </div>
+      </form>
+
+      {group.group_currency && groupSlug ? (
+        <MigrateCurrencyDialog
+          open={migrateOpen}
+          onOpenChange={setMigrateOpen}
+          groupName={group.name ?? ""}
+          fromCurrency={group.group_currency}
+          groupSlug={groupSlug}
+        />
+      ) : null}
+      <Sheet open={historyOpen} onOpenChange={setHistoryOpen}>
+        <SheetContent
+          side="right"
+          className="w-full sm:max-w-md flex flex-col gap-4 overflow-y-auto p-6"
+          data-testid="migrations-history-sheet"
+        >
+          <SheetHeader className="p-0">
+            <SheetTitle>{t("groups:settings.migrationsTitle")}</SheetTitle>
+            <SheetDescription>{t("groups:settings.migrationsHelp")}</SheetDescription>
+          </SheetHeader>
+          <CurrencyMigrationsList loading={migrationsQuery.isLoading} migrations={migrations} />
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}
+
+// MembersSection — short list link out to /g/<slug>/members plus the
+// leave-group control. Both render for non-admins too: viewing the
+// member list is unrestricted, and a non-admin can always leave (only
+// last-admin is blocked, and only on the BE).
+function MembersSection({
+  groupId,
+  groupSlug,
+  isLastAdmin,
+  membersLoading,
+}: {
+  groupId: string
+  groupSlug: string | null
+  isLastAdmin: boolean
+  membersLoading: boolean
+}) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const leaveMutation = useLeaveGroup()
+  const toast = useAppToast()
+
   async function onLeave() {
     try {
       await leaveMutation.mutateAsync({ groupId })
@@ -157,279 +487,159 @@ function GroupSettingsBody({ groupId }: { groupId: string }) {
   }
 
   return (
-    <>
-      <RouteTitle title={t("groups:settings.title")} />
-      <div
-        className="mx-auto flex w-full max-w-2xl flex-col gap-8"
-        data-testid="group-settings-page"
-      >
-        <div className="space-y-1">
-          {/* Back returns to the previous location rather than hard-coding
-              /profile or /no-group: this page is reachable from the
-              GroupSelector dropdown, the members page, and onboarding;
-              any single destination would be wrong for some of them. */}
-          <button
-            type="button"
-            onClick={() => navigate(-1)}
-            data-testid="group-settings-back"
-            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            <ArrowLeft className="size-4" aria-hidden="true" />
-            {t("common:actions.back")}
-          </button>
-          <h1 className="text-2xl font-semibold tracking-tight">
-            {group.icon ? <span aria-hidden="true">{group.icon} </span> : null}
-            {group.name}
-          </h1>
-          <p className="text-sm text-muted-foreground">{t("groups:settings.subtitle")}</p>
-        </div>
+    <div className="space-y-6" data-testid="group-section-members">
+      <SectionTitle>{t("groups:settings.sections.members")}</SectionTitle>
 
-        {/* Identity (admins only — non-admins see read-only summary). */}
-        {isAdmin ? (
-          <form
-            className="space-y-4 rounded-xl border border-border bg-card p-5"
-            onSubmit={form.handleSubmit(onSave)}
-            noValidate
-          >
-            <div className="space-y-1.5">
-              <Label htmlFor="settings-group-name">{t("groups:settings.nameLabel")}</Label>
-              <Input
-                id="settings-group-name"
-                maxLength={100}
-                disabled={updateMutation.isPending}
-                aria-invalid={!!form.formState.errors.name}
-                data-testid="settings-name-input"
-                {...form.register("name")}
-              />
-              {form.formState.errors.name ? (
-                <p className="text-xs text-destructive" data-testid="settings-name-error">
-                  {t(form.formState.errors.name.message ?? "")}
-                </p>
-              ) : null}
-            </div>
-
-            <div className="space-y-1.5">
-              <Label>{t("groups:settings.iconLabel")}</Label>
-              <Controller
-                control={form.control}
-                name="icon"
-                render={({ field }) => (
-                  <IconPicker
-                    value={field.value}
-                    onChange={field.onChange}
-                    disabled={updateMutation.isPending}
-                    testId="group-settings-icon-picker"
-                  />
-                )}
-              />
-              {form.formState.errors.icon ? (
-                <p className="text-xs text-destructive" data-testid="settings-icon-error">
-                  {t(form.formState.errors.icon.message ?? "")}
-                </p>
-              ) : null}
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="settings-group-slug">{t("groups:settings.slugLabel")}</Label>
-              <Input
-                id="settings-group-slug"
-                value={group.slug ?? ""}
-                readOnly
-                disabled
-                className="font-mono text-xs"
-              />
-              <p className="text-[11px] text-muted-foreground">{t("groups:settings.slugHelp")}</p>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="settings-group-currency">{t("groups:settings.currencyLabel")}</Label>
-              <div className="flex gap-2">
-                <Input
-                  id="settings-group-currency"
-                  value={group.group_currency ?? "—"}
-                  readOnly
-                  disabled
-                  className="font-mono uppercase"
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="shrink-0 gap-1.5"
-                  // The BE blocks a second migration on the same group at the
-                  // start handler with 409 migration_in_progress. We mirror
-                  // that as a disabled CTA driven by the group's own
-                  // currency_migration_id (read-only on JSON:API; the
-                  // migration registry sets it). The 409 is the safety net
-                  // for the race between this read and the click.
-                  disabled={!!migrationInFlightId}
-                  title={migrationInFlightId ? t("errors:lockedDuringMigration") : undefined}
-                  aria-disabled={!!migrationInFlightId || undefined}
-                  onClick={() => setMigrateOpen(true)}
-                  data-testid="migrate-currency-open"
-                >
-                  <ArrowRightLeft className="size-3.5" aria-hidden="true" />
-                  {t("groups:settings.migrateCurrency")}
-                </Button>
-              </div>
-              <div className="flex flex-wrap items-center justify-between gap-2 pt-0.5">
-                <p className="text-[11px] text-muted-foreground">
-                  {t("groups:settings.migrateCurrencyHelp")}
-                </p>
-                {/* History link mounts only after at least one migration
-                    has been started — there's nothing useful behind it
-                    on a fresh group. Opens a right-side Sheet instead
-                    of inlining the list, since this is reference data
-                    a user opens occasionally, not the primary content
-                    of the page. */}
-                {migrations.length > 0 ? (
-                  <button
-                    type="button"
-                    onClick={() => setHistoryOpen(true)}
-                    className="inline-flex items-center gap-1 text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline transition-colors"
-                    data-testid="migrations-history-open"
-                  >
-                    <History className="size-3" aria-hidden="true" />
-                    {t("groups:settings.migrationsHistoryCta", {
-                      count: migrations.length,
-                    })}
-                  </button>
-                ) : null}
-              </div>
-            </div>
-
-            {serverError ? (
-              <Alert variant="destructive" data-testid="settings-server-error">
-                <AlertDescription>{serverError}</AlertDescription>
-              </Alert>
-            ) : null}
-
-            <div className="flex justify-end pt-2">
-              <Button
-                type="submit"
-                className="gap-2"
-                disabled={updateMutation.isPending}
-                data-testid="settings-save"
-              >
-                {updateMutation.isPending ? t("groups:settings.saving") : t("groups:settings.save")}
-                {!updateMutation.isPending ? <ArrowRight className="size-4" /> : null}
-              </Button>
-            </div>
-          </form>
-        ) : (
-          <div className="rounded-xl border border-border bg-muted/30 p-5 text-sm text-muted-foreground">
-            {t("members:adminOnlyHelp")}
-          </div>
-        )}
-
-        {/* Members shortcut — works for non-admins too (they see the list,
-            actions are gated inside MembersPage). */}
-        {group.slug ? (
-          <div className="rounded-xl border border-border bg-card p-4 flex items-center justify-between">
-            <div>
-              <p className="text-sm font-semibold">{t("groups:settings.membersLink")}</p>
-              <p className="text-xs text-muted-foreground">{t("members:subtitle")}</p>
-            </div>
-            <Button asChild variant="outline" size="sm" className="gap-1.5">
-              <Link
-                to={`/g/${encodeURIComponent(group.slug)}/members`}
-                data-testid="settings-members-link"
-              >
-                <Users className="size-3.5" aria-hidden="true" />
-                {t("groups:settings.membersLink")}
-              </Link>
-            </Button>
-          </div>
-        ) : null}
-
-        {/* Leave-group panel. The BE rejects "leave as last admin" with
-            a 422; we mirror that as a disabled button + explanation so
-            the user doesn't waste a round-trip. */}
-        <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+      {/* Members shortcut — works for non-admins too (they see the list,
+          actions are gated inside MembersPage). */}
+      {groupSlug ? (
+        <div className="rounded-xl border border-border bg-card p-4 flex items-center justify-between">
           <div>
-            <p className="text-sm font-semibold">{t("groups:settings.leaveTitle")}</p>
-            <p
-              className="text-xs text-muted-foreground mt-0.5"
-              data-testid={isLastAdmin ? "last-admin-notice" : undefined}
-            >
-              {isLastAdmin
-                ? t("groups:settings.leaveLastAdmin")
-                : t("groups:settings.leaveDescription")}
-            </p>
+            <p className="text-sm font-semibold">{t("groups:settings.membersLink")}</p>
+            <p className="text-xs text-muted-foreground">{t("members:subtitle")}</p>
           </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="gap-1.5 text-amber-600 border-amber-500/40 hover:bg-amber-500/10"
-            // Also gate on the membership query: while it's loading,
-            // adminCount defaults to 0 and isLastAdmin is false, so the
-            // last-admin guard would briefly let the click through. The
-            // BE rejects with 422 anyway, but the UX is cleaner if the
-            // button stays unclickable until we know the answer.
-            disabled={membersQuery.isLoading || isLastAdmin || leaveMutation.isPending}
-            aria-disabled={isLastAdmin || undefined}
-            title={isLastAdmin ? t("groups:settings.leaveLastAdminTitle") : undefined}
-            onClick={onLeave}
-            data-testid="leave-group-btn"
-          >
-            <LogOut className="size-3.5" aria-hidden="true" />
-            {t("groups:settings.leaveCta")}
+          <Button asChild variant="outline" size="sm" className="gap-1.5">
+            <Link
+              to={`/g/${encodeURIComponent(groupSlug)}/members`}
+              data-testid="settings-members-link"
+            >
+              <Users className="size-3.5" aria-hidden="true" />
+              {t("groups:settings.membersLink")}
+            </Link>
           </Button>
         </div>
+      ) : null}
 
-        {/* Danger zone (admins only). The dialog form lives below. */}
-        {isAdmin ? (
-          <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-5 space-y-3">
-            <p className="text-sm font-semibold text-destructive">
-              {t("groups:settings.dangerTitle")}
-            </p>
-            <p className="text-xs text-muted-foreground">
-              {t("groups:settings.dangerDescription")}
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="gap-1.5 text-destructive border-destructive/40 hover:bg-destructive/10"
-              onClick={() => setDeleteOpen(true)}
-              data-testid="delete-group-open"
-            >
-              <Trash2 className="size-3.5" aria-hidden="true" />
-              {t("groups:settings.deleteCta")}
-            </Button>
-          </div>
-        ) : null}
-
-        <DeleteGroupDialog
-          open={deleteOpen}
-          onOpenChange={setDeleteOpen}
-          group={{ id: groupId, name: group.name ?? "" }}
-        />
-        {isAdmin && group.group_currency && groupSlug ? (
-          <MigrateCurrencyDialog
-            open={migrateOpen}
-            onOpenChange={setMigrateOpen}
-            groupName={group.name ?? ""}
-            fromCurrency={group.group_currency}
-            groupSlug={groupSlug}
-          />
-        ) : null}
-        <Sheet open={historyOpen} onOpenChange={setHistoryOpen}>
-          <SheetContent
-            side="right"
-            className="w-full sm:max-w-md flex flex-col gap-4 overflow-y-auto p-6"
-            data-testid="migrations-history-sheet"
+      {/* Leave-group panel. The BE rejects "leave as last admin" with
+          a 422; we mirror that as a disabled button + explanation so
+          the user doesn't waste a round-trip. */}
+      <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+        <div>
+          <p className="text-sm font-semibold">{t("groups:settings.leaveTitle")}</p>
+          <p
+            className="text-xs text-muted-foreground mt-0.5"
+            data-testid={isLastAdmin ? "last-admin-notice" : undefined}
           >
-            <SheetHeader className="p-0">
-              <SheetTitle>{t("groups:settings.migrationsTitle")}</SheetTitle>
-              <SheetDescription>{t("groups:settings.migrationsHelp")}</SheetDescription>
-            </SheetHeader>
-            <CurrencyMigrationsList loading={migrationsQuery.isLoading} migrations={migrations} />
-          </SheetContent>
-        </Sheet>
+            {isLastAdmin
+              ? t("groups:settings.leaveLastAdmin")
+              : t("groups:settings.leaveDescription")}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="gap-1.5 text-amber-600 border-amber-500/40 hover:bg-amber-500/10"
+          // Also gate on the membership query: while it's loading,
+          // adminCount defaults to 0 and isLastAdmin is false, so the
+          // last-admin guard would briefly let the click through. The
+          // BE rejects with 422 anyway, but the UX is cleaner if the
+          // button stays unclickable until we know the answer.
+          disabled={membersLoading || isLastAdmin || leaveMutation.isPending}
+          aria-disabled={isLastAdmin || undefined}
+          title={isLastAdmin ? t("groups:settings.leaveLastAdminTitle") : undefined}
+          onClick={onLeave}
+          data-testid="leave-group-btn"
+        >
+          <LogOut className="size-3.5" aria-hidden="true" />
+          {t("groups:settings.leaveCta")}
+        </Button>
       </div>
-    </>
+    </div>
+  )
+}
+
+// DataSection — per-group storage usage panel + exports shortcut.
+// Moved here from /settings (user Preferences), where these were
+// rendered against an implicit "active group" fallback. Both are
+// strictly group-scoped, so they belong on the group page.
+function DataSection({ groupSlug }: { groupSlug: string | null }) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-6" data-testid="group-section-data">
+      <SectionTitle>{t("groups:settings.data.title")}</SectionTitle>
+
+      <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+        <div>
+          <p className="text-sm font-medium">{t("groups:settings.data.exportTitle")}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {t("groups:settings.data.exportDescription")}
+          </p>
+        </div>
+        {groupSlug ? (
+          <Button asChild size="sm" variant="outline" className="gap-1.5">
+            <Link
+              to={`/g/${encodeURIComponent(groupSlug)}/exports`}
+              data-testid="settings-open-exports"
+            >
+              <Download className="size-3.5" aria-hidden="true" />
+              {t("groups:settings.data.exportCta")}
+            </Link>
+          </Button>
+        ) : (
+          <p className="text-xs text-muted-foreground">{t("groups:settings.data.noGroupSlug")}</p>
+        )}
+      </div>
+
+      <StorageCard />
+    </div>
+  )
+}
+
+// ManagementSection — destructive group lifecycle actions. Admin-only;
+// non-admins see an empty-state explainer instead.
+function ManagementSection({
+  groupId,
+  groupName,
+  isAdmin,
+}: {
+  groupId: string
+  groupName: string
+  isAdmin: boolean
+}) {
+  const { t } = useTranslation()
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  if (!isAdmin) {
+    return (
+      <div className="space-y-6" data-testid="group-section-management">
+        <SectionTitle>{t("groups:settings.sections.management")}</SectionTitle>
+        <div className="rounded-xl border border-border bg-muted/30 p-5 text-sm text-muted-foreground">
+          {t("members:adminOnlyHelp")}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6" data-testid="group-section-management">
+      <SectionTitle>{t("groups:settings.sections.management")}</SectionTitle>
+
+      <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-5 space-y-3">
+        <p className="text-sm font-semibold text-destructive">
+          {t("groups:settings.dangerTitle")}
+        </p>
+        <p className="text-xs text-muted-foreground">{t("groups:settings.dangerDescription")}</p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="gap-1.5 text-destructive border-destructive/40 hover:bg-destructive/10"
+          onClick={() => setDeleteOpen(true)}
+          data-testid="delete-group-open"
+        >
+          <Trash2 className="size-3.5" aria-hidden="true" />
+          {t("groups:settings.deleteCta")}
+        </Button>
+      </div>
+
+      <DeleteGroupDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        group={{ id: groupId, name: groupName }}
+      />
+    </div>
   )
 }
 

--- a/frontend/src/pages/groups/__tests__/GroupSettingsPage.test.tsx
+++ b/frontend/src/pages/groups/__tests__/GroupSettingsPage.test.tsx
@@ -147,11 +147,16 @@ describe("<GroupSettingsPage />", () => {
 
   it("renders the form with name + icon prefilled and a read-only currency for an admin", async () => {
     server.use(...baseHandlers, adminMembership)
+    const user = userEvent.setup()
     renderSettings()
+    // Info section is the default — identity form should be present right away.
     await waitFor(() => expect(screen.getByTestId("settings-name-input")).toHaveValue("Household"))
-    expect(screen.getByTestId("settings-members-link")).toBeInTheDocument()
-    // Danger zone visible for admin.
-    expect(screen.getByTestId("delete-group-open")).toBeInTheDocument()
+    // Members shortcut lives behind the Members nav.
+    await user.click(screen.getByTestId("group-settings-nav-members"))
+    expect(await screen.findByTestId("settings-members-link")).toBeInTheDocument()
+    // Danger zone is admin-only, lives behind the Management nav.
+    await user.click(screen.getByTestId("group-settings-nav-management"))
+    expect(await screen.findByTestId("delete-group-open")).toBeInTheDocument()
   })
 
   it("hides admin-only sections when the viewer is not an admin", async () => {
@@ -174,10 +179,13 @@ describe("<GroupSettingsPage />", () => {
         })
       )
     )
+    const user = userEvent.setup()
     renderSettings()
     await waitFor(() => expect(screen.getByTestId("group-settings-page")).toBeInTheDocument())
-    // Non-admin: no name input, no danger zone.
+    // Non-admin Info: no name input — read-only "admin only" panel instead.
     expect(screen.queryByTestId("settings-name-input")).not.toBeInTheDocument()
+    // Non-admin Management: delete CTA is gated.
+    await user.click(screen.getByTestId("group-settings-nav-management"))
     expect(screen.queryByTestId("delete-group-open")).not.toBeInTheDocument()
   })
 
@@ -201,7 +209,10 @@ describe("<GroupSettingsPage />", () => {
         })
       )
     )
+    const user = userEvent.setup()
     renderSettings()
+    await waitFor(() => expect(screen.getByTestId("group-settings-page")).toBeInTheDocument())
+    await user.click(screen.getByTestId("group-settings-nav-members"))
     const leave = await screen.findByTestId("leave-group-btn")
     expect(leave).toBeDisabled()
   })
@@ -210,6 +221,8 @@ describe("<GroupSettingsPage />", () => {
     server.use(...baseHandlers, adminMembership)
     const user = userEvent.setup()
     renderSettings()
+    await waitFor(() => expect(screen.getByTestId("group-settings-page")).toBeInTheDocument())
+    await user.click(screen.getByTestId("group-settings-nav-management"))
     await user.click(await screen.findByTestId("delete-group-open"))
     const dialog = await screen.findByTestId("delete-group-dialog")
     expect(dialog).toBeInTheDocument()
@@ -231,6 +244,8 @@ describe("<GroupSettingsPage />", () => {
     )
     const user = userEvent.setup()
     renderSettings()
+    await waitFor(() => expect(screen.getByTestId("group-settings-page")).toBeInTheDocument())
+    await user.click(screen.getByTestId("group-settings-nav-management"))
     await user.click(await screen.findByTestId("delete-group-open"))
     await user.type(await screen.findByTestId("delete-confirm-word"), "Household")
     await user.type(screen.getByTestId("delete-password"), "secret-pw")


### PR DESCRIPTION
## Summary

- Split `GroupSettingsPage` into a left-rail + content-pane shell (Info / Members / Data & Storage / Management), mirroring the `SettingsPage` pattern instead of a flat card stack.
- Relocate `StorageCard` and the Export-data CTA from user Preferences into the group page's new **Data & Storage** section — they were per-group surfaces masquerading as personal ones. User Preferences loses its `data` section entirely; the account-deletion danger zone moves under `account.dangerZone.*` where it actually belongs.
- Bundled small fix: `design-mocks` `crypto.randomUUID()` → new `makeId()` fallback. `randomUUID` is undefined outside a secure context, so opening the mocks server on a plain-HTTP Tailscale host crashed `AddItemDialog` / `LocationDialog` / `FileBrowserView` on mount.

## Related issues

Refs #1612 — direct follow-up to PR #1613, which wired the dead `/g/:slug/system` route to `GroupSettingsPage`. This PR makes that page actually look like a settings hub.

The mock divergence is logged in `devdocs/frontend/design-deviations.md` (2026-05-09 entry) — the upstream mock predates both the storage surfaces and the sub-navigation pattern, so keeping the group page flat while user Preferences is sectioned would diverge the two hubs for no design payoff. User explicitly requested the four-section layout and the Storage/Export relocation.

## Test plan

- [x] `make test-frontend` — `SettingsPage.test.tsx` + `GroupSettingsPage.test.tsx` pass locally (15/15).
- [ ] `make lint`
- [ ] `make test`
- [ ] `make test-e2e` — `delete-group-dialog.spec.ts` and `groups.spec.ts` (last-admin protection) updated to click the Management / Members nav before reaching the relevant CTAs; both should be green.
- [ ] Manual smoke: visit `/groups/:id/settings`, walk each of the four sub-sections, confirm Storage card + Export CTA render and link out correctly, confirm delete-group dialog still reachable under Management.
- [ ] Manual smoke: visit `/settings`, confirm the `Data & storage` section is gone, confirm account deletion (with "not yet available" notice) lives under Account.
- [ ] (Optional) Open design-mocks on a Tailscale hostname (plain HTTP) and confirm AddItemDialog / LocationDialog / FileBrowserView no longer crash on mount.