### PR TITLE
[#1541] File preview: small Dialog for non-previewable types

### DIFF
--- a/frontend/src/components/files/FileDetailSheet.tsx
+++ b/frontend/src/components/files/FileDetailSheet.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Download, ExternalLink, Maximize2, Pencil, Trash2 } from "lucide-react"
 
+import { FilePreviewOtherDialog } from "@/components/files/FilePreviewOtherDialog"
 import { ImageViewer, type GalleryImage } from "@/components/files/ImageViewer"
 import { PdfViewer } from "@/components/files/PdfViewer"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -22,11 +23,15 @@ import { useAppToast } from "@/hooks/useAppToast"
 import { useConfirm } from "@/hooks/useConfirm"
 import { formatDateTime } from "@/lib/intl"
 
-// Right-side drawer surfaced from the list page when the user opens a
-// file. Renders an inline preview (image via <img>, PDF via <embed>,
-// other types fall back to a "Download to view" placeholder), the
-// metadata block, and the action row (Open in new tab / Download /
-// Edit / Delete). Edit deep-links to the standalone edit page.
+// Entry point for the file detail surface. Routes by MIME category
+// once the file resolves: image + PDF stay on the right-side Sheet
+// (inline preview + metadata block + Open / Download / Edit / Delete
+// action row, with the fullscreen ImageViewer / PdfViewer for the
+// gallery + zoom flow); everything else opens a small focused Dialog
+// (`FilePreviewOtherDialog`) per the design mock — filename header,
+// "cannot preview" card with a Download CTA, destructive ghost Delete.
+// The loading + error state always renders inside the Sheet so the
+// surface is decided as soon as the fetch succeeds.
 export interface FileDetailSheetProps {
   fileId: string | null
   open: boolean
@@ -66,6 +71,8 @@ export function FileDetailSheet({
   // flow (#1448), so gate on path being truthy — an empty path means we have no
   // displayable filename even if `ext` is set (otherwise we'd render a stray ".pdf").
   const filename = file?.path ? `${file.path}${file.ext ?? ""}` : ""
+  const mime = file?.mime_type
+  const previewable = isImageMime(mime) || isPdfMime(mime)
 
   async function onDelete() {
     if (!file) return
@@ -83,6 +90,22 @@ export function FileDetailSheet({
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err))
     }
+  }
+
+  // Non-previewable mime → small focused Dialog (mock's "other" branch).
+  // We can only decide once the fetch resolves, so loading + error stay
+  // on the Sheet path below.
+  if (file && !previewable) {
+    return (
+      <FilePreviewOtherDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        file={file}
+        signedUrl={signedUrl}
+        onDelete={onDelete}
+        deletePending={deleteMutation.isPending}
+      />
+    )
   }
 
   return (
@@ -310,21 +333,7 @@ function FilePreview({ mime, url, alt, onExpandImage }: PreviewProps) {
     )
   }
 
-  if (isPdfMime(mime)) {
-    return <PdfViewer url={url} />
-  }
-
-  return <FallbackPreview />
-}
-
-function FallbackPreview() {
-  const { t } = useTranslation()
-  return (
-    <div
-      className="flex aspect-[4/3] w-full items-center justify-center rounded-md border bg-muted text-center text-sm text-muted-foreground"
-      data-testid="file-preview-fallback"
-    >
-      <p className="max-w-xs px-4">{t("files:detail.noPreview")}</p>
-    </div>
-  )
+  // Sheet path only renders for image / PDF — non-previewable mimes are
+  // routed to FilePreviewOtherDialog before reaching here.
+  return <PdfViewer url={url} />
 }

--- a/frontend/src/components/files/FileDetailSheet.tsx
+++ b/frontend/src/components/files/FileDetailSheet.tsx
@@ -333,7 +333,12 @@ function FilePreview({ mime, url, alt, onExpandImage }: PreviewProps) {
     )
   }
 
