### PR TITLE
[#1737] Scrub residual internal/errkit references from AI docs + comments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,7 +34,7 @@ items, their locations, and associated metadata. Please follow these guidelines 
 
 ### Go Development
 - `cd go` before operating on go code
-- Use `github.com/go-extras/errx` (and `github.com/go-extras/errx/stacktrace` imported as `errxtrace`) for error wrapping and stack traces; use the std `errors` package for sentinel errors
+- Use `github.com/go-extras/errx` (and `github.com/go-extras/errx/stacktrace` imported as `errxtrace`) for error wrapping and stack traces. Define sentinel errors with `errx.NewSentinel(...)` (see `go/services/errors.go`); reach for the std `errors` package only for `errors.Is` / `errors.As` checks.
 - Use `github.com/denisvmedia/inventario/internal/log` for logging (never use std `log` package). Using `log/slog` is
    acceptable but internal log is preferred
 - Use `github.com/frankban/quicktest` for tests, always imported with `qt` alias

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,7 @@ items, their locations, and associated metadata. Please follow these guidelines 
   - `go/registry/`: Data storage implementations (memory, postgres)
   - `go/models/`: Data models and entity definitions
   - `go/apiserver/`: HTTP API server implementation
-  - `go/internal/`: Internal packages (errkit, log, etc.)
+  - `go/internal/`: Internal packages (log, errormarshal, etc.)
 - `frontend/`: React 19 + TypeScript frontend (Tailwind v4 + shadcn/ui)
 - `e2e/`: End-to-end tests using Playwright
 - `docs/`: Swagger API documentation (auto-generated)
@@ -34,7 +34,7 @@ items, their locations, and associated metadata. Please follow these guidelines 
 
 ### Go Development
 - `cd go` before operating on go code
-- Use `github.com/denisvmedia/inventario/internal/errkit` for errors, but use std `errors` package for sentinel errors
+- Use `github.com/go-extras/errx` (and `github.com/go-extras/errx/stacktrace` imported as `errxtrace`) for error wrapping and stack traces; use the std `errors` package for sentinel errors
 - Use `github.com/denisvmedia/inventario/internal/log` for logging (never use std `log` package). Using `log/slog` is
    acceptable but internal log is preferred
 - Use `github.com/frankban/quicktest` for tests, always imported with `qt` alias

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ Uses Go Cloud Development Kit for storage abstraction:
 - In-app viewers for images (with zoom) and PDFs
 
 ### Error Handling
-Structured error handling with `errkit` package:
+Structured error handling with `github.com/go-extras/errx` and `github.com/go-extras/errx/stacktrace` (`errxtrace`):
 - Context-aware validation using `jellydator/validation`
 - Human-readable error messages
 - Proper HTTP status code mapping

--- a/go/internal/errormarshal/errormarshal.go
+++ b/go/internal/errormarshal/errormarshal.go
@@ -18,7 +18,7 @@ type jsonMinimalError struct {
 	Type string `json:"type,omitempty"`
 }
 
-// MarshalError marshals an error to JSON using a type-switch approach similar to errkit.
+// MarshalError marshals an error to JSON using a type-switch approach.
 // It returns the marshaled bytes and an error if marshaling fails.
 //
 // The function handles errors in this priority order:
@@ -83,7 +83,7 @@ func MarshalError(aerr error) ([]byte, error) {
 	}
 }
 
-// Marshal marshals an error to JSON, replicating the errkit.ForceMarshalError behavior.
+// Marshal marshals an error to JSON.
 // It always succeeds by falling back to a minimal error representation if marshaling fails.
 func Marshal(err error) json.RawMessage {
 	data, e := MarshalError(err)

--- a/go/internal/errormarshal/errormarshal_test.go
+++ b/go/internal/errormarshal/errormarshal_test.go
@@ -46,7 +46,7 @@ func TestMarshal_NilError(t *testing.T) {
 	result := errormarshal.Marshal(nil)
 	c.Assert(result, qt.IsNotNil)
 
-	// nil errors marshal to JSON null (matching original errkit behavior)
+	// nil errors marshal to JSON null
 	c.Assert(string(result), qt.Equals, "null")
 }
 


### PR DESCRIPTION
Closes #1737.

## Summary

The `go/internal/errkit` package itself was already removed from the Go source tree in earlier work. What remained were residual references that this PR cleans up:

- **`AGENTS.md`** — "Error Handling" section pointed at the deleted `errkit` package. Now points at `github.com/go-extras/errx` + `github.com/go-extras/errx/stacktrace` (`errxtrace`), matching the conventions all new service-layer code already uses (e.g. `go/services/maintenance_schedule_service.go`).
- **`.github/copilot-instructions.md`** — same fix, plus the repository-structure bullet that listed `errkit` under `go/internal/` is updated to list packages that actually exist (`log`, `errormarshal`, …).
- **`go/internal/errormarshal/errormarshal.go`** — drop "similar to errkit" / "replicating `errkit.ForceMarshalError` behavior" wording from godoc; the historical analogy refers to a deleted package and is dead context for new readers.
- **`go/internal/errormarshal/errormarshal_test.go`** — drop the "matching original errkit behavior" comment for the nil-error test; the JSON-null contract stands on its own.

No production code or behavior changes.

## Test plan

- [x] `grep -rn errkit go/ AGENTS.md .github/copilot-instructions.md` — no matches.
- [x] `golangci-lint run --fix ./internal/errormarshal/...` — clean.
- [x] `go test ./internal/errormarshal/...` — green.
- [x] `go build ./...` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidelines and agent docs: clarified preferred structured error-wrapping and stack-trace approach while retaining the standard sentinel-error pattern.
  * Clarified JSON marshaling behavior for error values in exported docs/comments.
  * Clarified test comment to state nil errors marshal to JSON null.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->