### PR TITLE
[#1385] Keyboard shortcuts cheat-sheet modal (?-driven, registry-backed)

### DIFF
--- a/e2e/tests/keyboard-shortcuts.spec.ts
+++ b/e2e/tests/keyboard-shortcuts.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * E2E for the keyboard-shortcuts cheat-sheet modal (#1385).
+ *
+ * The dialog is mounted by KeyboardShortcutsProvider at the Shell root,
+ * so any authenticated route should expose the global `?` keybinding.
+ * We drive it from `/locations` for parity with the command-palette
+ * spec — the underlying page being mounted is incidental to what we're
+ * asserting (the modal is application-wide chrome).
+ */
+import { test } from '../fixtures/app-fixture.js';
+import { expect } from '@playwright/test';
+import { navigateWithAuth } from './includes/auth.js';
+
+test.describe('Keyboard shortcuts dialog — `?` cheat sheet', () => {
+  test('opens with `?` and closes with Esc', async ({ page, recorder }) => {
+    await navigateWithAuth(page, '/locations', recorder);
+    await expect(page.locator('h1')).toBeVisible();
+
+    // No dialog initially.
+    const dialog = page.locator('[data-testid="keyboard-shortcuts-dialog"]');
+    await expect(dialog).toHaveCount(0);
+
+    // Press `?` (Shift+/) → dialog appears.
+    await page.keyboard.press('Shift+Slash');
+    await expect(dialog).toBeVisible();
+    await recorder.takeScreenshot('keyboard-shortcuts-01-open');
+
+    // Acceptance criterion: the Navigation/Search section is visible.
+    // We ship `search` (Cmd+K), `layout` (Cmd+B), and `help` (?) at MVP;
+    // assert all three section markers + the Cmd+K row are present.
+    await expect(dialog.locator('[data-testid="keyboard-shortcuts-section-search"]')).toBeVisible();
+    await expect(dialog.locator('[data-testid="keyboard-shortcuts-section-layout"]')).toBeVisible();
+    await expect(dialog.locator('[data-testid="keyboard-shortcuts-section-help"]')).toBeVisible();
+    await expect(dialog.locator('[data-testid="keyboard-shortcut-command-palette.open"]')).toBeVisible();
+
+    // Esc closes.
+    await page.keyboard.press('Escape');
+    await expect(dialog).toHaveCount(0);
+  });
+
+  test('filters the list as the user types', async ({ page, recorder }) => {
+    await navigateWithAuth(page, '/locations', recorder);
+    await expect(page.locator('h1')).toBeVisible();
+
+    await page.keyboard.press('Shift+Slash');
+    const dialog = page.locator('[data-testid="keyboard-shortcuts-dialog"]');
+    await expect(dialog).toBeVisible();
+
+    const filter = dialog.locator('[data-testid="keyboard-shortcuts-filter"]');
+    await filter.fill('sidebar');
+    await expect(dialog.locator('[data-testid="keyboard-shortcut-sidebar.toggle"]')).toBeVisible();
+    await expect(dialog.locator('[data-testid="keyboard-shortcut-command-palette.open"]')).toHaveCount(0);
+
+    // A query that matches nothing surfaces the empty state.
+    await filter.fill('zzzzznosuchshortcut');
+    await expect(dialog.locator('[data-testid="keyboard-shortcuts-empty"]')).toBeVisible();
+  });
+
+  test('Settings → Help → Keyboard shortcuts row opens the dialog', async ({ page, recorder }) => {
+    await navigateWithAuth(page, '/settings', recorder);
+    await expect(page.locator('h1')).toBeVisible();
+
+    // SettingsPage uses a section nav. Click the Help nav entry, which
+    // renders the help section (data-testid="section-help") with the
+    // shortcuts row inside it.
+    await page.locator('[data-testid="settings-nav-help"]').click();
+    await expect(page.locator('[data-testid="section-help"]')).toBeVisible();
+
+    await page.locator('[data-testid="help-row-shortcuts"]').click();
+    await expect(page.locator('[data-testid="keyboard-shortcuts-dialog"]')).toBeVisible();
+  });
+});

--- a/frontend/i18next.config.ts
+++ b/frontend/i18next.config.ts
@@ -290,6 +290,16 @@ export default defineConfig({
       //   extractor sees only the template literal; the four titles live in
       //   en/common.json's serverError subtree.
       "common:serverError.*",
+      // common:shortcuts.categories.* — KeyboardShortcutsDialog (#1385)
+      //   resolves each section heading via
+      //   `t(\`common:shortcuts.categories.${category}\`)` over the closed
+      //   ShortcutCategoryKey union (search/navigation/actions/layout/help).
+      // common:shortcuts.entries.* — every ShortcutDef in
+      //   features/shortcuts/registry.ts carries the label as a fully
+      //   qualified key under this subtree; the dialog reads it back via
+      //   `t(entry.labelKey)`, so the extractor sees only the lookup.
+      "common:shortcuts.categories.*",
+      "common:shortcuts.entries.*",
     ],
   },
 })

