### PR TITLE
[#1585] Storage quota warning email at 90% usage

### DIFF
--- a/go/apiserver/async_email_context_test.go
+++ b/go/apiserver/async_email_context_test.go
@@ -101,6 +101,10 @@ func (m *blockingEmailService) SendGroupInviteEmail(_ context.Context, _, _, _, 
 	return nil
 }
 
+func (m *blockingEmailService) SendStorageQuotaWarningEmail(_ context.Context, _, _, _ string, _, _ int, _, _ string, _ []string, _, _ string) error {
+	return nil
+}
+
 type registrationUserRegistry struct {
 	*mockUserRegistryForAuth
 }

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -174,6 +174,10 @@ func (m *mockEmailServiceForAuth) SendGroupInviteEmail(_ context.Context, _, _, 
 	return nil
 }
 
+func (m *mockEmailServiceForAuth) SendStorageQuotaWarningEmail(_ context.Context, _, _, _ string, _, _ int, _, _ string, _ []string, _, _ string) error {
+	return nil
+}
+
 // mockUserRegistryForAuth implements registry.UserRegistry for testing
 type mockUserRegistryForAuth struct {
 	users map[string]*models.User

--- a/go/cmd/inventario/run/all/all.go
+++ b/go/cmd/inventario/run/all/all.go
@@ -89,6 +89,9 @@ func (c *Command) run() error {
 	stopWarrantyReminder := bootstrap.StartWarrantyReminderWorker(ctx, rs, c.cfg)
 	defer stopWarrantyReminder()
 
+	stopStorageQuotaReminder := bootstrap.StartStorageQuotaReminderWorker(ctx, rs, c.cfg)
+	defer stopStorageQuotaReminder()
+
 	stopCurrencyMigration := bootstrap.StartCurrencyMigrationWorker(ctx, rs, c.cfg)
 	defer stopCurrencyMigration()
 

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	RefreshTokenCleanupInterval   string `yaml:"refresh_token_cleanup_interval" env:"REFRESH_TOKEN_CLEANUP_INTERVAL" env-default:""`
 	GroupPurgeInterval            string `yaml:"group_purge_interval" env:"GROUP_PURGE_INTERVAL" env-default:""`
 	WarrantyReminderInterval      string `yaml:"warranty_reminder_interval" env:"WARRANTY_REMINDER_INTERVAL" env-default:""`
+	StorageQuotaReminderInterval  string `yaml:"storage_quota_reminder_interval" env:"STORAGE_QUOTA_REMINDER_INTERVAL" env-default:""`
 	CurrencyMigrationInterval     string `yaml:"currency_migration_interval" env:"CURRENCY_MIGRATION_INTERVAL" env-default:""`
 	JWTSecret                     string `yaml:"jwt_secret" env:"JWT_SECRET" env-default:""`
 	FileSigningKey                string `yaml:"file_signing_key" env:"FILE_SIGNING_KEY" env-default:""`
@@ -167,6 +168,9 @@ func (c *Config) setWorkerDefaults() {
 	}
 	if c.WarrantyReminderInterval == "" {
 		c.WarrantyReminderInterval = defaults.GetWarrantyReminderInterval()
+	}
+	if c.StorageQuotaReminderInterval == "" {
+		c.StorageQuotaReminderInterval = defaults.GetStorageQuotaReminderInterval()
 	}
 	if c.CurrencyMigrationInterval == "" {
 		c.CurrencyMigrationInterval = defaults.GetCurrencyMigrationInterval()

--- a/go/cmd/inventario/run/bootstrap/durations.go
+++ b/go/cmd/inventario/run/bootstrap/durations.go
@@ -11,18 +11,19 @@ import (
 // bootstrap so that misconfiguration fails fast before any goroutines or the
 // HTTP listener are started.
 type WorkerDurations struct {
-	ExportPollInterval          time.Duration
-	ImportPollInterval          time.Duration
-	RestorePollInterval         time.Duration
-	RefreshTokenCleanupInterval time.Duration
-	GroupPurgeInterval          time.Duration
-	WarrantyReminderInterval    time.Duration
-	CurrencyMigrationInterval   time.Duration
-	ThumbnailPollInterval       time.Duration
-	ThumbnailCleanupInterval    time.Duration
-	ThumbnailJobRetentionPeriod time.Duration
-	ThumbnailJobBatchTimeout    time.Duration
-	DetachedThumbnailJobTimeout time.Duration
+	ExportPollInterval           time.Duration
+	ImportPollInterval           time.Duration
+	RestorePollInterval          time.Duration
+	RefreshTokenCleanupInterval  time.Duration
+	GroupPurgeInterval           time.Duration
+	WarrantyReminderInterval     time.Duration
+	StorageQuotaReminderInterval time.Duration
+	CurrencyMigrationInterval    time.Duration
+	ThumbnailPollInterval        time.Duration
+	ThumbnailCleanupInterval     time.Duration
+	ThumbnailJobRetentionPeriod  time.Duration
+	ThumbnailJobBatchTimeout     time.Duration
+	DetachedThumbnailJobTimeout  time.Duration
 }
 
 // parseWorkerDuration parses a single duration-valued flag. It enforces that
@@ -55,6 +56,7 @@ func ParseWorkerDurations(cfg *Config) (WorkerDurations, error) {
 		{"refresh-token-cleanup-interval", cfg.RefreshTokenCleanupInterval, &out.RefreshTokenCleanupInterval},
 		{"group-purge-interval", cfg.GroupPurgeInterval, &out.GroupPurgeInterval},
 		{"warranty-reminder-interval", cfg.WarrantyReminderInterval, &out.WarrantyReminderInterval},
+		{"storage-quota-reminder-interval", cfg.StorageQuotaReminderInterval, &out.StorageQuotaReminderInterval},
 		{"currency-migration-interval", cfg.CurrencyMigrationInterval, &out.CurrencyMigrationInterval},
 		{"thumbnail-poll-interval", cfg.ThumbnailPollInterval, &out.ThumbnailPollInterval},
 		{"thumbnail-cleanup-interval", cfg.ThumbnailCleanupInterval, &out.ThumbnailCleanupInterval},

--- a/go/cmd/inventario/run/bootstrap/durations_test.go
+++ b/go/cmd/inventario/run/bootstrap/durations_test.go
@@ -13,18 +13,19 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 	c := qt.New(t)
 
 	cfg := &bootstrap.Config{
-		ExportPollInterval:          "11s",
-		ImportPollInterval:          "12s",
-		RestorePollInterval:         "13s",
-		RefreshTokenCleanupInterval: "2h",
-		GroupPurgeInterval:          "7m",
-		WarrantyReminderInterval:    "30m",
-		CurrencyMigrationInterval:   "8s",
-		ThumbnailPollInterval:       "7s",
-		ThumbnailCleanupInterval:    "6m",
-		ThumbnailJobRetentionPeriod: "48h",
-		ThumbnailJobBatchTimeout:    "45s",
-		DetachedThumbnailJobTimeout: "3m",
+		ExportPollInterval:           "11s",
+		ImportPollInterval:           "12s",
+		RestorePollInterval:          "13s",
+		RefreshTokenCleanupInterval:  "2h",
+		GroupPurgeInterval:           "7m",
+		WarrantyReminderInterval:     "30m",
+		StorageQuotaReminderInterval: "20m",
+		CurrencyMigrationInterval:    "8s",
+		ThumbnailPollInterval:        "7s",
+		ThumbnailCleanupInterval:     "6m",
+		ThumbnailJobRetentionPeriod:  "48h",
+		ThumbnailJobBatchTimeout:     "45s",
+		DetachedThumbnailJobTimeout:  "3m",
 	}
 
 	got, err := bootstrap.ParseWorkerDurations(cfg)
@@ -35,6 +36,7 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 	c.Assert(got.RefreshTokenCleanupInterval, qt.Equals, 2*time.Hour)
 	c.Assert(got.GroupPurgeInterval, qt.Equals, 7*time.Minute)
 	c.Assert(got.WarrantyReminderInterval, qt.Equals, 30*time.Minute)
+	c.Assert(got.StorageQuotaReminderInterval, qt.Equals, 20*time.Minute)
 	c.Assert(got.CurrencyMigrationInterval, qt.Equals, 8*time.Second)
 	c.Assert(got.ThumbnailPollInterval, qt.Equals, 7*time.Second)
 	c.Assert(got.ThumbnailCleanupInterval, qt.Equals, 6*time.Minute)

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -28,6 +28,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags.StringVar(&cfg.RefreshTokenCleanupInterval, "refresh-token-cleanup-interval", cfg.RefreshTokenCleanupInterval, "Interval between refresh token cleanup runs (e.g., 1h, 30m)")
 	flags.StringVar(&cfg.GroupPurgeInterval, "group-purge-interval", cfg.GroupPurgeInterval, "Interval between group purge sweeps (hard-deletes pending_deletion groups and expired unused invites; e.g., 5m, 15m)")
 	flags.StringVar(&cfg.WarrantyReminderInterval, "warranty-reminder-interval", cfg.WarrantyReminderInterval, "Interval between warranty reminder sweeps (60/30/7-day expiry emails; e.g., 1h)")
+	flags.StringVar(&cfg.StorageQuotaReminderInterval, "storage-quota-reminder-interval", cfg.StorageQuotaReminderInterval, "Interval between storage quota warning sweeps (90% threshold emails; e.g., 1h)")
 	flags.StringVar(&cfg.CurrencyMigrationInterval, "currency-migration-interval", cfg.CurrencyMigrationInterval, "Currency migration worker active-poll interval (when pending rows exist; idle cadence is fixed at 1m). Values like 5s, 10s.")
 	flags.IntVar(&cfg.ThumbnailBatchSize, "thumbnail-batch-size", cfg.ThumbnailBatchSize, "Maximum thumbnail jobs processed per batch")
 	flags.StringVar(&cfg.ThumbnailPollInterval, "thumbnail-poll-interval", cfg.ThumbnailPollInterval, "Thumbnail worker poll interval (e.g., 5s, 10s)")

--- a/go/cmd/inventario/run/bootstrap/workers.go
+++ b/go/cmd/inventario/run/bootstrap/workers.go
@@ -143,6 +143,23 @@ func StartWarrantyReminderWorker(ctx context.Context, rs *RuntimeSetup, cfg *Con
 	return worker.Stop
 }
 
+// StartStorageQuotaReminderWorker wires and starts the storage quota
+// warning worker (#1585). Uses the configured interval from
+// rs.WorkerDurations and pulls the public URL from cfg for the two
+// deep-link blocks in the email template. The async email service
+// comes from rs.EmailLifecycle (already started by
+// StartEmailLifecycle in the housekeeping group).
+func StartStorageQuotaReminderWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) func() {
+	filesURL, settingsURL := buildStorageQuotaURLBuilders(cfg.PublicURL)
+	service := services.NewStorageQuotaReminderService(rs.FactorySet, rs.EmailLifecycle.Service, filesURL, settingsURL)
+	worker := services.NewStorageQuotaReminderWorker(
+		service,
+		services.WithStorageQuotaReminderInterval(rs.WorkerDurations.StorageQuotaReminderInterval),
+	)
+	worker.Start(ctx)
+	return worker.Stop
+}
+
 // StartCurrencyMigrationWorker wires and starts the currency migration
 // worker (#1552 / #202 §4.5). Returns a no-op stop function when the
 // feature flag is off OR the active backend is not postgres — TX2 of
@@ -211,4 +228,29 @@ func buildCommodityURLBuilder(publicURL string) func(string, string) string {
 		}
 		return publicURL + "/g/" + groupSlug + "/commodities/" + commodityID
 	}
+}
+
+// buildStorageQuotaURLBuilders returns the per-group files URL +
+// settings URL builders passed to StorageQuotaReminderService.
+// Returns (nil, nil) when no PublicURL is configured — the email
+// template suppresses each link block in that case rather than
+// printing a relative URL.
+func buildStorageQuotaURLBuilders(publicURL string) (filesURLBuilder, settingsURLBuilder func(string) string) {
+	publicURL = strings.TrimRight(strings.TrimSpace(publicURL), "/")
+	if publicURL == "" {
+		return nil, nil
+	}
+	filesURLBuilder = func(groupSlug string) string {
+		if groupSlug == "" {
+			return ""
+		}
+		return publicURL + "/g/" + groupSlug + "/files"
+	}
+	settingsURLBuilder = func(groupSlug string) string {
+		if groupSlug == "" {
+			return ""
+		}
+		return publicURL + "/g/" + groupSlug + "/settings"
+	}
+	return filesURLBuilder, settingsURLBuilder
 }

--- a/go/cmd/inventario/run/workers/workers.go
+++ b/go/cmd/inventario/run/workers/workers.go
@@ -146,6 +146,7 @@ func (c *Command) run() error {
 			bootstrap.StartLoginEventRetentionWorker,
 			bootstrap.StartGroupPurgeWorker,
 			bootstrap.StartWarrantyReminderWorker,
+			bootstrap.StartStorageQuotaReminderWorker,
 			bootstrap.StartCurrencyMigrationWorker,
 		}},
 	}

--- a/go/internal/defaults/defaults.go
+++ b/go/internal/defaults/defaults.go
@@ -22,16 +22,17 @@ type Database struct {
 
 // Workers contains default values for worker configuration
 type Workers struct {
-	MaxConcurrentExports        int
-	MaxConcurrentImports        int
-	MaxConcurrentRestores       int
-	ExportPollInterval          string // Export worker poll interval (e.g., "10s")
-	ImportPollInterval          string // Import worker poll interval (e.g., "10s")
-	RestorePollInterval         string // Restore worker poll interval (e.g., "10s")
-	RefreshTokenCleanupInterval string // Refresh token cleanup interval (e.g., "1h")
-	GroupPurgeInterval          string // Group purge worker interval (e.g., "5m")
-	WarrantyReminderInterval    string // Warranty reminder worker interval (e.g., "1h")
-	CurrencyMigrationInterval   string // Currency migration worker active-poll interval (e.g., "5s")
+	MaxConcurrentExports         int
+	MaxConcurrentImports         int
+	MaxConcurrentRestores        int
+	ExportPollInterval           string // Export worker poll interval (e.g., "10s")
+	ImportPollInterval           string // Import worker poll interval (e.g., "10s")
+	RestorePollInterval          string // Restore worker poll interval (e.g., "10s")
+	RefreshTokenCleanupInterval  string // Refresh token cleanup interval (e.g., "1h")
+	GroupPurgeInterval           string // Group purge worker interval (e.g., "5m")
+	WarrantyReminderInterval     string // Warranty reminder worker interval (e.g., "1h")
+	StorageQuotaReminderInterval string // Storage quota warning worker interval (e.g., "1h")
+	CurrencyMigrationInterval    string // Currency migration worker active-poll interval (e.g., "5s")
 }
 
 // ThumbnailGeneration contains default values for thumbnail generation configuration
@@ -84,16 +85,17 @@ func New() Config {
 			DSN: "memory://",
 		},
 		Workers: Workers{
-			MaxConcurrentExports:        3,
-			MaxConcurrentImports:        1,
-			MaxConcurrentRestores:       1,
-			ExportPollInterval:          "10s",
-			ImportPollInterval:          "10s",
-			RestorePollInterval:         "10s",
-			RefreshTokenCleanupInterval: "1h",
-			GroupPurgeInterval:          "5m",
-			WarrantyReminderInterval:    "1h",
-			CurrencyMigrationInterval:   "5s",
+			MaxConcurrentExports:         3,
+			MaxConcurrentImports:         1,
+			MaxConcurrentRestores:        1,
+			ExportPollInterval:           "10s",
+			ImportPollInterval:           "10s",
+			RestorePollInterval:          "10s",
+			RefreshTokenCleanupInterval:  "1h",
+			GroupPurgeInterval:           "5m",
+			WarrantyReminderInterval:     "1h",
+			StorageQuotaReminderInterval: "1h",
+			CurrencyMigrationInterval:    "5s",
 		},
 		ThumbnailGeneration: ThumbnailGeneration{
 			MaxConcurrentPerUser: 5,     // Maximum 5 simultaneous thumbnail generation jobs per user
@@ -190,6 +192,12 @@ func GetGroupPurgeInterval() string {
 // warranty reminder sweeps.
 func GetWarrantyReminderInterval() string {
 	return defaultConfig.Workers.WarrantyReminderInterval
+}
+
+// GetStorageQuotaReminderInterval returns the default interval
+// between storage quota warning sweeps (#1585).
+func GetStorageQuotaReminderInterval() string {
+	return defaultConfig.Workers.StorageQuotaReminderInterval
 }
 
 // GetCurrencyMigrationInterval returns the default active-poll interval

--- a/go/models/storage_quota_reminder.go
+++ b/go/models/storage_quota_reminder.go
@@ -1,0 +1,127 @@
+package models
+
+import (
+	"context"
+	"time"
+
+	"github.com/jellydator/validation"
+)
+
+// StorageQuotaThreshold names a quota-usage tier at which the storage
+// quota reminder worker emits an email. The numeric value is the
+// percentage of `used_bytes / quota_bytes` at which the email fires.
+// Values are part of the public surface (worker logs, Prometheus
+// label, idempotency row) — add new variants conservatively.
+type StorageQuotaThreshold int
+
+const (
+	// StorageQuota90Percent fires when a group's storage usage reaches
+	// 90% of its quota — the threshold called out in #1585's
+	// acceptance criteria. A passive heads-up so the user can free up
+	// space before uploads start failing once plans-aware enforcement
+	// (#1389) lands.
+	StorageQuota90Percent StorageQuotaThreshold = 90
+)
+
+// StorageQuotaThresholds is the canonical, ordered (smallest →
+// largest) list of thresholds the worker scans for. The smallest
+// threshold appears first so the worker can short-circuit a group
+// whose usage is below every tier.
+var StorageQuotaThresholds = []StorageQuotaThreshold{
+	StorageQuota90Percent,
+}
+
+// IsValid reports whether t is one of the canonical thresholds. Used
+// as a guard before persisting a reminder row and when decoding the
+// threshold value back from the database — anything else is a bug
+// upstream.
+func (t StorageQuotaThreshold) IsValid() bool {
+	return t == StorageQuota90Percent
+}
+
+// Ratio returns the fractional usage at which this threshold fires
+// (e.g. 0.9 for the 90% tier). Convenience for callers that compare
+// against `used_bytes / quota_bytes`.
+func (t StorageQuotaThreshold) Ratio() float64 {
+	return float64(t) / 100.0
+}
+
+var (
+	_ validation.Validatable            = (*StorageQuotaReminder)(nil)
+	_ validation.ValidatableWithContext = (*StorageQuotaReminder)(nil)
+	_ TenantGroupAwareIDable            = (*StorageQuotaReminder)(nil)
+)
+
+// Enable RLS for multi-tenant isolation on storage_quota_reminders.
+// Same shape as warranty_reminders — group-scoped + a separate
+// background-worker bypass policy so the periodic scan can read and
+// write across all groups.
+//
+//migrator:schema:rls:enable table="storage_quota_reminders" comment="Enable RLS for multi-tenant storage quota reminder isolation"
+//migrator:schema:rls:policy name="storage_quota_reminder_isolation" table="storage_quota_reminders" for="ALL" to="inventario_app" using="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != ''" with_check="tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != ''" comment="Ensures storage quota reminders are accessible only by their tenant and group"
+//migrator:schema:rls:policy name="storage_quota_reminder_background_worker_access" table="storage_quota_reminders" for="ALL" to="inventario_background_worker" using="true" with_check="true" comment="Allows background workers to record reminder emissions across all groups"
+
+// StorageQuotaReminder is the idempotency row written by the storage
+// quota reminder worker right after it successfully enqueues an
+// email. The (group_id, threshold_percent) tuple is unique —
+// re-running the worker for the same group at the same threshold
+// must not produce a second email.
+//
+// Reset semantics: when the worker observes a group whose usage has
+// fallen back below the threshold it deletes the matching row, so
+// the next time the threshold is re-crossed a fresh email fires.
+//
+// Rows are wiped indirectly when the parent group is hard-deleted
+// (ON DELETE CASCADE) so old reminders never block re-creating a
+// group with the same id.
+//
+//migrator:schema:table name="storage_quota_reminders"
+type StorageQuotaReminder struct {
+	//migrator:embedded mode="inline"
+	TenantGroupAwareEntityID
+
+	// ThresholdPercent is the StorageQuotaThreshold this row accounts
+	// for (90 in v1). Stored as INTEGER rather than text so future
+	// 80 / 95 tiers can compare numerically.
+	//migrator:schema:field name="threshold_percent" type="INTEGER" not_null="true"
+	ThresholdPercent int `json:"threshold_percent" db:"threshold_percent"`
+
+	// SentAt is the wall-clock time the email was enqueued (not
+	// necessarily delivered — the email queue is async). Surfacing
+	// this directly is enough for support/audit purposes; the email
+	// queue's own job log records final delivery.
+	//migrator:schema:field name="sent_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	SentAt time.Time `json:"sent_at" db:"sent_at"`
+}
+
+// StorageQuotaReminderIndexes defines indexes for
+// storage_quota_reminders. The unique (group_id, threshold_percent)
+// composite is the idempotency key the worker reads + writes.
+type StorageQuotaReminderIndexes struct {
+	// Unique idempotency key — at most one reminder row per (group,
+	// threshold). The worker checks this before enqueueing email and
+	// deletes the matching row when usage drops back below the
+	// threshold so future re-crossings fire again.
+	//migrator:schema:index name="idx_storage_quota_reminders_group_threshold" fields="group_id,threshold_percent" unique="true" table="storage_quota_reminders"
+	_ int
+
+	// Tenant-scoped index for housekeeping queries.
+	//migrator:schema:index name="idx_storage_quota_reminders_tenant_id" fields="tenant_id" table="storage_quota_reminders"
+	_ int
+}
+
+func (*StorageQuotaReminder) Validate() error {
+	return ErrMustUseValidateWithContext
+}
+
+func (s *StorageQuotaReminder) ValidateWithContext(ctx context.Context) error {
+	return validation.ValidateStructWithContext(ctx, s,
+		validation.Field(&s.TenantGroupAwareEntityID),
+		validation.Field(&s.ThresholdPercent, validation.Required, validation.By(func(any) error {
+			if !StorageQuotaThreshold(s.ThresholdPercent).IsValid() {
+				return validation.NewError("invalid_threshold", "invalid storage quota reminder threshold")
+			}
+			return nil
+		})),
+	)
+}

--- a/go/registry/factories.go
+++ b/go/registry/factories.go
@@ -150,6 +150,7 @@ type FactorySet struct {
 	GroupNotificationPrefRegistry         GroupNotificationPrefRegistry // Per-group notification opt-outs (#1648); tenant-scoped, user-filtered in application logic
 	GroupPurger                           GroupPurger                   // GroupPurger hard-deletes group-scoped data during purge ticks
 	WarrantyReminderRegistry              WarrantyReminderRegistry      // WarrantyReminderRegistry is the worker idempotency store; service-mode only
+	StorageQuotaReminderRegistry          StorageQuotaReminderRegistry  // StorageQuotaReminderRegistry is the storage quota warning worker idempotency store; service-mode only (#1585)
 	CurrencyMigrationRegistryFactory      CurrencyMigrationRegistryFactory
 }
 
@@ -275,6 +276,7 @@ func (fs *FactorySet) CreateUserRegistrySet(ctx context.Context) (*Set, error) {
 		GroupNotificationPrefRegistry:  fs.GroupNotificationPrefRegistry,
 		GroupPurger:                    fs.GroupPurger,
 		WarrantyReminderRegistry:       fs.WarrantyReminderRegistry,
+		StorageQuotaReminderRegistry:   fs.StorageQuotaReminderRegistry,
 		CurrencyMigrationRegistry:      currencyMigrationRegistry,
 	}, nil
 }
@@ -312,6 +314,7 @@ func (fs *FactorySet) CreateServiceRegistrySet() *Set {
 		GroupNotificationPrefRegistry:  fs.GroupNotificationPrefRegistry,
 		GroupPurger:                    fs.GroupPurger,
 		WarrantyReminderRegistry:       fs.WarrantyReminderRegistry,
+		StorageQuotaReminderRegistry:   fs.StorageQuotaReminderRegistry,
 		CurrencyMigrationRegistry:      fs.CurrencyMigrationRegistryFactory.CreateServiceRegistry(),
 	}
 }

--- a/go/registry/memory/files.go
+++ b/go/registry/memory/files.go
@@ -296,6 +296,38 @@ func (r *FileRegistry) SumSizeBreakdown(ctx context.Context) (registry.StorageBr
 	return breakdown, nil
 }
 
+// SumSizeBreakdownByGroup mirrors SumSizeBreakdown but for an explicit
+// (tenant_id, group_id) tuple — see the interface doc. Iterates the
+// shared file map filtered by the tuple so the worker can compute
+// per-group usage without instantiating a request-scoped registry.
+func (r *FileRegistry) SumSizeBreakdownByGroup(ctx context.Context, tenantID, groupID string) (registry.StorageBreakdown, error) {
+	files, err := r.ListByGroup(ctx, tenantID, groupID)
+	if err != nil {
+		return registry.StorageBreakdown{}, err
+	}
+
+	var breakdown registry.StorageBreakdown
+	for _, file := range files {
+		if file.File == nil {
+			continue
+		}
+		size := file.SizeBytes
+		if file.LinkedEntityType == "export" {
+			breakdown.Exports += size
+			continue
+		}
+		switch file.Category {
+		case models.FileCategoryImages:
+			breakdown.Images += size
+		case models.FileCategoryDocuments:
+			breakdown.Documents += size
+		default:
+			breakdown.Other += size
+		}
+	}
+	return breakdown, nil
+}
+
 // ListByLinkedEntity returns files linked to a specific entity
 func (r *FileRegistry) ListByLinkedEntity(ctx context.Context, entityType, entityID string) ([]*models.FileEntity, error) {
 	allFiles, err := r.List(ctx)

--- a/go/registry/memory/memory.go
+++ b/go/registry/memory/memory.go
@@ -64,6 +64,7 @@ func NewFactorySet() *registry.FactorySet {
 	fs.GroupInviteAuditRegistry = NewGroupInviteAuditRegistry()
 	fs.GroupNotificationPrefRegistry = NewGroupNotificationPrefRegistry()
 	fs.WarrantyReminderRegistry = NewWarrantyReminderRegistry()
+	fs.StorageQuotaReminderRegistry = NewStorageQuotaReminderRegistry()
 	fs.CurrencyMigrationRegistryFactory = NewCurrencyMigrationRegistryFactory()
 	fs.GroupPurger = NewGroupPurger(
 		locationFactory,

--- a/go/registry/memory/storage_quota_reminders.go
+++ b/go/registry/memory/storage_quota_reminders.go
@@ -1,0 +1,93 @@
+package memory
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+var _ registry.StorageQuotaReminderRegistry = (*StorageQuotaReminderRegistry)(nil)
+
+type baseStorageQuotaReminderRegistry = Registry[models.StorageQuotaReminder, *models.StorageQuotaReminder]
+
+// StorageQuotaReminderRegistry is the in-memory implementation of the
+// idempotency store for the storage quota warning worker (#1585).
+// Mirrors the postgres registry — Create-once semantics enforced by
+// the (group_id, threshold_percent) tuple; DeleteByGroupThreshold lets
+// the worker reset the row when a group drops back below the
+// threshold.
+type StorageQuotaReminderRegistry struct {
+	*baseStorageQuotaReminderRegistry
+}
+
+func NewStorageQuotaReminderRegistry() *StorageQuotaReminderRegistry {
+	return &StorageQuotaReminderRegistry{
+		baseStorageQuotaReminderRegistry: NewRegistry[models.StorageQuotaReminder, *models.StorageQuotaReminder](),
+	}
+}
+
+// HasSent checks whether a row already exists for the given (group,
+// threshold) tuple.
+func (r *StorageQuotaReminderRegistry) HasSent(_ context.Context, groupID string, thresholdPercent int) (bool, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		v := pair.Value
+		if v.GroupID == groupID && v.ThresholdPercent == thresholdPercent {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// CreateOnce inserts the reminder row iff no row exists for the same
+// (group, threshold) tuple. Returns (false, nil) for the loser of a
+// race so the caller can treat happy-path and race-loser identically.
+//
+// The check + insert run under a single lock acquisition — without
+// that, two goroutines could both pass the existence scan, both
+// proceed to Create, and end up with duplicate idempotency rows. We
+// therefore insert directly into r.items here rather than delegating
+// to baseStorageQuotaReminderRegistry.Create (which takes the lock
+// again and would force us to drop ours mid-flight).
+func (r *StorageQuotaReminderRegistry) CreateOnce(_ context.Context, reminder models.StorageQuotaReminder) (bool, error) {
+	if reminder.SentAt.IsZero() {
+		reminder.SentAt = time.Now()
+	}
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		v := pair.Value
+		if v.GroupID == reminder.GroupID && v.ThresholdPercent == reminder.ThresholdPercent {
+			return false, nil
+		}
+	}
+	row := reminder
+	row.ID = uuid.New().String()
+	if row.UUID == "" {
+		row.UUID = uuid.New().String()
+	}
+	r.items.Set(row.ID, &row)
+	return true, nil
+}
+
+// DeleteByGroupThreshold removes the reminder row for the given
+// (group, threshold) tuple. Returns true when a row was actually
+// deleted — the worker uses that to log a "reset" event distinctly
+// from the no-op case.
+func (r *StorageQuotaReminderRegistry) DeleteByGroupThreshold(_ context.Context, groupID string, thresholdPercent int) (bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		v := pair.Value
+		if v.GroupID == groupID && v.ThresholdPercent == thresholdPercent {
+			r.items.Delete(pair.Key)
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -531,6 +531,42 @@ func (r *FileRegistry) ListPendingSizeBackfill(ctx context.Context, limit int) (
 	return files, nil
 }
 
+// SumSizeBreakdownByGroup mirrors SumSizeBreakdown but for an explicit
+// (tenant_id, group_id) tuple. Runs as background-worker (no RLS) so
+// the storage quota warning worker (#1585) can compute usage per
+// group while iterating every tenant. Same CASE-aggregate as
+// SumSizeBreakdown, with the (tenant_id, group_id) tuple bolted onto
+// the WHERE clause.
+func (r *FileRegistry) SumSizeBreakdownByGroup(ctx context.Context, tenantID, groupID string) (registry.StorageBreakdown, error) {
+	if tenantID == "" {
+		return registry.StorageBreakdown{}, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
+	}
+	if groupID == "" {
+		return registry.StorageBreakdown{}, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+	}
+	var breakdown registry.StorageBreakdown
+	err := store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		sqlQuery := fmt.Sprintf(`
+			SELECT
+				COALESCE(SUM(CASE WHEN linked_entity_type = 'export' THEN size_bytes ELSE 0 END), 0) AS exports,
+				COALESCE(SUM(CASE WHEN linked_entity_type IS DISTINCT FROM 'export' AND category = 'images' THEN size_bytes ELSE 0 END), 0) AS images,
+				COALESCE(SUM(CASE WHEN linked_entity_type IS DISTINCT FROM 'export' AND category = 'documents' THEN size_bytes ELSE 0 END), 0) AS documents,
+				COALESCE(SUM(CASE WHEN linked_entity_type IS DISTINCT FROM 'export' AND category = 'other' THEN size_bytes ELSE 0 END), 0) AS other
+			FROM %s
+			WHERE tenant_id = $1 AND group_id = $2`, r.tableNames.Files())
+
+		row := tx.QueryRowxContext(ctx, sqlQuery, tenantID, groupID)
+		if err := row.Scan(&breakdown.Exports, &breakdown.Images, &breakdown.Documents, &breakdown.Other); err != nil {
+			return errxtrace.Wrap("failed to scan storage breakdown by group", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return registry.StorageBreakdown{}, errxtrace.Wrap("failed to sum size breakdown by group", err)
+	}
+	return breakdown, nil
+}
+
 // SumSizeBreakdown returns per-bucket byte totals for the current
 // (tenant, group) scope (#1388). RLS handles the tenant+group filter;
 // the SQL splits export bundles (linked_entity_type='export') out of

--- a/go/registry/postgres/group_purger.go
+++ b/go/registry/postgres/group_purger.go
@@ -66,6 +66,12 @@ var purgeOrder = []func(t store.TableNames) string{
 	// commodities cascade.
 	func(t store.TableNames) string { return string(t.WarrantyReminders()) },
 
+	// Storage quota reminder idempotency rows (#1585). Group-scoped
+	// idempotency rows must drop before the parent location_groups row;
+	// the orchestration layer hard-deletes the group itself, so the FK
+	// on group_id is left without ON DELETE CASCADE.
+	func(t store.TableNames) string { return string(t.StorageQuotaReminders()) },
+
 	// Inventory hierarchy.
 	func(t store.TableNames) string { return string(t.Commodities()) },
 	func(t store.TableNames) string { return string(t.Areas()) },

--- a/go/registry/postgres/postgres.go
+++ b/go/registry/postgres/postgres.go
@@ -58,6 +58,7 @@ func NewFactorySet(dbx *sqlx.DB) *registry.FactorySet {
 	fs.GroupNotificationPrefRegistry = NewGroupNotificationPrefRegistry(dbx)
 	fs.GroupPurger = NewGroupPurger(dbx)
 	fs.WarrantyReminderRegistry = NewWarrantyReminderRegistry(dbx)
+	fs.StorageQuotaReminderRegistry = NewStorageQuotaReminderRegistry(dbx)
 	fs.CurrencyMigrationRegistryFactory = NewCurrencyMigrationRegistry(dbx)
 	fs.PingFn = dbx.PingContext
 

--- a/go/registry/postgres/storage_quota_reminders.go
+++ b/go/registry/postgres/storage_quota_reminders.go
@@ -1,0 +1,140 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-extras/errx"
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+var _ registry.StorageQuotaReminderRegistry = (*StorageQuotaReminderRegistry)(nil)
+
+// StorageQuotaReminderRegistry is the postgres-backed idempotency
+// store for the storage quota warning worker (#1585). Runs in service
+// mode (background-worker role) so cross-tenant inserts during the
+// periodic scan are not blocked by RLS.
+type StorageQuotaReminderRegistry struct {
+	dbx        *sqlx.DB
+	tableNames store.TableNames
+}
+
+func NewStorageQuotaReminderRegistry(dbx *sqlx.DB) *StorageQuotaReminderRegistry {
+	return &StorageQuotaReminderRegistry{
+		dbx:        dbx,
+		tableNames: store.DefaultTableNames,
+	}
+}
+
+// HasSent reports whether a row already exists for the given (group,
+// threshold) tuple.
+func (r *StorageQuotaReminderRegistry) HasSent(ctx context.Context, groupID string, thresholdPercent int) (bool, error) {
+	if groupID == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+	}
+	var count int
+	err := store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`SELECT COUNT(*) FROM %s WHERE group_id = $1 AND threshold_percent = $2`,
+			r.tableNames.StorageQuotaReminders(),
+		)
+		return tx.QueryRowxContext(ctx, query, groupID, thresholdPercent).Scan(&count)
+	})
+	if err != nil {
+		return false, errxtrace.Wrap("failed to check storage quota reminder existence", err)
+	}
+	return count > 0, nil
+}
+
+// CreateOnce inserts the row iff no row exists for the same
+// (group_id, threshold_percent). Returns (false, nil) if the unique
+// index already has the tuple — duplicate-key is a normal happy-path
+// outcome here, not an error.
+func (r *StorageQuotaReminderRegistry) CreateOnce(ctx context.Context, reminder models.StorageQuotaReminder) (bool, error) {
+	if reminder.GroupID == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+	}
+	if !models.StorageQuotaThreshold(reminder.ThresholdPercent).IsValid() {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ThresholdPercent"))
+	}
+	if reminder.SentAt.IsZero() {
+		reminder.SentAt = time.Now()
+	}
+	if reminder.GetID() == "" {
+		reminder.SetID(uuid.NewString())
+	}
+
+	inserted := false
+	err := store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`INSERT INTO %s (id, tenant_id, group_id, created_by_user_id, threshold_percent, sent_at)
+			 VALUES ($1, $2, $3, $4, $5, $6)
+			 ON CONFLICT (group_id, threshold_percent) DO NOTHING`,
+			r.tableNames.StorageQuotaReminders(),
+		)
+		res, execErr := tx.ExecContext(ctx, query,
+			reminder.GetID(),
+			reminder.TenantID,
+			reminder.GroupID,
+			reminder.CreatedByUserID,
+			reminder.ThresholdPercent,
+			reminder.SentAt.UTC(),
+		)
+		if execErr != nil {
+			// Treat unique-violation as the no-op outcome too — defence
+			// in depth in case the conflict-target ever drifts from the
+			// unique index.
+			if isUniqueViolation(execErr) {
+				return nil
+			}
+			return execErr
+		}
+		n, _ := res.RowsAffected()
+		if n > 0 {
+			inserted = true
+		}
+		return nil
+	})
+	if err != nil {
+		return false, errxtrace.Wrap("failed to insert storage quota reminder", err)
+	}
+	return inserted, nil
+}
+
+// DeleteByGroupThreshold removes the reminder row for the given
+// (group, threshold) tuple. Returns true when a row was actually
+// deleted so the caller can log a "reset" event distinctly from the
+// no-op case. Used by the worker when a group drops back below the
+// threshold so a future re-crossing fires a fresh email.
+func (r *StorageQuotaReminderRegistry) DeleteByGroupThreshold(ctx context.Context, groupID string, thresholdPercent int) (bool, error) {
+	if groupID == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+	}
+	deleted := false
+	err := store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`DELETE FROM %s WHERE group_id = $1 AND threshold_percent = $2`,
+			r.tableNames.StorageQuotaReminders(),
+		)
+		res, execErr := tx.ExecContext(ctx, query, groupID, thresholdPercent)
+		if execErr != nil {
+			return execErr
+		}
+		n, _ := res.RowsAffected()
+		if n > 0 {
+			deleted = true
+		}
+		return nil
+	})
+	if err != nil {
+		return false, errxtrace.Wrap("failed to delete storage quota reminder", err)
+	}
+	return deleted, nil
+}

