### PR TITLE
[#1540] Typed server-error banner for CommodityFormDialog

### DIFF
--- a/frontend/i18next.config.ts
+++ b/frontend/i18next.config.ts
@@ -54,6 +54,13 @@ export default defineConfig({
     preservePatterns: [
       "stubs:*",
       "common:nav.*",
+      // common:onboarding.steps.* — OnboardingTour renders each of the 7
+      //   step titles + descriptions via
+      //   `t(\`common:onboarding.steps.${step.key}.title\`)` over the closed
+      //   StepKey union (welcome, addItem, navDashboard, navLocations,
+      //   navItems, navWarranties, navFiles). Dynamic keys; the extractor
+      //   sees only the template literal. (#1543)
+      "common:onboarding.steps.*",
       "auth:validation.*",
       "auth:passwordStrength.*",
       "auth:session.*",
@@ -269,6 +276,14 @@ export default defineConfig({
       "groups:migration.status.*",
       "groups:settings.dialog.step*",
       "groups:settings.sections.*",
+      // settings:loginHistory.outcomes.* + .methods.* — LoginHistoryPage
+      //   resolves the badge label via a static OUTCOME_I18N_KEY /
+      //   METHOD_I18N_KEY lookup map keyed on the BE enum value
+      //   (models.LoginOutcome / LoginMethod). The extractor sees only
+      //   `t(OUTCOME_I18N_KEY[outcome])` so each per-variant key has to
+      //   survive the sweep via the wildcard.
+      "settings:loginHistory.outcomes.*",
+      "settings:loginHistory.methods.*",
       // common:serverError.*.title — ServerErrorBanner picks the title via
       //   `t(\`common:serverError.${kind}.title\`)` over the closed
       //   ServerErrorKind union (network/validation/conflict/unknown). The

--- a/frontend/i18next.config.ts
+++ b/frontend/i18next.config.ts
@@ -269,6 +269,12 @@ export default defineConfig({
       "groups:migration.status.*",
       "groups:settings.dialog.step*",
       "groups:settings.sections.*",
+      // common:serverError.*.title — ServerErrorBanner picks the title via
+      //   `t(\`common:serverError.${kind}.title\`)` over the closed
+      //   ServerErrorKind union (network/validation/conflict/unknown). The
+      //   extractor sees only the template literal; the four titles live in
+      //   en/common.json's serverError subtree.
+      "common:serverError.*",
     ],
   },
 })

--- a/frontend/src/components/ServerErrorBanner.tsx
+++ b/frontend/src/components/ServerErrorBanner.tsx
@@ -1,0 +1,74 @@
+import { useTranslation } from "react-i18next"
+import { AlertTriangle, RefreshCw, WifiOff } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { type ClassifiedServerError, isRetryableKind } from "@/lib/server-error"
+
+interface ServerErrorBannerProps {
+  // Classified error from `classifyServerError`. Pass `null` to render
+  // nothing — callers can wire `{error ? <ServerErrorBanner … /> : null}`
+  // or `<ServerErrorBanner error={error} />` either way works.
+  error: ClassifiedServerError | null
+  // Re-run the failing operation. Only shown for `network` / `unknown`
+  // kinds (validation / conflict need user action — see `isRetryableKind`).
+  // Omit the prop entirely to hide Retry even for retryable kinds (e.g.
+  // when the calling form doesn't support an in-place retry).
+  onRetry?: () => void
+  // True while a retry is in flight — disables the Retry button so the
+  // user can't stack requests. Caller drives this from its own
+  // mutation/submitting state.
+  isRetrying?: boolean
+  // Stable hook for E2E + integration tests so they don't have to
+  // text-match the headline copy.
+  testId?: string
+  // Optional override for the headline copy. Defaults to
+  // `common:serverError.<kind>.title` and is rarely needed — surface-
+  // specific copy can live in the message itself.
+  titleOverride?: string
+  // Optional className passthrough for wrapper layout (e.g. `mt-3`).
+  className?: string
+}
+
+// Typed server-error banner — single visual contract across the app so
+// users learn the affordances (Retry vs. fix-and-resubmit) once. Kind
+// classification lives in `lib/server-error.ts`; this component is just
+// a presentational consumer.
+export function ServerErrorBanner({
+  error,
+  onRetry,
+  isRetrying,
+  testId,
+  titleOverride,
+  className,
+}: ServerErrorBannerProps) {
+  const { t } = useTranslation()
+  if (!error) return null
+  const { kind, message } = error
+  const title = titleOverride ?? t(`common:serverError.${kind}.title`)
+  const Icon = kind === "network" ? WifiOff : AlertTriangle
+  const showRetry = !!onRetry && isRetryableKind(kind)
+  return (
+    <Alert variant="destructive" className={className} data-testid={testId} data-error-kind={kind}>
+      <Icon className="size-4" aria-hidden="true" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>
+        <p>{message}</p>
+        {showRetry ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={onRetry}
+            disabled={isRetrying}
+            className="mt-2"
+            data-testid={testId ? `${testId}-retry` : undefined}
+          >
+            <RefreshCw className="size-3.5" aria-hidden="true" />
+            {t("common:serverError.retry")}
+          </Button>
+        ) : null}
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/frontend/src/components/__tests__/ServerErrorBanner.test.tsx
+++ b/frontend/src/components/__tests__/ServerErrorBanner.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { ServerErrorBanner } from "@/components/ServerErrorBanner"
+import { renderWithProviders } from "@/test/render"
+
+describe("<ServerErrorBanner />", () => {
+  it("renders nothing when error is null", () => {
+    const { container } = renderWithProviders({
+      children: <ServerErrorBanner error={null} testId="b" />,
+    })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("shows the network title and a Retry button when onRetry is provided", async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+    renderWithProviders({
+      children: (
+        <ServerErrorBanner
+          error={{ kind: "network", message: "Failed to fetch" }}
+          onRetry={onRetry}
+          testId="b"
+        />
+      ),
+    })
+    expect(screen.getByText("Can't reach the server")).toBeInTheDocument()
+    expect(screen.getByText("Failed to fetch")).toBeInTheDocument()
+    const retry = screen.getByRole("button", { name: /try again/i })
+    await user.click(retry)
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it("hides Retry for validation kind even when onRetry is provided", () => {
+    // Validation/conflict need the user to edit before a re-submit
+    // could succeed — see lib/server-error::isRetryableKind. The
+    // banner must not surface a Retry that would just stack failures.
+    renderWithProviders({
+      children: (
+        <ServerErrorBanner
+          error={{ kind: "validation", message: "Name is required" }}
+          onRetry={() => {}}
+          testId="b"
+        />
+      ),
+    })
+    expect(screen.getByText("Please check the highlighted fields")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /try again/i })).not.toBeInTheDocument()
+  })
+
+  it("hides Retry for conflict kind", () => {
+    renderWithProviders({
+      children: (
+        <ServerErrorBanner
+          error={{ kind: "conflict", message: "Already taken" }}
+          onRetry={() => {}}
+          testId="b"
+        />
+      ),
+    })
+    expect(screen.getByText("This conflicts with another change")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /try again/i })).not.toBeInTheDocument()
+  })
+
+  it("hides Retry when onRetry is omitted, even for retryable kinds", () => {
+    renderWithProviders({
+      children: <ServerErrorBanner error={{ kind: "unknown", message: "Boom" }} testId="b" />,
+    })
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /try again/i })).not.toBeInTheDocument()
+  })
+
+  it("disables Retry while isRetrying is true", () => {
+    renderWithProviders({
+      children: (
+        <ServerErrorBanner
+          error={{ kind: "network", message: "Failed to fetch" }}
+          onRetry={() => {}}
+          isRetrying
+          testId="b"
+        />
+      ),
+    })
+    expect(screen.getByRole("button", { name: /try again/i })).toBeDisabled()
+  })
+
+  it("exposes data-error-kind on the alert for assertions and styling hooks", () => {
+    renderWithProviders({
+      children: <ServerErrorBanner error={{ kind: "validation", message: "x" }} testId="b" />,
+    })
+    expect(screen.getByTestId("b")).toHaveAttribute("data-error-kind", "validation")
+  })
+})

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -46,7 +46,8 @@ import { TagsInput } from "@/components/files/TagsInput"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { HttpError } from "@/lib/http"
 import { clearPendingFiles, loadPendingFiles, savePendingFiles } from "@/lib/pending-files-store"
-import { parseServerError } from "@/lib/server-error"
+import { type ClassifiedServerError, classifyServerError } from "@/lib/server-error"
+import { ServerErrorBanner } from "@/components/ServerErrorBanner"
 import { useQueryClient } from "@tanstack/react-query"
 import { uploadFile, updateFile } from "@/features/files/api"
 import { categoryFromMime } from "@/features/files/constants"
@@ -200,7 +201,7 @@ export function CommodityFormDialog({
   const [visitedSteps, setVisitedSteps] = useState<Set<FormStepKey>>(
     () => new Set(mode === "create" ? [] : ["basics"])
   )
-  const [serverError, setServerError] = useState<string | null>(null)
+  const [serverError, setServerError] = useState<ClassifiedServerError | null>(null)
   // Save-as-draft confirmation. Open when the user dismisses the
   // dialog (Escape, click-outside, X button, or the explicit Cancel
   // footer button) while the form is dirty in create mode — gives
@@ -536,9 +537,12 @@ export function CommodityFormDialog({
       }
       // Pull the BE's actual error detail out of the HttpError envelope
       // (JSON:API `errors[0].detail` / `error` / `message`) instead of
-      // showing the bare "Request to … failed with NNN" wrapper. Falls
-      // back to a generic copy when the body has nothing useful.
-      setServerError(parseServerError(err, t("commodities:form.serverError")))
+      // showing the bare "Request to … failed with NNN" wrapper, and
+      // classify it so the banner can pick the right title + decide
+      // whether to offer a Retry button (network / unknown only —
+      // validation / conflict need the user to edit before resubmit).
+      // Falls back to a generic copy when the body has nothing useful.
+      setServerError(classifyServerError(err, t("commodities:form.serverError")))
     }
   }
 
@@ -822,11 +826,17 @@ export function CommodityFormDialog({
             ) : null}
           </StepResizeWrapper>
 
-          {serverError ? (
-            <p className="text-sm text-destructive" data-testid="commodity-form-error">
-              {serverError}
-            </p>
-          ) : null}
+          <ServerErrorBanner
+            error={serverError}
+            // Retry re-runs the form's existing submit pipeline with
+            // the current values (the user has neither edited nor
+            // navigated away — the same payload is still in RHF state).
+            // Only `network` / `unknown` kinds show the button; the
+            // banner gates that internally via `isRetryableKind`.
+            onRetry={() => void handleSubmit(submit)()}
+            isRetrying={!!isPending}
+            testId="commodity-form-error"
+          />
         </form>
 
         {step === "ai" ? (

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -33,6 +33,47 @@
     "tags": "Tags",
     "warranties": "Warranties"
   },
+  "onboarding": {
+    "ariaLabel": "Product tour",
+    "back": "Back",
+    "done": "Done",
+    "next": "Next",
+    "restart": "Tour",
+    "restartMenuItem": "Restart product tour",
+    "restartTitle": "Restart product tour",
+    "skip": "Skip",
+    "skipLabel": "Skip tour",
+    "steps": {
+      "addItem": {
+        "description": "Tap here to add any item to your inventory — appliances, electronics, furniture, tools. Capture purchase price, serial number, and photos.",
+        "title": "Add your first item"
+      },
+      "navDashboard": {
+        "description": "Your home base. See a summary of total inventory value, warranty statuses, recent items, and key stats at a glance.",
+        "title": "Dashboard overview"
+      },
+      "navFiles": {
+        "description": "Upload receipts, manuals, warranty certificates, and photos — all attached directly to items, locations, or areas.",
+        "title": "Attach files"
+      },
+      "navItems": {
+        "description": "See every item in your inventory. Filter by category, search by name, sort by value — and open any item for full details.",
+        "title": "Browse all items"
+      },
+      "navLocations": {
+        "description": "Structure your inventory by rooms and zones. Create locations like \"Kitchen\" or \"Garage\", then divide them into areas.",
+        "title": "Organize by location"
+      },
+      "navWarranties": {
+        "description": "Never miss an expiring warranty again. {{brand}} tracks every warranty and alerts you before they run out.",
+        "title": "Track warranties"
+      },
+      "welcome": {
+        "description": "Your personal home inventory system. Track every item, warranty, file, and receipt — all in one place. Let's take a quick tour.",
+        "title": "Welcome to {{brand}}"
+      }
+    }
+  },
   "serverError": {
     "conflict": {
       "title": "This conflicts with another change"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -33,6 +33,21 @@
     "tags": "Tags",
     "warranties": "Warranties"
   },
+  "serverError": {
+    "conflict": {
+      "title": "This conflicts with another change"
+    },
+    "network": {
+      "title": "Can't reach the server"
+    },
+    "retry": "Try again",
+    "unknown": {
+      "title": "Something went wrong"
+    },
+    "validation": {
+      "title": "Please check the highlighted fields"
+    }
+  },
   "shell": {
     "account": "Account",
     "commandGroupNavigation": "Navigation",

--- a/frontend/src/lib/__tests__/server-error.test.ts
+++ b/frontend/src/lib/__tests__/server-error.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { HttpError } from "@/lib/http"
-import { parseServerError } from "@/lib/server-error"
+import { classifyServerError, isRetryableKind, parseServerError } from "@/lib/server-error"
 
 describe("parseServerError", () => {
   it("returns the trimmed string body when the server replied with plain text", () => {
@@ -32,5 +32,57 @@ describe("parseServerError", () => {
 
   it("returns plain Error message when present", () => {
     expect(parseServerError(new Error("network"), "fallback")).toBe("network")
+  })
+})
+
+describe("classifyServerError", () => {
+  it("classifies a non-HttpError as network and surfaces the Error message", () => {
+    const result = classifyServerError(new TypeError("Failed to fetch"), "fallback")
+    expect(result).toEqual({ kind: "network", message: "Failed to fetch" })
+  })
+
+  it("classifies a thrown non-Error value as network with the fallback copy", () => {
+    expect(classifyServerError(undefined, "Connection lost")).toEqual({
+      kind: "network",
+      message: "Connection lost",
+    })
+  })
+
+  it.each([400, 422] as const)("classifies %i as validation", (status) => {
+    const err = new HttpError("boom", status, "/x", { errors: [{ detail: "Name required" }] })
+    expect(classifyServerError(err, "fallback")).toEqual({
+      kind: "validation",
+      message: "Name required",
+    })
+  })
+
+  it.each([409, 412, 423] as const)("classifies %i as conflict", (status) => {
+    const err = new HttpError("boom", status, "/x", { error: "Already taken" })
+    expect(classifyServerError(err, "fallback")).toEqual({
+      kind: "conflict",
+      message: "Already taken",
+    })
+  })
+
+  it.each([403, 404, 500, 502, 503, 504] as const)("classifies %i as unknown", (status) => {
+    const err = new HttpError("boom", status, "/x", null)
+    expect(classifyServerError(err, "Try again")).toEqual({
+      kind: "unknown",
+      message: "Try again",
+    })
+  })
+})
+
+describe("isRetryableKind", () => {
+  it("offers Retry for network and unknown", () => {
+    expect(isRetryableKind("network")).toBe(true)
+    expect(isRetryableKind("unknown")).toBe(true)
+  })
+
+  it("hides Retry for validation and conflict", () => {
+    // Both kinds need user action before re-submit could succeed —
+    // showing Retry would just queue another failure.
+    expect(isRetryableKind("validation")).toBe(false)
+    expect(isRetryableKind("conflict")).toBe(false)
   })
 })

--- a/frontend/src/lib/server-error.ts
+++ b/frontend/src/lib/server-error.ts
@@ -50,6 +50,54 @@ export function parseServerError(err: unknown, fallback: string): string {
   return fallback
 }
 
+// Discriminated kind so banners can switch headline + retry affordance
+// without each caller re-deriving the classification.
+//
+//   - network    fetch threw before any HTTP response (offline, DNS,
+//                CORS preflight failed, etc.). Always safe to retry.
+//   - validation BE rejected the payload (400 / 422). User has to edit
+//                inputs — retry is *not* offered.
+//   - conflict   stale write / unique violation (409 / 412 / 423).
+//                User has to reconcile — retry is not offered.
+//   - unknown    everything else (403, 404, 5xx, parser errors).
+//                Retry is offered since the cause may be transient.
+export type ServerErrorKind = "network" | "validation" | "conflict" | "unknown"
+
+export interface ClassifiedServerError {
+  kind: ServerErrorKind
+  message: string
+}
+
+// Maps a thrown value to a kind + the same user-facing message
+// `parseServerError` would return. Network errors are anything that
+// isn't an HttpError (the http layer only constructs HttpError when a
+// real HTTP response came back); validation/conflict are decided by
+// status code. The message body still wins over the kind's generic
+// copy when one is present — kind is a hint for affordances (Retry
+// button visibility, title copy), not a replacement for the BE's
+// detail string.
+export function classifyServerError(err: unknown, fallback: string): ClassifiedServerError {
+  if (!(err instanceof HttpError)) {
+    const msg = err instanceof Error && err.message ? err.message : fallback
+    return { kind: "network", message: msg }
+  }
+  const message = parseServerError(err, fallback)
+  if (err.status === 400 || err.status === 422) {
+    return { kind: "validation", message }
+  }
+  if (err.status === 409 || err.status === 412 || err.status === 423) {
+    return { kind: "conflict", message }
+  }
+  return { kind: "unknown", message }
+}
+
+// Convenience for banner components — validation and conflict need
+// user action before a re-submit could succeed, so the Retry button
+// is hidden in those cases. Network/unknown are retried in place.
+export function isRetryableKind(kind: ServerErrorKind): boolean {
+  return kind === "network" || kind === "unknown"
+}
+
 // Extracts the JSON:API error code from the first `errors[]` entry, if
 // present. Returns null otherwise. Lets callers branch on stable
 // machine-readable codes (e.g. "currency_migration.preview_expired") rather


### PR DESCRIPTION
## Summary

Ships item 2 of the #1540 follow-up checklist — replaces the plain `<p class="text-destructive">` in `CommodityFormDialog` with a typed `ServerErrorBanner` so users learn whether to retry, fix a field, or reconcile a conflict.

- `lib/server-error.ts` now exports `classifyServerError(err, fallback)` returning a discriminated `{ kind, message }` (`network` / `validation` / `conflict` / `unknown`). Companion `isRetryableKind` gates the Retry button — validation / conflict need user action before a re-submit could succeed, so showing Retry there would just queue another failure.
- New `components/ServerErrorBanner.tsx` — destructive `<Alert>` with a kind-keyed title (`common:serverError.<kind>.title`), the BE detail message, and an outline Retry button surfaced only when the caller passes `onRetry` AND the kind is retryable. `WifiOff` icon for network, `AlertTriangle` for the rest. `data-error-kind` attribute lets integration / e2e tests hook in without text-matching the headline copy.
- `CommodityFormDialog` swaps the inline `<p>` for `<ServerErrorBanner>` and replaces its `parseServerError → string` call with `classifyServerError`. Retry re-invokes `handleSubmit(submit)()` so the same payload is re-sent without making the user click "Add item" again. `isPending` (already a prop) drives `isRetrying` so stacked retries can't pile up.
- `i18next.config.ts` adds `common:serverError.*` to `preservePatterns` so the extractor doesn't strip the four dynamic kind titles on the next CI extract pass.

## Item-by-item against #1540

- [x] **Replace currency `<Input>` with `<CurrencyCombobox>` in Purchase step** — already shipped earlier (`CommodityFormDialog.tsx` line 1364 wraps `original_price_currency` in `<CurrencyCombobox variant="compact">`). This PR doesn't re-do that work.
- [x] **Typed server-error banner (`network` / `conflict` / `validation` / `unknown` with retry + per-field bullets)** — shipped here. Per-field bullets are NOT in the banner because the dialog already maps BE validation errors back onto each field via RHF `setError` and renders them inline via `FieldError` — re-rendering them as banner bullets would just duplicate the signal. The banner's headline ("Please check the highlighted fields") points the user at the existing inline errors.
- [ ] **AI photo-scan offer step before the multi-step form** — stays deferred. Needs a vision/AI BE service that doesn't exist (effort **L** per the audit). The current AI surface in the dialog already shows the deferral stub with a tracker link to #1540, so the UX honestly signals what's coming without faking it. Item kept open on #1540 until the vision service lands.

## Test plan

- [x] `frontend npx vitest run` — 824 passed, 4 skipped (15 new: 13 classifyServerError cases via `it.each` over the status-code matrix + 2 isRetryableKind cases; 7 ServerErrorBanner component cases)
- [x] `frontend npm run lint`
- [x] `frontend npx tsc --noEmit`
- [x] `frontend npm run format:check`
- [x] `frontend npm run i18n:check`
- [ ] Manual: open Add item dialog, hit the BE with a 422 → banner renders with "Please check the highlighted fields" headline + the BE detail + no Retry button; sidebar inline field errors still highlight the offending field.
- [ ] Manual: open Add item dialog, stop the BE → banner renders with "Can't reach the server" headline + Retry button; click Retry → request re-fires.

Refs #1540, #1527.