### PR TITLE
[#1654] LocationsList more-actions trigger: z-stack + cursor + icon decision

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -172,6 +172,15 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 - **Approved by**: agent-suggested — the sticky strip is a self-contained mock pattern; the real shell makes it redundant.
 - **Reversion plan**: Permanent unless the app ever loses its persistent TopBar. Reconciliation would mean adding a `sticky` variant to `LocationsBreadcrumb` and using it from `LocationDetailPage` / `AreaDetailPage` once the shell decision changes.
 
+#### 2026-05-17 — LocationCard "more actions" trigger keeps the 3-dot `MoreHorizontal` glyph instead of the mock's `MoveHorizontal` alias
+
+- **Issue/PR**: #1654 / PR (pending)
+- **Mock**: [`design-mocks/src/views/LocationPickerView.tsx`](../../design-mocks/src/views/LocationPickerView.tsx) imports `MoveHorizontal as MoreHorizontal` (line 3) and renders the renamed component as the per-row "more actions" trigger (lines 577, 645). `MoveHorizontal` is the left-right arrow glyph (`↔`), not the 3-dot glyph the local name implies.
+- **Reality**: `frontend/src/pages/locations/LocationsListPage.tsx` imports the real `MoreHorizontal` (3-dot `• • •`) from `lucide-react` and uses it on the per-row dropdown trigger.
+- **Why**: The mock's alias is a typo — the canonical "more actions" affordance across the wider codebase, including [`design-mocks/CLAUDE.md`](../../design-mocks/CLAUDE.md)'s Dropdown Menu example, is `MoreHorizontal` (3 dots). Following the typo would diverge from every other "more actions" trigger in the app (`MembersPage.tsx`, `LocationDetailPage.tsx`'s `AreaTile`, the mock's own Dropdown Menu reference snippet) and substitute an arrow glyph that does not communicate "menu trigger". Per the issue body the user explicitly framed this as a typo to be ignored.
+- **Approved by**: user (explicit) — issue body: "likely the three-dots `MoreHorizontal` is correct for a 'more actions' trigger and the mock alias is a typo".
+- **Reversion plan**: Permanent unless the upstream `inventario-design` repo deliberately rewrites the affordance to use `MoveHorizontal`. If that happens, drop this entry and switch the import to `MoveHorizontal as MoreHorizontal` here and on every other "more actions" call-site.
+
 #### 2026-05-10 — Per-area items panel ships v1 with two stats + simple list (no toolbar / files) — _resolved 2026-05-12_
 
 - **Issue/PR**: #1531 (item 1) / PR _pending_

--- a/e2e/tests/locations-crud.spec.ts
+++ b/e2e/tests/locations-crud.spec.ts
@@ -49,4 +49,78 @@ test.describe('Locations CRUD', () => {
     recorder.log(`Step ${step++}: deleting "${renamed.name}"`);
     await deleteLocation(page, recorder, renamed.name, locationId);
   });
+
+  // #1654 regression: the per-row "more actions" trigger
+  // (`location-card-menu`) shares pixel space with the absolute
+  // overlay `<Link data-testid="location-card-link">` that makes
+  // the whole card click-through to /locations/:id. CSS painting
+  // order put the positioned Link above the in-flow actions
+  // cluster, so a click landing on the trigger fell through to the
+  // Link and navigated away instead of opening the dropdown. The
+  // fix elevates the actions cluster with `relative z-10`; this
+  // spec asserts the dropdown opens on click and the page stays on
+  // /locations (no navigation).
+  test('LocationCard "more actions" trigger opens the dropdown without navigating (#1654)', async ({
+    page,
+    recorder,
+  }) => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const target = {
+      name: `E2E LocCard ${suffix}`,
+      address: `7 Trigger Way, Test City`,
+    };
+
+    let step = 1;
+    recorder.log(`Step ${step++}: navigating to /locations`);
+    await navigateTo(page, recorder, TO_LOCATIONS);
+
+    recorder.log(`Step ${step++}: creating "${target.name}"`);
+    const locationId = await createLocation(page, recorder, target);
+
+    recorder.log(`Step ${step++}: back to /locations for trigger-click test`);
+    await navigateTo(page, recorder, TO_LOCATIONS);
+
+    const card = page.locator(
+      `[data-testid="location-card"][data-location-id="${locationId}"]`,
+    );
+    await card.waitFor({ state: 'visible', timeout: 10000 });
+
+    const urlBeforeClick = page.url();
+
+    // Hover reveals the trigger (the button is `opacity-0` until
+    // `group-hover`, and Playwright's auto-actionability does hover
+    // before clicking — but we hover explicitly here so the
+    // recorder + screenshot reflect the real path the user takes).
+    await card.hover();
+    await recorder.takeScreenshot('location-more-01-hover');
+
+    const trigger = card.locator('[data-testid="location-card-menu"]');
+    // `Receives Events` actionability check exercises CSS hit
+    // testing — if the overlay Link covers the trigger this fails
+    // with a timeout instead of an outright incorrect navigation.
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+    await recorder.takeScreenshot('location-more-02-open');
+
+    // The dropdown's Add-area item is rendered into the body via
+    // Radix's portal once the menu opens.
+    await expect(page.locator('[data-testid="location-card-add-area"]')).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Critical: we must still be on /locations, NOT on
+    // /locations/:id — i.e. the trigger click did not fall through
+    // to the overlay Link.
+    expect(page.url()).toBe(urlBeforeClick);
+
+    // Close the menu via Escape so cleanup below sees a clean
+    // surface, then delete the fixture.
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-testid="location-card-add-area"]')).toBeHidden({
+      timeout: 5000,
+    });
+
+    recorder.log(`Step ${step++}: cleanup — delete "${target.name}"`);
+    await deleteLocation(page, recorder, target.name, locationId);
+  });
 });

