### PR TITLE
[#1624] Reject invalid ISO 4217 to_currency at currency-migration preview/start

### DIFF
--- a/go/apiserver/currency_migrations.go
+++ b/go/apiserver/currency_migrations.go
@@ -48,6 +48,7 @@ const (
 	codeCurrencyMigrationRestoreInProgress = "currency_migration.restore_in_progress"
 	codeCurrencyMigrationDailyCapReached   = "currency_migration.daily_cap_reached"
 	codeCurrencyMigrationLocked            = "currency_migration.locked"
+	codeCurrencyMigrationInvalidToCurrency = "currency_migration.invalid_to_currency"
 )
 
 // Constants from #202 §4 — code-resident, not config-driven (the
@@ -166,6 +167,12 @@ func (api *currencyMigrationsAPI) preview(w http.ResponseWriter, r *http.Request
 	}
 	attrs := input.Data.Attributes
 
+	if !attrs.ToCurrency.IsValid() {
+		_ = codedUnprocessableEntityError(w, r,
+			fmt.Errorf("to_currency %q is not a valid ISO 4217 code", string(attrs.ToCurrency)),
+			codeCurrencyMigrationInvalidToCurrency)
+		return
+	}
 	if attrs.FromCurrency != group.GroupCurrency {
 		_ = codedUnprocessableEntityError(w, r,
 			fmt.Errorf("from_currency must equal group's current currency (%s)", group.GroupCurrency),
@@ -493,6 +500,12 @@ func requireGroupNotMigrating(opts GroupMigrationLockOptions) func(http.Handler)
 // guards on the request body. Returns false (and writes the response)
 // when the body is invalid; true to continue.
 func validateStartAttributes(w http.ResponseWriter, r *http.Request, attrs *jsonapi.CurrencyMigrationStartAttributes, group *models.LocationGroup) bool {
+	if !attrs.ToCurrency.IsValid() {
+		_ = codedUnprocessableEntityError(w, r,
+			fmt.Errorf("to_currency %q is not a valid ISO 4217 code", string(attrs.ToCurrency)),
+			codeCurrencyMigrationInvalidToCurrency)
+		return false
+	}
 	if attrs.FromCurrency != group.GroupCurrency {
 		_ = codedUnprocessableEntityError(w, r,
 			fmt.Errorf("from_currency must equal group's current currency (%s)", group.GroupCurrency),

--- a/go/apiserver/currency_migrations_test.go
+++ b/go/apiserver/currency_migrations_test.go
@@ -182,6 +182,42 @@ func TestCurrencyMigrations_Preview_ZeroRateRejected422(t *testing.T) {
 	assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.rate_invalid")
 }
 
+// Garbage to_currency must be rejected at the preview boundary with a
+// stable JSON:API code so the FE can render a targeted error instead of
+// the generic 422 the registry-layer ValidateWithContext used to return
+// (issue #1624).
+func TestCurrencyMigrations_Preview_InvalidToCurrencyRejected422(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "FOO", "0.9"))
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.invalid_to_currency")
+	// No preview token must be issued for an invalid to_currency — the
+	// error response must not carry one through the data envelope.
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathMatches("$.errors[0].code", qt.Not(qt.Equals)), "")
+}
+
+// Same gap on the start handler — without the ISO check, garbage
+// to_currency only failed inside CurrencyMigrationRegistry.Create with a
+// generic wrapped 422.
+func TestCurrencyMigrations_Start_InvalidToCurrencyRejected422(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newCurrencyMigrationParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Token value is irrelevant — the IsValid guard short-circuits before
+	// VerifyPreviewToken is even called.
+	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations", testUser.ID, startBody("USD", "FOO", "0.9", "any-token"))
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.invalid_to_currency")
+}
+
 func TestCurrencyMigrations_Start_Happy_AndCreatesPendingRow(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/apiserver/currency_migrations_test.go
+++ b/go/apiserver/currency_migrations_test.go
@@ -196,9 +196,6 @@ func TestCurrencyMigrations_Preview_InvalidToCurrencyRejected422(t *testing.T) {
 
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 	assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.invalid_to_currency")
-	// No preview token must be issued for an invalid to_currency — the
-	// error response must not carry one through the data envelope.
-	c.Assert(rr.Body.Bytes(), checkers.JSONPathMatches("$.errors[0].code", qt.Not(qt.Equals)), "")
 }
 
 // Same gap on the start handler — without the ISO check, garbage


### PR DESCRIPTION
Closes #1624.

## Summary

- `apiserver/currency_migrations.go`: add `attrs.ToCurrency.IsValid()` guard at the top of both `preview` and `validateStartAttributes`. Garbage codes (`"FOO"`, lowercased forms, etc.) are now rejected with 422 and the new stable code `currency_migration.invalid_to_currency` *before* a preview token is issued or any registry write is attempted.
- New constant `codeCurrencyMigrationInvalidToCurrency` joins the existing `codeCurrencyMigration*` set so the FE has a stable code to branch on.
- Mirrors the pattern already established at `apiserver/groups.go:401-405` for `createGroup`.

Skipped the optional `from_currency` defence-in-depth bonus from the issue: the existing `from_mismatch` check already rejects any `from_currency` that does not equal `group.GroupCurrency`, and validating against a hypothetically corrupt group row would add validation for a scenario the create path already prevents.

## What was wrong

Both handlers previously checked `from != group.GroupCurrency`, `from == to`, and `ValidateRate(rate)` but did **not** call `ToCurrency.IsValid()`. An invalid ISO code like `"FOO"`:
- in `preview`: passed all three checks and the registry happily issued a 10-minute HMAC-signed `preview_token` for it,
- in `start`: was caught much later inside `CurrencyMigrationRegistry.Create` → wrapped 422 without a stable JSON:API code.

## Test plan

- [x] `go test ./apiserver/ -run 'TestCurrencyMigrations_Preview_InvalidToCurrencyRejected422|TestCurrencyMigrations_Start_InvalidToCurrencyRejected422' -v` — new tests pass.
- [x] `go test ./apiserver/ -run 'TestCurrencyMigrations'` — full currency-migration suite passes (no regressions in same-currency / from-mismatch / rate-invalid / token / state-drift / in-flight / restore / lock / 429 / 403 paths).
- [x] `go test ./apiserver/ -count=1 -timeout=180s` — entire apiserver package green.
- [x] `golangci-lint run --fix ./apiserver/...` — 0 issues.