### PR TITLE
chore(githooks): add Go lint gate to pre-commit (nolintguard + qtlint + golangci-lint)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,9 +5,13 @@
 # - Staged frontend src files → `prettier --check`
 # - Staged frontend code (ts/tsx/js/mjs/cjs)  → `eslint --max-warnings=0`
 # - Staged e2e .ts files → `prettier --check`
+# - Staged Go files → `go tool nolintguard ./...`, `go tool qtlint ./...`,
+#   and `golangci-lint run` scoped to the staged packages. nolintguard /
+#   qtlint are fast project-wide scans; golangci-lint stays per-package
+#   so it doesn't blow the commit budget.
 #
-# The heavier checks (typecheck, i18n drift) live in `.githooks/pre-push`
-# so they fire once per push, not once per commit.
+# The heavier FE checks (typecheck, i18n drift, vitest coverage) live
+# in `.githooks/pre-push` so they fire once per push, not once per commit.
 #
 # Install via `./scripts/install-hooks.sh` (sets `core.hooksPath=.githooks`
 # in the local clone). The hook is opt-in per checkout — npm postinstall
@@ -36,6 +40,7 @@ fi
 fe_format=()
 fe_code=()
 e2e_files=()
+go_files=()
 for path in "${staged_all[@]}"; do
   if [[ "$path" =~ ^frontend/src/.+\.(ts|tsx|css|json|md)$ ]]; then
     fe_format+=("${path#frontend/}")
@@ -45,6 +50,14 @@ for path in "${staged_all[@]}"; do
   fi
   if [[ "$path" =~ ^e2e/.+\.ts$ ]]; then
     e2e_files+=("${path#e2e/}")
+  fi
+  # Go gate. Generated files (`*_generated.go`, `mock_*.go`) are skipped
+  # — they're authored by codegen and typically don't pass the same lint
+  # rules that apply to handwritten code.
+  if [[ "$path" =~ ^go/.+\.go$ ]] \
+      && [[ ! "$path" =~ _generated\.go$ ]] \
+      && [[ ! "$(basename "$path")" =~ ^mock_ ]]; then
+    go_files+=("${path#go/}")
   fi
 done
 
