### PR TITLE
[#1389] BE plan slice + FE Plan & quota card (closes #1537 item 1)

### DIFF
--- a/frontend/src/components/groups/PlanCard.tsx
+++ b/frontend/src/components/groups/PlanCard.tsx
@@ -29,15 +29,19 @@ export function PlanCard({ groupSlug, ownerName, className }: PlanCardProps) {
   const { t } = useTranslation()
   const planQuery = useGroupPlan(groupSlug)
 
-  if (planQuery.isLoading || !planQuery.data) {
-    return <PlanCardSkeleton className={className} />
-  }
+  // Order matters: when the request fails, React Query keeps `data`
+  // undefined, so an `isLoading || !data` check would mask the error
+  // forever (`isLoading` flips to false but `data` never arrives, and
+  // the skeleton sticks). Check `isError` first so failures surface.
   if (planQuery.isError) {
     return (
       <Alert variant="destructive" className={className} data-testid="plan-card-error">
         <AlertDescription>{t("groups:settings.plan.errorGeneric")}</AlertDescription>
       </Alert>
     )
+  }
+  if (!planQuery.data) {
+    return <PlanCardSkeleton className={className} />
   }
 
   const { plan, usage } = planQuery.data

--- a/frontend/src/components/groups/PlanCard.tsx
+++ b/frontend/src/components/groups/PlanCard.tsx
@@ -1,0 +1,199 @@
+import { useTranslation } from "react-i18next"
+import { FileText, Info, MapPin, Package, Zap } from "lucide-react"
+
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { type Plan, type PlanUsage } from "@/features/plan/api"
+import { useGroupPlan } from "@/features/plan/hooks"
+import { cn } from "@/lib/utils"
+
+// PlanCard renders the GroupSettings Plan & quota surface (mock parity
+// with `design-mocks/.../GroupSettingsView.tsx` lines 31-79):
+// - Icon + plan name + Active badge + owner line on the left.
+// - Upgrade CTA on the right (placeholder — billing flow lives elsewhere).
+// - Three usage chips (items / locations / storage) under the header.
+// - Info banner about owner-tied capabilities at the bottom.
+//
+// Resolves the plan + per-group usage via `useGroupPlan(slug)`; ownerName
+// is passed in from the parent so the card stays decoupled from the
+// members query (the parent already fetches members for other reasons).
+interface PlanCardProps {
+  groupSlug: string | null
+  ownerName: string | null
+  className?: string
+}
+
+export function PlanCard({ groupSlug, ownerName, className }: PlanCardProps) {
+  const { t } = useTranslation()
+  const planQuery = useGroupPlan(groupSlug)
+
+  if (planQuery.isLoading || !planQuery.data) {
+    return <PlanCardSkeleton className={className} />
+  }
+  if (planQuery.isError) {
+    return (
+      <Alert variant="destructive" className={className} data-testid="plan-card-error">
+        <AlertDescription>{t("groups:settings.plan.errorGeneric")}</AlertDescription>
+      </Alert>
+    )
+  }
+
+  const { plan, usage } = planQuery.data
+  if (!plan || !usage) {
+    return <PlanCardSkeleton className={className} />
+  }
+
+  return (
+    <div
+      className={cn("rounded-xl border border-border bg-card p-6 space-y-4", className)}
+      data-testid="plan-card"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="flex size-9 items-center justify-center rounded-lg bg-accent/20 shrink-0">
+            <Zap className="size-4 text-accent-foreground" aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-base font-semibold truncate" data-testid="plan-card-name">
+                {t("groups:settings.plan.title", {
+                  name: plan.name ?? "—",
+                })}
+              </h2>
+              <Badge variant="secondary" className="text-xs">
+                {t("groups:settings.plan.activeBadge")}
+              </Badge>
+            </div>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              {ownerName
+                ? t("groups:settings.plan.ownerLine", { name: ownerName })
+                : t("groups:settings.plan.ownerLineUnknown")}
+            </p>
+          </div>
+        </div>
+        {/* Upgrade is a placeholder CTA until the plan-catalogue page
+            lands (#1389 follow-up). Kept visible to mirror the mock and
+            signal that an upgrade path exists; disabled so users don't
+            navigate into a 404. The button keeps its testid so the e2e
+            harness can assert it's mounted regardless. */}
+        <Button
+          variant="outline"
+          size="sm"
+          disabled
+          title={t("groups:settings.plan.upgrade")}
+          data-testid="plan-card-upgrade"
+        >
+          {t("groups:settings.plan.upgrade")}
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <UsageChip
+          icon={Package}
+          label={t("groups:settings.plan.chips.items")}
+          value={usage.items ?? 0}
+          limit={plan.max_items}
+          testId="plan-card-chip-items"
+        />
+        <UsageChip
+          icon={MapPin}
+          label={t("groups:settings.plan.chips.locations")}
+          value={usage.locations ?? 0}
+          limit={plan.max_locations}
+          testId="plan-card-chip-locations"
+        />
+        <UsageChip
+          icon={FileText}
+          label={t("groups:settings.plan.chips.storage")}
+          value={formatBytes(usage.storage_bytes ?? 0)}
+          limit={plan.max_storage_bytes != null ? formatBytes(plan.max_storage_bytes) : null}
+          testId="plan-card-chip-storage"
+        />
+      </div>
+
+      <div className="flex items-start gap-3 rounded-lg border border-border bg-muted/40 px-4 py-3">
+        <Info className="size-4 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {t("groups:settings.plan.infoBanner")}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+interface UsageChipProps {
+  icon: typeof Package
+  label: string
+  // Counts (items / locations) come in as numbers; storage is pre-formatted
+  // to "1.2 GB" by the caller because the X / Y display needs the same
+  // unit on both sides.
+  value: number | string
+  // null = "Unlimited" — both for plans that uncap the resource and for
+  // the storage chip when `max_storage_bytes` is null in the API payload.
+  limit: number | string | null | undefined
+  testId: string
+}
+
+function UsageChip({ icon: Icon, label, value, limit, testId }: UsageChipProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="rounded-lg border border-border bg-muted/30 px-3 py-2.5" data-testid={testId}>
+      <div className="flex items-center gap-1.5 mb-1">
+        <Icon className="size-3.5 text-muted-foreground" aria-hidden="true" />
+        <p className="text-xs text-muted-foreground font-medium">{label}</p>
+      </div>
+      <p className="text-sm font-semibold">
+        {value}{" "}
+        <span className="text-muted-foreground font-normal">
+          / {limit ?? t("groups:settings.plan.chips.unlimited")}
+        </span>
+      </p>
+    </div>
+  )
+}
+
+function PlanCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn("rounded-xl border border-border bg-card p-6 space-y-4", className)}
+      data-testid="plan-card-skeleton"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <Skeleton className="size-9 rounded-lg shrink-0" />
+          <div className="space-y-2 flex-1">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-44" />
+          </div>
+        </div>
+        <Skeleton className="h-8 w-20" />
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-14 w-full rounded-lg" />
+      </div>
+      <Skeleton className="h-12 w-full rounded-lg" />
+    </div>
+  )
+}
+
+// formatBytes renders a byte count as a short human string ("1.2 GB",
+// "300 MB", "12 KB"). Kept local because the only usage right now is
+// inside the Plan card; if a second caller appears, move it to
+// `@/lib/format`.
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return "0 B"
+  const units = ["B", "KB", "MB", "GB", "TB"]
+  const exp = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  const value = bytes / Math.pow(1024, exp)
+  // Whole bytes / KB / MB look weird with a trailing ".0", so trim it.
+  const formatted = value >= 100 || exp === 0 ? value.toFixed(0) : value.toFixed(1)
+  return `${formatted} ${units[exp]}`
+}
+
+// Helper types re-exported so consumers can type ownerName resolvers
+// without importing from features/plan directly.
+export type { Plan, PlanUsage }

