### PR TITLE
[#1655] compose: share image across 4 services + schema-lag defense

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,11 +75,20 @@ services:
       start_period: 5s
 
   # Database Bootstrap Service (runs on every startup - idempotent)
+  #
+  # `inventario-bootstrap`, `inventario-migrate`, `inventario-init-data` and
+  # `inventario` all run the same binary from the same Dockerfile target and
+  # MUST share one image tag. If each service had its own `build:` block,
+  # Compose would publish four independent tags
+  # (`inventario-inventario`, `inventario-inventario-migrate`, …) and
+  # `docker compose build inventario` would silently leave the other three
+  # at whatever they were last built against — including a migrate container
+  # running an OLD binary whose embedded migrations don't include anything
+  # the app binary added since the previous build. See issue #1655 for the
+  # incident (location/invite 500s caused by a stale migrate image missing
+  # migrations 1779300000–1779600000).
   inventario-bootstrap:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
+    image: inventario:dev
     restart: "no"
     depends_on:
       postgres:
@@ -97,11 +106,10 @@ services:
     command: ["sh", "/app/bootstrap.sh"]
 
   # Database Migration Service (runs on every startup)
+  # Shares `inventario:dev` with the other three inventario services — see
+  # the comment on `inventario-bootstrap` for the rationale.
   inventario-migrate:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
+    image: inventario:dev
     restart: "no"
     depends_on:
       inventario-bootstrap:
@@ -116,11 +124,10 @@ services:
     command: ["sh", "/app/migrate.sh"]
 
   # Initial Data Setup Service (runs only once using external state tracking)
+  # Shares `inventario:dev` with the other three inventario services — see
+  # the comment on `inventario-bootstrap` for the rationale.
   inventario-init-data:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
+    image: inventario:dev
     restart: "no"
     depends_on:
       inventario-migrate:
@@ -151,7 +158,11 @@ services:
     command: ["sh", "/app/init-data.sh"]
 
   # Inventario Application (Production)
+  # Owns the single `build:` block; the other three inventario services
+  # reuse the resulting image via `image: inventario:dev`. Rebuilding this
+  # service rebuilds for everyone (see comment on inventario-bootstrap).
   inventario:
+    image: inventario:dev
     build:
       context: .
       dockerfile: Dockerfile
@@ -376,6 +387,8 @@ services:
         go build -o /app/inventario
         echo "Running migrations..."
         /app/inventario migrate up
+        echo "Asserting schema_migrations matches the binary (defense for #1655)..."
+        /app/inventario migrate verify
         echo "Generating schema updates..."
         /app/inventario migrate generate
         echo "Count migrations..."
@@ -386,6 +399,7 @@ services:
         /app/inventario migrate up
         echo "Verifying migrations are up to date..."
         /app/inventario migrate status
+        /app/inventario migrate verify
         echo "Verify no additional migrations are needed..."
         /app/inventario migrate generate
         echo "Count migrations again..."

--- a/frontend/src/lib/__tests__/global-error-toast.test.ts
+++ b/frontend/src/lib/__tests__/global-error-toast.test.ts
@@ -44,7 +44,7 @@ describe("notifyGlobalServerError", () => {
 
   it("falls back to the generic message when the body has no useful detail", () => {
     notifyGlobalServerError(
-      new HttpError("server", 500, "/x", { errors: [{ status: "Internal Server UserError" }] }),
+      new HttpError("server", 500, "/x", { errors: [{ status: "Internal Server Error" }] }),
       undefined
     )
     expect(errorMock).toHaveBeenCalledWith("Server error. Please try again later.")

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -62,7 +62,7 @@ func NewInternalServerError(err error) jsonapi.Error {
 	return jsonapi.Error{
 		Err:            err,
 		HTTPStatusCode: http.StatusInternalServerError,
-		StatusText:     "Internal Server UserError",
+		StatusText:     "Internal Server Error",
 	}
 }
 

--- a/go/apiserver/errors_test.go
+++ b/go/apiserver/errors_test.go
@@ -1,0 +1,26 @@
+package apiserver_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/apiserver"
+)
+
+// TestNewInternalServerError_StatusText guards against the typo fixed in
+// #1655 ("Internal Server UserError" → "Internal Server Error") reappearing.
+// The StatusText shows up in the JSON:API error envelope on every 500, gets
+// logged in operator dashboards, and is also asserted by the frontend's
+// global error toast — keeping it correct is a contract with both humans and
+// machines.
+func TestNewInternalServerError_StatusText(t *testing.T) {
+	c := qt.New(t)
+
+	e := apiserver.NewInternalServerError(errors.New("boom"))
+
+	c.Assert(e.HTTPStatusCode, qt.Equals, http.StatusInternalServerError)
+	c.Assert(e.StatusText, qt.Equals, "Internal Server Error")
+}

--- a/go/cmd/inventario/db/migrate/migrate.go
+++ b/go/cmd/inventario/db/migrate/migrate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/denisvmedia/inventario/cmd/inventario/db/migrate/down"
 	"github.com/denisvmedia/inventario/cmd/inventario/db/migrate/list"
 	"github.com/denisvmedia/inventario/cmd/inventario/db/migrate/up"
+	"github.com/denisvmedia/inventario/cmd/inventario/db/migrate/verify"
 	"github.com/denisvmedia/inventario/cmd/inventario/shared"
 )
 
@@ -75,6 +76,7 @@ MIGRATION SAFETY:
 	cmd.AddCommand(list.New(dbConfig).Cmd())
 	cmd.AddCommand(down.New(dbConfig).Cmd())
 	cmd.AddCommand(data.New(dbConfig).Cmd())
+	cmd.AddCommand(verify.New(dbConfig).Cmd())
 
 	return cmd
 }

--- a/go/cmd/inventario/db/migrate/verify/config.go
+++ b/go/cmd/inventario/db/migrate/verify/config.go
@@ -1,0 +1,5 @@
+package verify
+
+type Config struct {
+	MigrationsDir string `yaml:"migrations_dir" env:"DB_MIGRATIONS_DIR" env-default:"./migrations"`
+}

--- a/go/cmd/inventario/db/migrate/verify/config.go
+++ b/go/cmd/inventario/db/migrate/verify/config.go
@@ -1,5 +1,8 @@
 package verify
 
+import "time"
+
 type Config struct {
-	MigrationsDir string `yaml:"migrations_dir" env:"DB_MIGRATIONS_DIR" env-default:"./migrations"`
+	MigrationsDir string        `yaml:"migrations_dir" env:"DB_MIGRATIONS_DIR" env-default:"./migrations"`
+	Timeout       time.Duration `yaml:"timeout" env:"DB_VERIFY_TIMEOUT" env-default:"30s"`
 }

--- a/go/cmd/inventario/db/migrate/verify/verify.go
+++ b/go/cmd/inventario/db/migrate/verify/verify.go
@@ -34,13 +34,13 @@ the version recorded in schema_migrations. Exits non-zero with a clear
 diagnostic when the database is behind — the typical symptom of a
 docker-compose stack whose migrate container shipped a stale image (#1655).
 
+The check is bounded by --timeout (default 30s) so CI / orchestration
+scripts get a deterministic failure on a slow or unreachable DB rather
+than a hung command.
+
 Examples:
   inventario migrate verify
-
-Exit codes:
-  0  schema is up-to-date (or DB is ahead — warning logged)
-  1  schema lags the binary's embedded migrations
-  2  could not perform the check (DB unreachable, etc.)`,
+  inventario migrate verify --timeout=5s`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.verify(dbConfig)
 		},
@@ -54,16 +54,24 @@ func (c *Command) registerFlags() {
 	shared.TryReadSection("migrate", &c.config)
 	c.Cmd().Flags().StringVar(&c.config.MigrationsDir, "migrations-dir", c.config.MigrationsDir, "Directory containing migration files (fallback when no embedded migrations)")
 	c.Cmd().Flags().Lookup("migrations-dir").Hidden = true
+	c.Cmd().Flags().DurationVar(&c.config.Timeout, "timeout", c.config.Timeout, "Bound the DB round-trip so a hung connection can't stall CI/operator scripts")
 }
 
 func (c *Command) verify(dbConfig *shared.DatabaseConfig) error {
 	dsn := dbConfig.DBDSN
 	m := migrator.NewWithFallback(dsn, c.config.MigrationsDir)
 
+	ctx, cancel := context.WithTimeout(context.Background(), c.config.Timeout)
+	defer cancel()
+
 	fmt.Println("=== MIGRATE VERIFY ===")
-	if err := m.VerifySchemaUpToDate(context.Background()); err != nil {
+	if err := m.VerifySchemaUpToDate(ctx); err != nil {
+		// All errors propagate up to root cobra, which os.Exit(1)s — see
+		// cmd/inventario/inventario.go. Operator scripts that care about
+		// "schema lagged vs DB unreachable" should grep the stderr message
+		// or use errors.Is in a wrapping Go caller; we deliberately don't
+		// promise distinct exit codes the harness can't actually emit.
 		if errors.Is(err, migrator.ErrSchemaLagsBinary) {
-			// Caller scripts in CI care about this specific exit code.
 			return err
 		}
 		return fmt.Errorf("verify failed: %w", err)

--- a/go/cmd/inventario/db/migrate/verify/verify.go
+++ b/go/cmd/inventario/db/migrate/verify/verify.go
@@ -1,0 +1,74 @@
+// Package verify exposes the `inventario migrate verify` subcommand. It
+// compares the binary's embedded migration files against the version row in
+// schema_migrations and fails non-zero when the DB is behind — the symptom
+// of the docker-compose stale-image bug documented in issue #1655.
+package verify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/denisvmedia/inventario/cmd/internal/command"
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/schema/migrations/migrator"
+)
+
+type Command struct {
+	command.Base
+
+	config Config
+}
+
+// New constructs the `migrate verify` subcommand.
+func New(dbConfig *shared.DatabaseConfig) *Command {
+	c := &Command{}
+
+	c.Base = command.NewBase(&cobra.Command{
+		Use:   "verify",
+		Short: "Verify the database schema is up-to-date with this binary",
+		Long: `Compare the highest migration version embedded in this binary against
+the version recorded in schema_migrations. Exits non-zero with a clear
+diagnostic when the database is behind — the typical symptom of a
+docker-compose stack whose migrate container shipped a stale image (#1655).
+
+Examples:
+  inventario migrate verify
+
+Exit codes:
+  0  schema is up-to-date (or DB is ahead — warning logged)
+  1  schema lags the binary's embedded migrations
+  2  could not perform the check (DB unreachable, etc.)`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.verify(dbConfig)
+		},
+	})
+
+	c.registerFlags()
+	return c
+}
+
+func (c *Command) registerFlags() {
+	shared.TryReadSection("migrate", &c.config)
+	c.Cmd().Flags().StringVar(&c.config.MigrationsDir, "migrations-dir", c.config.MigrationsDir, "Directory containing migration files (fallback when no embedded migrations)")
+	c.Cmd().Flags().Lookup("migrations-dir").Hidden = true
+}
+
+func (c *Command) verify(dbConfig *shared.DatabaseConfig) error {
+	dsn := dbConfig.DBDSN
+	m := migrator.NewWithFallback(dsn, c.config.MigrationsDir)
+
+	fmt.Println("=== MIGRATE VERIFY ===")
+	if err := m.VerifySchemaUpToDate(context.Background()); err != nil {
+		if errors.Is(err, migrator.ErrSchemaLagsBinary) {
+			// Caller scripts in CI care about this specific exit code.
+			return err
+		}
+		return fmt.Errorf("verify failed: %w", err)
+	}
+
+	fmt.Println("Schema is up-to-date with the binary's embedded migrations.")
+	return nil
+}

--- a/go/cmd/inventario/run/bootstrap/bootstrap.go
+++ b/go/cmd/inventario/run/bootstrap/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/go-extras/go-kit/must"
 
@@ -150,14 +151,21 @@ func logStartupInfo(mode Mode, addr, dsn string) {
 //
 // Memory and other in-process registries don't run real migrations — skip
 // the check there so dev workflows and unit tests stay friction-free.
+//
+// The check is bounded by schemaVerifyTimeout so a slow / unreachable DB
+// can't block startup indefinitely; orchestrators see a deterministic boot
+// failure they can retry rather than a hung pod.
 func verifySchemaMatchesBinary(dsn string) error {
 	lowered := strings.ToLower(strings.TrimSpace(dsn))
 	if !strings.HasPrefix(lowered, "postgres://") && !strings.HasPrefix(lowered, "postgresql://") {
 		return nil
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), schemaVerifyTimeout)
+	defer cancel()
+
 	m := migrator.NewWithFallback(dsn, "")
-	if err := m.VerifySchemaUpToDate(context.Background()); err != nil {
+	if err := m.VerifySchemaUpToDate(ctx); err != nil {
 		if errors.Is(err, migrator.ErrSchemaLagsBinary) {
 			slog.Error("refusing to start: database schema lags the binary's embedded migrations — re-run migrate from the current image (see #1655)",
 				"error", err,
@@ -167,6 +175,12 @@ func verifySchemaMatchesBinary(dsn string) error {
 	}
 	return nil
 }
+
+// schemaVerifyTimeout caps the startup pre-flight schema check. Long enough
+// to absorb a cold connection pool + first query on a freshly-started
+// postgres, short enough that an orchestrator's readiness probe can
+// distinguish a hung DB from a missing migration.
+const schemaVerifyTimeout = 30 * time.Second
 
 // resolveFactorySet selects the registry implementation that matches the DSN
 // scheme and instantiates its factory set.

--- a/go/cmd/inventario/run/bootstrap/bootstrap.go
+++ b/go/cmd/inventario/run/bootstrap/bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/denisvmedia/inventario/cmd/inventario/shared"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/schema/migrations/migrator"
 )
 
 // Mode identifies which `run` subcommand is driving the bootstrap. It selects
@@ -56,6 +57,10 @@ func Build(cfg *Config, dbConfig *shared.DatabaseConfig, mode Mode) (*RuntimeSet
 
 	logInventarioEnv()
 	logStartupInfo(mode, cfg.Addr, dsn)
+
+	if err := verifySchemaMatchesBinary(dsn); err != nil {
+		return nil, err
+	}
 
 	factorySet, err := resolveFactorySet(dsn)
 	if err != nil {
@@ -133,6 +138,34 @@ func logStartupInfo(mode Mode, addr, dsn string) {
 	default:
 		slog.Info("Starting server", "addr", addr, "db-dsn", parsedDSN.String())
 	}
+}
+
+// verifySchemaMatchesBinary refuses to start the app when the database has
+// fewer migrations applied than this binary's embed.FS expects. The bug it
+// catches (issue #1655) is the docker-compose footgun where four services
+// each owned their own image tag, and a rebuild of one left the migrate
+// container shipping a stale binary. Result: the app boots happily, points
+// at a half-migrated schema, and queries fail with "column does not exist"
+// from the request path.
+//
+// Memory and other in-process registries don't run real migrations — skip
+// the check there so dev workflows and unit tests stay friction-free.
+func verifySchemaMatchesBinary(dsn string) error {
+	lowered := strings.ToLower(strings.TrimSpace(dsn))
+	if !strings.HasPrefix(lowered, "postgres://") && !strings.HasPrefix(lowered, "postgresql://") {
+		return nil
+	}
+
+	m := migrator.NewWithFallback(dsn, "")
+	if err := m.VerifySchemaUpToDate(context.Background()); err != nil {
+		if errors.Is(err, migrator.ErrSchemaLagsBinary) {
+			slog.Error("refusing to start: database schema lags the binary's embedded migrations — re-run migrate from the current image (see #1655)",
+				"error", err,
+			)
+		}
+		return err
+	}
+	return nil
 }
 
 // resolveFactorySet selects the registry implementation that matches the DSN

--- a/go/schema/migrations/migrations.go
+++ b/go/schema/migrations/migrations.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -63,4 +64,46 @@ func ListMigrations(fsys fs.FS) ([]string, error) {
 
 	sort.Strings(files)
 	return files, nil
+}
+
+// MaxVersion returns the highest migration version found in the provided
+// migration filesystem, or 0 if none are present. The filesystem must follow
+// ptah's naming convention: `<unix-seconds>_<description>.up.sql`. Used to
+// compare an app/migrator binary's embedded migrations against the version
+// recorded in `schema_migrations` so we can detect when a stale binary
+// (for example the migrate container in a multi-image docker-compose stack —
+// see #1655) left the DB behind the binary actually running.
+func MaxVersion(fsys fs.FS) (int64, error) {
+	entries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		return 0, fmt.Errorf("failed to read migration filesystem: %w", err)
+	}
+
+	var max int64
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		// Only look at .up.sql to avoid double-counting (.down.sql carries
+		// the same version prefix).
+		if !strings.HasSuffix(name, ".up.sql") {
+			continue
+		}
+		prefix, _, ok := strings.Cut(name, "_")
+		if !ok {
+			continue
+		}
+		v, err := strconv.ParseInt(prefix, 10, 64)
+		if err != nil {
+			// Not a versioned migration file — silently skip rather than
+			// fail the whole comparison.
+			continue
+		}
+		if v > max {
+			max = v
+		}
+	}
+
+	return max, nil
 }

--- a/go/schema/migrations/migrations.go
+++ b/go/schema/migrations/migrations.go
@@ -79,7 +79,7 @@ func MaxVersion(fsys fs.FS) (int64, error) {
 		return 0, fmt.Errorf("failed to read migration filesystem: %w", err)
 	}
 
-	var max int64
+	var maxVer int64
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -100,10 +100,10 @@ func MaxVersion(fsys fs.FS) (int64, error) {
 			// fail the whole comparison.
 			continue
 		}
-		if v > max {
-			max = v
+		if v > maxVer {
+			maxVer = v
 		}
 	}
 
-	return max, nil
+	return maxVer, nil
 }

--- a/go/schema/migrations/migrations_test.go
+++ b/go/schema/migrations/migrations_test.go
@@ -13,25 +13,25 @@ func TestMaxVersion_TakesHighestUpFile(t *testing.T) {
 	c := qt.New(t)
 
 	fsys := fstest.MapFS{
-		"1779000000_first.up.sql":   {Data: []byte("--")},
-		"1779000000_first.down.sql": {Data: []byte("--")},
-		"1779500000_third.up.sql":   {Data: []byte("--")},
-		"1779500000_third.down.sql": {Data: []byte("--")},
-		"1779200000_second.up.sql":  {Data: []byte("--")},
+		"1779000000_first.up.sql":    {Data: []byte("--")},
+		"1779000000_first.down.sql":  {Data: []byte("--")},
+		"1779500000_third.up.sql":    {Data: []byte("--")},
+		"1779500000_third.down.sql":  {Data: []byte("--")},
+		"1779200000_second.up.sql":   {Data: []byte("--")},
 		"1779200000_second.down.sql": {Data: []byte("--")},
 	}
 
-	max, err := migrations.MaxVersion(fsys)
+	maxVer, err := migrations.MaxVersion(fsys)
 	c.Assert(err, qt.IsNil)
-	c.Assert(max, qt.Equals, int64(1779500000))
+	c.Assert(maxVer, qt.Equals, int64(1779500000))
 }
 
 func TestMaxVersion_EmptyFSReturnsZero(t *testing.T) {
 	c := qt.New(t)
 
-	max, err := migrations.MaxVersion(fstest.MapFS{})
+	maxVer, err := migrations.MaxVersion(fstest.MapFS{})
 	c.Assert(err, qt.IsNil)
-	c.Assert(max, qt.Equals, int64(0))
+	c.Assert(maxVer, qt.Equals, int64(0))
 }
 
 func TestMaxVersion_IgnoresUnversionedAndDownFiles(t *testing.T) {
@@ -41,15 +41,15 @@ func TestMaxVersion_IgnoresUnversionedAndDownFiles(t *testing.T) {
 	// would double-count; junk filenames (no integer prefix) are skipped so
 	// a stray README never crashes the comparison.
 	fsys := fstest.MapFS{
-		"README.md":               {Data: []byte("hi")},
-		"1779100000_real.up.sql":  {Data: []byte("--")},
-		"1779100000_real.down.sql": {Data: []byte("--")},
+		"README.md":                   {Data: []byte("hi")},
+		"1779100000_real.up.sql":      {Data: []byte("--")},
+		"1779100000_real.down.sql":    {Data: []byte("--")},
 		"not_a_version_prefix.up.sql": {Data: []byte("--")},
 	}
 
-	max, err := migrations.MaxVersion(fsys)
+	maxVer, err := migrations.MaxVersion(fsys)
 	c.Assert(err, qt.IsNil)
-	c.Assert(max, qt.Equals, int64(1779100000))
+	c.Assert(maxVer, qt.Equals, int64(1779100000))
 }
 
 // TestMaxVersion_EmbeddedFS_NonZero protects against the embed directive in
@@ -62,7 +62,7 @@ func TestMaxVersion_EmbeddedFS_NonZero(t *testing.T) {
 	fsys, err := migrations.EmbeddedMigrationsFS()
 	c.Assert(err, qt.IsNil)
 
-	max, err := migrations.MaxVersion(fsys)
+	maxVer, err := migrations.MaxVersion(fsys)
 	c.Assert(err, qt.IsNil)
-	c.Assert(max > 0, qt.IsTrue, qt.Commentf("expected at least one embedded migration"))
+	c.Assert(maxVer > 0, qt.IsTrue, qt.Commentf("expected at least one embedded migration"))
 }

--- a/go/schema/migrations/migrations_test.go
+++ b/go/schema/migrations/migrations_test.go
@@ -1,0 +1,68 @@
+package migrations_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/schema/migrations"
+)
+
+func TestMaxVersion_TakesHighestUpFile(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"1779000000_first.up.sql":   {Data: []byte("--")},
+		"1779000000_first.down.sql": {Data: []byte("--")},
+		"1779500000_third.up.sql":   {Data: []byte("--")},
+		"1779500000_third.down.sql": {Data: []byte("--")},
+		"1779200000_second.up.sql":  {Data: []byte("--")},
+		"1779200000_second.down.sql": {Data: []byte("--")},
+	}
+
+	max, err := migrations.MaxVersion(fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(max, qt.Equals, int64(1779500000))
+}
+
+func TestMaxVersion_EmptyFSReturnsZero(t *testing.T) {
+	c := qt.New(t)
+
+	max, err := migrations.MaxVersion(fstest.MapFS{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(max, qt.Equals, int64(0))
+}
+
+func TestMaxVersion_IgnoresUnversionedAndDownFiles(t *testing.T) {
+	c := qt.New(t)
+
+	// Only the .up.sql files contribute. .down.sql carrying the same prefix
+	// would double-count; junk filenames (no integer prefix) are skipped so
+	// a stray README never crashes the comparison.
+	fsys := fstest.MapFS{
+		"README.md":               {Data: []byte("hi")},
+		"1779100000_real.up.sql":  {Data: []byte("--")},
+		"1779100000_real.down.sql": {Data: []byte("--")},
+		"not_a_version_prefix.up.sql": {Data: []byte("--")},
+	}
+
+	max, err := migrations.MaxVersion(fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(max, qt.Equals, int64(1779100000))
+}
+
+// TestMaxVersion_EmbeddedFS_NonZero protects against the embed directive in
+// migrations.go silently breaking — e.g. a refactor that renames `_sqldata`
+// without updating the `//go:embed` line. If the embedded FS becomes empty,
+// VerifySchemaUpToDate would silently degrade to a no-op everywhere.
+func TestMaxVersion_EmbeddedFS_NonZero(t *testing.T) {
+	c := qt.New(t)
+
+	fsys, err := migrations.EmbeddedMigrationsFS()
+	c.Assert(err, qt.IsNil)
+
+	max, err := migrations.MaxVersion(fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(max > 0, qt.IsTrue, qt.Commentf("expected at least one embedded migration"))
+}

--- a/go/schema/migrations/migrator/migrator.go
+++ b/go/schema/migrations/migrator/migrator.go
@@ -21,6 +21,14 @@ import (
 	"github.com/denisvmedia/inventario/schema/migrations"
 )
 
+// ErrSchemaLagsBinary is returned by VerifySchemaUpToDate when the binary
+// holding the embedded migrations has a higher max version than what's
+// recorded in the database's schema_migrations table. The most common cause
+// is the docker-compose footgun documented in #1655: the migrate container
+// shipped a stale binary whose embed.FS was missing migrations the app
+// container's binary later expected.
+var ErrSchemaLagsBinary = errx.NewSentinel("database schema lags the binary's embedded migrations")
+
 type Args struct {
 	DryRun bool
 }
@@ -97,7 +105,86 @@ func (m *Migrator) MigrateUp(ctx context.Context, args Args) error {
 		return errxtrace.Wrap("failed to run migrations", err)
 	}
 
+	// Defense in depth (#1655): after a successful MigrateUp the highest
+	// version recorded in schema_migrations should equal the highest version
+	// embedded in this binary. If it doesn't — ptah claimed success but the
+	// row count says otherwise — surface it loudly rather than letting the
+	// caller assume the DB is fully migrated.
+	if err := m.verifyAgainst(ctx, ptahMigrator); err != nil {
+		return errxtrace.Wrap("post-migrate schema verification failed", err)
+	}
+
 	m.logger.Info("Migrations completed successfully")
+	return nil
+}
+
+// VerifySchemaUpToDate opens its own connection to compare the binary's
+// embedded migrations against schema_migrations.version in the database.
+// It returns ErrSchemaLagsBinary when the DB is behind. Designed to be
+// called from non-migrator entry points (e.g. app startup) so a stale
+// docker-compose migrate container can't quietly leave the app running
+// against a half-migrated schema (#1655).
+func (m *Migrator) VerifySchemaUpToDate(ctx context.Context) error {
+	conn, err := dbschema.ConnectToDatabase(m.dbURL)
+	if err != nil {
+		return errxtrace.Wrap("failed to connect to database", err)
+	}
+	defer conn.Close()
+
+	ptahMigrator, err := migrator.NewFSMigrator(conn, m.migFS)
+	if err != nil {
+		return errxtrace.Wrap("failed to create Ptah migrator", err)
+	}
+
+	return m.verifyAgainst(ctx, ptahMigrator)
+}
+
+// verifyAgainst compares the max embedded migration version against the DB's
+// schema_migrations.version (current_version, the highest applied) via the
+// provided ptah migrator. Shared helper for MigrateUp (post-apply check) and
+// VerifySchemaUpToDate (standalone check).
+func (m *Migrator) verifyAgainst(ctx context.Context, ptahMigrator *migrator.Migrator) error {
+	embedMax, err := migrations.MaxVersion(m.migFS)
+	if err != nil {
+		return errxtrace.Wrap("failed to inspect embedded migrations", err)
+	}
+	if embedMax == 0 {
+		// Nothing embedded — either pre-migration dev workflow or a test
+		// fixture. Nothing to verify against.
+		return nil
+	}
+
+	dbVersion, err := ptahMigrator.GetCurrentVersion(ctx)
+	if err != nil {
+		return errxtrace.Wrap("failed to read schema_migrations.version", err)
+	}
+
+	return compareSchemaVersion(m.logger, int64(dbVersion), embedMax)
+}
+
+// compareSchemaVersion is the pure decision arm of verifyAgainst, split out
+// for unit testing. dbVersion is what schema_migrations reports; embedMax is
+// the highest version we have embedded in the binary.
+func compareSchemaVersion(logger *slog.Logger, dbVersion, embedMax int64) error {
+	switch {
+	case dbVersion < embedMax:
+		logger.Error("schema_migrations.version is behind the binary's embedded migrations — most likely a stale migrate image (see #1655)",
+			"db_version", dbVersion,
+			"embedded_max_version", embedMax,
+		)
+		return errxtrace.Wrap(
+			fmt.Sprintf("db version %d, embedded max %d", dbVersion, embedMax),
+			ErrSchemaLagsBinary,
+		)
+	case dbVersion > embedMax:
+		// DB ahead of binary is also worth flagging: it usually means an
+		// operator manually applied newer migrations or rolled the binary
+		// back. Not necessarily fatal, so warn rather than error.
+		logger.Warn("schema_migrations.version is ahead of the binary's embedded migrations",
+			"db_version", dbVersion,
+			"embedded_max_version", embedMax,
+		)
+	}
 	return nil
 }
 

--- a/go/schema/migrations/migrator/migrator.go
+++ b/go/schema/migrations/migrator/migrator.go
@@ -107,9 +107,10 @@ func (m *Migrator) MigrateUp(ctx context.Context, args Args) error {
 
 	// Defense in depth (#1655): after a successful MigrateUp the highest
 	// version recorded in schema_migrations should equal the highest version
-	// embedded in this binary. If it doesn't — ptah claimed success but the
-	// row count says otherwise — surface it loudly rather than letting the
-	// caller assume the DB is fully migrated.
+	// embedded in this binary. If it doesn't — ptah returned success but the
+	// version stored in schema_migrations is lower than the binary expects —
+	// surface it loudly rather than letting the caller assume the DB is fully
+	// migrated.
 	if err := m.verifyAgainst(ctx, ptahMigrator); err != nil {
 		return errxtrace.Wrap("post-migrate schema verification failed", err)
 	}

--- a/go/schema/migrations/migrator/migrator_internal_test.go
+++ b/go/schema/migrations/migrator/migrator_internal_test.go
@@ -1,6 +1,9 @@
 package migrator
 
 import (
+	"errors"
+	"io"
+	"log/slog"
 	"net/url"
 	"testing"
 
@@ -27,4 +30,59 @@ func TestNew_StripsPGXPoolParamsFromStoredDSN(t *testing.T) {
 	c.Assert(q.Has("pool_max_conns"), qt.IsFalse, qt.Commentf("pool_max_conns must be stripped to keep lib/pq happy"))
 	c.Assert(q.Has("pool_min_conns"), qt.IsFalse, qt.Commentf("pool_min_conns must be stripped to keep lib/pq happy"))
 	c.Assert(q.Get("sslmode"), qt.Equals, "disable", qt.Commentf("non-pool params must be preserved"))
+}
+
+// TestCompareSchemaVersion is the decision-arm test for the #1655 defense:
+// after a successful MigrateUp the DB version should match the binary's
+// embedded max version. Behind → fatal (the bug). Equal → pass. Ahead → warn.
+func TestCompareSchemaVersion(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tests := []struct {
+		name      string
+		dbVersion int64
+		embedMax  int64
+		wantErr   error
+	}{
+		{
+			name:      "in sync — passes silently",
+			dbVersion: 1779600000,
+			embedMax:  1779600000,
+		},
+		{
+			name:      "db behind binary — the #1655 footprint",
+			dbVersion: 1779200000,
+			embedMax:  1779600000,
+			wantErr:   ErrSchemaLagsBinary,
+		},
+		{
+			name:      "db ahead of binary — operator rolled the binary back, warn only",
+			dbVersion: 1779700000,
+			embedMax:  1779600000,
+		},
+		{
+			name:      "both zero — fresh dev DB or empty fixture, no error",
+			dbVersion: 0,
+			embedMax:  0,
+		},
+		{
+			name:      "fresh DB against real binary — db lags",
+			dbVersion: 0,
+			embedMax:  1779600000,
+			wantErr:   ErrSchemaLagsBinary,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			err := compareSchemaVersion(logger, tt.dbVersion, tt.embedMax)
+			if tt.wantErr == nil {
+				c.Assert(err, qt.IsNil)
+				return
+			}
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(errors.Is(err, tt.wantErr), qt.IsTrue, qt.Commentf("expected %v, got %v", tt.wantErr, err))
+		})
+	}
 }


### PR DESCRIPTION
Closes #1655.

## Summary

The docker-compose footgun reported in #1655 was four services
(`inventario`, `inventario-bootstrap`, `inventario-migrate`,
`inventario-init-data`) each owning their own `build:` block, which made
Compose publish four independent image tags. A naive
`docker compose build inventario` left the other three running whatever
they had been built against — concretely a migrate container whose
embedded migrations were missing `1779300000`–`1779600000` (rename file
category, backfill warranty, location/area icon+description, members
role taxonomy), so the freshly rebuilt app would 500 on location/invite
creates with `column "icon" does not exist` / `column "invitee_email"
does not exist`.

Three layers of fix, each independently useful:

1. **Compose: one image, one build block.** `inventario` now owns the
   `build:` block; the other three reuse `image: inventario:dev`. Rebuilds
   propagate to all four services automatically.
2. **Migrator defense-in-depth.** New `migrations.MaxVersion`,
   `migrator.VerifySchemaUpToDate` and the
   `migrator.ErrSchemaLagsBinary` sentinel — invoked at the end of
   `MigrateUp`, from `bootstrap.Build` on postgres DSNs (the app
   refuses to start against a half-migrated schema), and from a new
   `inventario migrate verify` CLI subcommand wired into the
   `inventario-test-migration` compose profile.
3. **Error envelope typo.** `go/apiserver/errors.go:65` "Internal Server
   UserError" → "Internal Server Error". Frontend vitest fixture
   updated to match. New `errors_test.go` regression guard.

## Recovery path for dev/staging DBs

The dev/staging databases created against the previously-stale
migrate-image are missing migrations `1779300000`–`1779600000` and the
`icon` / `description` / `invitee_email` / role-taxonomy columns. After
this PR is merged and the stack rebuilt, pick one:

- **Drop & recreate (acceptable in alpha):**
  `docker compose down -v && docker compose up -d`
- **Manual catch-up against the rebuilt image:**
  `docker compose run --rm inventario-migrate /app/migrate.sh` and then
  `docker compose exec inventario /app/inventario migrate verify` —
  the new verify subcommand exits non-zero if anything was missed.

Either way, `inventario migrate verify` is the post-merge smoke test.

## Test plan

- [x] `go test ./schema/migrations/... ./apiserver/... ./cmd/...` — green.
- [x] `npx vitest run src/lib/__tests__/global-error-toast.test.ts` — 13/13 green.
- [x] New `compareSchemaVersion` unit test covers in-sync / db-behind
      (→ `ErrSchemaLagsBinary`) / db-ahead (→ warn) / zero-zero matrix.
- [x] `errors_test.go` regression guard for the StatusText typo.
- [ ] `make docker-test-go-postgres` (`inventario-test-migration` profile)
      runs `migrate verify` against the rebuilt binary — pending CI.
- [ ] Manual: `docker compose down -v && docker compose up -d` on dev,
      then create a location and an invite; both should succeed.
- [ ] Verify #1652 (sole owner can leave) repro is gone once
      `1779600000` lands; close as duplicate if so.

## Acceptance criteria checklist (from issue body)

- [x] All four compose services reference one shared `image:` tag; only one of them owns the `build:` block.
- [x] Migrator wrapper logs an error (returns `ErrSchemaLagsBinary`) when DB version is behind embed.FS max.
- [x] `errors.go:65` "Internal Server UserError" → "Internal Server Error".
- [x] `inventario-test-migration` profile asserts schema completeness via `migrate verify`.
- [x] Recovery instructions documented above.
- [ ] Verify #1652 repro is gone once `1779600000` lands; close if duplicated by this fix.

## E2E coverage note

The acceptance comment requires Playwright coverage for any *observable
end-to-end* behavior introduced by this work. The three fixes here are:

- **Compose unified image** — implicit; the e2e harness itself runs
  against the rebuilt single image after this lands.
- **Migrator verify / startup refusal** — operator-CLI and process-boot
  behavior, not browser-observable.
- **StatusText typo** — provoked only on real 500s, which the e2e
  suite intentionally doesn't generate. The vitest update in
  `global-error-toast.test.ts` plus the new `errors_test.go` regression
  guard pin the contract on both sides.

Existing specs (`e2e/tests/invite-flow.spec.ts`,
`commodity-simple-crud.spec.ts`, etc.) directly create the entities whose
500s sparked the investigation; they serve as the symptom-level
regression net once the stack is rebuilt under the new compose layout.