### PR TITLE
[#1536] Log Data & Storage relocation deviation, close bundle

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -253,6 +253,15 @@ _None yet._
 - **Approved by**: user (explicit) — confirmed during PR-A planning when picking "full BE+FE implementation".
 - **Reversion plan**: If the cross-user query pattern shows up, move just the notification rows into a structured table via a one-time data migration; the SettingsObject pointer fields can stay (mark them deprecated) until the FE catches up.
 
+#### 2026-05-16 — `Data & Storage` section is on Group Settings, not user Preferences
+
+- **Issue/PR**: #1536 item 3 / closure PR (relocation shipped earlier in PR #1637 + PR-A sub-issue #1643)
+- **Mock**: [`design-mocks/src/views/SettingsView.tsx`](../../design-mocks/src/views/SettingsView.tsx) L26-L33 lists `data` as the fifth nav entry inside the per-user Preferences left rail; the `DataSection` component (L402-L451) renders storage progress + automatic-backup / cross-device-sync toggles + Export-data (JSON / CSV) buttons as a personal-settings card.
+- **Reality**: `frontend/src/pages/SettingsPage.tsx` `SECTIONS` ships five entries — `account / appearance / notifications / privacy / help` — with no `data` entry. The Storage card (`<StorageCard />`) and the Export-data CTA live on `GroupSettingsPage` instead, behind the group-scoped `/g/{slug}/settings#data` route. Backup automation and cross-device sync are not implemented (no BE).
+- **Why**: Storage usage and Export are strictly per-group (RLS-scoped); surfacing them on a per-user page meant rendering against an implicit "active group" fallback. Relocating them to `GroupSettingsPage` (PR #1637) keeps the data-scope contract honest and consolidates per-group surfaces in one place — matches the 2026-05-09 + 2026-05-12 Group Settings deviation entries above. Automatic backup + cross-device sync stay deferred until the plan / quota model lands (#1389) and a real backup automation feature is scoped — the mock's standalone toggles would be inert today.
+- **Approved by**: user (explicit) — selected the Data-section relocation in the #1643 PR-A scope question and confirmed during the #1637 group-settings refactor.
+- **Reversion plan**: Permanent for the relocation. If automatic backup / cross-device sync ship in the future, they belong on `GroupSettingsPage` for the same RLS / per-group-scope reason, not in the user Preferences left rail.
+
 #### 2026-05-12 — User-level "Preferred currency" selector is display-only (not yet wired to formatting)
 
 - **Issue/PR**: #1536 item 4 / PR-A (sub-issue #1643)


### PR DESCRIPTION
## Summary

Closes the design-audit Settings expansion bundle (#1536). Every sub-item shipped through its sub-issues / earlier PRs; this PR just finalises the audit trail.

- Item 3 (Data & Storage) was resolved by **relocating** the storage + export surfaces to `GroupSettingsPage` instead of adding a user-Preferences `data` nav entry (per-group scope = per-group surface). The rationale already lives under the 2026-05-09 / 2026-05-12 Group-Settings entries in `devdocs/frontend/design-deviations.md`, but had no dedicated `#1536`-tagged deviation alongside items 4 and 5 — this PR adds the missing entry.
- The parent #1536 checklist was updated to tick every box with the shipping PR / sub-issue / deviation reference.

## Shipping references (already merged)

| Item | Status | Where it shipped |
| --- | --- | --- |
| 1. Notifications preferences | ✅ shipped | #1643 / PR-A — autosave on `settings` table, closes #1373 |
| 2. Privacy & Security (2FA + sessions + history) | ✅ shipped | #1644 / PR #1674 + #1645 / PR #1675 |
| 3. Data & Storage | ✅ relocated | PR #1637 + #1643 nav cleanup; `StorageCard` + Export live on `GroupSettingsPage`; backup/sync deferred (no BE) |
| 4. Appearance (Currency + Default view) | ✅ shipped | #1643 / PR-A |
| 5. Help & Support (Contact support + version Badge) | ✅ shipped | #1643 / PR-A |
| Bonus theme card order | ✅ shipped | #1643 / PR-A (`SettingsPage.tsx:425-429`) |

Deferred (not in #1536 scope): connected accounts (#1395), backup automation + cross-device sync (need plan/quota model #1389 + BE feature work).

Closes #1536.

## Test plan

- [ ] CI pipelines green (this is a docs-only change — no behavioural surface)
- [ ] Markdown render of the new deviation entry on the rendered diff