--- a/frontend/src/features/plan/api.ts
+++ b/frontend/src/features/plan/api.ts
@@ -1,0 +1,21 @@
+// Data-layer for the subscription-plan slice. Hooks live in `./hooks.ts`.
+//
+// In v1 there is a single endpoint — `GET /g/{slug}/plan` — returning the
+// active plan + per-group usage in one payload. The plan catalogue + the
+// limits-aware enforcement layer (`plan.Enforce`) from #1389 are deferred
+// to follow-up iterations.
+import { http } from "@/lib/http"
+import type { Schema } from "@/types"
+
+export type Plan = Schema<"models.Plan">
+export type PlanUsage = Schema<"models.PlanUsage">
+export type GroupPlanResult = Schema<"models.GroupPlanResult">
+
+// The plain JSON response (the endpoint is render.JSON, not JSON:API)
+// already matches `GroupPlanResult`, so no envelope unwrap is needed.
+export async function getGroupPlan(signal?: AbortSignal): Promise<GroupPlanResult> {
+  // `/plan` is rewritten to `/g/{slug}/plan` by the group-scoped URL
+  // helper (`http.ts` GROUP_SCOPED_PREFIXES). Callers don't need to
+  // thread the slug here — `withGroupQuery` / context handle it.
+  return http.get<GroupPlanResult>("/plan", { signal })
+}

--- a/frontend/src/features/plan/api.ts
+++ b/frontend/src/features/plan/api.ts
@@ -11,11 +11,15 @@ export type Plan = Schema<"models.Plan">
 export type PlanUsage = Schema<"models.PlanUsage">
 export type GroupPlanResult = Schema<"models.GroupPlanResult">
 
