### PR TITLE
[#1661] Backup & Restore: optional description, real 422 reason, mock-aligned header

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -345,6 +345,15 @@ _None yet._
 - **Approved by**: agent-suggested — keeps behaviour-truth over mock-fidelity on a strictly-better-UX call; user invited to revert if visual parity matters.
 - **Reversion plan**: Drop the `&& !dry_run` guard and update the test if upstream insists on always-on warning.
 
+#### 2026-05-16 — "New export" stays a dedicated page (`/exports/new`), not a Dialog
+
+- **Issue/PR**: #1661 / PR (this branch)
+- **Mock**: [`design-mocks/src/views/BackupView.tsx`](../../design-mocks/src/views/BackupView.tsx) L498-L536 opens the "Create Export" CTA as a single-step `Dialog` (RadioGroup of types → submit footer).
+- **Reality**: `frontend/src/pages/exports/ExportNewPage.tsx` is preserved as a standalone two-step wizard route (`/g/{slug}/exports/new`): step 1 picks scope + the optional `selected_items` set + `include_file_data`, step 2 confirms with an optional description and the synthesised-default hint.
+- **Why**: The wizard's step 1 carries the `SelectedItemsPicker` tree (locations → areas → commodities) which is too tall for a dialog on mobile and benefits from a dedicated URL that survives accidental nav-aways and is shareable in support contexts. Step 2's description field + summary pane also wants room. The page surface predates the mock and the wizard's two-step shape was deliberately chosen on the previous polish pass.
+- **Approved by**: user (explicit) — issue #1661 acceptance criterion 5 ("PRESERVE — no Dialog (intentional)").
+- **Reversion plan**: Permanent unless the upstream mock adopts a wizard-shaped Dialog. The component is the only consumer of `/exports/new`; ripping it out requires a Dialog scaffold plus moving `SelectedItemsPicker` into the dialog body.
+
 ### Other
 
 #### 2026-05-15 — Tags settings page: All / Item / File scope tabs above the flat list

--- a/e2e/tests/exports-react.spec.ts
+++ b/e2e/tests/exports-react.spec.ts
@@ -134,8 +134,9 @@ test.describe('Exports / Restores (React)', () => {
     await page.getByTestId('wizard-submit').click()
 
     // The wizard navigates to the detail page on success; the description
-    // header should render the synthesised default, not "No description."
+    // header should render the synthesised default ending in " UTC" — not
+    // "No description.", and not a local-time-looking string.
     await expect(page.getByTestId('page-export-detail')).toBeVisible({ timeout: 30_000 })
-    await expect(page.getByText(/Backup · Full database · /)).toBeVisible()
+    await expect(page.getByText(/Backup · Full database · .+ UTC$/)).toBeVisible()
   })
 })

--- a/e2e/tests/exports-react.spec.ts
+++ b/e2e/tests/exports-react.spec.ts
@@ -98,4 +98,44 @@ test.describe('Exports / Restores (React)', () => {
       firstRestore.locator('[data-testid="status-completed"], [data-testid="status-failed"]'),
     ).toBeVisible({ timeout: 30_000 })
   })
+
+  // #1661 — Description is no longer required server-side (validation.Required
+  // dropped on Export.Description), and the service synthesises a
+  // "Backup · {type label} · {date}" default so the list row is never blank.
+  // This spec drives the empty-description path through the full wizard and
+  // asserts the detail page surfaces the synthesised text.
+  test('create export with empty description succeeds and surfaces synthesised default', async ({
+    page,
+    request,
+  }) => {
+    // Seed minimal data so the export captures something meaningful.
+    const auth = await extractApiAuth(page)
+    const group = await resolveActiveGroup(request, auth)
+    const { areaId } = await ensureLocationAndArea(request, auth, group.slug)
+    await createCommodityViaAPI(
+      request,
+      auth,
+      group.slug,
+      { name: `exports-empty-desc-${Date.now()}`, areaId },
+      group.groupCurrency,
+    )
+
+    await gotoExports(page)
+    await page.getByTestId('exports-create-button').click()
+    await expect(page).toHaveURL(/\/exports\/new/)
+    await expect(page.getByTestId('wizard-step-1-content')).toBeVisible()
+    await page.getByTestId('wizard-next').click()
+
+    await expect(page.getByTestId('wizard-step-2-content')).toBeVisible()
+    // Leave description blank — the BE should synthesise the default.
+    // Sanity-check that the hint copy is rendered so future regressions
+    // (someone reinstates the required marker) get caught here.
+    await expect(page.getByTestId('wizard-description-hint')).toBeVisible()
+    await page.getByTestId('wizard-submit').click()
+
+    // The wizard navigates to the detail page on success; the description
+    // header should render the synthesised default, not "No description."
+    await expect(page.getByTestId('page-export-detail')).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByText(/Backup · Full database · /)).toBeVisible()
+  })
 })

