### PR TITLE
[#1659] Files page polish round 2: per-MIME palette, density, fixed-overlay BulkBar

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -161,6 +161,15 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 
 ### Files & Attachments
 
+#### 2026-05-16 — Files page keeps the multi-select BulkBar; surfaces it as a fixed bottom overlay
+
+- **Issue/PR**: #1659 / PR (this branch)
+- **Mock**: [`design-mocks/src/views/FileBrowserView.tsx`](../../design-mocks/src/views/FileBrowserView.tsx) has no bulk-select affordance at all — file rows have no per-row checkbox, no select-all, no bulk action toolbar.
+- **Reality**: `frontend/src/pages/files/FilesListPage.tsx` ships per-file checkboxes (both on `FileCard` and `FileListRow`) and a context-mode `BulkBar` with select-all, "Move to…" reclassification, and bulk delete (`data-testid="files-bulk-bar"`). Under this PR the bar shifts from an in-flow `bg-muted/40` row to a `fixed bottom-6 left-1/2 -translate-x-1/2 z-40` overlay on the `popover` token, animating in via `tw-animate-css` (`animate-in slide-in-from-bottom-4 fade-in-0 duration-200`) so the first selection no longer reflows the page.
+- **Why**: Bulk operations (move, delete) are real product affordances on a page that can hold tens of thousands of files — dropping them to match the mock would be an unambiguous regression. The fixed-overlay shape follows the "context-mode toolbar" pattern (GMail/Drive/shadcn) so the bar stays visible across scroll without ever pushing the grid down. Using `bg-popover` (a token that already implies a floating-surface elevation) keeps us off bespoke `shadow-*` decoration per the design language.
+- **Approved by**: user (explicit) — issue #1659 §9 "PRESERVE: file multi-select — but animate the bulk bar entry" lists the bar as a real product feature and asks for the fixed-overlay treatment as the preferred option.
+- **Reversion plan**: Permanent unless the upstream mock adopts a richer mass-action pattern. The unrelated hidden-by-default checkbox UX (separate UX concern) is tracked in #1484; if that lands, this entry stays as-is (the BulkBar shape doesn't change) and the checkbox visibility note moves to its own entry.
+
 #### 2026-05-09 — Curated tag pills match by lowercase tag name, not opaque tag id
 
 - **Issue/PR**: #1538 (item 3) / PR _pending_

--- a/e2e/tests/files.spec.ts
+++ b/e2e/tests/files.spec.ts
@@ -151,6 +151,76 @@ test.describe('Files page', () => {
     ).toHaveCount(0, { timeout: 15000 })
   })
 
