### PR TITLE
[#1611] Commodity status transitions: capture date / note / sale_price metadata

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -126,6 +126,7 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 - **Why**: BE-driven. `models.Commodity` carries no `status_date` / `status_note` / `sale_price` columns; the Ptah migrations would need to land on the BE before a richer FE can persist the user's input. Building the dialog FE-only would silently drop the captured metadata, which is worse UX than the current confirm flow. Issue #1611 carries the full BE + FE plan and gets the deviation "Resolved: ..." line on merge.
 - **Approved by**: agent-suggested-then-user-confirmed — scoped FE-only by the existing `CommodityDetailPage.tsx` BE-comment ("Adding the metadata is a follow-up that needs BE work first").
 - **Reversion plan**: Resolve when [#1611](https://github.com/denisvmedia/inventario/issues/1611) lands the BE schema columns + FE `StatusTransitionDialog` — the metadata block then surfaces on this card.
+- **Resolved**: 2026-05-17, #1611 — `models.Commodity` now carries `status_date` / `status_note` / `sale_price`; `CommodityDetailPage.tsx` opens `StatusTransitionDialog` for forward transitions and renders the captured metadata rows on the terminal-status info card. Revert clears the three columns so the BE's per-row invariant holds.
 
 #### 2026-05-10 — Commodity grid card purchase-date chip
 

--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -126,7 +126,7 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 - **Why**: BE-driven. `models.Commodity` carries no `status_date` / `status_note` / `sale_price` columns; the Ptah migrations would need to land on the BE before a richer FE can persist the user's input. Building the dialog FE-only would silently drop the captured metadata, which is worse UX than the current confirm flow. Issue #1611 carries the full BE + FE plan and gets the deviation "Resolved: ..." line on merge.
 - **Approved by**: agent-suggested-then-user-confirmed — scoped FE-only by the existing `CommodityDetailPage.tsx` BE-comment ("Adding the metadata is a follow-up that needs BE work first").
 - **Reversion plan**: Resolve when [#1611](https://github.com/denisvmedia/inventario/issues/1611) lands the BE schema columns + FE `StatusTransitionDialog` — the metadata block then surfaces on this card.
-- **Resolved**: 2026-05-17, #1611 — `models.Commodity` now carries `status_date` / `status_note` / `sale_price`; `CommodityDetailPage.tsx` opens `StatusTransitionDialog` for forward transitions and renders the captured metadata rows on the terminal-status info card. Revert clears the three columns so the BE's per-row invariant holds.
+- **Resolved**: 2026-05-17, PR #1727 — back to 1:1.
 
 #### 2026-05-10 — Commodity grid card purchase-date chip
 

--- a/frontend/i18next.config.ts
+++ b/frontend/i18next.config.ts
@@ -154,6 +154,13 @@ export default defineConfig({
       "commodities:detail.filesTab.drop*",
       "commodities:detail.filesTab.empty*",
       "commodities:detail.filesTab.cta*",
+      // commodities:detail.statusTransitionDialog.{description,errors,
+      //   notePlaceholder}.* — StatusTransitionDialog (#1611) builds copy
+      //   via `t(`commodities:detail.statusTransitionDialog.description.${targetStatus}`)`
+      //   over the closed forward-transition set
+      //   (sold/lost/disposed/written_off), plus dynamic error-message
+      //   keys flowing through RHF errors[name].message (zod schemas).
+      "commodities:detail.statusTransitionDialog.*",
       // warranties:list.tab.* — WarrantiesListPage builds tab labels
       //   via `t(\`warranties:list.tab.${s}\`)` over the closed
       //   {all,active,expiring,expired,none} union.

--- a/frontend/src/components/items/StatusTransitionDialog.tsx
+++ b/frontend/src/components/items/StatusTransitionDialog.tsx
@@ -95,7 +95,15 @@ const statusTransitionSchema = z
     // a string; we coerce here. Empty string → undefined so the cross-
     // field refinement can distinguish "not entered" from "entered 0".
     sale_price: z
-      .union([z.literal(""), z.string().regex(/^\d+(\.\d{1,2})?$/, "commodities:detail.statusTransitionDialog.errors.salePriceInvalid")])
+      .union([
+        z.literal(""),
+        z
+          .string()
+          .regex(
+            /^\d+(\.\d{1,2})?$/,
+            "commodities:detail.statusTransitionDialog.errors.salePriceInvalid"
+          ),
+      ])
       .optional(),
     // Carried through from props so the cross-field rule can branch.
     target_status: z.string(),
@@ -272,7 +280,9 @@ export function StatusTransitionDialog({
               id="status-transition-note"
               rows={2}
               className="resize-none"
-              placeholder={t(`commodities:detail.statusTransitionDialog.notePlaceholder.${targetStatus}`)}
+              placeholder={t(
+                `commodities:detail.statusTransitionDialog.notePlaceholder.${targetStatus}`
+              )}
               data-testid="status-transition-note"
               {...register("status_note")}
             />

--- a/frontend/src/components/items/StatusTransitionDialog.tsx
+++ b/frontend/src/components/items/StatusTransitionDialog.tsx
@@ -1,0 +1,308 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import { z } from "zod"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import type { CommodityStatusValue } from "@/features/commodities/constants"
+
+// CURRENCY_SYMBOLS mirrors the mock's `CURRENCIES` lookup. We only need
+// the symbol prefix for the sale-price input adornment; the rest of
+// currency handling (rendering values, conversion) lives in
+// `formatCurrency` / `<CurrencyCombobox>` and is not duplicated here.
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  USD: "$",
+  EUR: "€",
+  GBP: "£",
+  JPY: "¥",
+  CHF: "CHF",
+  CAD: "$",
+  AUD: "$",
+  CZK: "Kč",
+  PLN: "zł",
+  HUF: "Ft",
+  SEK: "kr",
+  NOK: "kr",
+  DKK: "kr",
+  RON: "lei",
+  BGN: "лв",
+  RUB: "₽",
+  UAH: "₴",
+  TRY: "₺",
+  CNY: "¥",
+  INR: "₹",
+  BRL: "R$",
+  MXN: "$",
+  KRW: "₩",
+  IDR: "Rp",
+  VND: "₫",
+  THB: "฿",
+  SGD: "$",
+  HKD: "$",
+  ZAR: "R",
+}
+
+function currencySymbolFor(code: string | undefined): string {
+  if (!code) return "$"
+  return CURRENCY_SYMBOLS[code] ?? code
+}
+
+// todayISO returns the local-date YYYY-MM-DD used as the default
+// status-date. Matches LendDialog.todayISO: the input is `type="date"`,
+// which already speaks local-calendar, so anchoring to local time
+// avoids a one-day shift for users west of UTC.
+function todayISO(): string {
+  const d = new Date()
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}
+
+// statusTransitionSchema validates the dialog payload. `status_date` is
+// always required (the BE enforces the same when leaving in_use, see
+// #1611's apiserver/commodities.go handler). `sale_price` is required
+// AND non-negative when the target is `sold`; the FE drops it from the
+// payload for any other target.
+//
+// Validation messages are i18n keys so the form can render localised
+// errors via `t(form.formState.errors.X.message)` — same pattern used
+// by the loans + auth forms.
+const statusTransitionSchema = z
+  .object({
+    status_date: z
+      .string()
+      .min(1, "commodities:detail.statusTransitionDialog.errors.dateRequired")
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "commodities:detail.statusTransitionDialog.errors.dateInvalid"),
+    status_note: z
+      .string()
+      .max(1024, "commodities:detail.statusTransitionDialog.errors.noteTooLong")
+      .optional()
+      .default(""),
+    // The form uses an `<input type="number">` so the value comes in as
+    // a string; we coerce here. Empty string → undefined so the cross-
+    // field refinement can distinguish "not entered" from "entered 0".
+    sale_price: z
+      .union([z.literal(""), z.string().regex(/^\d+(\.\d{1,2})?$/, "commodities:detail.statusTransitionDialog.errors.salePriceInvalid")])
+      .optional(),
+    // Carried through from props so the cross-field rule can branch.
+    target_status: z.string(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.target_status === "sold") {
+      if (!val.sale_price || val.sale_price === "") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["sale_price"],
+          message: "commodities:detail.statusTransitionDialog.errors.salePriceRequired",
+        })
+      }
+    }
+  })
+
+export type StatusTransitionFormInput = z.input<typeof statusTransitionSchema>
+
+// StatusTransitionPayload is the normalised shape the caller hands to
+// the PATCH wiring. `sale_price` is included only for sold; an empty
+// `status_note` becomes "" (the BE column is `TEXT NOT NULL`-style:
+// empty string is the "no note" sentinel).
+export interface StatusTransitionPayload {
+  status_date: string
+  status_note: string
+  sale_price?: number
+}
+
+export interface StatusTransitionDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Target terminal status the user picked from the action row. */
+  targetStatus: CommodityStatusValue | null
+  /** Item's original purchase currency — drives the sale-price symbol. */
+  purchaseCurrency?: string
+  onSubmit: (payload: StatusTransitionPayload) => Promise<void>
+  isPending?: boolean
+}
+
+export function StatusTransitionDialog({
+  open,
+  onOpenChange,
+  targetStatus,
+  purchaseCurrency,
+  onSubmit,
+  isPending = false,
+}: StatusTransitionDialogProps) {
+  const { t } = useTranslation(["commodities", "common"])
+  const {
+    formState: { errors, isSubmitting },
+    handleSubmit,
+    register,
+    reset,
+    setValue,
+  } = useForm<StatusTransitionFormInput>({
+    resolver: zodResolver(statusTransitionSchema),
+    defaultValues: {
+      status_date: todayISO(),
+      status_note: "",
+      sale_price: "",
+      target_status: targetStatus ?? "",
+    },
+  })
+
+  // Reset on open so a previous confirmation doesn't leave stale text
+  // / sale-price in the form when the user re-opens it later (or picks
+  // a different terminal status from the action row).
+  useEffect(() => {
+    if (open) {
+      reset({
+        status_date: todayISO(),
+        status_note: "",
+        sale_price: "",
+        target_status: targetStatus ?? "",
+      })
+    }
+  }, [open, reset, targetStatus])
+
+  // Keep target_status synced if the parent flips the status while the
+  // dialog is mounted (e.g., user re-picks from the chip row without
+  // closing in between).
+  useEffect(() => {
+    setValue("target_status", targetStatus ?? "")
+  }, [targetStatus, setValue])
+
+  if (!targetStatus) return null
+
+  const statusLabel = t(`commodities:status.${targetStatus}`)
+  const symbol = currencySymbolFor(purchaseCurrency)
+  const isSold = targetStatus === "sold"
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md" data-testid="status-transition-dialog">
+        <DialogHeader>
+          <DialogTitle>
+            {t("commodities:detail.statusTransitionDialog.title", { label: statusLabel })}
+          </DialogTitle>
+          <DialogDescription>
+            {t(`commodities:detail.statusTransitionDialog.description.${targetStatus}`)}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="flex flex-col gap-4"
+          // noValidate: zod owns validation; matches LendDialog so
+          // webkit's HTML5 validator can't block submission on a
+          // partially-typed `<input type="number">` value.
+          noValidate
+          onSubmit={handleSubmit(async (values) => {
+            const payload: StatusTransitionPayload = {
+              status_date: values.status_date,
+              status_note: values.status_note ?? "",
+            }
+            if (isSold && values.sale_price && values.sale_price !== "") {
+              payload.sale_price = Number(values.sale_price)
+            }
+            await onSubmit(payload)
+          })}
+        >
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="status-transition-date">
+              {t("commodities:detail.statusTransitionDialog.dateLabel")}
+            </Label>
+            <Input
+              id="status-transition-date"
+              type="date"
+              data-testid="status-transition-date"
+              {...register("status_date")}
+            />
+            {errors.status_date?.message ? (
+              <p className="text-xs text-destructive" data-testid="status-transition-date-error">
+                {t(errors.status_date.message)}
+              </p>
+            ) : null}
+          </div>
+
+          {isSold ? (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="status-transition-sale-price">
+                {t("commodities:detail.statusTransitionDialog.salePriceLabel")}
+              </Label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                  {symbol}
+                </span>
+                <Input
+                  id="status-transition-sale-price"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  inputMode="decimal"
+                  className="pl-8"
+                  data-testid="status-transition-sale-price"
+                  {...register("sale_price")}
+                />
+              </div>
+              {errors.sale_price?.message ? (
+                <p
+                  className="text-xs text-destructive"
+                  data-testid="status-transition-sale-price-error"
+                >
+                  {t(errors.sale_price.message)}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="status-transition-note">
+              {t("commodities:detail.statusTransitionDialog.noteLabel")}
+            </Label>
+            <Textarea
+              id="status-transition-note"
+              rows={2}
+              className="resize-none"
+              placeholder={t(`commodities:detail.statusTransitionDialog.notePlaceholder.${targetStatus}`)}
+              data-testid="status-transition-note"
+              {...register("status_note")}
+            />
+            {errors.status_note?.message ? (
+              <p className="text-xs text-destructive" data-testid="status-transition-note-error">
+                {t(errors.status_note.message)}
+              </p>
+            ) : null}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting || isPending}
+              data-testid="status-transition-cancel"
+            >
+              {t("common:actions.cancel")}
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSubmitting || isPending}
+              data-testid="status-transition-confirm"
+            >
+              {t("common:actions.confirm")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/items/__tests__/StatusTransitionDialog.test.tsx
+++ b/frontend/src/components/items/__tests__/StatusTransitionDialog.test.tsx
@@ -1,0 +1,120 @@
+import { axe } from "jest-axe"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeAll, describe, expect, it, vi } from "vitest"
+
+import { StatusTransitionDialog } from "@/components/items/StatusTransitionDialog"
+import { initI18n } from "@/i18n"
+
+beforeAll(async () => {
+  await initI18n({ lng: "en" })
+})
+
+describe("<StatusTransitionDialog />", () => {
+  it("submits with the date default + empty note for a non-sold target", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <StatusTransitionDialog
+        open
+        targetStatus="lost"
+        purchaseCurrency="USD"
+        onSubmit={onSubmit}
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByTestId("status-transition-confirm"))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    const call = onSubmit.mock.calls[0]?.[0]
+    expect(call.status_date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(call.status_note).toBe("")
+    expect(call.sale_price).toBeUndefined()
+  })
+
+  it("renders the sale-price field with the purchase currency symbol when target=sold", async () => {
+    render(
+      <StatusTransitionDialog
+        open
+        targetStatus="sold"
+        purchaseCurrency="EUR"
+        onSubmit={vi.fn()}
+        onOpenChange={vi.fn()}
+      />
+    )
+    const priceInput = screen.getByTestId("status-transition-sale-price")
+    expect(priceInput).toBeInTheDocument()
+    // The € symbol prefix is rendered as a sibling span; verify it
+    // appears in the surrounding markup so a currency swap does ripple
+    // through to the input adornment.
+    expect(screen.getByText("€")).toBeInTheDocument()
+  })
+
+  it("blocks submit when sale_price is empty and target=sold", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <StatusTransitionDialog
+        open
+        targetStatus="sold"
+        purchaseCurrency="USD"
+        onSubmit={onSubmit}
+        onOpenChange={vi.fn()}
+      />
+    )
+    await user.click(screen.getByTestId("status-transition-confirm"))
+
+    expect(await screen.findByTestId("status-transition-sale-price-error")).toBeInTheDocument()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it("threads the captured sale_price + note when submitting a sold transition", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(
+      <StatusTransitionDialog
+        open
+        targetStatus="sold"
+        purchaseCurrency="USD"
+        onSubmit={onSubmit}
+        onOpenChange={vi.fn()}
+      />
+    )
+    await user.type(screen.getByTestId("status-transition-sale-price"), "99.5")
+    await user.type(screen.getByTestId("status-transition-note"), "Sold to Bob")
+    await user.click(screen.getByTestId("status-transition-confirm"))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    const call = onSubmit.mock.calls[0]?.[0]
+    expect(call.sale_price).toBe(99.5)
+    expect(call.status_note).toBe("Sold to Bob")
+  })
+
+  it("renders nothing when targetStatus is null", () => {
+    const { container } = render(
+      <StatusTransitionDialog
+        open
+        targetStatus={null}
+        purchaseCurrency="USD"
+        onSubmit={vi.fn()}
+        onOpenChange={vi.fn()}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("is axe-clean while open", async () => {
+    const { baseElement } = render(
+      <StatusTransitionDialog
+        open
+        targetStatus="sold"
+        purchaseCurrency="USD"
+        onSubmit={vi.fn()}
+        onOpenChange={vi.fn()}
+      />
+    )
+    const results = await axe(baseElement)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -134,6 +134,31 @@
       "heading": "Change Status",
       "title": "Mark as {{label}}?"
     },
+    "statusTransitionDialog": {
+      "dateLabel": "Date",
+      "description": {
+        "disposed": "Permanently remove this item from your inventory.",
+        "lost": "Mark this item as lost. You can still revert later.",
+        "sold": "Record the sale of this item, including the proceeds.",
+        "written_off": "Write off this item — usually for insurance or accounting."
+      },
+      "errors": {
+        "dateInvalid": "Please enter a valid date.",
+        "dateRequired": "Date is required.",
+        "noteTooLong": "Note must be 1024 characters or fewer.",
+        "salePriceInvalid": "Please enter a valid amount.",
+        "salePriceRequired": "Sale price is required when marking as sold."
+      },
+      "noteLabel": "Notes (optional)",
+      "notePlaceholder": {
+        "disposed": "Details…",
+        "lost": "Last seen at…",
+        "sold": "Sold to…",
+        "written_off": "Details…"
+      },
+      "salePriceLabel": "Sale Price",
+      "title": "Mark as {{label}}"
+    },
     "tabs": {
       "details": "Details",
       "files": "Files",
@@ -144,7 +169,10 @@
     "terminalStatus": {
       "revert": "Revert to In Use",
       "revertConfirmDescription": "This puts the item back into active use. You can mark it as sold, lost, disposed, or written off again later.",
-      "revertConfirmTitle": "Revert to In Use?"
+      "revertConfirmTitle": "Revert to In Use?",
+      "salePrice": "Sale price: {{value}}",
+      "statusDate": "Date: {{date}}",
+      "statusNote": "{{note}}"
     },
     "warranty": {
       "daysRemaining_one": "{{count}} day remaining",

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -130,9 +130,7 @@
     "sheetDescriptionFallback": "Inspect, edit, or manage files for the selected item.",
     "sheetTitleFallback": "Item details",
     "statusTransition": {
-      "description": "Mark this item as {{label}}? You can revert from the edit dialog later.",
-      "heading": "Change Status",
-      "title": "Mark as {{label}}?"
+      "heading": "Change Status"
     },
     "statusTransitionDialog": {
       "dateLabel": "Date",
@@ -171,8 +169,7 @@
       "revertConfirmDescription": "This puts the item back into active use. You can mark it as sold, lost, disposed, or written off again later.",
       "revertConfirmTitle": "Revert to In Use?",
       "salePrice": "Sale price: {{value}}",
-      "statusDate": "Date: {{date}}",
-      "statusNote": "{{note}}"
+      "statusDate": "Date: {{date}}"
     },
     "warranty": {
       "daysRemaining_one": "{{count}} day remaining",

--- a/frontend/src/pages/commodities/CommodityDetailPage.tsx
+++ b/frontend/src/pages/commodities/CommodityDetailPage.tsx
@@ -45,6 +45,10 @@ import { DropOverlay } from "@/components/files/DropOverlay"
 import { UploadFilesDialog } from "@/components/files/UploadFilesDialog"
 import { useFileDropZone } from "@/components/files/useFileDropZone"
 import { CommodityFormDialog } from "@/components/items/CommodityFormDialog"
+import {
+  StatusTransitionDialog,
+  type StatusTransitionPayload,
+} from "@/components/items/StatusTransitionDialog"
 import { LendTab } from "@/components/loans/LendTab"
 import { ServiceTab } from "@/components/services/ServiceTab"
 import { RouteTitle } from "@/components/routing/RouteTitle"
@@ -200,6 +204,10 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
   // path leaves it empty so the user picks files inside the dialog.
   const [uploadOpen, setUploadOpen] = useState(false)
   const [pendingDropFiles, setPendingDropFiles] = useState<File[]>([])
+  // #1611: forward-transition target gates the StatusTransitionDialog.
+  // Null = dialog closed. Revert keeps the lighter useConfirm path
+  // (no metadata to capture).
+  const [transitionTarget, setTransitionTarget] = useState<CommodityStatusValue | null>(null)
   const dropZone = useFileDropZone({
     onFiles: (files) => {
       setPendingDropFiles(files)
@@ -358,37 +366,58 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
     }
   }
 
-  // CHANGE STATUS quick action: confirm + PATCH the commodity's
-  // `status`. Drives both the forward transitions surfaced inside the
-  // "Change Status" bar (in_use → sold/lost/disposed/written_off) and
-  // the "Revert to In Use" affordance on the terminal-status info
-  // card. The mock's StatusTransitionDialog also captures a
-  // status_date / status_note / sale_price triple, but our BE schema
-  // doesn't carry those fields — we just transition the status and
-  // surface a toast. Adding the metadata is a follow-up that needs
-  // BE work first; the Revert path is FE-only and works against the
-  // current schema.
+  // CHANGE STATUS quick action: drives the row's status transitions.
+  // Forward transitions (in_use → sold/lost/disposed/written_off) open
+  // the StatusTransitionDialog (#1611) so the user can record the
+  // status_date / status_note / sale_price triple the BE persists.
+  // Revert (terminal → in_use) keeps the lighter useConfirm path and
+  // explicitly clears the three metadata fields so the BE's model
+  // validation invariant (status_date NULL when status==in_use,
+  // sale_price NULL when status!=sold) holds on the next write.
   async function handleStatusTransition(next: CommodityStatusValue) {
     if (!commodity) return
-    const isRevert = next === "in_use"
+    if (next !== "in_use") {
+      setTransitionTarget(next)
+      return
+    }
     const ok = await confirm({
-      title: isRevert
-        ? t("commodities:detail.terminalStatus.revertConfirmTitle")
-        : t("commodities:detail.statusTransition.title", {
-            label: t(`commodities:status.${next}`),
-          }),
-      description: isRevert
-        ? t("commodities:detail.terminalStatus.revertConfirmDescription")
-        : t("commodities:detail.statusTransition.description", {
-            label: t(`commodities:status.${next}`),
-          }),
+      title: t("commodities:detail.terminalStatus.revertConfirmTitle"),
+      description: t("commodities:detail.terminalStatus.revertConfirmDescription"),
       confirmLabel: t("common:actions.confirm"),
-      destructive: next === "lost" || next === "written_off",
+      destructive: false,
     })
     if (!ok) return
     try {
-      await update.mutateAsync({ ...commodity, status: next })
+      await update.mutateAsync({
+        ...commodity,
+        status: next,
+        status_date: undefined,
+        status_note: "",
+        sale_price: undefined,
+      })
       toast.success(t("commodities:toast.statusUpdated"))
+    } catch {
+      toast.error(t("commodities:toast.statusUpdateError"))
+    }
+  }
+
+  // handleTransitionConfirm bridges the StatusTransitionDialog's
+  // captured payload to the PATCH wiring. Threads the three new
+  // metadata columns alongside the status flip. `sale_price` is
+  // included by the dialog only for `sold`; for other targets it
+  // stays absent so the BE's per-row invariant holds.
+  async function handleTransitionConfirm(payload: StatusTransitionPayload) {
+    if (!commodity || !transitionTarget) return
+    try {
+      await update.mutateAsync({
+        ...commodity,
+        status: transitionTarget,
+        status_date: payload.status_date,
+        status_note: payload.status_note,
+        sale_price: payload.sale_price,
+      })
+      toast.success(t("commodities:toast.statusUpdated"))
+      setTransitionTarget(null)
     } catch {
       toast.error(t("commodities:toast.statusUpdateError"))
     }
@@ -624,19 +653,13 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
           </div>
         ) : null}
 
-        {/* Terminal-status info card (#1530 item 1) — surfaces the
-            current status alongside a "Revert to In Use" affordance
-            once the commodity has left `in_use`. The mock
-            (`ItemDetail.tsx` 736-762) also carries a transition
-            date / note / sale price; those need BE schema columns
-            (`status_date` / `status_note` / `sale_price` on
-            `models.Commodity`) before we can wire them — building
-            the inputs FE-only would silently drop the captured
-            metadata. Tracked as the StatusTransitionDialog
-            follow-up. The status_pill row above already advertises
-            the current state; this card adds the explanatory
-            "item has changed state" framing + the explicit revert
-            CTA the mock requires. */}
+        {/* Terminal-status info card (#1530 item 1 + #1611) — surfaces
+            the current status, the metadata captured during the
+            transition (date / note / sale_price), and the explicit
+            "Revert to In Use" CTA the mock requires (lines 736-762).
+            Each metadata row gates on its column being set, so rows
+            that pre-date #1611 (NULL metadata) collapse to just the
+            label + Revert pair — the prior shipped behaviour. */}
         {status && status !== "in_use" ? (
           <div
             className={cn(
@@ -656,6 +679,34 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
                 {t(`commodities:status.${status}`)}
               </p>
             </div>
+            {commodity.status_date ? (
+              <p
+                className="text-xs text-muted-foreground"
+                data-testid="commodity-detail-terminal-status-date"
+              >
+                {t("commodities:detail.terminalStatus.statusDate", {
+                  date: formatDate(commodity.status_date),
+                })}
+              </p>
+            ) : null}
+            {commodity.status_note ? (
+              <p
+                className="text-xs text-muted-foreground"
+                data-testid="commodity-detail-terminal-status-note"
+              >
+                {commodity.status_note}
+              </p>
+            ) : null}
+            {commodity.sale_price != null ? (
+              <p
+                className="text-xs text-muted-foreground"
+                data-testid="commodity-detail-terminal-status-sale-price"
+              >
+                {t("commodities:detail.terminalStatus.salePrice", {
+                  value: formatCurrency(Number(commodity.sale_price), purchaseCurrency),
+                })}
+              </p>
+            ) : null}
             <Button
               type="button"
               variant="ghost"
@@ -754,6 +805,17 @@ export function CommodityDetailContent({ id, variant = "page" }: CommodityDetail
         locations={locations.data ?? []}
         defaultCurrency={currency}
         onSubmit={handleSave}
+        isPending={update.isPending}
+      />
+
+      <StatusTransitionDialog
+        open={transitionTarget !== null}
+        onOpenChange={(o) => {
+          if (!o) setTransitionTarget(null)
+        }}
+        targetStatus={transitionTarget}
+        purchaseCurrency={purchaseCurrency}
+        onSubmit={handleTransitionConfirm}
         isPending={update.isPending}
       />
 

--- a/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
@@ -401,6 +401,91 @@ describe("<CommodityDetailPage />", () => {
     await waitFor(() => expect(document.body).not.toHaveAttribute("data-scroll-locked"))
   })
 
+  // #1611 — terminal-status info card surfaces the captured
+  // status_date / status_note / sale_price triple alongside the Revert
+  // CTA. Each row gates on its column being set so pre-#1611 rows with
+  // NULL metadata still render cleanly.
+  it("renders status_date / status_note / sale_price rows when the BE persists the metadata", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.detail(SLUG, ID, {
+        ...commodityFixture,
+        attributes: {
+          ...commodityFixture.attributes,
+          status: "sold",
+          status_date: "2026-05-17",
+          status_note: "Sold to Bob",
+          sale_price: 99.5,
+        },
+      })
+    )
+    renderDetail()
+    await screen.findByTestId("commodity-detail-terminal-status")
+    expect(screen.getByTestId("commodity-detail-terminal-status-date")).toHaveTextContent(
+      /2026/
+    )
+    expect(screen.getByTestId("commodity-detail-terminal-status-note")).toHaveTextContent(
+      "Sold to Bob"
+    )
+    expect(screen.getByTestId("commodity-detail-terminal-status-sale-price")).toHaveTextContent(
+      /\$99\.50/
+    )
+  })
+
+  it("hides the status_date / status_note / sale_price rows when the BE has no metadata", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.detail(SLUG, ID, {
+        ...commodityFixture,
+        attributes: { ...commodityFixture.attributes, status: "sold" },
+      })
+    )
+    renderDetail()
+    await screen.findByTestId("commodity-detail-terminal-status")
+    expect(screen.queryByTestId("commodity-detail-terminal-status-date")).toBeNull()
+    expect(screen.queryByTestId("commodity-detail-terminal-status-note")).toBeNull()
+    expect(screen.queryByTestId("commodity-detail-terminal-status-sale-price")).toBeNull()
+  })
+
+  // #1611 — forward transitions open the StatusTransitionDialog
+  // instead of the legacy useConfirm modal, then thread the captured
+  // status_date / sale_price into the PATCH payload.
+  it("threads sale_price + status_date into the PATCH when marking as sold", async () => {
+    const user = userEvent.setup()
+    let capturedBody: Record<string, unknown> | null = null
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...commodityHandlers.detail(SLUG, ID, commodityFixture),
+      // Inline override to capture the request body — the shared
+      // commodityHandlers.update fixture doesn't expose it.
+      (await import("msw")).http.put(
+        `*/api/v1/g/${encodeURIComponent(SLUG)}/commodities/${encodeURIComponent(ID)}`,
+        async ({ request }) => {
+          const json = (await request.json()) as { data?: { attributes?: Record<string, unknown> } }
+          capturedBody = json.data?.attributes ?? null
+          return (await import("msw")).HttpResponse.json({
+            data: {
+              ...commodityFixture,
+              attributes: { ...commodityFixture.attributes, status: "sold" },
+            },
+          })
+        }
+      )
+    )
+    renderDetail()
+    await user.click(await screen.findByTestId("commodity-detail-transition-sold"))
+    const priceInput = await screen.findByTestId("status-transition-sale-price")
+    await user.type(priceInput, "150")
+    await user.click(screen.getByTestId("status-transition-confirm"))
+    await waitFor(() => expect(capturedBody).not.toBeNull())
+    expect(capturedBody?.status).toBe("sold")
+    expect(capturedBody?.sale_price).toBe(150)
+    expect(String(capturedBody?.status_date ?? "")).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
   it("has no axe violations on a populated detail", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),

--- a/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommodityDetailPage.test.tsx
@@ -422,9 +422,7 @@ describe("<CommodityDetailPage />", () => {
     )
     renderDetail()
     await screen.findByTestId("commodity-detail-terminal-status")
-    expect(screen.getByTestId("commodity-detail-terminal-status-date")).toHaveTextContent(
-      /2026/
-    )
+    expect(screen.getByTestId("commodity-detail-terminal-status-date")).toHaveTextContent(/2026/)
     expect(screen.getByTestId("commodity-detail-terminal-status-note")).toHaveTextContent(
       "Sold to Bob"
     )

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -7695,9 +7695,31 @@ export type components = {
             part_numbers?: string[];
             purchase_date?: string;
             registered_date?: string;
+            /**
+             * @description SalePrice is the realised proceeds for a `sold` transition. NULL
+             *     for any other status. Stored in the commodity's original purchase
+             *     currency — sale-side currency reporting is out of scope for #1611.
+             */
+            sale_price?: number;
             serial_number?: string;
             short_name?: string;
             status?: components["schemas"]["models.CommodityStatus"];
+            /**
+             * @description StatusDate is the day the user reported the commodity's transition
+             *     out of `in_use`. Captured by the FE `StatusTransitionDialog` (issue
+             *     #1611) and surfaced on the terminal-status info card. PDate is a
+             *     day-precision string — the mock uses `<input type="date">` so we
+             *     don't need sub-day granularity. NULL while `status = in_use` or
+             *     for terminal rows that pre-date this column.
+             */
+            status_date?: string;
+            /**
+             * @description StatusNote is the free-form note recorded alongside a status
+             *     transition (e.g. "Sold to Bob" / "Last seen at the airport"). NULL
+             *     for `in_use` rows and pre-existing terminal rows. Bounded by the
+             *     same 1024-char ceiling we use for Comments to keep the BE/UI sane.
+             */
+            status_note?: string;
             tags?: string[];
             type?: components["schemas"]["models.CommodityType"];
             urls?: string;

--- a/go/apiserver/commodities.go
+++ b/go/apiserver/commodities.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	"github.com/jellydator/validation"
+	"github.com/shopspring/decimal"
 
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/internal/validationctx"
@@ -405,6 +406,32 @@ func (api *commoditiesAPI) deleteCommodity(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// validateForwardStatusTransition enforces the #1611 cross-field rule
+// that needs the previous row's status (which the model layer doesn't
+// carry): leaving in_use requires status_date, and marking as sold
+// additionally requires sale_price. Returns nil when the transition is
+// not "leaving in_use" or all required fields are present. Per-row
+// invariants (sale_price only when sold, status_date only when not
+// in_use) stay at the model layer via ValidateWithContext.
+func validateForwardStatusTransition(prev, next models.CommodityStatus, statusDate models.PDate, salePrice *decimal.Decimal) error {
+	if prev != models.CommodityStatusInUse || next == models.CommodityStatusInUse {
+		return nil
+	}
+	if statusDate == nil || string(*statusDate) == "" {
+		return validation.Errors{
+			"status_date": validation.NewError("status_date_required_on_transition",
+				"status date is required when leaving in_use"),
+		}
+	}
+	if next == models.CommodityStatusSold && salePrice == nil {
+		return validation.Errors{
+			"sale_price": validation.NewError("sale_price_required_for_sold",
+				"sale price is required when marking as sold"),
+		}
+	}
+	return nil
+}
+
 // updateCommodity updates a commodity.
 // @Summary Update a commodity
 // @Description Update a commodity
@@ -466,6 +493,21 @@ func (api *commoditiesAPI) updateCommodity(w http.ResponseWriter, r *http.Reques
 			return
 		}
 		updateData.Tags = models.ValuerSlice[string](slugs)
+	}
+
+	// #1611: terminal-status metadata. The cross-field rule "status_date
+	// is required whenever the transition leaves in_use" depends on the
+	// previous row's status — which the model layer doesn't carry — so
+	// it's enforced here. Per-row invariants (sale_price only when
+	// status=sold, status_date only when status != in_use) are enforced
+	// at the model layer via ValidateWithContext, and the FE is
+	// responsible for sending a clean payload on revert (clearing the
+	// three metadata fields when flipping back to in_use). Pre-existing
+	// terminal rows with NULL metadata stay valid on edits that don't
+	// change the status.
+	if err := validateForwardStatusTransition(commodity.Status, updateData.Status, updateData.StatusDate, updateData.SalePrice); err != nil {
+		unprocessableEntityError(w, r, err)
+		return
 	}
 
 	// #1554: a 1 → >1 quantity bump must be blocked when the row still

--- a/go/apiserver/commodities_test.go
+++ b/go/apiserver/commodities_test.go
@@ -582,6 +582,212 @@ func TestCommodityCoverPatch_RejectsImageInWrongCategory(t *testing.T) {
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 }
 
+// commodityUpdateBody builds a minimal-valid PUT body for a commodity,
+// then applies the caller's overrides. The fixture row is the
+// non-draft commodity used elsewhere in this file.
+func commodityUpdateBody(c *qt.C, commodity *models.Commodity, override func(*models.Commodity)) *bytes.Reader {
+	purchaseDate := commodity.PurchaseDate
+	if purchaseDate == nil || string(*purchaseDate) == "" {
+		purchaseDate = models.ToPDate("2022-01-01")
+	}
+	attrs := &models.Commodity{
+		Name:                   commodity.Name,
+		ShortName:              commodity.ShortName,
+		AreaID:                 commodity.AreaID,
+		Type:                   commodity.Type,
+		Count:                  commodity.Count,
+		OriginalPrice:          commodity.OriginalPrice,
+		OriginalPriceCurrency:  commodity.OriginalPriceCurrency,
+		ConvertedOriginalPrice: commodity.ConvertedOriginalPrice,
+		CurrentPrice:           commodity.CurrentPrice,
+		Status:                 commodity.Status,
+		PurchaseDate:           purchaseDate,
+		Draft:                  commodity.Draft,
+	}
+	if override != nil {
+		override(attrs)
+	}
+	obj := &jsonapi.CommodityRequest{
+		Data: &jsonapi.CommodityData{
+			ID:         commodity.ID,
+			Type:       "commodities",
+			Attributes: models.WithID(commodity.ID, attrs),
+		},
+	}
+	data, err := json.Marshal(obj)
+	c.Assert(err, qt.IsNil)
+	return bytes.NewReader(data)
+}
+
+// TestCommodityUpdate_StatusTransition_RequiresStatusDate exercises the
+// #1611 handler check: leaving in_use without a status_date returns 422.
+func TestCommodityUpdate_StatusTransition_RequiresStatusDate(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	commodity := must.Must(registrySet.CommodityRegistry.List(context.Background()))[0]
+	c.Assert(commodity.Status, qt.Equals, models.CommodityStatusInUse)
+
+	body := commodityUpdateBody(c, commodity, func(m *models.Commodity) {
+		m.Status = models.CommodityStatusLost
+	})
+	req := must.Must(http.NewRequest("PUT", "/api/v1/g/"+testGroup.Slug+"/commodities/"+commodity.ID, body))
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+	apiserver.APIServer(params, &mockRestoreWorker{hasRunningRestores: false}).ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body=%s", rr.Body.String()))
+}
+
+// TestCommodityUpdate_StatusTransition_RequiresSalePrice exercises the
+// #1611 handler check: marking as sold without a sale_price returns 422.
+func TestCommodityUpdate_StatusTransition_RequiresSalePrice(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	commodity := must.Must(registrySet.CommodityRegistry.List(context.Background()))[0]
+	c.Assert(commodity.Status, qt.Equals, models.CommodityStatusInUse)
+
+	body := commodityUpdateBody(c, commodity, func(m *models.Commodity) {
+		m.Status = models.CommodityStatusSold
+		m.StatusDate = models.ToPDate("2026-05-17")
+	})
+	req := must.Must(http.NewRequest("PUT", "/api/v1/g/"+testGroup.Slug+"/commodities/"+commodity.ID, body))
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+	apiserver.APIServer(params, &mockRestoreWorker{hasRunningRestores: false}).ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body=%s", rr.Body.String()))
+}
+
+// TestCommodityUpdate_StatusTransition_PersistsMetadataOnSold writes a
+// full forward transition to `sold` and asserts the three new columns
+// round-trip in the response envelope.
+func TestCommodityUpdate_StatusTransition_PersistsMetadataOnSold(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	commodity := must.Must(registrySet.CommodityRegistry.List(context.Background()))[0]
+	c.Assert(commodity.Status, qt.Equals, models.CommodityStatusInUse)
+	salePrice := must.Must(decimal.NewFromString("123.45"))
+
+	body := commodityUpdateBody(c, commodity, func(m *models.Commodity) {
+		m.Status = models.CommodityStatusSold
+		m.StatusDate = models.ToPDate("2026-05-17")
+		m.StatusNote = "Sold to Bob"
+		m.SalePrice = &salePrice
+	})
+	req := must.Must(http.NewRequest("PUT", "/api/v1/g/"+testGroup.Slug+"/commodities/"+commodity.ID, body))
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+	apiserver.APIServer(params, &mockRestoreWorker{hasRunningRestores: false}).ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK, qt.Commentf("body=%s", rr.Body.String()))
+	resp := rr.Body.Bytes()
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.status"), string(models.CommodityStatusSold))
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.status_date"), "2026-05-17")
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.status_note"), "Sold to Bob")
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.sale_price"), "123.45")
+}
+
+// TestCommodityUpdate_StatusTransition_LostKeepsSalePriceNil checks that a
+// non-sold forward transition persists status_date + status_note while
+// sale_price stays unset.
+func TestCommodityUpdate_StatusTransition_LostKeepsSalePriceNil(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	commodity := must.Must(registrySet.CommodityRegistry.List(context.Background()))[0]
+
+	body := commodityUpdateBody(c, commodity, func(m *models.Commodity) {
+		m.Status = models.CommodityStatusLost
+		m.StatusDate = models.ToPDate("2026-05-17")
+		m.StatusNote = "Last seen at the office"
+	})
+	req := must.Must(http.NewRequest("PUT", "/api/v1/g/"+testGroup.Slug+"/commodities/"+commodity.ID, body))
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+	apiserver.APIServer(params, &mockRestoreWorker{hasRunningRestores: false}).ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK, qt.Commentf("body=%s", rr.Body.String()))
+	resp := rr.Body.Bytes()
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.status"), string(models.CommodityStatusLost))
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.status_date"), "2026-05-17")
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.status_note"), "Last seen at the office")
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.sale_price"), nil)
+}
+
+// TestCommodityUpdate_StatusTransition_RevertClearsMetadata reverts a
+// terminal-status row back to in_use and asserts the three metadata
+// columns get cleared by the handler.
+func TestCommodityUpdate_StatusTransition_RevertClearsMetadata(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	commodity := must.Must(registrySet.CommodityRegistry.List(context.Background()))[0]
+	salePrice := must.Must(decimal.NewFromString("99.00"))
+
+	// Phase 1: move row to sold with full metadata.
+	body := commodityUpdateBody(c, commodity, func(m *models.Commodity) {
+		m.Status = models.CommodityStatusSold
+		m.StatusDate = models.ToPDate("2026-05-17")
+		m.StatusNote = "Sold to Alice"
+		m.SalePrice = &salePrice
+	})
+	req := must.Must(http.NewRequest("PUT", "/api/v1/g/"+testGroup.Slug+"/commodities/"+commodity.ID, body))
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+	apiserver.APIServer(params, &mockRestoreWorker{hasRunningRestores: false}).ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK, qt.Commentf("phase 1 body=%s", rr.Body.String()))
+
+	// Phase 2: revert. The FE clears the metadata when flipping back to
+	// in_use — the BE's model validation enforces the consistency
+	// invariant on every write, so a clean payload is the contract.
+	reloaded := must.Must(registrySet.CommodityRegistry.Get(context.Background(), commodity.ID))
+	body2 := commodityUpdateBody(c, reloaded, func(m *models.Commodity) {
+		m.Status = models.CommodityStatusInUse
+		m.StatusDate = nil
+		m.StatusNote = ""
+		m.SalePrice = nil
+	})
+	req2 := must.Must(http.NewRequest("PUT", "/api/v1/g/"+testGroup.Slug+"/commodities/"+commodity.ID, body2))
+	addTestUserAuthHeader(req2, testUser.ID)
+	rr2 := httptest.NewRecorder()
+	apiserver.APIServer(params, &mockRestoreWorker{hasRunningRestores: false}).ServeHTTP(rr2, req2)
+	c.Assert(rr2.Code, qt.Equals, http.StatusOK, qt.Commentf("phase 2 body=%s", rr2.Body.String()))
+	resp := rr2.Body.Bytes()
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.status"), string(models.CommodityStatusInUse))
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.status_date"), nil)
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.status_note"), "")
+	c.Check(resp, checkers.JSONPathEquals("$.data.attributes.sale_price"), nil)
+}
+
+// TestCommodityUpdate_StatusTransition_SalePriceForbiddenWhenNotSold
+// guards the per-row invariant: sale_price set with a non-sold status is
+// rejected. The handler's "leaving in_use" branch covers sold-specific
+// edges; this catches the model-level rule on edits that don't touch
+// the status transition path (e.g. status=lost + sale_price=...).
+func TestCommodityUpdate_StatusTransition_SalePriceForbiddenWhenNotSold(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+	registrySet := getRegistrySetFromParams(params, testUser)
+	commodity := must.Must(registrySet.CommodityRegistry.List(context.Background()))[0]
+	salePrice := must.Must(decimal.NewFromString("50.00"))
+
+	body := commodityUpdateBody(c, commodity, func(m *models.Commodity) {
+		m.Status = models.CommodityStatusLost
+		m.StatusDate = models.ToPDate("2026-05-17")
+		m.SalePrice = &salePrice
+	})
+	req := must.Must(http.NewRequest("PUT", "/api/v1/g/"+testGroup.Slug+"/commodities/"+commodity.ID, body))
+	addTestUserAuthHeader(req, testUser.ID)
+	rr := httptest.NewRecorder()
+	apiserver.APIServer(params, &mockRestoreWorker{hasRunningRestores: false}).ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity, qt.Commentf("body=%s", rr.Body.String()))
+}
+
 func TestCommodityCoverPatch_NotFoundForUnknownFile(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -8738,6 +8738,10 @@ const docTemplate = `{
                 "registered_date": {
                     "type": "string"
                 },
+                "sale_price": {
+                    "description": "SalePrice is the realised proceeds for a ` + "`" + `sold` + "`" + ` transition. NULL\nfor any other status. Stored in the commodity's original purchase\ncurrency — sale-side currency reporting is out of scope for #1611.",
+                    "type": "number"
+                },
                 "serial_number": {
                     "type": "string"
                 },
@@ -8746,6 +8750,14 @@ const docTemplate = `{
                 },
                 "status": {
                     "$ref": "#/definitions/models.CommodityStatus"
+                },
+                "status_date": {
+                    "description": "StatusDate is the day the user reported the commodity's transition\nout of ` + "`" + `in_use` + "`" + `. Captured by the FE ` + "`" + `StatusTransitionDialog` + "`" + ` (issue\n#1611) and surfaced on the terminal-status info card. PDate is a\nday-precision string — the mock uses ` + "`" + `\u003cinput type=\"date\"\u003e` + "`" + ` so we\ndon't need sub-day granularity. NULL while ` + "`" + `status = in_use` + "`" + ` or\nfor terminal rows that pre-date this column.",
+                    "type": "string"
+                },
+                "status_note": {
+                    "description": "StatusNote is the free-form note recorded alongside a status\ntransition (e.g. \"Sold to Bob\" / \"Last seen at the airport\"). NULL\nfor ` + "`" + `in_use` + "`" + ` rows and pre-existing terminal rows. Bounded by the\nsame 1024-char ceiling we use for Comments to keep the BE/UI sane.",
+                    "type": "string"
                 },
                 "tags": {
                     "type": "array",

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -8731,6 +8731,10 @@
                 "registered_date": {
                     "type": "string"
                 },
+                "sale_price": {
+                    "description": "SalePrice is the realised proceeds for a `sold` transition. NULL\nfor any other status. Stored in the commodity's original purchase\ncurrency — sale-side currency reporting is out of scope for #1611.",
+                    "type": "number"
+                },
                 "serial_number": {
                     "type": "string"
                 },
@@ -8739,6 +8743,14 @@
                 },
                 "status": {
                     "$ref": "#/definitions/models.CommodityStatus"
+                },
+                "status_date": {
+                    "description": "StatusDate is the day the user reported the commodity's transition\nout of `in_use`. Captured by the FE `StatusTransitionDialog` (issue\n#1611) and surfaced on the terminal-status info card. PDate is a\nday-precision string — the mock uses `\u003cinput type=\"date\"\u003e` so we\ndon't need sub-day granularity. NULL while `status = in_use` or\nfor terminal rows that pre-date this column.",
+                    "type": "string"
+                },
+                "status_note": {
+                    "description": "StatusNote is the free-form note recorded alongside a status\ntransition (e.g. \"Sold to Bob\" / \"Last seen at the airport\"). NULL\nfor `in_use` rows and pre-existing terminal rows. Bounded by the\nsame 1024-char ceiling we use for Comments to keep the BE/UI sane.",
+                    "type": "string"
                 },
                 "tags": {
                     "type": "array",

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -2202,12 +2202,34 @@ definitions:
         type: string
       registered_date:
         type: string
+      sale_price:
+        description: |-
+          SalePrice is the realised proceeds for a `sold` transition. NULL
+          for any other status. Stored in the commodity's original purchase
+          currency — sale-side currency reporting is out of scope for #1611.
+        type: number
       serial_number:
         type: string
       short_name:
         type: string
       status:
         $ref: '#/definitions/models.CommodityStatus'
+      status_date:
+        description: |-
+          StatusDate is the day the user reported the commodity's transition
+          out of `in_use`. Captured by the FE `StatusTransitionDialog` (issue
+          #1611) and surfaced on the terminal-status info card. PDate is a
+          day-precision string — the mock uses `<input type="date">` so we
+          don't need sub-day granularity. NULL while `status = in_use` or
+          for terminal rows that pre-date this column.
+        type: string
+      status_note:
+        description: |-
+          StatusNote is the free-form note recorded alongside a status
+          transition (e.g. "Sold to Bob" / "Last seen at the airport"). NULL
+          for `in_use` rows and pre-existing terminal rows. Bounded by the
+          same 1024-char ceiling we use for Comments to keep the BE/UI sane.
+        type: string
       tags:
         items:
           type: string

--- a/go/models/commodity.go
+++ b/go/models/commodity.go
@@ -179,6 +179,26 @@ type Commodity struct {
 	// Always either both NULL or both set (DB CHECK constraint enforces).
 	//migrator:schema:field name="acquisition_currency" type="TEXT"
 	AcquisitionCurrency *Currency `json:"acquisition_currency,omitempty" db:"acquisition_currency" userinput:"false" readonly:"true"`
+
+	// StatusDate is the day the user reported the commodity's transition
+	// out of `in_use`. Captured by the FE `StatusTransitionDialog` (issue
+	// #1611) and surfaced on the terminal-status info card. PDate is a
+	// day-precision string — the mock uses `<input type="date">` so we
+	// don't need sub-day granularity. NULL while `status = in_use` or
+	// for terminal rows that pre-date this column.
+	//migrator:schema:field name="status_date" type="TEXT"
+	StatusDate PDate `json:"status_date" db:"status_date"`
+	// StatusNote is the free-form note recorded alongside a status
+	// transition (e.g. "Sold to Bob" / "Last seen at the airport"). NULL
+	// for `in_use` rows and pre-existing terminal rows. Bounded by the
+	// same 1024-char ceiling we use for Comments to keep the BE/UI sane.
+	//migrator:schema:field name="status_note" type="TEXT"
+	StatusNote string `json:"status_note" db:"status_note"`
+	// SalePrice is the realised proceeds for a `sold` transition. NULL
+	// for any other status. Stored in the commodity's original purchase
+	// currency — sale-side currency reporting is out of scope for #1611.
+	//migrator:schema:field name="sale_price" type="DECIMAL(15,2)"
+	SalePrice *decimal.Decimal `json:"sale_price,omitempty" db:"sale_price"`
 }
 
 // WarrantyStatus is the computed warranty state of a commodity. It is
@@ -383,6 +403,33 @@ func (a *Commodity) ValidateWithContext(ctx context.Context) error {
 			v, _ := a.CurrentPrice.Float64()
 			return validation.Min(0.00).Validate(v)
 		}))),
+		// #1611: terminal-status metadata. The cross-field "required
+		// when the transition leaves in_use" check lives in the
+		// updateCommodity handler (it needs the previous status,
+		// which the model layer doesn't carry); these rules cover the
+		// per-row invariants that hold on every write.
+		validation.Field(&a.StatusNote, validation.Length(0, 1024)),
+		validation.Field(&a.SalePrice, validation.By(func(any) error {
+			if a.SalePrice == nil {
+				return nil
+			}
+			if a.Status != CommodityStatusSold {
+				return validation.NewError("status_forbids_sale_price",
+					"sale price can only be recorded when status is sold")
+			}
+			v, _ := a.SalePrice.Float64()
+			return validation.Min(0.00).Validate(v)
+		})),
+		validation.Field(&a.StatusDate, validation.By(func(any) error {
+			if a.StatusDate == nil || string(*a.StatusDate) == "" {
+				return nil
+			}
+			if a.Status == CommodityStatusInUse {
+				return validation.NewError("status_forbids_status_date",
+					"status date cannot be set when status is in_use")
+			}
+			return nil
+		})),
 	)
 
 	return validation.ValidateStructWithContext(ctx, a, fields...)

--- a/go/models/commodity_test.go
+++ b/go/models/commodity_test.go
@@ -283,6 +283,34 @@ func TestCommodity_ValidateWithContext_UnhappyPaths(t *testing.T) {
 			},
 			errorContains: "purchase_date: cannot be blank",
 		},
+		{
+			// #1611: sale_price + non-sold status is a per-row invariant.
+			name: "sale_price forbidden when status is lost",
+			modifyCommodity: func(c *models.Commodity) {
+				c.Status = models.CommodityStatusLost
+				c.PurchaseDate = models.ToPDate("2026-01-01")
+				price := decimal.NewFromFloat(10)
+				c.SalePrice = &price
+				c.StatusDate = models.ToPDate("2026-05-17")
+			},
+			modifyContext: func(ctx context.Context) context.Context {
+				return validationctx.WithGroupCurrency(ctx, "USD")
+			},
+			errorContains: "sale_price",
+		},
+		{
+			// #1611: status_date + in_use is a per-row invariant. Forces
+			// the FE to clear the metadata on revert.
+			name: "status_date forbidden when status is in_use",
+			modifyCommodity: func(c *models.Commodity) {
+				c.PurchaseDate = models.ToPDate("2026-01-01")
+				c.StatusDate = models.ToPDate("2026-05-17")
+			},
+			modifyContext: func(ctx context.Context) context.Context {
+				return validationctx.WithGroupCurrency(ctx, "USD")
+			},
+			errorContains: "status_date",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/go/schema/migrations/_sqldata/1780200000_add_commodity_status_metadata.down.sql
+++ b/go/schema/migrations/_sqldata/1780200000_add_commodity_status_metadata.down.sql
@@ -1,0 +1,14 @@
+-- Migration rollback
+-- Generated on: 2026-05-17T08:12:49Z
+-- Direction: DOWN
+
+-- Remove columns from table: commodities --
+-- ALTER statements: --
+ALTER TABLE commodities DROP COLUMN sale_price CASCADE;
+-- WARNING: Dropping column commodities.sale_price with CASCADE - This will delete data and dependent objects! --
+-- ALTER statements: --
+ALTER TABLE commodities DROP COLUMN status_date CASCADE;
+-- WARNING: Dropping column commodities.status_date with CASCADE - This will delete data and dependent objects! --
+-- ALTER statements: --
+ALTER TABLE commodities DROP COLUMN status_note CASCADE;
+-- WARNING: Dropping column commodities.status_note with CASCADE - This will delete data and dependent objects! --;

--- a/go/schema/migrations/_sqldata/1780200000_add_commodity_status_metadata.up.sql
+++ b/go/schema/migrations/_sqldata/1780200000_add_commodity_status_metadata.up.sql
@@ -1,0 +1,11 @@
+-- Migration generated from schema differences
+-- Generated on: 2026-05-17T08:12:49Z
+-- Direction: UP
+
+-- Add/modify columns for table: commodities --
+-- ALTER statements: --
+ALTER TABLE commodities ADD COLUMN sale_price DECIMAL(15,2);
+-- ALTER statements: --
+ALTER TABLE commodities ADD COLUMN status_date TEXT;
+-- ALTER statements: --
+ALTER TABLE commodities ADD COLUMN status_note TEXT;


### PR DESCRIPTION
Closes #1611 — the BE + FE follow-up to PR #1610's terminal-status info card.

## Backend

- `models.Commodity` gains three columns: `status_date` (`TEXT`, day-precision), `status_note` (`TEXT`, 1024-char cap), `sale_price` (`DECIMAL(15,2)`).
- Per-row invariants on the model: `sale_price` only when `status=sold`; `status_date` only when `status != in_use`. The FE clears the three on revert to keep the row consistent.
- `updateCommodity` handler enforces the cross-field rule that needs the previous status: leaving `in_use` requires `status_date`, and marking as `sold` additionally requires `sale_price`. Extracted to `validateForwardStatusTransition` to keep `gocyclo` happy.
- Ptah migration `1780200000_add_commodity_status_metadata` generated from the model annotations. Existing terminal-status rows stay valid — their NULL metadata simply hides the corresponding rows on the FE card (the issue's "no historical backfill" requirement).
- New BE tests cover the four happy / unhappy transition paths plus the model-level per-row invariants.

## Frontend

- New `StatusTransitionDialog` (`frontend/src/components/items/StatusTransitionDialog.tsx`, RHF + zod, mock parity with [`design-mocks/src/components/ItemDetail.tsx`](https://github.com/denisvmedia/inventario/blob/master/design-mocks/src/components/ItemDetail.tsx) lines 113–185) opens for any forward transition from `in_use`. Collects date (required), optional note, and sale price (required for `sold`, hidden for others). The currency symbol prefix mirrors the commodity's purchase currency.
- `CommodityDetailPage.handleStatusTransition` routes forward transitions to the dialog and keeps the lighter `useConfirm` path for revert — revert now explicitly clears `status_date` / `status_note` / `sale_price` in the PATCH payload so the BE's per-row invariant holds.
- Terminal-status info card surfaces the captured `status_date` / `status_note` / `sale_price` triple between the icon row and the Revert CTA (mock parity with `ItemDetail.tsx` lines 736–762). Each row gates on its column being set so pre-#1611 rows render unchanged.
- i18n keys under `commodities:detail.statusTransitionDialog.*` and `commodities:detail.terminalStatus.{statusDate,statusNote,salePrice}`.
- New Vitest specs for the dialog (6) and three additional `CommodityDetailPage` cases covering the metadata rows + the PATCH body threading.

## Deviations

Resolved the 2026-05-09 [`devdocs/frontend/design-deviations.md`](https://github.com/denisvmedia/inventario/blob/master/devdocs/frontend/design-deviations.md) entry "Terminal-status info card without date / note / sale_price metadata" with a `**Resolved**: 2026-05-17, #1611` line.

## Validation

- `make lint-go` — 0 issues.
- `make lint-frontend` — 0 issues.
- `make lint-migrations` against an ephemeral Postgres — "Schema is in sync — no pending migrations."
- `make test` — Go: all packages pass; Vitest: 937 passed / 4 skipped.

## Test plan

- [ ] On a fresh commodity, click each terminal-status button on the "Change Status" row — the dialog opens, the title reflects the picked status, and the sale-price field only renders for **Sold**.
- [ ] Submit the dialog with an empty date — the form blocks and surfaces the required-date error.
- [ ] Mark as **Sold** with a price, note, and date — the row flips to sold and the terminal-status card shows the three metadata rows.
- [ ] Click **Revert to In Use** — confirm dialog appears; on confirm, the row flips back and the metadata rows disappear (the BE columns are cleared in the payload).
- [ ] Edit an existing terminal row without changing status — no validation error (BE tolerates NULL metadata on pre-#1611 rows).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commodity status transitions now capture/validate transition date, notes, and sale price (required for sold).
  * Terminal status info card shows date, notes, and sale price formatted in purchase currency.
  * Reverting from terminal status clears captured metadata.

* **Documentation**
  * API docs, OpenAPI/Swagger and i18n entries updated; design-deviation entry marked resolved.

* **Tests**
  * Added frontend and backend tests covering status-transition flows and validation.

* **Chores**
  * DB migration added to store status metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->