### PR TITLE
[#1480][#1591] Harden flaky e2e specs (group switch, loan edit, password validation, commodity edit)

### DIFF
--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -847,14 +847,18 @@ test.describe('Group selection persistence (#1262 / #1300)', () => {
       await page.waitForSelector('.group-selector', { state: 'visible', timeout: 10000 });
 
       // Watch for the PUT /auth/me the selector fires after switching. The
-      // call is debounced (~400ms), so we use waitForRequest which polls
-      // the network rather than snapshot-checking. Filtering on the
-      // exact default_group_id makes the assertion tight.
-      const putPromise = page.waitForRequest(
-        (req) =>
-          req.url().includes('/api/v1/auth/me') &&
-          req.method() === 'PUT' &&
-          (req.postData() || '').includes(createdGroupId),
+      // call is debounced (~400ms). Wait on the *response* (not just the
+      // request) so the BE has finished committing the change before we
+      // issue the follow-up GET /auth/me — otherwise the GET can land on
+      // the stale row and assert `null` instead of `createdGroupId`
+      // (issue #1480: chromium-observed race; fundamentally any browser).
+      const putPromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/api/v1/auth/me') &&
+          resp.request().method() === 'PUT' &&
+          (resp.request().postData() || '').includes(createdGroupId) &&
+          resp.status() >= 200 &&
+          resp.status() < 300,
         { timeout: 15000 },
       );
 
@@ -871,8 +875,8 @@ test.describe('Group selection persistence (#1262 / #1300)', () => {
 
       await expect(page.locator('.group-selector__name')).toHaveText(groupName, { timeout: 10000 });
 
-      const putRequest = await putPromise;
-      const putBody = JSON.parse(putRequest.postData() ?? '{}');
+      const putResponse = await putPromise;
+      const putBody = JSON.parse(putResponse.request().postData() ?? '{}');
       expect(putBody.default_group_id).toBe(createdGroupId);
 
       // Server-side round-trip: the preference survives a cold re-read of

--- a/e2e/tests/includes/commodities.ts
+++ b/e2e/tests/includes/commodities.ts
@@ -524,6 +524,17 @@ export async function editCommodity(
     timeout: 5000,
   });
   await page.click('[data-testid="commodity-form-submit"]');
+  // Wait for the form dialog to actually leave the DOM before the caller
+  // continues. The cached detail query revalidates against the new row
+  // only after the submit-then-close chain (mutation → setOpen(false) →
+  // Radix transition) settles. Webkit-on-macOS schedules that chain
+  // slower than chromium/firefox; a stale `commodity-form` in the DOM
+  // when the next assertion runs is exactly the symptom #1591 logged
+  // ("commodity-form not in DOM at edit-submit time" on a follow-up
+  // action) and the same shape as the #1705 webkit hang.
+  await page
+    .locator('[data-testid="commodity-form-dialog"]')
+    .waitFor({ state: "hidden", timeout: 30000 });
   // Stay on the detail page (no navigate after edit; the form just
   // closes the dialog and revalidates the cached detail query).
   await expect(page).toHaveURL(/\/commodities\/[0-9a-fA-F-]{36}(\?.*)?$/);

--- a/e2e/tests/loans.spec.ts
+++ b/e2e/tests/loans.spec.ts
@@ -227,8 +227,23 @@ test.describe('Commodity loans — lend out + return round-trip', () => {
       const dueInput = page.getByTestId('edit-loan-due-back-at')
       await expect(dueInput).toHaveValue('')
       await expect(page.getByTestId('edit-loan-clear-due-back')).toHaveCount(0)
+      // Hold the PATCH response promise *before* clicking — webkit-on-macOS
+      // schedules the form-submit → useUpdateLoan → setEditing(null) chain
+      // slower than chromium/firefox, so a default-5s `toBeHidden` can
+      // expire while Radix is still finishing its close transition (#1591
+      // recurrence; same shape on #1705's webkit lane). Waiting on the PATCH
+      // response pins the assertion to the network round-trip rather than a
+      // wallclock guess.
+      const patchPromise = page.waitForResponse(
+        (resp) =>
+          /\/loans\/[^/]+$/.test(resp.url()) &&
+          resp.request().method() === 'PATCH' &&
+          resp.status() >= 200 && resp.status() < 300,
+        { timeout: 15000 },
+      )
       await page.getByTestId('edit-loan-submit').click()
-      await expect(page.getByTestId('edit-loan-dialog')).toBeHidden()
+      await patchPromise
+      await expect(page.getByTestId('edit-loan-dialog')).toBeHidden({ timeout: 15000 })
 
       // Current-loan card no longer mentions a due date.
       await expect(currentCard).toBeVisible()

--- a/e2e/tests/profile.spec.ts
+++ b/e2e/tests/profile.spec.ts
@@ -158,8 +158,11 @@ authTest.describe('Profile page — password change section', () => {
     // offending field rather than as a top-of-form banner, so we drive
     // the field-scoped testid directly. (Server-error banner stays on
     // `.password-form .error-banner` for actual API failures.)
+    // Generous timeout for webkit-on-macOS: RHF's resolver fires on a
+    // different microtask schedule there, and the default-5s window can
+    // expire while the error is still en route to the DOM (#1591).
     const newErr = page.locator('[data-testid="new-password-error"]');
-    await expect(newErr).toBeVisible();
+    await expect(newErr).toBeVisible({ timeout: 10000 });
     await expect(newErr).toContainText('differ');
   });
 
@@ -173,7 +176,7 @@ authTest.describe('Profile page — password change section', () => {
     await page.click('[data-testid="change-password-submit"]');
 
     const confirmErr = page.locator('[data-testid="confirm-password-error"]');
-    await expect(confirmErr).toBeVisible();
+    await expect(confirmErr).toBeVisible({ timeout: 10000 });
     await expect(confirmErr).toContainText('match');
   });
 });


### PR DESCRIPTION
Closes #1480, closes #1591. Same shape as the webkit flake observed on PR #1705 — preempts that recurrence too.

## Summary

Four targeted test-side fixes for the recurring e2e flakes. All are spec hardening (no FE / BE / docs touched) so the blast radius is small and the change is reviewable end-to-end.

### `groups.spec.ts:808` — #1480 chromium race on `PUT /auth/me`

The test was using `page.waitForRequest` which resolves the moment the request goes on the wire — not when the BE has finished committing. The immediate follow-up `GET /api/v1/auth/me` then raced ahead of the PUT response and read `default_group_id == null` (the symptom verbatim from #1480).

Swap to `page.waitForResponse` filtered on a 2xx status, and source the request body from `response.request().postData()` for the subsequent body assertion. After this the read can only fire once the BE confirms the write.

### `loans.spec.ts:149` — #1591 webkit-on-macOS recurrence

The "edit existing loan: clear due date" test asserts `getByTestId('edit-loan-dialog')` is hidden right after clicking submit. On webkit-on-macOS the submit → mutation → `setEditing(null)` → Radix `data-state` flip chain consistently exceeds the default 5s `expect`-timeout (#1591 stanzas across PR #1587/#1593/#1614/#1705 all show 10s of `data-state="open"` waits).

Hold a `waitForResponse` for `PATCH /loans/{id}` before the click and `await` it before `toBeHidden` (now with a 15s explicit timeout). The assertion is pinned to the network round-trip rather than a wallclock guess.

### `profile.spec.ts:148` and `:166` — #1591 webkit RHF resolver timing

The "same current and new password" and "mismatched confirmation" tests assert that an RHF cross-field validation error becomes visible after submit. Webkit's `submit` event handling diverges on disabled empty buttons, so the resolver fires on a different microtask schedule than chromium/firefox.

Bump both `toBeVisible` calls to a 10s timeout so the slower webkit path has room to render.

### `e2e/tests/includes/commodities.ts:editCommodity` — #1591 webkit Radix close

The helper clicked `commodity-form-submit` and immediately moved on — relying on the cached detail query revalidation to "look right" by the next assertion. On webkit the same Radix-close-transition latency would otherwise leave a stale form mounted, surfaced by #1591's "commodity-form not in DOM at edit-submit time" stanza when the next test action queries the form via `page.evaluate`.

Wait for `commodity-form-dialog` to reach `state: "hidden"` (30s timeout) after the submit click so the helper only returns once Radix has finished tearing the dialog down.

## Why not also `waitForResponse(PATCH /commodities/{id})` in `editCommodity`?

Tried it; it regressed chromium because the multi-step form submit path occasionally serialises the network call differently than I'd predicted and the 30s wait timed out. The dialog-hidden wait is observable from the user-perspective end state and is strictly stronger than the response wait for this particular test — once the dialog hides, the mutation must have resolved (otherwise `setOpen(false)` is never reached).

## Test plan

Verified locally on chromium / firefox / webkit (single pass, `--workers=2`):

| Browser | groups | loans | profile | commodity-simple-crud |
| --- | --- | --- | --- | --- |
| chromium | ✓ | ✓ | ✓ | (cleanup race at `commodity-simple-crud.spec.ts:164`, unrelated to this PR) |
| firefox | ✓ | ✓ | ✓ | (same cleanup race) |
| webkit | ✓ | ✓ | ✓ | ✓ |

Net: 10/12 pass, 2 failures both at `commodity-simple-crud.spec.ts:164` — a post-edit `waitForSelector('[data-testid="location-card"][data-location-id="${locationId}"]')` cleanup step that predates this PR. It was previously hidden behind the editCommodity flake; with that fixed, the cleanup race becomes visible. Out of scope here; the four target specs (`#1480` + the three `#1591` recurrences) are green, including on the webkit lane that #1591 + #1705 specifically failed.

- [x] `npx tsc --noEmit` clean
- [x] groups / loans / profile / commodity-edit-helper local repro across all 3 browsers
- [ ] CI green
- [ ] Webkit lane green on a follow-up CI run (the recurring-flake heuristic from #1591)