### PR TITLE
[#1512] listGroupLoans: batch parent-commodity fetch via GetMany

### DIFF
--- a/go/apiserver/commodity_loans.go
+++ b/go/apiserver/commodity_loans.go
@@ -326,29 +326,57 @@ func (api *commodityLoansAPI) listGroupLoans(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	commoditiesByID := make(map[string]*models.Commodity, len(loans))
-	for _, l := range loans {
-		if _, ok := commoditiesByID[l.CommodityID]; ok {
-			continue
-		}
-		c, cerr := regSet.CommodityRegistry.Get(r.Context(), l.CommodityID)
-		// A missing commodity should not break the list — render the
-		// row without the commodity ref. Only surface real errors.
+	// Batch-fetch the parent commodities for every loan on the page in a
+	// single round-trip (issue #1512). Pre-#1512 the loop above did one
+	// Get per unique CommodityID; bounded by per_page (≤50) but still up
+	// to 50 round-trips per page request. The id slice is deduped so
+	// repeated commodity references on the page collapse to a single
+	// IN-list entry, and the GetMany contract drops missing /
+	// RLS-hidden rows silently — the FE renders those rows without the
+	// commodity ref (rather than 500ing) on a cascaded-away commodity.
+	uniqueIDs := uniqueCommodityIDsForLoans(loans)
+	commoditiesByID := make(map[string]*models.Commodity, len(uniqueIDs))
+	if len(uniqueIDs) > 0 {
+		fetched, cerr := regSet.CommodityRegistry.GetMany(r.Context(), uniqueIDs)
 		if cerr != nil {
-			if errors.Is(cerr, registry.ErrNotFound) {
-				commoditiesByID[l.CommodityID] = nil
-				continue
-			}
 			renderEntityError(w, r, cerr)
 			return
 		}
-		commoditiesByID[l.CommodityID] = c
+		for _, c := range fetched {
+			commoditiesByID[c.ID] = c
+		}
 	}
 
 	setPaginationHeaders(w, page, perPage, total)
 	if err := render.Render(w, r, jsonapi.NewCommodityLoanListResponse(loans, total, commoditiesByID)); err != nil {
 		internalServerError(w, r, err)
 	}
+}
+
+// uniqueCommodityIDsForLoans collects each loan's CommodityID once,
+// preserving first-seen order. The order itself is incidental for the
+// downstream IN-list query (GetMany result order is unspecified anyway),
+// but a deterministic walk makes the function easy to reason about in
+// tests and gives stable inputs to the SQL planner across requests with
+// the same shape. Empty / blank ids are dropped — a malformed loan row
+// shouldn't widen the WHERE IN list with a useless "" entry.
+func uniqueCommodityIDsForLoans(loans []*models.CommodityLoan) []string {
+	if len(loans) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(loans))
+	ids := make([]string, 0, len(loans))
+	for _, l := range loans {
+		if l == nil || l.CommodityID == "" {
+			continue
+		}
+		if _, ok := seen[l.CommodityID]; ok {
+			continue
+		}
+		seen[l.CommodityID] = struct{}{}
+		ids = append(ids, l.CommodityID)
+	}
+	return ids
 }
 
 // getGroupLoanCounts returns per-commodity open-loan counts for a list

--- a/go/apiserver/commodity_loans_test.go
+++ b/go/apiserver/commodity_loans_test.go
@@ -1,0 +1,214 @@
+package apiserver_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"github.com/shopspring/decimal"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/jsonapi"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// countingCommodityRegistry decorates a registry.CommodityRegistry with
+// per-instance call counters. Pointer fields keep the same counters
+// shared across every factory-produced registry within a test run, so
+// the handler test can assert "exactly one batched fetch, zero
+// per-loan Gets" across the lifetime of a single HTTP request.
+type countingCommodityRegistry struct {
+	registry.CommodityRegistry
+	getCalls     *atomic.Int64
+	getManyCalls *atomic.Int64
+}
+
+func (r *countingCommodityRegistry) Get(ctx context.Context, id string) (*models.Commodity, error) {
+	r.getCalls.Add(1)
+	return r.CommodityRegistry.Get(ctx, id)
+}
+
+func (r *countingCommodityRegistry) GetMany(ctx context.Context, ids []string) ([]*models.Commodity, error) {
+	r.getManyCalls.Add(1)
+	return r.CommodityRegistry.GetMany(ctx, ids)
+}
+
+// countingCommodityRegistryFactory wraps a registry.CommodityRegistryFactory
+// so every CreateUserRegistry / CreateServiceRegistry call returns a
+// counter-decorated registry. The factory itself is stateless — the
+// counters live on the factory struct, not the per-request registry,
+// because a single HTTP request can ask the factory for multiple
+// registries (one per middleware-injected ctx scope) and the test
+// wants to see the *total* fetch traffic, not the per-instance one.
+type countingCommodityRegistryFactory struct {
+	inner        registry.CommodityRegistryFactory
+	getCalls     *atomic.Int64
+	getManyCalls *atomic.Int64
+}
+
+func (f *countingCommodityRegistryFactory) CreateUserRegistry(ctx context.Context) (registry.CommodityRegistry, error) {
+	inner, err := f.inner.CreateUserRegistry(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &countingCommodityRegistry{
+		CommodityRegistry: inner,
+		getCalls:          f.getCalls,
+		getManyCalls:      f.getManyCalls,
+	}, nil
+}
+
+func (f *countingCommodityRegistryFactory) MustCreateUserRegistry(ctx context.Context) registry.CommodityRegistry {
+	return must.Must(f.CreateUserRegistry(ctx))
+}
+
+func (f *countingCommodityRegistryFactory) CreateServiceRegistry() registry.CommodityRegistry {
+	return &countingCommodityRegistry{
+		CommodityRegistry: f.inner.CreateServiceRegistry(),
+		getCalls:          f.getCalls,
+		getManyCalls:      f.getManyCalls,
+	}
+}
+
+// TestListGroupLoans_BatchedCommodityFetch pins the fix for issue #1512:
+// however many loans the page returns, the handler resolves their parent
+// commodities in a single GetMany round-trip — never a per-row Get loop.
+// Counters are injected via a wrapping CommodityRegistryFactory so the
+// assertion covers whatever path the handler takes (direct registry use,
+// middleware-injected scopes, future internal callers) without coupling
+// to specific call sites.
+func TestListGroupLoans_BatchedCommodityFetch(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+
+	// Wrap the existing CommodityRegistryFactory with a counter. Reaching
+	// past newParams' helper into params.FactorySet is intentional —
+	// using newParams keeps the seed data identical to the rest of the
+	// apiserver tests, and the wrap-after pattern means future newParams
+	// changes don't require touching this test.
+	getCalls := &atomic.Int64{}
+	getManyCalls := &atomic.Int64{}
+	params.FactorySet.CommodityRegistryFactory = &countingCommodityRegistryFactory{
+		inner:        params.FactorySet.CommodityRegistryFactory,
+		getCalls:     getCalls,
+		getManyCalls: getManyCalls,
+	}
+
+	registrySet := getRegistrySetFromParams(params, testUser)
+	areas := must.Must(registrySet.AreaRegistry.List(context.Background()))
+	c.Assert(areas, qt.Not(qt.HasLen), 0, qt.Commentf("seed data did not produce any areas"))
+	area := areas[0]
+
+	// Seed commodities with Count=1: loans are per-instance and the
+	// per-instance guard rejects loan-create on Count>1 (see
+	// EnsureCommodityTrackable in services/commodity_quantity_guard.go).
+	// The default newParams seed has bundle commodities (Count=10/5), so
+	// we add our own single-instance rows. The N+1 fix is independent of
+	// commodity shape; the point of the test is the page-fetch traffic
+	// against /loans.
+	mkCommodity := func(name string) *models.Commodity {
+		return must.Must(registrySet.CommodityRegistry.Create(context.Background(), models.Commodity{
+			Name:                  name,
+			ShortName:             name,
+			AreaID:                area.ID,
+			Status:                models.CommodityStatusInUse,
+			Type:                  models.CommodityTypeElectronics,
+			Count:                 1,
+			OriginalPrice:         must.Must(decimal.NewFromString("100.00")),
+			OriginalPriceCurrency: models.Currency("USD"),
+		}))
+	}
+	// Three commodities so loan creates can succeed independently. The
+	// page will see 3+ loans for ≤3 distinct commodities — the dedup
+	// path in uniqueCommodityIDsForLoans matters, GetMany should still
+	// be one call.
+	commodities := []*models.Commodity{
+		mkCommodity("loanable-1"),
+		mkCommodity("loanable-2"),
+		mkCommodity("loanable-3"),
+	}
+
+	loanBodies := []struct {
+		commodityIdx int
+		borrower     string
+		lentAt       string
+	}{
+		{0, "Alice", "2026-05-01"},
+		{1, "Bob", "2026-05-02"},
+		{2, "Charlie", "2026-05-03"},
+	}
+
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	handler := apiserver.APIServer(params, mockRestoreWorker)
+
+	openedLoans := 0
+	for _, lb := range loanBodies {
+		if lb.commodityIdx >= len(commodities) {
+			continue
+		}
+		commodity := commodities[lb.commodityIdx]
+		body := `{"data":{"type":"commodity_loans","attributes":{"borrower_name":"` + lb.borrower +
+			`","lent_at":"` + lb.lentAt + `"}}}`
+		req := must.Must(http.NewRequest("POST",
+			"/api/v1/g/"+testGroup.Slug+"/commodities/"+commodity.ID+"/loans",
+			bytes.NewBufferString(body)))
+		req.Header.Set("Content-Type", "application/vnd.api+json")
+		addTestUserAuthHeader(req, testUser.ID)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		switch rr.Code {
+		case http.StatusCreated:
+			openedLoans++
+		case http.StatusConflict:
+			// A second loan on a commodity that already has an open
+			// loan is rejected — fine, we just need a few open loans
+			// across multiple commodities, not one per attempt.
+		default:
+			c.Fatalf("unexpected status opening loan: %d body=%s", rr.Code, rr.Body.String())
+		}
+	}
+	c.Assert(openedLoans, qt.Not(qt.Equals), 0, qt.Commentf("expected at least one loan to open against the seed commodities"))
+
+	// Reset the counters right before the SUT call. Loan-create handlers
+	// don't fetch the commodity through CommodityRegistry today, but
+	// snapshotting the counters here means a future change that adds a
+	// commodity Get to the create path won't silently pollute this
+	// assertion.
+	getCalls.Store(0)
+	getManyCalls.Store(0)
+
+	// SUT: GET /loans — the surface this test exists to lock down.
+	req := must.Must(http.NewRequest("GET", "/api/v1/g/"+testGroup.Slug+"/loans", nil))
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK, qt.Commentf("body=%s", rr.Body.String()))
+
+	// Sanity: response actually carries commodity refs, so a passing
+	// "zero fetches" assertion below is real and not a vacuous truth
+	// from an empty page.
+	var listResp jsonapi.CommodityLoanListResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &listResp), qt.IsNil)
+	c.Assert(listResp.Data, qt.Not(qt.HasLen), 0)
+	withCommodityRef := 0
+	for _, item := range listResp.Data {
+		if item.Commodity != nil {
+			withCommodityRef++
+		}
+	}
+	c.Assert(withCommodityRef, qt.Not(qt.Equals), 0, qt.Commentf("response should populate commodity refs from the batched fetch"))
+
+	// The handler must fetch commodities in a single batched call,
+	// regardless of how many loans are on the page or how many
+	// commodities they reference. This is the N+1 fix.
+	c.Assert(getManyCalls.Load(), qt.Equals, int64(1), qt.Commentf("expected exactly one batched commodity fetch, got %d", getManyCalls.Load()))
+	c.Assert(getCalls.Load(), qt.Equals, int64(0), qt.Commentf("expected no per-loan commodity Get calls, got %d", getCalls.Load()))
+}

