### PR TITLE
[#1662 #1660 #1652] Edit-location 422 + Members polish + ≥1-member invariant

### DIFF
--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -654,6 +654,60 @@ test.describe('Leave Group UI — last admin protection (#1259)', () => {
       expect(deleteResp.status()).toBe(204);
     }
   });
+
+  // #1652: even if a client bypasses the disabled "Leave group" button
+  // and hits POST /groups/{id}/leave directly, the BE must reject the
+  // sole-owner leave with 422 (defense-in-depth). The FE-side gate is
+  // covered by the test above; this one pins the API-level invariant.
+  test('POST /groups/{id}/leave rejects the sole owner with 422 (#1652)', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    const groupName = `Sole Owner Leave API ${Date.now()}`;
+    const createResp = await request.post('/api/v1/groups', {
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+        'X-CSRF-Token': csrfToken,
+      },
+      data: { data: { type: 'groups', attributes: { name: groupName, icon: '🛡️' } } },
+    });
+    expect(createResp.status()).toBe(201);
+    const groupId = (await createResp.json()).data.id;
+
+    try {
+      const leaveResp = await request.post(`/api/v1/groups/${groupId}/leave`, {
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+      });
+      // 422 with the ErrLastOwner sentinel; the FE renders the
+      // `leaveLastAdmin` notice for this case. A 204 here would mean
+      // the group is now orphaned (the bug #1652 exists to prevent).
+      expect(leaveResp.status()).toBe(422);
+      const leaveBody = await leaveResp.json();
+      expect(JSON.stringify(leaveBody)).toContain('last owner');
+    } finally {
+      const deleteResp = await request.delete(`/api/v1/groups/${groupId}`, {
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { confirm_word: groupName, password: 'TestPassword123' },
+      });
+      expect(deleteResp.status()).toBe(204);
+    }
+  });
 });
 
 test.describe('Group selection persistence (#1262 / #1300)', () => {

--- a/e2e/tests/includes/locations.ts
+++ b/e2e/tests/includes/locations.ts
@@ -47,6 +47,53 @@ export async function createLocation(
     return locationId;
 }
 
+// Edit an existing location's name + address from the list page.
+// Drives the LocationCard "Edit" affordance (post-#1531 the dropdown
+// holds Add area + Delete but the title <Link> is the canonical
+// detail-page entry; edit lives on the detail header). We navigate to
+// detail, click the header Edit button, fill the dialog and submit.
+// Captures the PUT response so the new attributes are read straight
+// from the wire instead of fishing them back out of the DOM (which
+// flaps under optimistic-update timing).
+export async function editLocationViaDetail(
+    page: Page,
+    recorder: TestRecorder,
+    locationId: string,
+    updated: { name: string; address?: string },
+): Promise<void> {
+    await recorder.takeScreenshot('locations-edit-01-before-edit');
+    await page.locator(`[data-testid="location-card"][data-location-id="${locationId}"] a`).first().click();
+    await page.locator('[data-testid="page-location-detail"]').waitFor({ state: 'visible', timeout: 10000 });
+    await page.locator('[data-testid="location-detail-edit"]').click();
+    await page.locator('[data-testid="location-form-dialog"]').waitFor({ state: 'visible' });
+
+    await page.fill('#location-name', updated.name);
+    if (updated.address !== undefined) {
+        await page.fill('#location-address', updated.address);
+    }
+    await recorder.takeScreenshot('location-edit-02-form-filled');
+
+    const [putResponse] = await Promise.all([
+        page.waitForResponse(
+            (response) =>
+                new URL(response.url()).pathname.endsWith(`/locations/${locationId}`) &&
+                response.request().method() === 'PUT' &&
+                response.status() === 200,
+            { timeout: 30000 },
+        ),
+        page.click('[data-testid="location-form-submit"]'),
+    ]);
+    const body = await putResponse.json();
+    if (body?.data?.attributes?.name !== updated.name) {
+        throw new Error(`editLocationViaDetail: BE returned name "${body?.data?.attributes?.name}", expected "${updated.name}"`);
+    }
+
+    // Dialog closes on success; the detail heading reflects the new name.
+    await page.locator('[data-testid="location-form-dialog"]').waitFor({ state: 'hidden', timeout: 5000 });
+    await expect(page.locator('[data-testid="page-location-detail"] h1')).toContainText(updated.name);
+    await recorder.takeScreenshot('location-edit-03-saved');
+}
+
 export async function deleteLocation(
     page: Page,
     recorder: TestRecorder,

--- a/e2e/tests/locations-crud.spec.ts
+++ b/e2e/tests/locations-crud.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from '@playwright/test';
+
+import { test } from '../fixtures/app-fixture.js';
+import { createLocation, deleteLocation, editLocationViaDetail } from './includes/locations.js';
+import { TO_LOCATIONS, navigateTo } from './includes/navigate.js';
+
+// #1662 regression: the PUT envelope used to omit `data.id`, so the
+// BE id-match check at apiserver/locations.go:229 rejected every edit
+// with a bare 422 (no body the FE could surface). The dialog also
+// silently wiped any inline error when the post-mutation refetch
+// landed a fresh `location` prop reference, so the user saw nothing
+// on the first failed submit. This spec exercises a full
+// create-edit-delete loop and asserts the edit reaches the server
+// with a matching id and updates the rendered heading.
+test.describe('Locations CRUD', () => {
+  test('create → edit → delete a location end-to-end (#1662)', async ({ page, recorder }) => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const initial = {
+      name: `E2E Location ${suffix}`,
+      address: `1 Original Way, Test City`,
+    };
+    const renamed = {
+      name: `E2E Location ${suffix} (renamed)`,
+      address: `2 Updated Way, Test City`,
+    };
+
+    let step = 1;
+    recorder.log(`Step ${step++}: navigating to /locations`);
+    await navigateTo(page, recorder, TO_LOCATIONS);
+
+    recorder.log(`Step ${step++}: creating "${initial.name}"`);
+    const locationId = await createLocation(page, recorder, initial);
+
+    recorder.log(`Step ${step++}: editing via detail header`);
+    await editLocationViaDetail(page, recorder, locationId, renamed);
+
+    // After save we're on /locations/:id; navigate back so deleteLocation's
+    // list-page path applies (the helper auto-detects detail, but the
+    // post-edit detail re-render is the spot where a stale `location`
+    // prop reference used to clobber inline errors — re-asserting the
+    // heading after the navigate guards that the refetch didn't blank the
+    // page either).
+    recorder.log(`Step ${step++}: navigating back to /locations`);
+    await navigateTo(page, recorder, TO_LOCATIONS);
+    await expect(
+      page.locator(`[data-testid="location-card"][data-location-id="${locationId}"]`),
+    ).toContainText(renamed.name);
+
+    recorder.log(`Step ${step++}: deleting "${renamed.name}"`);
+    await deleteLocation(page, recorder, renamed.name, locationId);
+  });
+});

--- a/frontend/src/components/locations/AreaFormDialog.tsx
+++ b/frontend/src/components/locations/AreaFormDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useTranslation } from "react-i18next"
@@ -62,18 +62,36 @@ export function AreaFormDialog({
     },
   })
 
+  // Same shape as LocationFormDialog: reset on the open transition
+  // and on the first prop-change-with-data after open, but never on
+  // later reference changes — that would clobber the user's typing
+  // and clear a freshly-set inline error when the host's optimistic
+  // mutation rolls back and the onSettled refetch lands.
+  const wasOpenRef = useRef(false)
+  const hasPrefilledRef = useRef(false)
   useEffect(() => {
-    // Sync external (open, area) props → form values + serverError state.
-    if (open) {
+    if (open && !wasOpenRef.current) {
       form.reset({
         name: area?.name ?? "",
         location_id: area?.location_id ?? defaultLocationId ?? locations[0]?.id ?? "",
         icon: area?.icon ?? "",
       })
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setServerError(null)
+      // For edit mode the prefill is "done" once we have an `area`;
+      // for create mode there's nothing to wait for, so mark as
+      // prefilled immediately.
+      hasPrefilledRef.current = !!area || !isEdit
+    } else if (open && !hasPrefilledRef.current && area) {
+      form.reset({
+        name: area.name ?? "",
+        location_id: area.location_id ?? defaultLocationId ?? locations[0]?.id ?? "",
+        icon: area.icon ?? "",
+      })
+      hasPrefilledRef.current = true
     }
-  }, [open, area, defaultLocationId, locations, form])
+    if (!open) hasPrefilledRef.current = false
+    wasOpenRef.current = open
+  }, [open, area, defaultLocationId, locations, form, isEdit])
 
   async function handle(values: AreaFormInput) {
     setServerError(null)

--- a/frontend/src/components/locations/AreaFormDialog.tsx
+++ b/frontend/src/components/locations/AreaFormDialog.tsx
@@ -62,35 +62,41 @@ export function AreaFormDialog({
     },
   })
 
-  // Same shape as LocationFormDialog: reset on the open transition
-  // and on the first prop-change-with-data after open, but never on
-  // later reference changes — that would clobber the user's typing
-  // and clear a freshly-set inline error when the host's optimistic
-  // mutation rolls back and the onSettled refetch lands.
+  // Same shape as LocationFormDialog. Three reset triggers:
+  //   1. open false → true.
+  //   2. editing target id changes while open (route-param swap on
+  //      `/areas/:id/edit` reuses the dialog instance).
+  //   3. first prop with data after open (deep-link route mounts
+  //      before useArea resolves).
+  // Same-id reference churn (optimistic patch + rollback + onSettled
+  // refetch) is ignored so the inline error survives. In create mode
+  // there's no target id; we mark "prefilled" on the open transition
+  // so subsequent prop-renders don't reset the user's typing.
   const wasOpenRef = useRef(false)