@@ -71,6 +84,45 @@ if [[ ${#e2e_files[@]} -gt 0 ]]; then
   if ! (cd e2e && npx --no-install prettier --check "${e2e_files[@]}"); then
     echo "✗ e2e prettier check failed on the staged files above. Run 'cd e2e && npx prettier --write <files>' to fix." >&2
     failed=1
+  fi
+fi
+
+if [[ ${#go_files[@]} -gt 0 ]]; then
+  # Reduce staged Go files to the unique set of package directories.
+  # golangci-lint is package-aware (needs every file in a package to
+  # type-check correctly), so passing dirs is the right granularity and
+  # also keeps the invocation count low when many files land in one
+  # package. nolintguard + qtlint are cheap enough to run project-wide
+  # — same scope as `make lint-go` — so any new drift is caught.
+  declare -A go_pkgs_set=()
+  for f in "${go_files[@]}"; do
+    go_pkgs_set["./$(dirname "$f")"]=1
+  done
+  go_pkgs=()
+  for pkg in "${!go_pkgs_set[@]}"; do go_pkgs+=("$pkg"); done
+
+  echo "▸ pre-commit: go nolintguard ./..."
+  if ! (cd go && go tool nolintguard ./...); then
+    echo "✗ nolintguard failed. See output above; resolve the //nolint annotation drift it flagged." >&2
+    failed=1
+  fi
+
+  echo "▸ pre-commit: go qtlint ./..."
+  if ! (cd go && go tool qtlint ./...); then
+    echo "✗ qtlint failed. Run 'make lint-go-fix' to auto-fix (qtlint -fix)." >&2
+    failed=1
+  fi
+
+  if ! command -v golangci-lint >/dev/null 2>&1; then
+    echo "✗ pre-commit: golangci-lint not installed — see https://golangci-lint.run/usage/install/" >&2
+    echo "  Or bypass once with: git commit --no-verify" >&2
+    failed=1
+  else
+    echo "▸ pre-commit: go golangci-lint (staged packages: ${go_pkgs[*]})"
+    if ! (cd go && golangci-lint run "${go_pkgs[@]}"); then
+      echo "✗ golangci-lint failed in the staged packages. Run 'cd go && golangci-lint run --fix ${go_pkgs[*]}' for autofixes, or 'make lint-go-fix' for the full project." >&2
+      failed=1
+    fi
   fi
 fi
 

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -27,7 +27,10 @@ git config --local core.hooksPath .githooks
 
 echo "✓ Hooks installed → core.hooksPath = .githooks"
 echo ""
-echo "Pre-commit gate: frontend prettier --check + eslint on staged files."
-echo "Pre-push gate:   frontend typecheck + i18n drift (when FE changed)."
+echo "Pre-commit gate: frontend prettier --check + eslint (staged files);"
+echo "                 Go nolintguard + qtlint (./...) + golangci-lint (staged packages)."
+echo "Pre-push gate:   frontend typecheck + i18n drift + vitest --coverage"
+echo "                 (when FE changed)."
 echo ""
 echo "Bypass once with --no-verify (commit) or --no-verify (push); CI still runs the full suite."
+echo "Same .git/config is shared by all worktrees — installing here covers every worktree."


### PR DESCRIPTION
## Summary

AI-driven commits keep landing Go that fails lint. The existing pre-commit hook only gated FE prettier+eslint; Go was uncovered until CI / pre-push. This PR extends the hook so a staged `go/**/*.go` change also runs the same three checks `make lint-go` runs — `go tool nolintguard ./...`, `go tool qtlint ./...`, and `golangci-lint run` — with one optimisation: golangci-lint is scoped to **the package directories that contain staged files**, not the whole repo.

Generated files (`*_generated.go`, `mock_*.go`) are excluded.

Same fail-on-error / `--no-verify` behaviour as before; the existing failure message already reminds the user how to bypass.

Also fixes a latent issue this PR surfaced while installing: `core.hooksPath` was previously set to an absolute path pointing at the empty `.git/hooks/` dir, so the committed hooks weren't firing at all. Running `./scripts/install-hooks.sh` (idempotent) now writes the **relative** `.githooks` value to `.git/config`. Because the per-clone git config is shared by all `git worktree` clones, a single install covers every worktree — and the relative path resolves to each worktree's checked-out `.githooks/` directory.

## What's gated (and where)

| Stage      | Frontend                                              | Go                                                                                |
|------------|-------------------------------------------------------|-----------------------------------------------------------------------------------|
| pre-commit | prettier + eslint on staged files                     | **nolintguard ./..., qtlint ./..., golangci-lint &lt;staged packages&gt;** (new)  |
| pre-push   | typecheck + i18n drift + vitest --coverage (FE changes only) | —                                                                          |
| CI         | full suite                                            | full suite                                                                        |

## Test plan

- [x] `./scripts/install-hooks.sh` sets `core.hooksPath = .githooks` (relative). Verified the value is visible from a `.claude/worktrees/issue-1662-edit-location-errors` checkout.
- [x] FE-only commit (this PR) passes the hook — Go branch correctly no-ops when no Go is staged.
- [ ] Reviewer: stage an intentionally lint-broken `*.go` file in any package and run `git commit` — should fail at the matching tool (`golangci-lint`, `qtlint`, or `nolintguard`) with the suggested autofix command, and `--no-verify` should still bypass.
- [ ] Reviewer: stage a Go change in a single subpackage and confirm `golangci-lint run` only touches that package (printed in `▸ pre-commit:` line).

## Notes

- `make lint-go` order preserved: nolintguard → qtlint → golangci-lint, so any user used to the Makefile output reads the same flow.
- If `golangci-lint` binary is missing, the hook prints the install URL and fails — same UX as for any other missing tool.