--- a/frontend/src/i18n/locales/en/exports.json
+++ b/frontend/src/i18n/locales/en/exports.json
@@ -57,12 +57,15 @@
     "uploadProgress": "Uploading file…"
   },
   "list": {
+    "countLabel_one": "{{count}} export",
+    "countLabel_other": "{{count}} exports",
     "deletedBadge": "Deleted",
     "description": "Generate downloadable backups of your inventory and use existing exports to restore data into this group.",
     "empty": "No exports yet — create your first one to keep a backup of this group.",
     "emptyFiltered": "No deleted exports.",
     "imported": "Imported",
-    "title": "Backup & exports"
+    "sectionHeader": "Exports",
+    "title": "Backup & Restore"
   },
   "polling": {
     "live": "Live"
@@ -147,6 +150,9 @@
     "back": "Back",
     "cancel": "Cancel",
     "creating": "Creating export…",
+    "descriptionHint": "Optional. If left blank, we name it for you: \"Backup · Full database · 2026-05-13 10:42\".",
+    "descriptionLabelOptional": "Description (optional)",
+    "descriptionPlaceholder": "e.g. Backup · Full database · 2026-05-13 10:42",
     "intro": "Pick what to back up. The export job runs in the background and lets you download the result when it finishes.",
     "next": "Next",
     "scope": {
@@ -167,7 +173,6 @@
     "step3Title": "Export job",
     "submit": "Create export",
     "summary": {
-      "description": "Description",
       "includeFileData": "Attachments",
       "includeFileDataNo": "Metadata only",
       "includeFileDataYes": "Inline base64",

--- a/frontend/src/i18n/locales/en/exports.json
+++ b/frontend/src/i18n/locales/en/exports.json
@@ -150,9 +150,9 @@
     "back": "Back",
     "cancel": "Cancel",
     "creating": "Creating export…",
-    "descriptionHint": "Optional. If left blank, we name it for you: \"Backup · Full database · 2026-05-13 10:42\".",
+    "descriptionHint": "Optional. If left blank, we name it for you: \"Backup · Full database · 2026-05-13 10:42 UTC\".",
     "descriptionLabelOptional": "Description (optional)",
-    "descriptionPlaceholder": "e.g. Backup · Full database · 2026-05-13 10:42",
+    "descriptionPlaceholder": "e.g. Backup · Full database · 2026-05-13 10:42 UTC",
     "intro": "Pick what to back up. The export job runs in the background and lets you download the result when it finishes.",
     "next": "Next",
     "scope": {

--- a/frontend/src/pages/exports/ExportDetailPage.tsx
+++ b/frontend/src/pages/exports/ExportDetailPage.tsx
@@ -15,6 +15,7 @@ import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
 import { useConfirm } from "@/hooks/useConfirm"
 import { formatBytes, formatDateTime } from "@/lib/intl"
+import { parseServerError } from "@/lib/server-error"
 
 export function ExportDetailPage() {
   const { t } = useTranslation(["exports", "common"])
@@ -53,7 +54,9 @@ export function ExportDetailPage() {
       toast.success(t("exports:removal.success"))
       navigate(`/g/${encodeURIComponent(slug)}/exports`)
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      // Surface BE-side JSON:API detail (e.g. "export still has an active
+      // restore in progress") instead of the bare HTTP wrapper.
+      const message = parseServerError(err, String(err))
       toast.error(t("exports:errors.deleteFailed", { error: message }))
     }
   }

--- a/frontend/src/pages/exports/ExportImportPage.tsx
+++ b/frontend/src/pages/exports/ExportImportPage.tsx
@@ -12,6 +12,7 @@ import { useImportBackup, useUploadRestoreFile } from "@/features/export/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
 import { formatBytes } from "@/lib/intl"
+import { parseServerError } from "@/lib/server-error"
 
 export function ExportImportPage() {
   const { t } = useTranslation(["exports", "common"])
@@ -48,7 +49,10 @@ export function ExportImportPage() {
       // — the only meaningful next step is to actually run the restore.
       navigate(`/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(created.id)}/restore`)
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      // Same JSON:API extraction as ExportNewPage — let the user see the
+      // BE's `errors[].detail` (e.g. "Description must be 500 chars or
+      // fewer") instead of the bare HTTP wrapper.
+      const message = parseServerError(err, String(err))
       const key = uploadMutation.isError
         ? "exports:errors.uploadFailed"
         : "exports:errors.importFailed"

--- a/frontend/src/pages/exports/ExportNewPage.tsx
+++ b/frontend/src/pages/exports/ExportNewPage.tsx
@@ -305,9 +305,7 @@ function Step2({ state, setState, isPending, onBack, onSubmit }: Step2Props) {
   return (
     <section className="flex flex-col gap-5" data-testid="wizard-step-2-content">
       <div className="flex flex-col gap-2">
-        <Label htmlFor="export-description">
-          {t("exports:wizard.descriptionLabelOptional")}
-        </Label>
+        <Label htmlFor="export-description">{t("exports:wizard.descriptionLabelOptional")}</Label>
         <Input
           id="export-description"
           value={state.description}

--- a/frontend/src/pages/exports/ExportNewPage.tsx
+++ b/frontend/src/pages/exports/ExportNewPage.tsx
@@ -12,6 +12,7 @@ import { type ExportSelectedItem, type ExportType } from "@/features/export/api"
 import { useCreateExport } from "@/features/export/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
+import { parseServerError } from "@/lib/server-error"
 import { cn } from "@/lib/utils"
 
 type WizardStep = 1 | 2
@@ -90,7 +91,11 @@ export function ExportNewPage() {
           navigate(`/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(created.id)}`)
         },
         onError: (err) => {
-          const message = err instanceof Error ? err.message : String(err)
+          // Surface the JSON:API `errors[].detail` (or `.title`) so the user
+          // sees the real reason (e.g. "Description must be 500 chars or
+          // fewer") instead of the bare HTTP wrapper. The bare wrapper read
+          // as: "Request to /api/v1/g/.../exports failed with 422".
+          const message = parseServerError(err, String(err))
           toast.error(t("exports:errors.createFailed", { error: message }))
         },
       }
@@ -300,15 +305,25 @@ function Step2({ state, setState, isPending, onBack, onSubmit }: Step2Props) {
   return (
     <section className="flex flex-col gap-5" data-testid="wizard-step-2-content">
       <div className="flex flex-col gap-2">
-        <Label htmlFor="export-description">{t("exports:wizard.summary.description")}</Label>
+        <Label htmlFor="export-description">
+          {t("exports:wizard.descriptionLabelOptional")}
+        </Label>
         <Input
           id="export-description"
           value={state.description}
           onChange={(e) => setState({ ...state, description: e.target.value })}
-          placeholder={t("exports:detail.noDescription")}
+          placeholder={t("exports:wizard.descriptionPlaceholder")}
           maxLength={500}
           data-testid="wizard-description"
+          aria-describedby="export-description-hint"
         />
+        <p
+          id="export-description-hint"
+          className="text-xs text-muted-foreground"
+          data-testid="wizard-description-hint"
+        >
+          {t("exports:wizard.descriptionHint")}
+        </p>
       </div>
 
       <dl

--- a/frontend/src/pages/exports/ExportRestorePage.tsx
+++ b/frontend/src/pages/exports/ExportRestorePage.tsx
@@ -14,6 +14,7 @@ import { useGroupMigrationLock } from "@/features/currency-migration/lock"
 import { useCreateRestore, useExport } from "@/features/export/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
+import { parseServerError } from "@/lib/server-error"
 
 const defaultState: RestoreOptionsFormValue = {
   description: "",
@@ -68,7 +69,10 @@ export function ExportRestorePage() {
           navigate(detailHref)
         },
         onError: (err) => {
-          const message = err instanceof Error ? err.message : String(err)
+          // Surface the BE's JSON:API `errors[].detail` (or `.title`) — same
+          // anti-pattern fix as ExportNewPage. The bare HTTP wrapper hid the
+          // actual reason behind "Request to /api/... failed with 422".
+          const message = parseServerError(err, String(err))
           toast.error(t("exports:errors.restoreCreateFailed", { error: message }))
         },
       }

--- a/frontend/src/pages/exports/ExportsListPage.tsx
+++ b/frontend/src/pages/exports/ExportsListPage.tsx
@@ -80,10 +80,7 @@ export function ExportsListPage() {
   }
 
   return (
-    <div
-      className="flex w-full flex-col gap-8 p-6 mx-auto max-w-4xl"
-      data-testid="page-exports"
-    >
+    <div className="flex w-full flex-col gap-8 p-6 mx-auto max-w-4xl" data-testid="page-exports">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex flex-col gap-1.5">
           <div className="flex items-center gap-2">
@@ -147,10 +144,7 @@ export function ExportsListPage() {
       <div className="flex items-center gap-2" data-testid="exports-section-header">
         <HardDriveDownload className="size-4 text-muted-foreground" aria-hidden="true" />
         <h2 className="text-base font-semibold">{t("exports:list.sectionHeader")}</h2>
-        <span
-          className="ml-auto text-xs text-muted-foreground"
-          data-testid="exports-section-count"
-        >
+        <span className="ml-auto text-xs text-muted-foreground" data-testid="exports-section-count">
           {t("exports:list.countLabel", { count: visibleItems.length })}
         </span>
       </div>

--- a/frontend/src/pages/exports/ExportsListPage.tsx
+++ b/frontend/src/pages/exports/ExportsListPage.tsx
@@ -1,4 +1,4 @@
-import { Plus, Upload } from "lucide-react"
+import { HardDriveDownload, Plus, Upload } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useSearchParams } from "react-router-dom"
@@ -15,6 +15,7 @@ import { type Export } from "@/features/export/api"
 import { useDeleteExport, useExports } from "@/features/export/hooks"
 import { useAppToast } from "@/hooks/useAppToast"
 import { useConfirm } from "@/hooks/useConfirm"
+import { parseServerError } from "@/lib/server-error"
 
 function exportUrl(slug: string, ...segments: (string | undefined)[]): string {
   const encodedSlug = encodeURIComponent(slug)
@@ -71,17 +72,27 @@ export function ExportsListPage() {
       await deleteMutation.mutateAsync(exp.id)
       toast.success(t("exports:removal.success"))
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      // Surface BE-side JSON:API detail (e.g. "export still has an active
+      // restore in progress") instead of the bare HTTP wrapper.
+      const message = parseServerError(err, String(err))
       toast.error(t("exports:errors.deleteFailed", { error: message }))
     }
   }
 
   return (
-    <div className="flex flex-col gap-6 p-6" data-testid="page-exports">
+    <div
+      className="flex w-full flex-col gap-8 p-6 mx-auto max-w-4xl"
+      data-testid="page-exports"
+    >
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex flex-col gap-1.5">
           <div className="flex items-center gap-2">
-            <h1 className="text-2xl font-semibold tracking-tight">{t("exports:list.title")}</h1>
+            <h1
+              className="scroll-m-20 text-3xl font-semibold tracking-tight"
+              data-testid="exports-page-title"
+            >
+              {t("exports:list.title")}
+            </h1>
             {isLive && (
               <span
                 className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
@@ -131,6 +142,17 @@ export function ExportsListPage() {
           />
           {t("exports:actions.showDeleted")}
         </label>
+      </div>
+
+      <div className="flex items-center gap-2" data-testid="exports-section-header">
+        <HardDriveDownload className="size-4 text-muted-foreground" aria-hidden="true" />
+        <h2 className="text-base font-semibold">{t("exports:list.sectionHeader")}</h2>
+        <span
+          className="ml-auto text-xs text-muted-foreground"
+          data-testid="exports-section-count"
+        >
+          {t("exports:list.countLabel", { count: visibleItems.length })}
+        </span>
       </div>
 
       {isInitialLoading ? (

--- a/go/apiserver/exports_test.go
+++ b/go/apiserver/exports_test.go
@@ -378,6 +378,11 @@ func TestExportCreate_EmptyDescription_SynthesisesDefault(t *testing.T) {
 	c.Assert(desc, qt.Not(qt.Equals), "", qt.Commentf("expected synthesised default, got empty"))
 	c.Assert(strings.HasPrefix(desc, "Backup · Full database · "), qt.IsTrue,
 		qt.Commentf("expected 'Backup · Full database · …' prefix, got: %q", desc))
+	// The trailing " UTC" suffix is part of the wire contract — it tells
+	// the user the timestamp isn't local time. Asserted explicitly to
+	// catch regressions on the format string.
+	c.Assert(strings.HasSuffix(desc, " UTC"), qt.IsTrue,
+		qt.Commentf("expected ' UTC' suffix, got: %q", desc))
 }
 
 // TestExportCreate_WhitespaceDescription_SynthesisesDefault verifies that
@@ -440,4 +445,6 @@ func TestExportCreate_WhitespaceDescription_SynthesisesDefault(t *testing.T) {
 
 	c.Assert(strings.HasPrefix(response.Data.Attributes.Description, "Backup · "), qt.IsTrue,
 		qt.Commentf("expected 'Backup · …' prefix, got: %q", response.Data.Attributes.Description))
+	c.Assert(strings.HasSuffix(response.Data.Attributes.Description, " UTC"), qt.IsTrue,
+		qt.Commentf("expected ' UTC' suffix, got: %q", response.Data.Attributes.Description))
 }

--- a/go/apiserver/exports_test.go
+++ b/go/apiserver/exports_test.go
@@ -315,3 +315,129 @@ func TestExportCreate_SetsCreatedDate(t *testing.T) {
 	hasValidTimezone := strings.HasSuffix(createdDateStr, "Z") || strings.Contains(createdDateStr, "+") || strings.Contains(createdDateStr, "-")
 	c.Assert(hasValidTimezone, qt.IsTrue, qt.Commentf("Expected RFC3339 format with timezone, got: %s", createdDateStr))
 }
+
+// TestExportCreate_EmptyDescription_SynthesisesDefault verifies that POST
+// /exports with an empty description is accepted (no 422) and that the
+// service synthesises a "Backup · {type label} · {date}" default so the
+// list row is never blank. Covers acceptance criterion #1 of issue #1661.
+func TestExportCreate_EmptyDescription_SynthesisesDefault(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+
+	testUser := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: "test-tenant-id",
+		},
+		Email:    "test+empty-desc@example.com",
+		Name:     "Test User",
+		IsActive: true,
+	}
+	testUser.SetPassword("Password123")
+	createdUser := must.Must(factorySet.UserRegistry.Create(context.Background(), testUser))
+
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	r.Use(apiserver.JWTMiddleware(testJWTSecret, factorySet.UserRegistry, nil))
+	r.Use(apiserver.RegistrySetMiddleware(factorySet))
+
+	params := apiserver.Params{
+		FactorySet:     factorySet,
+		UploadLocation: "memory://",
+		JWTSecret:      testJWTSecret,
+	}
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	r.Route("/exports", apiserver.Exports(params, mockRestoreWorker))
+
+	requestPayload := jsonapi.ExportCreateRequest{
+		Data: &jsonapi.ExportCreateRequestData{
+			Type: "exports",
+			Attributes: &models.Export{
+				Type:        models.ExportTypeFullDatabase,
+				Description: "", // user left it blank
+			},
+		},
+	}
+
+	payloadBytes, err := json.Marshal(requestPayload)
+	c.Assert(err, qt.IsNil)
+
+	req := httptest.NewRequest("POST", "/exports", bytes.NewReader(payloadBytes))
+	req.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(req, createdUser.ID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	c.Assert(w.Code, qt.Equals, http.StatusCreated, qt.Commentf("body: %s", w.Body.String()))
+
+	var response jsonapi.ExportResponse
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	c.Assert(err, qt.IsNil)
+
+	desc := response.Data.Attributes.Description
+	c.Assert(desc, qt.Not(qt.Equals), "", qt.Commentf("expected synthesised default, got empty"))
+	c.Assert(strings.HasPrefix(desc, "Backup · Full database · "), qt.IsTrue,
+		qt.Commentf("expected 'Backup · Full database · …' prefix, got: %q", desc))
+}
+
+// TestExportCreate_WhitespaceDescription_SynthesisesDefault verifies that
+// whitespace-only descriptions are treated as empty (and replaced by the
+// synthesised default). Prevents the BE from persisting a useless "   "
+// description that the FE would render as a blank row.
+func TestExportCreate_WhitespaceDescription_SynthesisesDefault(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+
+	testUser := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: "test-tenant-id",
+		},
+		Email:    "test+whitespace-desc@example.com",
+		Name:     "Test User",
+		IsActive: true,
+	}
+	testUser.SetPassword("Password123")
+	createdUser := must.Must(factorySet.UserRegistry.Create(context.Background(), testUser))
+
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	r.Use(apiserver.JWTMiddleware(testJWTSecret, factorySet.UserRegistry, nil))
+	r.Use(apiserver.RegistrySetMiddleware(factorySet))
+
+	params := apiserver.Params{
+		FactorySet:     factorySet,
+		UploadLocation: "memory://",
+		JWTSecret:      testJWTSecret,
+	}
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	r.Route("/exports", apiserver.Exports(params, mockRestoreWorker))
+
+	requestPayload := jsonapi.ExportCreateRequest{
+		Data: &jsonapi.ExportCreateRequestData{
+			Type: "exports",
+			Attributes: &models.Export{
+				Type:        models.ExportTypeFullDatabase,
+				Description: "   \t  ",
+			},
+		},
+	}
+
+	payloadBytes, err := json.Marshal(requestPayload)
+	c.Assert(err, qt.IsNil)
+
+	req := httptest.NewRequest("POST", "/exports", bytes.NewReader(payloadBytes))
+	req.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(req, createdUser.ID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	c.Assert(w.Code, qt.Equals, http.StatusCreated, qt.Commentf("body: %s", w.Body.String()))
+
+	var response jsonapi.ExportResponse
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(strings.HasPrefix(response.Data.Attributes.Description, "Backup · "), qt.IsTrue,
+		qt.Commentf("expected 'Backup · …' prefix, got: %q", response.Data.Attributes.Description))
+}

--- a/go/apiserver/exports_test.go
+++ b/go/apiserver/exports_test.go
@@ -448,3 +448,125 @@ func TestExportCreate_WhitespaceDescription_SynthesisesDefault(t *testing.T) {
 	c.Assert(strings.HasSuffix(response.Data.Attributes.Description, " UTC"), qt.IsTrue,
 		qt.Commentf("expected ' UTC' suffix, got: %q", response.Data.Attributes.Description))
 }
+
+// TestExportCreate_LongWhitespaceDescription_SynthesisesDefault covers the
+// edge case flagged in Copilot review on PR #1707: if the user submits a
+// 500+ char description that's only whitespace, it should still be treated
+// as blank (and replaced by the synthesised default), not 422-rejected by
+// the length cap. The normalisation must happen BEFORE validation.
+func TestExportCreate_LongWhitespaceDescription_SynthesisesDefault(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+
+	testUser := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: "test-tenant-id",
+		},
+		Email:    "test+long-whitespace-desc@example.com",
+		Name:     "Test User",
+		IsActive: true,
+	}
+	testUser.SetPassword("Password123")
+	createdUser := must.Must(factorySet.UserRegistry.Create(context.Background(), testUser))
+
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	r.Use(apiserver.JWTMiddleware(testJWTSecret, factorySet.UserRegistry, nil))
+	r.Use(apiserver.RegistrySetMiddleware(factorySet))
+
+	params := apiserver.Params{
+		FactorySet:     factorySet,
+		UploadLocation: "memory://",
+		JWTSecret:      testJWTSecret,
+	}
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	r.Route("/exports", apiserver.Exports(params, mockRestoreWorker))
+
+	// 501 chars of spaces — would trip the length(0,500) cap if normalisation
+	// ran after validation. The service must normalise first.
+	requestPayload := jsonapi.ExportCreateRequest{
+		Data: &jsonapi.ExportCreateRequestData{
+			Type: "exports",
+			Attributes: &models.Export{
+				Type:        models.ExportTypeFullDatabase,
+				Description: strings.Repeat(" ", 501),
+			},
+		},
+	}
+
+	payloadBytes, err := json.Marshal(requestPayload)
+	c.Assert(err, qt.IsNil)
+
+	req := httptest.NewRequest("POST", "/exports", bytes.NewReader(payloadBytes))
+	req.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(req, createdUser.ID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	c.Assert(w.Code, qt.Equals, http.StatusCreated, qt.Commentf("body: %s", w.Body.String()))
+
+	var response jsonapi.ExportResponse
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(strings.HasPrefix(response.Data.Attributes.Description, "Backup · "), qt.IsTrue,
+		qt.Commentf("expected synthesised 'Backup · …', got: %q", response.Data.Attributes.Description))
+	c.Assert(strings.HasSuffix(response.Data.Attributes.Description, " UTC"), qt.IsTrue,
+		qt.Commentf("expected ' UTC' suffix, got: %q", response.Data.Attributes.Description))
+}
+
+// TestExportCreate_NonWhitespaceTooLongDescription_Rejects ensures we did NOT
+// break the length cap on real (non-whitespace) descriptions. A 501-char
+// non-whitespace string must still 422.
+func TestExportCreate_NonWhitespaceTooLongDescription_Rejects(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+
+	testUser := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: "test-tenant-id",
+		},
+		Email:    "test+too-long-desc@example.com",
+		Name:     "Test User",
+		IsActive: true,
+	}
+	testUser.SetPassword("Password123")
+	createdUser := must.Must(factorySet.UserRegistry.Create(context.Background(), testUser))
+
+	r := chi.NewRouter()
+	r.Use(render.SetContentType(render.ContentTypeJSON))
+	r.Use(apiserver.JWTMiddleware(testJWTSecret, factorySet.UserRegistry, nil))
+	r.Use(apiserver.RegistrySetMiddleware(factorySet))
+
+	params := apiserver.Params{
+		FactorySet:     factorySet,
+		UploadLocation: "memory://",
+		JWTSecret:      testJWTSecret,
+	}
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	r.Route("/exports", apiserver.Exports(params, mockRestoreWorker))
+
+	requestPayload := jsonapi.ExportCreateRequest{
+		Data: &jsonapi.ExportCreateRequestData{
+			Type: "exports",
+			Attributes: &models.Export{
+				Type:        models.ExportTypeFullDatabase,
+				Description: strings.Repeat("x", 501),
+			},
+		},
+	}
+
+	payloadBytes, err := json.Marshal(requestPayload)
+	c.Assert(err, qt.IsNil)
+
+	req := httptest.NewRequest("POST", "/exports", bytes.NewReader(payloadBytes))
+	req.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(req, createdUser.ID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	c.Assert(w.Code, qt.Equals, http.StatusUnprocessableEntity,
+		qt.Commentf("expected 422 for 501-char description, body: %s", w.Body.String()))
+}

--- a/go/backup/export/userinput.go
+++ b/go/backup/export/userinput.go
@@ -33,14 +33,15 @@ func exportTypeLabel(t models.ExportType) string {
 
 // defaultExportDescription builds the synthesised description used when the
 // user submits a blank description. The wire format intentionally matches
-// the literal in the issue ("Backup · {Type label} · {Created at}") so the
-// list row stays meaningful without forcing the user to type one.
-// `createdAt` is formatted in UTC for stability across deployments — the FE
-// renders local-time on the row, this string is the persisted fallback.
+// the literal in the issue ("Backup · {Type label} · {Created at UTC}") so
+// the list row stays meaningful without forcing the user to type one. The
+// trailing " UTC" suffix is load-bearing — without it the timestamp reads
+// as local time, which is ambiguous for users in non-UTC timezones (and
+// inconsistent with the actual persisted value, which is always UTC).
 func defaultExportDescription(e *models.Export) string {
 	created := "—"
 	if e.CreatedDate != nil {
-		created = e.CreatedDate.ToTime().UTC().Format("2006-01-02 15:04")
+		created = e.CreatedDate.ToTime().UTC().Format("2006-01-02 15:04") + " UTC"
 	}
 	return "Backup · " + exportTypeLabel(e.Type) + " · " + created
 }

--- a/go/backup/export/userinput.go
+++ b/go/backup/export/userinput.go
@@ -2,12 +2,48 @@ package export
 
 import (
 	"context"
+	"strings"
 
 	errxtrace "github.com/go-extras/errx/stacktrace"
 
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 )
+
+// exportTypeLabel returns a short human-readable label for the export type,
+// matching the labels used on the FE export-row chip. Falls back to the raw
+// enum string for unknown values.
+func exportTypeLabel(t models.ExportType) string {
+	switch t {
+	case models.ExportTypeFullDatabase:
+		return "Full database"
+	case models.ExportTypeSelectedItems:
+		return "Selected items"
+	case models.ExportTypeLocations:
+		return "Locations"
+	case models.ExportTypeAreas:
+		return "Areas"
+	case models.ExportTypeCommodities:
+		return "Items"
+	case models.ExportTypeImported:
+		return "Imported"
+	}
+	return string(t)
+}
+
+// defaultExportDescription builds the synthesised description used when the
+// user submits a blank description. The wire format intentionally matches
+// the literal in the issue ("Backup · {Type label} · {Created at}") so the
+// list row stays meaningful without forcing the user to type one.
+// `createdAt` is formatted in UTC for stability across deployments — the FE
+// renders local-time on the row, this string is the persisted fallback.
+func defaultExportDescription(e *models.Export) string {
+	created := "—"
+	if e.CreatedDate != nil {
+		created = e.CreatedDate.ToTime().UTC().Format("2006-01-02 15:04")
+	}
+	return "Backup · " + exportTypeLabel(e.Type) + " · " + created
+}
 
 // CreateExportFromUserInput creates a new export record from user input.
 // The export record is created with status "pending" and is ready for processing.
@@ -19,6 +55,14 @@ func CreateExportFromUserInput(ctx context.Context, registrySet *registry.Set, i
 	}
 
 	export := models.NewExportFromUserInput(input)
+
+	// Synthesise a default description when the user leaves it blank, so the
+	// list row never renders as an empty line. Done after NewExportFromUserInput
+	// stamps CreatedDate, so the date in the synthesised string matches the
+	// row's persisted timestamp. Whitespace-only is treated as empty.
+	if strings.TrimSpace(export.Description) == "" {
+		export.Description = defaultExportDescription(&export)
+	}
 
 	// Extract tenant and user from context
 	tenantID, userID, err := ExtractTenantUserFromContext(ctx)

--- a/go/backup/export/userinput.go
+++ b/go/backup/export/userinput.go
@@ -50,6 +50,16 @@ func defaultExportDescription(e *models.Export) string {
 // The export record is created with status "pending" and is ready for processing.
 // It will be processed by the ExportWorker in the background.
 func CreateExportFromUserInput(ctx context.Context, registrySet *registry.Set, input *models.Export) (models.Export, error) {
+	// Normalise whitespace-only descriptions to "" BEFORE validation so the
+	// length(0, 500) cap doesn't reject a 500+ char blob of spaces — the
+	// service's intent is "treat blank as missing and synthesise a default",
+	// and a 422 for unprintable whitespace would surprise the user. We mutate
+	// the caller's pointer in place because the validator and the subsequent
+	// NewExportFromUserInput copy both read from the same struct.
+	if input != nil && strings.TrimSpace(input.Description) == "" {
+		input.Description = ""
+	}
+
 	// Validate the export
 	if err := input.ValidateWithContext(ctx); err != nil {
 		return models.Export{}, errxtrace.Wrap("failed to validate export", err)
@@ -60,8 +70,8 @@ func CreateExportFromUserInput(ctx context.Context, registrySet *registry.Set, i
 	// Synthesise a default description when the user leaves it blank, so the
 	// list row never renders as an empty line. Done after NewExportFromUserInput
 	// stamps CreatedDate, so the date in the synthesised string matches the
-	// row's persisted timestamp. Whitespace-only is treated as empty.
-	if strings.TrimSpace(export.Description) == "" {
+	// row's persisted timestamp.
+	if export.Description == "" {
 		export.Description = defaultExportDescription(&export)
 	}
 

--- a/go/jsonapi/exports.go
+++ b/go/jsonapi/exports.go
@@ -3,6 +3,7 @@ package jsonapi
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/render"
 	"github.com/go-extras/errx"
@@ -106,6 +107,17 @@ type ExportCreateRequest struct {
 var _ render.Binder = (*ExportCreateRequest)(nil)
 
 func (cr *ExportCreateRequest) Bind(r *http.Request) error {
+	// Normalise whitespace-only Description to "" BEFORE the validation
+	// cascade reaches models.Export.ValidateWithContext — otherwise a 500+
+	// char blob of spaces trips the length(0,500) cap with a 422, contrary
+	// to the service's intent of "treat blank as missing and synthesise a
+	// default". Run as part of Bind so the rule applies at the HTTP edge,
+	// where every entrypoint for ExportCreateRequest funnels through.
+	if cr.Data != nil && cr.Data.Attributes != nil &&
+		strings.TrimSpace(cr.Data.Attributes.Description) == "" {
+		cr.Data.Attributes.Description = ""
+	}
+
 	err := cr.ValidateWithContext(r.Context())
 	if err != nil {
 		return err

--- a/go/models/export.go
+++ b/go/models/export.go
@@ -247,7 +247,10 @@ func (e *Export) ValidateWithContext(ctx context.Context) error {
 	fields := make([]*validation.FieldRules, 0)
 
 	fields = append(fields,
-		validation.Field(&e.Description, validation.Required, validation.Length(0, 500)),
+		// Description is optional — the service layer synthesises a sensible
+		// "Backup · {type} · {date}" default when the user leaves it blank, so
+		// the list row never renders as an empty line.
+		validation.Field(&e.Description, validation.Length(0, 500)),
 		validation.Field(&e.Type, validation.Required),
 	)
 

--- a/go/models/export_test.go
+++ b/go/models/export_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -109,4 +110,27 @@ func TestExport_ValidateWithContext(t *testing.T) {
 
 	err = validSelectedExport.ValidateWithContext(ctx)
 	c.Assert(err, qt.IsNil)
+
+	// Empty description is now allowed at the model layer — the service
+	// synthesises a default (see go/backup/export/userinput.go). Issue #1661.
+	emptyDescExport := &models.Export{
+		Type:        models.ExportTypeFullDatabase,
+		Status:      models.ExportStatusPending,
+		Description: "",
+		CreatedDate: createdDate,
+	}
+
+	err = emptyDescExport.ValidateWithContext(ctx)
+	c.Assert(err, qt.IsNil)
+
+	// Length cap still applies — 501 characters is rejected.
+	longDescExport := &models.Export{
+		Type:        models.ExportTypeFullDatabase,
+		Status:      models.ExportStatusPending,
+		Description: strings.Repeat("x", 501),
+		CreatedDate: createdDate,
+	}
+
+	err = longDescExport.ValidateWithContext(ctx)
+	c.Assert(err, qt.IsNotNil)
 }


### PR DESCRIPTION
Closes #1661.

## Summary

Picks up the four-item polish pass on `/g/{slug}/exports`:

1. **BE** — `validation.Required` dropped on `Export.Description`. The service synthesises `Backup · {Type label} · {YYYY-MM-DD HH:MM UTC}` when the user submits a blank (or whitespace-only) description, so the list row is never blank. `Length(0, 500)` cap preserved.
2. **FE** — every `useMutation` callback / `try…catch` site under `frontend/src/pages/exports/` now goes through `parseServerError` (the existing JSON:API helper from #1553), so the 422 toast surfaces the real `errors[].detail` (e.g. "Description must be 500 chars or fewer") instead of the bare HTTP wrapper.
3. **FE header** — page wrapper → `gap-8 p-6 max-w-4xl mx-auto w-full`, H1 → `scroll-m-20 text-3xl font-semibold tracking-tight`, title → "Backup & Restore" (matches mock and is a more accurate description of what the page actually does — restore lives here too).
4. **FE list overline** — adds the `HardDriveDownload` icon + "Exports" h2 + plural-aware "{N} export(s)" count row above the list (mirrors `BackupView.tsx`). Count respects the `show_deleted` toggle.
5. **FE wizard** — description field marked optional with a hint that previews the synthesised default placeholder.
6. **Preserved** — page-based new-export flow (`/exports/new`) kept rather than collapsed to a Dialog; logged in `devdocs/frontend/design-deviations.md`.

## What's NOT changed

- Restore flows (dialog + page) — already covered by #1534.
- Swagger / api.d.ts — no schema shape change, only a validation rule (which isn't reflected in the swagger output).

## Test plan

- [x] Go: `go test ./models/... ./apiserver/... ./backup/... ./jsonapi/... ./services/...` — all green; new `TestExportCreate_EmptyDescription_SynthesisesDefault` + `TestExportCreate_WhitespaceDescription_SynthesisesDefault` cover the BE path; `TestExport_ValidateWithContext` extended for empty + length-cap.
- [x] Go: `golangci-lint run --fix ./...` — 0 issues.
- [x] Frontend: `npm test` — 839 passed / 4 skipped (119 files).
- [x] Frontend: `npm run typecheck`, `npm run lint`, `npx i18next-cli extract --ci` — all clean.
- [ ] E2E (CI): new spec `create export with empty description succeeds and surfaces synthesised default` drives the wizard end-to-end and asserts the detail page renders `Backup · Full database · …`.
- [ ] Visual review via `screenshot-review` skill against `design-mocks/src/views/BackupView.tsx` once CI is green.

## Related

- #1534 (closed) — earlier Backup & Restore polish pass; this issue picks up what was missed.
- #1553 / `frontend/src/lib/server-error.ts` — canonical FE error-extraction helper that we sweep onto every `pages/exports/` mutation callback here.
- #1655 — same "Internal Server UserError" envelope wording polish; not triggered by these flows so no follow-up needed here.