### PR TITLE
[#1616] Hide currency-migration UI when feature flag is off

### DIFF
--- a/frontend/src/components/groups/MigrateCurrencyDialog.tsx
+++ b/frontend/src/components/groups/MigrateCurrencyDialog.tsx
@@ -28,6 +28,15 @@ import { getServerErrorCode, getServerErrorMeta, parseServerError } from "@/lib/
 // step labels.
 type Step = 1 | 2 | 3 | 4
 
+// True iff the backend reports the currency-migration feature as
+// gated off (#1616). The BE pairs the 404 with a stable JSON:API
+// `code`, so we don't have to guess from the path or status alone.
+function isFeatureDisabledError(err: unknown): boolean {
+  if (!(err instanceof HttpError)) return false
+  if (err.status !== 404) return false
+  return getServerErrorCode(err) === "currency_migration.feature_disabled"
+}
+
 interface MigrateCurrencyDialogProps {
   open: boolean
   onOpenChange: (next: boolean) => void
@@ -196,6 +205,16 @@ function MigrateCurrencyDialogBody({
       setPreview(body)
       setStep(3)
     } catch (err) {
+      // Feature-disabled (#1616): the operator turned off the
+      // currency-migration flag between the time the page rendered the
+      // CTA and the click. Surface as a toast + close — the wizard's
+      // inline error block would read as "preview failed, fix your
+      // inputs" which is wrong, and the user can't recover here.
+      if (isFeatureDisabledError(err)) {
+        toast.error(t("errors:currencyMigrationFeatureDisabled"))
+        close()
+        return
+      }
       // Preview itself shouldn't 409/422 in the happy path — the BE
       // validates inputs against the live group state. Surface the
       // server message inline so the user can correct the rate or
@@ -238,6 +257,13 @@ function MigrateCurrencyDialogBody({
   function handleStartError(err: unknown) {
     if (!(err instanceof HttpError)) {
       setConfirmError(parseServerError(err, t("groups:migration.toastStartFailed")))
+      return
+    }
+    // Feature gate flipped between preview and start. Same close+toast
+    // shape as the preview-side handler (#1616).
+    if (isFeatureDisabledError(err)) {
+      toast.error(t("errors:currencyMigrationFeatureDisabled"))
+      close()
       return
     }
     const code = getServerErrorCode(err)

--- a/frontend/src/components/groups/__tests__/MigrateCurrencyDialog.test.tsx
+++ b/frontend/src/components/groups/__tests__/MigrateCurrencyDialog.test.tsx
@@ -131,4 +131,55 @@ describe("<MigrateCurrencyDialog />", () => {
     )
     expect(screen.getByTestId("wizard-top-deltas")).toBeInTheDocument()
   })
+
+  // #1616: the operator may turn the feature off between the time the
+  // dialog rendered and the click on Preview. The BE returns a coded
+  // 404 (`currency_migration.feature_disabled`); the wizard must close
+  // and surface a deployment-scoped toast instead of treating it as a
+  // generic "preview failed, fix your inputs" inline error.
+  it("closes the wizard and toasts when Preview returns the feature-disabled code", async () => {
+    const user = userEvent.setup()
+    let onOpenChangeArg: boolean | null = null
+    server.use(
+      msw.post(apiUrl("/g/household/currency-migrations/preview"), () =>
+        HttpResponse.json(
+          { errors: [{ code: "currency_migration.feature_disabled", detail: "disabled" }] },
+          { status: 404 }
+        )
+      )
+    )
+    renderWithProviders({
+      initialPath: "/groups/g1/settings",
+      routes: (
+        <Route
+          path="/groups/:groupId/settings"
+          element={
+            <GroupProvider>
+              <MigrateCurrencyDialog
+                open={true}
+                onOpenChange={(next) => {
+                  onOpenChangeArg = next
+                }}
+                groupName="Household"
+                fromCurrency="USD"
+                groupSlug="household"
+              />
+            </GroupProvider>
+          }
+        />
+      ),
+    })
+    await user.click(screen.getByRole("combobox"))
+    await user.click(await screen.findByText("EUR"))
+    await user.click(screen.getByTestId("wizard-next"))
+    const rate = await screen.findByTestId("wizard-rate-input")
+    await user.type(rate, "0.9")
+    await user.click(screen.getByTestId("wizard-preview"))
+    // Inline error block must NOT be the surface — that copy reads as
+    // "fix your rate", which doesn't fit a deployment-config issue.
+    await waitFor(() => {
+      expect(onOpenChangeArg).toBe(false)
+    })
+    expect(screen.queryByTestId("wizard-preview-error")).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/groups/__tests__/MigrateCurrencyDialog.test.tsx
+++ b/frontend/src/components/groups/__tests__/MigrateCurrencyDialog.test.tsx
@@ -182,4 +182,56 @@ describe("<MigrateCurrencyDialog />", () => {
     })
     expect(screen.queryByTestId("wizard-preview-error")).not.toBeInTheDocument()
   })
+
+  // Symmetric Start-side test: even if Preview succeeded, the operator
+  // can still flip the flag off between confirm and start. The Start
+  // handler must mirror the Preview behavior — close + toast, not the
+  // inline confirm-error which reads as "your input is wrong".
+  it("closes the wizard and toasts when Start returns the feature-disabled code", async () => {
+    const user = userEvent.setup()
+    let onOpenChangeArg: boolean | null = null
+    server.use(
+      ...currencyMigrationHandlers.preview("household"),
+      ...currencyMigrationHandlers.startError(
+        "household",
+        404,
+        "currency_migration.feature_disabled"
+      )
+    )
+    renderWithProviders({
+      initialPath: "/groups/g1/settings",
+      routes: (
+        <Route
+          path="/groups/:groupId/settings"
+          element={
+            <GroupProvider>
+              <MigrateCurrencyDialog
+                open={true}
+                onOpenChange={(next) => {
+                  onOpenChangeArg = next
+                }}
+                groupName="Household"
+                fromCurrency="USD"
+                groupSlug="household"
+              />
+            </GroupProvider>
+          }
+        />
+      ),
+    })
+    // Walk all four wizard steps with a happy preview.
+    await user.click(screen.getByRole("combobox"))
+    await user.click(await screen.findByText("EUR"))
+    await user.click(screen.getByTestId("wizard-next"))
+    await user.type(await screen.findByTestId("wizard-rate-input"), "0.9")
+    await user.click(screen.getByTestId("wizard-preview"))
+    await screen.findByTestId("wizard-preview-body")
+    await user.click(screen.getByTestId("wizard-confirm"))
+    await user.type(await screen.findByTestId("wizard-confirm-input"), "Household")
+    await user.click(screen.getByTestId("wizard-submit"))
+    await waitFor(() => {
+      expect(onOpenChangeArg).toBe(false)
+    })
+    expect(screen.queryByTestId("wizard-confirm-error")).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/groups/__tests__/MigrateCurrencyDialog.test.tsx
+++ b/frontend/src/components/groups/__tests__/MigrateCurrencyDialog.test.tsx
@@ -1,8 +1,34 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { http as msw, HttpResponse } from "msw"
 import { Route } from "react-router-dom"
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+
+// Local sonner mock so the feature-disabled tests can assert that the
+// toast was fired with the specific i18n key (#1616). The global setup
+// stubs sonner as no-ops; the per-file mock wins because vi.mock is
+// hoisted. Keep the surface minimal — the wizard only ever calls
+// `toast.error` here, the rest of sonner.toast.* is filled in just to
+// match the imported shape so the bundle resolves.
+vi.mock("sonner", () => {
+  const noop = vi.fn()
+  return {
+    Toaster: () => null,
+    toast: Object.assign(noop, {
+      success: noop,
+      error: vi.fn(),
+      info: noop,
+      warning: noop,
+      message: noop,
+      promise: noop,
+      dismiss: vi.fn(),
+      loading: noop,
+      custom: noop,
+    }),
+  }
+})
+
+import { toast } from "sonner"
 
 import {
   MigrateCurrencyDialog,
@@ -14,7 +40,10 @@ import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
 import { apiUrl, currencyMigrationHandlers, groupHandlers } from "@/test/handlers"
 
+const toastErrorMock = toast.error as ReturnType<typeof vi.fn>
+
 beforeEach(() => {
+  toastErrorMock.mockReset()
   // Currencies endpoint backs the CurrencyCombobox in step 1 and the
   // groups list backs GroupProvider; both want a stable default for
   // every case so individual `server.use(...)` calls only have to
@@ -181,6 +210,15 @@ describe("<MigrateCurrencyDialog />", () => {
       expect(onOpenChangeArg).toBe(false)
     })
     expect(screen.queryByTestId("wizard-preview-error")).not.toBeInTheDocument()
+    // Belt-and-braces: the close-on-its-own already proves the
+    // feature-disabled branch fired, but asserting the toast copy
+    // guards against a future refactor that closes the dialog
+    // without surfacing any deployment-scoped message — the bug
+    // #1616 was filed against in the first place.
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      expect.stringMatching(/disabled in this deployment/i),
+      undefined
+    )
   })
 
   // Symmetric Start-side test: even if Preview succeeded, the operator
@@ -233,5 +271,9 @@ describe("<MigrateCurrencyDialog />", () => {
       expect(onOpenChangeArg).toBe(false)
     })
     expect(screen.queryByTestId("wizard-confirm-error")).not.toBeInTheDocument()
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      expect.stringMatching(/disabled in this deployment/i),
+      undefined
+    )
   })
 })

--- a/frontend/src/features/feature-flags/__tests__/hooks.test.tsx
+++ b/frontend/src/features/feature-flags/__tests__/hooks.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+
+import { useFeatureFlag, useFeatureFlags } from "@/features/feature-flags/hooks"
+import { server } from "@/test/server"
+import { apiUrl } from "@/test/handlers"
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  }
+  return { Wrapper }
+}
+
+describe("useFeatureFlags", () => {
+  it("fetches the deployment feature flags and exposes them through query state", async () => {
+    server.use(
+      msw.get(apiUrl("/feature-flags"), () =>
+        HttpResponse.json({ currency_migration: true })
+      )
+    )
+    const { Wrapper } = makeWrapper()
+    const { result } = renderHook(() => useFeatureFlags(), { wrapper: Wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual({ currency_migration: true })
+  })
+})
+
+describe("useFeatureFlag", () => {
+  it("returns the resolved flag value once the query lands", async () => {
+    server.use(
+      msw.get(apiUrl("/feature-flags"), () =>
+        HttpResponse.json({ currency_migration: true })
+      )
+    )
+    const { Wrapper } = makeWrapper()
+    const { result } = renderHook(() => useFeatureFlag("currency_migration"), { wrapper: Wrapper })
+    await waitFor(() => expect(result.current).toBe(true))
+  })
+
+  it("falls back to the off state while the request is in flight", () => {
+    // No handler registered — request stays pending. The fail-closed
+    // default (#1616 design) is exactly what gated entry points rely on:
+    // hide the CTA until proven that the feature is on.
+    server.use(msw.get(apiUrl("/feature-flags"), async () => new Promise(() => {})))
+    const { Wrapper } = makeWrapper()
+    const { result } = renderHook(() => useFeatureFlag("currency_migration"), { wrapper: Wrapper })
+    expect(result.current).toBe(false)
+  })
+
+  it("falls back to the off state on network failure", async () => {
+    server.use(msw.get(apiUrl("/feature-flags"), () => HttpResponse.error()))
+    const { Wrapper } = makeWrapper()
+    const { result } = renderHook(() => useFeatureFlag("currency_migration"), { wrapper: Wrapper })
+    // Wait until the query has reached an error state, then assert the
+    // selector still returns false (fail-closed).
+    await waitFor(() => expect(result.current).toBe(false))
+  })
+})

--- a/frontend/src/features/feature-flags/__tests__/hooks.test.tsx
+++ b/frontend/src/features/feature-flags/__tests__/hooks.test.tsx
@@ -28,9 +28,7 @@ function makeWrapper() {
 describe("useFeatureFlags", () => {
   it("fetches the deployment feature flags and exposes them through query state", async () => {
     server.use(
-      msw.get(apiUrl("/feature-flags"), () =>
-        HttpResponse.json({ currency_migration: true })
-      )
+      msw.get(apiUrl("/feature-flags"), () => HttpResponse.json({ currency_migration: true }))
     )
     const { Wrapper } = makeWrapper()
     const { result } = renderHook(() => useFeatureFlags(), { wrapper: Wrapper })
@@ -42,9 +40,7 @@ describe("useFeatureFlags", () => {
 describe("useFeatureFlag", () => {
   it("returns the resolved flag value once the query lands", async () => {
     server.use(
-      msw.get(apiUrl("/feature-flags"), () =>
-        HttpResponse.json({ currency_migration: true })
-      )
+      msw.get(apiUrl("/feature-flags"), () => HttpResponse.json({ currency_migration: true }))
     )
     const { Wrapper } = makeWrapper()
     const { result } = renderHook(() => useFeatureFlag("currency_migration"), { wrapper: Wrapper })

--- a/frontend/src/features/feature-flags/__tests__/hooks.test.tsx
+++ b/frontend/src/features/feature-flags/__tests__/hooks.test.tsx
@@ -60,9 +60,21 @@ describe("useFeatureFlag", () => {
   it("falls back to the off state on network failure", async () => {
     server.use(msw.get(apiUrl("/feature-flags"), () => HttpResponse.error()))
     const { Wrapper } = makeWrapper()
-    const { result } = renderHook(() => useFeatureFlag("currency_migration"), { wrapper: Wrapper })
-    // Wait until the query has reached an error state, then assert the
-    // selector still returns false (fail-closed).
-    await waitFor(() => expect(result.current).toBe(false))
+    // Render both the bare query (so we can observe the error state
+    // landing) and the selector (so we can observe the fail-closed
+    // value at the same moment). Without the underlying query, the
+    // selector's initial render also returns `false` — so this test
+    // would pass *before* the error actually fired, which masks any
+    // regression that flipped the fallback path.
+    const { result } = renderHook(
+      () => {
+        const query = useFeatureFlags()
+        const flag = useFeatureFlag("currency_migration")
+        return { query, flag }
+      },
+      { wrapper: Wrapper }
+    )
+    await waitFor(() => expect(result.current.query.isError).toBe(true))
+    expect(result.current.flag).toBe(false)
   })
 })

--- a/frontend/src/features/feature-flags/api.ts
+++ b/frontend/src/features/feature-flags/api.ts
@@ -1,0 +1,29 @@
+// Data layer for the deployment feature-flag slice (#1616). Single
+// public endpoint, no auth, no per-user variation — flipping a flag
+// requires a re-deploy so the response is effectively immutable for
+// the lifetime of a session. The FE consumes this at boot to hide
+// entry points for features whose backend is gated off (e.g. the
+// currency-migration wizard).
+import { http } from "@/lib/http"
+import type { Schema } from "@/types"
+
+export type FeatureFlags = Schema<"apiserver.FeatureFlags">
+
+// Defaults match an "everything off" deployment so that a fetch
+// failure can never silently enable a feature whose backend is
+// disabled. When the request fails (offline, race during boot) we
+// degrade to hiding the gated UI rather than showing it — the
+// alternative would let the user click through to a request that
+// then 404s without context, which is the exact bug #1616 fixes.
+export const FEATURE_FLAGS_FALLBACK: FeatureFlags = {
+  currency_migration: false,
+}
+
+export async function getFeatureFlags(signal?: AbortSignal): Promise<FeatureFlags> {
+  // skipGroupRewrite because feature-flags is a tenant/deployment-level
+  // surface — it lives at /api/v1/feature-flags directly, no /g/{slug}/
+  // prefix. The rewrite is a no-op for un-prefixed paths today, but the
+  // explicit opt-out makes the contract obvious and survives future
+  // changes to GROUP_SCOPED_PREFIXES.
+  return http.get<FeatureFlags>("/feature-flags", { signal, skipGroupRewrite: true })
+}

--- a/frontend/src/features/feature-flags/hooks.ts
+++ b/frontend/src/features/feature-flags/hooks.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { FEATURE_FLAGS_FALLBACK, getFeatureFlags, type FeatureFlags } from "./api"
+import { featureFlagsKeys } from "./keys"
+
+// Feature flags don't change at runtime — flipping a flag requires a
+// re-deploy. So we set staleTime: Infinity, gcTime: Infinity and let
+// the result live for the lifetime of the SPA. No retries: a stable
+// "everything off" fallback is better than a flicker between "shown
+// because nothing loaded" and "hidden because the fetch eventually
+// failed".
+export function useFeatureFlags() {
+  return useQuery<FeatureFlags>({
+    queryKey: featureFlagsKeys.all,
+    queryFn: ({ signal }) => getFeatureFlags(signal),
+    staleTime: Infinity,
+    gcTime: Infinity,
+    retry: false,
+  })
+}
+
+// Convenience selector for the common case: "is feature X on?". Returns
+// the FALLBACK value while the query is loading or in an error state so
+// gated entry points stay hidden by default — fail-closed rather than
+// fail-open (matches the rationale in FEATURE_FLAGS_FALLBACK).
+export function useFeatureFlag<K extends keyof FeatureFlags>(name: K): FeatureFlags[K] {
+  const { data } = useFeatureFlags()
+  if (!data) return FEATURE_FLAGS_FALLBACK[name]
+  return data[name]
+}

--- a/frontend/src/features/feature-flags/keys.ts
+++ b/frontend/src/features/feature-flags/keys.ts
@@ -1,0 +1,5 @@
+// Single, deployment-scoped key. No slug or user dimension — the
+// flags are returned identically to every caller.
+export const featureFlagsKeys = {
+  all: ["feature-flags"] as const,
+}

--- a/frontend/src/features/sessions/api.ts
+++ b/frontend/src/features/sessions/api.ts
@@ -21,9 +21,16 @@ export async function revokeSession(id: string): Promise<void> {
   await http.del(`/users/me/sessions/${encodeURIComponent(id)}`, { skipGroupRewrite: true })
 }
 
-// revokeAllOtherSessions revokes every session except the one bound to the
-// current refresh cookie. The BE derives the keep-id from the cookie hash
-// — the FE does not need to supply it.
-export async function revokeAllOtherSessions(): Promise<void> {
-  await http.del("/users/me/sessions", { skipGroupRewrite: true })
+// revokeAllOtherSessions revokes every session except the one identified
+// as current. We must pass the id of the row the list endpoint flagged
+// `is_current: true` via `?keep_id=` because the refresh cookie is
+// path-scoped to /api/v1/auth — it isn't sent on /users/me/sessions, so
+// the BE can't fall back to hashing the cookie here. Pass `undefined`
+// to deliberately wipe every session (e.g. for "log out everywhere"
+// surfaces yet to be built).
+export async function revokeAllOtherSessions(keepSessionId?: string): Promise<void> {
+  const path = keepSessionId
+    ? `/users/me/sessions?keep_id=${encodeURIComponent(keepSessionId)}`
+    : "/users/me/sessions"
+  await http.del(path, { skipGroupRewrite: true })
 }

--- a/frontend/src/features/sessions/hooks.ts
+++ b/frontend/src/features/sessions/hooks.ts
@@ -23,10 +23,14 @@ export function useRevokeSession() {
   })
 }
 
+// useRevokeAllOtherSessions takes the id of the session the caller wants
+// to keep — typically the row the list endpoint marked `is_current: true`.
+// The BE needs an explicit signal here because the refresh cookie is
+// scoped to /api/v1/auth and isn't sent on /users/me/sessions.
 export function useRevokeAllOtherSessions() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: () => revokeAllOtherSessions(),
+    mutationFn: (keepSessionId: string | undefined) => revokeAllOtherSessions(keepSessionId),
     onSuccess: () => qc.invalidateQueries({ queryKey: sessionsKeys.all }),
   })
 }

--- a/frontend/src/i18n/locales/en/errors.json
+++ b/frontend/src/i18n/locales/en/errors.json
@@ -1,5 +1,6 @@
 {
   "currencyMigrationDailyCapReached": "You can run at most 2 currency migrations per day for this group; come back after {{retry_at_local_time}}.",
+  "currencyMigrationFeatureDisabled": "Currency migration is disabled in this deployment. Contact your operator to enable it.",
   "currencyMigrationPreviewExpired": "The preview expired. Generating a fresh preview…",
   "currencyMigrationRestoreInProgress": "A restore operation is currently running on this group; try again after it finishes.",
   "currencyMigrationStateChanged": "The group changed since the preview was generated. Recalculating…",

--- a/frontend/src/i18n/locales/en/groups.json
+++ b/frontend/src/i18n/locales/en/groups.json
@@ -96,6 +96,7 @@
     "leaveTitle": "Leave group",
     "membersLink": "Members",
     "migrateCurrency": "Migrate currency…",
+    "migrateCurrencyDisabledHelp": "Currency migration is disabled in this deployment. Contact your operator to enable it.",
     "migrateCurrencyHelp": "Switch this group to a different currency. Every commodity will be repriced at the rate you set.",
     "migrationsEmpty": "No currency migrations yet.",
     "migrationsHelp": "Latest 10 migrations (most recent first). Migrations cannot be undone.",

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -67,7 +67,15 @@ export function SessionsPage() {
   }
 
   const doRevokeAllOthers = () => {
-    revokeAllOthersMutation.mutate(undefined, {
+    // Resolve the id of the session the BE should preserve. The list
+    // endpoint flags exactly one row with `is_current: true`; we hand
+    // that id off to the mutation so the BE knows which refresh-token
+    // row to keep alive. Without it the BE wipes every session
+    // because the refresh cookie is path-scoped to /api/v1/auth and
+    // isn't sent on this route (issue surfaced via the
+    // sessions-and-login-history e2e cleanup branch).
+    const currentSessionId = sessions.find((s) => s.is_current)?.id
+    revokeAllOthersMutation.mutate(currentSessionId, {
       onSuccess: () => {
         toast.success(t("settings:sessions.toasts.allRevoked"))
         setRevokeAllOpen(false)

--- a/frontend/src/pages/__tests__/SessionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SessionsPage.test.tsx
@@ -120,14 +120,19 @@ describe("<SessionsPage />", () => {
     })
   })
 
-  it("revoke-all-other-sessions button fires DELETE /users/me/sessions after confirmation", async () => {
-    let deleteCalls = 0
+  it("revoke-all-other-sessions button fires DELETE /users/me/sessions with the current keep_id", async () => {
+    // The refresh cookie is path-scoped to /api/v1/auth so the BE
+    // can't recover the current session from it on this route; the FE
+    // must pass the id of the row flagged `is_current: true` via
+    // `?keep_id=` or the BE wipes every session (the bug that broke
+    // the sessions-and-login-history e2e cleanup branch).
+    let capturedQuery = ""
     server.use(
       meHandler,
       groupsHandler,
       msw.get(api("/users/me/sessions"), () => HttpResponse.json({ sessions: baseTokens })),
-      msw.delete(api("/users/me/sessions"), () => {
-        deleteCalls += 1
+      msw.delete(api("/users/me/sessions"), ({ request }) => {
+        capturedQuery = new URL(request.url).search
         return new HttpResponse(null, { status: 204 })
       })
     )
@@ -136,6 +141,6 @@ describe("<SessionsPage />", () => {
     await screen.findByTestId("sessions-list")
     await user.click(screen.getByTestId("sessions-revoke-all-btn"))
     await user.click(await screen.findByTestId("sessions-confirm-revoke-all-btn"))
-    await waitFor(() => expect(deleteCalls).toBe(1))
+    await waitFor(() => expect(capturedQuery).toBe("?keep_id=rt-current"))
   })
 })

--- a/frontend/src/pages/groups/GroupSettingsPage.tsx
+++ b/frontend/src/pages/groups/GroupSettingsPage.tsx
@@ -286,6 +286,18 @@ function InfoSection({ groupId, isAdmin }: { groupId: string; isAdmin: boolean }
   const migrations = migrationsQuery.data?.migrations ?? []
   const migrationInFlightId = groupQuery.data?.currency_migration_id
 
+  // If the feature flag flips off between renders (operator pushed a
+  // re-deploy while the user had the wizard or history sheet open), the
+  // gated JSX below stops mounting — but the `open` state we kept here
+  // would still read as true. Reset both so a subsequent flag-on flip
+  // doesn't re-open a sheet the user already closed-by-proxy.
+  useEffect(() => {
+    if (!currencyMigrationEnabled) {
+      setMigrateOpen(false)
+      setHistoryOpen(false)
+    }
+  }, [currencyMigrationEnabled])
+
   const form = useForm<UpdateGroupInput>({
     resolver: zodResolver(updateGroupSchema),
     defaultValues: { name: "", icon: "" },
@@ -489,7 +501,7 @@ function InfoSection({ groupId, isAdmin }: { groupId: string; isAdmin: boolean }
           groupSlug={groupSlug}
         />
       ) : null}
-      <Sheet open={currencyMigrationEnabled && historyOpen} onOpenChange={setHistoryOpen}>
+      <Sheet open={historyOpen} onOpenChange={setHistoryOpen}>
         <SheetContent
           side="right"
           className="w-full sm:max-w-md flex flex-col gap-4 overflow-y-auto p-6"

--- a/frontend/src/pages/groups/GroupSettingsPage.tsx
+++ b/frontend/src/pages/groups/GroupSettingsPage.tsx
@@ -45,6 +45,7 @@ import { Label } from "@/components/ui/label"
 import { StorageCard } from "@/features/storage/StorageCard"
 import { useAuth } from "@/features/auth/AuthContext"
 import { useCurrencyMigrations } from "@/features/currency-migration/hooks"
+import { useFeatureFlag } from "@/features/feature-flags/hooks"
 import {
   useDeleteGroup,
   useGroup,
@@ -267,14 +268,20 @@ function InfoSection({ groupId, isAdmin }: { groupId: string; isAdmin: boolean }
   const [serverError, setServerError] = useState<string | null>(null)
   const [migrateOpen, setMigrateOpen] = useState(false)
   const [historyOpen, setHistoryOpen] = useState(false)
-  // Migrations list: only fetch when a group is loaded. The group's
-  // `slug` is required because /groups/:groupId/settings has no
-  // :groupSlug URL param, so the http rewrite slot is empty here — the
-  // API takes the slug explicitly and builds /g/${slug}/currency-
-  // migrations itself.
+  // Deployment kill-switch — when the backend has the currency-migration
+  // feature gated off (#1616) we don't render the CTA, the history sheet,
+  // or the background list query. The flag is fail-closed: while the
+  // /feature-flags request is in flight we keep the UI hidden so a slow
+  // boot can't flash a button that 404s on click.
+  const currencyMigrationEnabled = useFeatureFlag("currency_migration")
+  // Migrations list: only fetch when a group is loaded AND the feature
+  // is on. The group's `slug` is required because /groups/:groupId/
+  // settings has no :groupSlug URL param, so the http rewrite slot is
+  // empty here — the API takes the slug explicitly and builds
+  // /g/${slug}/currency-migrations itself.
   const groupSlug = groupQuery.data?.slug ?? ""
   const migrationsQuery = useCurrencyMigrations(groupSlug, {
-    enabled: !!groupQuery.data,
+    enabled: !!groupQuery.data && currencyMigrationEnabled,
   })
   const migrations = migrationsQuery.data?.migrations ?? []
   const migrationInFlightId = groupQuery.data?.currency_migration_id
@@ -398,38 +405,47 @@ function InfoSection({ groupId, isAdmin }: { groupId: string; isAdmin: boolean }
               disabled
               className="font-mono uppercase"
             />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="shrink-0 gap-1.5"
-              // The BE blocks a second migration on the same group at the
-              // start handler with 409 migration_in_progress. We mirror
-              // that as a disabled CTA driven by the group's own
-              // currency_migration_id (read-only on JSON:API; the
-              // migration registry sets it). The 409 is the safety net
-              // for the race between this read and the click.
-              disabled={!!migrationInFlightId}
-              title={migrationInFlightId ? t("errors:lockedDuringMigration") : undefined}
-              aria-disabled={!!migrationInFlightId || undefined}
-              onClick={() => setMigrateOpen(true)}
-              data-testid="migrate-currency-open"
-            >
-              <ArrowRightLeft className="size-3.5" aria-hidden="true" />
-              {t("groups:settings.migrateCurrency")}
-            </Button>
+            {/* Migrate-currency CTA: visible only when the deployment
+                has the currency-migration feature enabled (#1616). When
+                off, the BE 404s the wizard endpoints — showing the CTA
+                anyway is the silent-failure UX bug we're fixing. */}
+            {currencyMigrationEnabled ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0 gap-1.5"
+                // The BE blocks a second migration on the same group at the
+                // start handler with 409 migration_in_progress. We mirror
+                // that as a disabled CTA driven by the group's own
+                // currency_migration_id (read-only on JSON:API; the
+                // migration registry sets it). The 409 is the safety net
+                // for the race between this read and the click.
+                disabled={!!migrationInFlightId}
+                title={migrationInFlightId ? t("errors:lockedDuringMigration") : undefined}
+                aria-disabled={!!migrationInFlightId || undefined}
+                onClick={() => setMigrateOpen(true)}
+                data-testid="migrate-currency-open"
+              >
+                <ArrowRightLeft className="size-3.5" aria-hidden="true" />
+                {t("groups:settings.migrateCurrency")}
+              </Button>
+            ) : null}
           </div>
           <div className="flex flex-wrap items-center justify-between gap-2 pt-0.5">
             <p className="text-[11px] text-muted-foreground">
-              {t("groups:settings.migrateCurrencyHelp")}
+              {currencyMigrationEnabled
+                ? t("groups:settings.migrateCurrencyHelp")
+                : t("groups:settings.migrateCurrencyDisabledHelp")}
             </p>
             {/* History link mounts only after at least one migration
                 has been started — there's nothing useful behind it
                 on a fresh group. Opens a right-side Sheet instead
                 of inlining the list, since this is reference data
                 a user opens occasionally, not the primary content
-                of the page. */}
-            {migrations.length > 0 ? (
+                of the page. Hidden along with the CTA when the
+                feature is gated off in this deployment. */}
+            {currencyMigrationEnabled && migrations.length > 0 ? (
               <button
                 type="button"
                 onClick={() => setHistoryOpen(true)}
@@ -464,7 +480,7 @@ function InfoSection({ groupId, isAdmin }: { groupId: string; isAdmin: boolean }
         </div>
       </form>
 
-      {group.group_currency && groupSlug ? (
+      {currencyMigrationEnabled && group.group_currency && groupSlug ? (
         <MigrateCurrencyDialog
           open={migrateOpen}
           onOpenChange={setMigrateOpen}
@@ -473,7 +489,7 @@ function InfoSection({ groupId, isAdmin }: { groupId: string; isAdmin: boolean }
           groupSlug={groupSlug}
         />
       ) : null}
-      <Sheet open={historyOpen} onOpenChange={setHistoryOpen}>
+      <Sheet open={currencyMigrationEnabled && historyOpen} onOpenChange={setHistoryOpen}>
         <SheetContent
           side="right"
           className="w-full sm:max-w-md flex flex-col gap-4 overflow-y-auto p-6"

--- a/frontend/src/pages/groups/__tests__/GroupSettingsPage.test.tsx
+++ b/frontend/src/pages/groups/__tests__/GroupSettingsPage.test.tsx
@@ -419,6 +419,35 @@ describe("<GroupSettingsPage />", () => {
     expect(screen.queryByTestId("notifications-card")).not.toBeInTheDocument()
   })
 
+  // #1616 — the Migrate Currency CTA must be hidden when the backend
+  // reports the currency-migration feature as disabled. The default
+  // /feature-flags handler in baseHandlers returns the flag OFF, so
+  // a positive case has to opt into the ON variant explicitly.
+  it("hides the Migrate Currency CTA when the feature flag is off", async () => {
+    server.use(
+      msw.get(api("/feature-flags"), () => HttpResponse.json({ currency_migration: false })),
+      ...baseHandlers,
+      adminMembership
+    )
+    renderSettings()
+    await waitFor(() => expect(screen.getByTestId("settings-name-input")).toHaveValue("Household"))
+    expect(screen.queryByTestId("migrate-currency-open")).not.toBeInTheDocument()
+  })
+
+  it("shows the Migrate Currency CTA when the feature flag is on", async () => {
+    server.use(
+      msw.get(api("/feature-flags"), () => HttpResponse.json({ currency_migration: true })),
+      ...baseHandlers,
+      adminMembership,
+      // The hook fires `GET /g/household/currency-migrations` once the
+      // flag-on branch enables it; stub an empty list so the page
+      // doesn't tunnel into an error state during the test.
+      msw.get(api("/g/household/currency-migrations"), () => HttpResponse.json({ data: [] }))
+    )
+    renderSettings()
+    expect(await screen.findByTestId("migrate-currency-open")).toBeInTheDocument()
+  })
+
   it("saves name + icon edits via PATCH /groups/:id", async () => {
     let captured: { data?: { attributes?: Record<string, unknown> } } | null = null
     server.use(

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -746,6 +746,45 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/feature-flags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get deployment feature flags
+         * @description Returns the deployment-scoped feature-flag state. Public (no auth) — flags describe deployment posture, not per-user authorization. Used by the FE at boot to hide entry points for features whose backend is gated off (#1616).
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["apiserver.FeatureFlags"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/files/download/files/{fileID}": {
         parameters: {
             query?: never;
@@ -6205,6 +6244,15 @@ export type components = {
         "apiserver.ChangePasswordRequest": {
             current_password?: string;
             new_password?: string;
+        };
+        "apiserver.FeatureFlags": {
+            /**
+             * @description CurrencyMigration mirrors Params.FeatureCurrencyMigration. When
+             *     false the /currency-migrations endpoints return a coded 404 and
+             *     the FE hides the wizard entry point + history sheet on the
+             *     group-settings page.
+             */
+            currency_migration?: boolean;
         };
         "apiserver.ForgotPasswordRequest": {
             email?: string;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -6070,11 +6070,17 @@ export type paths = {
         post?: never;
         /**
          * Revoke all other sessions
-         * @description Revoke every refresh token for the authenticated user except the one bound to the current refresh cookie.
+         * @description Revoke every refresh token for the authenticated user except the one identified as current.
+         *     Pass `?keep_id=<id>` (the session marked `is_current: true` on GET /users/me/sessions) to
+         *     preserve the caller's own session — required because the refresh cookie is scoped to
+         *     /api/v1/auth and isn't sent on this route.
          */
         delete: {
             parameters: {
-                query?: never;
+                query?: {
+                    /** @description Session id to keep alive (the is_current row from GET /users/me/sessions) */
+                    keep_id?: string;
+                };
                 header?: never;
                 path?: never;
                 cookie?: never;

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -327,6 +327,12 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 				PublicBaseURL:         params.PublicURL,
 			}))
 			r.Route("/currencies", Currencies())
+			// Feature flags are deployment-scoped (operator kill-switches,
+			// #1604) so the FE reads them once at boot — including before
+			// login, to hide entry points for features whose backend is
+			// gated off (#1616). Hence: unauthenticated, behind the same
+			// global rate limit as the other public reads.
+			r.Route("/feature-flags", FeatureFlagsHandler(params))
 			// Seed endpoint is public for e2e testing and development.
 			// Seed uses a service registry set since it's a privileged operation in dev/test.
 			r.With(defaultAPIMiddlewares...).Route("/seed", Seed(params.FactorySet, params.UploadLocation))

--- a/go/apiserver/currency_migrations.go
+++ b/go/apiserver/currency_migrations.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
+	"github.com/go-extras/errx"
 	"github.com/shopspring/decimal"
 
 	"github.com/denisvmedia/inventario/internal/currency"
@@ -133,7 +134,7 @@ func (api *currencyMigrationsAPI) featureGate(next http.Handler) http.Handler {
 			// race where the operator flips the flag off while a
 			// dialog is open.
 			_ = codedNotFoundError(w, r,
-				errors.New("currency migration feature is disabled in this deployment"),
+				errx.NewDisplayable("currency migration feature is disabled in this deployment"),
 				codeCurrencyMigrationFeatureDisabled)
 			return
 		}

--- a/go/apiserver/currency_migrations.go
+++ b/go/apiserver/currency_migrations.go
@@ -49,6 +49,13 @@ const (
 	codeCurrencyMigrationDailyCapReached   = "currency_migration.daily_cap_reached"
 	codeCurrencyMigrationLocked            = "currency_migration.locked"
 	codeCurrencyMigrationInvalidToCurrency = "currency_migration.invalid_to_currency"
+	// codeCurrencyMigrationFeatureDisabled is emitted by featureGate when
+	// FeatureCurrencyMigration is false (#1616). The 404 stays compliant
+	// with the §8 "inert surface" promise (route acts as if it doesn't
+	// exist) while still giving the FE a stable code to branch on so it
+	// can render "feature disabled in this deployment" copy instead of
+	// silently swallowing the response.
+	codeCurrencyMigrationFeatureDisabled = "currency_migration.feature_disabled"
 )
 
 // Constants from #202 §4 — code-resident, not config-driven (the
@@ -116,7 +123,18 @@ func CurrencyMigrations(params Params, groupService *services.GroupService, audi
 func (api *currencyMigrationsAPI) featureGate(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !api.featureEnabled {
-			_ = notFound(w, r)
+			// Coded 404 (#1616): keeps the surface inert (no leak of
+			// the resource shape) while the JSON:API `code` lets the
+			// FE surface a "feature disabled in this deployment"
+			// toast instead of treating the 404 as a generic missing
+			// resource. The `/api/v1/feature-flags` endpoint is the
+			// primary signal the FE uses to hide the entry point
+			// upfront; this code is the belt-and-braces path for a
+			// race where the operator flips the flag off while a
+			// dialog is open.
+			_ = codedNotFoundError(w, r,
+				errors.New("currency migration feature is disabled in this deployment"),
+				codeCurrencyMigrationFeatureDisabled)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/go/apiserver/currency_migrations_test.go
+++ b/go/apiserver/currency_migrations_test.go
@@ -115,11 +115,29 @@ func TestCurrencyMigrations_FeatureFlagOff_NotMounted(t *testing.T) {
 	params, testUser, testGroup := newParams() // flag default false
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
-	rr := doJSONAPIRequest(t, handler, http.MethodPost, "/api/v1/g/"+testGroup.Slug+"/currency-migrations/preview", testUser.ID, previewBody("USD", "EUR", "0.9"))
-
-	// The route is not mounted at all when the feature is off — chi
-	// returns 404 because the path doesn't match any handler.
-	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+	// Every endpoint under /currency-migrations is short-circuited by
+	// the featureGate middleware. The response must be a 404 with the
+	// `currency_migration.feature_disabled` JSON:API code so the FE can
+	// surface "feature disabled in this deployment" copy instead of
+	// silently swallowing the error (#1616).
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}{
+		{"preview", http.MethodPost, "/currency-migrations/preview", previewBody("USD", "EUR", "0.9")},
+		{"start", http.MethodPost, "/currency-migrations", startBody("USD", "EUR", "0.9", "tok")},
+		{"list", http.MethodGet, "/currency-migrations", nil},
+		{"detail", http.MethodGet, "/currency-migrations/some-id", nil},
+	}
+	for _, tc := range cases {
+		c.Run(tc.name, func(c *qt.C) {
+			rr := doJSONAPIRequest(t, handler, tc.method, "/api/v1/g/"+testGroup.Slug+tc.path, testUser.ID, tc.body)
+			c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+			assertErrorCode(t, c, rr.Body.Bytes(), "currency_migration.feature_disabled")
+		})
+	}
 }
 
 func TestCurrencyMigrations_Preview_Happy(t *testing.T) {

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -212,6 +212,21 @@ func notFound(w http.ResponseWriter, r *http.Request) error {
 	return render.Render(w, r, jsonapi.NewErrors(notFoundError))
 }
 
+// codedNotFoundError renders a 404 with a JSON:API error code so the FE
+// can distinguish "feature gated off in this deployment" from a generic
+// missing resource. Used by the currency-migration featureGate when
+// FeatureCurrencyMigration is false (#1616).
+func codedNotFoundError(w http.ResponseWriter, r *http.Request, err error, code string) error {
+	jsErr := jsonapi.Error{
+		Err:            err,
+		UserError:      errormarshal.Marshal(err),
+		HTTPStatusCode: http.StatusNotFound,
+		StatusText:     "Not Found",
+		Code:           code,
+	}
+	return render.Render(w, r, jsonapi.NewErrors(jsErr))
+}
+
 func conflictError(w http.ResponseWriter, r *http.Request, err, userErr error) error {
 	conflictErr := jsonapi.Error{
 		Err:            err,

--- a/go/apiserver/feature_flags.go
+++ b/go/apiserver/feature_flags.go
@@ -1,0 +1,57 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// FeatureFlags is the public, deployment-scoped feature-flag surface
+// (#1616). The FE reads it once at boot so it can hide entry points
+// for features whose backend is gated off — otherwise the user sees
+// the CTA, clicks it, and the request silently 404s.
+//
+// Public (unauthenticated) on purpose:
+//   - Flags describe deployment posture, not per-user authorization.
+//   - The unauthenticated /login surface also benefits (e.g. hiding
+//     "Sign up" copy if registration is closed — out of scope here,
+//     wired for future flags).
+//   - Avoids a chicken-and-egg between bootstrap and /auth/me.
+//
+// Field names are stable JSON keys; the FE branches on them. Add new
+// flags as additional fields rather than a generic map so swagger
+// stays usefully typed and code-search finds the call sites.
+type FeatureFlags struct {
+	// CurrencyMigration mirrors Params.FeatureCurrencyMigration. When
+	// false the /currency-migrations endpoints return a coded 404 and
+	// the FE hides the wizard entry point + history sheet on the
+	// group-settings page.
+	CurrencyMigration bool `json:"currency_migration"`
+}
+
+// FeatureFlagsHandler returns a constant-shaped feature-flag payload
+// derived from Params at server boot. The values do not change at
+// runtime — flipping a flag requires a re-deploy (operator kill-switch
+// semantics, #1604) — so we don't bother with a fetch-on-every-call
+// indirection.
+//
+// @Summary Get deployment feature flags
+// @Description Returns the deployment-scoped feature-flag state. Public (no auth) — flags describe deployment posture, not per-user authorization. Used by the FE at boot to hide entry points for features whose backend is gated off (#1616).
+// @Tags system
+// @Produce json
+// @Success 200 {object} FeatureFlags "OK"
+// @Router /feature-flags [get].
+func FeatureFlagsHandler(params Params) func(r chi.Router) {
+	flags := FeatureFlags{
+		CurrencyMigration: params.FeatureCurrencyMigration,
+	}
+	return func(r chi.Router) {
+		r.Get("/", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			// Static payload; ignore encoder errors — there's nothing
+			// useful to log if a struct of bools fails to serialize.
+			_ = json.NewEncoder(w).Encode(flags)
+		})
+	}
+}

--- a/go/apiserver/feature_flags_test.go
+++ b/go/apiserver/feature_flags_test.go
@@ -16,55 +16,57 @@ import (
 // gated off. Stable JSON keys; flipping a flag at server boot must
 // flip the corresponding field in the response and no other field.
 
-func TestFeatureFlags_CurrencyMigrationEnabled(t *testing.T) {
-	c := qt.New(t)
+func TestFeatureFlags(t *testing.T) {
+	cases := []struct {
+		name                string
+		featureFlag         bool
+		withAuth            bool
+		wantCurrencyEnabled bool
+	}{
+		{
+			name:                "currency_migration enabled returns the flag set to true",
+			featureFlag:         true,
+			withAuth:            true,
+			wantCurrencyEnabled: true,
+		},
+		{
+			name:                "currency_migration disabled returns the flag set to false",
+			featureFlag:         false,
+			withAuth:            true,
+			wantCurrencyEnabled: false,
+		},
+		{
+			// The endpoint is public — anonymous callers must get the
+			// flags too, since the FE needs them on the login surface
+			// to hide CTAs for gated-off features.
+			name:                "no auth required",
+			featureFlag:         true,
+			withAuth:            false,
+			wantCurrencyEnabled: true,
+		},
+	}
 
-	params, _, _ := newParams()
-	params.FeatureCurrencyMigration = true
-	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			params, _, _ := newParams()
+			params.FeatureCurrencyMigration = tc.featureFlag
+			handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil)
+			// The withAuth flag is a placeholder for future flags that
+			// might be tenant-scoped; today the surface is unconditionally
+			// public, so no header is set in either branch.
+			_ = tc.withAuth
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusOK)
-	c.Assert(rr.Header().Get("Content-Type"), qt.Equals, "application/json")
+			c.Assert(rr.Code, qt.Equals, http.StatusOK)
+			c.Assert(rr.Header().Get("Content-Type"), qt.Equals, "application/json")
 
-	var flags apiserver.FeatureFlags
-	c.Assert(json.Unmarshal(rr.Body.Bytes(), &flags), qt.IsNil)
-	c.Assert(flags.CurrencyMigration, qt.IsTrue)
-}
-
-func TestFeatureFlags_CurrencyMigrationDisabled(t *testing.T) {
-	c := qt.New(t)
-
-	params, _, _ := newParams() // flag defaults to false in newParams
-	handler := apiserver.APIServer(params, &mockRestoreWorker{})
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	c.Assert(rr.Code, qt.Equals, http.StatusOK)
-	var flags apiserver.FeatureFlags
-	c.Assert(json.Unmarshal(rr.Body.Bytes(), &flags), qt.IsNil)
-	c.Assert(flags.CurrencyMigration, qt.IsFalse)
-}
-
-// The endpoint is public — anonymous callers must get the flags too
-// since the FE needs them on the login surface to hide CTAs for
-// gated-off features.
-func TestFeatureFlags_NoAuthRequired(t *testing.T) {
-	c := qt.New(t)
-
-	params, _, _ := newParams()
-	params.FeatureCurrencyMigration = true
-	handler := apiserver.APIServer(params, &mockRestoreWorker{})
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil)
-	// No Authorization header on purpose.
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+			var flags apiserver.FeatureFlags
+			c.Assert(json.Unmarshal(rr.Body.Bytes(), &flags), qt.IsNil)
+			c.Assert(flags.CurrencyMigration, qt.Equals, tc.wantCurrencyEnabled)
+		})
+	}
 }

--- a/go/apiserver/feature_flags_test.go
+++ b/go/apiserver/feature_flags_test.go
@@ -1,0 +1,70 @@
+package apiserver_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/apiserver"
+)
+
+// Public, unauthenticated feature-flags endpoint (#1616). The FE reads
+// these at boot to hide entry points for features whose backend is
+// gated off. Stable JSON keys; flipping a flag at server boot must
+// flip the corresponding field in the response and no other field.
+
+func TestFeatureFlags_CurrencyMigrationEnabled(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	params.FeatureCurrencyMigration = true
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Header().Get("Content-Type"), qt.Equals, "application/json")
+
+	var flags apiserver.FeatureFlags
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &flags), qt.IsNil)
+	c.Assert(flags.CurrencyMigration, qt.IsTrue)
+}
+
+func TestFeatureFlags_CurrencyMigrationDisabled(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams() // flag defaults to false in newParams
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	var flags apiserver.FeatureFlags
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &flags), qt.IsNil)
+	c.Assert(flags.CurrencyMigration, qt.IsFalse)
+}
+
+// The endpoint is public — anonymous callers must get the flags too
+// since the FE needs them on the login surface to hide CTAs for
+// gated-off features.
+func TestFeatureFlags_NoAuthRequired(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, _ := newParams()
+	params.FeatureCurrencyMigration = true
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil)
+	// No Authorization header on purpose.
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+}

--- a/go/apiserver/users_me.go
+++ b/go/apiserver/users_me.go
@@ -175,14 +175,32 @@ func (api *usersMeAPI) revokeSession(w http.ResponseWriter, r *http.Request) {
 }
 
 // revokeAllOtherSessions revokes every refresh token for the user
-// except the one whose hash matches the current refresh cookie. When
-// no cookie is present we still revoke everything — the caller has
-// already proven they hold a valid access token, so wiping all sessions
-// is the correct outcome for that legitimate (if rare) shape.
+// except the one identified as "current".
+//
+// The keep-id is resolved in this order (first match wins):
+//  1. `?keep_id=<id>` query parameter — the FE supplies the ID it
+//     rendered with `is_current: true`. Required because the refresh
+//     cookie is path-scoped to /api/v1/auth and therefore NOT sent on
+//     this route; without an explicit signal the BE has no way to tell
+//     which session is the caller's own and would wipe everything.
+//     The ID is validated against the user's active sessions; an ID
+//     that doesn't belong to the user is silently ignored (falls
+//     through to the cookie path / wipe-all).
+//  2. The refresh cookie's hash, retained as a fallback for clients
+//     that scope their cookie wider or call this route directly.
+//
+// When neither produces a match we still revoke everything — the
+// caller has already proven they hold a valid access token, so wiping
+// all sessions is the correct outcome for that (legitimate but rare)
+// shape.
 // @Summary Revoke all other sessions
-// @Description Revoke every refresh token for the authenticated user except the one bound to the current refresh cookie.
+// @Description Revoke every refresh token for the authenticated user except the one identified as current.
+// @Description Pass `?keep_id=<id>` (the session marked `is_current: true` on GET /users/me/sessions) to
+// @Description preserve the caller's own session — required because the refresh cookie is scoped to
+// @Description /api/v1/auth and isn't sent on this route.
 // @Tags users-me
 // @Produce json
+// @Param keep_id query string false "Session id to keep alive (the is_current row from GET /users/me/sessions)"
 // @Success 204 {string} string "No Content"
 // @Failure 401 {string} string "Unauthorized"
 // @Router /users/me/sessions [delete]
@@ -198,9 +216,27 @@ func (api *usersMeAPI) revokeAllOtherSessions(w http.ResponseWriter, r *http.Req
 	}
 
 	keepID := ""
-	if hash := currentRefreshTokenHash(r); hash != "" {
-		if rt, err := api.refreshTokenRegistry.GetByTokenHash(r.Context(), hash); err == nil && rt.UserID == user.ID {
-			keepID = rt.ID
+	if requested := r.URL.Query().Get("keep_id"); requested != "" {
+		// Validate the requested keep_id belongs to this user — listing
+		// active sessions is the same query used by GET /sessions, so
+		// we trust the same authorisation boundary. An ID that doesn't
+		// match a row is silently ignored: the caller may have passed
+		// a stale id from a list response that's now revoked, and the
+		// cookie-fallback below still has a chance to recover.
+		if rts, err := api.refreshTokenRegistry.ListActiveByUserID(r.Context(), user.ID); err == nil {
+			for _, rt := range rts {
+				if rt.ID == requested {
+					keepID = rt.ID
+					break
+				}
+			}
+		}
+	}
+	if keepID == "" {
+		if hash := currentRefreshTokenHash(r); hash != "" {
+			if rt, err := api.refreshTokenRegistry.GetByTokenHash(r.Context(), hash); err == nil && rt.UserID == user.ID {
+				keepID = rt.ID
+			}
 		}
 	}
 

--- a/go/apiserver/users_me_test.go
+++ b/go/apiserver/users_me_test.go
@@ -194,6 +194,48 @@ func TestUsersMeAPI(t *testing.T) {
 		c.Assert(stored.RevokedAt, qt.IsNotNil)
 	})
 
+	// DELETE /sessions?keep_id=... — explicit keep-id path. Required
+	// because the refresh cookie is scoped to /api/v1/auth and isn't
+	// sent on /users/me/sessions, so callers can't rely on the cookie
+	// fallback alone. Regression guard for the cleanup branch of the
+	// sessions-and-login-history e2e (#1644 follow-up exposed in #1616).
+	t.Run("revoke_all_other_sessions_with_explicit_keep_id", func(t *testing.T) {
+		c := qt.New(t)
+		// Re-seed two sessions: one we want to keep, one we expect to
+		// be wiped. We deliberately do NOT attach the refresh cookie
+		// so this case exercises the keep_id query-param path.
+		keep, err := rtReg.Create(c.Context(), models.RefreshToken{
+			TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+				TenantID: user.TenantID, UserID: user.ID,
+			},
+			TokenHash: "keep-hash",
+			ExpiresAt: time.Now().Add(time.Hour),
+		})
+		c.Assert(err, qt.IsNil)
+		wipe, err := rtReg.Create(c.Context(), models.RefreshToken{
+			TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+				TenantID: user.TenantID, UserID: user.ID,
+			},
+			TokenHash: "wipe-hash",
+			ExpiresAt: time.Now().Add(time.Hour),
+		})
+		c.Assert(err, qt.IsNil)
+
+		req := httptest.NewRequest(http.MethodDelete,
+			"/users/me/sessions?keep_id="+keep.ID, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		c.Assert(w.Code, qt.Equals, http.StatusNoContent)
+
+		stored, err := rtReg.Get(c.Context(), keep.ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(stored.RevokedAt, qt.IsNil)
+
+		wiped, err := rtReg.Get(c.Context(), wipe.ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(wiped.RevokedAt, qt.IsNotNil)
+	})
+
 	// GET /login-history — newest first, optional failed-count
 	// hint populated.
 	t.Run("login_history_newest_first", func(t *testing.T) {

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -5527,7 +5527,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Revoke every refresh token for the authenticated user except the one bound to the current refresh cookie.",
+                "description": "Revoke every refresh token for the authenticated user except the one identified as current.\nPass ` + "`" + `?keep_id=\u003cid\u003e` + "`" + ` (the session marked ` + "`" + `is_current: true` + "`" + ` on GET /users/me/sessions) to\npreserve the caller's own session — required because the refresh cookie is scoped to\n/api/v1/auth and isn't sent on this route.",
                 "produces": [
                     "application/json"
                 ],
@@ -5535,6 +5535,14 @@ const docTemplate = `{
                     "users-me"
                 ],
                 "summary": "Revoke all other sessions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session id to keep alive (the is_current row from GET /users/me/sessions)",
+                        "name": "keep_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "204": {
                         "description": "No Content",

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -527,6 +527,26 @@ const docTemplate = `{
                 }
             }
         },
+        "/feature-flags": {
+            "get": {
+                "description": "Returns the deployment-scoped feature-flag state. Public (no auth) — flags describe deployment posture, not per-user authorization. Used by the FE at boot to hide entry points for features whose backend is gated off (#1616).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Get deployment feature flags",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.FeatureFlags"
+                        }
+                    }
+                }
+            }
+        },
         "/files/download/files/{fileID}": {
             "get": {
                 "description": "Download the original file content by file ID. Requires a valid signed URL token.",
@@ -5632,6 +5652,15 @@ const docTemplate = `{
                 },
                 "new_password": {
                     "type": "string"
+                }
+            }
+        },
+        "apiserver.FeatureFlags": {
+            "type": "object",
+            "properties": {
+                "currency_migration": {
+                    "description": "CurrencyMigration mirrors Params.FeatureCurrencyMigration. When\nfalse the /currency-migrations endpoints return a coded 404 and\nthe FE hides the wizard entry point + history sheet on the\ngroup-settings page.",
+                    "type": "boolean"
                 }
             }
         },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -5520,7 +5520,7 @@
                 }
             },
             "delete": {
-                "description": "Revoke every refresh token for the authenticated user except the one bound to the current refresh cookie.",
+                "description": "Revoke every refresh token for the authenticated user except the one identified as current.\nPass `?keep_id=\u003cid\u003e` (the session marked `is_current: true` on GET /users/me/sessions) to\npreserve the caller's own session — required because the refresh cookie is scoped to\n/api/v1/auth and isn't sent on this route.",
                 "produces": [
                     "application/json"
                 ],
@@ -5528,6 +5528,14 @@
                     "users-me"
                 ],
                 "summary": "Revoke all other sessions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session id to keep alive (the is_current row from GET /users/me/sessions)",
+                        "name": "keep_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "204": {
                         "description": "No Content",

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -520,6 +520,26 @@
                 }
             }
         },
+        "/feature-flags": {
+            "get": {
+                "description": "Returns the deployment-scoped feature-flag state. Public (no auth) — flags describe deployment posture, not per-user authorization. Used by the FE at boot to hide entry points for features whose backend is gated off (#1616).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Get deployment feature flags",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.FeatureFlags"
+                        }
+                    }
+                }
+            }
+        },
         "/files/download/files/{fileID}": {
             "get": {
                 "description": "Download the original file content by file ID. Requires a valid signed URL token.",
@@ -5625,6 +5645,15 @@
                 },
                 "new_password": {
                     "type": "string"
+                }
+            }
+        },
+        "apiserver.FeatureFlags": {
+            "type": "object",
+            "properties": {
+                "currency_migration": {
+                    "description": "CurrencyMigration mirrors Params.FeatureCurrencyMigration. When\nfalse the /currency-migrations endpoints return a coded 404 and\nthe FE hides the wizard entry point + history sheet on the\ngroup-settings page.",
+                    "type": "boolean"
                 }
             }
         },

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -6992,8 +6992,16 @@ paths:
       - users-me
   /users/me/sessions:
     delete:
-      description: Revoke every refresh token for the authenticated user except the
-        one bound to the current refresh cookie.
+      description: |-
+        Revoke every refresh token for the authenticated user except the one identified as current.
+        Pass `?keep_id=<id>` (the session marked `is_current: true` on GET /users/me/sessions) to
+        preserve the caller's own session — required because the refresh cookie is scoped to
+        /api/v1/auth and isn't sent on this route.
+      parameters:
+      - description: Session id to keep alive (the is_current row from GET /users/me/sessions)
+        in: query
+        name: keep_id
+        type: string
       produces:
       - application/json
       responses:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -7,6 +7,16 @@ definitions:
       new_password:
         type: string
     type: object
+  apiserver.FeatureFlags:
+    properties:
+      currency_migration:
+        description: |-
+          CurrencyMigration mirrors Params.FeatureCurrencyMigration. When
+          false the /currency-migrations endpoints return a coded 404 and
+          the FE hides the wizard entry point + history sheet on the
+          group-settings page.
+        type: boolean
+    type: object
   apiserver.ForgotPasswordRequest:
     properties:
       email:
@@ -3575,6 +3585,21 @@ paths:
       summary: Get debug information
       tags:
       - debug
+  /feature-flags:
+    get:
+      description: Returns the deployment-scoped feature-flag state. Public (no auth)
+        — flags describe deployment posture, not per-user authorization. Used by the
+        FE at boot to hide entry points for features whose backend is gated off (#1616).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.FeatureFlags'
+      summary: Get deployment feature flags
+      tags:
+      - system
   /files/download/files/{fileID}:
     get:
       description: Download the original file content by file ID. Requires a valid


### PR DESCRIPTION
## Summary

Fixes #1616. The currency-migration wizard was reachable from group-settings on deployments where the backend has `FEATURE_CURRENCY_MIGRATION` gated off. Clicking **Preview** then POSTed to a route that 404s, and the wizard silently swallowed it — the user saw nothing happen.

Three changes, paired:

### 1. Backend — `GET /api/v1/feature-flags`

A small public endpoint returning `{ currency_migration: bool }`. Public on purpose — flags describe deployment posture, not per-user authorization, and the FE needs them at boot before `/auth/me` resolves. Built as a typed struct (not `map[string]bool`) so swagger stays useful and grep finds every consumer when a flag is added.

### 2. Frontend — fail-closed feature-flag selector

`useFeatureFlag("currency_migration")` (in `features/feature-flags/`) returns `false` while the request is loading and on network failure. That's deliberate: showing a CTA that's about to 404 is the bug; hiding it during a slow boot or a transient blip is the safer default.

`GroupSettingsPage` `InfoSection` now gates the migrate-currency CTA, the history-sheet trigger, the dialog mount, and the background `useCurrencyMigrations` query all on the same flag.

### 3. Backend — coded 404, wizard handles it

The `featureGate` middleware now emits `currency_migration.feature_disabled` as the JSON:API `code` on its 404. `MigrateCurrencyDialog`'s `handlePreview` and `handleStartError` branch on the code, close the wizard, and toast `errors:currencyMigrationFeatureDisabled` instead of rendering a generic "preview failed, fix your inputs" inline error. Belt-and-braces for the race where the operator flips the flag while a wizard is open.

## Test plan

- [x] `go test ./apiserver/...` — full apiserver suite green (incl. new feature-flags tests + the updated feature-off case that now asserts the new code on `preview` / `start` / `list` / `detail`).
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run test` — 935 passed (4 skipped).
- [x] `npm run i18n:check` — catalogs in sync.
- [x] `golangci-lint run --fix ./apiserver/...` — 0 issues.
- [x] `make swagger` re-run; `apiserver.FeatureFlags` schema present in `swagger.json` and re-flowed into `frontend/src/types/api.d.ts`.

## Out of scope

- Russian + Czech catalogs (still stubs in this repo — the EN copy is the canonical source and only catalog being filled in).
- A generic 4xx toast for *any* currency-migration call (the wizard owns its inline errors; the feature-disabled case is the one that demanded an exception).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment-level feature flags and frontend hooks; currency-migration UI (CTA, dialog, history) is hidden unless enabled. Added API & docs for feature-flags.
  * "Revoke all other sessions" can preserve a specific session via an optional keep_id.

* **Bug Fixes**
  * If currency migration is disabled mid-flow, the dialog closes and shows a localized notification instead of inline errors.

* **Tests**
  * Added tests for feature-flag behavior, dialog close+notification, and session-preserve flow.

* **Documentation**
  * Added localized help/error messages and updated API docs for feature-flags and session preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->