--- a/go/registry/postgres/store/tablenames.go
+++ b/go/registry/postgres/store/tablenames.go
@@ -32,6 +32,7 @@ type TableNames struct {
 	CommodityLoans          func() TableName
 	CommodityServices       func() TableName
 	WarrantyReminders       func() TableName
+	StorageQuotaReminders   func() TableName
 	CurrencyMigrations      func() TableName
 	CurrencyMigrationAudit  func() TableName
 }
@@ -66,6 +67,7 @@ var DefaultTableNames = TableNames{
 	CommodityLoans:          func() TableName { return "commodity_loans" },
 	CommodityServices:       func() TableName { return "commodity_services" },
 	WarrantyReminders:       func() TableName { return "warranty_reminders" },
+	StorageQuotaReminders:   func() TableName { return "storage_quota_reminders" },
 	CurrencyMigrations:      func() TableName { return "currency_migrations" },
 	CurrencyMigrationAudit:  func() TableName { return "currency_migration_audit_rows" },
 }

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -342,6 +342,14 @@ type FileRegistry interface {
 	// quota visualization lists them as a distinct row.
 	SumSizeBreakdown(ctx context.Context) (StorageBreakdown, error)
 
+	// SumSizeBreakdownByGroup mirrors SumSizeBreakdown but for an
+	// explicit (tenant_id, group_id) tuple instead of the RLS-scoped
+	// caller (#1585). Service-mode only — used by the storage quota
+	// warning worker, which iterates every group from a background
+	// context where no per-group RLS is active. The same export-bundle
+	// split applies.
+	SumSizeBreakdownByGroup(ctx context.Context, tenantID, groupID string) (StorageBreakdown, error)
+
 	// ListPendingSizeBackfill streams up to limit file rows whose
 	// size_bytes is still zero — the rows that pre-date #1388 and need
 	// the boot-time backfill to re-stat the blob and write the actual
@@ -933,6 +941,38 @@ type WarrantyReminderRegistry interface {
 	CreateOnce(ctx context.Context, reminder models.WarrantyReminder) (bool, error)
 }
 
+// StorageQuotaReminderRegistry is the worker-only registry that
+// records "storage quota warning at threshold X has been emitted for
+// group Y" rows (#1585). The (group_id, threshold_percent) tuple is
+// unique — Create returns (false, nil) for the loser of a race so the
+// worker can treat the happy path and the race-loser path identically
+// (both mean "no email is needed from this tick").
+//
+// Reset semantics: the worker calls DeleteByGroupThreshold whenever a
+// group's usage drops back below the threshold so the next re-cross
+// fires a fresh email. There is no user-facing surface on this table.
+//
+// All operations run under the background-worker RLS bypass.
+type StorageQuotaReminderRegistry interface {
+	// HasSent reports whether a reminder row already exists for the
+	// given (group, threshold) tuple. Used by the worker to skip the
+	// email-render path when the row is present.
+	HasSent(ctx context.Context, groupID string, thresholdPercent int) (bool, error)
+
+	// CreateOnce attempts to insert the reminder row. Returns
+	// (true, nil) if this call won the insert and the caller may
+	// proceed to send the email. Returns (false, nil) when a row for
+	// the same tuple already exists (idempotency: another tick or
+	// process beat us). Other errors are returned as-is.
+	CreateOnce(ctx context.Context, reminder models.StorageQuotaReminder) (bool, error)
+
+	// DeleteByGroupThreshold removes the reminder row for the given
+	// (group, threshold) tuple, returning true when a row was actually
+	// deleted. Called by the worker when a group drops back below the
+	// threshold so a future re-crossing fires a fresh email.
+	DeleteByGroupThreshold(ctx context.Context, groupID string, thresholdPercent int) (bool, error)
+}
+
 // LocationGroupRegistry manages location groups within a tenant.
 // Groups are tenant-scoped (not user-scoped) — access is controlled via memberships.
 type LocationGroupRegistry interface {
@@ -1291,6 +1331,7 @@ type Set struct {
 	GroupNotificationPrefRegistry  GroupNotificationPrefRegistry // Per-user per-group notification opt-outs (#1648); tenant-scoped, user-filtered in application logic
 	GroupPurger                    GroupPurger                   // GroupPurger bulk-removes group-scoped entities during the purge worker's tick
 	WarrantyReminderRegistry       WarrantyReminderRegistry      // WarrantyReminderRegistry is the idempotency store for the warranty reminder worker; service-mode only
+	StorageQuotaReminderRegistry   StorageQuotaReminderRegistry  // StorageQuotaReminderRegistry is the idempotency store for the storage quota warning worker; service-mode only (#1585)
 	CurrencyMigrationRegistry      CurrencyMigrationRegistry     // Currency migration operation rows + audit + HMAC token signing (issue #1550 / epic #202)
 }
 

--- a/go/schema/migrations/_sqldata/1778949444_add_storage_quota_reminders.down.sql
+++ b/go/schema/migrations/_sqldata/1778949444_add_storage_quota_reminders.down.sql
@@ -1,0 +1,13 @@
+-- Migration rollback
+-- Generated on: 2026-05-16T16:37:24Z
+-- Direction: DOWN
+
+DROP INDEX IF EXISTS idx_storage_quota_reminders_group_threshold;
+DROP INDEX IF EXISTS idx_storage_quota_reminders_tenant_id;
+-- Drop RLS policy storage_quota_reminder_background_worker_access from table storage_quota_reminders
+DROP POLICY IF EXISTS storage_quota_reminder_background_worker_access ON storage_quota_reminders;
+-- Drop RLS policy storage_quota_reminder_isolation from table storage_quota_reminders
+DROP POLICY IF EXISTS storage_quota_reminder_isolation ON storage_quota_reminders;
+-- NOTE: RLS policies were removed from table storage_quota_reminders - verify if RLS should be disabled --
+-- WARNING: This will delete all data!
+DROP TABLE IF EXISTS storage_quota_reminders CASCADE;

--- a/go/schema/migrations/_sqldata/1778949444_add_storage_quota_reminders.up.sql
+++ b/go/schema/migrations/_sqldata/1778949444_add_storage_quota_reminders.up.sql
@@ -1,0 +1,34 @@
+-- Migration generated from schema differences
+-- Generated on: 2026-05-16T16:37:24Z
+-- Direction: UP
+
+-- POSTGRES TABLE: storage_quota_reminders --
+CREATE TABLE storage_quota_reminders (
+  threshold_percent INTEGER NOT NULL,
+  sent_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  tenant_id TEXT NOT NULL,
+  group_id TEXT NOT NULL,
+  created_by_user_id TEXT NOT NULL,
+  id TEXT PRIMARY KEY NOT NULL,
+  uuid TEXT NOT NULL DEFAULT (gen_random_uuid())::text
+);
+-- ALTER statements: --
+ALTER TABLE storage_quota_reminders ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id);
+-- ALTER statements: --
+ALTER TABLE storage_quota_reminders ADD CONSTRAINT fk_entity_group FOREIGN KEY (group_id) REFERENCES location_groups(id);
+-- ALTER statements: --
+ALTER TABLE storage_quota_reminders ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id);
+-- Enable RLS for storage_quota_reminders table
+ALTER TABLE storage_quota_reminders ENABLE ROW LEVEL SECURITY;
+-- Allows background workers to record reminder emissions across all groups
+DROP POLICY IF EXISTS storage_quota_reminder_background_worker_access ON storage_quota_reminders;
+CREATE POLICY storage_quota_reminder_background_worker_access ON storage_quota_reminders FOR ALL TO inventario_background_worker
+    USING (true)
+    WITH CHECK (true);
+-- Ensures storage quota reminders are accessible only by their tenant and group
+DROP POLICY IF EXISTS storage_quota_reminder_isolation ON storage_quota_reminders;
+CREATE POLICY storage_quota_reminder_isolation ON storage_quota_reminders FOR ALL TO inventario_app
+    USING (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != '')
+    WITH CHECK (tenant_id = get_current_tenant_id() AND get_current_tenant_id() IS NOT NULL AND get_current_tenant_id() != '' AND group_id = get_current_group_id() AND get_current_group_id() IS NOT NULL AND get_current_group_id() != '');
+CREATE UNIQUE INDEX IF NOT EXISTS idx_storage_quota_reminders_group_threshold ON storage_quota_reminders (group_id, threshold_percent);
+CREATE INDEX IF NOT EXISTS idx_storage_quota_reminders_tenant_id ON storage_quota_reminders (tenant_id);

