### PR TITLE
[#1615] /profile: drop duplicate email row from meta strip

### DIFF
--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom"
 import {
   Building2,
   Calendar,
-  Mail,
   Package,
   Pencil,
   ShieldCheck,
@@ -195,12 +194,6 @@ export function ProfilePage() {
                     : t("settings:profile.noGroupSet")}
                 </span>
               </div>
-              {email ? (
-                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                  <Mail className="size-3.5" aria-hidden="true" />
-                  <span>{email}</span>
-                </div>
-              ) : null}
             </div>
           </div>
         </section>

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -99,6 +99,10 @@ describe("<ProfilePage />", () => {
     )
     expect(screen.getByTestId("profile-email")).toHaveTextContent("alex@example.com")
     expect(screen.getByTestId("profile-default-group")).toHaveTextContent("Household")
+    // The mock surface (UserProfileView) shows email exactly once — under
+    // the name. Guard against the duplicate `Mail` row that lived in the
+    // meta strip until #1615 alongside Building2 + member-since.
+    expect(screen.getAllByText("alex@example.com")).toHaveLength(1)
   })
 
   it("falls back to 'no group set' when default_group_id is unset", async () => {


### PR DESCRIPTION
## Summary

Closes #1615 — drops the duplicate `Mail`-icon row from `/profile`'s meta strip so email renders exactly once on the page (under the name in the identity card), matching `design-mocks/src/views/UserProfileView.tsx`.

The other items on #1615 already shipped, so with this PR every in-scope checklist item is closed:

| Item | Where |
|---|---|
| 1. Stat cards row (4-up grid) | PR #1672 |
| 2. Tabs (Groups + Activity) | PR #1672 — Groups in place of mock's "Inventory" per #1653's deliberate maintainer call; Activity is empty-state per the issue's "ship UI now, wire feed later" allowance |
| 3. Defensive `member since` date handling | PR #1673 |
| 4. **Drop duplicate email in meta row** | **this PR** |
| 5. Cover banner radial glows | already in `ProfilePage.tsx:115-121` (shipped with #1672) |
| 6. EditProfilePage left-rail layout | explicitly **out of scope** per the issue body |

## What changed

- `frontend/src/pages/ProfilePage.tsx` — removed the third meta-strip entry (`<Mail>` icon + `<span>{email}</span>`); dropped the now-unused `Mail` lucide import.
- `frontend/src/pages/__tests__/ProfilePage.test.tsx` — added one assertion to the existing "renders the user's name, email, and member-since" case: `expect(screen.getAllByText("alex@example.com")).toHaveLength(1)` so the duplicate can't sneak back in.

The identity-line email (`profile-email` testid, line 178-180) stays — that's the one the mock keeps.

## Test plan

- [x] `npx vitest run` — 828 / 832 (4 pre-existing skips), incl. the new dedupe assertion.
- [x] `npx eslint src/pages/ProfilePage.tsx src/pages/__tests__/ProfilePage.test.tsx` — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx prettier --check …` — clean.
- [ ] Visual confirmation — the meta row should now read `🏠 Default group: <name>` + `📅 Member since <date>` (when present) and nothing else; the email under the name is unchanged.