-  // Sheet path only renders for image / PDF — non-previewable mimes are
-  // routed to FilePreviewOtherDialog before reaching here.
-  return <PdfViewer url={url} />
+  if (isPdfMime(mime)) {
+    return <PdfViewer url={url} />
+  }
+
+  // Defensive: the entry-point routing in FileDetailSheet sends every
+  // non-image / non-PDF mime to FilePreviewOtherDialog before reaching
+  // here, so this only fires if a future caller bypasses the gate.
+  return <div className="aspect-[4/3] w-full rounded-md bg-muted" aria-hidden="true" />
 }

--- a/frontend/src/components/files/FilePreviewOtherDialog.tsx
+++ b/frontend/src/components/files/FilePreviewOtherDialog.tsx
@@ -1,0 +1,110 @@
+import { useTranslation } from "react-i18next"
+import { Download, File as FileIcon, Trash2 } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
+import { formatBytes, formatDateTime } from "@/lib/intl"
+import type { Schema } from "@/types"
+
+type FileEntity = Schema<"models.FileEntity"> & { id: string }
+
+export interface FilePreviewOtherDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  file: FileEntity
+  signedUrl?: string
+  onDelete: () => void
+  deletePending: boolean
+}
+
+// Small focused Dialog for files whose MIME type can't be previewed in
+// the browser (everything outside image/* and application/pdf). Mirrors
+// `design-mocks/src/components/FilePreviewDialog.tsx` "other" branch:
+// filename header + meta strip · centred "cannot preview" card with a
+// Download CTA · destructive ghost button. The fullscreen Sheet path
+// stays the home for image/PDF — see FileDetailSheet.
+export function FilePreviewOtherDialog({
+  open,
+  onOpenChange,
+  file,
+  signedUrl,
+  onDelete,
+  deletePending,
+}: FilePreviewOtherDialogProps) {
+  const { t } = useTranslation()
+
+  const filename = file.path ? `${file.path}${file.ext ?? ""}` : ""
+  const headerLabel = file.title?.trim() || filename || file.id
+  const size =
+    typeof file.size_bytes === "number" && file.size_bytes > 0 ? formatBytes(file.size_bytes) : null
+  const uploaded = file.created_at ? formatDateTime(file.created_at) : null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md" data-testid="file-preview-other-dialog">
+        <DialogTitle className="sr-only">{t("files:detail.metadataTitle")}</DialogTitle>
+        <DialogDescription className="sr-only">{t("files:detail.noPreview")}</DialogDescription>
+
+        <div className="flex items-start gap-3 pr-6">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+            <FileIcon className="size-5 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p
+              className="truncate text-base font-semibold leading-snug"
+              data-testid="file-preview-other-filename"
+            >
+              {headerLabel}
+            </p>
+            <p className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+              {size ? <span data-testid="file-preview-other-size">{size}</span> : null}
+              {size && uploaded ? <span aria-hidden="true">·</span> : null}
+              {uploaded ? (
+                <span data-testid="file-preview-other-uploaded">
+                  {t("files:detail.uploadedAt")} {uploaded}
+                </span>
+              ) : null}
+              {file.tags && file.tags.length > 0
+                ? file.tags.map((tag) => (
+                    <Badge key={tag} variant="secondary" className="h-4 px-1.5 text-[10px]">
+                      {tag}
+                    </Badge>
+                  ))
+                : null}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-1 flex flex-col items-center justify-center gap-4 rounded-xl border border-border bg-muted/40 px-6 py-8 text-center">
+          <div className="flex size-14 items-center justify-center rounded-xl border border-border bg-background">
+            <FileIcon className="size-7 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <p className="max-w-xs text-xs text-muted-foreground">{t("files:detail.noPreview")}</p>
+          {signedUrl ? (
+            <Button asChild size="sm" className="gap-1.5">
+              <a href={signedUrl} download data-testid="file-preview-other-download">
+                <Download className="size-3.5" aria-hidden="true" />
+                {t("files:detail.download")}
+              </a>
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="flex justify-end pt-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 text-destructive hover:bg-destructive/10 hover:text-destructive"
+            onClick={onDelete}
+            disabled={deletePending}
+            data-testid="file-preview-other-delete"
+          >
+            <Trash2 className="size-3.5" aria-hidden="true" />
+            {t("files:detail.delete")}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/files/FilePreviewOtherDialog.tsx
+++ b/frontend/src/components/files/FilePreviewOtherDialog.tsx
@@ -4,15 +4,13 @@ import { Download, File as FileIcon, Trash2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
+import type { FileEntity } from "@/features/files/api"
 import { formatBytes, formatDateTime } from "@/lib/intl"
-import type { Schema } from "@/types"
-
-type FileEntity = Schema<"models.FileEntity"> & { id: string }
 
 export interface FilePreviewOtherDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  file: FileEntity
+  file: FileEntity & { id: string }
   signedUrl?: string
   onDelete: () => void
   deletePending: boolean

--- a/frontend/src/components/files/__tests__/FileDetailSheet.test.tsx
+++ b/frontend/src/components/files/__tests__/FileDetailSheet.test.tsx
@@ -81,7 +81,7 @@ describe("<FileDetailSheet />", () => {
     expect(screen.getByText("q4")).toBeInTheDocument()
   })
 
-  it("renders the no-preview fallback when MIME isn't image or PDF", async () => {
+  it("routes to the small Dialog (not the Sheet) when MIME isn't image or PDF", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),
       ...fileHandlers.detail(
@@ -95,15 +95,26 @@ describe("<FileDetailSheet />", () => {
           path: "stuff",
           ext: ".zip",
           mime_type: "application/zip",
+          size_bytes: 1024,
+          created_at: "2026-04-30T10:00:00Z",
         },
         { url: "https://cdn.example/stuff.zip" }
       )
     )
     renderSheet("f1")
-    expect(await screen.findByTestId("file-preview-fallback")).toBeInTheDocument()
+    expect(await screen.findByTestId("file-preview-other-dialog")).toBeInTheDocument()
+    // Sheet-only metadata block and action row should not render.
+    expect(screen.queryByTestId("file-detail-sheet")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("file-detail-edit")).not.toBeInTheDocument()
+    // Dialog shows the filename header, size, and Download CTA.
+    expect(screen.getByTestId("file-preview-other-filename")).toHaveTextContent("Archive")
+    expect(screen.getByTestId("file-preview-other-download")).toHaveAttribute(
+      "href",
+      "https://cdn.example/stuff.zip"
+    )
   })
 
-  it("delete button is disabled while a delete is in flight (renders without crashing)", async () => {
+  it("delete button renders enabled on the small Dialog branch", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),
       ...fileHandlers.detail(SLUG, "f1", {
@@ -117,8 +128,8 @@ describe("<FileDetailSheet />", () => {
       })
     )
     renderSheet("f1")
-    await waitFor(() => expect(screen.getByTestId("file-detail-delete")).toBeInTheDocument())
-    expect(screen.getByTestId("file-detail-delete")).not.toBeDisabled()
+    await waitFor(() => expect(screen.getByTestId("file-preview-other-delete")).toBeInTheDocument())
+    expect(screen.getByTestId("file-preview-other-delete")).not.toBeDisabled()
   })
 
   it("renders the dash fallback when path is an empty string (regression #1483)", async () => {
@@ -156,13 +167,16 @@ describe("<FileDetailSheet />", () => {
   it("renders the bare path when ext is missing", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),
+      // Use a PDF so the file stays on the Sheet path (which renders
+      // the metadata block with the filename row). Non-previewable
+      // mimes route to the small Dialog after #1541.
       ...fileHandlers.detail(SLUG, "f1", {
         id: "f1",
         title: "Note",
-        category: "other",
-        type: "other",
+        category: "documents",
+        type: "document",
         path: "notes-2026",
-        mime_type: "text/plain",
+        mime_type: "application/pdf",
       })
     )
     renderSheet("f1")
@@ -171,19 +185,42 @@ describe("<FileDetailSheet />", () => {
     )
   })
 
+  it("clicking Delete on the small Dialog opens the confirm prompt", async () => {
+    const user = userEvent.setup()
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...fileHandlers.detail(SLUG, "f1", {
+        id: "f1",
+        title: "Archive",
+        category: "other",
+        type: "archive",
+        path: "stuff",
+        ext: ".zip",
+        mime_type: "application/zip",
+      })
+    )
+    renderSheet("f1")
+    const deleteBtn = await screen.findByTestId("file-preview-other-delete")
+    await user.click(deleteBtn)
+    expect(await screen.findByTestId("confirm-dialog")).toBeInTheDocument()
+    expect(screen.getByTestId("confirm-accept")).toBeInTheDocument()
+  })
+
   it("clicking Edit calls onEdit with the file id", async () => {
     const user = userEvent.setup()
     const onEdit = vi.fn()
     server.use(
       ...groupHandlers.list(groupFixture),
+      // Edit affordance lives on the Sheet path — use a PDF so the
+      // mime routing keeps the test on that surface.
       ...fileHandlers.detail(SLUG, "f1", {
         id: "f1",
         title: "X",
-        category: "other",
-        type: "other",
+        category: "documents",
+        type: "document",
         path: "x",
-        ext: "",
-        mime_type: "application/octet-stream",
+        ext: ".pdf",
+        mime_type: "application/pdf",
       })
     )
     renderSheet("f1", onEdit)


### PR DESCRIPTION
Closes #1541.

## Summary

`FileDetailSheet` now branches by MIME category once the file resolves:

- **image/** + **application/pdf** → existing right-side Sheet (inline preview, metadata block, Open / Download / Edit / Delete row, fullscreen `ImageViewer` / `PdfViewer` for gallery + zoom). Gallery navigation via `imageSiblings` is preserved.
- **everything else** → new focused `sm:max-w-md` `FilePreviewOtherDialog` matching [`design-mocks/src/components/FilePreviewDialog.tsx`](https://github.com/denisvmedia/inventario/blob/master/design-mocks/src/components/FilePreviewDialog.tsx) "other" branch: filename header with file-icon tile, `size · uploaded · tag pills` meta strip, a centred "cannot preview" card with a Download CTA, and a destructive ghost **Delete file** button that flows through the existing `useConfirm` prompt.

Loading and error states keep rendering inside the Sheet — the mime is unknown until the fetch succeeds, so the surface is only switched once we know what we have.

## Files

- **new** `frontend/src/components/files/FilePreviewOtherDialog.tsx` — the small focused Dialog. Reuses existing i18n keys (`files:detail.noPreview`, `files:detail.metadataTitle`, `files:detail.download`, `files:detail.delete`, `files:detail.uploadedAt`) so this is a zero-key change. Sr-only `DialogTitle` + `DialogDescription` cover the Radix a11y requirement without disturbing the mock-faithful visible header.
- **modified** `frontend/src/components/files/FileDetailSheet.tsx` — adds the `previewable` branch and the early return into the new Dialog before the Sheet render. Drops the now-unreachable `FallbackPreview` body. Edit button stays on the Sheet path (mock-faithful — non-previewable files reach Edit through future overflow-menu work).
- **modified** `frontend/src/components/files/__tests__/FileDetailSheet.test.tsx` — non-previewable scenarios now assert the new Dialog testIds (`file-preview-other-dialog`, `-filename`, `-download`, `-delete`); the Edit and "bare path when ext is missing" cases switched to PDF fixtures so they exercise the Sheet path; new delete-flow test verifies clicking Delete on the Dialog opens the project's confirm prompt.

## Mock parity

> Mock screenshot: `assets/screenshots-1527/dialogs-light/file-preview.png`

Header tile, meta strip layout, "cannot preview" card, Download CTA, and the destructive ghost Delete button at the bottom-right of the dialog all mirror the mock. The only intentional difference: the dialog has a sr-only `DialogTitle` (Radix a11y requirement) — visually identical, only screen-readers notice.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run i18n:check` — catalogs in sync
- [x] `npm run test` — **829/829** pass (8/8 in `FileDetailSheet.test.tsx`)
- [ ] Manual: open a `.zip` / `.docx` / archive file from `/files` → confirm small Dialog renders with filename, size, uploaded date, Download CTA, Delete; image + PDF still open the Sheet with inline preview and the Edit row.