--- a/go/services/email_async_service.go
+++ b/go/services/email_async_service.go
@@ -184,6 +184,24 @@ func (s *AsyncEmailService) SendGroupInviteEmail(ctx context.Context, to, invite
 	})
 }
 
+// SendStorageQuotaWarningEmail enqueues a "your group is approaching
+// its storage quota" email (#1585).
+func (s *AsyncEmailService) SendStorageQuotaWarningEmail(ctx context.Context, to, name, groupName string, thresholdPercent, usagePercent int, usedHuman, quotaHuman string, breakdownLines []string, filesURL, settingsURL string) error {
+	return s.enqueue(ctx, emailJob{
+		TemplateType:          emailTemplateStorageQuotaWarning,
+		To:                    to,
+		Name:                  name,
+		GroupName:             groupName,
+		ThresholdPercent:      thresholdPercent,
+		UsagePercent:          usagePercent,
+		StorageUsedHuman:      usedHuman,
+		StorageQuotaHuman:     quotaHuman,
+		StorageBreakdownLines: breakdownLines,
+		StorageFilesURL:       filesURL,
+		StorageSettingsURL:    settingsURL,
+	})
+}
+
 func (s *AsyncEmailService) enqueue(ctx context.Context, job emailJob) error {
 	job.ID = uuid.NewString()
 	job.To = strings.TrimSpace(job.To)

--- a/go/services/email_queue.go
+++ b/go/services/email_queue.go
@@ -32,6 +32,20 @@ type emailJob struct {
 	GroupName   string     `json:"group_name,omitempty"`
 	Role        string     `json:"role,omitempty"`
 	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	// Storage-quota fields. Optional and only populated by
+	// AsyncEmailService.SendStorageQuotaWarningEmail. GroupName
+	// piggybacks on the group-invite field above. ThresholdPercent
+	// is the matched tier (e.g. 90); UsagePercent is the rounded
+	// actual percentage at send time (>= threshold). Human strings
+	// are pre-formatted (e.g. "135 MiB") so the renderer doesn't
+	// have to redo unit conversion.
+	ThresholdPercent      int      `json:"threshold_percent,omitempty"`
+	UsagePercent          int      `json:"usage_percent,omitempty"`
+	StorageUsedHuman      string   `json:"storage_used_human,omitempty"`
+	StorageQuotaHuman     string   `json:"storage_quota_human,omitempty"`
+	StorageBreakdownLines []string `json:"storage_breakdown_lines,omitempty"`
+	StorageFilesURL       string   `json:"storage_files_url,omitempty"`
+	StorageSettingsURL    string   `json:"storage_settings_url,omitempty"`
 }
 
 // newEmailQueue selects Redis-backed queueing when configured; otherwise it

--- a/go/services/email_service.go
+++ b/go/services/email_service.go
@@ -45,6 +45,19 @@ type EmailService interface {
 	// inviteURL is the constructed /invite/{token} URL the recipient
 	// clicks. expiresAt makes the urgency explicit.
 	SendGroupInviteEmail(ctx context.Context, to, inviterName, groupName, role, inviteURL string, expiresAt time.Time) error
+
+	// SendStorageQuotaWarningEmail requests delivery of a "your group
+	// is approaching its storage quota" email (#1585). thresholdPercent
+	// is the StorageQuotaThreshold the worker matched (90); usagePercent
+	// is the actual rounded percentage at send time (>= threshold,
+	// possibly higher). usedHuman / quotaHuman are short
+	// human-readable byte counts (e.g. "135 MiB"). breakdownLines is
+	// the per-bucket label slice rendered into a bullet list — the
+	// caller controls the bucket names and ordering. filesURL points
+	// at the group's files page; settingsURL at Settings → Data &
+	// storage. Either URL may be empty: the template suppresses the
+	// matching link block when so.
+	SendStorageQuotaWarningEmail(ctx context.Context, to, name, groupName string, thresholdPercent, usagePercent int, usedHuman, quotaHuman string, breakdownLines []string, filesURL, settingsURL string) error
 }
 
 // EmailProvider identifies which transport backend should be instantiated by
@@ -285,6 +298,28 @@ func (s *StubEmailService) SendWarrantyReminderEmail(_ context.Context, to, name
 		"commodity_url", commodityURL,
 		"threshold_days", thresholdDays,
 	)
+	return nil
+}
+
+// SendStorageQuotaWarningEmail logs the storage quota warning event
+// without dispatching anything externally — useful in tests and the
+// "stub" provider profile.
+func (s *StubEmailService) SendStorageQuotaWarningEmail(_ context.Context, to, name, groupName string, thresholdPercent, usagePercent int, usedHuman, quotaHuman string, breakdownLines []string, filesURL, settingsURL string) error {
+	attrs := []any{
+		"to", to,
+		"name", name,
+		"group_name", groupName,
+		"threshold_percent", thresholdPercent,
+		"usage_percent", usagePercent,
+		"used", usedHuman,
+		"quota", quotaHuman,
+		"breakdown_lines", breakdownLines,
+	}
+	if s.logEmailURLs {
+		attrs = append(attrs, "files_url", filesURL, "settings_url", settingsURL)
+	}
+	//nolint:sloglint // structured fields are constructed dynamically.
+	slog.Info("STUB email: storage quota warning", attrs...)
 	return nil
 }
 

