### PR TITLE
[#1390] StatTeaserCard + NoGroup illustrative stats strip

### DIFF
--- a/e2e/tests/home.spec.ts
+++ b/e2e/tests/home.spec.ts
@@ -32,4 +32,30 @@ test.describe('Home Page', () => {
     await expect(page.locator('[data-testid="dashboard-total-value"]')).toBeVisible();
   });
 
+  test('hero stat cards drill into the matching list pages (#1390)', async ({ page }) => {
+    // Click each hero card and assert the resulting URL pathname +
+    // query — the cards must land the user on the surface the issue
+    // promises (items → /commodities, warranties → /warranties with
+    // the right tab pre-selected, value → /commodities). The list
+    // pages own their own e2e specs; this test only pins the routing
+    // contract.
+    const startUrl = page.url();
+    const groupPath = new URL(startUrl).pathname.replace(/\/?$/, "");
+
+    await page.locator('[data-testid="dashboard-commodities-count"]').click();
+    await expect(page).toHaveURL(`${groupPath}/commodities`);
+
+    await page.goto(startUrl);
+    await page.locator('[data-testid="dashboard-active-warranties"]').click();
+    await expect(page).toHaveURL(`${groupPath}/warranties?tab=active`);
+
+    await page.goto(startUrl);
+    await page.locator('[data-testid="dashboard-expired-warranties"]').click();
+    await expect(page).toHaveURL(`${groupPath}/warranties?tab=expired`);
+
+    await page.goto(startUrl);
+    await page.locator('[data-testid="dashboard-total-value"]').click();
+    await expect(page).toHaveURL(`${groupPath}/commodities`);
+  });
+
 });

--- a/e2e/tests/no-group-redirect.spec.ts
+++ b/e2e/tests/no-group-redirect.spec.ts
@@ -88,6 +88,19 @@ test.describe('No-group redirects (#1261, real fixture #1277)', () => {
     await expect(page.locator('[data-testid="no-group-create-button"]')).toBeVisible();
   });
 