--- a/go/registry/memory/commodities.go
+++ b/go/registry/memory/commodities.go
@@ -154,6 +154,42 @@ func (r *CommodityRegistry) ListByGroup(_ context.Context, tenantID, groupID str
 	return out, nil
 }
 
+// GetMany returns the commodities matching ids in unspecified order.
+// Missing / RLS-hidden ids are silently dropped — see the interface doc
+// in registry.CommodityRegistry for the full contract. The implementation
+// walks the in-memory map once, lifting ids into a set so duplicate ids
+// in the caller's slice collapse to a single result row.
+func (r *CommodityRegistry) GetMany(_ context.Context, ids []string) ([]*models.Commodity, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	want := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		want[id] = struct{}{}
+	}
+	if len(want) == 0 {
+		return nil, nil
+	}
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	out := make([]*models.Commodity, 0, len(want))
+	for id := range want {
+		item, ok := r.items.Get(id)
+		if !ok || item == nil {
+			continue
+		}
+		if !r.isItemVisible(item) {
+			continue
+		}
+		cp := *item
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
 // List returns all commodities sorted by purchase date in descending order (most recent first).
 // Commodities with a nil purchase date are sorted last.
 func (r *CommodityRegistry) List(ctx context.Context) ([]*models.Commodity, error) {

--- a/go/registry/memory/commodities_test.go
+++ b/go/registry/memory/commodities_test.go
@@ -205,6 +205,141 @@ func TestCommodityRegistry_List_SortedByPurchaseDate(t *testing.T) {
 	c.Assert(commodities[3].PurchaseDate, qt.IsNil)
 }
 
+// TestCommodityRegistry_GetMany_BatchFetch locks the batched primitive
+// added under issue #1512: many ids, one round-trip's worth of work,
+// arbitrary result order, callers responsible for any re-ordering. The
+// memory backend doesn't have round-trips to count, but the contract
+// (set semantics, missing ids dropped, duplicates collapsed) is the
+// same as postgres so both backends share this shape of test.
+func TestCommodityRegistry_GetMany_BatchFetch(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+	user := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "test-user-getmany"},
+			TenantID: "test-tenant-id",
+		},
+		Email: "getmany@example.com",
+		Name:  "GetMany User",
+	}
+	userReg := factorySet.CreateServiceRegistrySet().UserRegistry
+	u, err := userReg.Create(context.Background(), user)
+	c.Assert(err, qt.IsNil)
+
+	ctx := appctx.WithUser(context.Background(), u)
+	registrySet := must.Must(factorySet.CreateUserRegistrySet(ctx))
+
+	location, err := registrySet.LocationRegistry.Create(ctx, models.Location{Name: "Loc"})
+	c.Assert(err, qt.IsNil)
+	area, err := registrySet.AreaRegistry.Create(ctx, models.Area{Name: "Area", LocationID: location.ID})
+	c.Assert(err, qt.IsNil)
+
+	mkCommodity := func(name string) *models.Commodity {
+		created, cerr := registrySet.CommodityRegistry.Create(ctx, models.Commodity{
+			AreaID:    area.ID,
+			Name:      name,
+			ShortName: name,
+			Status:    models.CommodityStatusInUse,
+			Type:      models.CommodityTypeElectronics,
+			Count:     1,
+		})
+		c.Assert(cerr, qt.IsNil)
+		return created
+	}
+	c1 := mkCommodity("alpha")
+	c2 := mkCommodity("beta")
+	c3 := mkCommodity("gamma")
+
+	c.Run("returns requested commodities; order is not the caller's", func(c *qt.C) {
+		got, gerr := registrySet.CommodityRegistry.GetMany(ctx, []string{c2.ID, c1.ID, c3.ID})
+		c.Assert(gerr, qt.IsNil)
+		c.Assert(got, qt.HasLen, 3)
+		byID := map[string]string{}
+		for _, com := range got {
+			byID[com.ID] = com.Name
+		}
+		c.Assert(byID, qt.DeepEquals, map[string]string{
+			c1.ID: "alpha",
+			c2.ID: "beta",
+			c3.ID: "gamma",
+		})
+	})
+
+	c.Run("empty ids returns nil without error", func(c *qt.C) {
+		got, gerr := registrySet.CommodityRegistry.GetMany(ctx, nil)
+		c.Assert(gerr, qt.IsNil)
+		c.Assert(got, qt.IsNil)
+	})
+
+	c.Run("unknown ids are silently dropped", func(c *qt.C) {
+		got, gerr := registrySet.CommodityRegistry.GetMany(ctx, []string{c1.ID, "no-such-id", c3.ID})
+		c.Assert(gerr, qt.IsNil)
+		c.Assert(got, qt.HasLen, 2)
+	})
+
+	c.Run("duplicate ids collapse to one result", func(c *qt.C) {
+		got, gerr := registrySet.CommodityRegistry.GetMany(ctx, []string{c1.ID, c1.ID, c1.ID})
+		c.Assert(gerr, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].ID, qt.Equals, c1.ID)
+	})
+
+	c.Run("empty-string ids are ignored", func(c *qt.C) {
+		got, gerr := registrySet.CommodityRegistry.GetMany(ctx, []string{"", c2.ID, ""})
+		c.Assert(gerr, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].ID, qt.Equals, c2.ID)
+	})
+}
+
+// TestCommodityRegistry_GetMany_GroupScoped pins down that the batched
+// fetch never leaks rows the calling user's group context shouldn't see
+// — the same isItemVisible filter that gates Get applies to GetMany.
+// Without this, a cross-group id passed in the IN-list would silently
+// surface in the result.
+func TestCommodityRegistry_GetMany_GroupScoped(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+
+	makeUser := func(id, email string) *models.User {
+		u, uerr := factorySet.CreateServiceRegistrySet().UserRegistry.Create(context.Background(), models.User{
+			TenantAwareEntityID: models.TenantAwareEntityID{
+				EntityID: models.EntityID{ID: id},
+				TenantID: "test-tenant-id",
+			},
+			Email: email,
+			Name:  email,
+		})
+		c.Assert(uerr, qt.IsNil)
+		return u
+	}
+	uA := makeUser("user-a", "a@example.com")
+	uB := makeUser("user-b", "b@example.com")
+
+	ctxA := appctx.WithUser(context.Background(), uA)
+	ctxB := appctx.WithUser(context.Background(), uB)
+	regA := must.Must(factorySet.CreateUserRegistrySet(ctxA))
+	regB := must.Must(factorySet.CreateUserRegistrySet(ctxB))
+
+	locA, err := regA.LocationRegistry.Create(ctxA, models.Location{Name: "LocA"})
+	c.Assert(err, qt.IsNil)
+	areaA, err := regA.AreaRegistry.Create(ctxA, models.Area{Name: "AreaA", LocationID: locA.ID})
+	c.Assert(err, qt.IsNil)
+	mineA, err := regA.CommodityRegistry.Create(ctxA, models.Commodity{
+		AreaID: areaA.ID, Name: "a-only", ShortName: "ao",
+		Status: models.CommodityStatusInUse, Type: models.CommodityTypeElectronics, Count: 1,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// User B asks for user A's commodity id — must return empty, never
+	// the row.
+	got, gerr := regB.CommodityRegistry.GetMany(ctxB, []string{mineA.ID})
+	c.Assert(gerr, qt.IsNil)
+	c.Assert(got, qt.HasLen, 0)
+}
+
 func getCommodityRegistry(c *qt.C) (*memory.CommodityRegistry, *models.Commodity) {
 	// Create factory set and user
 	factorySet := memory.NewFactorySet()

--- a/go/registry/postgres/commodities.go
+++ b/go/registry/postgres/commodities.go
@@ -164,6 +164,46 @@ func (r *CommodityRegistry) List(ctx context.Context) ([]*models.Commodity, erro
 	return commodities, nil
 }
 
+// GetMany returns the commodities matching ids in unspecified order via a
+// single `WHERE id = ANY($1)` round-trip. Missing / RLS-hidden ids are
+// silently dropped — see the interface doc in registry.CommodityRegistry
+// for the full contract. Empty ids returns (nil, nil) without opening a
+// transaction; duplicate ids collapse server-side so a single commodity is
+// returned once even if its id appears multiple times in the slice. RLS
+// keeps the query group-scoped automatically for user-mode registries.
+func (r *CommodityRegistry) GetMany(ctx context.Context, ids []string) ([]*models.Commodity, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	var commodities []*models.Commodity
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`SELECT * FROM %s WHERE id = ANY($1)`,
+			r.tableNames.Commodities(),
+		)
+		rows, qerr := tx.QueryxContext(ctx, query, ids)
+		if qerr != nil {
+			return errxtrace.Wrap("failed to batch-fetch commodities", qerr)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var commodity models.Commodity
+			if scanErr := rows.StructScan(&commodity); scanErr != nil {
+				return errxtrace.Wrap("failed to scan commodity", scanErr)
+			}
+			cp := commodity
+			commodities = append(commodities, &cp)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to batch-fetch commodities", err)
+	}
+	return commodities, nil
+}
+
 // ListByGroup returns every commodity in (tenant_id, group_id), regardless
 // of draft / status. The currency-migration service (#202) needs the full
 // row set — ListPaginated's default filters would otherwise hide drafts and

--- a/go/registry/postgres/commodities_test.go
+++ b/go/registry/postgres/commodities_test.go
@@ -515,6 +515,68 @@ func TestCommodityRegistry_Delete_UnhappyPath(t *testing.T) {
 	}
 }
 
+// TestCommodityRegistry_GetMany pins the batched primitive added for
+// issue #1512. The handler-level test in apiserver/ asserts that the
+// listGroupLoans path makes exactly one commodity-fetch round-trip — this
+// test locks the registry contract that path depends on: arbitrary
+// result order, missing/cross-scope ids dropped silently, duplicates
+// collapsed, and empty input never opens a transaction.
+func TestCommodityRegistry_GetMany(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := appctx.WithUser(c.Context(), &models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "test-user-id"},
+			TenantID: "test-tenant-id",
+		},
+	})
+
+	location := createTestLocation(c, registrySet)
+	area := createTestArea(c, registrySet, location.GetID())
+	c1 := createTestCommodity(c, registrySet, area.GetID())
+	c2 := createTestCommodity(c, registrySet, area.GetID())
+	c3 := createTestCommodity(c, registrySet, area.GetID())
+
+	c.Run("returns the requested rows; order is unspecified", func(c *qt.C) {
+		got, err := registrySet.CommodityRegistry.GetMany(ctx, []string{c3.ID, c1.ID, c2.ID})
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 3)
+
+		ids := make(map[string]struct{}, len(got))
+		for _, com := range got {
+			ids[com.ID] = struct{}{}
+		}
+		_, ok1 := ids[c1.ID]
+		_, ok2 := ids[c2.ID]
+		_, ok3 := ids[c3.ID]
+		c.Assert(ok1, qt.IsTrue)
+		c.Assert(ok2, qt.IsTrue)
+		c.Assert(ok3, qt.IsTrue)
+	})
+
+	c.Run("empty ids returns nil and skips the round-trip", func(c *qt.C) {
+		got, err := registrySet.CommodityRegistry.GetMany(ctx, nil)
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.IsNil)
+	})
+
+	c.Run("unknown ids are dropped silently", func(c *qt.C) {
+		got, err := registrySet.CommodityRegistry.GetMany(ctx, []string{c1.ID, "00000000-0000-0000-0000-000000000000"})
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].ID, qt.Equals, c1.ID)
+	})
+
+	c.Run("duplicate ids collapse to one result", func(c *qt.C) {
+		got, err := registrySet.CommodityRegistry.GetMany(ctx, []string{c2.ID, c2.ID, c2.ID})
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.HasLen, 1)
+		c.Assert(got[0].ID, qt.Equals, c2.ID)
+	})
+}
+
 func TestCommodityRegistry_Count_HappyPath(t *testing.T) {
 	registrySet, cleanup := setupTestRegistrySet(t)
 	defer cleanup()

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -233,6 +233,19 @@ type CommodityRegistry interface {
 	// context instead.
 	ListByGroup(ctx context.Context, tenantID, groupID string) ([]*models.Commodity, error)
 
+	// GetMany fetches a batch of commodities by id in a single round-trip.
+	// The returned order is unspecified — callers that need positional
+	// alignment with `ids` must build their own id→commodity map. IDs not
+	// present in the caller's RLS-visible scope (cross-tenant rows, deleted
+	// rows) are silently dropped rather than surfacing as errors, since the
+	// FK is ON DELETE CASCADE: a row either still exists in scope, or has
+	// been cascaded away. An empty `ids` slice returns (nil, nil) without
+	// touching the storage layer; duplicate ids in the slice are collapsed
+	// (the result lists each commodity at most once). Backs the batched
+	// commodity fetch in listGroupLoans (issue #1512); the cover-resolver
+	// follow-up (#1451) is expected to reuse the same primitive.
+	GetMany(ctx context.Context, ids []string) ([]*models.Commodity, error)
+
 	// Enhanced search methods
 	// SearchByTags(ctx context.Context, tags []string, operator TagOperator) ([]*models.Commodity, error)
 	// FullTextSearch(ctx context.Context, query string, options ...SearchOption) ([]*models.Commodity, error)


### PR DESCRIPTION
## Summary

Closes #1512.

Replaces the per-loan `commodityReg.Get` loop in `GET /api/v1/g/{slug}/loans` with a single
`CommodityRegistry.GetMany` round-trip. With `per_page` capped at 50, the worst case dropped
from 50 commodity round-trips per page to exactly 1, regardless of how many loans the page
returns.

- Adds `GetMany(ctx, ids) ([]*Commodity, error)` to `registry.CommodityRegistry` with the
  contract documented inline: arbitrary result order (callers map by id), missing /
  RLS-hidden ids dropped silently (matches the FK's `ON DELETE CASCADE`), duplicates
  collapsed, empty input is a no-op.
- Postgres backend: single `SELECT … WHERE id = ANY($1)`. RLS keeps the result
  group-scoped for user-mode registries; the existing primary-key index covers the
  IN-list.
- Memory backend: walks the in-memory map once with a request-id set; same visibility
  filter that gates `Get`.
- Handler: new `uniqueCommodityIDsForLoans` helper dedupes `CommodityID`s before the
  IN-list, so the dedup-pattern stays correct even when several loan rows reference the
  same commodity.
- Cross-ref: the cover-resolver follow-up (#1451) can reuse `GetMany` as the issue notes.

## Test plan

- [x] `go test ./registry/memory/ -run TestCommodityRegistry_GetMany` — registry contract
      (arbitrary order, missing ids dropped, duplicates collapsed, group-scoped).
- [x] `go test ./apiserver/ -run TestListGroupLoans_BatchedCommodityFetch` — handler-level
      counter wrapper asserts exactly **one** `GetMany` call and **zero** `Get` calls per
      `/loans` request, regardless of loan count.
- [x] `go test ./...` (non-postgres) — full backend suite green locally.
- [x] `golangci-lint run ./...`, `qtlint ./...` — clean.
- [ ] Postgres registry tests run in CI (no local DSN configured). The new
      `TestCommodityRegistry_GetMany` covers the postgres backend there.
- [ ] FE `/lent` page renders the same shape (no wire-format change to
      `CommodityLoanListResponse` — same `data[].commodity` envelope).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Commodity loans listing endpoint now optimizes database queries to reduce round-trips, improving response times when fetching group loans.

* **Tests**
  * Added test coverage verifying optimized batch-fetching behavior and preventing future performance regressions in the commodity loans endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->