### PR TITLE
[#1680] Pin History timestamps to UTC so they agree with Date added

### DIFF
--- a/frontend/src/features/commodities/CommodityHistoryTimeline.tsx
+++ b/frontend/src/features/commodities/CommodityHistoryTimeline.tsx
@@ -163,9 +163,10 @@ function TimelineRow({ event, areaName }: RowProps) {
   // " UTC" suffix is appended manually because Intl rejects combining
   // `dateStyle`/`timeStyle` with `timeZoneName`, and we want users to
   // realise the time isn't on their wall clock.
-  const occurred = event.occurredAt
-    ? `${formatDateTime(event.occurredAt, { timeZone: "UTC" })} UTC`
-    : ""
+  const occurred = (() => {
+    const formatted = formatDateTime(event.occurredAt, { timeZone: "UTC" })
+    return formatted ? `${formatted} UTC` : ""
+  })()
   return (
     <li className="text-sm" data-testid={`history-row-${event.kind}`}>
       <span className="absolute -ml-[26px] mt-0.5 grid size-5 place-items-center rounded-full bg-background border border-border text-muted-foreground">

--- a/frontend/src/features/commodities/CommodityHistoryTimeline.tsx
+++ b/frontend/src/features/commodities/CommodityHistoryTimeline.tsx
@@ -155,7 +155,17 @@ interface RowProps {
 function TimelineRow({ event, areaName }: RowProps) {
   const { t } = useTranslation()
   const actor = event.actor?.name?.trim() || event.actor?.email?.trim() || ""
-  const occurred = event.occurredAt ? formatDateTime(event.occurredAt) : ""
+  // Pin to UTC so the rendered calendar day agrees with the meta-grid
+  // "Date added" field (`formatDate` UTC-pins YYYY-MM-DD strings like
+  // `registered_date`). Rendering this row's instant in the viewer's
+  // local TZ would let it straddle the UTC midnight boundary and
+  // disagree with the sibling date-only column (issue #1680). The
+  // " UTC" suffix is appended manually because Intl rejects combining
+  // `dateStyle`/`timeStyle` with `timeZoneName`, and we want users to
+  // realise the time isn't on their wall clock.
+  const occurred = event.occurredAt
+    ? `${formatDateTime(event.occurredAt, { timeZone: "UTC" })} UTC`
+    : ""
   return (
     <li className="text-sm" data-testid={`history-row-${event.kind}`}>
       <span className="absolute -ml-[26px] mt-0.5 grid size-5 place-items-center rounded-full bg-background border border-border text-muted-foreground">

--- a/frontend/src/features/commodities/__tests__/CommodityHistoryTimeline.test.tsx
+++ b/frontend/src/features/commodities/__tests__/CommodityHistoryTimeline.test.tsx
@@ -395,6 +395,36 @@ describe("<CommodityHistoryTimeline />", () => {
     expect(await screen.findByTestId("history-error")).toHaveTextContent(/Couldn't load activity/i)
   })
 
+  // Issue #1680: the meta-grid "Date added" field (driven by
+  // `registered_date`, a YYYY-MM-DD string) is UTC-pinned by `formatDate`,
+  // so the History row's "Added this item" timestamp must agree on the
+  // calendar day even when the underlying instant straddles UTC
+  // midnight in the viewer's local TZ. The 00:24 UTC fixture below is
+  // May 15 in every timezone west of UTC; locking both the UTC date and
+  // the "UTC" suffix means a regression that drops the `timeZone` pin
+  // (and silently reintroduces local-TZ rendering) fails this row
+  // regardless of where CI happens to run.
+  it("renders occurred_at pinned to UTC so it agrees with the meta-grid Date added", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.events(SLUG, COMMODITY_ID, [
+        {
+          id: "e1",
+          kind: "created",
+          occurred_at: "2024-05-16T00:24:00Z",
+          after: { name: "Bicycle" },
+          meta: { actor },
+        },
+      ])
+    )
+    renderTimeline()
+    const row = await screen.findByTestId("history-row-created")
+    expect(row).toHaveTextContent(/May 16, 2024/)
+    expect(row).toHaveTextContent(/UTC/)
+    expect(row).not.toHaveTextContent(/May 15, 2024/)
+  })
+
   it("is axe-clean when populated", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),

--- a/frontend/src/lib/__tests__/intl.test.ts
+++ b/frontend/src/lib/__tests__/intl.test.ts
@@ -128,6 +128,24 @@ describe("formatDate / formatDateTime", () => {
     })
     expect(out).toMatch(/Apr 29, 2026/)
   })
+
+  // Issue #1680: when the History timeline renders an instant whose UTC
+  // calendar day differs from the viewer's local one, the row's date
+  // would disagree with the meta-grid "Date added" field that
+  // `formatDate` UTC-pins for YYYY-MM-DD strings. Pinning `formatDateTime`
+  // to UTC makes them line up. The fixture's UTC instant is May 16
+  // (00:24 UTC); in any timezone west of UTC the *local* date is still
+  // May 15, so a missing `timeZone: "UTC"` would render "May 15".
+  it("formatDateTime pins to the requested timeZone", () => {
+    const utc = formatDateTime("2024-05-16T00:24:00Z", {
+      locale: "en-US",
+      timeZone: "UTC",
+    })
+    expect(utc).toMatch(/May 16, 2024/)
+    // Pin the rendered clock to the UTC instant — 12:24 AM, not the
+    // viewer's local time (which would shift the hours by their offset).
+    expect(utc).toMatch(/12:24/)
+  })
 })
 
 describe("formatPartialDate", () => {

--- a/frontend/src/lib/intl.ts
+++ b/frontend/src/lib/intl.ts
@@ -168,10 +168,22 @@ export function formatRelative(value: Date | string, opts: { locale?: string } =
 }
 
 // formatDateTime: same as formatDate but with the time portion. Use when
-// the user needs to see both (e.g. activity log timestamps).
+// the user needs to see both (e.g. activity log timestamps). Pass an
+// explicit `timeZone` (e.g. "UTC") to align the rendered calendar day
+// with a sibling date-only field that was already UTC-pinned by
+// `formatDate` — without it, an instant near UTC midnight straddles the
+// day boundary in the viewer's local TZ and disagrees with a YYYY-MM-DD
+// counterpart (issue #1680). Intl forbids combining `dateStyle`/`timeStyle`
+// with `timeZoneName`, so callers that need a "UTC" suffix should append
+// it themselves rather than asking for it via Intl options.
 export function formatDateTime(
   value: Date | string,
-  opts: { dateStyle?: DateStyle; timeStyle?: DateStyle; locale?: string } = {}
+  opts: {
+    dateStyle?: DateStyle
+    timeStyle?: DateStyle
+    locale?: string
+    timeZone?: string
+  } = {}
 ): string {
   const locale = opts.locale ?? currentLocale()
   const date = value instanceof Date ? value : new Date(value)
@@ -179,6 +191,7 @@ export function formatDateTime(
   return getDateFormatter(locale, {
     dateStyle: opts.dateStyle ?? "medium",
     timeStyle: opts.timeStyle ?? "short",
+    ...(opts.timeZone ? { timeZone: opts.timeZone } : {}),
   }).format(date)
 }
 


### PR DESCRIPTION
Fixes #1680.

## Why

The commodity detail page surfaces the same registration moment in
two places that disagree by one calendar day in non-UTC locales:

- **Date added** (meta grid) renders `registered_date` — a
  `YYYY-MM-DD` string — via `formatDate`, which UTC-pins ISO
  date-only inputs.
- **History → "Added this item"** renders the `created` event's
  `occurred_at` (an instant) via `formatDateTime`, which defaulted
  to the viewer's local timezone.

For an instant near UTC midnight, the two helpers settle on
different calendar days. The issue captured "Date added: 5/16/24"
vs. "Added this item — May 15, 2024, 12:24 PM" on the seeded
Bicycle row.

## What

- `formatDateTime` now accepts an optional `timeZone` so callers
  can pin to UTC (or any tz). `dateStyle` + `timeStyle` cannot be
  combined with `timeZoneName` in `Intl.DateTimeFormat`, so callers
  that want a "UTC" suffix concatenate it themselves.
- `CommodityHistoryTimeline` pins every row's timestamp to UTC and
  appends " UTC" so the displayed clock isn't mistaken for local
  wall-clock time. The calendar day now always agrees with the
  meta-grid "Date added" column.

## Test plan

- [x] `npm test -- intl.test.ts` (new UTC-pinning tests pass)
- [x] `npm test -- CommodityHistoryTimeline.test.tsx` (new
      issue-1680 regression test passes; existing 9 tests unchanged)
- [x] `npm test -- CommodityDetailPage.test.tsx` (21 tests pass)
- [x] `npm run lint`
- [ ] Manual: visit `/g/:slug/commodities/<bicycle-id>` after a
      fresh seed; confirm "Date added" and "Added this item" agree
      on the calendar day and that the History row shows the time
      followed by "UTC".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commodity history timestamps now consistently display in UTC with an explicit "UTC" suffix, preventing date discrepancies across timezones.

* **New Features**
  * Date/time formatting now supports explicit timezone pinning so calendar dates remain consistent when needed.

* **Tests**
  * Added tests verifying UTC timestamp formatting and prevention of timezone-dependent date shifts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->