-  const hasPrefilledRef = useRef(false)
+  const prefilledIdRef = useRef<string | undefined>(undefined)
+  const createPrefilledRef = useRef(false)
   useEffect(() => {
-    if (open && !wasOpenRef.current) {
+    if (!open) {
+      wasOpenRef.current = false
+      prefilledIdRef.current = undefined
+      createPrefilledRef.current = false
+      return
+    }
+    const justOpened = !wasOpenRef.current
+    const targetId = area?.id
+    const targetChanged = targetId !== undefined && targetId !== prefilledIdRef.current
+    const needCreateInit = !isEdit && !createPrefilledRef.current
+    if (justOpened || targetChanged || needCreateInit) {
       form.reset({
         name: area?.name ?? "",
         location_id: area?.location_id ?? defaultLocationId ?? locations[0]?.id ?? "",
         icon: area?.icon ?? "",
       })
       setServerError(null)
-      // For edit mode the prefill is "done" once we have an `area`;
-      // for create mode there's nothing to wait for, so mark as
-      // prefilled immediately.
-      hasPrefilledRef.current = !!area || !isEdit
-    } else if (open && !hasPrefilledRef.current && area) {
-      form.reset({
-        name: area.name ?? "",
-        location_id: area.location_id ?? defaultLocationId ?? locations[0]?.id ?? "",
-        icon: area.icon ?? "",
-      })
-      hasPrefilledRef.current = true
+      if (targetId !== undefined) prefilledIdRef.current = targetId
+      if (!isEdit) createPrefilledRef.current = true
     }
-    if (!open) hasPrefilledRef.current = false
-    wasOpenRef.current = open
+    wasOpenRef.current = true
   }, [open, area, defaultLocationId, locations, form, isEdit])
 
   async function handle(values: AreaFormInput) {

--- a/frontend/src/components/locations/LocationFormDialog.tsx
+++ b/frontend/src/components/locations/LocationFormDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useTranslation } from "react-i18next"
@@ -58,21 +58,44 @@ export function LocationFormDialog({
     defaultValues: { name: "", address: "", icon: "", description: "" },
   })
 
-  // Reset the form whenever the dialog reopens or the editing target
-  // changes — without this, opening the dialog after editing one
-  // location would prefill with the previous location's name.
+  // Reset/prefill is split into "open transition" + "first prop with
+  // data after open" so a refetch mid-edit can't wipe a freshly-set
+  // `serverError` (the catch in `handle` runs after the mutation
+  // rolls back; the previous version's effect cleared the alert when
+  // the onSettled refetch handed back a new `location` reference,
+  // even with identical content). Both refs are seeded false so the
+  // /locations/:id/edit deep-link path — which mounts with open=true
+  // and `location` still resolving — still prefills once the query
+  // lands.
+  const wasOpenRef = useRef(false)
+  const hasPrefilledRef = useRef(false)
   useEffect(() => {
-    // Sync external (open, location) props → form values + serverError.
-    if (open) {
+    if (open && !wasOpenRef.current) {
+      // True open transition (false → true). Full reset.
       form.reset({
         name: location?.name ?? "",
         address: location?.address ?? "",
         icon: location?.icon ?? "",
         description: location?.description ?? "",
       })
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setServerError(null)
+      hasPrefilledRef.current = !!location
+    } else if (open && !hasPrefilledRef.current && location) {
+      // Still-open, first time the location data is non-null. Used by
+      // the deep-link route where the dialog mounts before useLocation
+      // resolves. Prefill ONLY this once — later prop-reference
+      // changes (optimistic update + rollback + onSettled refetch)
+      // are inert.
+      form.reset({
+        name: location.name ?? "",
+        address: location.address ?? "",
+        icon: location.icon ?? "",
+        description: location.description ?? "",
+      })
+      hasPrefilledRef.current = true
     }
+    if (!open) hasPrefilledRef.current = false
+    wasOpenRef.current = open
   }, [open, location, form])
 
   async function handle(values: LocationFormInput) {

--- a/frontend/src/components/locations/LocationFormDialog.tsx
+++ b/frontend/src/components/locations/LocationFormDialog.tsx
@@ -58,20 +58,30 @@ export function LocationFormDialog({
     defaultValues: { name: "", address: "", icon: "", description: "" },
   })
 
-  // Reset/prefill is split into "open transition" + "first prop with
-  // data after open" so a refetch mid-edit can't wipe a freshly-set
-  // `serverError` (the catch in `handle` runs after the mutation
-  // rolls back; the previous version's effect cleared the alert when
-  // the onSettled refetch handed back a new `location` reference,
-  // even with identical content). Both refs are seeded false so the
-  // /locations/:id/edit deep-link path — which mounts with open=true
-  // and `location` still resolving — still prefills once the query
-  // lands.
+  // Reset/prefill fires on three triggers and three triggers only:
+  //   1. open transitions false → true (typical open + clear stale error).
+  //   2. the editing target id changes while the dialog stays open
+  //      (deep-link navigation between `/locations/:id/edit` routes;
+  //      LocationDetailPage keeps the same component instance when
+  //      :id changes, so the dialog persists and we have to notice).
+  //   3. the first `location` prop with data arrives after open
+  //      (deep-link route mounts with open=true but the useLocation
+  //      query still resolving — we prefill once it lands).
+  // Refetch-induced reference churn for the SAME id is ignored, so
+  // the catch in `handle` can set `serverError` and the refetch
+  // doesn't wipe the inline alert (the original #1662 bug).
   const wasOpenRef = useRef(false)
-  const hasPrefilledRef = useRef(false)
+  const prefilledIdRef = useRef<string | undefined>(undefined)
   useEffect(() => {
-    if (open && !wasOpenRef.current) {
-      // True open transition (false → true). Full reset.
+    if (!open) {
+      wasOpenRef.current = false
+      prefilledIdRef.current = undefined
+      return
+    }
+    const justOpened = !wasOpenRef.current
+    const targetId = location?.id
+    const targetChanged = targetId !== undefined && targetId !== prefilledIdRef.current
+    if (justOpened || targetChanged) {
       form.reset({
         name: location?.name ?? "",
         address: location?.address ?? "",
@@ -79,23 +89,9 @@ export function LocationFormDialog({
         description: location?.description ?? "",
       })
       setServerError(null)
-      hasPrefilledRef.current = !!location
-    } else if (open && !hasPrefilledRef.current && location) {
-      // Still-open, first time the location data is non-null. Used by
-      // the deep-link route where the dialog mounts before useLocation
-      // resolves. Prefill ONLY this once — later prop-reference
-      // changes (optimistic update + rollback + onSettled refetch)
-      // are inert.
-      form.reset({
-        name: location.name ?? "",
-        address: location.address ?? "",
-        icon: location.icon ?? "",
-        description: location.description ?? "",
-      })
-      hasPrefilledRef.current = true
+      prefilledIdRef.current = targetId ?? prefilledIdRef.current
     }
-    if (!open) hasPrefilledRef.current = false
-    wasOpenRef.current = open
+    wasOpenRef.current = true
   }, [open, location, form])
 
   async function handle(values: LocationFormInput) {

--- a/frontend/src/components/locations/__tests__/LocationFormDialog.test.tsx
+++ b/frontend/src/components/locations/__tests__/LocationFormDialog.test.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from "react"
+import { beforeEach, describe, expect, it } from "vitest"
+import { act, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { LocationFormDialog } from "@/components/locations/LocationFormDialog"
+import { renderWithProviders } from "@/test/render"
+import type { Location } from "@/features/locations/api"
+
+// Direct-mount tests for LocationFormDialog. The host pages
+// (LocationsListPage / LocationDetailPage) wire the dialog into
+// useLocation/useUpdateLocation; here we exercise the dialog as a
+// pure component so the reset/prefill behavior is exercised without
+// staging an entire mutation cycle. See #1662 for the inline-error
+// race the reset logic exists to fix, and the Copilot review on
+// PR #1666 for the deep-link-:id-change case the "swaps form
+// contents …" test pins down.
+
+interface Controls {
+  setLocation: (loc: Location | null | undefined) => void
+}
+
+// Renders the dialog with a host that exposes setState through a
+// `bind` callback. Direct buttons would trip Radix Dialog's
+// outside-click handler and close the modal; the imperative
+// setState path lets the test mutate `location` without simulating
+// a click outside the modal.
+function ControlledHost({
+  initialLocation,
+  bind,
+}: {
+  initialLocation: Location | null | undefined
+  bind: (c: Controls) => void
+}) {
+  const [loc, setLoc] = useState<Location | null | undefined>(initialLocation)
+  useEffect(() => {
+    bind({ setLocation: setLoc })
+  }, [bind])
+  return (
+    <LocationFormDialog
+      open
+      onOpenChange={() => undefined}
+      location={loc}
+      onSubmit={async () => undefined}
+    />
+  )
+}
+
+beforeEach(() => {
+  // Cleanup happens implicitly via React Testing Library's
+  // auto-cleanup; no shared mutable state to reset here.
+})
+
+describe("<LocationFormDialog />", () => {
+  it("prefills from the location prop on mount", async () => {
+    renderWithProviders({
+      children: (
+        <ControlledHost
+          initialLocation={{
+            id: "loc-a",
+            name: "Alpha",
+            address: "Alpha St",
+            icon: "🅰️",
+            description: "alpha desc",
+          }}
+          bind={() => undefined}
+        />
+      ),
+    })
+    const nameInput = await screen.findByTestId("location-name-input")
+    await waitFor(() => expect(nameInput).toHaveValue("Alpha"))
+    expect(screen.getByTestId("location-address-input")).toHaveValue("Alpha St")
+  })
+
+  it("resets to the new location when `id` changes while the dialog stays open (#1666 Copilot review)", async () => {
+    const user = userEvent.setup()
+    let controls: Controls | null = null
+    renderWithProviders({
+      children: (
+        <ControlledHost
+          initialLocation={{
+            id: "loc-a",
+            name: "Alpha",
+            address: "Alpha St",
+            icon: "🅰️",
+            description: "",
+          }}
+          bind={(c) => {
+            controls = c
+          }}
+        />
+      ),
+    })
+    const nameInput = await screen.findByTestId("location-name-input")
+    await waitFor(() => expect(nameInput).toHaveValue("Alpha"))
+    // User types something; without the id-change reset that would
+    // ride along with the saved data into the next location.
+    await user.type(nameInput, " edited")
+    expect(nameInput).toHaveValue("Alpha edited")
+    // Deep-link nav to /locations/loc-b/edit: same dialog instance,
+    // different `location.id`. The form MUST reset to loc-b's
+    // values — saving as-is would send loc-a's typed name to
+    // /locations/loc-b which is a real data-corruption foot-gun.
+    act(() => {
+      controls!.setLocation({
+        id: "loc-b",
+        name: "Beta",
+        address: "Beta Ave",
+        icon: "🅱️",
+        description: "",
+      })
+    })
+    await waitFor(() => expect(nameInput).toHaveValue("Beta"))
+    expect(screen.getByTestId("location-address-input")).toHaveValue("Beta Ave")
+  })
+
+  it("does NOT reset on a same-id reference change (preserves typing + inline error)", async () => {
+    const user = userEvent.setup()
+    let controls: Controls | null = null
+    const initial: Location = {
+      id: "loc-a",
+      name: "Alpha",
+      address: "",
+      icon: "",
+      description: "",
+    }
+    renderWithProviders({
+      children: (
+        <ControlledHost
+          initialLocation={initial}
+          bind={(c) => {
+            controls = c
+          }}
+        />
+      ),
+    })
+    const nameInput = await screen.findByTestId("location-name-input")
+    await waitFor(() => expect(nameInput).toHaveValue("Alpha"))
+    await user.clear(nameInput)
+    await user.type(nameInput, "Mid-edit")
+    expect(nameInput).toHaveValue("Mid-edit")
+    // Same id, fresh ref — models the optimistic-update /
+    // onSettled-refetch reference churn that previously wiped the
+    // user's typing (and the inline serverError) on every render.
+    act(() => {
+      controls!.setLocation({ ...initial })
+    })
+    // Tick once for the effect to run; nameInput must still hold
+    // the typed-but-unsaved value.
+    await Promise.resolve()
+    expect(nameInput).toHaveValue("Mid-edit")
+  })
+})

--- a/frontend/src/features/areas/api.ts
+++ b/frontend/src/features/areas/api.ts
@@ -75,7 +75,13 @@ export interface UpdateAreaRequest {
 }
 
 export async function updateArea(id: string, req: UpdateAreaRequest): Promise<Area> {
-  const body = await http.put<AreaResponse>(`/areas/${encodeURIComponent(id)}`, envelope(req))
+  // BE rejects PUTs whose body's `data.id` doesn't match the URL id
+  // (apiserver/areas.go:212). The shared `envelope()` helper omits
+  // `id` because create-time we don't know it yet; splice it in here
+  // for update. Same pattern as commodities + locations.
+  const body = await http.put<AreaResponse>(`/areas/${encodeURIComponent(id)}`, {
+    data: { ...envelope(req).data, id },
+  })
   if (!body.data?.attributes) {
     throw new Error("Update-area response missing data.attributes")
   }

--- a/frontend/src/features/locations/api.ts
+++ b/frontend/src/features/locations/api.ts
@@ -80,10 +80,14 @@ export interface UpdateLocationRequest {
 }
 
 export async function updateLocation(id: string, req: UpdateLocationRequest): Promise<Location> {
-  const body = await http.put<LocationResponse>(
-    `/locations/${encodeURIComponent(id)}`,
-    envelope(req)
-  )
+  // BE rejects PUTs whose body's `data.id` doesn't match the URL id —
+  // mirroring the JSON:API contract that callers identify the resource
+  // both ways (apiserver/locations.go:229). The shared `envelope()`
+  // helper omits `id` because create-time we don't know it yet; for
+  // update we splice it in here. Same pattern as commodities.
+  const body = await http.put<LocationResponse>(`/locations/${encodeURIComponent(id)}`, {
+    data: { ...envelope(req).data, id },
+  })
   if (!body.data?.attributes) {
     throw new Error("Update-location response missing data.attributes")
   }

--- a/frontend/src/i18n/locales/en/groups.json
+++ b/frontend/src/i18n/locales/en/groups.json
@@ -91,6 +91,7 @@
     "leaveError": "Couldn't leave the group.",
     "leaveLastAdmin": "You are the last owner of this group. Promote another member to owner before leaving — or delete the group below.",
     "leaveLastAdminTitle": "You are the last owner. Promote another member first, or delete the group.",
+    "leaveLastMember": "You're the last member of this group. Delete the group instead — leaving would orphan it with no one able to administer or remove it.",
     "leaveSuccess": "You left the group.",
     "leaveTitle": "Leave group",
     "membersLink": "Members",

--- a/frontend/src/pages/groups/GroupSettingsPage.tsx
+++ b/frontend/src/pages/groups/GroupSettingsPage.tsx
@@ -60,7 +60,7 @@ import {
 } from "@/features/group/schemas"
 import { useAppToast } from "@/hooks/useAppToast"
 import { HttpError } from "@/lib/http"
-import { parseServerError } from "@/lib/server-error"
+import { getServerErrorCode, parseServerError } from "@/lib/server-error"
 import { cn } from "@/lib/utils"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 
@@ -516,6 +516,18 @@ function MembersSection({
       toast.success(t("groups:settings.leaveSuccess"))
       navigate("/no-group")
     } catch (err) {
+      // #1652: distinct copy for the ≥1-member invariant. Without
+      // the code-match the toast collapses to the generic
+      // "Couldn't leave" path, which hides the actionable hint
+      // ("delete the group instead"). leaveLastAdmin already covers
+      // the sole-owner case via the disabled button + inline notice
+      // above, but we still surface a specific toast for the rare
+      // race where the gate is bypassed (membership query loading,
+      // role-data drift, etc.).
+      if (getServerErrorCode(err) === "group.last_member") {
+        toast.error(t("groups:settings.leaveLastMember"))
+        return
+      }
       toast.error(parseServerError(err, t("groups:settings.leaveError")))
     }
   }

--- a/frontend/src/pages/groups/MembersPage.tsx
+++ b/frontend/src/pages/groups/MembersPage.tsx
@@ -131,10 +131,7 @@ export function MembersPage() {
   return (
     <>
       <RouteTitle title={t("members:title")} />
-      <div
-        className="mx-auto flex w-full max-w-3xl flex-col gap-8 p-6"
-        data-testid="members-page"
-      >
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 p-6" data-testid="members-page">
         <header className="flex items-start justify-between gap-3">
           <div>
             <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">

--- a/frontend/src/pages/groups/MembersPage.tsx
+++ b/frontend/src/pages/groups/MembersPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ElementType } from "react"
 import { useTranslation } from "react-i18next"
-import { Link } from "react-router-dom"
 import {
   Check,
   Clock,
@@ -9,7 +8,6 @@ import {
   Eye,
   Mail,
   MoreHorizontal,
-  Settings,
   Shield,
   Trash2,
   User as UserIcon,
@@ -133,10 +131,15 @@ export function MembersPage() {
   return (
     <>
       <RouteTitle title={t("members:title")} />
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-8" data-testid="members-page">
+      <div
+        className="mx-auto flex w-full max-w-3xl flex-col gap-8 p-6"
+        data-testid="members-page"
+      >
         <header className="flex items-start justify-between gap-3">
           <div>
-            <h1 className="text-2xl font-semibold tracking-tight">{t("members:title")}</h1>
+            <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">
+              {t("members:title")}
+            </h1>
             <p className="text-sm text-muted-foreground">
               {t("members:subtitle")}
               {currentGroup?.name ? (
@@ -148,6 +151,12 @@ export function MembersPage() {
             </p>
           </div>
           <div className="flex items-center gap-2 shrink-0">
+            {/* #1660: the Group-settings shortcut button was dropped —
+                the same destination is reachable from the sidebar's
+                Manage › Group settings row and the GroupSelector's
+                shortcut, so duplicating it here added noise without
+                reachability. Invite stays as the sole header CTA, in
+                parity with design-mocks/src/views/MembersView.tsx. */}
             {canManageMembers ? (
               <Button
                 type="button"
@@ -158,17 +167,6 @@ export function MembersPage() {
               >
                 <UserPlus className="size-3.5" aria-hidden="true" />
                 {t("members:invite.cta")}
-              </Button>
-            ) : null}
-            {canManageMembers && currentGroup?.id ? (
-              <Button asChild variant="outline" size="sm" className="gap-1.5">
-                <Link
-                  to={`/groups/${encodeURIComponent(currentGroup.id)}/settings`}
-                  data-testid="members-group-settings-link"
-                >
-                  <Settings className="size-3.5" aria-hidden="true" />
-                  {t("groups:settings.title")}
-                </Link>
               </Button>
             ) : null}
           </div>
@@ -620,7 +618,7 @@ function PendingInvitesSection({
 
   return (
     <section className="space-y-3" data-testid="invites-section">
-      <h2 className="text-sm font-semibold">{t("members:invites.title")}</h2>
+      <h2 className="text-base font-semibold">{t("members:invites.title")}</h2>
       {isLoading ? (
         <p className="text-sm text-muted-foreground">{t("members:invites.title")}…</p>
       ) : isError ? (

--- a/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
+++ b/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
@@ -243,6 +243,13 @@ describe("<LocationDetailPage />", () => {
     )
     renderDetail(`/g/${SLUG}/locations/loc1`, { initialMode: "edit" })
     await screen.findByTestId("location-form-dialog")
+    // The dialog mounts with empty form defaults; `name` is required
+    // by the zod schema, so clicking submit before the location
+    // query lands would be stopped by RHF validation and never issue
+    // the PUT (Copilot review on #1666). Wait for the prefill to
+    // land before driving the submit.
+    const nameInput = await screen.findByTestId("location-name-input")
+    await waitFor(() => expect(nameInput).toHaveValue("Main House"))
     const submit = screen.getByTestId("location-form-submit")
     await user.click(submit)
     const alert = await screen.findByTestId("location-form-server-error")
@@ -251,9 +258,7 @@ describe("<LocationDetailPage />", () => {
     // must also surface — the alert sticks across re-renders.
     await user.click(submit)
     await waitFor(() => expect(putCount).toBe(2))
-    expect(screen.getByTestId("location-form-server-error")).toHaveTextContent(
-      "Name already taken"
-    )
+    expect(screen.getByTestId("location-form-server-error")).toHaveTextContent("Name already taken")
   })
 
   it("sends `data.id` on the edit PUT envelope so the BE id-match check passes (#1662)", async () => {
@@ -276,6 +281,10 @@ describe("<LocationDetailPage />", () => {
     renderDetail(`/g/${SLUG}/locations/loc1`, { initialMode: "edit" })
     await screen.findByTestId("location-form-dialog")
     const nameInput = await screen.findByTestId("location-name-input")
+    // Wait for the prefill so user.clear / user.type aren't racing
+    // the location-query-resolves prefill effect (which would
+    // otherwise clobber "Renamed" with "Main House" mid-typing).
+    await waitFor(() => expect(nameInput).toHaveValue("Main House"))
     await user.clear(nameInput)
     await user.type(nameInput, "Renamed")
     await user.click(screen.getByTestId("location-form-submit"))

--- a/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
+++ b/frontend/src/pages/locations/__tests__/LocationDetailPage.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest"
 import { Route } from "react-router-dom"
 import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { http, HttpResponse } from "msw"
 
 import { LocationDetailPage } from "@/pages/locations/LocationDetailPage"
 import { GroupProvider } from "@/features/group/GroupContext"
@@ -9,6 +10,7 @@ import { ConfirmProvider } from "@/hooks/useConfirm"
 import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
 import {
+  apiUrl,
   areaHandlers,
   commodityHandlers,
   fileHandlers,
@@ -216,6 +218,68 @@ describe("<LocationDetailPage />", () => {
     expect(
       await screen.findByRole("heading", { name: /attach files to garage/i })
     ).toBeInTheDocument()
+  })
+
+  it("surfaces the BE detail when the edit PUT 422s and keeps the alert across the onSettled refetch (#1662)", async () => {
+    const user = userEvent.setup()
+    let putCount = 0
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.detail(SLUG, "loc1", locationResource("loc1", { name: "Main House" })),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Main House" })]),
+      ...areaHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, []),
+      // BE returns a JSON:API 422 with a real `detail`; the dialog
+      // must surface that string and keep it visible after the
+      // post-mutation refetch lands (the previous race wiped it via
+      // the dialog's reset-on-`location`-prop-change effect).
+      http.put(apiUrl(`/g/${SLUG}/locations/loc1`), () => {
+        putCount += 1
+        return HttpResponse.json(
+          { errors: [{ status: "422", detail: "Name already taken" }] },
+          { status: 422 }
+        )
+      })
+    )
+    renderDetail(`/g/${SLUG}/locations/loc1`, { initialMode: "edit" })
+    await screen.findByTestId("location-form-dialog")
+    const submit = screen.getByTestId("location-form-submit")
+    await user.click(submit)
+    const alert = await screen.findByTestId("location-form-server-error")
+    expect(alert).toHaveTextContent("Name already taken")
+    // First-submit must already toast/inline-render. Second submit
+    // must also surface — the alert sticks across re-renders.
+    await user.click(submit)
+    await waitFor(() => expect(putCount).toBe(2))
+    expect(screen.getByTestId("location-form-server-error")).toHaveTextContent(
+      "Name already taken"
+    )
+  })
+
+  it("sends `data.id` on the edit PUT envelope so the BE id-match check passes (#1662)", async () => {
+    const user = userEvent.setup()
+    let observedDataId: unknown = undefined
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.detail(SLUG, "loc1", locationResource("loc1", { name: "Main House" })),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Main House" })]),
+      ...areaHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, []),
+      http.put(apiUrl(`/g/${SLUG}/locations/loc1`), async ({ request }) => {
+        const body = (await request.json()) as { data?: { id?: string } }
+        observedDataId = body.data?.id
+        return HttpResponse.json({
+          data: locationResource("loc1", { name: "Renamed" }),
+        })
+      })
+    )
+    renderDetail(`/g/${SLUG}/locations/loc1`, { initialMode: "edit" })
+    await screen.findByTestId("location-form-dialog")
+    const nameInput = await screen.findByTestId("location-name-input")
+    await user.clear(nameInput)
+    await user.type(nameInput, "Renamed")
+    await user.click(screen.getByTestId("location-form-submit"))
+    await waitFor(() => expect(observedDataId).toBe("loc1"))
   })
 
   it("shows the drop overlay while files are dragged over the location detail page (#1448)", async () => {

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -320,6 +320,10 @@ func (m *mockGroupMembershipRegistryForAuth) DeleteWithMemberInvariants(_ contex
 	return nil
 }
 
+func (m *mockGroupMembershipRegistryForAuth) UpdateRoleWithMemberInvariants(_ context.Context, _ string, _ models.GroupRole) (*models.GroupMembership, error) {
+	return nil, nil
+}
+
 // erroringGroupMembershipRegistry is a minimal GroupMembershipRegistry whose
 // GetByGroupAndUser always returns a caller-supplied error. Used to exercise
 // the "registry error ≠ ErrNotFound" branch that must surface as 500.
@@ -385,6 +389,10 @@ func (m *erroringGroupMembershipRegistry) CreateUnderCap(_ context.Context, _ mo
 
 func (m *erroringGroupMembershipRegistry) DeleteWithMemberInvariants(_ context.Context, _ string) error {
 	return m.err
+}
+
+func (m *erroringGroupMembershipRegistry) UpdateRoleWithMemberInvariants(_ context.Context, _ string, _ models.GroupRole) (*models.GroupMembership, error) {
+	return nil, m.err
 }
 
 func TestAuthAPI_Login(t *testing.T) {

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -316,6 +316,10 @@ func (m *mockGroupMembershipRegistryForAuth) CreateUnderCap(_ context.Context, _
 	return nil, false, nil
 }
 
+func (m *mockGroupMembershipRegistryForAuth) DeleteWithMemberInvariants(_ context.Context, _ string) error {
+	return nil
+}
+
 // erroringGroupMembershipRegistry is a minimal GroupMembershipRegistry whose
 // GetByGroupAndUser always returns a caller-supplied error. Used to exercise
 // the "registry error ≠ ErrNotFound" branch that must surface as 500.
@@ -377,6 +381,10 @@ func (m *erroringGroupMembershipRegistry) ListByGroupWithUsers(_ context.Context
 
 func (m *erroringGroupMembershipRegistry) CreateUnderCap(_ context.Context, _ models.GroupMembership, _ int) (*models.GroupMembership, bool, error) {
 	return nil, false, m.err
+}
+
+func (m *erroringGroupMembershipRegistry) DeleteWithMemberInvariants(_ context.Context, _ string) error {
+	return m.err
 }
 
 func TestAuthAPI_Login(t *testing.T) {

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -120,6 +120,19 @@ func toJSONAPIError(err error) jsonapi.Error {
 		// ErrLastOwner; ErrLastAdmin stays for backwards compatibility
 		// with any caller that hasn't migrated.
 		return NewUnprocessableEntityError(err)
+	case errors.Is(err, services.ErrLastMember):
+		// #1652 defense-in-depth: removing the last member of any role
+		// is rejected even when the owner check would pass vacuously.
+		// 422 mirrors ErrLastOwner; the JSON:API `code` lets the FE
+		// surface distinct copy ("delete the group instead") instead
+		// of muddling it with the "last owner — transfer first" path.
+		return jsonapi.Error{
+			Err:            err,
+			UserError:      errormarshal.Marshal(err),
+			HTTPStatusCode: http.StatusUnprocessableEntity,
+			StatusText:     "Unprocessable Entity",
+			Code:           "group.last_member",
+		}
 	case errors.Is(err, services.ErrInviteNotByEmail):
 		// Resending a legacy token-only invite (no captured email)
 		// is a business-rule violation: 422, not 500.

--- a/go/registry/errors.go
+++ b/go/registry/errors.go
@@ -87,4 +87,21 @@ var (
 	// ErrPreviewTokenExpired signals that the preview token's embedded
 	// expiry is in the past. Maps to 409 currency_migration.preview_expired.
 	ErrPreviewTokenExpired = errx.NewSentinel("preview token expired")
+
+	// ErrLastOwner signals that DeleteWithMemberInvariants refused to
+	// remove the only owner row in a group. Mirrors the user-facing
+	// invariant in services.ErrLastOwner (which wraps this on its way
+	// to the handler). Living at the registry layer lets the
+	// transactional delete path return it directly from under the
+	// per-group lock without re-classifying through the service.
+	// #1652.
+	ErrLastOwner = errx.NewSentinel("cannot remove the last owner from a group")
+
+	// ErrLastMember signals that DeleteWithMemberInvariants refused to
+	// drop the group to zero memberships. Defense-in-depth companion
+	// to ErrLastOwner: even if the role taxonomy ever drifts and the
+	// owner check passes vacuously (e.g. the leaving user lands in a
+	// non-owner role on a single-member group), the member-count
+	// invariant still blocks the leave. #1652.
+	ErrLastMember = errx.NewSentinel("cannot remove the last member from a group")
 )

--- a/go/registry/memory/group_memberships.go
+++ b/go/registry/memory/group_memberships.go
@@ -218,6 +218,45 @@ func (r *GroupMembershipRegistry) DeleteWithMemberInvariants(_ context.Context, 
 	return nil
 }
 
+// UpdateRoleWithMemberInvariants shares the same write lock as
+// DeleteWithMemberInvariants so a concurrent leave + owner-demotion
+// pair can no longer both observe ownerCount=2 and both commit —
+// they serialize under the registry's mutex (#1652). Postgres uses
+// the same pg_advisory_xact_lock key for the same effect.
+func (r *GroupMembershipRegistry) UpdateRoleWithMemberInvariants(_ context.Context, membershipID string, newRole models.GroupRole) (*models.GroupMembership, error) {
+	if membershipID == "" {
+		return nil, registry.ErrFieldRequired
+	}
+	if err := newRole.Validate(); err != nil {
+		return nil, registry.ErrFieldRequired
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	target, ok := r.items.Get(membershipID)
+	if !ok {
+		return nil, registry.ErrNotFound
+	}
+
+	if target.Role == models.GroupRoleOwner && newRole != models.GroupRoleOwner {
+		ownerCount := 0
+		for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+			m := pair.Value
+			if m.GroupID == target.GroupID && m.Role == models.GroupRoleOwner {
+				ownerCount++
+			}
+		}
+		if ownerCount <= 1 {
+			return nil, registry.ErrLastOwner
+		}
+	}
+
+	target.Role = newRole
+	out := *target
+	return &out, nil
+}
+
 func (r *GroupMembershipRegistry) CountOwnersByGroup(_ context.Context, groupID string) (int, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()

--- a/go/registry/memory/group_memberships.go
+++ b/go/registry/memory/group_memberships.go
@@ -169,6 +169,55 @@ func (r *GroupMembershipRegistry) CountAdminsByGroup(_ context.Context, groupID 
 	return count, nil
 }
 
+// DeleteWithMemberInvariants atomically counts the group's
+// memberships, enforces the two ≥1-owner / ≥1-member invariants, and
+// deletes the row — all under the embedded Registry's write lock
+// (#1652). The lock is the in-memory equivalent of the postgres
+// per-group advisory lock: two goroutines calling this for the same
+// group serialize, so a race where both pass the count check and
+// both delete is impossible.
+func (r *GroupMembershipRegistry) DeleteWithMemberInvariants(_ context.Context, membershipID string) error {
+	if membershipID == "" {
+		return registry.ErrFieldRequired
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	target, ok := r.items.Get(membershipID)
+	if !ok {
+		return registry.ErrNotFound
+	}
+
+	groupID := target.GroupID
+	memberCount := 0
+	ownerCount := 0
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		m := pair.Value
+		if m.GroupID != groupID {
+			continue
+		}
+		memberCount++
+		if m.Role == models.GroupRoleOwner {
+			ownerCount++
+		}
+	}
+
+	// Owner-first ordering so a sole-owner self-leave surfaces the
+	// more specific ErrLastOwner ("transfer ownership first"); the
+	// member-count fallback only fires when the owner check passes
+	// vacuously (role data drift on a single-member group).
+	if target.Role == models.GroupRoleOwner && ownerCount <= 1 {
+		return registry.ErrLastOwner
+	}
+	if memberCount <= 1 {
+		return registry.ErrLastMember
+	}
+
+	r.items.Delete(membershipID)
+	return nil
+}
+
 func (r *GroupMembershipRegistry) CountOwnersByGroup(_ context.Context, groupID string) (int, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()

--- a/go/registry/postgres/group_memberships.go
+++ b/go/registry/postgres/group_memberships.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"time"
@@ -391,6 +392,126 @@ func (r *GroupMembershipRegistry) CountOwnersByGroup(ctx context.Context, groupI
 		return 0, errxtrace.Wrap("failed to count owners by group", err)
 	}
 	return count, nil
+}
+
+// DeleteWithMemberInvariants atomically removes a membership while
+// two transactional invariants are enforced under a per-group
+// advisory lock (#1652). The lock serializes concurrent leaves
+// against the same group so two members on a two-row group cannot
+// both pass the count check and both delete (the count(*) under the
+// advisory lock acts as the FOR UPDATE the AC asks for, without
+// pulling every membership row into memory only to lock them). If
+// the row's role is owner and removing it would drop the owner count
+// to zero, ErrLastOwner is returned without touching the row; if
+// removing it would drop the total membership count to zero,
+// ErrLastMember is returned (defense-in-depth — catches the case
+// where role data has drifted so the owner check passes vacuously).
+// Returns ErrNotFound if no row with the given id exists.
+func (r *GroupMembershipRegistry) DeleteWithMemberInvariants(ctx context.Context, membershipID string) error {
+	if membershipID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// Look up the row first so we know the group_id we need to
+		// lock on. The lookup runs before the lock acquisition — that
+		// is OK because the lock scopes the count+delete, not the
+		// initial existence check; if the row vanishes between the
+		// SELECT and the DELETE the DELETE returns 0 rows and we
+		// surface ErrNotFound below.
+		var found struct {
+			GroupID string `db:"group_id"`
+			Role    string `db:"role"`
+		}
+		lookup := fmt.Sprintf(`SELECT group_id, role FROM %s WHERE id = $1`, r.tableNames.GroupMemberships())
+		if scanErr := tx.QueryRowxContext(ctx, lookup, membershipID).StructScan(&found); scanErr != nil {
+			if errors.Is(scanErr, sql.ErrNoRows) {
+				return errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
+					"entity_type", "GroupMembership",
+					"entity_id", membershipID,
+				))
+			}
+			return errxtrace.Wrap("failed to look up membership for invariant-checked delete", scanErr)
+		}
+
+		// Per-group advisory lock: hashtext(group_id) keys the lock so
+		// concurrent leaves against different groups don't block each
+		// other, but two leaves against the same group serialize. The
+		// lock is xact-scoped (released on COMMIT/ROLLBACK) so the
+		// surrounding tx controls its lifetime.
+		if _, lockErr := tx.ExecContext(ctx,
+			`SELECT pg_advisory_xact_lock(hashtext('group_membership_leave'), hashtext($1))`,
+			found.GroupID,
+		); lockErr != nil {
+			return errxtrace.Wrap("failed to acquire per-group leave lock", lockErr)
+		}
+
+		// Invariant A — ≥1 owner. Checked first so a sole-owner self-
+		// leave (which is also a sole-member leave) surfaces the more
+		// specific ErrLastOwner — the FE renders a "transfer
+		// ownership first" path that's directly actionable. The
+		// member-count fallback only fires when the owner check
+		// passes vacuously (role data drift; defense-in-depth).
+		if found.Role == string(models.GroupRoleOwner) {
+			var ownerCount int
+			countOwners := fmt.Sprintf(
+				`SELECT COUNT(*) FROM %s WHERE group_id = $1 AND role = $2`,
+				r.tableNames.GroupMemberships(),
+			)
+			if scanErr := tx.QueryRowContext(ctx, countOwners, found.GroupID, string(models.GroupRoleOwner)).Scan(&ownerCount); scanErr != nil {
+				return errxtrace.Wrap("failed to count owners under leave lock", scanErr)
+			}
+			if ownerCount <= 1 {
+				return errxtrace.Classify(registry.ErrLastOwner, errx.Attrs(
+					"group_id", found.GroupID,
+				))
+			}
+		}
+
+		// Invariant B — ≥1 member. Count under the lock so a
+		// concurrent leave can't drop the total from 2 → 0.
+		var memberCount int
+		countMembers := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE group_id = $1`, r.tableNames.GroupMemberships())
+		if scanErr := tx.QueryRowContext(ctx, countMembers, found.GroupID).Scan(&memberCount); scanErr != nil {
+			return errxtrace.Wrap("failed to count group memberships under leave lock", scanErr)
+		}
+		if memberCount <= 1 {
+			return errxtrace.Classify(registry.ErrLastMember, errx.Attrs(
+				"group_id", found.GroupID,
+			))
+		}
+
+		del := fmt.Sprintf(`DELETE FROM %s WHERE id = $1`, r.tableNames.GroupMemberships())
+		res, delErr := tx.ExecContext(ctx, del, membershipID)
+		if delErr != nil {
+			return errxtrace.Wrap("failed to delete membership under leave lock", delErr)
+		}
+		affected, raErr := res.RowsAffected()
+		if raErr != nil {
+			return errxtrace.Wrap("failed to read rows-affected", raErr)
+		}
+		if affected == 0 {
+			// Raced with another leave / delete; the row is gone.
+			return errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
+				"entity_type", "GroupMembership",
+				"entity_id", membershipID,
+			))
+		}
+		return nil
+	})
+	if err != nil {
+		// Pass-through the classified sentinels so callers can
+		// errors.Is them; wrap only genuinely-unexpected paths.
+		if errors.Is(err, registry.ErrLastOwner) ||
+			errors.Is(err, registry.ErrLastMember) ||
+			errors.Is(err, registry.ErrNotFound) ||
+			errors.Is(err, registry.ErrFieldRequired) {
+			return err
+		}
+		return errxtrace.Wrap("failed to delete membership with invariants", err)
+	}
+	return nil
 }
 
 // ListByGroupWithUsers joins group_memberships with users so the

--- a/go/registry/postgres/group_memberships.go
+++ b/go/registry/postgres/group_memberships.go
@@ -514,6 +514,91 @@ func (r *GroupMembershipRegistry) DeleteWithMemberInvariants(ctx context.Context
 	return nil
 }
 
+// UpdateRoleWithMemberInvariants atomically swaps the row's role
+// under the SAME per-group advisory lock key DeleteWithMemberInvariants
+// uses (#1652). Without sharing the key, a concurrent leave +
+// owner-demotion pair could both observe ownerCount=2 before either
+// committed and both commit — leaving the group with zero owners.
+// With it the second op (whichever wins the lock second) sees the
+// first op's effect and bails out with ErrLastOwner.
+func (r *GroupMembershipRegistry) UpdateRoleWithMemberInvariants(ctx context.Context, membershipID string, newRole models.GroupRole) (*models.GroupMembership, error) {
+	if membershipID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+	if err := newRole.Validate(); err != nil {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Role"))
+	}
+
+	var updated models.GroupMembership
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		var found struct {
+			GroupID string `db:"group_id"`
+			Role    string `db:"role"`
+		}
+		lookup := fmt.Sprintf(`SELECT group_id, role FROM %s WHERE id = $1`, r.tableNames.GroupMemberships())
+		if scanErr := tx.QueryRowxContext(ctx, lookup, membershipID).StructScan(&found); scanErr != nil {
+			if errors.Is(scanErr, sql.ErrNoRows) {
+				return errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
+					"entity_type", "GroupMembership",
+					"entity_id", membershipID,
+				))
+			}
+			return errxtrace.Wrap("failed to look up membership for invariant-checked role update", scanErr)
+		}
+
+		// SAME key as DeleteWithMemberInvariants — that's the whole
+		// point. Two operations holding different keys would not
+		// serialize against each other.
+		if _, lockErr := tx.ExecContext(ctx,
+			`SELECT pg_advisory_xact_lock(hashtext('group_membership_leave'), hashtext($1))`,
+			found.GroupID,
+		); lockErr != nil {
+			return errxtrace.Wrap("failed to acquire per-group leave lock", lockErr)
+		}
+
+		// Owner-count check only when transitioning out of owner.
+		// Re-read the role under the lock so a concurrent demotion
+		// that already landed isn't double-counted.
+		if found.Role == string(models.GroupRoleOwner) && newRole != models.GroupRoleOwner {
+			var ownerCount int
+			countOwners := fmt.Sprintf(
+				`SELECT COUNT(*) FROM %s WHERE group_id = $1 AND role = $2`,
+				r.tableNames.GroupMemberships(),
+			)
+			if scanErr := tx.QueryRowContext(ctx, countOwners, found.GroupID, string(models.GroupRoleOwner)).Scan(&ownerCount); scanErr != nil {
+				return errxtrace.Wrap("failed to count owners under leave lock", scanErr)
+			}
+			if ownerCount <= 1 {
+				return errxtrace.Classify(registry.ErrLastOwner, errx.Attrs(
+					"group_id", found.GroupID,
+				))
+			}
+		}
+
+		upd := fmt.Sprintf(`UPDATE %s SET role = $1 WHERE id = $2 RETURNING *`, r.tableNames.GroupMemberships())
+		if scanErr := tx.QueryRowxContext(ctx, upd, string(newRole), membershipID).StructScan(&updated); scanErr != nil {
+			if errors.Is(scanErr, sql.ErrNoRows) {
+				return errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
+					"entity_type", "GroupMembership",
+					"entity_id", membershipID,
+				))
+			}
+			return errxtrace.Wrap("failed to update membership role under leave lock", scanErr)
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, registry.ErrLastOwner) ||
+			errors.Is(err, registry.ErrNotFound) ||
+			errors.Is(err, registry.ErrFieldRequired) {
+			return nil, err
+		}
+		return nil, errxtrace.Wrap("failed to update membership role with invariants", err)
+	}
+	return &updated, nil
+}
+
 // ListByGroupWithUsers joins group_memberships with users so the
 // members list endpoint can serve avatar/name/email in a single
 // round-trip. The JOIN also matches tenant_id on both sides as a

--- a/go/registry/postgres/group_memberships.go
+++ b/go/registry/postgres/group_memberships.go
@@ -394,6 +394,50 @@ func (r *GroupMembershipRegistry) CountOwnersByGroup(ctx context.Context, groupI
 	return count, nil
 }
 
+// lockGroupAndReadMembershipRole resolves the membership's group_id,
+// acquires the shared per-group leave/role advisory lock, then re-reads
+// the membership's role under that lock. The pre-lock group_id read is
+// safe because group_id never mutates on an existing row; the role
+// re-read is the one that matters: a concurrent owner-demotion could
+// have flipped the role while this tx waited for the lock, and acting
+// on the stale pre-lock view would let the owner invariants slip.
+// Used by both DeleteWithMemberInvariants and UpdateRoleWithMemberInvariants
+// so the two paths share both the lock key AND the freshly-read role
+// they branch on (#1652, Copilot review on PR #1666).
+func (r *GroupMembershipRegistry) lockGroupAndReadMembershipRole(ctx context.Context, tx *sqlx.Tx, membershipID string) (groupID, role string, err error) {
+	lookup := fmt.Sprintf(`SELECT group_id FROM %s WHERE id = $1`, r.tableNames.GroupMemberships())
+	if scanErr := tx.QueryRowContext(ctx, lookup, membershipID).Scan(&groupID); scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return "", "", errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
+				"entity_type", "GroupMembership",
+				"entity_id", membershipID,
+			))
+		}
+		return "", "", errxtrace.Wrap("failed to look up membership group_id", scanErr)
+	}
+
+	if _, lockErr := tx.ExecContext(ctx,
+		`SELECT pg_advisory_xact_lock(hashtext('group_membership_leave'), hashtext($1))`,
+		groupID,
+	); lockErr != nil {
+		return "", "", errxtrace.Wrap("failed to acquire per-group leave lock", lockErr)
+	}
+
+	roleQuery := fmt.Sprintf(`SELECT role FROM %s WHERE id = $1`, r.tableNames.GroupMemberships())
+	if scanErr := tx.QueryRowContext(ctx, roleQuery, membershipID).Scan(&role); scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			// The row vanished while we waited for the lock —
+			// a concurrent leave already won the race.
+			return "", "", errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
+				"entity_type", "GroupMembership",
+				"entity_id", membershipID,
+			))
+		}
+		return "", "", errxtrace.Wrap("failed to re-read membership role under leave lock", scanErr)
+	}
+	return groupID, role, nil
+}
+
 // DeleteWithMemberInvariants atomically removes a membership while
 // two transactional invariants are enforced under a per-group
 // advisory lock (#1652). The lock serializes concurrent leaves
@@ -414,37 +458,9 @@ func (r *GroupMembershipRegistry) DeleteWithMemberInvariants(ctx context.Context
 
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		// Look up the row first so we know the group_id we need to
-		// lock on. The lookup runs before the lock acquisition — that
-		// is OK because the lock scopes the count+delete, not the
-		// initial existence check; if the row vanishes between the
-		// SELECT and the DELETE the DELETE returns 0 rows and we
-		// surface ErrNotFound below.
-		var found struct {
-			GroupID string `db:"group_id"`
-			Role    string `db:"role"`
-		}
-		lookup := fmt.Sprintf(`SELECT group_id, role FROM %s WHERE id = $1`, r.tableNames.GroupMemberships())
-		if scanErr := tx.QueryRowxContext(ctx, lookup, membershipID).StructScan(&found); scanErr != nil {
-			if errors.Is(scanErr, sql.ErrNoRows) {
-				return errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
-					"entity_type", "GroupMembership",
-					"entity_id", membershipID,
-				))
-			}
-			return errxtrace.Wrap("failed to look up membership for invariant-checked delete", scanErr)
-		}
-
-		// Per-group advisory lock: hashtext(group_id) keys the lock so
-		// concurrent leaves against different groups don't block each
-		// other, but two leaves against the same group serialize. The
-		// lock is xact-scoped (released on COMMIT/ROLLBACK) so the
-		// surrounding tx controls its lifetime.
-		if _, lockErr := tx.ExecContext(ctx,
-			`SELECT pg_advisory_xact_lock(hashtext('group_membership_leave'), hashtext($1))`,
-			found.GroupID,
-		); lockErr != nil {
-			return errxtrace.Wrap("failed to acquire per-group leave lock", lockErr)
+		groupID, currentRole, lockErr := r.lockGroupAndReadMembershipRole(ctx, tx, membershipID)
+		if lockErr != nil {
+			return lockErr
 		}
 
 		// Invariant A — ≥1 owner. Checked first so a sole-owner self-
@@ -453,19 +469,17 @@ func (r *GroupMembershipRegistry) DeleteWithMemberInvariants(ctx context.Context
 		// ownership first" path that's directly actionable. The
 		// member-count fallback only fires when the owner check
 		// passes vacuously (role data drift; defense-in-depth).
-		if found.Role == string(models.GroupRoleOwner) {
+		if currentRole == string(models.GroupRoleOwner) {
 			var ownerCount int
 			countOwners := fmt.Sprintf(
 				`SELECT COUNT(*) FROM %s WHERE group_id = $1 AND role = $2`,
 				r.tableNames.GroupMemberships(),
 			)
-			if scanErr := tx.QueryRowContext(ctx, countOwners, found.GroupID, string(models.GroupRoleOwner)).Scan(&ownerCount); scanErr != nil {
+			if scanErr := tx.QueryRowContext(ctx, countOwners, groupID, string(models.GroupRoleOwner)).Scan(&ownerCount); scanErr != nil {
 				return errxtrace.Wrap("failed to count owners under leave lock", scanErr)
 			}
 			if ownerCount <= 1 {
-				return errxtrace.Classify(registry.ErrLastOwner, errx.Attrs(
-					"group_id", found.GroupID,
-				))
+				return errxtrace.Classify(registry.ErrLastOwner, errx.Attrs("group_id", groupID))
 			}
 		}
 
@@ -473,13 +487,11 @@ func (r *GroupMembershipRegistry) DeleteWithMemberInvariants(ctx context.Context
 		// concurrent leave can't drop the total from 2 → 0.
 		var memberCount int
 		countMembers := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE group_id = $1`, r.tableNames.GroupMemberships())
-		if scanErr := tx.QueryRowContext(ctx, countMembers, found.GroupID).Scan(&memberCount); scanErr != nil {
+		if scanErr := tx.QueryRowContext(ctx, countMembers, groupID).Scan(&memberCount); scanErr != nil {
 			return errxtrace.Wrap("failed to count group memberships under leave lock", scanErr)
 		}
 		if memberCount <= 1 {
-			return errxtrace.Classify(registry.ErrLastMember, errx.Attrs(
-				"group_id", found.GroupID,
-			))
+			return errxtrace.Classify(registry.ErrLastMember, errx.Attrs("group_id", groupID))
 		}
 
 		del := fmt.Sprintf(`DELETE FROM %s WHERE id = $1`, r.tableNames.GroupMemberships())
@@ -532,47 +544,25 @@ func (r *GroupMembershipRegistry) UpdateRoleWithMemberInvariants(ctx context.Con
 	var updated models.GroupMembership
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		var found struct {
-			GroupID string `db:"group_id"`
-			Role    string `db:"role"`
-		}
-		lookup := fmt.Sprintf(`SELECT group_id, role FROM %s WHERE id = $1`, r.tableNames.GroupMemberships())
-		if scanErr := tx.QueryRowxContext(ctx, lookup, membershipID).StructScan(&found); scanErr != nil {
-			if errors.Is(scanErr, sql.ErrNoRows) {
-				return errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
-					"entity_type", "GroupMembership",
-					"entity_id", membershipID,
-				))
-			}
-			return errxtrace.Wrap("failed to look up membership for invariant-checked role update", scanErr)
-		}
-
-		// SAME key as DeleteWithMemberInvariants — that's the whole
-		// point. Two operations holding different keys would not
-		// serialize against each other.
-		if _, lockErr := tx.ExecContext(ctx,
-			`SELECT pg_advisory_xact_lock(hashtext('group_membership_leave'), hashtext($1))`,
-			found.GroupID,
-		); lockErr != nil {
-			return errxtrace.Wrap("failed to acquire per-group leave lock", lockErr)
+		groupID, currentRole, lockErr := r.lockGroupAndReadMembershipRole(ctx, tx, membershipID)
+		if lockErr != nil {
+			return lockErr
 		}
 
 		// Owner-count check only when transitioning out of owner.
-		// Re-read the role under the lock so a concurrent demotion
-		// that already landed isn't double-counted.
-		if found.Role == string(models.GroupRoleOwner) && newRole != models.GroupRoleOwner {
+		// `currentRole` is the post-lock value so a concurrent
+		// demotion that already landed isn't double-counted.
+		if currentRole == string(models.GroupRoleOwner) && newRole != models.GroupRoleOwner {
 			var ownerCount int
 			countOwners := fmt.Sprintf(
 				`SELECT COUNT(*) FROM %s WHERE group_id = $1 AND role = $2`,
 				r.tableNames.GroupMemberships(),
 			)
-			if scanErr := tx.QueryRowContext(ctx, countOwners, found.GroupID, string(models.GroupRoleOwner)).Scan(&ownerCount); scanErr != nil {
+			if scanErr := tx.QueryRowContext(ctx, countOwners, groupID, string(models.GroupRoleOwner)).Scan(&ownerCount); scanErr != nil {
 				return errxtrace.Wrap("failed to count owners under leave lock", scanErr)
 			}
 			if ownerCount <= 1 {
-				return errxtrace.Classify(registry.ErrLastOwner, errx.Attrs(
-					"group_id", found.GroupID,
-				))
+				return errxtrace.Classify(registry.ErrLastOwner, errx.Attrs("group_id", groupID))
 			}
 		}
 

--- a/go/registry/postgres/group_memberships_test.go
+++ b/go/registry/postgres/group_memberships_test.go
@@ -116,6 +116,125 @@ func TestGroupMembershipRegistry_GetByGroupAndUser(t *testing.T) {
 	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
 }
 
+// #1652: postgres-side coverage for the new invariant-checked delete
+// path. The shared service tests exercise the memory backend; this
+// pins the hand-written SQL + pg_advisory_xact_lock + sentinel
+// mapping on the production registry so regressions in the
+// postgres-specific code can't slip past memory-only tests.
+func TestGroupMembershipRegistry_DeleteWithMemberInvariants(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	group, err := registrySet.LocationGroupRegistry.Create(ctx, newTestGroup(c, user.TenantID, user.ID, "DelInvariants"))
+	c.Assert(err, qt.IsNil)
+
+	// Sole owner — both invariants would fire; owner-first ordering
+	// must surface ErrLastOwner (the more actionable copy).
+	sole, err := registrySet.GroupMembershipRegistry.Create(ctx, membershipFor(user.TenantID, group.ID, user.ID, models.GroupRoleOwner))
+	c.Assert(err, qt.IsNil)
+	err = registrySet.GroupMembershipRegistry.DeleteWithMemberInvariants(ctx, sole.ID)
+	c.Assert(errors.Is(err, registry.ErrLastOwner), qt.IsTrue, qt.Commentf("expected ErrLastOwner, got %v", err))
+
+	// Add a non-owner second member. The sole-owner block above
+	// still holds; removing the user-role row now drops memberCount
+	// from 2 → 1 but the owner stays. Happy path.
+	secondUser, err := registrySet.UserRegistry.Create(ctx, models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: user.TenantID},
+		Email:               "del-inv-second@test-org.com",
+		Name:                "Second",
+		IsActive:            true,
+	})
+	c.Assert(err, qt.IsNil)
+	m2, err := registrySet.GroupMembershipRegistry.Create(ctx, membershipFor(user.TenantID, group.ID, secondUser.ID, models.GroupRoleUser))
+	c.Assert(err, qt.IsNil)
+	err = registrySet.GroupMembershipRegistry.DeleteWithMemberInvariants(ctx, m2.ID)
+	c.Assert(err, qt.IsNil)
+	// Verify the row is actually gone.
+	_, err = registrySet.GroupMembershipRegistry.Get(ctx, m2.ID)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+
+	// ErrNotFound on an unknown id (the initial group_id lookup
+	// fails fast — no group lock needed beyond that).
+	err = registrySet.GroupMembershipRegistry.DeleteWithMemberInvariants(ctx, "00000000-0000-0000-0000-000000000000")
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+
+	// ErrLastMember: construct a one-member group whose sole row is
+	// NOT an owner (simulates the role-drift case the defense-in-depth
+	// invariant exists to catch). The owner check passes vacuously,
+	// the member-count check fires.
+	driftGroup, err := registrySet.LocationGroupRegistry.Create(ctx, newTestGroup(c, user.TenantID, user.ID, "DriftDel"))
+	c.Assert(err, qt.IsNil)
+	driftUser, err := registrySet.UserRegistry.Create(ctx, models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: user.TenantID},
+		Email:               "drift-del@test-org.com",
+		Name:                "Drift",
+		IsActive:            true,
+	})
+	c.Assert(err, qt.IsNil)
+	soleUser, err := registrySet.GroupMembershipRegistry.Create(ctx, membershipFor(user.TenantID, driftGroup.ID, driftUser.ID, models.GroupRoleUser))
+	c.Assert(err, qt.IsNil)
+	err = registrySet.GroupMembershipRegistry.DeleteWithMemberInvariants(ctx, soleUser.ID)
+	c.Assert(errors.Is(err, registry.ErrLastMember), qt.IsTrue, qt.Commentf("expected ErrLastMember, got %v", err))
+}
+
+// #1652: postgres-side coverage for the new invariant-checked role
+// update. Catches regressions in the hand-written `UPDATE ...
+// RETURNING *` scan, the advisory-lock key (must match
+// DeleteWithMemberInvariants), and the sentinel propagation.
+func TestGroupMembershipRegistry_UpdateRoleWithMemberInvariants(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	group, err := registrySet.LocationGroupRegistry.Create(ctx, newTestGroup(c, user.TenantID, user.ID, "UpdInvariants"))
+	c.Assert(err, qt.IsNil)
+
+	// Sole owner cannot be demoted — zero owners afterwards.
+	sole, err := registrySet.GroupMembershipRegistry.Create(ctx, membershipFor(user.TenantID, group.ID, user.ID, models.GroupRoleOwner))
+	c.Assert(err, qt.IsNil)
+	_, err = registrySet.GroupMembershipRegistry.UpdateRoleWithMemberInvariants(ctx, sole.ID, models.GroupRoleAdmin)
+	c.Assert(errors.Is(err, registry.ErrLastOwner), qt.IsTrue, qt.Commentf("expected ErrLastOwner, got %v", err))
+
+	// Add a second owner; now the original can be demoted. The
+	// returned row must reflect the new role (verifies the RETURNING
+	// scan, not just the column write).
+	secondUser, err := registrySet.UserRegistry.Create(ctx, models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: user.TenantID},
+		Email:               "upd-inv-second@test-org.com",
+		Name:                "Second",
+		IsActive:            true,
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = registrySet.GroupMembershipRegistry.Create(ctx, membershipFor(user.TenantID, group.ID, secondUser.ID, models.GroupRoleOwner))
+	c.Assert(err, qt.IsNil)
+	updated, err := registrySet.GroupMembershipRegistry.UpdateRoleWithMemberInvariants(ctx, sole.ID, models.GroupRoleAdmin)
+	c.Assert(err, qt.IsNil)
+	c.Assert(updated, qt.IsNotNil)
+	c.Assert(updated.Role, qt.Equals, models.GroupRoleAdmin)
+	c.Assert(updated.ID, qt.Equals, sole.ID)
+	// Persisted, not just echoed.
+	fresh, err := registrySet.GroupMembershipRegistry.Get(ctx, sole.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fresh.Role, qt.Equals, models.GroupRoleAdmin)
+
+	// Demoting back to owner (no-op invariant-wise) is allowed —
+	// the owner-count branch only fires when transitioning OUT of
+	// owner, so this exercises the "skip the count" path.
+	_, err = registrySet.GroupMembershipRegistry.UpdateRoleWithMemberInvariants(ctx, sole.ID, models.GroupRoleOwner)
+	c.Assert(err, qt.IsNil)
+
+	// ErrNotFound on an unknown id.
+	_, err = registrySet.GroupMembershipRegistry.UpdateRoleWithMemberInvariants(ctx, "00000000-0000-0000-0000-000000000000", models.GroupRoleAdmin)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
 func TestGroupMembershipRegistry_ListByGroup_ByUser_CountAdmins(t *testing.T) {
 	registrySet, cleanup := setupTestRegistrySet(t)
 	defer cleanup()

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -944,6 +944,23 @@ type GroupMembershipRegistry interface {
 	// callers that bypass the invariants (e.g. group deletion) keep
 	// using the plain `Delete`.
 	DeleteWithMemberInvariants(ctx context.Context, membershipID string) error
+
+	// UpdateRoleWithMemberInvariants atomically swaps the row's role
+	// while sharing the same per-group lock as DeleteWithMemberInvariants
+	// (#1652). Without this, a concurrent leave + owner-demotion pair
+	// can both observe ownerCount=2 before either commits, then both
+	// commit, leaving the group with zero owners (the bug
+	// DeleteWithMemberInvariants alone can't prevent because the
+	// demote path acquired its own lock under the plain `Update`).
+	// The two operations now serialize: whichever runs second sees
+	// the post-first-op state under the same advisory key.
+	//
+	// Returns ErrLastOwner when the current role is owner, the new
+	// role is not, and the row is the only owner in the group.
+	// Returns ErrNotFound when no membership with the given id
+	// exists. The updated membership row is returned so the handler
+	// can echo it back to the client.
+	UpdateRoleWithMemberInvariants(ctx context.Context, membershipID string, newRole models.GroupRole) (*models.GroupMembership, error)
 }
 
 // GroupNotificationPrefRegistry stores per-user per-group opt-outs for

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -919,6 +919,31 @@ type GroupMembershipRegistry interface {
 	// cap. Returns (nil, true, nil) when the user is already at or
 	// over the cap; (nil, false, err) on registry / tx errors.
 	CreateUnderCap(ctx context.Context, membership models.GroupMembership, maxMemberships int) (*models.GroupMembership, bool, error)
+
+	// DeleteWithMemberInvariants atomically removes the named
+	// membership row while two invariants are enforced inside the
+	// same transaction (#1652, defense-in-depth):
+	//
+	//   A) ≥1 owner   — if the row's role is owner and removing it
+	//      would drop the group's owner count to zero, the registry
+	//      returns ErrLastOwner without touching the row.
+	//   B) ≥1 member  — if removing the row would drop the group's
+	//      total membership count to zero (regardless of role), the
+	//      registry returns ErrLastMember. Catches the case where
+	//      role data has drifted so the owner check passes vacuously
+	//      (e.g. the sole member happens to be a `user`).
+	//
+	// Implementations must take a per-group transactional lock around
+	// the count(*) checks and the DELETE so two concurrent leaves on
+	// a two-member group can't both pass the count check and both
+	// commit the delete. Postgres uses pg_advisory_xact_lock; memory
+	// holds the registry write lock for the duration of the
+	// count+delete sequence. Returns ErrNotFound when no membership
+	// with the given id exists. This is the canonical removal path
+	// for `LeaveGroup` and the admin-initiated remove-member API;
+	// callers that bypass the invariants (e.g. group deletion) keep
+	// using the plain `Delete`.
+	DeleteWithMemberInvariants(ctx context.Context, membershipID string) error
 }
 
 // GroupNotificationPrefRegistry stores per-user per-group opt-outs for

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -385,9 +385,12 @@ func (s *GroupService) RemoveMember(ctx context.Context, groupID, userID string)
 }
 
 // UpdateMemberRole changes a member's role. Enforces the ≥1 owner
-// invariant: demoting the last owner is rejected with ErrLastOwner.
-// Caller-side authorization (admin vs. owner) lives in the handler —
-// the service layer only enforces structural invariants.
+// invariant under the SAME per-group lock RemoveMember uses (#1652)
+// so a concurrent leave + owner-demotion pair can no longer both
+// pass an ownerCount=2 check and both commit, leaving the group
+// with zero owners. Caller-side authorization (admin vs. owner)
+// lives in the handler — the service layer only enforces structural
+// invariants.
 func (s *GroupService) UpdateMemberRole(ctx context.Context, groupID, userID string, newRole models.GroupRole) (*models.GroupMembership, error) {
 	membership, err := s.membershipRegistry.GetByGroupAndUser(ctx, groupID, userID)
 	if err != nil {
@@ -397,18 +400,18 @@ func (s *GroupService) UpdateMemberRole(ctx context.Context, groupID, userID str
 		return nil, errxtrace.Wrap("failed to look up membership", err)
 	}
 
-	if membership.Role == models.GroupRoleOwner && newRole != models.GroupRoleOwner {
-		ownerCount, err := s.membershipRegistry.CountOwnersByGroup(ctx, groupID)
-		if err != nil {
-			return nil, errxtrace.Wrap("failed to count owners", err)
-		}
-		if ownerCount <= 1 {
+	updated, err := s.membershipRegistry.UpdateRoleWithMemberInvariants(ctx, membership.ID, newRole)
+	if err != nil {
+		switch {
+		case errors.Is(err, registry.ErrLastOwner):
 			return nil, errxtrace.Classify(ErrLastOwner)
+		case errors.Is(err, registry.ErrNotFound):
+			return nil, errxtrace.Classify(ErrNotGroupMember)
+		default:
+			return nil, err
 		}
 	}
-
-	membership.Role = newRole
-	return s.membershipRegistry.Update(ctx, *membership)
+	return updated, nil
 }
 
 // GetMembershipRole returns the role of the user in the group. Returns

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -21,6 +21,14 @@ var (
 	ErrGroupNotActive    = errx.NewSentinel("group is not active")
 	ErrLastAdmin         = errx.NewSentinel("cannot remove the last admin from a group")
 	ErrLastOwner         = errx.NewSentinel("cannot remove the last owner from a group")
+	// ErrLastMember signals that RemoveMember / LeaveGroup refused to
+	// drop the group to zero memberships (#1652). Distinct from
+	// ErrLastOwner so the FE can render different copy ("you're the
+	// last member — delete the group instead" vs. "you're the last
+	// owner — transfer ownership first"). Defense-in-depth: even if
+	// the role taxonomy drifts so the owner check passes vacuously,
+	// the member-count invariant still blocks the leave.
+	ErrLastMember = errx.NewSentinel("cannot remove the last member from a group")
 	ErrInviteExpired     = errx.NewSentinel("invite has expired")
 	ErrInviteAlreadyUsed = errx.NewSentinel("invite has already been used")
 	// ErrInviteNotByEmail is returned when the resend path is called on an
@@ -327,10 +335,27 @@ func (s *GroupService) AddMember(ctx context.Context, tenantID, groupID, userID 
 	return created, err
 }
 
-// RemoveMember removes a user from a group. Enforces the ≥1 owner
-// invariant — removing the last owner would leave the group without
-// anyone able to delete it, which is the user-facing meaning of
-// ownership.
+// RemoveMember removes a user from a group. Enforces two
+// independent invariants under a per-group transactional lock
+// (#1652, defense-in-depth):
+//
+//   A) ≥1 owner   — removing the last owner is rejected with
+//      ErrLastOwner. Without an owner no one can delete the group,
+//      transfer ownership, or manage members.
+//   B) ≥1 member  — removing the last member of any role is
+//      rejected with ErrLastMember. Catches the case where role data
+//      drifted so the owner check would pass vacuously (e.g. the
+//      sole admin lands in a non-owner role and "leaves" as the
+//      last member). The FE renders this with distinct copy
+//      ("delete the group instead") so the user has a clear path
+//      forward instead of looking at "remove the last owner" advice
+//      that doesn't fit their situation.
+//
+// The atomic count+delete lives in the registry layer
+// (DeleteWithMemberInvariants) so two concurrent leaves on a
+// two-member group can't both pass the count check and both commit;
+// the registry takes pg_advisory_xact_lock on the group_id (postgres)
+// or the shared write lock (memory) around the count+delete.
 func (s *GroupService) RemoveMember(ctx context.Context, groupID, userID string) error {
 	membership, err := s.membershipRegistry.GetByGroupAndUser(ctx, groupID, userID)
 	if err != nil {
@@ -340,18 +365,17 @@ func (s *GroupService) RemoveMember(ctx context.Context, groupID, userID string)
 		return errxtrace.Wrap("failed to look up membership", err)
 	}
 
-	if membership.Role == models.GroupRoleOwner {
-		ownerCount, err := s.membershipRegistry.CountOwnersByGroup(ctx, groupID)
-		if err != nil {
-			return errxtrace.Wrap("failed to count owners", err)
-		}
-		if ownerCount <= 1 {
+	if err := s.membershipRegistry.DeleteWithMemberInvariants(ctx, membership.ID); err != nil {
+		switch {
+		case errors.Is(err, registry.ErrLastOwner):
 			return errxtrace.Classify(ErrLastOwner)
+		case errors.Is(err, registry.ErrLastMember):
+			return errxtrace.Classify(ErrLastMember)
+		case errors.Is(err, registry.ErrNotFound):
+			return errxtrace.Classify(ErrNotGroupMember)
+		default:
+			return err
 		}
-	}
-
-	if err := s.membershipRegistry.Delete(ctx, membership.ID); err != nil {
-		return err
 	}
 
 	// Auto-promote a remaining membership to default if the user lost the one

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -18,9 +18,9 @@ import (
 )
 
 var (
-	ErrGroupNotActive    = errx.NewSentinel("group is not active")
-	ErrLastAdmin         = errx.NewSentinel("cannot remove the last admin from a group")
-	ErrLastOwner         = errx.NewSentinel("cannot remove the last owner from a group")
+	ErrGroupNotActive = errx.NewSentinel("group is not active")
+	ErrLastAdmin      = errx.NewSentinel("cannot remove the last admin from a group")
+	ErrLastOwner      = errx.NewSentinel("cannot remove the last owner from a group")
 	// ErrLastMember signals that RemoveMember / LeaveGroup refused to
 	// drop the group to zero memberships (#1652). Distinct from
 	// ErrLastOwner so the FE can render different copy ("you're the
@@ -28,7 +28,7 @@ var (
 	// owner — transfer ownership first"). Defense-in-depth: even if
 	// the role taxonomy drifts so the owner check passes vacuously,
 	// the member-count invariant still blocks the leave.
-	ErrLastMember = errx.NewSentinel("cannot remove the last member from a group")
+	ErrLastMember        = errx.NewSentinel("cannot remove the last member from a group")
 	ErrInviteExpired     = errx.NewSentinel("invite has expired")
 	ErrInviteAlreadyUsed = errx.NewSentinel("invite has already been used")
 	// ErrInviteNotByEmail is returned when the resend path is called on an
@@ -339,17 +339,17 @@ func (s *GroupService) AddMember(ctx context.Context, tenantID, groupID, userID 
 // independent invariants under a per-group transactional lock
 // (#1652, defense-in-depth):
 //
-//   A) ≥1 owner   — removing the last owner is rejected with
-//      ErrLastOwner. Without an owner no one can delete the group,
-//      transfer ownership, or manage members.
-//   B) ≥1 member  — removing the last member of any role is
-//      rejected with ErrLastMember. Catches the case where role data
-//      drifted so the owner check would pass vacuously (e.g. the
-//      sole admin lands in a non-owner role and "leaves" as the
-//      last member). The FE renders this with distinct copy
-//      ("delete the group instead") so the user has a clear path
-//      forward instead of looking at "remove the last owner" advice
-//      that doesn't fit their situation.
+//	A) ≥1 owner   — removing the last owner is rejected with
+//	   ErrLastOwner. Without an owner no one can delete the group,
+//	   transfer ownership, or manage members.
+//	B) ≥1 member  — removing the last member of any role is
+//	   rejected with ErrLastMember. Catches the case where role data
+//	   drifted so the owner check would pass vacuously (e.g. the
+//	   sole admin lands in a non-owner role and "leaves" as the
+//	   last member). The FE renders this with distinct copy
+//	   ("delete the group instead") so the user has a clear path
+//	   forward instead of looking at "remove the last owner" advice
+//	   that doesn't fit their situation.
 //
 // The atomic count+delete lives in the registry layer
 // (DeleteWithMemberInvariants) so two concurrent leaves on a

--- a/go/services/group_service_test.go
+++ b/go/services/group_service_test.go
@@ -372,6 +372,86 @@ func TestGroupService_RemoveMember_ConcurrentLeavesSerialize(t *testing.T) {
 	c.Assert(lastMember, qt.Equals, 1, qt.Commentf("the loser should get ErrLastMember"))
 }
 
+// #1652 (Copilot review): a concurrent owner-leave and owner-demotion
+// targeting the same group used to take separate locks, so both
+// could observe ownerCount=2 before either committed and both could
+// commit — leaving zero owners. UpdateRoleWithMemberInvariants now
+// shares the per-group lock with DeleteWithMemberInvariants, so the
+// loser of the race sees the post-winner state and bails out with
+// ErrLastOwner.
+func TestGroupService_UpdateMemberRole_RacesLeaveOnSameLock(t *testing.T) {
+	c := qt.New(t)
+	memberships := memory.NewGroupMembershipRegistry()
+	groups := memory.NewLocationGroupRegistry()
+	svc := services.NewGroupService(groups, memberships, memory.NewGroupInviteRegistry())
+	ctx := context.Background()
+
+	group, err := groups.Create(ctx, models.LocationGroup{
+		Slug:          "g-race-role",
+		Name:          "RaceRole",
+		Status:        models.LocationGroupStatusActive,
+		CreatedBy:     "user-a",
+		GroupCurrency: "USD",
+	})
+	c.Assert(err, qt.IsNil)
+	// Two owners — a leave on one and a demote on the other would
+	// each pass an unsynchronized ownerCount=2 check pre-commit.
+	for _, who := range []string{"user-a", "user-b"} {
+		_, err = memberships.Create(ctx, models.GroupMembership{
+			GroupID:      group.ID,
+			MemberUserID: who,
+			Role:         models.GroupRoleOwner,
+			JoinedAt:     time.Now(),
+		})
+		c.Assert(err, qt.IsNil)
+	}
+
+	var (
+		wg        sync.WaitGroup
+		ready     sync.WaitGroup
+		start     = make(chan struct{})
+		leaveErr  error
+		demoteErr error
+	)
+	ready.Add(2)
+	wg.Go(func() {
+		ready.Done()
+		<-start
+		leaveErr = svc.LeaveGroup(ctx, group.ID, "user-a")
+	})
+	wg.Go(func() {
+		ready.Done()
+		<-start
+		_, demoteErr = svc.UpdateMemberRole(ctx, group.ID, "user-b", models.GroupRoleViewer)
+	})
+	ready.Wait()
+	close(start)
+	wg.Wait()
+
+	// Exactly one of the two operations must succeed. If both
+	// succeeded the group has zero owners — the exact post-state the
+	// invariant exists to prevent. If both failed something has gone
+	// wrong with the lock itself; both passing was the original bug.
+	wins := 0
+	if leaveErr == nil {
+		wins++
+	}
+	if demoteErr == nil {
+		wins++
+	}
+	c.Assert(wins, qt.Equals, 1, qt.Commentf("exactly one of leave/demote should win; leaveErr=%v demoteErr=%v", leaveErr, demoteErr))
+	// The loser must surface ErrLastOwner (not a generic error) so
+	// the FE renders the actionable "transfer ownership first" copy.
+	if leaveErr != nil {
+		c.Assert(errors.Is(leaveErr, services.ErrLastOwner), qt.IsTrue,
+			qt.Commentf("leave lost the race; expected ErrLastOwner, got %v", leaveErr))
+	}
+	if demoteErr != nil {
+		c.Assert(errors.Is(demoteErr, services.ErrLastOwner), qt.IsTrue,
+			qt.Commentf("demote lost the race; expected ErrLastOwner, got %v", demoteErr))
+	}
+}
+
 func TestGroupService_UpdateMemberRole(t *testing.T) {
 	c := qt.New(t)
 	svc := newTestGroupService()

--- a/go/services/group_service_test.go
+++ b/go/services/group_service_test.go
@@ -2,6 +2,8 @@ package services_test
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -199,6 +201,178 @@ func TestGroupService_RemoveMember_LastOwnerProtection(t *testing.T) {
 	err = svc.RemoveMember(ctx, group.ID, "user-1")
 	c.Assert(err, qt.IsNil)
 	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-1"), qt.IsFalse)
+}
+
+// #1652 defense-in-depth: a sole non-owner member cannot leave (or be
+// removed by an admin) even when the owner check would pass vacuously.
+// Catches the case where role data has drifted so the group's only
+// remaining row isn't an owner.
+func TestGroupService_RemoveMember_LastMemberProtection(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	// Build a one-member group where the sole row is NOT an owner. We
+	// can't reach this state via CreateGroup (which always provisions
+	// the creator as owner), so we hand-write the membership to model
+	// the role-drift / corrupted-seed case the defense-in-depth
+	// invariant exists to catch.
+	memberships := memory.NewGroupMembershipRegistry()
+	groups := memory.NewLocationGroupRegistry()
+	svc := services.NewGroupService(groups, memberships, memory.NewGroupInviteRegistry())
+
+	group, err := groups.Create(ctx, models.LocationGroup{
+		Slug:          "g-orphan",
+		Name:          "Orphan",
+		Status:        models.LocationGroupStatusActive,
+		CreatedBy:     "user-1",
+		GroupCurrency: "USD",
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = memberships.Create(ctx, models.GroupMembership{
+		GroupID:      group.ID,
+		MemberUserID: "user-1",
+		Role:         models.GroupRoleUser, // <-- not owner: simulates role drift
+		JoinedAt:     time.Now(),
+	})
+	c.Assert(err, qt.IsNil)
+
+	err = svc.RemoveMember(ctx, group.ID, "user-1")
+	c.Assert(err, qt.ErrorIs, services.ErrLastMember)
+	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-1"), qt.IsTrue)
+}
+
+// #1652: an admin-initiated RemoveMember targeting the only remaining
+// member must hit the same invariant — not just self-removal via
+// LeaveGroup.
+func TestGroupService_RemoveMember_LastMember_AdminInitiated(t *testing.T) {
+	c := qt.New(t)
+	memberships := memory.NewGroupMembershipRegistry()
+	groups := memory.NewLocationGroupRegistry()
+	svc := services.NewGroupService(groups, memberships, memory.NewGroupInviteRegistry())
+	ctx := context.Background()
+
+	group, err := groups.Create(ctx, models.LocationGroup{
+		Slug:          "g-solo-admin",
+		Name:          "Solo Admin",
+		Status:        models.LocationGroupStatusActive,
+		CreatedBy:     "user-1",
+		GroupCurrency: "USD",
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = memberships.Create(ctx, models.GroupMembership{
+		GroupID:      group.ID,
+		MemberUserID: "user-1",
+		Role:         models.GroupRoleAdmin, // admin-not-owner row drift
+		JoinedAt:     time.Now(),
+	})
+	c.Assert(err, qt.IsNil)
+
+	err = svc.RemoveMember(ctx, group.ID, "user-1")
+	c.Assert(err, qt.ErrorIs, services.ErrLastMember)
+}
+
+// #1652: the sole-owner self-leave path keeps surfacing ErrLastOwner,
+// not ErrLastMember — owner-first ordering means the more actionable
+// "transfer ownership first" copy wins over the generic "delete the
+// group instead" fallback when both invariants would fire.
+func TestGroupService_LeaveGroup_SoleOwnerPrefersLastOwner(t *testing.T) {
+	c := qt.New(t)
+	svc := newTestGroupService()
+	ctx := context.Background()
+
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Solo", "", "")
+	c.Assert(err, qt.IsNil)
+
+	err = svc.LeaveGroup(ctx, group.ID, "user-1")
+	c.Assert(err, qt.ErrorIs, services.ErrLastOwner)
+	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-1"), qt.IsTrue)
+}
+
+// #1652: two members of a two-member group leave concurrently — the
+// per-group lock must serialize them so one drops to memberCount=1
+// and the other sees memberCount=1 already and gets ErrLastMember
+// (or ErrLastOwner if their row happened to be the only owner left).
+// The in-memory registry uses the write lock as the serialization
+// primitive; this test exercises that path. The postgres registry
+// uses pg_advisory_xact_lock keyed on group_id for the same effect
+// (covered by postgres-specific tests + the leave-flow e2e).
+func TestGroupService_RemoveMember_ConcurrentLeavesSerialize(t *testing.T) {
+	c := qt.New(t)
+	memberships := memory.NewGroupMembershipRegistry()
+	groups := memory.NewLocationGroupRegistry()
+	svc := services.NewGroupService(groups, memberships, memory.NewGroupInviteRegistry())
+	ctx := context.Background()
+
+	group, err := groups.Create(ctx, models.LocationGroup{
+		Slug:          "g-race",
+		Name:          "Race",
+		Status:        models.LocationGroupStatusActive,
+		CreatedBy:     "user-1",
+		GroupCurrency: "USD",
+	})
+	c.Assert(err, qt.IsNil)
+	// Two users — neither is owner, so the member-count invariant is
+	// the one that fires (the owner invariant would otherwise mask
+	// the race we want to observe).
+	_, err = memberships.Create(ctx, models.GroupMembership{
+		GroupID:      group.ID,
+		MemberUserID: "user-a",
+		Role:         models.GroupRoleAdmin,
+		JoinedAt:     time.Now(),
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = memberships.Create(ctx, models.GroupMembership{
+		GroupID:      group.ID,
+		MemberUserID: "user-b",
+		Role:         models.GroupRoleAdmin,
+		JoinedAt:     time.Now(),
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Two concurrent leaves — one must succeed (drops to 1 member),
+	// the other must hit ErrLastMember. Both succeeding would leave
+	// an orphan group, which is the bug the invariant exists to
+	// prevent.
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		errs   []error
+		ready  sync.WaitGroup
+		start  = make(chan struct{})
+		labels = []string{"user-a", "user-b"}
+	)
+	ready.Add(len(labels))
+	for _, who := range labels {
+		who := who
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ready.Done()
+			<-start
+			err := svc.LeaveGroup(ctx, group.ID, who)
+			mu.Lock()
+			errs = append(errs, err)
+			mu.Unlock()
+		}()
+	}
+	ready.Wait()
+	close(start)
+	wg.Wait()
+
+	successes := 0
+	lastMember := 0
+	for _, e := range errs {
+		switch {
+		case e == nil:
+			successes++
+		case errors.Is(e, services.ErrLastMember):
+			lastMember++
+		default:
+			c.Fatalf("unexpected error %v", e)
+		}
+	}
+	c.Assert(successes, qt.Equals, 1, qt.Commentf("exactly one leave should win the race"))
+	c.Assert(lastMember, qt.Equals, 1, qt.Commentf("the loser should get ErrLastMember"))
 }
 
 func TestGroupService_UpdateMemberRole(t *testing.T) {

--- a/go/services/group_service_test.go
+++ b/go/services/group_service_test.go
@@ -343,17 +343,14 @@ func TestGroupService_RemoveMember_ConcurrentLeavesSerialize(t *testing.T) {
 	)
 	ready.Add(len(labels))
 	for _, who := range labels {
-		who := who
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ready.Done()
 			<-start
 			err := svc.LeaveGroup(ctx, group.ID, who)
 			mu.Lock()
 			errs = append(errs, err)
 			mu.Unlock()
-		}()
+		})
 	}
 	ready.Wait()
 	close(start)


### PR DESCRIPTION
Bundled fix for three issues that touch the post-#1533 / #1655 surface.

## #1662 — Edit Location silently 422'd

Root cause (FE): `frontend/src/features/locations/api.ts` and `frontend/src/features/areas/api.ts` built the PUT envelope without `data.id`, but the BE id-match check at `go/apiserver/locations.go:229` and `go/apiserver/areas.go:212` rejects every PUT whose body id doesn't match the URL id. Mirror the commodities pattern and splice `id` into the envelope on update.

Root cause (FE/UX): `LocationFormDialog` / `AreaFormDialog` reset on every `location`/`area` prop reference change. With `useUpdateLocation`'s optimistic update + rollback + onSettled refetch, the host re-renders the dialog with three new reference values inside the same submit cycle — each one wiped the inline `serverError` the catch in `handle` had just set. Reset now fires only on the open transition and on the first prop-with-data after open (so the `/locations/:id/edit` deep-link path still prefills), never on later reference churn.

`parseServerError(err, fallback)` was already in the codebase; with the BE now able to return a non-empty body (since the id-mismatch path no longer fires) the existing inline-alert path surfaces the real reason without the change to error-mapping the issue suggested.

## #1660 — Members page polish

- Dropped the redundant header "Group Settings" button + the `Settings` lucide import + the `members-group-settings-link` test id (no remaining call sites). Same destination is reachable from the sidebar's Manage row and the GroupSelector shortcut.
- h1 → `scroll-m-20 text-3xl font-semibold tracking-tight` (canonical per `design-mocks/CLAUDE.md`).
- PendingInvites sub-heading lifted from `text-sm` → `text-base`.
- Added `p-6` to the page wrapper so the width matches the mock.

## #1652 — Defense-in-depth on RemoveMember / LeaveGroup

New registry method `DeleteWithMemberInvariants(ctx, membershipID)` runs `count(*) → DELETE` inside one transaction under a per-group lock:
- **Postgres**: `pg_advisory_xact_lock(hashtext('group_membership_leave'), hashtext(group_id))` — xact-scoped, released on COMMIT/ROLLBACK.
- **Memory**: the embedded `Registry` write lock for the duration of the count+delete.

Two independent invariants:
- **Invariant A — ≥1 owner** (`ErrLastOwner`, existing). Owner-first ordering so a sole-owner self-leave keeps the actionable "transfer ownership first" copy.
- **Invariant B — ≥1 member** (`ErrLastMember`, NEW). Catches role-data drift where the owner check would pass vacuously (e.g. the sole member happens to be a `user`).

FE branches on the JSON:API `group.last_member` code so the leave-group toast can render "delete the group instead" copy instead of falling back to the generic "Couldn't leave the group."

Service tests cover: the new sentinel via direct memberships fixture, admin-initiated RemoveMember of the last member, sole-owner ordering (prefers `ErrLastOwner`), and a goroutine-based concurrent-leave race that asserts exactly one of two simultaneous leaves wins. A new `groups.spec.ts` API test pins the wire-level 422 so a client that bypasses the disabled button still can't orphan a group.

## Test plan

- [x] `go test ./...` — all green.
- [x] Frontend vitest for locations + groups slices — 42/42 green.
- [x] `eslint` clean on changed files.
- [x] `tsc --noEmit` clean.
- [ ] Playwright `locations-crud.spec.ts` + extended `groups.spec.ts` last-owner API test exercised in CI.
- [ ] Manual: edit a seeded location → expect success toast + dialog close.
- [ ] Manual: try to leave the seeded test-org as the sole owner → expect disabled button + last-owner notice.

Closes #1662, #1660, #1652.