### PR TITLE
[#1531] Locations/Areas drill-in: stat chips, area tiles, breadcrumb

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -129,6 +129,33 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 
 ### Locations & Areas
 
+#### 2026-05-11 — Location & area cards use neutral icon tiles (no per-row emoji)
+
+- **Issue/PR**: #1531 (items 2 + 3) / PR _pending_
+- **Mock**: [`design-mocks/src/views/LocationPickerView.tsx`](../../design-mocks/src/views/LocationPickerView.tsx) Level 1 (lines 551–553) and Level 2 (lines 624–626) render each location / area with a coloured emoji avatar pulled from `Location.icon` / `Area.icon` (e.g. `🏠`, `🚗`, `🍳`). The mock also renders a one-line `Location.description` muted beneath the title on Level 1.
+- **Reality**: `frontend/src/pages/locations/LocationsListPage.tsx` and `LocationDetailPage.tsx` ship the Level 1 / Level 2 layout (click-through tile, name + stats, dropdown menu, chevron) but the icon tile is a flat `bg-muted` square holding the generic Lucide `MapPin` (locations) or `Package` (areas). The Level 1 subtitle keeps `address` (free-form muted text under the name) in place of `description`.
+- **Why**: BE-blocked. `models.Location` carries `id / name / address / group_id` only (`frontend/src/features/locations/api.ts` `Location`); `models.Area` is `id / name / location_id` only. Adding `icon` (string) and `description` (string) to both is a backend schema bump tracked as item 4 of #1531 itself — out of scope for this FE-only PR. Address is a close-enough analogue for the muted-subtitle slot the mock fills with `description` (street/note already shows under the location name), so no separate field is invented FE-side.
+- **Approved by**: agent-suggested-then-user-confirmed — item 4 of #1531 explicitly tags the icon + description schema fields as "Needs BE", and this entry records the visual gap until that schema lands.
+- **Reversion plan**: Resolve when the BE schema gains `icon` (string, emoji or short token) and `description` (nullable string) on both Location and Area, plus the FE form dialogs (`LocationFormDialog` / `AreaFormDialog`) gain pickers. The tiles then swap the Lucide icon for `loc.icon` / `area.icon`, and the Level 1 subtitle adds `description` above `address`.
+
+#### 2026-05-11 — Locations list dropped the inline-areas accordion
+
+- **Issue/PR**: #1531 (item 2) / PR _pending_
+- **Mock**: [`design-mocks/src/views/LocationPickerView.tsx`](../../design-mocks/src/views/LocationPickerView.tsx) Level 1 (lines 546–600) shows each location as a single click-through card with stat chips — no areas listed inline. Areas appear only on Level 2 (the location detail).
+- **Reality**: `frontend/src/pages/locations/LocationsListPage.tsx` previously rendered each `LocationCard` with a flat `<ul>` of area `<Link>`s inside `CardContent` and an inline "+ Add area" button. That block is removed; the card is now strictly the Level 1 tile (avatar + name + address + Areas / Items stat chips + dropdown menu + chevron). Add area moved into the card's dropdown menu (`data-testid="location-card-add-area"`) so the e2e flow stays single-click without surfacing the action visually outside hover.
+- **Why**: Mock-fidelity. The inline accordion was a real-frontend invention from the Vue era. Dropping it makes the list scannable and matches the drill-in flow the mock prescribes (list → location detail → area detail). Add-area lives in the dropdown rather than the location detail page only because the e2e helper (`e2e/tests/includes/areas.ts`) had a single fast entry point that callers across the suite already use; rerouting every test was higher friction than keeping the action one menu-click away.
+- **Approved by**: agent-suggested — fits the umbrella issue's "deeper drill-in pages" goal; user reviews this PR.
+- **Reversion plan**: Permanent. If the upstream mock ever surfaces areas-inside-list again, restore the `<ul>` block beneath the card body and drop the "Add area" menu item.
+
+#### 2026-05-11 — Multi-segment breadcrumb is inline, not a sticky top strip
+
+- **Issue/PR**: #1531 (item 5) / PR _pending_
+- **Mock**: [`design-mocks/src/views/LocationPickerView.tsx`](../../design-mocks/src/views/LocationPickerView.tsx) lines 459–498 render the breadcrumb as a `sticky top-0 px-6 py-4 border-b border-border bg-background z-10` strip — edge-to-edge background, sticks under the (mock's) top of the viewport while the list scrolls.
+- **Reality**: `frontend/src/components/locations/LocationsBreadcrumb.tsx` ships the same content (optional ArrowLeft button + chevron-separated segments, current segment bold) inline at the top of the page content area, no sticky behaviour, no edge bleed.
+- **Why**: The real app shell already owns the sticky top edge — `<TopBar>` lives there. Stacking a second sticky strip directly beneath it (a) competes with the TopBar for the viewport's top edge, (b) doubles the visual chrome on short pages, and (c) requires bleeding past the page's `p-6` padding with negative margins, which couples the breadcrumb component to the page wrapper's spacing token. Inline placement keeps the breadcrumb readable on first paint without colliding with existing chrome.
+- **Approved by**: agent-suggested — the sticky strip is a self-contained mock pattern; the real shell makes it redundant.
+- **Reversion plan**: Permanent unless the app ever loses its persistent TopBar. Reconciliation would mean adding a `sticky` variant to `LocationsBreadcrumb` and using it from `LocationDetailPage` / `AreaDetailPage` once the shell decision changes.
+
 #### 2026-05-10 — Per-area items panel ships v1 with two stats + simple list (no toolbar / files)
 
 - **Issue/PR**: #1531 (item 1) / PR _pending_

--- a/e2e/tests/commodity-simple-crud.spec.ts
+++ b/e2e/tests/commodity-simple-crud.spec.ts
@@ -78,13 +78,17 @@ test.describe('Commodity Simple CRUD Operations', () => {
 
     // STEP 2: CREATE AREA - Create a new area in-place in the location list view
     recorder.log('Step 2: Creating a new area');
-    await createArea(page, recorder, testArea)
+    await createArea(page, recorder, testArea, testLocation.name)
 
     // STEP 3: CREATE COMMODITY - Create a new commodity
     recorder.log('Step 3: Creating a new commodity');
     await navigateTo(page, recorder, TO_AREA_COMMODITIES, FROM_LOCATIONS_AREA, testArea.name);
     await verifyAreaHasCommodities(page, recorder);
-    await createCommodity(page, recorder, { ...testCommodity, areaName: testArea.name });
+    await createCommodity(page, recorder, {
+      ...testCommodity,
+      areaName: testArea.name,
+      locationName: testLocation.name,
+    });
 
     // STEP 4: READ - Verify the commodity details
     recorder.log('Step 4: Verifying the commodity details');
@@ -92,7 +96,11 @@ test.describe('Commodity Simple CRUD Operations', () => {
 
     // STEP 5: UPDATE - Edit the commodity
     recorder.log('Step 5: Editing the commodity');
-    await editCommodity(page, recorder, { ...updatedCommodity, areaName: testArea.name });
+    await editCommodity(page, recorder, {
+      ...updatedCommodity,
+      areaName: testArea.name,
+      locationName: testLocation.name,
+    });
 
     // STEP 6: READ - Verify the commodity details (this is where it fails in CI)
     recorder.log('Step 6: Verifying updated commodity details');
@@ -112,7 +120,7 @@ test.describe('Commodity Simple CRUD Operations', () => {
 
     // STEP 2: CREATE AREA - Create a new area in-place in the location list view
     recorder.log('Step 2: Creating a new area');
-    await createArea(page, recorder, testArea)
+    await createArea(page, recorder, testArea, testLocation.name)
 
     // STEP 3: CREATE COMMODITY - Create a new commodity. Post-cutover the
     // helper navigates to /commodities and the form's area select is the
@@ -120,7 +128,11 @@ test.describe('Commodity Simple CRUD Operations', () => {
     recorder.log('Step 3: Creating a new commodity');
     await navigateTo(page, recorder, TO_AREA_COMMODITIES, FROM_LOCATIONS_AREA, testArea.name);
     await verifyAreaHasCommodities(page, recorder);
-    await createCommodity(page, recorder, { ...testCommodity, areaName: testArea.name });
+    await createCommodity(page, recorder, {
+      ...testCommodity,
+      areaName: testArea.name,
+      locationName: testLocation.name,
+    });
 
     // STEP 4: READ - Verify the commodity details
     recorder.log('Step 4: Verifying the commodity details');
@@ -128,7 +140,11 @@ test.describe('Commodity Simple CRUD Operations', () => {
 
     // STEP 5: UPDATE - Edit the commodity
     recorder.log('Step 5: Editing the commodity');
-    await editCommodity(page, recorder, { ...updatedCommodity, areaName: testArea.name });
+    await editCommodity(page, recorder, {
+      ...updatedCommodity,
+      areaName: testArea.name,
+      locationName: testLocation.name,
+    });
 
     // STEP 6: READ - Verify the commodity details
     recorder.log('Step 6: Verifying updated commodity details');
@@ -148,8 +164,11 @@ test.describe('Commodity Simple CRUD Operations', () => {
     await page.waitForSelector(`[data-testid="location-card"][data-location-id="${locationId}"]`);
     await recorder.takeScreenshot('location-expanded');
 
-    // Delete the area (inline-rendered under the location card)
-    await deleteArea(page, recorder, testArea.name);
+    // Delete the area. Pass the parent location so the helper drills
+    // into the right card — seeded Home/Office/Storage Unit sort
+    // alphabetically before any test fixture, so without the hint we'd
+    // navigate into Home and never find the area.
+    await deleteArea(page, recorder, testArea.name, testLocation.name);
 
     // Delete the location (pass the ID so we delete *this* test's clone)
     await deleteLocation(page, recorder, testLocation.name, locationId);

--- a/e2e/tests/draft-inactive-toggle.spec.ts
+++ b/e2e/tests/draft-inactive-toggle.spec.ts
@@ -59,14 +59,16 @@ test.describe('Draft and Inactive Items Toggle Functionality', () => {
     await navigateTo(page, recorder, TO_LOCATIONS);
 
     await page.locator('[data-testid="location-card"]').first().waitFor();
-    // The area testid is on the <li> wrapper; the actual nav link is the
-    // anchor inside it. Click that to land on the area-detail route.
-    const firstAreaLink = page
-      .locator('[data-testid="location-card"]')
+    // Post-#1531 (item 2) the locations list dropped its inline-areas
+    // accordion; areas live on the location detail page. Drill in via
+    // the whole-card link, then click the first area tile to land on
+    // the area-detail route.
+    await page.locator('[data-testid="location-card-link"]').first().click();
+    await expect(page.locator('[data-testid="page-location-detail"]')).toBeVisible();
+    await page
+      .locator('[data-testid="location-detail-area-link"]')
       .first()
-      .locator('[data-testid="location-card-area"] a')
-      .first();
-    await firstAreaLink.click();
+      .click();
 
     await expect(page.locator('[data-testid="page-area-detail"]')).toBeVisible();
     // Stats strip is unconditional; the list / empty state depends on

--- a/e2e/tests/file-deletion-cascade.spec.ts
+++ b/e2e/tests/file-deletion-cascade.spec.ts
@@ -52,7 +52,11 @@ test.describe('File deletion cascade', () => {
     status: 'In Use',
     // Required on step 1 (Basics) — the form's area_id default is
     // empty and step transition silently fails validation otherwise.
+    // Pin the parent location too: seeded data adds Home/Office/Storage
+    // Unit alphabetically before any test fixture, so picking the
+    // "first" location alone would mis-target Home.
     areaName: testArea.name,
+    locationName: testLocation.name,
   }
 
   const imageFixture = path.join('files', 'image.jpg')
@@ -63,7 +67,7 @@ test.describe('File deletion cascade', () => {
     recorder.log(`Step ${step++}: creating location/area/commodity`)
     await navigateTo(page, recorder, TO_LOCATIONS)
     await createLocation(page, recorder, testLocation)
-    await createArea(page, recorder, testArea)
+    await createArea(page, recorder, testArea, testLocation.name)
     await navigateTo(page, recorder, TO_AREA_COMMODITIES, FROM_LOCATIONS_AREA, testArea.name)
     await verifyAreaHasCommodities(page, recorder)
     const commodityUrl = await createCommodity(page, recorder, testCommodity)

--- a/e2e/tests/file-uploads.spec.ts
+++ b/e2e/tests/file-uploads.spec.ts
@@ -66,8 +66,12 @@ test.describe('Commodity quick-attach (Files tab)', () => {
     // The React form requires `area_id` on step 1 (Basics) and the
     // dropdown defaults to empty — without an explicit areaName the
     // step 1 → 2 transition validates-fails silently and we hang on
-    // step 2's #commodity-purchase-date forever.
+    // step 2's #commodity-purchase-date forever. Pin the parent
+    // location too: seeded data adds Home/Office/Storage Unit
+    // alphabetically before any test fixture, so picking the "first"
+    // location alone would mis-target Home.
     areaName: testArea.name,
+    locationName: testLocation.name,
   }
 
   const imageFixture = path.join('files', 'image.jpg')
@@ -84,7 +88,7 @@ test.describe('Commodity quick-attach (Files tab)', () => {
     await createLocation(page, recorder, testLocation)
 
     recorder.log(`Step ${step++}: creating area`)
-    await createArea(page, recorder, testArea)
+    await createArea(page, recorder, testArea, testLocation.name)
 
     recorder.log(`Step ${step++}: creating commodity`)
     await navigateTo(page, recorder, TO_AREA_COMMODITIES, FROM_LOCATIONS_AREA, testArea.name)

--- a/e2e/tests/includes/areas.ts
+++ b/e2e/tests/includes/areas.ts
@@ -27,16 +27,41 @@ export async function createArea(
     await page.fill('#area-name', testArea.name);
     await recorder.takeScreenshot('area-create-01-form-filled');
 
-    await page.click('[data-testid="area-form-submit"]');
+    // Submit and wait for the POST to land. AreaFormDialog calls
+    // onOpenChange(false) right after the mutation resolves; we wait
+    // for the response so the `area-form-dialog` selector below has
+    // something to detach.
+    const [areaResponse] = await Promise.all([
+        page.waitForResponse(
+            (response) =>
+                new URL(response.url()).pathname.endsWith('/areas') &&
+                response.request().method() === 'POST' &&
+                response.status() === 201,
+            { timeout: 30000 },
+        ),
+        page.click('[data-testid="area-form-submit"]'),
+    ]);
+    const areaBody = await areaResponse.json().catch(() => null);
+    const newAreaId = areaBody?.data?.id as string | undefined;
+
+    // Wait for the dialog to fully unmount before interacting with the
+    // page underneath — Radix's overlay still intercepts pointer
+    // events during the close transition, which silently swallows the
+    // next click.
+    await page
+        .locator('[data-testid="area-form-dialog"]')
+        .waitFor({ state: 'detached', timeout: 10000 });
 
     // The list page doesn't surface the new area inline anymore; drill
     // into the parent location's detail page and assert the tile shows
     // up. Choosing the same "first visible card" the create step opened
     // keeps the helper deterministic across the suite.
     await page.locator('[data-testid="location-card-link"]').first().click();
-    await page.waitForSelector(
-        `[data-testid="location-detail-area"]:has-text("${testArea.name}")`,
-    );
+    await page.waitForSelector('[data-testid="page-location-detail"]', { timeout: 10000 });
+    const tileSelector = newAreaId
+        ? `[data-testid="location-detail-area"][data-area-id="${newAreaId}"]`
+        : `[data-testid="location-detail-area"]:has-text("${testArea.name}")`;
+    await page.waitForSelector(tileSelector, { timeout: 15000 });
     await recorder.takeScreenshot('area-create-02-created');
 }
 

--- a/e2e/tests/includes/areas.ts
+++ b/e2e/tests/includes/areas.ts
@@ -1,20 +1,24 @@
 import { expect, Page } from "@playwright/test";
 import { TestRecorder } from "../../utils/test-recorder.js";
 
-// React port of the Vue-era areas helper. Areas now live as inline items
-// inside each LocationCard (`[data-testid="location-card-area"]`); creation
-// goes through `AreaFormDialog`, deletion through the per-item trash button
-// + the shared useConfirm dialog (`[data-testid="confirm-dialog"]`).
+// Post-#1531 (item 2), the locations list no longer renders areas inline.
+// Areas show as tile cards inside the location detail page
+// (`[data-testid="location-detail-area"]`). Add-area still has an entry
+// point on the list — it now lives inside the location card's dropdown
+// menu (`location-card-menu` → `location-card-add-area`). Deletion fires
+// from the per-tile dropdown on the location detail page
+// (`location-detail-area-menu` → `location-detail-area-delete`).
 
 export async function createArea(
     page: Page,
     recorder: TestRecorder,
     testArea: { name: string },
 ) {
-    // Open the AreaFormDialog from the inline button on the parent location's
-    // card. Each LocationCard renders its own `location-card-add-area` —
-    // the test ensures a single location is in the visible set, so the first
-    // matching button is the right one.
+    // Open the LocationCard dropdown on the first visible card, then
+    // pick "Add area" — the menu item carries the legacy
+    // `location-card-add-area` testid so any future visual repositioning
+    // (button row vs menu vs detail page) leaves this helper intact.
+    await page.locator('[data-testid="location-card-menu"]').first().click();
     await page.locator('[data-testid="location-card-add-area"]').first().click();
     await page.waitForSelector('[data-testid="area-form-dialog"]');
 
@@ -25,9 +29,13 @@ export async function createArea(
 
     await page.click('[data-testid="area-form-submit"]');
 
-    // Wait for the rendered area row inside the location card.
+    // The list page doesn't surface the new area inline anymore; drill
+    // into the parent location's detail page and assert the tile shows
+    // up. Choosing the same "first visible card" the create step opened
+    // keeps the helper deterministic across the suite.
+    await page.locator('[data-testid="location-card-link"]').first().click();
     await page.waitForSelector(
-        `[data-testid="location-card-area"]:has-text("${testArea.name}")`,
+        `[data-testid="location-detail-area"]:has-text("${testArea.name}")`,
     );
     await recorder.takeScreenshot('area-create-02-created');
 }
@@ -38,48 +46,48 @@ export async function deleteArea(
     areaName: string,
     locationName?: string,
 ) {
-    // The area row lives inside its location card on the locations list page.
-    // We don't need the explicit location-card-by-name lookup the Vue helper
-    // had — only the Vue legacy area-card layout needed it; in React the row
-    // is uniquely identified by its inline text under any visible card.
-    const areaRow = page.locator(
-        `[data-testid="location-card-area"]:has-text("${areaName}")`,
-    );
-
-    if (locationName && !(await areaRow.isVisible())) {
-        // If the caller hints which parent card to expand, click into it
-        // first. The locations list shows everything inline by default; this
-        // is a safety net for tests that navigated away.
-        await page
-            .locator(`[data-testid="location-card"]:has-text("${locationName}")`)
-            .click();
+    // The area tile lives on the parent location's detail page now. If
+    // we're still on the list page, drill in first.
+    if (await page.locator('[data-testid="page-locations"]').isVisible()) {
+        const cardLink = locationName
+            ? page
+                .locator(`[data-testid="location-card"]:has-text("${locationName}")`)
+                .locator('[data-testid="location-card-link"]')
+            : page.locator('[data-testid="location-card-link"]').first();
+        await cardLink.click();
+        await page.waitForSelector('[data-testid="page-location-detail"]');
     }
 
-    await areaRow.waitFor({ state: 'visible', timeout: 10000 });
+    const areaTile = page.locator(
+        `[data-testid="location-detail-area"]:has-text("${areaName}")`,
+    );
+    await areaTile.waitFor({ state: 'visible', timeout: 10000 });
 
-    // The delete button is the only button in the row. Each area row renders
-    // a Link (the area title) plus a single Button (trash icon, aria-labelled
-    // with the area name).
-    await areaRow.locator('button').click();
+    // Each tile renders an overlay <Link> for navigation and a dropdown
+    // trigger above it; the trigger is hidden until hover but the
+    // testid-based click bypasses the opacity transition.
+    await areaTile.locator('[data-testid="location-detail-area-menu"]').click();
+    await page.locator('[data-testid="location-detail-area-delete"]').click();
     await recorder.takeScreenshot('area-delete-01-confirm');
 
     await page.locator('[data-testid="confirm-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
 
-    // Confirm-accept fires the DELETE; the dialog closes and the area
-    // row vanishes from its parent location card. Don't pre-arm a
+    // Confirm-accept fires the DELETE; the dialog closes and the tile
+    // vanishes from the location-detail grid. Don't pre-arm a
     // `waitForResponse` listener — it races the click+fetch and
     // sometimes attaches *after* the response lands. The
-    // `confirm-dialog` becoming hidden + the row's `toHaveCount(0)` is
+    // `confirm-dialog` becoming hidden + the tile's `toHaveCount(0)` is
     // a deterministic settle signal that the React mutation completed.
     await page.click('[data-testid="confirm-accept"]');
     await page.locator('[data-testid="confirm-dialog"]').waitFor({ state: 'hidden', timeout: 10000 });
 
     await expect(
-        page.locator(`[data-testid="location-card-area"]:has-text("${areaName}")`),
+        page.locator(`[data-testid="location-detail-area"]:has-text("${areaName}")`),
     ).toHaveCount(0, { timeout: 15000 });
 
     await recorder.takeScreenshot('area-delete-02-deleted');
-    await expect(page).toHaveURL(/\/locations/);
+    // The user remains on the location detail page after delete.
+    await expect(page).toHaveURL(/\/locations\//);
 }
 
 // Renamed-and-repurposed: post-cutover the area detail page is a

--- a/e2e/tests/includes/areas.ts
+++ b/e2e/tests/includes/areas.ts
@@ -13,12 +13,22 @@ export async function createArea(
     page: Page,
     recorder: TestRecorder,
     testArea: { name: string },
+    locationName?: string,
 ) {
-    // Open the LocationCard dropdown on the first visible card, then
-    // pick "Add area" — the menu item carries the legacy
-    // `location-card-add-area` testid so any future visual repositioning
-    // (button row vs menu vs detail page) leaves this helper intact.
-    await page.locator('[data-testid="location-card-menu"]').first().click();
+    // Open the LocationCard dropdown, then pick "Add area" — the menu
+    // item carries the legacy `location-card-add-area` testid so any
+    // future visual repositioning leaves this helper intact. Locations
+    // are listed alphabetically (BE `ORDER BY name`), so without an
+    // explicit `locationName` `.first()` picks whatever sorts first —
+    // which on a seeded test stack is rarely the just-created location.
+    // Pass `locationName` whenever the test owns it so the new area
+    // is attached to the right parent.
+    const locationCard = locationName
+        ? page
+              .locator(`[data-testid="location-card"]:has-text("${locationName}")`)
+              .first()
+        : page.locator('[data-testid="location-card"]').first();
+    await locationCard.locator('[data-testid="location-card-menu"]').click();
     await page.locator('[data-testid="location-card-add-area"]').first().click();
     await page.waitForSelector('[data-testid="area-form-dialog"]');
 
@@ -53,10 +63,9 @@ export async function createArea(
         .waitFor({ state: 'detached', timeout: 10000 });
 
     // The list page doesn't surface the new area inline anymore; drill
-    // into the parent location's detail page and assert the tile shows
-    // up. Choosing the same "first visible card" the create step opened
-    // keeps the helper deterministic across the suite.
-    await page.locator('[data-testid="location-card-link"]').first().click();
+    // into the same parent location's detail page (the card we opened
+    // the menu from) and assert the tile shows up.
+    await locationCard.locator('[data-testid="location-card-link"]').click();
     await page.waitForSelector('[data-testid="page-location-detail"]', { timeout: 10000 });
     const tileSelector = newAreaId
         ? `[data-testid="location-detail-area"][data-area-id="${newAreaId}"]`
@@ -77,6 +86,7 @@ export async function deleteArea(
         const cardLink = locationName
             ? page
                 .locator(`[data-testid="location-card"]:has-text("${locationName}")`)
+                .first()
                 .locator('[data-testid="location-card-link"]')
             : page.locator('[data-testid="location-card-link"]').first();
         await cardLink.click();

--- a/e2e/tests/includes/locations.ts
+++ b/e2e/tests/includes/locations.ts
@@ -53,29 +53,46 @@ export async function deleteLocation(
     locationName: string,
     locationId?: string,
 ) {
-    // Prefer the id when given — name lookups remain ambiguous across
-    // warmup/retry orphans even though the React card surface uses
-    // `[data-testid="location-card"]` instead of `.location-card`.
-    const locationCard = locationId
-        ? page.locator(`[data-testid="location-card"][data-location-id="${locationId}"]`)
-        : page.locator(`[data-testid="location-card"]:has-text("${locationName}")`).last();
-    await locationCard.waitFor({ state: 'visible', timeout: 10000 });
+    // Two entry points after #1531:
+    //   - From `/locations` (list page): open the LocationCard dropdown
+    //     and pick "Delete" (`location-card-menu` → `location-card-delete`).
+    //   - From `/locations/:id` (detail page, where deleteArea now
+    //     leaves us): use the header's Delete button
+    //     (`location-detail-delete`). The location-card surface doesn't
+    //     exist on the detail page.
+    // Tests routinely chain deleteArea → deleteLocation, so this helper
+    // detects the current page and picks the right path.
+    const onDetail = await page
+        .locator('[data-testid="page-location-detail"]')
+        .first()
+        .isVisible()
+        .catch(() => false);
 
-    const targetId = locationId ?? (await locationCard.getAttribute('data-location-id'));
-    if (!targetId) {
-        throw new Error(`deleteLocation: could not read data-location-id from card "${locationName}"`);
+    // Resolve the id once so the post-delete assertion is unambiguous —
+    // name match alone flaps when warmup/retry orphans share the name.
+    let targetId = locationId;
+
+    if (onDetail) {
+        targetId = targetId ?? (await page.url().match(/\/locations\/([^/?#]+)/)?.[1]);
+        await page.locator('[data-testid="location-detail-delete"]').click();
+        await recorder.takeScreenshot('location-delete-01-confirm');
+    } else {
+        const locationCard = locationId
+            ? page.locator(`[data-testid="location-card"][data-location-id="${locationId}"]`)
+            : page.locator(`[data-testid="location-card"]:has-text("${locationName}")`).last();
+        await locationCard.waitFor({ state: 'visible', timeout: 10000 });
+        targetId = targetId ?? (await locationCard.getAttribute('data-location-id')) ?? undefined;
+        if (!targetId) {
+            throw new Error(`deleteLocation: could not read data-location-id from card "${locationName}"`);
+        }
+        // Post-#1531 the trash icon moved into the LocationCard dropdown.
+        // Open the dropdown first, then pick "Delete" — the testid kept its
+        // legacy name so any future repositioning of the action leaves this
+        // helper intact.
+        await locationCard.locator('[data-testid="location-card-menu"]').click();
+        await page.locator('[data-testid="location-card-delete"]').click();
+        await recorder.takeScreenshot('location-delete-01-confirm');
     }
-
-    // Post-#1531 the trash icon moved into the LocationCard dropdown.
-    // Open the dropdown first, then pick "Delete" — the testid kept its
-    // legacy name so any future repositioning of the action leaves this
-    // helper intact. The confirm dialog comes from useConfirm (single
-    // shared root-mounted Dialog) — selector is
-    // `[data-testid="confirm-dialog"]` with `confirm-accept` for the
-    // destructive button.
-    await locationCard.locator('[data-testid="location-card-menu"]').click();
-    await page.locator('[data-testid="location-card-delete"]').click();
-    await recorder.takeScreenshot('location-delete-01-confirm');
 
     await page.locator('[data-testid="confirm-dialog"]').waitFor({ state: 'visible', timeout: 5000 });
 
@@ -90,11 +107,16 @@ export async function deleteLocation(
     await page.click('[data-testid="confirm-accept"]');
     await page.locator('[data-testid="confirm-dialog"]').waitFor({ state: 'hidden', timeout: 30000 });
 
-    // Assert the specific card is gone — name match alone is unreliable when
-    // a sibling test left a same-named orphan.
-    await expect(
-        page.locator(`[data-testid="location-card"][data-location-id="${targetId}"]`),
-    ).toHaveCount(0, { timeout: 30000 });
+    // After delete from the detail page, the React app navigates back
+    // to /locations; from the list page, the card simply unmounts. Both
+    // paths converge on /locations with no card carrying targetId — that's
+    // the deterministic settle signal.
+    await page.waitForURL((url) => /\/locations(\?|$)/.test(url.pathname), { timeout: 30000 });
+    if (targetId) {
+        await expect(
+            page.locator(`[data-testid="location-card"][data-location-id="${targetId}"]`),
+        ).toHaveCount(0, { timeout: 30000 });
+    }
 
     await recorder.takeScreenshot('location-delete-02-deleted');
     await expect(page).toHaveURL(/\/locations/);

--- a/e2e/tests/includes/locations.ts
+++ b/e2e/tests/includes/locations.ts
@@ -66,11 +66,15 @@ export async function deleteLocation(
         throw new Error(`deleteLocation: could not read data-location-id from card "${locationName}"`);
     }
 
-    // Click the trash icon button on the card. The confirm dialog comes from
-    // useConfirm (single shared root-mounted Dialog) — selector is
+    // Post-#1531 the trash icon moved into the LocationCard dropdown.
+    // Open the dropdown first, then pick "Delete" — the testid kept its
+    // legacy name so any future repositioning of the action leaves this
+    // helper intact. The confirm dialog comes from useConfirm (single
+    // shared root-mounted Dialog) — selector is
     // `[data-testid="confirm-dialog"]` with `confirm-accept` for the
     // destructive button.
-    await locationCard.locator('[data-testid="location-card-delete"]').click();
+    await locationCard.locator('[data-testid="location-card-menu"]').click();
+    await page.locator('[data-testid="location-card-delete"]').click();
     await recorder.takeScreenshot('location-delete-01-confirm');
 
     await page.locator('[data-testid="confirm-dialog"]').waitFor({ state: 'visible', timeout: 5000 });

--- a/e2e/tests/storage-usage.spec.ts
+++ b/e2e/tests/storage-usage.spec.ts
@@ -36,7 +36,11 @@ test.describe('Storage usage', () => {
     originalPriceCurrency: 'CZK',
     purchaseDate: new Date().toISOString().split('T')[0],
     status: 'In Use',
+    // Pin the parent location too: seeded data adds
+    // Home/Office/Storage Unit alphabetically before any test fixture,
+    // so picking the "first" location alone would mis-target Home.
     areaName: testArea.name,
+    locationName: testLocation.name,
   }
   const imageFixture = path.join('files', 'image.jpg')
   const imageFixtureAbsPath = path.join(
@@ -76,7 +80,7 @@ test.describe('Storage usage', () => {
 
     recorder.log(`Step ${step++}: create location/area/commodity`)
     await createLocation(page, recorder, testLocation)
-    await createArea(page, recorder, testArea)
+    await createArea(page, recorder, testArea, testLocation.name)
     await navigateTo(page, recorder, TO_AREA_COMMODITIES, FROM_LOCATIONS_AREA, testArea.name)
     await verifyAreaHasCommodities(page, recorder)
     await createCommodity(page, recorder, testCommodity)

--- a/frontend/src/components/locations/LocationsBreadcrumb.tsx
+++ b/frontend/src/components/locations/LocationsBreadcrumb.tsx
@@ -16,16 +16,33 @@ interface LocationsBreadcrumbProps {
   // page (bold, non-interactive) regardless of whether it carries a
   // `to`. Earlier segments with a `to` are rendered as Links; without
   // a `to` they fall back to muted plain text (e.g. while a parent
-  // detail still loads).
+  // detail still loads). "#" / empty strings are treated as absent so
+  // a placeholder href doesn't leave the user one click away from a
+  // bare-hash URL change.
   segments: BreadcrumbSegment[]
   // Optional leading back-chevron target. Mirrors
   // `design-mocks/src/views/LocationPickerView.tsx` L460-L465: an
   // ArrowLeft button that always walks one level up. Hidden when
-  // omitted.
+  // omitted or when the caller passes a placeholder ("#" / "").
   backHref?: string
+  // aria-label for the back-chevron button. Hidden from sighted users.
   backLabel?: string
+  // aria-label for the `<nav>` itself. Defaults to "Breadcrumb" so screen
+  // readers always announce the landmark even when the caller wires
+  // backLabel only.
+  navLabel?: string
   className?: string
   testId?: string
+}
+
+// Treat "#" and empty strings as "no destination" — callers wire these
+// up before `currentGroup.slug` resolves and we don't want the back
+// button (or a clickable parent segment) to leave the user one click
+// away from a bare-hash URL change.
+function realHref(href: string | undefined): string | undefined {
+  if (!href) return undefined
+  if (href === "#") return undefined
+  return href
 }
 
 // Multi-segment breadcrumb used on location and area detail pages.
@@ -38,18 +55,20 @@ export function LocationsBreadcrumb({
   segments,
   backHref,
   backLabel,
+  navLabel,
   className,
   testId,
 }: LocationsBreadcrumbProps) {
   if (segments.length === 0) return null
   const lastIndex = segments.length - 1
+  const effectiveBackHref = realHref(backHref)
   return (
     <nav
-      aria-label={backLabel ?? "Breadcrumb"}
+      aria-label={navLabel ?? "Breadcrumb"}
       className={cn("flex items-center gap-2", className)}
       data-testid={testId ?? "locations-breadcrumb"}
     >
-      {backHref ? (
+      {effectiveBackHref ? (
         <Button
           asChild
           variant="ghost"
@@ -58,7 +77,7 @@ export function LocationsBreadcrumb({
           aria-label={backLabel ?? "Back"}
           data-testid="locations-breadcrumb-back"
         >
-          <Link to={backHref}>
+          <Link to={effectiveBackHref}>
             <ArrowLeft className="size-4" aria-hidden="true" />
           </Link>
         </Button>
@@ -66,6 +85,7 @@ export function LocationsBreadcrumb({
       <ol className="flex min-w-0 flex-1 items-center gap-1.5">
         {segments.map((segment, i) => {
           const isCurrent = i === lastIndex
+          const segmentHref = realHref(segment.to)
           return (
             <li key={i} className="flex min-w-0 items-center gap-1.5">
               {i > 0 ? (
@@ -74,7 +94,7 @@ export function LocationsBreadcrumb({
                   aria-hidden="true"
                 />
               ) : null}
-              {isCurrent || !segment.to ? (
+              {isCurrent || !segmentHref ? (
                 <span
                   className={cn(
                     "truncate text-sm",
@@ -87,7 +107,7 @@ export function LocationsBreadcrumb({
                 </span>
               ) : (
                 <Link
-                  to={segment.to}
+                  to={segmentHref}
                   className="truncate text-sm text-muted-foreground transition-colors hover:text-foreground"
                   data-testid={segment.testId}
                 >

--- a/frontend/src/components/locations/LocationsBreadcrumb.tsx
+++ b/frontend/src/components/locations/LocationsBreadcrumb.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from "react"
+import { Link } from "react-router-dom"
+import { ArrowLeft, ChevronRight } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export interface BreadcrumbSegment {
+  label: ReactNode
+  to?: string
+  testId?: string
+}
+
+interface LocationsBreadcrumbProps {
+  // Ordered root → current. The last segment renders as the current
+  // page (bold, non-interactive) regardless of whether it carries a
+  // `to`. Earlier segments with a `to` are rendered as Links; without
+  // a `to` they fall back to muted plain text (e.g. while a parent
+  // detail still loads).
+  segments: BreadcrumbSegment[]
+  // Optional leading back-chevron target. Mirrors
+  // `design-mocks/src/views/LocationPickerView.tsx` L460-L465: an
+  // ArrowLeft button that always walks one level up. Hidden when
+  // omitted.
+  backHref?: string
+  backLabel?: string
+  className?: string
+  testId?: string
+}
+
+// Multi-segment breadcrumb used on location and area detail pages.
+// Ports `design-mocks/src/views/LocationPickerView.tsx` L459-L498:
+// optional left ArrowLeft + chevron-separated clickable segments with
+// the current one bold. Non-sticky here — the existing app shell already
+// owns the sticky TopBar slot, so adding a second sticky strip below it
+// would compete for the top edge of the viewport.
+export function LocationsBreadcrumb({
+  segments,
+  backHref,
+  backLabel,
+  className,
+  testId,
+}: LocationsBreadcrumbProps) {
+  if (segments.length === 0) return null
+  const lastIndex = segments.length - 1
+  return (
+    <nav
+      aria-label={backLabel ?? "Breadcrumb"}
+      className={cn("flex items-center gap-2", className)}
+      data-testid={testId ?? "locations-breadcrumb"}
+    >
+      {backHref ? (
+        <Button
+          asChild
+          variant="ghost"
+          size="icon"
+          className="-ml-1 size-8 shrink-0"
+          aria-label={backLabel ?? "Back"}
+          data-testid="locations-breadcrumb-back"
+        >
+          <Link to={backHref}>
+            <ArrowLeft className="size-4" aria-hidden="true" />
+          </Link>
+        </Button>
+      ) : null}
+      <ol className="flex min-w-0 flex-1 items-center gap-1.5">
+        {segments.map((segment, i) => {
+          const isCurrent = i === lastIndex
+          return (
+            <li key={i} className="flex min-w-0 items-center gap-1.5">
+              {i > 0 ? (
+                <ChevronRight
+                  className="size-3.5 shrink-0 text-muted-foreground"
+                  aria-hidden="true"
+                />
+              ) : null}
+              {isCurrent || !segment.to ? (
+                <span
+                  className={cn(
+                    "truncate text-sm",
+                    isCurrent ? "font-semibold text-foreground" : "text-muted-foreground"
+                  )}
+                  aria-current={isCurrent ? "page" : undefined}
+                  data-testid={segment.testId}
+                >
+                  {segment.label}
+                </span>
+              ) : (
+                <Link
+                  to={segment.to}
+                  className="truncate text-sm text-muted-foreground transition-colors hover:text-foreground"
+                  data-testid={segment.testId}
+                >
+                  {segment.label}
+                </Link>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -36,8 +36,6 @@
     "edit": "Edit",
     "errorDescription": "Reload the page or try again in a moment.",
     "errorTitle": "Could not load this item",
-    "sheetDescriptionFallback": "Inspect, edit, or manage files for the selected item.",
-    "sheetTitleFallback": "Item details",
     "fields": {
       "area": "Area",
       "comments": "Notes",
@@ -129,6 +127,8 @@
     "notFoundTitle": "Item not found",
     "noValue": "—",
     "print": "Print",
+    "sheetDescriptionFallback": "Inspect, edit, or manage files for the selected item.",
+    "sheetTitleFallback": "Item details",
     "statusTransition": {
       "description": "Mark this item as {{label}}? You can revert from the edit dialog later.",
       "heading": "Change Status",

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -36,6 +36,8 @@
     "edit": "Edit",
     "errorDescription": "Reload the page or try again in a moment.",
     "errorTitle": "Could not load this item",
+    "sheetDescriptionFallback": "Inspect, edit, or manage files for the selected item.",
+    "sheetTitleFallback": "Item details",
     "fields": {
       "area": "Area",
       "comments": "Notes",

--- a/frontend/src/i18n/locales/en/locations.json
+++ b/frontend/src/i18n/locales/en/locations.json
@@ -27,6 +27,9 @@
     "namePlaceholder": "e.g. Kitchen, Living Room, Workshop…",
     "submitting": "Saving…"
   },
+  "breadcrumb": {
+    "locations": "Locations"
+  },
   "delete": {
     "areaDescription": "Items already filed in this area will lose their area assignment. This cannot be undone.",
     "areaTitle": "Delete area \"{{name}}\"?",
@@ -36,9 +39,14 @@
     "locationTitle": "Delete location \"{{name}}\"?"
   },
   "detail": {
+    "areaExpiring_one": "{{count}} warranty expiring",
+    "areaExpiring_other": "{{count}} warranties expiring",
+    "areaItems_one": "{{formatted}} item",
+    "areaItems_other": "{{formatted}} items",
     "areasDescription_one": "{{count}} area",
     "areasDescription_other": "{{count}} areas",
     "areasEmpty": "No areas yet. Add one to start organising what's stored in this location.",
+    "areasEmptyTitle": "No areas yet",
     "areasTitle": "Areas",
     "back": "Back to locations",
     "edit": "Edit",
@@ -62,10 +70,9 @@
     "submitting": "Saving…"
   },
   "list": {
+    "actionsLabel": "Open menu for {{name}}",
     "addArea": "Add area",
     "addLocation": "Add location",
-    "deleteArea": "Delete area {{name}}",
-    "deleteLocation": "Delete location",
     "documentTitle": "Locations",
     "emptyDescription": "Locations are the physical places you keep things — houses, units, vehicles, anywhere your items live. Add your first one to start organising.",
     "emptyTitle": "No locations yet",
@@ -74,6 +81,10 @@
     "heading": "Locations",
     "searchEmpty": "No locations match your search.",
     "searchPlaceholder": "Search locations or areas…",
+    "statsAreas_one": "{{count}} area",
+    "statsAreas_other": "{{count}} areas",
+    "statsItems_one": "{{formatted}} item",
+    "statsItems_other": "{{formatted}} items",
     "subtitle": "Where your inventory lives — physical places, plus the areas inside them."
   },
   "toast": {

--- a/frontend/src/i18n/locales/en/locations.json
+++ b/frontend/src/i18n/locales/en/locations.json
@@ -28,7 +28,8 @@
     "submitting": "Saving…"
   },
   "breadcrumb": {
-    "locations": "Locations"
+    "locations": "Locations",
+    "navLabel": "Locations breadcrumb"
   },
   "delete": {
     "areaDescription": "Items already filed in this area will lose their area assignment. This cannot be undone.",

--- a/frontend/src/pages/areas/AreaDetailPage.tsx
+++ b/frontend/src/pages/areas/AreaDetailPage.tsx
@@ -142,6 +142,7 @@ export function AreaDetailPage({ initialMode }: AreaDetailPageProps = {}) {
         <LocationsBreadcrumb
           backHref={breadcrumbBackHref}
           backLabel={t("locations:areaDetail.back")}
+          navLabel={t("locations:breadcrumb.navLabel")}
           segments={[
             {
               label: t("locations:breadcrumb.locations"),

--- a/frontend/src/pages/areas/AreaDetailPage.tsx
+++ b/frontend/src/pages/areas/AreaDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { Link, useMatch, useNavigate, useParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import { ArrowLeft, ChevronRight, MapPin, Package, Pencil, Trash2, TrendingUp } from "lucide-react"
+import { ChevronRight, Package, Pencil, Trash2, TrendingUp } from "lucide-react"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
+import { LocationsBreadcrumb } from "@/components/locations/LocationsBreadcrumb"
 import { AreaFormDialog } from "@/components/locations/AreaFormDialog"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { WarrantyBadge } from "@/components/warranty/WarrantyBadge"
@@ -122,12 +123,14 @@ export function AreaDetailPage({ initialMode }: AreaDetailPageProps = {}) {
     )
   }
 
-  const backHref =
+  const locationsHref = slug ? `/g/${encodeURIComponent(slug)}/locations` : "#"
+  const parentHref =
     slug && area.data?.location_id
       ? `/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(area.data.location_id)}`
-      : slug
-        ? `/g/${encodeURIComponent(slug)}/locations`
-        : "#"
+      : undefined
+  // The breadcrumb's back chevron mirrors the most-natural "one level
+  // up" target: parent location when known, locations list otherwise.
+  const breadcrumbBackHref = parentHref ?? locationsHref
 
   return (
     <>
@@ -136,13 +139,27 @@ export function AreaDetailPage({ initialMode }: AreaDetailPageProps = {}) {
         className="flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full"
         data-testid="page-area-detail"
       >
-        <Link
-          to={backHref}
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="size-4" aria-hidden="true" />
-          {parent.data ? parent.data.name : t("locations:areaDetail.back")}
-        </Link>
+        <LocationsBreadcrumb
+          backHref={breadcrumbBackHref}
+          backLabel={t("locations:areaDetail.back")}
+          segments={[
+            {
+              label: t("locations:breadcrumb.locations"),
+              to: locationsHref,
+              testId: "breadcrumb-locations",
+            },
+            {
+              label: parent.data?.name ?? t("locations:detail.fallbackTitle"),
+              to: parentHref,
+              testId: "breadcrumb-location",
+            },
+            {
+              label: area.data?.name ?? t("locations:areaDetail.fallbackTitle"),
+              testId: "breadcrumb-current",
+            },
+          ]}
+          testId="area-detail-breadcrumb"
+        />
 
         {area.isLoading ? (
           <div className="space-y-3" data-testid="area-detail-loading">
@@ -156,12 +173,6 @@ export function AreaDetailPage({ initialMode }: AreaDetailPageProps = {}) {
                 <Package className="size-5 text-muted-foreground" aria-hidden="true" />
                 <span className="truncate">{area.data.name}</span>
               </h1>
-              {parent.data ? (
-                <p className="mt-1 text-sm text-muted-foreground inline-flex items-center gap-1.5">
-                  <MapPin className="size-3.5" aria-hidden="true" />
-                  {parent.data.name}
-                </p>
-              ) : null}
             </div>
             <div className="flex items-center gap-2 shrink-0">
               <Button

--- a/frontend/src/pages/areas/__tests__/AreaDetailPage.test.tsx
+++ b/frontend/src/pages/areas/__tests__/AreaDetailPage.test.tsx
@@ -102,12 +102,24 @@ describe("<AreaDetailPage />", () => {
       })
     )
     renderDetail(`/g/${SLUG}/areas/a1`)
-    await waitFor(() => expect(screen.getByText("Kitchen")).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Kitchen" })).toBeInTheDocument()
+    )
     // Parent-location resolves on a chained fetch (area → location_id
-    // → /locations/:id), so wait again for the breadcrumb.
+    // → /locations/:id), so wait again for the breadcrumb to fill in.
+    const crumbs = await screen.findByTestId("area-detail-breadcrumb")
     await waitFor(() => {
-      expect(screen.getAllByText("Main House").length).toBeGreaterThan(0)
+      expect(within(crumbs).getByTestId("breadcrumb-location")).toHaveTextContent("Main House")
     })
+    expect(within(crumbs).getByTestId("breadcrumb-locations")).toHaveAttribute(
+      "href",
+      `/g/${SLUG}/locations`
+    )
+    expect(within(crumbs).getByTestId("breadcrumb-location")).toHaveAttribute(
+      "href",
+      `/g/${SLUG}/locations/loc1`
+    )
+    expect(within(crumbs).getByTestId("breadcrumb-current")).toHaveTextContent("Kitchen")
     // Stats strip + empty-state list.
     expect(await screen.findByTestId("area-detail-items-stats")).toBeInTheDocument()
     expect(screen.getByTestId("area-detail-items-empty")).toBeInTheDocument()

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -32,7 +32,13 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
-import { Sheet, SheetContent } from "@/components/ui/sheet"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
 import { CommodityFilesTab } from "@/components/files/CommodityFilesTab"
 import { DropOverlay } from "@/components/files/DropOverlay"
@@ -1455,6 +1461,7 @@ export function CommodityDetailPage() {
 // back to going back in history; if even that fails, the route's
 // catch-all `<NotFoundPage>` would handle it after the page reloads.
 export function CommodityDetailSheet() {
+  const { t } = useTranslation()
   const { id = "" } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const location = useLocation()
@@ -1488,6 +1495,17 @@ export function CommodityDetailSheet() {
         className="w-full sm:max-w-lg flex flex-col gap-0 overflow-y-auto p-0"
         data-testid="commodity-detail-sheet"
       >
+        {/* Radix Dialog (which Sheet wraps) emits a console warning
+            unless a DialogTitle/SheetTitle is mounted inside
+            DialogContent. The visible commodity name lives inside
+            CommodityDetailContent's own header (`<h1
+            data-testid="commodity-detail-name">`) which Radix can't
+            see, so we mirror it sr-only here. The fallback copy
+            covers the brief window before `useCommodity` resolves. */}
+        <SheetHeader className="sr-only">
+          <SheetTitle>{t("commodities:detail.sheetTitleFallback")}</SheetTitle>
+          <SheetDescription>{t("commodities:detail.sheetDescriptionFallback")}</SheetDescription>
+        </SheetHeader>
         <CommodityDetailContent id={id} variant="sheet" />
       </SheetContent>
     </Sheet>

--- a/frontend/src/pages/locations/LocationDetailPage.tsx
+++ b/frontend/src/pages/locations/LocationDetailPage.tsx
@@ -159,8 +159,10 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
   }
 
   // Per-area item + expiring-warranty counts derived from the page's
-  // single commodities fetch. Empty while loading; tiles render the
-  // count chip as "—" in that window.
+  // single commodities fetch. Empty while loading or on error; tiles
+  // render the count chip as "—" in those windows. Match-by-truncation
+  // only when data actually exists (an error leaves data undefined, so
+  // total/rows are both 0 and would otherwise look "not truncated").
   const { itemCounts, expiringCounts, isTruncated } = useMemo(() => {
     const itemMap = new Map<string, number>()
     const expiringMap = new Map<string, number>()
@@ -175,9 +177,13 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
     return {
       itemCounts: itemMap,
       expiringCounts: expiringMap,
-      isTruncated: (itemsForCounts.data?.total ?? 0) > rows.length,
+      isTruncated: !!itemsForCounts.data && (itemsForCounts.data.total ?? 0) > rows.length,
     }
   }, [itemsForCounts.data])
+  // Network/API failure → counts are unknown, not zero. Treat `isError`
+  // as "still loading" so AreaTile keeps the "—" affordance instead of
+  // implying empty.
+  const itemsCountIsUnknown = itemsForCounts.isLoading || itemsForCounts.isError
 
   if (location.isError) {
     return (
@@ -320,7 +326,7 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
                           area={area}
                           itemCount={count}
                           expiringCount={expiring}
-                          itemCountLoading={itemsForCounts.isLoading}
+                          itemCountLoading={itemsCountIsUnknown}
                           itemCountTruncated={isTruncated}
                           onDelete={() => handleDeleteArea(area)}
                         />

--- a/frontend/src/pages/locations/LocationDetailPage.tsx
+++ b/frontend/src/pages/locations/LocationDetailPage.tsx
@@ -211,6 +211,7 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
         <LocationsBreadcrumb
           backHref={locationsHref}
           backLabel={t("locations:detail.back")}
+          navLabel={t("locations:breadcrumb.navLabel")}
           segments={[
             {
               label: t("locations:breadcrumb.locations"),
@@ -408,10 +409,20 @@ function AreaTile({
       ? `/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(area.id)}/edit`
       : "#"
   const interactive = detailHref !== "#"
+  // Truncation states mirror LocationsListPage's chip: the page-level
+  // commodities fetch is capped, so an area whose items happen to live
+  // past the cap can sample to 0 even when the real count isn't. Show
+  // "—" instead of "0" in that case so the tile doesn't imply emptiness.
+  // - loading                              → "—"
+  // - truncated AND ≥1 in the sample       → "{n}+" (at-least)
+  // - truncated AND 0 in the sample        → "—" (true count unknown)
+  // - not truncated                        → exact count
   const itemCountLabel = itemCountLoading
     ? "—"
-    : itemCountTruncated && itemCount >= 1
-      ? `${itemCount}+`
+    : itemCountTruncated
+      ? itemCount >= 1
+        ? `${itemCount}+`
+        : "—"
       : String(itemCount)
   return (
     <div
@@ -430,10 +441,14 @@ function AreaTile({
           data-testid="location-detail-area-link"
         />
       ) : null}
-      <div className="relative flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+      {/* Inert decorative + text columns — `pointer-events-none` lets
+          the overlay <Link> above receive clicks anywhere on the tile.
+          The actions column re-enables pointer events on its
+          interactive children only. */}
+      <div className="pointer-events-none flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
         <Package className="size-5" aria-hidden="true" />
       </div>
-      <div className="relative flex min-w-0 flex-1 flex-col gap-0.5">
+      <div className="pointer-events-none flex min-w-0 flex-1 flex-col gap-0.5">
         <p className="truncate text-sm font-semibold">{area.name}</p>
         <p className="text-xs text-muted-foreground">
           {t("locations:detail.areaItems", { count: itemCount, formatted: itemCountLabel })}
@@ -448,14 +463,14 @@ function AreaTile({
           </Badge>
         ) : null}
       </div>
-      <div className="relative flex shrink-0 items-center gap-1">
+      <div className="pointer-events-none flex shrink-0 items-center gap-1">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               type="button"
               variant="ghost"
               size="icon"
-              className="size-7 opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+              className="pointer-events-auto size-7 opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
               aria-label={t("locations:list.actionsLabel", { name: area.name ?? "" })}
               data-testid="location-detail-area-menu"
             >

--- a/frontend/src/pages/locations/LocationDetailPage.tsx
+++ b/frontend/src/pages/locations/LocationDetailPage.tsx
@@ -1,20 +1,31 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Link, useMatch, useNavigate, useParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import { ArrowLeft, ChevronRight, MapPin, Pencil, Plus, Trash2 } from "lucide-react"
+import { ChevronRight, MapPin, MoreHorizontal, Package, Pencil, Plus, Trash2 } from "lucide-react"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DropOverlay } from "@/components/files/DropOverlay"
 import { EntityFilesPanel } from "@/components/files/EntityFilesPanel"
 import { UploadFilesDialog } from "@/components/files/UploadFilesDialog"
 import { useFileDropZone } from "@/components/files/useFileDropZone"
+import { LocationsBreadcrumb } from "@/components/locations/LocationsBreadcrumb"
 import { LocationFormDialog } from "@/components/locations/LocationFormDialog"
 import { AreaFormDialog } from "@/components/locations/AreaFormDialog"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { useAreas, useCreateArea, useDeleteArea } from "@/features/areas/hooks"
+import { useCommodities } from "@/features/commodities/hooks"
+import { warrantyStatus } from "@/features/commodities/constants"
 import {
   useDeleteLocation,
   useLocation,
@@ -24,16 +35,25 @@ import {
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
 import { useConfirm } from "@/hooks/useConfirm"
+import { cn } from "@/lib/utils"
 import type { Area } from "@/features/areas/api"
 
 interface LocationDetailPageProps {
   initialMode?: "edit"
 }
 
-// /locations/:id — single-location detail. Renders metadata + the
-// location's areas, with edit / add-area / delete actions. The
-// /locations/:id/edit deep link mounts this same component with
-// `initialMode="edit"`; both routes auto-open the matching dialog.
+// Cap the single page-level commodities fetch behind area tiles —
+// matches LocationsListPage's cap so a navigate from list → detail
+// reuses the cached query. Partial counts beyond the cap surface as
+// "{N}+" on tiles.
+const ITEM_COUNT_FETCH_CAP = 500
+
+// /locations/:id — single-location detail. Renders the multi-segment
+// breadcrumb, metadata + edit/delete header, the responsive area tile
+// grid (per `design-mocks/src/views/LocationPickerView.tsx` Level 2)
+// and the Location Files panel underneath. The /locations/:id/edit
+// deep link mounts this same component with `initialMode="edit"`;
+// both routes auto-open the edit dialog.
 export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}) {
   const { t } = useTranslation()
   const params = useParams<{ id: string }>()
@@ -45,6 +65,10 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
   const location = useLocation(id, { enabled: !!currentGroup })
   const allLocations = useLocations({ enabled: !!currentGroup })
   const allAreas = useAreas({ enabled: !!currentGroup })
+  const itemsForCounts = useCommodities(
+    { perPage: ITEM_COUNT_FETCH_CAP, includeInactive: false },
+    { enabled: !!currentGroup }
+  )
   const updateLocation = useUpdateLocation(id)
   const deleteLocation = useDeleteLocation()
   const createArea = useCreateArea()
@@ -134,6 +158,27 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
     }
   }
 
+  // Per-area item + expiring-warranty counts derived from the page's
+  // single commodities fetch. Empty while loading; tiles render the
+  // count chip as "—" in that window.
+  const { itemCounts, expiringCounts, isTruncated } = useMemo(() => {
+    const itemMap = new Map<string, number>()
+    const expiringMap = new Map<string, number>()
+    const rows = itemsForCounts.data?.commodities ?? []
+    for (const c of rows) {
+      if (!c.area_id) continue
+      itemMap.set(c.area_id, (itemMap.get(c.area_id) ?? 0) + 1)
+      if (warrantyStatus({ warranty_expires_at: c.warranty_expires_at }) === "expiring") {
+        expiringMap.set(c.area_id, (expiringMap.get(c.area_id) ?? 0) + 1)
+      }
+    }
+    return {
+      itemCounts: itemMap,
+      expiringCounts: expiringMap,
+      isTruncated: (itemsForCounts.data?.total ?? 0) > rows.length,
+    }
+  }, [itemsForCounts.data])
+
   if (location.isError) {
     return (
       <div className="flex flex-col gap-6 p-6 max-w-3xl mx-auto w-full">
@@ -147,7 +192,7 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
   }
 
   const myAreas = (allAreas.data ?? []).filter((a) => a.location_id === id)
-  const backHref = slug ? `/g/${encodeURIComponent(slug)}/locations` : "#"
+  const locationsHref = slug ? `/g/${encodeURIComponent(slug)}/locations` : "#"
 
   return (
     <>
@@ -163,13 +208,22 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
             hint={t("files:entityPanel.dropHint")}
           />
         ) : null}
-        <Link
-          to={backHref}
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="size-4" aria-hidden="true" />
-          {t("locations:detail.back")}
-        </Link>
+        <LocationsBreadcrumb
+          backHref={locationsHref}
+          backLabel={t("locations:detail.back")}
+          segments={[
+            {
+              label: t("locations:breadcrumb.locations"),
+              to: locationsHref,
+              testId: "breadcrumb-locations",
+            },
+            {
+              label: location.data?.name ?? t("locations:detail.fallbackTitle"),
+              testId: "breadcrumb-current",
+            },
+          ]}
+          testId="location-detail-breadcrumb"
+        />
 
         {location.isLoading ? (
           <div className="space-y-3" data-testid="location-detail-loading">
@@ -212,75 +266,69 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
               </div>
             </header>
 
-            <Card>
-              <CardHeader>
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <CardTitle className="text-base">{t("locations:detail.areasTitle")}</CardTitle>
-                    <CardDescription>
-                      {t("locations:detail.areasDescription", { count: myAreas.length })}
-                    </CardDescription>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setDialog({ kind: "create-area" })}
-                    data-testid="location-detail-add-area"
-                    className="gap-2"
-                  >
-                    <Plus className="size-3.5" aria-hidden="true" />
-                    {t("locations:list.addArea")}
-                  </Button>
-                </div>
-              </CardHeader>
-              <CardContent>
-                {myAreas.length === 0 ? (
-                  <p
-                    className="text-sm text-muted-foreground"
-                    data-testid="location-detail-areas-empty"
-                  >
-                    {t("locations:detail.areasEmpty")}
+            <section className="flex flex-col gap-3" data-testid="location-detail-areas-section">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-base font-semibold">{t("locations:detail.areasTitle")}</h2>
+                  <p className="text-sm text-muted-foreground">
+                    {t("locations:detail.areasDescription", { count: myAreas.length })}
                   </p>
-                ) : (
-                  <ul className="divide-y divide-border rounded-md border border-border">
-                    {myAreas.map((area) => {
-                      const areaHref =
-                        slug && area.id
-                          ? `/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(area.id)}`
-                          : "#"
-                      return (
-                        <li
-                          key={area.id}
-                          className="flex items-center justify-between px-3 py-2"
-                          data-testid="location-detail-area"
-                        >
-                          <Link
-                            to={areaHref}
-                            className="flex items-center gap-2 text-sm hover:underline min-w-0"
-                          >
-                            <ChevronRight
-                              className="size-3.5 text-muted-foreground"
-                              aria-hidden="true"
-                            />
-                            <span className="truncate">{area.name}</span>
-                          </Link>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => handleDeleteArea(area)}
-                            aria-label={t("locations:list.deleteArea", { name: area.name ?? "" })}
-                          >
-                            <Trash2 className="size-3.5 text-destructive" aria-hidden="true" />
-                          </Button>
-                        </li>
-                      )
-                    })}
-                  </ul>
-                )}
-              </CardContent>
-            </Card>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setDialog({ kind: "create-area" })}
+                  data-testid="location-detail-add-area"
+                  className="gap-2"
+                >
+                  <Plus className="size-3.5" aria-hidden="true" />
+                  {t("locations:list.addArea")}
+                </Button>
+              </div>
+
+              {myAreas.length === 0 ? (
+                <Card data-testid="location-detail-areas-empty">
+                  <CardHeader>
+                    <CardTitle className="text-base">
+                      {t("locations:detail.areasEmptyTitle")}
+                    </CardTitle>
+                    <CardDescription>{t("locations:detail.areasEmpty")}</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setDialog({ kind: "create-area" })}
+                      className="gap-2"
+                    >
+                      <Plus className="size-3.5" aria-hidden="true" />
+                      {t("locations:list.addArea")}
+                    </Button>
+                  </CardContent>
+                </Card>
+              ) : (
+                <ul className="grid gap-3 sm:grid-cols-2" data-testid="location-detail-areas-grid">
+                  {myAreas.map((area) => {
+                    const count = area.id ? (itemCounts.get(area.id) ?? 0) : 0
+                    const expiring = area.id ? (expiringCounts.get(area.id) ?? 0) : 0
+                    return (
+                      <li key={area.id}>
+                        <AreaTile
+                          area={area}
+                          itemCount={count}
+                          expiringCount={expiring}
+                          itemCountLoading={itemsForCounts.isLoading}
+                          itemCountTruncated={isTruncated}
+                          onDelete={() => handleDeleteArea(area)}
+                        />
+                      </li>
+                    )
+                  })}
+                </ul>
+              )}
+            </section>
 
             <EntityFilesPanel
               linkedEntityType="location"
@@ -324,5 +372,119 @@ export function LocationDetailPage({ initialMode }: LocationDetailPageProps = {}
         initialFiles={pendingDropFiles}
       />
     </>
+  )
+}
+
+interface AreaTileProps {
+  area: Area
+  itemCount: number
+  expiringCount: number
+  itemCountLoading: boolean
+  itemCountTruncated: boolean
+  onDelete: () => void
+}
+
+// AreaTile is the Level-2 mock card per
+// `design-mocks/src/views/LocationPickerView.tsx` L615-L668: rounded
+// border, icon avatar, name, "{n} item(s)", optional expiring pill,
+// dropdown menu (reveal on hover), chevron. The avatar uses a generic
+// Package icon — the mock's per-area emoji `icon` field isn't yet on
+// `models.Area` (see devdocs/frontend/design-deviations.md).
+function AreaTile({
+  area,
+  itemCount,
+  expiringCount,
+  itemCountLoading,
+  itemCountTruncated,
+  onDelete,
+}: AreaTileProps) {
+  const { t } = useTranslation()
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug
+  const detailHref =
+    slug && area.id ? `/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(area.id)}` : "#"
+  const editHref =
+    slug && area.id
+      ? `/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(area.id)}/edit`
+      : "#"
+  const interactive = detailHref !== "#"
+  const itemCountLabel = itemCountLoading
+    ? "—"
+    : itemCountTruncated && itemCount >= 1
+      ? `${itemCount}+`
+      : String(itemCount)
+  return (
+    <div
+      className={cn(
+        "group relative flex items-start gap-3 rounded-xl border border-border bg-card p-4 transition-all",
+        interactive && "hover:-translate-y-0.5 hover:border-primary/20 hover:shadow-sm"
+      )}
+      data-testid="location-detail-area"
+      data-area-id={area.id}
+    >
+      {interactive ? (
+        <Link
+          to={detailHref}
+          aria-label={area.name ?? ""}
+          className="absolute inset-0 rounded-xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring/50"
+          data-testid="location-detail-area-link"
+        />
+      ) : null}
+      <div className="relative flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+        <Package className="size-5" aria-hidden="true" />
+      </div>
+      <div className="relative flex min-w-0 flex-1 flex-col gap-0.5">
+        <p className="truncate text-sm font-semibold">{area.name}</p>
+        <p className="text-xs text-muted-foreground">
+          {t("locations:detail.areaItems", { count: itemCount, formatted: itemCountLabel })}
+        </p>
+        {expiringCount > 0 ? (
+          <Badge
+            variant="secondary"
+            className="mt-1 h-5 self-start border-0 bg-status-expiring/10 px-1.5 text-[10px] text-status-expiring"
+            data-testid="location-detail-area-expiring"
+          >
+            {t("locations:detail.areaExpiring", { count: expiringCount })}
+          </Badge>
+        ) : null}
+      </div>
+      <div className="relative flex shrink-0 items-center gap-1">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-7 opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+              aria-label={t("locations:list.actionsLabel", { name: area.name ?? "" })}
+              data-testid="location-detail-area-menu"
+            >
+              <MoreHorizontal className="size-3.5" aria-hidden="true" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem asChild data-testid="location-detail-area-edit">
+              <Link to={editHref}>
+                <Pencil className="mr-2 size-4" aria-hidden="true" />
+                {t("locations:detail.edit")}
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={onDelete}
+              className="text-destructive focus:text-destructive"
+              data-testid="location-detail-area-delete"
+            >
+              <Trash2 className="mr-2 size-4" aria-hidden="true" />
+              {t("common:actions.delete")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <ChevronRight
+          className="size-3.5 text-muted-foreground transition-colors group-hover:text-foreground"
+          aria-hidden="true"
+        />
+      </div>
+    </div>
   )
 }

--- a/frontend/src/pages/locations/LocationsListPage.tsx
+++ b/frontend/src/pages/locations/LocationsListPage.tsx
@@ -345,10 +345,20 @@ function LocationCard({
   // resolves (the hooks gate on !!currentGroup, so this is rare but
   // possible during first paint).
   const interactive = detailHref !== "#"
+  // Truncation states: we sampled a capped page of commodities, so any
+  // location whose items happen to live past the cap can sample to 0
+  // even when the real count is non-zero. Surface that ambiguity
+  // explicitly instead of rendering "0" (which would imply emptiness).
+  // - loading                              → "—"
+  // - truncated AND ≥1 in the sample       → "{n}+" (at-least)
+  // - truncated AND 0 in the sample        → "—" (true count unknown)
+  // - not truncated                        → exact count
   const itemCountLabel = itemCountLoading
     ? "—"
-    : itemCountTruncated && itemCount >= 1
-      ? `${itemCount}+`
+    : itemCountTruncated
+      ? itemCount >= 1
+        ? `${itemCount}+`
+        : "—"
       : String(itemCount)
   return (
     <div
@@ -371,10 +381,14 @@ function LocationCard({
           data-testid="location-card-link"
         />
       ) : null}
-      <div className="relative flex size-14 shrink-0 items-center justify-center rounded-xl bg-muted text-muted-foreground">
+      {/* Inert decorative + text columns — `pointer-events-none` lets
+          the overlay <Link> above receive clicks anywhere on the card.
+          The actions column re-enables pointer events on its
+          interactive children (dropdown trigger) only. */}
+      <div className="pointer-events-none flex size-14 shrink-0 items-center justify-center rounded-xl bg-muted text-muted-foreground">
         <MapPin className="size-6" aria-hidden="true" />
       </div>
-      <div className="relative flex min-w-0 flex-1 flex-col gap-1">
+      <div className="pointer-events-none flex min-w-0 flex-1 flex-col gap-1">
         <p className="truncate text-base font-semibold">{location.name}</p>
         {location.address ? (
           <p className="truncate text-sm text-muted-foreground">{location.address}</p>
@@ -396,14 +410,14 @@ function LocationCard({
           </span>
         </div>
       </div>
-      <div className="relative flex shrink-0 items-center gap-1">
+      <div className="pointer-events-none flex shrink-0 items-center gap-1">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               type="button"
               variant="ghost"
               size="icon"
-              className="size-8 opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+              className="pointer-events-auto size-8 opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
               aria-label={t("locations:list.actionsLabel", { name: location.name ?? "" })}
               data-testid="location-card-menu"
             >

--- a/frontend/src/pages/locations/LocationsListPage.tsx
+++ b/frontend/src/pages/locations/LocationsListPage.tsx
@@ -1,22 +1,39 @@
 import { useEffect, useMemo, useState } from "react"
 import { Link, useMatch, useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import { ChevronRight, MapPin, Plus, Search, Trash2 } from "lucide-react"
+import {
+  ChevronRight,
+  Layers,
+  MapPin,
+  MoreHorizontal,
+  Package,
+  Plus,
+  Search,
+  Trash2,
+} from "lucide-react"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { LocationFormDialog } from "@/components/locations/LocationFormDialog"
 import { AreaFormDialog } from "@/components/locations/AreaFormDialog"
 import { RouteTitle } from "@/components/routing/RouteTitle"
-import { useAreas, useCreateArea, useDeleteArea } from "@/features/areas/hooks"
+import { useAreas, useCreateArea } from "@/features/areas/hooks"
+import { useCommodities } from "@/features/commodities/hooks"
 import { useCreateLocation, useDeleteLocation, useLocations } from "@/features/locations/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
 import { useConfirm } from "@/hooks/useConfirm"
-import type { Area } from "@/features/areas/api"
+import { cn } from "@/lib/utils"
 import type { Location } from "@/features/locations/api"
 
 interface LocationsListPageProps {
@@ -24,12 +41,21 @@ interface LocationsListPageProps {
   initialMode?: "create"
 }
 
-// /locations — list of every location in the active group, with the
-// nested areas surfaced inline. Add buttons open the matching dialog
-// (`LocationFormDialog` / `AreaFormDialog`); both dialogs are also
-// reachable via /locations/new — that route mounts this same page
-// with `initialMode="create"` so a deep link can open the create
-// modal on top of the list.
+// Cap the single page-level commodities fetch used to derive per-location
+// item-count chips. Large enough to cover typical groups; partial counts
+// past this are surfaced as "{N}+" so the chip stays useful instead of
+// silently undercounting.
+const ITEM_COUNT_FETCH_CAP = 500
+
+// /locations — list of every location in the active group. Each card is
+// a click-through tile (MapPin avatar + name + address + areas/items
+// stat chips + chevron) routed to the location detail. Per
+// `design-mocks/src/views/LocationPickerView.tsx` Level 1; the previous
+// inline area list was dropped because the mock surfaces areas only on
+// the detail page. Add buttons open the matching dialog
+// (`LocationFormDialog` / `AreaFormDialog`); /locations/new mounts this
+// same page with `initialMode="create"` so a deep link can open the
+// create modal on top of the list.
 export function LocationsListPage({ initialMode }: LocationsListPageProps = {}) {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -39,10 +65,18 @@ export function LocationsListPage({ initialMode }: LocationsListPageProps = {}) 
 
   const locations = useLocations({ enabled })
   const areas = useAreas({ enabled })
+  // Active-only, page-level fetch used purely for per-area count
+  // aggregation behind the stat chips. Capped at ITEM_COUNT_FETCH_CAP —
+  // a partial sample on bigger groups is still useful (chip becomes
+  // "{N}+") and the cap avoids paying full inventory-scan cost on a
+  // route that historically didn't read commodities at all.
+  const itemsForCounts = useCommodities(
+    { perPage: ITEM_COUNT_FETCH_CAP, includeInactive: false },
+    { enabled }
+  )
   const createLocation = useCreateLocation()
   const deleteLocation = useDeleteLocation()
   const createArea = useCreateArea()
-  const deleteArea = useDeleteArea()
 
   const toast = useAppToast()
   const confirm = useConfirm()
@@ -81,6 +115,19 @@ export function LocationsListPage({ initialMode }: LocationsListPageProps = {}) 
       navigate(`/g/${encodeURIComponent(slug)}/locations`, { replace: true })
     }
   }
+
+  // Per-area item counts derived once from the page-level commodities
+  // fetch. The map is empty while loading; LocationCard handles the
+  // loading branch by skipping the chip number.
+  const areaItemCounts = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const c of itemsForCounts.data?.commodities ?? []) {
+      if (c.area_id) map.set(c.area_id, (map.get(c.area_id) ?? 0) + 1)
+    }
+    return map
+  }, [itemsForCounts.data])
+  const itemsCountTruncated =
+    (itemsForCounts.data?.total ?? 0) > (itemsForCounts.data?.commodities.length ?? 0)
 
   const filteredLocations = useMemo(() => {
     const list = locations.data ?? []
@@ -130,23 +177,6 @@ export function LocationsListPage({ initialMode }: LocationsListPageProps = {}) 
       toast.success(t("locations:toast.locationDeleted"))
     } catch {
       toast.error(t("locations:toast.locationDeleteError"))
-    }
-  }
-
-  async function handleDeleteArea(area: Area) {
-    if (!area.id) return
-    const ok = await confirm({
-      title: t("locations:delete.areaTitle", { name: area.name ?? "" }),
-      description: t("locations:delete.areaDescription"),
-      confirmLabel: t("common:actions.delete"),
-      destructive: true,
-    })
-    if (!ok) return
-    try {
-      await deleteArea.mutateAsync(area.id)
-      toast.success(t("locations:toast.areaDeleted"))
-    } catch {
-      toast.error(t("locations:toast.areaDeleteError"))
     }
   }
 
@@ -234,14 +264,20 @@ export function LocationsListPage({ initialMode }: LocationsListPageProps = {}) 
           <ul className="space-y-3">
             {filteredLocations.map((loc) => {
               const locAreas = (areas.data ?? []).filter((a) => a.location_id === loc.id)
+              const itemCount = locAreas.reduce(
+                (sum, a) => sum + (a.id ? (areaItemCounts.get(a.id) ?? 0) : 0),
+                0
+              )
               return (
                 <li key={loc.id}>
                   <LocationCard
                     location={loc}
-                    areas={locAreas}
+                    areaCount={locAreas.length}
+                    itemCount={itemCount}
+                    itemCountLoading={itemsForCounts.isLoading}
+                    itemCountTruncated={itemsCountTruncated}
                     onAddArea={() => setDialog({ kind: "create-area", locationId: loc.id })}
                     onDeleteLocation={() => handleDeleteLocation(loc)}
-                    onDeleteArea={(a) => handleDeleteArea(a)}
                   />
                 </li>
               )
@@ -275,21 +311,27 @@ export function LocationsListPage({ initialMode }: LocationsListPageProps = {}) 
 
 interface LocationCardProps {
   location: Location
-  areas: Area[]
+  areaCount: number
+  itemCount: number
+  itemCountLoading: boolean
+  itemCountTruncated: boolean
   onAddArea: () => void
   onDeleteLocation: () => void
-  onDeleteArea: (area: Area) => void
 }
 
-// LocationCard owns one location + its inline area list. Extracted as
-// a separate component so the list page stays readable; nothing here
-// needs hooks on its own (parent owns state + mutations).
+// LocationCard renders one location as a click-through tile per the
+// Level 1 mock (`design-mocks/src/views/LocationPickerView.tsx`
+// L546-L600). The icon avatar is the generic MapPin tile — the mock's
+// per-location emoji `icon` field isn't yet on `models.Location`, see
+// devdocs/frontend/design-deviations.md ("Locations & Areas").
 function LocationCard({
   location,
-  areas,
+  areaCount,
+  itemCount,
+  itemCountLoading,
+  itemCountTruncated,
   onAddArea,
   onDeleteLocation,
-  onDeleteArea,
 }: LocationCardProps) {
   const { t } = useTranslation()
   const { currentGroup } = useCurrentGroup()
@@ -298,83 +340,97 @@ function LocationCard({
     slug && location.id
       ? `/g/${encodeURIComponent(slug)}/locations/${encodeURIComponent(location.id)}`
       : "#"
-
+  // Tile is link-only when the slug + id route exists; otherwise render
+  // as a plain card to keep the page usable while the GroupContext
+  // resolves (the hooks gate on !!currentGroup, so this is rare but
+  // possible during first paint).
+  const interactive = detailHref !== "#"
+  const itemCountLabel = itemCountLoading
+    ? "—"
+    : itemCountTruncated && itemCount >= 1
+      ? `${itemCount}+`
+      : String(itemCount)
   return (
-    <Card data-testid="location-card" data-location-id={location.id}>
-      <CardHeader>
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <CardTitle className="flex items-center gap-2 text-base">
-              <MapPin className="size-4 text-muted-foreground" aria-hidden="true" />
-              <Link to={detailHref} className="hover:underline truncate">
-                {location.name}
-              </Link>
-            </CardTitle>
-            {location.address ? (
-              <CardDescription className="truncate">{location.address}</CardDescription>
-            ) : null}
-          </div>
-          <div className="flex items-center gap-1.5 shrink-0">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={onAddArea}
-              data-testid="location-card-add-area"
-              className="gap-1.5"
-            >
-              <Plus className="size-3.5" aria-hidden="true" />
-              {t("locations:list.addArea")}
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={onDeleteLocation}
-              data-testid="location-card-delete"
-              aria-label={t("locations:list.deleteLocation")}
-            >
-              <Trash2 className="size-4 text-destructive" aria-hidden="true" />
-            </Button>
-          </div>
-        </div>
-      </CardHeader>
-      {areas.length > 0 ? (
-        <CardContent className="pt-0">
-          <ul className="divide-y divide-border rounded-md border border-border">
-            {areas.map((area) => {
-              const areaHref =
-                slug && area.id
-                  ? `/g/${encodeURIComponent(slug)}/areas/${encodeURIComponent(area.id)}`
-                  : "#"
-              return (
-                <li
-                  key={area.id}
-                  className="flex items-center justify-between px-3 py-2"
-                  data-testid="location-card-area"
-                >
-                  <Link
-                    to={areaHref}
-                    className="flex items-center gap-2 text-sm hover:underline min-w-0"
-                  >
-                    <ChevronRight className="size-3.5 text-muted-foreground" aria-hidden="true" />
-                    <span className="truncate">{area.name}</span>
-                  </Link>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => onDeleteArea(area)}
-                    aria-label={t("locations:list.deleteArea", { name: area.name ?? "" })}
-                  >
-                    <Trash2 className="size-3.5 text-destructive" aria-hidden="true" />
-                  </Button>
-                </li>
-              )
-            })}
-          </ul>
-        </CardContent>
+    <div
+      className={cn(
+        "group relative flex items-center gap-4 rounded-2xl border border-border bg-card p-5 transition-all",
+        interactive && "hover:-translate-y-0.5 hover:border-primary/20 hover:shadow-sm"
+      )}
+      data-testid="location-card"
+      data-location-id={location.id}
+    >
+      {interactive ? (
+        // Card-wide click target. Positioned-absolute fill so the
+        // dropdown trigger + items below it can sit on top with their
+        // own pointer events. aria-label gives screen readers the same
+        // affordance as the visible title without duplicating it.
+        <Link
+          to={detailHref}
+          aria-label={location.name ?? ""}
+          className="absolute inset-0 rounded-2xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring/50"
+          data-testid="location-card-link"
+        />
       ) : null}
-    </Card>
+      <div className="relative flex size-14 shrink-0 items-center justify-center rounded-xl bg-muted text-muted-foreground">
+        <MapPin className="size-6" aria-hidden="true" />
+      </div>
+      <div className="relative flex min-w-0 flex-1 flex-col gap-1">
+        <p className="truncate text-base font-semibold">{location.name}</p>
+        {location.address ? (
+          <p className="truncate text-sm text-muted-foreground">{location.address}</p>
+        ) : null}
+        <div className="mt-1 flex flex-wrap items-center gap-3">
+          <span
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+            data-testid="location-card-stat-areas"
+          >
+            <Layers className="size-3.5" aria-hidden="true" />
+            {t("locations:list.statsAreas", { count: areaCount })}
+          </span>
+          <span
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+            data-testid="location-card-stat-items"
+          >
+            <Package className="size-3.5" aria-hidden="true" />
+            {t("locations:list.statsItems", { count: itemCount, formatted: itemCountLabel })}
+          </span>
+        </div>
+      </div>
+      <div className="relative flex shrink-0 items-center gap-1">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-8 opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+              aria-label={t("locations:list.actionsLabel", { name: location.name ?? "" })}
+              data-testid="location-card-menu"
+            >
+              <MoreHorizontal className="size-4" aria-hidden="true" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={onAddArea} data-testid="location-card-add-area">
+              <Plus className="mr-2 size-4" aria-hidden="true" />
+              {t("locations:list.addArea")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={onDeleteLocation}
+              className="text-destructive focus:text-destructive"
+              data-testid="location-card-delete"
+            >
+              <Trash2 className="mr-2 size-4" aria-hidden="true" />
+              {t("common:actions.delete")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <ChevronRight
+          className="size-4 text-muted-foreground transition-colors group-hover:text-foreground"
+          aria-hidden="true"
+        />
+      </div>
+    </div>
   )
 }

--- a/frontend/src/pages/locations/LocationsListPage.tsx
+++ b/frontend/src/pages/locations/LocationsListPage.tsx
@@ -117,8 +117,8 @@ export function LocationsListPage({ initialMode }: LocationsListPageProps = {}) 
   }
 
   // Per-area item counts derived once from the page-level commodities
-  // fetch. The map is empty while loading; LocationCard handles the
-  // loading branch by skipping the chip number.
+  // fetch. The map is empty while loading or on error; LocationCard
+  // handles both branches by rendering "—" instead of the count digit.
   const areaItemCounts = useMemo(() => {
     const map = new Map<string, number>()
     for (const c of itemsForCounts.data?.commodities ?? []) {
@@ -126,8 +126,14 @@ export function LocationsListPage({ initialMode }: LocationsListPageProps = {}) 
     }
     return map
   }, [itemsForCounts.data])
+  // Network/API failure → counts are unknown, not zero. Funnel `isError`
+  // into the same "loading" branch the chip already renders as "—" so
+  // the UI doesn't claim an exact 0 when the request bombed out. Match
+  // by truncation only when the data actually exists.
+  const itemsCountIsUnknown = itemsForCounts.isLoading || itemsForCounts.isError
   const itemsCountTruncated =
-    (itemsForCounts.data?.total ?? 0) > (itemsForCounts.data?.commodities.length ?? 0)
+    !!itemsForCounts.data &&
+    (itemsForCounts.data.total ?? 0) > (itemsForCounts.data.commodities.length ?? 0)
 
   const filteredLocations = useMemo(() => {
     const list = locations.data ?? []
@@ -274,7 +280,7 @@ export function LocationsListPage({ initialMode }: LocationsListPageProps = {}) 
                     location={loc}
                     areaCount={locAreas.length}
                     itemCount={itemCount}
-                    itemCountLoading={itemsForCounts.isLoading}
+                    itemCountLoading={itemsCountIsUnknown}
                     itemCountTruncated={itemsCountTruncated}
                     onAddArea={() => setDialog({ kind: "create-area", locationId: loc.id })}
                     onDeleteLocation={() => handleDeleteLocation(loc)}

--- a/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
+++ b/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { Route } from "react-router-dom"
-import { screen, waitFor } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import { LocationDetailPage } from "@/pages/locations/LocationDetailPage"
@@ -8,7 +8,13 @@ import { GroupProvider } from "@/features/group/GroupContext"
 import { ConfirmProvider } from "@/hooks/useConfirm"
 import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
-import { areaHandlers, fileHandlers, groupHandlers, locationHandlers } from "@/test/handlers"
+import {
+  areaHandlers,
+  commodityHandlers,
+  fileHandlers,
+  groupHandlers,
+  locationHandlers,
+} from "@/test/handlers"
 import { clearAuth, setAccessToken } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
@@ -25,6 +31,18 @@ function locationResource(id: string, attrs: { name: string; address?: string })
 
 function areaResource(id: string, attrs: { name: string; location_id: string }) {
   return { id, type: "areas", attributes: { ...attrs, id } }
+}
+
+interface CommodityAttrs {
+  name: string
+  area_id: string
+  status?: string
+  type?: string
+  warranty_expires_at?: string
+}
+
+function commodityResource(id: string, attrs: CommodityAttrs) {
+  return { id, type: "commodities", attributes: { ...attrs, id } }
 }
 
 function renderDetail(initialPath: string, props: { initialMode?: "edit" } = {}) {
@@ -53,7 +71,7 @@ beforeEach(() => {
 })
 
 describe("<LocationDetailPage />", () => {
-  it("renders the location's metadata and its area list", async () => {
+  it("renders the breadcrumb + metadata + area tile grid with per-area item counts", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),
       ...locationHandlers.detail(
@@ -69,15 +87,58 @@ describe("<LocationDetailPage />", () => {
         areaResource("a1", { name: "Kitchen", location_id: "loc1" }),
         areaResource("a2", { name: "Workshop", location_id: "loc1" }),
         areaResource("a3", { name: "Other-Group", location_id: "loc-other" }),
+      ]),
+      ...commodityHandlers.list(SLUG, [
+        commodityResource("c1", { name: "Espresso", area_id: "a1", status: "in_use" }),
+        commodityResource("c2", { name: "Toaster", area_id: "a1", status: "in_use" }),
+        commodityResource("c3", { name: "Drill", area_id: "a2", status: "in_use" }),
       ])
     )
     renderDetail(`/g/${SLUG}/locations/loc1`)
-    await waitFor(() => expect(screen.getByText("Main House")).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Main House" })).toBeInTheDocument()
+    )
     expect(screen.getByText("12 Elm St")).toBeInTheDocument()
+    // Breadcrumb shows Locations / Main House.
+    const crumbs = screen.getByTestId("location-detail-breadcrumb")
+    expect(within(crumbs).getByTestId("breadcrumb-locations")).toHaveAttribute(
+      "href",
+      `/g/${SLUG}/locations`
+    )
+    expect(within(crumbs).getByTestId("breadcrumb-current")).toHaveTextContent("Main House")
     // Only the two areas whose location_id === loc1 are surfaced.
-    const rows = await screen.findAllByTestId("location-detail-area")
-    expect(rows).toHaveLength(2)
-    expect(rows[0]).toHaveTextContent("Kitchen")
+    const tiles = await screen.findAllByTestId("location-detail-area")
+    expect(tiles).toHaveLength(2)
+    const kitchen = tiles.find((t) => within(t).queryByText("Kitchen"))!
+    expect(within(kitchen).getByText("2 items")).toBeInTheDocument()
+    const workshop = tiles.find((t) => within(t).queryByText("Workshop"))!
+    expect(within(workshop).getByText("1 item")).toBeInTheDocument()
+  })
+
+  it("surfaces the warranty-expiring pill when an area carries expiring items", async () => {
+    const soon = new Date()
+    soon.setDate(soon.getDate() + 30)
+    const expiresAt = soon.toISOString().slice(0, 10)
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.detail(SLUG, "loc1", locationResource("loc1", { name: "Main House" })),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Main House" })]),
+      ...areaHandlers.list(SLUG, [areaResource("a1", { name: "Kitchen", location_id: "loc1" })]),
+      ...commodityHandlers.list(SLUG, [
+        commodityResource("c1", {
+          name: "Espresso",
+          area_id: "a1",
+          status: "in_use",
+          warranty_expires_at: expiresAt,
+        }),
+        commodityResource("c2", { name: "Toaster", area_id: "a1", status: "in_use" }),
+      ])
+    )
+    renderDetail(`/g/${SLUG}/locations/loc1`)
+    const tile = await screen.findByTestId("location-detail-area")
+    expect(within(tile).getByTestId("location-detail-area-expiring")).toHaveTextContent(
+      "1 warranty expiring"
+    )
   })
 
   it("auto-opens the edit dialog when initialMode='edit'", async () => {
@@ -85,21 +146,25 @@ describe("<LocationDetailPage />", () => {
       ...groupHandlers.list(groupFixture),
       ...locationHandlers.detail(SLUG, "loc1", locationResource("loc1", { name: "Garage" })),
       ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Garage" })]),
-      ...areaHandlers.list(SLUG, [])
+      ...areaHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, [])
     )
     renderDetail(`/g/${SLUG}/locations/loc1`, { initialMode: "edit" })
     expect(await screen.findByTestId("location-form-dialog")).toBeInTheDocument()
   })
 
-  it("renders the empty-areas copy when the location has no areas", async () => {
+  it("renders the empty-areas card when the location has no areas", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),
       ...locationHandlers.detail(SLUG, "loc2", locationResource("loc2", { name: "Cottage" })),
       ...locationHandlers.list(SLUG, [locationResource("loc2", { name: "Cottage" })]),
-      ...areaHandlers.list(SLUG, [])
+      ...areaHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, [])
     )
     renderDetail(`/g/${SLUG}/locations/loc2`)
-    await waitFor(() => expect(screen.getByText("Cottage")).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Cottage" })).toBeInTheDocument()
+    )
     expect(screen.getByTestId("location-detail-areas-empty")).toBeInTheDocument()
   })
 
@@ -110,7 +175,8 @@ describe("<LocationDetailPage />", () => {
       ...locationHandlers.detail(SLUG, "loc1", locationResource("loc1", { name: "Garage" })),
       ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Garage" })]),
       ...areaHandlers.list(SLUG, []),
-      ...fileHandlers.list(SLUG, [])
+      ...fileHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, [])
     )
     renderDetail(`/g/${SLUG}/locations/loc1`)
     const attach = await screen.findByTestId("entity-files-panel-attach")
@@ -132,7 +198,8 @@ describe("<LocationDetailPage />", () => {
       // its background GET /files would hit MSW's onUnhandledRequest:
       // "error" hook (set in src/test/setup.ts) and surface as a
       // post-test warning even if the assertions complete first.
-      ...fileHandlers.list(SLUG, [])
+      ...fileHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, [])
     )
     renderDetail(`/g/${SLUG}/locations/loc1`)
     const page = await screen.findByTestId("page-location-detail")

--- a/frontend/src/pages/locations/__tests__/LocationsListPage.test.tsx
+++ b/frontend/src/pages/locations/__tests__/LocationsListPage.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { Route } from "react-router-dom"
-import { screen, waitFor } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { axe } from "jest-axe"
 
@@ -9,7 +9,7 @@ import { GroupProvider } from "@/features/group/GroupContext"
 import { ConfirmProvider } from "@/hooks/useConfirm"
 import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
-import { areaHandlers, groupHandlers, locationHandlers } from "@/test/handlers"
+import { areaHandlers, commodityHandlers, groupHandlers, locationHandlers } from "@/test/handlers"
 import { clearAuth, setAccessToken } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
@@ -58,7 +58,8 @@ describe("<LocationsListPage />", () => {
     server.use(
       ...groupHandlers.list(groupFixture),
       ...locationHandlers.list(SLUG, []),
-      ...areaHandlers.list(SLUG, [])
+      ...areaHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, [])
     )
     renderList()
     await waitFor(() => {
@@ -66,7 +67,7 @@ describe("<LocationsListPage />", () => {
     })
   })
 
-  it("renders locations + their nested areas", async () => {
+  it("renders each location as a click-through tile with stat chips", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),
       ...locationHandlers.list(SLUG, [
@@ -76,14 +77,67 @@ describe("<LocationsListPage />", () => {
       ...areaHandlers.list(SLUG, [
         areaResource("a1", { name: "Kitchen", location_id: "loc1" }),
         areaResource("a2", { name: "Workshop", location_id: "loc2" }),
+        areaResource("a3", { name: "Pantry", location_id: "loc1" }),
+      ]),
+      // Two items in loc1 (a1 + a3 collectively → 2), one in loc2 (a2).
+      ...commodityHandlers.list(SLUG, [
+        {
+          id: "c1",
+          type: "commodities",
+          attributes: {
+            id: "c1",
+            name: "Espresso",
+            area_id: "a1",
+            status: "in_use",
+            type: "white_goods",
+          },
+        },
+        {
+          id: "c2",
+          type: "commodities",
+          attributes: {
+            id: "c2",
+            name: "Mixer",
+            area_id: "a3",
+            status: "in_use",
+            type: "white_goods",
+          },
+        },
+        {
+          id: "c3",
+          type: "commodities",
+          attributes: {
+            id: "c3",
+            name: "Drill",
+            area_id: "a2",
+            status: "in_use",
+            type: "white_goods",
+          },
+        },
       ])
     )
     renderList()
-    await waitFor(() => expect(screen.getAllByTestId("location-card")).toHaveLength(2))
-    expect(screen.getByText("Main House")).toBeInTheDocument()
-    expect(screen.getByText("12 Elm St")).toBeInTheDocument()
-    expect(screen.getByText("Kitchen")).toBeInTheDocument()
-    expect(screen.getByText("Workshop")).toBeInTheDocument()
+    const cards = await screen.findAllByTestId("location-card")
+    expect(cards).toHaveLength(2)
+    const main = cards.find((c) => within(c).queryByText("Main House"))!
+    expect(main).toBeDefined()
+    expect(within(main).getByText("12 Elm St")).toBeInTheDocument()
+    // Each card is wrapped by an absolute-positioned <Link> with the
+    // location name as aria-label; the chevron + dropdown menu live on
+    // top of it.
+    expect(within(main).getByTestId("location-card-link")).toHaveAttribute(
+      "href",
+      `/g/${SLUG}/locations/loc1`
+    )
+    // Stat chips render via i18next plural keys.
+    const mainAreas = within(main).getByTestId("location-card-stat-areas")
+    expect(mainAreas).toHaveTextContent("2 areas")
+    const mainItems = within(main).getByTestId("location-card-stat-items")
+    expect(mainItems).toHaveTextContent("2 items")
+
+    const garage = cards.find((c) => within(c).queryByText("Garage"))!
+    expect(within(garage).getByTestId("location-card-stat-areas")).toHaveTextContent("1 area")
+    expect(within(garage).getByTestId("location-card-stat-items")).toHaveTextContent("1 item")
   })
 
   it("filters by query against location and area names", async () => {
@@ -93,7 +147,8 @@ describe("<LocationsListPage />", () => {
         locationResource("loc1", { name: "Main House" }),
         locationResource("loc2", { name: "Garage" }),
       ]),
-      ...areaHandlers.list(SLUG, [areaResource("a1", { name: "Kitchen", location_id: "loc1" })])
+      ...areaHandlers.list(SLUG, [areaResource("a1", { name: "Kitchen", location_id: "loc1" })]),
+      ...commodityHandlers.list(SLUG, [])
     )
     renderList()
     await waitFor(() => expect(screen.getAllByTestId("location-card")).toHaveLength(2))
@@ -111,7 +166,8 @@ describe("<LocationsListPage />", () => {
     server.use(
       ...groupHandlers.list(groupFixture),
       ...locationHandlers.list(SLUG, []),
-      ...areaHandlers.list(SLUG, [])
+      ...areaHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, [])
     )
     renderList()
     const user = userEvent.setup()
@@ -127,7 +183,8 @@ describe("<LocationsListPage />", () => {
     server.use(
       ...groupHandlers.list(groupFixture),
       ...locationHandlers.list(SLUG, []),
-      ...areaHandlers.list(SLUG, [])
+      ...areaHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, [])
     )
     setAccessToken("good-token")
     renderWithProviders({
@@ -160,11 +217,27 @@ describe("<LocationsListPage />", () => {
     expect(await screen.findByTestId("location-form-dialog")).toBeInTheDocument()
   })
 
+  it("opens the AreaFormDialog from the LocationCard dropdown's Add area item", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Main House" })]),
+      ...areaHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, [])
+    )
+    renderList()
+    const card = await screen.findByTestId("location-card")
+    const user = userEvent.setup()
+    await user.click(within(card).getByTestId("location-card-menu"))
+    await user.click(await screen.findByTestId("location-card-add-area"))
+    expect(await screen.findByTestId("area-form-dialog")).toBeInTheDocument()
+  })
+
   it("has no axe violations once data has loaded", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),
       ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Main House" })]),
-      ...areaHandlers.list(SLUG, [])
+      ...areaHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, [])
     )
     const { container } = renderList()
     await waitFor(() => expect(screen.getAllByTestId("location-card")).toHaveLength(1))


### PR DESCRIPTION
Refs #1531. Ships items 2, 3, and 5 of the umbrella. Item 1 (v1) already landed in PR #1632; item 4 (BE schema for `icon` + `description`) stays deferred — logged in `devdocs/frontend/design-deviations.md`.

## What ships

### Item 2 — Locations list per-location stat chips

`frontend/src/pages/locations/LocationsListPage.tsx`. Each `LocationCard` is now a click-through tile per the Level 1 mock (`design-mocks/src/views/LocationPickerView.tsx` L546-L600): `MapPin` avatar tile, name, address (the muted-subtitle slot the mock fills with `description` — see deviation), `Layers` "`{n}` areas" / `Package` "`{n}` items" stat chips, dropdown menu (Add area / Delete), `ChevronRight` drill, hover lift. The inline-areas accordion is gone — areas now show on the location detail per the mock.

### Item 3 — Location detail area grid + expiring badge

`frontend/src/pages/locations/LocationDetailPage.tsx`. The flat area `<ul>` is replaced with a responsive `sm:grid-cols-2` `AreaTile` grid per the Level 2 mock (L615-L668): `Package` avatar, name, "`{n}` item(s)", optional `{n} warranty expiring` pill (status-expiring token), per-tile dropdown menu (Edit / Delete), chevron, hover lift. Empty state becomes a Card-with-CTA. `EntityFilesPanel` stays below.

### Item 5 — Multi-segment breadcrumb

New `frontend/src/components/locations/LocationsBreadcrumb.tsx`, wired into both detail pages. `Locations › Loc` on location detail, `Locations › Loc › Area` on area detail. Optional `ArrowLeft` back-chevron, chevron-separated `ol`/`li`, last segment bold + non-interactive. Replaces the old `← back` Link on both pages — and the duplicate `MapPin + parent.name` subtitle on the area detail (now in the breadcrumb).

### Counts derivation

Per-area item counts (and expiring counts on the detail page) come from a single page-level `useCommodities({ perPage: 500, includeInactive: false })` aggregation, grouped by `area_id` in a `useMemo`. Same query key on list + detail → cache reuse on navigate. Partial counts past the 500-cap surface as "`{N}+`" so the chip never silently undercounts. The BE could replace this with a `count` field on `jsonapi.NamedTotal` later — punt is the cheap path until/if needed.

## Deferred / out of scope

| Mock element | Why | Tracking |
|---|---|---|
| Per-location / per-area emoji `icon` avatar tiles | BE-blocked — `models.Location` has `id/name/address/group_id` only; `models.Area` has `id/name/location_id` only. Adding `icon` (string) and `description` (string) is item 4 of #1531 itself. | #1531 item 4 (BE schema) |
| Sticky breadcrumb strip | App shell already owns the sticky TopBar slot; second sticky would compete with it. | Permanent (deviation logged) |
| Inline-areas accordion on the list | Mock Level 1 doesn't have it (areas surface only on Level 2). | Permanent (deviation logged) |
| Full `<ItemsPanel>` toolbar on area detail / area Files panel / active-warranties stat | From item 1 v1 (PR #1632), still open under #1531. | #1531 item 1 follow-ups |

All three deviations are logged in [`devdocs/frontend/design-deviations.md`](https://github.com/denisvmedia/inventario/blob/master/devdocs/frontend/design-deviations.md) under "Locations & Areas".

## E2E + testids

`e2e/tests/includes/areas.ts` — the inline-areas row is gone, so:
- `createArea` opens the `LocationCard` dropdown (`location-card-menu` → `location-card-add-area`), submits, drills into the location detail via `location-card-link`, asserts the tile shows up.
- `deleteArea` drills into the location detail first (if the test landed on the list), opens the per-tile dropdown (`location-detail-area-menu` → `location-detail-area-delete`), confirms.

`e2e/tests/draft-inactive-toggle.spec.ts` reaches the per-area items list via `location-card-link` → `location-detail-area-link` instead of the old inline row.

New / preserved testIds: `location-card-link`, `location-card-stat-areas`, `location-card-stat-items`, `location-card-menu`, `location-card-add-area` (now in dropdown), `location-card-delete`, `location-detail-area` (now on tile div), `location-detail-area-link`, `location-detail-area-menu`, `location-detail-area-edit`, `location-detail-area-delete`, `location-detail-area-expiring`, `location-detail-areas-grid`, `location-detail-areas-empty`, `location-detail-breadcrumb`, `area-detail-breadcrumb`, `breadcrumb-locations`, `breadcrumb-location`, `breadcrumb-current`.

## i18n

- **New:** `locations:breadcrumb.locations`, `locations:list.actionsLabel`, `locations:list.statsAreas_one/_other`, `locations:list.statsItems_one/_other` (uses `{{formatted}}` so the chip can render "`{N}+`"), `locations:detail.areaItems_one/_other`, `locations:detail.areaExpiring_one/_other`, `locations:detail.areasEmptyTitle`.
- **Removed (no remaining call sites):** `locations:list.deleteArea`, `locations:list.deleteLocation` (their inline trash buttons are gone).
- cs/ru stay `{}` (lazy-fallback to en), per project convention.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 760/760 pass (4 skipped)
- [x] `npm run format:check` — clean
- [x] `npx i18next-cli extract --ci` — clean (auto-pruned the two removed keys; no missing ones)
- [x] Local smoke against `./bin/inventario run --db-dsn=memory://`: list tiles + chips, drill into location detail (breadcrumb + area grid + Files panel), drill into area detail (3-segment breadcrumb + stats + items list), Add location dialog, Attach files dialog on location detail. Visual proof to follow in the issue.
- [ ] `make test-e2e` — the updated `area-create` / `area-delete` flow + `draft-inactive-toggle` spec are the new touchpoints.