--- a/go/services/email_templates.go
+++ b/go/services/email_templates.go
@@ -19,12 +19,13 @@ var emailTemplatesFS embed.FS
 type emailTemplateType string
 
 const (
-	emailTemplateVerification     emailTemplateType = "verification"
-	emailTemplatePasswordReset    emailTemplateType = "password_reset"
-	emailTemplatePasswordChange   emailTemplateType = "password_changed"
-	emailTemplateWelcome          emailTemplateType = "welcome"
-	emailTemplateWarrantyReminder emailTemplateType = "warranty_reminder"
-	emailTemplateGroupInvite      emailTemplateType = "group_invite"
+	emailTemplateVerification        emailTemplateType = "verification"
+	emailTemplatePasswordReset       emailTemplateType = "password_reset"
+	emailTemplatePasswordChange      emailTemplateType = "password_changed"
+	emailTemplateWelcome             emailTemplateType = "welcome"
+	emailTemplateWarrantyReminder    emailTemplateType = "warranty_reminder"
+	emailTemplateGroupInvite         emailTemplateType = "group_invite"
+	emailTemplateStorageQuotaWarning emailTemplateType = "storage_quota_warning"
 )
 
 type renderedEmail struct {
@@ -55,6 +56,20 @@ type emailTemplateData struct {
 	GroupName   string
 	Role        string
 	ExpiresAt   string
+	// Storage-quota fields. Empty for every other template type.
+	// ThresholdPercent is the matched tier (e.g. 90); UsagePercent
+	// is the actual rounded percentage at send time. UsedHuman /
+	// QuotaHuman are pre-formatted (e.g. "135 MiB"). BreakdownLines
+	// is the per-bucket label slice rendered into a bullet list.
+	// FilesURL / SettingsURL may be empty: the template suppresses
+	// the matching link block when so.
+	ThresholdPercent int
+	UsagePercent     int
+	UsedHuman        string
+	QuotaHuman       string
+	BreakdownLines   []string
+	FilesURL         string
+	SettingsURL      string
 }
 
 // newEmailTemplateRenderer parses all embedded template files and builds a
@@ -66,21 +81,23 @@ func newEmailTemplateRenderer() (*emailTemplateRenderer, error) {
 	}
 	// #nosec G101 -- these are template file paths, not credentials.
 	htmlTemplateFiles := map[emailTemplateType]string{
-		emailTemplateVerification:     "email_templates/verification.html.tmpl",
-		emailTemplatePasswordReset:    "email_templates/password_reset.html.tmpl",
-		emailTemplatePasswordChange:   "email_templates/password_changed.html.tmpl",
-		emailTemplateWelcome:          "email_templates/welcome.html.tmpl",
-		emailTemplateWarrantyReminder: "email_templates/warranty_reminder.html.tmpl",
-		emailTemplateGroupInvite:      "email_templates/group_invite.html.tmpl",
+		emailTemplateVerification:        "email_templates/verification.html.tmpl",
+		emailTemplatePasswordReset:       "email_templates/password_reset.html.tmpl",
+		emailTemplatePasswordChange:      "email_templates/password_changed.html.tmpl",
+		emailTemplateWelcome:             "email_templates/welcome.html.tmpl",
+		emailTemplateWarrantyReminder:    "email_templates/warranty_reminder.html.tmpl",
+		emailTemplateGroupInvite:         "email_templates/group_invite.html.tmpl",
+		emailTemplateStorageQuotaWarning: "email_templates/storage_quota_warning.html.tmpl",
 	}
 	// #nosec G101 -- these are template file paths, not credentials.
 	textTemplateFiles := map[emailTemplateType]string{
-		emailTemplateVerification:     "email_templates/verification.txt.tmpl",
-		emailTemplatePasswordReset:    "email_templates/password_reset.txt.tmpl",
-		emailTemplatePasswordChange:   "email_templates/password_changed.txt.tmpl",
-		emailTemplateWelcome:          "email_templates/welcome.txt.tmpl",
-		emailTemplateWarrantyReminder: "email_templates/warranty_reminder.txt.tmpl",
-		emailTemplateGroupInvite:      "email_templates/group_invite.txt.tmpl",
+		emailTemplateVerification:        "email_templates/verification.txt.tmpl",
+		emailTemplatePasswordReset:       "email_templates/password_reset.txt.tmpl",
+		emailTemplatePasswordChange:      "email_templates/password_changed.txt.tmpl",
+		emailTemplateWelcome:             "email_templates/welcome.txt.tmpl",
+		emailTemplateWarrantyReminder:    "email_templates/warranty_reminder.txt.tmpl",
+		emailTemplateGroupInvite:         "email_templates/group_invite.txt.tmpl",
+		emailTemplateStorageQuotaWarning: "email_templates/storage_quota_warning.txt.tmpl",
 	}
 
 	for tt, file := range htmlTemplateFiles {
@@ -120,15 +137,22 @@ func (r *emailTemplateRenderer) render(job emailJob) (renderedEmail, error) {
 	}
 
 	data := emailTemplateData{
-		Name:          strings.TrimSpace(job.Name),
-		URL:           job.URL,
-		CommodityName: strings.TrimSpace(job.CommodityName),
-		CommodityURL:  strings.TrimSpace(job.CommodityURL),
-		ExpiryDate:    strings.TrimSpace(job.ExpiryDate),
-		ThresholdDays: job.ThresholdDays,
-		InviterName:   strings.TrimSpace(job.InviterName),
-		GroupName:     strings.TrimSpace(job.GroupName),
-		Role:          strings.TrimSpace(job.Role),
+		Name:             strings.TrimSpace(job.Name),
+		URL:              job.URL,
+		CommodityName:    strings.TrimSpace(job.CommodityName),
+		CommodityURL:     strings.TrimSpace(job.CommodityURL),
+		ExpiryDate:       strings.TrimSpace(job.ExpiryDate),
+		ThresholdDays:    job.ThresholdDays,
+		InviterName:      strings.TrimSpace(job.InviterName),
+		GroupName:        strings.TrimSpace(job.GroupName),
+		Role:             strings.TrimSpace(job.Role),
+		ThresholdPercent: job.ThresholdPercent,
+		UsagePercent:     job.UsagePercent,
+		UsedHuman:        strings.TrimSpace(job.StorageUsedHuman),
+		QuotaHuman:       strings.TrimSpace(job.StorageQuotaHuman),
+		BreakdownLines:   job.StorageBreakdownLines,
+		FilesURL:         strings.TrimSpace(job.StorageFilesURL),
+		SettingsURL:      strings.TrimSpace(job.StorageSettingsURL),
 	}
 	if data.Name == "" {
 		data.Name = "there"
@@ -183,6 +207,8 @@ func subjectByTemplateType(tt emailTemplateType) (string, bool) {
 		return "Inventario warranty reminder", true
 	case emailTemplateGroupInvite:
 		return "You're invited to a group on Inventario", true
+	case emailTemplateStorageQuotaWarning:
+		return "Your group is approaching its storage quota", true
 	default:
 		return "", false
 	}

--- a/go/services/email_templates/storage_quota_warning.html.tmpl
+++ b/go/services/email_templates/storage_quota_warning.html.tmpl
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<body>
+<p>Hi {{.Name}},</p>
+<p>The Inventario group <strong>{{.GroupName}}</strong> is using
+<strong>{{.UsedHuman}}</strong> of its <strong>{{.QuotaHuman}}</strong>
+storage quota — that's <strong>{{.UsagePercent}}%</strong>, past the
+{{.ThresholdPercent}}% warning threshold.</p>
+{{- if .BreakdownLines}}
+<p>Current usage by category:</p>
+<ul>
+{{- range .BreakdownLines}}
+<li>{{.}}</li>
+{{- end}}
+</ul>
+{{- end}}
+<p>You can free up space by deleting items, exports or files you no
+longer need.</p>
+{{- if .FilesURL}}
+<p>Review files: <a href="{{.FilesURL}}">{{.FilesURL}}</a></p>
+{{- end}}
+{{- if .SettingsURL}}
+<p>Open Settings → Data &amp; storage: <a href="{{.SettingsURL}}">{{.SettingsURL}}</a></p>
+{{- end}}
+<p>Inventario sends this once when the threshold is first crossed. A
+fresh email fires only if usage drops back below the threshold and
+crosses it again.</p>
+</body>
+</html>

--- a/go/services/email_templates/storage_quota_warning.txt.tmpl
+++ b/go/services/email_templates/storage_quota_warning.txt.tmpl
@@ -1,0 +1,19 @@
+Hi {{.Name}},
+
+The Inventario group {{.GroupName}} is using {{.UsedHuman}} of its
+{{.QuotaHuman}} storage quota — that's {{.UsagePercent}}%, past the
+{{.ThresholdPercent}}% warning threshold.
+{{if .BreakdownLines}}
+Current usage by category:
+{{range .BreakdownLines}}  - {{.}}
+{{end}}{{end}}
+You can free up space by deleting items, exports or files you no
+longer need.
+{{if .FilesURL}}
+Review files: {{.FilesURL}}
+{{end}}{{if .SettingsURL}}
+Open Settings → Data & storage: {{.SettingsURL}}
+{{end}}
+Inventario sends this once when the threshold is first crossed. A
+fresh email fires only if usage drops back below the threshold and
+crosses it again.

--- a/go/services/storage_quota_reminder_service.go
+++ b/go/services/storage_quota_reminder_service.go
@@ -1,0 +1,520 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// StorageQuotaReminderService scans every group, computes its
+// used/quota ratio, and:
+//
+//  1. emits one email per group per quota tier crossed via
+//     idempotency rows (write-after-send; same race ordering as
+//     WarrantyReminderService);
+//  2. resets a previously-emitted row when a group's usage falls
+//     back below the threshold, so a future re-crossing fires a
+//     fresh email.
+//
+// The service is stateless — RemindOnce takes the clock as an
+// argument so unit tests can pin "now" to a fixed value and assert
+// the cadence boundaries without time-injection scaffolding.
+//
+// Per-user notification preferences are NOT consulted in v1: the
+// reminder targets group admins and is operational rather than
+// product-promotional. Hooking into the notifications.Service
+// surface is tracked as a follow-up (per the issue body).
+type StorageQuotaReminderService struct {
+	factorySet *registry.FactorySet
+	emailSvc   EmailService
+
+	// quotaBytesFor returns the per-group quota in bytes. Defaults to
+	// DefaultGroupStorageQuotaBytes when nil; tests inject a tiny
+	// quota so the threshold-crossing cases are deterministic without
+	// staging hundreds of MiB of test files.
+	quotaBytesFor func(groupID string) int64
+
+	// urlBuilders compose the deep links printed in the reminder
+	// email. Both are optional — when nil, the template suppresses the
+	// matching link block. publicURL ownership lives in the bootstrap
+	// layer, like the warranty reminder.
+	filesURLBuilder    func(groupSlug string) string
+	settingsURLBuilder func(groupSlug string) string
+}
+
+// NewStorageQuotaReminderService constructs the service. emailSvc may
+// be nil in tests that only assert the idempotency-row side; in
+// production callers always pass a non-nil EmailService.
+func NewStorageQuotaReminderService(
+	factorySet *registry.FactorySet,
+	emailSvc EmailService,
+	filesURLBuilder func(groupSlug string) string,
+	settingsURLBuilder func(groupSlug string) string,
+) *StorageQuotaReminderService {
+	return &StorageQuotaReminderService{
+		factorySet:         factorySet,
+		emailSvc:           emailSvc,
+		filesURLBuilder:    filesURLBuilder,
+		settingsURLBuilder: settingsURLBuilder,
+	}
+}
+
+// WithQuotaBytesFor lets callers (tests + a future plans-aware
+// runtime) override the per-group quota lookup. Returns the same
+// service for fluent chaining.
+func (s *StorageQuotaReminderService) WithQuotaBytesFor(fn func(groupID string) int64) *StorageQuotaReminderService {
+	s.quotaBytesFor = fn
+	return s
+}
+
+// StorageQuotaReminderStats summarises the outcome of one sweep.
+// SentByThreshold counts new idempotency rows partitioned by tier;
+// ResetByThreshold counts rows wiped because their group dropped
+// back below the threshold. Failed is the cross-tier count of groups
+// whose threshold processing failed (typically transient queue
+// outages or DB errors); the next sweep retries.
+type StorageQuotaReminderStats struct {
+	SentByThreshold  map[models.StorageQuotaThreshold]int
+	ResetByThreshold map[models.StorageQuotaThreshold]int
+	Failed           int
+}
+
+// Sent returns the total number of newly-inserted idempotency rows
+// across every threshold. Convenience for callers that don't need
+// the per-threshold breakdown.
+func (s StorageQuotaReminderStats) Sent() int {
+	total := 0
+	for _, v := range s.SentByThreshold {
+		total += v
+	}
+	return total
+}
+
+// Reset returns the total number of reminder rows wiped this sweep
+// because their group fell back below the matched threshold.
+func (s StorageQuotaReminderStats) Reset() int {
+	total := 0
+	for _, v := range s.ResetByThreshold {
+		total += v
+	}
+	return total
+}
+
+// RemindOnce runs one sweep pinned to `now`. Returns the per-tier
+// counters; a non-nil error is only returned when the initial group
+// listing itself fails.
+func (s *StorageQuotaReminderService) RemindOnce(ctx context.Context, now time.Time) (StorageQuotaReminderStats, error) {
+	stats := StorageQuotaReminderStats{
+		SentByThreshold:  map[models.StorageQuotaThreshold]int{},
+		ResetByThreshold: map[models.StorageQuotaThreshold]int{},
+	}
+	if s.factorySet == nil {
+		return stats, errxtrace.Wrap("storage quota reminder service: factorySet is required", registry.ErrFieldRequired)
+	}
+	if s.factorySet.LocationGroupRegistry == nil {
+		return stats, errxtrace.Wrap("storage quota reminder service: LocationGroupRegistry is required", registry.ErrFieldRequired)
+	}
+	if s.factorySet.StorageQuotaReminderRegistry == nil {
+		return stats, errxtrace.Wrap("storage quota reminder service: StorageQuotaReminderRegistry is required", registry.ErrFieldRequired)
+	}
+	if s.factorySet.FileRegistryFactory == nil {
+		return stats, errxtrace.Wrap("storage quota reminder service: FileRegistryFactory is required", registry.ErrFieldRequired)
+	}
+
+	groups, err := s.factorySet.LocationGroupRegistry.List(ctx)
+	if err != nil {
+		return stats, errxtrace.Wrap("storage quota reminder: list groups", err)
+	}
+
+	fileReg := s.factorySet.FileRegistryFactory.CreateServiceRegistry()
+	for _, g := range groups {
+		if g == nil {
+			continue
+		}
+		s.processGroup(ctx, fileReg, g, &stats, now)
+	}
+	return stats, nil
+}
+
+// processGroup runs one (group) leg of a sweep. Errors are folded
+// into stats.Failed + slog rather than bubbled out so a single bad
+// group never short-circuits the whole sweep.
+func (s *StorageQuotaReminderService) processGroup(
+	ctx context.Context,
+	fileReg registry.FileRegistry,
+	g *models.LocationGroup,
+	stats *StorageQuotaReminderStats,
+	now time.Time,
+) {
+	usedBytes, breakdown, ratioErr := s.computeGroupUsage(ctx, fileReg, g)
+	if ratioErr != nil {
+		stats.Failed++
+		slog.Error("storage quota reminder: usage lookup failed",
+			"group_id", g.ID,
+			"tenant_id", g.TenantID,
+			"error", ratioErr,
+		)
+		return
+	}
+	quota := s.quotaBytes(g.ID)
+	if quota <= 0 {
+		// No quota configured for this group — nothing to warn
+		// about. Treat as "below every threshold" so any stale
+		// reminder rows get reset.
+		s.resetEveryThreshold(ctx, stats, g)
+		return
+	}
+	ratio := float64(usedBytes) / float64(quota)
+	for _, threshold := range models.StorageQuotaThresholds {
+		if ratio >= threshold.Ratio() {
+			s.processThresholdCrossed(ctx, g, threshold, usedBytes, quota, breakdown, now, stats)
+			continue
+		}
+		s.processThresholdBelow(ctx, g, threshold, stats)
+	}
+}
+
+// processThresholdCrossed handles the ratio >= threshold branch:
+// HasSent → enqueue → CreateOnce, counting stats accordingly.
+func (s *StorageQuotaReminderService) processThresholdCrossed(
+	ctx context.Context,
+	g *models.LocationGroup,
+	threshold models.StorageQuotaThreshold,
+	usedBytes, quotaBytes int64,
+	breakdown registry.StorageBreakdown,
+	now time.Time,
+	stats *StorageQuotaReminderStats,
+) {
+	ok, processErr := s.processCrossed(ctx, g, threshold, usedBytes, quotaBytes, breakdown, now)
+	if processErr != nil {
+		stats.Failed++
+		slog.Error("storage quota reminder failed",
+			"group_id", g.ID,
+			"tenant_id", g.TenantID,
+			"threshold_percent", int(threshold),
+			"error", processErr,
+		)
+		return
+	}
+	if ok {
+		stats.SentByThreshold[threshold]++
+	}
+}
+
+// processThresholdBelow handles the ratio < threshold branch:
+// delete any prior reminder row so a future re-crossing fires fresh.
+func (s *StorageQuotaReminderService) processThresholdBelow(
+	ctx context.Context,
+	g *models.LocationGroup,
+	threshold models.StorageQuotaThreshold,
+	stats *StorageQuotaReminderStats,
+) {
+	reset, resetErr := s.factorySet.StorageQuotaReminderRegistry.DeleteByGroupThreshold(ctx, g.ID, int(threshold))
+	if resetErr != nil {
+		stats.Failed++
+		slog.Error("storage quota reminder: reset failed",
+			"group_id", g.ID,
+			"threshold_percent", int(threshold),
+			"error", resetErr,
+		)
+		return
+	}
+	if reset {
+		stats.ResetByThreshold[threshold]++
+		slog.Info("storage quota reminder reset",
+			"group_id", g.ID,
+			"threshold_percent", int(threshold),
+		)
+	}
+}
+
+// resetEveryThreshold wipes every reminder tier for the given group.
+// Called when a group has no configured quota — equivalent to
+// "definitely below every threshold". Errors per threshold are
+// counted into stats.Failed but never bubbled up: the next sweep
+// retries.
+func (s *StorageQuotaReminderService) resetEveryThreshold(ctx context.Context, stats *StorageQuotaReminderStats, g *models.LocationGroup) {
+	for _, threshold := range models.StorageQuotaThresholds {
+		reset, resetErr := s.factorySet.StorageQuotaReminderRegistry.DeleteByGroupThreshold(ctx, g.ID, int(threshold))
+		if resetErr != nil {
+			stats.Failed++
+			slog.Error("storage quota reminder: reset failed (no-quota path)",
+				"group_id", g.ID,
+				"threshold_percent", int(threshold),
+				"error", resetErr,
+			)
+			continue
+		}
+		if reset {
+			stats.ResetByThreshold[threshold]++
+		}
+	}
+}
+
+// computeGroupUsage returns the group's total bytes used + the
+// per-bucket breakdown. The breakdown is the same shape rendered in
+// the FE storage card; reusing it in the email keeps the two
+// surfaces consistent.
+func (s *StorageQuotaReminderService) computeGroupUsage(
+	ctx context.Context,
+	files registry.FileRegistry,
+	g *models.LocationGroup,
+) (int64, registry.StorageBreakdown, error) {
+	breakdown, err := files.SumSizeBreakdownByGroup(ctx, g.TenantID, g.ID)
+	if err != nil {
+		return 0, registry.StorageBreakdown{}, err
+	}
+	return breakdown.Total(), breakdown, nil
+}
+
+// processCrossed handles one (group, threshold) pair where the
+// ratio is at or above the tier. Mirrors WarrantyReminderService's
+// HasSent → enqueue → CreateOnce ordering (write-after-send) so a
+// failed enqueue leaves no row and the next sweep retries.
+func (s *StorageQuotaReminderService) processCrossed(
+	ctx context.Context,
+	g *models.LocationGroup,
+	threshold models.StorageQuotaThreshold,
+	usedBytes, quotaBytes int64,
+	breakdown registry.StorageBreakdown,
+	now time.Time,
+) (bool, error) {
+	already, err := s.factorySet.StorageQuotaReminderRegistry.HasSent(ctx, g.ID, int(threshold))
+	if err != nil {
+		return false, errxtrace.Wrap("storage quota reminder: check existing row", err)
+	}
+	if already {
+		return false, nil
+	}
+
+	// Stub-mode short-circuit: tests / dev environments without an
+	// email service still want the idempotency row written so the
+	// sweep counter is meaningful.
+	if s.emailSvc == nil {
+		ok, commitErr := s.commitReminderRow(ctx, g, threshold, now)
+		if commitErr != nil {
+			return false, errxtrace.Wrap("storage quota reminder: insert idempotency row (no email service)", commitErr)
+		}
+		if ok {
+			slog.Info("storage quota reminder row inserted (no email service configured)",
+				"group_id", g.ID,
+				"threshold_percent", int(threshold),
+			)
+		}
+		return ok, nil
+	}
+
+	recipients, err := s.recipientsForGroup(ctx, g)
+	if err != nil {
+		return false, errxtrace.Wrap("storage quota reminder: resolve recipients", err)
+	}
+	if len(recipients) == 0 {
+		// No admins to notify — write the row so the worker stops
+		// re-evaluating this (group, threshold) on every tick. The
+		// SentByThreshold counter still reflects "actually-emitted
+		// emails", so we return false here even though a row was
+		// committed: the unreachable-group case shouldn't bump the
+		// reminders_sent counter the operator reads.
+		_, commitErr := s.commitReminderRow(ctx, g, threshold, now)
+		if commitErr != nil {
+			return false, errxtrace.Wrap("storage quota reminder: insert idempotency row (no recipients)", commitErr)
+		}
+		slog.Warn("storage quota reminder: no admin recipients found for group",
+			"group_id", g.ID,
+			"tenant_id", g.TenantID,
+		)
+		return false, nil
+	}
+
+	filesURL := s.buildFilesURL(g.Slug)
+	settingsURL := s.buildSettingsURL(g.Slug)
+	usagePercent := int(float64(usedBytes) * 100 / float64(quotaBytes))
+	usedHuman := formatBytes(usedBytes)
+	quotaHuman := formatBytes(quotaBytes)
+	breakdownLines := buildBreakdownLines(breakdown)
+
+	enqueueErrs := 0
+	var firstEnqueueErr error
+	for _, r := range recipients {
+		sendErr := s.emailSvc.SendStorageQuotaWarningEmail(
+			ctx,
+			r.email, r.name,
+			g.Name,
+			int(threshold), usagePercent,
+			usedHuman, quotaHuman,
+			breakdownLines,
+			filesURL, settingsURL,
+		)
+		if sendErr != nil {
+			enqueueErrs++
+			if firstEnqueueErr == nil {
+				firstEnqueueErr = sendErr
+			}
+			slog.Error("storage quota reminder: enqueue failed",
+				"group_id", g.ID,
+				"to", r.email,
+				"error", sendErr,
+			)
+		}
+	}
+	if enqueueErrs == len(recipients) {
+		// Every recipient enqueue failed. Don't commit the
+		// idempotency row — let the next sweep retry.
+		return false, errxtrace.Wrap("storage quota reminder: all enqueues failed", firstEnqueueErr)
+	}
+	ok, err := s.commitReminderRow(ctx, g, threshold, now)
+	if err != nil {
+		return false, errxtrace.Wrap("storage quota reminder: insert idempotency row", err)
+	}
+	return ok, nil
+}
+
+// commitReminderRow writes the (group, threshold) idempotency row
+// stamped with the sweep's `now`. Returns (true, nil) iff this call
+// won the unique-constraint race; (false, nil) for the loser.
+//
+// The reminder row's CreatedByUserID is the group's CreatedByUserID
+// (an admin from the group lifecycle) — this is for audit only; the
+// row is never user-readable.
+func (s *StorageQuotaReminderService) commitReminderRow(
+	ctx context.Context,
+	g *models.LocationGroup,
+	threshold models.StorageQuotaThreshold,
+	now time.Time,
+) (bool, error) {
+	reminder := models.StorageQuotaReminder{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        g.TenantID,
+			GroupID:         g.ID,
+			CreatedByUserID: g.CreatedBy,
+		},
+		ThresholdPercent: int(threshold),
+		SentAt:           now,
+	}
+	return s.factorySet.StorageQuotaReminderRegistry.CreateOnce(ctx, reminder)
+}
+
+type storageQuotaRecipient struct {
+	email string
+	name  string
+}
+
+// recipientsForGroup returns every admin user that should receive a
+// quota warning for the given group. Falls back to the group's
+// CreatedByUserID when the memberships registry is unwired or
+// returns no admins, so a single-user / pre-#1533 setup still gets a
+// notification.
+func (s *StorageQuotaReminderService) recipientsForGroup(ctx context.Context, g *models.LocationGroup) ([]storageQuotaRecipient, error) {
+	out := make([]storageQuotaRecipient, 0, 4)
+	if s.factorySet.GroupMembershipRegistry != nil {
+		members, err := s.factorySet.GroupMembershipRegistry.ListByGroup(ctx, g.ID)
+		if err != nil {
+			return nil, err
+		}
+		seen := make(map[string]struct{}, len(members))
+		for _, m := range members {
+			if m == nil || m.Role != models.GroupRoleAdmin {
+				continue
+			}
+			user, err := s.factorySet.UserRegistry.Get(ctx, m.MemberUserID)
+			if err != nil {
+				slog.Warn("storage quota reminder: skip member with missing user",
+					"user_id", m.MemberUserID,
+					"group_id", g.ID,
+					"error", err,
+				)
+				continue
+			}
+			if user == nil || strings.TrimSpace(user.Email) == "" {
+				continue
+			}
+			if _, dup := seen[user.Email]; dup {
+				continue
+			}
+			seen[user.Email] = struct{}{}
+			out = append(out, storageQuotaRecipient{email: user.Email, name: user.Name})
+		}
+	}
+
+	if len(out) == 0 && g.CreatedBy != "" {
+		user, err := s.factorySet.UserRegistry.Get(ctx, g.CreatedBy)
+		if err == nil && user != nil && strings.TrimSpace(user.Email) != "" {
+			out = append(out, storageQuotaRecipient{email: user.Email, name: user.Name})
+		}
+	}
+	return out, nil
+}
+
+// quotaBytes returns the configured quota for the group, falling
+// back to DefaultGroupStorageQuotaBytes when no override is wired.
+// Zero or negative means "no quota / disabled" — the worker then
+// treats every tier as if the group were below it.
+func (s *StorageQuotaReminderService) quotaBytes(groupID string) int64 {
+	if s.quotaBytesFor != nil {
+		return s.quotaBytesFor(groupID)
+	}
+	return DefaultGroupStorageQuotaBytes
+}
+
+func (s *StorageQuotaReminderService) buildFilesURL(slug string) string {
+	if s.filesURLBuilder == nil || slug == "" {
+		return ""
+	}
+	return s.filesURLBuilder(slug)
+}
+
+func (s *StorageQuotaReminderService) buildSettingsURL(slug string) string {
+	if s.settingsURLBuilder == nil || slug == "" {
+		return ""
+	}
+	return s.settingsURLBuilder(slug)
+}
+
+// formatBytes renders a byte count as a short human-readable string
+// (e.g. "135 MiB", "1.2 GiB"). Used in the email body so the
+// recipient sees "135 MiB / 150 MiB" rather than raw byte counts.
+// Binary units match the FE storage card.
+func formatBytes(n int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case n >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(n)/float64(gib))
+	case n >= mib:
+		return fmt.Sprintf("%.0f MiB", float64(n)/float64(mib))
+	case n >= kib:
+		return fmt.Sprintf("%.0f KiB", float64(n)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
+// buildBreakdownLines turns a StorageBreakdown into the per-bucket
+// label slice rendered in the email body. Buckets that are
+// zero-sized are dropped — no "Images: 0 B" rows.
+func buildBreakdownLines(b registry.StorageBreakdown) []string {
+	lines := make([]string, 0, 4)
+	if b.Images > 0 {
+		lines = append(lines, fmt.Sprintf("Images: %s", formatBytes(b.Images)))
+	}
+	if b.Documents > 0 {
+		lines = append(lines, fmt.Sprintf("Documents: %s", formatBytes(b.Documents)))
+	}
+	if b.Other > 0 {
+		lines = append(lines, fmt.Sprintf("Other: %s", formatBytes(b.Other)))
+	}
+	if b.Exports > 0 {
+		lines = append(lines, fmt.Sprintf("Export bundles: %s", formatBytes(b.Exports)))
+	}
+	return lines
+}

--- a/go/services/storage_quota_reminder_service_test.go
+++ b/go/services/storage_quota_reminder_service_test.go
@@ -1,0 +1,434 @@
+package services_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// recordingStorageQuotaEmailService captures
+// SendStorageQuotaWarningEmail invocations so tests can assert (a) the
+// number of sends and (b) the (group, threshold, percent) tuple each
+// invocation matched. Every other Send* method is a no-op — the
+// storage quota service only ever calls
+// SendStorageQuotaWarningEmail.
+type recordingStorageQuotaEmailService struct {
+	mu    sync.Mutex
+	calls []recordedStorageQuotaEmail
+}
+
+type recordedStorageQuotaEmail struct {
+	to               string
+	name             string
+	groupName        string
+	thresholdPercent int
+	usagePercent     int
+	usedHuman        string
+	quotaHuman       string
+	breakdownLines   []string
+	filesURL         string
+	settingsURL      string
+}
+
+func (r *recordingStorageQuotaEmailService) SendVerificationEmail(_ context.Context, _ string, _ string, _ string) error {
+	return nil
+}
+
+func (r *recordingStorageQuotaEmailService) SendPasswordResetEmail(_ context.Context, _ string, _ string, _ string) error {
+	return nil
+}
+
+func (r *recordingStorageQuotaEmailService) SendPasswordChangedEmail(_ context.Context, _ string, _ string, _ time.Time) error {
+	return nil
+}
+
+func (r *recordingStorageQuotaEmailService) SendWelcomeEmail(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (r *recordingStorageQuotaEmailService) SendWarrantyReminderEmail(_ context.Context, _, _, _, _, _ string, _ int) error {
+	return nil
+}
+
+func (r *recordingStorageQuotaEmailService) SendGroupInviteEmail(_ context.Context, _, _, _, _, _ string, _ time.Time) error {
+	return nil
+}
+
+func (r *recordingStorageQuotaEmailService) SendStorageQuotaWarningEmail(_ context.Context, to, name, groupName string, thresholdPercent, usagePercent int, usedHuman, quotaHuman string, breakdownLines []string, filesURL, settingsURL string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, recordedStorageQuotaEmail{
+		to:               to,
+		name:             name,
+		groupName:        groupName,
+		thresholdPercent: thresholdPercent,
+		usagePercent:     usagePercent,
+		usedHuman:        usedHuman,
+		quotaHuman:       quotaHuman,
+		breakdownLines:   append([]string(nil), breakdownLines...),
+		filesURL:         filesURL,
+		settingsURL:      settingsURL,
+	})
+	return nil
+}
+
+func (r *recordingStorageQuotaEmailService) snapshot() []recordedStorageQuotaEmail {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedStorageQuotaEmail, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// storageQuotaFixture spins up a fresh memory FactorySet with one
+// user + tenant + group, returning the bits the tests need to set
+// up file bytes and instantiate the service. testQuotaBytes pins
+// the quota tiny so the test doesn't need to stage hundreds of MiB
+// of bytes to cross a 90% threshold.
+type storageQuotaFixture struct {
+	factorySet     *registry.FactorySet
+	tenantID       string
+	userID         string
+	groupID        string
+	groupName      string
+	groupSlug      string
+	testQuotaBytes int64
+	serviceRegSet  *registry.Set
+}
+
+func newStorageQuotaFixture(c *qt.C) *storageQuotaFixture {
+	c.Helper()
+	factorySet := memory.NewFactorySet()
+	const tenantID = "sq-tenant"
+	const testQuotaBytes int64 = 100
+
+	_, err := factorySet.TenantRegistry.Create(context.Background(), models.Tenant{
+		EntityID: models.EntityID{ID: tenantID},
+		Name:     "SQ Tenant",
+		Slug:     "sq-tenant",
+	})
+	c.Assert(err, qt.IsNil)
+
+	user, err := factorySet.UserRegistry.Create(context.Background(), models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Email:               "admin@example.com",
+		Name:                "SQ Admin",
+		IsActive:            true,
+	})
+	c.Assert(err, qt.IsNil)
+
+	group, err := factorySet.LocationGroupRegistry.Create(context.Background(), models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Slug:                must.Must(models.GenerateGroupSlug()),
+		Name:                "SQ Group",
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           user.ID,
+	})
+	c.Assert(err, qt.IsNil)
+
+	return &storageQuotaFixture{
+		factorySet:     factorySet,
+		tenantID:       tenantID,
+		userID:         user.ID,
+		groupID:        group.ID,
+		groupName:      group.Name,
+		groupSlug:      group.Slug,
+		testQuotaBytes: testQuotaBytes,
+		serviceRegSet:  factorySet.CreateServiceRegistrySet(),
+	}
+}
+
+func (f *storageQuotaFixture) addFileBytes(c *qt.C, sizeBytes int64) string {
+	c.Helper()
+	file, err := f.serviceRegSet.FileRegistry.Create(context.Background(), models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        f.tenantID,
+			GroupID:         f.groupID,
+			CreatedByUserID: f.userID,
+		},
+		Title:    "doc",
+		Type:     models.FileTypeDocument,
+		Category: models.FileCategoryDocuments,
+		File: &models.File{
+			Path:         "doc",
+			OriginalPath: "doc.txt",
+			Ext:          ".txt",
+			MIMEType:     "text/plain",
+			SizeBytes:    sizeBytes,
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	return file.ID
+}
+
+func (f *storageQuotaFixture) deleteFile(c *qt.C, id string) {
+	c.Helper()
+	c.Assert(f.serviceRegSet.FileRegistry.Delete(context.Background(), id), qt.IsNil)
+}
+
+func (f *storageQuotaFixture) newService(emailSvc services.EmailService) *services.StorageQuotaReminderService {
+	return services.NewStorageQuotaReminderService(
+		f.factorySet,
+		emailSvc,
+		func(slug string) string { return "https://example.test/g/" + slug + "/files" },
+		func(slug string) string { return "https://example.test/g/" + slug + "/settings" },
+	).WithQuotaBytesFor(func(_ string) int64 { return f.testQuotaBytes })
+}
+
+// TestStorageQuotaReminderService_BelowThreshold_NoEmail pins the
+// trivial path: a group nowhere near the threshold produces no
+// idempotency rows + no emails.
+func TestStorageQuotaReminderService_BelowThreshold_NoEmail(t *testing.T) {
+	c := qt.New(t)
+	f := newStorageQuotaFixture(c)
+	f.addFileBytes(c, 50) // 50/100 = 50% — below the 90% threshold.
+
+	email := &recordingStorageQuotaEmailService{}
+	svc := f.newService(email)
+
+	stats, err := svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.Failed, qt.Equals, 0)
+	c.Assert(stats.Sent(), qt.Equals, 0)
+	c.Assert(email.snapshot(), qt.HasLen, 0)
+
+	has, err := f.factorySet.StorageQuotaReminderRegistry.HasSent(context.Background(), f.groupID, int(models.StorageQuota90Percent))
+	c.Assert(err, qt.IsNil)
+	c.Assert(has, qt.IsFalse)
+}
+
+// TestStorageQuotaReminderService_CrossesThreshold_SendsOnce pins the
+// "89 → 90 sends, 91 → 92 does NOT re-send" half of the acceptance
+// criteria. Idempotency row guarantees the second tick is a no-op
+// even as usage keeps rising past the threshold.
+func TestStorageQuotaReminderService_CrossesThreshold_SendsOnce(t *testing.T) {
+	c := qt.New(t)
+	f := newStorageQuotaFixture(c)
+	f.addFileBytes(c, 90) // 90/100 = 90% exactly — threshold matched.
+
+	email := &recordingStorageQuotaEmailService{}
+	svc := f.newService(email)
+
+	// Tick 1: crosses 90% → one email, one idempotency row.
+	stats, err := svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.Failed, qt.Equals, 0)
+	c.Assert(stats.Sent(), qt.Equals, 1)
+	c.Assert(stats.SentByThreshold[models.StorageQuota90Percent], qt.Equals, 1)
+	calls := email.snapshot()
+	c.Assert(calls, qt.HasLen, 1)
+	c.Assert(calls[0].thresholdPercent, qt.Equals, 90)
+	c.Assert(calls[0].usagePercent, qt.Equals, 90)
+	c.Assert(calls[0].to, qt.Equals, "admin@example.com")
+	c.Assert(calls[0].groupName, qt.Equals, f.groupName)
+	c.Assert(calls[0].filesURL, qt.Contains, f.groupSlug)
+	c.Assert(calls[0].settingsURL, qt.Contains, f.groupSlug)
+
+	// Tick 2: same usage, same threshold → idempotency row blocks the
+	// second emission.
+	stats, err = svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.Sent(), qt.Equals, 0)
+	c.Assert(email.snapshot(), qt.HasLen, 1)
+
+	// Tick 3: usage rises further (91 → 92) — still no resend until
+	// the row is reset.
+	f.addFileBytes(c, 5) // 95/100 = 95%.
+	stats, err = svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.Sent(), qt.Equals, 0)
+	c.Assert(email.snapshot(), qt.HasLen, 1)
+}
+
+// TestStorageQuotaReminderService_DropsBelowThreshold_ResetsRow
+// pins the "90 → 89 should reset" half of the acceptance criteria.
+// Once usage falls back below the threshold the worker deletes the
+// row so a future re-crossing fires a fresh email.
+func TestStorageQuotaReminderService_DropsBelowThreshold_ResetsRow(t *testing.T) {
+	c := qt.New(t)
+	f := newStorageQuotaFixture(c)
+	fileID := f.addFileBytes(c, 90) // start at the threshold.
+
+	email := &recordingStorageQuotaEmailService{}
+	svc := f.newService(email)
+
+	// Tick 1: row + email.
+	_, err := svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	has, err := f.factorySet.StorageQuotaReminderRegistry.HasSent(context.Background(), f.groupID, int(models.StorageQuota90Percent))
+	c.Assert(err, qt.IsNil)
+	c.Assert(has, qt.IsTrue)
+
+	// Drop below threshold by deleting the file.
+	f.deleteFile(c, fileID)
+
+	// Tick 2: ratio == 0 → reset counter ticks, row removed, no extra
+	// email.
+	stats, err := svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.Reset(), qt.Equals, 1)
+	c.Assert(stats.ResetByThreshold[models.StorageQuota90Percent], qt.Equals, 1)
+	c.Assert(stats.Sent(), qt.Equals, 0)
+	has, err = f.factorySet.StorageQuotaReminderRegistry.HasSent(context.Background(), f.groupID, int(models.StorageQuota90Percent))
+	c.Assert(err, qt.IsNil)
+	c.Assert(has, qt.IsFalse)
+	c.Assert(email.snapshot(), qt.HasLen, 1)
+}
+
+// TestStorageQuotaReminderService_ReCrossesAfterReset_SendsSecondEmail
+// pins the full reset → re-cross loop: a group whose usage drops
+// below the threshold then rises back above it must receive a
+// SECOND email, distinct from the first.
+func TestStorageQuotaReminderService_ReCrossesAfterReset_SendsSecondEmail(t *testing.T) {
+	c := qt.New(t)
+	f := newStorageQuotaFixture(c)
+	fileA := f.addFileBytes(c, 90)
+
+	email := &recordingStorageQuotaEmailService{}
+	svc := f.newService(email)
+
+	// Tick 1: first email.
+	_, err := svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(email.snapshot(), qt.HasLen, 1)
+
+	// Drop below threshold.
+	f.deleteFile(c, fileA)
+	_, err = svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(email.snapshot(), qt.HasLen, 1, qt.Commentf("no email expected on the reset tick"))
+
+	// Rise back above threshold — fresh row + fresh email.
+	f.addFileBytes(c, 95)
+	stats, err := svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.Sent(), qt.Equals, 1)
+	c.Assert(email.snapshot(), qt.HasLen, 2)
+}
+
+// TestStorageQuotaReminderService_NoQuota_NoEmail guards the
+// nullable-quota path the plans-aware future relies on: a group with
+// zero quota (e.g. unlimited plan) must never fire a reminder.
+func TestStorageQuotaReminderService_NoQuota_NoEmail(t *testing.T) {
+	c := qt.New(t)
+	f := newStorageQuotaFixture(c)
+	f.addFileBytes(c, 1000) // far above any default quota.
+
+	email := &recordingStorageQuotaEmailService{}
+	svc := services.NewStorageQuotaReminderService(
+		f.factorySet,
+		email,
+		nil, nil,
+	).WithQuotaBytesFor(func(string) int64 { return 0 })
+
+	stats, err := svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.Sent(), qt.Equals, 0)
+	c.Assert(email.snapshot(), qt.HasLen, 0)
+}
+
+// TestStorageQuotaReminderService_EnqueueFailureRetries pins the
+// write-after-send ordering: when every recipient's email enqueue
+// fails (queue down), the idempotency row must NOT be written so
+// the next sweep retries. Mirrors the warranty reminder regression
+// test.
+func TestStorageQuotaReminderService_EnqueueFailureRetries(t *testing.T) {
+	c := qt.New(t)
+	f := newStorageQuotaFixture(c)
+	f.addFileBytes(c, 90)
+
+	failing := &failingEmailService{}
+	svc := f.newService(failing)
+
+	// Tick 1: every enqueue fails → failed counter ticks, no row.
+	stats, err := svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.Failed, qt.Equals, 1)
+	c.Assert(stats.Sent(), qt.Equals, 0)
+	has, err := f.factorySet.StorageQuotaReminderRegistry.HasSent(context.Background(), f.groupID, int(models.StorageQuota90Percent))
+	c.Assert(err, qt.IsNil)
+	c.Assert(has, qt.IsFalse)
+
+	// Tick 2: queue recovers (swap out email service) — fresh sweep,
+	// row committed, exactly one email enqueued.
+	recording := &recordingStorageQuotaEmailService{}
+	svc = f.newService(recording)
+	stats, err = svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.Sent(), qt.Equals, 1)
+	c.Assert(recording.snapshot(), qt.HasLen, 1)
+}
+
+// TestStorageQuotaReminderService_NoRecipients_RowStillCommitted
+// covers the edge case where the group has no admin recipients
+// (no memberships AND no CreatedBy user). The worker must commit the
+// idempotency row anyway so it doesn't repeatedly sweep an
+// unreachable group on every tick.
+func TestStorageQuotaReminderService_NoRecipients_RowStillCommitted(t *testing.T) {
+	c := qt.New(t)
+	factorySet := memory.NewFactorySet()
+	const tenantID = "sq-orphan-tenant"
+	_, err := factorySet.TenantRegistry.Create(context.Background(), models.Tenant{
+		EntityID: models.EntityID{ID: tenantID},
+		Name:     "Orphan",
+		Slug:     "sq-orphan",
+	})
+	c.Assert(err, qt.IsNil)
+	// Group with empty CreatedBy field — the fixture intentionally
+	// skips creating any user / membership rows. Validation requires
+	// a non-empty CreatedBy at Create time, so we generate a UUID
+	// here but never insert the matching User row — the worker's
+	// recipient lookup falls through and out is empty.
+	group, err := factorySet.LocationGroupRegistry.Create(context.Background(), models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Slug:                must.Must(models.GenerateGroupSlug()),
+		Name:                "Orphan Group",
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           "00000000-orphan-user",
+	})
+	c.Assert(err, qt.IsNil)
+
+	serviceRegSet := factorySet.CreateServiceRegistrySet()
+	_, err = serviceRegSet.FileRegistry.Create(context.Background(), models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        tenantID,
+			GroupID:         group.ID,
+			CreatedByUserID: "00000000-orphan-user",
+		},
+		Title:    "doc",
+		Type:     models.FileTypeDocument,
+		Category: models.FileCategoryDocuments,
+		File: &models.File{
+			Path:         "doc",
+			OriginalPath: "doc.txt",
+			Ext:          ".txt",
+			MIMEType:     "text/plain",
+			SizeBytes:    95,
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	email := &recordingStorageQuotaEmailService{}
+	svc := services.NewStorageQuotaReminderService(factorySet, email, nil, nil).
+		WithQuotaBytesFor(func(string) int64 { return 100 })
+
+	stats, err := svc.RemindOnce(context.Background(), time.Now().UTC())
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.Failed, qt.Equals, 0)
+	c.Assert(stats.Sent(), qt.Equals, 0, qt.Commentf("no recipients => no email enqueued"))
+	c.Assert(email.snapshot(), qt.HasLen, 0)
+	// But the row must still be committed so we stop re-evaluating
+	// this (group, threshold) on every tick.
+	has, err := factorySet.StorageQuotaReminderRegistry.HasSent(context.Background(), group.ID, int(models.StorageQuota90Percent))
+	c.Assert(err, qt.IsNil)
+	c.Assert(has, qt.IsTrue)
+}