--- a/frontend/src/app/Shell.tsx
+++ b/frontend/src/app/Shell.tsx
@@ -9,6 +9,7 @@ import { OnboardingTour, TOUR_STEPS } from "@/components/OnboardingTour"
 import { TopBar } from "@/components/TopBar"
 import { Toaster } from "@/components/ui/sonner"
 import { useAuth } from "@/features/auth/AuthContext"
+import { KeyboardShortcutsProvider } from "@/features/shortcuts"
 import { ConfirmProvider } from "@/hooks/useConfirm"
 import { useOnboardingTour } from "@/hooks/useOnboardingTour"
 import { RouteTitleProvider } from "@/components/routing/RouteTitle"
@@ -45,33 +46,35 @@ export function Shell() {
   return (
     <RouteTitleProvider>
       <ConfirmProvider>
-        <SidebarProvider>
-          <AppSidebar onRestartTour={tour.restart} />
-          <SidebarInset>
-            <TopBar />
-            <CurrencyMigrationBanner />
-            {/* count=0 today — once the invites query lands (#1413) it will
-                read from the user's pending-invites list. */}
-            <InviteBanner count={0} />
-            <main className="flex-1 overflow-y-auto">
-              <div className="container mx-auto p-6">
-                <Outlet />
-              </div>
-            </main>
-          </SidebarInset>
-          <CommandPalette />
-          <Toaster />
-          {tour.isOpen ? (
-            <OnboardingTour
-              step={tour.step}
-              totalSteps={TOUR_STEPS.length}
-              onNext={tour.next}
-              onPrev={tour.prev}
-              onFinish={tour.finish}
-              onSkip={tour.skip}
-            />
-          ) : null}
-        </SidebarProvider>
+        <KeyboardShortcutsProvider>
+          <SidebarProvider>
+            <AppSidebar onRestartTour={tour.restart} />
+            <SidebarInset>
+              <TopBar />
+              <CurrencyMigrationBanner />
+              {/* count=0 today — once the invites query lands (#1413) it will
+                  read from the user's pending-invites list. */}
+              <InviteBanner count={0} />
+              <main className="flex-1 overflow-y-auto">
+                <div className="container mx-auto p-6">
+                  <Outlet />
+                </div>
+              </main>
+            </SidebarInset>
+            <CommandPalette />
+            <Toaster />
+            {tour.isOpen ? (
+              <OnboardingTour
+                step={tour.step}
+                totalSteps={TOUR_STEPS.length}
+                onNext={tour.next}
+                onPrev={tour.prev}
+                onFinish={tour.finish}
+                onSkip={tour.skip}
+              />
+            ) : null}
+          </SidebarProvider>
+        </KeyboardShortcutsProvider>
       </ConfirmProvider>
     </RouteTitleProvider>
   )

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -164,7 +164,7 @@ const ExportRestorePage = lazy(() =>
 //     - group-exempt onboarding-friendly routes (mirrors the legacy
 //       GROUP_EXEMPT_ROUTE_NAMES list): no-group, profile, groups/new,
 //       groups/:id/settings, plus the mock-only "coming soon" stubs that
-//       don't need a group (plans, help/shortcuts, whats-new).
+//       don't need a group (plans, help, whats-new).
 //     - group-required routes: / (redirects to /g/<first-slug> or /no-group)
 //       and the entire /g/:groupSlug/* subtree.
 //   - catch-all: NotFoundPage.
@@ -231,7 +231,11 @@ export function AppRoutes() {
               issue, not the destination of these links. */}
           <Route path="/plans" element={<ComingSoonPage surface="plans" />} />
           <Route path="/help" element={<ComingSoonPage surface="helpCenter" />} />
-          <Route path="/help/shortcuts" element={<ComingSoonPage surface="helpShortcuts" />} />
+          {/* Keyboard shortcuts (#1385) is a click-to-open modal owned
+              by Shell.tsx via KeyboardShortcutsProvider, not a routed
+              page — Settings → Help → Keyboard shortcuts opens it
+              directly, and the global `?` keybinding works everywhere
+              the Shell is mounted. */}
           <Route path="/whats-new" element={<ComingSoonPage surface="whatsNew" />} />
           {/* UI Showcase — dev-only design-system reference (#1542). The
               chunk only ships in dev builds; in prod the route is

--- a/frontend/src/components/coming-soon/registry.ts
+++ b/frontend/src/components/coming-soon/registry.ts
@@ -17,7 +17,6 @@ import {
   FileText,
   Files,
   HelpCircle,
-  Keyboard,
   Link2,
   MessageSquare,
   Monitor,
@@ -48,7 +47,6 @@ export const SURFACES = {
   // Page-level stubs (full routes).
   plans: { icon: CreditCard, tracker: 1389, kind: "page" },
   helpCenter: { icon: HelpCircle, tracker: 1384, kind: "page" },
-  helpShortcuts: { icon: Keyboard, tracker: 1385, kind: "page" },
   whatsNew: { icon: Sparkles, tracker: 1386, kind: "page" },
   insuranceReport: { icon: FileText, tracker: 1370, kind: "page" },
 

--- a/frontend/src/features/group/GroupContext.tsx
+++ b/frontend/src/features/group/GroupContext.tsx
@@ -38,7 +38,6 @@ const PATHS_WITH_GROUP_QUERY = new Set([
   "/groups/new",
   "/plans",
   "/help",
-  "/help/shortcuts",
   "/whats-new",
 ])
 

--- a/frontend/src/features/shortcuts/KeyboardShortcutsDialog.tsx
+++ b/frontend/src/features/shortcuts/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useMemo, useState } from "react"
+import { Search } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+
+import {
+  CATEGORY_ORDER,
+  SHORTCUTS,
+  type ShortcutCategoryKey,
+  type ShortcutDef,
+  detectIsMac,
+  formatCombo,
+} from "./registry"
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+// The cheat-sheet modal for issue #1385. Driven entirely by the
+// SHORTCUTS array in registry.ts — no hard-coded list lives here, so a
+// new entry in the registry surfaces automatically. The filter input at
+// the top is a plain substring match against the (translated) action
+// label, the category name, and the literal combo string; press `?`
+// anywhere with no input focused to open the dialog, `Esc` to close.
+export function KeyboardShortcutsDialog({ open, onOpenChange }: KeyboardShortcutsDialogProps) {
+  const { t } = useTranslation()
+  const [filter, setFilter] = useState("")
+  const isMac = useMemo(() => detectIsMac(), [])
+
+  // Reset the filter when the dialog closes so the next open starts
+  // empty. Otherwise the user's last query sits there and silently
+  // narrows the list when they reopen the dialog later.
+  useEffect(() => {
+    // Sync from external open prop → local filter input.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (!open) setFilter("")
+  }, [open])
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase()
+    if (!q) return SHORTCUTS
+    return SHORTCUTS.filter((s) => {
+      const label = t(s.labelKey).toLowerCase()
+      const cat = t(`common:shortcuts.categories.${s.categoryKey}`).toLowerCase()
+      const combo = s.combo.toLowerCase()
+      return label.includes(q) || cat.includes(q) || combo.includes(q)
+    })
+  }, [filter, t])
+
+  const grouped = useMemo(() => {
+    const byCategory = new Map<ShortcutCategoryKey, ShortcutDef[]>()
+    for (const entry of filtered) {
+      const bucket = byCategory.get(entry.categoryKey) ?? []
+      bucket.push(entry)
+      byCategory.set(entry.categoryKey, bucket)
+    }
+    // CATEGORY_ORDER defines display order; categories absent from the
+    // filtered set drop out, anything not listed there falls through
+    // at the end (defensive — every registry entry SHOULD use one of
+    // the declared categories).
+    const orderedKeys: ShortcutCategoryKey[] = [
+      ...CATEGORY_ORDER.filter((k) => byCategory.has(k)),
+      ...Array.from(byCategory.keys()).filter((k) => !CATEGORY_ORDER.includes(k)),
+    ]
+    return orderedKeys.map((key) => [key, byCategory.get(key)!] as const)
+  }, [filtered])
+
+  const trimmedFilter = filter.trim()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl sm:max-w-2xl" data-testid="keyboard-shortcuts-dialog">
+        <DialogHeader>
+          <DialogTitle>{t("common:shortcuts.title")}</DialogTitle>
+          <DialogDescription>{t("common:shortcuts.description")}</DialogDescription>
+        </DialogHeader>
+        <div className="relative">
+          <Search
+            className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            value={filter}
+            onChange={(event) => setFilter(event.target.value)}
+            placeholder={t("common:shortcuts.filterPlaceholder")}
+            aria-label={t("common:shortcuts.filterPlaceholder")}
+            className="pl-9"
+            data-testid="keyboard-shortcuts-filter"
+          />
+        </div>
+        {grouped.length === 0 ? (
+          <p
+            className="py-6 text-center text-sm text-muted-foreground"
+            data-testid="keyboard-shortcuts-empty"
+          >
+            {t("common:shortcuts.empty", { query: trimmedFilter })}
+          </p>
+        ) : (
+          <div className="space-y-6">
+            {grouped.map(([category, items]) => (
+              <section key={category} data-testid={`keyboard-shortcuts-section-${category}`}>
+                <h3 className="mb-2 text-sm font-medium text-muted-foreground">
+                  {t(`common:shortcuts.categories.${category}`)}
+                </h3>
+                <div className="divide-y divide-border rounded-xl border border-border">
+                  {items.map((entry) => (
+                    <ShortcutRow key={entry.id} entry={entry} isMac={isMac} />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface ShortcutRowProps {
+  entry: ShortcutDef
+  isMac: boolean
+}
+
+function ShortcutRow({ entry, isMac }: ShortcutRowProps) {
+  const { t } = useTranslation()
+  const chords = formatCombo(entry.combo, isMac)
+  return (
+    <div
+      className="flex items-center justify-between gap-4 p-3"
+      data-testid={`keyboard-shortcut-${entry.id}`}
+    >
+      <span className="text-sm">{t(entry.labelKey)}</span>
+      <div className="flex items-center gap-2">
+        {chords.map((chord, chordIndex) => (
+          // Chord index is a stable position within the immutable combo
+          // string, so using it as a React key is safe here.
+          <span key={chordIndex} className="flex items-center gap-1">
+            {chord.map((key, keyIndex) => (
+              // Same reasoning — fixed position inside an immutable chord.
+              <span key={keyIndex} className="flex items-center gap-1">
+                <kbd className="rounded-md border border-border bg-muted px-2 py-0.5 font-mono text-xs">
+                  {key}
+                </kbd>
+                {keyIndex < chord.length - 1 ? (
+                  <span className="text-xs text-muted-foreground">+</span>
+                ) : null}
+              </span>
+            ))}
+            {chordIndex < chords.length - 1 ? (
+              <span className="text-xs text-muted-foreground">{t("common:shortcuts.then")}</span>
+            ) : null}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/shortcuts/KeyboardShortcutsProvider.tsx
+++ b/frontend/src/features/shortcuts/KeyboardShortcutsProvider.tsx
@@ -1,0 +1,87 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+
+import { KeyboardShortcutsDialog } from "./KeyboardShortcutsDialog"
+
+interface KeyboardShortcutsContextValue {
+  // True while the cheat-sheet modal is open.
+  open: boolean
+  // Imperative open/close used by Settings → Help → Keyboard shortcuts
+  // (and any future surface that wants a click-to-open button).
+  setOpen: (open: boolean) => void
+  // Convenience toggle wired to the global `?` listener.
+  toggle: () => void
+}
+
+const Context = createContext<KeyboardShortcutsContextValue | undefined>(undefined)
+
+interface KeyboardShortcutsProviderProps {
+  children: ReactNode
+}
+
+// Mounts at the Shell root so every authenticated page can:
+//   1. open the cheat sheet via `?` (Shift + /) — handled here,
+//   2. trigger it imperatively via `useKeyboardShortcutsDialog().setOpen(true)`.
+//
+// The `?` listener follows the same skip-when-typing rule the CommandPalette
+// applies for Cmd+K: if the focused element is an `<input>`, `<textarea>`,
+// `<select>`, or a contenteditable, the keypress is left alone so users can
+// type the literal character into the field.
+export function KeyboardShortcutsProvider({ children }: KeyboardShortcutsProviderProps) {
+  const [open, setOpen] = useState(false)
+
+  const toggle = useCallback(() => setOpen((prev) => !prev), [])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      // We only react to a bare `?`. Modifier-laden combos like Cmd+? or
+      // Shift+Alt+? are intentionally ignored so we don't conflict with
+      // browser/OS shortcuts that include the same physical key.
+      if (event.key !== "?") return
+      if (event.metaKey || event.ctrlKey || event.altKey) return
+      if (isEditableTarget(event.target)) return
+      event.preventDefault()
+      setOpen((prev) => !prev)
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [])
+
+  const value = useMemo<KeyboardShortcutsContextValue>(
+    () => ({ open, setOpen, toggle }),
+    [open, toggle]
+  )
+
+  return (
+    <Context.Provider value={value}>
+      {children}
+      <KeyboardShortcutsDialog open={open} onOpenChange={setOpen} />
+    </Context.Provider>
+  )
+}
+
+// Consumed by any surface that wants to open the cheat sheet
+// imperatively — most importantly the Settings → Help → Keyboard
+// shortcuts row. Throws when called outside the provider so we surface
+// integration bugs early instead of silently no-oping.
+export function useKeyboardShortcutsDialog(): KeyboardShortcutsContextValue {
+  const ctx = useContext(Context)
+  if (!ctx) {
+    throw new Error("useKeyboardShortcutsDialog must be used inside <KeyboardShortcutsProvider>")
+  }
+  return ctx
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.isContentEditable) return true
+  const tag = target.tagName
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT"
+}

--- a/frontend/src/features/shortcuts/__tests__/KeyboardShortcutsDialog.test.tsx
+++ b/frontend/src/features/shortcuts/__tests__/KeyboardShortcutsDialog.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+import { fireEvent, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { KeyboardShortcutsProvider, useKeyboardShortcutsDialog } from "@/features/shortcuts"
+import { renderWithProviders } from "@/test/render"
+
+function OpenButton() {
+  const { setOpen } = useKeyboardShortcutsDialog()
+  return (
+    <button type="button" onClick={() => setOpen(true)}>
+      open
+    </button>
+  )
+}
+
+function harness() {
+  return renderWithProviders({
+    children: (
+      <KeyboardShortcutsProvider>
+        <OpenButton />
+      </KeyboardShortcutsProvider>
+    ),
+  })
+}
+
+describe("<KeyboardShortcutsDialog />", () => {
+  it("opens via the global `?` keybinding and closes on Esc", async () => {
+    harness()
+    expect(screen.queryByTestId("keyboard-shortcuts-dialog")).not.toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: "?" })
+    const dialog = await screen.findByTestId("keyboard-shortcuts-dialog")
+    expect(dialog).toBeVisible()
+
+    // Esc closes the dialog (Radix handles this internally).
+    await userEvent.keyboard("{Escape}")
+    await waitFor(() =>
+      expect(screen.queryByTestId("keyboard-shortcuts-dialog")).not.toBeInTheDocument()
+    )
+  })
+
+  it("opens imperatively via setOpen() — the Settings → Help entry point", async () => {
+    harness()
+    await userEvent.click(screen.getByRole("button", { name: /open/i }))
+    expect(await screen.findByTestId("keyboard-shortcuts-dialog")).toBeVisible()
+  })
+
+  it("skips the `?` binding while typing in an input", () => {
+    const { container } = renderWithProviders({
+      children: (
+        <KeyboardShortcutsProvider>
+          <input data-testid="probe" />
+        </KeyboardShortcutsProvider>
+      ),
+    })
+    const input = within(container).getByTestId("probe")
+    input.focus()
+    fireEvent.keyDown(input, { key: "?", target: input })
+    expect(screen.queryByTestId("keyboard-shortcuts-dialog")).not.toBeInTheDocument()
+  })
+
+  it("ignores `?` when combined with a modifier", () => {
+    harness()
+    fireEvent.keyDown(window, { key: "?", metaKey: true })
+    expect(screen.queryByTestId("keyboard-shortcuts-dialog")).not.toBeInTheDocument()
+    fireEvent.keyDown(window, { key: "?", ctrlKey: true })
+    expect(screen.queryByTestId("keyboard-shortcuts-dialog")).not.toBeInTheDocument()
+  })
+
+  it("renders the Navigation/Search/Help section the cheat sheet ships with", async () => {
+    harness()
+    fireEvent.keyDown(window, { key: "?" })
+    const dialog = await screen.findByTestId("keyboard-shortcuts-dialog")
+    // Categories that contain at least one MVP shortcut appear.
+    expect(within(dialog).getByTestId("keyboard-shortcuts-section-search")).toBeInTheDocument()
+    expect(within(dialog).getByTestId("keyboard-shortcuts-section-layout")).toBeInTheDocument()
+    expect(within(dialog).getByTestId("keyboard-shortcuts-section-help")).toBeInTheDocument()
+    // Every MVP entry has a row.
+    expect(within(dialog).getByTestId("keyboard-shortcut-command-palette.open")).toBeInTheDocument()
+    expect(within(dialog).getByTestId("keyboard-shortcut-sidebar.toggle")).toBeInTheDocument()
+    expect(within(dialog).getByTestId("keyboard-shortcut-shortcuts.show")).toBeInTheDocument()
+  })
+
+  it("filters the list by label substring", async () => {
+    harness()
+    fireEvent.keyDown(window, { key: "?" })
+    const dialog = await screen.findByTestId("keyboard-shortcuts-dialog")
+    const filter = within(dialog).getByTestId("keyboard-shortcuts-filter")
+    await userEvent.type(filter, "sidebar")
+    // Only the sidebar row should remain.
+    expect(within(dialog).getByTestId("keyboard-shortcut-sidebar.toggle")).toBeInTheDocument()
+    expect(
+      within(dialog).queryByTestId("keyboard-shortcut-command-palette.open")
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders an empty state when no shortcut matches the filter", async () => {
+    harness()
+    fireEvent.keyDown(window, { key: "?" })
+    const dialog = await screen.findByTestId("keyboard-shortcuts-dialog")
+    const filter = within(dialog).getByTestId("keyboard-shortcuts-filter")
+    await userEvent.type(filter, "zzzzzznothing")
+    expect(within(dialog).getByTestId("keyboard-shortcuts-empty")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/shortcuts/__tests__/registry.test.ts
+++ b/frontend/src/features/shortcuts/__tests__/registry.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  CATEGORY_ORDER,
+  SHORTCUTS,
+  type ShortcutCategoryKey,
+  formatCombo,
+} from "@/features/shortcuts"
+
+describe("shortcuts/registry", () => {
+  it("contains the three shortcuts the cheat sheet ships with at MVP", () => {
+    const ids = SHORTCUTS.map((s) => s.id)
+    expect(ids).toEqual(["command-palette.open", "sidebar.toggle", "shortcuts.show"])
+  })
+
+  it("guarantees every entry uses a category from CATEGORY_ORDER", () => {
+    const known = new Set<ShortcutCategoryKey>(CATEGORY_ORDER)
+    for (const entry of SHORTCUTS) {
+      expect(known).toContain(entry.categoryKey)
+    }
+  })
+
+  it("uses unique stable ids per entry", () => {
+    const ids = SHORTCUTS.map((s) => s.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  describe("formatCombo", () => {
+    it("renders Mod as ⌘ on Mac", () => {
+      expect(formatCombo("Mod+K", true)).toEqual([["⌘", "K"]])
+    })
+
+    it("renders Mod as Ctrl on non-Mac", () => {
+      expect(formatCombo("Mod+K", false)).toEqual([["Ctrl", "K"]])
+    })
+
+    it("uppercases single-character keys", () => {
+      expect(formatCombo("Mod+b", false)).toEqual([["Ctrl", "B"]])
+    })
+
+    it("leaves long key names alone", () => {
+      expect(formatCombo("Esc", false)).toEqual([["Esc"]])
+    })
+
+    it("splits chord sequences on whitespace", () => {
+      expect(formatCombo("g h", false)).toEqual([["G"], ["H"]])
+    })
+
+    it("renders modifier glyphs differently per platform", () => {
+      expect(formatCombo("Shift+Alt+P", true)).toEqual([["⇧", "⌥", "P"]])
+      expect(formatCombo("Shift+Alt+P", false)).toEqual([["Shift", "Alt", "P"]])
+    })
+
+    it("maps arrow keys to glyphs on both platforms", () => {
+      expect(formatCombo("ArrowUp", false)).toEqual([["↑"]])
+      expect(formatCombo("ArrowDown", true)).toEqual([["↓"]])
+    })
+
+    it("renders a bare '?' as the literal character", () => {
+      expect(formatCombo("?", false)).toEqual([["?"]])
+    })
+  })
+})

--- a/frontend/src/features/shortcuts/index.ts
+++ b/frontend/src/features/shortcuts/index.ts
@@ -1,0 +1,19 @@
+// Public surface for the shortcuts feature (#1385).
+//
+//   - KeyboardShortcutsProvider — mount once at the Shell root; owns the
+//     dialog state and the global `?` keydown listener.
+//   - useKeyboardShortcutsDialog — hook used by Settings (and future
+//     surfaces) to open the cheat sheet imperatively.
+//   - SHORTCUTS / formatCombo / etc. — exported for tests and for any
+//     UI that wants to render the registry inline (e.g. a future
+//     onboarding tour step).
+export { KeyboardShortcutsDialog } from "./KeyboardShortcutsDialog"
+export { KeyboardShortcutsProvider, useKeyboardShortcutsDialog } from "./KeyboardShortcutsProvider"
+export {
+  CATEGORY_ORDER,
+  SHORTCUTS,
+  detectIsMac,
+  formatCombo,
+  type ShortcutCategoryKey,
+  type ShortcutDef,
+} from "./registry"

--- a/frontend/src/features/shortcuts/registry.ts
+++ b/frontend/src/features/shortcuts/registry.ts
@@ -1,0 +1,112 @@
+// Central registry of every keyboard shortcut surfaced by the app.
+// KeyboardShortcutsDialog renders this array — adding a new entry here
+// is the one and only step needed to make a shortcut show up in the
+// cheat sheet (#1385). The actual key listener still lives in whichever
+// component owns the behavior (the registry is a display contract, not
+// a binding mechanism), so the convention is: wire the listener in the
+// component AND add a matching descriptor here.
+//
+// Combo notation:
+//   - "Mod"           → ⌘ on macOS, Ctrl on every other platform.
+//   - "Shift", "Alt", "Meta", "Ctrl" → literal modifiers (rendered with
+//     platform-appropriate glyphs by formatCombo).
+//   - Single-character literals are uppercased ("k" → "K"). Special keys
+//     ("Esc", "Enter", "Tab", "ArrowUp", "/") render as-is or with their
+//     conventional glyph.
+//   - Chord steps are space-separated: `"g h"` means "press G, then H".
+//   - Modifier-and-key chords use `+`: `"Mod+K"`, `"Mod+Shift+P"`.
+
+export type ShortcutCategoryKey = "navigation" | "actions" | "search" | "help" | "layout"
+
+export interface ShortcutDef {
+  // Stable identifier — used as a React key and a test-id hook.
+  id: string
+  // Combo string in the notation above.
+  combo: string
+  // i18n key for the action label (fully namespaced, e.g.
+  // "common:shortcuts.entries.openPalette"). Resolved at render time by
+  // the dialog so platform users see translated copy.
+  labelKey: string
+  // Category bucket used to group entries in the cheat sheet.
+  categoryKey: ShortcutCategoryKey
+}
+
+// The catalog. Ordered roughly by likely-discovery frequency: search
+// surfaces first (Cmd+K is the headline shortcut), then layout, then
+// help. Order within a category controls the row order in the dialog.
+export const SHORTCUTS: readonly ShortcutDef[] = [
+  {
+    id: "command-palette.open",
+    combo: "Mod+K",
+    labelKey: "common:shortcuts.entries.openPalette",
+    categoryKey: "search",
+  },
+  {
+    id: "sidebar.toggle",
+    combo: "Mod+B",
+    labelKey: "common:shortcuts.entries.toggleSidebar",
+    categoryKey: "layout",
+  },
+  {
+    id: "shortcuts.show",
+    combo: "?",
+    labelKey: "common:shortcuts.entries.showShortcuts",
+    categoryKey: "help",
+  },
+] as const
+
+// Category render order is independent of registry-insertion order so
+// the dialog UI is stable when entries get added or reordered.
+export const CATEGORY_ORDER: readonly ShortcutCategoryKey[] = [
+  "search",
+  "navigation",
+  "actions",
+  "layout",
+  "help",
+]
+
+// Detect whether the user is on a Mac-family device. We treat iPad and
+// iPhone the same as desktop macOS for the purposes of glyph rendering
+// even though those platforms don't expose a physical Command key — the
+// underlying assumption is that anyone reading this dialog on a
+// touchscreen is on a hardware keyboard or AssistiveTouch where ⌘ is
+// the intuitive symbol.
+export function detectIsMac(): boolean {
+  if (typeof navigator === "undefined") return false
+  return /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent)
+}
+
+// Split a combo string into chord steps, then each chord into the
+// individual keys it requires. The returned shape is
+// `chord[][]` so the dialog can render multi-step chords like
+// "g h" as two separate `<kbd>` groups joined by a "then" separator.
+export function formatCombo(combo: string, isMac: boolean): string[][] {
+  return combo.split(" ").map((chord) => chord.split("+").map((key) => formatKey(key, isMac)))
+}
+
+function formatKey(key: string, isMac: boolean): string {
+  switch (key) {
+    case "Mod":
+      return isMac ? "⌘" : "Ctrl"
+    case "Shift":
+      return isMac ? "⇧" : "Shift"
+    case "Alt":
+      return isMac ? "⌥" : "Alt"
+    case "Meta":
+      return isMac ? "⌘" : "Meta"
+    case "Ctrl":
+      return isMac ? "⌃" : "Ctrl"
+    case "Enter":
+      return isMac ? "↵" : "Enter"
+    case "ArrowUp":
+      return "↑"
+    case "ArrowDown":
+      return "↓"
+    case "ArrowLeft":
+      return "←"
+    case "ArrowRight":
+      return "→"
+    default:
+      return key.length === 1 ? key.toUpperCase() : key
+  }
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -119,5 +119,24 @@
     "toggleDensity": "Toggle density",
     "toggleTheme": "Toggle theme"
   },
+  "shortcuts": {
+    "categories": {
+      "actions": "Actions",
+      "help": "Help",
+      "layout": "Layout",
+      "navigation": "Navigation",
+      "search": "Search"
+    },
+    "description": "Press a combination to jump around the app. Press ? any time to reopen this list.",
+    "empty": "No shortcuts match \"{{query}}\".",
+    "entries": {
+      "openPalette": "Open command palette",
+      "showShortcuts": "Show keyboard shortcuts",
+      "toggleSidebar": "Toggle sidebar"
+    },
+    "filterPlaceholder": "Filter shortcuts…",
+    "then": "then",
+    "title": "Keyboard shortcuts"
+  },
   "trackedBy": "Tracked by {{ref}}."
 }

--- a/frontend/src/i18n/locales/en/stubs.json
+++ b/frontend/src/i18n/locales/en/stubs.json
@@ -20,7 +20,6 @@
   "groupCreate": "Create group",
   "groupSettings": "Group settings",
   "helpCenter": "Help center",
-  "helpShortcuts": "Keyboard shortcuts",
   "insurance": "Insurance",
   "inviteAccept": "Accept invite",
   "locationDetail": "Location",
@@ -55,10 +54,6 @@
     "helpCenter": {
       "description": "Browse articles and guides for using Inventario.",
       "title": "Help center"
-    },
-    "helpShortcuts": {
-      "description": "View every keyboard shortcut used across the app.",
-      "title": "Keyboard shortcuts"
     },
     "insuranceReport": {
       "description": "Print-ready snapshot of an item's insurance-relevant details.",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -30,6 +30,7 @@ import { Switch } from "@/components/ui/switch"
 import { useAuth } from "@/features/auth/AuthContext"
 import { useLogout, useUpdateProfile } from "@/features/auth/hooks"
 import { useCurrentGroup } from "@/features/group/GroupContext"
+import { useKeyboardShortcutsDialog } from "@/features/shortcuts"
 import {
   SETTING_APPEARANCE_DEFAULT_ITEMS_VIEW,
   SETTING_APPEARANCE_PREFERRED_DISPLAY_CURRENCY,
@@ -821,17 +822,23 @@ function PrivacyRow({ label, description, badge, badgeVariant, to, testId }: Pri
 
 function HelpSection() {
   const { t } = useTranslation()
+  const shortcutsDialog = useKeyboardShortcutsDialog()
 
-  // Five rows: docs (#1384), shortcuts (#1385), what's new (#1386 — with
-  // a marketing v{Major.Minor} badge per design-audit #1536), send
-  // feedback (#1387 — still a ComingSoon stub), contact support
-  // (mailto fallback while a real ticketing surface is scoped). Real
-  // destinations behind each route are ComingSoonPage already; this
-  // section mostly acts as a discovery aid.
+  // Five rows: docs (#1384), shortcuts (#1385 — opens the cheat-sheet
+  // modal in-place), what's new (#1386 — with a marketing v{Major.Minor}
+  // badge per design-audit #1536), send feedback (#1387 — still a
+  // ComingSoon stub), contact support (mailto fallback while a real
+  // ticketing surface is scoped). Real destinations behind each route
+  // are ComingSoonPage already; this section mostly acts as a discovery
+  // aid.
   type HelpRowKey = "documentation" | "shortcuts" | "whatsNew" | "feedback" | "contactSupport"
+  // `href: null` → renders the ComingSoonBanner inline.
+  // `href: "modal:shortcuts"` → renders a click-to-open <button> wired
+  //   to the keyboard-shortcuts dialog. Using a sentinel string keeps
+  //   the row map flat and the renderer easy to follow.
   const rows: Array<{ key: HelpRowKey; href: string | null }> = [
     { key: "documentation", href: "/help" },
-    { key: "shortcuts", href: "/help/shortcuts" },
+    { key: "shortcuts", href: "modal:shortcuts" },
     { key: "whatsNew", href: "/whats-new" },
     { key: "feedback", href: null },
     { key: "contactSupport", href: "mailto:support@inventario.app" },
@@ -851,10 +858,12 @@ function HelpSection() {
               </div>
             )
           }
-          // Two-arm union: external (mailto) or in-app route. Both use the
-          // same chrome — chevron-right + label + description. The
-          // version Badge only renders on the "whatsNew" row.
+          // Three-arm union: modal trigger (in-app dialog), external
+          // (mailto), or in-app route. All three use the same chrome —
+          // chevron-right + label + description. The version Badge only
+          // renders on the "whatsNew" row.
           const labelKey = key
+          const isModal = href.startsWith("modal:")
           const isExternal = href.startsWith("mailto:") || href.startsWith("http")
           const RowInner = (
             <>
@@ -871,6 +880,20 @@ function HelpSection() {
               </p>
             </>
           )
+          if (isModal) {
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => shortcutsDialog.setOpen(true)}
+                data-testid={`help-row-${key}`}
+                className="flex w-full items-center justify-between p-4 text-left transition-colors hover:bg-muted/50"
+              >
+                <div>{RowInner}</div>
+                <ArrowRight className="size-4 text-muted-foreground" aria-hidden="true" />
+              </button>
+            )
+          }
           if (isExternal) {
             return (
               <a

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -8,6 +8,7 @@ import { axe } from "jest-axe"
 import { SettingsPage } from "@/pages/SettingsPage"
 import { AuthProvider } from "@/features/auth/AuthContext"
 import { GroupProvider } from "@/features/group/GroupContext"
+import { KeyboardShortcutsProvider } from "@/features/shortcuts"
 import { ThemeProvider } from "@/components/theme-provider"
 import { DensityProvider } from "@/hooks/useDensity"
 import { ConfirmProvider } from "@/hooks/useConfirm"
@@ -38,7 +39,9 @@ function renderSettings(initialPath: string = "/settings") {
                 <AuthProvider>
                   <GroupProvider>
                     <ConfirmProvider>
-                      <SettingsPage />
+                      <KeyboardShortcutsProvider>
+                        <SettingsPage />
+                      </KeyboardShortcutsProvider>
                     </ConfirmProvider>
                   </GroupProvider>
                 </AuthProvider>
@@ -285,5 +288,19 @@ describe("<SettingsPage />", () => {
     await user.click(await screen.findByTestId("settings-nav-help"))
     expect(screen.getByTestId("help-row-contactSupport")).toBeInTheDocument()
     expect(screen.getByTestId("help-row-whatsNew-badge")).toBeInTheDocument()
+  })
+
+  it("Keyboard shortcuts row opens the cheat-sheet dialog in place (#1385)", async () => {
+    server.use(...baseHandlers)
+    const user = userEvent.setup()
+    renderSettings()
+    await user.click(await screen.findByTestId("settings-nav-help"))
+    const row = screen.getByTestId("help-row-shortcuts")
+    // The row is a click-to-open trigger, not a navigation link — the
+    // dialog handles its own routing-free lifecycle.
+    expect(row.tagName).toBe("BUTTON")
+    expect(screen.queryByTestId("keyboard-shortcuts-dialog")).not.toBeInTheDocument()
+    await user.click(row)
+    expect(await screen.findByTestId("keyboard-shortcuts-dialog")).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

Closes #1385.

- New `features/shortcuts/` feature with a single `SHORTCUTS` registry (combo + i18n labelKey + categoryKey). The cheat-sheet modal renders this array, so adding a new entry there is the only step needed for it to appear in the dialog — no duplicated lists.
- `KeyboardShortcutsDialog` shows grouped sections with a fuzzy filter input, renders combos as `<kbd>` chips with platform-aware glyphs (⌘/Ctrl, ⇧/Shift, ⌥/Alt). Closes with Esc via Radix.
- `KeyboardShortcutsProvider` mounts at the `Shell` root and binds `?` globally, applying the same skip-when-typing rule the `CommandPalette` already uses for Cmd+K (input/textarea/contenteditable focus releases the keypress, no modifier-laden combos).
- Settings → Help → Keyboard shortcuts row is now a click-to-open button instead of the `/help/shortcuts` Coming-Soon link. The placeholder route + ComingSoon registry entry + `stubs.json` keys are dropped.
- i18n: `common:shortcuts.*` keys (including `categories.*` and `entries.*` template-literal patterns) added to `i18next.config.ts` preserve list.

## Acceptance criteria (from #1385)

- [x] `?` key opens the modal globally (except when an input/textarea/contenteditable is focused)
- [x] Reads shortcuts from the central registry — no duplicated list
- [x] Categories + filter
- [x] `Cmd` vs `Ctrl` rendered correctly per OS (also covers `⇧/⌥`)
- [x] Reachable from the Help section in Settings (the user-facing Help surface)
- [x] e2e: hit `?`, modal appears with the navigation/search section visible; close with Esc

## Test plan

- [ ] `npm run typecheck` — passes locally
- [ ] `npm run lint` — passes locally
- [ ] `npm run test` — passes locally (126 files, 921 tests)
- [ ] `npm run build` + `npm run size` — within budgets
- [ ] CI: lint + test + e2e all green
- [ ] Manual: press `?` from any authenticated page; type `sidebar` in the filter; close with Esc; click Settings → Help → Keyboard shortcuts → modal opens