### PR TITLE
[#1387] feedback: cover too-many-diagnostics-entries 400 boundary

### DIFF
--- a/go/apiserver/feedback_test.go
+++ b/go/apiserver/feedback_test.go
@@ -230,6 +230,26 @@ func TestFeedback_Validation(t *testing.T) {
 		},
 		{name: "bad_reply_to", body: `{"type":"bug","message":"x","reply_to_email":"not-an-email"}`},
 		{name: "malformed_json", body: `not-json`},
+		{
+			name: "too_many_diagnostics_lines",
+			body: func() string {
+				// 33 entries — one over the documented cap of 32. Distinct
+				// keys are required because Diagnostics is a map.
+				diag := make(map[string]string, 33)
+				for i := range 33 {
+					diag[fmt.Sprintf("k%02d", i)] = "v"
+				}
+				out, err := json.Marshal(struct {
+					Type        string            `json:"type"`
+					Message     string            `json:"message"`
+					Diagnostics map[string]string `json:"diagnostics"`
+				}{Type: "bug", Message: "x", Diagnostics: diag})
+				if err != nil {
+					panic(err)
+				}
+				return string(out)
+			}(),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Follow-up to #1734. Lands the CodeRabbit-flagged validation case that I missed in the merge window of the original PR.

## What

One new sub-test in `TestFeedback_Validation` — `too_many_diagnostics_lines` — that submits 33 diagnostics entries (one over the documented `feedbackMaxDiagnosticsEntries = 32` cap) and asserts the handler returns **400** without touching the email service.

## Why

The 32-entry cap is a structural guard against runaway loops dumping unbounded rows into the support inbox; the merged PR enforced it in the handler but had no test pinning the boundary. CodeRabbit flagged this as a nitpick on #1734 — the reply is at https://github.com/denisvmedia/inventario/pull/1734#issuecomment-4471405191.

## Companion case explicitly NOT added

CodeRabbit's nitpick paired this with a `diagnostic_line_too_long` (1025-byte value) → 400 case. I deliberately did **not** add that one: the handler truncates oversize per-line values to `feedbackMaxDiagnosticsValueBytes` and appends `…` in `formatFeedbackDiagnostics` (`go/apiserver/feedback.go:270-271`) — graceful degradation so a long URL or stack frame doesn't reject the whole submission. Promoting that to a 400 would be a behaviour change, not a test addition.

## Test plan

- [x] `go test -count=1 -run "TestFeedback_Validation" ./apiserver` — all 6 sub-tests green (5 prior + 1 new)
- [x] `golangci-lint run --fix --timeout=2m ./apiserver/feedback_test.go` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added validation test to verify the feedback endpoint properly rejects requests with excessive diagnostics entries and returns a 400 Bad Request error. The test ensures downstream services are not invoked for invalid submissions, maintaining system integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->