--- a/go/services/storage_quota_reminder_worker.go
+++ b/go/services/storage_quota_reminder_worker.go
@@ -1,0 +1,183 @@
+package services
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const defaultStorageQuotaReminderInterval = 1 * time.Hour
+
+// Prometheus counters for the storage quota reminder worker.
+// Registered lazily at package init via promauto against the default
+// registry.
+//
+// Labels:
+//   - threshold: "90" — matches StorageQuotaThreshold percentage.
+//
+// Failures + resets stay unlabelled because every event is logged
+// with the threshold tag and slicing by reason is rarely useful —
+// the operator goes to logs once they see the counter tick.
+var (
+	storageQuotaRemindersSentTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_storage_quota_reminders_sent_total",
+		Help: "Number of storage quota warning emails enqueued, partitioned by threshold percent.",
+	}, []string{"threshold"})
+	storageQuotaRemindersResetTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_storage_quota_reminders_reset_total",
+		Help: "Number of storage quota reminder rows wiped because usage dropped back below the threshold.",
+	}, []string{"threshold"})
+	storageQuotaReminderFailuresTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "inventario_storage_quota_reminder_failures_total",
+		Help: "Number of per-group storage quota reminder failures (logged; will be retried next tick).",
+	})
+)
+
+// StorageQuotaReminderWorker periodically runs
+// StorageQuotaReminderService. Mirrors WarrantyReminderWorker —
+// single goroutine driven by a ticker, with a best-effort graceful
+// stop.
+type StorageQuotaReminderWorker struct {
+	service  *StorageQuotaReminderService
+	interval time.Duration
+	clock    func() time.Time
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+// StorageQuotaReminderOption customizes a StorageQuotaReminderWorker.
+type StorageQuotaReminderOption func(*storageQuotaReminderOptions)
+
+type storageQuotaReminderOptions struct {
+	interval time.Duration
+	clock    func() time.Time
+}
+
+// WithStorageQuotaReminderInterval overrides the default tick
+// cadence. Non-positive values are ignored — the configured default
+// is kept.
+func WithStorageQuotaReminderInterval(d time.Duration) StorageQuotaReminderOption {
+	return func(o *storageQuotaReminderOptions) {
+		if d > 0 {
+			o.interval = d
+		}
+	}
+}
+
+// WithStorageQuotaReminderClock overrides the now-source the worker
+// hands to RemindOnce. Used by tests to pin the clock; production
+// passes time.Now indirectly via the default.
+func WithStorageQuotaReminderClock(now func() time.Time) StorageQuotaReminderOption {
+	return func(o *storageQuotaReminderOptions) {
+		if now != nil {
+			o.clock = now
+		}
+	}
+}
+
+// NewStorageQuotaReminderWorker constructs the worker. The default
+// cadence is one hour — quota usage rarely changes faster than that
+// and a shorter cadence risks repeated SUM(size_bytes) queries
+// across every tenant for no behavioural gain.
+func NewStorageQuotaReminderWorker(service *StorageQuotaReminderService, opts ...StorageQuotaReminderOption) *StorageQuotaReminderWorker {
+	options := storageQuotaReminderOptions{
+		interval: defaultStorageQuotaReminderInterval,
+		clock:    time.Now,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return &StorageQuotaReminderWorker{
+		service:  service,
+		interval: options.interval,
+		clock:    options.clock,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start launches the goroutine. No-op if no service is configured.
+func (w *StorageQuotaReminderWorker) Start(ctx context.Context) {
+	if w.service == nil {
+		slog.Warn("StorageQuotaReminderWorker: no service configured, skipping startup")
+		return
+	}
+	w.wg.Go(func() {
+		w.run(ctx)
+	})
+	slog.Info("Storage quota reminder worker started", "interval", w.interval)
+}
+
+// Stop signals the worker and waits for the goroutine to exit.
+func (w *StorageQuotaReminderWorker) Stop() {
+	w.stopOnce.Do(func() {
+		close(w.stopCh)
+	})
+	w.wg.Wait()
+	slog.Info("Storage quota reminder worker stopped")
+}
+
+func (w *StorageQuotaReminderWorker) run(ctx context.Context) {
+	// Run once at startup so the first tick doesn't have to wait the
+	// full interval after a deploy. Same rationale as the warranty
+	// reminder worker.
+	w.tick(ctx)
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			w.tick(ctx)
+		}
+	}
+}
+
+// tick runs a single sweep. The service returns per-threshold stats
+// so the worker can emit one Prometheus series per threshold value.
+func (w *StorageQuotaReminderWorker) tick(ctx context.Context) {
+	stats, err := w.service.RemindOnce(ctx, w.clock())
+	if err != nil {
+		slog.Error("Storage quota reminder sweep failed", "error", err)
+		return
+	}
+	if stats.Failed > 0 {
+		storageQuotaReminderFailuresTotal.Add(float64(stats.Failed))
+	}
+	for threshold, count := range stats.SentByThreshold {
+		if count > 0 {
+			storageQuotaRemindersSentTotal.
+				WithLabelValues(strconv.Itoa(int(threshold))).
+				Add(float64(count))
+		}
+	}
+	for threshold, count := range stats.ResetByThreshold {
+		if count > 0 {
+			storageQuotaRemindersResetTotal.
+				WithLabelValues(strconv.Itoa(int(threshold))).
+				Add(float64(count))
+		}
+	}
+	if total := stats.Sent(); total > 0 || stats.Reset() > 0 {
+		slog.Info("Storage quota reminder sweep completed",
+			"reminders_sent", total,
+			"reminders_reset", stats.Reset(),
+			"failed", stats.Failed,
+		)
+	} else {
+		slog.Debug("Storage quota reminder sweep completed",
+			"reminders_sent", 0,
+			"reminders_reset", 0,
+			"failed", stats.Failed,
+		)
+	}
+}

--- a/go/services/storage_usage_service_test.go
+++ b/go/services/storage_usage_service_test.go
@@ -71,6 +71,10 @@ func (s *stubFileRegistry) ListPendingSizeBackfill(context.Context, int) ([]*mod
 	panic("not implemented")
 }
 
+func (s *stubFileRegistry) SumSizeBreakdownByGroup(context.Context, string, string) (registry.StorageBreakdown, error) {
+	panic("not implemented")
+}
+
 var _ registry.FileRegistry = (*stubFileRegistry)(nil)
 
 func TestStorageUsageService_TotalsAndQuota(t *testing.T) {

--- a/go/services/warranty_reminder_service_test.go
+++ b/go/services/warranty_reminder_service_test.go
@@ -69,6 +69,9 @@ func (r *recordingEmailService) SendWarrantyReminderEmail(_ context.Context, to,
 func (*recordingEmailService) SendGroupInviteEmail(_ context.Context, _, _, _, _, _ string, _ time.Time) error {
 	return nil
 }
+func (*recordingEmailService) SendStorageQuotaWarningEmail(_ context.Context, _, _, _ string, _, _ int, _, _ string, _ []string, _, _ string) error {
+	return nil
+}
 
 func (r *recordingEmailService) snapshot() []recordedWarrantyEmail {
 	r.mu.Lock()
@@ -99,6 +102,9 @@ func (failingEmailService) SendWarrantyReminderEmail(_ context.Context, _ string
 	return errors.New("queue down")
 }
 func (failingEmailService) SendGroupInviteEmail(_ context.Context, _, _, _, _, _ string, _ time.Time) error {
+	return errors.New("queue down")
+}
+func (failingEmailService) SendStorageQuotaWarningEmail(_ context.Context, _, _, _ string, _, _ int, _, _ string, _ []string, _, _ string) error {
 	return errors.New("queue down")
 }
 


### PR DESCRIPTION
Closes #1585.

## Summary

Periodic background worker scans every group's `used / quota` ratio and emails group admins once the 90% tier is crossed. Mirrors the warranty-reminder shape: `(group_id, threshold_percent)` idempotency rows written under the background-worker RLS bypass, **write-after-send** ordering so a queue outage replays on the next sweep, **deletion-on-reset** so a group that drops below the threshold gets a fresh email when it crosses again.

## Backend

| Layer | Change |
|---|---|
| Schema | Migration `1778949444_add_storage_quota_reminders` adds the `storage_quota_reminders` table (RLS isolation policy + `inventario_background_worker` bypass; unique `(group_id, threshold_percent)`; per-tenant index). |
| Model | `models.StorageQuotaReminder` + `StorageQuotaThreshold` enum (only `StorageQuota90Percent = 90` in v1; stored as INTEGER so 80/95 tiers fit later). |
| Registry | New `StorageQuotaReminderRegistry` interface (`HasSent` / `CreateOnce` / `DeleteByGroupThreshold`) with memory + postgres impls; wired into `FactorySet` + `Set` service-mode side. |
| FileRegistry | New `SumSizeBreakdownByGroup(tenant, group)` — service-mode variant of `SumSizeBreakdown` so the worker computes per-group usage without instantiating a request-scoped registry per group. |
| Service | `services.StorageQuotaReminderService` — `RemindOnce(ctx, now)` lists every group, computes ratio, and per threshold either fires a fresh reminder (HasSent → enqueue → CreateOnce) or wipes a prior row (DeleteByGroupThreshold). Returns per-tier `SentByThreshold` + `ResetByThreshold` + `Failed`. |
| Worker | `services.StorageQuotaReminderWorker` runs at startup + every interval. Prometheus: `inventario_storage_quota_reminders_sent_total{threshold}`, `..._reset_total{threshold}`, `..._failures_total`. |
| Email | New template type `storage_quota_warning`, embedded `email_templates/storage_quota_warning.{html,txt}.tmpl`, subject "Your group is approaching its storage quota". `SendStorageQuotaWarningEmail` on the `EmailService` interface, `AsyncEmailService` impl, `StubEmailService` stub. |
| Bootstrap | `StartStorageQuotaReminderWorker` added to the **Housekeeping** worker group in `run/workers` and `run/all`. New `--storage-quota-reminder-interval` flag (env `STORAGE_QUOTA_REMINDER_INTERVAL`), default `1h` via `defaults.GetStorageQuotaReminderInterval()`. |
| GroupPurger | `storage_quota_reminders` joins the FK-safe DELETE sweep alongside `warranty_reminders`. |

## Design notes

- **Per-user notification preferences are not wired in v1.** The reminder targets group admins and is operational rather than promotional; the issue notes prefs as a follow-up. Plumbing `notifications.Service` can land separately without changing the worker's outer shape.
- **Recipient resolution** mirrors the warranty worker: admins from `GroupMembershipRegistry`, fall back to the group's `CreatedBy` if no admins resolve. Viewer-role members are skipped — admins are the people who can act on the warning.
- **Reset on no quota.** If a future plans-aware path returns `quota_bytes = 0` ("unlimited"), every prior reminder row for the group is wiped — equivalent to "below every threshold".
- **The `SentByThreshold` counter only ticks on actually-emitted emails.** When a group has no admin recipients we commit the idempotency row so the worker doesn't re-evaluate every tick, but `SentByThreshold` stays at zero so the Prometheus series matches the email-queue activity an operator sees.

## Tests

- **7 new unit tests** in `services/storage_quota_reminder_service_test.go` cover the AC threshold-crossing semantics:
  - `BelowThreshold_NoEmail` — 50% ratio fires nothing.
  - `CrossesThreshold_SendsOnce` — 90% sends; same/higher usage doesn't re-send.
  - `DropsBelowThreshold_ResetsRow` — going back under wipes the row.
  - `ReCrossesAfterReset_SendsSecondEmail` — reset → re-cross fires a fresh email.
  - `NoQuota_NoEmail` — `quota_bytes = 0` short-circuits to "below every threshold".
  - `EnqueueFailureRetries` — queue down → no row, next sweep retries.
  - `NoRecipients_RowStillCommitted` — group with no admins still gets the idempotency row (no infinite re-eval) but `SentByThreshold` stays at zero.
- Existing test stubs (warranty, auth, async-email-context, storage-usage) gain `SendStorageQuotaWarningEmail` shims so they still satisfy the `EmailService` interface.
- Full Go suite green; `golangci-lint run` clean.

## Out of scope (follow-ups)

- **E2E AC (mailpit cross / reset / recross via docker-compose).** The unit tests cover the reset/recross/idempotency semantics exhaustively. The mailpit e2e needs a per-group quota override env (so the worker doesn't fire on parallel tests' default admin group), which is a Docker Compose change worth its own PR.
- **Per-user notification preferences integration** with `notifications.Service` (issue calls this out as a follow-up once that surface lands).
- **Hard quota enforcement at upload time** — explicitly out of scope per the issue (tied to #1389 plans story).

## Test plan

- [x] `go test ./...` — full Go suite green.
- [x] `golangci-lint run` — clean.
- [ ] Manual: seed a group above 90% usage, run `inventario run workers` with a short `--storage-quota-reminder-interval`, observe the warning email + idempotency row.
- [ ] Manual: drop usage back below 90%, observe the reset log line + row deletion.