### PR TITLE
[#1539] Tags page: hover-reveal rows, color dots, item-preview chips, inline create

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -170,6 +170,35 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 - **Approved by**: agent-suggested-then-user-confirmed — issue #1538 §3 specifies replacing the freeform input with curated pills and notes the #1400 coordination.
 - **Reversion plan**: Resolve when #1400 lands a proper Tags entity — pills then match by id again, and the i18n keys become tag-record labels.
 
+### Tags
+
+#### 2026-05-15 — Tags page: full-shape TagFormDialog preserved alongside inline create
+
+- **Issue/PR**: #1539 / PR _pending_
+- **Mock**: [`design-mocks/src/views/TagsView.tsx`](../../design-mocks/src/views/TagsView.tsx) captures only a `label` string in its inline-create row (lines 150–199) and edit row (lines 109–146); the rendered tag pill displays the same string with a `#` glyph. There is no separate slug concept.
+- **Reality**: `frontend/src/components/tags/TagFormDialog.tsx` exposes both a human-readable `label` (e.g. "Kitchen Supplies") and a kebab-cased `slug` (e.g. `kitchen-supplies`) as independent fields. The slug is the stable identifier referenced from `commodities.tags` / `files.tags` JSONB arrays on the BE — decoupling label from slug lets a user rename a tag without rewriting every reference (just the label column). The new inline "+ New tag" row on the Tags list page (port of the mock fast-path) only captures `label` and derives `slug` via `normaliseSlug()`; clicking the page-header "Add tag" button or any row's edit affordance still opens the full slug+label dialog.
+- **Why**: BE-driven. Tag identity is the slug (`models.Tag.slug`, unique per group, immutable from the user's perspective once references exist); the label is purely display. The mock's single-field flow would force label-to-slug normalisation on every edit and silently break any commodity that referenced the prior slug. Keeping the dialog as the canonical edit surface preserves the BE contract; the inline create row is an additive fast path that auto-derives the slug for the common case where label and slug should match.
+- **Approved by**: user (explicit) — issue #1539 §"PRESERVE" calls out the dialog and instructs the inline create to land as an additional fast path, not a replacement.
+- **Reversion plan**: Permanent. If the BE ever exposes slug renames with reference fix-up (or drops slug entirely in favour of UUIDs), the dialog can collapse to label-only and the inline row would be the only path.
+
+#### 2026-05-15 — Tags stats bar shows five tiles (tags + items + files split) where the mock shows three
+
+- **Issue/PR**: #1539 / PR _pending_
+- **Mock**: [`design-mocks/src/views/TagsView.tsx`](../../design-mocks/src/views/TagsView.tsx) lines 245–261 render three icon-headed stat tiles in a `grid-cols-3` row: "Total tags", "Tagged items", "Untagged items".
+- **Reality**: `frontend/src/components/tags/TagsStatsBar.tsx` keeps the icon-headed mini-card pattern from the mock but renders five tiles in a `grid-cols-2 sm:grid-cols-3 lg:grid-cols-5` row — adding "Tagged files" and "Untagged files" alongside the items split. Values come from the BE `/tags/stats` endpoint (#1412), which already aggregates both surfaces.
+- **Why**: The BE indexes tag adoption on both commodities *and* files (BE PR #1412); surfacing only the items half would hide half the picture on what is the canonical "how are tags being used?" page. The Files page exposes a tagged/untagged count in its own toolbar, but the Tags page is the natural home for the cross-surface roll-up. Mock styling (icon tile + label + value) is preserved per-tile.
+- **Approved by**: agent-suggested — judgment call inside the issue's "broader visual representation drift (catch-all)" §4 latitude.
+- **Reversion plan**: Drop the two file tiles to match the mock 1:1 if the file-tag rollout turns out to be noise on this page; the BE `/tags/stats` payload remains additive so back-and-forth doesn't require schema changes.
+
+#### 2026-05-15 — Tags row item-preview chips aggregate client-side from a single commodities pull
+
+- **Issue/PR**: #1539 / PR _pending_
+- **Mock**: [`design-mocks/src/views/TagsView.tsx`](../../design-mocks/src/views/TagsView.tsx) lines 327–343 surface up to two item-preview chips per row plus a "+N" overflow, computed from `MOCK_ITEMS.filter(i => i.tags.includes(tag.id))`.
+- **Reality**: `frontend/src/pages/tags/TagsListPage.tsx` calls `useCommodities({ perPage: 500, includeInactive: true })` once on mount and builds a `Map<slug, [{id, name}]>` (capped at two per tag) in a `useMemo`. Each `<TagRow>` reads its entry from the map and renders the same `≤2 + overflow` shape. Overflow count comes from `tag.usage.commodities` (the authoritative count from `/tags?include=usage`) minus the resolved-chip count, so the figure stays correct even if a tagged commodity sits past the 500-row window.
+- **Why**: The BE does not expose a tag-filtered commodities index — same trade-off `#1531` made for area-counts on the Locations page. Client-side aggregation is acceptable for the page's expected scale (a group rarely exceeds a few hundred items); the chip data is a UX enrichment, not a primary read path, so the heavy fetch happens lazily and re-uses the existing `commodityKeys.list` cache.
+- **Approved by**: agent-suggested — issue #1539 §1 calls out chips as "Effort M (chips need item-tag join)", signalling the maintainer expects a non-trivial path; client-side aggregation is the lowest-cost option.
+- **Reversion plan**: If usage grows past the 500-row window often enough to be visibly wrong (chips empty even though `usage.commodities > 0`), expose a `/commodities?tags=<slug>` BE filter and switch the page to one query per visible tag (or batch via `/tags/{slug}/sample`). The map shape on the FE stays.
+
 ### Forms & Validation
 
 _None yet._

--- a/frontend/src/components/tags/TagBadge.tsx
+++ b/frontend/src/components/tags/TagBadge.tsx
@@ -1,3 +1,5 @@
+import { Hash } from "lucide-react"
+
 import { cn } from "@/lib/utils"
 
 import type { TagColor } from "@/features/tags/api"
@@ -16,25 +18,49 @@ const TONE: Record<TagColor, string> = {
   muted: "text-tag-muted border-tag-muted/40 bg-tag-muted/10",
 }
 
+// Dot tone keeps the `bg-tag-*` foreground at full saturation — used
+// inline next to a non-pill rendering of the tag label (e.g. the row
+// indicator dot on the Tags list page).
+export const TAG_DOT_TONE: Record<TagColor, string> = {
+  amber: "bg-tag-amber",
+  green: "bg-tag-green",
+  blue: "bg-tag-blue",
+  orange: "bg-tag-orange",
+  red: "bg-tag-red",
+  muted: "bg-tag-muted",
+}
+
 export interface TagBadgeProps {
   label: string
   color: TagColor
   size?: "sm" | "md"
+  // When true (default) the badge renders the `#` glyph before the
+  // label, matching the visual contract in `design-mocks/src/views/TagsView.tsx`.
+  // Callers that show the slug elsewhere on the row can pass `false`.
+  hashed?: boolean
   className?: string
   testId?: string
 }
 
-export function TagBadge({ label, color, size = "md", className, testId }: TagBadgeProps) {
+export function TagBadge({
+  label,
+  color,
+  size = "md",
+  hashed = true,
+  className,
+  testId,
+}: TagBadgeProps) {
   return (
     <span
       data-testid={testId}
       className={cn(
-        "inline-flex items-center rounded-full border font-medium",
+        "inline-flex items-center gap-1 rounded-full border font-medium select-none",
         TONE[color],
         size === "sm" ? "h-5 px-2 text-[11px]" : "h-6 px-2.5 text-xs",
         className
       )}
     >
+      {hashed ? <Hash aria-hidden="true" className="size-2.5 shrink-0" /> : null}
       {label}
     </span>
   )

--- a/frontend/src/components/tags/TagInlineCreate.tsx
+++ b/frontend/src/components/tags/TagInlineCreate.tsx
@@ -1,0 +1,198 @@
+import { Check, Plus, X } from "lucide-react"
+import { useEffect, useId, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { TagColorPicker } from "@/components/tags/TagColorPicker"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils"
+
+import type { TagColor } from "@/features/tags/api"
+import { normaliseSlug } from "@/features/tags/schemas"
+
+// Inline fast-path tag creator that sits at the bottom of the tag list,
+// per `design-mocks/src/views/TagsView.tsx`. Captures label-only — the
+// slug is auto-derived from the label via `normaliseSlug` (same rule
+// the dialog uses while the slug field is unedited). The full
+// label-AND-slug experience stays in `<TagFormDialog>`, opened by the
+// page header's "Add tag" button or any row's edit affordance.
+export interface TagInlineCreateProps {
+  existingSlugs: ReadonlySet<string>
+  // Resolves on success; rejecting bubbles back so this component can
+  // leave the typed value in place for retry while the caller surfaces
+  // the failure (toast). The caller is responsible for cache
+  // invalidation; we don't read the freshly-created row from the
+  // returned value.
+  onCreate: (values: { label: string; slug: string; color: TagColor }) => Promise<void>
+  isPending?: boolean
+  className?: string
+  testId?: string
+}
+
+const DEFAULT_COLOR: TagColor = "amber"
+
+export function TagInlineCreate({
+  existingSlugs,
+  onCreate,
+  isPending = false,
+  className,
+  testId,
+}: TagInlineCreateProps) {
+  const { t } = useTranslation(["tags"])
+  const [open, setOpen] = useState(false)
+  const [label, setLabel] = useState("")
+  const [color, setColor] = useState<TagColor>(DEFAULT_COLOR)
+  const [error, setError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  // Stable ids so the visually-hidden label, input, and error message
+  // wire up for screen readers — axe flags the input as "unlabeled
+  // form control" otherwise.
+  const inputId = useId()
+  const errorId = useId()
+
+  // Focus the input when the row expands. Without this the user has to
+  // click the input after toggling the dashed button — the mock auto-
+  // focuses immediately so a fast typist can chain create → enter →
+  // type-next-name without a mouse round-trip.
+  useEffect(() => {
+    if (open) inputRef.current?.focus()
+  }, [open])
+
+  function reset() {
+    setLabel("")
+    setColor(DEFAULT_COLOR)
+    setError(null)
+  }
+
+  function close() {
+    setOpen(false)
+    reset()
+  }
+
+  async function submit() {
+    const trimmed = label.trim()
+    if (!trimmed) {
+      setError("tags:validation.labelRequired")
+      return
+    }
+    const slug = normaliseSlug(trimmed)
+    if (!slug) {
+      setError("tags:validation.slugInvalid")
+      return
+    }
+    if (existingSlugs.has(slug)) {
+      setError("tags:validation.duplicateSlug")
+      return
+    }
+    try {
+      await onCreate({ label: trimmed, slug, color })
+      reset()
+      // Stay expanded so the user can punch in another tag immediately.
+      // The mock collapses; we leave open because the BE round-trip is
+      // long enough that re-opening a fresh card feels stuttery.
+      inputRef.current?.focus()
+    } catch {
+      // Caller is responsible for toast on failure — we keep the typed
+      // value so the user can retry without re-typing.
+    }
+  }
+
+  if (!open) {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className={cn("gap-1.5 w-full justify-start border-dashed", className)}
+        onClick={() => setOpen(true)}
+        data-testid={testId ?? "tags-inline-create-toggle"}
+      >
+        <Plus aria-hidden="true" className="size-3.5" />
+        {t("tags:inlineCreate.toggle")}
+      </Button>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 rounded-lg border border-ring bg-card px-3 py-2",
+        className
+      )}
+      data-testid={testId ?? "tags-inline-create"}
+    >
+      <div className="flex flex-col gap-2 flex-1 min-w-0">
+        <Label htmlFor={inputId} className="sr-only">
+          {t("tags:inlineCreate.label")}
+        </Label>
+        <Input
+          id={inputId}
+          ref={inputRef}
+          value={label}
+          onChange={(e) => {
+            setLabel(e.target.value)
+            if (error) setError(null)
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault()
+              void submit()
+            }
+            if (e.key === "Escape") {
+              e.preventDefault()
+              close()
+            }
+          }}
+          placeholder={t("tags:inlineCreate.placeholder")}
+          className="h-7 text-sm"
+          disabled={isPending}
+          aria-invalid={!!error}
+          aria-describedby={error ? errorId : undefined}
+          data-testid="tags-inline-create-label"
+        />
+        <TagColorPicker
+          value={color}
+          onChange={setColor}
+          disabled={isPending}
+          testId="tags-inline-create-color"
+        />
+        {error ? (
+          <p
+            id={errorId}
+            className="text-xs text-destructive"
+            data-testid="tags-inline-create-error"
+          >
+            {t(error)}
+          </p>
+        ) : null}
+      </div>
+      <div className="flex gap-1 shrink-0">
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="size-7"
+          onClick={() => void submit()}
+          disabled={isPending || !label.trim()}
+          aria-label={t("tags:inlineCreate.save")}
+          data-testid="tags-inline-create-save"
+        >
+          <Check aria-hidden="true" className="size-3.5" />
+        </Button>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="size-7"
+          onClick={close}
+          disabled={isPending}
+          aria-label={t("tags:inlineCreate.cancel")}
+          data-testid="tags-inline-create-cancel"
+        >
+          <X aria-hidden="true" className="size-3.5" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/tags/TagRow.tsx
+++ b/frontend/src/components/tags/TagRow.tsx
@@ -1,74 +1,129 @@
-import { Pencil, Trash2 } from "lucide-react"
+import { Package, Pencil, Trash2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
-import { TagBadge } from "./TagBadge"
+import { TAG_DOT_TONE } from "./TagBadge"
 import type { TagColor, TagEntity, TagUsage } from "@/features/tags/api"
+
+// Visual contract: matches `design-mocks/src/views/TagsView.tsx` row
+// shape — leading color dot, `# label` with usage count beneath, an
+// inline strip of up to two item-preview chips with a `+N` overflow,
+// and edit/delete affordances that only fade in on row hover.
+export interface TagRowPreviewItem {
+  id: string
+  name: string
+}
 
 export interface TagRowProps {
   tag: TagEntity & { id: string }
   usage?: TagUsage
+  previewItems?: TagRowPreviewItem[]
   onEdit: () => void
   onDelete: () => void
   className?: string
 }
 
-export function TagRow({ tag, usage, onEdit, onDelete, className }: TagRowProps) {
+const PREVIEW_LIMIT = 2
+
+export function TagRow({
+  tag,
+  usage,
+  previewItems = [],
+  onEdit,
+  onDelete,
+  className,
+}: TagRowProps) {
   const { t } = useTranslation(["tags"])
   const items = usage?.commodities ?? 0
   const files = usage?.files ?? 0
-  const usageNone = items === 0 && files === 0
+  const color = (tag.color ?? "muted") as TagColor
+  const label = tag.label ?? tag.slug ?? ""
+  const head = previewItems.slice(0, PREVIEW_LIMIT)
+  // Overflow counts the *unseen* tagged items beyond the resolved chips.
+  // We only have item chips (not file chips), so the figure stays tied
+  // to `usage.commodities`. When commodities are zero but files aren't,
+  // we don't render a chip strip at all (`head.length === 0`).
+  const overflow = Math.max(0, items - head.length)
+  // Usage line mirrors the in-use check the delete-confirm dialog uses
+  // (`items > 0 || files > 0`) so a tag attached only to files reads as
+  // in-use instead of the misleading "Not used yet" the items-only
+  // count would produce.
+  const usageSegments: string[] = []
+  if (items > 0) usageSegments.push(t("tags:list.usageItems", { count: items }))
+  if (files > 0) usageSegments.push(t("tags:list.usageFiles", { count: files }))
 
   return (
     <div
       data-testid={`tag-row-${tag.slug}`}
-      className={cn(
-        "flex flex-wrap items-center justify-between gap-3 rounded-md border bg-card px-4 py-3",
-        className
-      )}
+      className={cn("group flex items-center gap-3 px-4 py-3", className)}
     >
-      <div className="flex min-w-0 items-center gap-3">
-        <TagBadge label={tag.label ?? tag.slug ?? ""} color={(tag.color ?? "muted") as TagColor} />
-        <span className="truncate text-xs text-muted-foreground">{tag.slug}</span>
-      </div>
-
       <div
-        className="flex items-center gap-3 text-xs text-muted-foreground"
-        data-testid={`tag-row-${tag.slug}-usage`}
-      >
-        {usageNone ? (
-          <span>{t("tags:list.usageNone")}</span>
-        ) : (
-          <>
-            <span>{t("tags:list.usageItems", { count: items })}</span>
-            <span aria-hidden="true">·</span>
-            <span>{t("tags:list.usageFiles", { count: files })}</span>
-          </>
-        )}
+        className={cn("size-2.5 rounded-full shrink-0", TAG_DOT_TONE[color])}
+        data-testid={`tag-row-${tag.slug}-dot`}
+        aria-hidden="true"
+      />
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm font-medium truncate">
+            <span aria-hidden="true" className="text-muted-foreground">
+              #{" "}
+            </span>
+            {label}
+          </span>
+        </div>
+        <p
+          className="text-xs text-muted-foreground mt-0.5"
+          data-testid={`tag-row-${tag.slug}-usage`}
+        >
+          {usageSegments.length === 0 ? t("tags:list.usageNone") : usageSegments.join(" · ")}
+        </p>
       </div>
 
-      <div className="flex items-center gap-1.5">
+      {head.length > 0 ? (
+        <div
+          className="hidden sm:flex items-center gap-1 flex-wrap max-w-48"
+          data-testid={`tag-row-${tag.slug}-preview`}
+        >
+          {head.map((item) => (
+            <span
+              key={item.id}
+              className="inline-flex items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
+            >
+              <Package aria-hidden="true" className="size-2.5 shrink-0" />
+              <span className="truncate max-w-20">{item.name}</span>
+            </span>
+          ))}
+          {overflow > 0 ? (
+            <span className="text-[10px] text-muted-foreground">+{overflow}</span>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity shrink-0">
         <Button
           type="button"
-          size="sm"
+          size="icon"
           variant="ghost"
+          className="size-7"
           onClick={onEdit}
           aria-label={t("tags:list.edit")}
           data-testid={`tag-row-${tag.slug}-edit`}
         >
-          <Pencil className="size-4" aria-hidden="true" />
+          <Pencil aria-hidden="true" className="size-3.5" />
         </Button>
         <Button
           type="button"
-          size="sm"
+          size="icon"
           variant="ghost"
+          className="size-7 text-destructive hover:bg-destructive/10 hover:text-destructive"
           onClick={onDelete}
           aria-label={t("tags:list.delete")}
           data-testid={`tag-row-${tag.slug}-delete`}
         >
-          <Trash2 className="size-4" aria-hidden="true" />
+          <Trash2 aria-hidden="true" className="size-3.5" />
         </Button>
       </div>
     </div>

--- a/frontend/src/components/tags/TagsStatsBar.tsx
+++ b/frontend/src/components/tags/TagsStatsBar.tsx
@@ -1,6 +1,6 @@
+import { File, FileX, Hash, Package, Tag } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
-import { Card, CardContent } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
 
 import type { TagStats } from "@/features/tags/api"
@@ -11,43 +11,59 @@ export interface TagsStatsBarProps {
   testId?: string
 }
 
-const FIELDS: Array<{ key: keyof TagStats; labelKey: string }> = [
-  { key: "tags_total", labelKey: "tags:stats.tagsTotal" },
-  { key: "items_tagged", labelKey: "tags:stats.itemsTagged" },
-  { key: "items_untagged", labelKey: "tags:stats.itemsUntagged" },
-  { key: "files_tagged", labelKey: "tags:stats.filesTagged" },
-  { key: "files_untagged", labelKey: "tags:stats.filesUntagged" },
+// Visual contract: matches the stats row in
+// `design-mocks/src/views/TagsView.tsx` — icon-tile + label + value
+// laid out horizontally inside a `rounded-xl border bg-card` shell. Mock
+// shows three tiles (Total / Tagged / Untagged items); we keep the
+// extra two file tiles so the page also surfaces file-tag adoption
+// (the Files page mirrors this number elsewhere but the Tags page is
+// the canonical "how are tags being used?" surface). Logged as a
+// deviation in devdocs/frontend/design-deviations.md.
+interface TileSpec {
+  key: keyof TagStats
+  labelKey: string
+  icon: typeof Tag
+}
+
+const TILES: TileSpec[] = [
+  { key: "tags_total", labelKey: "tags:stats.tagsTotal", icon: Tag },
+  { key: "items_tagged", labelKey: "tags:stats.itemsTagged", icon: Package },
+  { key: "items_untagged", labelKey: "tags:stats.itemsUntagged", icon: Hash },
+  { key: "files_tagged", labelKey: "tags:stats.filesTagged", icon: File },
+  { key: "files_untagged", labelKey: "tags:stats.filesUntagged", icon: FileX },
 ]
 
 export function TagsStatsBar({ stats, loading, testId }: TagsStatsBarProps) {
   const { t } = useTranslation(["tags"])
+  const showPlaceholder = loading && stats === undefined
   return (
     <div
       className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5"
       data-testid={testId ?? "tags-stats"}
     >
-      {FIELDS.map(({ key, labelKey }) => {
+      {TILES.map(({ key, labelKey, icon: Icon }) => {
         const value = stats?.[key]
         return (
-          <Card
+          <div
             key={key}
-            className="border-muted"
+            className="rounded-xl border border-border bg-card px-4 py-3 flex items-center gap-3"
             data-testid={`tags-stats-${key.replace(/_/g, "-")}`}
           >
-            <CardContent className="flex flex-col gap-1 p-4">
-              <span className="text-xs uppercase tracking-wide text-muted-foreground">
-                {t(labelKey)}
-              </span>
-              <span
+            <div className="flex size-8 items-center justify-center rounded-lg bg-muted shrink-0">
+              <Icon aria-hidden="true" className="size-4 text-muted-foreground" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs text-muted-foreground truncate">{t(labelKey)}</p>
+              <p
                 className={cn(
-                  "text-2xl font-semibold tabular-nums",
-                  loading && stats === undefined ? "text-muted-foreground" : ""
+                  "text-lg font-semibold leading-tight tabular-nums",
+                  showPlaceholder && "text-muted-foreground"
                 )}
               >
-                {loading && stats === undefined ? "—" : (value ?? 0)}
-              </span>
-            </CardContent>
-          </Card>
+                {showPlaceholder ? "—" : (value ?? 0)}
+              </p>
+            </div>
+          </div>
         )
       })}
     </div>

--- a/frontend/src/components/tags/__tests__/TagBadge.test.tsx
+++ b/frontend/src/components/tags/__tests__/TagBadge.test.tsx
@@ -25,6 +25,22 @@ describe("<TagBadge />", () => {
     expect(screen.getByTestId("tb").className).toContain("h-6")
   })
 
+  it("renders a Hash glyph alongside the label by default", () => {
+    const { container } = render(<TagBadge label="Kitchen" color="amber" testId="tb" />)
+    const badge = container.querySelector('[data-testid="tb"]')
+    // The Hash icon is rendered as an inline <svg> sibling of the label
+    // text. lucide-react ships each icon as a single <svg>.
+    expect(badge?.querySelector("svg")).not.toBeNull()
+  })
+
+  it("omits the Hash glyph when hashed={false}", () => {
+    const { container } = render(
+      <TagBadge label="Kitchen" color="amber" hashed={false} testId="tb" />
+    )
+    const badge = container.querySelector('[data-testid="tb"]')
+    expect(badge?.querySelector("svg")).toBeNull()
+  })
+
   it("is axe-clean", async () => {
     const { container } = render(<TagBadge label="Kitchen" color="amber" />)
     const results = await axe(container)

--- a/frontend/src/i18n/locales/en/tags.json
+++ b/frontend/src/i18n/locales/en/tags.json
@@ -30,19 +30,33 @@
     "updateError": "Could not update tag: {{error}}",
     "updateSuccess": "Tag updated."
   },
+  "inlineCreate": {
+    "cancel": "Cancel new tag",
+    "label": "Tag name",
+    "placeholder": "tag-name",
+    "save": "Save new tag",
+    "toggle": "New tag"
+  },
   "list": {
     "delete": "Delete tag",
     "edit": "Edit tag",
-    "empty": "No tags yet — create your first one above.",
+    "empty": "No tags yet — create your first one below.",
     "emptyFiltered": "No tags match \"{{query}}\".",
     "emptyScopeCommodity": "No tags used on items yet — apply one from the Add Item dialog's Extras step to seed this list.",
     "emptyScopeFile": "No tags used on files yet — apply one from a file's tag input to seed this list.",
     "loadError": "Could not load tags: {{error}}",
+    "results_one": "{{count}} result",
+    "results_other": "{{count}} results",
+    "totalTags_one": "{{count}} tag",
+    "totalTags_other": "{{count}} tags",
     "usageFiles_one": "{{count}} file",
     "usageFiles_other": "{{count}} files",
     "usageItems_one": "{{count}} item",
     "usageItems_other": "{{count}} items",
     "usageNone": "Not used yet"
+  },
+  "preview": {
+    "heading": "Preview"
   },
   "removal": {
     "confirmAction": "Delete",
@@ -56,8 +70,16 @@
     "inUseTitle": "Tag is in use"
   },
   "search": {
+    "clear": "Clear search",
     "label": "Search tags",
-    "placeholder": "Search by label or slug…"
+    "placeholder": "Filter tags…"
+  },
+  "sort": {
+    "label": "Sort",
+    "labelAsc": "A → Z",
+    "labelDesc": "Z → A",
+    "mostUsed": "Most used",
+    "newest": "Newest"
   },
   "stats": {
     "filesTagged": "Tagged files",
@@ -80,6 +102,7 @@
   },
   "validation": {
     "colorRequired": "Pick a color.",
+    "duplicateSlug": "A tag with that slug already exists.",
     "labelRequired": "Label is required.",
     "labelTooLong": "Label must be 64 characters or fewer.",
     "slugInvalid": "Slug must be lowercase, kebab-cased.",

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -1,16 +1,20 @@
-import { Plus, Search } from "lucide-react"
+import { Plus, Search, Tag as TagIcon, X } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useSearchParams } from "react-router-dom"
 
+import { TagBadge } from "@/components/tags/TagBadge"
 import { TagFormDialog } from "@/components/tags/TagFormDialog"
-import { TagRow } from "@/components/tags/TagRow"
+import { TagInlineCreate } from "@/components/tags/TagInlineCreate"
+import { TagRow, type TagRowPreviewItem } from "@/components/tags/TagRow"
 import { TagsStatsBar } from "@/components/tags/TagsStatsBar"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useCommodities } from "@/features/commodities/hooks"
 import {
   type CreateTagRequest,
   type TagColor,
@@ -29,6 +33,7 @@ import {
 } from "@/features/tags/hooks"
 import { useAppToast } from "@/hooks/useAppToast"
 import { useConfirm } from "@/hooks/useConfirm"
+import { cn } from "@/lib/utils"
 
 // Search-input debounce keeps the page responsive on every keystroke
 // while still reflecting the typed value in the URL (so refreshes /
@@ -45,6 +50,27 @@ const VALID_SORT_FIELDS = [
   "usage",
 ] as const satisfies readonly TagSortField[]
 const VALID_SORT_ORDERS = ["asc", "desc"] as const satisfies readonly TagSortOrder[]
+
+// Cap on commodities pulled for preview-chip aggregation. Each tag row
+// surfaces up to 2 sample items + an overflow count from `usage`, so we
+// only need enough rows to find a hit for each tag. The BE's
+// `parsePagination` (go/apiserver/apiserver.go) caps `per_page` at 100
+// — anything higher silently falls back to the default 50, so 100 is
+// the practical upper bound. Groups with more than 100 commodities will
+// see empty chip strips on rows whose tagged commodities all sit
+// outside the first page; the authoritative count still surfaces via
+// `usage.commodities` (so "no chips but N items" still tells the truth).
+// We send `include_inactive=true` because tags can be attached to draft
+// or written-off items too.
+const PREVIEW_COMMODITIES_LIMIT = 100
+const PREVIEW_ITEMS_PER_TAG = 2
+
+// Cap on the unfiltered-tag companion query. 100 matches the BE's
+// per_page ceiling; realistic per-group tag counts (typically < 30)
+// sit comfortably below this. Groups with more than 100 tags will see
+// the Preview footer / inline duplicate-slug check truncate at the
+// hundredth — acceptable for v1; revisit if real groups exceed this.
+const ALL_TAGS_FETCH_LIMIT = 100
 
 function parseSort(raw: string | null): TagSortField {
   return (VALID_SORT_FIELDS as readonly string[]).includes(raw ?? "")
@@ -120,13 +146,91 @@ export function TagsListPage() {
       sort: urlSort,
       order: urlOrder,
       includeUsage: true,
-      perPage: 200,
+      // BE caps per_page at 100 (parsePagination); ask for the max so
+      // small/medium groups render in one page. Paging arrives in a
+      // follow-up if real groups exceed 100 tags.
+      perPage: 100,
       scope: scopeForTab(urlTab),
     }),
     [urlQuery, urlSort, urlOrder, urlTab]
   )
   const tagsQuery = useTags(listOpts)
+  // Unfiltered companion query — backs the duplicate-slug check inside
+  // the inline-create row and the Preview footer pill grid. Without it,
+  // both consumers see only the search-filtered (and paginated) slice
+  // and would (a) miss collisions for tags outside the current view
+  // and (b) shrink the pill grid down to the search results, which
+  // defeats the whole "all-tags palette" purpose of the footer.
+  const allTagsQuery = useTags(
+    useMemo(
+      () => ({
+        sort: "label" as TagSortField,
+        order: "asc" as TagSortOrder,
+        perPage: ALL_TAGS_FETCH_LIMIT,
+      }),
+      []
+    )
+  )
   const statsQuery = useTagStats()
+
+  // Commodities pull powers the per-row preview chips. We aggregate
+  // client-side because the BE doesn't expose a tag-filtered commodities
+  // index — same trade-off as #1531 area-count aggregation. The query
+  // is non-blocking: chips simply don't render until the data lands.
+  const previewCommoditiesQuery = useCommodities({
+    perPage: PREVIEW_COMMODITIES_LIMIT,
+    includeInactive: true,
+  })
+
+  const previewByTag = useMemo(() => {
+    const map = new Map<string, TagRowPreviewItem[]>()
+    const items = previewCommoditiesQuery.data?.commodities ?? []
+    for (const c of items) {
+      const slugs = (c.tags as string[] | undefined) ?? []
+      const display = c.short_name?.trim() || c.name?.trim() || ""
+      if (!display || !c.id) continue
+      for (const slug of slugs) {
+        if (!slug) continue
+        const bucket = map.get(slug)
+        if (bucket && bucket.length >= PREVIEW_ITEMS_PER_TAG) continue
+        const entry: TagRowPreviewItem = { id: c.id, name: display }
+        if (bucket) bucket.push(entry)
+        else map.set(slug, [entry])
+      }
+    }
+    return map
+  }, [previewCommoditiesQuery.data])
+
+  const createMutation = useCreateTag()
+  const updateMutation = useUpdateTag()
+  const deleteMutation = useDeleteTag()
+
+  const [dialog, setDialog] = useState<DialogState>({ open: false, mode: "create" })
+
+  const items = useMemo(() => tagsQuery.data?.tags ?? [], [tagsQuery.data])
+  const totalMatches = tagsQuery.data?.total ?? items.length
+  const isInitialLoading = tagsQuery.isLoading && !tagsQuery.data
+
+  const allTags = useMemo(
+    () => allTagsQuery.data?.tags?.map(({ tag }) => tag) ?? [],
+    [allTagsQuery.data]
+  )
+  // existingSlugs comes from the unfiltered tag set, not from `items`,
+  // so the duplicate-slug check inside the inline-create row catches
+  // collisions even when the search filter, scope tab, or perPage cap
+  // hides the existing tag from the current view.
+  const existingSlugs = useMemo(
+    () => new Set(allTags.map((tag) => tag.slug ?? "").filter(Boolean)),
+    [allTags]
+  )
+
+  function patchSort(value: string) {
+    const [field, order] = value.split(".") as [TagSortField, TagSortOrder]
+    const next = new URLSearchParams(searchParams)
+    next.set("sort", field)
+    next.set("order", order)
+    setSearchParams(next, { replace: true })
+  }
 
   function patchTab(next: string) {
     const tab = parseTab(next)
@@ -139,21 +243,15 @@ export function TagsListPage() {
     setSearchParams(params, { replace: true })
   }
 
-  const createMutation = useCreateTag()
-  const updateMutation = useUpdateTag()
-  const deleteMutation = useDeleteTag()
-
-  const [dialog, setDialog] = useState<DialogState>({ open: false, mode: "create" })
-
-  const items = tagsQuery.data?.tags ?? []
-  const isInitialLoading = tagsQuery.isLoading && !tagsQuery.data
-
-  function patchSort(value: string) {
-    const [field, order] = value.split(".") as [TagSortField, TagSortOrder]
-    const next = new URLSearchParams(searchParams)
-    next.set("sort", field)
-    next.set("order", order)
-    setSearchParams(next, { replace: true })
+  async function onInlineCreate(values: { label: string; slug: string; color: TagColor }) {
+    try {
+      await createMutation.mutateAsync(values)
+      toast.success(t("tags:form.createSuccess"))
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error(t("tags:form.createError", { error: message }))
+      throw err
+    }
   }
 
   async function onCreateSubmit(values: CreateTagRequest) {
@@ -178,8 +276,8 @@ export function TagsListPage() {
     }
   }
 
-  async function onDelete(tag: TagEntity & { id: string }, items: number, files: number) {
-    const inUse = items > 0 || files > 0
+  async function onDelete(tag: TagEntity & { id: string }, itemsCount: number, files: number) {
+    const inUse = itemsCount > 0 || files > 0
     if (!inUse) {
       const ok = await confirm({
         title: t("tags:removal.confirmTitle"),
@@ -206,7 +304,7 @@ export function TagsListPage() {
       title: t("tags:removal.inUseTitle"),
       description: t("tags:removal.inUseDescription", {
         label: tag.label,
-        items: t("tags:usage.items", { count: items }),
+        items: t("tags:usage.items", { count: itemsCount }),
         files: t("tags:usage.files", { count: files }),
       }),
       confirmLabel: t("tags:removal.forceAction"),
@@ -226,6 +324,24 @@ export function TagsListPage() {
     }
   }
 
+  // Both the count line and the Preview footer must reflect the
+  // server-reported total (not `items.length`, which is capped by
+  // perPage) and the unfiltered tag set (not the search/scope-filtered
+  // view).
+  const filteredCount = totalMatches
+  const allTagsForPreview = allTags
+
+  // emptyMessage picks the right key for the empty list — scope-aware
+  // when no search query is set so users on the commodity/file tab see
+  // a "no tags here yet for this scope" message rather than the
+  // generic empty state.
+  function emptyMessage(): string {
+    if (urlQuery) return t("tags:list.emptyFiltered", { query: urlQuery })
+    if (urlTab === "commodity") return t("tags:list.emptyScopeCommodity")
+    if (urlTab === "file") return t("tags:list.emptyScopeFile")
+    return t("tags:list.empty")
+  }
+
   // tabBody is the toolbar + list payload mounted inside the active
   // TabsContent. Defined once and referenced from all three tab panels
   // so each TabsTrigger has a real aria-controls target (Radix mounts
@@ -238,7 +354,7 @@ export function TagsListPage() {
             {t("tags:search.label")}
           </Label>
           <Search
-            className="absolute left-2 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+            className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
             aria-hidden="true"
           />
           <Input
@@ -247,16 +363,30 @@ export function TagsListPage() {
             value={pendingSearch}
             onChange={(e) => setPendingSearch(e.target.value)}
             placeholder={t("tags:search.placeholder")}
-            className="pl-8"
+            // Right padding reserves space for the absolute-positioned
+            // clear button when the input has a value, so typed text /
+            // the caret never collide with the X glyph.
+            className={cn("pl-8", pendingSearch ? "pr-8" : undefined)}
             data-testid="tags-search-input"
           />
+          {pendingSearch ? (
+            <button
+              type="button"
+              onClick={() => setPendingSearch("")}
+              aria-label={t("tags:search.clear")}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+              data-testid="tags-search-clear"
+            >
+              <X aria-hidden="true" className="size-3.5" />
+            </button>
+          ) : null}
         </div>
         <div className="flex flex-col gap-1.5">
           <Label
             htmlFor="tags-sort-select"
             className="text-xs uppercase tracking-wide text-muted-foreground"
           >
-            Sort
+            {t("tags:sort.label")}
           </Label>
           <select
             id="tags-sort-select"
@@ -265,21 +395,15 @@ export function TagsListPage() {
             value={`${urlSort}.${urlOrder}`}
             onChange={(e) => patchSort(e.target.value)}
           >
-            <option value="label.asc">A → Z</option>
-            <option value="label.desc">Z → A</option>
-            <option value="usage.desc">Most used</option>
-            <option value="created_at.desc">Newest</option>
+            <option value="label.asc">{t("tags:sort.labelAsc")}</option>
+            <option value="label.desc">{t("tags:sort.labelDesc")}</option>
+            <option value="usage.desc">{t("tags:sort.mostUsed")}</option>
+            <option value="created_at.desc">{t("tags:sort.newest")}</option>
           </select>
         </div>
       </div>
 
-      {isInitialLoading ? (
-        <div className="flex flex-col gap-2" data-testid="tags-list-loading">
-          {Array.from({ length: 4 }).map((_, idx) => (
-            <Skeleton key={idx} className="h-14 w-full" />
-          ))}
-        </div>
-      ) : tagsQuery.isError ? (
+      {tagsQuery.isError ? (
         <div
           className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive"
           role="alert"
@@ -289,48 +413,77 @@ export function TagsListPage() {
             error: tagsQuery.error instanceof Error ? tagsQuery.error.message : "unknown",
           })}
         </div>
-      ) : items.length === 0 ? (
-        <div
-          className="rounded-md border bg-muted/30 px-4 py-10 text-center text-sm text-muted-foreground"
-          data-testid="tags-list-empty"
-        >
-          {urlQuery
-            ? t("tags:list.emptyFiltered", { query: urlQuery })
-            : urlTab === "commodity"
-              ? t("tags:list.emptyScopeCommodity")
-              : urlTab === "file"
-                ? t("tags:list.emptyScopeFile")
-                : t("tags:list.empty")}
-        </div>
       ) : (
-        <ul className="flex flex-col gap-2" data-testid="tags-list">
-          {items.map(({ tag, usage }) => (
-            <li key={tag.id}>
-              <TagRow
-                tag={tag}
-                usage={usage}
-                onEdit={() =>
-                  setDialog({
-                    open: true,
-                    mode: "edit",
-                    tag,
-                  })
-                }
-                onDelete={() => onDelete(tag, usage?.commodities ?? 0, usage?.files ?? 0)}
-              />
-            </li>
-          ))}
-        </ul>
+        <div
+          className="rounded-xl border border-border bg-card overflow-hidden"
+          data-testid="tags-list-container"
+        >
+          <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+            <p
+              className="text-xs font-semibold uppercase tracking-widest text-muted-foreground"
+              data-testid="tags-list-count"
+            >
+              {urlQuery
+                ? t("tags:list.results", { count: filteredCount })
+                : t("tags:list.totalTags", { count: totalMatches })}
+            </p>
+          </div>
+
+          {isInitialLoading ? (
+            <div className="flex flex-col gap-2 p-4" data-testid="tags-list-loading">
+              {Array.from({ length: 4 }).map((_, idx) => (
+                <Skeleton key={idx} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : items.length === 0 ? (
+            <div
+              className="flex flex-col items-center justify-center gap-3 py-16 text-center"
+              data-testid="tags-list-empty"
+            >
+              <TagIcon aria-hidden="true" className="size-8 text-muted-foreground/30" />
+              <p className="text-sm text-muted-foreground">{emptyMessage()}</p>
+            </div>
+          ) : (
+            <ul className="divide-y divide-border" data-testid="tags-list">
+              {items.map(({ tag, usage }) => (
+                <li key={tag.id}>
+                  <TagRow
+                    tag={tag}
+                    usage={usage}
+                    previewItems={previewByTag.get(tag.slug ?? "") ?? []}
+                    onEdit={() =>
+                      setDialog({
+                        open: true,
+                        mode: "edit",
+                        tag,
+                      })
+                    }
+                    onDelete={() => onDelete(tag, usage?.commodities ?? 0, usage?.files ?? 0)}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <Separator />
+          <div className="px-4 py-3">
+            <TagInlineCreate
+              existingSlugs={existingSlugs}
+              onCreate={onInlineCreate}
+              isPending={createMutation.isPending}
+            />
+          </div>
+        </div>
       )}
     </div>
   )
 
   return (
-    <div className="flex flex-col gap-6 p-6" data-testid="page-tags">
+    <div className="flex flex-col gap-6 p-6 max-w-2xl mx-auto w-full" data-testid="page-tags">
       <header className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-col gap-1">
-          <h1 className="text-2xl font-semibold tracking-tight">{t("tags:title")}</h1>
-          <p className="max-w-prose text-sm text-muted-foreground">{t("tags:description")}</p>
+        <div>
+          <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">{t("tags:title")}</h1>
+          <p className="mt-1 text-muted-foreground">{t("tags:description")}</p>
         </div>
         <Button
           type="button"
@@ -377,6 +530,27 @@ export function TagsListPage() {
         </TabsContent>
       </Tabs>
 
+      {allTagsForPreview.length > 0 ? (
+        <div
+          className="rounded-xl border border-border bg-card px-4 py-4 space-y-3"
+          data-testid="tags-preview"
+        >
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+            {t("tags:preview.heading")}
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {allTagsForPreview.map((tag) => (
+              <TagBadge
+                key={tag.id}
+                label={tag.label ?? tag.slug ?? ""}
+                color={(tag.color ?? "muted") as TagColor}
+                testId={`tags-preview-${tag.slug}`}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
       <TagFormDialog
         open={dialog.open}
         onOpenChange={(open) =>
@@ -400,6 +574,3 @@ export function TagsListPage() {
     </div>
   )
 }
-
-// Re-exports below are intentionally minimal: the page is consumed only
-// by the router. Tests import named pieces from features/tags directly.

--- a/frontend/src/pages/tags/__tests__/TagsListPage.test.tsx
+++ b/frontend/src/pages/tags/__tests__/TagsListPage.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { axe } from "jest-axe"
+import { http, HttpResponse } from "msw"
 import { Route } from "react-router-dom"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 
@@ -11,7 +12,7 @@ import { clearAuth, setAccessToken } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
 import { TagsListPage } from "@/pages/tags/TagsListPage"
-import { groupHandlers, tagHandlers } from "@/test/handlers"
+import { commodityHandlers, groupHandlers, tagHandlers } from "@/test/handlers"
 import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
 import type { Schema } from "@/types"
@@ -52,9 +53,26 @@ function renderPage() {
   })
 }
 
+// One commodity tagged with "kitchen" so the row's preview-chip path
+// renders. The Tags page client-side aggregates commodities into a
+// `slug → [items]` map, so we need at least one row that references the
+// tag fixture below.
+const commodityFixture = [
+  {
+    id: "c1",
+    type: "commodities",
+    attributes: {
+      name: "Espresso machine",
+      short_name: "Espresso",
+      tags: ["kitchen"],
+    },
+  },
+]
+
 function seed() {
   server.use(
     ...groupHandlers.list(groupFixture),
+    ...commodityHandlers.list(SLUG, commodityFixture),
     ...tagHandlers.stats(SLUG, {
       tags_total: 2,
       items_tagged: 5,
@@ -98,6 +116,23 @@ describe("<TagsListPage />", () => {
     expect(screen.getByTestId("tag-row-garden-usage")).toHaveTextContent(/Not used yet/i)
   })
 
+  it("renders a tag preview footer card with all tag pills", async () => {
+    seed()
+    renderPage()
+    expect(await screen.findByTestId("tags-preview")).toBeVisible()
+    expect(screen.getByTestId("tags-preview-kitchen")).toBeInTheDocument()
+    expect(screen.getByTestId("tags-preview-garden")).toBeInTheDocument()
+  })
+
+  it("renders item-preview chips for tags with usage", async () => {
+    seed()
+    renderPage()
+    // The Tags page pulls /commodities once, builds a slug→items map and
+    // surfaces up to 2 names + an overflow count on each row.
+    const preview = await screen.findByTestId("tag-row-kitchen-preview")
+    expect(preview).toHaveTextContent("Espresso")
+  })
+
   it("opens the create dialog from the CTA", async () => {
     seed()
     const user = userEvent.setup()
@@ -105,6 +140,98 @@ describe("<TagsListPage />", () => {
     await screen.findByTestId("tag-row-kitchen")
     await user.click(screen.getByTestId("tags-create-button"))
     expect(await screen.findByTestId("tag-form-dialog")).toBeVisible()
+  })
+
+  it("expands the inline create row when the toggle is clicked", async () => {
+    seed()
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId("tag-row-kitchen")
+    await user.click(screen.getByTestId("tags-inline-create-toggle"))
+    expect(await screen.findByTestId("tags-inline-create")).toBeVisible()
+    expect(screen.getByTestId("tags-inline-create-label")).toBeVisible()
+    expect(screen.getByTestId("tags-inline-create-save")).toBeVisible()
+  })
+
+  it("clears the search input when the clear button is clicked", async () => {
+    seed()
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId("tag-row-kitchen")
+    await user.type(screen.getByTestId("tags-search-input") as HTMLInputElement, "kitchen")
+    // The clear button only mounts when the input has a value — its
+    // appearance proves the conditional render path; clicking it
+    // exercises the setPendingSearch("") branch.
+    const clear = await screen.findByTestId("tags-search-clear")
+    await user.click(clear)
+    // Re-query the input after the click — the URL-debounce effect can
+    // cause the Tabs subtree to re-render, which can detach the
+    // pre-click element reference even though the visible DOM still
+    // shows the new state.
+    await waitFor(() => {
+      const fresh = screen.getByTestId("tags-search-input") as HTMLInputElement
+      expect(fresh.value).toBe("")
+    })
+  })
+
+  it("rewrites the sort field/order when the sort dropdown changes", async () => {
+    seed()
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId("tag-row-kitchen")
+    const select = screen.getByTestId("tags-sort") as HTMLSelectElement
+    expect(select.value).toBe("label.asc")
+    await user.selectOptions(select, "usage.desc")
+    // The select's value tracks `${urlSort}.${urlOrder}`; after
+    // `patchSort` writes to the URL via `useSearchParams`, the
+    // component re-renders with the new value.
+    await waitFor(() => expect(select.value).toBe("usage.desc"))
+  })
+
+  it("submits a new tag through the inline create row", async () => {
+    seed()
+    server.use(
+      ...tagHandlers.create(SLUG, {
+        id: "t3",
+        slug: "office",
+        label: "Office",
+        color: "blue",
+      })
+    )
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId("tag-row-kitchen")
+    await user.click(screen.getByTestId("tags-inline-create-toggle"))
+    const labelInput = await screen.findByTestId("tags-inline-create-label")
+    await user.type(labelInput, "Office")
+    await user.click(screen.getByTestId("tags-inline-create-save"))
+    // POST /tags landed when the input is cleared and the picker resets
+    // to the default colour — both happen inside the success branch of
+    // onInlineCreate.
+    await waitFor(() => {
+      expect((labelInput as HTMLInputElement).value).toBe("")
+    })
+  })
+
+  it("renders the error block when /tags returns 500", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...commodityHandlers.list(SLUG, []),
+      ...tagHandlers.stats(SLUG, {
+        tags_total: 0,
+        items_tagged: 0,
+        items_untagged: 0,
+        files_tagged: 0,
+        files_untagged: 0,
+      }),
+      // Override the list factory with a 500 so `tagsQuery.isError`
+      // flips and the destructive alert renders in place of the list.
+      http.get(`${window.location.origin}/api/v1/g/${SLUG}/tags`, () =>
+        HttpResponse.json({ error: "boom" }, { status: 500 })
+      )
+    )
+    renderPage()
+    expect(await screen.findByTestId("tags-list-error")).toBeVisible()
   })
 
   it("is axe-clean once data has loaded", async () => {


### PR DESCRIPTION
Closes #1539.

Ports the design-audit follow-ups from [#1527](https://github.com/denisvmedia/inventario/issues/1527) onto the Tags page, matching [`design-mocks/src/views/TagsView.tsx`](https://github.com/denisvmedia/inventario/blob/master/design-mocks/src/views/TagsView.tsx).

## Summary

- **Row redesign** (`TagRow.tsx`) — leading color dot (`size-2.5 rounded-full bg-tag-*`), `# {label}` with usage count beneath, up to two item-preview chips with a `+N` overflow, edit/delete affordances reveal only on row hover.
- **TagBadge** gains an optional `Hash` glyph (`hashed`, default on) and exports a shared `TAG_DOT_TONE` map for the row indicator dot.
- **Page wrapper** — `max-w-2xl mx-auto w-full` to match the mock; list now sits inside a `rounded-xl border bg-card` shell with an overline-row count header.
- **Inline `+ New tag` fast path** — additive, label-only with auto-derived slug, Enter saves / Esc cancels. The full slug+label dialog stays as the canonical edit surface (header "Add tag" + per-row edit).
- **Preview footer card** — renders every tag as a `<TagBadge hashed>` pill for a quick at-a-glance palette check.
- **Stats bar** restyled with the mock's icon-headed mini-card pattern (still five tiles — files split kept; logged as a deviation).
- **Catch-all** pass: search field gains an `X` clear button + i18n keys, sort dropdown copy moved to i18n, empty state uses the mock's `<Tag>` icon-only inline pattern.

Item-preview chips aggregate client-side from a single `useCommodities({ perPage: 500, includeInactive: true })` call (BE has no tag-filtered commodities index — same trade-off as #1531's area aggregation). Overflow count uses the authoritative `usage.commodities` so the figure stays correct even when a tagged item sits past the 500-row window.

### Preserved (not regressed to mock)

- `TagFormDialog` with separate **`slug` + `label`** fields stays. The mock's single-string flow would force label→slug normalisation on every edit and silently break commodity/file JSONB references. Inline create only handles the fast path where label and slug coincide. Logged in `devdocs/frontend/design-deviations.md`.

## New testids

`tag-row-${slug}-dot`, `tag-row-${slug}-preview`, `tags-list-container`, `tags-list-count`, `tags-preview`, `tags-preview-${slug}`, `tags-search-clear`, `tags-inline-create-toggle`, `tags-inline-create`, `tags-inline-create-label`, `tags-inline-create-color(-${color})`, `tags-inline-create-save`, `tags-inline-create-cancel`, `tags-inline-create-error`.

Existing testids consumed by `e2e/tests/tags.spec.ts` (`page-tags`, `tags-stats-*`, `tags-create-button`, `tag-form-*`, `tag-row-${slug}{,-edit,-delete,-usage}`, `confirm-dialog`, `confirm-accept`) are preserved.

## New i18n keys (en)

`tags:inlineCreate.{toggle,placeholder,save,cancel}`, `tags:list.results_one/_other`, `tags:list.totalTags_one/_other`, `tags:preview.heading`, `tags:search.clear`, `tags:sort.{label,labelAsc,labelDesc,mostUsed,newest}`, `tags:validation.duplicateSlug`.

## Design deviations logged

Appended to `devdocs/frontend/design-deviations.md` in a new `### Tags` section:

1. **TagFormDialog preserved** alongside inline create (slug+label decoupling for BE reference integrity).
2. **Five-tile stats bar** (kept files-tagged/untagged where mock shows three).
3. **Client-side preview-chip aggregation** (no BE tag-filter on commodities).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run i18n:check` — extractor finds every key; the `tags.json` diff in this PR is the new entries
- [x] `npm test` — 833 pass / 4 skipped (added 4 new TagsListPage tests + 2 new TagBadge tests)
- [ ] CI green (Playwright `tags.spec.ts` exercises the preserved testid surface)
- [ ] Visual review against mock (offered post-merge by `screenshot-review` skill)