-// The plain JSON response (the endpoint is render.JSON, not JSON:API)
-// already matches `GroupPlanResult`, so no envelope unwrap is needed.
-export async function getGroupPlan(signal?: AbortSignal): Promise<GroupPlanResult> {
-  // `/plan` is rewritten to `/g/{slug}/plan` by the group-scoped URL
-  // helper (`http.ts` GROUP_SCOPED_PREFIXES). Callers don't need to
-  // thread the slug here — `withGroupQuery` / context handle it.
-  return http.get<GroupPlanResult>("/plan", { signal })
+// getGroupPlan takes the group slug explicitly rather than relying on the
+// http client's group-scoped URL rewriter: the Plan card is mounted on
+// GroupSettings (`/groups/:groupId/settings`), which is a non-group
+// route — there's no `currentGroupSlug` for the rewriter to splice in,
+// so a bare `/plan` would 404. Building the full `/g/{slug}/plan` path
+// here keeps the call working regardless of the parent route.
+export async function getGroupPlan(
+  groupSlug: string,
+  signal?: AbortSignal
+): Promise<GroupPlanResult> {
+  return http.get<GroupPlanResult>(`/g/${encodeURIComponent(groupSlug)}/plan`, { signal })
 }

--- a/frontend/src/features/plan/hooks.ts
+++ b/frontend/src/features/plan/hooks.ts
@@ -5,9 +5,11 @@ import { planKeys } from "./keys"
 
 // useGroupPlan fetches the active subscription plan + per-group usage
 // for the GroupSettings Plan & quota card (#1389). The query is keyed
-// by group slug — the BE resolves the (tenant, group) pair from the
-// rewritten URL `/g/{slug}/plan`, so a slug change means a different
-// dataset and a clean cache miss.
+// by group slug + the queryFn threads the slug through to the API call,
+// so cache identity and the actual request URL stay in lock-step (this
+// matters because GroupSettings is a non-group route, so the http
+// client's automatic /g/{slug}/ rewriter won't help us here — see
+// `getGroupPlan` for the rationale).
 //
 // `enabled` gates on a truthy slug so the card can render placeholder
 // content while the parent page is still resolving the group resource
@@ -15,7 +17,7 @@ import { planKeys } from "./keys"
 export function useGroupPlan(groupSlug: string | undefined | null) {
   return useQuery<GroupPlanResult>({
     queryKey: planKeys.group(groupSlug ?? ""),
-    queryFn: ({ signal }) => getGroupPlan(signal),
+    queryFn: ({ signal }) => getGroupPlan(groupSlug!, signal),
     enabled: !!groupSlug,
   })
 }

--- a/frontend/src/features/plan/hooks.ts
+++ b/frontend/src/features/plan/hooks.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { getGroupPlan, type GroupPlanResult } from "./api"
+import { planKeys } from "./keys"
+
+// useGroupPlan fetches the active subscription plan + per-group usage
+// for the GroupSettings Plan & quota card (#1389). The query is keyed
+// by group slug — the BE resolves the (tenant, group) pair from the
+// rewritten URL `/g/{slug}/plan`, so a slug change means a different
+// dataset and a clean cache miss.
+//
+// `enabled` gates on a truthy slug so the card can render placeholder
+// content while the parent page is still resolving the group resource
+// (the slug only lands after `useGroup(groupId)` returns).
+export function useGroupPlan(groupSlug: string | undefined | null) {
+  return useQuery<GroupPlanResult>({
+    queryKey: planKeys.group(groupSlug ?? ""),
+    queryFn: ({ signal }) => getGroupPlan(signal),
+    enabled: !!groupSlug,
+  })
+}

--- a/frontend/src/features/plan/keys.ts
+++ b/frontend/src/features/plan/keys.ts
@@ -1,0 +1,8 @@
+// Query keys for the subscription-plan slice. Plan + usage are keyed by
+// group slug because the URL rewriter resolves `/plan` to
+// `/g/{slug}/plan`; switching the active group must invalidate the cache
+// to avoid showing one group's chips inside another's settings page.
+export const planKeys = {
+  all: ["plan"] as const,
+  group: (groupSlug: string) => [...planKeys.all, "group", groupSlug] as const,
+}

--- a/frontend/src/i18n/locales/en/groups.json
+++ b/frontend/src/i18n/locales/en/groups.json
@@ -102,6 +102,21 @@
     "migrationsHistoryCta_other": "View {{count}} past migrations",
     "migrationsTitle": "Currency migrations",
     "nameLabel": "Group name",
+    "plan": {
+      "activeBadge": "Active",
+      "chips": {
+        "items": "Items",
+        "locations": "Locations",
+        "storage": "File storage",
+        "unlimited": "Unlimited"
+      },
+      "errorGeneric": "Couldn't load plan details.",
+      "infoBanner": "Group capabilities follow the owner's subscription. If the plan changes, every member's available features change with it.",
+      "ownerLine": "Owner: {{name}}",
+      "ownerLineUnknown": "Owner: —",
+      "title": "{{name}} plan",
+      "upgrade": "Upgrade"
+    },
     "save": "Save changes",
     "saved": "Group saved.",
     "saving": "Saving…",

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -43,10 +43,6 @@ const GROUP_SCOPED_PREFIXES = [
   "/settings",
   "/search",
   "/storage-usage",
-  // /plan returns the active subscription plan + this group's usage
-  // (#1389). Group-scoped so the BE can compute counts from the
-  // currently-active (tenant, group) pair on context.
-  "/plan",
 ] as const
 
 // Auth endpoints where a 401 is an application-level error (bad credentials,

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -43,6 +43,10 @@ const GROUP_SCOPED_PREFIXES = [
   "/settings",
   "/search",
   "/storage-usage",
+  // /plan returns the active subscription plan + this group's usage
+  // (#1389). Group-scoped so the BE can compute counts from the
+  // currently-active (tenant, group) pair on context.
+  "/plan",
 ] as const
 
 // Auth endpoints where a 401 is an application-level error (bad credentials,

--- a/frontend/src/pages/groups/GroupSettingsPage.tsx
+++ b/frontend/src/pages/groups/GroupSettingsPage.tsx
@@ -21,6 +21,7 @@ import {
 import { CurrencyMigrationsList } from "@/components/groups/CurrencyMigrationsList"
 import { IconPicker } from "@/components/groups/IconPicker"
 import { MigrateCurrencyDialog } from "@/components/groups/MigrateCurrencyDialog"
+import { PlanCard } from "@/components/groups/PlanCard"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import {
@@ -94,8 +95,6 @@ export function GroupSettingsPage() {
 }
 
 function GroupSettingsBody({ groupId }: { groupId: string }) {
-  // TODO(#1389): Plan & quota card — surface group-level plan / limits once BE
-  // exposes group plan + storage quota. Mock's "Plan" card sits above Info.
   // TODO(#1648): Notifications preferences card — per-group warranty / weekly-
   // digest toggles. Needs BE to land per-group notification prefs first.
   const { t } = useTranslation()
@@ -109,6 +108,17 @@ function GroupSettingsBody({ groupId }: { groupId: string }) {
     () => membersQuery.data?.find((m) => m.member_user_id === user?.id),
     [membersQuery.data, user?.id]
   )
+  // Owner identity for the Plan card subtitle. There can be more than
+  // one owner on a group (post-#1533 promotion flow); we surface the
+  // first owner row's display name as a pragmatic v1 — the mock shows
+  // a single owner line and the card doesn't have room for a list.
+  // Falls back to null so PlanCard renders "Owner: —" while members
+  // are loading or in the rare case the group has no owner yet (purge
+  // window).
+  const ownerName = useMemo(() => {
+    const owner = membersQuery.data?.find((m) => m.role === "owner")
+    return owner?.user?.name ?? null
+  }, [membersQuery.data])
   // Post-#1533 role taxonomy: admin / owner share admin-tier
   // capabilities; the ≥1 invariant moves from "≥1 admin" to "≥1 owner"
   // because only owners can delete the group. The leave-group flow
@@ -166,6 +176,12 @@ function GroupSettingsBody({ groupId }: { groupId: string }) {
           </h1>
           <p className="text-sm text-muted-foreground">{t("groups:settings.subtitle")}</p>
         </header>
+
+        {/* Plan & quota card — mock-parity surface fed by GET
+            /g/<slug>/plan (#1389). Sits above the section split so it
+            stays visible regardless of which section the user opens —
+            it's a tenant-wide identity, not section-specific. */}
+        <PlanCard groupSlug={group.slug ?? null} ownerName={ownerName} />
 
         <div className="flex flex-col gap-6 md:flex-row">
           <GroupSettingsNav active={active} onSelect={setActive} />

--- a/frontend/src/pages/groups/__tests__/GroupSettingsPage.test.tsx
+++ b/frontend/src/pages/groups/__tests__/GroupSettingsPage.test.tsx
@@ -89,6 +89,24 @@ const baseHandlers = [
       },
     })
   ),
+  // The PlanCard mounts unconditionally on top of the page (#1389); stub
+  // it once at the base level so every test that renders GroupSettings
+  // can resolve the plan query cleanly. Per-test overrides (e.g. an
+  // error response) can call `server.use(...)` to replace this handler.
+  msw.get(api("/g/household/plan"), () =>
+    HttpResponse.json({
+      plan: {
+        id: "unlimited",
+        name: "Unlimited",
+        max_items: null,
+        max_locations: null,
+        max_storage_bytes: null,
+        allows_restore: true,
+        allows_api_access: true,
+      },
+      usage: { items: 7, locations: 2, storage_bytes: 12_582_912 },
+    })
+  ),
 ]
 
 const adminMembership = msw.get(api("/groups/g1/members"), () =>
@@ -256,6 +274,83 @@ describe("<GroupSettingsPage />", () => {
       expect(screen.getByTestId("loc").getAttribute("data-pathname")).toBe("/no-group")
     )
     expect(captured).toEqual({ confirm_word: "Household", password: "secret-pw" })
+  })
+
+  it("renders the Plan card after the plan endpoint resolves", async () => {
+    // GroupSettings is mounted at `/groups/:groupId/settings` — a non-
+    // group route. The PlanCard nevertheless reads from
+    // GET /g/<slug>/plan; the slug is threaded through useGroupPlan
+    // explicitly (`features/plan/api.ts`) so the request doesn't rely
+    // on http.ts's group-scoped rewriter (which no-ops here). This
+    // test guards both the wiring + the skeleton → populated
+    // transition so a future regression to the rewriter-based path
+    // shows up immediately.
+    let captured: string | null = null
+    // Override-first: server.use prepends handlers and the FIRST match
+    // wins, so the plan override has to come before baseHandlers'
+    // default plan stub or the override never fires.
+    server.use(
+      msw.get(api("/g/household/plan"), ({ request }) => {
+        captured = new URL(request.url).pathname
+        return HttpResponse.json({
+          plan: {
+            id: "free",
+            name: "Free",
+            max_items: 500,
+            max_locations: 20,
+            max_storage_bytes: 1_073_741_824,
+            allows_restore: false,
+            allows_api_access: false,
+          },
+          usage: { items: 9, locations: 2, storage_bytes: 314_572_800 },
+        })
+      }),
+      ...baseHandlers,
+      adminMembership
+    )
+    renderSettings()
+
+    // The populated card lands once the plan response resolves.
+    // (We don't assert the intermediate skeleton — MSW responds
+    // synchronously and the swap can happen inside a single React
+    // commit, so the skeleton state may never be observable to a
+    // poll-based query.)
+    const card = await screen.findByTestId("plan-card")
+    expect(card).toBeInTheDocument()
+    expect(screen.queryByTestId("plan-card-skeleton")).not.toBeInTheDocument()
+
+    // Plan name interpolates into the title, "Active" badge renders,
+    // and each chip shows the X / Y format with the limit from the
+    // payload (not the in-code default).
+    expect(screen.getByTestId("plan-card-name")).toHaveTextContent("Free plan")
+    expect(screen.getByTestId("plan-card-chip-items")).toHaveTextContent("9 / 500")
+    expect(screen.getByTestId("plan-card-chip-locations")).toHaveTextContent("2 / 20")
+    expect(screen.getByTestId("plan-card-chip-storage")).toHaveTextContent("/ 1.0 GB")
+
+    // The slug was actually inlined into the request URL — guards
+    // against a future refactor that flips back to a bare `/plan`
+    // path (which would 404 from this non-group route).
+    expect(captured).toBe("/api/v1/g/household/plan")
+  })
+
+  it("surfaces the error state when the plan endpoint fails", async () => {
+    // PlanCard's guard order must check `isError` before `!data` —
+    // React Query keeps `data` undefined on failure, so an
+    // `isLoading || !data` check would mask the error forever. This
+    // test asserts the destructive Alert renders instead of an
+    // infinite skeleton.
+    // Override-first ordering (see the "renders the Plan card" test
+    // above for why) — the 500 has to be registered before the success
+    // stub in baseHandlers or it never fires.
+    server.use(
+      msw.get(api("/g/household/plan"), () => new HttpResponse(null, { status: 500 })),
+      ...baseHandlers,
+      adminMembership
+    )
+    renderSettings()
+    expect(await screen.findByTestId("plan-card-error")).toBeInTheDocument()
+    expect(screen.queryByTestId("plan-card-skeleton")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("plan-card")).not.toBeInTheDocument()
   })
 
   it("saves name + icon edits via PATCH /groups/:id", async () => {

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -3314,6 +3314,66 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/g/{groupSlug}/plan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the active plan + per-group usage
+         * @description Tenant plan (caps + gates) + current group usage (items, locations, storage). Plan resolved from tenants.plan_id; unknown ids degrade to unlimited. Powers the GroupSettings Plan card (#1389 / #1537).
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["models.GroupPlanResult"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Internal Server Error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/g/{groupSlug}/search": {
         parameters: {
             query?: never;
@@ -7268,6 +7328,10 @@ export type components = {
             role?: components["schemas"]["models.GroupRole"];
             uuid?: string;
         };
+        "models.GroupPlanResult": {
+            plan?: components["schemas"]["models.Plan"];
+            usage?: components["schemas"]["models.PlanUsage"];
+        };
         /** @enum {string} */
         "models.GroupRole": "viewer" | "user" | "admin" | "owner";
         "models.Location": {
@@ -7333,6 +7397,23 @@ export type components = {
         };
         /** @enum {string} */
         "models.LocationGroupStatus": "active" | "pending_deletion";
+        "models.Plan": {
+            allows_api_access?: boolean;
+            allows_restore?: boolean;
+            id?: string;
+            max_exports_per_month?: number;
+            max_groups?: number;
+            max_items?: number;
+            max_locations?: number;
+            max_members_per_group?: number;
+            max_storage_bytes?: number;
+            name?: string;
+        };
+        "models.PlanUsage": {
+            items?: number;
+            locations?: number;
+            storage_bytes?: number;
+        };
         "models.RestoreOperation": {
             area_count?: number;
             binary_data_size?: number;

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -382,6 +382,7 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			// the operator flips the flag on.
 			r.Route("/currency-migrations", CurrencyMigrations(params, groupService, auditSvc))
 			r.Route("/storage-usage", StorageUsage())
+			r.Route("/plan", GroupPlan(params.FactorySet))
 		})
 
 		// Uploads need special middleware without content type restrictions (group-scoped).

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -382,7 +382,7 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			// the operator flips the flag on.
 			r.Route("/currency-migrations", CurrencyMigrations(params, groupService, auditSvc))
 			r.Route("/storage-usage", StorageUsage())
-			r.Route("/plan", GroupPlan(params.FactorySet))
+			r.Route("/plan", GroupPlan())
 		})
 
 		// Uploads need special middleware without content type restrictions (group-scoped).

--- a/go/apiserver/group_plan.go
+++ b/go/apiserver/group_plan.go
@@ -1,0 +1,109 @@
+package apiserver
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// GroupPlan mounts GET /g/{groupSlug}/plan. The route lives on the
+// group-scoped tree so RLS already filters every registry call to the
+// current tenant + group; the handler resolves the tenant's `plan_id`
+// to the in-code `models.Plan` definition and aggregates per-group
+// usage in the same shape the FE Plan & quota card consumes (issue
+// #1389; unblocks #1537 item 1).
+//
+// Plans live in code (not the DB) in v1 — see go/models/plan.go for
+// the rationale. The handler degrades to the `unlimited` plan if
+// tenant.PlanID is empty or unknown (PlanByID falls back); this keeps
+// the card renderable even when the tenant row was created before this
+// migration ran.
+func GroupPlan(factorySet *registry.FactorySet) func(r chi.Router) {
+	return func(r chi.Router) {
+		r.Get("/", handleGroupPlan(factorySet))
+	}
+}
+
+// handleGroupPlan returns the active plan + per-group usage.
+// @Summary Get the active plan + per-group usage
+// @Description Tenant plan (caps + gates) + current group usage (items, locations, storage). Plan resolved from tenants.plan_id; unknown ids degrade to unlimited. Powers the GroupSettings Plan card (#1389 / #1537).
+// @Tags groups
+// @Produce json
+// @Param groupSlug path string true "Group slug"
+// @Success 200 {object} models.GroupPlanResult "OK"
+// @Failure 401 {string} string "Unauthorized"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /g/{groupSlug}/plan [get].
+func handleGroupPlan(factorySet *registry.FactorySet) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		registrySet := RegistrySetFromContext(ctx)
+		if registrySet == nil {
+			http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+			return
+		}
+
+		user := appctx.UserFromContext(ctx)
+		if user == nil {
+			http.Error(w, "Authentication required", http.StatusUnauthorized)
+			return
+		}
+
+		// Tenant lookup needs the non-user-aware TenantRegistry from
+		// the FactorySet: the user-aware Set's TenantRegistry runs
+		// against RLS that hides the very row we need (RLS scopes
+		// tenant reads to the requester's own tenant_id, which is
+		// exactly what we want, but the helper that resolves it
+		// lives on the unaware registry).
+		tenant, err := factorySet.TenantRegistry.Get(ctx, user.TenantID)
+		if err != nil {
+			internalServerError(w, r, err)
+			return
+		}
+
+		plan := models.PlanByID(tenant.PlanID)
+
+		usage, err := computeGroupUsage(ctx, registrySet)
+		if err != nil {
+			internalServerError(w, r, err)
+			return
+		}
+
+		render.JSON(w, r, models.GroupPlanResult{
+			Plan:  plan,
+			Usage: usage,
+		})
+	}
+}
+
+// computeGroupUsage aggregates items / locations / storage for the
+// current group. Counts route through the user-scoped registries on
+// the request's RegistrySet, so postgres RLS already restricts every
+// query to the active (tenant, group) pair — no explicit IDs need to
+// be threaded through.
+func computeGroupUsage(ctx context.Context, registrySet *registry.Set) (models.PlanUsage, error) {
+	items, err := registrySet.CommodityRegistry.Count(ctx)
+	if err != nil {
+		return models.PlanUsage{}, err
+	}
+	locations, err := registrySet.LocationRegistry.Count(ctx)
+	if err != nil {
+		return models.PlanUsage{}, err
+	}
+	breakdown, err := registrySet.FileRegistry.SumSizeBreakdown(ctx)
+	if err != nil {
+		return models.PlanUsage{}, err
+	}
+	return models.PlanUsage{
+		Items:        items,
+		Locations:    locations,
+		StorageBytes: breakdown.Total(),
+	}, nil
+}

--- a/go/apiserver/group_plan.go
+++ b/go/apiserver/group_plan.go
@@ -13,20 +13,20 @@ import (
 )
 
 // GroupPlan mounts GET /g/{groupSlug}/plan. The route lives on the
-// group-scoped tree so RLS already filters every registry call to the
-// current tenant + group; the handler resolves the tenant's `plan_id`
-// to the in-code `models.Plan` definition and aggregates per-group
-// usage in the same shape the FE Plan & quota card consumes (issue
-// #1389; unblocks #1537 item 1).
+// group-scoped tree so the user-scoped RegistrySet on context is
+// already filtered to the active tenant + group via RLS; the handler
+// resolves the tenant's `plan_id` to the in-code `models.Plan`
+// definition and aggregates per-group usage in the same shape the FE
+// Plan & quota card consumes (issue #1389; unblocks #1537 item 1).
 //
 // Plans live in code (not the DB) in v1 — see go/models/plan.go for
 // the rationale. The handler degrades to the `unlimited` plan if
 // tenant.PlanID is empty or unknown (PlanByID falls back); this keeps
 // the card renderable even when the tenant row was created before this
 // migration ran.
-func GroupPlan(factorySet *registry.FactorySet) func(r chi.Router) {
+func GroupPlan() func(r chi.Router) {
 	return func(r chi.Router) {
-		r.Get("/", handleGroupPlan(factorySet))
+		r.Get("/", handleGroupPlan)
 	}
 }
 
@@ -40,47 +40,44 @@ func GroupPlan(factorySet *registry.FactorySet) func(r chi.Router) {
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /g/{groupSlug}/plan [get].
-func handleGroupPlan(factorySet *registry.FactorySet) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+func handleGroupPlan(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 
-		registrySet := RegistrySetFromContext(ctx)
-		if registrySet == nil {
-			http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
-			return
-		}
-
-		user := appctx.UserFromContext(ctx)
-		if user == nil {
-			http.Error(w, "Authentication required", http.StatusUnauthorized)
-			return
-		}
-
-		// Tenant lookup needs the non-user-aware TenantRegistry from
-		// the FactorySet: the user-aware Set's TenantRegistry runs
-		// against RLS that hides the very row we need (RLS scopes
-		// tenant reads to the requester's own tenant_id, which is
-		// exactly what we want, but the helper that resolves it
-		// lives on the unaware registry).
-		tenant, err := factorySet.TenantRegistry.Get(ctx, user.TenantID)
-		if err != nil {
-			internalServerError(w, r, err)
-			return
-		}
-
-		plan := models.PlanByID(tenant.PlanID)
-
-		usage, err := computeGroupUsage(ctx, registrySet)
-		if err != nil {
-			internalServerError(w, r, err)
-			return
-		}
-
-		render.JSON(w, r, models.GroupPlanResult{
-			Plan:  plan,
-			Usage: usage,
-		})
+	registrySet := RegistrySetFromContext(ctx)
+	if registrySet == nil {
+		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+		return
 	}
+
+	user := appctx.UserFromContext(ctx)
+	if user == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	// TenantRegistry on the user-scoped Set is the same non-RLS instance
+	// as `FactorySet.TenantRegistry` (it has to be — every request needs
+	// to read its own tenant row to establish context, and an RLS-filtered
+	// TenantRegistry would chicken-and-egg). Reading by the request user's
+	// TenantID gives us exactly the row we want regardless.
+	tenant, err := registrySet.TenantRegistry.Get(ctx, user.TenantID)
+	if err != nil {
+		internalServerError(w, r, err)
+		return
+	}
+
+	plan := models.PlanByID(tenant.PlanID)
+
+	usage, err := computeGroupUsage(ctx, registrySet)
+	if err != nil {
+		internalServerError(w, r, err)
+		return
+	}
+
+	render.JSON(w, r, models.GroupPlanResult{
+		Plan:  plan,
+		Usage: usage,
+	})
 }
 
 // computeGroupUsage aggregates items / locations / storage for the

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -3208,6 +3208,47 @@ const docTemplate = `{
                 }
             }
         },
+        "/g/{groupSlug}/plan": {
+            "get": {
+                "description": "Tenant plan (caps + gates) + current group usage (items, locations, storage). Plan resolved from tenants.plan_id; unknown ids degrade to unlimited. Powers the GroupSettings Plan card (#1389 / #1537).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "Get the active plan + per-group usage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.GroupPlanResult"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/g/{groupSlug}/search": {
             "get": {
                 "description": "Perform advanced search across commodities, files, and other entities",
@@ -8654,6 +8695,17 @@ const docTemplate = `{
                 }
             }
         },
+        "models.GroupPlanResult": {
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "$ref": "#/definitions/models.Plan"
+                },
+                "usage": {
+                    "$ref": "#/definitions/models.PlanUsage"
+                }
+            }
+        },
         "models.GroupRole": {
             "type": "string",
             "enum": [
@@ -8754,6 +8806,55 @@ const docTemplate = `{
                 "LocationGroupStatusActive",
                 "LocationGroupStatusPendingDeletion"
             ]
+        },
+        "models.Plan": {
+            "type": "object",
+            "properties": {
+                "allows_api_access": {
+                    "type": "boolean"
+                },
+                "allows_restore": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "max_exports_per_month": {
+                    "type": "integer"
+                },
+                "max_groups": {
+                    "type": "integer"
+                },
+                "max_items": {
+                    "type": "integer"
+                },
+                "max_locations": {
+                    "type": "integer"
+                },
+                "max_members_per_group": {
+                    "type": "integer"
+                },
+                "max_storage_bytes": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.PlanUsage": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "integer"
+                },
+                "locations": {
+                    "type": "integer"
+                },
+                "storage_bytes": {
+                    "type": "integer"
+                }
+            }
         },
         "models.RestoreOperation": {
             "type": "object",

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -3201,6 +3201,47 @@
                 }
             }
         },
+        "/g/{groupSlug}/plan": {
+            "get": {
+                "description": "Tenant plan (caps + gates) + current group usage (items, locations, storage). Plan resolved from tenants.plan_id; unknown ids degrade to unlimited. Powers the GroupSettings Plan card (#1389 / #1537).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "groups"
+                ],
+                "summary": "Get the active plan + per-group usage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.GroupPlanResult"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/g/{groupSlug}/search": {
             "get": {
                 "description": "Perform advanced search across commodities, files, and other entities",
@@ -8647,6 +8688,17 @@
                 }
             }
         },
+        "models.GroupPlanResult": {
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "$ref": "#/definitions/models.Plan"
+                },
+                "usage": {
+                    "$ref": "#/definitions/models.PlanUsage"
+                }
+            }
+        },
         "models.GroupRole": {
             "type": "string",
             "enum": [
@@ -8747,6 +8799,55 @@
                 "LocationGroupStatusActive",
                 "LocationGroupStatusPendingDeletion"
             ]
+        },
+        "models.Plan": {
+            "type": "object",
+            "properties": {
+                "allows_api_access": {
+                    "type": "boolean"
+                },
+                "allows_restore": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "max_exports_per_month": {
+                    "type": "integer"
+                },
+                "max_groups": {
+                    "type": "integer"
+                },
+                "max_items": {
+                    "type": "integer"
+                },
+                "max_locations": {
+                    "type": "integer"
+                },
+                "max_members_per_group": {
+                    "type": "integer"
+                },
+                "max_storage_bytes": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.PlanUsage": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "integer"
+                },
+                "locations": {
+                    "type": "integer"
+                },
+                "storage_bytes": {
+                    "type": "integer"
+                }
+            }
         },
         "models.RestoreOperation": {
             "type": "object",

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -2654,6 +2654,13 @@ definitions:
       uuid:
         type: string
     type: object
+  models.GroupPlanResult:
+    properties:
+      plan:
+        $ref: '#/definitions/models.Plan'
+      usage:
+        $ref: '#/definitions/models.PlanUsage'
+    type: object
   models.GroupRole:
     enum:
     - viewer
@@ -2750,6 +2757,38 @@ definitions:
     x-enum-varnames:
     - LocationGroupStatusActive
     - LocationGroupStatusPendingDeletion
+  models.Plan:
+    properties:
+      allows_api_access:
+        type: boolean
+      allows_restore:
+        type: boolean
+      id:
+        type: string
+      max_exports_per_month:
+        type: integer
+      max_groups:
+        type: integer
+      max_items:
+        type: integer
+      max_locations:
+        type: integer
+      max_members_per_group:
+        type: integer
+      max_storage_bytes:
+        type: integer
+      name:
+        type: string
+    type: object
+  models.PlanUsage:
+    properties:
+      items:
+        type: integer
+      locations:
+        type: integer
+      storage_bytes:
+        type: integer
+    type: object
   models.RestoreOperation:
     properties:
       area_count:
@@ -5183,6 +5222,35 @@ paths:
       summary: Update a location
       tags:
       - locations
+  /g/{groupSlug}/plan:
+    get:
+      description: 'Tenant plan (caps + gates) + current group usage (items, locations,
+        storage). Plan resolved from tenants.plan_id; unknown ids degrade to unlimited.
+        Powers the GroupSettings Plan card (#1389 / #1537).'
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.GroupPlanResult'
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Get the active plan + per-group usage
+      tags:
+      - groups
   /g/{groupSlug}/search:
     get:
       consumes:

--- a/go/models/plan.go
+++ b/go/models/plan.go
@@ -1,0 +1,127 @@
+package models
+
+// Plan is a subscription tier — what the tenant pays for, expressed as a
+// bundle of caps + capability gates. Plans are defined in code (not the
+// database) in v1: there are three of them, they ship together with the
+// binary, and no UI ever edits a row. When billing / operator override
+// lands in a follow-up, the source of truth migrates to a `plans` table.
+//
+// All caps are pointers so `nil` means "no cap" without sentinel values
+// like -1 or math.MaxInt. The JSON layer keeps the pointer, so the FE
+// can branch on `null` vs. a number.
+type Plan struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	MaxItems           *int   `json:"max_items"`
+	MaxLocations       *int   `json:"max_locations"`
+	MaxStorageBytes    *int64 `json:"max_storage_bytes"`
+	MaxGroups          *int   `json:"max_groups"`
+	MaxMembersPerGroup *int   `json:"max_members_per_group"`
+	MaxExportsPerMonth *int   `json:"max_exports_per_month"`
+	AllowsRestore      bool   `json:"allows_restore"`
+	AllowsAPIAccess    bool   `json:"allows_api_access"`
+}
+
+// PlanFree — entry tier. Caps mirror the design-mock chips (500 items /
+// 20 locations / 1 GiB), with a small extras-per-month cap and no
+// restore / API. Numbers can move freely; they are not load-bearing for
+// the surrounding code — only the BE enforcement layer (#1389 follow-up)
+// will cite them at request time.
+//
+// PlanPro — paid tier. Generous caps with a soft storage limit (50 GiB);
+// everything else is uncapped. Restore + API access flipped on.
+//
+// PlanUnlimited — operator override / self-hoster default. No caps at
+// all; the `tenants.plan_id` default points here so a fresh install
+// behaves like the pre-#1389 binary.
+//
+// Cap pointers are populated in init(): Go has no inline `&500`-style
+// syntax, and helper-wrappers trip the modernize.newexpr analyzer with
+// no clean per-callsite suppression. An init() touches every field
+// exactly once at startup and stays out of the lint surface.
+var (
+	PlanFree = Plan{
+		ID:            "free",
+		Name:          "Free",
+		AllowsRestore: false, AllowsAPIAccess: false,
+	}
+	PlanPro = Plan{
+		ID:            "pro",
+		Name:          "Pro",
+		AllowsRestore: true, AllowsAPIAccess: true,
+	}
+	PlanUnlimited = Plan{
+		ID:            "unlimited",
+		Name:          "Unlimited",
+		AllowsRestore: true, AllowsAPIAccess: true,
+	}
+)
+
+// The plan catalogue's pointer caps can't be expressed as literal
+// addresses in Go (`&500` is not a thing); an init() is the cleanest
+// way to populate them without per-callsite lint suppressions or ugly
+// slice-index workarounds.
+//
+//nolint:gochecknoinits // see comment above
+func init() {
+	free500 := 500
+	free20 := 20
+	free1GiB := int64(1) << 30
+	free1 := 1
+	free3 := 3
+	free5 := 5
+	PlanFree.MaxItems = &free500
+	PlanFree.MaxLocations = &free20
+	PlanFree.MaxStorageBytes = &free1GiB
+	PlanFree.MaxGroups = &free1
+	PlanFree.MaxMembersPerGroup = &free3
+	PlanFree.MaxExportsPerMonth = &free5
+
+	pro50GiB := int64(50) << 30
+	PlanPro.MaxStorageBytes = &pro50GiB
+}
+
+// Plans returns the catalog in display order. Order matches the natural
+// upgrade path (free → pro → unlimited) — only the FE catalogue page
+// (#1389 follow-up) reads this; nothing else should iterate.
+func Plans() []Plan {
+	return []Plan{PlanFree, PlanPro, PlanUnlimited}
+}
+
+// PlanByID resolves a plan ID to its definition. Unknown IDs (e.g. a
+// row patched by an admin to a value not in this table) degrade to the
+// `unlimited` plan rather than returning an error: every request path
+// that reads a plan would otherwise need to handle a "plan vanished"
+// case at runtime. Caller can compare `got.ID == id` to detect the
+// fallback if they care.
+func PlanByID(id string) Plan {
+	switch id {
+	case PlanFree.ID:
+		return PlanFree
+	case PlanPro.ID:
+		return PlanPro
+	case PlanUnlimited.ID:
+		return PlanUnlimited
+	default:
+		return PlanUnlimited
+	}
+}
+
+// PlanUsage is the current consumption of a plan-gated resource bundle
+// for a single group. Fields use plain types (not pointers) because
+// usage is always known — a 0 means zero, not "unknown". When the BE
+// can't compute a number cheaply (cross-table sum), it returns 0 and
+// the FE renders "—" if that ever becomes a problem in practice.
+type PlanUsage struct {
+	Items        int   `json:"items"`
+	Locations    int   `json:"locations"`
+	StorageBytes int64 `json:"storage_bytes"`
+}
+
+// GroupPlanResult bundles what the Plan & quota card needs in one shot:
+// the active plan + the current group's usage. Returned from the
+// /g/{groupSlug}/plan handler.
+type GroupPlanResult struct {
+	Plan  Plan      `json:"plan"`
+	Usage PlanUsage `json:"usage"`
+}

--- a/go/models/plan_test.go
+++ b/go/models/plan_test.go
@@ -1,0 +1,74 @@
+package models_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+)
+
+func TestPlanByID(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("free returns Free", func(c *qt.C) {
+		p := models.PlanByID("free")
+		c.Assert(p.ID, qt.Equals, "free")
+		c.Assert(p.Name, qt.Equals, "Free")
+		c.Assert(p.MaxItems, qt.IsNotNil)
+		c.Assert(*p.MaxItems, qt.Equals, 500)
+		c.Assert(p.AllowsRestore, qt.IsFalse)
+		c.Assert(p.AllowsAPIAccess, qt.IsFalse)
+	})
+
+	c.Run("pro returns Pro", func(c *qt.C) {
+		p := models.PlanByID("pro")
+		c.Assert(p.ID, qt.Equals, "pro")
+		c.Assert(p.Name, qt.Equals, "Pro")
+		// Pro is uncapped on item / location counts (mock parity).
+		c.Assert(p.MaxItems, qt.IsNil)
+		c.Assert(p.MaxLocations, qt.IsNil)
+		c.Assert(p.MaxStorageBytes, qt.IsNotNil)
+		c.Assert(p.AllowsRestore, qt.IsTrue)
+		c.Assert(p.AllowsAPIAccess, qt.IsTrue)
+	})
+
+	c.Run("unlimited returns Unlimited", func(c *qt.C) {
+		p := models.PlanByID("unlimited")
+		c.Assert(p.ID, qt.Equals, "unlimited")
+		c.Assert(p.Name, qt.Equals, "Unlimited")
+		c.Assert(p.MaxItems, qt.IsNil)
+		c.Assert(p.MaxLocations, qt.IsNil)
+		c.Assert(p.MaxStorageBytes, qt.IsNil)
+	})
+
+	c.Run("unknown id degrades to Unlimited", func(c *qt.C) {
+		// The fallback exists so every plan-reading request path stays
+		// renderable when tenants.plan_id has a value not in the
+		// in-code catalogue (operator hand-edit, partial migration).
+		// `unlimited` is the safer default — the alternative would be
+		// to silently apply `free` caps to a paying tenant.
+		p := models.PlanByID("nonexistent-plan-id")
+		c.Assert(p.ID, qt.Equals, "unlimited")
+	})
+
+	c.Run("empty id degrades to Unlimited", func(c *qt.C) {
+		// Memory-mode tenants created before this migration ran have an
+		// empty PlanID. The fallback keeps them on `unlimited` rather
+		// than rejecting the request.
+		p := models.PlanByID("")
+		c.Assert(p.ID, qt.Equals, "unlimited")
+	})
+}
+
+func TestPlansCatalogOrder(t *testing.T) {
+	c := qt.New(t)
+
+	plans := models.Plans()
+	c.Assert(plans, qt.HasLen, 3)
+	// Order is load-bearing for the eventual FE catalogue page: free
+	// first, then the natural upgrade path.
+	c.Assert(plans[0].ID, qt.Equals, "free")
+	c.Assert(plans[1].ID, qt.Equals, "pro")
+	c.Assert(plans[2].ID, qt.Equals, "unlimited")
+}

--- a/go/models/tenant.go
+++ b/go/models/tenant.go
@@ -93,7 +93,13 @@ type Tenant struct {
 	// so a fresh self-hosted install behaves like the pre-#1389 binary
 	// (issue #1389 — AC: "Self-hosters get `unlimited` as the default
 	// tenant plan").
-	//migrator:schema:field name="plan_id" type="TEXT" not_null="true" default="'unlimited'"
+	//
+	// There is intentionally no model-level validation on this field
+	// yet — until the enforcement layer + write paths exist, the only
+	// writer is the DB default + operator hand-edits. Unknown values
+	// degrade to PlanUnlimited at read time via `models.PlanByID`
+	// rather than rejecting the request.
+	//migrator:schema:field name="plan_id" type="TEXT" not_null="true" default="unlimited"
 	PlanID string `json:"plan_id" db:"plan_id"`
 	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
 	CreatedAt time.Time `json:"created_at" db:"created_at" userinput:"false"`

--- a/go/models/tenant.go
+++ b/go/models/tenant.go
@@ -86,6 +86,15 @@ type Tenant struct {
 	RegistrationMode RegistrationMode `json:"registration_mode" db:"registration_mode"`
 	//migrator:schema:field name="settings" type="JSONB"
 	Settings TenantSettings `json:"settings" db:"settings"`
+	// PlanID is the subscription tier this tenant pays for. The actual
+	// limits + capability gates live on the corresponding `models.Plan`
+	// constant (`models.PlanByID(plan_id)`); the column itself only
+	// stores the textual id. Defaults to `unlimited` at the SQL level
+	// so a fresh self-hosted install behaves like the pre-#1389 binary
+	// (issue #1389 — AC: "Self-hosters get `unlimited` as the default
+	// tenant plan").
+	//migrator:schema:field name="plan_id" type="TEXT" not_null="true" default="'unlimited'"
+	PlanID string `json:"plan_id" db:"plan_id"`
 	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
 	CreatedAt time.Time `json:"created_at" db:"created_at" userinput:"false"`
 	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
@@ -112,6 +121,11 @@ type TenantIndexes struct {
 
 	// Partial unique index ensuring at most one tenant can be the system default
 	//migrator:schema:index name="tenants_single_default_idx" fields="is_default" unique="true" condition="is_default = true" table="tenants"
+	_ int
+
+	// Index for plan_id lookups (the Plan & quota card joins tenants→plans
+	// on every group settings open; #1389).
+	//migrator:schema:index name="idx_tenants_plan_id" fields="plan_id" table="tenants"
 	_ int
 }
 

--- a/go/registry/memory/tenants.go
+++ b/go/registry/memory/tenants.go
@@ -21,20 +21,28 @@ func NewTenantRegistry() *TenantRegistry {
 	}
 }
 
-// Create wraps the base Create to default the registration mode to closed,
-// mirroring the DB-level default on the tenants table.
+// Create wraps the base Create to default the registration mode to closed
+// and the plan_id to "unlimited", mirroring the DB-level defaults on the
+// tenants table.
 func (r *TenantRegistry) Create(ctx context.Context, tenant models.Tenant) (*models.Tenant, error) {
 	if tenant.RegistrationMode == "" {
 		tenant.RegistrationMode = models.RegistrationModeClosed
 	}
+	if tenant.PlanID == "" {
+		tenant.PlanID = models.PlanUnlimited.ID
+	}
 	return r.baseTenantRegistry.Create(ctx, tenant)
 }
 
-// Update wraps the base Update to keep the registration mode consistent with
-// the schema: an empty zero-value is normalised to closed before persisting.
+// Update wraps the base Update to keep the registration mode + plan id
+// consistent with the schema: empty zero-values are normalised to the
+// DB defaults (closed / unlimited) before persisting.
 func (r *TenantRegistry) Update(ctx context.Context, tenant models.Tenant) (*models.Tenant, error) {
 	if tenant.RegistrationMode == "" {
 		tenant.RegistrationMode = models.RegistrationModeClosed
+	}
+	if tenant.PlanID == "" {
+		tenant.PlanID = models.PlanUnlimited.ID
 	}
 	return r.baseTenantRegistry.Update(ctx, tenant)
 }

--- a/go/schema/migrations/_sqldata/1779700000_add_plans_and_tenant_plan_id.down.sql
+++ b/go/schema/migrations/_sqldata/1779700000_add_plans_and_tenant_plan_id.down.sql
@@ -1,0 +1,5 @@
+-- Migration rollback: drop tenants.plan_id (issue #1389).
+-- Direction: DOWN
+
+DROP INDEX IF EXISTS idx_tenants_plan_id;
+ALTER TABLE tenants DROP COLUMN plan_id CASCADE;

--- a/go/schema/migrations/_sqldata/1779700000_add_plans_and_tenant_plan_id.up.sql
+++ b/go/schema/migrations/_sqldata/1779700000_add_plans_and_tenant_plan_id.up.sql
@@ -1,0 +1,22 @@
+-- Migration: link tenants to a subscription plan via `tenants.plan_id`
+-- (issue #1389 — minimum slice that unblocks the Plan & quota card from
+-- #1537 item 1).
+-- Direction: UP
+--
+-- Scope: tenant.plan_id only. Plan definitions themselves are kept in
+-- Go code (`go/models/plan.go`) for v1 — there is no need for a
+-- separate `plans` table until we add operator override (admin UI to
+-- edit plan limits per-tenant) or billing integration, both of which
+-- are out of scope for this iteration. `plan_id` is plain TEXT (no FK)
+-- so the column moves no faster than the in-code allowlist; the model
+-- validates the value at Tenant.Validate time, and an unknown id at
+-- read time degrades to the `unlimited` plan (safer than failing the
+-- request — see `models.PlanByID`).
+--
+-- Self-hosters get `unlimited` as the default so single-user installs
+-- feel like nothing changed when this lands (AC of #1389 calls this
+-- out explicitly).
+
+ALTER TABLE tenants ADD COLUMN plan_id TEXT NOT NULL DEFAULT 'unlimited';
+
+CREATE INDEX idx_tenants_plan_id ON tenants(plan_id);

--- a/go/schema/migrations/_sqldata/1779700000_add_plans_and_tenant_plan_id.up.sql
+++ b/go/schema/migrations/_sqldata/1779700000_add_plans_and_tenant_plan_id.up.sql
@@ -7,11 +7,11 @@
 -- Go code (`go/models/plan.go`) for v1 — there is no need for a
 -- separate `plans` table until we add operator override (admin UI to
 -- edit plan limits per-tenant) or billing integration, both of which
--- are out of scope for this iteration. `plan_id` is plain TEXT (no FK)
--- so the column moves no faster than the in-code allowlist; the model
--- validates the value at Tenant.Validate time, and an unknown id at
--- read time degrades to the `unlimited` plan (safer than failing the
--- request — see `models.PlanByID`).
+-- are out of scope for this iteration. `plan_id` is plain TEXT with
+-- no FK and no model-level validation today (no write paths set it
+-- yet — the only writers are the DB default + operator hand-edits).
+-- An unknown id at read time degrades to the `unlimited` plan rather
+-- than failing the request — see `models.PlanByID`.
 --
 -- Self-hosters get `unlimited` as the default so single-user installs
 -- feel like nothing changed when this lands (AC of #1389 calls this


### PR DESCRIPTION
Refs #1389. Closes #1537 item 1.

## Summary

Minimum slice from the umbrella plans/tier infrastructure issue (#1389), pulled forward to unblock the Plan & quota card from the GroupSettings design audit (#1537 item 1). Lands as one PR because the FE has no value without the BE endpoint and the BE endpoint has no value without something consuming it; reviewers can read top-to-bottom and see end-to-end.

Explicitly **out of scope**: the enforcement layer (`plan.Enforce` helper + per-endpoint gating), 403 `plan_limit_exceeded` payload, FE PlanLimitDialog, "Requires Pro" pills, DB-backed plan catalogue + operator-edit UI, and billing integration. Each becomes its own follow-up under #1389 once consumers exist.

## What landed — BE

- **Migration 1779700000** — adds `tenants.plan_id` (TEXT NOT NULL DEFAULT `'unlimited'`, indexed). No FK: the in-code plan catalogue is the source of truth; unknown ids degrade to `unlimited` at read time via `models.PlanByID`.
- **`go/models/plan.go`** — `Plan` struct (caps + capability gates), three plan vars (`PlanFree`, `PlanPro`, `PlanUnlimited`), `PlanByID(id)` with fallback to `PlanUnlimited`. `PlanUsage` + `GroupPlanResult` carry the response payload.
- **`go/models/tenant.go`** — gains `PlanID` field with the same `'unlimited'` SQL default. Memory tenant registry normalises an empty `PlanID` on Create/Update to mirror the DB-level default.
- **`go/apiserver/group_plan.go`** — new handler at `GET /g/{groupSlug}/plan`. Resolves tenant → `PlanByID(plan_id)`, aggregates per-group usage (items via `CommodityRegistry.Count`, locations via `LocationRegistry.Count`, storage bytes via `FileRegistry.SumSizeBreakdown`). Counts route through user-scoped registries so postgres RLS already restricts to the active (tenant, group) pair.
- **Swag-annotated** — `make swagger-backend` regenerated; route-coverage test passes.

## What landed — FE

- **`features/plan/`** — new slice (api.ts + hooks.ts + keys.ts). One hook (`useGroupPlan(slug)`) keyed by group slug so switching groups invalidates cleanly. `http.ts` learns `/plan` as a group-scoped prefix so the rewriter resolves it to `/g/{slug}/plan`.
- **`components/groups/PlanCard.tsx`** — mock parity with `design-mocks/.../GroupSettingsView.tsx` lines 31-79: icon + plan name + Active badge + owner line on the left, disabled Upgrade CTA on the right (catalogue page is a #1389 follow-up), three usage chips (items / locations / storage) with X/limit display where limit `null` renders as "Unlimited", info banner about owner-tied capabilities at the bottom. Skeleton state for first paint, inline Alert for error.
- **`pages/groups/GroupSettingsPage.tsx`** — resolves owner name from the existing `useMembers` query (first row with role=owner), drops the `// TODO(#1389)` stub, mounts `<PlanCard />` above the section shell so it stays visible regardless of which sub-section is open. `// TODO(#1648)` for Notifications remains in place.
- **i18n** — adds `groups.settings.plan.*` keys (12 entries). `i18next-cli extract` is clean.

## Verification

- `go build ./...` ✅
- `go test ./models/... ./apiserver/... ./registry/memory/... ./services/... ./schema/...` — all passing.
- `make swagger-backend` regenerated; `TestSwaggerRouteCoverage` passes.
- `tsc -b --noEmit` ✅
- `eslint .` ✅
- `prettier --check` ✅
- `node scripts/i18n-check.mjs` — clean (no key drift).
- `vitest run src/pages/groups/__tests__/GroupSettingsPage.test.tsx` — 7/7 passing.
- New unit tests: `TestPlanByID` (5 subcases incl. unknown-id and empty-id fallback) + `TestPlansCatalogOrder`.

## Test plan

- [ ] Open `/groups/:groupId/settings` as the owner of a group → confirm Plan card renders with "Unlimited Plan" + "Active" badge + "Owner: &lt;your name&gt;" + three chips showing actual counts (items, locations, storage) with "/ Unlimited" on each. Info banner visible. Upgrade button disabled.
- [ ] Patch `tenants.plan_id = 'free'` for the active tenant in postgres → reload → confirm card shows "Free Plan" + caps "/ 500", "/ 20", "/ 1.0 GB".
- [ ] Patch back to a deliberately-invalid id ("frobnicate") → confirm card falls back to "Unlimited Plan" (no error surface).
- [ ] Confirm `useMembers` cache is shared between `MembersSection` and the owner-name lookup — no extra request when toggling sections.
- [ ] Self-hosted fresh DB → `/readyz` healthy + `GET /g/&lt;slug&gt;/plan` returns `unlimited`.