### PR TITLE
[#1625] commodity: drop validation.Required on CurrentPrice

### DIFF
--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -241,14 +241,6 @@ export function CommodityFormDialog({
   // save-as-draft confirm and the user loses the draft silently
   // (the same problem the auto-save was trying to prevent).
   const [draftRehydrated, setDraftRehydrated] = useState(false)
-  // Tracks whether the user has manually typed into Current Value.
-  // Until they do, the input live-mirrors Original Price in the
-  // same-currency case (BE field-level Required on CurrentPrice
-  // forces a non-zero value even though PriceRule says it's
-  // optional — see #1625). Once the user edits the field, the
-  // mirror stops; flipping back to "untouched" requires a fresh
-  // dialog open.
-  const currentPriceManualRef = useRef(false)
   // Drafts only persist for create mode — editing an existing item
   // never auto-saves to storage (the BE row is the canonical state).
   const persistDrafts = mode === "create" && !!draftKey
@@ -314,13 +306,6 @@ export function CommodityFormDialog({
     // returns non-empty.
     setPendingFiles([])
     setPendingFilesLoaded(false)
-    // Edit mode opens with an existing current_price; treat that as
-    // already user-set so the mirror never overwrites it. Create
-    // mode starts clean — mirror is on until first manual edit.
-    // A rehydrated draft also counts as "already user-set" — we
-    // shouldn't overwrite values the user typed during a previous
-    // visit just because they refresh and come back.
-    currentPriceManualRef.current = mode === "edit" || restoredFromDraft
 
     // Pending files restoration. Browser-level reloads (manual,
     // mobile-OS tab kill, etc) wipe in-memory state; IDB persists
@@ -390,32 +375,6 @@ export function CommodityFormDialog({
     if (!open || !persistDrafts || !draftKey || !pendingFilesLoaded) return
     void savePendingFiles(draftKey, pendingFiles)
   }, [open, persistDrafts, draftKey, pendingFiles, pendingFilesLoaded])
-
-  // Live mirror: in create mode, when purchase currency matches the
-  // group currency and the user hasn't manually edited Current Value
-  // yet, push the typed Original Price into Current Value so the
-  // input visibly tracks. Stops as soon as the user types into the
-  // Current Value field (PurchaseStep marks `currentPriceManualRef`
-  // on user-driven onChange). Reset by the dialog-open effect above.
-  // Tracking this with a ref + setValue rather than a derived render
-  // value because BE field-level Required (#1625) means the mirrored
-  // value needs to actually live in the form state, not just look
-  // like it does in the DOM.
-  useEffect(() => {
-    if (!open || mode !== "create") return
-    const subscription = watch((values, info) => {
-      if (info.name !== "original_price" && info.name !== "original_price_currency") return
-      if (currentPriceManualRef.current) return
-      const purchaseCurrency = (values.original_price_currency ?? "").trim().toUpperCase()
-      const groupCurrencyUpper = (defaultCurrency ?? "").trim().toUpperCase()
-      if (!purchaseCurrency || purchaseCurrency !== groupCurrencyUpper) return
-      const next = (values.original_price ?? "") as string
-      // Use shouldDirty=false so the mirror doesn't itself flip the
-      // form's dirty flag — that's reserved for real user intent.
-      setValue("current_price", next, { shouldDirty: false, shouldValidate: false })
-    })
-    return () => subscription.unsubscribe()
-  }, [open, mode, watch, setValue, defaultCurrency])
 
   async function nextStep() {
     const fields = STEP_FIELDS[step]
@@ -810,9 +769,6 @@ export function CommodityFormDialog({
                 errors={errors}
                 watch={watch}
                 defaultCurrency={defaultCurrency}
-                onCurrentPriceUserEdit={() => {
-                  currentPriceManualRef.current = true
-                }}
               />
             ) : null}
             {step === "warranty" ? (
@@ -1293,13 +1249,7 @@ function priceInputPaddingClass(symbol: string): string {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see BasicsStep
 function PurchaseStep(props: any) {
   const { t } = useTranslation()
-  const { register, control, errors, watch, defaultCurrency, onCurrentPriceUserEdit } = props
-  // Wrap RHF's register output for current_price so user-driven
-  // onChange events also flip the dialog's
-  // `currentPriceManualRef` — once that fires, the dialog's
-  // live-mirror effect stops auto-filling Current Value with
-  // Original Price.
-  const currentPriceReg = register("current_price")
+  const { register, control, errors, watch, defaultCurrency } = props
   // Required-ness on Purchase fields is dynamic. Drafts relax all
   // four (purchase_date / original_price / converted / current);
   // commodity submits require them. Schema is in
@@ -1464,11 +1414,7 @@ function PurchaseStep(props: any) {
                 min={0}
                 placeholder="0"
                 className={cn("bg-background", groupPadClass)}
-                {...currentPriceReg}
-                onChange={(e) => {
-                  onCurrentPriceUserEdit?.()
-                  currentPriceReg.onChange(e)
-                }}
+                {...register("current_price")}
                 aria-required={requireWhenNotDraft || undefined}
                 aria-invalid={!!errors.current_price}
               />
@@ -1484,7 +1430,11 @@ function PurchaseStep(props: any) {
         </div>
       ) : (
         <div className="flex flex-col gap-1.5">
-          <FieldLabel htmlFor="commodity-current-price" required={requireWhenNotDraft}>
+          {/* #1625: same-currency Current Value is optional — the original
+              price already carries the canonical amount in the group's
+              currency. The label drops the "required" asterisk and the
+              input drops aria-required accordingly. */}
+          <FieldLabel htmlFor="commodity-current-price">
             {t("commodities:fields.currentPrice")}
           </FieldLabel>
           <div className="relative">
@@ -1501,12 +1451,7 @@ function PurchaseStep(props: any) {
               min={0}
               placeholder="0"
               className={groupPadClass}
-              {...currentPriceReg}
-              onChange={(e) => {
-                onCurrentPriceUserEdit?.()
-                currentPriceReg.onChange(e)
-              }}
-              aria-required={requireWhenNotDraft || undefined}
+              {...register("current_price")}
               aria-invalid={!!errors.current_price}
             />
           </div>
@@ -2573,47 +2518,39 @@ function toRequest(
     const trimmed = v.trim()
     return trimmed === "" ? undefined : trimmed
   }
-  // BE rule (commodity.go:378 + the matching custom validator):
-  // when the purchase currency matches the group's currency,
-  // `converted_original_price` MUST be 0 — the original price is
-  // already expressed in group currency, so a non-zero converted
-  // amount would conflict. The mock hides the converted-price field
-  // entirely in this case (AddItemDialog L1198 isForeignCurrency =
-  // false branch); we mirror that visually, and force the value to
-  // 0 here so the BE's same-currency invariant is satisfied. Foreign
-  // currency: pass through whatever the user typed.
+  // BE rule (PriceRule.ErrConvertedPriceNotZero in
+  // go/models/rules/price.go): when the purchase currency matches the
+  // group's currency, `converted_original_price` MUST be 0 — the
+  // original price is already expressed in group currency, so a
+  // non-zero converted amount would conflict. The mock hides the
+  // converted-price field entirely in this case (AddItemDialog L1198
+  // isForeignCurrency = false branch); we mirror that visually, and
+  // force the value to 0 here so the BE's same-currency invariant is
+  // satisfied.
   const original = num(values.original_price)
   const convertedFromForm = num(values.converted_original_price)
   const currentFromForm = num(values.current_price)
   const sameCurrency =
     !!groupCurrency &&
     values.original_price_currency.trim().toUpperCase() === groupCurrency.trim().toUpperCase()
-  // TODO(#1625): remove this same-currency mirror once the BE drops
-  // `validation.Required` from `CurrentPrice` in commodity.go:382.
-  // PriceRule's design intent is that current_price=0 is valid in the
-  // same-currency case (the unit test in price_test.go:42-47 covers
-  // this), but the field-level `Required` contradicts the rule and
-  // makes BE refuse any same-currency row with an empty Current Value.
-  // Same-currency: force converted=0 (BE invariant) + mirror
-  // current←original when blank.
-  // Foreign-currency: schema enforces "at least one of converted /
-  // current > 0" — but the BE *also* has `validation.Required` on
-  // each individual field for non-draft commodities. So leaving the
-  // sibling blank passes our schema and 422s on submit. Mirror the
-  // present value into the missing sibling so both fields are set;
-  // PriceRule still passes (both > 0), and the user's "either one"
-  // mental model from the UI copy survives. Explicit 0s are
-  // preserved (`?? `, not `||`) so an edit-mode foreign row that
-  // genuinely has converted=0 / current>0 round-trips unchanged.
+  // Foreign-currency: ConvertedOriginalPrice still carries
+  // `validation.Required` at the BE for non-draft commodities, so an
+  // omitted value JSON-decodes to the zero struct and is rejected.
+  // The schema's cross-field rule lets the user satisfy "at-least-one"
+  // by filling only the current-value field; mirror that into
+  // converted so the BE invariant survives. Explicit 0s are preserved
+  // (`?? `, not `||`) so an edit-mode row that genuinely has
+  // converted=0 / current>0 round-trips unchanged.
+  // CurrentPrice carries no field-level Required anymore (#1625), so
+  // we never need to mirror in the other direction — passing through
+  // whatever the user typed is enough.
   let converted: number | undefined
-  let current: number | undefined
   if (sameCurrency) {
     converted = 0
-    current = currentFromForm ?? original
   } else {
     converted = convertedFromForm ?? currentFromForm
-    current = currentFromForm ?? convertedFromForm
   }
+  const current = currentFromForm
   return {
     name: values.name.trim(),
     short_name: values.short_name.trim(),

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -1358,8 +1358,16 @@ function PurchaseStep(props: any) {
             <span className="font-semibold">{t("commodities:fields.foreignCurrencyDetected")}</span>{" "}
             {t("commodities:fields.foreignCurrencyBanner", { groupCurrency })}
           </p>
+          {/* Foreign-currency mode: the cross-field rule is
+              "at-least-one-of (converted, current) > 0" — neither
+              field is individually required. Drop the required
+              asterisk and aria-required on both so the markup
+              matches the actual rule. The "or" divider below makes
+              the OR relationship visible; schema-level
+              NO_PRICE_IN_GROUP_CURRENCY catches the
+              both-empty case. */}
           <div className="flex flex-col gap-1.5">
-            <FieldLabel htmlFor="commodity-converted-price" required={requireWhenNotDraft}>
+            <FieldLabel htmlFor="commodity-converted-price">
               {t("commodities:fields.convertedOriginalPrice", { groupCurrency })}
             </FieldLabel>
             <div className="relative">
@@ -1376,7 +1384,6 @@ function PurchaseStep(props: any) {
                 min={0}
                 placeholder="0"
                 className={cn("bg-background", groupPadClass)}
-                aria-required={requireWhenNotDraft || undefined}
                 {...register("converted_original_price")}
                 aria-invalid={!!errors.converted_original_price}
               />
@@ -1397,7 +1404,7 @@ function PurchaseStep(props: any) {
             <div className="h-px flex-1 bg-amber-300/60 dark:bg-amber-900/60" />
           </div>
           <div className="flex flex-col gap-1.5">
-            <FieldLabel htmlFor="commodity-current-price" required={requireWhenNotDraft}>
+            <FieldLabel htmlFor="commodity-current-price">
               {t("commodities:fields.currentPriceForeign", { groupCurrency })}
             </FieldLabel>
             <div className="relative">
@@ -1415,7 +1422,6 @@ function PurchaseStep(props: any) {
                 placeholder="0"
                 className={cn("bg-background", groupPadClass)}
                 {...register("current_price")}
-                aria-required={requireWhenNotDraft || undefined}
                 aria-invalid={!!errors.current_price}
               />
             </div>

--- a/frontend/src/features/commodities/schemas.ts
+++ b/frontend/src/features/commodities/schemas.ts
@@ -25,7 +25,6 @@ const PURCHASE_DATE_REQUIRED = "commodities:validation.purchaseDateRequired"
 const PURCHASE_DATE_FUTURE = "commodities:validation.purchaseDateFuture"
 const ORIGINAL_PRICE_REQUIRED = "commodities:validation.originalPriceRequired"
 const CONVERTED_PRICE_REQUIRED = "commodities:validation.convertedPriceRequired"
-const CURRENT_PRICE_REQUIRED = "commodities:validation.currentPriceRequired"
 const COMMENTS_TOO_LONG = "commodities:validation.commentsTooLong"
 const NOT_A_NUMBER = "commodities:validation.notANumber"
 // #1554: a Count > 1 commodity (a bundle of interchangeable units)
@@ -181,10 +180,13 @@ const baseCommoditySchema = z
         })
       }
     }
-    // Non-draft commodities require purchase_date and the price triad
-    // (original / converted / current) — see
-    // models.Commodity.ValidateWithContext's `whenNotDraft` block. Drafts
-    // skip these checks so the user can save partial state.
+    // Non-draft commodities require purchase_date and original_price —
+    // see models.Commodity.ValidateWithContext's `whenNotDraft` block.
+    // Drafts skip these checks so the user can save partial state.
+    // current_price required-ness was dropped in #1625 (PriceRule is
+    // the single source of truth for cross-field price invariants).
+    // converted_original_price required-ness is currency-dependent and
+    // lives in `buildCommoditySchema(groupCurrency)` below.
     if (vals.draft) return
     if (!vals.purchase_date) {
       ctx.addIssue({
@@ -198,15 +200,6 @@ const baseCommoditySchema = z
         path: ["original_price"],
         code: z.ZodIssueCode.custom,
         message: ORIGINAL_PRICE_REQUIRED,
-      })
-    }
-    // converted_original_price required-ness is currency-dependent and
-    // lives in `buildCommoditySchema(groupCurrency)` instead.
-    if (vals.current_price === "") {
-      ctx.addIssue({
-        path: ["current_price"],
-        code: z.ZodIssueCode.custom,
-        message: CURRENT_PRICE_REQUIRED,
       })
     }
   })

--- a/frontend/src/i18n/locales/en/commodities.json
+++ b/frontend/src/i18n/locales/en/commodities.json
@@ -407,7 +407,6 @@
     "convertedPriceRequired": "Converted original price is required for non-draft items.",
     "countMin": "Quantity must be at least 1.",
     "currencyRequired": "Currency is required.",
-    "currentPriceRequired": "Current value is required for non-draft items.",
     "nameRequired": "Name is required.",
     "nameTooLong": "Name must be 200 characters or fewer.",
     "noPriceInGroupCurrency": "Enter at least one of converted price or current value so the item is reportable in group currency.",

--- a/go/models/commodity.go
+++ b/go/models/commodity.go
@@ -399,7 +399,13 @@ func (a *Commodity) ValidateWithContext(ctx context.Context) error {
 			v, _ := a.ConvertedOriginalPrice.Float64()
 			return validation.Min(0.00).Validate(v)
 		}))),
-		validation.Field(&a.CurrentPrice, whenNotDraft.WithRules(validation.Required, validation.By(func(any) error {
+		// #1625: no validation.Required here. The cross-field PriceRule on
+		// OriginalPrice (line above) is the single source of truth for
+		// "at least one price is set" — it already rejects the all-zero
+		// foreign-currency case via ErrNoPriceInGroupCurrency and explicitly
+		// allows current_price = 0 in the same-currency case (the original
+		// price carries the canonical value, no conversion needed).
+		validation.Field(&a.CurrentPrice, whenNotDraft.WithRules(validation.By(func(any) error {
 			v, _ := a.CurrentPrice.Float64()
 			return validation.Min(0.00).Validate(v)
 		}))),

--- a/go/models/commodity_test.go
+++ b/go/models/commodity_test.go
@@ -391,6 +391,29 @@ func TestCommodity_ValidateWithContext_PriceValidation_HappyPath(t *testing.T) {
 			},
 			groupCurrency: "USD",
 		},
+		{
+			// #1625: same-currency commodity may omit current_price; PriceRule
+			// allows the all-zero case when original price carries the
+			// canonical value and no conversion is needed. Uses the struct
+			// zero value (decimal.Decimal{}, value=nil) — the form the field
+			// takes when the FE omits it or sends JSON null — because that is
+			// the path validation.Required actually rejects.
+			name: "Group currency with omitted current price",
+			commodity: models.Commodity{
+				Name:                   "Test Commodity",
+				ShortName:              "TC",
+				Type:                   models.CommodityTypeElectronics,
+				AreaID:                 "area1",
+				Count:                  1,
+				OriginalPrice:          decimal.NewFromFloat(100.00),
+				OriginalPriceCurrency:  "USD",
+				ConvertedOriginalPrice: decimal.Zero,
+				CurrentPrice:           decimal.Decimal{},
+				Status:                 models.CommodityStatusInUse,
+				PurchaseDate:           models.ToPDate("2023-01-01"),
+			},
+			groupCurrency: "USD",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Closes #1625.

## Why

`models.Commodity.ValidateWithContext` layered `validation.Required` on top of the cross-field `PriceRule` for `CurrentPrice`. The two contradicted: `PriceRule` (`go/models/rules/price.go`) explicitly allows the all-zero case in the same-currency branch (rule 3, asserted by `rules/price_test.go:42-47`), but the field-level Required defeated that intent and 422'd any non-draft commodity whose `current_price` JSON-decoded to the `decimal.Decimal` struct zero (omitted field / `null`).

The symptom in the wizard: same-currency item with Original Price filled but Current Value left blank could not be saved — BE returned `current_price: cannot be blank`. The mock's `AddItemDialog` deliberately hides the Current Value field entirely in the same-currency branch (`AddItemDialog.tsx:1198 isForeignCurrency = false`), confirming the design intent that current is optional when original already sits in group currency.

## What changed

### Backend (`go/models/commodity.go`)
- Drop `validation.Required` from the `whenNotDraft` rule on `CurrentPrice`. Keep `Min(0.00)`. `PriceRule` is now the single source of truth for cross-field price invariants.
- The empirical edge case worth noting: `validation.Required` passes for `decimal.Zero` / `decimal.NewFromInt(0)` (their internal `*big.Int` is non-nil so `reflect.DeepEqual` against the type's zero value returns false) but **fails** for `decimal.Decimal{}` (the struct zero — what an omitted or `null` JSON field unmarshals to). The new test reflects this by using `decimal.Decimal{}`, not `decimal.Zero`, so it exercises the production failure path.

### Test (`go/models/commodity_test.go`)
- Add `Group currency with omitted current price` case to `TestCommodity_ValidateWithContext_PriceValidation_HappyPath`: non-draft commodity, same currency (USD/USD), `original_price = 100`, `converted = 0`, `current = decimal.Decimal{}`. Validates without error.

### Frontend
- `CommodityFormDialog.tsx`: remove the live `current_price ← original_price` mirror (`currentPriceManualRef`, the watch-driven `useEffect`, and the `onCurrentPriceUserEdit` wiring through `PurchaseStep`). Remove the matching same-currency mirror inside `toRequest()`. Drop the `// TODO(#1625)` comment. The foreign-currency `converted ← current` mirror **stays** — it serves `ConvertedOriginalPrice.Required`, which is unchanged by this PR.
- In same-currency mode the Current Value field loses its required asterisk to match the new optional semantics.
- `features/commodities/schemas.ts`: drop the non-draft `current_price === ""` rejection. The cross-field "at-least-one-of-(converted, current) > 0" rule in `buildCommoditySchema` still fires for the foreign-currency case where it actually matters.
- `i18n/locales/en/commodities.json`: drop the now-unused `currentPriceRequired` key.

## Acceptance (from #1625)

- [x] `validation.Required` removed from `CurrentPrice` in `go/models/commodity.go`
- [x] New happy-path test in `commodity_test.go`: non-draft commodity, same currency, omitted `current_price` (struct zero), `converted_original_price = 0`, `original_price > 0` validates without error
- [x] FE mirror in `CommodityFormDialog.tsx::toRequest` removed and the issue's `// TODO` comment dropped
- [ ] Smoke test in the wizard: same-currency item without Current Value filled saves cleanly *(local Go tests + the new happy-path case cover the BE side; FE typecheck/lint/tests all green — manual smoke deferred to reviewer)*

## Test plan

- `go test ./models/... ./services/... ./apiserver/...` — green (incl. the new sub-case)
- `golangci-lint run --fix ./models/...` — 0 issues
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run test` — 984 passed / 4 skipped (unchanged baseline)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unintended automatic synchronization between price fields; inputs now reflect direct user entry.
  * Made current price optional for commodity entries; cross-field price invariants are preserved by validation.

* **Documentation**
  * Removed obsolete "current price required" validation message from English translations.

* **Tests**
  * Added a validation test case covering omitted current price in group-currency scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->