### PR TITLE
[#1647] Add description field to LocationGroup

### DIFF
--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -5022,7 +5022,7 @@ export type paths = {
         head?: never;
         /**
          * Update group
-         * @description Updates a location group's name and icon. The group_currency field is set once at creation and cannot be changed here — see issue #202 for the currency-migration tool. Requires group admin role.
+         * @description Updates a location group's name, icon, and description. The group_currency field is set once at creation and cannot be changed here — see issue #202 for the currency-migration tool. Requires group admin role.
          */
         patch: {
             parameters: {
@@ -7287,6 +7287,13 @@ export type components = {
         };
         "jsonapi.LocationGroupAttributes": {
             /**
+             * @description Description is the free-form one-line subtitle surfaced on the
+             *     group settings page and the sidebar group-switcher (#1647).
+             *     Optional; empty string means "no description". Capped at
+             *     200 chars to match the locations.description cap.
+             */
+            description?: string;
+            /**
              * @description GroupCurrency is set once at group creation and is immutable after.
              *     On create the handler validates the ISO code and defaults to USD
              *     when nil. On update the handler rejects a change with 422 — a
@@ -8107,6 +8114,13 @@ export type components = {
              *     non-authenticated paths don't synthesize a misleading role).
              */
             readonly current_user_role?: components["schemas"]["models.GroupRole"];
+            /**
+             * @description Description is a free-form one-liner rendered as the muted subtitle
+             *     on the group settings page and the sidebar group-switcher. Empty
+             *     string means "no description" — same convention as Location.Description
+             *     (#1531 item 4). Issue #1647.
+             */
+            description?: string;
             /**
              * @description GroupCurrency is the ISO-4217 code the group values its inventory in. It is
              *     a property of the group (not the user) because a user can belong to

--- a/go/apiserver/groups.go
+++ b/go/apiserver/groups.go
@@ -422,7 +422,7 @@ func (api *groupsAPI) createGroup(w http.ResponseWriter, r *http.Request) {
 		groupCurrency = *attrs.GroupCurrency
 	}
 
-	group, err := api.groupService.CreateGroup(r.Context(), user.TenantID, user.ID, attrs.Name, attrs.Icon, groupCurrency)
+	group, err := api.groupService.CreateGroup(r.Context(), user.TenantID, user.ID, attrs.Name, attrs.Icon, attrs.Description, groupCurrency)
 	if err != nil {
 		renderEntityError(w, r, err)
 		return
@@ -483,7 +483,7 @@ func (api *groupsAPI) getGroup(w http.ResponseWriter, r *http.Request) {
 
 // updateGroup updates a group's metadata.
 // @Summary Update group
-// @Description Updates a location group's name and icon. The group_currency field is set once at creation and cannot be changed here — see issue #202 for the currency-migration tool. Requires group admin role.
+// @Description Updates a location group's name, icon, and description. The group_currency field is set once at creation and cannot be changed here — see issue #202 for the currency-migration tool. Requires group admin role.
 // @Tags groups
 // @Accept json-api
 // @Produce json-api
@@ -518,7 +518,7 @@ func (api *groupsAPI) updateGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updated, err := api.groupService.UpdateGroup(r.Context(), group.ID, attrs.Name, attrs.Icon)
+	updated, err := api.groupService.UpdateGroup(r.Context(), group.ID, attrs.Name, attrs.Icon, attrs.Description)
 	if err != nil {
 		renderEntityError(w, r, err)
 		return

--- a/go/apiserver/groups_test.go
+++ b/go/apiserver/groups_test.go
@@ -292,6 +292,128 @@ func TestGroupsAPI_CreateGroup_AcceptsCuratedIcon(t *testing.T) {
 	c.Assert(groups[0].Icon, qt.Equals, "📦")
 }
 
+// TestGroupsAPI_CreateGroup_PersistsDescription pins the create-side
+// round-trip for the description field added by #1647. Empty string is
+// the unset value (omitempty on the wire) — the explicit non-empty case
+// here makes sure the attribute survives the apiserver → service →
+// registry chain.
+func TestGroupsAPI_CreateGroup_PersistsDescription(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, "")
+
+	resp := postGroup(t, env, map[string]any{
+		"name":        "Group With Description",
+		"description": "Household items shared by the family",
+	})
+	c.Assert(resp.Code, qt.Equals, http.StatusCreated, qt.Commentf("body: %s", resp.Body.String()))
+
+	groups := must.Must(env.factorySet.LocationGroupRegistry.List(context.Background()))
+	c.Assert(groups, qt.HasLen, 1)
+	c.Assert(groups[0].Description, qt.Equals, "Household items shared by the family")
+}
+
+// TestGroupsAPI_CreateGroup_RejectsDescriptionOverCap pins the 200-char
+// validation cap from jsonapi.LocationGroupAttributes — anything longer
+// surfaces as 422 at bind time instead of being silently truncated.
+func TestGroupsAPI_CreateGroup_RejectsDescriptionOverCap(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, "")
+
+	tooLong := make([]byte, 201)
+	for i := range tooLong {
+		tooLong[i] = 'a'
+	}
+	resp := postGroup(t, env, map[string]any{
+		"name":        "Over Cap",
+		"description": string(tooLong),
+	})
+	c.Assert(resp.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body: %s", resp.Body.String()))
+}
+
+// TestGroupsAPI_UpdateGroup_UpdatesDescription is the patch-side
+// counterpart — admin PATCH can set, change, and clear the description.
+// Clearing happens with an explicit empty string on the wire (omitempty
+// only drops the field when serializing; on the way in we accept "").
+func TestGroupsAPI_UpdateGroup_UpdatesDescription(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, models.Currency("USD"))
+
+	// Seed a starting description directly on the row so the test isn't
+	// coupled to create-time wiring (covered by the create test above).
+	env.group.Description = "Initial subtitle"
+	must.Must(env.factorySet.LocationGroupRegistry.Update(context.Background(), *env.group))
+
+	// Patch with a new value.
+	resp := patchGroup(t, env, map[string]any{
+		"name":        env.group.Name,
+		"description": "Updated subtitle",
+	})
+	c.Assert(resp.Code, qt.Equals, http.StatusOK, qt.Commentf("body: %s", resp.Body.String()))
+
+	current := must.Must(env.factorySet.LocationGroupRegistry.Get(context.Background(), env.group.ID))
+	c.Assert(current.Description, qt.Equals, "Updated subtitle")
+
+	// Clearing the field round-trips as the empty string. The frontend
+	// admin form sends "" when the textarea is emptied, so this is the
+	// realistic clear path — not omitting the key from the body.
+	resp = patchGroup(t, env, map[string]any{
+		"name":        env.group.Name,
+		"description": "",
+	})
+	c.Assert(resp.Code, qt.Equals, http.StatusOK, qt.Commentf("body: %s", resp.Body.String()))
+
+	current = must.Must(env.factorySet.LocationGroupRegistry.Get(context.Background(), env.group.ID))
+	c.Assert(current.Description, qt.Equals, "")
+}
+
+// TestGroupsAPI_UpdateGroup_RejectsDescriptionOverCap mirrors the create
+// guard at PATCH time. Important because the frontend never enforces the
+// cap before send.
+func TestGroupsAPI_UpdateGroup_RejectsDescriptionOverCap(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, models.Currency("USD"))
+
+	tooLong := make([]byte, 201)
+	for i := range tooLong {
+		tooLong[i] = 'a'
+	}
+	resp := patchGroup(t, env, map[string]any{
+		"name":        env.group.Name,
+		"description": string(tooLong),
+	})
+	c.Assert(resp.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body: %s", resp.Body.String()))
+
+	current := must.Must(env.factorySet.LocationGroupRegistry.Get(context.Background(), env.group.ID))
+	c.Assert(current.Description, qt.Equals, "")
+}
+
+// TestGroupsAPI_GetGroup_SurfacesDescription ensures the field is part of
+// the GET response payload (not just stored on the row). The frontend
+// reads description off the response of /groups and /groups/{id} to
+// render the sidebar subtitle.
+func TestGroupsAPI_GetGroup_SurfacesDescription(t *testing.T) {
+	c := qt.New(t)
+
+	env := newGroupTestEnv(t, models.Currency("USD"))
+	env.group.Description = "Visible on the wire"
+	must.Must(env.factorySet.LocationGroupRegistry.Update(context.Background(), *env.group))
+
+	req := httptest.NewRequest(http.MethodGet, "/groups/"+env.group.ID, http.NoBody)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	c.Assert(w.Code, qt.Equals, http.StatusOK, qt.Commentf("body: %s", w.Body.String()))
+
+	var got jsonapi.LocationGroupResponse
+	c.Assert(json.Unmarshal(w.Body.Bytes(), &got), qt.IsNil)
+	c.Assert(got.Data, qt.IsNotNil)
+	c.Assert(got.Data.Attributes, qt.IsNotNil)
+	c.Assert(got.Data.Attributes.Description, qt.Equals, "Visible on the wire")
+}
+
 func TestGroupsAPI_UpdateGroup_RejectsIconOutsideCuratedSet(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/apiserver/registration_invite_test.go
+++ b/go/apiserver/registration_invite_test.go
@@ -39,7 +39,7 @@ func newInviteFixture(c *qt.C) *inviteFixture {
 	svc := services.NewGroupService(groupReg, members, invites)
 
 	creatorID := "creator-user"
-	group, err := svc.CreateGroup(context.Background(), inviteTestTenantID, creatorID, "Test Group", "", models.Currency("USD"))
+	group, err := svc.CreateGroup(context.Background(), inviteTestTenantID, creatorID, "Test Group", "", "", models.Currency("USD"))
 	c.Assert(err, qt.IsNil)
 
 	return &inviteFixture{

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -4713,7 +4713,7 @@ const docTemplate = `{
                 }
             },
             "patch": {
-                "description": "Updates a location group's name and icon. The group_currency field is set once at creation and cannot be changed here — see issue #202 for the currency-migration tool. Requires group admin role.",
+                "description": "Updates a location group's name, icon, and description. The group_currency field is set once at creation and cannot be changed here — see issue #202 for the currency-migration tool. Requires group admin role.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -7861,6 +7861,10 @@ const docTemplate = `{
         "jsonapi.LocationGroupAttributes": {
             "type": "object",
             "properties": {
+                "description": {
+                    "description": "Description is the free-form one-line subtitle surfaced on the\ngroup settings page and the sidebar group-switcher (#1647).\nOptional; empty string means \"no description\". Capped at\n200 chars to match the locations.description cap.",
+                    "type": "string"
+                },
                 "group_currency": {
                     "description": "GroupCurrency is set once at group creation and is immutable after.\nOn create the handler validates the ISO code and defaults to USD\nwhen nil. On update the handler rejects a change with 422 — a\nreprice-aware currency migration is tracked under #202.",
                     "type": "string"
@@ -9460,6 +9464,10 @@ const docTemplate = `{
                         }
                     ],
                     "readOnly": true
+                },
+                "description": {
+                    "description": "Description is a free-form one-liner rendered as the muted subtitle\non the group settings page and the sidebar group-switcher. Empty\nstring means \"no description\" — same convention as Location.Description\n(#1531 item 4). Issue #1647.",
+                    "type": "string"
                 },
                 "group_currency": {
                     "description": "GroupCurrency is the ISO-4217 code the group values its inventory in. It is\na property of the group (not the user) because a user can belong to\ngroups valued in different currencies. Admins change it via the group's\nupdate endpoint; changing it triggers a reprice of the group's commodities.",

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -4706,7 +4706,7 @@
                 }
             },
             "patch": {
-                "description": "Updates a location group's name and icon. The group_currency field is set once at creation and cannot be changed here — see issue #202 for the currency-migration tool. Requires group admin role.",
+                "description": "Updates a location group's name, icon, and description. The group_currency field is set once at creation and cannot be changed here — see issue #202 for the currency-migration tool. Requires group admin role.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -7854,6 +7854,10 @@
         "jsonapi.LocationGroupAttributes": {
             "type": "object",
             "properties": {
+                "description": {
+                    "description": "Description is the free-form one-line subtitle surfaced on the\ngroup settings page and the sidebar group-switcher (#1647).\nOptional; empty string means \"no description\". Capped at\n200 chars to match the locations.description cap.",
+                    "type": "string"
+                },
                 "group_currency": {
                     "description": "GroupCurrency is set once at group creation and is immutable after.\nOn create the handler validates the ISO code and defaults to USD\nwhen nil. On update the handler rejects a change with 422 — a\nreprice-aware currency migration is tracked under #202.",
                     "type": "string"
@@ -9453,6 +9457,10 @@
                         }
                     ],
                     "readOnly": true
+                },
+                "description": {
+                    "description": "Description is a free-form one-liner rendered as the muted subtitle\non the group settings page and the sidebar group-switcher. Empty\nstring means \"no description\" — same convention as Location.Description\n(#1531 item 4). Issue #1647.",
+                    "type": "string"
                 },
                 "group_currency": {
                     "description": "GroupCurrency is the ISO-4217 code the group values its inventory in. It is\na property of the group (not the user) because a user can belong to\ngroups valued in different currencies. Admins change it via the group's\nupdate endpoint; changing it triggers a reprice of the group's commodities.",

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1588,6 +1588,13 @@ definitions:
     type: object
   jsonapi.LocationGroupAttributes:
     properties:
+      description:
+        description: |-
+          Description is the free-form one-line subtitle surfaced on the
+          group settings page and the sidebar group-switcher (#1647).
+          Optional; empty string means "no description". Capped at
+          200 chars to match the locations.description cap.
+        type: string
       group_currency:
         description: |-
           GroupCurrency is set once at group creation and is immutable after.
@@ -2861,6 +2868,13 @@ definitions:
           callers — none exist today on /groups, but the field is optional so
           non-authenticated paths don't synthesize a misleading role).
         readOnly: true
+      description:
+        description: |-
+          Description is a free-form one-liner rendered as the muted subtitle
+          on the group settings page and the sidebar group-switcher. Empty
+          string means "no description" — same convention as Location.Description
+          (#1531 item 4). Issue #1647.
+        type: string
       group_currency:
         description: |-
           GroupCurrency is the ISO-4217 code the group values its inventory in. It is
@@ -6430,7 +6444,7 @@ paths:
     patch:
       consumes:
       - application/vnd.api+json
-      description: 'Updates a location group''s name and icon. The group_currency
+      description: 'Updates a location group''s name, icon, and description. The group_currency
         field is set once at creation and cannot be changed here — see issue #202
         for the currency-migration tool. Requires group admin role.'
       parameters:

--- a/go/jsonapi/groups.go
+++ b/go/jsonapi/groups.go
@@ -107,6 +107,11 @@ type LocationGroupRequest struct {
 type LocationGroupAttributes struct {
 	Name string `json:"name"`
 	Icon string `json:"icon,omitempty"`
+	// Description is the free-form one-line subtitle surfaced on the
+	// group settings page and the sidebar group-switcher (#1647).
+	// Optional; empty string means "no description". Capped at
+	// 200 chars to match the locations.description cap.
+	Description string `json:"description,omitempty"`
 	// GroupCurrency is set once at group creation and is immutable after.
 	// On create the handler validates the ISO code and defaults to USD
 	// when nil. On update the handler rejects a change with 422 — a
@@ -143,6 +148,7 @@ func (la *LocationGroupAttributes) ValidateWithContext(ctx context.Context) erro
 	return validation.ValidateStructWithContext(ctx, la,
 		validation.Field(&la.Name, validation.Required, validation.Length(1, 100)),
 		validation.Field(&la.Icon, validation.By(validateGroupIcon)),
+		validation.Field(&la.Description, validation.Length(0, 200)),
 	)
 }
 

--- a/go/models/location_group.go
+++ b/go/models/location_group.go
@@ -62,6 +62,13 @@ type LocationGroup struct {
 	//migrator:schema:field name="icon" type="TEXT"
 	Icon string `json:"icon" db:"icon"`
 
+	// Description is a free-form one-liner rendered as the muted subtitle
+	// on the group settings page and the sidebar group-switcher. Empty
+	// string means "no description" — same convention as Location.Description
+	// (#1531 item 4). Issue #1647.
+	//migrator:schema:field name="description" type="TEXT" not_null="true" default=""
+	Description string `json:"description" db:"description"`
+
 	// Status indicates whether the group is active or pending deletion.
 	//migrator:schema:field name="status" type="TEXT" not_null="true" default="active"
 	Status LocationGroupStatus `json:"status" db:"status"`
@@ -141,6 +148,10 @@ func (lg *LocationGroup) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&lg.TenantID, rules.NotEmpty),
 		validation.Field(&lg.CreatedBy, rules.NotEmpty),
 		validation.Field(&lg.GroupCurrency, validation.Required),
+		// Mirrors the frontend cap on the matching field for Locations
+		// (frontend/src/features/locations/schemas.ts, 200 chars). Empty
+		// string is the unset value, so no NotEmpty.
+		validation.Field(&lg.Description, validation.Length(0, 200)),
 	)
 
 	return validation.ValidateStructWithContext(ctx, lg, fields...)

--- a/go/schema/migrations/_sqldata/1780000000_add_location_group_description.down.sql
+++ b/go/schema/migrations/_sqldata/1780000000_add_location_group_description.down.sql
@@ -1,0 +1,9 @@
+-- Migration rollback: drop the description column added by the companion
+-- UP migration (issue #1647).
+-- Direction: DOWN
+--
+-- CASCADE only matters if a future view / generated column references the
+-- column — none today, but mirroring the locations/areas rollback pattern
+-- from 1779500000_add_location_area_icon_description.down.sql.
+
+ALTER TABLE location_groups DROP COLUMN description CASCADE;

--- a/go/schema/migrations/_sqldata/1780000000_add_location_group_description.up.sql
+++ b/go/schema/migrations/_sqldata/1780000000_add_location_group_description.up.sql
@@ -1,0 +1,10 @@
+-- Migration: add a free-form `description` column to location_groups
+-- so the group settings page (#1537 item 4) and the sidebar group switcher
+-- (#1537 item 5) can render a one-line muted subtitle per group.
+-- Direction: UP
+--
+-- Mirrors the locations.description pattern from 1779500000 (issue #1531
+-- item 4): TEXT NOT NULL DEFAULT '' so existing rows keep working with an
+-- empty subtitle until the admin sets one. Issue #1647.
+
+ALTER TABLE location_groups ADD COLUMN description TEXT NOT NULL DEFAULT '';

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -130,8 +130,9 @@ func (s *GroupService) SetUserRegistry(userRegistry registry.UserRegistry) {
 // CreateGroup creates a new location group and adds the creator as its admin.
 // An empty groupCurrency falls back to USD so memory-backed registries (which
 // don't apply DB defaults) still produce a valid group — commodity validation
-// would otherwise trip on an empty currency.
-func (s *GroupService) CreateGroup(ctx context.Context, tenantID, userID, name, icon string, groupCurrency models.Currency) (*models.LocationGroup, error) {
+// would otherwise trip on an empty currency. `description` is an optional
+// free-form one-liner (issue #1647); the empty string means "no description".
+func (s *GroupService) CreateGroup(ctx context.Context, tenantID, userID, name, icon, description string, groupCurrency models.Currency) (*models.LocationGroup, error) {
 	maxMemberships := MaxGroupMembershipsPerUser()
 	// Pre-check the cap before creating the group so we don't have to
 	// roll back a successful group insert when the user is already at
@@ -165,6 +166,7 @@ func (s *GroupService) CreateGroup(ctx context.Context, tenantID, userID, name, 
 		Slug:          slug,
 		Name:          name,
 		Icon:          icon,
+		Description:   description,
 		Status:        models.LocationGroupStatusActive,
 		CreatedBy:     userID,
 		GroupCurrency: groupCurrency,
@@ -230,8 +232,10 @@ func (s *GroupService) GetGroupBySlug(ctx context.Context, tenantID, slug string
 	return s.groupRegistry.GetBySlug(ctx, tenantID, slug)
 }
 
-// UpdateGroup updates group metadata. Only name and icon can be changed.
-func (s *GroupService) UpdateGroup(ctx context.Context, groupID, name, icon string) (*models.LocationGroup, error) {
+// UpdateGroup updates group metadata. Only name, icon, and description can
+// be changed — `group_currency` is immutable here (tracked under #202), the
+// remaining columns are server-managed.
+func (s *GroupService) UpdateGroup(ctx context.Context, groupID, name, icon, description string) (*models.LocationGroup, error) {
 	group, err := s.groupRegistry.Get(ctx, groupID)
 	if err != nil {
 		return nil, err
@@ -243,6 +247,7 @@ func (s *GroupService) UpdateGroup(ctx context.Context, groupID, name, icon stri
 
 	group.Name = name
 	group.Icon = icon
+	group.Description = description
 	group.UpdatedAt = time.Now()
 
 	return s.groupRegistry.Update(ctx, *group)

--- a/go/services/group_service_test.go
+++ b/go/services/group_service_test.go
@@ -61,7 +61,7 @@ func TestGroupService_CreateGroup(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "My Group", "📦", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "My Group", "📦", "", "")
 	c.Assert(err, qt.IsNil)
 	c.Assert(group, qt.IsNotNil)
 	c.Assert(group.Name, qt.Equals, "My Group")
@@ -80,9 +80,9 @@ func TestGroupService_ListUserGroups(t *testing.T) {
 	ctx := context.Background()
 
 	// Create two groups for the same user
-	g1, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group 1", "", "")
+	g1, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group 1", "", "", "")
 	c.Assert(err, qt.IsNil)
-	g2, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group 2", "", "")
+	g2, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group 2", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	groups, err := svc.ListUserGroups(ctx, "tenant-1", "user-1")
@@ -99,13 +99,34 @@ func TestGroupService_UpdateGroup(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Old Name", "🏠", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Old Name", "🏠", "", "")
 	c.Assert(err, qt.IsNil)
 
-	updated, err := svc.UpdateGroup(ctx, group.ID, "New Name", "🏢")
+	updated, err := svc.UpdateGroup(ctx, group.ID, "New Name", "🏢", "Renamed subtitle")
 	c.Assert(err, qt.IsNil)
 	c.Assert(updated.Name, qt.Equals, "New Name")
 	c.Assert(updated.Icon, qt.Equals, "🏢")
+	c.Assert(updated.Description, qt.Equals, "Renamed subtitle")
+
+	// Clearing the description round-trips as the empty string; mirrors
+	// the apiserver-level test for the textarea-emptied UI path.
+	cleared, err := svc.UpdateGroup(ctx, group.ID, "New Name", "🏢", "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(cleared.Description, qt.Equals, "")
+}
+
+// TestGroupService_CreateGroup_PersistsDescription pins the create-side
+// round-trip for the description field added by #1647 at the service
+// boundary — complements the apiserver-level test that covers the JSON
+// payload binding.
+func TestGroupService_CreateGroup_PersistsDescription(t *testing.T) {
+	c := qt.New(t)
+	svc := newTestGroupService()
+	ctx := context.Background()
+
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Family", "🏠", "Shared household stuff", "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(group.Description, qt.Equals, "Shared household stuff")
 }
 
 func TestGroupService_InitiateGroupDeletion(t *testing.T) {
@@ -113,7 +134,7 @@ func TestGroupService_InitiateGroupDeletion(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "To Delete", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "To Delete", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	// Wrong confirmation word
@@ -130,7 +151,7 @@ func TestGroupService_InitiateGroupDeletion(t *testing.T) {
 	c.Assert(deleted.Status, qt.Equals, models.LocationGroupStatusPendingDeletion)
 
 	// Cannot update a pending_deletion group
-	_, err = svc.UpdateGroup(ctx, group.ID, "New Name", "")
+	_, err = svc.UpdateGroup(ctx, group.ID, "New Name", "", "")
 	c.Assert(err, qt.IsNotNil)
 }
 
@@ -139,7 +160,7 @@ func TestGroupService_AddMember(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	// Add a new member
@@ -158,7 +179,7 @@ func TestGroupService_RemoveMember(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	// Add a second member
@@ -178,7 +199,7 @@ func TestGroupService_RemoveMember_LastOwnerProtection(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	// The sole owner cannot be removed — would leave the group without
@@ -280,7 +301,7 @@ func TestGroupService_LeaveGroup_SoleOwnerPrefersLastOwner(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Solo", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Solo", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	err = svc.LeaveGroup(ctx, group.ID, "user-1")
@@ -457,7 +478,7 @@ func TestGroupService_UpdateMemberRole(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	// Add a second owner so user-1 can be demoted without tripping
@@ -481,7 +502,7 @@ func TestGroupService_UpdateMemberRole_LastOwnerProtection(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	// Cannot demote the last owner.
@@ -494,7 +515,7 @@ func TestGroupService_LeaveGroup(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	// Add a second owner so the first can leave without violating the
@@ -513,7 +534,7 @@ func TestGroupService_LeaveGroup_LastOwnerProtection(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	// The sole owner cannot leave.
@@ -540,7 +561,7 @@ func TestGroupService_InviteFlow(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	// Create invite
@@ -574,7 +595,7 @@ func TestGroupService_RevokeInviteForGroup(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	invite, err := svc.CreateInvite(ctx, "tenant-1", group.ID, "user-1", 24*time.Hour)
@@ -594,10 +615,10 @@ func TestGroupService_RevokeInviteForGroup_WrongGroup(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group A", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group A", "", "", "")
 	c.Assert(err, qt.IsNil)
 
-	otherGroup, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group B", "", "")
+	otherGroup, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group B", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	invite, err := svc.CreateInvite(ctx, "tenant-1", group.ID, "user-1", 24*time.Hour)
@@ -614,7 +635,7 @@ func TestGroupService_RevokeInviteForGroup_CannotRevokeUsed(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	invite, err := svc.CreateInvite(ctx, "tenant-1", group.ID, "user-1", 24*time.Hour)
@@ -634,7 +655,7 @@ func TestGroupService_ListActiveInvites(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	// Create two invites
@@ -653,7 +674,7 @@ func TestGroupService_GetGroupBySlug(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	found, err := svc.GetGroupBySlug(ctx, "tenant-1", group.Slug)
@@ -674,7 +695,7 @@ func TestGroupService_EnsureDefaultGroup_PromotesFirstMembership(t *testing.T) {
 	user := seedUser(c, users, "tenant-1", "alice@example.com")
 
 	// Brand-new user creates their first group → that group becomes default.
-	group, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "First", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "First", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	stored, err := users.Get(ctx, user.ID)
@@ -689,12 +710,12 @@ func TestGroupService_EnsureDefaultGroup_KeepsExistingPreference(t *testing.T) {
 	ctx := context.Background()
 	user := seedUser(c, users, "tenant-1", "alice@example.com")
 
-	g1, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "First", "", "")
+	g1, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "First", "", "", "")
 	c.Assert(err, qt.IsNil)
 	// A second group must NOT clobber the user's existing default — the
 	// invariant only requires that *some* membership is the default, not
 	// that the latest one wins.
-	g2, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "Second", "", "")
+	g2, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "Second", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	stored, err := users.Get(ctx, user.ID)
@@ -711,7 +732,7 @@ func TestGroupService_EnsureDefaultGroup_AcceptInviteAsBrandNewUser(t *testing.T
 	owner := seedUser(c, users, "tenant-1", "owner@example.com")
 	invitee := seedUser(c, users, "tenant-1", "invitee@example.com")
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", owner.ID, "Shared", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", owner.ID, "Shared", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	invite, err := svc.CreateInvite(ctx, "tenant-1", group.ID, owner.ID, 24*time.Hour)
@@ -733,9 +754,9 @@ func TestGroupService_EnsureDefaultGroup_RepromotesOnLeave(t *testing.T) {
 	user := seedUser(c, users, "tenant-1", "alice@example.com")
 
 	// User belongs to two groups they created; default points at g1.
-	g1, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "First", "", "")
+	g1, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "First", "", "", "")
 	c.Assert(err, qt.IsNil)
-	g2, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "Second", "", "")
+	g2, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "Second", "", "", "")
 	c.Assert(err, qt.IsNil)
 	stored, err := users.Get(ctx, user.ID)
 	c.Assert(err, qt.IsNil)
@@ -760,7 +781,7 @@ func TestGroupService_EnsureDefaultGroup_LastMembershipLeavesNullDefault(t *test
 	ctx := context.Background()
 	user := seedUser(c, users, "tenant-1", "alice@example.com")
 
-	g1, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "Only", "", "")
+	g1, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "Only", "", "", "")
 	c.Assert(err, qt.IsNil)
 	// Add a co-owner so the leaving owner doesn't trip the ≥1 owner guard.
 	_, err = svc.AddMember(ctx, "tenant-1", g1.ID, "co-owner", models.GroupRoleOwner)
@@ -782,9 +803,9 @@ func TestGroupService_EnsureDefaultGroup_DeterministicByJoinedAt(t *testing.T) {
 
 	// Two memberships with explicit joined_at so the deterministic earliest-
 	// joined-at tiebreak is unambiguous regardless of map iteration order.
-	earlyGroup, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "Early", "", "")
+	earlyGroup, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "Early", "", "", "")
 	c.Assert(err, qt.IsNil)
-	lateGroup, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "Late", "", "")
+	lateGroup, err := svc.CreateGroup(ctx, "tenant-1", user.ID, "Late", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	rows, err := memberships.ListByUser(ctx, "tenant-1", user.ID)
@@ -825,19 +846,19 @@ func TestGroupService_MembershipCap_CreateGroup(t *testing.T) {
 
 	// Fill the cap with three groups for the same user.
 	for i := range services.MaxGroupMembershipsPerUser() {
-		_, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "G", "", "")
+		_, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "G", "", "", "")
 		c.Assert(err, qt.IsNil, qt.Commentf("group %d should fit under the cap", i+1))
 	}
 
 	// The next CreateGroup must be rejected with the typed sentinel —
 	// surface code (and the FE) match on it to render the right copy.
-	_, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Overflow", "", "")
+	_, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Overflow", "", "", "")
 	c.Assert(err, qt.ErrorIs, services.ErrTooManyGroupMemberships)
 
 	// A different user is unaffected — the cap is per-user, not
 	// per-tenant. This guards against accidentally globbing the
 	// membership count across users in a future refactor.
-	_, err = svc.CreateGroup(ctx, "tenant-1", "user-2", "Other", "", "")
+	_, err = svc.CreateGroup(ctx, "tenant-1", "user-2", "Other", "", "", "")
 	c.Assert(err, qt.IsNil)
 }
 
@@ -849,7 +870,7 @@ func TestGroupService_MembershipCap_AddMember(t *testing.T) {
 	// user-1 owns three groups (== cap).
 	groups := make([]string, services.MaxGroupMembershipsPerUser())
 	for i := range groups {
-		g, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "G", "", "")
+		g, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "G", "", "", "")
 		c.Assert(err, qt.IsNil)
 		groups[i] = g.ID
 	}
@@ -865,7 +886,7 @@ func TestGroupService_MembershipCap_AddMember(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Now the cap is reached — creating a fourth group for user-2 fails.
-	_, err = svc.CreateGroup(ctx, "tenant-1", "user-2", "Fourth", "", "")
+	_, err = svc.CreateGroup(ctx, "tenant-1", "user-2", "Fourth", "", "", "")
 	c.Assert(err, qt.ErrorIs, services.ErrTooManyGroupMemberships)
 }
 
@@ -876,7 +897,7 @@ func TestGroupService_GetMembershipRole(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	// Group creator is owner post-#1533.
@@ -894,7 +915,7 @@ func TestGroupService_HasRoleAtLeast(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 	_, err = svc.AddMember(ctx, "tenant-1", group.ID, "viewer-2", models.GroupRoleViewer)
 	c.Assert(err, qt.IsNil)
@@ -946,7 +967,7 @@ func TestGroupService_IsGroupOwner(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 	_, err = svc.AddMember(ctx, "tenant-1", group.ID, "admin-2", models.GroupRoleAdmin)
 	c.Assert(err, qt.IsNil)
@@ -961,7 +982,7 @@ func TestGroupService_CreateInviteWithEmail(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	email := "invitee@example.com"
@@ -989,7 +1010,7 @@ func TestGroupService_AcceptInvite_UsesInviteRole(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	email := "invitee@example.com"
@@ -1009,7 +1030,7 @@ func TestGroupService_ResendInvite(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	email := "invitee@example.com"
@@ -1034,7 +1055,7 @@ func TestGroupService_ResendInvite(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, services.ErrInviteNotByEmail)
 
 	// Wrong-group ownership is rejected.
-	otherGroup, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Other", "", "")
+	otherGroup, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Other", "", "", "")
 	c.Assert(err, qt.IsNil)
 	_, err = svc.ResendInvite(ctx, otherGroup.ID, invite.ID, 0)
 	c.Assert(err, qt.ErrorIs, services.ErrInviteNotInGroup)
@@ -1047,7 +1068,7 @@ func TestGroupService_ListMembersWithUsers_NoUserRegistry(t *testing.T) {
 	svc := newTestGroupService()
 	ctx := context.Background()
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 	_, err = svc.AddMember(ctx, "tenant-1", group.ID, "user-2", models.GroupRoleUser)
 	c.Assert(err, qt.IsNil)
@@ -1070,7 +1091,7 @@ func TestGroupService_ListMembersWithUsers_JoinedFields(t *testing.T) {
 	owner := seedUser(c, users, "tenant-1", "owner@example.com")
 	other := seedUser(c, users, "tenant-1", "other@example.com")
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", owner.ID, "Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", owner.ID, "Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 	_, err = svc.AddMember(ctx, "tenant-1", group.ID, other.ID, models.GroupRoleUser)
 	c.Assert(err, qt.IsNil)
@@ -1098,9 +1119,9 @@ func TestGroupService_AttachCurrentUserRoles_PopulatesRolePerGroup(t *testing.T)
 
 	caller := seedUser(c, users, "tenant-1", "caller@example.com")
 
-	ownerGroup, err := svc.CreateGroup(ctx, "tenant-1", caller.ID, "Owner Group", "", "")
+	ownerGroup, err := svc.CreateGroup(ctx, "tenant-1", caller.ID, "Owner Group", "", "", "")
 	c.Assert(err, qt.IsNil)
-	userGroup, err := svc.CreateGroup(ctx, "tenant-1", caller.ID, "User Group", "", "")
+	userGroup, err := svc.CreateGroup(ctx, "tenant-1", caller.ID, "User Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 	// Demote the caller to `user` in the second group via the membership
 	// registry directly — promotion paths go through ChangeMemberRole,
@@ -1132,7 +1153,7 @@ func TestGroupService_AttachCurrentUserRoles_LeavesNilWhenNoMembership(t *testin
 	owner := seedUser(c, users, "tenant-1", "owner@example.com")
 	outsider := seedUser(c, users, "tenant-1", "outsider@example.com")
 
-	group, err := svc.CreateGroup(ctx, "tenant-1", owner.ID, "Owner Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", owner.ID, "Owner Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	groups := []*models.LocationGroup{group}
@@ -1146,7 +1167,7 @@ func TestGroupService_AttachCurrentUserRole_SingleGroup(t *testing.T) {
 	ctx := context.Background()
 
 	owner := seedUser(c, users, "tenant-1", "owner@example.com")
-	group, err := svc.CreateGroup(ctx, "tenant-1", owner.ID, "Owner Group", "", "")
+	group, err := svc.CreateGroup(ctx, "tenant-1", owner.ID, "Owner Group", "", "", "")
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(svc.AttachCurrentUserRole(ctx, group, "tenant-1", owner.ID), qt.IsNil)


### PR DESCRIPTION
## Summary

Closes #1647 — adds a free-form `description` column to `LocationGroup` so the group settings page (#1537 item 4) and the sidebar group-switcher (#1537 item 5) can render a one-line muted subtitle per group. Unblocks the FE TODO markers already placed in `frontend/src/pages/groups/GroupSettingsPage.tsx` and `frontend/src/components/GroupSelector.tsx`.

## Decisions

- **Length cap:** 200 chars — matches the `description` cap on `frontend/src/features/locations/schemas.ts` for parity with the Location/Area descriptions shipped in #1531 item 4.
- **Default:** empty string. Mirrors the locations.description pattern (`NOT NULL DEFAULT ''`) so existing rows keep rendering with no subtitle until an admin opts in.
- **PATCH gating:** admin-only, mirroring the existing `name`/`icon` gates on `/groups/{groupID}`. The frontend admin form sends `""` to clear the field; the binder accepts that explicit empty as the clear path.
- **Migration timestamp:** `1780000000_add_location_group_description` — one step after `1779900000_add_user_mfa_secrets` (the previous tip).

## Files

- `go/schema/migrations/_sqldata/1780000000_add_location_group_description.{up,down}.sql` — new migration
- `go/models/location_group.go` — `Description` field with `migrator:schema:field` annotation + 200-char validator
- `go/jsonapi/groups.go` — `Description` in `LocationGroupAttributes` + bind-time length cap
- `go/services/group_service.go` — `CreateGroup` / `UpdateGroup` thread the field through
- `go/apiserver/groups.go` — POST/PATCH handlers pass `attrs.Description` along; swagger doc-comment updated for the PATCH summary
- `go/docs/{docs.go,swagger.json,swagger.yaml}` + `frontend/src/types/api.d.ts` — regenerated via `make swagger`
- Tests: `go/apiserver/groups_test.go` (create / patch / get round-trip + 200-char rejection on both paths); `go/services/group_service_test.go` (service-layer round-trip + clear)
- Existing test call sites for `CreateGroup` / `UpdateGroup` were updated for the new positional arg.

## Test plan

- [x] `go test ./apiserver/... ./services/... ./jsonapi/... ./models/... ./registry/memory/... ./schema/...` green locally
- [x] `golangci-lint run --fix` clean
- [x] `make swagger` regenerated; both `go/docs/swagger.json` and `frontend/src/types/api.d.ts` carry the new field
- [ ] CI green
- [ ] FE follow-up (separate PR / issue): wire the InfoSection Textarea + GroupSelector subtitle now that the schema is live