### PR TITLE
[#1653] Profile page: identity polish + 4-stat snapshot + Groups & Activity tabs

### DIFF
--- a/e2e/tests/profile.spec.ts
+++ b/e2e/tests/profile.spec.ts
@@ -269,11 +269,14 @@ authTest.describe('Profile page — read-only landing (#1653)', () => {
 
   authTest('Groups tab lists groups with role + members count', async ({ page }) => {
     await page.goto('/profile');
-    // The seed gives the admin at least one group, so the empty-state stub
-    // must not appear. The list (or first tile) does.
-    await expect(page.getByTestId('profile-groups-empty')).toHaveCount(0);
     const tiles = page.getByTestId('profile-group-tile');
+    // Wait for the first tile to land (not for `empty-state count=0`) —
+    // before the /groups round-trip resolves the empty-state can flash
+    // briefly. Now that GroupsTabBody owns an explicit loading state,
+    // the empty-state stays hidden during loading, but anchoring the
+    // assertion on the positive signal is still less racy.
     await expect(tiles.first()).toBeVisible();
+    await expect(page.getByTestId('profile-groups-empty')).toHaveCount(0);
     const firstTile = tiles.first();
     await expect(firstTile.getByTestId('profile-group-tile-name')).toBeVisible();
     // Role badge is sourced from the BE's `current_user_role` field — the

--- a/e2e/tests/profile.spec.ts
+++ b/e2e/tests/profile.spec.ts
@@ -226,6 +226,86 @@ authTest.describe('Profile page — password change API', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Profile page — read-only landing redesign (#1653)
+// Covers the identity card, 4-stat snapshot, and the Tabs (Groups + Activity)
+// that ProfilePage renders before any edit affordance is reached.
+// ---------------------------------------------------------------------------
+
+authTest.describe('Profile page — read-only landing (#1653)', () => {
+  authTest('renders identity card with stable initials avatar', async ({ page }) => {
+    await page.goto('/profile');
+    await expect(page.getByTestId('profile-page')).toBeVisible();
+    // The hidden <h1> carries the route's accessible name; the user's name
+    // sits below as visible content via `data-testid="profile-name"`. Both
+    // should be present so the page never reads as "empty heading" to a
+    // screen reader.
+    await expect(page.getByTestId('profile-name')).toBeVisible();
+    await expect(page.getByTestId('profile-email')).toBeVisible();
+    // The Edit affordance must remain wired — the read-only redesign keeps
+    // the same `/profile/edit` link that the old layout had.
+    await expect(page.getByTestId('profile-edit-link')).toHaveAttribute('href', /\/profile\/edit/);
+  });
+
+  authTest('renders the 4-stat snapshot grid', async ({ page }) => {
+    await page.goto('/profile');
+    await expect(page.getByTestId('profile-stats')).toBeVisible();
+    await expect(page.getByTestId('profile-stat-items')).toBeVisible();
+    await expect(page.getByTestId('profile-stat-active-warranties')).toBeVisible();
+    await expect(page.getByTestId('profile-stat-expiring-warranties')).toBeVisible();
+    await expect(page.getByTestId('profile-stat-est-value')).toBeVisible();
+  });
+
+  authTest('renders Groups + Activity tabs; Groups tab is active by default', async ({ page }) => {
+    await page.goto('/profile');
+    await expect(page.getByTestId('profile-tab-groups')).toBeVisible();
+    await expect(page.getByTestId('profile-tab-activity')).toBeVisible();
+    // Radix wires `data-state="active"` on the selected trigger.
+    await expect(page.getByTestId('profile-tab-groups')).toHaveAttribute('data-state', 'active');
+    await expect(page.getByTestId('profile-tab-activity')).toHaveAttribute(
+      'data-state',
+      'inactive'
+    );
+  });
+
+  authTest('Groups tab lists groups with role + members count', async ({ page }) => {
+    await page.goto('/profile');
+    // The seed gives the admin at least one group, so the empty-state stub
+    // must not appear. The list (or first tile) does.
+    await expect(page.getByTestId('profile-groups-empty')).toHaveCount(0);
+    const tiles = page.getByTestId('profile-group-tile');
+    await expect(tiles.first()).toBeVisible();
+    const firstTile = tiles.first();
+    await expect(firstTile.getByTestId('profile-group-tile-name')).toBeVisible();
+    // Role badge is sourced from the BE's `current_user_role` field — the
+    // seeded admin owns at least one group, so the badge text falls in the
+    // role taxonomy from #1533.
+    await expect(firstTile.getByTestId('profile-group-tile-role')).toBeVisible();
+    const role = await firstTile.getByTestId('profile-group-tile-role').getAttribute('data-role');
+    expect(['owner', 'admin', 'user', 'viewer']).toContain(role);
+    // Tile is a `<Link>` to /g/{slug}; href is wired so cmd-click works.
+    const href = await firstTile.getAttribute('href');
+    expect(href).toMatch(/^\/g\/[A-Za-z0-9_-]+$/);
+  });
+
+  authTest('clicking a group tile navigates to /g/{slug}', async ({ page }) => {
+    await page.goto('/profile');
+    const firstTile = page.getByTestId('profile-group-tile').first();
+    await expect(firstTile).toBeVisible();
+    const href = await firstTile.getAttribute('href');
+    await firstTile.click();
+    await expect(page).toHaveURL(new RegExp(href!.replace(/\//g, '\\/')));
+  });
+
+  authTest('Activity tab surfaces the empty-state shell when no feed is wired', async ({
+    page,
+  }) => {
+    await page.goto('/profile');
+    await page.getByTestId('profile-tab-activity').click();
+    await expect(page.getByTestId('profile-activity-empty')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Login page — session expired message
 // (raw test — no auth fixture so the router does not redirect away from /login)
 // ---------------------------------------------------------------------------

--- a/frontend/.size-limit.json
+++ b/frontend/.size-limit.json
@@ -12,7 +12,7 @@
   {
     "name": "CSS",
     "path": "dist/assets/index-*.css",
-    "limit": "17 KB",
+    "limit": "18 KB",
     "gzip": true
   },
   {

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn("group/tabs flex gap-2 data-[orientation=horizontal]:flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -112,6 +112,8 @@
     "groupsTab": {
       "emptyDescription": "Create a group or accept an invite to start tracking inventory.",
       "emptyTitle": "You're not in any groups yet",
+      "errorDescription": "We couldn't load your groups right now. Try again in a moment.",
+      "errorTitle": "Couldn't load your groups",
       "membersCount_one": "{{count}} member",
       "membersCount_other": "{{count}} members",
       "moreGroups_one": "+{{count}} more group",

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -92,8 +92,7 @@
   "profile": {
     "activityTab": {
       "emptyDescription": "We're building a personalised activity feed. Until then, item-level history lives on each commodity's detail page.",
-      "emptyTitle": "No recent activity yet",
-      "subIssue": "Track this on #1672"
+      "emptyTitle": "No recent activity yet"
     },
     "defaultGroup": "Default group",
     "defaultGroupHelp": "After login you'll land here. Pick another group at any time.",

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -90,6 +90,11 @@
     "title": "Privacy & security"
   },
   "profile": {
+    "activityTab": {
+      "emptyDescription": "We're building a personalised activity feed. Until then, item-level history lives on each commodity's detail page.",
+      "emptyTitle": "No recent activity yet",
+      "subIssue": "Track this on #1672"
+    },
     "defaultGroup": "Default group",
     "defaultGroupHelp": "After login you'll land here. Pick another group at any time.",
     "defaultGroupSaved": "Default group updated.",
@@ -105,6 +110,19 @@
       "title": "Edit profile"
     },
     "editProfile": "Edit profile",
+    "groupsTab": {
+      "emptyDescription": "Create a group or accept an invite to start tracking inventory.",
+      "emptyTitle": "You're not in any groups yet",
+      "membersCount_one": "{{count}} member",
+      "membersCount_other": "{{count}} members",
+      "moreGroups_one": "+{{count}} more group",
+      "moreGroups_other": "+{{count}} more groups",
+      "roleAdmin": "Admin",
+      "roleOwner": "Owner",
+      "roleUser": "Member",
+      "roleViewer": "Viewer",
+      "tileAria": "Open {{name}}"
+    },
     "heading": "My Profile",
     "memberSince": "Member since {{date}}",
     "noEmail": "No email on file",
@@ -128,7 +146,17 @@
       "title": "Change password"
     },
     "planFree": "Free plan",
+    "stats": {
+      "activeWarranties": "Active warranties",
+      "estValue": "Est. value",
+      "expiringSoon": "Expiring soon",
+      "items": "Items"
+    },
     "subtitle": "Your account, identity, and group preferences.",
+    "tabs": {
+      "activity": "Activity",
+      "groups": "Groups"
+    },
     "title": "My profile",
     "upgrade": "Upgrade"
   },

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -16,6 +16,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ComingSoonBanner } from "@/components/coming-soon"
 import { RouteTitle } from "@/components/routing/RouteTitle"
@@ -62,27 +63,25 @@ export function ProfilePage() {
       : null
 
   // Stat snapshot pulls from the active group's dashboard data (#1653
-  // acceptance criteria). When no group is selected the cards show a dash
-  // so the layout is stable but no misleading zeros render.
+  // acceptance criteria). The dash placeholder covers three branches: no
+  // active group, the dashboard query still settling, OR a fetch error —
+  // we'd rather render a stable "—" than a misleading "0 items / $0" when
+  // the API is actually unreachable.
   const hasGroupContext = !!currentGroup
   const groupCurrency = currentGroup?.group_currency ?? "USD"
+  const statsReady = hasGroupContext && !dashboard.isLoading && !dashboard.isError
   const dash = "—"
   const statValues = {
-    items: hasGroupContext && !dashboard.isLoading ? String(dashboard.totalItems) : dash,
-    activeWarranties:
-      hasGroupContext && !dashboard.isLoading
-        ? String(dashboard.warrantyStatusCounts.active)
-        : dash,
-    expiringSoon:
-      hasGroupContext && !dashboard.isLoading
-        ? String(dashboard.warrantyStatusCounts.expiring)
-        : dash,
-    estValue:
-      hasGroupContext && !dashboard.isLoading
-        ? formatCurrency(dashboard.totalValue, groupCurrency)
-        : dash,
+    items: statsReady ? String(dashboard.totalItems) : dash,
+    activeWarranties: statsReady ? String(dashboard.warrantyStatusCounts.active) : dash,
+    expiringSoon: statsReady ? String(dashboard.warrantyStatusCounts.expiring) : dash,
+    estValue: statsReady ? formatCurrency(dashboard.totalValue, groupCurrency) : dash,
   }
 
+  // Distinguish "still loading" from "loaded and empty" so the Groups tab
+  // doesn't flash the empty state during the /groups round-trip — and so
+  // the e2e harness doesn't catch the flicker mid-fetch.
+  const groupsLoading = groups === undefined
   const visibleGroups = (groups ?? []).slice(0, MAX_GROUP_TILES)
   const overflowGroups = Math.max(0, (groups?.length ?? 0) - MAX_GROUP_TILES)
 
@@ -245,6 +244,7 @@ export function ProfilePage() {
               groups={visibleGroups}
               overflow={overflowGroups}
               currentSlug={currentGroup?.slug}
+              isLoading={groupsLoading}
             />
           </TabsContent>
 
@@ -316,10 +316,30 @@ interface GroupsTabBodyProps {
   groups: LocationGroup[]
   overflow: number
   currentSlug?: string
+  isLoading: boolean
 }
 
-function GroupsTabBody({ groups, overflow, currentSlug }: GroupsTabBodyProps) {
+function GroupsTabBody({ groups, overflow, currentSlug, isLoading }: GroupsTabBodyProps) {
   const { t } = useTranslation()
+
+  // While the /groups round-trip is in flight, render skeleton tiles
+  // (not the empty-state) so the layout doesn't flash "you're not in any
+  // groups yet" before the first list resolves. The e2e harness also
+  // relies on this: `toHaveCount(0)` on `profile-groups-empty` after a
+  // bare `goto` would race the fetch otherwise.
+  if (isLoading) {
+    return (
+      <div
+        className="grid gap-3 sm:grid-cols-2"
+        data-testid="profile-groups-loading"
+        aria-busy="true"
+      >
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-[62px] rounded-xl" />
+        ))}
+      </div>
+    )
+  }
 
   if (groups.length === 0) {
     return (

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -49,7 +49,12 @@ function initialsFor(name?: string, email?: string): string {
 export function ProfilePage() {
   const { t } = useTranslation()
   const { user } = useAuth()
-  const { data: groups } = useGroups()
+  // Keep the full query handle (not just `data`) so the Groups tab can
+  // distinguish "still fetching" from "fetched + error" — `data` stays
+  // `undefined` in both cases under React Query, which would otherwise
+  // pin the skeleton state forever on first-load errors.
+  const groupsQuery = useGroups()
+  const groups = groupsQuery.data
   const { currentGroup } = useCurrentGroup()
   const dashboard = useDashboardData()
 
@@ -78,10 +83,14 @@ export function ProfilePage() {
     estValue: statsReady ? formatCurrency(dashboard.totalValue, groupCurrency) : dash,
   }
 
-  // Distinguish "still loading" from "loaded and empty" so the Groups tab
-  // doesn't flash the empty state during the /groups round-trip — and so
-  // the e2e harness doesn't catch the flicker mid-fetch.
-  const groupsLoading = groups === undefined
+  // Distinguish "still loading" from "loaded and empty" and from "errored
+  // out on first load" so the Groups tab body picks the right surface
+  // (skeleton / empty-state / error-state). React Query keeps `data`
+  // undefined on both first-load fetch and first-load error — gating on
+  // `isLoading` (not `data === undefined`) is what keeps the skeleton
+  // from pinning forever when /groups 5xxs.
+  const groupsLoading = groupsQuery.isLoading
+  const groupsError = groupsQuery.isError && !groups
   const visibleGroups = (groups ?? []).slice(0, MAX_GROUP_TILES)
   const overflowGroups = Math.max(0, (groups?.length ?? 0) - MAX_GROUP_TILES)
 
@@ -245,6 +254,7 @@ export function ProfilePage() {
               overflow={overflowGroups}
               currentSlug={currentGroup?.slug}
               isLoading={groupsLoading}
+              isError={groupsError}
             />
           </TabsContent>
 
@@ -317,9 +327,10 @@ interface GroupsTabBodyProps {
   overflow: number
   currentSlug?: string
   isLoading: boolean
+  isError: boolean
 }
 
-function GroupsTabBody({ groups, overflow, currentSlug, isLoading }: GroupsTabBodyProps) {
+function GroupsTabBody({ groups, overflow, currentSlug, isLoading, isError }: GroupsTabBodyProps) {
   const { t } = useTranslation()
 
   // While the /groups round-trip is in flight, render skeleton tiles
@@ -337,6 +348,27 @@ function GroupsTabBody({ groups, overflow, currentSlug, isLoading }: GroupsTabBo
         {Array.from({ length: 4 }).map((_, i) => (
           <Skeleton key={i} className="h-[62px] rounded-xl" />
         ))}
+      </div>
+    )
+  }
+
+  // First-load error: React Query keeps `data` undefined and `isLoading`
+  // false in this case. Surface a distinct empty-with-error state instead
+  // of either the "no groups" copy (misleading) or an indefinite skeleton.
+  if (isError) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center gap-3 rounded-xl border border-border bg-card px-6 py-12 text-center"
+        data-testid="profile-groups-error"
+        role="status"
+      >
+        <Users className="size-8 text-muted-foreground/40" aria-hidden="true" />
+        <div>
+          <p className="text-sm font-semibold">{t("settings:profile.groupsTab.errorTitle")}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t("settings:profile.groupsTab.errorDescription")}
+          </p>
+        </div>
       </div>
     )
   }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,17 +1,38 @@
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
-import { Building2, Calendar, Mail, Pencil, Zap } from "lucide-react"
+import {
+  Building2,
+  Calendar,
+  Mail,
+  Package,
+  Pencil,
+  ShieldCheck,
+  TrendingUp,
+  Users,
+  Zap,
+} from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ComingSoonBanner } from "@/components/coming-soon"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { useAuth } from "@/features/auth/AuthContext"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useGroups } from "@/features/group/hooks"
+import { useDashboardData } from "@/features/dashboard/hooks"
+import type { LocationGroup } from "@/features/group/api"
+import type { GroupRole } from "@/features/group/api"
 import { withGroupQuery } from "@/lib/group-aware-url"
-import { formatDate } from "@/lib/intl"
+import { formatCurrency, formatDate } from "@/lib/intl"
+
+// Cap the Groups tab grid at MAX_GROUP_TILES; the "+N more" affordance
+// matches the design mock's overflow pattern. Picked so the grid stays
+// at or below 3 visual rows on a 2-column layout — beyond that we'd be
+// better off sending the user to a dedicated "all groups" surface.
+const MAX_GROUP_TILES = 6
 
 // Initials for the avatar fallback. "Alex Johnson" → "AJ", "alex" → "A".
 // We keep at most two letters and fall back to the email's local part if
@@ -29,12 +50,8 @@ export function ProfilePage() {
   const { user } = useAuth()
   const { data: groups } = useGroups()
   const { currentGroup } = useCurrentGroup()
+  const dashboard = useDashboardData()
 
-  // Derived display name. While the /auth/me probe is in flight the
-  // user object is undefined, so this would be the empty string and the
-  // <h1> would render empty — axe flags that as `empty-heading`. We
-  // fall back to "—" so the heading always has a non-empty accessible
-  // name; the real name slots in once the probe resolves.
   const derivedName = user?.name?.trim() || (user?.email?.split("@")[0] ?? "")
   const name = derivedName || "—"
   const email = user?.email ?? t("settings:profile.noEmail")
@@ -44,15 +61,40 @@ export function ProfilePage() {
       ? (groups.find((g) => g.id === user.default_group_id) ?? null)
       : null
 
+  // Stat snapshot pulls from the active group's dashboard data (#1653
+  // acceptance criteria). When no group is selected the cards show a dash
+  // so the layout is stable but no misleading zeros render.
+  const hasGroupContext = !!currentGroup
+  const groupCurrency = currentGroup?.group_currency ?? "USD"
+  const dash = "—"
+  const statValues = {
+    items: hasGroupContext && !dashboard.isLoading ? String(dashboard.totalItems) : dash,
+    activeWarranties:
+      hasGroupContext && !dashboard.isLoading
+        ? String(dashboard.warrantyStatusCounts.active)
+        : dash,
+    expiringSoon:
+      hasGroupContext && !dashboard.isLoading
+        ? String(dashboard.warrantyStatusCounts.expiring)
+        : dash,
+    estValue:
+      hasGroupContext && !dashboard.isLoading
+        ? formatCurrency(dashboard.totalValue, groupCurrency)
+        : dash,
+  }
+
+  const visibleGroups = (groups ?? []).slice(0, MAX_GROUP_TILES)
+  const overflowGroups = Math.max(0, (groups?.length ?? 0) - MAX_GROUP_TILES)
+
   return (
     <>
       <RouteTitle title={t("settings:profile.title")} />
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6" data-testid="profile-page">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 p-6" data-testid="profile-page">
         {/* Identity card. Banner + avatar + name + plan badge. The cover
             stripe pattern is taken from the design mock; the avatar shows
             initials because uploads are tracked under #1382. */}
-        <section className="rounded-2xl border border-border overflow-hidden">
-          <div className="relative h-24 bg-primary overflow-hidden">
+        <section className="overflow-hidden rounded-2xl border border-border">
+          <div className="relative h-28 overflow-hidden bg-primary">
             <div
               aria-hidden="true"
               className="absolute inset-0 opacity-[0.07]"
@@ -61,11 +103,19 @@ export function ProfilePage() {
                   "repeating-linear-gradient(-45deg, currentColor 0, currentColor 1px, transparent 1px, transparent 10px)",
               }}
             />
+            <div
+              aria-hidden="true"
+              className="absolute -bottom-6 -left-6 size-36 rounded-full bg-primary-foreground/10 blur-2xl"
+            />
+            <div
+              aria-hidden="true"
+              className="absolute -top-4 right-12 size-24 rounded-full bg-primary-foreground/5 blur-xl"
+            />
             <Button
               asChild
               variant="secondary"
               size="sm"
-              className="absolute top-3 right-3 gap-1.5 bg-background/80 hover:bg-background/95 backdrop-blur-sm shadow-sm"
+              className="absolute top-3 right-3 gap-1.5 bg-background/80 shadow-sm backdrop-blur-sm hover:bg-background/95"
             >
               <Link
                 to={withGroupQuery("/profile/edit", currentGroup?.slug)}
@@ -78,18 +128,25 @@ export function ProfilePage() {
           </div>
 
           <div className="px-5 pb-5">
-            <div className="flex items-end justify-between -mt-9 mb-3">
-              <div
-                className="flex size-[72px] items-center justify-center rounded-2xl bg-card border-4 border-background text-xl font-bold text-primary shadow-md"
-                aria-hidden="true"
-              >
-                {initialsFor(user?.name, user?.email)}
+            <div className="-mt-9 mb-3 flex items-end justify-between">
+              {/* The mock wraps the avatar in a `relative group` so the
+                  camera-upload overlay can sit inside on hover (#1382).
+                  We keep the wrapper even without the overlay so the
+                  alignment math (avatar bottom vs. plan-cluster bottom)
+                  matches the mock exactly. */}
+              <div className="relative group">
+                <div
+                  className="flex size-[72px] items-center justify-center rounded-2xl border-4 border-background bg-card text-xl font-bold text-primary shadow-md"
+                  aria-hidden="true"
+                >
+                  {initialsFor(user?.name, user?.email)}
+                </div>
               </div>
-              <div className="flex items-center gap-2 mb-1">
+              <div className="mb-1 flex items-center gap-2">
                 <Badge variant="outline" className="text-xs font-medium">
                   {t("settings:profile.planFree")}
                 </Badge>
-                <Button asChild variant="outline" size="sm" className="gap-1.5 h-7 px-2.5 text-xs">
+                <Button asChild variant="outline" size="sm" className="h-7 gap-1.5 px-2.5 text-xs">
                   <Link
                     to={withGroupQuery("/plans", currentGroup?.slug)}
                     data-testid="profile-upgrade-link"
@@ -101,7 +158,7 @@ export function ProfilePage() {
               </div>
             </div>
 
-            <div className="space-y-0.5 mb-4">
+            <div className="mb-4 space-y-0.5">
               {/* H1 is a stable page title ("My Profile") so the route's
                   accessible name doesn't shift with whatever name the user
                   has set — the live identity (name + email) sits below as
@@ -140,9 +197,65 @@ export function ProfilePage() {
           </div>
         </section>
 
-        {/* Avatar upload tracker — visible per-section stub linked to #1382.
-            The decorative initials avatar above is the placeholder; this
-            banner is what tells the user uploads are coming. */}
+        {/* Stat snapshot — 4-up grid, mock parity (UserProfileView.tsx:127). */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4" data-testid="profile-stats">
+          <StatTile
+            icon={Package}
+            label={t("settings:profile.stats.items")}
+            value={statValues.items}
+            testId="profile-stat-items"
+          />
+          <StatTile
+            icon={ShieldCheck}
+            label={t("settings:profile.stats.activeWarranties")}
+            value={statValues.activeWarranties}
+            iconClassName="text-status-active"
+            valueClassName="text-status-active"
+            testId="profile-stat-active-warranties"
+          />
+          <StatTile
+            icon={ShieldCheck}
+            label={t("settings:profile.stats.expiringSoon")}
+            value={statValues.expiringSoon}
+            iconClassName="text-status-expiring"
+            valueClassName="text-status-expiring"
+            testId="profile-stat-expiring-warranties"
+          />
+          <StatTile
+            icon={TrendingUp}
+            label={t("settings:profile.stats.estValue")}
+            value={statValues.estValue}
+            testId="profile-stat-est-value"
+          />
+        </div>
+
+        {/* Tabs: Groups (mock's "Inventory" repurposed per issue) + Activity. */}
+        <Tabs defaultValue="groups" data-testid="profile-tabs">
+          <TabsList variant="line" className="justify-start">
+            <TabsTrigger value="groups" data-testid="profile-tab-groups">
+              {t("settings:profile.tabs.groups")}
+            </TabsTrigger>
+            <TabsTrigger value="activity" data-testid="profile-tab-activity">
+              {t("settings:profile.tabs.activity")}
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="groups" className="mt-4" data-testid="profile-tab-groups-content">
+            <GroupsTabBody
+              groups={visibleGroups}
+              overflow={overflowGroups}
+              currentSlug={currentGroup?.slug}
+            />
+          </TabsContent>
+
+          <TabsContent value="activity" className="mt-4" data-testid="profile-tab-activity-content">
+            <ActivityTabBody />
+          </TabsContent>
+        </Tabs>
+
+        {/* Avatar upload tracker — keep the per-section stub linked to
+            #1382. Demoted below the snapshot so it doesn't compete with
+            the new identity → stats → tabs primary scan. */}
         <ComingSoonBanner surface="profilePhoto" />
 
         <Separator />
@@ -152,7 +265,7 @@ export function ProfilePage() {
             {t("settings:profile.subtitle")}{" "}
             <Link
               to={withGroupQuery("/settings", currentGroup?.slug)}
-              className="font-medium text-foreground hover:underline underline-offset-4"
+              className="font-medium text-foreground underline-offset-4 hover:underline"
             >
               {t("settings:title")}
             </Link>
@@ -161,5 +274,181 @@ export function ProfilePage() {
         </div>
       </div>
     </>
+  )
+}
+
+interface StatTileProps {
+  icon: React.ElementType
+  label: string
+  value: string
+  iconClassName?: string
+  valueClassName?: string
+  testId: string
+}
+
+function StatTile({
+  icon: Icon,
+  label,
+  value,
+  iconClassName,
+  valueClassName,
+  testId,
+}: StatTileProps) {
+  return (
+    <Card className="gap-2 py-4" data-testid={testId}>
+      <CardHeader className="px-4 pb-0">
+        <Icon className={`size-4 ${iconClassName ?? "text-foreground"}`} aria-hidden="true" />
+      </CardHeader>
+      <CardContent className="px-4">
+        <p
+          className={`text-xl font-bold tracking-tight ${valueClassName ?? "text-foreground"}`}
+          data-testid={`${testId}-value`}
+        >
+          {value}
+        </p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{label}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+interface GroupsTabBodyProps {
+  groups: LocationGroup[]
+  overflow: number
+  currentSlug?: string
+}
+
+function GroupsTabBody({ groups, overflow, currentSlug }: GroupsTabBodyProps) {
+  const { t } = useTranslation()
+
+  if (groups.length === 0) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center gap-3 rounded-xl border border-border bg-card px-6 py-12 text-center"
+        data-testid="profile-groups-empty"
+      >
+        <Users className="size-8 text-muted-foreground/40" aria-hidden="true" />
+        <div>
+          <p className="text-sm font-semibold">{t("settings:profile.groupsTab.emptyTitle")}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t("settings:profile.groupsTab.emptyDescription")}
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div data-testid="profile-groups-list">
+      <div className="grid gap-3 sm:grid-cols-2">
+        {groups.map((group) => (
+          <GroupTile key={group.id ?? group.slug} group={group} currentSlug={currentSlug} />
+        ))}
+      </div>
+      {overflow > 0 ? (
+        <p
+          className="mt-3 text-center text-xs text-muted-foreground"
+          data-testid="profile-groups-overflow"
+        >
+          {t("settings:profile.groupsTab.moreGroups", { count: overflow })}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+interface GroupTileProps {
+  group: LocationGroup
+  currentSlug?: string
+}
+
+function GroupTile({ group, currentSlug }: GroupTileProps) {
+  const { t } = useTranslation()
+  const slug = group.slug ?? ""
+  const href = slug ? `/g/${slug}` : "/groups"
+  const memberCount = group.members_count ?? 0
+  const role = group.current_user_role
+  const roleLabel = roleLabelFor(t, role)
+  const isActive = !!currentSlug && currentSlug === slug
+  const icon = group.icon?.trim() ?? ""
+
+  return (
+    <Link
+      to={href}
+      data-testid="profile-group-tile"
+      data-group-slug={slug}
+      aria-label={t("settings:profile.groupsTab.tileAria", { name: group.name ?? "" })}
+      className={`flex items-center gap-3 rounded-xl border border-border bg-card p-3 text-left transition-all hover:-translate-y-0.5 hover:shadow-sm focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none ${
+        isActive ? "border-primary/40" : ""
+      }`}
+    >
+      <div
+        className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-base"
+        aria-hidden="true"
+      >
+        {icon || <Building2 className="size-4 text-muted-foreground" />}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium" data-testid="profile-group-tile-name">
+          {group.name ?? slug}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {t("settings:profile.groupsTab.membersCount", { count: memberCount })}
+        </p>
+      </div>
+      {role ? (
+        <Badge
+          variant="outline"
+          className="shrink-0 text-xs font-medium"
+          data-testid="profile-group-tile-role"
+          data-role={role}
+        >
+          {roleLabel}
+        </Badge>
+      ) : null}
+    </Link>
+  )
+}
+
+// roleLabelFor maps a GroupRole to its translated display string. Inlined
+// switch-with-literal-keys (rather than `t(\`...${role}\`)`) so the i18n
+// extractor can see each key statically — dynamic keys silently disappear
+// from the extracted catalogue and ship as the raw key in production.
+function roleLabelFor(t: (key: string) => string, role: GroupRole | undefined): string {
+  switch (role) {
+    case "owner":
+      return t("settings:profile.groupsTab.roleOwner")
+    case "admin":
+      return t("settings:profile.groupsTab.roleAdmin")
+    case "user":
+      return t("settings:profile.groupsTab.roleUser")
+    case "viewer":
+      return t("settings:profile.groupsTab.roleViewer")
+    default:
+      return t("settings:profile.groupsTab.roleUser")
+  }
+}
+
+function ActivityTabBody() {
+  const { t } = useTranslation()
+  // The dedicated activity feed lives behind a sub-issue (#1672); until
+  // it ships we render an empty-state shell that matches the mock's
+  // activity-list card frame so the tab body never measures empty.
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-3 rounded-xl border border-border bg-card px-6 py-12 text-center"
+      data-testid="profile-activity-empty"
+    >
+      <Calendar className="size-8 text-muted-foreground/40" aria-hidden="true" />
+      <div>
+        <p className="text-sm font-semibold">{t("settings:profile.activityTab.emptyTitle")}</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {t("settings:profile.activityTab.emptyDescription")}
+        </p>
+        <p className="mt-2 text-xs text-muted-foreground">
+          {t("settings:profile.activityTab.subIssue")}
+        </p>
+      </div>
+    </div>
   )
 }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -431,9 +431,11 @@ function roleLabelFor(t: (key: string) => string, role: GroupRole | undefined): 
 
 function ActivityTabBody() {
   const { t } = useTranslation()
-  // The dedicated activity feed lives behind a sub-issue (#1672); until
-  // it ships we render an empty-state shell that matches the mock's
-  // activity-list card frame so the tab body never measures empty.
+  // The dedicated user-scoped activity feed isn't wired yet — the
+  // commodity-events registry only exposes a per-commodity reader today
+  // (#1450), and the audit_logs reader is admin-only. Render an
+  // empty-state shell matching the mock's activity-list card frame so
+  // the tab body never measures empty; the wired feed lands separately.
   return (
     <div
       className="flex flex-col items-center justify-center gap-3 rounded-xl border border-border bg-card px-6 py-12 text-center"
@@ -444,9 +446,6 @@ function ActivityTabBody() {
         <p className="text-sm font-semibold">{t("settings:profile.activityTab.emptyTitle")}</p>
         <p className="mt-1 text-xs text-muted-foreground">
           {t("settings:profile.activityTab.emptyDescription")}
-        </p>
-        <p className="mt-2 text-xs text-muted-foreground">
-          {t("settings:profile.activityTab.subIssue")}
         </p>
       </div>
     </div>

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -195,6 +195,22 @@ describe("<ProfilePage />", () => {
       expect(screen.queryByTestId("profile-groups-list")).not.toBeInTheDocument()
     })
 
+    it("renders the error state when /groups fails on first load", async () => {
+      server.use(
+        msw.get(api("/auth/me"), () =>
+          HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+        ),
+        msw.get(api("/groups"), () => new HttpResponse(null, { status: 500 }))
+      )
+      renderProfile()
+      // The error tile must surface — without an explicit error branch the
+      // tab would pin the loading skeleton forever, because React Query
+      // keeps `data` undefined when the first fetch errors.
+      await waitFor(() => expect(screen.getByTestId("profile-groups-error")).toBeInTheDocument())
+      expect(screen.queryByTestId("profile-groups-loading")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("profile-groups-empty")).not.toBeInTheDocument()
+    })
+
     it("renders a single group tile with the user's role", async () => {
       server.use(
         msw.get(api("/auth/me"), () =>

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -37,7 +37,10 @@ function renderProfile(initialPath = "/profile") {
 
 // Stub the commodities + values endpoints used by `useDashboardData` so the
 // 4-stat snapshot tile renders concrete numbers instead of the still-loading
-// dash placeholder. Tests that don't assert on stats can skip this.
+// dash placeholder. The values payload mirrors the real BE shape
+// (`data.attributes.global_total` + per-location/area breakdown lists with
+// `{id,name,value}`) so the stub doesn't accidentally mask a contract
+// regression — even though the page only reads `global_total` today.
 function mockDashboardEndpoints(slug: string) {
   return [
     msw.get(api(`/g/${slug}/commodities`), () =>
@@ -47,7 +50,15 @@ function mockDashboardEndpoints(slug: string) {
       })
     ),
     msw.get(api(`/g/${slug}/commodities/values`), () =>
-      HttpResponse.json({ data: { attributes: { global: 0 } } })
+      HttpResponse.json({
+        data: {
+          attributes: {
+            global_total: 0,
+            location_totals: [],
+            area_totals: [],
+          },
+        },
+      })
     ),
   ]
 }

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { http as msw, HttpResponse } from "msw"
 import { Route } from "react-router-dom"
-import { screen, waitFor } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { axe } from "jest-axe"
 
 import { ProfilePage } from "@/pages/ProfilePage"
@@ -15,10 +16,10 @@ import { __resetHttpForTests } from "@/lib/http"
 
 const api = (path: string) => `${window.location.origin}/api/v1${path}`
 
-function renderProfile() {
+function renderProfile(initialPath = "/profile") {
   setAccessToken("good-token")
   return renderWithProviders({
-    initialPath: "/profile",
+    initialPath,
     routes: (
       <Route
         path="/profile"
@@ -32,6 +33,23 @@ function renderProfile() {
       />
     ),
   })
+}
+
+// Stub the commodities + values endpoints used by `useDashboardData` so the
+// 4-stat snapshot tile renders concrete numbers instead of the still-loading
+// dash placeholder. Tests that don't assert on stats can skip this.
+function mockDashboardEndpoints(slug: string) {
+  return [
+    msw.get(api(`/g/${slug}/commodities`), () =>
+      HttpResponse.json({
+        data: [],
+        meta: { commodities: 0, total: 0, page: 1, per_page: 100, total_pages: 1 },
+      })
+    ),
+    msw.get(api(`/g/${slug}/commodities/values`), () =>
+      HttpResponse.json({ data: { attributes: { global: 0 } } })
+    ),
+  ]
 }
 
 beforeEach(() => {
@@ -118,5 +136,229 @@ describe("<ProfilePage />", () => {
       expect(screen.getByTestId("profile-name")).toHaveTextContent("Alex Johnson")
     )
     expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it("renders the initials avatar from the user's name", async () => {
+    server.use(
+      msw.get(api("/auth/me"), () =>
+        HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex Johnson" })
+      ),
+      msw.get(api("/groups"), () => HttpResponse.json({ data: [] }))
+    )
+    renderProfile()
+    // The avatar is rendered as a presentational `aria-hidden="true"` tile
+    // (the heading carries the accessible name). Look it up via the inner
+    // text content so this test exercises the actual rendering path the
+    // user sees, not just the API contract.
+    await waitFor(() => {
+      const card = screen.getByTestId("profile-page")
+      expect(within(card).getByText("AJ")).toBeInTheDocument()
+    })
+  })
+
+  it("renders the 4-up stat snapshot grid", async () => {
+    server.use(
+      msw.get(api("/auth/me"), () =>
+        HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+      ),
+      msw.get(api("/groups"), () => HttpResponse.json({ data: [] }))
+    )
+    renderProfile()
+    await waitFor(() => expect(screen.getByTestId("profile-stats")).toBeInTheDocument())
+    expect(screen.getByTestId("profile-stat-items")).toBeInTheDocument()
+    expect(screen.getByTestId("profile-stat-active-warranties")).toBeInTheDocument()
+    expect(screen.getByTestId("profile-stat-expiring-warranties")).toBeInTheDocument()
+    expect(screen.getByTestId("profile-stat-est-value")).toBeInTheDocument()
+  })
+
+  describe("Groups tab", () => {
+    it("renders the empty state when the user has no groups", async () => {
+      server.use(
+        msw.get(api("/auth/me"), () =>
+          HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+        ),
+        msw.get(api("/groups"), () => HttpResponse.json({ data: [] }))
+      )
+      renderProfile()
+      await waitFor(() => expect(screen.getByTestId("profile-groups-empty")).toBeInTheDocument())
+      expect(screen.queryByTestId("profile-groups-list")).not.toBeInTheDocument()
+    })
+
+    it("renders a single group tile with the user's role", async () => {
+      server.use(
+        msw.get(api("/auth/me"), () =>
+          HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+        ),
+        msw.get(api("/groups"), () =>
+          HttpResponse.json({
+            data: [
+              {
+                id: "g1",
+                type: "groups",
+                attributes: {
+                  id: "g1",
+                  slug: "household",
+                  name: "Household",
+                  members_count: 3,
+                  current_user_role: "owner",
+                },
+              },
+            ],
+          })
+        )
+      )
+      renderProfile()
+      await waitFor(() => {
+        const tiles = screen.getAllByTestId("profile-group-tile")
+        expect(tiles).toHaveLength(1)
+      })
+      const tile = screen.getByTestId("profile-group-tile")
+      expect(within(tile).getByTestId("profile-group-tile-name")).toHaveTextContent("Household")
+      expect(within(tile).getByTestId("profile-group-tile-role")).toHaveTextContent(/Owner/i)
+      expect(tile).toHaveAttribute("href", "/g/household")
+      expect(tile).toHaveAttribute("data-group-slug", "household")
+    })
+
+    it("renders multiple group tiles with their own role badges", async () => {
+      server.use(
+        msw.get(api("/auth/me"), () =>
+          HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+        ),
+        msw.get(api("/groups"), () =>
+          HttpResponse.json({
+            data: [
+              {
+                id: "g1",
+                type: "groups",
+                attributes: {
+                  id: "g1",
+                  slug: "household",
+                  name: "Household",
+                  members_count: 3,
+                  current_user_role: "owner",
+                },
+              },
+              {
+                id: "g2",
+                type: "groups",
+                attributes: {
+                  id: "g2",
+                  slug: "family",
+                  name: "Family",
+                  members_count: 5,
+                  current_user_role: "user",
+                },
+              },
+              {
+                id: "g3",
+                type: "groups",
+                attributes: {
+                  id: "g3",
+                  slug: "office",
+                  name: "Office",
+                  members_count: 12,
+                  current_user_role: "admin",
+                },
+              },
+            ],
+          })
+        )
+      )
+      renderProfile()
+      await waitFor(() => {
+        const tiles = screen.getAllByTestId("profile-group-tile")
+        expect(tiles).toHaveLength(3)
+      })
+      const tiles = screen.getAllByTestId("profile-group-tile")
+      const roles = tiles.map((tile) =>
+        tile.querySelector('[data-testid="profile-group-tile-role"]')?.getAttribute("data-role")
+      )
+      expect(roles).toEqual(["owner", "user", "admin"])
+      // Each tile is a Link → /g/{slug} so cmd/ctrl-click still works.
+      expect(tiles[0]).toHaveAttribute("href", "/g/household")
+      expect(tiles[1]).toHaveAttribute("href", "/g/family")
+      expect(tiles[2]).toHaveAttribute("href", "/g/office")
+    })
+
+    it("renders a +N overflow row when groups exceed the tile cap", async () => {
+      const groups = Array.from({ length: 9 }, (_, i) => ({
+        id: `g${i}`,
+        type: "groups",
+        attributes: {
+          id: `g${i}`,
+          slug: `group-${i}`,
+          name: `Group ${i}`,
+          members_count: 1,
+          current_user_role: "user",
+        },
+      }))
+      server.use(
+        msw.get(api("/auth/me"), () =>
+          HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+        ),
+        msw.get(api("/groups"), () => HttpResponse.json({ data: groups }))
+      )
+      renderProfile()
+      await waitFor(() => {
+        expect(screen.getAllByTestId("profile-group-tile")).toHaveLength(6)
+      })
+      // 9 total - 6 visible = 3 overflow.
+      expect(screen.getByTestId("profile-groups-overflow")).toHaveTextContent(/\+3/)
+    })
+  })
+
+  describe("Activity tab", () => {
+    it("renders the empty state and switches in via the tab control", async () => {
+      server.use(
+        msw.get(api("/auth/me"), () =>
+          HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+        ),
+        msw.get(api("/groups"), () => HttpResponse.json({ data: [] }))
+      )
+      renderProfile()
+      await waitFor(() => expect(screen.getByTestId("profile-tab-activity")).toBeInTheDocument())
+      const user = userEvent.setup()
+      await user.click(screen.getByTestId("profile-tab-activity"))
+      await waitFor(() => expect(screen.getByTestId("profile-activity-empty")).toBeInTheDocument())
+    })
+  })
+
+  describe("Stat snapshot", () => {
+    it("renders item count and est. value once the active group resolves", async () => {
+      server.use(
+        msw.get(api("/auth/me"), () =>
+          HttpResponse.json({
+            id: "u1",
+            email: "alex@example.com",
+            name: "Alex",
+            default_group_id: "g1",
+          })
+        ),
+        msw.get(api("/groups"), () =>
+          HttpResponse.json({
+            data: [
+              {
+                id: "g1",
+                type: "groups",
+                attributes: {
+                  id: "g1",
+                  slug: "household",
+                  name: "Household",
+                  group_currency: "USD",
+                  members_count: 1,
+                  current_user_role: "owner",
+                },
+              },
+            ],
+          })
+        ),
+        ...mockDashboardEndpoints("household")
+      )
+      renderProfile("/profile?g=household")
+      await waitFor(() => {
+        expect(screen.getByTestId("profile-stat-items-value")).toHaveTextContent("0")
+      })
+      expect(screen.getByTestId("profile-stat-est-value-value").textContent).toMatch(/\$/)
+    })
   })
 })

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -7496,6 +7496,16 @@ export type components = {
              */
             readonly currency_migration_id?: string;
             /**
+             * @description CurrentUserRole is the caller's GroupRole within this group, populated
+             *     by the /groups handlers from the request's authenticated user. It lets
+             *     surfaces like the Profile page Groups tab (#1653) render a per-tile
+             *     role badge in one round-trip instead of fetching memberships per
+             *     group. nil when the lister has no associated user (system-mode
+             *     callers — none exist today on /groups, but the field is optional so
+             *     non-authenticated paths don't synthesize a misleading role).
+             */
+            readonly current_user_role?: components["schemas"]["models.GroupRole"];
+            /**
              * @description GroupCurrency is the ISO-4217 code the group values its inventory in. It is
              *     a property of the group (not the user) because a user can belong to
              *     groups valued in different currencies. Admins change it via the group's

--- a/go/apiserver/groups.go
+++ b/go/apiserver/groups.go
@@ -468,9 +468,10 @@ func (api *groupsAPI) getGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Populate LocationGroup.CurrentUserRole for parity with the list
-	// response (#1653). groupCtx already enforced membership for non-admin
-	// callers, so a nil role here is rare but not impossible (e.g. observer
-	// paths where the role lookup races a concurrent removal).
+	// response (#1653). The requireGroupMember middleware higher up the
+	// chain already gates this endpoint on membership, so a nil role
+	// here is rare — the realistic case is a race where the user is
+	// removed from the group concurrently with this read.
 	if user := GetUserFromRequest(r); user != nil {
 		if err := api.groupService.AttachCurrentUserRole(r.Context(), group, user.TenantID, user.ID); err != nil {
 			internalServerError(w, r, err)

--- a/go/apiserver/groups.go
+++ b/go/apiserver/groups.go
@@ -376,14 +376,9 @@ func (api *groupsAPI) listGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Populate LocationGroup.CurrentUserRole so the Profile page Groups
-	// tab (#1653) and any other surface can render the caller's role
-	// per group without a per-tile members lookup. One ListByUser
-	// round-trip covers every group in the list.
-	if err := api.groupService.AttachCurrentUserRoles(r.Context(), groups, user.TenantID, user.ID); err != nil {
-		internalServerError(w, r, err)
-		return
-	}
+	// CurrentUserRole is populated inline by ListUserGroups above —
+	// it reuses the membership rows it had to load anyway, so no
+	// extra round-trip is needed here (#1653).
 
 	total := len(groups)
 	resp := jsonapi.NewLocationGroupsResponse(groups, total, 1, total)

--- a/go/apiserver/groups.go
+++ b/go/apiserver/groups.go
@@ -376,6 +376,15 @@ func (api *groupsAPI) listGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Populate LocationGroup.CurrentUserRole so the Profile page Groups
+	// tab (#1653) and any other surface can render the caller's role
+	// per group without a per-tile members lookup. One ListByUser
+	// round-trip covers every group in the list.
+	if err := api.groupService.AttachCurrentUserRoles(r.Context(), groups, user.TenantID, user.ID); err != nil {
+		internalServerError(w, r, err)
+		return
+	}
+
 	total := len(groups)
 	resp := jsonapi.NewLocationGroupsResponse(groups, total, 1, total)
 	if err := render.Render(w, r, resp); err != nil {
@@ -456,6 +465,17 @@ func (api *groupsAPI) getGroup(w http.ResponseWriter, r *http.Request) {
 	if err := api.groupService.AttachMembersCount(r.Context(), group); err != nil {
 		internalServerError(w, r, err)
 		return
+	}
+
+	// Populate LocationGroup.CurrentUserRole for parity with the list
+	// response (#1653). groupCtx already enforced membership for non-admin
+	// callers, so a nil role here is rare but not impossible (e.g. observer
+	// paths where the role lookup races a concurrent removal).
+	if user := GetUserFromRequest(r); user != nil {
+		if err := api.groupService.AttachCurrentUserRole(r.Context(), group, user.TenantID, user.ID); err != nil {
+			internalServerError(w, r, err)
+			return
+		}
 	}
 
 	resp := jsonapi.NewLocationGroupResponse(group)

--- a/go/apiserver/groups_test.go
+++ b/go/apiserver/groups_test.go
@@ -441,3 +441,83 @@ func TestGroupsAPI_GetGroup_IncludesMembersCount(t *testing.T) {
 	// Only the seeded owner is a member of this fresh group.
 	c.Assert(out.Data.Attributes.MembersCount, qt.Equals, 1)
 }
+
+// Issue #1653: /groups list payloads carry `current_user_role` so the Profile
+// page Groups tab can render the caller's role per group without a per-tile
+// members lookup.
+func TestGroupsAPI_ListGroups_IncludesCurrentUserRole(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, models.Currency("USD"))
+
+	req := httptest.NewRequest(http.MethodGet, "/groups", nil)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	c.Assert(w.Code, qt.Equals, http.StatusOK, qt.Commentf("body: %s", w.Body.String()))
+
+	var out jsonapi.LocationGroupsResponse
+	c.Assert(json.Unmarshal(w.Body.Bytes(), &out), qt.IsNil)
+	c.Assert(out.Data, qt.HasLen, 1)
+	role := out.Data[0].Attributes.CurrentUserRole
+	c.Assert(role, qt.IsNotNil)
+	c.Assert(*role, qt.Equals, models.GroupRoleOwner)
+}
+
+func TestGroupsAPI_GetGroup_IncludesCurrentUserRole(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, models.Currency("USD"))
+
+	req := httptest.NewRequest(http.MethodGet, "/groups/"+env.group.ID, nil)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	c.Assert(w.Code, qt.Equals, http.StatusOK, qt.Commentf("body: %s", w.Body.String()))
+
+	var out jsonapi.LocationGroupResponse
+	c.Assert(json.Unmarshal(w.Body.Bytes(), &out), qt.IsNil)
+	role := out.Data.Attributes.CurrentUserRole
+	c.Assert(role, qt.IsNotNil)
+	c.Assert(*role, qt.Equals, models.GroupRoleOwner)
+}
+
+func TestGroupsAPI_ListGroups_CurrentUserRoleMatchesPerGroupMembership(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, models.Currency("USD"))
+
+	// Add a second group where the caller is just a `user`, not an owner.
+	// listGroups returns every group the user belongs to — verify the role
+	// is sourced per-group, not from a shared bucket.
+	slug := must.Must(models.GenerateGroupSlug())
+	secondGroup := must.Must(env.factorySet.LocationGroupRegistry.Create(context.Background(), models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: env.user.TenantID},
+		Slug:                slug,
+		Name:                "Second Group",
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           env.user.ID,
+		GroupCurrency:       models.Currency("USD"),
+	}))
+	must.Must(env.factorySet.GroupMembershipRegistry.Create(context.Background(), models.GroupMembership{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: env.user.TenantID},
+		GroupID:             secondGroup.ID,
+		MemberUserID:        env.user.ID,
+		Role:                models.GroupRoleUser,
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/groups", nil)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	c.Assert(w.Code, qt.Equals, http.StatusOK, qt.Commentf("body: %s", w.Body.String()))
+
+	var out jsonapi.LocationGroupsResponse
+	c.Assert(json.Unmarshal(w.Body.Bytes(), &out), qt.IsNil)
+	c.Assert(out.Data, qt.HasLen, 2)
+	byID := make(map[string]*models.GroupRole, 2)
+	for _, item := range out.Data {
+		byID[item.ID] = item.Attributes.CurrentUserRole
+	}
+	c.Assert(byID[env.group.ID], qt.IsNotNil)
+	c.Assert(*byID[env.group.ID], qt.Equals, models.GroupRoleOwner)
+	c.Assert(byID[secondGroup.ID], qt.IsNotNil)
+	c.Assert(*byID[secondGroup.ID], qt.Equals, models.GroupRoleUser)
+}

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -8881,6 +8881,15 @@ const docTemplate = `{
                     "type": "string",
                     "readOnly": true
                 },
+                "current_user_role": {
+                    "description": "CurrentUserRole is the caller's GroupRole within this group, populated\nby the /groups handlers from the request's authenticated user. It lets\nsurfaces like the Profile page Groups tab (#1653) render a per-tile\nrole badge in one round-trip instead of fetching memberships per\ngroup. nil when the lister has no associated user (system-mode\ncallers — none exist today on /groups, but the field is optional so\nnon-authenticated paths don't synthesize a misleading role).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.GroupRole"
+                        }
+                    ],
+                    "readOnly": true
+                },
                 "group_currency": {
                     "description": "GroupCurrency is the ISO-4217 code the group values its inventory in. It is\na property of the group (not the user) because a user can belong to\ngroups valued in different currencies. Admins change it via the group's\nupdate endpoint; changing it triggers a reprice of the group's commodities.",
                     "type": "string"

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -8874,6 +8874,15 @@
                     "type": "string",
                     "readOnly": true
                 },
+                "current_user_role": {
+                    "description": "CurrentUserRole is the caller's GroupRole within this group, populated\nby the /groups handlers from the request's authenticated user. It lets\nsurfaces like the Profile page Groups tab (#1653) render a per-tile\nrole badge in one round-trip instead of fetching memberships per\ngroup. nil when the lister has no associated user (system-mode\ncallers — none exist today on /groups, but the field is optional so\nnon-authenticated paths don't synthesize a misleading role).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.GroupRole"
+                        }
+                    ],
+                    "readOnly": true
+                },
                 "group_currency": {
                     "description": "GroupCurrency is the ISO-4217 code the group values its inventory in. It is\na property of the group (not the user) because a user can belong to\ngroups valued in different currencies. Admins change it via the group's\nupdate endpoint; changing it triggers a reprice of the group's commodities.",
                     "type": "string"

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -2731,6 +2731,18 @@ definitions:
           ptah's topological sort handles the pair via deferred FK creation.
         readOnly: true
         type: string
+      current_user_role:
+        allOf:
+        - $ref: '#/definitions/models.GroupRole'
+        description: |-
+          CurrentUserRole is the caller's GroupRole within this group, populated
+          by the /groups handlers from the request's authenticated user. It lets
+          surfaces like the Profile page Groups tab (#1653) render a per-tile
+          role badge in one round-trip instead of fetching memberships per
+          group. nil when the lister has no associated user (system-mode
+          callers — none exist today on /groups, but the field is optional so
+          non-authenticated paths don't synthesize a misleading role).
+        readOnly: true
       group_currency:
         description: |-
           GroupCurrency is the ISO-4217 code the group values its inventory in. It is

--- a/go/models/location_group.go
+++ b/go/models/location_group.go
@@ -97,6 +97,15 @@ type LocationGroup struct {
 	// (pending invites excluded) populated by the /groups
 	// handlers. Not stored — see issue #1650.
 	MembersCount int `json:"members_count" db:"-" userinput:"false" readonly:"true"`
+
+	// CurrentUserRole is the caller's GroupRole within this group, populated
+	// by the /groups handlers from the request's authenticated user. It lets
+	// surfaces like the Profile page Groups tab (#1653) render a per-tile
+	// role badge in one round-trip instead of fetching memberships per
+	// group. nil when the lister has no associated user (system-mode
+	// callers — none exist today on /groups, but the field is optional so
+	// non-authenticated paths don't synthesize a misleading role).
+	CurrentUserRole *GroupRole `json:"current_user_role,omitempty" db:"-" userinput:"false" readonly:"true"`
 }
 
 // LocationGroupIndexes defines PostgreSQL indexes for the location_groups table.

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -349,8 +349,9 @@ func (s *GroupService) AttachMembersCounts(ctx context.Context, groups []*models
 // group from the given user's membership in that group. Used by GET /groups/{id}
 // so the detail response carries the caller's role without forcing the FE to
 // roundtrip the members list (issue #1653). NotFound on the membership lookup
-// is swallowed — a user who can see a group via context middleware but isn't
-// formally a member (admin observer paths) gets a nil role rather than an error.
+// is swallowed — the realistic case is a race where membership is removed
+// concurrently between the requireGroupMember middleware admitting the caller
+// and this populate firing; ship a nil role rather than 500.
 func (s *GroupService) AttachCurrentUserRole(ctx context.Context, group *models.LocationGroup, tenantID, userID string) error {
 	if group == nil {
 		return nil

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -345,6 +345,64 @@ func (s *GroupService) AttachMembersCounts(ctx context.Context, groups []*models
 	return nil
 }
 
+// AttachCurrentUserRole populates LocationGroup.CurrentUserRole for a single
+// group from the given user's membership in that group. Used by GET /groups/{id}
+// so the detail response carries the caller's role without forcing the FE to
+// roundtrip the members list (issue #1653). NotFound on the membership lookup
+// is swallowed — a user who can see a group via context middleware but isn't
+// formally a member (admin observer paths) gets a nil role rather than an error.
+func (s *GroupService) AttachCurrentUserRole(ctx context.Context, group *models.LocationGroup, tenantID, userID string) error {
+	if group == nil {
+		return nil
+	}
+	membership, err := s.membershipRegistry.GetByGroupAndUser(ctx, group.ID, userID)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotFound) {
+			group.CurrentUserRole = nil
+			return nil
+		}
+		return errxtrace.Wrap("failed to load membership for current user", err)
+	}
+	role := membership.Role
+	group.CurrentUserRole = &role
+	_ = tenantID // accepted for symmetry with AttachCurrentUserRoles; membership rows are already tenant-scoped via RLS.
+	return nil
+}
+
+// AttachCurrentUserRoles is the batch variant for GET /groups, populating
+// LocationGroup.CurrentUserRole on every group with a single ListByUser
+// round-trip rather than N. Groups the user is no longer a member of (a
+// race against concurrent removal) are left with a nil role. See issue
+// #1653 for the consuming surface (Profile page Groups tab).
+func (s *GroupService) AttachCurrentUserRoles(ctx context.Context, groups []*models.LocationGroup, tenantID, userID string) error {
+	if len(groups) == 0 {
+		return nil
+	}
+	memberships, err := s.membershipRegistry.ListByUser(ctx, tenantID, userID)
+	if err != nil {
+		return errxtrace.Wrap("failed to list memberships for current user", err)
+	}
+	byGroup := make(map[string]models.GroupRole, len(memberships))
+	for _, m := range memberships {
+		if m == nil {
+			continue
+		}
+		byGroup[m.GroupID] = m.Role
+	}
+	for _, g := range groups {
+		if g == nil {
+			continue
+		}
+		if role, ok := byGroup[g.ID]; ok {
+			r := role
+			g.CurrentUserRole = &r
+		} else {
+			g.CurrentUserRole = nil
+		}
+	}
+	return nil
+}
+
 // ListMembers returns all members of a group.
 func (s *GroupService) ListMembers(ctx context.Context, groupID string) ([]*models.GroupMembership, error) {
 	return s.membershipRegistry.ListByGroup(ctx, groupID)

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -267,7 +267,10 @@ func (s *GroupService) InitiateGroupDeletion(ctx context.Context, groupID, confi
 	return err
 }
 
-// ListUserGroups returns all active groups the user belongs to.
+// ListUserGroups returns all active groups the user belongs to. Each returned
+// group has its CurrentUserRole populated from the same ListByUser query that
+// resolves which groups the user belongs to — no extra round-trip needed for
+// /groups consumers that want the role per tile (#1653).
 func (s *GroupService) ListUserGroups(ctx context.Context, tenantID, userID string) ([]*models.LocationGroup, error) {
 	memberships, err := s.membershipRegistry.ListByUser(ctx, tenantID, userID)
 	if err != nil {
@@ -288,6 +291,8 @@ func (s *GroupService) ListUserGroups(ctx context.Context, tenantID, userID stri
 			return nil, errxtrace.Wrap("failed to load group for membership", err, errx.Attrs("group_id", m.GroupID))
 		}
 		if group.IsActive() {
+			role := m.Role
+			group.CurrentUserRole = &role
 			groups = append(groups, group)
 		}
 	}

--- a/go/services/group_service_test.go
+++ b/go/services/group_service_test.go
@@ -1087,3 +1087,75 @@ func TestGroupService_ListMembersWithUsers_JoinedFields(t *testing.T) {
 	c.Assert(seenEmails["owner@example.com"], qt.IsTrue)
 	c.Assert(seenEmails["other@example.com"], qt.IsTrue)
 }
+
+// Issue #1653: AttachCurrentUserRoles populates per-group caller roles using
+// a single ListByUser round-trip, so the Profile page Groups tab can render
+// a role badge per tile without N member lookups.
+func TestGroupService_AttachCurrentUserRoles_PopulatesRolePerGroup(t *testing.T) {
+	c := qt.New(t)
+	svc, users, memberships := newTestGroupServiceWithUsers()
+	ctx := context.Background()
+
+	caller := seedUser(c, users, "tenant-1", "caller@example.com")
+
+	ownerGroup, err := svc.CreateGroup(ctx, "tenant-1", caller.ID, "Owner Group", "", "")
+	c.Assert(err, qt.IsNil)
+	userGroup, err := svc.CreateGroup(ctx, "tenant-1", caller.ID, "User Group", "", "")
+	c.Assert(err, qt.IsNil)
+	// Demote the caller to `user` in the second group via the membership
+	// registry directly — promotion paths go through ChangeMemberRole,
+	// which has its own invariants we don't want to entangle here.
+	membership, err := svc.GetMembership(ctx, userGroup.ID, caller.ID)
+	c.Assert(err, qt.IsNil)
+	membership.Role = models.GroupRoleUser
+	_, err = memberships.Update(ctx, *membership)
+	c.Assert(err, qt.IsNil)
+
+	groups := []*models.LocationGroup{ownerGroup, userGroup}
+	c.Assert(svc.AttachCurrentUserRoles(ctx, groups, "tenant-1", caller.ID), qt.IsNil)
+
+	byID := map[string]*models.GroupRole{}
+	for _, g := range groups {
+		byID[g.ID] = g.CurrentUserRole
+	}
+	c.Assert(byID[ownerGroup.ID], qt.IsNotNil)
+	c.Assert(*byID[ownerGroup.ID], qt.Equals, models.GroupRoleOwner)
+	c.Assert(byID[userGroup.ID], qt.IsNotNil)
+	c.Assert(*byID[userGroup.ID], qt.Equals, models.GroupRoleUser)
+}
+
+func TestGroupService_AttachCurrentUserRoles_LeavesNilWhenNoMembership(t *testing.T) {
+	c := qt.New(t)
+	svc, users, _ := newTestGroupServiceWithUsers()
+	ctx := context.Background()
+
+	owner := seedUser(c, users, "tenant-1", "owner@example.com")
+	outsider := seedUser(c, users, "tenant-1", "outsider@example.com")
+
+	group, err := svc.CreateGroup(ctx, "tenant-1", owner.ID, "Owner Group", "", "")
+	c.Assert(err, qt.IsNil)
+
+	groups := []*models.LocationGroup{group}
+	c.Assert(svc.AttachCurrentUserRoles(ctx, groups, "tenant-1", outsider.ID), qt.IsNil)
+	c.Assert(groups[0].CurrentUserRole, qt.IsNil)
+}
+
+func TestGroupService_AttachCurrentUserRole_SingleGroup(t *testing.T) {
+	c := qt.New(t)
+	svc, users, _ := newTestGroupServiceWithUsers()
+	ctx := context.Background()
+
+	owner := seedUser(c, users, "tenant-1", "owner@example.com")
+	group, err := svc.CreateGroup(ctx, "tenant-1", owner.ID, "Owner Group", "", "")
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(svc.AttachCurrentUserRole(ctx, group, "tenant-1", owner.ID), qt.IsNil)
+	c.Assert(group.CurrentUserRole, qt.IsNotNil)
+	c.Assert(*group.CurrentUserRole, qt.Equals, models.GroupRoleOwner)
+
+	// Non-member caller leaves the role nil rather than erroring.
+	outsider := seedUser(c, users, "tenant-1", "outsider@example.com")
+	group.CurrentUserRole = nil
+	c.Assert(svc.AttachCurrentUserRole(ctx, group, "tenant-1", outsider.ID), qt.IsNil)
+	c.Assert(group.CurrentUserRole, qt.IsNil)
+}


### PR DESCRIPTION
## Summary

Mock-parity rewrite of `/profile` (`frontend/src/pages/ProfilePage.tsx`) against `design-mocks/src/views/UserProfileView.tsx`, plus the BE plumbing to ship a `current_user_role` field on `LocationGroup` so the Groups tab can render a role badge per tile in one round-trip.

Closes #1653.

## What changed

### Frontend
- **Identity card:** banner `h-24 → h-28` for mock parity; avatar wrapped in `relative group` (sets up the #1382 camera-overlay slot without shipping it); page wrapper `gap-6 → gap-8`.
- **4-stat snapshot grid** (Items / Active warranties / Expiring soon / Est. value) reusing `useDashboardData()` against the active group. Renders dashes when there's no group context so the layout stays stable.
- **New `Tabs` shadcn primitive** (`frontend/src/components/ui/tabs.tsx`) with the `line` variant — 1:1 port of `design-mocks/src/components/ui/tabs.tsx`.
- **Groups tab:** 2-col grid of `LocationGroup` tiles with name + role badge + members count, click → `/g/{slug}`, `+N more` overflow when over the 6-tile cap. Role taxonomy follows #1533 (`owner` / `admin` / `user` / `viewer`).
- **Activity tab:** empty-state shell per the issue's "ship UI now, wire feed later" allowance — neither `commodity_events` nor `audit_logs` exposes a per-user reader today, so the wired feed is a separate piece of work.
- All colours through design tokens (`text-status-active`, `text-status-expiring`, `text-muted-foreground`); zero `text-green-*`/hex/inline-style colours.

### Backend
- `models.LocationGroup` gains `CurrentUserRole *GroupRole` (json `current_user_role`, `db:"-"`, readonly).
- `services.GroupService.AttachCurrentUserRole` (single) + `AttachCurrentUserRoles` (batch via `GroupMembershipRegistry.ListByUser` — one extra query for the whole list, not N).
- `apiserver` wires the populate into `listGroups` and `getGroup` right after the existing `MembersCount` enrichment.
- Swagger + frontend `api.d.ts` regenerated.

## Test plan
- [x] `go test ./models/... ./services/... ./apiserver/... -count=1` — green; new tests cover list+detail role match, multi-group role-per-tile, and the missing-membership/nil-role case.
- [x] `golangci-lint run ./models/... ./services/... ./apiserver/...` — clean.
- [x] `npx vitest run` — 806 / 810 passing (4 pre-existing skips), incl. 8 new ProfilePage tests (initials avatar, stat grid, Groups tab 0/1/N + overflow, Activity tab empty + tab switching, stat values once a group resolves).
- [x] `npx eslint src` + `npx tsc --noEmit` — clean.
- [x] `npm run i18n:check` — extraction in sync.
- [x] Prettier — clean.
- [ ] CI Playwright lane (extends `e2e/tests/profile.spec.ts` with the read-only landing describe — identity card, stat grid, tab visibility + default active, Groups tab list + click navigation, Activity tab empty state).
- [ ] Visual review via `screenshot-review` skill against `design-mocks/src/views/UserProfileView.tsx`.