### PR TITLE
[#1684] Dashboard hero: K/M/B compact-notation fallback for very large totals

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -338,7 +338,14 @@ _None yet._
 
 ### i18n & Formatting
 
-_None yet._
+#### 2026-05-16 — Dashboard hero: K/M/B compact-notation fallback at ≥1e7
+
+- **Issue/PR**: #1684 / PR (this change)
+- **Mock**: [`design-mocks/src/views/DashboardView.tsx`](../../design-mocks/src/views/DashboardView.tsx) `formatCurrency()` uses `Intl.NumberFormat(..., { maximumFractionDigits: 0 })` only — full digit groups regardless of magnitude. Hard-coded to `en-US` + USD in the mock; doesn't model low-denomination currencies.
+- **Reality**: `frontend/src/lib/intl.ts`'s `formatCurrency` now accepts `notation?: "standard" | "compact"`. `frontend/src/pages/Dashboard.tsx`'s hero call site switches to `notation: "compact"` once `data.totalValue >= 1e7`, otherwise keeps `compact: true` (no cents). So `$329,849` reads the same as it did post-#1678 for a typical group, while a HUF 100,000,000 inventory renders as "HUF 100M" instead of clipping. Per-item / detail / list surfaces never see compact-notation — they keep full precision via the default path.
+- **Why**: PR #1678 dropped cents (`compact: true`), which handles six-figure totals fine but still clips at 8–9 digits — common in HUF / IDR / VND / KRW / IRR. The threshold-based hybrid (#1684 "Option 2") keeps the current production reading for the vast majority of groups and only kicks in at the edges where width pressure is otherwise unsolvable without truncation or a separate font-size hack.
+- **Approved by**: user (explicit) — issue spec walked through the two options and noted Option 2 preserves the current "$329,849" reading; pre-authorized via the goal-message instruction to implement #1684.
+- **Reversion plan**: If a future hero design reflows to give the totals card more horizontal room (full-width hero strip), or if Intl ever ships a "narrow currency" mode that's locale-aware and width-aware, drop the threshold and revert to `compact: true` everywhere on the hero. The `notation` option on `formatCurrency` stays — its existence is orthogonal to whether the dashboard uses it.
 
 ### Tables & Lists
 

--- a/frontend/src/lib/__tests__/intl.test.ts
+++ b/frontend/src/lib/__tests__/intl.test.ts
@@ -33,6 +33,67 @@ describe("formatCurrency", () => {
   it("uses the i18next-resolved locale by default", () => {
     expect(formatCurrency(10, "USD")).toBe("$10.00")
   })
+
+  // `compact: true` drops cents — matches PR #1678's dashboard-hero
+  // pattern. JPY-style zero-fraction currencies stay unchanged because
+  // they already render without cents.
+  it("compact: true drops cents on a six-figure total", () => {
+    expect(formatCurrency(329849.3, "CZK", { locale: "cs-CZ", compact: true })).toMatch(
+      /^329\s?849\sKč$/
+    )
+  })
+
+  // notation: "compact" switches to K/M/B form — the #1684 fix for
+  // low-denomination currencies (HUF / IDR / VND / KRW / IRR / …) where
+  // even cents-dropped totals run to 8–9 chars and still clip the
+  // half-screen stat-card cell. We pin `maximumFractionDigits: 1` so a
+  // non-round magnitude keeps one fractional digit ("$329.8K", "$1.2B")
+  // — Intl's own default, but pinned explicitly to stay stable across
+  // Node / browser versions.
+  it('notation: "compact" renders six-figure USD as $329.8K', () => {
+    expect(formatCurrency(329849, "USD", { locale: "en-US", notation: "compact" })).toBe("$329.8K")
+  })
+
+  it('notation: "compact" renders HUF 100,000,000 as the "HUF 100M" hero form', () => {
+    // en-US locale on HUF renders as "HUF" + NNBSP + "100M". Compare
+    // via regex so the test isn't fragile to which exact whitespace
+    // code-point Intl picks across runtimes — the binding constraint
+    // from #1684 is total *width*, and an 8-glyph string passes.
+    const out = formatCurrency(1e8, "HUF", { locale: "en-US", notation: "compact" })
+    expect(out).toMatch(/^HUF\s100M$/)
+    expect(out.length).toBeLessThanOrEqual(8)
+  })
+
+  it('notation: "compact" surfaces a single fractional digit for non-round magnitudes', () => {
+    // 1.23B fits the stat card; 1,234,567,890 does not. Pinning
+    // maximumFractionDigits: 1 keeps the cache key stable across Node
+    // versions where Intl's compact default has historically wobbled.
+    expect(formatCurrency(1.234e9, "USD", { locale: "en-US", notation: "compact" })).toBe("$1.2B")
+  })
+
+  // notation: "compact" supersedes compact: true — both options were
+  // valid in PR #1678, but Intl's compact form is already integer
+  // (or `.x`) so they don't compose. Document the precedence so a
+  // caller passing both doesn't accidentally re-introduce cents.
+  it('notation: "compact" takes precedence over compact: true', () => {
+    const a = formatCurrency(1e8, "USD", { locale: "en-US", notation: "compact" })
+    const b = formatCurrency(1e8, "USD", {
+      locale: "en-US",
+      notation: "compact",
+      compact: true,
+    })
+    expect(b).toBe(a)
+  })
+
+  // notation: "standard" is the explicit no-op — same output as
+  // omitting the option entirely. Lets callers thread a runtime
+  // decision (`useCompactNotation ? "compact" : "standard"`) without a
+  // second formatCurrency call site.
+  it('notation: "standard" matches the unconfigured default', () => {
+    expect(formatCurrency(329849.3, "USD", { locale: "en-US", notation: "standard" })).toBe(
+      formatCurrency(329849.3, "USD", { locale: "en-US" })
+    )
+  })
 })
 
 describe("formatDate / formatDateTime", () => {

--- a/frontend/src/lib/intl.ts
+++ b/frontend/src/lib/intl.ts
@@ -54,19 +54,38 @@ function getDateFormatter(locale: string, opts: Intl.DateTimeFormatOptions): Int
 // 329,849.30") clips at narrow widths and the cents are noise next to
 // six-figure totals. Detail / print / list surfaces should keep the
 // default (full precision) so per-item prices don't lose their cents.
+//
+// `notation: "compact"` switches to Intl's K/M/B compact form ("$329K",
+// "HUF 100M") — needed for low-denomination currencies (HUF, IDR, VND,
+// KRW, …) where even "no-cents" totals can run to 8–9 digits and still
+// clip the half-screen stat-card cell on mobile (#1684). Use sparingly:
+// the reading changes from a precise figure to a magnitude, so reserve
+// it for hero surfaces where width pressure is the binding constraint.
+// When `notation: "compact"` is set, `compact: true` is moot — Intl's
+// compact form is already integer (or `.x`) per its own rules.
 export function formatCurrency(
   amount: number,
   currency: string,
-  opts: { locale?: string; compact?: boolean } = {}
+  opts: { locale?: string; compact?: boolean; notation?: "standard" | "compact" } = {}
 ): string {
   const locale = opts.locale ?? currentLocale()
+  const isCompactNotation = opts.notation === "compact"
   return getNumberFormatter(locale, {
     style: "currency",
     currency,
     // Most currencies use the ISO-defined fraction digit count; let Intl
     // decide so JPY shows 0 decimals while USD shows 2 — unless the
-    // caller asks for the compact whole-amount form.
-    ...(opts.compact ? { maximumFractionDigits: 0, minimumFractionDigits: 0 } : {}),
+    // caller asks for the compact whole-amount form or compact-notation
+    // K/M/B form.
+    ...(isCompactNotation
+      ? // `1.2M` reads better than `1M` for non-round magnitudes —
+        // matches Intl's own default for `notation: "compact"` but pin
+        // it explicitly so the cache key stays stable across Node /
+        // browser versions that might differ on the unspecified default.
+        { notation: "compact", maximumFractionDigits: 1 }
+      : opts.compact
+        ? { maximumFractionDigits: 0, minimumFractionDigits: 0 }
+        : {}),
   }).format(amount)
 }
 

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -98,6 +98,37 @@ describe("<DashboardPage />", () => {
     expect(rows[2]).toHaveTextContent("Office chair")
   })
 
+  // #1684: low-denomination currencies (HUF / IDR / VND / KRW / IRR / …)
+  // hit 8–9 digit totals routinely and clip the half-screen stat-card
+  // cell even with cents dropped. At ≥1e7 the hero hands off to
+  // `notation: "compact"` so the total reads as K/M/B instead.
+  it("switches the total-value hero to K/M/B compact notation at very large totals", async () => {
+    const hufGroup: Schema<"models.LocationGroup">[] = [
+      { id: "g1", slug: SLUG, name: "Household", group_currency: "HUF" },
+    ]
+    server.use(
+      ...groupHandlers.list(hufGroup),
+      ...commodityHandlers.list(SLUG, []),
+      // 100M HUF — well past the 1e7 threshold. The compact form drops
+      // every grouping comma and renders "HUF 100M" instead of "HUF
+      // 100,000,000" (15 chars, clips on mobile).
+      ...commodityHandlers.values(SLUG, { globalTotal: 1e8 })
+    )
+    renderDashboard()
+    // Wait for the commodities query to resolve (matches the loading
+    // gate the page uses) before asserting on the value cell.
+    await waitFor(() =>
+      expect(screen.getByTestId("dashboard-commodities-count")).toHaveTextContent("0")
+    )
+    // Intl uses a non-breaking space between "HUF" and "100M" — match
+    // via regex so the test isn't fragile to which whitespace
+    // code-point the runtime picks.
+    await waitFor(() =>
+      expect(screen.getByTestId("dashboard-total-value").textContent ?? "").toMatch(/HUF\s100M/)
+    )
+    expect(screen.getByTestId("dashboard-total-value")).not.toHaveTextContent("100,000,000")
+  })
+
   it("links each stat card to its drill-down (commodities or warranties tab)", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -62,9 +62,23 @@ export function DashboardPage() {
   // and run to the edge on desktop. Matches the design-mock
   // `formatCurrency` (maximumFractionDigits: 0). Cents on a six-figure
   // total are noise; the per-item detail pages keep full precision.
+  //
+  // Threshold-based switch to K/M/B notation (#1684): even cents-dropped
+  // totals exceed the half-screen stat-card cell when the currency is
+  // low-denomination (HUF 100,000,000 = 14 chars and still clips). At
+  // 1e7 and above we hand off to `notation: "compact"` so the hero
+  // renders "$329K" / "HUF 100M" / "HUF 1.2B" instead. The threshold
+  // preserves the existing "$329,849" reading for typical totals — only
+  // the long-tail (low-denom currency, very-high-inventory groups)
+  // surface the K/M/B form.
+  const useCompactNotation = data.totalValue >= 1e7
   const formattedValue = data.isLoading
     ? "—"
-    : formatCurrency(data.totalValue, currency, { compact: true })
+    : formatCurrency(
+        data.totalValue,
+        currency,
+        useCompactNotation ? { notation: "compact" } : { compact: true }
+      )
   const activeCount = data.warrantyStatusCounts.active
   const expiringCount = data.warrantyStatusCounts.expiring
   const expiredCount = data.warrantyStatusCounts.expired


### PR DESCRIPTION
Closes #1684.

PR #1678 dropped cents from the hero (`compact: true`), which handles the median six-figure case fine but still clips at 8–9 digits. Low-denomination currencies (HUF / IDR / VND / KRW / IRR / …) hit this routinely:

```
HUF 100,000,000   ← 14 chars, no cents — still clips on mobile (~180px effective per cell)
HUF 1,234,567,890 ← 17 chars — crowds even `lg:grid-cols-4` (~320px effective per cell)
```

This PR implements the issue's **Option 2 — threshold-based hybrid**: keep the current production reading for typical totals, switch to Intl's `notation: "compact"` only at the edges.

## API

`formatCurrency()` (`frontend/src/lib/intl.ts`) now accepts `notation?: "standard" | "compact"`. When `"compact"`, it passes through to `Intl.NumberFormat({ notation: "compact", maximumFractionDigits: 1 })` — `1.2K` / `100M` / `1.2B` form. The 1-digit max is pinned explicitly so the cache key stays stable across Node / browser versions that have historically differed on Intl's unspecified default.

`compact: true` (no-cents) remains; `notation: "compact"` supersedes it (Intl's compact form is already integer-or-`.x` per its own rules).

## Dashboard call site

`frontend/src/pages/Dashboard.tsx` switches based on a threshold:

```ts
const useCompactNotation = data.totalValue >= 1e7
const formattedValue = data.isLoading
  ? "—"
  : formatCurrency(
      data.totalValue,
      currency,
      useCompactNotation ? { notation: "compact" } : { compact: true }
    )
```

- under 1e7 — keeps `compact: true` (post-#1678 reading: `$329,849`)
- at or above 1e7 — switches to `notation: "compact"`: `HUF 100M`, `$1.2B`

Only the hero is affected. Per-item / detail / list / print surfaces never see compact-notation — they keep the default full-precision path.

## Side-effects

- Logged the deviation in `devdocs/frontend/design-deviations.md` under **i18n & Formatting** — the design-mock `formatCurrency` is hard-coded to `maximumFractionDigits: 0` only and doesn't model low-denomination currencies.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test` — 909 passed, 4 pre-existing skipped (was 908 before; one new Dashboard test asserts the HUF-100M threshold path)
- [x] `intl.test.ts` — 6 new cases covering compact-notation rendering (USD/HUF), fraction-digit precision, precedence over `compact: true`, and the `notation: "standard"` no-op