### PR TITLE
[#1542] Maintenance page (with 503 bounce) + dev-only UI Showcase

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -28,6 +28,16 @@ const AreaDetailPage = lazy(() =>
 const NotFoundPage = lazy(() =>
   import("@/pages/NotFound").then((m) => ({ default: m.NotFoundPage }))
 )
+const MaintenancePage = lazy(() =>
+  import("@/pages/MaintenancePage").then((m) => ({ default: m.MaintenancePage }))
+)
+// UI Showcase is a dev-only design-system reference (#1542). Only chunked
+// in when the build is a dev build — `import.meta.env.DEV` is statically
+// dead-code-eliminable by Vite, so production bundles don't carry the
+// showcase code at all.
+const UIShowcasePage = import.meta.env.DEV
+  ? lazy(() => import("@/pages/UIShowcasePage").then((m) => ({ default: m.UIShowcasePage })))
+  : null
 const RootRedirect = lazy(() =>
   import("@/pages/RootRedirect").then((m) => ({ default: m.RootRedirect }))
 )
@@ -184,6 +194,13 @@ export function AppRoutes() {
         <Route path="/verify-email" element={<VerifyEmailPage />} />
         <Route path="/invite/:token" element={<InviteAcceptPage />} />
 
+        {/* Maintenance is a public route — when the API returns 503 the
+            http client bounces here before the auth probe even fires.
+            Anything that fetches from inside this page would re-trigger
+            the 503 bounce, which is why the page reads its context from
+            URL params instead. #1542 / design-audit #1527. */}
+        <Route path="/maintenance" element={<MaintenancePage />} />
+
         {/* Authenticated subtree: GroupProvider mounts once at the top so
             every protected page reads currentGroup from the same source.
             Shell (#1406) is the chrome — sidebar, top bar, palette,
@@ -216,6 +233,10 @@ export function AppRoutes() {
           <Route path="/help" element={<ComingSoonPage surface="helpCenter" />} />
           <Route path="/help/shortcuts" element={<ComingSoonPage surface="helpShortcuts" />} />
           <Route path="/whats-new" element={<ComingSoonPage surface="whatsNew" />} />
+          {/* UI Showcase — dev-only design-system reference (#1542). The
+              chunk only ships in dev builds; in prod the route is
+              omitted entirely. */}
+          {UIShowcasePage ? <Route path="/_dev/ui-showcase" element={<UIShowcasePage />} /> : null}
 
           {/* Legacy unscoped paths — Vue era didn't carry /g/:slug. The
               React router only mounts those resources under /g/:slug, so

--- a/frontend/src/features/auth/AuthContext.tsx
+++ b/frontend/src/features/auth/AuthContext.tsx
@@ -6,6 +6,7 @@ import { HttpError } from "@/lib/http"
 import {
   __resetNavigationForTests,
   setNavigateToLogin as setHttpNavigateToLogin,
+  setNavigateToMaintenance as setHttpNavigateToMaintenance,
 } from "@/lib/navigation"
 
 import { useCurrentUser, useLogout } from "./hooks"
@@ -54,6 +55,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const params = new URLSearchParams({ redirect: currentPath })
       if (reason) params.set("reason", reason)
       navigate(`/login?${params.toString()}`)
+    })
+    // The http client (#1403) bounces here on a 503 from the API; the
+    // Retry-After + X-Maintenance-Status headers carry the operator's
+    // ETA + per-component status (api/database/storage) so the page can
+    // render the mock-faithful status card. URL params keep the page
+    // refresh-safe (#1542).
+    setHttpNavigateToMaintenance(({ retryAfter, componentStatus }) => {
+      const params = new URLSearchParams()
+      if (retryAfter) params.set("retry_after", retryAfter)
+      if (componentStatus) params.set("status", componentStatus)
+      const qs = params.toString()
+      navigate(qs ? `/maintenance?${qs}` : "/maintenance")
     })
     return () => __resetNavigationForTests()
   }, [navigate])

--- a/frontend/src/i18n/locales/en/errors.json
+++ b/frontend/src/i18n/locales/en/errors.json
@@ -8,6 +8,25 @@
     "server": "Server error. Please try again later."
   },
   "lockedDuringMigration": "Locked while a currency migration is running.",
+  "maintenance": {
+    "badge": "Scheduled maintenance",
+    "components": {
+      "api": "API",
+      "database": "Database",
+      "storage": "File storage"
+    },
+    "description": "The system is temporarily unavailable while we perform scheduled maintenance. This usually takes less than 30 minutes.",
+    "documentTitle": "Scheduled maintenance",
+    "heading": "We'll be right back",
+    "resumeAt": "Expected to resume at {{time}}.",
+    "retry": "Try again",
+    "statusHeading": "Status",
+    "statusLabels": {
+      "degraded": "Degraded",
+      "maintenance": "Maintenance",
+      "operational": "Operational"
+    }
+  },
   "notFound": {
     "description": "The page you requested doesn’t exist or has been moved.",
     "documentTitle": "Page not found",

--- a/frontend/src/lib/__tests__/http.test.ts
+++ b/frontend/src/lib/__tests__/http.test.ts
@@ -8,7 +8,11 @@ import {
   setCsrfToken,
 } from "@/lib/auth-storage"
 import { __resetGroupContextForTests, setCurrentGroupSlug } from "@/lib/group-context"
-import { __resetNavigationForTests, setNavigateToLogin } from "@/lib/navigation"
+import {
+  __resetNavigationForTests,
+  setNavigateToLogin,
+  setNavigateToMaintenance,
+} from "@/lib/navigation"
 import { server } from "@/test/server"
 import { http as msw, HttpResponse } from "msw"
 
@@ -236,6 +240,50 @@ describe("error handling", () => {
   it("throws HttpError on 5xx (no swallowing — see #1210)", async () => {
     server.use(msw.get(api("/groups"), () => HttpResponse.json({ error: "boom" }, { status: 503 })))
     await expect(http.get("/groups")).rejects.toBeInstanceOf(HttpError)
+  })
+
+  it("503 bounces through navigateToMaintenance with Retry-After + X-Maintenance-Status headers (#1542)", async () => {
+    server.use(
+      msw.get(api("/groups"), () =>
+        HttpResponse.json(null, {
+          status: 503,
+          headers: {
+            "Retry-After": "900",
+            "X-Maintenance-Status": "api=degraded,database=maintenance,storage=operational",
+          },
+        })
+      )
+    )
+    const navigate = vi.fn()
+    setNavigateToMaintenance(navigate)
+    await expect(http.get("/groups")).rejects.toBeInstanceOf(HttpError)
+    expect(navigate).toHaveBeenCalledOnce()
+    expect(navigate).toHaveBeenCalledWith({
+      retryAfter: "900",
+      componentStatus: "api=degraded,database=maintenance,storage=operational",
+    })
+  })
+
+  it("503 does NOT re-bounce when the user is already on /maintenance (#1542 — avoids reload loop)", async () => {
+    server.use(msw.get(api("/groups"), () => HttpResponse.json(null, { status: 503 })))
+    const navigate = vi.fn()
+    setNavigateToMaintenance(navigate)
+    const originalLocation = window.location
+    // jsdom's `location` is a getter — override just the pathname for the
+    // duration of this test so the early-return in the http client fires.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, pathname: "/maintenance" },
+    })
+    try {
+      await expect(http.get("/groups")).rejects.toBeInstanceOf(HttpError)
+      expect(navigate).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      })
+    }
   })
 
   it("forwards AbortSignal to fetch", async () => {

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -15,7 +15,7 @@ import {
   setCsrfToken,
 } from "./auth-storage"
 import { getCurrentGroupSlug } from "./group-context"
-import { navigateToLogin } from "./navigation"
+import { navigateToLogin, navigateToMaintenance } from "./navigation"
 
 const BASE_URL = "/api/v1"
 
@@ -298,6 +298,19 @@ async function performRequest<T = unknown>(
 
   if (response.status === 401) {
     return (await handle401(url, path, init, response)) as HttpResponse<T>
+  }
+  if (response.status === 503) {
+    // BE convention (#1542): a 503 means the API is in scheduled maintenance
+    // or otherwise unreachable. Bounce the user to /maintenance with the
+    // Retry-After + X-Maintenance-Status headers carried as URL params so a
+    // refresh keeps showing the page. The actual HttpError still propagates
+    // so any onError that wanted to react (e.g. revalidation queries) can.
+    if (typeof window !== "undefined" && !window.location.pathname.startsWith("/maintenance")) {
+      navigateToMaintenance({
+        retryAfter: response.headers.get("Retry-After"),
+        componentStatus: response.headers.get("X-Maintenance-Status"),
+      })
+    }
   }
   const data = (await parseBody(response)) as T
   if (!response.ok) {

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -33,7 +33,41 @@ export function setNavigateToLogin(fn: NavigateToLogin): void {
   navigator = fn
 }
 
-// Test-only: restore the default navigator between cases.
+// Maintenance redirect — installed by AuthProvider so the http client's
+// 503-handler can bounce to /maintenance without reaching for
+// window.location.href (same reasoning as navigateToLogin above).
+//
+// retryAfter is parsed from the standard `Retry-After` HTTP header (RFC 9110):
+// the BE may send either an HTTP-date or a delta-seconds value. We pass it
+// through verbatim as a string; the maintenance page resolves it to a local
+// time. componentStatus is sourced from an optional
+// `X-Maintenance-Status: api=degraded,database=maintenance,storage=operational`
+// header so an outage that only affects part of the stack can still
+// communicate the surviving components without bouncing every request
+// (#1542 item 1 / design-audit #1527).
+export interface MaintenanceContext {
+  retryAfter: string | null
+  componentStatus: string | null
+}
+
+export type NavigateToMaintenance = (ctx: MaintenanceContext) => void
+
+const defaultNavigateToMaintenance: NavigateToMaintenance = (ctx) => {
+  console.warn("[navigation] navigateToMaintenance called before SPA navigator was installed", ctx)
+}
+
+let maintenanceNavigator: NavigateToMaintenance = defaultNavigateToMaintenance
+
+export function navigateToMaintenance(ctx: MaintenanceContext): void {
+  maintenanceNavigator(ctx)
+}
+
+export function setNavigateToMaintenance(fn: NavigateToMaintenance): void {
+  maintenanceNavigator = fn
+}
+
+// Test-only: restore the default navigators between cases.
 export function __resetNavigationForTests(): void {
   navigator = defaultNavigateToLogin
+  maintenanceNavigator = defaultNavigateToMaintenance
 }

--- a/frontend/src/pages/MaintenancePage.test.tsx
+++ b/frontend/src/pages/MaintenancePage.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+
+import { MaintenancePage } from "./MaintenancePage"
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <MaintenancePage />
+    </MemoryRouter>
+  )
+}
+
+describe("MaintenancePage", () => {
+  it("renders the heading + scheduled-maintenance badge + Status card with defaults when no headers are provided", () => {
+    renderAt("/maintenance")
+    expect(screen.getByRole("heading", { name: /right back/i, level: 1 })).toBeInTheDocument()
+    expect(screen.getByTestId("maintenance-badge")).toHaveTextContent(/scheduled/i)
+    // All three components default to "maintenance" when no per-component
+    // status header is sent — the most conservative read.
+    expect(screen.getByTestId("maintenance-status-api")).toHaveTextContent(/maintenance/i)
+    expect(screen.getByTestId("maintenance-status-database")).toHaveTextContent(/maintenance/i)
+    expect(screen.getByTestId("maintenance-status-storage")).toHaveTextContent(/maintenance/i)
+  })
+
+  it("renders per-component status colours from the X-Maintenance-Status URL param", () => {
+    renderAt("/maintenance?status=api%3Ddegraded%2Cdatabase%3Dmaintenance%2Cstorage%3Doperational")
+    expect(screen.getByTestId("maintenance-status-api")).toHaveTextContent(/degraded/i)
+    expect(screen.getByTestId("maintenance-status-database")).toHaveTextContent(/maintenance/i)
+    expect(screen.getByTestId("maintenance-status-storage")).toHaveTextContent(/operational/i)
+  })
+
+  it("renders the resume time when Retry-After delta-seconds is provided", () => {
+    renderAt("/maintenance?retry_after=900")
+    expect(screen.getByTestId("maintenance-resume")).toBeInTheDocument()
+  })
+
+  it("renders the resume time when Retry-After is an HTTP-date", () => {
+    const futureIso = new Date(Date.now() + 60 * 60 * 1000).toUTCString()
+    renderAt(`/maintenance?retry_after=${encodeURIComponent(futureIso)}`)
+    expect(screen.getByTestId("maintenance-resume")).toBeInTheDocument()
+  })
+
+  it("hides the resume line on invalid Retry-After input", () => {
+    renderAt("/maintenance?retry_after=not-a-date")
+    expect(screen.queryByTestId("maintenance-resume")).not.toBeInTheDocument()
+  })
+
+  it("hides the resume line once the resume time has already passed", () => {
+    const pastIso = new Date(Date.now() - 60 * 60 * 1000).toUTCString()
+    renderAt(`/maintenance?retry_after=${encodeURIComponent(pastIso)}`)
+    expect(screen.queryByTestId("maintenance-resume")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { useNavigate, useSearchParams } from "react-router-dom"
+import { Wrench } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+import { formatDateTime } from "@/lib/intl"
+
+// Stable status order so the row sequence on the page doesn't shuffle when
+// the BE rotates the X-Maintenance-Status header values. The mock
+// (design-mocks/src/views/EmptyStatesView.tsx L242-L258) renders API,
+// Database, File storage in that exact order.
+const COMPONENT_ORDER: ReadonlyArray<"api" | "database" | "storage"> = [
+  "api",
+  "database",
+  "storage",
+]
+
+type StatusKey = "operational" | "degraded" | "maintenance"
+
+function parseStatusHeader(raw: string | null): Record<string, StatusKey> {
+  // X-Maintenance-Status: "api=degraded,database=maintenance,storage=operational"
+  // Unknown component keys are dropped; unknown status values fall through to
+  // "maintenance" so the user sees the most conservative read of the
+  // operator's intent rather than a deceptive "Operational" pill.
+  if (!raw) return {}
+  const out: Record<string, StatusKey> = {}
+  for (const part of raw.split(",")) {
+    const [key, value] = part.split("=").map((s) => s.trim().toLowerCase())
+    if (!key || !value) continue
+    const normalized: StatusKey =
+      value === "operational" || value === "degraded" || value === "maintenance"
+        ? value
+        : "maintenance"
+    out[key] = normalized
+  }
+  return out
+}
+
+function parseRetryAfter(raw: string | null): Date | null {
+  // RFC 9110: Retry-After is either an HTTP-date or a delta-seconds value.
+  // Parse both. Invalid input → null so the page hides the "expected to
+  // resume" line rather than rendering "Invalid Date".
+  if (!raw) return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  // delta-seconds is purely digits.
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number.parseInt(trimmed, 10)
+    if (!Number.isFinite(seconds)) return null
+    return new Date(Date.now() + seconds * 1000)
+  }
+  const parsed = new Date(trimmed)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+// MaintenancePage — full-screen 503 state served when the API or storage is
+// down for scheduled maintenance. The HTTP client (lib/http.ts) bounces here
+// on a 503 with Retry-After + X-Maintenance-Status carried as URL params so
+// a refresh (or a deep-link share) keeps showing the page.
+//
+// Visual matches design-mocks/src/views/EmptyStatesView.tsx::MaintenanceView
+// (wrench tile, scheduled-maintenance pill, status card listing API /
+// Database / File storage, footer line with the local resume time).
+export function MaintenancePage() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [params] = useSearchParams()
+  const [now, setNow] = useState(() => Date.now())
+
+  // Tick once every 15s so the "expected to resume" countdown stays honest
+  // without burning CPU. Stops once the resume time has passed so we don't
+  // re-render forever on a forgotten tab.
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(Date.now()), 15_000)
+    return () => window.clearInterval(interval)
+  }, [])
+
+  const retryAt = useMemo(() => parseRetryAfter(params.get("retry_after")), [params])
+  const componentStatus = useMemo(() => parseStatusHeader(params.get("status")), [params])
+  const hasResumePassed = retryAt ? retryAt.getTime() < now : false
+
+  function handleRetry() {
+    // A fresh navigation re-runs the HTTP probes; if the API is back up the
+    // 503 handler stops bouncing and the user lands on their previous page.
+    navigate("/")
+  }
+
+  return (
+    <>
+      <RouteTitle title={t("errors:maintenance.documentTitle")} />
+      <div
+        className="flex min-h-screen flex-1 flex-col items-center justify-center gap-6 px-6 py-24 text-center"
+        data-testid="page-maintenance"
+      >
+        <div className="relative flex size-32 items-center justify-center">
+          <div className="absolute size-32 rounded-full bg-muted/60" aria-hidden="true" />
+          <div className="absolute size-20 rounded-full bg-muted" aria-hidden="true" />
+          <Wrench className="relative size-10 text-muted-foreground/60" aria-hidden="true" />
+        </div>
+        <div className="max-w-sm space-y-2">
+          <div
+            className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted px-3 py-1 text-xs font-medium text-muted-foreground"
+            data-testid="maintenance-badge"
+          >
+            <span
+              className="size-1.5 animate-pulse rounded-full bg-status-expiring"
+              aria-hidden="true"
+            />
+            {t("errors:maintenance.badge")}
+          </div>
+          <h1 className="scroll-m-20 text-2xl font-bold tracking-tight">
+            {t("errors:maintenance.heading")}
+          </h1>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            {t("errors:maintenance.description")}
+          </p>
+        </div>
+
+        <div
+          className="w-full max-w-xs space-y-3 rounded-xl border border-border bg-card px-5 py-4 text-left"
+          data-testid="maintenance-status-card"
+        >
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+            {t("errors:maintenance.statusHeading")}
+          </p>
+          {COMPONENT_ORDER.map((key) => {
+            const status: StatusKey = componentStatus[key] ?? "maintenance"
+            const statusColor =
+              status === "operational"
+                ? "text-status-active"
+                : status === "degraded"
+                  ? "text-status-expiring"
+                  : "text-muted-foreground"
+            return (
+              <div
+                key={key}
+                className="flex items-center justify-between"
+                data-testid={`maintenance-status-${key}`}
+              >
+                <span className="text-sm">{t(`errors:maintenance.components.${key}`)}</span>
+                <span className={`text-xs font-medium ${statusColor}`}>
+                  {t(`errors:maintenance.statusLabels.${status}`)}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+
+        {retryAt && !hasResumePassed ? (
+          <p className="text-xs text-muted-foreground" data-testid="maintenance-resume">
+            {t("errors:maintenance.resumeAt", { time: formatDateTime(retryAt) })}
+          </p>
+        ) : null}
+
+        <Button onClick={handleRetry} data-testid="maintenance-retry">
+          {t("errors:maintenance.retry")}
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/UIShowcasePage.test.tsx
+++ b/frontend/src/pages/UIShowcasePage.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+
+import { UIShowcasePage } from "./UIShowcasePage"
+
+describe("UIShowcasePage", () => {
+  it("renders the showcase with the dev-only badge and tab strip", () => {
+    render(
+      <MemoryRouter>
+        <UIShowcasePage />
+      </MemoryRouter>
+    )
+    expect(screen.getByRole("heading", { name: /ui showcase/i, level: 1 })).toBeInTheDocument()
+    expect(screen.getByText(/dev only/i)).toBeInTheDocument()
+    // Tab triggers — verifying the 7 section tabs are rendered.
+    for (const label of [
+      "Buttons",
+      "Forms",
+      "Overlays",
+      "Feedback",
+      "Layout",
+      "Typography",
+      "Tokens",
+    ]) {
+      expect(screen.getByRole("tab", { name: label })).toBeInTheDocument()
+    }
+  })
+})

--- a/frontend/src/pages/UIShowcasePage.tsx
+++ b/frontend/src/pages/UIShowcasePage.tsx
@@ -1,0 +1,454 @@
+import { useState } from "react"
+import { Bell, Check, Info, Loader2, Plus, Search, ShieldAlert, Sparkles } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Separator } from "@/components/ui/separator"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Textarea } from "@/components/ui/textarea"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { RouteTitle } from "@/components/routing/RouteTitle"
+
+// UIShowcasePage — dev-only catalog of every shadcn/Radix primitive used in
+// the app. Mounted by the router only when `import.meta.env.DEV` is true
+// (see app/router.tsx). Designed to be opened during design-system
+// migrations to spot regressions in a single screen — not a production
+// feature. Loosely mirrors design-mocks/src/views/UIShowcaseView.tsx but
+// restricted to the primitives our frontend actually ships
+// (frontend/src/components/ui/). #1542 / design-audit #1527.
+export function UIShowcasePage() {
+  return (
+    <>
+      <RouteTitle title="UI Showcase (dev)" />
+      <div
+        className="mx-auto flex w-full max-w-6xl flex-col gap-8 p-6"
+        data-testid="page-ui-showcase"
+      >
+        <header className="space-y-1">
+          <div className="flex items-center gap-2">
+            <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">UI Showcase</h1>
+            <Badge variant="secondary">dev only</Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Reference catalog of shadcn/Radix primitives shipped in this app — kept here to spot
+            regressions during design-system work.
+          </p>
+        </header>
+
+        <Tabs defaultValue="buttons">
+          <TabsList>
+            <TabsTrigger value="buttons">Buttons</TabsTrigger>
+            <TabsTrigger value="forms">Forms</TabsTrigger>
+            <TabsTrigger value="overlays">Overlays</TabsTrigger>
+            <TabsTrigger value="feedback">Feedback</TabsTrigger>
+            <TabsTrigger value="layout">Layout</TabsTrigger>
+            <TabsTrigger value="typography">Typography</TabsTrigger>
+            <TabsTrigger value="tokens">Tokens</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="buttons" className="mt-6">
+            <ButtonsSection />
+          </TabsContent>
+          <TabsContent value="forms" className="mt-6">
+            <FormsSection />
+          </TabsContent>
+          <TabsContent value="overlays" className="mt-6">
+            <OverlaysSection />
+          </TabsContent>
+          <TabsContent value="feedback" className="mt-6">
+            <FeedbackSection />
+          </TabsContent>
+          <TabsContent value="layout" className="mt-6">
+            <LayoutSection />
+          </TabsContent>
+          <TabsContent value="typography" className="mt-6">
+            <TypographySection />
+          </TabsContent>
+          <TabsContent value="tokens" className="mt-6">
+            <TokensSection />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </>
+  )
+}
+
+function ShowcaseRow({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-3 rounded-xl border border-border bg-card p-4">
+      <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+        {title}
+      </p>
+      <div className="flex flex-wrap items-center gap-3">{children}</div>
+    </div>
+  )
+}
+
+function ButtonsSection() {
+  return (
+    <div className="space-y-4">
+      <ShowcaseRow title="Variants">
+        <Button>Default</Button>
+        <Button variant="secondary">Secondary</Button>
+        <Button variant="outline">Outline</Button>
+        <Button variant="ghost">Ghost</Button>
+        <Button variant="link">Link</Button>
+        <Button variant="destructive">Destructive</Button>
+      </ShowcaseRow>
+      <ShowcaseRow title="Sizes">
+        <Button size="sm">Small</Button>
+        <Button>Default</Button>
+        <Button size="lg">Large</Button>
+        <Button size="icon" aria-label="add">
+          <Plus className="size-4" aria-hidden="true" />
+        </Button>
+      </ShowcaseRow>
+      <ShowcaseRow title="States">
+        <Button disabled>Disabled</Button>
+        <Button>
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          Loading
+        </Button>
+        <Button>
+          <Sparkles className="size-4" aria-hidden="true" />
+          With icon
+        </Button>
+      </ShowcaseRow>
+    </div>
+  )
+}
+
+function FormsSection() {
+  const [check, setCheck] = useState(true)
+  const [toggle, setToggle] = useState(false)
+  const [radio, setRadio] = useState("one")
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Inputs</CardTitle>
+          <CardDescription>Text, password, search, number, textarea</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="showcase-text">Text</Label>
+            <Input id="showcase-text" placeholder="Type something…" />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="showcase-search">Search</Label>
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <Input id="showcase-search" placeholder="Search…" className="pl-8" />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="showcase-textarea">Textarea</Label>
+            <Textarea id="showcase-textarea" placeholder="Multi-line…" />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Selectors</CardTitle>
+          <CardDescription>Switch, checkbox, radio, select</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="showcase-switch">Switch</Label>
+            <Switch id="showcase-switch" checked={toggle} onCheckedChange={setToggle} />
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="showcase-check"
+              checked={check}
+              onCheckedChange={(v) => setCheck(v === true)}
+            />
+            <Label htmlFor="showcase-check">Checkbox</Label>
+          </div>
+          <RadioGroup value={radio} onValueChange={setRadio} className="flex gap-4">
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="one" id="r-one" />
+              <Label htmlFor="r-one">One</Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="two" id="r-two" />
+              <Label htmlFor="r-two">Two</Label>
+            </div>
+          </RadioGroup>
+          <div className="space-y-1.5">
+            <Label htmlFor="showcase-select">Select</Label>
+            <Select>
+              <SelectTrigger id="showcase-select">
+                <SelectValue placeholder="Pick one" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="apple">Apple</SelectItem>
+                <SelectItem value="banana">Banana</SelectItem>
+                <SelectItem value="cherry">Cherry</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function OverlaysSection() {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <ShowcaseRow title="Dialog">
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="outline">Open dialog</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Dialog title</DialogTitle>
+              <DialogDescription>Sample modal dialog</DialogDescription>
+            </DialogHeader>
+            <p className="text-sm text-muted-foreground">Body content goes here.</p>
+            <DialogFooter>
+              <Button variant="ghost">Cancel</Button>
+              <Button>Confirm</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </ShowcaseRow>
+      <ShowcaseRow title="Sheet (right slide-over)">
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="outline">Open sheet</Button>
+          </SheetTrigger>
+          <SheetContent>
+            <SheetHeader>
+              <SheetTitle>Sheet title</SheetTitle>
+              <SheetDescription>Slide-over panel.</SheetDescription>
+            </SheetHeader>
+          </SheetContent>
+        </Sheet>
+      </ShowcaseRow>
+      <ShowcaseRow title="Popover">
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline">Open popover</Button>
+          </PopoverTrigger>
+          <PopoverContent className="text-sm">Anchored popover content.</PopoverContent>
+        </Popover>
+      </ShowcaseRow>
+      <ShowcaseRow title="Tooltip">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="outline">Hover me</Button>
+          </TooltipTrigger>
+          <TooltipContent>Helpful hint</TooltipContent>
+        </Tooltip>
+      </ShowcaseRow>
+      <ShowcaseRow title="Dropdown menu">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline">Open menu</Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuLabel>Group</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>One</DropdownMenuItem>
+            <DropdownMenuItem>Two</DropdownMenuItem>
+            <DropdownMenuItem>Three</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </ShowcaseRow>
+    </div>
+  )
+}
+
+function FeedbackSection() {
+  return (
+    <div className="space-y-4">
+      <Alert>
+        <Info className="size-4" aria-hidden="true" />
+        <AlertTitle>Heads up</AlertTitle>
+        <AlertDescription>Informational alert content.</AlertDescription>
+      </Alert>
+      <Alert variant="destructive">
+        <ShieldAlert className="size-4" aria-hidden="true" />
+        <AlertTitle>Destructive</AlertTitle>
+        <AlertDescription>Something went wrong.</AlertDescription>
+      </Alert>
+      <ShowcaseRow title="Badges">
+        <Badge>Default</Badge>
+        <Badge variant="secondary">Secondary</Badge>
+        <Badge variant="outline">Outline</Badge>
+        <Badge variant="destructive">Destructive</Badge>
+      </ShowcaseRow>
+      <ShowcaseRow title="Status pills (semantic tokens)">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-status-active/10 px-2.5 py-0.5 text-xs font-medium text-status-active">
+          <Check className="size-3" aria-hidden="true" />
+          Active
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-status-expiring/10 px-2.5 py-0.5 text-xs font-medium text-status-expiring">
+          <Bell className="size-3" aria-hidden="true" />
+          Expiring
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-status-expired/10 px-2.5 py-0.5 text-xs font-medium text-status-expired">
+          Expired
+        </span>
+      </ShowcaseRow>
+      <ShowcaseRow title="Skeleton">
+        <Skeleton className="h-6 w-32" />
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-12 w-12 rounded-full" />
+      </ShowcaseRow>
+    </div>
+  )
+}
+
+function LayoutSection() {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Card</CardTitle>
+          <CardDescription>Header / content / footer slots</CardDescription>
+        </CardHeader>
+        <CardContent>Card body content.</CardContent>
+        <CardFooter className="gap-2">
+          <Button variant="ghost">Cancel</Button>
+          <Button>Save</Button>
+        </CardFooter>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>ScrollArea</CardTitle>
+          <CardDescription>Long-list scroll container</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ScrollArea className="h-32 rounded-md border">
+            <ul className="space-y-1 p-3 text-sm">
+              {Array.from({ length: 20 }, (_, i) => (
+                <li key={i}>Item {i + 1}</li>
+              ))}
+            </ul>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+      <Card className="md:col-span-2">
+        <CardHeader>
+          <CardTitle>Separator</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <p>Section A</p>
+          <Separator />
+          <p>Section B</p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function TypographySection() {
+  return (
+    <div className="space-y-4 rounded-xl border border-border bg-card p-6">
+      <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">
+        Heading 1 — Page title (3xl, semibold)
+      </h1>
+      <h2 className="text-2xl font-bold tracking-tight">Heading 2 — Section (2xl, bold)</h2>
+      <h3 className="text-xl font-semibold tracking-tight">Heading 3 — Subsection (xl)</h3>
+      <h4 className="text-lg font-semibold">Heading 4 — Card title (lg)</h4>
+      <p className="text-base">Body — base size for paragraphs.</p>
+      <p className="text-sm text-muted-foreground">
+        Muted small — descriptions, helper text, secondary metadata.
+      </p>
+      <p className="text-xs text-muted-foreground">Caption — timestamps, labels.</p>
+      <p className="font-mono text-sm">Mono — short_name, slugs, technical identifiers.</p>
+    </div>
+  )
+}
+
+function TokensSection() {
+  const palette: Array<{ label: string; className: string }> = [
+    { label: "background", className: "bg-background border" },
+    { label: "card", className: "bg-card border" },
+    { label: "muted", className: "bg-muted" },
+    { label: "primary", className: "bg-primary" },
+    { label: "secondary", className: "bg-secondary" },
+    { label: "accent", className: "bg-accent" },
+    { label: "destructive", className: "bg-destructive" },
+    { label: "border", className: "bg-border" },
+    { label: "status-active", className: "bg-status-active" },
+    { label: "status-expiring", className: "bg-status-expiring" },
+    { label: "status-expired", className: "bg-status-expired" },
+  ]
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Semantic colour tokens used by the design system. Light and dark themes both resolve to the
+        same names; the underlying colour switches based on `[data-theme]`.
+      </p>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+        {palette.map(({ label, className }) => (
+          <div
+            key={label}
+            className="flex flex-col items-center gap-2 rounded-xl border border-border p-3"
+          >
+            <div className={`size-14 rounded-md ${className}`} aria-hidden="true" />
+            <span className="font-mono text-xs">{label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #1542 — the two mock-only routes from the design-audit follow-up list in [#1527](https://github.com/denisvmedia/inventario/issues/1527).

## Summary

### 1. Maintenance / scheduled-downtime page

- **`frontend/src/pages/MaintenancePage.tsx`** matches the mock (`design-mocks/src/views/EmptyStatesView.tsx::MaintenanceView`): wrench tile, scheduled-maintenance pill, status card listing API / Database / File storage with per-component colour (operational green, degraded amber, maintenance muted), localised resume-time line.
- **`frontend/src/lib/http.ts`** intercepts 503 responses and bounces through the new `navigateToMaintenance` hook with `Retry-After` + `X-Maintenance-Status` headers forwarded as URL params, so a refresh (or a deep-link share) keeps showing the page. The `HttpError` is still thrown so React Query `onError` stays consistent.
- **Recursion guard:** re-entry while already on `/maintenance` is a no-op, so the page can render without bouncing itself.
- **`AuthProvider`** installs the SPA-aware navigator (mirrors the existing `navigateToLogin` pattern from #1404) so we never reach for `window.location.href`.

BE convention to flip the page on: respond `503` with optional `Retry-After: <seconds|HTTP-date>` and optional `X-Maintenance-Status: api=degraded,database=maintenance,storage=operational`.

### 2. UI Showcase (dev-only)

- **`frontend/src/pages/UIShowcasePage.tsx`** — 7-tab catalog (Buttons, Forms, Overlays, Feedback, Layout, Typography, Tokens) over every shadcn/Radix primitive shipped in `frontend/src/components/ui/`. Loosely mirrors `design-mocks/src/views/UIShowcaseView.tsx`, scoped down to what we actually ship.
- **`/`_dev/ui-showcase`** route mounted only when `import.meta.env.DEV` is true — Vite tree-shakes the chunk out of prod builds entirely.

## Tests

- `MaintenancePage.test.tsx` — defaults, per-component status header, delta-seconds + HTTP-date `Retry-After`, invalid input fallback, resume-already-passed hiding.
- `UIShowcasePage.test.tsx` — smoke test for the 7 tab triggers + dev badge.
- `http.test.ts` — two new specs for the 503 flow: navigator called with parsed headers, and no re-bounce when already on `/maintenance`.

## Gates

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run i18n:check` clean (after commit)
- [x] `npm test` 855/855 (+8 new cases over master's 847)

## What this PR is *not*

The other 3 still-open #1527 sub-issues (Notifications BE / AI photo scan / Onboarding tour) aren't bundled here on purpose — each is its own multi-day scope:

- **#1543** Onboarding tour — separate PR. Needs `data-tour=…` wiring across `AppSidebar`, the Add Item button, a portal-rendered overlay component, per-user "tour seen" persistence, a `RestartTourButton` in the topbar, and 7-step i18n in en/cs/ru.
- **#1540** AI photo scan — needs a vision backend service; the AI offer step in `CommodityFormDialog` is already wired (Scan button disabled awaiting BE).
- **#1536 item 3** Data & Storage — needs BE quota endpoint + JSON/CSV exports.

A separate comment on #1527 summarises which sub-issues already shipped and what's outstanding.

## Test plan

- [ ] CI green on this branch (typecheck / lint / vitest / Go suite / Playwright)
- [ ] Manual: hit `/maintenance` directly → page renders
- [ ] Manual: hit `/maintenance?retry_after=900&status=api%3Ddegraded%2Cdatabase%3Dmaintenance%2Cstorage%3Doperational` → status pills show correct colours, resume line shows a local time ~15 min in the future
- [ ] Manual (dev only): `/_dev/ui-showcase` → catalog renders, each tab clicks through cleanly
- [ ] Manual (prod build): `/_dev/ui-showcase` → catch-all NotFound (chunk not shipped)