--- a/frontend/src/pages/locations/LocationsListPage.tsx
+++ b/frontend/src/pages/locations/LocationsListPage.tsx
@@ -442,14 +442,24 @@ function LocationCard({
           </span>
         </div>
       </div>
-      <div className="pointer-events-none flex shrink-0 items-center gap-1">
+      {/* `relative z-10` is required even though the absolute overlay
+          `<Link>` sits earlier in the DOM. CSS painting order puts
+          positioned descendants (the Link, at z-auto = 0) above
+          in-flow non-positioned descendants (this actions cluster),
+          so without a stacking-context bump the trigger Button
+          loses every click to the Link even though it has
+          `pointer-events-auto`. Issue #1654. */}
+      <div className="pointer-events-none relative z-10 flex shrink-0 items-center gap-1">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               type="button"
               variant="ghost"
               size="icon"
-              className="pointer-events-auto size-8 opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+              // `cursor-pointer` is intentional: Tailwind v4 preflight
+              // strips `cursor: pointer` from native <button>; same
+              // workaround pattern as AppSidebar.tsx (sidebar Add-item).
+              className="pointer-events-auto size-8 cursor-pointer opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
               aria-label={t("locations:list.actionsLabel", { name: location.name ?? "" })}
               data-testid="location-card-menu"
             >

--- a/frontend/src/pages/locations/__tests__/LocationsListPage.test.tsx
+++ b/frontend/src/pages/locations/__tests__/LocationsListPage.test.tsx
@@ -269,6 +269,37 @@ describe("<LocationsListPage />", () => {
     expect(await screen.findByTestId("area-form-dialog")).toBeInTheDocument()
   })
 
+  // #1654 regression: the trigger Button has to ship with three
+  // contract classes that jsdom can't verify by clicking (no real
+  // CSS hit testing): `cursor-pointer` (Tailwind v4 preflight
+  // strips `cursor: pointer` from native <button>), and its
+  // parent wrapper needs `relative z-10` so the actions cluster
+  // sits above the absolute `location-card-link` overlay in CSS
+  // painting order. Without these, real browsers (and Playwright)
+  // route the click to the Link and navigate away. The Playwright
+  // spec in `e2e/tests/locations-crud.spec.ts` is authoritative;
+  // this guards the class contract so refactors don't silently
+  // re-introduce the bug between e2e runs.
+  it("ships the className contract that keeps the more-actions trigger clickable (#1654)", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...locationHandlers.list(SLUG, [locationResource("loc1", { name: "Main House" })]),
+      ...areaHandlers.list(SLUG, []),
+      ...commodityHandlers.list(SLUG, [])
+    )
+    renderList()
+    const card = await screen.findByTestId("location-card")
+    const trigger = within(card).getByTestId("location-card-menu")
+    expect(trigger.className).toMatch(/(?:^|\s)cursor-pointer(?:\s|$)/)
+    expect(trigger.className).toMatch(/(?:^|\s)pointer-events-auto(?:\s|$)/)
+    // Wrapper must be positioned + elevated so the trigger paints
+    // above the overlay Link.
+    const wrapper = trigger.parentElement
+    expect(wrapper).not.toBeNull()
+    expect(wrapper!.className).toMatch(/(?:^|\s)relative(?:\s|$)/)
+    expect(wrapper!.className).toMatch(/(?:^|\s)z-10(?:\s|$)/)
+  })
+
   it("has no axe violations once data has loaded", async () => {
     server.use(
       ...groupHandlers.list(groupFixture),


### PR DESCRIPTION
## Summary

Closes #1654.

The per-row "more actions" trigger on the Locations list (`LocationsListPage.tsx` `LocationCard`) had three issues against the design mock and against real-user expectations:

1. **Clicks didn't open the dropdown.** The trigger Button shared pixel space with the absolute-positioned overlay `<Link data-testid="location-card-link">` that turns the whole card into a click target. CSS painting order puts a positioned descendant with `z-auto` (the Link, step 6) above an in-flow non-positioned flex item (the actions cluster, step 3 / 5), so the click landed on the Link and navigated to `/locations/:id` instead of opening the menu. Even though the wrapper carried `pointer-events-none` and the Button re-enabled with `pointer-events-auto`, both Link and Button were valid hit-test candidates and the topmost-painted one won.
2. **Cursor stayed on the default arrow.** Tailwind v4 preflight strips `cursor: pointer` from native `<button>`; same workaround pattern the `AppSidebar.tsx` Add-item comment already documents.
3. **Icon decision.** The mock aliases `MoveHorizontal as MoreHorizontal` (`↔`) but every other "more actions" trigger in the app and the design-mocks Dropdown Menu reference snippet use the real `MoreHorizontal` (`• • •`). Per the issue body the alias is a typo; we keep the 3-dot glyph and log a deviation.

## Changes

- `frontend/src/pages/locations/LocationsListPage.tsx`
  - Actions cluster wrapper: `pointer-events-none flex shrink-0 items-center gap-1` → `pointer-events-none relative z-10 flex shrink-0 items-center gap-1` (creates a stacking context above the overlay Link).
  - Trigger Button: adds `cursor-pointer` to the className.
  - Inline comments explain both choices.
- `devdocs/frontend/design-deviations.md`
  - New entry under **Locations & Areas** documenting the `MoreHorizontal` / `MoveHorizontal` mock-typo decision.
- `frontend/src/pages/locations/__tests__/LocationsListPage.test.tsx`
  - New vitest case `ships the className contract that keeps the more-actions trigger clickable (#1654)` — guards the trigger's `cursor-pointer` + `pointer-events-auto` and the wrapper's `relative z-10`. (jsdom can't enforce real CSS hit-testing; Playwright is authoritative below.)
- `e2e/tests/locations-crud.spec.ts`
  - New Playwright case `LocationCard "more actions" trigger opens the dropdown without navigating (#1654)` — creates a fixture, hovers the card to reveal the trigger, exercises Playwright's `Receives Events` actionability check (which fails when the overlay Link covers the trigger), opens the menu, and asserts the URL did not change.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run i18n:check` — clean
- [x] `npm run test` — 903 passed, 4 skipped, 0 failed (incl. new className-contract case)
- [ ] CI Playwright suite — the new `LocationCard "more actions"` spec runs end-to-end against the docker compose stack
- [ ] Manual visual sweep on the Locations list — hover reveals the trigger, click opens the menu, cursor reads `pointer`, no navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "more actions" menu trigger on location cards to remain clickable and functional when overlays are present.

* **Tests**
  * Added end-to-end regression test for the menu dropdown interaction.
  * Added unit test to verify menu trigger styling requirements.

* **Documentation**
  * Documented a frontend design deviation regarding the location card menu icon.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->