+  test('NoGroupView renders the illustrative stats teaser strip (#1390)', async ({ page }) => {
+    // The three teaser cards land above the create-group CTA so the
+    // user sees the "tracked inventory" framing before being asked to
+    // commit. Numbers are static fixtures — the test only confirms
+    // they render, not the exact copy.
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/no-group$/);
+    await expect(page.locator('[data-testid="no-group-teaser"]')).toBeVisible();
+    await expect(page.locator('[data-testid="no-group-teaser-items"]')).toBeVisible();
+    await expect(page.locator('[data-testid="no-group-teaser-warranties"]')).toBeVisible();
+    await expect(page.locator('[data-testid="no-group-teaser-value"]')).toBeVisible();
+  });
+
   test('NoGroupView drives group creation and returns the user to /', async ({ page }) => {
     // This test stays mocked: a real POST /api/v1/groups would mutate
     // orphan's membership state and race the redirect tests above when the

--- a/frontend/src/components/StatTeaserCard.tsx
+++ b/frontend/src/components/StatTeaserCard.tsx
@@ -1,0 +1,80 @@
+import { Link } from "react-router-dom"
+import type { LucideIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+interface StatTeaserCardProps {
+  // Localised caption rendered above the value ("Items tracked").
+  label: string
+  // Pre-formatted headline value ("12", "$3,140"). Caller owns formatting
+  // so currency / locale stays under one roof.
+  value: string
+  // Optional Lucide icon for the left-rail mark. Omit for the auth-panel
+  // variant where the value stands on its own.
+  icon?: LucideIcon
+  // When set, the whole card becomes a router link. NoGroupPage uses fixed
+  // illustrative numbers and leaves this off; HomePage variants pass real
+  // drill-down targets.
+  href?: string
+  // Test handle so smoke tests can target a specific card without
+  // depending on its localised label.
+  testId?: string
+  className?: string
+}
+
+// StatTeaserCard renders one cell of an illustrative or summary stats
+// strip — three cards in NoGroupPage above the create-group CTA, and a
+// reusable building block for any future "value-prop at a glance" surface.
+// Layout follows the "Stats Row" recipe in design-mocks/CLAUDE.md §5
+// (icon-rail on the left, label-over-value stack on the right) so the
+// teaser inherits the rest of the app's visual rhythm without a new
+// design token.
+export function StatTeaserCard({
+  label,
+  value,
+  icon: Icon,
+  href,
+  testId,
+  className,
+}: StatTeaserCardProps) {
+  const body = (
+    <>
+      {Icon ? (
+        <div className="flex size-8 items-center justify-center rounded-lg bg-muted shrink-0">
+          <Icon aria-hidden="true" className="size-4 text-muted-foreground" />
+        </div>
+      ) : null}
+      <div className="min-w-0">
+        <p className="text-xs text-muted-foreground truncate">{label}</p>
+        <p className="text-lg font-semibold leading-tight">{value}</p>
+      </div>
+    </>
+  )
+
+  const base = cn(
+    "rounded-xl border border-border bg-card px-4 py-3 flex items-center gap-3",
+    className
+  )
+
+  if (!href) {
+    return (
+      <div className={base} data-testid={testId}>
+        {body}
+      </div>
+    )
+  }
+
+  return (
+    <Link
+      to={href}
+      data-testid={testId}
+      className={cn(
+        base,
+        "transition-colors hover:border-primary/30 hover:bg-muted/40",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      )}
+    >
+      {body}
+    </Link>
+  )
+}

--- a/frontend/src/components/__tests__/StatTeaserCard.test.tsx
+++ b/frontend/src/components/__tests__/StatTeaserCard.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { Package } from "lucide-react"
+import { screen } from "@testing-library/react"
+
+import { StatTeaserCard } from "@/components/StatTeaserCard"
+import { renderWithProviders } from "@/test/render"
+
+describe("<StatTeaserCard />", () => {
+  it("renders the label and value as plain text when no href is provided", () => {
+    renderWithProviders({
+      children: <StatTeaserCard label="Items tracked" value="12" icon={Package} testId="teaser" />,
+    })
+    const card = screen.getByTestId("teaser")
+    expect(card.tagName).toBe("DIV")
+    expect(card).toHaveTextContent("Items tracked")
+    expect(card).toHaveTextContent("12")
+  })
+
+  it("becomes a router link when href is set, drilling to the target route", () => {
+    renderWithProviders({
+      children: <StatTeaserCard label="Items" value="12" href="/g/x/commodities" testId="teaser" />,
+    })
+    const link = screen.getByTestId("teaser")
+    expect(link.tagName).toBe("A")
+    expect(link).toHaveAttribute("href", "/g/x/commodities")
+  })
+
+  it("omits the icon mark when no icon prop is passed", () => {
+    renderWithProviders({
+      children: <StatTeaserCard label="Items" value="12" testId="teaser" />,
+    })
+    expect(screen.getByTestId("teaser").querySelector("svg")).toBeNull()
+  })
+})

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -92,6 +92,15 @@
     "createGroupDescription": "Set up your own inventory and invite others.",
     "description": "You don't belong to any inventory group yet. Create one to start tracking your belongings.",
     "signOut": "Sign out instead",
+    "teaser": {
+      "caption": "Most users start with 5–20 items. Add yours →",
+      "estValueLabel": "Est. value",
+      "estValueValue": "$3,140",
+      "itemsLabel": "Items tracked",
+      "itemsValue": "12",
+      "warrantiesLabel": "Warranties active",
+      "warrantiesValue": "4"
+    },
     "title": "Welcome to Inventario"
   },
   "oauth": {

--- a/frontend/src/pages/NoGroupPage.tsx
+++ b/frontend/src/pages/NoGroupPage.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
-import { ArrowRight, Building2, Plus } from "lucide-react"
+import { ArrowRight, Building2, Package, Plus, ShieldCheck, TrendingUp } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { StatTeaserCard } from "@/components/StatTeaserCard"
 import { useLogout } from "@/features/auth/hooks"
 import { useCreateGroup } from "@/features/group/hooks"
 import { useAppToast } from "@/hooks/useAppToast"
@@ -83,6 +84,41 @@ export function NoGroupPage() {
             <h1 className="text-2xl font-semibold tracking-tight">{t("auth:noGroup.title")}</h1>
             <p className="text-sm text-muted-foreground leading-relaxed">
               {t("auth:noGroup.description")}
+            </p>
+          </div>
+
+          {/* Illustrative stats strip — fixed example numbers, not a live
+              query. The pattern is borrowed from the reference auth panel
+              (#1390) so a brand-new user sees what "tracked inventory"
+              actually looks like instead of an empty surface; the caption
+              below frames the numbers as typical rather than implying they
+              are theirs. Two-column on the narrowest viewports so the
+              currency cell doesn't squeeze the icon-rail into the value;
+              three-column from `sm:` up. */}
+          <div className="space-y-2" data-testid="no-group-teaser">
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3">
+              <StatTeaserCard
+                label={t("auth:noGroup.teaser.itemsLabel")}
+                value={t("auth:noGroup.teaser.itemsValue")}
+                icon={Package}
+                testId="no-group-teaser-items"
+              />
+              <StatTeaserCard
+                label={t("auth:noGroup.teaser.warrantiesLabel")}
+                value={t("auth:noGroup.teaser.warrantiesValue")}
+                icon={ShieldCheck}
+                testId="no-group-teaser-warranties"
+              />
+              <StatTeaserCard
+                label={t("auth:noGroup.teaser.estValueLabel")}
+                value={t("auth:noGroup.teaser.estValueValue")}
+                icon={TrendingUp}
+                testId="no-group-teaser-value"
+                className="col-span-2 sm:col-span-1"
+              />
+            </div>
+            <p className="text-center text-xs text-muted-foreground">
+              {t("auth:noGroup.teaser.caption")}
             </p>
           </div>
 

--- a/frontend/src/pages/__tests__/NoGroupPage.test.tsx
+++ b/frontend/src/pages/__tests__/NoGroupPage.test.tsx
@@ -65,6 +65,20 @@ describe("<NoGroupPage />", () => {
     expect(screen.queryByTestId("no-group-name-input")).not.toBeInTheDocument()
   })
 
+  it("renders the illustrative stats teaser strip above the CTA (#1390)", async () => {
+    server.use(...baseHandlers)
+    renderNoGroup()
+    expect(await screen.findByTestId("no-group-view")).toBeInTheDocument()
+    // All three teaser cards must render so the value-prop framing is
+    // there from first paint, and the cards are plain markers (no
+    // anchors) because the numbers are illustrative, not real.
+    expect(screen.getByTestId("no-group-teaser")).toBeInTheDocument()
+    expect(screen.getByTestId("no-group-teaser-items")).toBeInTheDocument()
+    expect(screen.getByTestId("no-group-teaser-warranties")).toBeInTheDocument()
+    expect(screen.getByTestId("no-group-teaser-value")).toBeInTheDocument()
+    expect(screen.getByTestId("no-group-teaser-items").tagName).toBe("DIV")
+  })
+
   it("clicking the CTA reveals the inline create-group form", async () => {
     server.use(...baseHandlers)
     const user = userEvent.setup()

--- a/frontend/src/pages/__tests__/NoGroupPage.test.tsx
+++ b/frontend/src/pages/__tests__/NoGroupPage.test.tsx
@@ -72,11 +72,17 @@ describe("<NoGroupPage />", () => {
     // All three teaser cards must render so the value-prop framing is
     // there from first paint, and the cards are plain markers (no
     // anchors) because the numbers are illustrative, not real.
-    expect(screen.getByTestId("no-group-teaser")).toBeInTheDocument()
+    const teaser = screen.getByTestId("no-group-teaser")
+    expect(teaser).toBeInTheDocument()
     expect(screen.getByTestId("no-group-teaser-items")).toBeInTheDocument()
     expect(screen.getByTestId("no-group-teaser-warranties")).toBeInTheDocument()
     expect(screen.getByTestId("no-group-teaser-value")).toBeInTheDocument()
     expect(screen.getByTestId("no-group-teaser-items").tagName).toBe("DIV")
+    // Pin DOM order: the teaser must precede the CTA so the value-prop
+    // framing reads before the user is asked to commit. A bare presence
+    // assertion wouldn't catch a reflow that swapped the two.
+    const cta = screen.getByTestId("no-group-create-button")
+    expect(teaser.compareDocumentPosition(cta) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0)
   })
 
   it("clicking the CTA reveals the inline create-group form", async () => {


### PR DESCRIPTION
Closes #1390.

## Summary

- Adds reusable `StatTeaserCard` (icon-rail + label/value stack, optional drill-down link) following the **Stats Row** recipe from `design-mocks/CLAUDE.md` §5 so the teaser inherits the rest of the app's visual rhythm.
- Wires three illustrative cards into `NoGroupPage` above the create-group CTA — fixed example numbers (`12 items tracked` / `4 warranties active` / `$3,140 est. value`) with a caption ("Most users start with 5–20 items. Add yours →") framing them as typical, not the user's own.
- Pins the HomeView contract in e2e: clicking each of the four hero stat cards lands on the right list page with the right `?tab=` query (already shipped via #1544; this PR just locks the routing in `home.spec.ts`).

## Acceptance criteria

- [x] `StatTeaserCard` component — `frontend/src/components/StatTeaserCard.tsx`
- [x] HomeView headline strip with stat cards — already shipped via #1544; routing now pinned by e2e
- [x] NoGroupView shows three illustrative cards above the CTAs
- [x] e2e: HomeView cards link to correct destinations (`home.spec.ts` `hero stat cards drill into the matching list pages`)

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 906/910 (4 pre-existing skips)
- [x] `npm run format:check` — clean
- [x] `npm run i18n:check` — clean
- [ ] CI e2e suite — to be verified once pipelines run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable stat teaser cards and an illustrative stats strip on the no-group page showing example inventory metrics (estimated value, items tracked, active warranties).
* **Tests**
  * Added unit tests for the stat teaser card and no-group page.
  * Added E2E tests verifying hero stat card drill-down routing and teaser strip visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->