### PR TITLE
[#1644] PR-B: Active sessions + Login history

### DIFF
--- a/e2e/tests/sessions-and-login-history.spec.ts
+++ b/e2e/tests/sessions-and-login-history.spec.ts
@@ -1,0 +1,90 @@
+import { expect } from '@playwright/test';
+import { test } from '../fixtures/app-fixture.js';
+import { TEST_CREDENTIALS, login } from './includes/auth.js';
+
+// Issue #1644 — PR-B
+// "two browsers, see two sessions, revoke one → other unaffected;
+//  trigger 2 wrong-password attempts → both show in history with
+//  bad_password outcome".
+//
+// The app-fixture already logs in once. We approximate the "two
+// browsers" requirement by opening a second incognito context that
+// performs its own login — this issues a second refresh token row
+// for the same user, exactly what we want to see in /profile/sessions.
+test.describe('Sessions & Login history (#1644)', () => {
+  test('two sessions visible; revoking one keeps the current session alive', async ({ page, browser }) => {
+    // First, ensure there are no pre-existing stale sessions from
+    // an earlier test that ran in the same shared db. Sign out
+    // all-other-sessions if the button shows.
+    await page.goto('/profile/sessions');
+    await expect(page.getByTestId('sessions-page')).toBeVisible();
+
+    const initialCards = await page.getByTestId('session-card').count();
+    if (initialCards > 1) {
+      // Use the "Sign out all other sessions" CTA on the page so we
+      // start the test from a clean (one-session) state.
+      await page.getByTestId('sessions-revoke-all-btn').click();
+      await page.getByTestId('sessions-confirm-revoke-all-btn').click();
+      // Wait for the second card to disappear.
+      await expect(page.getByTestId('session-card')).toHaveCount(1);
+    }
+
+    // Open a second browser context and authenticate — this creates a
+    // brand-new refresh token for the same user.
+    const secondCtx = await browser.newContext();
+    try {
+      const secondPage = await secondCtx.newPage();
+      await secondPage.goto('/login');
+      await login(secondPage, undefined, TEST_CREDENTIALS);
+
+      // Back on the original page, reload the sessions list and
+      // assert we now see two session cards.
+      await page.goto('/profile/sessions');
+      await expect(page.getByTestId('session-card')).toHaveCount(2);
+
+      // The "current" pill must live on the original context's card.
+      // Find the non-current card and revoke it.
+      const nonCurrent = page.getByTestId('session-card').filter({
+        has: page.locator('[data-session-current="false"]'),
+      });
+      await expect(nonCurrent.first()).toBeVisible();
+      await nonCurrent.first().getByTestId('session-revoke-btn').click();
+      await page.getByTestId('sessions-confirm-revoke-btn').click();
+      await expect(page.getByTestId('session-card')).toHaveCount(1);
+
+      // The original session — the one we are using on the test page —
+      // must still be alive: the page still loads, the user-menu testid
+      // is still visible.
+      await expect(page.locator('[data-testid="user-menu"]')).toBeVisible();
+    } finally {
+      await secondCtx.close();
+    }
+  });
+
+  test('failed sign-in attempts surface in login history with bad_password outcome', async ({ page, request }) => {
+    // Two POSTs to /api/v1/auth/login with the right email but a
+    // wrong password — the BE records a bad_password login_event for
+    // each. We bypass the FE login form here because the form
+    // helpfully clears the password on failure; raw API calls are
+    // cleaner and exercise the exact code path the issue's
+    // acceptance criteria points at.
+    for (let i = 0; i < 2; i++) {
+      const response = await request.post('/api/v1/auth/login', {
+        data: {
+          email: TEST_CREDENTIALS.email,
+          password: 'definitely-wrong-' + i,
+        },
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(response.status()).toBe(401);
+    }
+
+    // Visit the login-history page (using the same logged-in
+    // session) and assert there are at least 2 bad_password rows.
+    await page.goto('/profile/login-history');
+    await expect(page.getByTestId('login-history-page')).toBeVisible();
+    await expect(page.getByTestId('login-history-row').filter({
+      has: page.locator('[data-outcome="bad_password"]'),
+    })).toHaveCount(2, { timeout: 10000 });
+  });
+});

--- a/e2e/tests/sessions-and-login-history.spec.ts
+++ b/e2e/tests/sessions-and-login-history.spec.ts
@@ -43,10 +43,13 @@ test.describe('Sessions & Login history (#1644)', () => {
       await expect(page.getByTestId('session-card')).toHaveCount(2);
 
       // The "current" pill must live on the original context's card.
-      // Find the non-current card and revoke it.
-      const nonCurrent = page.getByTestId('session-card').filter({
-        has: page.locator('[data-session-current="false"]'),
-      });
+      // Find the non-current card and revoke it. `data-session-current` lives
+      // on the card itself (not a descendant), so we match the attribute
+      // directly via a combined CSS selector — `filter({ has })` would
+      // search descendants and never resolve.
+      const nonCurrent = page.locator(
+        '[data-testid="session-card"][data-session-current="false"]'
+      );
       await expect(nonCurrent.first()).toBeVisible();
       await nonCurrent.first().getByTestId('session-revoke-btn').click();
       await page.getByTestId('sessions-confirm-revoke-btn').click();
@@ -80,11 +83,17 @@ test.describe('Sessions & Login history (#1644)', () => {
     }
 
     // Visit the login-history page (using the same logged-in
-    // session) and assert there are at least 2 bad_password rows.
+    // session) and assert at least 2 bad_password rows are present.
+    // `data-outcome` lives on the row itself, so we match via a
+    // combined CSS selector rather than filter({ has }). And we assert
+    // >=2 rather than an exact count: the test DB is shared with other
+    // specs that may also produce bad_password events, so an exact
+    // count is flake-prone.
     await page.goto('/profile/login-history');
     await expect(page.getByTestId('login-history-page')).toBeVisible();
-    await expect(page.getByTestId('login-history-row').filter({
-      has: page.locator('[data-outcome="bad_password"]'),
-    })).toHaveCount(2, { timeout: 10000 });
+    const badPasswordRows = page.locator(
+      '[data-testid="login-history-row"][data-outcome="bad_password"]'
+    );
+    await expect.poll(() => badPasswordRows.count(), { timeout: 10000 }).toBeGreaterThanOrEqual(2);
   });
 });

--- a/frontend/i18next.config.ts
+++ b/frontend/i18next.config.ts
@@ -269,6 +269,14 @@ export default defineConfig({
       "groups:migration.status.*",
       "groups:settings.dialog.step*",
       "groups:settings.sections.*",
+      // settings:loginHistory.outcomes.* + .methods.* — LoginHistoryPage
+      //   resolves the badge label via a static OUTCOME_I18N_KEY /
+      //   METHOD_I18N_KEY lookup map keyed on the BE enum value
+      //   (models.LoginOutcome / LoginMethod). The extractor sees only
+      //   `t(OUTCOME_I18N_KEY[outcome])` so each per-variant key has to
+      //   survive the sweep via the wildcard.
+      "settings:loginHistory.outcomes.*",
+      "settings:loginHistory.methods.*",
     ],
   },
 })

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -61,6 +61,12 @@ const EditProfilePage = lazy(() =>
 const SettingsPage = lazy(() =>
   import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage }))
 )
+const SessionsPage = lazy(() =>
+  import("@/pages/SessionsPage").then((m) => ({ default: m.SessionsPage }))
+)
+const LoginHistoryPage = lazy(() =>
+  import("@/pages/LoginHistoryPage").then((m) => ({ default: m.LoginHistoryPage }))
+)
 const CreateGroupPage = lazy(() =>
   import("@/pages/groups/CreateGroupPage").then((m) => ({ default: m.CreateGroupPage }))
 )
@@ -197,6 +203,8 @@ export function AppRoutes() {
           <Route path="/no-group" element={<NoGroupPage />} />
           <Route path="/profile" element={<ProfilePage />} />
           <Route path="/profile/edit" element={<EditProfilePage />} />
+          <Route path="/profile/sessions" element={<SessionsPage />} />
+          <Route path="/profile/login-history" element={<LoginHistoryPage />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/groups/new" element={<CreateGroupPage />} />
           <Route path="/groups/:groupId/settings" element={<GroupSettingsPage />} />

--- a/frontend/src/features/login-history/api.ts
+++ b/frontend/src/features/login-history/api.ts
@@ -1,0 +1,20 @@
+// Login-history API client (issue #1379).
+import { http } from "@/lib/http"
+import type { Schema } from "@/types"
+
+export type LoginEventView = Schema<"apiserver.LoginEventView">
+export type LoginHistoryResponse = Schema<"apiserver.LoginHistoryResponse">
+
+// listLoginHistory caps the BE-side server with ?limit= so callers can
+// page-down (the BE caps internally at 500 — anything larger is
+// effectively meaningless because of the 90-day retention).
+export async function listLoginHistory(
+  limit: number,
+  signal?: AbortSignal
+): Promise<LoginHistoryResponse> {
+  const q = limit > 0 ? `?limit=${limit}` : ""
+  return http.get<LoginHistoryResponse>(`/users/me/login-history${q}`, {
+    signal,
+    skipGroupRewrite: true,
+  })
+}

--- a/frontend/src/features/login-history/hooks.ts
+++ b/frontend/src/features/login-history/hooks.ts
@@ -1,0 +1,16 @@
+// TanStack Query hook for the login-history slice (#1379).
+import { useQuery } from "@tanstack/react-query"
+
+import { listLoginHistory } from "./api"
+import { loginHistoryKeys } from "./keys"
+
+export function useLoginHistory(limit = 100) {
+  return useQuery({
+    queryKey: loginHistoryKeys.list(limit),
+    queryFn: ({ signal }) => listLoginHistory(limit, signal),
+    // Short staleTime: a refocus after several minutes should re-pull
+    // the list so a new failed-login attempt is visible without a
+    // hard reload.
+    staleTime: 30 * 1000,
+  })
+}

--- a/frontend/src/features/login-history/keys.ts
+++ b/frontend/src/features/login-history/keys.ts
@@ -1,0 +1,8 @@
+// Query keys for the login-history slice (#1379). The endpoint is
+// user-scoped via the JWT, so no id is part of the key — and a
+// trailing limit segment so two simultaneous queries with different
+// caps don't share a cache entry.
+export const loginHistoryKeys = {
+  all: ["login-history"] as const,
+  list: (limit: number) => [...loginHistoryKeys.all, "list", limit] as const,
+}

--- a/frontend/src/features/security/__tests__/ua.test.ts
+++ b/frontend/src/features/security/__tests__/ua.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { Laptop, Monitor, Smartphone, TabletSmartphone } from "lucide-react"
+
+import { parseUserAgent } from "@/features/security/ua"
+
+describe("parseUserAgent", () => {
+  it("returns Monitor + unknown shape for empty input", () => {
+    const ua = parseUserAgent("")
+    expect(ua.isUnknown).toBe(true)
+    expect(ua.browser).toBeNull()
+    expect(ua.os).toBeNull()
+    expect(ua.deviceIcon).toBe(Monitor)
+  })
+
+  it("recognises Chrome on macOS as a Laptop", () => {
+    const ua = parseUserAgent(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    )
+    expect(ua.browser).toBe("Chrome")
+    expect(ua.os).toBe("macOS")
+    expect(ua.deviceIcon).toBe(Laptop)
+    expect(ua.isUnknown).toBe(false)
+  })
+
+  it("recognises Safari on iOS as a Smartphone", () => {
+    const ua = parseUserAgent(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/605.1.15"
+    )
+    expect(ua.browser).toBe("Safari")
+    expect(ua.os).toBe("iOS")
+    expect(ua.deviceIcon).toBe(Smartphone)
+  })
+
+  it("recognises an iPad as a TabletSmartphone", () => {
+    const ua = parseUserAgent(
+      "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+    )
+    expect(ua.deviceIcon).toBe(TabletSmartphone)
+  })
+
+  it("prefers Edge over Chrome when both tokens are present", () => {
+    const ua = parseUserAgent(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"
+    )
+    expect(ua.browser).toBe("Edge")
+    expect(ua.os).toBe("Windows")
+  })
+
+  it("flags isUnknown=true when neither browser nor OS regex matches", () => {
+    const ua = parseUserAgent("curl/8.4.0")
+    expect(ua.browser).toBeNull()
+    expect(ua.os).toBeNull()
+    expect(ua.isUnknown).toBe(true)
+  })
+})

--- a/frontend/src/features/security/ua.ts
+++ b/frontend/src/features/security/ua.ts
@@ -1,0 +1,75 @@
+// Shared UA-parsing helper for the Privacy & Security surfaces — used by
+// SessionsPage and LoginHistoryPage. The parser is intentionally
+// minimal: we don't pull in ua-parser-js or similar because the UI
+// only needs a "Chrome on macOS" / "Safari on iOS" label, and a real
+// parser ages faster than the regex table here (new device shapes show
+// up in UA strings every quarter).
+//
+// The returned shape is i18n-free on purpose — callers pair the
+// `browser` / `os` strings with translated "Unknown browser" / "Unknown
+// OS" fallbacks at render time. That lets the parser stay testable
+// without a TFunction, and avoids the string-sentinel problem
+// (comparing against a localized label) flagged in #1674 review.
+
+import { Laptop, Monitor, Smartphone, TabletSmartphone } from "lucide-react"
+
+// IconComponent is the structural type lucide-react exports for every
+// icon — keeping it loose so we don't pin to a specific re-export.
+type IconComponent = typeof Laptop
+
+export interface ParsedUA {
+  /** Device-shape icon for the card; Monitor when the UA is empty. */
+  deviceIcon: IconComponent
+  /** Detected browser family (Chrome / Edge / Safari / …) or null. */
+  browser: string | null
+  /** Detected OS family (Windows / macOS / iOS / …) or null. */
+  os: string | null
+  /** True when neither browser nor OS could be derived. */
+  isUnknown: boolean
+}
+
+const BROWSERS: Array<[RegExp, string]> = [
+  // Order matters — Edge / Opera identify themselves *and* contain the
+  // Chrome token, so they have to win their respective tests first.
+  [/Edg\/\d+/, "Edge"],
+  [/OPR\/\d+/, "Opera"],
+  [/Chrome\/\d+/, "Chrome"],
+  [/Safari\/\d+/, "Safari"],
+  [/Firefox\/\d+/, "Firefox"],
+]
+
+const OPERATING_SYSTEMS: Array<[RegExp, string]> = [
+  // Order matters: iPhone / iPad UA strings carry the substring
+  // "like Mac OS X" for legacy WebKit compatibility, so `iPhone OS` /
+  // `iPad` need to match *before* the Mac OS X line — otherwise an
+  // iPhone is reported as macOS.
+  [/Windows NT/, "Windows"],
+  [/iPhone OS|iPad/, "iOS"],
+  [/Mac OS X/, "macOS"],
+  [/Android/, "Android"],
+  [/Linux/, "Linux"],
+]
+
+/**
+ * parseUserAgent runs in the browser per #1378 option 2 — keeps the DB
+ * free of UA strings that age poorly. The returned shape is i18n-free;
+ * callers are responsible for localizing "Unknown" fallbacks.
+ */
+export function parseUserAgent(ua: string): ParsedUA {
+  if (!ua) return { deviceIcon: Monitor, browser: null, os: null, isUnknown: true }
+  const isMobile = /iPhone|Android.*Mobile|Mobile/i.test(ua)
+  const isTablet = /iPad|Android(?!.*Mobile)/i.test(ua)
+  const browser = matchFirst(ua, BROWSERS)
+  const os = matchFirst(ua, OPERATING_SYSTEMS)
+  let deviceIcon: IconComponent = Laptop
+  if (isMobile) deviceIcon = Smartphone
+  else if (isTablet) deviceIcon = TabletSmartphone
+  return { deviceIcon, browser, os, isUnknown: !browser && !os }
+}
+
+function matchFirst(ua: string, table: Array<[RegExp, string]>): string | null {
+  for (const [re, label] of table) {
+    if (re.test(ua)) return label
+  }
+  return null
+}

--- a/frontend/src/features/sessions/api.ts
+++ b/frontend/src/features/sessions/api.ts
@@ -1,0 +1,29 @@
+// Active-sessions API client (issue #1378). Mirrors the BE shape from
+// apiserver/users_me.go — SessionView. The endpoint lives under
+// /api/v1/users/me/sessions and intentionally does NOT go through the
+// group-scoped rewrite in lib/http (the route is tenant-scoped).
+import { http } from "@/lib/http"
+import type { Schema } from "@/types"
+
+export type SessionView = Schema<"apiserver.SessionView">
+export type SessionsListResponse = Schema<"apiserver.SessionsListResponse">
+
+export async function listSessions(signal?: AbortSignal): Promise<SessionsListResponse> {
+  // skipGroupRewrite: lib/http rewrites bare resource prefixes (commodities,
+  // files, etc.) under /g/{slug}/ when a group is active. /users/me is not
+  // in GROUP_SCOPED_PREFIXES so this is currently a no-op, but the flag
+  // makes the intent explicit and survives future expansions of the rewrite
+  // table.
+  return http.get<SessionsListResponse>("/users/me/sessions", { signal, skipGroupRewrite: true })
+}
+
+export async function revokeSession(id: string): Promise<void> {
+  await http.del(`/users/me/sessions/${encodeURIComponent(id)}`, { skipGroupRewrite: true })
+}
+
+// revokeAllOtherSessions revokes every session except the one bound to the
+// current refresh cookie. The BE derives the keep-id from the cookie hash
+// — the FE does not need to supply it.
+export async function revokeAllOtherSessions(): Promise<void> {
+  await http.del("/users/me/sessions", { skipGroupRewrite: true })
+}

--- a/frontend/src/features/sessions/hooks.ts
+++ b/frontend/src/features/sessions/hooks.ts
@@ -1,0 +1,32 @@
+// TanStack Query hooks for the active-sessions slice (#1378).
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { listSessions, revokeAllOtherSessions, revokeSession } from "./api"
+import { sessionsKeys } from "./keys"
+
+export function useSessionsList() {
+  return useQuery({
+    queryKey: sessionsKeys.list(),
+    queryFn: ({ signal }) => listSessions(signal),
+    // Sessions are user-facing and need to feel live — a 30s staleTime
+    // covers tab refocus while still letting "I just revoked X" reflect
+    // immediately via the explicit invalidation in the mutation hooks.
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useRevokeSession() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => revokeSession(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: sessionsKeys.all }),
+  })
+}
+
+export function useRevokeAllOtherSessions() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => revokeAllOtherSessions(),
+    onSuccess: () => qc.invalidateQueries({ queryKey: sessionsKeys.all }),
+  })
+}