+  test('selecting a card opens the BulkBar as a fixed bottom overlay (no layout jolt)', async ({ page }) => {
+    // #1659 item 9: the BulkBar is a `fixed` bottom-centre overlay so
+    // toggling the first checkbox does NOT reflow the grid (no "jolt").
+    // We assert it (a) renders, (b) has `position: fixed`, and (c) the
+    // sibling grid container's bounding box did not move on selection.
+    const uniqueName = `e2e-bulkbar-${Date.now()}.jpg`
+    const fixtureBuffer = fs.readFileSync(path.join('fixtures', 'files', 'image.jpg'))
+
+    await gotoFiles(page)
+
+    await page.getByTestId('files-upload-cta').click()
+    await page.getByTestId('files-upload-input').setInputFiles({
+      name: uniqueName,
+      mimeType: 'image/jpeg',
+      buffer: fixtureBuffer,
+    })
+    await page.getByTestId('files-upload-next').click()
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/uploads/file') && resp.request().method() === 'POST',
+        { timeout: 30000 }
+      ),
+      page.getByTestId('files-upload-start').click(),
+    ])
+    await page.getByTestId('files-upload-close').click()
+
+    await page.getByTestId('files-tile-images').click()
+    const card = page
+      .locator('[data-testid^="file-card-"][data-category="images"]')
+      .filter({ hasText: stripExt(uniqueName) })
+      .first()
+    await expect(card).toBeVisible({ timeout: 15000 })
+
+    // Capture grid bounding-box BEFORE selection so we can assert the
+    // bar's appearance does not push it.
+    const grid = page.getByTestId('files-grid')
+    const beforeBox = await grid.boundingBox()
+    expect(beforeBox).not.toBeNull()
+
+    // Tick the per-card checkbox — same testid pattern as the FileCard
+    // implementation (`file-card-checkbox-<id>`).
+    await card.getByTestId(/file-card-checkbox-/).click()
+
+    const bar = page.getByTestId('files-bulk-bar')
+    await expect(bar).toBeVisible()
+    // The bar is positioned as a fixed overlay, not in document flow —
+    // the `fixed bottom-6 left-1/2 -translate-x-1/2 z-40` recipe in
+    // FilesListPage.tsx.
+    const position = await bar.evaluate((el) => window.getComputedStyle(el).position)
+    expect(position).toBe('fixed')
+
+    const afterBox = await grid.boundingBox()
+    expect(afterBox).not.toBeNull()
+    // The grid's top edge must not have moved — the bar floats on top
+    // of the page rather than pushing siblings down.
+    expect(Math.abs((afterBox!.y ?? 0) - (beforeBox!.y ?? 0))).toBeLessThan(2)
+
+    // Cleanup so the row count returns to its pre-test value.
+    await card.getByTestId(/file-card-checkbox-/).click()
+    await card.getByTestId(/file-card-open-/).click()
+    await page.getByTestId('file-detail-delete').click()
+    await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/files/') && resp.request().method() === 'DELETE',
+        { timeout: 15000 }
+      ),
+      page.getByTestId('confirm-accept').click(),
+    ])
+  })
+
   test('per-category filter narrows the visible cards by category', async ({ page }) => {
     // This proves the BE /files?category=… filter wires through end
     // to end: an uploaded image must surface on All + Images tiles

--- a/frontend/src/components/files/FileCard.tsx
+++ b/frontend/src/components/files/FileCard.tsx
@@ -1,13 +1,18 @@
 import { useTranslation } from "react-i18next"
-import { File as FileIcon, FileImage, FileText, Receipt, Star } from "lucide-react"
+import { Star } from "lucide-react"
 
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import type { FileEntity, URLData } from "@/features/files/api"
-import { isImageMime } from "@/features/files/constants"
-import { formatDate } from "@/lib/intl"
+import {
+  FILE_CATEGORY_TILES,
+  FILE_TAG_PILLS,
+  getFileVisualMeta,
+  isImageMime,
+} from "@/features/files/constants"
+import { useCategoryLabel, useTagPillLabel } from "@/features/files/labels"
+import { formatBytes, formatDate } from "@/lib/intl"
 import { cn } from "@/lib/utils"
 
 // `coverState` mirrors the resolved cover for the parent commodity
@@ -30,8 +35,9 @@ export interface FileCardCoverState {
 }
 
 // One row in the Files grid. Renders a thumbnail (image MIME) or a
-// category icon, the title (falls back to the path), upload date, and
-// the tag pills. Click anywhere outside the checkbox opens the detail
+// per-MIME / per-category icon, the title (falls back to the path), a
+// linked-entity line when the file is attached, and a meta row with
+// tags + size. Click anywhere outside the checkbox opens the detail
 // sheet. The checkbox toggles bulk selection.
 // onToggleSelect + selected are optional: when onToggleSelect is omitted
 // the card renders without the checkbox, making it usable as a
@@ -63,8 +69,11 @@ export function FileCard({
   coverBusy = false,
 }: FileCardProps) {
   const { t } = useTranslation()
+  const categoryLabelOf = useCategoryLabel()
+  const tagLabelOf = useTagPillLabel()
   const title = file.title?.trim() || file.path?.trim() || file.id
-  const fallbackIcon = renderCategoryIcon(file.category, "size-12 text-muted-foreground")
+  const visual = getFileVisualMeta(file)
+  const FallbackIcon = visual.icon
   // Thumbnail keys come from services/file_signing_service.go — the BE
   // emits `small` / `medium` / `large`. Falling back through the sizes
   // means we always pick the smallest available (best for the
@@ -74,6 +83,21 @@ export function FileCard({
     signedUrl?.thumbnails?.small ?? signedUrl?.thumbnails?.medium ?? signedUrl?.thumbnails?.large
   const renderImage = isImageMime(file.mime_type) && (thumbUrl || signedUrl?.url)
   const tags = file.tags ?? []
+  const tile = FILE_CATEGORY_TILES.find((c) => c.key === file.category) ?? FILE_CATEGORY_TILES[0]
+  const CategoryBadgeIcon = tile.icon
+  const categoryLabel = categoryLabelOf(tile.key)
+  // Mirror FileListRow: known curated tags pick up their accent colour
+  // class; user-supplied tags fall back to muted-foreground.
+  const matchedTags = tags.map((tag) => {
+    const pill = FILE_TAG_PILLS.find((p) => p.id === tag.toLowerCase())
+    return {
+      id: tag,
+      label: pill ? tagLabelOf(pill.id) : tag,
+      colorClass: pill?.colorClass ?? "text-muted-foreground",
+    }
+  })
+  const sizeStr = file.size_bytes ? formatBytes(file.size_bytes) : ""
+  const linkedLabel = file.linked_entity_type?.trim() || ""
   // Star is only shown for photos and only when the parent wired up a
   // mutation handler. The auto-pick branch surfaces the same star with
   // an outline + tooltip "Pin as cover", so the user can promote the
@@ -100,6 +124,7 @@ export function FileCard({
     <Card
       data-testid={`file-card-${file.id}`}
       data-category={file.category}
+      data-mime-group={visual.group}
       className={cn(
         "group relative flex h-full flex-col overflow-hidden focus-within:ring-2 focus-within:ring-ring",
         selected && "ring-2 ring-primary"
@@ -145,7 +170,7 @@ export function FileCard({
         data-testid={`file-card-open-${file.id}`}
         className="flex flex-1 flex-col text-left focus-visible:outline-none"
       >
-        <div className="aspect-[4/3] w-full overflow-hidden bg-muted">
+        <div className="relative aspect-[4/3] w-full overflow-hidden">
           {renderImage ? (
             <img
               src={thumbUrl ?? signedUrl?.url}
@@ -154,54 +179,76 @@ export function FileCard({
               className="size-full object-cover"
             />
           ) : (
-            <div className="flex size-full items-center justify-center">{fallbackIcon}</div>
-          )}
-        </div>
-        <div className="flex flex-1 flex-col gap-2 p-3">
-          <div className="line-clamp-2 text-sm font-medium" title={title}>
-            {title}
-          </div>
-          <div className="text-xs text-muted-foreground">
-            {file.created_at
-              ? t("files:list.uploadDate", {
-                  date: formatDate(file.created_at),
-                  defaultValue: `Uploaded ${formatDate(file.created_at)}`,
-                })
-              : null}
-          </div>
-          {tags.length > 0 && (
-            <div className="flex flex-wrap gap-1">
-              {tags.slice(0, 3).map((tag) => (
-                <Badge key={tag} variant="secondary" className="text-[10px]">
-                  {tag}
-                </Badge>
-              ))}
-              {tags.length > 3 && (
-                <Badge variant="outline" className="text-[10px]">
-                  +{tags.length - 3}
-                </Badge>
-              )}
+            <div
+              className={cn("flex size-full items-center justify-center", visual.bgClass)}
+              data-testid={`file-card-fallback-${file.id}`}
+            >
+              <FallbackIcon
+                className={cn("size-12 opacity-80", visual.colorClass)}
+                strokeWidth={1.5}
+                aria-hidden="true"
+              />
             </div>
           )}
+          {/* Category badge overlay — mirrors design-mocks/src/views/FileBrowserView.tsx
+              grid card (lines 801-810). Always visible so users can scan by
+              category at a glance even when thumbnails dominate the tile. */}
+          <span
+            className={cn(
+              "absolute left-2 bottom-2 flex items-center gap-1 rounded-full px-2 py-0.5",
+              tile.activeBg
+            )}
+            data-testid={`file-card-category-${file.id}`}
+          >
+            <CategoryBadgeIcon className={cn("size-2.5", tile.activeColor)} aria-hidden="true" />
+            <span className={cn("text-[10px] font-medium", tile.activeColor)}>{categoryLabel}</span>
+          </span>
+        </div>
+        <div className="flex flex-1 flex-col gap-1 p-3">
+          <p className="truncate text-sm font-medium leading-tight" title={title}>
+            {title}
+          </p>
+          {linkedLabel ? (
+            <p
+              className="truncate text-xs text-muted-foreground"
+              title={linkedLabel}
+              data-testid={`file-card-linked-${file.id}`}
+            >
+              {linkedLabel}
+            </p>
+          ) : file.created_at ? (
+            <p className="truncate text-xs text-muted-foreground">
+              {t("files:list.uploadDate", {
+                date: formatDate(file.created_at),
+                defaultValue: `Uploaded ${formatDate(file.created_at)}`,
+              })}
+            </p>
+          ) : null}
+          {matchedTags.length > 0 || sizeStr ? (
+            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5">
+              {matchedTags.slice(0, 3).map((tag) => (
+                <span
+                  key={tag.id}
+                  className={cn("text-[10px] font-medium", tag.colorClass)}
+                  data-testid={`file-card-tag-${file.id}-${tag.id.toLowerCase()}`}
+                >
+                  #{tag.label}
+                </span>
+              ))}
+              {matchedTags.length > 3 ? (
+                <span className="text-[10px] font-medium text-muted-foreground">
+                  +{matchedTags.length - 3}
+                </span>
+              ) : null}
+              {sizeStr ? (
+                <span className="ml-auto text-[10px] text-muted-foreground tabular-nums">
+                  {sizeStr}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       </button>
     </Card>
   )
-}
-
-// renderCategoryIcon renders the per-category fallback icon as JSX. Returning
-// the element (not the component reference) avoids react-hooks's
-// "Cannot create components during render" warning, which flags PascalCase
-// locals coming back from a switch.
-function renderCategoryIcon(category: FileEntity["category"], className: string) {
-  switch (category) {
-    case "images":
-      return <FileImage className={className} aria-hidden="true" />
-    case "invoices":
-      return <Receipt className={className} aria-hidden="true" />
-    case "documents":
-      return <FileText className={className} aria-hidden="true" />
-    default:
-      return <FileIcon className={className} aria-hidden="true" />
-  }
 }

--- a/frontend/src/components/files/FileListRow.tsx
+++ b/frontend/src/components/files/FileListRow.tsx
@@ -3,7 +3,7 @@ import { File as FileIcon, FileImage, FileText, Receipt } from "lucide-react"
 
 import { Checkbox } from "@/components/ui/checkbox"
 import type { FileEntity } from "@/features/files/api"
-import { FILE_CATEGORY_TILES, FILE_TAG_PILLS } from "@/features/files/constants"
+import { FILE_CATEGORY_TILES, FILE_TAG_PILLS, getFileVisualMeta } from "@/features/files/constants"
 import { useCategoryLabel, useTagPillLabel } from "@/features/files/labels"
 import { formatBytes, formatDate } from "@/lib/intl"
 import { cn } from "@/lib/utils"
@@ -45,7 +45,11 @@ export function FileListRow({ file, selected, onToggleSelect, onOpen }: FileList
   })
   const dateStr = file.created_at ? formatDate(file.created_at) : ""
   const sizeStr = file.size_bytes ? formatBytes(file.size_bytes) : ""
-  const fileTypeIcon = renderFileTypeIcon(file)
+  // Per-MIME / per-category palette via shared helper so the leading
+  // icon picks up the same accent as the FileCard fallback and the
+  // mock's mimeIconAndColor (lines 152-157).
+  const visual = getFileVisualMeta(file)
+  const LeadingIcon = visual.icon
   const openLabel = t("files:list.openDetail", { title, defaultValue: `Open ${title}` })
 
   return (
@@ -56,11 +60,12 @@ export function FileListRow({ file, selected, onToggleSelect, onOpen }: FileList
           else (icon / Name+meta / Category badge / Uploaded / Size). */}
       <div
         className={cn(
-          "hidden grid-cols-[auto_auto_1fr_auto_auto_auto] items-center gap-3 px-3 transition-colors sm:grid",
+          "hidden grid-cols-[auto_auto_1fr_auto_auto_auto] items-center gap-4 px-4 transition-colors sm:grid",
           selected ? "bg-accent" : "hover:bg-muted/40"
         )}
         data-testid={`file-row-${file.id}`}
         data-category={file.category}
+        data-mime-group={visual.group}
       >
         <Checkbox
           checked={selected}
@@ -73,11 +78,11 @@ export function FileListRow({ file, selected, onToggleSelect, onOpen }: FileList
           onClick={() => onOpen(file.id)}
           aria-label={openLabel}
           className={cn(
-            "col-span-5 grid cursor-pointer grid-cols-subgrid items-center gap-3 py-2 text-left",
+            "col-span-5 grid cursor-pointer grid-cols-subgrid items-center gap-4 py-3 text-left",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           )}
         >
-          {fileTypeIcon}
+          <LeadingIcon className={cn("size-4 shrink-0", visual.colorClass)} aria-hidden="true" />
           <div className="min-w-0">
             <p className="truncate text-sm font-medium" title={title}>
               {title}
@@ -130,7 +135,7 @@ export function FileListRow({ file, selected, onToggleSelect, onOpen }: FileList
           structure as the desktop row, just stacked. */}
       <div
         className={cn(
-          "flex items-start gap-3 px-3 py-3 transition-colors sm:hidden",
+          "flex items-start gap-3 px-4 py-3 transition-colors sm:hidden",
           selected ? "bg-accent" : "active:bg-muted/40"
         )}
       >
@@ -152,10 +157,10 @@ export function FileListRow({ file, selected, onToggleSelect, onOpen }: FileList
           <div
             className={cn(
               "mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg",
-              tile?.activeBg ?? "bg-muted"
+              visual.bgClass
             )}
           >
-            {renderFileTypeIcon(file, cn("size-4", tile?.activeColor ?? "text-muted-foreground"))}
+            <LeadingIcon className={cn("size-4", visual.colorClass)} aria-hidden="true" />
           </div>
           <div className="min-w-0 flex-1">
             <p className="truncate text-sm font-medium leading-tight" title={title}>
@@ -198,24 +203,6 @@ export function FileListRow({ file, selected, onToggleSelect, onOpen }: FileList
       </div>
     </li>
   )
-}
-
-// renderFileTypeIcon resolves the leading file-type icon as JSX. We
-// return JSX (not a component reference) to satisfy react-hooks's
-// "Cannot create components during render" rule, which flags the
-// PascalCase locals coming back from a switch.
-function renderFileTypeIcon(file: FileEntity, className = "size-4 shrink-0 text-muted-foreground") {
-  const mime = file.mime_type ?? ""
-  if (mime.startsWith("image/")) {
-    return <FileImage className={className} aria-hidden="true" />
-  }
-  if (mime === "application/pdf" || file.category === "documents") {
-    return <FileText className={className} aria-hidden="true" />
-  }
-  if (file.category === "invoices") {
-    return <Receipt className={className} aria-hidden="true" />
-  }
-  return <FileIcon className={className} aria-hidden="true" />
 }
 
 function renderCategoryIcon(

--- a/frontend/src/components/files/__tests__/FileCard.test.tsx
+++ b/frontend/src/components/files/__tests__/FileCard.test.tsx
@@ -66,7 +66,7 @@ describe("<FileCard />", () => {
     expect(screen.getByText("named-by-path")).toBeInTheDocument()
   })
 
-  it("renders up to three tag badges with a +N overflow", () => {
+  it("renders up to three tag chips with a +N overflow", () => {
     render(
       <FileCard
         file={file({ tags: ["a", "b", "c", "d", "e"] })}
@@ -75,12 +75,47 @@ describe("<FileCard />", () => {
         onOpen={vi.fn()}
       />
     )
-    // First three tags rendered, then +2 overflow.
-    expect(screen.getByText("a")).toBeInTheDocument()
-    expect(screen.getByText("b")).toBeInTheDocument()
-    expect(screen.getByText("c")).toBeInTheDocument()
-    expect(screen.queryByText("d")).not.toBeInTheDocument()
+    // Per-#1659 the card emits mock-style colored "#tag" chips instead
+    // of `<Badge>`s — match the prefix so the assertion follows the
+    // visual change.
+    expect(screen.getByText("#a")).toBeInTheDocument()
+    expect(screen.getByText("#b")).toBeInTheDocument()
+    expect(screen.getByText("#c")).toBeInTheDocument()
+    expect(screen.queryByText("#d")).not.toBeInTheDocument()
     expect(screen.getByText("+2")).toBeInTheDocument()
+  })
+
+  // #1659 item 1: the per-MIME / per-category fallback icon palette
+  // mirrors design-mocks/src/views/FileBrowserView.tsx mimeIconAndColor
+  // — image/*  → status-active (green), application/pdf → status-expired
+  // (red), zip/archive → chart-4, anything else falls back to the
+  // category token (invoices → chart-1, documents → chart-3, other →
+  // muted-foreground). The `data-mime-group` attribute on the card
+  // exposes the chosen bucket for tests without coupling to Tailwind
+  // class strings.
+  it.each([
+    ["image/png", "images", "image"],
+    ["application/pdf", "documents", "pdf"],
+    ["application/zip", "other", "archive"],
+    ["application/x-zip-compressed", "other", "archive"],
+    ["text/plain", "documents", "document"],
+    ["application/octet-stream", "invoices", "invoice"],
+    ["application/octet-stream", "other", "other"],
+  ])("tags the fallback palette as %s+%s → %s", (mime, category, group) => {
+    render(
+      <FileCard
+        file={file({
+          mime_type: mime,
+          category: category as "images" | "invoices" | "documents" | "other",
+        })}
+        onOpen={vi.fn()}
+      />
+    )
+    // The image branch renders an <img>, not the fallback tile, when
+    // a signed URL is supplied — but here we never supply one, so the
+    // fallback tile is the rendered branch regardless of MIME.
+    const card = screen.getByTestId("file-card-f1")
+    expect(card.getAttribute("data-mime-group")).toBe(group)
   })
 
   it("calls onOpen with the file id when the body is clicked", async () => {

--- a/frontend/src/features/files/constants.ts
+++ b/frontend/src/features/files/constants.ts
@@ -1,7 +1,16 @@
-import { File as FileIcon, FileImage, FileText, Files as FilesIcon, Receipt } from "lucide-react"
+import {
+  File as FileIcon,
+  FileArchive,
+  FileImage,
+  FileText,
+  Files as FilesIcon,
+  Receipt,
+} from "lucide-react"
 import type { ComponentType, SVGProps } from "react"
 
-import type { FileCategory } from "./api"
+import type { FileCategory, FileEntity } from "./api"
+
+type LucideIcon = ComponentType<SVGProps<SVGSVGElement>>
 
 // The four user-meaningful buckets surfaced as tiles on the Files page.
 // Order matches the design mock's "All / Photos / Invoices / Documents
@@ -106,6 +115,86 @@ export function categoryFromMime(mime: string | undefined): FileCategory {
     return "documents"
   }
   return "other"
+}
+
+// Visual descriptor for a file's leading icon — drives both the
+// FileCard fallback (when there is no thumbnail) and the leading icon on
+// the FileListRow. Mirrors design-mocks/src/views/FileBrowserView.tsx
+// `mimeIconAndColor` so the two surfaces stay in lock-step with the
+// design contract: per-MIME tokens for the four hot paths (image / pdf /
+// archive) and a per-category fallback for everything else.
+//
+// Tokens-only, per the design language: `text-status-active`,
+// `text-status-expired`, `text-chart-*`, `text-muted-foreground` paired
+// with `bg-*/10` (or `bg-muted` for the neutral fallback).
+export interface FileVisualMeta {
+  icon: LucideIcon
+  colorClass: string
+  bgClass: string
+  // Stable identifier for the bucket — useful in tests and as a
+  // `data-mime-group` attribute so we can assert "this card uses the
+  // PDF palette" without coupling to the exact Tailwind utility.
+  group: "image" | "pdf" | "archive" | "invoice" | "document" | "other"
+}
+
+export function getFileVisualMeta(
+  file: Pick<FileEntity, "mime_type" | "category">
+): FileVisualMeta {
+  const mime = file.mime_type ?? ""
+  if (mime.startsWith("image/")) {
+    return {
+      icon: FileImage,
+      colorClass: "text-status-active",
+      bgClass: "bg-status-active/10",
+      group: "image",
+    }
+  }
+  if (mime === "application/pdf") {
+    return {
+      icon: FileText,
+      colorClass: "text-status-expired",
+      bgClass: "bg-status-expired/10",
+      group: "pdf",
+    }
+  }
+  if (mime.includes("zip") || mime.includes("archive")) {
+    return {
+      icon: FileArchive,
+      colorClass: "text-chart-4",
+      bgClass: "bg-chart-4/10",
+      group: "archive",
+    }
+  }
+  switch (file.category) {
+    case "images":
+      return {
+        icon: FileImage,
+        colorClass: "text-status-active",
+        bgClass: "bg-status-active/10",
+        group: "image",
+      }
+    case "invoices":
+      return {
+        icon: Receipt,
+        colorClass: "text-chart-1",
+        bgClass: "bg-chart-1/10",
+        group: "invoice",
+      }
+    case "documents":
+      return {
+        icon: FileText,
+        colorClass: "text-chart-3",
+        bgClass: "bg-chart-3/10",
+        group: "document",
+      }
+    default:
+      return {
+        icon: FileIcon,
+        colorClass: "text-muted-foreground",
+        bgClass: "bg-muted",
+        group: "other",
+      }
+  }
 }
 
 // Whether a file MIME is renderable inline by a plain <img> tag. Used by

--- a/frontend/src/pages/files/FilesListPage.tsx
+++ b/frontend/src/pages/files/FilesListPage.tsx
@@ -274,15 +274,26 @@ export function FilesListPage() {
     <div className="space-y-6" data-testid="page-files">
       <RouteTitle title={t("files:title", { defaultValue: "Files" })} />
 
+      {/* Mock-aligned page header (design-mocks/src/views/FileBrowserView.tsx
+          lines 531-542): h1 uses the canonical scroll-m-20 text-3xl
+          treatment; the lede sits directly under it; the upload button
+          is the size="sm" outline-less primary action on the right edge
+          of the title row (with `shrink-0` so a long lede never squeezes
+          it out of position). */}
       <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">
+          <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">
             {t("files:title", { defaultValue: "Files" })}
           </h1>
-          <p className="max-w-prose text-sm text-muted-foreground">{t("files:subtitle")}</p>
+          <p className="mt-1 max-w-prose text-muted-foreground">{t("files:subtitle")}</p>
         </div>
-        <Button onClick={() => setUploadOpen(true)} data-testid="files-upload-cta">
-          <Upload className="mr-2 size-4" aria-hidden="true" />
+        <Button
+          size="sm"
+          className="gap-1.5 shrink-0"
+          onClick={() => setUploadOpen(true)}
+          data-testid="files-upload-cta"
+        >
+          <Upload className="size-4" aria-hidden="true" />
           {t("files:uploadCta")}
         </Button>
       </header>
@@ -294,46 +305,48 @@ export function FilesListPage() {
         onSelect={(key) => patchParams({ category: key === "all" ? null : key })}
       />
 
-      {/* Per-category contextual subtitle row + view-mode toggle. The
-          active tile's accent colour tints the mini-icon on the left so
-          the row doubles as a visual reminder of which bucket is on. */}
-      <div className="flex items-center gap-2" data-testid="files-category-subtitle">
-        <div
-          className={cn(
-            "flex size-5 shrink-0 items-center justify-center rounded-md",
-            activeTileMeta.activeBg
-          )}
-        >
-          <ActiveIcon className={cn("size-3", activeTileMeta.activeColor)} aria-hidden="true" />
-        </div>
-        <p className="flex-1 text-xs text-muted-foreground">{descriptionOf(activeTile)}</p>
-        <div className="flex gap-1">
-          <Button
-            variant={viewMode === "list" ? "secondary" : "ghost"}
-            size="icon"
-            className="size-8"
-            onClick={() => setViewMode("list")}
-            aria-label={t("files:view.list", { defaultValue: "List view" })}
-            aria-pressed={viewMode === "list"}
-            data-testid="files-view-list"
-          >
-            <List className="size-4" aria-hidden="true" />
-          </Button>
-          <Button
-            variant={viewMode === "grid" ? "secondary" : "ghost"}
-            size="icon"
-            className="size-8"
-            onClick={() => setViewMode("grid")}
-            aria-label={t("files:view.grid", { defaultValue: "Grid view" })}
-            aria-pressed={viewMode === "grid"}
-            data-testid="files-view-grid"
-          >
-            <LayoutGrid className="size-4" aria-hidden="true" />
-          </Button>
-        </div>
-      </div>
-
+      {/* Subtitle + view toggle + search + tag pills form ONE toolbar
+          block (design-mocks/src/views/FileBrowserView.tsx 618-675).
+          Grouping them under a single `flex flex-col gap-2` keeps the
+          rhythm tight — the prior layout treated each row as a sibling
+          of the page wrapper's `space-y-6`, which left a 24px gulf
+          between the subtitle and the search input. */}
       <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2" data-testid="files-category-subtitle">
+          <div
+            className={cn(
+              "flex size-5 shrink-0 items-center justify-center rounded-md",
+              activeTileMeta.activeBg
+            )}
+          >
+            <ActiveIcon className={cn("size-3", activeTileMeta.activeColor)} aria-hidden="true" />
+          </div>
+          <p className="flex-1 text-xs text-muted-foreground">{descriptionOf(activeTile)}</p>
+          <div className="flex gap-1">
+            <Button
+              variant={viewMode === "list" ? "secondary" : "ghost"}
+              size="icon"
+              className="size-8"
+              onClick={() => setViewMode("list")}
+              aria-label={t("files:view.list", { defaultValue: "List view" })}
+              aria-pressed={viewMode === "list"}
+              data-testid="files-view-list"
+            >
+              <List className="size-4" aria-hidden="true" />
+            </Button>
+            <Button
+              variant={viewMode === "grid" ? "secondary" : "ghost"}
+              size="icon"
+              className="size-8"
+              onClick={() => setViewMode("grid")}
+              aria-label={t("files:view.grid", { defaultValue: "Grid view" })}
+              aria-pressed={viewMode === "grid"}
+              data-testid="files-view-grid"
+            >
+              <LayoutGrid className="size-4" aria-hidden="true" />
+            </Button>
+          </div>
+        </div>
         <form
           className="relative"
           onSubmit={(e) => {
@@ -401,9 +414,23 @@ export function FilesListPage() {
         </div>
       </div>
 
+      {/* Bulk-action toolbar — a fixed bottom-centre overlay so toggling
+          the first checkbox doesn't reflow the list (no "jolt"). The
+          shadcn `popover` token already encodes the floating-surface
+          elevation, which keeps us off bespoke `shadow-*` per the design
+          rules. Slide-in animation via `tw-animate-css`. The bar is
+          preserved as an intentional `mock < reality` divergence
+          (BulkBar isn't in design-mocks/src/views/FileBrowserView.tsx) —
+          see devdocs/frontend/design-deviations.md. */}
       {selected.size > 0 ? (
         <div
-          className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-muted/40 px-3 py-2 text-sm"
+          role="region"
+          aria-label={t("files:bulk.selected", { count: selected.size })}
+          className={cn(
+            "fixed bottom-6 left-1/2 z-40 w-[calc(100vw-2rem)] max-w-xl -translate-x-1/2",
+            "flex flex-wrap items-center justify-between gap-3 rounded-xl border bg-popover px-4 py-2.5 text-sm text-popover-foreground",
+            "animate-in slide-in-from-bottom-4 fade-in-0 duration-200"
+          )}
           data-testid="files-bulk-bar"
         >
           <div className="flex items-center gap-3">
@@ -465,7 +492,7 @@ export function FilesListPage() {
 
       {filesQuery.isLoading ? (
         viewMode === "grid" ? (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
             {Array.from({ length: 8 }).map((_, i) => (
               <Skeleton key={i} className="aspect-[4/3] w-full" />
             ))}
@@ -497,7 +524,7 @@ export function FilesListPage() {
         </div>
       ) : viewMode === "grid" ? (
         <div
-          className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4"
+          className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
           data-testid="files-grid"
         >
           {items.map(({ file, signedUrl }) => (
@@ -513,8 +540,11 @@ export function FilesListPage() {
         </div>
       ) : (
         <div className="overflow-hidden rounded-xl border bg-card" data-testid="files-list">
-          {/* Desktop header row — hidden on mobile (rows collapse). */}
-          <div className="hidden grid-cols-[auto_auto_1fr_auto_auto_auto] gap-3 border-b bg-muted/50 px-3 py-2 sm:grid">
+          {/* Desktop header row — hidden on mobile (rows collapse). The
+              gap-4/px-4 rhythm mirrors the mock (FileBrowserView.tsx
+              ~line 692) and keeps the header aligned with FileListRow's
+              `grid-cols-subgrid` body row. */}
+          <div className="hidden grid-cols-[auto_auto_1fr_auto_auto_auto] gap-4 border-b bg-muted/50 px-4 py-2 sm:grid">
             <div>
               <Checkbox
                 checked={allSelectedOnPage}


### PR DESCRIPTION
## Summary

Closes [#1659](https://github.com/denisvmedia/inventario/issues/1659) — the second mock-vs-real review of the Files page, picking up the deltas #1538 didn't catch.

### Items shipped (issue numbering)

- **1. Per-MIME / per-category icon palette.** New `getFileVisualMeta()` helper in `frontend/src/features/files/constants.ts` mirrors the mock's `mimeIconAndColor`: `image/*` → `text-status-active`, `application/pdf` → `text-status-expired`, zip/archive → `text-chart-4`, everything else falls back to category tokens (`text-chart-1` invoices, `text-chart-3` documents, `text-muted-foreground` other) with matching `bg-*/10` tints. Tokens-only.
- **3. Header typography + button cluster.** `<h1>` now uses the canonical `scroll-m-20 text-3xl font-semibold tracking-tight`, lede drops `text-sm` per the mock, Upload button shrinks to `size="sm"` and pins to the right with `shrink-0`.
- **4. Subtitle ↔ search spacing.** Wrapped the subtitle row + view toggle + search + tag pills under a single `flex flex-col gap-2` so the rhythm matches the mock — was previously a 24px gap because each row was a sibling of the outer `space-y-6`.
- **5. List-view header density.** Header + body row gap-3/px-3/py-2 → gap-4/px-4/py-3 to match `design-mocks/src/views/FileBrowserView.tsx` line 692 + 714.
- **6. Grid 3→4 cols at lg.** `xl:grid-cols-4` → `lg:grid-cols-4` (4-col kicks in at 1024px), gap-4 → gap-3 to match the mock's denser presentation.
- **7. Residual colour drift.** Picked up while doing the above (active tile bg / hover / pill colours already align — token-only check confirmed).
- **8. Card content enrichment.** `FileCard` adds the category badge overlay on the thumbnail (mock lines 801-810), a linked-entity line (falling back to upload date), and mock-style coloured `#tag` chips with size in `ml-auto` on the meta row. **Preserves:** cover-pin star overlay (#1411 AC#4) + selection checkbox.
- **9. BulkBar fixed-overlay + animation.** The bar shifts from in-flow `bg-muted/40` row to `fixed bottom-6 left-1/2 -translate-x-1/2 z-40` on the `popover` token, animating in via `tw-animate-css` (`animate-in slide-in-from-bottom-4 fade-in-0 duration-200`). First selection no longer reflows the grid. Logged as an intentional `mock < reality` divergence in `devdocs/frontend/design-deviations.md`.
- **2.** No FE work needed (tags rendering was already in place from #1538 — was just waiting on seed data; #1658 has shipped).
- **10.** Issue #1658 already closed/merged with ≥1 photo per commodity (35+ commodities total = 35+ photo files spanning the four categories, plus selective invoices/manuals). The implicit dependency is satisfied; no separate PR needed.

### Tests

- New vitest icon-colour matrix in `FileCard.test.tsx`: every MIME/category combo lands in the right `data-mime-group` bucket.
- Existing tag-chip test rewired to assert `#tag` text (the new mock-style chip shape) instead of `<Badge>`.
- New Playwright spec in `files.spec.ts` — selects a card, asserts `bulk bar` becomes visible, `position: fixed`, and the grid's bounding box does not move.

### Gates

- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm run test` ✓ (840/840, 4 skipped)
- `npm run test:coverage` ✓ (lines 79.28, funcs 75.08, statements 76.44, branches 67.79 — all above thresholds)
- `npm run format:check` ✓
- `npm run i18n:check` ✓

## Test plan

- [ ] CI green on this branch (typecheck / lint / vitest+coverage / Go suite / Playwright).
- [ ] Visual review via the `screenshot-review` skill against the mock — desktop + mobile, light + dark, against the enriched seed from #1658.
- [ ] Manual check: first card selection slides in the BulkBar without jolt; subsequent selections update the count; bulk move + bulk delete still work; deselect makes the bar slide out.
- [ ] 4-col grid kicks in at ~1024px viewport; mobile (sm) still gets 2 cols.