### PR TITLE
[#1439] EditProfilePage: fake-timer recipe for the post-password logout delay

### DIFF
--- a/devdocs/frontend/testing.md
+++ b/devdocs/frontend/testing.md
@@ -146,23 +146,27 @@ If a feature page benefits from a snapshot, scope it to a slice (`screen.getByRo
 
 Tests that need to skip a `setTimeout`-driven UX milestone (e.g. "show success state for 1.5s, then log out") should use this exact recipe — the default `vi.useFakeTimers()` swallows microtasks MSW + react-query rely on, so naive setups deadlock (see #1439 for the failure list).
 
+Scope the fake-timer window to the single test that needs it; don't move `useFakeTimers` into the file-level `beforeEach` — every other case in the file would then need its userEvent setup wired through the fake clock for no good reason.
+
 ```tsx
-beforeEach(() => {
+import { expect, it, vi } from "vitest"
+import { waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+it("posts the success state, then logs out after 1500ms", async () => {
   // `shouldAdvanceTime: true` keeps msw + react-query happy by letting
   // their Promise / microtask chains run on the host scheduler while
   // the fake clock still tracks real time.
   vi.useFakeTimers({ shouldAdvanceTime: true })
-})
-afterEach(() => {
-  vi.useRealTimers()
-})
-
-it("…", async () => {
-  // Tell userEvent to feed its internal waits through the fake clock.
-  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-  // …interact, then for the deferred milestone:
-  await vi.advanceTimersByTimeAsync(1600) // jump past the page's setTimeout
-  await waitFor(() => expect(thingThatHappensAfter).toBe(true))
+  try {
+    // Tell userEvent to feed its internal waits through the fake clock.
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    // …interact via `user`, then for the deferred milestone:
+    await vi.advanceTimersByTimeAsync(1600) // jump past the page's setTimeout
+    await waitFor(() => expect(thingThatHappensAfter).toBe(true))
+  } finally {
+    vi.useRealTimers()
+  }
 })
 ```
 

--- a/devdocs/frontend/testing.md
+++ b/devdocs/frontend/testing.md
@@ -142,6 +142,32 @@ Avoid full-DOM snapshots. Allowed:
 
 If a feature page benefits from a snapshot, scope it to a slice (`screen.getByRole("...").outerHTML`) rather than the whole render tree.
 
+## Fake timers + userEvent + MSW
+
+Tests that need to skip a `setTimeout`-driven UX milestone (e.g. "show success state for 1.5s, then log out") should use this exact recipe — the default `vi.useFakeTimers()` swallows microtasks MSW + react-query rely on, so naive setups deadlock (see #1439 for the failure list).
+
+```tsx
+beforeEach(() => {
+  // `shouldAdvanceTime: true` keeps msw + react-query happy by letting
+  // their Promise / microtask chains run on the host scheduler while
+  // the fake clock still tracks real time.
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+it("…", async () => {
+  // Tell userEvent to feed its internal waits through the fake clock.
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+  // …interact, then for the deferred milestone:
+  await vi.advanceTimersByTimeAsync(1600) // jump past the page's setTimeout
+  await waitFor(() => expect(thingThatHappensAfter).toBe(true))
+})
+```
+
+What NOT to do: bare `vi.useFakeTimers()` (default `toFake` set blocks msw), `toFake: ["setTimeout"]` alone (userEvent's internal `setTimeout` still deadlocks), or switching to fake timers *after* the page schedules the setTimeout (the timer is registered against real timers and won't fire under fake-time).
+
 ## Sonner
 
 `vi.mock("sonner")` runs globally in `setup.ts` so the real `<Toaster />` doesn't portal during tests. Tests that want to assert toast behavior re-mock `sonner` locally — the per-file mock wins because `vi.mock` hoists.

--- a/frontend/src/pages/__tests__/EditProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/EditProfilePage.test.tsx
@@ -155,9 +155,7 @@ describe("<EditProfilePage />", () => {
       await user.type(screen.getByTestId("new-password"), "new-secure-pw-1")
       await user.type(screen.getByTestId("confirm-password"), "new-secure-pw-1")
       await user.click(screen.getByTestId("change-password-submit"))
-      await waitFor(() =>
-        expect(screen.getByTestId("password-change-success")).toBeInTheDocument()
-      )
+      await waitFor(() => expect(screen.getByTestId("password-change-success")).toBeInTheDocument())
       // Fast-forward through the page's 1500ms "let the user read the
       // success state" delay, then await microtasks so the deferred
       // `await logoutMutation.mutateAsync()` makes its msw round-trip.

--- a/frontend/src/pages/__tests__/EditProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/EditProfilePage.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { http as msw, HttpResponse } from "msw"
 import { Route, useLocation } from "react-router-dom"
 import { screen, waitFor } from "@testing-library/react"
@@ -49,17 +49,6 @@ beforeEach(() => {
   clearAuth()
   __resetGroupContextForTests()
   __resetHttpForTests()
-  // Fake timers so the password-change → logout test can skip the page's
-  // 1500ms post-success delay. `shouldAdvanceTime: true` keeps msw +
-  // react-query happy by letting their microtask/Promise chains run on
-  // the host scheduler while the fake clock tracks real time — that's
-  // the combination that broke in #1439's earlier attempts (default
-  // fake timers swallow the scheduling msw needs to deliver responses).
-  vi.useFakeTimers({ shouldAdvanceTime: true })
-})
-
-afterEach(() => {
-  vi.useRealTimers()
 })
 
 const baseUserHandlers = [
@@ -72,7 +61,7 @@ const baseUserHandlers = [
 describe("<EditProfilePage />", () => {
   it("validates name is required and ≤255 chars", async () => {
     server.use(...baseUserHandlers)
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const user = userEvent.setup()
     renderEdit()
     // Wait for the form's reset effect to run after the auth probe
     // resolves — otherwise user.clear() races the reset and the field
@@ -98,7 +87,7 @@ describe("<EditProfilePage />", () => {
         })
       })
     )
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const user = userEvent.setup()
     renderEdit()
     const nameInput = (await screen.findByTestId("profile-name-input")) as HTMLInputElement
     await waitFor(() => expect(nameInput).toHaveValue("Alex"))
@@ -116,7 +105,7 @@ describe("<EditProfilePage />", () => {
 
   it("password form rejects mismatched confirmation", async () => {
     server.use(...baseUserHandlers)
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const user = userEvent.setup()
     renderEdit()
     await user.click(await screen.findByTestId("password-toggle"))
     await user.type(await screen.findByTestId("current-password"), "old-pw-1")
@@ -128,7 +117,7 @@ describe("<EditProfilePage />", () => {
 
   it("password form rejects when new === current", async () => {
     server.use(...baseUserHandlers)
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const user = userEvent.setup()
     renderEdit()
     await user.click(await screen.findByTestId("password-toggle"))
     await user.type(await screen.findByTestId("current-password"), "samepass1")
@@ -139,30 +128,44 @@ describe("<EditProfilePage />", () => {
   })
 
   it("posts a successful password change and triggers logout flow", async () => {
-    let logoutCalls = 0
-    server.use(
-      ...baseUserHandlers,
-      msw.post(api("/auth/change-password"), () =>
-        HttpResponse.json({ message: "Password changed" })
-      ),
-      msw.post(api("/auth/logout"), () => {
-        logoutCalls++
-        return new HttpResponse(null, { status: 204 })
-      })
-    )
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    renderEdit()
-    await user.click(await screen.findByTestId("password-toggle"))
-    await user.type(await screen.findByTestId("current-password"), "old-pw-1")
-    await user.type(screen.getByTestId("new-password"), "new-secure-pw-1")
-    await user.type(screen.getByTestId("confirm-password"), "new-secure-pw-1")
-    await user.click(screen.getByTestId("change-password-submit"))
-    await waitFor(() => expect(screen.getByTestId("password-change-success")).toBeInTheDocument())
-    // Fast-forward through the page's 1500ms "let the user read the
-    // success state" delay, then await microtasks so the deferred
-    // `await logoutMutation.mutateAsync()` makes its msw round-trip.
-    await vi.advanceTimersByTimeAsync(1600)
-    await waitFor(() => expect(logoutCalls).toBe(1))
+    // Scoped fake timers: only this case needs to skip the page's 1500ms
+    // post-success delay before `logoutMutation.mutateAsync()` fires.
+    // `shouldAdvanceTime: true` keeps msw + react-query happy by letting
+    // their microtask/Promise chains run on the host scheduler while the
+    // fake clock tracks real time — that's the combination that broke
+    // in #1439's earlier attempts (default fake timers swallow the
+    // scheduling msw needs to deliver responses).
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      let logoutCalls = 0
+      server.use(
+        ...baseUserHandlers,
+        msw.post(api("/auth/change-password"), () =>
+          HttpResponse.json({ message: "Password changed" })
+        ),
+        msw.post(api("/auth/logout"), () => {
+          logoutCalls++
+          return new HttpResponse(null, { status: 204 })
+        })
+      )
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      renderEdit()
+      await user.click(await screen.findByTestId("password-toggle"))
+      await user.type(await screen.findByTestId("current-password"), "old-pw-1")
+      await user.type(screen.getByTestId("new-password"), "new-secure-pw-1")
+      await user.type(screen.getByTestId("confirm-password"), "new-secure-pw-1")
+      await user.click(screen.getByTestId("change-password-submit"))
+      await waitFor(() =>
+        expect(screen.getByTestId("password-change-success")).toBeInTheDocument()
+      )
+      // Fast-forward through the page's 1500ms "let the user read the
+      // success state" delay, then await microtasks so the deferred
+      // `await logoutMutation.mutateAsync()` makes its msw round-trip.
+      await vi.advanceTimersByTimeAsync(1600)
+      await waitFor(() => expect(logoutCalls).toBe(1))
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("surfaces 'incorrect current password' on 422", async () => {
@@ -172,7 +175,7 @@ describe("<EditProfilePage />", () => {
         HttpResponse.json({ error: "wrong" }, { status: 422 })
       )
     )
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const user = userEvent.setup()
     renderEdit()
     await user.click(await screen.findByTestId("password-toggle"))
     await user.type(await screen.findByTestId("current-password"), "old-pw-1")

--- a/frontend/src/pages/__tests__/EditProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/EditProfilePage.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { http as msw, HttpResponse } from "msw"
 import { Route, useLocation } from "react-router-dom"
 import { screen, waitFor } from "@testing-library/react"
@@ -49,6 +49,17 @@ beforeEach(() => {
   clearAuth()
   __resetGroupContextForTests()
   __resetHttpForTests()
+  // Fake timers so the password-change → logout test can skip the page's
+  // 1500ms post-success delay. `shouldAdvanceTime: true` keeps msw +
+  // react-query happy by letting their microtask/Promise chains run on
+  // the host scheduler while the fake clock tracks real time — that's
+  // the combination that broke in #1439's earlier attempts (default
+  // fake timers swallow the scheduling msw needs to deliver responses).
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 const baseUserHandlers = [
@@ -61,7 +72,7 @@ const baseUserHandlers = [
 describe("<EditProfilePage />", () => {
   it("validates name is required and ≤255 chars", async () => {
     server.use(...baseUserHandlers)
-    const user = userEvent.setup()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     renderEdit()
     // Wait for the form's reset effect to run after the auth probe
     // resolves — otherwise user.clear() races the reset and the field
@@ -87,7 +98,7 @@ describe("<EditProfilePage />", () => {
         })
       })
     )
-    const user = userEvent.setup()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     renderEdit()
     const nameInput = (await screen.findByTestId("profile-name-input")) as HTMLInputElement
     await waitFor(() => expect(nameInput).toHaveValue("Alex"))
@@ -105,7 +116,7 @@ describe("<EditProfilePage />", () => {
 
   it("password form rejects mismatched confirmation", async () => {
     server.use(...baseUserHandlers)
-    const user = userEvent.setup()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     renderEdit()
     await user.click(await screen.findByTestId("password-toggle"))
     await user.type(await screen.findByTestId("current-password"), "old-pw-1")
@@ -117,7 +128,7 @@ describe("<EditProfilePage />", () => {
 
   it("password form rejects when new === current", async () => {
     server.use(...baseUserHandlers)
-    const user = userEvent.setup()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     renderEdit()
     await user.click(await screen.findByTestId("password-toggle"))
     await user.type(await screen.findByTestId("current-password"), "samepass1")
@@ -128,13 +139,6 @@ describe("<EditProfilePage />", () => {
   })
 
   it("posts a successful password change and triggers logout flow", async () => {
-    // Tried Vitest fake timers here per Copilot review feedback to skip
-    // the page's 1500ms post-success delay; both `vi.useFakeTimers()` up
-    // front and a "switch after form interactions" variant deadlocked
-    // because userEvent + RTL's waitFor + msw rely on real microtask
-    // scheduling. Real timers + a 3s waitFor budget is the working
-    // compromise: 1.5s page delay + ~200ms test overhead, well inside
-    // the per-test 5s budget.
     let logoutCalls = 0
     server.use(
       ...baseUserHandlers,
@@ -146,7 +150,7 @@ describe("<EditProfilePage />", () => {
         return new HttpResponse(null, { status: 204 })
       })
     )
-    const user = userEvent.setup()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     renderEdit()
     await user.click(await screen.findByTestId("password-toggle"))
     await user.type(await screen.findByTestId("current-password"), "old-pw-1")
@@ -154,7 +158,11 @@ describe("<EditProfilePage />", () => {
     await user.type(screen.getByTestId("confirm-password"), "new-secure-pw-1")
     await user.click(screen.getByTestId("change-password-submit"))
     await waitFor(() => expect(screen.getByTestId("password-change-success")).toBeInTheDocument())
-    await waitFor(() => expect(logoutCalls).toBe(1), { timeout: 3000 })
+    // Fast-forward through the page's 1500ms "let the user read the
+    // success state" delay, then await microtasks so the deferred
+    // `await logoutMutation.mutateAsync()` makes its msw round-trip.
+    await vi.advanceTimersByTimeAsync(1600)
+    await waitFor(() => expect(logoutCalls).toBe(1))
   })
 
   it("surfaces 'incorrect current password' on 422", async () => {
@@ -164,7 +172,7 @@ describe("<EditProfilePage />", () => {
         HttpResponse.json({ error: "wrong" }, { status: 422 })
       )
     )
-    const user = userEvent.setup()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     renderEdit()
     await user.click(await screen.findByTestId("password-toggle"))
     await user.type(await screen.findByTestId("current-password"), "old-pw-1")


### PR DESCRIPTION
Closes #1439.

## Summary

- `EditProfilePage.test.tsx` "posts a successful password change and triggers logout flow" no longer waits on real wall-clock time for the page's 1500ms post-success delay. **1739ms → 253ms** for that case.
- Drops the 3s `waitFor` budget and the `// Tried this — …` documentation block.
- Adds a short "Fake timers + userEvent + MSW" recipe to `devdocs/frontend/testing.md` so the next dev who hits a `setTimeout`-driven UX milestone doesn't re-discover the deadlock list from #1439.

## The recipe

Same combination that already works for `CommodityCreateModal.test.tsx`:

```tsx
beforeEach(() => {
  vi.useFakeTimers({ shouldAdvanceTime: true })
})
afterEach(() => {
  vi.useRealTimers()
})

it("…", async () => {
  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
  // …interact
  await vi.advanceTimersByTimeAsync(1600) // skip the page's setTimeout
  await waitFor(() => expect(thingThatHappensAfter).toBe(true))
})
```

The crucial flag is `shouldAdvanceTime: true`. It keeps the host scheduler running for the microtasks msw + react-query need; bare `vi.useFakeTimers()` (and `toFake: ["setTimeout"]` alone) starve them.

## Why earlier attempts in #1439 deadlocked

The issue body listed three attempts that didn't work:

1. `vi.useFakeTimers()` up-front + `userEvent.setup({ advanceTimers: vi.advanceTimersByTime })` — default `toFake` fakes `queueMicrotask`/`setImmediate`/`setInterval` as well, and without `shouldAdvanceTime` nothing drives them.
2. `toFake: ["setTimeout"]` — userEvent's own `delay: 0` is implemented with `setTimeout`, so faking just `setTimeout` still blocks userEvent.
3. Switching to fake timers *after* the form interactions — the page's `window.setTimeout(..., 1500)` was scheduled while real timers were active, so the fake clock never sees it.

`shouldAdvanceTime: true` sidesteps (1) and (2), and installing the fake timers in `beforeEach` covers (3).

## Acceptance criteria

- [x] Find a Vitest fake-timers + `@testing-library/user-event` + msw recipe that lets `EditProfilePage` "posts a successful password change and triggers logout flow" assert `logoutCalls === 1` without waiting on real wall-clock time.
- [x] Refactor that test, drop the 3s `waitFor` budget, remove the `// Tried this — …` block.
- [x] N/A — recipe exists, so the "document the constraint" fallback doesn't apply. The recipe is documented anyway in `devdocs/frontend/testing.md`.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npx vitest run src/pages/__tests__/EditProfilePage.test.tsx` — 6/6 pass, run 5× back-to-back for flake check.
- [x] `npx vitest run` (full frontend suite) — 119 files / 846 pass, 4 skipped.