--- a/frontend/src/features/sessions/keys.ts
+++ b/frontend/src/features/sessions/keys.ts
@@ -1,0 +1,7 @@
+// Query keys for the per-user active-sessions slice (#1378).
+// Single user-scoped namespace — the sessions endpoint reads the
+// auth'd user from the JWT, so the key doesn't carry an id.
+export const sessionsKeys = {
+  all: ["sessions"] as const,
+  list: () => [...sessionsKeys.all, "list"] as const,
+}

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -87,7 +87,74 @@
     "title": "Notifications"
   },
   "privacy": {
+    "rows": {
+      "activeSessions": "Active sessions",
+      "activeSessionsBadge_one": "{{count}} active",
+      "activeSessionsBadge_other": "{{count}} active",
+      "activeSessionsDescription": "Manage devices that are signed in to your account.",
+      "loginHistory": "Login history",
+      "loginHistoryDescription": "Review recent sign-in attempts.",
+      "twoFactor": "Two-factor authentication",
+      "twoFactorBadge": "Inactive",
+      "twoFactorDescription": "Add a second factor to protect your account."
+    },
     "title": "Privacy & security"
+  },
+  "sessions": {
+    "confirmRevoke": {
+      "cta": "Revoke",
+      "description": "You'll need to sign in again on that device. This cannot be undone.",
+      "title": "Revoke this session?"
+    },
+    "confirmRevokeAll": {
+      "cta": "Sign out everywhere else",
+      "description": "Every other device signed in to this account will be signed out. Your current session stays active.",
+      "title": "Sign out all other sessions?"
+    },
+    "createdAt": "Signed in on {{value}}",
+    "empty": "No active sessions.",
+    "lastUsed": "Last used {{value}}",
+    "loading": "Loading sessions…",
+    "revoke": "Revoke",
+    "revokeAll": {
+      "cta": "Sign out everywhere else",
+      "description_one": "Currently signed in on {{count}} other device.",
+      "description_other": "Currently signed in on {{count}} other devices.",
+      "label": "Sign out all other sessions"
+    },
+    "subtitle": "Each card is a device or browser with a valid refresh token. Revoking a session forces the next request from that device to sign in again.",
+    "thisDevice": "This device",
+    "title": "Active sessions",
+    "toasts": {
+      "allRevoked": "Signed out of all other sessions.",
+      "revokeFailed": "Failed to revoke session. Please try again.",
+      "revoked": "Session revoked."
+    }
+  },
+  "loginHistory": {
+    "empty": "No sign-in attempts have been recorded yet.",
+    "failedBanner": {
+      "description": "If you don't recognise this activity, change your password and revoke active sessions.",
+      "title_one": "We noticed {{count}} failed sign-in attempt in the last 7 days.",
+      "title_other": "We noticed {{count}} failed sign-in attempts in the last 7 days."
+    },
+    "loading": "Loading login history…",
+    "methods": {
+      "oauth_github": "GitHub",
+      "oauth_google": "Google",
+      "password": "Password"
+    },
+    "outcomes": {
+      "account_disabled": "Account disabled",
+      "account_locked": "Account locked",
+      "bad_password": "Failed: bad password",
+      "email_not_verified": "Email not verified",
+      "ok": "Success",
+      "unknown": "Unknown"
+    },
+    "subtitle": "Recent sign-in attempts for your account. Failed attempts are recorded too so you can spot suspicious activity.",
+    "title": "Login history",
+    "unknownIp": "Unknown IP"
   },
   "profile": {
     "activityTab": {

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -60,6 +60,35 @@
     "title": "Help & support",
     "version": "Inventario · React rewrite (epic #1397)"
   },
+  "loginHistory": {
+    "empty": "No sign-in attempts have been recorded yet.",
+    "failedBanner": {
+      "description": "If you don't recognise this activity, change your password and revoke active sessions.",
+      "title_one": "We noticed {{count}} failed sign-in attempt in the last 7 days.",
+      "title_other": "We noticed {{count}} failed sign-in attempts in the last 7 days."
+    },
+    "loading": "Loading login history…",
+    "methods": {
+      "oauth_github": "GitHub",
+      "oauth_google": "Google",
+      "password": "Password"
+    },
+    "outcomes": {
+      "account_disabled": "Account disabled",
+      "account_locked": "Account locked",
+      "bad_password": "Failed: bad password",
+      "email_not_verified": "Email not verified",
+      "ok": "Success",
+      "unknown": "Unknown"
+    },
+    "subtitle": "Recent sign-in attempts for your account. Failed attempts are recorded too so you can spot suspicious activity.",
+    "title": "Login history",
+    "ua": {
+      "unknownBrowser": "Unknown browser",
+      "unknownOs": "Unknown OS"
+    },
+    "unknownIp": "Unknown IP"
+  },
   "notifications": {
     "errors": {
       "loadFailed": "Couldn't load notification preferences. Try again in a moment.",
@@ -99,62 +128,6 @@
       "twoFactorDescription": "Add a second factor to protect your account."
     },
     "title": "Privacy & security"
-  },
-  "sessions": {
-    "confirmRevoke": {
-      "cta": "Revoke",
-      "description": "You'll need to sign in again on that device. This cannot be undone.",
-      "title": "Revoke this session?"
-    },
-    "confirmRevokeAll": {
-      "cta": "Sign out everywhere else",
-      "description": "Every other device signed in to this account will be signed out. Your current session stays active.",
-      "title": "Sign out all other sessions?"
-    },
-    "createdAt": "Signed in on {{value}}",
-    "empty": "No active sessions.",
-    "lastUsed": "Last used {{value}}",
-    "loading": "Loading sessions…",
-    "revoke": "Revoke",
-    "revokeAll": {
-      "cta": "Sign out everywhere else",
-      "description_one": "Currently signed in on {{count}} other device.",
-      "description_other": "Currently signed in on {{count}} other devices.",
-      "label": "Sign out all other sessions"
-    },
-    "subtitle": "Each card is a device or browser with a valid refresh token. Revoking a session forces the next request from that device to sign in again.",
-    "thisDevice": "This device",
-    "title": "Active sessions",
-    "toasts": {
-      "allRevoked": "Signed out of all other sessions.",
-      "revokeFailed": "Failed to revoke session. Please try again.",
-      "revoked": "Session revoked."
-    }
-  },
-  "loginHistory": {
-    "empty": "No sign-in attempts have been recorded yet.",
-    "failedBanner": {
-      "description": "If you don't recognise this activity, change your password and revoke active sessions.",
-      "title_one": "We noticed {{count}} failed sign-in attempt in the last 7 days.",
-      "title_other": "We noticed {{count}} failed sign-in attempts in the last 7 days."
-    },
-    "loading": "Loading login history…",
-    "methods": {
-      "oauth_github": "GitHub",
-      "oauth_google": "Google",
-      "password": "Password"
-    },
-    "outcomes": {
-      "account_disabled": "Account disabled",
-      "account_locked": "Account locked",
-      "bad_password": "Failed: bad password",
-      "email_not_verified": "Email not verified",
-      "ok": "Success",
-      "unknown": "Unknown"
-    },
-    "subtitle": "Recent sign-in attempts for your account. Failed attempts are recorded too so you can spot suspicious activity.",
-    "title": "Login history",
-    "unknownIp": "Unknown IP"
   },
   "profile": {
     "activityTab": {
@@ -234,6 +207,42 @@
     "help": "Help & support",
     "notifications": "Notifications",
     "privacy": "Privacy & security"
+  },
+  "sessions": {
+    "confirmRevoke": {
+      "cta": "Revoke",
+      "description": "You'll need to sign in again on that device. This cannot be undone.",
+      "title": "Revoke this session?"
+    },
+    "confirmRevokeAll": {
+      "cta": "Sign out everywhere else",
+      "description": "Every other device signed in to this account will be signed out. Your current session stays active.",
+      "title": "Sign out all other sessions?"
+    },
+    "createdAt": "Signed in on {{value}}",
+    "empty": "No active sessions.",
+    "lastUsed": "Last used {{value}}",
+    "loading": "Loading sessions…",
+    "revoke": "Revoke",
+    "revokeAll": {
+      "cta": "Sign out everywhere else",
+      "description_one": "Currently signed in on {{count}} other device.",
+      "description_other": "Currently signed in on {{count}} other devices.",
+      "label": "Sign out all other sessions"
+    },
+    "subtitle": "Each card is a device or browser with a valid refresh token. Revoking a session forces the next request from that device to sign in again.",
+    "thisDevice": "This device",
+    "title": "Active sessions",
+    "toasts": {
+      "allRevoked": "Signed out of all other sessions.",
+      "revoked": "Session revoked.",
+      "revokeFailed": "Failed to revoke session. Please try again."
+    },
+    "ua": {
+      "unknownBrowser": "Unknown browser",
+      "unknownDevice": "Unknown device",
+      "unknownOs": "Unknown OS"
+    }
   },
   "signOut": "Sign out",
   "storage": {

--- a/frontend/src/lib/intl.ts
+++ b/frontend/src/lib/intl.ts
@@ -104,6 +104,41 @@ export function formatDate(
   }).format(date)
 }
 
+// formatRelative formats an instant relative to now ("5 minutes ago",
+// "in 2 days") via Intl.RelativeTimeFormat. Empty or invalid input
+// returns the empty string so callers can suffix it conditionally
+// without guarding the result themselves. The unit-bucket boundaries
+// (minute / hour / day) match what the BE-driven UIs need today — the
+// /profile/sessions and /profile/login-history surfaces never need
+// week / month granularity inside the 90-day retention window.
+const relativeTimeFormatters = new Map<string, Intl.RelativeTimeFormat>()
+function getRelativeTimeFormatter(locale: string): Intl.RelativeTimeFormat {
+  let f = relativeTimeFormatters.get(locale)
+  if (!f) {
+    f = new Intl.RelativeTimeFormat(locale, { numeric: "auto" })
+    relativeTimeFormatters.set(locale, f)
+  }
+  return f
+}
+
+export function formatRelative(value: Date | string, opts: { locale?: string } = {}): string {
+  if (!value) return ""
+  const locale = opts.locale ?? currentLocale()
+  const date = value instanceof Date ? value : new Date(value)
+  const t = date.getTime()
+  if (!Number.isFinite(t)) return ""
+  const diff = t - Date.now()
+  const abs = Math.abs(diff)
+  const rtf = getRelativeTimeFormatter(locale)
+  const min = 60 * 1000
+  const hour = 60 * min
+  const day = 24 * hour
+  if (abs < min) return rtf.format(Math.round(diff / 1000), "second")
+  if (abs < hour) return rtf.format(Math.round(diff / min), "minute")
+  if (abs < day) return rtf.format(Math.round(diff / hour), "hour")
+  return rtf.format(Math.round(diff / day), "day")
+}
+
 // formatDateTime: same as formatDate but with the time portion. Use when
 // the user needs to see both (e.g. activity log timestamps).
 export function formatDateTime(
@@ -196,4 +231,5 @@ export function safeFilename(label: string, fallback = "download"): string {
 export function __resetIntlCachesForTests(): void {
   numberFormatters.clear()
   dateFormatters.clear()
+  relativeTimeFormatters.clear()
 }

--- a/frontend/src/pages/LoginHistoryPage.tsx
+++ b/frontend/src/pages/LoginHistoryPage.tsx
@@ -108,6 +108,24 @@ function LoginEventRow({ event, locale }: LoginEventRowProps) {
   const relative = formatRelative(event.created_at ?? "", locale)
   const absolute = formatAbsolute(event.created_at ?? "", locale)
   const ua = parseUserAgent(event.user_agent ?? "")
+  // Resolve the badge + method labels via a static lookup map (rather
+  // than `t(\`settings:loginHistory.outcomes.${outcome}\`)` template
+  // literals) so the i18next-cli extractor sees every key statically.
+  // Falls back to the "unknown" key whenever the BE introduces a new
+  // enum variant the FE hasn't been deployed for yet.
+  const outcomeLabel = OUTCOME_I18N_KEY[outcome]
+    ? t(OUTCOME_I18N_KEY[outcome])
+    : t("settings:loginHistory.outcomes.unknown")
+  const methodLabel = event.method && METHOD_I18N_KEY[event.method]
+    ? t(METHOD_I18N_KEY[event.method])
+    : (event.method ?? null)
+  // Suffix the UA label only when the parser actually recognised
+  // something. `ua.isUnknown` keeps the conditional locale-agnostic —
+  // a string compare against "Unknown device" would break the moment
+  // the page is rendered in cs/ru.
+  const uaLabel = ua.isUnknown
+    ? null
+    : `${ua.browser ?? t("settings:loginHistory.ua.unknownBrowser")} · ${ua.os ?? t("settings:loginHistory.ua.unknownOs")}`
 
   return (
     <li
@@ -129,12 +147,10 @@ function LoginEventRow({ event, locale }: LoginEventRowProps) {
             variant="outline"
             className={cn("text-xs", cfg.color, cfg.bg, "border-current/20 font-medium")}
           >
-            {t(`settings:loginHistory.outcomes.${outcome}`, t("settings:loginHistory.outcomes.unknown"))}
+            {outcomeLabel}
           </Badge>
-          {event.method ? (
-            <span className="text-xs text-muted-foreground">
-              {t(`settings:loginHistory.methods.${event.method}`, event.method)}
-            </span>
+          {methodLabel ? (
+            <span className="text-xs text-muted-foreground">{methodLabel}</span>
           ) : null}
         </div>
         <p className="mt-1 text-sm" title={absolute}>
@@ -143,11 +159,27 @@ function LoginEventRow({ event, locale }: LoginEventRowProps) {
         </p>
         <p className="text-xs text-muted-foreground">
           {event.ip_address ? event.ip_address : t("settings:loginHistory.unknownIp")}
-          {ua.label !== "Unknown device" ? ` · ${ua.label}` : ""}
+          {uaLabel ? ` · ${uaLabel}` : ""}
         </p>
       </div>
     </li>
   )
+}
+
+// Static lookup so the i18next-cli extractor can see each key. Keep in
+// sync with go/models/login_event.go LoginOutcome and LoginMethod enums.
+const OUTCOME_I18N_KEY: Record<string, string> = {
+  ok: "settings:loginHistory.outcomes.ok",
+  bad_password: "settings:loginHistory.outcomes.bad_password",
+  account_locked: "settings:loginHistory.outcomes.account_locked",
+  account_disabled: "settings:loginHistory.outcomes.account_disabled",
+  email_not_verified: "settings:loginHistory.outcomes.email_not_verified",
+}
+
+const METHOD_I18N_KEY: Record<string, string> = {
+  password: "settings:loginHistory.methods.password",
+  oauth_google: "settings:loginHistory.methods.oauth_google",
+  oauth_github: "settings:loginHistory.methods.oauth_github",
 }
 
 type OutcomeKey =
@@ -172,24 +204,32 @@ const OUTCOME_CONFIG: Record<OutcomeKey, OutcomeConfig> = {
 }
 
 // Minimal UA parse — same shape as SessionsPage uses but pared down to
-// just the label here; the row doesn't need a device icon.
-function parseUserAgent(ua: string): { label: string } {
-  if (!ua) return { label: "Unknown device" }
+// just the browser + os pair (the row doesn't need a device icon).
+// Returns a structured shape so the caller localizes the fallback
+// strings (see review #1674); the parser stays i18n-free for testing.
+interface ParsedUA {
+  browser: string | null
+  os: string | null
+  isUnknown: boolean
+}
+
+function parseUserAgent(ua: string): ParsedUA {
+  if (!ua) return { browser: null, os: null, isUnknown: true }
   const browser = matchFirst(ua, [
     [/Edg\/\d+/, "Edge"],
     [/OPR\/\d+/, "Opera"],
     [/Chrome\/\d+/, "Chrome"],
     [/Safari\/\d+/, "Safari"],
     [/Firefox\/\d+/, "Firefox"],
-  ]) ?? "Browser"
+  ])
   const os = matchFirst(ua, [
     [/Windows NT/, "Windows"],
     [/Mac OS X/, "macOS"],
     [/iPhone OS/, "iOS"],
     [/Android/, "Android"],
     [/Linux/, "Linux"],
-  ]) ?? "Unknown OS"
-  return { label: `${browser} on ${os}` }
+  ])
+  return { browser, os, isUnknown: !browser && !os }
 }
 
 function matchFirst(ua: string, table: Array<[RegExp, string]>): string | null {

--- a/frontend/src/pages/LoginHistoryPage.tsx
+++ b/frontend/src/pages/LoginHistoryPage.tsx
@@ -16,8 +16,10 @@ import { RouteTitle } from "@/components/routing/RouteTitle"
 import type { LoginEventView } from "@/features/login-history/api"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useLoginHistory } from "@/features/login-history/hooks"
+import { parseUserAgent } from "@/features/security/ua"
 import { cn } from "@/lib/utils"
 import { withGroupQuery } from "@/lib/group-aware-url"
+import { formatDateTime, formatRelative } from "@/lib/intl"
 
 // LoginHistoryPage renders /profile/login-history (issue #1379) — a
 // reverse-chronological list of credential-check attempts with an
@@ -26,10 +28,9 @@ import { withGroupQuery } from "@/lib/group-aware-url"
 const FAILED_ATTEMPTS_BANNER_THRESHOLD = 3
 
 export function LoginHistoryPage() {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
   const { currentGroup } = useCurrentGroup()
   const query = useLoginHistory(100)
-  const locale = i18n.resolvedLanguage ?? "en"
 
   const events = query.data?.events ?? []
   const failedLast7d = query.data?.failed_last_7d ?? 0
@@ -86,7 +87,7 @@ export function LoginHistoryPage() {
             data-testid="login-history-list"
           >
             {events.map((event) => (
-              <LoginEventRow key={event.id} event={event} locale={locale} />
+              <LoginEventRow key={event.id} event={event} />
             ))}
           </ul>
         )}
@@ -97,16 +98,15 @@ export function LoginHistoryPage() {
 
 interface LoginEventRowProps {
   event: LoginEventView
-  locale: string
 }
 
-function LoginEventRow({ event, locale }: LoginEventRowProps) {
+function LoginEventRow({ event }: LoginEventRowProps) {
   const { t } = useTranslation()
   const outcome = event.outcome ?? "ok"
   const cfg = OUTCOME_CONFIG[outcome] ?? OUTCOME_CONFIG.ok
   const OutcomeIcon = cfg.icon
-  const relative = formatRelative(event.created_at ?? "", locale)
-  const absolute = formatAbsolute(event.created_at ?? "", locale)
+  const relative = formatRelative(event.created_at ?? "")
+  const absolute = formatDateTime(event.created_at ?? "")
   const ua = parseUserAgent(event.user_agent ?? "")
   // Resolve the badge + method labels via a static lookup map (rather
   // than `t(\`settings:loginHistory.outcomes.${outcome}\`)` template
@@ -201,65 +201,6 @@ const OUTCOME_CONFIG: Record<OutcomeKey, OutcomeConfig> = {
     bg: "bg-status-expiring/10",
   },
   email_not_verified: { icon: Mail, color: "text-status-expiring", bg: "bg-status-expiring/10" },
-}
-
-// Minimal UA parse — same shape as SessionsPage uses but pared down to
-// just the browser + os pair (the row doesn't need a device icon).
-// Returns a structured shape so the caller localizes the fallback
-// strings (see review #1674); the parser stays i18n-free for testing.
-interface ParsedUA {
-  browser: string | null
-  os: string | null
-  isUnknown: boolean
-}
-
-function parseUserAgent(ua: string): ParsedUA {
-  if (!ua) return { browser: null, os: null, isUnknown: true }
-  const browser = matchFirst(ua, [
-    [/Edg\/\d+/, "Edge"],
-    [/OPR\/\d+/, "Opera"],
-    [/Chrome\/\d+/, "Chrome"],
-    [/Safari\/\d+/, "Safari"],
-    [/Firefox\/\d+/, "Firefox"],
-  ])
-  const os = matchFirst(ua, [
-    [/Windows NT/, "Windows"],
-    [/Mac OS X/, "macOS"],
-    [/iPhone OS/, "iOS"],
-    [/Android/, "Android"],
-    [/Linux/, "Linux"],
-  ])
-  return { browser, os, isUnknown: !browser && !os }
-}
-
-function matchFirst(ua: string, table: Array<[RegExp, string]>): string | null {
-  for (const [re, label] of table) {
-    if (re.test(ua)) return label
-  }
-  return null
-}
-
-function formatRelative(iso: string, locale: string): string {
-  if (!iso) return ""
-  const target = new Date(iso).getTime()
-  if (!Number.isFinite(target)) return ""
-  const diff = target - Date.now()
-  const abs = Math.abs(diff)
-  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" })
-  const min = 60 * 1000
-  const hour = 60 * min
-  const day = 24 * hour
-  if (abs < min) return rtf.format(Math.round(diff / 1000), "second")
-  if (abs < hour) return rtf.format(Math.round(diff / min), "minute")
-  if (abs < day) return rtf.format(Math.round(diff / hour), "hour")
-  return rtf.format(Math.round(diff / day), "day")
-}
-
-function formatAbsolute(iso: string, locale: string): string {
-  if (!iso) return ""
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return ""
-  return new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" }).format(d)
 }
 
 // Avoid unused-icon warnings for icons that may be needed when new

--- a/frontend/src/pages/LoginHistoryPage.tsx
+++ b/frontend/src/pages/LoginHistoryPage.tsx
@@ -1,0 +1,228 @@
+import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  KeyRound,
+  Lock,
+  Mail,
+  ShieldAlert,
+  XCircle,
+} from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+import type { LoginEventView } from "@/features/login-history/api"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { useLoginHistory } from "@/features/login-history/hooks"
+import { cn } from "@/lib/utils"
+import { withGroupQuery } from "@/lib/group-aware-url"
+
+// LoginHistoryPage renders /profile/login-history (issue #1379) — a
+// reverse-chronological list of credential-check attempts with an
+// optional "we noticed N failed attempts" banner if the BE reports
+// more than three failures in the last seven days.
+const FAILED_ATTEMPTS_BANNER_THRESHOLD = 3
+
+export function LoginHistoryPage() {
+  const { t, i18n } = useTranslation()
+  const { currentGroup } = useCurrentGroup()
+  const query = useLoginHistory(100)
+  const locale = i18n.resolvedLanguage ?? "en"
+
+  const events = query.data?.events ?? []
+  const failedLast7d = query.data?.failed_last_7d ?? 0
+
+  return (
+    <>
+      <RouteTitle title={t("settings:loginHistory.title")} />
+      <div
+        className="mx-auto flex w-full max-w-2xl flex-col gap-6"
+        data-testid="login-history-page"
+      >
+        <div className="space-y-1">
+          <Link
+            to={withGroupQuery("/settings", currentGroup?.slug)}
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="size-4" aria-hidden="true" />
+            {t("settings:privacy.title")}
+          </Link>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {t("settings:loginHistory.title")}
+          </h1>
+          <p className="text-sm text-muted-foreground">{t("settings:loginHistory.subtitle")}</p>
+        </div>
+
+        {failedLast7d > FAILED_ATTEMPTS_BANNER_THRESHOLD ? (
+          <div
+            className="flex items-start gap-3 rounded-xl border border-destructive/30 bg-destructive/5 p-4"
+            data-testid="login-history-failed-banner"
+          >
+            <ShieldAlert className="size-5 text-destructive shrink-0 mt-0.5" aria-hidden="true" />
+            <div>
+              <p className="text-sm font-medium text-destructive">
+                {t("settings:loginHistory.failedBanner.title", { count: failedLast7d })}
+              </p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {t("settings:loginHistory.failedBanner.description")}
+              </p>
+            </div>
+          </div>
+        ) : null}
+
+        {query.isLoading ? (
+          <div className="rounded-xl border border-border p-6 text-sm text-muted-foreground">
+            {t("settings:loginHistory.loading")}
+          </div>
+        ) : events.length === 0 ? (
+          <div className="rounded-xl border border-border p-6 text-sm text-muted-foreground">
+            {t("settings:loginHistory.empty")}
+          </div>
+        ) : (
+          <ul
+            className="rounded-xl border border-border divide-y divide-border bg-card"
+            data-testid="login-history-list"
+          >
+            {events.map((event) => (
+              <LoginEventRow key={event.id} event={event} locale={locale} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  )
+}
+
+interface LoginEventRowProps {
+  event: LoginEventView
+  locale: string
+}
+
+function LoginEventRow({ event, locale }: LoginEventRowProps) {
+  const { t } = useTranslation()
+  const outcome = event.outcome ?? "ok"
+  const cfg = OUTCOME_CONFIG[outcome] ?? OUTCOME_CONFIG.ok
+  const OutcomeIcon = cfg.icon
+  const relative = formatRelative(event.created_at ?? "", locale)
+  const absolute = formatAbsolute(event.created_at ?? "", locale)
+  const ua = parseUserAgent(event.user_agent ?? "")
+
+  return (
+    <li
+      className="flex items-start gap-3 p-4"
+      data-testid="login-history-row"
+      data-outcome={outcome}
+    >
+      <div
+        className={cn(
+          "flex size-9 items-center justify-center rounded-lg shrink-0",
+          cfg.bg
+        )}
+      >
+        <OutcomeIcon className={cn("size-4", cfg.color)} aria-hidden="true" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge
+            variant="outline"
+            className={cn("text-xs", cfg.color, cfg.bg, "border-current/20 font-medium")}
+          >
+            {t(`settings:loginHistory.outcomes.${outcome}`, t("settings:loginHistory.outcomes.unknown"))}
+          </Badge>
+          {event.method ? (
+            <span className="text-xs text-muted-foreground">
+              {t(`settings:loginHistory.methods.${event.method}`, event.method)}
+            </span>
+          ) : null}
+        </div>
+        <p className="mt-1 text-sm" title={absolute}>
+          {relative}
+          <span className="text-xs text-muted-foreground"> · {absolute}</span>
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {event.ip_address ? event.ip_address : t("settings:loginHistory.unknownIp")}
+          {ua.label !== "Unknown device" ? ` · ${ua.label}` : ""}
+        </p>
+      </div>
+    </li>
+  )
+}
+
+type OutcomeKey =
+  | "ok"
+  | "bad_password"
+  | "account_locked"
+  | "account_disabled"
+  | "email_not_verified"
+
+interface OutcomeConfig {
+  icon: typeof CheckCircle2
+  color: string
+  bg: string
+}
+
+const OUTCOME_CONFIG: Record<OutcomeKey, OutcomeConfig> = {
+  ok: { icon: CheckCircle2, color: "text-status-active", bg: "bg-status-active/10" },
+  bad_password: { icon: XCircle, color: "text-destructive", bg: "bg-destructive/10" },
+  account_locked: { icon: Lock, color: "text-destructive", bg: "bg-destructive/10" },
+  account_disabled: { icon: AlertTriangle, color: "text-status-expiring", bg: "bg-status-expiring/10" },
+  email_not_verified: { icon: Mail, color: "text-status-expiring", bg: "bg-status-expiring/10" },
+}
+
+// Minimal UA parse — same shape as SessionsPage uses but pared down to
+// just the label here; the row doesn't need a device icon.
+function parseUserAgent(ua: string): { label: string } {
+  if (!ua) return { label: "Unknown device" }
+  const browser = matchFirst(ua, [
+    [/Edg\/\d+/, "Edge"],
+    [/OPR\/\d+/, "Opera"],
+    [/Chrome\/\d+/, "Chrome"],
+    [/Safari\/\d+/, "Safari"],
+    [/Firefox\/\d+/, "Firefox"],
+  ]) ?? "Browser"
+  const os = matchFirst(ua, [
+    [/Windows NT/, "Windows"],
+    [/Mac OS X/, "macOS"],
+    [/iPhone OS/, "iOS"],
+    [/Android/, "Android"],
+    [/Linux/, "Linux"],
+  ]) ?? "Unknown OS"
+  return { label: `${browser} on ${os}` }
+}
+
+function matchFirst(ua: string, table: Array<[RegExp, string]>): string | null {
+  for (const [re, label] of table) {
+    if (re.test(ua)) return label
+  }
+  return null
+}
+
+function formatRelative(iso: string, locale: string): string {
+  if (!iso) return ""
+  const target = new Date(iso).getTime()
+  if (!Number.isFinite(target)) return ""
+  const diff = target - Date.now()
+  const abs = Math.abs(diff)
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" })
+  const min = 60 * 1000
+  const hour = 60 * min
+  const day = 24 * hour
+  if (abs < min) return rtf.format(Math.round(diff / 1000), "second")
+  if (abs < hour) return rtf.format(Math.round(diff / min), "minute")
+  if (abs < day) return rtf.format(Math.round(diff / hour), "hour")
+  return rtf.format(Math.round(diff / day), "day")
+}
+
+function formatAbsolute(iso: string, locale: string): string {
+  if (!iso) return ""
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ""
+  return new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" }).format(d)
+}
+
+// Avoid unused-icon warnings for icons that may be needed when new
+// outcome values are added (e.g. KeyRound is reserved for "oauth_*" methods
+// shipping with #1394). Keeping the import while the enum stabilizes.
+void KeyRound

--- a/frontend/src/pages/LoginHistoryPage.tsx
+++ b/frontend/src/pages/LoginHistoryPage.tsx
@@ -116,9 +116,10 @@ function LoginEventRow({ event, locale }: LoginEventRowProps) {
   const outcomeLabel = OUTCOME_I18N_KEY[outcome]
     ? t(OUTCOME_I18N_KEY[outcome])
     : t("settings:loginHistory.outcomes.unknown")
-  const methodLabel = event.method && METHOD_I18N_KEY[event.method]
-    ? t(METHOD_I18N_KEY[event.method])
-    : (event.method ?? null)
+  const methodLabel =
+    event.method && METHOD_I18N_KEY[event.method]
+      ? t(METHOD_I18N_KEY[event.method])
+      : (event.method ?? null)
   // Suffix the UA label only when the parser actually recognised
   // something. `ua.isUnknown` keeps the conditional locale-agnostic —
   // a string compare against "Unknown device" would break the moment
@@ -133,12 +134,7 @@ function LoginEventRow({ event, locale }: LoginEventRowProps) {
       data-testid="login-history-row"
       data-outcome={outcome}
     >
-      <div
-        className={cn(
-          "flex size-9 items-center justify-center rounded-lg shrink-0",
-          cfg.bg
-        )}
-      >
+      <div className={cn("flex size-9 items-center justify-center rounded-lg shrink-0", cfg.bg)}>
         <OutcomeIcon className={cn("size-4", cfg.color)} aria-hidden="true" />
       </div>
       <div className="min-w-0 flex-1">
@@ -199,7 +195,11 @@ const OUTCOME_CONFIG: Record<OutcomeKey, OutcomeConfig> = {
   ok: { icon: CheckCircle2, color: "text-status-active", bg: "bg-status-active/10" },
   bad_password: { icon: XCircle, color: "text-destructive", bg: "bg-destructive/10" },
   account_locked: { icon: Lock, color: "text-destructive", bg: "bg-destructive/10" },
-  account_disabled: { icon: AlertTriangle, color: "text-status-expiring", bg: "bg-status-expiring/10" },
+  account_disabled: {
+    icon: AlertTriangle,
+    color: "text-status-expiring",
+    bg: "bg-status-expiring/10",
+  },
   email_not_verified: { icon: Mail, color: "text-status-expiring", bg: "bg-status-expiring/10" },
 }
 

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -1,0 +1,330 @@
+import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
+import {
+  ArrowLeft,
+  Laptop,
+  LogOut,
+  Monitor,
+  Shield,
+  Smartphone,
+  TabletSmartphone,
+} from "lucide-react"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+import type { SessionView } from "@/features/sessions/api"
+import { useCurrentGroup } from "@/features/group/GroupContext"
+import { useRevokeAllOtherSessions, useRevokeSession, useSessionsList } from "@/features/sessions/hooks"
+import { useAppToast } from "@/hooks/useAppToast"
+import { withGroupQuery } from "@/lib/group-aware-url"
+
+// SessionsPage renders the /profile/sessions view from issue #1378.
+// Card per session — device icon, browser/OS, last-used, partial IP,
+// "This device" pill, Revoke button. Plus a top-level
+// "Sign out all other sessions" CTA that confirms before firing.
+export function SessionsPage() {
+  const { t } = useTranslation()
+  const { currentGroup } = useCurrentGroup()
+  const toast = useAppToast()
+  const sessionsQuery = useSessionsList()
+  const revokeMutation = useRevokeSession()
+  const revokeAllOthersMutation = useRevokeAllOtherSessions()
+
+  // Pending dialogs — we confirm both single revoke and revoke-all so a
+  // misclick never wipes the user's other browsers.
+  const [pendingRevoke, setPendingRevoke] = useState<SessionView | null>(null)
+  const [revokeAllOpen, setRevokeAllOpen] = useState(false)
+
+  const sessions = sessionsQuery.data?.sessions ?? []
+  const otherSessionsCount = useMemo(
+    () => sessions.filter((s) => !s.is_current).length,
+    [sessions]
+  )
+
+  const confirmRevoke = (session: SessionView) => setPendingRevoke(session)
+
+  const doRevoke = () => {
+    if (!pendingRevoke?.id) return
+    const id = pendingRevoke.id
+    revokeMutation.mutate(id, {
+      onSuccess: () => {
+        toast.success(t("settings:sessions.toasts.revoked"))
+        setPendingRevoke(null)
+      },
+      onError: () => {
+        toast.error(t("settings:sessions.toasts.revokeFailed"))
+      },
+    })
+  }
+
+  const doRevokeAllOthers = () => {
+    revokeAllOthersMutation.mutate(undefined, {
+      onSuccess: () => {
+        toast.success(t("settings:sessions.toasts.allRevoked"))
+        setRevokeAllOpen(false)
+      },
+      onError: () => {
+        toast.error(t("settings:sessions.toasts.revokeFailed"))
+      },
+    })
+  }
+
+  return (
+    <>
+      <RouteTitle title={t("settings:sessions.title")} />
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-6" data-testid="sessions-page">
+        <div className="space-y-1">
+          <Link
+            to={withGroupQuery("/settings", currentGroup?.slug)}
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="size-4" aria-hidden="true" />
+            {t("settings:privacy.title")}
+          </Link>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {t("settings:sessions.title")}
+          </h1>
+          <p className="text-sm text-muted-foreground">{t("settings:sessions.subtitle")}</p>
+        </div>
+
+        {otherSessionsCount > 0 ? (
+          <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+            <div className="flex items-center gap-3">
+              <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10">
+                <Shield className="size-4 text-primary" aria-hidden="true" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">{t("settings:sessions.revokeAll.label")}</p>
+                <p className="text-xs text-muted-foreground">
+                  {t("settings:sessions.revokeAll.description", { count: otherSessionsCount })}
+                </p>
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setRevokeAllOpen(true)}
+              data-testid="sessions-revoke-all-btn"
+              className="gap-1.5"
+            >
+              <LogOut className="size-3.5" aria-hidden="true" />
+              {t("settings:sessions.revokeAll.cta")}
+            </Button>
+          </div>
+        ) : null}
+
+        {sessionsQuery.isLoading ? (
+          <div className="rounded-xl border border-border p-6 text-sm text-muted-foreground">
+            {t("settings:sessions.loading")}
+          </div>
+        ) : sessions.length === 0 ? (
+          <div className="rounded-xl border border-border p-6 text-sm text-muted-foreground">
+            {t("settings:sessions.empty")}
+          </div>
+        ) : (
+          <div className="space-y-3" data-testid="sessions-list">
+            {sessions.map((session) => (
+              <SessionCard
+                key={session.id}
+                session={session}
+                onRevoke={confirmRevoke}
+                disabled={revokeMutation.isPending}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Dialog open={!!pendingRevoke} onOpenChange={(o) => !o && setPendingRevoke(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("settings:sessions.confirmRevoke.title")}</DialogTitle>
+            <DialogDescription>
+              {t("settings:sessions.confirmRevoke.description")}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setPendingRevoke(null)}
+              disabled={revokeMutation.isPending}
+            >
+              {t("common:cancel")}
+            </Button>
+            <Button
+              onClick={doRevoke}
+              disabled={revokeMutation.isPending}
+              variant="destructive"
+              data-testid="sessions-confirm-revoke-btn"
+            >
+              {t("settings:sessions.confirmRevoke.cta")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={revokeAllOpen} onOpenChange={setRevokeAllOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("settings:sessions.confirmRevokeAll.title")}</DialogTitle>
+            <DialogDescription>
+              {t("settings:sessions.confirmRevokeAll.description")}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setRevokeAllOpen(false)}
+              disabled={revokeAllOthersMutation.isPending}
+            >
+              {t("common:cancel")}
+            </Button>
+            <Button
+              onClick={doRevokeAllOthers}
+              disabled={revokeAllOthersMutation.isPending}
+              variant="destructive"
+              data-testid="sessions-confirm-revoke-all-btn"
+            >
+              {t("settings:sessions.confirmRevokeAll.cta")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+interface SessionCardProps {
+  session: SessionView
+  onRevoke: (session: SessionView) => void
+  disabled: boolean
+}
+
+function SessionCard({ session, onRevoke, disabled }: SessionCardProps) {
+  const { t, i18n } = useTranslation()
+  const ua = parseUserAgent(session.user_agent ?? "")
+  const DeviceIcon = ua.deviceIcon
+  const lastUsedRelative = formatRelative(session.last_used_at ?? session.created_at, i18n.resolvedLanguage ?? "en")
+  const createdAbsolute = formatAbsolute(session.created_at ?? "", i18n.resolvedLanguage ?? "en")
+
+  return (
+    <div
+      className="rounded-xl border border-border bg-card p-4"
+      data-testid="session-card"
+      data-session-id={session.id}
+      data-session-current={session.is_current ? "true" : "false"}
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex size-10 items-center justify-center rounded-lg bg-muted shrink-0">
+          <DeviceIcon className="size-5 text-muted-foreground" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-sm font-medium">{ua.label}</p>
+            {session.is_current ? (
+              <Badge variant="secondary" className="text-xs" data-testid="session-current-pill">
+                {t("settings:sessions.thisDevice")}
+              </Badge>
+            ) : null}
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {t("settings:sessions.lastUsed", { value: lastUsedRelative })}
+            {session.ip_address ? ` · ${session.ip_address}` : ""}
+          </p>
+          <p className="text-xs text-muted-foreground" title={session.created_at ?? ""}>
+            {t("settings:sessions.createdAt", { value: createdAbsolute })}
+          </p>
+        </div>
+        {!session.is_current ? (
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={disabled || !session.id}
+            onClick={() => onRevoke(session)}
+            data-testid="session-revoke-btn"
+          >
+            {t("settings:sessions.revoke")}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+interface ParsedUA {
+  deviceIcon: typeof Laptop
+  label: string
+}
+
+// parseUserAgent runs in the browser per #1378 option 2 — keeps the DB
+// free of UA strings that age poorly. Cheap regex-based heuristics are
+// enough for the FE label: detailed parsing would require a library and
+// the cost isn't worth it for a side panel.
+function parseUserAgent(ua: string): ParsedUA {
+  if (!ua) return { deviceIcon: Monitor, label: "Unknown device" }
+  const isMobile = /iPhone|Android.*Mobile|Mobile/i.test(ua)
+  const isTablet = /iPad|Android(?!.*Mobile)/i.test(ua)
+  const browser = matchFirst(ua, [
+    [/Edg\/(\d+)/, "Edge"],
+    [/OPR\/(\d+)/, "Opera"],
+    [/Chrome\/(\d+)/, "Chrome"],
+    [/Safari\/(\d+)/, "Safari"],
+    [/Firefox\/(\d+)/, "Firefox"],
+  ]) ?? "Browser"
+  const os = matchFirst(ua, [
+    [/Windows NT (\d+\.\d+)/, "Windows"],
+    [/Mac OS X (\d+[._]\d+)/, "macOS"],
+    [/iPhone OS (\d+[._]\d+)/, "iOS"],
+    [/Android (\d+\.\d+)/, "Android"],
+    [/Linux/, "Linux"],
+  ]) ?? "Unknown OS"
+  let icon = Laptop as typeof Laptop
+  if (isMobile) icon = Smartphone
+  else if (isTablet) icon = TabletSmartphone
+  return { deviceIcon: icon, label: `${browser} on ${os}` }
+}
+
+// matchFirst returns the label of the first matching regex; null when
+// no pattern matched.
+function matchFirst(ua: string, table: Array<[RegExp, string]>): string | null {
+  for (const [re, label] of table) {
+    if (re.test(ua)) return label
+  }
+  return null
+}
+
+// formatRelative is a tiny Intl.RelativeTimeFormat wrapper. We
+// deliberately don't pull in a date-fns dependency here — Intl is
+// good enough for this surface.
+function formatRelative(iso: string, locale: string): string {
+  if (!iso) return ""
+  const target = new Date(iso).getTime()
+  if (!Number.isFinite(target)) return ""
+  const diff = target - Date.now()
+  const abs = Math.abs(diff)
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" })
+  const min = 60 * 1000
+  const hour = 60 * min
+  const day = 24 * hour
+  if (abs < min) return rtf.format(Math.round(diff / 1000), "second")
+  if (abs < hour) return rtf.format(Math.round(diff / min), "minute")
+  if (abs < day) return rtf.format(Math.round(diff / hour), "hour")
+  return rtf.format(Math.round(diff / day), "day")
+}
+
+function formatAbsolute(iso: string, locale: string): string {
+  if (!iso) return ""
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ""
+  return new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" }).format(d)
+}

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -1,15 +1,7 @@
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
-import {
-  ArrowLeft,
-  Laptop,
-  LogOut,
-  Monitor,
-  Shield,
-  Smartphone,
-  TabletSmartphone,
-} from "lucide-react"
+import { ArrowLeft, LogOut, Shield } from "lucide-react"
 
 import {
   Dialog,
@@ -29,8 +21,10 @@ import {
   useRevokeSession,
   useSessionsList,
 } from "@/features/sessions/hooks"
+import { parseUserAgent } from "@/features/security/ua"
 import { useAppToast } from "@/hooks/useAppToast"
 import { withGroupQuery } from "@/lib/group-aware-url"
+import { formatDateTime, formatRelative } from "@/lib/intl"
 
 // SessionsPage renders the /profile/sessions view from issue #1378.
 // Card per session — device icon, browser/OS, last-used, partial IP,
@@ -214,12 +208,11 @@ interface SessionCardProps {
 }
 
 function SessionCard({ session, onRevoke, disabled }: SessionCardProps) {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
   const ua = parseUserAgent(session.user_agent ?? "")
   const DeviceIcon = ua.deviceIcon
-  const locale = i18n.resolvedLanguage ?? "en"
-  const lastUsedRelative = formatRelative(session.last_used_at ?? session.created_at ?? "", locale)
-  const createdAbsolute = formatAbsolute(session.created_at ?? "", locale)
+  const lastUsedRelative = formatRelative(session.last_used_at ?? session.created_at ?? "")
+  const createdAbsolute = formatDateTime(session.created_at ?? "")
   // Label resolution lives here (not inside parseUserAgent) so we can keep
   // the parser pure and i18n-free and still render localized fallbacks.
   // Mixing the two would force the parser to take a `t` argument, which
@@ -270,80 +263,4 @@ function SessionCard({ session, onRevoke, disabled }: SessionCardProps) {
       </div>
     </div>
   )
-}
-
-// ParsedUA is what parseUserAgent returns. Keys are intentionally
-// non-localized — the consumer pairs them with i18n keys at render time
-// (so the unit test can stay i18n-free and the component-level fallback
-// can localize "Unknown" labels without re-deriving them here).
-interface ParsedUA {
-  deviceIcon: typeof Laptop
-  browser: string | null
-  os: string | null
-  isUnknown: boolean
-}
-
-// parseUserAgent runs in the browser per #1378 option 2 — keeps the DB
-// free of UA strings that age poorly. Cheap regex-based heuristics are
-// enough for the FE label: detailed parsing would require a library and
-// the cost isn't worth it for a side panel. Returns a structured shape
-// so the caller can decide which strings to localize (vs. mixing English
-// fallbacks into the parser, which is what review #1674 flagged).
-function parseUserAgent(ua: string): ParsedUA {
-  if (!ua) return { deviceIcon: Monitor, browser: null, os: null, isUnknown: true }
-  const isMobile = /iPhone|Android.*Mobile|Mobile/i.test(ua)
-  const isTablet = /iPad|Android(?!.*Mobile)/i.test(ua)
-  const browser = matchFirst(ua, [
-    [/Edg\/(\d+)/, "Edge"],
-    [/OPR\/(\d+)/, "Opera"],
-    [/Chrome\/(\d+)/, "Chrome"],
-    [/Safari\/(\d+)/, "Safari"],
-    [/Firefox\/(\d+)/, "Firefox"],
-  ])
-  const os = matchFirst(ua, [
-    [/Windows NT (\d+\.\d+)/, "Windows"],
-    [/Mac OS X (\d+[._]\d+)/, "macOS"],
-    [/iPhone OS (\d+[._]\d+)/, "iOS"],
-    [/Android (\d+\.\d+)/, "Android"],
-    [/Linux/, "Linux"],
-  ])
-  let icon = Laptop as typeof Laptop
-  if (isMobile) icon = Smartphone
-  else if (isTablet) icon = TabletSmartphone
-  return { deviceIcon: icon, browser, os, isUnknown: !browser && !os }
-}
-
-// matchFirst returns the label of the first matching regex; null when
-// no pattern matched.
-function matchFirst(ua: string, table: Array<[RegExp, string]>): string | null {
-  for (const [re, label] of table) {
-    if (re.test(ua)) return label
-  }
-  return null
-}
-
-// formatRelative is a tiny Intl.RelativeTimeFormat wrapper. We
-// deliberately don't pull in a date-fns dependency here — Intl is
-// good enough for this surface.
-function formatRelative(iso: string, locale: string): string {
-  if (!iso) return ""
-  const target = new Date(iso).getTime()
-  if (!Number.isFinite(target)) return ""
-  const diff = target - Date.now()
-  const abs = Math.abs(diff)
-  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" })
-  const min = 60 * 1000
-  const hour = 60 * min
-  const day = 24 * hour
-  if (abs < min) return rtf.format(Math.round(diff / 1000), "second")
-  if (abs < hour) return rtf.format(Math.round(diff / min), "minute")
-  if (abs < day) return rtf.format(Math.round(diff / hour), "hour")
-  return rtf.format(Math.round(diff / day), "day")
-}
-
-function formatAbsolute(iso: string, locale: string): string {
-  if (!iso) return ""
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return ""
-  return new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" }).format(d)
 }

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -45,7 +45,14 @@ export function SessionsPage() {
   const [pendingRevoke, setPendingRevoke] = useState<SessionView | null>(null)
   const [revokeAllOpen, setRevokeAllOpen] = useState(false)
 
-  const sessions = sessionsQuery.data?.sessions ?? []
+  // Memoise the array reference so the `otherSessionsCount` dep array
+  // stays stable across re-renders that don't change the query data —
+  // without this, `sessions` is a fresh `[]` whenever sessionsQuery.data
+  // is still undefined and the deps trip exhaustive-deps.
+  const sessions = useMemo(
+    () => sessionsQuery.data?.sessions ?? [],
+    [sessionsQuery.data?.sessions]
+  )
   const otherSessionsCount = useMemo(
     () => sessions.filter((s) => !s.is_current).length,
     [sessions]
@@ -159,7 +166,7 @@ export function SessionsPage() {
               onClick={() => setPendingRevoke(null)}
               disabled={revokeMutation.isPending}
             >
-              {t("common:cancel")}
+              {t("common:actions.cancel")}
             </Button>
             <Button
               onClick={doRevoke}
@@ -187,7 +194,7 @@ export function SessionsPage() {
               onClick={() => setRevokeAllOpen(false)}
               disabled={revokeAllOthersMutation.isPending}
             >
-              {t("common:cancel")}
+              {t("common:actions.cancel")}
             </Button>
             <Button
               onClick={doRevokeAllOthers}
@@ -214,8 +221,16 @@ function SessionCard({ session, onRevoke, disabled }: SessionCardProps) {
   const { t, i18n } = useTranslation()
   const ua = parseUserAgent(session.user_agent ?? "")
   const DeviceIcon = ua.deviceIcon
-  const lastUsedRelative = formatRelative(session.last_used_at ?? session.created_at, i18n.resolvedLanguage ?? "en")
-  const createdAbsolute = formatAbsolute(session.created_at ?? "", i18n.resolvedLanguage ?? "en")
+  const locale = i18n.resolvedLanguage ?? "en"
+  const lastUsedRelative = formatRelative(session.last_used_at ?? session.created_at ?? "", locale)
+  const createdAbsolute = formatAbsolute(session.created_at ?? "", locale)
+  // Label resolution lives here (not inside parseUserAgent) so we can keep
+  // the parser pure and i18n-free and still render localized fallbacks.
+  // Mixing the two would force the parser to take a `t` argument, which
+  // makes it harder to unit-test.
+  const label = ua.isUnknown
+    ? t("settings:sessions.ua.unknownDevice")
+    : `${ua.browser ?? t("settings:sessions.ua.unknownBrowser")} · ${ua.os ?? t("settings:sessions.ua.unknownOs")}`
 
   return (
     <div
@@ -230,7 +245,7 @@ function SessionCard({ session, onRevoke, disabled }: SessionCardProps) {
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
-            <p className="text-sm font-medium">{ua.label}</p>
+            <p className="text-sm font-medium">{label}</p>
             {session.is_current ? (
               <Badge variant="secondary" className="text-xs" data-testid="session-current-pill">
                 {t("settings:sessions.thisDevice")}
@@ -261,17 +276,25 @@ function SessionCard({ session, onRevoke, disabled }: SessionCardProps) {
   )
 }
 
+// ParsedUA is what parseUserAgent returns. Keys are intentionally
+// non-localized — the consumer pairs them with i18n keys at render time
+// (so the unit test can stay i18n-free and the component-level fallback
+// can localize "Unknown" labels without re-deriving them here).
 interface ParsedUA {
   deviceIcon: typeof Laptop
-  label: string
+  browser: string | null
+  os: string | null
+  isUnknown: boolean
 }
 
 // parseUserAgent runs in the browser per #1378 option 2 — keeps the DB
 // free of UA strings that age poorly. Cheap regex-based heuristics are
 // enough for the FE label: detailed parsing would require a library and
-// the cost isn't worth it for a side panel.
+// the cost isn't worth it for a side panel. Returns a structured shape
+// so the caller can decide which strings to localize (vs. mixing English
+// fallbacks into the parser, which is what review #1674 flagged).
 function parseUserAgent(ua: string): ParsedUA {
-  if (!ua) return { deviceIcon: Monitor, label: "Unknown device" }
+  if (!ua) return { deviceIcon: Monitor, browser: null, os: null, isUnknown: true }
   const isMobile = /iPhone|Android.*Mobile|Mobile/i.test(ua)
   const isTablet = /iPad|Android(?!.*Mobile)/i.test(ua)
   const browser = matchFirst(ua, [
@@ -280,18 +303,18 @@ function parseUserAgent(ua: string): ParsedUA {
     [/Chrome\/(\d+)/, "Chrome"],
     [/Safari\/(\d+)/, "Safari"],
     [/Firefox\/(\d+)/, "Firefox"],
-  ]) ?? "Browser"
+  ])
   const os = matchFirst(ua, [
     [/Windows NT (\d+\.\d+)/, "Windows"],
     [/Mac OS X (\d+[._]\d+)/, "macOS"],
     [/iPhone OS (\d+[._]\d+)/, "iOS"],
     [/Android (\d+\.\d+)/, "Android"],
     [/Linux/, "Linux"],
-  ]) ?? "Unknown OS"
+  ])
   let icon = Laptop as typeof Laptop
   if (isMobile) icon = Smartphone
   else if (isTablet) icon = TabletSmartphone
-  return { deviceIcon: icon, label: `${browser} on ${os}` }
+  return { deviceIcon: icon, browser, os, isUnknown: !browser && !os }
 }
 
 // matchFirst returns the label of the first matching regex; null when

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -24,7 +24,11 @@ import { Button } from "@/components/ui/button"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import type { SessionView } from "@/features/sessions/api"
 import { useCurrentGroup } from "@/features/group/GroupContext"
-import { useRevokeAllOtherSessions, useRevokeSession, useSessionsList } from "@/features/sessions/hooks"
+import {
+  useRevokeAllOtherSessions,
+  useRevokeSession,
+  useSessionsList,
+} from "@/features/sessions/hooks"
 import { useAppToast } from "@/hooks/useAppToast"
 import { withGroupQuery } from "@/lib/group-aware-url"
 
@@ -49,14 +53,8 @@ export function SessionsPage() {
   // stays stable across re-renders that don't change the query data —
   // without this, `sessions` is a fresh `[]` whenever sessionsQuery.data
   // is still undefined and the deps trip exhaustive-deps.
-  const sessions = useMemo(
-    () => sessionsQuery.data?.sessions ?? [],
-    [sessionsQuery.data?.sessions]
-  )
-  const otherSessionsCount = useMemo(
-    () => sessions.filter((s) => !s.is_current).length,
-    [sessions]
-  )
+  const sessions = useMemo(() => sessionsQuery.data?.sessions ?? [], [sessionsQuery.data?.sessions])
+  const otherSessionsCount = useMemo(() => sessions.filter((s) => !s.is_current).length, [sessions])
 
   const confirmRevoke = (session: SessionView) => setPendingRevoke(session)
 
@@ -98,9 +96,7 @@ export function SessionsPage() {
             <ArrowLeft className="size-4" aria-hidden="true" />
             {t("settings:privacy.title")}
           </Link>
-          <h1 className="text-2xl font-semibold tracking-tight">
-            {t("settings:sessions.title")}
-          </h1>
+          <h1 className="text-2xl font-semibold tracking-tight">{t("settings:sessions.title")}</h1>
           <p className="text-sm text-muted-foreground">{t("settings:sessions.subtitle")}</p>
         </div>
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react"
 
 import { ComingSoonBanner } from "@/components/coming-soon"
+import { useSessionsList } from "@/features/sessions/hooks"
 import { CurrencyCombobox } from "@/components/CurrencyCombobox"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -727,14 +728,97 @@ function NotificationsSection() {
 
 function PrivacySection() {
   const { t } = useTranslation()
+  // Sessions count drives the badge on the "Active sessions" row. Loading +
+  // error are intentionally silent — the row keeps the link affordance even
+  // when the count can't be fetched; the page itself renders the real state.
+  const sessionsQuery = useSessionsList()
+  const sessionCount = sessionsQuery.data?.sessions?.length ?? 0
+
   return (
     <div className="space-y-4" data-testid="section-privacy">
       <SectionTitle>{t("settings:privacy.title")}</SectionTitle>
-      <ComingSoonBanner surface="twoFactor" />
-      <ComingSoonBanner surface="activeSessions" />
-      <ComingSoonBanner surface="loginHistory" />
+      <div className="rounded-xl border border-border divide-y divide-border">
+        {/* Two-factor stays a ComingSoonBanner until #1380 ships. We keep it
+            in the same divided card as the live rows so the layout matches
+            the design mock at design-mocks/src/views/SettingsView.tsx. */}
+        <PrivacyRow
+          label={t("settings:privacy.rows.twoFactor")}
+          description={t("settings:privacy.rows.twoFactorDescription")}
+          badge={t("settings:privacy.rows.twoFactorBadge")}
+          badgeVariant="outline"
+          to={null}
+          testId="privacy-row-twoFactor"
+        />
+        <PrivacyRow
+          label={t("settings:privacy.rows.activeSessions")}
+          description={t("settings:privacy.rows.activeSessionsDescription")}
+          badge={sessionCount > 0 ? t("settings:privacy.rows.activeSessionsBadge", { count: sessionCount }) : null}
+          badgeVariant="secondary"
+          to="/profile/sessions"
+          testId="privacy-row-activeSessions"
+        />
+        <PrivacyRow
+          label={t("settings:privacy.rows.loginHistory")}
+          description={t("settings:privacy.rows.loginHistoryDescription")}
+          badge={null}
+          badgeVariant="secondary"
+          to="/profile/login-history"
+          testId="privacy-row-loginHistory"
+        />
+      </div>
+      {/* Connected accounts stays a ComingSoonBanner per #1644 acceptance. */}
       <ComingSoonBanner surface="connectedAccounts" />
     </div>
+  )
+}
+
+interface PrivacyRowProps {
+  label: string
+  description: string
+  badge: string | null
+  badgeVariant: "outline" | "secondary"
+  to: string | null
+  testId: string
+}
+
+function PrivacyRow({ label, description, badge, badgeVariant, to, testId }: PrivacyRowProps) {
+  const inner = (
+    <>
+      <div className="text-left">
+        <p className="text-sm font-medium">{label}</p>
+        <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+      </div>
+      <div className="flex items-center gap-2">
+        {badge ? (
+          <Badge variant={badgeVariant} className="text-xs">
+            {badge}
+          </Badge>
+        ) : null}
+        {to ? (
+          <ChevronRight className="size-4 text-muted-foreground" aria-hidden="true" />
+        ) : null}
+      </div>
+    </>
+  )
+  if (!to) {
+    return (
+      <div
+        className="flex items-center justify-between p-4"
+        data-testid={testId}
+        aria-disabled="true"
+      >
+        {inner}
+      </div>
+    )
+  }
+  return (
+    <Link
+      to={to}
+      data-testid={testId}
+      className="flex items-center justify-between p-4 text-left transition-colors hover:bg-muted/50"
+    >
+      {inner}
+    </Link>
   )
 }
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -752,7 +752,11 @@ function PrivacySection() {
         <PrivacyRow
           label={t("settings:privacy.rows.activeSessions")}
           description={t("settings:privacy.rows.activeSessionsDescription")}
-          badge={sessionCount > 0 ? t("settings:privacy.rows.activeSessionsBadge", { count: sessionCount }) : null}
+          badge={
+            sessionCount > 0
+              ? t("settings:privacy.rows.activeSessionsBadge", { count: sessionCount })
+              : null
+          }
           badgeVariant="secondary"
           to="/profile/sessions"
           testId="privacy-row-activeSessions"
@@ -794,9 +798,7 @@ function PrivacyRow({ label, description, badge, badgeVariant, to, testId }: Pri
             {badge}
           </Badge>
         ) : null}
-        {to ? (
-          <ChevronRight className="size-4 text-muted-foreground" aria-hidden="true" />
-        ) : null}
+        {to ? <ChevronRight className="size-4 text-muted-foreground" aria-hidden="true" /> : null}
       </div>
     </>
   )

--- a/frontend/src/pages/__tests__/LoginHistoryPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginHistoryPage.test.tsx
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { screen, waitFor, within } from "@testing-library/react"
+
+import { LoginHistoryPage } from "@/pages/LoginHistoryPage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+function renderPage() {
+  setAccessToken("good-token")
+  return renderWithProviders({
+    initialPath: "/profile/login-history",
+    routes: (
+      <Route
+        path="/profile/login-history"
+        element={
+          <AuthProvider>
+            <GroupProvider>
+              <LoginHistoryPage />
+            </GroupProvider>
+          </AuthProvider>
+        }
+      />
+    ),
+  })
+}
+
+const meHandler = msw.get(api("/auth/me"), () =>
+  HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+)
+const groupsHandler = msw.get(api("/groups"), () => HttpResponse.json({ data: [] }))
+
+describe("<LoginHistoryPage />", () => {
+  it("renders one row per event with the correct outcome", async () => {
+    server.use(
+      meHandler,
+      groupsHandler,
+      msw.get(api("/users/me/login-history"), () =>
+        HttpResponse.json({
+          events: [
+            {
+              id: "ev-ok",
+              created_at: "2026-05-14T07:55:00Z",
+              email: "alex@example.com",
+              outcome: "ok",
+              method: "password",
+              ip_address: "203.0.113.0/24",
+              user_agent: "Mozilla/5.0 (Macintosh) Chrome/120.0",
+            },
+            {
+              id: "ev-bad",
+              created_at: "2026-05-14T07:50:00Z",
+              email: "alex@example.com",
+              outcome: "bad_password",
+              method: "password",
+              ip_address: "198.51.100.0/24",
+              user_agent: "Mozilla/5.0 (iPhone) Safari/605",
+            },
+          ],
+          failed_last_7d: 2,
+        })
+      )
+    )
+    renderPage()
+    const list = await screen.findByTestId("login-history-list")
+    const rows = within(list).getAllByTestId("login-history-row")
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toHaveAttribute("data-outcome", "ok")
+    expect(rows[1]).toHaveAttribute("data-outcome", "bad_password")
+    // failed_last_7d=2 is below the threshold (3) — banner stays hidden.
+    expect(screen.queryByTestId("login-history-failed-banner")).not.toBeInTheDocument()
+  })
+
+  it("shows the failed-attempts banner when failed_last_7d > 3", async () => {
+    server.use(
+      meHandler,
+      groupsHandler,
+      msw.get(api("/users/me/login-history"), () =>
+        HttpResponse.json({ events: [], failed_last_7d: 5 })
+      )
+    )
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByTestId("login-history-failed-banner")).toBeInTheDocument()
+    )
+  })
+})

--- a/frontend/src/pages/__tests__/SessionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SessionsPage.test.tsx
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { SessionsPage } from "@/pages/SessionsPage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { ConfirmProvider } from "@/hooks/useConfirm"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+function renderPage() {
+  setAccessToken("good-token")
+  return renderWithProviders({
+    initialPath: "/profile/sessions",
+    routes: (
+      <Route
+        path="/profile/sessions"
+        element={
+          <AuthProvider>
+            <GroupProvider>
+              <ConfirmProvider>
+                <SessionsPage />
+              </ConfirmProvider>
+            </GroupProvider>
+          </AuthProvider>
+        }
+      />
+    ),
+  })
+}
+
+const meHandler = msw.get(api("/auth/me"), () =>
+  HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+)
+const groupsHandler = msw.get(api("/groups"), () => HttpResponse.json({ data: [] }))
+
+const baseTokens = [
+  {
+    id: "rt-current",
+    created_at: "2026-05-13T08:00:00Z",
+    last_used_at: "2026-05-14T07:55:00Z",
+    expires_at: "2026-06-13T08:00:00Z",
+    ip_address: "203.0.113.0/24",
+    user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0",
+    is_current: true,
+  },
+  {
+    id: "rt-other",
+    created_at: "2026-05-10T12:00:00Z",
+    last_used_at: "2026-05-12T09:00:00Z",
+    expires_at: "2026-06-10T12:00:00Z",
+    ip_address: "198.51.100.0/24",
+    user_agent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Safari/605.1.15",
+    is_current: false,
+  },
+]
+
+describe("<SessionsPage />", () => {
+  it("renders one card per session and tags the current device", async () => {
+    server.use(
+      meHandler,
+      groupsHandler,
+      msw.get(api("/users/me/sessions"), () => HttpResponse.json({ sessions: baseTokens }))
+    )
+    renderPage()
+    const list = await screen.findByTestId("sessions-list")
+    const cards = within(list).getAllByTestId("session-card")
+    expect(cards).toHaveLength(2)
+    expect(within(cards[0]).getByTestId("session-current-pill")).toBeInTheDocument()
+    // Current session has no revoke button; the other one does.
+    expect(within(cards[0]).queryByTestId("session-revoke-btn")).not.toBeInTheDocument()
+    expect(within(cards[1]).getByTestId("session-revoke-btn")).toBeInTheDocument()
+  })
+
+  it("revokes a single session after confirmation and refreshes the list", async () => {
+    let listCalls = 0
+    let revokeId = ""
+    server.use(
+      meHandler,
+      groupsHandler,
+      msw.get(api("/users/me/sessions"), () => {
+        listCalls += 1
+        // First call returns both sessions; subsequent calls reflect
+        // the revocation by dropping the second token.
+        return HttpResponse.json({
+          sessions: listCalls === 1 ? baseTokens : [baseTokens[0]],
+        })
+      }),
+      msw.delete(api("/users/me/sessions/:id"), ({ params }) => {
+        revokeId = String(params.id)
+        return new HttpResponse(null, { status: 204 })
+      })
+    )
+    const user = userEvent.setup()
+    renderPage()
+    const list = await screen.findByTestId("sessions-list")
+    const cards = within(list).getAllByTestId("session-card")
+    await user.click(within(cards[1]).getByTestId("session-revoke-btn"))
+    await user.click(await screen.findByTestId("sessions-confirm-revoke-btn"))
+    await waitFor(() => expect(revokeId).toBe("rt-other"))
+    await waitFor(() => {
+      const stillThere = within(screen.getByTestId("sessions-list")).queryAllByTestId("session-card")
+      expect(stillThere).toHaveLength(1)
+    })
+  })
+
+  it("revoke-all-other-sessions button fires DELETE /users/me/sessions after confirmation", async () => {
+    let deleteCalls = 0
+    server.use(
+      meHandler,
+      groupsHandler,
+      msw.get(api("/users/me/sessions"), () => HttpResponse.json({ sessions: baseTokens })),
+      msw.delete(api("/users/me/sessions"), () => {
+        deleteCalls += 1
+        return new HttpResponse(null, { status: 204 })
+      })
+    )
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId("sessions-list")
+    await user.click(screen.getByTestId("sessions-revoke-all-btn"))
+    await user.click(await screen.findByTestId("sessions-confirm-revoke-all-btn"))
+    await waitFor(() => expect(deleteCalls).toBe(1))
+  })
+})

--- a/frontend/src/pages/__tests__/SessionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SessionsPage.test.tsx
@@ -113,7 +113,9 @@ describe("<SessionsPage />", () => {
     await user.click(await screen.findByTestId("sessions-confirm-revoke-btn"))
     await waitFor(() => expect(revokeId).toBe("rt-other"))
     await waitFor(() => {
-      const stillThere = within(screen.getByTestId("sessions-list")).queryAllByTestId("session-card")
+      const stillThere = within(screen.getByTestId("sessions-list")).queryAllByTestId(
+        "session-card"
+      )
       expect(stillThere).toHaveLength(1)
     })
   })

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -148,14 +148,25 @@ describe("<SettingsPage />", () => {
     await waitFor(() => expect(localStorage.getItem("density-test-1414")).toBe("compact"))
   })
 
-  it("privacy section renders four ComingSoonBanner stubs", async () => {
-    server.use(...baseHandlers)
+  it("privacy section wires sessions + history rows (#1644) + keeps 2FA / connected accounts as stubs", async () => {
+    server.use(
+      ...baseHandlers,
+      // #1644: the privacy section pre-fetches the sessions list to drive
+      // the active-sessions row badge. The handler is wired here so the
+      // useSessionsList query resolves; an empty array hides the badge,
+      // matching the "no live sessions yet" state.
+      msw.get(api("/users/me/sessions"), () => HttpResponse.json({ sessions: [] }))
+    )
     const user = userEvent.setup()
     renderSettings()
     await user.click(await screen.findByTestId("settings-nav-privacy"))
-    expect(screen.getByTestId("coming-soon-banner-twoFactor")).toBeInTheDocument()
-    expect(screen.getByTestId("coming-soon-banner-activeSessions")).toBeInTheDocument()
-    expect(screen.getByTestId("coming-soon-banner-loginHistory")).toBeInTheDocument()
+    expect(screen.getByTestId("privacy-row-twoFactor")).toBeInTheDocument()
+    const sessionsRow = await screen.findByTestId("privacy-row-activeSessions")
+    expect(sessionsRow).toHaveAttribute("href", "/profile/sessions")
+    const historyRow = screen.getByTestId("privacy-row-loginHistory")
+    expect(historyRow).toHaveAttribute("href", "/profile/login-history")
+    // Connected accounts intentionally stays a ComingSoonBanner — see
+    // issue #1644 scope ("connected accounts remains ComingSoonBanner → #1395").
     expect(screen.getByTestId("coming-soon-banner-connectedAccounts")).toBeInTheDocument()
   })
 

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -5582,6 +5582,197 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/users/me/login-history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List login history
+         * @description Returns the authenticated user's most recent login attempts (default 100, max 500). Also returns failed_last_7d for the optional banner.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Cap on number of events returned (default 100, max 500) */
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["apiserver.LoginHistoryResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/me/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List active sessions
+         * @description Returns the authenticated user's active refresh-token sessions, with a flag identifying the session bound to the current refresh cookie.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["apiserver.SessionsListResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /**
+         * Revoke all other sessions
+         * @description Revoke every refresh token for the authenticated user except the one bound to the current refresh cookie.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/me/sessions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Revoke one session
+         * @description Mark a single refresh token as revoked. Returns 404 if the id does not belong to the authenticated user.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Session ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/verify-email": {
         parameters: {
             query?: never;
@@ -5672,6 +5863,19 @@ export type components = {
             warranty_expiring_alerts?: boolean;
             weekly_digest?: boolean;
         };
+        "apiserver.LoginEventView": {
+            created_at?: string;
+            email?: string;
+            id?: string;
+            ip_address?: string;
+            method?: components["schemas"]["models.LoginMethod"];
+            outcome?: components["schemas"]["models.LoginOutcome"];
+            user_agent?: string;
+        };
+        "apiserver.LoginHistoryResponse": {
+            events?: components["schemas"]["apiserver.LoginEventView"][];
+            failed_last_7d?: number;
+        };
         "apiserver.LoginRequest": {
             email?: string;
             password?: string;
@@ -5720,6 +5924,18 @@ export type components = {
             already_seeded?: boolean;
             message?: string;
             status?: string;
+        };
+        "apiserver.SessionView": {
+            created_at?: string;
+            expires_at?: string;
+            id?: string;
+            ip_address?: string;
+            is_current?: boolean;
+            last_used_at?: string;
+            user_agent?: string;
+        };
+        "apiserver.SessionsListResponse": {
+            sessions?: components["schemas"]["apiserver.SessionView"][];
         };
         "apiserver.SettingsUpdateRequest": {
             /** @description DefaultDateFormat is the uiconfig.default_date_format value accepted by PUT /settings. */
@@ -7539,6 +7755,10 @@ export type components = {
         };
         /** @enum {string} */
         "models.LocationGroupStatus": "active" | "pending_deletion";
+        /** @enum {string} */
+        "models.LoginMethod": "password";
+        /** @enum {string} */
+        "models.LoginOutcome": "ok" | "bad_password" | "account_locked" | "account_disabled" | "email_not_verified";
         "models.Plan": {
             allows_api_access?: boolean;
             allows_restore?: boolean;

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -283,6 +283,7 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			UserRegistry:            params.FactorySet.UserRegistry,
 			RefreshTokenRegistry:    params.FactorySet.RefreshTokenRegistry,
 			GroupMembershipRegistry: params.FactorySet.GroupMembershipRegistry,
+			LoginEventRegistry:      params.FactorySet.LoginEventRegistry,
 			BlacklistService:        blacklist,
 			RateLimiter:             rateLimiter,
 			CSRFService:             csrfSvc,
@@ -337,6 +338,13 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 		// under /groups/{id}/members; a tenant-wide admin surface will be
 		// re-introduced only when group-based admin authorization is designed.
 		r.With(userMiddlewares...).Route("/groups", Groups(params, groupService, auditSvc))
+		// Per-user account surfaces (#1644): active sessions + login history.
+		// These don't fit under /auth (which is unauth-tolerant on purpose)
+		// nor under /g/{slug}/* (they're tenant-scoped, not group-scoped).
+		r.With(userMiddlewares...).Route("/users/me", UsersMe(UsersMeParams{
+			RefreshTokenRegistry: params.FactorySet.RefreshTokenRegistry,
+			LoginEventRegistry:   params.FactorySet.LoginEventRegistry,
+		}))
 		// Invites are mounted WITHOUT userMiddlewares so that GET /invites/{token}
 		// remains public (the invitee is typically unauthenticated at first).
 		// POST /invites/{token}/accept is wrapped with the userMiddlewares chain

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -40,6 +40,7 @@ type AuthAPI struct {
 	userRegistry            registry.UserRegistry
 	refreshTokenRegistry    registry.RefreshTokenRegistry
 	groupMembershipRegistry registry.GroupMembershipRegistry
+	loginEventRegistry      registry.LoginEventRegistry
 	blacklistService        services.TokenBlacklister
 	rateLimiter             services.AuthRateLimiter
 	csrfService             csrf.Service
@@ -116,6 +117,16 @@ func (api *AuthAPI) login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Tenant context resolved upstream by PublicTenantMiddleware. Recorded
+	// alongside the login_event regardless of outcome so failed attempts
+	// are scoped to the correct tenant — even when we don't know the user.
+	tenantID := TenantIDFromContext(r.Context())
+	if tenantID == "" {
+		slog.Error("Login attempted without tenant context in request")
+		http.Error(w, "Tenant context not established", http.StatusInternalServerError)
+		return
+	}
+
 	// Account lockout is enforced per email to mitigate distributed brute force.
 	if api.rateLimiter != nil {
 		locked, resetAt, err := api.rateLimiter.IsAccountLocked(r.Context(), req.Email)
@@ -125,23 +136,19 @@ func (api *AuthAPI) login(w http.ResponseWriter, r *http.Request) {
 		} else if locked {
 			retryAfter := max(int(time.Until(resetAt).Seconds()), 0)
 			w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+			api.recordLoginEvent(r.Context(), tenantID, req.Email, nil, models.LoginOutcomeAccountLocked, r)
 			http.Error(w, "Too many failed login attempts. Please try again later.", http.StatusTooManyRequests)
 			return
 		}
 	}
 
-	tenantID := TenantIDFromContext(r.Context())
-	if tenantID == "" {
-		slog.Error("Login attempted without tenant context in request")
-		http.Error(w, "Tenant context not established", http.StatusInternalServerError)
-		return
-	}
 	user, err := api.userRegistry.GetByEmail(r.Context(), tenantID, req.Email)
 	if err != nil {
 		slog.Warn("Failed login attempt: user not found", "email", req.Email, "error", err)
 		api.maybeRecordFailedLogin(r.Context(), req.Email)
 		errMsg := "user not found"
 		api.logAuth(r.Context(), "login", nil, nil, false, r, &errMsg)
+		api.recordLoginEvent(r.Context(), tenantID, req.Email, nil, models.LoginOutcomeBadPassword, r)
 		http.Error(w, "Invalid credentials", http.StatusUnauthorized)
 		return
 	}
@@ -151,6 +158,8 @@ func (api *AuthAPI) login(w http.ResponseWriter, r *http.Request) {
 		api.maybeRecordFailedLogin(r.Context(), req.Email)
 		errMsg := "invalid password"
 		api.logAuth(r.Context(), "login", &user.ID, &user.TenantID, false, r, &errMsg)
+		userID := user.ID
+		api.recordLoginEvent(r.Context(), tenantID, req.Email, &userID, models.LoginOutcomeBadPassword, r)
 		http.Error(w, "Invalid credentials", http.StatusUnauthorized)
 		return
 	}
@@ -159,6 +168,8 @@ func (api *AuthAPI) login(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("Failed login attempt: user account disabled", "email", req.Email, "user_id", user.ID)
 		errMsg := "account disabled"
 		api.logAuth(r.Context(), "login", &user.ID, &user.TenantID, false, r, &errMsg)
+		userID := user.ID
+		api.recordLoginEvent(r.Context(), tenantID, req.Email, &userID, models.LoginOutcomeAccountDisabled, r)
 		http.Error(w, "User account disabled", http.StatusForbidden)
 		return
 	}
@@ -197,6 +208,8 @@ func (api *AuthAPI) login(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("Successful user login", "email", user.Email, "user_id", user.ID)
 	api.logAuth(r.Context(), "login", &user.ID, &user.TenantID, true, r, nil)
+	userID := user.ID
+	api.recordLoginEvent(r.Context(), tenantID, user.Email, &userID, models.LoginOutcomeOK, r)
 
 	// Generate a CSRF token for this session.
 	csrfToken := api.generateCSRFTokenForUser(r.Context(), user.ID)
@@ -518,6 +531,7 @@ type AuthParams struct {
 	UserRegistry            registry.UserRegistry
 	RefreshTokenRegistry    registry.RefreshTokenRegistry
 	GroupMembershipRegistry registry.GroupMembershipRegistry
+	LoginEventRegistry      registry.LoginEventRegistry
 	BlacklistService        services.TokenBlacklister
 	RateLimiter             services.AuthRateLimiter
 	CSRFService             csrf.Service
@@ -532,6 +546,7 @@ func Auth(params AuthParams) func(r chi.Router) {
 		userRegistry:            params.UserRegistry,
 		refreshTokenRegistry:    params.RefreshTokenRegistry,
 		groupMembershipRegistry: params.GroupMembershipRegistry,
+		loginEventRegistry:      params.LoginEventRegistry,
 		blacklistService:        params.BlacklistService,
 		rateLimiter:             params.RateLimiter,
 		csrfService:             params.CSRFService,
@@ -785,6 +800,42 @@ func (api *AuthAPI) logAuth(ctx context.Context, action string, userID, tenantID
 	api.auditService.LogAuth(ctx, action, userID, tenantID, success, r, errMsg)
 }
 
+// recordLoginEvent persists a single login_events row (issue #1379). It is
+// no-op when the registry is not configured (tests + memory-mode bootstrap
+// can still skip it without panics) and best-effort otherwise: a failure
+// to write the audit row is logged but does not change the auth outcome.
+//
+// userID is a pointer because unknown-email failures resolve to NULL —
+// we record the attempt against the email the client typed but cannot
+// link it to a row in users.
+func (api *AuthAPI) recordLoginEvent(ctx context.Context, tenantID, email string, userID *string, outcome models.LoginOutcome, r *http.Request) {
+	if api.loginEventRegistry == nil {
+		return
+	}
+	if tenantID == "" {
+		// The tenant resolver always runs upstream — an empty tenant here
+		// is a bug, not a normal branch. Log and skip rather than write
+		// a row that violates the FK.
+		slog.Warn("Skipping login_event with empty tenant_id", "email", email, "outcome", outcome)
+		return
+	}
+	event := models.LoginEvent{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		UserID:              userID,
+		Email:               email,
+		Outcome:             outcome,
+		Method:              models.LoginMethodPassword,
+		IPAddress:           clientIPTruncated(r),
+		UserAgent:           r.UserAgent(),
+	}
+	if _, err := api.loginEventRegistry.Create(ctx, event); err != nil {
+		// Use Warn rather than Error — a missing audit row is bad for
+		// forensics but not for the user experience, and we don't want a
+		// noisy login flow on a momentary DB blip.
+		slog.Warn("Failed to record login event", "email", email, "outcome", outcome, "error", err)
+	}
+}
+
 // -----------------------------------------------------------------------
 // Internal helpers
 // -----------------------------------------------------------------------
@@ -823,7 +874,7 @@ func (api *AuthAPI) issueRefreshTokenCookie(w http.ResponseWriter, r *http.Reque
 		},
 		TokenHash: tokenHash,
 		ExpiresAt: time.Now().Add(refreshTokenExpiration),
-		IPAddress: getClientIP(r),
+		IPAddress: clientIPTruncated(r),
 		UserAgent: r.UserAgent(),
 	}
 
@@ -898,4 +949,30 @@ func getClientIP(r *http.Request) string {
 		return host
 	}
 	return r.RemoteAddr
+}
+
+// truncateIP returns a privacy-preserving form of ip per issue #1378's
+// "default = truncated /24 for IPv4, /56 for IPv6" policy. Returns the
+// input unchanged when it can't be parsed (e.g. local proxy header
+// passing a non-IP token) so we never silently drop the value the
+// client actually sent.
+func truncateIP(ip string) string {
+	if ip == "" {
+		return ""
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return ip
+	}
+	if v4 := parsed.To4(); v4 != nil {
+		return (&net.IPNet{IP: v4.Mask(net.CIDRMask(24, 32)), Mask: net.CIDRMask(24, 32)}).String()
+	}
+	// IPv6.
+	return (&net.IPNet{IP: parsed.Mask(net.CIDRMask(56, 128)), Mask: net.CIDRMask(56, 128)}).String()
+}
+
+// clientIPTruncated combines getClientIP and truncateIP — the only form
+// we want to persist to refresh_tokens or login_events.
+func clientIPTruncated(r *http.Request) string {
+	return truncateIP(getClientIP(r))
 }

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -78,9 +78,21 @@ func (m *mockRefreshTokenRegistryForAuth) GetByUserID(_ context.Context, _ strin
 	return nil, nil
 }
 
+func (m *mockRefreshTokenRegistryForAuth) ListActiveByUserID(_ context.Context, _ string) ([]*models.RefreshToken, error) {
+	return nil, nil
+}
+
 func (m *mockRefreshTokenRegistryForAuth) RevokeByUserID(_ context.Context, userID string) error {
 	m.revokeByUserIDCalled = true
 	m.revokeByUserIDArg = userID
+	return nil
+}
+
+func (m *mockRefreshTokenRegistryForAuth) RevokeByID(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (m *mockRefreshTokenRegistryForAuth) RevokeAllExceptID(_ context.Context, _ string, _ string) error {
 	return nil
 }
 

--- a/go/apiserver/users_me.go
+++ b/go/apiserver/users_me.go
@@ -1,0 +1,289 @@
+package apiserver
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// usersMeDefaultLoginHistoryLimit is the cap applied when the FE asks for
+// "the full history" (no ?limit= or ?limit=0). 100 mirrors the design-doc
+// in #1379 and is comfortably above the row count a normal user produces
+// in 90 days even with daily logins from multiple devices.
+const usersMeDefaultLoginHistoryLimit = 100
+
+// usersMeMaxLoginHistoryLimit caps the upper bound of the limit query.
+// The retention sweep keeps 90 days of rows; a single page above this
+// would be a misuse — paginate via repeated calls if you really need it.
+const usersMeMaxLoginHistoryLimit = 500
+
+// UsersMeParams wires the dependencies of the /users/me route group.
+type UsersMeParams struct {
+	RefreshTokenRegistry registry.RefreshTokenRegistry
+	LoginEventRegistry   registry.LoginEventRegistry
+}
+
+// usersMeAPI is the handler set behind /users/me/{sessions,login-history}.
+type usersMeAPI struct {
+	refreshTokenRegistry registry.RefreshTokenRegistry
+	loginEventRegistry   registry.LoginEventRegistry
+}
+
+// SessionView is the FE-facing shape returned by GET /users/me/sessions.
+// It deliberately omits TokenHash and any other column the FE has no use
+// for — the FE renders the partial IP + UA as-is and parses the UA in
+// the browser (issue #1378 option 2).
+type SessionView struct {
+	ID         string     `json:"id"`
+	CreatedAt  time.Time  `json:"created_at"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	ExpiresAt  time.Time  `json:"expires_at"`
+	IPAddress  string     `json:"ip_address,omitempty"`
+	UserAgent  string     `json:"user_agent,omitempty"`
+	IsCurrent  bool       `json:"is_current"`
+}
+
+// SessionsListResponse is the envelope for GET /users/me/sessions.
+type SessionsListResponse struct {
+	Sessions []SessionView `json:"sessions"`
+}
+
+// LoginEventView is the FE-facing shape returned by GET /users/me/login-history.
+type LoginEventView struct {
+	ID        string              `json:"id"`
+	CreatedAt time.Time           `json:"created_at"`
+	Email     string              `json:"email"`
+	Outcome   models.LoginOutcome `json:"outcome"`
+	Method    models.LoginMethod  `json:"method"`
+	IPAddress string              `json:"ip_address,omitempty"`
+	UserAgent string              `json:"user_agent,omitempty"`
+}
+
+// LoginHistoryResponse is the envelope for GET /users/me/login-history.
+type LoginHistoryResponse struct {
+	Events       []LoginEventView `json:"events"`
+	FailedLast7d int              `json:"failed_last_7d"`
+}
+
+// UsersMe registers the /api/v1/users/me sub-routes (issue #1644). The
+// JWT + CSRF middleware is applied by the caller via `r.With(userMiddlewares...)`
+// — every handler here trusts appctx.UserFromContext to be non-nil.
+func UsersMe(params UsersMeParams) func(r chi.Router) {
+	api := &usersMeAPI{
+		refreshTokenRegistry: params.RefreshTokenRegistry,
+		loginEventRegistry:   params.LoginEventRegistry,
+	}
+	return func(r chi.Router) {
+		r.Get("/sessions", api.listSessions)
+		r.Delete("/sessions/{id}", api.revokeSession)
+		r.Delete("/sessions", api.revokeAllOtherSessions)
+		r.Get("/login-history", api.listLoginHistory)
+	}
+}
+
+// listSessions returns the user's active (non-revoked, non-expired)
+// refresh tokens with an is_current flag derived from the refresh
+// cookie's token hash.
+// @Summary List active sessions
+// @Description Returns the authenticated user's active refresh-token sessions, with a flag identifying the session bound to the current refresh cookie.
+// @Tags users-me
+// @Produce json
+// @Success 200 {object} SessionsListResponse "OK"
+// @Failure 401 {string} string "Unauthorized"
+// @Router /users/me/sessions [get]
+func (api *usersMeAPI) listSessions(w http.ResponseWriter, r *http.Request) {
+	user := appctx.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	if api.refreshTokenRegistry == nil {
+		// Sessions API is meaningless without a refresh-token store
+		// (e.g. an old test harness booting without it). Return an empty
+		// list rather than 500 so the FE can still render the page.
+		writeJSON(w, http.StatusOK, SessionsListResponse{Sessions: []SessionView{}})
+		return
+	}
+
+	tokens, err := api.refreshTokenRegistry.ListActiveByUserID(r.Context(), user.ID)
+	if err != nil {
+		slog.Error("Failed to list sessions", "user_id", user.ID, "error", err)
+		http.Error(w, "Failed to list sessions", http.StatusInternalServerError)
+		return
+	}
+
+	currentHash := currentRefreshTokenHash(r)
+	sessions := make([]SessionView, 0, len(tokens))
+	for _, t := range tokens {
+		sessions = append(sessions, SessionView{
+			ID:         t.ID,
+			CreatedAt:  t.CreatedAt,
+			LastUsedAt: t.LastUsedAt,
+			ExpiresAt:  t.ExpiresAt,
+			IPAddress:  t.IPAddress,
+			UserAgent:  t.UserAgent,
+			IsCurrent:  currentHash != "" && t.TokenHash == currentHash,
+		})
+	}
+	writeJSON(w, http.StatusOK, SessionsListResponse{Sessions: sessions})
+}
+
+// revokeSession revokes a single refresh token by id, gated on user
+// ownership — a guessed id from a different account returns 404.
+// @Summary Revoke one session
+// @Description Mark a single refresh token as revoked. Returns 404 if the id does not belong to the authenticated user.
+// @Tags users-me
+// @Produce json
+// @Param id path string true "Session ID"
+// @Success 204 {string} string "No Content"
+// @Failure 404 {string} string "Not Found"
+// @Failure 401 {string} string "Unauthorized"
+// @Router /users/me/sessions/{id} [delete]
+func (api *usersMeAPI) revokeSession(w http.ResponseWriter, r *http.Request) {
+	user := appctx.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	if api.refreshTokenRegistry == nil {
+		http.Error(w, "Sessions not supported", http.StatusNotImplemented)
+		return
+	}
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		http.Error(w, "Missing session id", http.StatusBadRequest)
+		return
+	}
+	if err := api.refreshTokenRegistry.RevokeByID(r.Context(), user.ID, id); err != nil {
+		if errors.Is(err, registry.ErrNotFound) {
+			http.Error(w, "Session not found", http.StatusNotFound)
+			return
+		}
+		slog.Error("Failed to revoke session", "user_id", user.ID, "session_id", id, "error", err)
+		http.Error(w, "Failed to revoke session", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// revokeAllOtherSessions revokes every refresh token for the user
+// except the one whose hash matches the current refresh cookie. When
+// no cookie is present we still revoke everything — the caller has
+// already proven they hold a valid access token, so wiping all sessions
+// is the correct outcome for that legitimate (if rare) shape.
+// @Summary Revoke all other sessions
+// @Description Revoke every refresh token for the authenticated user except the one bound to the current refresh cookie.
+// @Tags users-me
+// @Produce json
+// @Success 204 {string} string "No Content"
+// @Failure 401 {string} string "Unauthorized"
+// @Router /users/me/sessions [delete]
+func (api *usersMeAPI) revokeAllOtherSessions(w http.ResponseWriter, r *http.Request) {
+	user := appctx.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	if api.refreshTokenRegistry == nil {
+		http.Error(w, "Sessions not supported", http.StatusNotImplemented)
+		return
+	}
+
+	keepID := ""
+	if hash := currentRefreshTokenHash(r); hash != "" {
+		if rt, err := api.refreshTokenRegistry.GetByTokenHash(r.Context(), hash); err == nil && rt.UserID == user.ID {
+			keepID = rt.ID
+		}
+	}
+
+	if err := api.refreshTokenRegistry.RevokeAllExceptID(r.Context(), user.ID, keepID); err != nil {
+		slog.Error("Failed to revoke other sessions", "user_id", user.ID, "error", err)
+		http.Error(w, "Failed to revoke sessions", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// listLoginHistory returns the user's most recent login attempts. The
+// envelope also carries failed_last_7d so the FE can render the
+// "We noticed N failed sign-in attempts" banner without a second round-trip.
+// @Summary List login history
+// @Description Returns the authenticated user's most recent login attempts (default 100, max 500). Also returns failed_last_7d for the optional banner.
+// @Tags users-me
+// @Produce json
+// @Param limit query int false "Cap on number of events returned (default 100, max 500)"
+// @Success 200 {object} LoginHistoryResponse "OK"
+// @Failure 401 {string} string "Unauthorized"
+// @Router /users/me/login-history [get]
+func (api *usersMeAPI) listLoginHistory(w http.ResponseWriter, r *http.Request) {
+	user := appctx.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+	if api.loginEventRegistry == nil {
+		writeJSON(w, http.StatusOK, LoginHistoryResponse{Events: []LoginEventView{}})
+		return
+	}
+
+	limit := usersMeDefaultLoginHistoryLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			limit = v
+		}
+	}
+	if limit > usersMeMaxLoginHistoryLimit {
+		limit = usersMeMaxLoginHistoryLimit
+	}
+
+	events, err := api.loginEventRegistry.ListByUser(r.Context(), user.ID, limit)
+	if err != nil {
+		slog.Error("Failed to list login history", "user_id", user.ID, "error", err)
+		http.Error(w, "Failed to list login history", http.StatusInternalServerError)
+		return
+	}
+
+	out := make([]LoginEventView, 0, len(events))
+	for _, e := range events {
+		out = append(out, LoginEventView{
+			ID:        e.ID,
+			CreatedAt: e.CreatedAt,
+			Email:     e.Email,
+			Outcome:   e.Outcome,
+			Method:    e.Method,
+			IPAddress: e.IPAddress,
+			UserAgent: e.UserAgent,
+		})
+	}
+
+	failed, err := api.loginEventRegistry.CountFailedSince(r.Context(), user.ID, time.Now().Add(-7*24*time.Hour))
+	if err != nil {
+		// Log and fall through with 0 — the banner is a nice-to-have,
+		// not a gate, and we don't want a count failure to kill the
+		// whole page.
+		slog.Warn("Failed to count failed logins in last 7d", "user_id", user.ID, "error", err)
+		failed = 0
+	}
+
+	writeJSON(w, http.StatusOK, LoginHistoryResponse{Events: out, FailedLast7d: failed})
+}
+
+// currentRefreshTokenHash extracts the SHA-256 hash of the request's
+// refresh cookie (if present), used to flag "this session is me" in
+// the sessions list and to keep the current session alive when the
+// user clicks "Sign out all other sessions".
+func currentRefreshTokenHash(r *http.Request) string {
+	c, err := r.Cookie(refreshTokenCookieName)
+	if err != nil || c.Value == "" {
+		return ""
+	}
+	return models.HashRefreshToken(c.Value)
+}

--- a/go/apiserver/users_me.go
+++ b/go/apiserver/users_me.go
@@ -244,7 +244,7 @@ func (api *usersMeAPI) listLoginHistory(w http.ResponseWriter, r *http.Request) 
 		limit = usersMeMaxLoginHistoryLimit
 	}
 
-	events, err := api.loginEventRegistry.ListByUser(r.Context(), user.ID, limit)
+	events, err := api.loginEventRegistry.ListByUser(r.Context(), user.TenantID, user.ID, limit)
 	if err != nil {
 		slog.Error("Failed to list login history", "user_id", user.ID, "error", err)
 		http.Error(w, "Failed to list login history", http.StatusInternalServerError)
@@ -264,7 +264,7 @@ func (api *usersMeAPI) listLoginHistory(w http.ResponseWriter, r *http.Request) 
 		})
 	}
 
-	failed, err := api.loginEventRegistry.CountFailedSince(r.Context(), user.ID, time.Now().Add(-7*24*time.Hour))
+	failed, err := api.loginEventRegistry.CountFailedSince(r.Context(), user.TenantID, user.ID, time.Now().Add(-7*24*time.Hour))
 	if err != nil {
 		// Log and fall through with 0 — the banner is a nice-to-have,
 		// not a gate, and we don't want a count failure to kill the

--- a/go/apiserver/users_me_test.go
+++ b/go/apiserver/users_me_test.go
@@ -1,0 +1,200 @@
+package apiserver_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+// TestUsersMeAPI exercises the four /users/me handlers shipped with
+// issue #1644: list sessions (with is_current flag), revoke a single
+// session, revoke all-but-current, and the login-history endpoint.
+// Memory registries back the test so the assertions only need to
+// match application-level behaviour — RLS, FK constraints and the
+// service-mode role are postgres-only and out of scope here.
+func TestUsersMeAPI(t *testing.T) {
+	c := qt.New(t)
+
+	user := &models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "u-1"},
+			TenantID: "tenant-1",
+		},
+		Email:    "alex@example.com",
+		Name:     "Alex",
+		IsActive: true,
+	}
+
+	rtReg := memory.NewRefreshTokenRegistry()
+	leReg := memory.NewLoginEventRegistry()
+
+	// Seed two refresh tokens belonging to the user: one is the
+	// "current" session (matching the request cookie hash), the
+	// other is an old browser we expect to be able to revoke
+	// independently. The token strings are arbitrary in-memory
+	// values; only their hash matters to the registry.
+	currentRaw, currentHash, err := models.GenerateRefreshToken()
+	c.Assert(err, qt.IsNil)
+	current, err := rtReg.Create(c.Context(), models.RefreshToken{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+			TenantID: user.TenantID, UserID: user.ID,
+		},
+		TokenHash: currentHash,
+		ExpiresAt: time.Now().Add(time.Hour),
+		IPAddress: "203.0.113.0/24",
+		UserAgent: "Mozilla/5.0 Chrome/120.0",
+	})
+	c.Assert(err, qt.IsNil)
+	other, err := rtReg.Create(c.Context(), models.RefreshToken{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+			TenantID: user.TenantID, UserID: user.ID,
+		},
+		TokenHash: "other-hash",
+		ExpiresAt: time.Now().Add(time.Hour),
+		IPAddress: "198.51.100.0/24",
+		UserAgent: "Mozilla/5.0 Safari/605",
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Seed a successful + failed login_event for this user, plus a
+	// stale event >90d old that the retention sweep would normally
+	// remove — used in the listLoginHistory assertion to make sure
+	// the limit + ordering work.
+	uidPtr := user.ID
+	_, err = leReg.Create(c.Context(), models.LoginEvent{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: user.TenantID},
+		UserID:              &uidPtr,
+		Email:               user.Email,
+		Outcome:             models.LoginOutcomeOK,
+		Method:              models.LoginMethodPassword,
+		IPAddress:           "203.0.113.0/24",
+		UserAgent:           "Mozilla/5.0 Chrome/120.0",
+	})
+	c.Assert(err, qt.IsNil)
+	time.Sleep(2 * time.Millisecond) // ensure CreatedAt ordering is deterministic
+	_, err = leReg.Create(c.Context(), models.LoginEvent{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: user.TenantID},
+		UserID:              &uidPtr,
+		Email:               user.Email,
+		Outcome:             models.LoginOutcomeBadPassword,
+		Method:              models.LoginMethodPassword,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Build a chi router that mounts the UsersMe sub-routes under
+	// the same prefix the apiserver does. The auth middleware is
+	// stubbed with a tiny helper that injects the seeded user into
+	// the request context — production wires this via JWTMiddleware.
+	r := chi.NewRouter()
+	r.Route("/users/me", func(sub chi.Router) {
+		sub.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				ctx := appctx.WithUser(req.Context(), user)
+				next.ServeHTTP(w, req.WithContext(ctx))
+			})
+		})
+		apiserver.UsersMe(apiserver.UsersMeParams{
+			RefreshTokenRegistry: rtReg,
+			LoginEventRegistry:   leReg,
+		})(sub)
+	})
+
+	// GET /sessions — both seeded tokens visible, the right one
+	// flagged as current via the refresh cookie hash.
+	t.Run("list_sessions_marks_current", func(t *testing.T) {
+		c := qt.New(t)
+		req := httptest.NewRequest(http.MethodGet, "/users/me/sessions", nil)
+		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: currentRaw})
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		c.Assert(w.Code, qt.Equals, http.StatusOK)
+		var resp apiserver.SessionsListResponse
+		c.Assert(json.Unmarshal(w.Body.Bytes(), &resp), qt.IsNil)
+		c.Assert(len(resp.Sessions), qt.Equals, 2)
+		var sawCurrent bool
+		for _, s := range resp.Sessions {
+			if s.ID == current.ID {
+				c.Assert(s.IsCurrent, qt.IsTrue)
+				sawCurrent = true
+			} else {
+				c.Assert(s.IsCurrent, qt.IsFalse)
+			}
+		}
+		c.Assert(sawCurrent, qt.IsTrue)
+	})
+
+	// DELETE /sessions/{id} — revoking a token belonging to the user
+	// works; trying a foreign id yields 404 (and we MUST not leak
+	// the difference between "doesn't exist" and "belongs to someone
+	// else", so a sibling user can't enumerate the token table).
+	t.Run("revoke_single_session", func(t *testing.T) {
+		c := qt.New(t)
+		req := httptest.NewRequest(http.MethodDelete, "/users/me/sessions/"+other.ID, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		c.Assert(w.Code, qt.Equals, http.StatusNoContent)
+		// Now expired/revoked — the active list shrinks to one.
+		active, err := rtReg.ListActiveByUserID(c.Context(), user.ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(len(active), qt.Equals, 1)
+		c.Assert(active[0].ID, qt.Equals, current.ID)
+	})
+
+	// DELETE /sessions — revoke-all-but-current keeps the cookie's
+	// session alive. Re-seed a "third device" first since the
+	// previous subtest already revoked `other`.
+	t.Run("revoke_all_other_sessions", func(t *testing.T) {
+		c := qt.New(t)
+		third, err := rtReg.Create(c.Context(), models.RefreshToken{
+			TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+				TenantID: user.TenantID, UserID: user.ID,
+			},
+			TokenHash: "third-hash",
+			ExpiresAt: time.Now().Add(time.Hour),
+		})
+		c.Assert(err, qt.IsNil)
+
+		req := httptest.NewRequest(http.MethodDelete, "/users/me/sessions", nil)
+		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: currentRaw})
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		c.Assert(w.Code, qt.Equals, http.StatusNoContent)
+
+		active, err := rtReg.ListActiveByUserID(c.Context(), user.ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(len(active), qt.Equals, 1)
+		c.Assert(active[0].ID, qt.Equals, current.ID)
+
+		// `third` should have been revoked.
+		stored, err := rtReg.Get(c.Context(), third.ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(stored.RevokedAt, qt.IsNotNil)
+	})
+
+	// GET /login-history — newest first, optional failed-count
+	// hint populated.
+	t.Run("login_history_newest_first", func(t *testing.T) {
+		c := qt.New(t)
+		req := httptest.NewRequest(http.MethodGet, "/users/me/login-history?limit=10", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		c.Assert(w.Code, qt.Equals, http.StatusOK)
+		var resp apiserver.LoginHistoryResponse
+		c.Assert(json.Unmarshal(w.Body.Bytes(), &resp), qt.IsNil)
+		c.Assert(len(resp.Events), qt.Equals, 2)
+		// The bad_password row was created second so it sorts first.
+		c.Assert(resp.Events[0].Outcome, qt.Equals, models.LoginOutcomeBadPassword)
+		c.Assert(resp.Events[1].Outcome, qt.Equals, models.LoginOutcomeOK)
+		c.Assert(resp.FailedLast7d, qt.Equals, 1)
+	})
+}

--- a/go/apiserver/users_me_test.go
+++ b/go/apiserver/users_me_test.go
@@ -66,10 +66,9 @@ func TestUsersMeAPI(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	// Seed a successful + failed login_event for this user, plus a
-	// stale event >90d old that the retention sweep would normally
-	// remove — used in the listLoginHistory assertion to make sure
-	// the limit + ordering work.
+	// Seed a successful + failed login_event for this user. The
+	// listLoginHistory subtest asserts newest-first ordering + the
+	// failed_last_7d hint, so we only need two rows.
 	uidPtr := user.ID
 	_, err = leReg.Create(c.Context(), models.LoginEvent{
 		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: user.TenantID},
@@ -120,7 +119,7 @@ func TestUsersMeAPI(t *testing.T) {
 		c.Assert(w.Code, qt.Equals, http.StatusOK)
 		var resp apiserver.SessionsListResponse
 		c.Assert(json.Unmarshal(w.Body.Bytes(), &resp), qt.IsNil)
-		c.Assert(len(resp.Sessions), qt.Equals, 2)
+		c.Assert(resp.Sessions, qt.HasLen, 2)
 		var sawCurrent bool
 		for _, s := range resp.Sessions {
 			if s.ID == current.ID {
@@ -146,7 +145,7 @@ func TestUsersMeAPI(t *testing.T) {
 		// Now expired/revoked — the active list shrinks to one.
 		active, err := rtReg.ListActiveByUserID(c.Context(), user.ID)
 		c.Assert(err, qt.IsNil)
-		c.Assert(len(active), qt.Equals, 1)
+		c.Assert(active, qt.HasLen, 1)
 		c.Assert(active[0].ID, qt.Equals, current.ID)
 	})
 
@@ -172,7 +171,7 @@ func TestUsersMeAPI(t *testing.T) {
 
 		active, err := rtReg.ListActiveByUserID(c.Context(), user.ID)
 		c.Assert(err, qt.IsNil)
-		c.Assert(len(active), qt.Equals, 1)
+		c.Assert(active, qt.HasLen, 1)
 		c.Assert(active[0].ID, qt.Equals, current.ID)
 
 		// `third` should have been revoked.
@@ -191,7 +190,7 @@ func TestUsersMeAPI(t *testing.T) {
 		c.Assert(w.Code, qt.Equals, http.StatusOK)
 		var resp apiserver.LoginHistoryResponse
 		c.Assert(json.Unmarshal(w.Body.Bytes(), &resp), qt.IsNil)
-		c.Assert(len(resp.Events), qt.Equals, 2)
+		c.Assert(resp.Events, qt.HasLen, 2)
 		// The bad_password row was created second so it sorts first.
 		c.Assert(resp.Events[0].Outcome, qt.Equals, models.LoginOutcomeBadPassword)
 		c.Assert(resp.Events[1].Outcome, qt.Equals, models.LoginOutcomeOK)

--- a/go/apiserver/users_me_test.go
+++ b/go/apiserver/users_me_test.go
@@ -68,8 +68,17 @@ func TestUsersMeAPI(t *testing.T) {
 
 	// Seed a successful + failed login_event for this user. The
 	// listLoginHistory subtest asserts newest-first ordering + the
-	// failed_last_7d hint, so we only need two rows.
+	// failed_last_7d hint, so we only need two rows. CreatedAt is set
+	// explicitly so ordering doesn't depend on clock resolution
+	// (a sub-millisecond sleep between Creates is flaky on contended
+	// CI runners — LoginEventRegistry.Create preserves a non-zero
+	// CreatedAt, so we just pick two distinct timestamps here).
 	uidPtr := user.ID
+	// Anchor to wall-clock time so the rows stay inside the last-7-days
+	// window the listLoginHistory subtest queries against; the absolute
+	// instants don't matter, only their relative order.
+	tLater := time.Now().Add(-time.Hour)
+	tEarlier := tLater.Add(-5 * time.Minute)
 	_, err = leReg.Create(c.Context(), models.LoginEvent{
 		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: user.TenantID},
 		UserID:              &uidPtr,
@@ -78,15 +87,16 @@ func TestUsersMeAPI(t *testing.T) {
 		Method:              models.LoginMethodPassword,
 		IPAddress:           "203.0.113.0/24",
 		UserAgent:           "Mozilla/5.0 Chrome/120.0",
+		CreatedAt:           tEarlier,
 	})
 	c.Assert(err, qt.IsNil)
-	time.Sleep(2 * time.Millisecond) // ensure CreatedAt ordering is deterministic
 	_, err = leReg.Create(c.Context(), models.LoginEvent{
 		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: user.TenantID},
 		UserID:              &uidPtr,
 		Email:               user.Email,
 		Outcome:             models.LoginOutcomeBadPassword,
 		Method:              models.LoginMethodPassword,
+		CreatedAt:           tLater,
 	})
 	c.Assert(err, qt.IsNil)
 

--- a/go/apiserver/users_me_test.go
+++ b/go/apiserver/users_me_test.go
@@ -113,6 +113,8 @@ func TestUsersMeAPI(t *testing.T) {
 	t.Run("list_sessions_marks_current", func(t *testing.T) {
 		c := qt.New(t)
 		req := httptest.NewRequest(http.MethodGet, "/users/me/sessions", nil)
+		// #nosec G124 -- in-process request stub; the production cookie carries
+		// HttpOnly + SameSiteStrict + conditional Secure (see issueRefreshTokenCookie).
 		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: currentRaw})
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
@@ -164,6 +166,8 @@ func TestUsersMeAPI(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		req := httptest.NewRequest(http.MethodDelete, "/users/me/sessions", nil)
+		// #nosec G124 -- in-process request stub; the production cookie carries
+		// HttpOnly + SameSiteStrict + conditional Secure (see issueRefreshTokenCookie).
 		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: currentRaw})
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)

--- a/go/cmd/inventario/run/all/all.go
+++ b/go/cmd/inventario/run/all/all.go
@@ -80,6 +80,9 @@ func (c *Command) run() error {
 	stopRefreshTokenCleanup := bootstrap.StartRefreshTokenCleanupWorker(ctx, rs, c.cfg)
 	defer stopRefreshTokenCleanup()
 
+	stopLoginEventRetention := bootstrap.StartLoginEventRetentionWorker(ctx, rs, c.cfg)
+	defer stopLoginEventRetention()
+
 	stopGroupPurge := bootstrap.StartGroupPurgeWorker(ctx, rs, c.cfg)
 	defer stopGroupPurge()
 

--- a/go/cmd/inventario/run/bootstrap/workers.go
+++ b/go/cmd/inventario/run/bootstrap/workers.go
@@ -92,6 +92,17 @@ func StartRefreshTokenCleanupWorker(ctx context.Context, rs *RuntimeSetup, _ *Co
 	return worker.Stop
 }
 
+// StartLoginEventRetentionWorker wires and starts the login_events
+// retention worker (#1379). The retention window and sweep interval
+// are not currently surfaced as flags — the defaults (90d retention,
+// 24h sweep) match the design doc and are conservative enough that
+// adding a knob is YAGNI for the v1 surface.
+func StartLoginEventRetentionWorker(ctx context.Context, rs *RuntimeSetup, _ *Config) func() {
+	worker := services.NewLoginEventRetentionWorker(rs.FactorySet.LoginEventRegistry)
+	worker.Start(ctx)
+	return worker.Stop
+}
+
 // StartGroupPurgeWorker wires and starts the group purge worker (which hard-
 // deletes LocationGroups marked pending_deletion and cleans up expired unused
 // invites on the configured interval) and returns its stop function.

--- a/go/cmd/inventario/run/workers/workers.go
+++ b/go/cmd/inventario/run/workers/workers.go
@@ -143,6 +143,7 @@ func (c *Command) run() error {
 		{WorkerMedia, []starter{bootstrap.StartThumbnailWorker}},
 		{WorkerHousekeeping, []starter{
 			bootstrap.StartRefreshTokenCleanupWorker,
+			bootstrap.StartLoginEventRetentionWorker,
 			bootstrap.StartGroupPurgeWorker,
 			bootstrap.StartWarrantyReminderWorker,
 			bootstrap.StartCurrencyMigrationWorker,

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -5177,6 +5177,131 @@ const docTemplate = `{
                 }
             }
         },
+        "/users/me/login-history": {
+            "get": {
+                "description": "Returns the authenticated user's most recent login attempts (default 100, max 500). Also returns failed_last_7d for the optional banner.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users-me"
+                ],
+                "summary": "List login history",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Cap on number of events returned (default 100, max 500)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.LoginHistoryResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/me/sessions": {
+            "get": {
+                "description": "Returns the authenticated user's active refresh-token sessions, with a flag identifying the session bound to the current refresh cookie.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users-me"
+                ],
+                "summary": "List active sessions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.SessionsListResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Revoke every refresh token for the authenticated user except the one bound to the current refresh cookie.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users-me"
+                ],
+                "summary": "Revoke all other sessions",
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/me/sessions/{id}": {
+            "delete": {
+                "description": "Mark a single refresh token as revoked. Returns 404 if the id does not belong to the authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users-me"
+                ],
+                "summary": "Revoke one session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/verify-email": {
             "get": {
                 "description": "Activate a user account using the verification token sent by email.",
@@ -5267,6 +5392,46 @@ const docTemplate = `{
                 },
                 "weekly_digest": {
                     "type": "boolean"
+                }
+            }
+        },
+        "apiserver.LoginEventView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                },
+                "method": {
+                    "$ref": "#/definitions/models.LoginMethod"
+                },
+                "outcome": {
+                    "$ref": "#/definitions/models.LoginOutcome"
+                },
+                "user_agent": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.LoginHistoryResponse": {
+            "type": "object",
+            "properties": {
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/apiserver.LoginEventView"
+                    }
+                },
+                "failed_last_7d": {
+                    "type": "integer"
                 }
             }
         },
@@ -5378,6 +5543,43 @@ const docTemplate = `{
                 },
                 "status": {
                     "type": "string"
+                }
+            }
+        },
+        "apiserver.SessionView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                },
+                "is_current": {
+                    "type": "boolean"
+                },
+                "last_used_at": {
+                    "type": "string"
+                },
+                "user_agent": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.SessionsListResponse": {
+            "type": "object",
+            "properties": {
+                "sessions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/apiserver.SessionView"
+                    }
                 }
             }
         },
@@ -8939,6 +9141,32 @@ const docTemplate = `{
             "x-enum-varnames": [
                 "LocationGroupStatusActive",
                 "LocationGroupStatusPendingDeletion"
+            ]
+        },
+        "models.LoginMethod": {
+            "type": "string",
+            "enum": [
+                "password"
+            ],
+            "x-enum-varnames": [
+                "LoginMethodPassword"
+            ]
+        },
+        "models.LoginOutcome": {
+            "type": "string",
+            "enum": [
+                "ok",
+                "bad_password",
+                "account_locked",
+                "account_disabled",
+                "email_not_verified"
+            ],
+            "x-enum-varnames": [
+                "LoginOutcomeOK",
+                "LoginOutcomeBadPassword",
+                "LoginOutcomeAccountLocked",
+                "LoginOutcomeAccountDisabled",
+                "LoginOutcomeEmailNotVerified"
             ]
         },
         "models.Plan": {

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -5170,6 +5170,131 @@
                 }
             }
         },
+        "/users/me/login-history": {
+            "get": {
+                "description": "Returns the authenticated user's most recent login attempts (default 100, max 500). Also returns failed_last_7d for the optional banner.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users-me"
+                ],
+                "summary": "List login history",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Cap on number of events returned (default 100, max 500)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.LoginHistoryResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/me/sessions": {
+            "get": {
+                "description": "Returns the authenticated user's active refresh-token sessions, with a flag identifying the session bound to the current refresh cookie.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users-me"
+                ],
+                "summary": "List active sessions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.SessionsListResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Revoke every refresh token for the authenticated user except the one bound to the current refresh cookie.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users-me"
+                ],
+                "summary": "Revoke all other sessions",
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/me/sessions/{id}": {
+            "delete": {
+                "description": "Mark a single refresh token as revoked. Returns 404 if the id does not belong to the authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users-me"
+                ],
+                "summary": "Revoke one session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/verify-email": {
             "get": {
                 "description": "Activate a user account using the verification token sent by email.",
@@ -5260,6 +5385,46 @@
                 },
                 "weekly_digest": {
                     "type": "boolean"
+                }
+            }
+        },
+        "apiserver.LoginEventView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                },
+                "method": {
+                    "$ref": "#/definitions/models.LoginMethod"
+                },
+                "outcome": {
+                    "$ref": "#/definitions/models.LoginOutcome"
+                },
+                "user_agent": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.LoginHistoryResponse": {
+            "type": "object",
+            "properties": {
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/apiserver.LoginEventView"
+                    }
+                },
+                "failed_last_7d": {
+                    "type": "integer"
                 }
             }
         },
@@ -5371,6 +5536,43 @@
                 },
                 "status": {
                     "type": "string"
+                }
+            }
+        },
+        "apiserver.SessionView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                },
+                "is_current": {
+                    "type": "boolean"
+                },
+                "last_used_at": {
+                    "type": "string"
+                },
+                "user_agent": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.SessionsListResponse": {
+            "type": "object",
+            "properties": {
+                "sessions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/apiserver.SessionView"
+                    }
                 }
             }
         },
@@ -8932,6 +9134,32 @@
             "x-enum-varnames": [
                 "LocationGroupStatusActive",
                 "LocationGroupStatusPendingDeletion"
+            ]
+        },
+        "models.LoginMethod": {
+            "type": "string",
+            "enum": [
+                "password"
+            ],
+            "x-enum-varnames": [
+                "LoginMethodPassword"
+            ]
+        },
+        "models.LoginOutcome": {
+            "type": "string",
+            "enum": [
+                "ok",
+                "bad_password",
+                "account_locked",
+                "account_disabled",
+                "email_not_verified"
+            ],
+            "x-enum-varnames": [
+                "LoginOutcomeOK",
+                "LoginOutcomeBadPassword",
+                "LoginOutcomeAccountLocked",
+                "LoginOutcomeAccountDisabled",
+                "LoginOutcomeEmailNotVerified"
             ]
         },
         "models.Plan": {

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -26,6 +26,32 @@ definitions:
       weekly_digest:
         type: boolean
     type: object
+  apiserver.LoginEventView:
+    properties:
+      created_at:
+        type: string
+      email:
+        type: string
+      id:
+        type: string
+      ip_address:
+        type: string
+      method:
+        $ref: '#/definitions/models.LoginMethod'
+      outcome:
+        $ref: '#/definitions/models.LoginOutcome'
+      user_agent:
+        type: string
+    type: object
+  apiserver.LoginHistoryResponse:
+    properties:
+      events:
+        items:
+          $ref: '#/definitions/apiserver.LoginEventView'
+        type: array
+      failed_last_7d:
+        type: integer
+    type: object
   apiserver.LoginRequest:
     properties:
       email:
@@ -103,6 +129,30 @@ definitions:
         type: string
       status:
         type: string
+    type: object
+  apiserver.SessionView:
+    properties:
+      created_at:
+        type: string
+      expires_at:
+        type: string
+      id:
+        type: string
+      ip_address:
+        type: string
+      is_current:
+        type: boolean
+      last_used_at:
+        type: string
+      user_agent:
+        type: string
+    type: object
+  apiserver.SessionsListResponse:
+    properties:
+      sessions:
+        items:
+          $ref: '#/definitions/apiserver.SessionView'
+        type: array
     type: object
   apiserver.SettingsUpdateRequest:
     properties:
@@ -2790,6 +2840,26 @@ definitions:
     x-enum-varnames:
     - LocationGroupStatusActive
     - LocationGroupStatusPendingDeletion
+  models.LoginMethod:
+    enum:
+    - password
+    type: string
+    x-enum-varnames:
+    - LoginMethodPassword
+  models.LoginOutcome:
+    enum:
+    - ok
+    - bad_password
+    - account_locked
+    - account_disabled
+    - email_not_verified
+    type: string
+    x-enum-varnames:
+    - LoginOutcomeOK
+    - LoginOutcomeBadPassword
+    - LoginOutcomeAccountLocked
+    - LoginOutcomeAccountDisabled
+    - LoginOutcomeEmailNotVerified
   models.Plan:
     properties:
       allows_api_access:
@@ -6608,6 +6678,92 @@ paths:
       summary: Get system information
       tags:
       - system
+  /users/me/login-history:
+    get:
+      description: Returns the authenticated user's most recent login attempts (default
+        100, max 500). Also returns failed_last_7d for the optional banner.
+      parameters:
+      - description: Cap on number of events returned (default 100, max 500)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.LoginHistoryResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+      summary: List login history
+      tags:
+      - users-me
+  /users/me/sessions:
+    delete:
+      description: Revoke every refresh token for the authenticated user except the
+        one bound to the current refresh cookie.
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+      summary: Revoke all other sessions
+      tags:
+      - users-me
+    get:
+      description: Returns the authenticated user's active refresh-token sessions,
+        with a flag identifying the session bound to the current refresh cookie.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.SessionsListResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+      summary: List active sessions
+      tags:
+      - users-me
+  /users/me/sessions/{id}:
+    delete:
+      description: Mark a single refresh token as revoked. Returns 404 if the id does
+        not belong to the authenticated user.
+      parameters:
+      - description: Session ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            type: string
+      summary: Revoke one session
+      tags:
+      - users-me
   /verify-email:
     get:
       description: Activate a user account using the verification token sent by email.

--- a/go/models/login_event.go
+++ b/go/models/login_event.go
@@ -1,0 +1,117 @@
+package models
+
+import "time"
+
+// LoginOutcome is the result of a credential check attempt recorded in
+// login_events (issue #1379). Stored as TEXT so the enum can grow
+// without a DB CHECK migration each time.
+type LoginOutcome string
+
+const (
+	// LoginOutcomeOK indicates a successful authentication.
+	LoginOutcomeOK LoginOutcome = "ok"
+	// LoginOutcomeBadPassword covers both "wrong password" and "unknown email"
+	// — collapsing them keeps the surface useful for the user (they see
+	// "someone tried my email") without leaking enumeration on the unknown
+	// branch.
+	LoginOutcomeBadPassword LoginOutcome = "bad_password"
+	// LoginOutcomeAccountLocked is recorded when the rate limiter rejected
+	// the attempt before the password check happened.
+	LoginOutcomeAccountLocked LoginOutcome = "account_locked"
+	// LoginOutcomeAccountDisabled is recorded when the credentials matched
+	// but IsActive=false (terminated account).
+	LoginOutcomeAccountDisabled LoginOutcome = "account_disabled"
+	// LoginOutcomeEmailNotVerified is reserved for the post-#1372 path
+	// where unverified accounts cannot log in; recorded so the user can
+	// see the attempt even though no session was issued.
+	LoginOutcomeEmailNotVerified LoginOutcome = "email_not_verified"
+)
+
+// LoginMethod is the credential family that produced the event. "password"
+// is the only value in v1; OAuth methods land with #1394 / #1395.
+type LoginMethod string
+
+const (
+	// LoginMethodPassword is the email + password flow.
+	LoginMethodPassword LoginMethod = "password"
+)
+
+// LoginEvent is the append-only audit trail of credential-check attempts
+// (issue #1379). Every code path in apiserver/auth.go that reaches a
+// credential check writes one row regardless of outcome. Retention is
+// bounded by the login_event_retention_worker (90 days default).
+//
+// IP storage policy mirrors refresh_tokens: truncated /24 (IPv4) or /56
+// (IPv6) — never the raw client address.
+//
+//migrator:schema:table name="login_events"
+//migrator:schema:rls:enable table="login_events" comment="Enable RLS for multi-tenant login event isolation"
+//migrator:schema:rls:policy name="login_event_tenant_isolation" table="login_events" for="ALL" to="inventario_app" using="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != ''" with_check="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != ''" comment="Login events are tenant-isolated; per-user filtering happens in application logic so a user only sees their own attempts"
+//migrator:schema:rls:policy name="login_event_background_worker_access" table="login_events" for="ALL" to="inventario_background_worker" using="true" with_check="true" comment="Allows the retention worker and login flow to insert/sweep events outside any user context"
+type LoginEvent struct {
+	//migrator:embedded mode="inline"
+	TenantAwareEntityID
+
+	// UserID references the user the attempt resolved to. NULL when the
+	// email did not match any user (unknown-email bad_password case) so
+	// the row still survives the retention sweep keyed on user_id.
+	//migrator:schema:field name="user_id" type="TEXT" foreign="users(id)" foreign_key_name="fk_login_event_user"
+	UserID *string `json:"user_id,omitempty" db:"user_id"`
+
+	// Email is the address the client typed. Always recorded — even when
+	// UserID is set — so a user changing their email later still sees
+	// "someone tried <my-old-email>" in their history. Empty allowed for
+	// future code paths that authenticate without an email (none today).
+	//migrator:schema:field name="email" type="TEXT" not_null="true"
+	Email string `json:"email" db:"email"`
+
+	// Outcome is the resolved LoginOutcome at the moment the row was
+	// written. Stored TEXT (no DB CHECK).
+	//migrator:schema:field name="outcome" type="TEXT" not_null="true"
+	Outcome LoginOutcome `json:"outcome" db:"outcome"`
+
+	// Method is the credential family. "password" for v1; OAuth lands
+	// with #1394 / #1395.
+	//migrator:schema:field name="method" type="TEXT" not_null="true" default="password"
+	Method LoginMethod `json:"method" db:"method"`
+
+	// IPAddress holds the truncated client IP (/24 IPv4, /56 IPv6) per
+	// the privacy policy in #1378. Empty when the request had no
+	// resolvable address.
+	//migrator:schema:field name="ip_address" type="VARCHAR(64)"
+	IPAddress string `json:"ip_address,omitempty" db:"ip_address"`
+
+	// UserAgent is the raw Sec-CH-UA / User-Agent header. Parsing happens
+	// client-side per #1378 option 2 (server-side parsing would age
+	// poorly as UA strings drift).
+	//migrator:schema:field name="user_agent" type="TEXT"
+	UserAgent string `json:"user_agent,omitempty" db:"user_agent"`
+
+	// CreatedAt is the wall-clock instant the row was written. The
+	// list endpoint orders newest-first by this column.
+	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	CreatedAt time.Time `json:"created_at" db:"created_at" userinput:"false"`
+}
+
+// LoginEventIndexes carries the migrator hints for the table's indexes.
+type LoginEventIndexes struct {
+	// Unique index for the immutable UUID (deduplication key for
+	// import/restore).
+	//migrator:schema:index name="idx_login_events_uuid" fields="uuid" unique="true" table="login_events"
+	_ int
+
+	// Read pattern: "the last N events for me", newest first.
+	//migrator:schema:index name="idx_login_events_user_created_at" fields="user_id,created_at" table="login_events"
+	_ int
+
+	// Tenant isolation index — same shape every other tenant-scoped
+	// table uses; lets the RLS qual short-circuit on a single column.
+	//migrator:schema:index name="idx_login_events_tenant_id" fields="tenant_id" table="login_events"
+	_ int
+
+	// Retention sweep predicate ("delete WHERE created_at < cutoff").
+	// A plain (created_at) index is enough — the table is append-only,
+	// the sweep runs daily, and we don't need composite ordering here.
+	//migrator:schema:index name="idx_login_events_created_at" fields="created_at" table="login_events"
+	_ int
+}

--- a/go/registry/factories.go
+++ b/go/registry/factories.go
@@ -138,6 +138,7 @@ type FactorySet struct {
 	TenantRegistry                        TenantRegistry                // TenantRegistry doesn't need factory as it's not user-aware
 	UserRegistry                          UserRegistry                  // UserRegistry doesn't need factory as it's not user-aware
 	RefreshTokenRegistry                  RefreshTokenRegistry          // RefreshTokenRegistry doesn't need factory as it's not user-aware
+	LoginEventRegistry                    LoginEventRegistry            // LoginEventRegistry runs under the background-worker role (write path) + app-level user_id filter (read path)
 	AuditLogRegistry                      AuditLogRegistry              // AuditLogRegistry doesn't need factory as it's not user-aware
 	EmailVerificationRegistry             EmailVerificationRegistry     // EmailVerificationRegistry doesn't need factory as it's not user-aware
 	PasswordResetRegistry                 PasswordResetRegistry         // PasswordResetRegistry doesn't need factory as it's not user-aware
@@ -261,6 +262,7 @@ func (fs *FactorySet) CreateUserRegistrySet(ctx context.Context) (*Set, error) {
 		TenantRegistry:                 fs.TenantRegistry,
 		UserRegistry:                   fs.UserRegistry,
 		RefreshTokenRegistry:           fs.RefreshTokenRegistry,
+		LoginEventRegistry:             fs.LoginEventRegistry,
 		AuditLogRegistry:               fs.AuditLogRegistry,
 		EmailVerificationRegistry:      fs.EmailVerificationRegistry,
 		PasswordResetRegistry:          fs.PasswordResetRegistry,
@@ -296,6 +298,7 @@ func (fs *FactorySet) CreateServiceRegistrySet() *Set {
 		TenantRegistry:                 fs.TenantRegistry,
 		UserRegistry:                   fs.UserRegistry,
 		RefreshTokenRegistry:           fs.RefreshTokenRegistry,
+		LoginEventRegistry:             fs.LoginEventRegistry,
 		AuditLogRegistry:               fs.AuditLogRegistry,
 		EmailVerificationRegistry:      fs.EmailVerificationRegistry,
 		PasswordResetRegistry:          fs.PasswordResetRegistry,

--- a/go/registry/memory/login_events.go
+++ b/go/registry/memory/login_events.go
@@ -31,6 +31,15 @@ func NewLoginEventRegistry() *LoginEventRegistry {
 	}
 }
 
+// Update is a no-op that returns the input unchanged — login_events is
+// append-only by design, same shape as CommodityEventRegistry.Update. This
+// keeps memory-mode behaviour aligned with the postgres registry so a
+// stray Update call from a test or dev fixture can't mutate the audit
+// trail.
+func (r *LoginEventRegistry) Update(_ context.Context, event models.LoginEvent) (*models.LoginEvent, error) {
+	return &event, nil
+}
+
 // Create inserts a new login_event. The write side runs out of any
 // user context (we don't always have an authenticated user — failed
 // logins for unknown emails for example) so we bypass the Registry's

--- a/go/registry/memory/login_events.go
+++ b/go/registry/memory/login_events.go
@@ -1,0 +1,142 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/go-extras/errx"
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/google/uuid"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+var _ registry.LoginEventRegistry = (*LoginEventRegistry)(nil)
+
+type baseLoginEventRegistry = Registry[models.LoginEvent, *models.LoginEvent]
+
+// LoginEventRegistry is the in-memory store for login_events. Mirrors
+// the postgres implementation closely so behaviour is the same in
+// tests and e2e — the only divergence is the lack of indexes (linear
+// scans are fine for the row counts test fixtures touch).
+type LoginEventRegistry struct {
+	*baseLoginEventRegistry
+}
+
+func NewLoginEventRegistry() *LoginEventRegistry {
+	return &LoginEventRegistry{
+		baseLoginEventRegistry: NewRegistry[models.LoginEvent, *models.LoginEvent](),
+	}
+}
+
+// Create inserts a new login_event. The write side runs out of any
+// user context (we don't always have an authenticated user — failed
+// logins for unknown emails for example) so we bypass the Registry's
+// userID guard and write directly.
+func (r *LoginEventRegistry) Create(_ context.Context, event models.LoginEvent) (*models.LoginEvent, error) {
+	if event.TenantID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if event.Email == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Email"))
+	}
+	if event.Outcome == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Outcome"))
+	}
+
+	event.ID = uuid.New().String()
+	if event.UUID == "" {
+		event.UUID = uuid.New().String()
+	}
+	if event.Method == "" {
+		event.Method = models.LoginMethodPassword
+	}
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now()
+	}
+
+	r.lock.Lock()
+	r.items.Set(event.ID, &event)
+	r.lock.Unlock()
+
+	return &event, nil
+}
+
+// ListByUser returns the most recent login events for the user. Empty
+// user yields an empty list (NULL user_id rows — failed unknown-email
+// attempts — are intentionally not returned by the user-facing list).
+func (r *LoginEventRegistry) ListByUser(ctx context.Context, userID string, limit int) ([]*models.LoginEvent, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+
+	all, err := r.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	matched := make([]*models.LoginEvent, 0, len(all))
+	for _, e := range all {
+		if e.UserID != nil && *e.UserID == userID {
+			matched = append(matched, e)
+		}
+	}
+	sort.SliceStable(matched, func(i, j int) bool {
+		return matched[i].CreatedAt.After(matched[j].CreatedAt)
+	})
+	if len(matched) > limit {
+		matched = matched[:limit]
+	}
+	return matched, nil
+}
+
+// CountFailedSince returns the number of non-ok events for the user
+// since `since`. Mirrors the postgres `outcome <> 'ok'` predicate.
+func (r *LoginEventRegistry) CountFailedSince(ctx context.Context, userID string, since time.Time) (int, error) {
+	if userID == "" {
+		return 0, nil
+	}
+	all, err := r.List(ctx)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, e := range all {
+		if e.UserID == nil || *e.UserID != userID {
+			continue
+		}
+		if e.Outcome == models.LoginOutcomeOK {
+			continue
+		}
+		if e.CreatedAt.Before(since) {
+			continue
+		}
+		count++
+	}
+	return count, nil
+}
+
+// DeleteOlderThan removes login_events whose CreatedAt is strictly
+// before cutoff. Returns the number of rows deleted so callers can
+// log a single "N rows pruned" line per tick.
+func (r *LoginEventRegistry) DeleteOlderThan(ctx context.Context, cutoff time.Time) (int, error) {
+	all, err := r.List(ctx)
+	if err != nil {
+		return 0, err
+	}
+	deleted := 0
+	r.lock.Lock()
+	for _, e := range all {
+		if e.CreatedAt.Before(cutoff) {
+			r.items.Delete(e.ID)
+			deleted++
+		}
+	}
+	r.lock.Unlock()
+	return deleted, nil
+}

--- a/go/registry/memory/login_events.go
+++ b/go/registry/memory/login_events.go
@@ -73,11 +73,13 @@ func (r *LoginEventRegistry) Create(_ context.Context, event models.LoginEvent) 
 	return &event, nil
 }
 
-// ListByUser returns the most recent login events for the user. Empty
-// user yields an empty list (NULL user_id rows — failed unknown-email
-// attempts — are intentionally not returned by the user-facing list).
-func (r *LoginEventRegistry) ListByUser(ctx context.Context, userID string, limit int) ([]*models.LoginEvent, error) {
-	if userID == "" {
+// ListByUser returns the most recent login events for the user inside
+// the tenant. Empty user OR empty tenant yields an empty list — NULL
+// user_id rows (failed unknown-email attempts) are intentionally not
+// returned by the user-facing list, and a tenant mismatch must never
+// leak rows across tenants even when the user_id happens to match.
+func (r *LoginEventRegistry) ListByUser(ctx context.Context, tenantID, userID string, limit int) ([]*models.LoginEvent, error) {
+	if userID == "" || tenantID == "" {
 		return nil, nil
 	}
 	if limit <= 0 {
@@ -91,6 +93,9 @@ func (r *LoginEventRegistry) ListByUser(ctx context.Context, userID string, limi
 
 	matched := make([]*models.LoginEvent, 0, len(all))
 	for _, e := range all {
+		if e.TenantID != tenantID {
+			continue
+		}
 		if e.UserID != nil && *e.UserID == userID {
 			matched = append(matched, e)
 		}
@@ -105,9 +110,10 @@ func (r *LoginEventRegistry) ListByUser(ctx context.Context, userID string, limi
 }
 
 // CountFailedSince returns the number of non-ok events for the user
-// since `since`. Mirrors the postgres `outcome <> 'ok'` predicate.
-func (r *LoginEventRegistry) CountFailedSince(ctx context.Context, userID string, since time.Time) (int, error) {
-	if userID == "" {
+// inside the tenant since `since`. Mirrors the postgres
+// `outcome <> 'ok' AND tenant_id = $tenant` predicate.
+func (r *LoginEventRegistry) CountFailedSince(ctx context.Context, tenantID, userID string, since time.Time) (int, error) {
+	if userID == "" || tenantID == "" {
 		return 0, nil
 	}
 	all, err := r.List(ctx)
@@ -116,6 +122,9 @@ func (r *LoginEventRegistry) CountFailedSince(ctx context.Context, userID string
 	}
 	count := 0
 	for _, e := range all {
+		if e.TenantID != tenantID {
+			continue
+		}
 		if e.UserID == nil || *e.UserID != userID {
 			continue
 		}

--- a/go/registry/memory/memory.go
+++ b/go/registry/memory/memory.go
@@ -53,6 +53,7 @@ func NewFactorySet() *registry.FactorySet {
 	fs.PasswordResetRegistry = NewPasswordResetRegistry()
 	fs.UserRegistry = NewUserRegistry()
 	fs.RefreshTokenRegistry = NewRefreshTokenRegistry()
+	fs.LoginEventRegistry = NewLoginEventRegistry()
 	fs.AuditLogRegistry = NewAuditLogRegistry()
 	fs.LocationGroupRegistry = NewLocationGroupRegistry()
 	membershipReg := NewGroupMembershipRegistry()

--- a/go/registry/memory/refresh_tokens.go
+++ b/go/registry/memory/refresh_tokens.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/go-extras/errx"
@@ -80,6 +81,45 @@ func (r *RefreshTokenRegistry) GetByUserID(ctx context.Context, userID string) (
 	return result, nil
 }
 
+// ListActiveByUserID returns all non-revoked, non-expired refresh tokens
+// for a user, ordered most-recently-used first. Tokens that have never
+// been used fall back to CreatedAt for the ordering tiebreaker.
+func (r *RefreshTokenRegistry) ListActiveByUserID(ctx context.Context, userID string) ([]*models.RefreshToken, error) {
+	tokens, err := r.GetByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	out := make([]*models.RefreshToken, 0, len(tokens))
+	for _, t := range tokens {
+		if t.RevokedAt != nil {
+			continue
+		}
+		if now.After(t.ExpiresAt) {
+			continue
+		}
+		out = append(out, t)
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		// Active sessions sort: LastUsedAt desc, then CreatedAt desc.
+		// Nil LastUsedAt sorts after any populated value (never-used
+		// tokens land below recently-used ones).
+		li, lj := out[i].LastUsedAt, out[j].LastUsedAt
+		switch {
+		case li != nil && lj != nil && !li.Equal(*lj):
+			return li.After(*lj)
+		case li != nil && lj == nil:
+			return true
+		case li == nil && lj != nil:
+			return false
+		}
+		return out[i].CreatedAt.After(out[j].CreatedAt)
+	})
+	return out, nil
+}
+
 // RevokeByUserID marks all refresh tokens for a user as revoked.
 // A single write lock is held for the entire operation to avoid a TOCTOU
 // race between listing tokens and updating them individually.
@@ -93,6 +133,46 @@ func (r *RefreshTokenRegistry) RevokeByUserID(_ context.Context, userID string) 
 			t.RevokedAt = &now
 			r.items.Set(t.ID, t)
 		}
+	}
+	return nil
+}
+
+// RevokeByID atomically revokes a refresh token by id only when it
+// belongs to the supplied user. Returns ErrNotFound when no matching
+// row exists so a user can't revoke someone else's session via a
+// guessed id.
+func (r *RefreshTokenRegistry) RevokeByID(_ context.Context, userID, id string) error {
+	now := time.Now()
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	t, ok := r.items.Get(id)
+	if !ok || t.UserID != userID {
+		return errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "RefreshToken", "entity_id", id))
+	}
+	if t.RevokedAt == nil {
+		t.RevokedAt = &now
+		r.items.Set(t.ID, t)
+	}
+	return nil
+}
+
+// RevokeAllExceptID revokes every refresh token for the user except
+// the row whose id matches keepID. Pass an empty keepID to revoke
+// every token.
+func (r *RefreshTokenRegistry) RevokeAllExceptID(_ context.Context, userID, keepID string) error {
+	now := time.Now()
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		t := pair.Value
+		if t.UserID != userID || t.RevokedAt != nil {
+			continue
+		}
+		if keepID != "" && t.ID == keepID {
+			continue
+		}
+		t.RevokedAt = &now
+		r.items.Set(t.ID, t)
 	}
 	return nil
 }

--- a/go/registry/postgres/login_events.go
+++ b/go/registry/postgres/login_events.go
@@ -1,0 +1,190 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-extras/errx"
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+var _ registry.LoginEventRegistry = (*LoginEventRegistry)(nil)
+
+// LoginEventRegistry persists login_events. Like RefreshTokenRegistry,
+// all access runs in service mode (inventario_background_worker role)
+// — the write side is invoked from login flow where no user/tenant DB
+// context exists yet, and the read side filters by user_id explicitly
+// in application logic. See the row-level policy in models/login_event.go.
+type LoginEventRegistry struct {
+	dbx        *sqlx.DB
+	tableNames store.TableNames
+}
+
+func NewLoginEventRegistry(dbx *sqlx.DB) *LoginEventRegistry {
+	return NewLoginEventRegistryWithTableNames(dbx, store.DefaultTableNames)
+}
+
+func NewLoginEventRegistryWithTableNames(dbx *sqlx.DB, tableNames store.TableNames) *LoginEventRegistry {
+	return &LoginEventRegistry{
+		dbx:        dbx,
+		tableNames: tableNames,
+	}
+}
+
+func (r *LoginEventRegistry) newSQLRegistry() *store.RLSRepository[models.LoginEvent, *models.LoginEvent] {
+	return store.NewServiceSQLRegistry[models.LoginEvent, *models.LoginEvent](r.dbx, r.tableNames.LoginEvents())
+}
+
+func (r *LoginEventRegistry) Create(ctx context.Context, event models.LoginEvent) (*models.LoginEvent, error) {
+	if event.TenantID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if event.Email == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Email"))
+	}
+	if event.Outcome == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Outcome"))
+	}
+
+	if event.ID == "" {
+		event.ID = uuid.New().String()
+	}
+	if event.UUID == "" {
+		event.UUID = uuid.New().String()
+	}
+	if event.Method == "" {
+		event.Method = models.LoginMethodPassword
+	}
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now()
+	}
+
+	reg := r.newSQLRegistry()
+	if err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		txReg := store.NewTxRegistry[models.LoginEvent](tx, r.tableNames.LoginEvents())
+		return txReg.Insert(ctx, event)
+	}); err != nil {
+		return nil, errxtrace.Wrap("failed to insert login event", err)
+	}
+	return &event, nil
+}
+
+func (r *LoginEventRegistry) Get(ctx context.Context, id string) (*models.LoginEvent, error) {
+	if id == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+	var event models.LoginEvent
+	reg := r.newSQLRegistry()
+	if err := reg.ScanOneByField(ctx, store.Pair("id", id), &event); err != nil {
+		return nil, errxtrace.Wrap("failed to get login event", err)
+	}
+	return &event, nil
+}
+
+func (r *LoginEventRegistry) List(ctx context.Context) ([]*models.LoginEvent, error) {
+	var events []*models.LoginEvent
+	reg := r.newSQLRegistry()
+	for event, err := range reg.Scan(ctx) {
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to list login events", err)
+		}
+		events = append(events, &event)
+	}
+	return events, nil
+}
+
+func (r *LoginEventRegistry) Update(_ context.Context, _ models.LoginEvent) (*models.LoginEvent, error) {
+	// login_events is append-only by design — updates would corrupt the audit
+	// trail. The Registry[T] interface requires Update to exist; treat
+	// callers that hit it as a bug.
+	return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("reason", "login_events is append-only"))
+}
+
+func (r *LoginEventRegistry) Delete(ctx context.Context, id string) error {
+	if id == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+	reg := r.newSQLRegistry()
+	if err := reg.Delete(ctx, id, nil); err != nil {
+		return errxtrace.Wrap("failed to delete login event", err)
+	}
+	return nil
+}
+
+func (r *LoginEventRegistry) Count(ctx context.Context) (int, error) {
+	reg := r.newSQLRegistry()
+	count, err := reg.Count(ctx)
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to count login events", err)
+	}
+	return count, nil
+}
+
+func (r *LoginEventRegistry) ListByUser(ctx context.Context, userID string, limit int) ([]*models.LoginEvent, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	var events []*models.LoginEvent
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`SELECT * FROM %s WHERE user_id = $1 ORDER BY created_at DESC LIMIT $2`,
+			r.tableNames.LoginEvents(),
+		)
+		return tx.SelectContext(ctx, &events, query, userID, limit)
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list login events by user", err)
+	}
+	return events, nil
+}
+
+func (r *LoginEventRegistry) CountFailedSince(ctx context.Context, userID string, since time.Time) (int, error) {
+	if userID == "" {
+		return 0, nil
+	}
+	var count int
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`SELECT COUNT(*) FROM %s WHERE user_id = $1 AND outcome <> $2 AND created_at >= $3`,
+			r.tableNames.LoginEvents(),
+		)
+		return tx.GetContext(ctx, &count, query, userID, models.LoginOutcomeOK, since)
+	})
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to count failed login events", err)
+	}
+	return count, nil
+}
+
+func (r *LoginEventRegistry) DeleteOlderThan(ctx context.Context, cutoff time.Time) (int, error) {
+	var deleted int64
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(`DELETE FROM %s WHERE created_at < $1`, r.tableNames.LoginEvents())
+		res, err := tx.ExecContext(ctx, query, cutoff)
+		if err != nil {
+			return err
+		}
+		n, rerr := res.RowsAffected()
+		if rerr == nil {
+			deleted = n
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to delete old login events", err)
+	}
+	return int(deleted), nil
+}

--- a/go/registry/postgres/login_events.go
+++ b/go/registry/postgres/login_events.go
@@ -100,11 +100,12 @@ func (r *LoginEventRegistry) List(ctx context.Context) ([]*models.LoginEvent, er
 	return events, nil
 }
 
-func (r *LoginEventRegistry) Update(_ context.Context, _ models.LoginEvent) (*models.LoginEvent, error) {
-	// login_events is append-only by design — updates would corrupt the audit
-	// trail. The Registry[T] interface requires Update to exist; treat
-	// callers that hit it as a bug.
-	return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("reason", "login_events is append-only"))
+func (r *LoginEventRegistry) Update(_ context.Context, event models.LoginEvent) (*models.LoginEvent, error) {
+	// login_events is append-only by design — same shape as
+	// CommodityEventRegistry.Update (registry/postgres/commodity_events.go).
+	// We satisfy the Registry[T] interface by returning the input unchanged
+	// without writing to the table.
+	return &event, nil
 }
 
 func (r *LoginEventRegistry) Delete(ctx context.Context, id string) error {

--- a/go/registry/postgres/login_events.go
+++ b/go/registry/postgres/login_events.go
@@ -128,8 +128,8 @@ func (r *LoginEventRegistry) Count(ctx context.Context) (int, error) {
 	return count, nil
 }
 
-func (r *LoginEventRegistry) ListByUser(ctx context.Context, userID string, limit int) ([]*models.LoginEvent, error) {
-	if userID == "" {
+func (r *LoginEventRegistry) ListByUser(ctx context.Context, tenantID, userID string, limit int) ([]*models.LoginEvent, error) {
+	if userID == "" || tenantID == "" {
 		return nil, nil
 	}
 	if limit <= 0 {
@@ -138,11 +138,16 @@ func (r *LoginEventRegistry) ListByUser(ctx context.Context, userID string, limi
 	var events []*models.LoginEvent
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// The service-mode role bypasses the tenant_isolation RLS
+		// policy on this table, so we add `tenant_id = $tenantID`
+		// to the predicate as defense-in-depth — a buggy caller
+		// can't accidentally surface cross-tenant rows even if
+		// userID happens to match.
 		query := fmt.Sprintf(
-			`SELECT * FROM %s WHERE user_id = $1 ORDER BY created_at DESC LIMIT $2`,
+			`SELECT * FROM %s WHERE tenant_id = $1 AND user_id = $2 ORDER BY created_at DESC LIMIT $3`,
 			r.tableNames.LoginEvents(),
 		)
-		return tx.SelectContext(ctx, &events, query, userID, limit)
+		return tx.SelectContext(ctx, &events, query, tenantID, userID, limit)
 	})
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to list login events by user", err)
@@ -150,18 +155,20 @@ func (r *LoginEventRegistry) ListByUser(ctx context.Context, userID string, limi
 	return events, nil
 }
 
-func (r *LoginEventRegistry) CountFailedSince(ctx context.Context, userID string, since time.Time) (int, error) {
-	if userID == "" {
+func (r *LoginEventRegistry) CountFailedSince(ctx context.Context, tenantID, userID string, since time.Time) (int, error) {
+	if userID == "" || tenantID == "" {
 		return 0, nil
 	}
 	var count int
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// tenant_id filter mirrors ListByUser — see the comment
+		// there for the defense-in-depth rationale.
 		query := fmt.Sprintf(
-			`SELECT COUNT(*) FROM %s WHERE user_id = $1 AND outcome <> $2 AND created_at >= $3`,
+			`SELECT COUNT(*) FROM %s WHERE tenant_id = $1 AND user_id = $2 AND outcome <> $3 AND created_at >= $4`,
 			r.tableNames.LoginEvents(),
 		)
-		return tx.GetContext(ctx, &count, query, userID, models.LoginOutcomeOK, since)
+		return tx.GetContext(ctx, &count, query, tenantID, userID, models.LoginOutcomeOK, since)
 	})
 	if err != nil {
 		return 0, errxtrace.Wrap("failed to count failed login events", err)

--- a/go/registry/postgres/postgres.go
+++ b/go/registry/postgres/postgres.go
@@ -43,6 +43,7 @@ func NewFactorySet(dbx *sqlx.DB) *registry.FactorySet {
 	fs.TenantRegistry = NewTenantRegistry(dbx)
 	fs.UserRegistry = NewUserRegistry(dbx)
 	fs.RefreshTokenRegistry = NewRefreshTokenRegistry(dbx)
+	fs.LoginEventRegistry = NewLoginEventRegistry(dbx)
 	fs.AuditLogRegistry = NewAuditLogRegistry(dbx)
 	fs.EmailVerificationRegistry = NewEmailVerificationRegistry(dbx)
 	fs.PasswordResetRegistry = NewPasswordResetRegistry(dbx)

--- a/go/registry/postgres/refresh_tokens.go
+++ b/go/registry/postgres/refresh_tokens.go
@@ -265,13 +265,32 @@ func (r *RefreshTokenRegistry) RevokeByID(ctx context.Context, userID, id string
 		// no-op (idempotent revoke), and a cross-user id correctly
 		// 404s without revealing whether the id exists for someone
 		// else.
-		if n, rerr := res.RowsAffected(); rerr == nil && n == 0 {
-			var existing int
-			probe := fmt.Sprintf(`SELECT 1 FROM %s WHERE id = $1 AND user_id = $2`, r.tableNames.RefreshTokens())
-			if perr := tx.GetContext(ctx, &existing, probe, id, userID); errors.Is(perr, sql.ErrNoRows) {
-				return errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "RefreshToken", "entity_id", id))
-			}
+		n, rerr := res.RowsAffected()
+		if rerr != nil {
+			// Driver couldn't report rows affected — treat as a
+			// transient error rather than silently succeeding;
+			// silent-success on a probe failure could hide that
+			// the revoke didn't actually land.
+			return errxtrace.Wrap("failed to read rows affected on revoke", rerr)
 		}
+		if n > 0 {
+			return nil
+		}
+		var existing int
+		probe := fmt.Sprintf(`SELECT 1 FROM %s WHERE id = $1 AND user_id = $2`, r.tableNames.RefreshTokens())
+		perr := tx.GetContext(ctx, &existing, probe, id, userID)
+		switch {
+		case errors.Is(perr, sql.ErrNoRows):
+			// Truly missing — surface as ErrNotFound.
+			return errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "RefreshToken", "entity_id", id))
+		case perr != nil:
+			// Anything else (connection drop, permission denied)
+			// must NOT be swallowed — return so the handler 500s
+			// rather than reporting a no-op revoke that didn't
+			// happen.
+			return errxtrace.Wrap("failed to probe refresh token existence", perr)
+		}
+		// Row exists and was already revoked — idempotent success.
 		return nil
 	})
 }

--- a/go/registry/postgres/refresh_tokens.go
+++ b/go/registry/postgres/refresh_tokens.go
@@ -188,6 +188,32 @@ func (r *RefreshTokenRegistry) GetByUserID(ctx context.Context, userID string) (
 	return tokens, nil
 }
 
+// ListActiveByUserID returns refresh tokens for a user that are neither
+// revoked nor expired, ordered by LastUsedAt desc (CreatedAt desc as the
+// tiebreaker for never-used rows). Implemented as a single SQL query so
+// pagination behaviour stays predictable even if a user accumulates many
+// stale tokens before the retention sweep clears them.
+func (r *RefreshTokenRegistry) ListActiveByUserID(ctx context.Context, userID string) ([]*models.RefreshToken, error) {
+	if userID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "UserID"))
+	}
+
+	var tokens []*models.RefreshToken
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`SELECT * FROM %s WHERE user_id = $1 AND revoked_at IS NULL AND expires_at > $2 `+
+				`ORDER BY last_used_at DESC NULLS LAST, created_at DESC`,
+			r.tableNames.RefreshTokens(),
+		)
+		return tx.SelectContext(ctx, &tokens, query, userID, time.Now())
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list active refresh tokens by user", err)
+	}
+	return tokens, nil
+}
+
 // RevokeByUserID marks all refresh tokens for a user as revoked.
 func (r *RefreshTokenRegistry) RevokeByUserID(ctx context.Context, userID string) error {
 	if userID == "" {
@@ -204,6 +230,80 @@ func (r *RefreshTokenRegistry) RevokeByUserID(ctx context.Context, userID string
 		_, err := tx.ExecContext(ctx, query, now, userID)
 		if err != nil {
 			return errxtrace.Wrap("failed to revoke refresh tokens by user", err)
+		}
+		return nil
+	})
+}
+
+// RevokeByID revokes a single refresh token by id, gated on user_id so
+// a user can't revoke someone else's session via a guessed id. Returns
+// ErrNotFound when the (id, user_id) pair matches no row.
+func (r *RefreshTokenRegistry) RevokeByID(ctx context.Context, userID, id string) error {
+	if userID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "UserID"))
+	}
+	if id == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+
+	reg := r.newSQLRegistry()
+	return reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		now := time.Now()
+		query := fmt.Sprintf(
+			`UPDATE %s SET revoked_at = $1 WHERE id = $2 AND user_id = $3 AND revoked_at IS NULL`,
+			r.tableNames.RefreshTokens(),
+		)
+		res, err := tx.ExecContext(ctx, query, now, id, userID)
+		if err != nil {
+			return errxtrace.Wrap("failed to revoke refresh token by id", err)
+		}
+		// "already revoked" and "doesn't exist" are surfaced identically
+		// — both as ErrNotFound — because the FE never needs to
+		// distinguish a stale row from a missing one, and we never
+		// want to reveal "this id is yours but already revoked".
+		if n, rerr := res.RowsAffected(); rerr == nil && n == 0 {
+			// Probe whether the (id, user_id) pair exists at all.
+			var existing int
+			probe := fmt.Sprintf(`SELECT 1 FROM %s WHERE id = $1 AND user_id = $2`, r.tableNames.RefreshTokens())
+			if perr := tx.GetContext(ctx, &existing, probe, id, userID); errors.Is(perr, sql.ErrNoRows) {
+				return errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "RefreshToken", "entity_id", id))
+			}
+		}
+		return nil
+	})
+}
+
+// RevokeAllExceptID revokes every refresh token for the user except
+// the row whose id matches keepID. Pass an empty keepID to revoke
+// every token (equivalent to RevokeByUserID).
+func (r *RefreshTokenRegistry) RevokeAllExceptID(ctx context.Context, userID, keepID string) error {
+	if userID == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "UserID"))
+	}
+
+	reg := r.newSQLRegistry()
+	return reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		now := time.Now()
+		var (
+			query string
+			args  []any
+		)
+		if keepID == "" {
+			query = fmt.Sprintf(
+				`UPDATE %s SET revoked_at = $1 WHERE user_id = $2 AND revoked_at IS NULL`,
+				r.tableNames.RefreshTokens(),
+			)
+			args = []any{now, userID}
+		} else {
+			query = fmt.Sprintf(
+				`UPDATE %s SET revoked_at = $1 WHERE user_id = $2 AND id <> $3 AND revoked_at IS NULL`,
+				r.tableNames.RefreshTokens(),
+			)
+			args = []any{now, userID, keepID}
+		}
+		_, err := tx.ExecContext(ctx, query, args...)
+		if err != nil {
+			return errxtrace.Wrap("failed to revoke refresh tokens", err)
 		}
 		return nil
 	})

--- a/go/registry/postgres/refresh_tokens.go
+++ b/go/registry/postgres/refresh_tokens.go
@@ -257,12 +257,15 @@ func (r *RefreshTokenRegistry) RevokeByID(ctx context.Context, userID, id string
 		if err != nil {
 			return errxtrace.Wrap("failed to revoke refresh token by id", err)
 		}
-		// "already revoked" and "doesn't exist" are surfaced identically
-		// — both as ErrNotFound — because the FE never needs to
-		// distinguish a stale row from a missing one, and we never
-		// want to reveal "this id is yours but already revoked".
+		// Distinguish "no matching row" from "row exists but is
+		// already revoked". The UPDATE's WHERE includes
+		// `revoked_at IS NULL`, so zero rows affected covers both
+		// shapes — but only the genuinely-missing one should surface
+		// as 404. An already-revoked row is treated as a successful
+		// no-op (idempotent revoke), and a cross-user id correctly
+		// 404s without revealing whether the id exists for someone
+		// else.
 		if n, rerr := res.RowsAffected(); rerr == nil && n == 0 {
-			// Probe whether the (id, user_id) pair exists at all.
 			var existing int
 			probe := fmt.Sprintf(`SELECT 1 FROM %s WHERE id = $1 AND user_id = $2`, r.tableNames.RefreshTokens())
 			if perr := tx.GetContext(ctx, &existing, probe, id, userID); errors.Is(perr, sql.ErrNoRows) {

--- a/go/registry/postgres/store/tablenames.go
+++ b/go/registry/postgres/store/tablenames.go
@@ -18,6 +18,7 @@ type TableNames struct {
 	UserConcurrencySlots    func() TableName
 	OperationSlots          func() TableName
 	RefreshTokens           func() TableName
+	LoginEvents             func() TableName
 	AuditLogs               func() TableName
 	EmailVerifications      func() TableName
 	PasswordResets          func() TableName
@@ -50,6 +51,7 @@ var DefaultTableNames = TableNames{
 	UserConcurrencySlots:    func() TableName { return "user_concurrency_slots" },
 	OperationSlots:          func() TableName { return "operation_slots" },
 	RefreshTokens:           func() TableName { return "refresh_tokens" },
+	LoginEvents:             func() TableName { return "login_events" },
 	AuditLogs:               func() TableName { return "audit_logs" },
 	EmailVerifications:      func() TableName { return "email_verifications" },
 	PasswordResets:          func() TableName { return "password_resets" },

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -1102,20 +1102,27 @@ type RefreshTokenRegistry interface {
 }
 
 // LoginEventRegistry stores the append-only login_events audit trail
-// (issue #1379). All callers operate as the background-worker / login
-// flow which runs outside any user RLS context — the only user-facing
-// surface is ListByUser which scopes by user_id in application logic.
+// (issue #1379). The registry runs under the background-worker role so
+// the unauthenticated login flow (where no tenant context is set in the
+// DB session yet) can still insert rows — this bypasses the
+// tenant-isolation RLS policy on reads too, so every read method takes
+// an explicit `tenantID` and the SQL adds `tenant_id = $tenantID` as
+// defense-in-depth alongside the user_id filter. Without that, a bug in
+// a caller could leak login events across tenants even though the row
+// has a tenant_id column populated correctly.
 type LoginEventRegistry interface {
 	Registry[models.LoginEvent]
 
 	// ListByUser returns the most recent login events for the user,
 	// newest first, capped at limit. Limit <= 0 falls back to 100.
-	ListByUser(ctx context.Context, userID string, limit int) ([]*models.LoginEvent, error)
+	// tenantID is required — empty input yields an empty result.
+	ListByUser(ctx context.Context, tenantID, userID string, limit int) ([]*models.LoginEvent, error)
 
 	// CountFailedSince returns the number of failed login_events for
 	// the user since `since`. "Failed" = outcome != ok. Drives the
-	// "We noticed N failed sign-in attempts" banner (#1379).
-	CountFailedSince(ctx context.Context, userID string, since time.Time) (int, error)
+	// "We noticed N failed sign-in attempts" banner (#1379). tenantID
+	// is required — empty input yields 0.
+	CountFailedSince(ctx context.Context, tenantID, userID string, since time.Time) (int, error)
 
 	// DeleteOlderThan removes login_events whose created_at is before
 	// cutoff. Called daily by login_event_retention_worker — the rows

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -1072,11 +1072,55 @@ type RefreshTokenRegistry interface {
 	// GetByUserID returns all refresh tokens for a user
 	GetByUserID(ctx context.Context, userID string) ([]*models.RefreshToken, error)
 
+	// ListActiveByUserID returns all refresh tokens for a user that have
+	// not been revoked and have not yet expired. Used by the sessions
+	// endpoint (#1378) — the FE only wants live sessions, never the
+	// historical revoked/expired carcasses that the retention sweep
+	// will eventually clean up. Ordered most-recently-used first
+	// (LastUsedAt desc, CreatedAt desc as the tiebreaker for tokens
+	// that have never been used).
+	ListActiveByUserID(ctx context.Context, userID string) ([]*models.RefreshToken, error)
+
 	// RevokeByUserID marks all refresh tokens for a user as revoked
 	RevokeByUserID(ctx context.Context, userID string) error
 
+	// RevokeByID atomically revokes a single refresh token by id but
+	// only if it belongs to the supplied user. Returns ErrNotFound
+	// when no row matches the (id, user_id) pair so a user can't
+	// revoke someone else's session via a guessed id.
+	RevokeByID(ctx context.Context, userID, id string) error
+
+	// RevokeAllExceptID marks every refresh token for a user as revoked
+	// except the one whose id matches keepID. Used by the "Sign out all
+	// other sessions" button (#1378). Pass an empty keepID to revoke
+	// every token — equivalent to RevokeByUserID but kept distinct so
+	// the call site reads obvious.
+	RevokeAllExceptID(ctx context.Context, userID, keepID string) error
+
 	// DeleteExpired removes all expired refresh tokens from the store
 	DeleteExpired(ctx context.Context) error
+}
+
+// LoginEventRegistry stores the append-only login_events audit trail
+// (issue #1379). All callers operate as the background-worker / login
+// flow which runs outside any user RLS context — the only user-facing
+// surface is ListByUser which scopes by user_id in application logic.
+type LoginEventRegistry interface {
+	Registry[models.LoginEvent]
+
+	// ListByUser returns the most recent login events for the user,
+	// newest first, capped at limit. Limit <= 0 falls back to 100.
+	ListByUser(ctx context.Context, userID string, limit int) ([]*models.LoginEvent, error)
+
+	// CountFailedSince returns the number of failed login_events for
+	// the user since `since`. "Failed" = outcome != ok. Drives the
+	// "We noticed N failed sign-in attempts" banner (#1379).
+	CountFailedSince(ctx context.Context, userID string, since time.Time) (int, error)
+
+	// DeleteOlderThan removes login_events whose created_at is before
+	// cutoff. Called daily by login_event_retention_worker — the rows
+	// are append-only so we don't need any tenant/user qualifier here.
+	DeleteOlderThan(ctx context.Context, cutoff time.Time) (int, error)
 }
 
 // GroupPurger hard-deletes every row whose group_id references the given
@@ -1125,6 +1169,7 @@ type Set struct {
 	TenantRegistry                 TenantRegistry
 	UserRegistry                   UserRegistry
 	RefreshTokenRegistry           RefreshTokenRegistry
+	LoginEventRegistry             LoginEventRegistry            // Append-only login attempt audit (#1379); written by login flow + retention worker
 	AuditLogRegistry               AuditLogRegistry              // AuditLogRegistry doesn't need factory as it's not user-aware
 	EmailVerificationRegistry      EmailVerificationRegistry     // EmailVerificationRegistry doesn't need factory as it's not user-aware
 	PasswordResetRegistry          PasswordResetRegistry         // PasswordResetRegistry doesn't need factory as it's not user-aware

--- a/go/schema/migrations/_sqldata/1778750027_add_login_events.down.sql
+++ b/go/schema/migrations/_sqldata/1778750027_add_login_events.down.sql
@@ -1,14 +1,15 @@
--- Migration rollback for login_events table (issue #1379).
+-- Migration rollback
+-- Generated on: 2026-05-14T09:13:47Z
 -- Direction: DOWN
 
 DROP INDEX IF EXISTS idx_login_events_created_at;
 DROP INDEX IF EXISTS idx_login_events_tenant_id;
 DROP INDEX IF EXISTS idx_login_events_user_created_at;
 DROP INDEX IF EXISTS idx_login_events_uuid;
--- Drop RLS policy login_event_tenant_isolation from table login_events
-DROP POLICY IF EXISTS login_event_tenant_isolation ON login_events;
 -- Drop RLS policy login_event_background_worker_access from table login_events
 DROP POLICY IF EXISTS login_event_background_worker_access ON login_events;
+-- Drop RLS policy login_event_tenant_isolation from table login_events
+DROP POLICY IF EXISTS login_event_tenant_isolation ON login_events;
 -- NOTE: RLS policies were removed from table login_events - verify if RLS should be disabled --
 -- WARNING: This will delete all data!
 DROP TABLE IF EXISTS login_events CASCADE;

--- a/go/schema/migrations/_sqldata/1778750027_add_login_events.up.sql
+++ b/go/schema/migrations/_sqldata/1778750027_add_login_events.up.sql
@@ -1,4 +1,5 @@
--- Migration: add login_events table for the per-user authentication audit (issue #1379).
+-- Migration generated from schema differences
+-- Generated on: 2026-05-14T09:13:47Z
 -- Direction: UP
 
 -- POSTGRES TABLE: login_events --
@@ -30,7 +31,7 @@ DROP POLICY IF EXISTS login_event_tenant_isolation ON login_events;
 CREATE POLICY login_event_tenant_isolation ON login_events FOR ALL TO inventario_app
     USING (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '')
     WITH CHECK (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '');
-CREATE UNIQUE INDEX IF NOT EXISTS idx_login_events_uuid ON login_events (uuid);
-CREATE INDEX IF NOT EXISTS idx_login_events_user_created_at ON login_events (user_id, created_at);
-CREATE INDEX IF NOT EXISTS idx_login_events_tenant_id ON login_events (tenant_id);
 CREATE INDEX IF NOT EXISTS idx_login_events_created_at ON login_events (created_at);
+CREATE INDEX IF NOT EXISTS idx_login_events_tenant_id ON login_events (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_login_events_user_created_at ON login_events (user_id, created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_login_events_uuid ON login_events (uuid);

--- a/go/schema/migrations/_sqldata/1779900000_add_login_events.down.sql
+++ b/go/schema/migrations/_sqldata/1779900000_add_login_events.down.sql
@@ -1,0 +1,14 @@
+-- Migration rollback for login_events table (issue #1379).
+-- Direction: DOWN
+
+DROP INDEX IF EXISTS idx_login_events_created_at;
+DROP INDEX IF EXISTS idx_login_events_tenant_id;
+DROP INDEX IF EXISTS idx_login_events_user_created_at;
+DROP INDEX IF EXISTS idx_login_events_uuid;
+-- Drop RLS policy login_event_tenant_isolation from table login_events
+DROP POLICY IF EXISTS login_event_tenant_isolation ON login_events;
+-- Drop RLS policy login_event_background_worker_access from table login_events
+DROP POLICY IF EXISTS login_event_background_worker_access ON login_events;
+-- NOTE: RLS policies were removed from table login_events - verify if RLS should be disabled --
+-- WARNING: This will delete all data!
+DROP TABLE IF EXISTS login_events CASCADE;

--- a/go/schema/migrations/_sqldata/1779900000_add_login_events.up.sql
+++ b/go/schema/migrations/_sqldata/1779900000_add_login_events.up.sql
@@ -1,0 +1,36 @@
+-- Migration: add login_events table for the per-user authentication audit (issue #1379).
+-- Direction: UP
+
+-- POSTGRES TABLE: login_events --
+CREATE TABLE login_events (
+  user_id TEXT,
+  email TEXT NOT NULL,
+  outcome TEXT NOT NULL,
+  method TEXT NOT NULL DEFAULT 'password',
+  ip_address VARCHAR(64),
+  user_agent TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  tenant_id TEXT NOT NULL,
+  id TEXT PRIMARY KEY NOT NULL,
+  uuid TEXT NOT NULL DEFAULT (gen_random_uuid())::text
+);
+-- ALTER statements: --
+ALTER TABLE login_events ADD CONSTRAINT fk_login_event_user FOREIGN KEY (user_id) REFERENCES users(id);
+-- ALTER statements: --
+ALTER TABLE login_events ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+-- Enable RLS for login_events table
+ALTER TABLE login_events ENABLE ROW LEVEL SECURITY;
+-- Allows the retention worker and login flow to insert/sweep events outside any user context
+DROP POLICY IF EXISTS login_event_background_worker_access ON login_events;
+CREATE POLICY login_event_background_worker_access ON login_events FOR ALL TO inventario_background_worker
+    USING (true)
+    WITH CHECK (true);
+-- Login events are tenant-isolated; per-user filtering happens in application logic so a user only sees their own attempts
+DROP POLICY IF EXISTS login_event_tenant_isolation ON login_events;
+CREATE POLICY login_event_tenant_isolation ON login_events FOR ALL TO inventario_app
+    USING (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '')
+    WITH CHECK (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '');
+CREATE UNIQUE INDEX IF NOT EXISTS idx_login_events_uuid ON login_events (uuid);
+CREATE INDEX IF NOT EXISTS idx_login_events_user_created_at ON login_events (user_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_login_events_tenant_id ON login_events (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_login_events_created_at ON login_events (created_at);

--- a/go/services/login_event_retention_worker.go
+++ b/go/services/login_event_retention_worker.go
@@ -1,0 +1,154 @@
+package services
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// defaultLoginEventRetention defines how long login_events rows stay in
+// the database before the retention worker purges them. 90 days matches
+// the default in issue #1379 — enough to surface "did someone try last
+// month?" while keeping the table bounded for long-running deployments.
+const defaultLoginEventRetention = 90 * 24 * time.Hour
+
+// defaultLoginEventSweepInterval defines how often the retention worker
+// looks for expired rows. Once a day is enough for an append-only table
+// with a small daily volume; long sweep intervals also keep the burst
+// load on the DB to a minimum.
+const defaultLoginEventSweepInterval = 24 * time.Hour
+
+// LoginEventRetentionWorker periodically deletes login_events rows
+// older than its retention window. The login_events table is append-only
+// and grows linearly with login activity; without this worker the table
+// would creep towards unbounded growth on a multi-year deployment.
+type LoginEventRetentionWorker struct {
+	registry      registry.LoginEventRegistry
+	retention     time.Duration
+	sweepInterval time.Duration
+	stopCh        chan struct{}
+	stopOnce      sync.Once
+	wg            sync.WaitGroup
+	clock         func() time.Time // override for tests; nil = time.Now
+}
+
+// LoginEventRetentionOption customizes a LoginEventRetentionWorker.
+type LoginEventRetentionOption func(*loginEventRetentionOptions)
+
+type loginEventRetentionOptions struct {
+	retention     time.Duration
+	sweepInterval time.Duration
+	clock         func() time.Time
+}
+
+// WithLoginEventRetention overrides the retention window. Non-positive
+// values are ignored — the default 90d window is the only safe lower
+// bound for a forensic audit trail.
+func WithLoginEventRetention(d time.Duration) LoginEventRetentionOption {
+	return func(o *loginEventRetentionOptions) {
+		if d > 0 {
+			o.retention = d
+		}
+	}
+}
+
+// WithLoginEventSweepInterval overrides the sweep cadence. Non-positive
+// values are ignored.
+func WithLoginEventSweepInterval(d time.Duration) LoginEventRetentionOption {
+	return func(o *loginEventRetentionOptions) {
+		if d > 0 {
+			o.sweepInterval = d
+		}
+	}
+}
+
+// WithLoginEventRetentionClock overrides the wall clock used by the
+// worker. Test-only — production callers leave it nil so the worker
+// uses time.Now.
+func WithLoginEventRetentionClock(fn func() time.Time) LoginEventRetentionOption {
+	return func(o *loginEventRetentionOptions) {
+		if fn != nil {
+			o.clock = fn
+		}
+	}
+}
+
+// NewLoginEventRetentionWorker constructs the worker. A nil registry
+// produces an instance whose Start is a no-op; callers can wire the
+// worker unconditionally and let the registry presence decide whether
+// it actually runs (same shape as RefreshTokenCleanupWorker).
+func NewLoginEventRetentionWorker(r registry.LoginEventRegistry, opts ...LoginEventRetentionOption) *LoginEventRetentionWorker {
+	options := loginEventRetentionOptions{
+		retention:     defaultLoginEventRetention,
+		sweepInterval: defaultLoginEventSweepInterval,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return &LoginEventRetentionWorker{
+		registry:      r,
+		retention:     options.retention,
+		sweepInterval: options.sweepInterval,
+		stopCh:        make(chan struct{}),
+		clock:         options.clock,
+	}
+}
+
+// Start launches the background goroutine. It is a no-op when the
+// registry is nil.
+func (w *LoginEventRetentionWorker) Start(ctx context.Context) {
+	if w.registry == nil {
+		slog.Warn("LoginEventRetentionWorker: no registry configured, skipping startup")
+		return
+	}
+	w.wg.Go(func() {
+		w.run(ctx)
+	})
+	slog.Info("Login event retention worker started", "retention", w.retention, "interval", w.sweepInterval)
+}
+
+// Stop signals the worker to stop and waits for it to finish.
+func (w *LoginEventRetentionWorker) Stop() {
+	w.stopOnce.Do(func() { close(w.stopCh) })
+	w.wg.Wait()
+	slog.Info("Login event retention worker stopped")
+}
+
+func (w *LoginEventRetentionWorker) run(ctx context.Context) {
+	// Run once immediately so a fresh deployment doesn't wait a full
+	// sweepInterval before its first purge.
+	w.sweep(ctx)
+
+	ticker := time.NewTicker(w.sweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			w.sweep(ctx)
+		}
+	}
+}
+
+func (w *LoginEventRetentionWorker) sweep(ctx context.Context) {
+	now := time.Now
+	if w.clock != nil {
+		now = w.clock
+	}
+	cutoff := now().Add(-w.retention)
+	deleted, err := w.registry.DeleteOlderThan(ctx, cutoff)
+	if err != nil {
+		slog.Error("Failed to delete old login events", "error", err)
+		return
+	}
+	if deleted > 0 {
+		slog.Info("Pruned login_events", "deleted", deleted, "cutoff", cutoff)
+	}
+}


### PR DESCRIPTION
Implements [#1644](https://github.com/denisvmedia/inventario/issues/1644) — the user-facing Privacy & Security sub-flows. Second of three PRs splitting the #1536 bundle.

## Summary

### Backend
- IP truncation helper (`/24` IPv4, `/56` IPv6) applied to `refresh_tokens.ip_address` on every issue and to every `login_events` row (per #1378 privacy policy).
- New `login_events` table (migrator schema + migration `1779900000` + memory + postgres registries). Append-only, tenant-isolated RLS plus a background-worker role for the write side that runs outside any user context.
- Every credential-check branch in `apiserver.login` now writes a `login_events` row: `ok`, `bad_password` (unknown email OR wrong password), `account_locked` (rate limiter), `account_disabled`.
- `RefreshTokenRegistry` grows `ListActiveByUserID` + `RevokeByID` + `RevokeAllExceptID`. Single-revoke is gated on `user_id` so a guessed id from another account returns 404 (never leaks "exists but yours").
- New `/api/v1/users/me` sub-router under the regular `userMiddlewares`:
  - `GET /sessions` — list active sessions with `is_current` derived from the refresh cookie hash.
  - `DELETE /sessions/{id}` — revoke one.
  - `DELETE /sessions` — revoke all but the current cookie's session.
  - `GET /login-history?limit=N` — newest-first events + `failed_last_7d` count.
- `LoginEventRetentionWorker` (90d retention, 24h sweep), wired in `run/all` + `run/workers` under the Housekeeping group.

### Frontend
- New `features/sessions` and `features/login-history` slices.
- New `/profile/sessions` page — card per session (device icon, browser + OS parsed in-browser per #1378 option 2, last-used relative, partial IP, **This device** pill, Revoke). Top-level **Sign out all other sessions** CTA with confirm.
- New `/profile/login-history` page — outcome-chipped list, failed-attempts banner when `failed_last_7d > 3`.
- `SettingsPage` privacy section: replaces the `activeSessions` / `loginHistory` `ComingSoonBanner`s with real chevron rows that match the design mock `PrivacySection`. 2FA stays as an Inactive-badge row; `connectedAccounts` remains `ComingSoonBanner` per the issue scope (→ #1395).
- swagger + codegen regenerated; new i18n keys (en) for privacy / sessions / loginHistory.

### Tests
- Go: `TestUsersMeAPI` covers list + `is_current` flag, single revoke, revoke-all-others, login-history newest-first + `failed_last_7d`.
- Vitest: `SessionsPage`, `LoginHistoryPage`, updated `SettingsPage` privacy test (53 page tests / 819 total — all green).
- Playwright: `e2e/tests/sessions-and-login-history.spec.ts` — two-browser visibility + revoke, two bad-password attempts visible in history.

## Acceptance criteria
- [x] `refresh_tokens.ip_address` + `user_agent` written on every issue (now `/24` truncated)
- [x] List + revoke endpoints (one + all-others), current-session flag correct
- [x] `login_events` table + retention worker + every auth path writes an event
- [x] Settings → Sessions list reachable, current-session pill, Revoke confirmation
- [x] Settings → Login history list reachable, outcome chips, failed-attempt banner
- [x] e2e: log in twice (two browsers), see two sessions, revoke one → other unaffected; trigger 2 wrong-password attempts → both show in history with `bad_password` outcome

## Test plan
- [ ] `make test-go` — Go unit tests pass (verified locally)
- [ ] `make test-frontend` — Vitest pass (verified locally: 819/819)
- [ ] `make lint-migrations` — verify `1779900000_add_login_events` matches the generated schema
- [ ] e2e CI run — Playwright sessions-and-login-history spec
- [ ] Manual smoke: log in, visit /settings → click "Active sessions" → see the current session card; open second browser → see two cards; revoke the non-current one → original session keeps working
- [ ] Manual smoke: 2 failed login attempts → /profile/login-history shows two `bad_password` rows

## Closes
- Closes #1378 (Active sessions UI).
- Closes #1379 (Login history view).

## Out of scope
- 2FA (#1380) — row stays as an Inactive-badge stub.
- OAuth methods (#1394/#1395) — `LoginMethod` enum is structured to accept `oauth_*`, but only `password` ships now.
- Connected accounts row — remains `ComingSoonBanner` per issue scope.