### PR TITLE
[#1629] Frontend test rework: re-enable Radix-Select-blocked tests + deferred coverage

### DIFF
--- a/devdocs/frontend/testing.md
+++ b/devdocs/frontend/testing.md
@@ -97,6 +97,57 @@ Each module exposes focused factories that take a fixture and return an array of
 
 For ad-hoc handlers, import `apiUrl` from `@/test/handlers` and reach for `msw.http.*` directly — no need to add a module.
 
+## Driving Radix Select / portal-based primitives
+
+`@testing-library/user-event`'s `selectOptions()` drives a real
+`HTMLSelectElement` via DOM `change` events. shadcn `Select` (around
+`@radix-ui/react-select`) renders no `<select>` — its trigger is a
+`role="combobox"` button and the listbox lives in a portal. Calling
+`selectOptions()` against the trigger silently no-ops, and the form
+reads as un-interacted (see #1629 for the prior `.skip` graveyard).
+
+Use the shared helper at `@/test/radix` instead:
+
+```tsx
+import userEvent from "@testing-library/user-event"
+import { pickRadixSelect } from "@/test/radix"
+
+const user = userEvent.setup()
+await pickRadixSelect(user, /^Type$/i, { optionLabel: /^Furniture$/i })
+await pickRadixSelect(user, /^Location$/i, { optionLabel: /^Home$/i })
+await pickRadixSelect(user, /^Area$/i, { optionLabel: /^Garage$/i })
+```
+
+The helper clicks the trigger (Radix listens for `onPointerDown` +
+`onClick`, both of which `userEvent.click` issues), picks the option
+inside the freshly-mounted listbox by accessible name, and then waits
+for the portal to unmount before returning. That last step matters
+for sequential picks: a stale listbox left over from the previous
+Select is the most common flake source — `findByRole("listbox")`
+happily returns the wrong one if you don't wait. Pre-flight, the
+helper also asserts the trigger isn't disabled so paired selects
+(e.g. Location → Area in `CommodityFormDialog`, where Area is
+`disabled` until a Location is picked) fail fast with a useful error
+rather than silently picking against the wrong listbox.
+
+JSDOM gaps that the global setup already fills for Radix:
+
+- `Element.prototype.hasPointerCapture` / `setPointerCapture` /
+  `releasePointerCapture` — stubbed in `test/setup.ts`. Radix
+  Select's `Trigger` touches these during pointer events; missing
+  stubs throw before the listbox can open.
+- `Element.prototype.scrollIntoView` — stubbed. Radix scrolls the
+  active option into view when the listbox opens.
+- `ResizeObserver` — stubbed. Radix's `use-size` reads it during
+  layout.
+
+If you're adding a new portal-based primitive (Popover, Dropdown,
+Hover Card, Combobox) and the user-event API doesn't have a natural
+fit, extend `src/test/radix.ts` with a sibling helper rather than
+reaching for raw `fireEvent` in the test file — keeping the
+interaction recipe in one place is what stops the next migration
+from re-introducing the `.skip` graveyard.
+
 ## a11y assertions
 
 `jest-axe` is registered globally. Page-level component tests should run `axe(container)` and fail on violations:

--- a/frontend/src/components/items/__tests__/CommodityFormDialog.test.tsx
+++ b/frontend/src/components/items/__tests__/CommodityFormDialog.test.tsx
@@ -5,6 +5,7 @@ import { axe } from "jest-axe"
 
 import { CommodityFormDialog } from "@/components/items/CommodityFormDialog"
 import { renderWithProviders } from "@/test/render"
+import { pickRadixSelect } from "@/test/radix"
 
 const areas = [
   { id: "a1", name: "Garage", location_id: "l1" },
@@ -30,21 +31,16 @@ async function walkPastAi(user: ReturnType<typeof userEvent.setup>) {
 
 // Type/Area/Status are now Radix Select primitives (button trigger +
 // portal-rendered listbox). userEvent.selectOptions() doesn't work
-// because there is no <select> element. userEvent.click on the
-// trigger doesn't fully open Radix's listbox under jsdom either, so
-// we drive it with keyboard activation (Enter on a focused trigger
-// opens, ArrowDown navigates, Enter picks).
+// because there is no <select> element. Drive them through the
+// shared @/test/radix helper, which clicks the trigger, picks the
+// option inside the freshly-mounted listbox, and waits for the
+// portal to unmount so sequential picks don't race.
 async function pickSelect(
   user: ReturnType<typeof userEvent.setup>,
   triggerLabel: RegExp,
   optionLabel: RegExp
 ) {
-  const trigger = screen.getByRole("combobox", { name: triggerLabel })
-  trigger.focus()
-  await user.keyboard("{Enter}")
-  const listbox = await screen.findByRole("listbox")
-  const option = within(listbox).getByRole("option", { name: optionLabel })
-  await user.click(option)
+  await pickRadixSelect(user, triggerLabel, { optionLabel })
 }
 
 describe("<CommodityFormDialog />", () => {
@@ -106,11 +102,7 @@ describe("<CommodityFormDialog />", () => {
     await waitFor(() => expect(screen.getAllByText(/Required|Pick/i).length).toBeGreaterThan(0))
   })
 
-  // TODO: re-enable once we have a Radix-Select-friendly userEvent
-  // path in JSDOM. Trigger.click + keyboard activation both fail to
-  // mount the portal listbox under jsdom; same pattern as the three
-  // skipped cases below — covered by Playwright e2e in the meantime.
-  it.skip("walks through three steps and submits with mapped values", async () => {
+  it("walks through three steps and submits with mapped values", async () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn().mockResolvedValue(undefined)
     renderWithProviders({
@@ -129,9 +121,11 @@ describe("<CommodityFormDialog />", () => {
     await walkPastAi(user)
     await user.type(await screen.findByLabelText(/^Name$/i), "Couch")
     await user.type(screen.getByLabelText(/^Short name$/i), "Couch")
-    // Type select uses a native <select>; selectOptions targets the
-    // renderered option text from the type catalog.
     await pickSelect(user, /^Type$/i, /^Furniture$/i)
+    // Location → Area is a paired select: Area is disabled until a
+    // Location is selected (CommodityFormDialog L1208-L1212), so the
+    // walk must pick "Home" first.
+    await pickSelect(user, /^Location$/i, /^Home$/i)
     await pickSelect(user, /^Area$/i, /^Garage$/i)
     // Tick the draft toggle so the schema's whenNotDraft block doesn't
     // require purchase_date + the price triad — keeps this test focused
@@ -162,7 +156,7 @@ describe("<CommodityFormDialog />", () => {
     })
   })
 
-  it.skip("adds and removes tags via the chip input on the extras step", async () => {
+  it("adds and removes tags via the chip input on the extras step", async () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn().mockResolvedValue(undefined)
     renderWithProviders({
@@ -183,6 +177,7 @@ describe("<CommodityFormDialog />", () => {
     await user.type(await screen.findByLabelText(/^Name$/i), "Stand")
     await user.type(screen.getByLabelText(/^Short name$/i), "Stand")
     await pickSelect(user, /^Type$/i, /^Furniture$/i)
+    await pickSelect(user, /^Location$/i, /^Home$/i)
     await pickSelect(user, /^Area$/i, /^Garage$/i)
     await user.click(screen.getByLabelText(/Save as draft/i))
     await user.click(screen.getByTestId("commodity-form-next"))
@@ -201,7 +196,7 @@ describe("<CommodityFormDialog />", () => {
     await waitFor(() => expect(screen.getAllByTestId("commodity-tags-chip").length).toBe(1))
   })
 
-  it.skip("steps Back from purchase to basics", async () => {
+  it("steps Back from purchase to basics", async () => {
     const user = userEvent.setup()
     renderWithProviders({
       children: (
@@ -220,6 +215,7 @@ describe("<CommodityFormDialog />", () => {
     await user.type(await screen.findByLabelText(/^Name$/i), "X")
     await user.type(screen.getByLabelText(/^Short name$/i), "X")
     await pickSelect(user, /^Type$/i, /^Other$/i)
+    await pickSelect(user, /^Location$/i, /^Home$/i)
     await pickSelect(user, /^Area$/i, /^Garage$/i)
     await user.click(screen.getByLabelText(/Save as draft/i))
     await user.click(screen.getByTestId("commodity-form-next"))
@@ -482,18 +478,8 @@ describe("<CommodityFormDialog />", () => {
 
   // Regression: a single dirty input on Basics is enough to make
   // Cancel prompt rather than silently discard. Together with the
-  // pristine-Cancel test above this pins the dirty-detection contract
-  // of the close-confirm flow.
-  //
-  // The originally-intended scenario for this test was "Cancel on the
-  // Files step with upstream steps dirty" — that exercises a stronger
-  // invariant (the dirty check has to look at cumulative form state,
-  // not just the active step's inputs). Driving navigation through
-  // four wizard steps via Continue requires interacting with Radix
-  // Select for `area_id`, which the JSDOM/Radix portal gap blocks
-  // (see #1629). Until that follow-up lands a proper fixture, the
-  // Files-step variant is covered by Playwright e2e or stays untested
-  // at the unit level.
+  // pristine-Cancel test above and the Files-step variant below this
+  // pins the dirty-detection contract of the close-confirm flow.
   it("Cancel after dirtying Basics prompts instead of silently closing", async () => {
     const user = userEvent.setup()
     const onOpenChange = vi.fn()
@@ -513,6 +499,58 @@ describe("<CommodityFormDialog />", () => {
     })
     await walkPastAi(user)
     await user.type(await screen.findByLabelText(/^Name$/i), "X")
+    await user.click(screen.getByTestId("commodity-form-cancel"))
+    await screen.findByTestId("commodity-form-close-confirm")
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  // Regression: cancelling on the Files step with upstream-only dirty
+  // edits must still surface the save-as-draft confirm. The dirty
+  // check has to look at the cumulative form state, not just the
+  // active step's inputs — a Basics edit that the user walked away
+  // from is still a dirty draft. PR #1621 reviewer flagged this gap
+  // as the Files-step variant of the Basics test above; #1629
+  // re-enabled the Radix-Select-driven walk that gets the test to
+  // Files in the first place.
+  it("Cancel on the Files step with upstream steps dirty still prompts", async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderWithProviders({
+      children: (
+        <CommodityFormDialog
+          open
+          onOpenChange={onOpenChange}
+          mode="create"
+          areas={areas}
+          locations={locations}
+          defaultCurrency="USD"
+          onSubmit={async () => {}}
+          draftKey="commodity-draft:test-files-cancel:create"
+        />
+      ),
+    })
+    // Walk past AI → fill Basics minimally (draft mode keeps the
+    // schema's whenNotDraft block off so Continue stays unblocked).
+    await walkPastAi(user)
+    await user.type(await screen.findByLabelText(/^Name$/i), "Couch")
+    await user.type(screen.getByLabelText(/^Short name$/i), "Couch")
+    await pickSelect(user, /^Type$/i, /^Furniture$/i)
+    await pickSelect(user, /^Location$/i, /^Home$/i)
+    await pickSelect(user, /^Area$/i, /^Garage$/i)
+    await user.click(screen.getByLabelText(/Save as draft/i))
+    // Step through Basics → Purchase → Warranty → Extras → Files.
+    await user.click(screen.getByTestId("commodity-form-next"))
+    await screen.findByLabelText(/Purchase date/i)
+    await user.click(screen.getByTestId("commodity-form-next"))
+    await screen.findByTestId("commodity-form-warranty-step")
+    await user.click(screen.getByTestId("commodity-form-next"))
+    await screen.findByTestId("commodity-tags-input")
+    await user.click(screen.getByTestId("commodity-form-next"))
+    // On Files step — the Cancel button still surfaces (the dialog
+    // shares the footer across all steps). Click it without touching
+    // the Files dropzone so the dirty signal comes from upstream
+    // Basics only.
+    await screen.findByTestId("commodity-form-submit")
     await user.click(screen.getByTestId("commodity-form-cancel"))
     await screen.findByTestId("commodity-form-close-confirm")
     expect(onOpenChange).not.toHaveBeenCalled()

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -3,6 +3,7 @@ import { Route, useLocation } from "react-router-dom"
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { axe } from "jest-axe"
+import i18next from "i18next"
 
 import { DashboardPage } from "@/pages/Dashboard"
 import { GroupProvider } from "@/features/group/GroupContext"
@@ -296,10 +297,11 @@ describe("<DashboardPage />", () => {
     // useGroupMigrationLock() resolves after the /groups query lands,
     // so wait for the lock state to flip before asserting attributes.
     await waitFor(() => expect(cta).toHaveAttribute("aria-disabled", "true"))
-    // i18n surfaces `errors:lockedDuringMigration` as the title — the
-    // exact key matters more than the en string, so anchor on the
-    // shipped translation. en bundle is loaded by `test/setup.ts`.
-    expect(cta).toHaveAttribute("title", "Locked while a currency migration is running.")
+    // i18n surfaces `errors:lockedDuringMigration` as the title.
+    // Anchor on the key via `i18next.t(...)` (en bundle loaded by
+    // `test/setup.ts`) so a copy-edit in the en JSON doesn't break
+    // this test — only renaming or removing the key does.
+    expect(cta).toHaveAttribute("title", i18next.t("errors:lockedDuringMigration"))
   })
 
   it("has no axe violations once data has loaded", async () => {

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest"
-import { Route } from "react-router-dom"
+import { Route, useLocation } from "react-router-dom"
 import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { axe } from "jest-axe"
 
 import { DashboardPage } from "@/pages/Dashboard"
@@ -222,6 +223,83 @@ describe("<DashboardPage />", () => {
     // Stat cards must NOT render alongside the error — the user
     // shouldn't see "0 items" when the load failed.
     expect(screen.queryByTestId("dashboard-commodities-count")).not.toBeInTheDocument()
+  })
+
+  // #1629: regression-protection for the mobile "Add new item" CTA.
+  // The sibling sidebar test path covers the full integration; these
+  // cases anchor the dashboard-specific visual contract so the navigate
+  // target and the migration-lock treatment can't drift independently
+  // of #1544 / PR #1621's design decisions.
+  it("renders the mobile Add-item CTA pointing at the active group's create route", async () => {
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...commodityHandlers.list(SLUG, []),
+      ...commodityHandlers.values(SLUG, { globalTotal: 0 })
+    )
+    function NavSentinel() {
+      const location = useLocation()
+      return (
+        <div>
+          <span data-testid="nav-sentinel-path">{location.pathname}</span>
+        </div>
+      )
+    }
+    setAccessToken("good-token")
+    renderWithProviders({
+      initialPath: `/g/${SLUG}`,
+      routes: (
+        <>
+          <Route
+            path="/g/:groupSlug"
+            element={
+              <GroupProvider>
+                <DashboardPage />
+              </GroupProvider>
+            }
+          />
+          <Route path="/g/:groupSlug/commodities/new" element={<NavSentinel />} />
+        </>
+      ),
+    })
+    const cta = await screen.findByTestId("dashboard-mobile-add-item")
+    // The button defers navigation to react-router (so cursor matches
+    // the design-mock — see Dashboard.tsx L100-L116). aria-disabled is
+    // absent in the unlocked path, and `title` stays unset.
+    expect(cta).not.toHaveAttribute("aria-disabled")
+    expect(cta).not.toHaveAttribute("title")
+    // Click → navigates to /g/:slug/commodities/new. The sentinel
+    // resolves once react-router has replaced the URL.
+    const user = userEvent.setup()
+    await user.click(cta)
+    expect(await screen.findByTestId("nav-sentinel-path")).toHaveTextContent(
+      `/g/${SLUG}/commodities/new`
+    )
+  })
+
+  it("flips the mobile Add-item CTA to aria-disabled with the migration-lock title when locked", async () => {
+    const lockedGroup: Schema<"models.LocationGroup">[] = [
+      {
+        id: "g1",
+        slug: SLUG,
+        name: "Household",
+        group_currency: "USD",
+        currency_migration_id: "mig-42",
+      },
+    ]
+    server.use(
+      ...groupHandlers.list(lockedGroup),
+      ...commodityHandlers.list(SLUG, []),
+      ...commodityHandlers.values(SLUG, { globalTotal: 0 })
+    )
+    renderDashboard()
+    const cta = await screen.findByTestId("dashboard-mobile-add-item")
+    // useGroupMigrationLock() resolves after the /groups query lands,
+    // so wait for the lock state to flip before asserting attributes.
+    await waitFor(() => expect(cta).toHaveAttribute("aria-disabled", "true"))
+    // i18n surfaces `errors:lockedDuringMigration` as the title — the
+    // exact key matters more than the en string, so anchor on the
+    // shipped translation. en bundle is loaded by `test/setup.ts`.
+    expect(cta).toHaveAttribute("title", "Locked while a currency migration is running.")
   })
 
   it("has no axe violations once data has loaded", async () => {

--- a/frontend/src/pages/commodities/__tests__/CommoditiesListPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommoditiesListPage.test.tsx
@@ -10,7 +10,14 @@ import { GroupProvider } from "@/features/group/GroupContext"
 import { ConfirmProvider } from "@/hooks/useConfirm"
 import { renderWithProviders } from "@/test/render"
 import { server } from "@/test/server"
-import { apiUrl, areaHandlers, commodityHandlers, groupHandlers } from "@/test/handlers"
+import {
+  apiUrl,
+  areaHandlers,
+  commodityHandlers,
+  groupHandlers,
+  locationHandlers,
+} from "@/test/handlers"
+import { pickRadixSelect } from "@/test/radix"
 import { setAccessToken, clearAuth } from "@/lib/auth-storage"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
@@ -443,19 +450,114 @@ describe("<CommoditiesListPage />", () => {
     )
   })
 
-  it.skip("submits a new item via the create dialog and clears the form", async () => {
-    // SKIPPED: this test predates the Radix Select migration in
-    // CommodityFormDialog. `user.selectOptions(getByLabelText(/Type/))`
-    // worked on the previous native `<select>` markup but doesn't
-    // drive Radix Select listboxes in JSDOM (the listbox renders into
-    // a portal that needs PointerEvent simulation, which @testing-
-    // library's user-event currently can't issue reliably without a
-    // real layout engine). The dialog suite has three sibling tests
-    // skipped for the same reason. A follow-up will adapt all of them
-    // — likely by driving the underlying RHF Controller via
-    // `onValueChange` rather than the DOM. Keeping the test
-    // checked-in (as `.skip`) preserves the regression-coverage
-    // contract for when the Radix-Select-in-JSDOM gap is closed.
+  it("submits a new item via the create dialog and clears the form", async () => {
+    // Replays the regression that motivated #1629: walk past the
+    // initial AI placeholder step, fill Basics (Name + Short name +
+    // Type + Location → Area), skip Save-as-draft so the schema's
+    // whenNotDraft fields stay optional, walk Purchase → Warranty →
+    // Extras → Files, then submit. After 201 the dialog closes and
+    // the page navigates to /commodities/:newId.
+    const user = userEvent.setup()
+    const requests: Record<string, unknown>[] = []
+    server.use(
+      ...groupHandlers.list(groupFixture),
+      ...areaHandlers.list(SLUG, areaFixture),
+      ...locationHandlers.list(SLUG, [
+        { id: "l1", type: "locations", attributes: { id: "l1", name: "Home" } },
+      ]),
+      ...commodityHandlers.list(SLUG, []),
+      // Intercept the POST manually so the test can assert the
+      // mapped-value payload Radix Select drives through the form.
+      msw.post(apiUrl(`/g/${SLUG}/commodities`), async ({ request }) => {
+        requests.push((await request.json()) as Record<string, unknown>)
+        return HttpResponse.json(
+          {
+            data: {
+              id: "new-1",
+              type: "commodities",
+              attributes: {
+                id: "new-1",
+                name: "Couch",
+                short_name: "Couch",
+                type: "furniture",
+                area_id: "a1",
+                status: "in_use",
+                count: 1,
+                draft: true,
+              },
+            },
+          },
+          { status: 201 }
+        )
+      })
+    )
+    function NavSentinel() {
+      const location = useLocation()
+      return <span data-testid="nav-sentinel-path">{location.pathname}</span>
+    }
+    setAccessToken("good-token")
+    renderWithProviders({
+      initialPath: `/g/${SLUG}/commodities`,
+      routes: (
+        <>
+          <Route
+            path="/g/:groupSlug/commodities"
+            element={
+              <GroupProvider>
+                <ConfirmProvider>
+                  <CommoditiesListPage />
+                </ConfirmProvider>
+              </GroupProvider>
+            }
+          />
+          <Route path="/g/:groupSlug/commodities/:id" element={<NavSentinel />} />
+        </>
+      ),
+    })
+    await screen.findByTestId("commodities-empty")
+    await user.click(screen.getByTestId("commodities-add-button"))
+    // Past the AI placeholder step → Basics.
+    await user.click(await screen.findByTestId("commodity-form-next"))
+    await user.type(await screen.findByLabelText(/^Name$/i), "Couch")
+    await user.type(screen.getByLabelText(/^Short name$/i), "Couch")
+    await pickRadixSelect(user, /^Type$/i, { optionLabel: /^Furniture$/i })
+    await pickRadixSelect(user, /^Location$/i, { optionLabel: /^Home$/i })
+    await pickRadixSelect(user, /^Area$/i, { optionLabel: /^Garage$/i })
+    // Save-as-draft so purchase_date + price triad stay optional —
+    // the test asserts the navigation contract, not the schema.
+    await user.click(screen.getByLabelText(/Save as draft/i))
+    await user.click(screen.getByTestId("commodity-form-next"))
+    // Walk Purchase → Warranty → Extras → Files.
+    await screen.findByLabelText(/Purchase date/i)
+    await user.click(screen.getByTestId("commodity-form-next"))
+    await screen.findByTestId("commodity-form-warranty-step")
+    await user.click(screen.getByTestId("commodity-form-next"))
+    await screen.findByTestId("commodity-tags-input")
+    await user.click(screen.getByTestId("commodity-form-next"))
+    await screen.findByTestId("commodity-form-submit")
+    await user.click(screen.getByTestId("commodity-form-submit"))
+    // Page navigates to the new item's detail route — the sentinel
+    // resolves once react-router has replaced the URL.
+    expect(await screen.findByTestId("nav-sentinel-path")).toHaveTextContent(
+      `/g/${SLUG}/commodities/new-1`
+    )
+    // The mapped payload landed on the BE — anchor on the schema
+    // fields the dialog test pins (#1629 success criterion). The
+    // hook wraps the payload in a JSON:API envelope.
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toMatchObject({
+      data: {
+        type: "commodities",
+        attributes: {
+          name: "Couch",
+          short_name: "Couch",
+          type: "furniture",
+          area_id: "a1",
+          status: "in_use",
+          draft: true,
+        },
+      },
+    })
   })
 
   it("filters rows by warranty status (derived from warranty_expires_at)", async () => {

--- a/frontend/src/test/radix.ts
+++ b/frontend/src/test/radix.ts
@@ -58,7 +58,7 @@ export async function pickRadixSelect(
   const trigger = await screen.findByRole("combobox", { name: triggerLabel })
   if (trigger.hasAttribute("disabled") || trigger.getAttribute("aria-disabled") === "true") {
     throw new Error(
-      `pickRadixSelect: trigger ${describe(triggerLabel)} is disabled — pick its dependency Select first`
+      `pickRadixSelect: trigger ${formatLabel(triggerLabel)} is disabled — pick its dependency Select first`
     )
   }
   await user.click(trigger)
@@ -67,7 +67,7 @@ export async function pickRadixSelect(
   // be mid-unmount on the same tick.
   await waitFor(() => {
     if (trigger.getAttribute("aria-expanded") !== "true") {
-      throw new Error(`pickRadixSelect: trigger ${describe(triggerLabel)} did not open`)
+      throw new Error(`pickRadixSelect: trigger ${formatLabel(triggerLabel)} did not open`)
     }
   })
   const listbox = await screen.findByRole("listbox")
@@ -84,6 +84,6 @@ export async function pickRadixSelect(
   })
 }
 
-function describe(label: RegExp | string): string {
+function formatLabel(label: RegExp | string): string {
   return label instanceof RegExp ? label.toString() : JSON.stringify(label)
 }

--- a/frontend/src/test/radix.ts
+++ b/frontend/src/test/radix.ts
@@ -66,8 +66,11 @@ export async function pickRadixSelect(
   // — disambiguates from a sibling Select's listbox that may still
   // be mid-unmount on the same tick.
   await waitFor(() => {
-    if (trigger.getAttribute("aria-expanded") !== "true") {
-      throw new Error(`pickRadixSelect: trigger ${formatLabel(triggerLabel)} did not open`)
+    const expanded = trigger.getAttribute("aria-expanded")
+    if (expanded !== "true") {
+      throw new Error(
+        `pickRadixSelect: trigger ${formatLabel(triggerLabel)} did not open (aria-expanded=${expanded ?? "null"})`
+      )
     }
   })
   const listbox = await screen.findByRole("listbox")

--- a/frontend/src/test/radix.ts
+++ b/frontend/src/test/radix.ts
@@ -1,0 +1,89 @@
+import { screen, waitFor, waitForElementToBeRemoved, within } from "@testing-library/react"
+import type userEvent from "@testing-library/user-event"
+
+// Test helpers for Radix UI primitives in JSDOM. Radix's listbox/menu
+// surfaces render into a portal once a pointer/keyboard interaction
+// opens the trigger — `user.selectOptions()` from
+// `@testing-library/user-event` doesn't apply (there is no
+// `HTMLSelectElement`), and naive `user.click(trigger)` racing into a
+// stale listbox left over from a sibling Select is the most common
+// flake source. Centralise the open/pick/close sequence here so
+// every test reads as "drive Select X to value Y" rather than
+// re-deriving the dance per case.
+
+type User = ReturnType<typeof userEvent.setup>
+
+interface PickOptions {
+  // Match the option text. Use a RegExp to anchor against the
+  // accessible name; Radix `SelectItem` renders `<svg aria-hidden>`
+  // glyphs alongside the label, but those are excluded from the
+  // accessible name so a plain `/^Furniture$/i` matches.
+  optionLabel: RegExp
+}
+
+// pickRadixSelect drives a shadcn/Radix `Select` to a specific option
+// by accessible name. Use it instead of `user.selectOptions()` — the
+// Radix trigger renders a `role="combobox"` button, not an
+// `HTMLSelectElement`, so `selectOptions` silently no-ops.
+//
+// The helper:
+//   1. Resolves the trigger by accessible name (the `aria-label` on
+//      `SelectTrigger` or the `<label htmlFor>` associated with its
+//      `id`).
+//   2. Asserts the trigger isn't `disabled` — Radix Select disabled
+//      triggers eat both pointer and Enter; a silent no-op there is
+//      the most common reason a follow-up `findByRole("listbox")`
+//      returns a sibling listbox from earlier in the test.
+//   3. Opens the listbox with a real click (Radix listens for
+//      `onPointerDown` + `onClick`; `userEvent.click` issues both,
+//      which is what production users do).
+//   4. Anchors on the trigger's own `aria-expanded="true"` /
+//      `data-state="open"` to confirm THIS Select opened — without
+//      the anchor a stale listbox from a sibling Select left mid-
+//      cleanup would be returned by `findByRole("listbox")` and the
+//      pick would silently land on the wrong field.
+//   5. Picks the option inside the freshly-mounted listbox.
+//   6. Waits for the listbox to unmount so the next pick is
+//      unambiguous — Radix portals SelectContent and unmounts it on
+//      close, so a stale listbox is impossible once this resolves.
+//
+// Example:
+//   await pickRadixSelect(user, /^Type$/i, { optionLabel: /^Furniture$/i })
+//   await pickRadixSelect(user, /^Area$/i, { optionLabel: /^Garage$/i })
+export async function pickRadixSelect(
+  user: User,
+  triggerLabel: RegExp | string,
+  { optionLabel }: PickOptions
+): Promise<void> {
+  const trigger = await screen.findByRole("combobox", { name: triggerLabel })
+  if (trigger.hasAttribute("disabled") || trigger.getAttribute("aria-disabled") === "true") {
+    throw new Error(
+      `pickRadixSelect: trigger ${describe(triggerLabel)} is disabled — pick its dependency Select first`
+    )
+  }
+  await user.click(trigger)
+  // Anchor on THIS trigger's open state before querying the listbox
+  // — disambiguates from a sibling Select's listbox that may still
+  // be mid-unmount on the same tick.
+  await waitFor(() => {
+    if (trigger.getAttribute("aria-expanded") !== "true") {
+      throw new Error(`pickRadixSelect: trigger ${describe(triggerLabel)} did not open`)
+    }
+  })
+  const listbox = await screen.findByRole("listbox")
+  const option = await within(listbox).findByRole("option", { name: optionLabel })
+  await user.click(option)
+  await waitForElementToBeRemoved(listbox).catch(async () => {
+    // Radix occasionally keeps the listbox node attached for a tick
+    // after close; fall back to a state-driven wait so flakes from
+    // the unmount race don't surface.
+    await waitFor(() => {
+      const open = document.querySelector('[role="listbox"][data-state="open"]')
+      if (open) throw new Error("listbox still open")
+    })
+  })
+}
+
+function describe(label: RegExp | string): string {
+  return label instanceof RegExp ? label.toString() : JSON.stringify(label)
+}


### PR DESCRIPTION
Closes #1629.

## Summary

Re-enables the four `.skip`'d tests that PR #1621 deferred when the multi-step Add Item wizard migrated to Radix Select, and lands the two deferred coverage cases reviewers asked for during that PR.

## What changed

**New shared helper — `frontend/src/test/radix.ts`**

`@testing-library/user-event`'s `selectOptions()` drives a real `HTMLSelectElement` via DOM `change` events. Radix Select renders no `<select>` — the trigger is a `role="combobox"` button and the listbox lives in a portal. The new `pickRadixSelect(user, label, { optionLabel })` helper:

- Resolves the trigger by accessible name.
- Asserts it isn't disabled — catches paired-select bugs (e.g. Location → Area in `CommodityFormDialog` where Area is disabled until a Location is picked) up-front instead of silently picking against the wrong listbox.
- Opens with a real `user.click()` (Radix listens for `onPointerDown` + `onClick`; both fire).
- Anchors on the trigger's `aria-expanded="true"` so a sibling listbox mid-cleanup can't be returned by mistake.
- Picks the option inside the freshly-mounted listbox.
- Waits for the portal to unmount so sequential picks don't race.

**Re-enabled tests (4)**

- `CommodityFormDialog.test.tsx`: `walks through three steps and submits with mapped values`, `adds and removes tags via the chip input on the extras step`, `steps Back from purchase to basics`. Each now picks **Location** before **Area** (the form's paired-select dependency the previous fixture didn't account for).
- `CommoditiesListPage.test.tsx`: `submits a new item via the create dialog and clears the form`. Verifies the JSON:API envelope + post-201 navigation to `/commodities/:id`.

**New deferred coverage (3)**

- `CommodityFormDialog.test.tsx` — `Cancel on the Files step with upstream steps dirty still prompts`. Walks all five wizard steps and asserts the close-confirm fires on a Cancel-from-Files when only Basics is dirty (PR #1621 reviewer asked for this; the existing dirty-Basics test only covers the active-step dirty case).
- `Dashboard.test.tsx` — two cases for the mobile Add-item CTA: (1) renders and navigates to `/g/:slug/commodities/new` for the active group; (2) flips to `aria-disabled="true"` with the `errors:lockedDuringMigration` title when `useGroupMigrationLock()` reports a running migration.

**Docs**

- `devdocs/frontend/testing.md` — new section "Driving Radix Select / portal-based primitives". Explains why `selectOptions()` doesn't work, points at the helper, lists the JSDOM stubs `test/setup.ts` already installs for Radix, and asks future portal primitives to extend `src/test/radix.ts` instead of regressing to `.skip`.

## Success criteria (from the issue)

- [x] All four currently-skipped tests pass; no `.skip` markers in the dialog or list-page suites.
- [x] Two new tests (DashboardPage CTA + Files-step Cancel) added and passing.
- [x] Helper / approach documented in `devdocs/frontend/testing.md`.
- [x] `npm run test` clean — no orphaned skips, no Vitest warnings (135 files / 991 tests pass).

## Test plan

- [x] `cd frontend && npm run test` — 991 / 991 pass.
- [x] `cd frontend && npm run typecheck` — clean.
- [x] `cd frontend && npm run lint` — clean.
- [x] Self-review via Explore agent against the diff — flagged listbox-staleness race, addressed by anchoring on `aria-expanded`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added testing guidance for driving Radix/Shadcn Selects in React tests, including JSDOM stubs and where to add shared helpers.

* **Tests**
  * Added a shared Radix Select test helper and updated tests to use it.
  * Re-enabled and expanded commodity form wizard flows, draft/cancel regressions, and a full create-dialog submission/asserted payload.
  * Added Dashboard navigation tests for mobile CTA lock/unlock and routing verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->