### PR TITLE
[#1392] Commodity-type marker: emoji → Lucide icon

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -35,6 +35,15 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 
 ### Items / Commodities
 
+#### 2026-05-16 — Commodity-type marker is a Lucide icon, not an emoji
+
+- **Issue/PR**: #1392 / PR (pending)
+- **Mock**: [`design-mocks/src/data/mock.ts`](../../design-mocks/src/data/mock.ts) defines `CATEGORY_ICONS` as an emoji map (`appliance: "🏠"`, `electronics: "💻"`, `tool: "🔧"`, `furniture: "🪑"`, `vehicle: "🚗"`, `other: "📦"`) and [`design-mocks/src/components/ItemsPanel.tsx`](../../design-mocks/src/components/ItemsPanel.tsx) / [`ItemDetail.tsx`](../../design-mocks/src/components/ItemDetail.tsx) render those emoji as the per-item visual marker on cards / rows / detail header.
+- **Reality**: `frontend/src/features/commodities/constants.ts` now exports `COMMODITY_TYPE_ICONS` as a `Record<CommodityTypeValue, LucideIcon>` using `Refrigerator` (white_goods), `Laptop` (electronics), `Wrench` (equipment), `Armchair` (furniture), `Shirt` (clothes), `Package` (other / fallback). `CommodityThumb`, the commodities list filter, the Add/Edit item dialog's type Select, the Areas panel list+grid, and the Commodity print header all render the Lucide icon component instead of the emoji glyph.
+- **Why**: User-approved in the issue body itself — emoji render inconsistently across OS font fallbacks (Windows vs. macOS vs. Linux), don't inherit theme `currentColor` for dark mode / muted-foreground, and rasterize differently at thumbnail vs. detail-hero sizes. Lucide is already a dependency, so this is zero new bundle weight; it also unifies the commodity surface with the rest of the app, which is Lucide-only per [`devdocs/frontend/icons.md`](icons.md) and [`devdocs/frontend/imports-and-bans.md`](imports-and-bans.md). The backend enum (`white_goods/electronics/equipment/furniture/clothes/other`) stays as-is — this is a pure presentation change.
+- **Approved by**: user (explicit) — issue #1392 spec calls out "Use **Phosphor or Lucide icons**, not emoji" with the same rationale, and selects Lucide for v1.
+- **Reversion plan**: Permanent for the commodity-type marker. Group / location / area icons are still emoji-based via the `IconPicker` (`features/group/icons.ts`) — that's a per-instance user choice, not a type-derived enum, and stays out of scope.
+
 #### 2026-05-10 — Add Item dialog: Tags surface as a tinted CTA card with empty-state suggestion chips
 
 - **Issue/PR**: #1544 / PR #1621

--- a/e2e/tests/commodity-type-icons.spec.ts
+++ b/e2e/tests/commodity-type-icons.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E coverage for the commodity-type Lucide icon mapping (#1392).
+ *
+ * Each row on `/commodities` carries a `CommodityThumb` that falls
+ * back to a type-keyed Lucide icon when no cover photo is set. The
+ * thumb exposes the type via `data-commodity-type` so the test can
+ * assert "every type renders its own distinct icon" without peeking
+ * at the SVG path. One commodity per backend type, all seeded via
+ * the API with `cover === undefined` so the thumb renders the icon
+ * branch and not the photo branch.
+ *
+ * Why this lives in e2e rather than vitest: the issue's acceptance
+ * criterion calls out "e2e: list view shows the right icon next to
+ * each item". Vitest covers the per-component fallback logic in
+ * `frontend/src/features/commodities/__tests__/CommodityThumb.test.tsx`;
+ * this spec walks the live React route over a real BE so a future
+ * refactor (e.g., a new wrapping component that drops the
+ * `data-commodity-type` hook) is caught here.
+ *
+ * Isolation: a per-run suffix keeps the visible set scoped via the
+ * search box (`?q=<suffix>`), so the assertions stay deterministic
+ * regardless of pre-existing seed data on the shared e2e DB.
+ */
+import { expect, type Page } from "@playwright/test"
+
+import { test } from "../fixtures/app-fixture.js"
+import {
+  createCommodityViaAPI,
+  deleteCommodityViaAPI,
+  ensureLocationAndArea,
+  extractApiAuth,
+  resolveActiveGroup,
+  type ResolvedGroup,
+} from "./includes/commodities-api.js"
+
+const TYPES = [
+  "white_goods",
+  "electronics",
+  "equipment",
+  "furniture",
+  "clothes",
+  "other",
+] as const
+
+async function gotoCommoditiesScoped(
+  page: Page,
+  group: ResolvedGroup,
+  q: string,
+): Promise<void> {
+  await page.goto(
+    `/g/${encodeURIComponent(group.slug)}/commodities?q=${encodeURIComponent(q)}`,
+  )
+  await expect(page.getByTestId("page-commodities")).toBeVisible()
+}
+
+test.describe("Commodity type icons (#1392)", () => {
+  test("each backend type renders its own fallback icon on the list", async ({
+    page,
+    request,
+  }) => {
+    const auth = await extractApiAuth(page)
+    const group = await resolveActiveGroup(request, auth)
+    const { areaId } = await ensureLocationAndArea(request, auth, group.slug)
+
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const seeded: { id: string; name: string; type: (typeof TYPES)[number] }[] = []
+    const cleanup = async () => {
+      for (const row of seeded) {
+        await deleteCommodityViaAPI(request, auth, group.slug, row.id).catch(
+          () => {},
+        )
+      }
+    }
+
+    try {
+      for (const tp of TYPES) {
+        const row = await createCommodityViaAPI(
+          request,
+          auth,
+          group.slug,
+          { name: `Icon ${tp} ${suffix}`, areaId, type: tp },
+          group.groupCurrency,
+        )
+        seeded.push({ ...row, type: tp })
+      }
+
+      await gotoCommoditiesScoped(page, group, suffix)
+
+      // Wait for every seeded card to materialise before asserting.
+      for (const row of seeded) {
+        await expect(
+          page.locator(`[data-commodity-id="${row.id}"]`),
+        ).toBeVisible({ timeout: 15000 })
+      }
+
+      // Per-type assertions: the thumb is in fallback mode (no cover
+      // was uploaded), the `data-commodity-type` attribute matches
+      // the seeded type, and a Lucide `<svg>` is rendered inside.
+      for (const row of seeded) {
+        const card = page.locator(`[data-commodity-id="${row.id}"]`)
+        const thumb = card.locator('[data-testid="commodity-card-thumb"]')
+        await expect(thumb).toHaveAttribute("data-state", "fallback")
+        await expect(thumb).toHaveAttribute("data-commodity-type", row.type)
+        await expect(thumb.locator("svg")).toHaveCount(1)
+      }
+
+      // The six rendered icons must be visually distinct — same
+      // `<svg>` element under the hood, but Lucide gives each glyph
+      // a unique `class` token (`lucide-refrigerator`, `lucide-laptop`,
+      // …). Collecting the class lists and asserting uniqueness keeps
+      // the test framework-agnostic and survives Lucide version bumps
+      // that change the actual path data.
+      const classes = await Promise.all(
+        seeded.map(async (row) => {
+          const svg = page
+            .locator(`[data-commodity-id="${row.id}"]`)
+            .locator('[data-testid="commodity-card-thumb"] svg')
+          const cls = (await svg.getAttribute("class")) ?? ""
+          return cls
+        }),
+      )
+      const unique = new Set(classes.filter((c) => c.length > 0))
+      expect(unique.size).toBe(seeded.length)
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -1129,12 +1129,15 @@ function BasicsStep(props: any) {
                   <SelectValue placeholder={t("commodities:fields.typePlaceholder")} />
                 </SelectTrigger>
                 <SelectContent>
-                  {COMMODITY_TYPES.map((tp) => (
-                    <SelectItem key={tp} value={tp}>
-                      <span className="mr-1">{COMMODITY_TYPE_ICONS[tp as CommodityTypeValue]}</span>
-                      {t(`commodities:type.${tp}`)}
-                    </SelectItem>
-                  ))}
+                  {COMMODITY_TYPES.map((tp) => {
+                    const Icon = COMMODITY_TYPE_ICONS[tp as CommodityTypeValue]
+                    return (
+                      <SelectItem key={tp} value={tp}>
+                        <Icon className="mr-1 size-3.5 text-muted-foreground" aria-hidden="true" />
+                        {t(`commodities:type.${tp}`)}
+                      </SelectItem>
+                    )
+                  })}
                 </SelectContent>
               </Select>
             )}

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -1133,7 +1133,7 @@ function BasicsStep(props: any) {
                     const Icon = COMMODITY_TYPE_ICONS[tp as CommodityTypeValue]
                     return (
                       <SelectItem key={tp} value={tp}>
-                        <Icon className="mr-1 size-3.5 text-muted-foreground" aria-hidden="true" />
+                        <Icon aria-hidden="true" />
                         {t(`commodities:type.${tp}`)}
                       </SelectItem>
                     )

--- a/frontend/src/features/commodities/CommodityThumb.tsx
+++ b/frontend/src/features/commodities/CommodityThumb.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react"
 
 import { cn } from "@/lib/utils"
-import { COMMODITY_TYPE_ICONS, type CommodityTypeValue } from "@/features/commodities/constants"
+import {
+  COMMODITY_TYPE_FALLBACK_ICON,
+  COMMODITY_TYPE_ICONS,
+  type CommodityTypeValue,
+} from "@/features/commodities/constants"
 import type { CommodityCover } from "@/features/commodities/api"
 
 // Thumbnail variant the BE generates today (`small` = 150px,
@@ -13,7 +17,7 @@ export type CommodityThumbVariant = "small" | "medium" | "auto"
 
 export interface CommodityThumbProps {
   cover?: CommodityCover
-  // Type drives the emoji fallback; mirrors `COMMODITY_TYPE_ICONS`.
+  // Type drives the Lucide icon fallback; mirrors `COMMODITY_TYPE_ICONS`.
   type?: CommodityTypeValue
   // Visible name used as the alt text. Falls back to a generic
   // "Commodity photo" when omitted so screen readers always have
@@ -26,7 +30,7 @@ export interface CommodityThumbProps {
   // `auto` picks `small` for boxes ≤ 150px and `medium` otherwise.
   variant?: CommodityThumbVariant
   // Tailwind classes appended to the outer slot. The default rounded
-  // muted box mirrors the existing emoji-only styling.
+  // muted box mirrors the existing icon-only styling.
   className?: string
   // `imgClassName` is forwarded onto the `<img>` itself when a cover is
   // rendered. Useful for the detail-page hero which wants
@@ -64,9 +68,9 @@ function pickThumbnailURL(
 }
 
 // CommodityThumb renders the cover photo for a commodity, falling back
-// to the type emoji when no cover is available or the image fails to
-// load. Used by the list card / table row, the Sheet preview, and the
-// detail-page hero (issue #1451 option A).
+// to the type Lucide icon when no cover is available or the image
+// fails to load. Used by the list card / table row, the Sheet preview,
+// and the detail-page hero (issue #1451 option A; icons in #1392).
 export function CommodityThumb({
   cover,
   type,
@@ -78,8 +82,8 @@ export function CommodityThumb({
   testId,
 }: CommodityThumbProps) {
   // Reset the load-failure flag when the cover URL changes — otherwise
-  // a once-failed image keeps rendering the emoji even after the user
-  // re-uploads a new working photo.
+  // a once-failed image keeps rendering the fallback icon even after
+  // the user re-uploads a new working photo.
   const url = cover ? pickThumbnailURL(cover, variant, size) : undefined
   const [failed, setFailed] = useState(false)
   useEffect(() => {
@@ -88,9 +92,12 @@ export function CommodityThumb({
     setFailed(false)
   }, [url])
 
-  const emoji = type ? COMMODITY_TYPE_ICONS[type] : "📦"
+  const Icon = type ? COMMODITY_TYPE_ICONS[type] : COMMODITY_TYPE_FALLBACK_ICON
   const dim = `${size}px`
   const showImage = Boolean(url) && !failed
+  // Icon glyph scales with the slot; cap at ~50% so it reads as a
+  // pictogram inside the rounded-lg tile rather than dominating it.
+  const iconPx = Math.max(12, Math.round(size * 0.5))
 
   return (
     <div
@@ -101,6 +108,7 @@ export function CommodityThumb({
       style={{ width: dim, height: dim }}
       data-testid={testId}
       data-state={showImage ? "image" : "fallback"}
+      data-commodity-type={type ?? "unknown"}
     >
       {showImage ? (
         <img
@@ -114,9 +122,13 @@ export function CommodityThumb({
           data-testid={testId ? `${testId}-img` : undefined}
         />
       ) : (
-        <span aria-hidden="true" className="text-lg leading-none">
-          {emoji}
-        </span>
+        <Icon
+          aria-hidden="true"
+          className="text-muted-foreground"
+          width={iconPx}
+          height={iconPx}
+          data-testid={testId ? `${testId}-icon` : undefined}
+        />
       )}
     </div>
   )

--- a/frontend/src/features/commodities/__tests__/CommodityThumb.test.tsx
+++ b/frontend/src/features/commodities/__tests__/CommodityThumb.test.tsx
@@ -24,25 +24,33 @@ describe("CommodityThumb", () => {
     expect(screen.getByTestId("t").getAttribute("data-state")).toBe("image")
   })
 
-  it("falls back to the type emoji when no cover is provided", () => {
+  it("falls back to the type icon when no cover is provided", () => {
     render(<CommodityThumb type="electronics" name="Macbook" size={36} testId="t" />)
     expect(screen.queryByRole("img")).toBeNull()
-    expect(screen.getByTestId("t").getAttribute("data-state")).toBe("fallback")
-    expect(screen.getByTestId("t").textContent).toContain("💻")
+    const slot = screen.getByTestId("t")
+    expect(slot.getAttribute("data-state")).toBe("fallback")
+    expect(slot.getAttribute("data-commodity-type")).toBe("electronics")
+    // Lucide renders an inline SVG inside the slot.
+    expect(slot.querySelector("svg")).not.toBeNull()
   })
 
-  it("renders the generic 📦 emoji when type is unknown", () => {
+  it("renders the generic fallback icon when type is unknown", () => {
     render(<CommodityThumb size={36} testId="t" />)
-    expect(screen.getByTestId("t").textContent).toContain("📦")
+    const slot = screen.getByTestId("t")
+    expect(slot.getAttribute("data-commodity-type")).toBe("unknown")
+    expect(slot.querySelector("svg")).not.toBeNull()
   })
 
-  it("falls back to the emoji when the image fails to load", () => {
+  it("falls back to the type icon when the image fails to load", () => {
     render(<CommodityThumb cover={cover} type="furniture" name="Sofa" size={36} testId="t" />)
     const img = screen.getByRole("img")
     fireEvent.error(img)
-    // After error: image gone, emoji shown.
+    // After error: image gone, icon shown.
     expect(screen.queryByRole("img")).toBeNull()
-    expect(screen.getByTestId("t").textContent).toContain("🪑")
+    const slot = screen.getByTestId("t")
+    expect(slot.getAttribute("data-state")).toBe("fallback")
+    expect(slot.getAttribute("data-commodity-type")).toBe("furniture")
+    expect(slot.querySelector("svg")).not.toBeNull()
   })
 
   it("picks the medium variant when the slot is larger than 150px", () => {

--- a/frontend/src/features/commodities/__tests__/api.test.ts
+++ b/frontend/src/features/commodities/__tests__/api.test.ts
@@ -83,7 +83,7 @@ describe("setCommodityCover", () => {
     expect(result.commodity.cover?.source).toBe("first_photo")
   })
 
-  it("treats a response with thumbnail-less cover as no cover (preserves emoji fallback)", async () => {
+  it("treats a response with thumbnail-less cover as no cover (preserves icon fallback)", async () => {
     server.use(
       http.patch(apiUrl(`/g/${SLUG}/commodities/c1/cover`), () =>
         HttpResponse.json({

--- a/frontend/src/features/commodities/api.ts
+++ b/frontend/src/features/commodities/api.ts
@@ -172,8 +172,8 @@ export async function listCommodities(
 // normalizeCover folds a BE `meta.covers[id]` payload into the FE's
 // `CommodityCover` shape. Returns undefined when the payload is missing
 // or doesn't carry the minimum (`file_id` + at least one thumbnail) the
-// renderer needs — same condition the FE treats as "fall back to emoji",
-// so the absent state is a single `cover === undefined` check.
+// renderer needs — same condition the FE treats as "fall back to type
+// icon", so the absent state is a single `cover === undefined` check.
 function normalizeCover(payload?: CoverPayload): CommodityCover | undefined {
   if (!payload?.file_id || !payload.thumbnails || Object.keys(payload.thumbnails).length === 0) {
     return undefined

--- a/frontend/src/features/commodities/constants.ts
+++ b/frontend/src/features/commodities/constants.ts
@@ -4,6 +4,9 @@
 // a new value here without a matching BE migration would generate
 // requests the server rejects.
 
+import { Armchair, Laptop, Package, Refrigerator, Shirt, Wrench } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+
 export const COMMODITY_TYPES = [
   "white_goods",
   "electronics",
@@ -15,17 +18,24 @@ export const COMMODITY_TYPES = [
 
 export type CommodityTypeValue = (typeof COMMODITY_TYPES)[number]
 
-// Emoji maps from the design mock (`inventario-design/src/data/mock.ts`)
-// — used to anchor each row visually. Kept inline (not i18n) because
-// they're decorative; localising would just re-emit the same emoji.
-export const COMMODITY_TYPE_ICONS: Record<CommodityTypeValue, string> = {
-  white_goods: "🏠",
-  electronics: "💻",
-  equipment: "🔧",
-  furniture: "🪑",
-  clothes: "👕",
-  other: "📦",
+// Lucide icon per commodity type — the single source of truth that
+// every commodity-type visual (list card, list row, filter dropdown,
+// type select, print header, thumbnail fallback, detail header) reads.
+// Lucide is preferred over emoji because it scales with text size,
+// inherits `currentColor` for theme-aware rendering (light/dark/
+// high-contrast), and avoids cross-platform font-fallback variation
+// in the rendered glyph (#1392). `COMMODITY_TYPE_FALLBACK_ICON` is the
+// generic-package icon used when the type is missing or unknown.
+export const COMMODITY_TYPE_ICONS: Record<CommodityTypeValue, LucideIcon> = {
+  white_goods: Refrigerator,
+  electronics: Laptop,
+  equipment: Wrench,
+  furniture: Armchair,
+  clothes: Shirt,
+  other: Package,
 }
+
+export const COMMODITY_TYPE_FALLBACK_ICON: LucideIcon = Package
 
 export const COMMODITY_STATUSES = ["in_use", "sold", "lost", "disposed", "written_off"] as const
 

--- a/frontend/src/pages/areas/AreaItemsPanel.tsx
+++ b/frontend/src/pages/areas/AreaItemsPanel.tsx
@@ -471,7 +471,7 @@ function Toolbar(props: ToolbarProps) {
                 checked={props.types.includes(tp)}
                 onCheckedChange={() => props.onToggleType(tp)}
               >
-                <Icon className="mr-1.5 size-3.5 text-muted-foreground" aria-hidden="true" />
+                <Icon aria-hidden="true" />
                 {t(`commodities:type.${tp}`)}
               </DropdownMenuCheckboxItem>
             )

--- a/frontend/src/pages/areas/AreaItemsPanel.tsx
+++ b/frontend/src/pages/areas/AreaItemsPanel.tsx
@@ -44,6 +44,7 @@ import {
   COMMODITY_STATUSES,
   COMMODITY_STATUS_TONES,
   COMMODITY_TYPES,
+  COMMODITY_TYPE_FALLBACK_ICON,
   COMMODITY_TYPE_ICONS,
   COMMODITY_WARRANTY_STATUSES,
   warrantyStatus,
@@ -462,16 +463,19 @@ function Toolbar(props: ToolbarProps) {
         <DropdownMenuContent align="start" className="w-44">
           <DropdownMenuLabel>{t("commodities:filter.type")}</DropdownMenuLabel>
           <DropdownMenuSeparator />
-          {COMMODITY_TYPES.map((tp) => (
-            <DropdownMenuCheckboxItem
-              key={tp}
-              checked={props.types.includes(tp)}
-              onCheckedChange={() => props.onToggleType(tp)}
-            >
-              <span className="mr-1.5">{COMMODITY_TYPE_ICONS[tp]}</span>
-              {t(`commodities:type.${tp}`)}
-            </DropdownMenuCheckboxItem>
-          ))}
+          {COMMODITY_TYPES.map((tp) => {
+            const Icon = COMMODITY_TYPE_ICONS[tp]
+            return (
+              <DropdownMenuCheckboxItem
+                key={tp}
+                checked={props.types.includes(tp)}
+                onCheckedChange={() => props.onToggleType(tp)}
+              >
+                <Icon className="mr-1.5 size-3.5 text-muted-foreground" aria-hidden="true" />
+                {t(`commodities:type.${tp}`)}
+              </DropdownMenuCheckboxItem>
+            )
+          })}
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -651,7 +655,9 @@ function List_({ rows, onPreview, currency, slug }: RowListProps) {
             const detailHref = `/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(row.id)}`
             const status = row.status as CommodityStatusValue | undefined
             const tone = status ? COMMODITY_STATUS_TONES[status] : ""
-            const typeIcon = COMMODITY_TYPE_ICONS[row.type as CommodityTypeValue] ?? "📦"
+            const typeKey = row.type as CommodityTypeValue | undefined
+            const TypeIcon =
+              (typeKey && COMMODITY_TYPE_ICONS[typeKey]) || COMMODITY_TYPE_FALLBACK_ICON
             const showStatusPill = status !== undefined && status !== "in_use"
             const wStatus = warrantyStatus({ warranty_expires_at: row.warranty_expires_at })
             return (
@@ -679,9 +685,10 @@ function List_({ rows, onPreview, currency, slug }: RowListProps) {
                   )}
                   data-testid="area-detail-items-row"
                   data-commodity-id={row.id}
+                  data-commodity-type={typeKey ?? "unknown"}
                 >
-                  <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-lg">
-                    <span aria-hidden="true">{typeIcon}</span>
+                  <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                    <TypeIcon className="size-4" aria-hidden="true" />
                   </div>
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5">
@@ -734,7 +741,9 @@ function Grid({ rows, onPreview, currency, slug }: RowListProps) {
           const detailHref = `/g/${encodeURIComponent(slug)}/commodities/${encodeURIComponent(row.id)}`
           const status = row.status as CommodityStatusValue | undefined
           const tone = status ? COMMODITY_STATUS_TONES[status] : ""
-          const typeIcon = COMMODITY_TYPE_ICONS[row.type as CommodityTypeValue] ?? "📦"
+          const typeKey = row.type as CommodityTypeValue | undefined
+          const TypeIcon =
+            (typeKey && COMMODITY_TYPE_ICONS[typeKey]) || COMMODITY_TYPE_FALLBACK_ICON
           const showStatusPill = status !== undefined && status !== "in_use"
           const wStatus = warrantyStatus({ warranty_expires_at: row.warranty_expires_at })
           return (
@@ -758,6 +767,7 @@ function Grid({ rows, onPreview, currency, slug }: RowListProps) {
               className="block"
               data-testid="area-detail-items-card"
               data-commodity-id={row.id}
+              data-commodity-type={typeKey ?? "unknown"}
             >
               <Card
                 className={cn(
@@ -767,8 +777,8 @@ function Grid({ rows, onPreview, currency, slug }: RowListProps) {
               >
                 <CardHeader className="pb-2">
                   <div className="flex items-start justify-between gap-2">
-                    <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-lg">
-                      <span aria-hidden="true">{typeIcon}</span>
+                    <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                      <TypeIcon className="size-4" aria-hidden="true" />
                     </div>
                     <div className="flex flex-wrap items-center justify-end gap-1.5">
                       {row.draft ? (

--- a/frontend/src/pages/commodities/CommoditiesListPage.tsx
+++ b/frontend/src/pages/commodities/CommoditiesListPage.tsx
@@ -747,7 +747,7 @@ function Toolbar(props: ToolbarProps) {
                 checked={props.types.includes(tp)}
                 onCheckedChange={() => props.onToggleType(tp)}
               >
-                <Icon className="mr-1.5 size-3.5 text-muted-foreground" aria-hidden="true" />
+                <Icon aria-hidden="true" />
                 {t(`commodities:type.${tp}`)}
               </DropdownMenuCheckboxItem>
             )

--- a/frontend/src/pages/commodities/CommoditiesListPage.tsx
+++ b/frontend/src/pages/commodities/CommoditiesListPage.tsx
@@ -739,16 +739,19 @@ function Toolbar(props: ToolbarProps) {
         <DropdownMenuContent align="start" className="w-44">
           <DropdownMenuLabel>{t("commodities:filter.type")}</DropdownMenuLabel>
           <DropdownMenuSeparator />
-          {COMMODITY_TYPES.map((tp) => (
-            <DropdownMenuCheckboxItem
-              key={tp}
-              checked={props.types.includes(tp)}
-              onCheckedChange={() => props.onToggleType(tp)}
-            >
-              <span className="mr-1.5">{COMMODITY_TYPE_ICONS[tp]}</span>
-              {t(`commodities:type.${tp}`)}
-            </DropdownMenuCheckboxItem>
-          ))}
+          {COMMODITY_TYPES.map((tp) => {
+            const Icon = COMMODITY_TYPE_ICONS[tp]
+            return (
+              <DropdownMenuCheckboxItem
+                key={tp}
+                checked={props.types.includes(tp)}
+                onCheckedChange={() => props.onToggleType(tp)}
+              >
+                <Icon className="mr-1.5 size-3.5 text-muted-foreground" aria-hidden="true" />
+                {t(`commodities:type.${tp}`)}
+              </DropdownMenuCheckboxItem>
+            )
+          })}
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/frontend/src/pages/commodities/CommodityPrintPage.tsx
+++ b/frontend/src/pages/commodities/CommodityPrintPage.tsx
@@ -9,7 +9,11 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { useAreas } from "@/features/areas/hooks"
 import { useCommodity } from "@/features/commodities/hooks"
-import { COMMODITY_TYPE_ICONS, type CommodityTypeValue } from "@/features/commodities/constants"
+import {
+  COMMODITY_TYPE_FALLBACK_ICON,
+  COMMODITY_TYPE_ICONS,
+  type CommodityTypeValue,
+} from "@/features/commodities/constants"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { formatCurrency, formatDate } from "@/lib/intl"
 
@@ -60,7 +64,7 @@ export function CommodityPrintPage() {
   }
 
   const type = commodity.type as CommodityTypeValue | undefined
-  const icon = type ? COMMODITY_TYPE_ICONS[type] : "📦"
+  const TypeIcon = (type && COMMODITY_TYPE_ICONS[type]) || COMMODITY_TYPE_FALLBACK_ICON
   // Per the BE: `original_price` lives in `original_price_currency`;
   // `converted_original_price` and `current_price` are in the group
   // group currency. Use both.
@@ -102,8 +106,11 @@ export function CommodityPrintPage() {
 
           <article className="print-sheet bg-card rounded-md border border-border p-8 shadow-sm">
             <header className="mb-6 flex items-start gap-4 border-b border-border pb-6">
-              <div className="flex size-12 shrink-0 items-center justify-center rounded-lg bg-muted text-2xl">
-                {icon}
+              <div
+                className="flex size-12 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground"
+                data-commodity-type={type ?? "unknown"}
+              >
+                <TypeIcon className="size-6" aria-hidden="true" />
               </div>
               <div className="flex-1 min-w-0">
                 <h1 className="text-2xl font-bold tracking-tight">{commodity.name}</h1>

--- a/frontend/src/pages/commodities/__tests__/CommoditiesListPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommoditiesListPage.test.tsx
@@ -133,7 +133,7 @@ describe("<CommoditiesListPage />", () => {
     expect(within(withoutDate!).queryByTestId("commodity-card-purchase-date")).toBeNull()
   })
 
-  it("renders the cover thumbnail when meta.covers is present and falls back to emoji otherwise", async () => {
+  it("renders the cover thumbnail when meta.covers is present and falls back to type icon otherwise", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),
       ...areaHandlers.list(SLUG, areaFixture),
@@ -164,12 +164,15 @@ describe("<CommoditiesListPage />", () => {
         .getByRole("img")
         .getAttribute("alt")
     ).toBe("MacBook Pro")
-    // c2 has no cover → fallback emoji renders.
+    // c2 has no cover → fallback Lucide icon renders (#1392). The
+    // slot exposes the type via `data-commodity-type` so the test does
+    // not have to peek at the exact SVG glyph.
     const withoutCover = screen
       .getAllByTestId("commodity-card-thumb")
       .find((el) => el.getAttribute("data-state") === "fallback")
     expect(withoutCover).toBeTruthy()
-    expect((withoutCover as HTMLElement).textContent).toContain("📦")
+    expect(withoutCover!.getAttribute("data-commodity-type")).toBe("other")
+    expect((withoutCover as HTMLElement).querySelector("svg")).not.toBeNull()
   })
 
   it("toggles between grid and list view", async () => {
@@ -328,7 +331,7 @@ describe("<CommoditiesListPage />", () => {
     await screen.findByTestId("commodity-card")
     await user.click(screen.getByTestId("commodities-filter-type"))
     // Furniture is one of the static type options rendered with its
-    // emoji from the design mock.
+    // Lucide icon from COMMODITY_TYPE_ICONS (#1392).
     await user.click(await screen.findByRole("menuitemcheckbox", { name: /Furniture/i }))
     // After toggling, the badge counter on the trigger flips to 1.
     await waitFor(() => {

--- a/frontend/src/test/handlers/commodities.ts
+++ b/frontend/src/test/handlers/commodities.ts
@@ -5,7 +5,7 @@ import { apiUrl } from "."
 // CoverFixture mirrors the `meta.covers[id]` payload the BE attaches to
 // commodity list responses (issue #1451 option A — first photo). Pass a
 // map `{commodityId: cover}` to `list()` to opt in; absent ids render
-// the type-emoji fallback, same as the real handler.
+// the type-icon fallback, same as the real handler.
 export interface CoverFixture {
   file_id: string
   thumbnails: Record<string, string>


### PR DESCRIPTION
Closes #1392.

## Summary

- `frontend/src/features/commodities/constants.ts` — `COMMODITY_TYPE_ICONS` switches from `Record<CommodityTypeValue, string>` (emoji glyph) to `Record<CommodityTypeValue, LucideIcon>` using `Refrigerator / Laptop / Wrench / Armchair / Shirt / Package`. Adds `COMMODITY_TYPE_FALLBACK_ICON = Package` for the "type missing / unknown" case so call sites no longer pass a literal `📦`.
- Consumers migrated (1:1 surface coverage of the issue's acceptance criteria — card / list / detail / form select / print header):
  - `frontend/src/features/commodities/CommodityThumb.tsx` — fallback branch now renders the Lucide component sized at ~50 % of the slot. Adds `data-commodity-type` so list-view tests can assert per-type icons without peeking at the SVG path.
  - `frontend/src/pages/commodities/CommoditiesListPage.tsx` — type-filter dropdown menu items render `<Icon className="size-3.5 text-muted-foreground" />` in place of the emoji `<span>`. List cards / rows already use `CommodityThumb`, so they inherit the icon swap.
  - `frontend/src/components/items/CommodityFormDialog.tsx` — type `Select` options render the Lucide icon next to the label.
  - `frontend/src/pages/areas/AreaItemsPanel.tsx` — three sites (filter dropdown, list row tile, grid card tile) render the Lucide icon inside the existing `rounded-lg bg-muted` slot. List + grid surfaces also expose `data-commodity-type` on the row / card.
  - `frontend/src/pages/commodities/CommodityPrintPage.tsx` — header tile renders `<Icon className="size-6" />` instead of the 2xl emoji.
- Backend untouched — the type enum (`white_goods / electronics / equipment / furniture / clothes / other`) stays as-is. This is a pure presentation swap.

## Acceptance criteria

- [x] `COMMODITY_TYPE_ICONS` map exported once, consumed everywhere
- [x] Icons in card / list / detail / form select (detail header already routes through `CommodityThumb`, which is migrated)
- [x] No backend change
- [x] e2e coverage that list view shows the right icon next to each item — `e2e/tests/commodity-type-icons.spec.ts` seeds one commodity per backend type, scopes the list via `?q=<suffix>`, and asserts (a) every thumb is in `data-state="fallback"`, (b) `data-commodity-type` matches the seeded type, (c) the six rendered SVGs carry distinct Lucide class tokens
- [x] Vitest coverage for the per-component fallback — `frontend/src/features/commodities/__tests__/CommodityThumb.test.tsx` reworked to assert the SVG renders and `data-commodity-type` round-trips (no more brittle `textContent.toContain("💻")` checks)

## Design fidelity

`design-mocks/src/data/mock.ts` ships emoji for commodity categories. This PR intentionally diverges — the deviation is logged in [`devdocs/frontend/design-deviations.md`](devdocs/frontend/design-deviations.md) under **Items / Commodities → 2026-05-16 — Commodity-type marker is a Lucide icon, not an emoji**, citing the issue's own rationale (OS font-fallback drift, no `currentColor` theming, no consistent stroke weight) and the fact that Lucide is already a dependency.

## Test plan

- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run format:check`
- [x] `cd frontend && npm run test` — 880 passed / 4 skipped (unchanged baseline + reworked `CommodityThumb` + tidied list/api copy)
- [x] `cd frontend && npm run build`
- [x] `cd frontend && npm run i18n:check` / `npm run codegen:check`
- [ ] `e2e/tests/commodity-type-icons.spec.ts` — runs in CI against the docker-compose e2e stack.