### PR TITLE
[#1313] Helm follow-ups from PR #1306 Copilot review

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -189,12 +189,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          # 55-char release name. Each split-mode resource appends a
-          # `-worker-<group>` (up to 20 chars) or `-apiserver` (10 chars)
-          # suffix. inventario.splitBaseName pre-truncates the base so the
+          # 53-char release name (helm's max). Combined with the
+          # 10-char `-inventario` chart-name suffix, the unpatched
+          # `inventario.fullname | trunc 63` would consume every
+          # available char, so the role suffixes (`-worker-<group>`
+          # up to 20 chars, or `-apiserver` 10 chars) would be sliced
+          # off by the trailing `trunc 63` and every resource would
+          # collapse to the same name.
+          # inventario.splitBaseName pre-truncates the base so the
           # suffix is never lost to the trailing trunc 63 — every
-          # Deployment/Service/HPA name in this render must remain unique.
-          helm template inventario-long-release-name-collision-check-helm-lint helm/inventario \
+          # Deployment/Service/HPA name in this render must remain
+          # unique.
+          helm template inventario-long-release-name-collision-check-helmlint helm/inventario \
             --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
             --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
             --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -164,3 +164,112 @@ jobs:
 
           cat /tmp/inventario-no-topology-error.log
           grep -Eq 'No run topology' /tmp/inventario-no-topology-error.log
+
+      - name: Verify workers-only configuration is rejected
+        run: |
+          set -euo pipefail
+
+          if helm template inventario helm/inventario \
+            --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
+            --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+            --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+            --set setupJob.initData.adminPassword=test \
+            --set run.all.enabled=false \
+            --set run.workers.media.enabled=true \
+            > /tmp/inventario-workers-only-render.yaml \
+            2> /tmp/inventario-workers-only-error.log; then
+            echo "Expected helm template to fail when any worker is enabled without run.apiserver." >&2
+            exit 1
+          fi
+
+          cat /tmp/inventario-workers-only-error.log
+          grep -Eq 'Workers-only mode is not supported' /tmp/inventario-workers-only-error.log
+
+      - name: Render chart in split mode with a long release name (name-collision guard)
+        run: |
+          set -euo pipefail
+
+          # 55-char release name. Each split-mode resource appends a
+          # `-worker-<group>` (up to 20 chars) or `-apiserver` (10 chars)
+          # suffix. inventario.splitBaseName pre-truncates the base so the
+          # suffix is never lost to the trailing trunc 63 — every
+          # Deployment/Service/HPA name in this render must remain unique.
+          helm template inventario-long-release-name-collision-check-helm-lint helm/inventario \
+            --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
+            --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+            --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+            --set setupJob.initData.adminPassword=test \
+            --set run.all.enabled=false \
+            --set run.apiserver.enabled=true \
+            --set run.workers.archive.enabled=true \
+            --set run.workers.emails.enabled=true \
+            --set run.workers.housekeeping.enabled=true \
+            --set run.workers.media.enabled=true \
+            > /tmp/inventario-long-release-render.yaml
+
+          # Extract every Deployment name in the render and require uniqueness.
+          # Without the splitBaseName pre-truncation, the -apiserver and -worker-*
+          # suffixes would collapse onto inventario.fullname and onto each other.
+          dep_names="$(awk '
+            /^kind: Deployment$/ { in_kind=1; next }
+            in_kind && /^metadata:/ { in_meta=1; next }
+            in_meta && /^  name: / { print $2; in_kind=0; in_meta=0; next }
+            /^---/ { in_kind=0; in_meta=0 }
+          ' /tmp/inventario-long-release-render.yaml)"
+
+          echo "Rendered Deployment names:"
+          echo "$dep_names"
+
+          dup_count="$(echo "$dep_names" | sort | uniq -d | wc -l)"
+          if [ "$dup_count" -ne 0 ]; then
+            echo "Duplicate Deployment names detected in long-release split render — name truncation collapsed the role suffix." >&2
+            echo "$dep_names" | sort | uniq -d >&2
+            exit 1
+          fi
+
+          # apiserver + 4 workers = 5 split-mode Deployments expected.
+          expected=5
+          actual="$(echo "$dep_names" | grep -c .)"
+          if [ "$actual" -ne "$expected" ]; then
+            echo "Expected ${expected} unique split-mode Deployment names, got ${actual}." >&2
+            exit 1
+          fi
+
+      - name: Verify empty-HPA-metrics configuration is rejected
+        run: |
+          set -euo pipefail
+
+          # autoscaling.enabled=true with both target* nulled and metrics=[]
+          # would render `spec.metrics:` with no items — invalid for
+          # autoscaling/v2. inventario.hpaMetrics fails the render instead.
+          if helm template inventario helm/inventario \
+            --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
+            --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+            --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+            --set setupJob.initData.adminPassword=test \
+            --set run.all.autoscaling.enabled=true \
+            --set run.all.autoscaling.targetCPUUtilizationPercentage=null \
+            --set run.all.autoscaling.targetMemoryUtilizationPercentage=null \
+            > /tmp/inventario-empty-hpa-render.yaml \
+            2> /tmp/inventario-empty-hpa-error.log; then
+            echo "Expected helm template to fail when autoscaling.enabled=true but no metrics are configured." >&2
+            exit 1
+          fi
+
+          cat /tmp/inventario-empty-hpa-error.log
+          grep -Eq 'no metrics are configured' /tmp/inventario-empty-hpa-error.log
+
+      - name: Render chart with HPA metrics supplied only via the extensible list
+        run: >-
+          helm template inventario helm/inventario
+          --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require'
+          --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest'
+          --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest'
+          --set setupJob.initData.adminPassword=test
+          --set run.all.autoscaling.enabled=true
+          --set run.all.autoscaling.targetCPUUtilizationPercentage=null
+          --set run.all.autoscaling.metrics[0].type=External
+          --set run.all.autoscaling.metrics[0].external.metric.name=inventario_jobs_pending
+          --set run.all.autoscaling.metrics[0].external.target.type=AverageValue
+          --set-string run.all.autoscaling.metrics[0].external.target.averageValue=5
+          > /tmp/inventario-hpa-external-render.yaml

--- a/helm/inventario/README.md
+++ b/helm/inventario/README.md
@@ -223,6 +223,50 @@ For the complete default surface, see `helm/inventario/values.yaml`.
 
   The CLI `--workers-only` / `--workers-exclude` flags still accept the old family names (`exports`, `imports`, `restores`, `thumbnails`, `token-cleanup`) for one release and log a deprecation warning; Helm values surface only the group keys.
 
+### Upgrading from chart 0.2.0 → 0.3.x
+
+Chart 0.3.0 reshaped the run-topology surface from a flat set of pod-shape keys at the chart root into the `run.*` hierarchy that supports both combined (`run all`) and split (`run apiserver` + `run workers`) deployments. The following top-level keys were **removed**; if your existing `values.yaml` (or `--set` arguments) still sets them, the chart silently falls back to its new defaults and your overrides are lost. Move each one under the matching `run.*` block before upgrading.
+
+| 0.2.0 (top-level) | 0.3.x (combined mode) | 0.3.x (split mode — API server) | 0.3.x (split mode — worker group) |
+| --- | --- | --- | --- |
+| `replicaCount` | `run.all.replicaCount` | `run.apiserver.replicaCount` | `run.workers.<group>.replicaCount` |
+| `resources` | `run.all.resources` | `run.apiserver.resources` | `run.workers.common.resources` (or `run.workers.<group>.resources` to override) |
+| `livenessProbe` | `run.all.livenessProbe` | `run.apiserver.livenessProbe` | `run.workers.common.livenessProbe` (worker probe port defaults to `probe`, not `3333`) |
+| `readinessProbe` | `run.all.readinessProbe` | `run.apiserver.readinessProbe` | `run.workers.common.readinessProbe` |
+| `podAnnotations` | `run.all.podAnnotations` | `run.apiserver.podAnnotations` | `run.workers.common.podAnnotations` (or per-group) |
+| `nodeSelector` | `run.all.nodeSelector` | `run.apiserver.nodeSelector` | `run.workers.common.nodeSelector` (or per-group) |
+| `tolerations` | `run.all.tolerations` | `run.apiserver.tolerations` | `run.workers.common.tolerations` (or per-group) |
+| `affinity` | `run.all.affinity` | `run.apiserver.affinity` | `run.workers.common.affinity` (or per-group) |
+| `priorityClassName` | `run.all.priorityClassName` | `run.apiserver.priorityClassName` | `run.workers.common.priorityClassName` (or per-group) |
+
+Other surfaces are unchanged: `image.*`, `service.*`, `ingress.*`, `serviceAccount.*`, `app.*`, `features.*`, `email.*`, `secrets.*`, `setupJob.*`, `persistence.*`, `podSecurityContext`, `containerSecurityContext`, and `demo.*` keep the same shape and meaning as in 0.2.0.
+
+If you previously enabled `autoscaling.*` at the chart root, that block was never wired in 0.2.0; 0.3.x introduces it as `run.<role>.autoscaling.*`.
+
+A typical upgrade looks like:
+
+```diff
+-replicaCount: 2
+-resources:
+-  requests:
+-    cpu: 200m
+-    memory: 384Mi
+-nodeSelector:
+-  workload: inventario
++run:
++  all:
++    enabled: true
++    replicaCount: 2
++    resources:
++      requests:
++        cpu: 200m
++        memory: 384Mi
++    nodeSelector:
++      workload: inventario
+```
+
+Run `helm template ... --debug | grep -E 'replicas|resources|nodeSelector|tolerations|affinity'` after rewriting your values to confirm the new render still reflects your overrides.
+
 ## Validation
 
 The chart is covered by the `helm-lint.yml` CI workflow across combined, split, demo, and misconfiguration scenarios. The commands below reproduce those scenarios locally:

--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -53,47 +53,82 @@ Usage: include "inventario.workerCliId" "housekeeping"
 {{- end -}}
 
 {{/*
-Compute whether any split role is enabled. Emits "true" or empty.
+Compute whether any worker role is enabled. Emits "true" or empty.
 */}}
-{{- define "inventario.splitEnabled" -}}
-{{- $split := .Values.run.apiserver.enabled -}}
+{{- define "inventario.anyWorkerEnabled" -}}
+{{- $any := false -}}
 {{- range $role := splitList " " (include "inventario.workerRoles" .) -}}
   {{- $cfg := index $.Values.run.workers $role -}}
-  {{- if and $cfg $cfg.enabled -}}{{- $split = true -}}{{- end -}}
+  {{- if and $cfg $cfg.enabled -}}{{- $any = true -}}{{- end -}}
 {{- end -}}
-{{- if $split -}}true{{- end -}}
+{{- if $any -}}true{{- end -}}
 {{- end -}}
 
 {{/*
-Validate the run topology. Fails the render when run.all and any
-split role (apiserver or any worker) are both enabled, or when
-neither mode is active.
+Compute whether split mode is active. Split mode is gated on the
+API-server: run.apiserver.enabled=true. Workers without an apiserver
+are rejected by validateRunMode.
+*/}}
+{{- define "inventario.splitEnabled" -}}
+{{- if .Values.run.apiserver.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Validate the run topology. Fails the render when:
+- run.all and any split role (apiserver or worker) are both enabled
+  (mutually exclusive), or
+- any worker is enabled while run.apiserver.enabled=false
+  (workers-only mode is not supported — there is nobody to serve
+  the HTTP API and the chart-managed Service / Ingress / NOTES
+  would dangle), or
+- no topology is active.
 */}}
 {{- define "inventario.validateRunMode" -}}
 {{- $all := .Values.run.all.enabled -}}
-{{- $split := eq (include "inventario.splitEnabled" .) "true" -}}
-{{- if and $all $split -}}
+{{- $apiserver := .Values.run.apiserver.enabled -}}
+{{- $anyWorker := eq (include "inventario.anyWorkerEnabled" .) "true" -}}
+{{- if and $all (or $apiserver $anyWorker) -}}
 {{- fail "run.all.enabled and split roles (run.apiserver or run.workers.<group>) are mutually exclusive. Set run.all.enabled=false when using split Deployments." -}}
 {{- end -}}
-{{- if not (or $all $split) -}}
-{{- fail "No run topology is active. Enable run.all (combined) or run.apiserver together with at least one run.workers.<group>.enabled=true (split)." -}}
+{{- if and $anyWorker (not $apiserver) -}}
+{{- fail "run.apiserver.enabled=true is required when any run.workers.<group>.enabled=true. Workers-only mode is not supported by this chart — enable run.apiserver alongside the workers." -}}
+{{- end -}}
+{{- if not (or $all $apiserver) -}}
+{{- fail "No run topology is active. Enable run.all (combined) or run.apiserver (split; workers optional)." -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Resource name suffix for the API-server split Deployment.
+Base name used to derive split-mode resource names. The base is
+truncated short enough to leave room for the longest known suffix
+(`-worker-housekeeping`, 20 chars) so concatenated names never
+collapse onto each other or onto inventario.fullname after the
+trailing trunc 63 in printf-then-trunc patterns. Resulting names
+remain unique per release because both inventario.fullname and
+this base are derived from .Release.Name + chart name.
+*/}}
+{{- define "inventario.splitBaseName" -}}
+{{- printf "%s-%s" .Release.Name (include "inventario.name" .) | trunc 43 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Resource name for the API-server split Deployment. The base is
+pre-truncated by inventario.splitBaseName so the `-apiserver`
+suffix is never lost to `trunc 63`.
 */}}
 {{- define "inventario.apiserverName" -}}
-{{- printf "%s-apiserver" (include "inventario.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-apiserver" (include "inventario.splitBaseName" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
-Resource name suffix for a per-worker-group Deployment.
+Resource name for a per-worker-group Deployment. The base is
+pre-truncated by inventario.splitBaseName so the `-worker-<role>`
+suffix is never lost to `trunc 63`.
 Usage: include "inventario.workerName" (dict "root" . "role" "media")
 */}}
 {{- define "inventario.workerName" -}}
 {{- $cli := include "inventario.workerCliId" .role -}}
-{{- printf "%s-worker-%s" (include "inventario.fullname" .root) $cli | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-worker-%s" (include "inventario.splitBaseName" .root) $cli | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -135,6 +170,36 @@ Usage: $cfg := include "inventario.workerConfig" (dict "root" . "role" "media") 
 {{- $override := deepCopy (default (dict) $role) -}}
 {{- $merged := mustMergeOverwrite $common $override -}}
 {{- toYaml $merged -}}
+{{- end -}}
+
+{{/*
+Build the HPA metrics list for an autoscaling block. CPU and memory
+target utilization percentages turn into Resource metric entries;
+any extra entries from `<block>.metrics` are appended verbatim.
+Fails the render when autoscaling.enabled=true but no metric ends
+up configured (empty `spec.metrics` is invalid for autoscaling/v2).
+The `scope` arg names the offending values path in the error.
+Usage:
+  include "inventario.hpaMetrics" (dict "cfg" .Values.run.all.autoscaling "scope" "run.all")
+Returns the indented YAML list ready to drop under `metrics:` with
+`{{- include "inventario.hpaMetrics" ... | nindent 4 }}`.
+*/}}
+{{- define "inventario.hpaMetrics" -}}
+{{- $cfg := .cfg -}}
+{{- $metrics := list -}}
+{{- if $cfg.targetCPUUtilizationPercentage -}}
+{{- $metrics = append $metrics (dict "type" "Resource" "resource" (dict "name" "cpu" "target" (dict "type" "Utilization" "averageUtilization" (int $cfg.targetCPUUtilizationPercentage)))) -}}
+{{- end -}}
+{{- if $cfg.targetMemoryUtilizationPercentage -}}
+{{- $metrics = append $metrics (dict "type" "Resource" "resource" (dict "name" "memory" "target" (dict "type" "Utilization" "averageUtilization" (int $cfg.targetMemoryUtilizationPercentage)))) -}}
+{{- end -}}
+{{- with $cfg.metrics -}}
+{{- $metrics = concat $metrics . -}}
+{{- end -}}
+{{- if not $metrics -}}
+{{- fail (printf "%s.autoscaling.enabled=true but no metrics are configured. Set %s.autoscaling.targetCPUUtilizationPercentage, .targetMemoryUtilizationPercentage, or add entries to .metrics — an empty spec.metrics list is invalid for autoscaling/v2." .scope .scope) -}}
+{{- end -}}
+{{- toYaml $metrics -}}
 {{- end -}}
 
 {{/*

--- a/helm/inventario/templates/hpa.yaml
+++ b/helm/inventario/templates/hpa.yaml
@@ -2,7 +2,9 @@
 HorizontalPodAutoscaler stubs. One HPA per enabled worker group
 (or apiserver) with autoscaling.enabled=true. Default metric is
 CPU; callers may extend via <group>.autoscaling.metrics (external
-or resource) and <group>.autoscaling.behavior.
+or resource) and <group>.autoscaling.behavior. The render fails
+when autoscaling.enabled=true resolves to an empty metrics list —
+see inventario.hpaMetrics.
 */}}
 {{- $root := . -}}
 
@@ -25,25 +27,7 @@ spec:
   minReplicas: {{ $cfg.minReplicas }}
   maxReplicas: {{ $cfg.maxReplicas }}
   metrics:
-    {{- if $cfg.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ $cfg.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if $cfg.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ $cfg.targetMemoryUtilizationPercentage }}
-    {{- end }}
-    {{- with $cfg.metrics }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "inventario.hpaMetrics" (dict "cfg" $cfg "scope" "run.all") | nindent 4 }}
   {{- with $cfg.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}
@@ -69,25 +53,7 @@ spec:
   minReplicas: {{ $cfg.minReplicas }}
   maxReplicas: {{ $cfg.maxReplicas }}
   metrics:
-    {{- if $cfg.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ $cfg.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if $cfg.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ $cfg.targetMemoryUtilizationPercentage }}
-    {{- end }}
-    {{- with $cfg.metrics }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "inventario.hpaMetrics" (dict "cfg" $cfg "scope" "run.apiserver") | nindent 4 }}
   {{- with $cfg.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}
@@ -103,6 +69,7 @@ spec:
 {{- $cli := include "inventario.workerCliId" $role }}
 {{- $name := include "inventario.workerName" (dict "root" $root "role" $role) }}
 {{- $acfg := $cfg.autoscaling }}
+{{- $scope := printf "run.workers.%s" $role }}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -119,25 +86,7 @@ spec:
   minReplicas: {{ $acfg.minReplicas }}
   maxReplicas: {{ $acfg.maxReplicas }}
   metrics:
-    {{- if $acfg.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ $acfg.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if $acfg.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ $acfg.targetMemoryUtilizationPercentage }}
-    {{- end }}
-    {{- with $acfg.metrics }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "inventario.hpaMetrics" (dict "cfg" $acfg "scope" $scope) | nindent 4 }}
   {{- with $acfg.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -17,17 +17,22 @@ image:
 # Run topology
 # ============================================================
 # Controls whether Inventario runs as one combined Deployment
-# (`inventario run all`, the default) or as per-worker-group
-# Deployments (`run apiserver` + one or more
+# (`inventario run all`, the default) or as per-role Deployments
+# (`run apiserver` + zero or more
 # `run workers --workers-only=<group>`).
 #
 # Exactly ONE of the following must be active:
 #   * run.all.enabled=true                (single Deployment)
-#   * run.apiserver.enabled=true AND at least one
-#     run.workers.<group>.enabled=true    (split Deployments)
+#   * run.apiserver.enabled=true          (split Deployments —
+#     workers are optional; pair with any subset of
+#     run.workers.<group>.enabled=true to offload work)
 #
-# Enabling run.all together with any split group is rejected at
-# template time.
+# Workers-only renders (any run.workers.<group>.enabled=true while
+# run.apiserver.enabled=false) are rejected at template time:
+# there is nobody to serve the HTTP API, and the chart-managed
+# Service / Ingress / NOTES would dangle.
+#
+# Enabling run.all together with any split role is also rejected.
 #
 # Per-role blocks (apiserver + each worker) deep-merge over the
 # role's defaults from run.workers.common for workers, and over


### PR DESCRIPTION
Closes #1313.

Addresses the 5 outstanding Copilot review threads on PR #1306 (helm split Deployments). Each item below maps 1:1 to a comment in the original review and is locked in by an additional CI scenario.

## Item 1 — `values.yaml` split-mode header now matches actual behaviour

[Original thread](https://github.com/denisvmedia/inventario/pull/1306#discussion_r3122197136)

The run-topology header used to say split mode required `run.apiserver.enabled=true` **and** at least one worker, but the chart and CI (`split-apiserver-only`) already accept apiserver-only renders. Rewrote the comment to make explicit that split mode is gated **only** on `run.apiserver.enabled=true`; workers are optional. The same comment now also calls out that workers-only renders are rejected (see Item 3).

## Item 2 — `helm/inventario/README.md`: explicit "Upgrading from 0.2.0 → 0.3.x" section

[Original thread](https://github.com/denisvmedia/inventario/pull/1306#discussion_r3122197163)

Added a dedicated subsection under "Upgrade notes" with a per-key mapping table for every removed top-level pod-shape key (`replicaCount`, `resources`, `livenessProbe`, `readinessProbe`, `podAnnotations`, `nodeSelector`, `tolerations`, `affinity`, `priorityClassName`), showing where each one moves under `run.all.*`, `run.apiserver.*`, or `run.workers.common.*`. Includes a diff example and a `helm template --debug | grep ...` verification command. The chart did **not** add silent fallbacks — existing values.yaml files that still set the old keys lose their overrides on upgrade, but the README now tells operators exactly what to rewrite.

## Item 3 — `_helpers.tpl` workers-only renders fail with a clear message

[Original thread](https://github.com/denisvmedia/inventario/pull/1306#discussion_r3122197183)

`inventario.validateRunMode` now fails the render with a precise error when any `run.workers.<group>.enabled=true` while `run.apiserver.enabled=false`. Previously, workers-only renders silently produced worker Deployments alongside a dangling `Service` (gated on `apiserverRendered`), an `Ingress`, and `NOTES.txt` text that all referenced an apiserver Service that never rendered. The new helper `inventario.anyWorkerEnabled` powers both the workers-only check and a tightened mutual-exclusion check; `inventario.splitEnabled` is now correctly gated only on `run.apiserver.enabled`.

This is the recommended-not-supported path from the Copilot suggestion, consistent with the Item 1 doc rewrite.

## Item 4 — `_helpers.tpl` apiserver/worker names never collide on long releases

[Original thread](https://github.com/denisvmedia/inventario/pull/1306#discussion_r3122197203)

Introduced `inventario.splitBaseName` that truncates `releaseName + "-" + chartName` to **43 chars** before any suffix is appended. The longest known suffix is `-worker-housekeeping` (20 chars), so `splitBaseName | "-worker-housekeeping" | trunc 63` never loses the role part. Both `inventario.apiserverName` and `inventario.workerName` now route through `splitBaseName`, so every consumer (deployments, services, HPAs) picks up the fix automatically.

CI gains a 55-char release-name scenario that renders the full split topology (apiserver + 4 workers), extracts every Deployment name, and asserts: (a) no duplicates; (b) exactly 5 unique names. Without the fix, multiple roles collapse onto the same `trunc 63` prefix and the assertion fails.

## Item 5 — `hpa.yaml` rejects empty `spec.metrics`

[Original thread](https://github.com/denisvmedia/inventario/pull/1306#discussion_r3122197224)

Extracted a new `inventario.hpaMetrics` helper that builds the metrics list dynamically:
- Resource entries for CPU / memory utilization when their target percentages are set
- All extensible entries from `.metrics` appended verbatim
- `fail` (option b from the Copilot suggestion) with a scoped error message when the resulting list is empty — `autoscaling/v2` rejects an empty `spec.metrics`, and silently omitting the key would just defer the failure to `kubectl apply`.

All three HPA blocks (`run.all`, `run.apiserver`, per-worker loop) now go through the helper, so the scoped error message names the offending values path (`run.all` / `run.apiserver` / `run.workers.<group>`).

CI gains two new scenarios: one that asserts the empty-metrics configuration is rejected with the expected error message, and one that renders successfully when CPU/memory targets are nulled but a single external metric is supplied via the extensible `.metrics` list.

## CI changes summary (`.github/workflows/helm-lint.yml`)

- **Verify workers-only configuration is rejected** — Item 3 guard.
- **Render chart in split mode with a long release name (name-collision guard)** — Item 4 guard; 55-char release, asserts 5 unique Deployment names.
- **Verify empty-HPA-metrics configuration is rejected** — Item 5 guard.
- **Render chart with HPA metrics supplied only via the extensible list** — Item 5 happy path; confirms `metrics: []` alone is no longer the only way to use the metrics surface.

## Validation

Local `helm` not available in this environment, so validation rides on the expanded CI suite above. All existing scenarios (combined, demo, split-all-roles, split-apiserver-only, split-workers-subset+HPA, missing-DSN, mutex, no-topology) remain in place and should continue to pass.

## PR review thread replies

Will reply to each of the 5 Copilot threads on #1306 with a pointer to this PR / the commit that addresses it after the PR is open and CI is green.