### PR TITLE
[#1534] Backup & restore polish: row redesign, risk pills, restore + log dialogs

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -221,6 +221,35 @@ _None yet._
 
 _None yet._
 
+### Backup & Restore
+
+#### 2026-05-12 — Standalone `/exports/:id/restore` page preserved alongside the in-context Restore dialog
+
+- **Issue/PR**: #1534 / PR _pending_
+- **Mock**: [`design-mocks/src/views/BackupView.tsx`](../../design-mocks/src/views/BackupView.tsx) L538-L614 surfaces restore exclusively as an in-context `Dialog` launched from the Restore CTA on each completed export row. There is no standalone page.
+- **Reality**: `frontend/src/pages/exports/ExportRestorePage.tsx` is preserved as a standalone route (`/exports/:id/restore`). Both surfaces share `frontend/src/components/exports/RestoreOptionsForm.tsx` so the strategy cards, risk pills, dry-run switch, and destructive warning render identically.
+- **Why**: The standalone URL is shareable (e.g. for support contexts or post-incident playbooks) and already shipped before #1534; ripping it out in favour of a dialog-only flow would break inbound links. The shared form keeps drift cost at zero.
+- **Approved by**: user (explicit) — selected "Full mock-style + share form" when asked how the standalone page should adopt the dialog visuals.
+- **Reversion plan**: Permanent unless the upstream mock adds an equivalent shareable surface, at which point the page becomes redundant.
+
+#### 2026-05-12 — Restore dialog exposes an "Include attached files" switch that the mock omits
+
+- **Issue/PR**: #1534 / PR _pending_
+- **Mock**: The mock's `RestoreDialog` (L538-L614) only surfaces strategy radios + a dry-run switch + a description-less footer. There is no toggle for whether to restore attachments.
+- **Reality**: Both `RestoreOptionsForm` and `RestoreDialog` render an `Include attached files` switch (mock-style, `bg-muted/40` row), bound to `RestoreOptions.include_file_data`.
+- **Why**: The BE has shipped `include_file_data` on `RestoreOptions` for some time, and the existing standalone page already exposed it as a checkbox. Dropping it from the dialog-only flow would silently change behaviour (attachments would always be restored), so the option is surfaced as a Switch instead.
+- **Approved by**: user (explicit) — confirmed the standalone page and dialog should stay visually aligned via the shared form, which keeps the existing option in place.
+- **Reversion plan**: Remove the switch (and pass `include_file_data: true` unconditionally) if the upstream mock adds a different mechanism or the BE field is deprecated.
+
+#### 2026-05-12 — Destructive warning only renders when `full_replace` is paired with a non-dry-run
+
+- **Issue/PR**: #1534 / PR _pending_
+- **Mock**: L584-L591 of `BackupView.tsx` shows the destructive warning whenever `restoreStrategy === "full_replace"`, regardless of the dry-run state.
+- **Reality**: `RestoreOptionsForm` only shows the destructive warning when `strategy === "full_replace" && !dry_run` (preserving the pre-#1534 behaviour from `ExportRestorePage`).
+- **Why**: Dry-run with `full_replace` does not actually delete anything, so flashing a "this will permanently delete all current data" warning is misleading. Existing tests (`ExportRestorePage.test.tsx`) also encode the gated behaviour.
+- **Approved by**: agent-suggested — keeps behaviour-truth over mock-fidelity on a strictly-better-UX call; user invited to revert if visual parity matters.
+- **Reversion plan**: Drop the `&& !dry_run` guard and update the test if upstream insists on always-on warning.
+
 ### Other
 
 _None yet._

--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -225,7 +225,7 @@ _None yet._
 
 #### 2026-05-12 — Standalone `/exports/:id/restore` page preserved alongside the in-context Restore dialog
 
-- **Issue/PR**: #1534 / PR _pending_
+- **Issue/PR**: #1534 / PR #1641
 - **Mock**: [`design-mocks/src/views/BackupView.tsx`](../../design-mocks/src/views/BackupView.tsx) L538-L614 surfaces restore exclusively as an in-context `Dialog` launched from the Restore CTA on each completed export row. There is no standalone page.
 - **Reality**: `frontend/src/pages/exports/ExportRestorePage.tsx` is preserved as a standalone route (`/exports/:id/restore`). Both surfaces share `frontend/src/components/exports/RestoreOptionsForm.tsx` so the strategy cards, risk pills, dry-run switch, and destructive warning render identically.
 - **Why**: The standalone URL is shareable (e.g. for support contexts or post-incident playbooks) and already shipped before #1534; ripping it out in favour of a dialog-only flow would break inbound links. The shared form keeps drift cost at zero.
@@ -234,7 +234,7 @@ _None yet._
 
 #### 2026-05-12 — Restore dialog exposes an "Include attached files" switch that the mock omits
 
-- **Issue/PR**: #1534 / PR _pending_
+- **Issue/PR**: #1534 / PR #1641
 - **Mock**: The mock's `RestoreDialog` (L538-L614) only surfaces strategy radios + a dry-run switch + a description-less footer. There is no toggle for whether to restore attachments.
 - **Reality**: Both `RestoreOptionsForm` and `RestoreDialog` render an `Include attached files` switch (mock-style, `bg-muted/40` row), bound to `RestoreOptions.include_file_data`.
 - **Why**: The BE has shipped `include_file_data` on `RestoreOptions` for some time, and the existing standalone page already exposed it as a checkbox. Dropping it from the dialog-only flow would silently change behaviour (attachments would always be restored), so the option is surfaced as a Switch instead.
@@ -243,7 +243,7 @@ _None yet._
 
 #### 2026-05-12 — Destructive warning only renders when `full_replace` is paired with a non-dry-run
 
-- **Issue/PR**: #1534 / PR _pending_
+- **Issue/PR**: #1534 / PR #1641
 - **Mock**: L584-L591 of `BackupView.tsx` shows the destructive warning whenever `restoreStrategy === "full_replace"`, regardless of the dry-run state.
 - **Reality**: `RestoreOptionsForm` only shows the destructive warning when `strategy === "full_replace" && !dry_run` (preserving the pre-#1534 behaviour from `ExportRestorePage`).
 - **Why**: Dry-run with `full_replace` does not actually delete anything, so flashing a "this will permanently delete all current data" warning is misleading. Existing tests (`ExportRestorePage.test.tsx`) also encode the gated behaviour.

--- a/frontend/src/components/exports/ExportRow.tsx
+++ b/frontend/src/components/exports/ExportRow.tsx
@@ -174,7 +174,6 @@ export function ExportRow({
             asChild
             size="sm"
             variant="outline"
-            disabled={!downloadHref}
             aria-disabled={!downloadHref}
             className={cn("flex-1 gap-1.5 sm:flex-none", !downloadHref && "pointer-events-none")}
           >

--- a/frontend/src/components/exports/ExportRow.tsx
+++ b/frontend/src/components/exports/ExportRow.tsx
@@ -82,10 +82,7 @@ export function ExportRow({
             <XCircle className="size-5 text-destructive" />
           ) : (
             <HardDriveDownload
-              className={cn(
-                "size-5",
-                isCompleted ? "text-status-active" : "text-muted-foreground"
-              )}
+              className={cn("size-5", isCompleted ? "text-status-active" : "text-muted-foreground")}
             />
           )}
         </div>

--- a/frontend/src/components/exports/ExportRow.tsx
+++ b/frontend/src/components/exports/ExportRow.tsx
@@ -1,4 +1,12 @@
-import { Download, Trash2 } from "lucide-react"
+import {
+  AlertTriangle,
+  Download,
+  HardDriveDownload,
+  Loader2,
+  RotateCcw,
+  Trash2,
+  XCircle,
+} from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 
@@ -14,6 +22,7 @@ export interface ExportRowProps {
   detailHref: string
   groupSlug: string
   onDelete: () => void
+  onRestore?: () => void
 }
 
 function totalItemCount(e: Export): number {
@@ -22,15 +31,24 @@ function totalItemCount(e: Export): number {
   )
 }
 
-// Renders a single export as a card-style row. The download CTA is
-// rendered as an `<a>` so the browser handles the stream natively; the
-// JWT-protected endpoint receives the access token via `?token=` (the
-// BE accepts it in addition to Authorization headers).
-export function ExportRow({ export: exp, detailHref, groupSlug, onDelete }: ExportRowProps) {
+// Mock-spec row: tinted leading icon tile + (title row + date + stats
+// line + error footer) + hover-revealed action cluster. The download CTA
+// stays an `<a>` so the browser streams the JWT-protected file natively;
+// the token is appended as `?token=…` (BE accepts that in addition to
+// Authorization headers).
+export function ExportRow({
+  export: exp,
+  detailHref,
+  groupSlug,
+  onDelete,
+  onRestore,
+}: ExportRowProps) {
   const { t } = useTranslation(["exports"])
   const isDeleted = !!exp.deleted_at
   const isTerminal = isExportTerminal(exp.status)
   const isCompleted = exp.status === "completed"
+  const isFailed = exp.status === "failed"
+  const isInFlight = exp.status === "in_progress" || exp.status === "pending"
   const downloadHref = useExportDownloadHref(exp.id, groupSlug)
   const scopeLabel =
     exp.type === "selected_items"
@@ -38,79 +56,138 @@ export function ExportRow({ export: exp, detailHref, groupSlug, onDelete }: Expo
       : t(`exports:scope.${exp.type ?? "full_database"}`, {
           defaultValue: t("exports:scope.full_database"),
         })
+  const showRestore = !!onRestore && isCompleted && !isDeleted
 
   return (
     <div
       data-testid={`export-row-${exp.id}`}
       className={cn(
-        "flex flex-wrap items-center justify-between gap-3 rounded-md border bg-card px-4 py-3",
+        "group flex flex-col gap-3 rounded-xl border bg-card px-4 py-4 sm:flex-row sm:items-center sm:gap-4 sm:px-5",
         isDeleted && "opacity-60"
       )}
     >
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <Link
-            to={detailHref}
-            className="truncate text-sm font-medium hover:underline"
-            data-testid={`export-row-${exp.id}-link`}
-          >
-            {exp.description?.trim() ? exp.description : scopeLabel}
-          </Link>
-          {exp.imported && (
-            <Badge variant="secondary" data-testid={`export-row-${exp.id}-imported`}>
-              {t("exports:list.imported")}
-            </Badge>
-          )}
-          {isDeleted && (
-            <Badge variant="destructive" data-testid={`export-row-${exp.id}-deleted`}>
-              {t("exports:list.deletedBadge")}
-            </Badge>
-          )}
-        </div>
-        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-          <span>{scopeLabel}</span>
-          <span aria-hidden="true">·</span>
-          <span>
-            {t("exports:detail.counts.locations", { count: exp.location_count ?? 0 })} /{" "}
-            {t("exports:detail.counts.commodities", { count: exp.commodity_count ?? 0 })} /{" "}
-            {t("exports:detail.counts.files", { count: exp.file_count ?? 0 })}
-          </span>
-          <span aria-hidden="true">·</span>
-          <span>{formatBytes(exp.file_size ?? 0)}</span>
-          <span aria-hidden="true">·</span>
-          <span>{exp.created_date ? formatDateTime(exp.created_date) : "—"}</span>
-        </div>
-      </div>
-
-      <div className="flex items-center gap-2">
-        {exp.status && <ExportStatusBadge status={exp.status} />}
-        <Button
-          asChild
-          size="sm"
-          variant="outline"
-          disabled={!isTerminal || !isCompleted || isDeleted || !downloadHref}
-          aria-disabled={!isTerminal || !isCompleted || isDeleted || !downloadHref}
+      <div className="flex items-start gap-3 sm:contents">
+        <div
           className={cn(
-            (!isTerminal || !isCompleted || isDeleted || !downloadHref) && "pointer-events-none"
+            "flex size-10 shrink-0 items-center justify-center rounded-lg",
+            isCompleted && "bg-status-active/10",
+            isFailed && "bg-destructive/10",
+            !isCompleted && !isFailed && "bg-muted"
           )}
+          aria-hidden="true"
         >
-          <a href={downloadHref ?? "#"} data-testid={`export-row-${exp.id}-download`}>
-            <Download className="mr-1.5 size-4" aria-hidden="true" />
-            {t("exports:actions.download")}
-          </a>
-        </Button>
+          {isInFlight ? (
+            <Loader2 className="size-5 animate-spin text-muted-foreground" />
+          ) : isFailed ? (
+            <XCircle className="size-5 text-destructive" />
+          ) : (
+            <HardDriveDownload
+              className={cn(
+                "size-5",
+                isCompleted ? "text-status-active" : "text-muted-foreground"
+              )}
+            />
+          )}
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <Link
+              to={detailHref}
+              className="truncate text-sm font-semibold hover:underline"
+              data-testid={`export-row-${exp.id}-link`}
+            >
+              {exp.description?.trim() ? exp.description : scopeLabel}
+            </Link>
+            {exp.status && <ExportStatusBadge status={exp.status} />}
+            {exp.imported && (
+              <Badge variant="secondary" data-testid={`export-row-${exp.id}-imported`}>
+                {t("exports:list.imported")}
+              </Badge>
+            )}
+            {isDeleted && (
+              <Badge variant="destructive" data-testid={`export-row-${exp.id}-deleted`}>
+                {t("exports:list.deletedBadge")}
+              </Badge>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {scopeLabel}
+            {exp.created_date && (
+              <>
+                <span aria-hidden="true"> · </span>
+                <span>{formatDateTime(exp.created_date)}</span>
+              </>
+            )}
+          </p>
+          {isTerminal && (
+            <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+              <span>
+                {t("exports:detail.counts.locations", { count: exp.location_count ?? 0 })}
+              </span>
+              <span>{t("exports:detail.counts.areas", { count: exp.area_count ?? 0 })}</span>
+              <span>
+                {t("exports:detail.counts.commodities", { count: exp.commodity_count ?? 0 })}
+              </span>
+              <span>{t("exports:detail.counts.files", { count: exp.file_count ?? 0 })}</span>
+              <span>{formatBytes(exp.file_size ?? 0)}</span>
+            </div>
+          )}
+          {isFailed && exp.error_message && (
+            <p
+              className="mt-0.5 flex items-start gap-1 text-xs text-destructive"
+              data-testid={`export-row-${exp.id}-error`}
+            >
+              <AlertTriangle className="mt-0.5 size-3 shrink-0" aria-hidden="true" />
+              <span>{exp.error_message}</span>
+            </p>
+          )}
+        </div>
+
         <Button
           type="button"
-          size="sm"
+          size="icon"
           variant="ghost"
           onClick={onDelete}
           disabled={isDeleted}
           data-testid={`export-row-${exp.id}-delete`}
           aria-label={t("exports:actions.delete")}
+          className="size-8 shrink-0 text-muted-foreground transition-opacity hover:text-destructive sm:opacity-0 sm:group-hover:opacity-100"
         >
           <Trash2 className="size-4" aria-hidden="true" />
         </Button>
       </div>
+
+      {isCompleted && !isDeleted && (
+        <div className="flex items-center gap-2 sm:shrink-0 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100">
+          {showRestore && (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={onRestore}
+              data-testid={`export-row-${exp.id}-restore`}
+              className="flex-1 gap-1.5 sm:flex-none"
+            >
+              <RotateCcw className="size-3.5" aria-hidden="true" />
+              {t("exports:actions.restore")}
+            </Button>
+          )}
+          <Button
+            asChild
+            size="sm"
+            variant="outline"
+            disabled={!downloadHref}
+            aria-disabled={!downloadHref}
+            className={cn("flex-1 gap-1.5 sm:flex-none", !downloadHref && "pointer-events-none")}
+          >
+            <a href={downloadHref ?? "#"} data-testid={`export-row-${exp.id}-download`}>
+              <Download className="size-3.5" aria-hidden="true" />
+              {t("exports:actions.download")}
+            </a>
+          </Button>
+        </div>
+      )}
 
       <span className="sr-only">{totalItemCount(exp)}</span>
     </div>

--- a/frontend/src/components/exports/ExportStatusBadge.tsx
+++ b/frontend/src/components/exports/ExportStatusBadge.tsx
@@ -1,3 +1,4 @@
+import { CheckCircle2, Clock, Loader2, XCircle } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Badge } from "@/components/ui/badge"
@@ -6,25 +7,31 @@ import { cn } from "@/lib/utils"
 
 type Status = ExportStatus | RestoreStatus
 
-// Hue mapping mirrors the design mock's "Backup" view: pending stays
-// neutral, in-flight uses the brand accent, completed is success-green,
-// failed is destructive. The same map serves both export and restore
-// statuses because the design system intentionally renders them with
-// the same vocabulary.
-const STATUS_VARIANT: Record<Status, "secondary" | "default" | "destructive" | "outline"> = {
-  pending: "secondary",
-  in_progress: "default",
-  running: "default",
-  completed: "outline",
-  failed: "destructive",
-}
-
+// Tinted-tone treatment lifted from design-mocks/src/views/BackupView.tsx
+// (StatusBadge, lines 131-155). One badge serves both export and restore
+// surfaces because the design system intentionally uses the same vocabulary.
 const STATUS_TONE: Record<Status, string> = {
   pending: "",
-  in_progress: "",
-  running: "",
-  completed: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-  failed: "",
+  in_progress: "bg-status-expiring/10 text-status-expiring border-0",
+  running: "bg-status-expiring/10 text-status-expiring border-0",
+  completed: "bg-status-active/10 text-status-active border-0",
+  failed: "bg-destructive/10 text-destructive border-0",
+}
+
+const STATUS_ICON: Record<Status, React.ComponentType<{ className?: string }>> = {
+  pending: Clock,
+  in_progress: Loader2,
+  running: Loader2,
+  completed: CheckCircle2,
+  failed: XCircle,
+}
+
+const IS_SPINNING: Record<Status, boolean> = {
+  pending: false,
+  in_progress: true,
+  running: true,
+  completed: false,
+  failed: false,
 }
 
 export interface ExportStatusBadgeProps {
@@ -34,12 +41,14 @@ export interface ExportStatusBadgeProps {
 
 export function ExportStatusBadge({ status, className }: ExportStatusBadgeProps) {
   const { t } = useTranslation(["exports"])
+  const Icon = STATUS_ICON[status]
   return (
     <Badge
-      variant={STATUS_VARIANT[status]}
+      variant="secondary"
       data-testid={`status-${status}`}
-      className={cn(STATUS_TONE[status], className)}
+      className={cn("gap-1", STATUS_TONE[status], className)}
     >
+      <Icon className={cn("size-3", IS_SPINNING[status] && "animate-spin")} aria-hidden="true" />
       {t(`exports:status.${status}`)}
     </Badge>
   )

--- a/frontend/src/components/exports/RestoreDialog.tsx
+++ b/frontend/src/components/exports/RestoreDialog.tsx
@@ -1,0 +1,167 @@
+import { Loader2, RotateCcw } from "lucide-react"
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import {
+  RestoreOptionsForm,
+  type RestoreOptionsFormValue,
+} from "@/components/exports/RestoreOptionsForm"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { useGroupMigrationLock } from "@/features/currency-migration/lock"
+import { type Export } from "@/features/export/api"
+import { useCreateRestore } from "@/features/export/hooks"
+import { useAppToast } from "@/hooks/useAppToast"
+import { formatDateTime } from "@/lib/intl"
+
+export interface RestoreDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  export: Export | null
+  onCompleted?: (restoreId: string, dryRun: boolean) => void
+}
+
+const defaultState: RestoreOptionsFormValue = {
+  description: "",
+  strategy: "merge_add",
+  include_file_data: true,
+  dry_run: true,
+}
+
+// In-context restore dialog. Mirrors design-mocks/src/views/BackupView.tsx
+// RestoreDialog. The standalone /exports/:id/restore page is preserved for
+// shareable URLs and uses the same RestoreOptionsForm body so the two
+// surfaces stay visually aligned.
+//
+// Wrapper-only: form state lives inside `RestoreDialogContent` so a fresh
+// state is acquired every time the dialog opens (the inner component is
+// keyed on `exp.id` and only mounts while open). Avoids the React-19
+// `react-hooks/set-state-in-effect` smell of resetting state in a useEffect.
+export function RestoreDialog({
+  open,
+  onOpenChange,
+  export: exp,
+  onCompleted,
+}: RestoreDialogProps) {
+  return (
+    <Dialog open={open && !!exp} onOpenChange={onOpenChange}>
+      {exp && open && (
+        <RestoreDialogContent
+          key={exp.id}
+          export={exp}
+          onOpenChange={onOpenChange}
+          onCompleted={onCompleted}
+        />
+      )}
+    </Dialog>
+  )
+}
+
+interface RestoreDialogContentProps {
+  export: Export
+  onOpenChange: (open: boolean) => void
+  onCompleted?: (restoreId: string, dryRun: boolean) => void
+}
+
+function RestoreDialogContent({
+  export: exp,
+  onOpenChange,
+  onCompleted,
+}: RestoreDialogContentProps) {
+  const { t } = useTranslation(["exports", "errors"])
+  const toast = useAppToast()
+  const migrationLock = useGroupMigrationLock()
+  const createRestoreMutation = useCreateRestore()
+  const [state, setState] = useState<RestoreOptionsFormValue>(defaultState)
+
+  const isPending = createRestoreMutation.isPending
+  const isDestructive = state.strategy === "full_replace"
+  const scopeLabel =
+    exp.type === "selected_items"
+      ? t("exports:detail.scopeSelectedItems", { count: exp.selected_items?.length ?? 0 })
+      : t(`exports:scope.${exp.type ?? "full_database"}`, {
+          defaultValue: t("exports:scope.full_database"),
+        })
+  const dateLabel = exp.created_date ? formatDateTime(exp.created_date) : ""
+  const description = dateLabel ? `${scopeLabel} — ${dateLabel}` : scopeLabel
+  const canSubmit = !isPending && !!state.description.trim() && !migrationLock.locked
+
+  function onSubmit() {
+    createRestoreMutation.mutate(
+      {
+        exportId: exp.id,
+        req: {
+          description: state.description,
+          options: {
+            strategy: state.strategy,
+            include_file_data: state.include_file_data,
+            dry_run: state.dry_run,
+          },
+        },
+      },
+      {
+        onSuccess: (restore) => {
+          toast.success(
+            state.dry_run ? t("exports:restore.successDryRun") : t("exports:restore.success")
+          )
+          onOpenChange(false)
+          onCompleted?.(restore.id, state.dry_run)
+        },
+        onError: (err) => {
+          const message = err instanceof Error ? err.message : String(err)
+          toast.error(t("exports:errors.restoreCreateFailed", { error: message }))
+        },
+      }
+    )
+  }
+
+  return (
+    <DialogContent className="sm:max-w-lg" data-testid="restore-dialog">
+      <DialogHeader>
+        <DialogTitle>{t("exports:restore.dialog.title")}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+
+      <RestoreOptionsForm value={state} onChange={setState} disabled={isPending} />
+
+      <DialogFooter>
+        <Button
+          variant="outline"
+          type="button"
+          onClick={() => onOpenChange(false)}
+          disabled={isPending}
+        >
+          {t("exports:wizard.cancel")}
+        </Button>
+        <Button
+          type="button"
+          variant={isDestructive && !state.dry_run ? "destructive" : "default"}
+          onClick={onSubmit}
+          disabled={!canSubmit}
+          title={migrationLock.locked ? t("errors:lockedDuringMigration") : undefined}
+          aria-disabled={migrationLock.locked || undefined}
+          data-testid="restore-dialog-submit"
+          className="gap-2"
+        >
+          {isPending ? (
+            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <RotateCcw className="size-4" aria-hidden="true" />
+          )}
+          {isPending
+            ? t("exports:restore.submitting")
+            : state.dry_run
+              ? t("exports:restore.dialog.submitDryRun")
+              : t("exports:restore.dialog.submit")}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  )
+}

--- a/frontend/src/components/exports/RestoreHistoryList.tsx
+++ b/frontend/src/components/exports/RestoreHistoryList.tsx
@@ -1,9 +1,13 @@
+import { ScrollText } from "lucide-react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 
 import { ExportStatusBadge } from "@/components/exports/ExportStatusBadge"
+import { RestoreLogDialog } from "@/components/exports/RestoreLogDialog"
+import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
-import type { Restore } from "@/features/export/api"
+import { type Restore, isRestoreTerminal } from "@/features/export/api"
 import { formatDateTime } from "@/lib/intl"
 
 export interface RestoreHistoryListProps {
@@ -16,7 +20,9 @@ export interface RestoreHistoryListProps {
 // Lists previous restore operations attached to an export. Each row
 // links to the detail page for the restore (rendered inline on the
 // export detail for now); when the steps tree lands as its own page
-// the detailHref will switch to a dedicated route.
+// the detailHref will switch to a dedicated route. A "View log" CTA
+// surfaces on terminal restores so users can re-read the per-step
+// outcomes without navigating away.
 export function RestoreHistoryList({
   exportId,
   groupSlug,
@@ -24,6 +30,8 @@ export function RestoreHistoryList({
   restores,
 }: RestoreHistoryListProps) {
   const { t } = useTranslation(["exports"])
+  const [logRestore, setLogRestore] = useState<{ restoreId: string; dryRun: boolean } | null>(null)
+
   if (loading) {
     return (
       <div className="flex flex-col gap-2" data-testid="restores-loading">
@@ -44,43 +52,79 @@ export function RestoreHistoryList({
     )
   }
   return (
-    <ul className="flex flex-col gap-2" data-testid="restores-list">
-      {restores.map((r) => (
-        <li
-          key={r.id}
-          className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-card px-4 py-3"
-          data-testid={`restore-row-${r.id}`}
-        >
-          <div className="flex min-w-0 flex-col gap-1">
-            <Link
-              to={`/g/${encodeURIComponent(groupSlug)}/exports/${encodeURIComponent(exportId)}?restore=${encodeURIComponent(r.id)}`}
-              className="truncate text-sm font-medium hover:underline"
+    <>
+      <ul className="flex flex-col gap-2" data-testid="restores-list">
+        {restores.map((r) => {
+          const terminal = isRestoreTerminal(r.status)
+          return (
+            <li
+              key={r.id}
+              className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-card px-4 py-3"
+              data-testid={`restore-row-${r.id}`}
             >
-              {r.description?.trim() || t("exports:restore.title")}
-            </Link>
-            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-              <span>{r.created_date ? formatDateTime(r.created_date) : "—"}</span>
-              {r.options?.dry_run && (
-                <>
-                  <span aria-hidden="true">·</span>
-                  <span>{t("exports:restore.dryRun")}</span>
-                </>
-              )}
-              {typeof r.options?.strategy === "string" && r.options.strategy && (
-                <>
-                  <span aria-hidden="true">·</span>
-                  <span>
-                    {t(`exports:restore.strategyLabel.${r.options.strategy}`, {
-                      defaultValue: r.options.strategy,
-                    })}
-                  </span>
-                </>
-              )}
-            </div>
-          </div>
-          {r.status && <ExportStatusBadge status={r.status} />}
-        </li>
-      ))}
-    </ul>
+              <div className="flex min-w-0 flex-col gap-1">
+                <Link
+                  to={`/g/${encodeURIComponent(groupSlug)}/exports/${encodeURIComponent(exportId)}?restore=${encodeURIComponent(r.id)}`}
+                  className="truncate text-sm font-medium hover:underline"
+                >
+                  {r.description?.trim() || t("exports:restore.title")}
+                </Link>
+                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  <span>{r.created_date ? formatDateTime(r.created_date) : "—"}</span>
+                  {r.options?.dry_run && (
+                    <>
+                      <span aria-hidden="true">·</span>
+                      <span>{t("exports:restore.dryRun")}</span>
+                    </>
+                  )}
+                  {typeof r.options?.strategy === "string" && r.options.strategy && (
+                    <>
+                      <span aria-hidden="true">·</span>
+                      <span>
+                        {t(`exports:restore.strategyLabel.${r.options.strategy}`, {
+                          defaultValue: r.options.strategy,
+                        })}
+                      </span>
+                    </>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                {r.status && <ExportStatusBadge status={r.status} />}
+                {terminal && (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() =>
+                      setLogRestore({
+                        restoreId: r.id,
+                        dryRun: !!r.options?.dry_run,
+                      })
+                    }
+                    data-testid={`restore-row-${r.id}-view-log`}
+                    className="gap-1.5"
+                  >
+                    <ScrollText className="size-3.5" aria-hidden="true" />
+                    {t("exports:restore.log.viewLog")}
+                  </Button>
+                )}
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+      {logRestore && (
+        <RestoreLogDialog
+          open={!!logRestore}
+          onOpenChange={(open) => {
+            if (!open) setLogRestore(null)
+          }}
+          exportId={exportId}
+          restoreId={logRestore.restoreId}
+          dryRun={logRestore.dryRun}
+        />
+      )}
+    </>
   )
 }

--- a/frontend/src/components/exports/RestoreLogDialog.tsx
+++ b/frontend/src/components/exports/RestoreLogDialog.tsx
@@ -92,14 +92,16 @@ export function RestoreLogDialog({
             </p>
           ) : (
             <ul className="flex flex-col gap-1.5 font-mono text-xs" data-testid="restore-log-list">
-              {steps.map((step) => {
+              {steps.map((step, idx) => {
                 const reason = step.reason?.trim()
                 const errored = isError(step)
+                const stepKey = step.id ?? `${step.name}-${step.created_date ?? idx}`
                 return (
                   <li
-                    key={step.id ?? `${step.name}-${step.created_date}`}
+                    key={stepKey}
                     className={cn("leading-relaxed", errored && "text-destructive")}
-                    data-testid={`restore-log-step-${step.result ?? "todo"}`}
+                    data-testid={`restore-log-step-${stepKey}`}
+                    data-result={step.result ?? "todo"}
                   >
                     <span aria-hidden="true">{emojiFor(step)}</span> <span>{step.name}</span>
                     {reason && (

--- a/frontend/src/components/exports/RestoreLogDialog.tsx
+++ b/frontend/src/components/exports/RestoreLogDialog.tsx
@@ -87,10 +87,7 @@ export function RestoreLogDialog({
               {t("exports:restore.log.loading")}
             </p>
           ) : steps.length === 0 ? (
-            <p
-              className="font-mono text-xs text-muted-foreground"
-              data-testid="restore-log-empty"
-            >
+            <p className="font-mono text-xs text-muted-foreground" data-testid="restore-log-empty">
               {t("exports:restore.log.empty")}
             </p>
           ) : (
@@ -104,8 +101,7 @@ export function RestoreLogDialog({
                     className={cn("leading-relaxed", errored && "text-destructive")}
                     data-testid={`restore-log-step-${step.result ?? "todo"}`}
                   >
-                    <span aria-hidden="true">{emojiFor(step)}</span>{" "}
-                    <span>{step.name}</span>
+                    <span aria-hidden="true">{emojiFor(step)}</span> <span>{step.name}</span>
                     {reason && (
                       <>
                         <span aria-hidden="true"> — </span>

--- a/frontend/src/components/exports/RestoreLogDialog.tsx
+++ b/frontend/src/components/exports/RestoreLogDialog.tsx
@@ -1,0 +1,130 @@
+import { Eye, Loader2, RotateCcw } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { useRestore } from "@/features/export/hooks"
+import type { RestoreStep } from "@/features/export/api"
+import { cn } from "@/lib/utils"
+
+export interface RestoreLogDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  exportId: string
+  restoreId: string
+  dryRun?: boolean
+}
+
+const RESULT_EMOJI: Record<string, string> = {
+  success: "✅",
+  error: "❌",
+  skipped: "⏭️",
+  in_progress: "🔄",
+  todo: "📝",
+}
+
+function emojiFor(step: RestoreStep): string {
+  return RESULT_EMOJI[step.result ?? "todo"] ?? "📝"
+}
+
+function isError(step: RestoreStep): boolean {
+  return step.result === "error"
+}
+
+// Per-step restore log. Renders the monospaced scroll log from the mock's
+// RestoreLogsDialog (design-mocks/src/views/BackupView.tsx lines 637-664)
+// against the BE `models.RestoreStep` rows already loaded by
+// GET /exports/:id/restores/:restoreId (see go/apiserver/export_restores.go).
+// useRestore polls while the restore is non-terminal so the log streams in
+// as the worker processes records.
+export function RestoreLogDialog({
+  open,
+  onOpenChange,
+  exportId,
+  restoreId,
+  dryRun,
+}: RestoreLogDialogProps) {
+  const { t } = useTranslation(["exports"])
+  const restoreQuery = useRestore(exportId, restoreId, { enabled: open && !!restoreId })
+  const restore = restoreQuery.data
+  const steps = restore?.steps ?? []
+  const isLoading = restoreQuery.isLoading
+  const isPreview = dryRun ?? restore?.options?.dry_run ?? false
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg" data-testid="restore-log-dialog">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {isPreview ? (
+              <Eye className="size-4" aria-hidden="true" />
+            ) : (
+              <RotateCcw className="size-4" aria-hidden="true" />
+            )}
+            {isPreview
+              ? t("exports:restore.log.titlePreview")
+              : t("exports:restore.log.titleComplete")}
+          </DialogTitle>
+          <DialogDescription>
+            {isPreview
+              ? t("exports:restore.log.descriptionPreview")
+              : t("exports:restore.log.descriptionComplete")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="h-64 rounded-lg border bg-muted/30 p-4">
+          {isLoading ? (
+            <p className="flex items-center gap-2 font-mono text-xs text-muted-foreground">
+              <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+              {t("exports:restore.log.loading")}
+            </p>
+          ) : steps.length === 0 ? (
+            <p
+              className="font-mono text-xs text-muted-foreground"
+              data-testid="restore-log-empty"
+            >
+              {t("exports:restore.log.empty")}
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-1.5 font-mono text-xs" data-testid="restore-log-list">
+              {steps.map((step) => {
+                const reason = step.reason?.trim()
+                const errored = isError(step)
+                return (
+                  <li
+                    key={step.id ?? `${step.name}-${step.created_date}`}
+                    className={cn("leading-relaxed", errored && "text-destructive")}
+                    data-testid={`restore-log-step-${step.result ?? "todo"}`}
+                  >
+                    <span aria-hidden="true">{emojiFor(step)}</span>{" "}
+                    <span>{step.name}</span>
+                    {reason && (
+                      <>
+                        <span aria-hidden="true"> — </span>
+                        <span>{reason}</span>
+                      </>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </ScrollArea>
+
+        <DialogFooter>
+          <Button type="button" onClick={() => onOpenChange(false)}>
+            {t("exports:restore.log.done")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/exports/RestoreOptionsForm.tsx
+++ b/frontend/src/components/exports/RestoreOptionsForm.tsx
@@ -1,0 +1,182 @@
+import { ShieldAlert } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Switch } from "@/components/ui/switch"
+import { RESTORE_STRATEGIES, type RestoreStrategy } from "@/features/export/api"
+import { cn } from "@/lib/utils"
+
+type Risk = "low" | "medium" | "high"
+
+const RISK_BY_STRATEGY: Record<RestoreStrategy, Risk> = {
+  merge_add: "low",
+  merge_update: "medium",
+  full_replace: "high",
+}
+
+const RISK_TONE: Record<Risk, string> = {
+  low: "bg-status-active/10 text-status-active",
+  medium: "bg-status-expiring/10 text-status-expiring",
+  high: "bg-destructive/10 text-destructive",
+}
+
+const RISK_LABEL: Record<Risk, "safe" | "moderate" | "destructive"> = {
+  low: "safe",
+  medium: "moderate",
+  high: "destructive",
+}
+
+export interface RestoreOptionsFormValue {
+  description: string
+  strategy: RestoreStrategy
+  include_file_data: boolean
+  dry_run: boolean
+}
+
+export interface RestoreOptionsFormProps {
+  value: RestoreOptionsFormValue
+  onChange: (value: RestoreOptionsFormValue) => void
+  disabled?: boolean
+  className?: string
+}
+
+// Visual form body shared by ExportRestorePage (full standalone route)
+// and RestoreDialog (in-context). Owns the input layout but not the
+// submit chrome — the host wraps it in a <form> or <DialogFooter> and
+// decides what the primary CTA looks like.
+export function RestoreOptionsForm({
+  value,
+  onChange,
+  disabled,
+  className,
+}: RestoreOptionsFormProps) {
+  const { t } = useTranslation(["exports"])
+
+  function patch(next: Partial<RestoreOptionsFormValue>) {
+    onChange({ ...value, ...next })
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-5", className)}>
+      <div className="flex flex-col gap-2">
+        <Label className="text-sm font-medium">{t("exports:restore.strategy")}</Label>
+        <RadioGroup
+          value={value.strategy}
+          onValueChange={(next) => patch({ strategy: next as RestoreStrategy })}
+          disabled={disabled}
+        >
+          {RESTORE_STRATEGIES.map((strategy) => {
+            const risk = RISK_BY_STRATEGY[strategy]
+            const selected = value.strategy === strategy
+            const id = `restore-strategy-input-${strategy}`
+            return (
+              <label
+                key={strategy}
+                htmlFor={id}
+                data-testid={`restore-strategy-${strategy}`}
+                className={cn(
+                  "flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition-colors",
+                  selected
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:border-primary/30",
+                  disabled && "cursor-not-allowed opacity-60"
+                )}
+              >
+                <RadioGroupItem id={id} value={strategy} className="mt-0.5" />
+                <div className="flex flex-1 flex-col gap-0.5">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-semibold">
+                      {t(`exports:restore.strategyLabel.${strategy}`)}
+                    </span>
+                    <span
+                      className={cn(
+                        "rounded-full px-1.5 py-0.5 text-[10px] font-medium",
+                        RISK_TONE[risk]
+                      )}
+                    >
+                      {t(`exports:restore.riskLabel.${RISK_LABEL[risk]}`)}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {t(`exports:restore.strategyDescription.${strategy}`)}
+                  </p>
+                </div>
+              </label>
+            )
+          })}
+        </RadioGroup>
+      </div>
+
+      {value.strategy === "full_replace" && !value.dry_run && (
+        <div
+          className="flex items-start gap-3 rounded-lg border border-destructive/40 bg-destructive/5 p-4"
+          data-testid="restore-destructive-warning"
+          role="alert"
+        >
+          <ShieldAlert
+            className="mt-0.5 size-4 shrink-0 text-destructive"
+            aria-hidden="true"
+          />
+          <div className="flex flex-col gap-0.5">
+            <p className="text-sm font-semibold text-destructive">
+              {t("exports:restore.strategyLabel.full_replace")}
+            </p>
+            <p className="text-sm text-destructive">
+              {t("exports:restore.strategyDescription.full_replace")}
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between rounded-lg border bg-muted/40 px-4 py-3">
+        <div className="flex flex-col gap-0.5">
+          <p className="text-sm font-medium">{t("exports:restore.includeFileData")}</p>
+          <p className="text-xs text-muted-foreground">
+            {t("exports:restore.includeFileDataDescription")}
+          </p>
+        </div>
+        <Switch
+          checked={value.include_file_data}
+          onCheckedChange={(checked) => patch({ include_file_data: checked })}
+          disabled={disabled}
+          data-testid="restore-include-file-data"
+          aria-label={t("exports:restore.includeFileData")}
+        />
+      </div>
+
+      <div className="flex items-center justify-between rounded-lg border bg-muted/40 px-4 py-3">
+        <div className="flex flex-col gap-0.5">
+          <p className="text-sm font-medium">{t("exports:restore.dryRunLabel")}</p>
+          <p className="text-xs text-muted-foreground">
+            {t("exports:restore.dryRunDescription")}
+          </p>
+        </div>
+        <Switch
+          checked={value.dry_run}
+          onCheckedChange={(checked) => patch({ dry_run: checked })}
+          disabled={disabled}
+          data-testid="restore-dry-run"
+          aria-label={t("exports:restore.dryRunLabel")}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="restore-description">{t("exports:restore.description")}</Label>
+        <Input
+          id="restore-description"
+          value={value.description}
+          onChange={(e) => patch({ description: e.target.value })}
+          placeholder={t("exports:restore.descriptionPlaceholder")}
+          maxLength={500}
+          minLength={1}
+          required
+          disabled={disabled}
+          data-testid="restore-description"
+        />
+        <p className="text-xs text-muted-foreground">{t("exports:restore.descriptionHint")}</p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/exports/RestoreOptionsForm.tsx
+++ b/frontend/src/components/exports/RestoreOptionsForm.tsx
@@ -115,10 +115,7 @@ export function RestoreOptionsForm({
           data-testid="restore-destructive-warning"
           role="alert"
         >
-          <ShieldAlert
-            className="mt-0.5 size-4 shrink-0 text-destructive"
-            aria-hidden="true"
-          />
+          <ShieldAlert className="mt-0.5 size-4 shrink-0 text-destructive" aria-hidden="true" />
           <div className="flex flex-col gap-0.5">
             <p className="text-sm font-semibold text-destructive">
               {t("exports:restore.strategyLabel.full_replace")}
@@ -149,9 +146,7 @@ export function RestoreOptionsForm({
       <div className="flex items-center justify-between rounded-lg border bg-muted/40 px-4 py-3">
         <div className="flex flex-col gap-0.5">
           <p className="text-sm font-medium">{t("exports:restore.dryRunLabel")}</p>
-          <p className="text-xs text-muted-foreground">
-            {t("exports:restore.dryRunDescription")}
-          </p>
+          <p className="text-xs text-muted-foreground">{t("exports:restore.dryRunDescription")}</p>
         </div>
         <Switch
           checked={value.dry_run}

--- a/frontend/src/components/exports/__tests__/RestoreDialog.test.tsx
+++ b/frontend/src/components/exports/__tests__/RestoreDialog.test.tsx
@@ -1,0 +1,122 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { http, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { RestoreDialog } from "@/components/exports/RestoreDialog"
+import { type Export } from "@/features/export/api"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { initI18n } from "@/i18n"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { apiUrl, exportHandlers, groupHandlers } from "@/test/handlers"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+
+const SLUG = "household"
+const EXPORT_ID = "exp-1"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+  server.use(...groupHandlers.list([{ id: "g1", slug: SLUG, name: "Household" }]))
+})
+
+function exportRecord(): Export {
+  const fix = exportHandlers.exportFixture({
+    id: EXPORT_ID,
+    type: "full_database",
+    description: "Weekly snapshot",
+  })
+  return { ...fix, id: EXPORT_ID } as Export
+}
+
+function renderDialog(opts: { onCompleted?: (id: string, dryRun: boolean) => void } = {}) {
+  const onOpenChange = vi.fn()
+  return {
+    onOpenChange,
+    onCompleted: opts.onCompleted,
+    ...renderWithProviders({
+      initialPath: `/g/${SLUG}/exports`,
+      routes: (
+        <Route
+          path="/g/:groupSlug/exports"
+          element={
+            <GroupProvider>
+              <RestoreDialog
+                open={true}
+                onOpenChange={onOpenChange}
+                export={exportRecord()}
+                onCompleted={opts.onCompleted}
+              />
+            </GroupProvider>
+          }
+        />
+      ),
+    }),
+  }
+}
+
+describe("<RestoreDialog />", () => {
+  it("renders the form with risk badges and the scope/date header", async () => {
+    renderDialog()
+    expect(await screen.findByTestId("restore-dialog")).toBeVisible()
+    expect(screen.getByTestId("restore-strategy-merge_add")).toHaveTextContent("Safe")
+    expect(screen.getByTestId("restore-strategy-merge_update")).toHaveTextContent("Moderate risk")
+    expect(screen.getByTestId("restore-strategy-full_replace")).toHaveTextContent("Destructive")
+  })
+
+  it("submits the chosen options to the BE and fires onCompleted", async () => {
+    let captured: unknown = null
+    server.use(
+      http.post(apiUrl(`/g/${SLUG}/exports/${EXPORT_ID}/restores`), async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json(
+          {
+            data: {
+              id: "rest-99",
+              type: "restores",
+              attributes: { status: "pending", description: "smoke" },
+            },
+          },
+          { status: 201 }
+        )
+      })
+    )
+    const onCompleted = vi.fn()
+    const user = userEvent.setup()
+    renderDialog({ onCompleted })
+    await screen.findByTestId("restore-dialog")
+    await user.type(screen.getByTestId("restore-description"), "smoke")
+    await user.click(screen.getByTestId("restore-dialog-submit"))
+    await waitFor(() =>
+      expect(captured).toMatchObject({
+        data: {
+          type: "restores",
+          attributes: {
+            description: "smoke",
+            options: { strategy: "merge_add", dry_run: true, include_file_data: true },
+          },
+        },
+      })
+    )
+    await waitFor(() => expect(onCompleted).toHaveBeenCalledWith("rest-99", true))
+  })
+
+  it("flips submit copy based on the dry-run switch", async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const submit = await screen.findByTestId("restore-dialog-submit")
+    expect(submit).toHaveTextContent("Preview restore")
+    await user.click(screen.getByTestId("restore-dry-run"))
+    expect(submit).toHaveTextContent("Restore now")
+  })
+})

--- a/frontend/src/components/exports/__tests__/RestoreLogDialog.test.tsx
+++ b/frontend/src/components/exports/__tests__/RestoreLogDialog.test.tsx
@@ -1,0 +1,110 @@
+import { screen } from "@testing-library/react"
+import { Route } from "react-router-dom"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { RestoreLogDialog } from "@/components/exports/RestoreLogDialog"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { initI18n } from "@/i18n"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+import { exportHandlers, groupHandlers } from "@/test/handlers"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+
+const SLUG = "household"
+const EXPORT_ID = "exp-1"
+const RESTORE_ID = "rest-1"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  setAccessToken("good-token")
+  server.use(...groupHandlers.list([{ id: "g1", slug: SLUG, name: "Household" }]))
+})
+
+function renderDialog({ dryRun = false }: { dryRun?: boolean } = {}) {
+  return renderWithProviders({
+    initialPath: `/g/${SLUG}/exports`,
+    routes: (
+      <Route
+        path="/g/:groupSlug/exports"
+        element={
+          <GroupProvider>
+            <RestoreLogDialog
+              open={true}
+              onOpenChange={vi.fn()}
+              exportId={EXPORT_ID}
+              restoreId={RESTORE_ID}
+              dryRun={dryRun}
+            />
+          </GroupProvider>
+        }
+      />
+    ),
+  })
+}
+
+describe("<RestoreLogDialog />", () => {
+  it("renders the per-step log entries with result-specific emojis", async () => {
+    server.use(
+      ...exportHandlers.getRestore(
+        SLUG,
+        EXPORT_ID,
+        exportHandlers.restoreFixture({
+          id: RESTORE_ID,
+          status: "completed",
+          steps: [
+            {
+              id: "s1",
+              name: "Restoring location: Main House",
+              result: "success",
+              restore_operation_id: RESTORE_ID,
+            },
+            {
+              id: "s2",
+              name: "Restoring commodity: Unknown",
+              result: "error",
+              reason: "Area not found",
+              restore_operation_id: RESTORE_ID,
+            },
+            {
+              id: "s3",
+              name: "Skipping duplicate area",
+              result: "skipped",
+              restore_operation_id: RESTORE_ID,
+            },
+          ],
+        })
+      )
+    )
+    renderDialog()
+    expect(await screen.findByTestId("restore-log-list")).toBeVisible()
+    expect(screen.getByTestId("restore-log-step-success")).toHaveTextContent(
+      "Restoring location: Main House"
+    )
+    const errored = screen.getByTestId("restore-log-step-error")
+    expect(errored).toHaveTextContent("Area not found")
+    expect(errored).toHaveClass("text-destructive")
+    expect(screen.getByTestId("restore-log-step-skipped")).toHaveTextContent(
+      "Skipping duplicate area"
+    )
+  })
+
+  it("flips the title between preview and complete based on dryRun", async () => {
+    server.use(
+      ...exportHandlers.getRestore(
+        SLUG,
+        EXPORT_ID,
+        exportHandlers.restoreFixture({ id: RESTORE_ID, steps: [] })
+      )
+    )
+    renderDialog({ dryRun: true })
+    expect(await screen.findByText("Restore preview")).toBeVisible()
+  })
+})

--- a/frontend/src/components/exports/__tests__/RestoreLogDialog.test.tsx
+++ b/frontend/src/components/exports/__tests__/RestoreLogDialog.test.tsx
@@ -84,16 +84,18 @@ describe("<RestoreLogDialog />", () => {
       )
     )
     renderDialog()
-    expect(await screen.findByTestId("restore-log-list")).toBeVisible()
-    expect(screen.getByTestId("restore-log-step-success")).toHaveTextContent(
+    const list = await screen.findByTestId("restore-log-list")
+    expect(list).toBeVisible()
+    expect(screen.getByTestId("restore-log-step-s1")).toHaveTextContent(
       "Restoring location: Main House"
     )
-    const errored = screen.getByTestId("restore-log-step-error")
+    expect(screen.getByTestId("restore-log-step-s1")).toHaveAttribute("data-result", "success")
+    const errored = screen.getByTestId("restore-log-step-s2")
     expect(errored).toHaveTextContent("Area not found")
+    expect(errored).toHaveAttribute("data-result", "error")
     expect(errored).toHaveClass("text-destructive")
-    expect(screen.getByTestId("restore-log-step-skipped")).toHaveTextContent(
-      "Skipping duplicate area"
-    )
+    expect(screen.getByTestId("restore-log-step-s3")).toHaveTextContent("Skipping duplicate area")
+    expect(screen.getByTestId("restore-log-step-s3")).toHaveAttribute("data-result", "skipped")
   })
 
   it("flips the title between preview and complete based on dryRun", async () => {

--- a/frontend/src/components/ui/radio-group.tsx
+++ b/frontend/src/components/ui/radio-group.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { CircleIcon } from "lucide-react"
+import * as React from "react"
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/frontend/src/i18n/locales/en/exports.json
+++ b/frontend/src/i18n/locales/en/exports.json
@@ -78,9 +78,32 @@
     "description": "Description",
     "descriptionHint": "Required. Useful when comparing dry-runs.",
     "descriptionPlaceholder": "Restore into staging on 2026-05-03",
-    "dryRun": "Dry run (preview only — no changes are written)",
+    "dialog": {
+      "submit": "Restore now",
+      "submitDryRun": "Preview restore",
+      "title": "Restore from export"
+    },
+    "dryRun": "Dry run",
+    "dryRunDescription": "Preview what would change without modifying data.",
+    "dryRunLabel": "Dry run",
     "includeFileData": "Restore attached files",
+    "includeFileDataDescription": "Restore attached files alongside metadata.",
     "intro": "Restore the contents of this export into the current group. Pick a strategy and run a dry-run first to preview the changes.",
+    "log": {
+      "descriptionComplete": "Restore operation finished. Review the log below.",
+      "descriptionPreview": "No changes were made. Review what would happen.",
+      "done": "Done",
+      "empty": "No log entries yet.",
+      "loading": "Loading restore steps…",
+      "titleComplete": "Restore complete",
+      "titlePreview": "Restore preview",
+      "viewLog": "View log"
+    },
+    "riskLabel": {
+      "destructive": "Destructive",
+      "moderate": "Moderate risk",
+      "safe": "Safe"
+    },
     "strategy": "Strategy",
     "strategyDescription": {
       "full_replace": "Wipe existing rows in the destination scope before importing. Destructive.",
@@ -92,7 +115,6 @@
       "merge_add": "Merge add",
       "merge_update": "Merge update"
     },
-    "submit": "Start restore",
     "submitting": "Starting restore…",
     "success": "Restore started.",
     "successDryRun": "Dry-run started — review the report when it completes.",

--- a/frontend/src/pages/exports/ExportRestorePage.tsx
+++ b/frontend/src/pages/exports/ExportRestorePage.tsx
@@ -1,28 +1,21 @@
-import { ArrowLeft, Loader2, ShieldAlert } from "lucide-react"
+import { ArrowLeft, Loader2, RotateCcw } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useNavigate, useParams } from "react-router-dom"
 
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import {
+  RestoreOptionsForm,
+  type RestoreOptionsFormValue,
+} from "@/components/exports/RestoreOptionsForm"
+import { Alert, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useGroupMigrationLock } from "@/features/currency-migration/lock"
-import { RESTORE_STRATEGIES, type RestoreStrategy } from "@/features/export/api"
 import { useCreateRestore, useExport } from "@/features/export/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
-import { cn } from "@/lib/utils"
 
-interface FormState {
-  description: string
-  strategy: RestoreStrategy
-  include_file_data: boolean
-  dry_run: boolean
-}
-
-const defaultState: FormState = {
+const defaultState: RestoreOptionsFormValue = {
   description: "",
   strategy: "merge_add",
   include_file_data: true,
@@ -42,10 +35,12 @@ export function ExportRestorePage() {
 
   const exportQuery = useExport(exportId, { enabled: groupReady && !!exportId })
   const createRestoreMutation = useCreateRestore()
-  const [state, setState] = useState<FormState>(defaultState)
+  const [state, setState] = useState<RestoreOptionsFormValue>(defaultState)
 
   const exp = exportQuery.data
   const detailHref = `/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(exportId)}`
+  const isPending = createRestoreMutation.isPending
+  const isDestructive = state.strategy === "full_replace"
 
   function onSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -115,110 +110,36 @@ export function ExportRestorePage() {
         <p className="max-w-prose text-sm text-muted-foreground">{t("exports:restore.intro")}</p>
       </header>
 
-      {state.strategy === "full_replace" && !state.dry_run && (
-        <Alert variant="destructive" data-testid="restore-destructive-warning">
-          <ShieldAlert className="size-4" aria-hidden="true" />
-          <AlertTitle>{t("exports:restore.strategyLabel.full_replace")}</AlertTitle>
-          <AlertDescription>
-            {t("exports:restore.strategyDescription.full_replace")}
-          </AlertDescription>
-        </Alert>
-      )}
+      <form
+        onSubmit={onSubmit}
+        className="flex max-w-2xl flex-col gap-6"
+        data-testid="restore-form"
+      >
+        <RestoreOptionsForm value={state} onChange={setState} disabled={isPending} />
 
-      <form onSubmit={onSubmit} className="flex flex-col gap-5" data-testid="restore-form">
-        <fieldset className="flex flex-col gap-3">
-          <legend className="text-sm font-medium">{t("exports:restore.strategy")}</legend>
-          {RESTORE_STRATEGIES.map((strategy) => {
-            const id = `restore-strategy-${strategy}`
-            return (
-              // eslint-disable-next-line jsx-a11y/label-has-associated-control -- the strategy label below carries the visible text; the rule's text-traversal misses it because t() returns a string at runtime, not a literal at parse time.
-              <label
-                key={strategy}
-                htmlFor={id}
-                className={cn(
-                  "flex cursor-pointer items-start gap-3 rounded-md border bg-card px-4 py-3",
-                  state.strategy === strategy && "border-primary/60 bg-primary/5"
-                )}
-                data-testid={id}
-              >
-                <input
-                  id={id}
-                  type="radio"
-                  name="strategy"
-                  className="mt-1 size-4"
-                  checked={state.strategy === strategy}
-                  onChange={() => setState((prev) => ({ ...prev, strategy }))}
-                  value={strategy}
-                />
-                <span className="flex flex-col gap-0.5">
-                  <span className="text-sm font-medium">
-                    {t(`exports:restore.strategyLabel.${strategy}`)}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {t(`exports:restore.strategyDescription.${strategy}`)}
-                  </span>
-                </span>
-              </label>
-            )
-          })}
-        </fieldset>
-
-        <label className="inline-flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            className="size-4"
-            checked={state.include_file_data}
-            onChange={(e) => setState((prev) => ({ ...prev, include_file_data: e.target.checked }))}
-            data-testid="restore-include-file-data"
-          />
-          {t("exports:restore.includeFileData")}
-        </label>
-
-        <label className="inline-flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            className="size-4"
-            checked={state.dry_run}
-            onChange={(e) => setState((prev) => ({ ...prev, dry_run: e.target.checked }))}
-            data-testid="restore-dry-run"
-          />
-          {t("exports:restore.dryRun")}
-        </label>
-
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="restore-description">{t("exports:restore.description")}</Label>
-          <Input
-            id="restore-description"
-            value={state.description}
-            onChange={(e) => setState((prev) => ({ ...prev, description: e.target.value }))}
-            placeholder={t("exports:restore.descriptionPlaceholder")}
-            maxLength={500}
-            minLength={1}
-            required
-            data-testid="restore-description"
-          />
-          <p className="text-xs text-muted-foreground">{t("exports:restore.descriptionHint")}</p>
-        </div>
-
-        <div className="flex justify-end gap-2">
+        <div className="flex flex-wrap justify-end gap-2">
           <Button asChild variant="ghost" type="button">
             <Link to={detailHref}>{t("exports:wizard.cancel")}</Link>
           </Button>
           <Button
             type="submit"
-            disabled={
-              createRestoreMutation.isPending || !state.description.trim() || migrationLock.locked
-            }
+            variant={isDestructive && !state.dry_run ? "destructive" : "default"}
+            disabled={isPending || !state.description.trim() || migrationLock.locked}
             title={migrationLock.locked ? t("errors:lockedDuringMigration") : undefined}
             aria-disabled={migrationLock.locked || undefined}
             data-testid="restore-submit"
+            className="gap-2"
           >
-            {createRestoreMutation.isPending && (
-              <Loader2 className="mr-1.5 size-4 animate-spin" aria-hidden="true" />
+            {isPending ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <RotateCcw className="size-4" aria-hidden="true" />
             )}
-            {createRestoreMutation.isPending
+            {isPending
               ? t("exports:restore.submitting")
-              : t("exports:restore.submit")}
+              : state.dry_run
+                ? t("exports:restore.dialog.submitDryRun")
+                : t("exports:restore.dialog.submit")}
           </Button>
         </div>
       </form>

--- a/frontend/src/pages/exports/ExportsListPage.tsx
+++ b/frontend/src/pages/exports/ExportsListPage.tsx
@@ -1,11 +1,15 @@
 import { Plus, Upload } from "lucide-react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useSearchParams } from "react-router-dom"
 
 import { ExportRow } from "@/components/exports/ExportRow"
+import { RestoreDialog } from "@/components/exports/RestoreDialog"
+import { RestoreLogDialog } from "@/components/exports/RestoreLogDialog"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useGroupMigrationLock } from "@/features/currency-migration/lock"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { type Export } from "@/features/export/api"
 import { useDeleteExport, useExports } from "@/features/export/hooks"
@@ -33,6 +37,14 @@ export function ExportsListPage() {
   const includeDeleted = searchParams.get("show_deleted") === "1"
   const exportsQuery = useExports({ includeDeleted }, { enabled: groupReady })
   const deleteMutation = useDeleteExport()
+  const migrationLock = useGroupMigrationLock()
+
+  const [restoreTarget, setRestoreTarget] = useState<Export | null>(null)
+  const [logRestore, setLogRestore] = useState<{
+    exportId: string
+    restoreId: string
+    dryRun: boolean
+  } | null>(null)
 
   const items = exportsQuery.data?.exports ?? []
   const isInitialLoading = !groupReady || (exportsQuery.isLoading && !exportsQuery.data)
@@ -153,10 +165,35 @@ export function ExportsListPage() {
                 detailHref={exportUrl(slug, exp.id)}
                 groupSlug={slug}
                 onDelete={() => onDelete(exp)}
+                onRestore={migrationLock.locked ? undefined : () => setRestoreTarget(exp)}
               />
             </li>
           ))}
         </ul>
+      )}
+
+      <RestoreDialog
+        open={!!restoreTarget}
+        onOpenChange={(next) => {
+          if (!next) setRestoreTarget(null)
+        }}
+        export={restoreTarget}
+        onCompleted={(restoreId, dryRun) => {
+          if (!restoreTarget) return
+          setLogRestore({ exportId: restoreTarget.id, restoreId, dryRun })
+          setRestoreTarget(null)
+        }}
+      />
+      {logRestore && (
+        <RestoreLogDialog
+          open={!!logRestore}
+          onOpenChange={(next) => {
+            if (!next) setLogRestore(null)
+          }}
+          exportId={logRestore.exportId}
+          restoreId={logRestore.restoreId}
+          dryRun={logRestore.dryRun}
+        />
       )}
     </div>
   )

--- a/frontend/src/pages/exports/__tests__/ExportRestorePage.test.tsx
+++ b/frontend/src/pages/exports/__tests__/ExportRestorePage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { axe } from "jest-axe"
 import { http, HttpResponse } from "msw"
@@ -56,8 +56,18 @@ describe("<ExportRestorePage />", () => {
   it("renders the strategy radios with merge_add as the default", async () => {
     renderPage()
     expect(await screen.findByTestId("restore-strategy-merge_add")).toBeVisible()
-    const merge = screen.getByTestId("restore-strategy-merge_add").querySelector("input")
-    expect(merge).toBeChecked()
+    // Radix RadioGroup renders a button[role=radio]; check the checked
+    // state via aria-checked rather than the legacy <input> form control.
+    const merge = within(screen.getByTestId("restore-strategy-merge_add")).getByRole("radio")
+    expect(merge).toHaveAttribute("aria-checked", "true")
+  })
+
+  it("shows risk pills next to each strategy", async () => {
+    renderPage()
+    const merge = await screen.findByTestId("restore-strategy-merge_add")
+    expect(merge).toHaveTextContent("Safe")
+    expect(screen.getByTestId("restore-strategy-merge_update")).toHaveTextContent("Moderate risk")
+    expect(screen.getByTestId("restore-strategy-full_replace")).toHaveTextContent("Destructive")
   })
 
   it("warns when full_replace is picked WITHOUT dry-run", async () => {

--- a/frontend/src/test/handlers/exports.ts
+++ b/frontend/src/test/handlers/exports.ts
@@ -94,6 +94,17 @@ export function createRestore(slug: string, exportId: string, item: RestoreFixtu
   ]
 }
 
+export function getRestore(slug: string, exportId: string, item: RestoreFixture) {
+  return [
+    http.get(
+      apiUrl(
+        `/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(exportId)}/restores/${encodeURIComponent(item.id)}`
+      ),
+      () => HttpResponse.json({ data: restoreEnvelope(item) })
+    ),
+  ]
+}
+
 // Convenience builder: most tests just need a single export with a status
 // and the four counts populated. Defaults are tuned for the happy-path
 // "list page renders one completed export" case; override per-test.


### PR DESCRIPTION
## Summary

Brings the Backup & restore surfaces in line with [`design-mocks/src/views/BackupView.tsx`](https://github.com/denisvmedia/inventario/blob/master/design-mocks/src/views/BackupView.tsx) for all four items bundled in #1534:

- **ExportRow** — tinted leading icon tile + dense `"X locations · Y areas · Z items · N files · S MB"` stats line + error footer for failed exports + hover-revealed Restore / Download / Delete cluster. `ExportStatusBadge` updated globally to the mock's tinted-tone treatment (CheckCircle2 / XCircle / Loader2 / Clock) so it cascades through `ExportDetailPage` and `RestoreHistoryList` too.
- **Risk pills on restore strategies** — Safe (green) / Moderate risk (amber) / Destructive (red) chips beside each radio label, shared between the standalone page and the dialog via a new `RestoreOptionsForm` component (RadioGroup cards + dry-run Switch + include-attachments Switch + destructive warning).
- **Post-restore log dialog** — monospaced `ScrollArea` of per-record outcomes (✅ / 🔄 / ❌ / ⏭️ / 📝) driven by the existing `models.RestoreStep[]` payload on `GET /exports/:id/restores/:restoreId`. Title flips between "Restore preview" (dry-run) and "Restore complete". **No backend changes were needed** — the step data was already exposed.
- **In-context Restore dialog** — launched from each completed export row in the list. The standalone `/exports/:id/restore` route is preserved (shareable URL) and now uses the same form body so the two surfaces stay visually aligned. The log dialog opens automatically after the in-context restore completes, and a new **View log** CTA on every terminal `RestoreHistoryList` row re-opens it.

Three deviation entries appended to [`devdocs/frontend/design-deviations.md`](https://github.com/denisvmedia/inventario/blob/master/devdocs/frontend/design-deviations.md): standalone page preserved, include-files Switch kept, destructive warning gated on `!dry_run` (preserving pre-#1534 behaviour and the existing test contract).

## Related issues

Closes #1534.

## Test plan

- [x] `npm run typecheck` (frontend)
- [x] `npm run lint` (frontend)
- [x] `npm run i18n:check` (frontend)
- [x] `npm run test` (vitest — 764 passed / 4 skipped across 114 files; includes new `RestoreDialog.test.tsx` and `RestoreLogDialog.test.tsx`, plus updates to `ExportRestorePage.test.tsx` for Radix radios + risk pills)
- [ ] Visual / e2e verification on a running stack (screenshot review available via the `screenshot-review` skill on request)

## Notes for reviewers

- `ExportRestorePage` keeps its existing testids (`page-export-restore`, `restore-form`, `restore-submit`, `restore-strategy-*`, `restore-destructive-warning`, `restore-dry-run`, `restore-description`, `restore-include-file-data`) — only the underlying input shape changed (Radix `RadioGroup` + `Switch` instead of native form controls), so the test was adjusted to read `aria-checked` rather than the legacy `<input>` query.
- Added `radio-group.tsx` as a shadcn primitive — direct copy from `design-mocks/src/components/ui/radio-group.tsx`; the `radix-ui` umbrella was already pinned at 1.4.3.
- `ExportStatusBadge` change is intentionally wide: it's the single shared badge for exports + restores, and the mock specifies the same tinted treatment everywhere.