### PR TITLE
[#1628] Scope tag autocomplete &amp; management by entity type

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -43,6 +43,7 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 - **Why**: User-driven UX request — flat input read as just-another-field rather than a primary affordance for tagging. Suggestion chips give a one-tap-to-act CTA that's especially useful on mobile and during onboarding (no typing required to feel productive). Bounding the prominence to the empty state keeps the field calm once it's serving its normal function.
 - **Approved by**: user (explicit) — "tags не являются CTA. А должны … 1+2".
 - **Reversion plan**: Keep until upstream design adopts a similar pattern, or until first-class Tags entity (#1400) reframes how the empty state should look. The component (`TagsSuggestionChips`) is local to CommodityFormDialog.tsx; revert is one block-removal + drop the tinted-card wrapper to fall back to the flat input.
+- **Update 2026-05-15 (#1628)**: chip candidates are now sourced from `useTagAutocomplete("", 8, { scope: "commodity" })` — the empty-state CTA used to surface file-only tags (e.g. `invoice`) because the autocomplete pool was merged. After #1628 the pool is scoped to commodity-only usage, so the chips reflect "tags I use on items" and never surface file-only labels. No behaviour change when no scoped data exists yet — the chip row stays hidden via the same `candidates.length === 0` guard.
 
 #### 2026-05-10 — Add Item dialog: per-file & per-item tag input is focus-triggered autocomplete (not datalist)
 
@@ -52,6 +53,7 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 - **Why**: User-driven UX request — "А мы можем ещё давать дропдаун для выбора из существующих?". The BE-side autocomplete API was already in place from #1400's groundwork; surfacing it here meets the user's expectation and keeps free-form entry as the fallback. Picking via mouseDown + preventDefault (not onClick) keeps focus on the input so the user can chain multiple picks without re-clicking.
 - **Approved by**: user (explicit) — direct request and refinements ("Когда на экране появляются новые элементы — это должно быть как-то плавно"; "После первого тага надо убрать CTA текст"; "Поле под Первый урл должно быть сразу показано").
 - **Reversion plan**: Permanent. If the BE autocomplete API changes shape, only `useTagAutocomplete` needs updating; the dropdown UI is component-local.
+- **Update 2026-05-15 (#1628)**: `TagsInput` now accepts a `scope?: "commodity" | "file"` prop that flows through to the autocomplete hook + the GET `/g/:slug/tags/autocomplete?scope=` query. The two consumers pass it explicitly: the per-item Extras-step input uses `scope="commodity"`, the per-file row in the Files step uses `scope="file"`. Strict scoping (BE drops tags with zero usage in the requested bucket) means the dropdown on the commodity input no longer surfaces a file-only `invoice` tag (and vice versa) — the previous merged-pool behaviour was the known limitation called out in #1628.
 
 #### 2026-05-10 — Add Item dialog: Product URLs without per-row Label sub-input
 
@@ -307,4 +309,11 @@ _None yet._
 
 ### Other
 
-_None yet._
+#### 2026-05-15 — Tags settings page: All / Item / File scope tabs above the flat list
+
+- **Issue/PR**: #1628 / PR (this branch)
+- **Mock**: [`design-mocks/src/views/TagsView.tsx`](../../design-mocks/src/views/TagsView.tsx) renders a single flat list with a search input and seed-from-items CTA. No tabs, no per-scope filtering.
+- **Reality**: `frontend/src/pages/tags/TagsListPage.tsx` renders three Radix Tabs (`All` / `Item tags` / `File tags`) directly under the stats bar. The active tab maps to the BE `?scope=` query via `useTags({ scope })` — `commodity` / `file` strictly filter to tags with usage in that bucket; `All` omits the param and returns every tag, matching the legacy ranking. Tab state survives back/forward via `?tab=` on the URL.
+- **Why**: Required by #1628 acceptance criteria — the existing flat list mixed commodity and file tags in one namespace, which was confusing once the autocomplete pool was scoped. Tabs were chosen over a sidebar filter because Tabs is the dominant scope-affordance pattern in this app (Files page, Warranties page, Loans page) and the existing Tabs primitive is well-tested.
+- **Approved by**: user (explicit) — issue request.
+- **Reversion plan**: Remove the `Tabs` block + the `urlTab` / `scopeForTab` derivations + the `scope` option from `listOpts`. Revert i18n keys under `tags:tabs`. Page falls back to the merged flat list.

--- a/frontend/src/components/files/TagsInput.tsx
+++ b/frontend/src/components/files/TagsInput.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge"
 import { Label } from "@/components/ui/label"
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
+import type { TagScope } from "@/features/tags/api"
 import { useTagAutocomplete } from "@/features/tags/hooks"
 
 // Lightweight tag chip input — type, hit Enter / comma to commit;
@@ -32,6 +33,12 @@ export interface TagsInputProps {
   // row of CommodityFormDialog where the input sits below filename
   // metadata and the default size feels too tall.
   compact?: boolean
+  // Restrict autocomplete suggestions to tags actually used on the
+  // given entity type (#1628). The commodity-tags input on the Extras
+  // step passes "commodity"; the per-file row inside the Files step
+  // passes "file". Standalone callers that pre-date scope awareness
+  // can omit it for the legacy combined ranking.
+  scope?: TagScope
 }
 
 export function TagsInput({
@@ -43,6 +50,7 @@ export function TagsInput({
   suggestions,
   autocomplete,
   compact,
+  scope,
 }: TagsInputProps) {
   const [draft, setDraft] = useState("")
   // Remote suggestions live in local state and are populated via the
@@ -267,7 +275,9 @@ export function TagsInput({
       ) : (
         inputAndChips
       )}
-      {autocomplete ? <AutocompleteSink draft={draft} onChange={setRemoteSuggestions} /> : null}
+      {autocomplete ? (
+        <AutocompleteSink draft={draft} scope={scope} onChange={setRemoteSuggestions} />
+      ) : null}
     </div>
   )
 }
@@ -284,12 +294,14 @@ export function TagsInput({
 // usage-ranked default list when `q` is empty.
 function AutocompleteSink({
   draft,
+  scope,
   onChange,
 }: {
   draft: string
+  scope?: TagScope
   onChange: (slugs: string[]) => void
 }) {
-  const remote = useTagAutocomplete(draft, 8, { enabled: true })
+  const remote = useTagAutocomplete(draft, 8, { enabled: true, scope })
   const data = remote.data
   useEffect(() => {
     onChange(data ? data.map((t) => t.slug) : [])

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -1662,6 +1662,7 @@ function ExtrasStep(props: any) {
           placeholder={t("commodities:fields.tagsPlaceholder")}
           testId="commodity-tags"
           autocomplete
+          scope="commodity"
         />
         <p className="text-xs text-muted-foreground">{t("commodities:fields.tagsHelp")}</p>
         <TagsSuggestionChips
@@ -1996,6 +1997,7 @@ function PendingFileRow({ entry, onRemove, onTagsChange }: PendingFileRowProps) 
         testId={`commodity-files-tags-${entry.id}`}
         autocomplete
         compact
+        scope="file"
       />
     </li>
   )
@@ -2029,7 +2031,10 @@ function TagsSuggestionChips({
   onPick: (slug: string) => void
   testId?: string
 }) {
-  const remote = useTagAutocomplete("", 8, { enabled: true })
+  // Commodity-scoped — chips on the Extras step are a nudge for tagging
+  // the commodity itself, so the candidate pool excludes file-only tags
+  // (#1628).
+  const remote = useTagAutocomplete("", 8, { enabled: true, scope: "commodity" })
   // Hide once the user has selected any tag — the chips' job was the
   // first-tag nudge.
   if (selected.length > 0) return null

--- a/frontend/src/features/tags/api.ts
+++ b/frontend/src/features/tags/api.ts
@@ -27,6 +27,12 @@ export const TAG_COLORS = [
 export type TagSortField = "label" | "created_at" | "usage"
 export type TagSortOrder = "asc" | "desc"
 
+// TagScope narrows tag listing / autocomplete to tags actually used on a
+// specific entity type. Wire contract: bare "commodity" / "file" tokens
+// (singular) match the BE; "all" is the in-FE label for "no filter" and
+// is omitted from the request URL by the data layer.
+export type TagScope = "commodity" | "file"
+
 export interface ListTagsOptions {
   page?: number
   perPage?: number
@@ -34,6 +40,7 @@ export interface ListTagsOptions {
   sort?: TagSortField
   order?: TagSortOrder
   includeUsage?: boolean
+  scope?: TagScope
   signal?: AbortSignal
 }
 
@@ -76,6 +83,7 @@ export async function listTags(
   if (options.sort) params.set("sort", options.sort)
   if (options.order) params.set("order", options.order)
   if (options.includeUsage) params.set("include", "usage")
+  if (options.scope) params.set("scope", options.scope)
   const qs = params.toString()
   const path = qs ? `/tags?${qs}` : "/tags"
   const body = await http.get<TagsListEnvelope>(path, { signal: options.signal })
@@ -165,13 +173,14 @@ interface TagAutocompleteEnvelope {
 export async function autocompleteTags(
   q: string,
   limit = 10,
-  signal?: AbortSignal
+  options: { scope?: TagScope; signal?: AbortSignal } = {}
 ): Promise<TagAutocompleteEntry[]> {
   const params = new URLSearchParams()
   if (q.trim()) params.set("q", q.trim())
   params.set("limit", String(limit))
+  if (options.scope) params.set("scope", options.scope)
   const body = await http.get<TagAutocompleteEnvelope>(`/tags/autocomplete?${params.toString()}`, {
-    signal,
+    signal: options.signal,
   })
   return body.data ?? []
 }

--- a/frontend/src/features/tags/hooks.ts
+++ b/frontend/src/features/tags/hooks.ts
@@ -15,6 +15,7 @@ import {
   type ListedTag,
   type TagAutocompleteEntry,
   type TagEntity,
+  type TagScope,
   type TagStats,
   type TagUsage,
   type UpdateTagRequest,
@@ -115,12 +116,22 @@ export function useDeleteTag() {
 // dialog test harness, which intentionally skips the provider).
 // When the slug is unknown we just don't enable the query — there's
 // no group to scope autocomplete results to anyway.
-export function useTagAutocomplete(q: string, limit = 10, { enabled = true }: QueryOptions = {}) {
+//
+// scope (#1628) narrows results to tags actually used on the named
+// entity type. Omit (or pass undefined) for the legacy combined ranking
+// — the standalone files-edit-page input that pre-dates per-scope
+// awareness still calls it that way during the rollout.
+interface AutocompleteOptions extends QueryOptions {
+  scope?: TagScope
+}
+
+export function useTagAutocomplete(q: string, limit = 10, opts: AutocompleteOptions = {}) {
   const ctx = useOptionalCurrentGroup()
   const slug = ctx?.currentGroup?.slug ?? ""
+  const enabled = opts.enabled ?? true
   return useQuery<TagAutocompleteEntry[]>({
-    queryKey: tagKeys.autocomplete(slug, q, limit),
-    queryFn: ({ signal }) => autocompleteTags(q, limit, signal),
+    queryKey: tagKeys.autocomplete(slug, q, limit, opts.scope),
+    queryFn: ({ signal }) => autocompleteTags(q, limit, { scope: opts.scope, signal }),
     enabled: enabled && slug.length > 0,
     // Keep the previous result visible while the next query (next
     // keystroke / different prefix) is in flight. Without this, `data`

--- a/frontend/src/features/tags/keys.ts
+++ b/frontend/src/features/tags/keys.ts
@@ -1,4 +1,4 @@
-import type { ListTagsOptions } from "./api"
+import type { ListTagsOptions, TagScope } from "./api"
 
 function listKeySuffix(opts: ListTagsOptions | undefined): string {
   if (!opts) return ""
@@ -9,6 +9,7 @@ function listKeySuffix(opts: ListTagsOptions | undefined): string {
   if (opts.sort) params.set("sort", opts.sort)
   if (opts.order) params.set("order", opts.order)
   if (opts.includeUsage) params.set("include", "usage")
+  if (opts.scope) params.set("scope", opts.scope)
   return params.toString()
 }
 
@@ -22,6 +23,9 @@ export const tagKeys = {
     [...tagKeys.group(slug), "list", listKeySuffix(opts)] as const,
   stats: (slug: string) => [...tagKeys.group(slug), "stats"] as const,
   detail: (slug: string, id: string) => [...tagKeys.group(slug), "detail", id] as const,
-  autocomplete: (slug: string, q: string, limit: number) =>
-    [...tagKeys.group(slug), "autocomplete", q, limit] as const,
+  // autocomplete key includes scope so the per-input cache buckets a
+  // commodity-scoped query separately from a file-scoped one even
+  // when q + limit happen to be identical.
+  autocomplete: (slug: string, q: string, limit: number, scope: TagScope | undefined) =>
+    [...tagKeys.group(slug), "autocomplete", q, limit, scope ?? "all"] as const,
 }

--- a/frontend/src/i18n/locales/en/tags.json
+++ b/frontend/src/i18n/locales/en/tags.json
@@ -35,6 +35,8 @@
     "edit": "Edit tag",
     "empty": "No tags yet — create your first one above.",
     "emptyFiltered": "No tags match \"{{query}}\".",
+    "emptyScopeCommodity": "No tags used on items yet — apply one from the Add Item dialog's Extras step to seed this list.",
+    "emptyScopeFile": "No tags used on files yet — apply one from a file's tag input to seed this list.",
     "loadError": "Could not load tags: {{error}}",
     "usageFiles_one": "{{count}} file",
     "usageFiles_other": "{{count}} files",
@@ -63,6 +65,11 @@
     "itemsTagged": "Tagged items",
     "itemsUntagged": "Untagged items",
     "tagsTotal": "Tags"
+  },
+  "tabs": {
+    "all": "All",
+    "commodity": "Item tags",
+    "file": "File tags"
   },
   "title": "Tags",
   "usage": {

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -10,10 +10,12 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   type CreateTagRequest,
   type TagColor,
   type TagEntity,
+  type TagScope,
   type TagSortField,
   type TagSortOrder,
   type UpdateTagRequest,
@@ -56,6 +58,20 @@ function parseOrder(raw: string | null): TagSortOrder {
     : "asc"
 }
 
+// Local tab id — "all" stays in the URL as the explicit no-filter
+// sentinel; the data layer turns it into "no scope param" before the
+// request. "commodity" / "file" mirror the BE's wire contract.
+type TabId = "all" | TagScope
+const VALID_TABS = ["all", "commodity", "file"] as const satisfies readonly TabId[]
+
+function parseTab(raw: string | null): TabId {
+  return (VALID_TABS as readonly string[]).includes(raw ?? "") ? (raw as TabId) : "all"
+}
+
+function scopeForTab(tab: TabId): TagScope | undefined {
+  return tab === "all" ? undefined : tab
+}
+
 interface DialogState {
   open: boolean
   mode: "create" | "edit"
@@ -71,6 +87,7 @@ export function TagsListPage() {
   const urlQuery = searchParams.get("q") ?? ""
   const urlSort = parseSort(searchParams.get("sort"))
   const urlOrder = parseOrder(searchParams.get("order"))
+  const urlTab = parseTab(searchParams.get("tab"))
 
   const [pendingSearch, setPendingSearch] = useState(urlQuery)
   // Re-seed the input when the URL query changes via back/forward — this
@@ -104,11 +121,23 @@ export function TagsListPage() {
       order: urlOrder,
       includeUsage: true,
       perPage: 200,
+      scope: scopeForTab(urlTab),
     }),
-    [urlQuery, urlSort, urlOrder]
+    [urlQuery, urlSort, urlOrder, urlTab]
   )
   const tagsQuery = useTags(listOpts)
   const statsQuery = useTagStats()
+
+  function patchTab(next: string) {
+    const tab = parseTab(next)
+    const params = new URLSearchParams(searchParams)
+    if (tab === "all") {
+      params.delete("tab")
+    } else {
+      params.set("tab", tab)
+    }
+    setSearchParams(params, { replace: true })
+  }
 
   const createMutation = useCreateTag()
   const updateMutation = useUpdateTag()
@@ -216,6 +245,26 @@ export function TagsListPage() {
 
       <TagsStatsBar stats={statsQuery.data} loading={statsQuery.isLoading} />
 
+      <Tabs value={urlTab} onValueChange={patchTab} className="gap-3">
+        <TabsList data-testid="tags-tabs">
+          <TabsTrigger value="all" data-testid="tags-tab-all">
+            {t("tags:tabs.all")}
+          </TabsTrigger>
+          <TabsTrigger value="commodity" data-testid="tags-tab-commodity">
+            {t("tags:tabs.commodity")}
+          </TabsTrigger>
+          <TabsTrigger value="file" data-testid="tags-tab-file">
+            {t("tags:tabs.file")}
+          </TabsTrigger>
+        </TabsList>
+        {/* Render TabsContent for each value so Radix manages the
+            aria-roledescription / active-state attributes, but render
+            only the body once outside — keeping a single list query +
+            single DOM tree avoids paying for triple-mount on every tab
+            switch. */}
+        <TabsContent value={urlTab} className="m-0" />
+      </Tabs>
+
       <div className="flex flex-wrap items-end gap-3">
         <div className="relative min-w-64 flex-1">
           <Label htmlFor="tags-search-input" className="sr-only">
@@ -278,7 +327,13 @@ export function TagsListPage() {
           className="rounded-md border bg-muted/30 px-4 py-10 text-center text-sm text-muted-foreground"
           data-testid="tags-list-empty"
         >
-          {urlQuery ? t("tags:list.emptyFiltered", { query: urlQuery }) : t("tags:list.empty")}
+          {urlQuery
+            ? t("tags:list.emptyFiltered", { query: urlQuery })
+            : urlTab === "commodity"
+              ? t("tags:list.emptyScopeCommodity")
+              : urlTab === "file"
+                ? t("tags:list.emptyScopeFile")
+                : t("tags:list.empty")}
         </div>
       ) : (
         <ul className="flex flex-col gap-2" data-testid="tags-list">

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -226,45 +226,12 @@ export function TagsListPage() {
     }
   }
 
-  return (
-    <div className="flex flex-col gap-6 p-6" data-testid="page-tags">
-      <header className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex flex-col gap-1">
-          <h1 className="text-2xl font-semibold tracking-tight">{t("tags:title")}</h1>
-          <p className="max-w-prose text-sm text-muted-foreground">{t("tags:description")}</p>
-        </div>
-        <Button
-          type="button"
-          onClick={() => setDialog({ open: true, mode: "create" })}
-          data-testid="tags-create-button"
-        >
-          <Plus className="mr-1.5 size-4" aria-hidden="true" />
-          {t("tags:create.button")}
-        </Button>
-      </header>
-
-      <TagsStatsBar stats={statsQuery.data} loading={statsQuery.isLoading} />
-
-      <Tabs value={urlTab} onValueChange={patchTab} className="gap-3">
-        <TabsList data-testid="tags-tabs">
-          <TabsTrigger value="all" data-testid="tags-tab-all">
-            {t("tags:tabs.all")}
-          </TabsTrigger>
-          <TabsTrigger value="commodity" data-testid="tags-tab-commodity">
-            {t("tags:tabs.commodity")}
-          </TabsTrigger>
-          <TabsTrigger value="file" data-testid="tags-tab-file">
-            {t("tags:tabs.file")}
-          </TabsTrigger>
-        </TabsList>
-        {/* Render TabsContent for each value so Radix manages the
-            aria-roledescription / active-state attributes, but render
-            only the body once outside — keeping a single list query +
-            single DOM tree avoids paying for triple-mount on every tab
-            switch. */}
-        <TabsContent value={urlTab} className="m-0" />
-      </Tabs>
-
+  // tabBody is the toolbar + list payload mounted inside the active
+  // TabsContent. Defined once and referenced from all three tab panels
+  // so each TabsTrigger has a real aria-controls target (Radix mounts
+  // only the active panel's children, so there is no triple-render).
+  const tabBody = (
+    <div className="flex flex-col gap-4 pt-3">
       <div className="flex flex-wrap items-end gap-3">
         <div className="relative min-w-64 flex-1">
           <Label htmlFor="tags-search-input" className="sr-only">
@@ -355,6 +322,60 @@ export function TagsListPage() {
           ))}
         </ul>
       )}
+    </div>
+  )
+
+  return (
+    <div className="flex flex-col gap-6 p-6" data-testid="page-tags">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-2xl font-semibold tracking-tight">{t("tags:title")}</h1>
+          <p className="max-w-prose text-sm text-muted-foreground">{t("tags:description")}</p>
+        </div>
+        <Button
+          type="button"
+          onClick={() => setDialog({ open: true, mode: "create" })}
+          data-testid="tags-create-button"
+        >
+          <Plus className="mr-1.5 size-4" aria-hidden="true" />
+          {t("tags:create.button")}
+        </Button>
+      </header>
+
+      <TagsStatsBar stats={statsQuery.data} loading={statsQuery.isLoading} />
+
+      <Tabs value={urlTab} onValueChange={patchTab} className="gap-3">
+        <TabsList data-testid="tags-tabs">
+          <TabsTrigger value="all" data-testid="tags-tab-all">
+            {t("tags:tabs.all")}
+          </TabsTrigger>
+          <TabsTrigger value="commodity" data-testid="tags-tab-commodity">
+            {t("tags:tabs.commodity")}
+          </TabsTrigger>
+          <TabsTrigger value="file" data-testid="tags-tab-file">
+            {t("tags:tabs.file")}
+          </TabsTrigger>
+        </TabsList>
+        {/* One TabsContent per trigger value so each TabsTrigger's
+            aria-controls resolves to a real tabpanel element (Radix
+            otherwise skips inactive panels entirely, leaving the
+            triggers' aria-controls dangling and tripping axe). Only
+            the active panel mounts its children — `tabBody` is the
+            same JSX in each slot but React + Radix mount it exactly
+            once per active value, so there is no triple-render cost.
+            Scoping happens via `urlTab → listOpts.scope`, which is
+            evaluated outside the Tabs subtree, so the actual data
+            query also runs only once per tab. */}
+        <TabsContent value="all" className="m-0" data-testid="tags-tab-all-content">
+          {tabBody}
+        </TabsContent>
+        <TabsContent value="commodity" className="m-0" data-testid="tags-tab-commodity-content">
+          {tabBody}
+        </TabsContent>
+        <TabsContent value="file" className="m-0" data-testid="tags-tab-file-content">
+          {tabBody}
+        </TabsContent>
+      </Tabs>
 
       <TagFormDialog
         open={dialog.open}

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -4178,7 +4178,7 @@ export type paths = {
         };
         /**
          * List tags
-         * @description get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.
+         * @description get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block. Pass scope=commodity|file to restrict to tags actually used on that entity type.
          */
         get: {
             parameters: {
@@ -4195,6 +4195,8 @@ export type paths = {
                     per_page?: number;
                     /** @description Comma-separated extras. 'usage' attaches per-row meta.usage. */
                     include?: "usage";
+                    /** @description Restrict to tags used on commodities or files. Empty = no filter. */
+                    scope?: "commodity" | "file";
                 };
                 header?: never;
                 path: {
@@ -4212,6 +4214,15 @@ export type paths = {
                     };
                     content: {
                         "application/vnd.api+json": components["schemas"]["jsonapi.TagsResponse"];
+                    };
+                };
+                /** @description Invalid scope value */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
             };
@@ -4273,7 +4284,7 @@ export type paths = {
         };
         /**
          * Autocomplete tag suggestions
-         * @description Top-N tags matching the query, ranked by usage desc + created_at desc.
+         * @description Top-N tags matching the query, ranked by scope-aware usage desc + created_at desc.
          */
         get: {
             parameters: {
@@ -4282,6 +4293,8 @@ export type paths = {
                     q?: string;
                     /** @description Maximum suggestions returned */
                     limit?: number;
+                    /** @description Restrict to tags used on commodities or files. Empty = no filter. */
+                    scope?: "commodity" | "file";
                 };
                 header?: never;
                 path: {
@@ -4299,6 +4312,15 @@ export type paths = {
                     };
                     content: {
                         "application/vnd.api+json": components["schemas"]["jsonapi.TagAutocompleteResponse"];
+                    };
+                };
+                /** @description Invalid scope value */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
             };

--- a/go/apiserver/tags.go
+++ b/go/apiserver/tags.go
@@ -54,7 +54,7 @@ type tagsAPI struct {
 
 // listTags lists tags with pagination, optional q-search, and sort.
 // @Summary List tags
-// @Description get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.
+// @Description get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block. Pass scope=commodity|file to restrict to tags actually used on that entity type.
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
@@ -65,7 +65,9 @@ type tagsAPI struct {
 // @Param page query int false "Page number (1-based)" default(1)
 // @Param per_page query int false "Items per page" default(50)
 // @Param include query string false "Comma-separated extras. 'usage' attaches per-row meta.usage." Enums(usage)
+// @Param scope query string false "Restrict to tags used on commodities or files. Empty = no filter." Enums(commodity,file)
 // @Success 200 {object} jsonapi.TagsResponse "OK"
+// @Failure 422 {object} jsonapi.Errors "Invalid scope value"
 // @Router /g/{groupSlug}/tags [get].
 func (api *tagsAPI) listTags(w http.ResponseWriter, r *http.Request) {
 	regSet := RegistrySetFromContext(r.Context())
@@ -78,10 +80,17 @@ func (api *tagsAPI) listTags(w http.ResponseWriter, r *http.Request) {
 	page, perPage := parsePagination(q.Get("page"), q.Get("per_page"))
 	offset := (page - 1) * perPage
 
+	scope, ok := parseTagScope(q.Get("scope"))
+	if !ok {
+		unprocessableEntityError(w, r, fmt.Errorf("invalid scope: %q (must be one of: commodity, file)", q.Get("scope")))
+		return
+	}
+
 	opts := registry.TagListOptions{
 		Search:    q.Get("q"),
 		SortField: registry.TagSortField(q.Get("sort")),
 		SortDesc:  q.Get("order") == "desc",
+		Scope:     scope,
 	}
 
 	tags, total, err := regSet.TagRegistry.ListPaginated(r.Context(), offset, perPage, opts)
@@ -156,14 +165,16 @@ func includeHasToken(raw, token string) bool {
 
 // autocompleteTags returns the top-N matching tags ranked by usage and recency.
 // @Summary Autocomplete tag suggestions
-// @Description Top-N tags matching the query, ranked by usage desc + created_at desc.
+// @Description Top-N tags matching the query, ranked by scope-aware usage desc + created_at desc.
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
 // @Param groupSlug path string true "Group slug"
 // @Param q query string false "Substring match against label and slug"
 // @Param limit query int false "Maximum suggestions returned" default(10)
+// @Param scope query string false "Restrict to tags used on commodities or files. Empty = no filter." Enums(commodity,file)
 // @Success 200 {object} jsonapi.TagAutocompleteResponse "OK"
+// @Failure 422 {object} jsonapi.Errors "Invalid scope value"
 // @Router /g/{groupSlug}/tags/autocomplete [get].
 func (api *tagsAPI) autocompleteTags(w http.ResponseWriter, r *http.Request) {
 	regSet := RegistrySetFromContext(r.Context())
@@ -179,8 +190,13 @@ func (api *tagsAPI) autocompleteTags(w http.ResponseWriter, r *http.Request) {
 			limit = parsed
 		}
 	}
+	scope, ok := parseTagScope(r.URL.Query().Get("scope"))
+	if !ok {
+		unprocessableEntityError(w, r, fmt.Errorf("invalid scope: %q (must be one of: commodity, file)", r.URL.Query().Get("scope")))
+		return
+	}
 
-	tags, err := regSet.TagRegistry.Search(r.Context(), q, limit)
+	tags, err := regSet.TagRegistry.Search(r.Context(), q, limit, scope)
 	if err != nil {
 		renderEntityError(w, r, err)
 		return
@@ -188,6 +204,18 @@ func (api *tagsAPI) autocompleteTags(w http.ResponseWriter, r *http.Request) {
 	if err := render.Render(w, r, jsonapi.NewTagAutocompleteResponse(tags)); err != nil {
 		internalServerError(w, r, err)
 	}
+}
+
+// parseTagScope validates and returns the requested tag scope from the
+// raw ?scope= query value. Returns (TagScopeAny, true) for the empty
+// string (treated as no filter). Returns (_, false) for any other value
+// the registry doesn't understand — handler converts to 422.
+func parseTagScope(raw string) (registry.TagScope, bool) {
+	candidate := registry.TagScope(strings.TrimSpace(raw))
+	if !candidate.IsValid() {
+		return registry.TagScopeAny, false
+	}
+	return candidate, true
 }
 
 // getTag returns a tag by id with usage breakdown.

--- a/go/apiserver/tags_test.go
+++ b/go/apiserver/tags_test.go
@@ -1,0 +1,55 @@
+package apiserver
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// parseTagScope is unexported, so this test lives in the apiserver
+// package itself. Pins the wire contract for ?scope= introduced in #1628:
+// empty / commodity / file are accepted; anything else 422s.
+func TestParseTagScope(t *testing.T) {
+	t.Run("empty string returns TagScopeAny + ok", func(t *testing.T) {
+		c := qt.New(t)
+		got, ok := parseTagScope("")
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(got, qt.Equals, registry.TagScopeAny)
+	})
+
+	t.Run("commodity parses", func(t *testing.T) {
+		c := qt.New(t)
+		got, ok := parseTagScope("commodity")
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(got, qt.Equals, registry.TagScopeCommodity)
+	})
+
+	t.Run("file parses", func(t *testing.T) {
+		c := qt.New(t)
+		got, ok := parseTagScope("file")
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(got, qt.Equals, registry.TagScopeFile)
+	})
+
+	t.Run("whitespace is trimmed", func(t *testing.T) {
+		c := qt.New(t)
+		got, ok := parseTagScope("  commodity  ")
+		c.Assert(ok, qt.IsTrue)
+		c.Assert(got, qt.Equals, registry.TagScopeCommodity)
+	})
+
+	t.Run("unknown value rejected", func(t *testing.T) {
+		c := qt.New(t)
+		got, ok := parseTagScope("bogus")
+		c.Assert(ok, qt.IsFalse)
+		c.Assert(got, qt.Equals, registry.TagScopeAny)
+	})
+
+	t.Run("commodities plural rejected — wire contract is singular", func(t *testing.T) {
+		c := qt.New(t)
+		_, ok := parseTagScope("commodities")
+		c.Assert(ok, qt.IsFalse)
+	})
+}

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -3932,7 +3932,7 @@ const docTemplate = `{
         },
         "/g/{groupSlug}/tags": {
             "get": {
-                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.",
+                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block. Pass scope=commodity|file to restrict to tags actually used on that entity type.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -3997,6 +3997,16 @@ const docTemplate = `{
                         "description": "Comma-separated extras. 'usage' attaches per-row meta.usage.",
                         "name": "include",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "commodity",
+                            "file"
+                        ],
+                        "type": "string",
+                        "description": "Restrict to tags used on commodities or files. Empty = no filter.",
+                        "name": "scope",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -4004,6 +4014,12 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.TagsResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Invalid scope value",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }
@@ -4056,7 +4072,7 @@ const docTemplate = `{
         },
         "/g/{groupSlug}/tags/autocomplete": {
             "get": {
-                "description": "Top-N tags matching the query, ranked by usage desc + created_at desc.",
+                "description": "Top-N tags matching the query, ranked by scope-aware usage desc + created_at desc.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -4087,6 +4103,16 @@ const docTemplate = `{
                         "description": "Maximum suggestions returned",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "commodity",
+                            "file"
+                        ],
+                        "type": "string",
+                        "description": "Restrict to tags used on commodities or files. Empty = no filter.",
+                        "name": "scope",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -4094,6 +4120,12 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.TagAutocompleteResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Invalid scope value",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -3925,7 +3925,7 @@
         },
         "/g/{groupSlug}/tags": {
             "get": {
-                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block.",
+                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block. Pass scope=commodity|file to restrict to tags actually used on that entity type.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -3990,6 +3990,16 @@
                         "description": "Comma-separated extras. 'usage' attaches per-row meta.usage.",
                         "name": "include",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "commodity",
+                            "file"
+                        ],
+                        "type": "string",
+                        "description": "Restrict to tags used on commodities or files. Empty = no filter.",
+                        "name": "scope",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -3997,6 +4007,12 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.TagsResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Invalid scope value",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }
@@ -4049,7 +4065,7 @@
         },
         "/g/{groupSlug}/tags/autocomplete": {
             "get": {
-                "description": "Top-N tags matching the query, ranked by usage desc + created_at desc.",
+                "description": "Top-N tags matching the query, ranked by scope-aware usage desc + created_at desc.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -4080,6 +4096,16 @@
                         "description": "Maximum suggestions returned",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "commodity",
+                            "file"
+                        ],
+                        "type": "string",
+                        "description": "Restrict to tags used on commodities or files. Empty = no filter.",
+                        "name": "scope",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -4087,6 +4113,12 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.TagAutocompleteResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Invalid scope value",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
                         }
                     }
                 }

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -5887,7 +5887,8 @@ paths:
       consumes:
       - application/vnd.api+json
       description: get tags with optional filtering. Pass include=usage to attach
-        a per-row meta.usage block.
+        a per-row meta.usage block. Pass scope=commodity|file to restrict to tags
+        actually used on that entity type.
       parameters:
       - description: Group slug
         in: path
@@ -5927,6 +5928,13 @@ paths:
         in: query
         name: include
         type: string
+      - description: Restrict to tags used on commodities or files. Empty = no filter.
+        enum:
+        - commodity
+        - file
+        in: query
+        name: scope
+        type: string
       produces:
       - application/vnd.api+json
       responses:
@@ -5934,6 +5942,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/jsonapi.TagsResponse'
+        "422":
+          description: Invalid scope value
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
       summary: List tags
       tags:
       - tags
@@ -6080,8 +6092,8 @@ paths:
     get:
       consumes:
       - application/vnd.api+json
-      description: Top-N tags matching the query, ranked by usage desc + created_at
-        desc.
+      description: Top-N tags matching the query, ranked by scope-aware usage desc
+        + created_at desc.
       parameters:
       - description: Group slug
         in: path
@@ -6097,6 +6109,13 @@ paths:
         in: query
         name: limit
         type: integer
+      - description: Restrict to tags used on commodities or files. Empty = no filter.
+        enum:
+        - commodity
+        - file
+        in: query
+        name: scope
+        type: string
       produces:
       - application/vnd.api+json
       responses:
@@ -6104,6 +6123,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/jsonapi.TagAutocompleteResponse'
+        "422":
+          description: Invalid scope value
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
       summary: Autocomplete tag suggestions
       tags:
       - tags

--- a/go/registry/memory/tags.go
+++ b/go/registry/memory/tags.go
@@ -162,26 +162,22 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 		return nil, 0, err
 	}
 
-	if opts.Search != "" {
-		needle := strings.ToLower(opts.Search)
-		filtered := all[:0:0]
-		for _, t := range all {
-			if strings.Contains(strings.ToLower(t.Label), needle) || strings.Contains(t.Slug, needle) {
-				filtered = append(filtered, t)
-			}
-		}
-		all = filtered
-	}
+	all = filterTagsBySearch(all, opts.Search)
 
-	usageBySlug := map[string]int{}
-	if opts.SortField == registry.TagSortUsage {
-		// Only walk commodities/files when usage sort is requested — it is
-		// the expensive case. Other sorts read fields directly off the tag.
-		usageBySlug, err = r.computeUsageMap(ctx)
+	// usagePerScope is computed when either (a) usage sort is selected or
+	// (b) a scope filter is in effect — both need per-tag-per-scope counts.
+	needUsage := opts.SortField == registry.TagSortUsage ||
+		opts.Scope == registry.TagScopeCommodity ||
+		opts.Scope == registry.TagScopeFile
+	var usagePerScope map[string]registry.TagUsage
+	if needUsage {
+		usagePerScope, err = r.computePerScopeUsageMap(ctx)
 		if err != nil {
 			return nil, 0, err
 		}
 	}
+
+	all = filterTagsByScope(all, opts.Scope, usagePerScope)
 
 	sortField := opts.SortField
 	if !sortField.IsValid() {
@@ -193,8 +189,8 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 		case registry.TagSortCreatedAt:
 			less = all[i].CreatedAt.Before(all[j].CreatedAt)
 		case registry.TagSortUsage:
-			ui := usageBySlug[all[i].Slug]
-			uj := usageBySlug[all[j].Slug]
+			ui := scopedUsage(usagePerScope[all[i].Slug], opts.Scope)
+			uj := scopedUsage(usagePerScope[all[j].Slug], opts.Scope)
 			if ui == uj {
 				less = strings.ToLower(all[i].Label) < strings.ToLower(all[j].Label)
 			} else {
@@ -221,29 +217,29 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 	return all[start:end], total, nil
 }
 
-func (r *TagRegistry) Search(ctx context.Context, q string, limit int) ([]*models.Tag, error) {
+func (r *TagRegistry) Search(ctx context.Context, q string, limit int, scope registry.TagScope) ([]*models.Tag, error) {
 	all, err := r.List(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	needle := strings.ToLower(q)
-	matched := all[:0:0]
-	for _, t := range all {
-		if needle == "" ||
-			strings.Contains(strings.ToLower(t.Label), needle) ||
-			strings.Contains(t.Slug, needle) {
-			matched = append(matched, t)
-		}
-	}
+	// Reuse the same substring filter as ListPaginated — empty q is a
+	// no-op pass-through, so the "match everything" case stays cheap.
+	matched := filterTagsBySearch(all, q)
 
-	usageBySlug, err := r.computeUsageMap(ctx)
+	usagePerScope, err := r.computePerScopeUsageMap(ctx)
 	if err != nil {
 		return nil, err
 	}
-	// Rank: usage desc, then created_at desc (recent wins ties).
+
+	// Strict scope filter — drop tags with zero usage in the requested
+	// bucket. Mirrors the postgres `>0` predicate.
+	matched = filterTagsByScope(matched, scope, usagePerScope)
+
+	// Rank: per-scope usage desc, then created_at desc (recent wins ties).
 	sort.SliceStable(matched, func(i, j int) bool {
-		ui, uj := usageBySlug[matched[i].Slug], usageBySlug[matched[j].Slug]
+		ui := scopedUsage(usagePerScope[matched[i].Slug], scope)
+		uj := scopedUsage(usagePerScope[matched[j].Slug], scope)
 		if ui != uj {
 			return ui > uj
 		}
@@ -254,6 +250,55 @@ func (r *TagRegistry) Search(ctx context.Context, q string, limit int) ([]*model
 		matched = matched[:limit]
 	}
 	return matched, nil
+}
+
+// scopedUsage returns the slice of TagUsage relevant to the requested
+// scope. TagScopeAny sums commodities + files; explicit scopes return
+// just that bucket.
+func scopedUsage(u registry.TagUsage, scope registry.TagScope) int {
+	switch scope {
+	case registry.TagScopeCommodity:
+		return u.Commodities
+	case registry.TagScopeFile:
+		return u.Files
+	default:
+		return u.Commodities + u.Files
+	}
+}
+
+// filterTagsBySearch is the substring-match helper shared by
+// ListPaginated and (indirectly) Search. Lifted out so the cognitive
+// complexity of ListPaginated stays under gocognit's threshold.
+func filterTagsBySearch(in []*models.Tag, search string) []*models.Tag {
+	if search == "" {
+		return in
+	}
+	needle := strings.ToLower(search)
+	filtered := in[:0:0]
+	for _, t := range in {
+		if strings.Contains(strings.ToLower(t.Label), needle) || strings.Contains(t.Slug, needle) {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}
+
+// filterTagsByScope drops tags with zero usage in the requested scope.
+// TagScopeAny is a no-op pass-through. Mirrors the postgres `>0`
+// predicate on scopedUsageExpr.
+func filterTagsByScope(in []*models.Tag, scope registry.TagScope, usagePerScope map[string]registry.TagUsage) []*models.Tag {
+	if scope != registry.TagScopeCommodity && scope != registry.TagScopeFile {
+		return in
+	}
+	filtered := in[:0:0]
+	for _, t := range in {
+		u := usagePerScope[t.Slug]
+		if (scope == registry.TagScopeCommodity && u.Commodities > 0) ||
+			(scope == registry.TagScopeFile && u.Files > 0) {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
 }
 
 func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[string]registry.TagUsage, error) {
@@ -369,16 +414,28 @@ func (r *TagRegistry) GetUsage(ctx context.Context, slug string) (registry.TagUs
 	return registry.TagUsage{Commodities: commodityCount, Files: fileCount}, nil
 }
 
-func (r *TagRegistry) computeUsageMap(ctx context.Context) (map[string]int, error) {
-	usage := map[string]int{}
+// computePerScopeUsageMap walks commodities + files once each and returns
+// a slug→TagUsage breakdown with separate Commodities / Files counts.
+// Mirrors the postgres `scopedUsageExpr` semantics: a commodity / file
+// with a duplicated slug in its tags array is counted at most once
+// (matching @> containment + COUNT(DISTINCT id)).
+func (r *TagRegistry) computePerScopeUsageMap(ctx context.Context) (map[string]registry.TagUsage, error) {
+	usage := map[string]registry.TagUsage{}
 
 	commodities, err := r.commodityRegistry.List(ctx)
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to list commodities", err)
 	}
 	for _, c := range commodities {
+		seen := map[string]struct{}{}
 		for _, slug := range c.Tags {
-			usage[slug]++
+			if _, dup := seen[slug]; dup {
+				continue
+			}
+			seen[slug] = struct{}{}
+			u := usage[slug]
+			u.Commodities++
+			usage[slug] = u
 		}
 	}
 
@@ -387,8 +444,15 @@ func (r *TagRegistry) computeUsageMap(ctx context.Context) (map[string]int, erro
 		return nil, errxtrace.Wrap("failed to list files", err)
 	}
 	for _, f := range files {
+		seen := map[string]struct{}{}
 		for _, slug := range f.Tags {
-			usage[slug]++
+			if _, dup := seen[slug]; dup {
+				continue
+			}
+			seen[slug] = struct{}{}
+			u := usage[slug]
+			u.Files++
+			usage[slug] = u
 		}
 	}
 	return usage, nil

--- a/go/registry/memory/tags_test.go
+++ b/go/registry/memory/tags_test.go
@@ -237,12 +237,123 @@ func TestTagRegistry_Memory_SearchRanksByUsage(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	got, err := fx.tagReg.Search(fx.ctx, "", 10)
+	got, err := fx.tagReg.Search(fx.ctx, "", 10, registry.TagScopeAny)
 	c.Assert(err, qt.IsNil)
 	c.Assert(got, qt.HasLen, 3)
 	c.Assert(got[0].Slug, qt.Equals, "gamma")
 	c.Assert(got[1].Slug, qt.Equals, "alpha")
 	c.Assert(got[2].Slug, qt.Equals, "beta")
+}
+
+// TestTagRegistry_Memory_SearchScoped exercises the per-scope filter +
+// ranking added for #1628: scope=commodity strictly excludes file-only
+// tags (and vice versa), and a tag used on both scopes appears in both
+// scoped result sets.
+func TestTagRegistry_Memory_SearchScoped(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagFixture(c, "group-1")
+
+	for _, slug := range []string{"kitchen", "invoice", "warranty", "unused"} {
+		_, err := fx.tagReg.Create(fx.ctx, models.Tag{
+			Slug: slug, Label: slug, Color: models.TagColorMuted,
+		})
+		c.Assert(err, qt.IsNil)
+	}
+
+	// kitchen → commodity only; invoice → file only; warranty → both.
+	_, err := fx.commodityReg.Create(fx.ctx, models.Commodity{
+		Name: "fridge", Status: models.CommodityStatusInUse, Type: models.CommodityTypeWhiteGoods,
+		Tags: models.ValuerSlice[string]{"kitchen", "warranty"},
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = fx.fileReg.Create(fx.ctx, models.FileEntity{
+		Title: "f", Type: models.FileTypeDocument, Category: models.FileCategoryInvoices,
+		Tags: models.StringSlice{"invoice", "warranty"},
+		File: &models.File{Path: "f", OriginalPath: "f.pdf", Ext: ".pdf", MIMEType: "application/pdf"},
+	})
+	c.Assert(err, qt.IsNil)
+
+	commodityScope, err := fx.tagReg.Search(fx.ctx, "", 10, registry.TagScopeCommodity)
+	c.Assert(err, qt.IsNil)
+	commodityScopeSlugs := make([]string, 0, len(commodityScope))
+	for _, t := range commodityScope {
+		commodityScopeSlugs = append(commodityScopeSlugs, t.Slug)
+	}
+	c.Assert(commodityScopeSlugs, qt.Contains, "kitchen")
+	c.Assert(commodityScopeSlugs, qt.Contains, "warranty")
+	c.Assert(commodityScopeSlugs, qt.Not(qt.Contains), "invoice") // file-only excluded
+	c.Assert(commodityScopeSlugs, qt.Not(qt.Contains), "unused")  // zero usage excluded
+
+	fileScope, err := fx.tagReg.Search(fx.ctx, "", 10, registry.TagScopeFile)
+	c.Assert(err, qt.IsNil)
+	fileScopeSlugs := make([]string, 0, len(fileScope))
+	for _, t := range fileScope {
+		fileScopeSlugs = append(fileScopeSlugs, t.Slug)
+	}
+	c.Assert(fileScopeSlugs, qt.Contains, "invoice")
+	c.Assert(fileScopeSlugs, qt.Contains, "warranty")
+	c.Assert(fileScopeSlugs, qt.Not(qt.Contains), "kitchen")
+	c.Assert(fileScopeSlugs, qt.Not(qt.Contains), "unused")
+
+	// TagScopeAny includes every tag even with zero usage — preserves
+	// the legacy pre-#1628 behaviour for the merged "All tags" tab.
+	all, err := fx.tagReg.Search(fx.ctx, "", 10, registry.TagScopeAny)
+	c.Assert(err, qt.IsNil)
+	c.Assert(all, qt.HasLen, 4)
+}
+
+// TestTagRegistry_Memory_ListPaginatedScoped mirrors SearchScoped for the
+// list endpoint: scope filter + correct totals.
+func TestTagRegistry_Memory_ListPaginatedScoped(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagFixture(c, "group-1")
+
+	for _, slug := range []string{"kitchen", "invoice", "warranty", "unused"} {
+		_, err := fx.tagReg.Create(fx.ctx, models.Tag{
+			Slug: slug, Label: slug, Color: models.TagColorMuted,
+		})
+		c.Assert(err, qt.IsNil)
+	}
+	_, err := fx.commodityReg.Create(fx.ctx, models.Commodity{
+		Name: "fridge", Status: models.CommodityStatusInUse, Type: models.CommodityTypeWhiteGoods,
+		Tags: models.ValuerSlice[string]{"kitchen", "warranty"},
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = fx.fileReg.Create(fx.ctx, models.FileEntity{
+		Title: "f", Type: models.FileTypeDocument, Category: models.FileCategoryInvoices,
+		Tags: models.StringSlice{"invoice", "warranty"},
+		File: &models.File{Path: "f", OriginalPath: "f.pdf", Ext: ".pdf", MIMEType: "application/pdf"},
+	})
+	c.Assert(err, qt.IsNil)
+
+	gotComm, totalComm, err := fx.tagReg.ListPaginated(fx.ctx, 0, 10, registry.TagListOptions{
+		Scope: registry.TagScopeCommodity,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(totalComm, qt.Equals, 2)
+	slugsComm := make([]string, 0, len(gotComm))
+	for _, t := range gotComm {
+		slugsComm = append(slugsComm, t.Slug)
+	}
+	c.Assert(slugsComm, qt.Contains, "kitchen")
+	c.Assert(slugsComm, qt.Contains, "warranty")
+
+	gotFile, totalFile, err := fx.tagReg.ListPaginated(fx.ctx, 0, 10, registry.TagListOptions{
+		Scope: registry.TagScopeFile,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(totalFile, qt.Equals, 2)
+	slugsFile := make([]string, 0, len(gotFile))
+	for _, t := range gotFile {
+		slugsFile = append(slugsFile, t.Slug)
+	}
+	c.Assert(slugsFile, qt.Contains, "invoice")
+	c.Assert(slugsFile, qt.Contains, "warranty")
+
+	gotAny, totalAny, err := fx.tagReg.ListPaginated(fx.ctx, 0, 10, registry.TagListOptions{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(totalAny, qt.Equals, 4)
+	c.Assert(gotAny, qt.HasLen, 4)
 }
 
 func TestTagRegistry_Memory_GetUsageBatch(t *testing.T) {

--- a/go/registry/postgres/tags.go
+++ b/go/registry/postgres/tags.go
@@ -142,17 +142,32 @@ func (r *TagRegistry) Delete(ctx context.Context, id string) error {
 	return r.newSQLRegistry().Delete(ctx, id, nil)
 }
 
-// usageExpr is the SQL expression that yields the per-tag total reference
-// count summed across commodities + files. The two `tags @>` operands use
-// the @> JSONB containment operator backed by the existing GIN indexes
-// (commodities_tags_gin_idx, files_tags_gin_idx).
-func (r *TagRegistry) usageExpr() string {
-	return fmt.Sprintf(
-		`((SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array(t.slug))
-		+ (SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array(t.slug)))`,
-		r.tableNames.Commodities(),
-		r.tableNames.Files(),
-	)
+// scopedUsageExpr returns the per-tag reference-count SQL expression for
+// a single scope: commodity-only, file-only, or commodities + files
+// combined (TagScopeAny). The expression is evaluated against the outer
+// `t` alias (the tags row), so callers must reference the tags table as
+// `t`. The two `tags @>` operands use the JSONB containment operator
+// backed by the existing GIN indexes (commodities_tags_gin_idx,
+// files_tags_gin_idx).
+//
+// Unknown scope values fall back to the combined (TagScopeAny) expression
+// — the handler validates the wire value before it reaches the registry,
+// so this is a defence-in-depth fallback rather than a routine code path.
+func (r *TagRegistry) scopedUsageExpr(scope registry.TagScope) string {
+	commodityExpr := fmt.Sprintf(
+		`(SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array(t.slug))`,
+		r.tableNames.Commodities())
+	fileExpr := fmt.Sprintf(
+		`(SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array(t.slug))`,
+		r.tableNames.Files())
+	switch scope {
+	case registry.TagScopeCommodity:
+		return commodityExpr
+	case registry.TagScopeFile:
+		return fileExpr
+	default:
+		return "(" + commodityExpr + " + " + fileExpr + ")"
+	}
 }
 
 func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts registry.TagListOptions) ([]*models.Tag, int, error) {
@@ -167,6 +182,13 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 			conditions = append(conditions, "(t.label ILIKE $1 OR t.slug ILIKE $2)")
 			pattern := "%" + opts.Search + "%"
 			args = append(args, pattern, pattern)
+		}
+		// Scope filter: usage-derived. A tag passes ?scope=commodity if it
+		// has at least one commodity referencing it; same for ?scope=file.
+		// TagScopeAny adds no condition.
+		scopeFilterExpr := r.scopedUsageExpr(opts.Scope)
+		if opts.Scope == registry.TagScopeCommodity || opts.Scope == registry.TagScopeFile {
+			conditions = append(conditions, scopeFilterExpr+" > 0")
 		}
 		whereClause := ""
 		if len(conditions) > 0 {
@@ -191,7 +213,10 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 		case registry.TagSortCreatedAt:
 			orderBy = fmt.Sprintf("ORDER BY t.created_at %s, t.label ASC", dir)
 		case registry.TagSortUsage:
-			orderBy = fmt.Sprintf("ORDER BY %s %s, t.label ASC", r.usageExpr(), dir)
+			// Usage sort uses the SAME scoped expression as the filter so
+			// the "Sort by usage" toggle on a scoped tab reflects per-scope
+			// usage rather than combined usage.
+			orderBy = fmt.Sprintf("ORDER BY %s %s, t.label ASC", scopeFilterExpr, dir)
 		default:
 			orderBy = fmt.Sprintf("ORDER BY LOWER(t.label) %s, t.id ASC", dir)
 		}
@@ -223,7 +248,7 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 	return tags, total, nil
 }
 
-func (r *TagRegistry) Search(ctx context.Context, q string, limit int) ([]*models.Tag, error) {
+func (r *TagRegistry) Search(ctx context.Context, q string, limit int, scope registry.TagScope) ([]*models.Tag, error) {
 	var tags []*models.Tag
 
 	reg := r.newSQLRegistry()
@@ -237,16 +262,25 @@ func (r *TagRegistry) Search(ctx context.Context, q string, limit int) ([]*model
 			args = append(args, pattern, pattern)
 			argIdx += 2
 		}
+		// Scope filter mirrors ListPaginated: strict exclusion of tags
+		// with zero usage in the requested scope, so the autocomplete
+		// dropdown on a commodity input never offers a file-only tag.
+		scopeUsageExpr := r.scopedUsageExpr(scope)
+		if scope == registry.TagScopeCommodity || scope == registry.TagScopeFile {
+			conditions = append(conditions, scopeUsageExpr+" > 0")
+		}
 		whereClause := ""
 		if len(conditions) > 0 {
 			whereClause = "WHERE " + strings.Join(conditions, " AND ")
 		}
 
-		// Rank by usage desc, then created_at desc (recency tiebreaker).
+		// Rank by per-scope usage desc, then created_at desc
+		// (recency tiebreaker). For TagScopeAny this is combined usage,
+		// matching the legacy pre-#1628 ranking.
 		args = append(args, limit)
 		query := fmt.Sprintf(
 			`SELECT t.* FROM %s t %s ORDER BY %s DESC, t.created_at DESC LIMIT $%d`,
-			r.tableNames.Tags(), whereClause, r.usageExpr(), argIdx,
+			r.tableNames.Tags(), whereClause, scopeUsageExpr, argIdx,
 		)
 
 		rows, err := tx.QueryxContext(ctx, query, args...)

--- a/go/registry/postgres/tags_test.go
+++ b/go/registry/postgres/tags_test.go
@@ -537,3 +537,91 @@ func TestTagService_Postgres_DeleteTag_ForceUnderConcurrentInsert(t *testing.T) 
 		}
 	}
 }
+
+// TestTagRegistry_Postgres_SearchScoped verifies the per-scope strict
+// filter on the autocomplete (Search) endpoint added for #1628. The
+// scoped expression must match what GetUsage returns for the same slug.
+func TestTagRegistry_Postgres_SearchScoped(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	// Seed four tags, vary usage by scope.
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "invoice")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "warranty")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "unused")
+
+	seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen", "warranty")
+	seedTagFile(c, fx.groupASet, fx.ctxA, "fridge-receipt", "invoice", "warranty")
+
+	gotCommodity, err := fx.groupASet.TagRegistry.Search(fx.ctxA, "", 10, registry.TagScopeCommodity)
+	c.Assert(err, qt.IsNil)
+	gotCommoditySlugs := make([]string, 0, len(gotCommodity))
+	for _, t := range gotCommodity {
+		gotCommoditySlugs = append(gotCommoditySlugs, t.Slug)
+	}
+	c.Assert(gotCommoditySlugs, qt.Contains, "kitchen")
+	c.Assert(gotCommoditySlugs, qt.Contains, "warranty")
+	c.Assert(gotCommoditySlugs, qt.Not(qt.Contains), "invoice")
+	c.Assert(gotCommoditySlugs, qt.Not(qt.Contains), "unused")
+
+	gotFile, err := fx.groupASet.TagRegistry.Search(fx.ctxA, "", 10, registry.TagScopeFile)
+	c.Assert(err, qt.IsNil)
+	gotFileSlugs := make([]string, 0, len(gotFile))
+	for _, t := range gotFile {
+		gotFileSlugs = append(gotFileSlugs, t.Slug)
+	}
+	c.Assert(gotFileSlugs, qt.Contains, "invoice")
+	c.Assert(gotFileSlugs, qt.Contains, "warranty")
+	c.Assert(gotFileSlugs, qt.Not(qt.Contains), "kitchen")
+	c.Assert(gotFileSlugs, qt.Not(qt.Contains), "unused")
+
+	// TagScopeAny includes every tag, including the unused one.
+	gotAny, err := fx.groupASet.TagRegistry.Search(fx.ctxA, "", 10, registry.TagScopeAny)
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotAny, qt.HasLen, 4)
+}
+
+// TestTagRegistry_Postgres_ListPaginatedScoped mirrors SearchScoped for
+// the paginated listing endpoint. Asserts both filter + total count.
+func TestTagRegistry_Postgres_ListPaginatedScoped(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "invoice")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "warranty")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "unused")
+
+	seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen", "warranty")
+	seedTagFile(c, fx.groupASet, fx.ctxA, "fridge-receipt", "invoice", "warranty")
+
+	got, total, err := fx.groupASet.TagRegistry.ListPaginated(fx.ctxA, 0, 50, registry.TagListOptions{
+		Scope: registry.TagScopeCommodity,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(total, qt.Equals, 2)
+	slugs := make([]string, 0, len(got))
+	for _, t := range got {
+		slugs = append(slugs, t.Slug)
+	}
+	c.Assert(slugs, qt.Contains, "kitchen")
+	c.Assert(slugs, qt.Contains, "warranty")
+
+	got, total, err = fx.groupASet.TagRegistry.ListPaginated(fx.ctxA, 0, 50, registry.TagListOptions{
+		Scope: registry.TagScopeFile,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(total, qt.Equals, 2)
+	slugs = slugs[:0]
+	for _, t := range got {
+		slugs = append(slugs, t.Slug)
+	}
+	c.Assert(slugs, qt.Contains, "invoice")
+	c.Assert(slugs, qt.Contains, "warranty")
+
+	got, total, err = fx.groupASet.TagRegistry.ListPaginated(fx.ctxA, 0, 50, registry.TagListOptions{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(total, qt.Equals, 4)
+	c.Assert(got, qt.HasLen, 4)
+}

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -361,6 +361,39 @@ func (s TagSortField) IsValid() bool {
 	return false
 }
 
+// TagScope narrows tag listing / autocomplete to tags that are actually used
+// on a specific entity type. Scope is *usage-derived* — there is no scope
+// column on the tags row itself; a tag's scope is whichever entity types
+// have at least one row referencing the tag via their JSONB tags array.
+//
+// A tag used on both commodities and files is multi-scope and shows up
+// under both TagScopeCommodity and TagScopeFile filters. A brand-new tag
+// with zero usage shows up only under TagScopeAny.
+//
+// Names are part of the public API surface (FE sends them as ?scope=).
+type TagScope string
+
+const (
+	// TagScopeAny matches every tag regardless of where it is used.
+	// Default when ?scope= is missing.
+	TagScopeAny TagScope = ""
+	// TagScopeCommodity matches tags referenced by at least one commodity.
+	TagScopeCommodity TagScope = "commodity"
+	// TagScopeFile matches tags referenced by at least one file.
+	TagScopeFile TagScope = "file"
+)
+
+// IsValid reports whether s is a known tag scope. Empty string is treated
+// as TagScopeAny by callers; this returns true for the empty string so the
+// handler can validate the raw query value uniformly.
+func (s TagScope) IsValid() bool {
+	switch s {
+	case TagScopeAny, TagScopeCommodity, TagScopeFile:
+		return true
+	}
+	return false
+}
+
 // TagListOptions narrows the result of TagRegistry.ListPaginated.
 type TagListOptions struct {
 	// Search runs case-insensitive substring match on label and slug.
@@ -369,6 +402,9 @@ type TagListOptions struct {
 	SortField TagSortField
 	// SortDesc reverses the natural order of the chosen field.
 	SortDesc bool
+	// Scope filters to tags actually used on the named entity type.
+	// TagScopeAny (or zero value) returns every tag.
+	Scope TagScope
 }
 
 // TagUsage is the per-tag breakdown of how many commodity / file rows
@@ -406,9 +442,15 @@ type TagRegistry interface {
 
 	// Search returns tags whose label or slug matches q (case-insensitive
 	// substring), capped at limit. Used by the autocomplete endpoint and
-	// ranked by usage desc + recency. Empty q returns the most-recently
-	// used tags, also capped at limit.
-	Search(ctx context.Context, q string, limit int) ([]*models.Tag, error)
+	// ranked by scope-aware usage desc + recency. Empty q returns the
+	// most-used tags within the requested scope, also capped at limit.
+	//
+	// When scope is TagScopeCommodity or TagScopeFile the result strictly
+	// excludes tags with zero usage in that scope (multi-scope tags that
+	// also have commodity OR file usage in the requested bucket are
+	// included). TagScopeAny ranks by combined commodity+file usage and
+	// includes every tag regardless of whether it has any usage yet.
+	Search(ctx context.Context, q string, limit int, scope TagScope) ([]*models.Tag, error)
 
 	// GetUsage returns the per-entity reference counts for a tag slug
 	// within the current group (commodities + files JSONB arrays


### PR DESCRIPTION
## Summary

Closes #1628. Adds a `scope=commodity|file` selector to the tag autocomplete + listing endpoints and surfaces it on both the Tags settings page (All / Item / File tabs) and as a per-input `scope` prop on `TagsInput`. Scope is **usage-derived** — no new column on `tags`, no migration needed; a tag's scope is whichever entity types actually reference it via their JSONB tags array. Tags used on both commodities and files appear in both scoped buckets automatically.

Picked option (1+) from the issue's design pass — option (3)'s `applicable_to` schema dimension is unnecessary now that #1400 has shipped the first-class Tag entity and we can compute scope from existing usage. Keeps the change boundary tight and avoids a one-way migration.

## BE

- `registry.TagScope` (`""` / `commodity` / `file`) + `IsValid()`.
- `TagListOptions.Scope` field; `TagRegistry.Search` signature grows the scope argument.
- Postgres + memory backends share `scopedUsageExpr` semantics: scoped queries strictly exclude tags with zero usage in the named bucket (multi-scope tags surface in both buckets). `TagScopeAny` keeps the legacy combined ranking and still includes zero-usage tags so the "All" tab shows everything.
- `apiserver/tags.go`: `parseTagScope` validates `?scope=` and 422s on bogus values; swagger annotations updated.
- New tests:
  - `postgres/tags_test.go`: `TestTagRegistry_Postgres_SearchScoped`, `TestTagRegistry_Postgres_ListPaginatedScoped`.
  - `memory/tags_test.go`: `TestTagRegistry_Memory_SearchScoped`, `TestTagRegistry_Memory_ListPaginatedScoped`.
  - `apiserver/tags_test.go` (new file): `TestParseTagScope` — pins the wire contract for empty / commodity / file / whitespace / unknown / "commodities" (plural rejected).

## FE

- `features/tags/api.ts`: `TagScope` type; `scope` flows through `autocompleteTags()`, `listTags({ scope })`, `useTagAutocomplete(q, limit, { scope })`, and `tagKeys.autocomplete` (cache split per scope).
- `components/files/TagsInput.tsx`: optional `scope` prop, forwarded to `AutocompleteSink`.
- `components/items/CommodityFormDialog.tsx`:
  - Extras-step `TagsInput` and the empty-state `TagsSuggestionChips` use `scope="commodity"`.
  - Per-file row in the Files step uses `scope="file"`.
- `pages/tags/TagsListPage.tsx`: All / Item tags / File tags Radix Tabs above the toolbar; URL `?tab=` survives back/forward. Scope-specific empty-state copy.
- i18n keys: `tags:tabs.{all,commodity,file}`, `tags:list.emptyScope{Commodity,File}`.

## Devdocs

- Added resolution lines (`Update 2026-05-15 (#1628)`) to the two 2026-05-10 entries that previously called out the merged-pool autocomplete.
- New entry under **Other** for the All / Item / File tabs — the mock's flat list has no scope affordance.

## Acceptance criteria (issue #1628)

- [x] BE autocomplete &amp; tag listing endpoints support a `scope` selector.
- [x] `useTagAutocomplete` and the tag list hook take a scope arg; #1544's surfaces pass the correct one.
- [x] Tags settings page has tabs for **Item tags**, **File tags**, and **All**.
- [x] Suggestion chips on the Extras step show only commodity-scope tags.
- [x] Per-file tag suggestions show only file-scope tags.
- [x] Existing tag data is auditable into per-scope assignments — derived from usage; no orphans by construction (multi-scope falls out for free).
- [x] Deviation-resolution lines on the existing #1544 tag entries.
- [x] New i18n keys captured (no new namespace, so no i18n.md update needed — keys follow existing conventions).

## Out of scope

- Surfacing a per-tag "used on items / used on files" badge in `TagRow`. The existing usage counts (`0 items · 3 files`) already convey scope; adding redundant badges felt noisy. Easy to bolt on later if requested.
- The Files-step per-file dropdown's optional suggestion-chip CTA (issue's question 5) — keeping the current focused popover-dropdown UX; not requested as an AC.

## Test plan

- [ ] `make test-backend` (memory + apiserver suites)
- [ ] `make test-integration` against postgres-test (TagRegistry_Postgres_SearchScoped + ListPaginatedScoped)
- [ ] `cd frontend && npm run typecheck && npm test && npm run lint && npm run i18n:check && npm run format:check`
- [ ] Manual: log in, open Tags page, switch tabs, confirm `?scope=` round-trips
- [ ] Manual: Add Item dialog Extras step — type, confirm dropdown excludes file-only tags (`invoice`)
- [ ] Manual: Add Item dialog Files step per-row tag input — type, confirm dropdown excludes commodity-only tags (`kitchen`)