### PR TITLE
[#1679] Fix /profile 4-stat snapshot rendering all dashes

### DIFF
--- a/frontend/src/lib/__tests__/http.test.ts
+++ b/frontend/src/lib/__tests__/http.test.ts
@@ -160,6 +160,70 @@ describe("group-scoped URL rewriting", () => {
       })
     }
   })
+
+  it("reads ?g=<slug> from window.location.search on path-clean routes (#1679)", async () => {
+    // Models the /profile auto-fill flow: BrowserRouter's setSearchParams
+    // calls history.replaceState which updates window.location.search
+    // synchronously, but the GroupProvider's slug-mirror useEffect lands
+    // one tick later. The first group-scoped fetch fired in the same
+    // commit (e.g. useDashboardData's `enabled` flipping true once
+    // currentGroup resolves) must rewrite from the URL — otherwise it
+    // 404s against `/commodities` and the profile snapshot stays as "—"
+    // forever (#1679).
+    const original = window.location
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { ...original, pathname: "/profile", search: "?g=household" },
+    })
+    try {
+      // Slot deliberately null — simulates the pre-effect state.
+      let captured: string | null = null
+      server.use(
+        msw.get(/.*/, ({ request }) => {
+          captured = new URL(request.url).pathname
+          return HttpResponse.json({ ok: true })
+        })
+      )
+      await http.get("/commodities")
+      expect(captured).toBe("/api/v1/g/household/commodities")
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        writable: true,
+        value: original,
+      })
+    }
+  })
+
+  it("path /g/:slug/* still wins over ?g=<other> when both are present", async () => {
+    // Sanity check: if the URL carries BOTH a path slug and a query
+    // slug (e.g. a malformed redirect or hand-typed URL), the path is
+    // authoritative — same precedence as before #1679.
+    const original = window.location
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { ...original, pathname: "/g/canonical/dashboard", search: "?g=stale" },
+    })
+    try {
+      let captured: string | null = null
+      server.use(
+        msw.get(/.*/, ({ request }) => {
+          captured = new URL(request.url).pathname
+          return HttpResponse.json({ ok: true })
+        })
+      )
+      await http.get("/commodities")
+      expect(captured).toBe("/api/v1/g/canonical/commodities")
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        writable: true,
+        value: original,
+      })
+    }
+  })
 })
 
 describe("auth + CSRF headers", () => {

--- a/frontend/src/lib/group-context.ts
+++ b/frontend/src/lib/group-context.ts
@@ -10,10 +10,29 @@ let currentGroupSlug: string | null = null
 // Extract the active group slug from the current URL. Per the GroupProvider
 // docstring the URL is the canonical source of truth; the module-level slot
 // is just a non-React mirror that gets written from a useEffect.
+//
+// Two URL shapes carry the slug:
+//   - `/g/<slug>/...` — canonical for inventory pages (path wins always).
+//   - `?g=<slug>`     — path-clean routes (/profile, /settings) pin the
+//                       active group via this query param (#1612 / #1613).
+//
+// Reading both here closes the same effect-timing race for the query-param
+// shape that path-shape already enjoyed: setSearchParams runs synchronously
+// (`history.replaceState`) so window.location.search is up-to-date the
+// instant /profile auto-fills `?g=`; the slug-mirror useEffect, by contrast,
+// lands one tick later — long after the post-render React-Query refetch that
+// `enabled` flipping to true just scheduled. Without this fallback that
+// first fetch would 404 against `/commodities` (no `/g/{slug}/` prefix),
+// leaving the snapshot stuck on the "—" placeholder until the user clicks
+// somewhere else (see #1679).
 function readSlugFromUrl(): string | null {
   if (typeof window === "undefined") return null
-  const match = window.location.pathname.match(/^\/g\/([^/]+)(?:\/|$)/)
-  return match ? decodeURIComponent(match[1]) : null
+  const path = window.location.pathname
+  const m = path.match(/^\/g\/([^/]+)(?:\/|$)/)
+  if (m) return decodeURIComponent(m[1])
+  const search = new URLSearchParams(window.location.search)
+  const queryParamSlug = search.get("g")
+  return queryParamSlug && queryParamSlug !== "" ? queryParamSlug : null
 }
 
 // URL wins over the slot whenever the path carries a /g/:slug/* prefix. Two

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -391,5 +391,95 @@ describe("<ProfilePage />", () => {
       })
       expect(screen.getByTestId("profile-stat-est-value-value").textContent).toMatch(/\$/)
     })
+
+    // Repro for #1679: visiting /profile with ?g=<default> in the URL
+    // (the auto-fill state that lands the moment groups resolve) must
+    // surface the snapshot for that group. Before the fix the dashboard
+    // fetch raced the GroupProvider's slug-mirror useEffect and 404'd
+    // against the un-rewritten /commodities path, leaving the four stat
+    // tiles stuck on the "—" placeholder. The MemoryRouter the test
+    // harness uses doesn't mirror its history to window.location, so we
+    // pin window.location.search directly to simulate the production
+    // state where BrowserRouter's setSearchParams already replaced the
+    // URL — that is the surface the http client's readSlugFromUrl reads.
+    it("resolves the snapshot to the default group on bare /profile (#1679)", async () => {
+      server.use(
+        msw.get(api("/auth/me"), () =>
+          HttpResponse.json({
+            id: "u1",
+            email: "alex@example.com",
+            name: "Alex",
+            default_group_id: "g1",
+          })
+        ),
+        msw.get(api("/groups"), () =>
+          HttpResponse.json({
+            data: [
+              {
+                id: "g1",
+                type: "groups",
+                attributes: {
+                  id: "g1",
+                  slug: "household",
+                  name: "Household",
+                  group_currency: "USD",
+                  members_count: 1,
+                  current_user_role: "owner",
+                },
+              },
+            ],
+          })
+        ),
+        msw.get(api("/g/household/commodities"), () =>
+          HttpResponse.json({
+            data: Array.from({ length: 36 }, (_, i) => ({
+              id: `c${i}`,
+              type: "commodities",
+              attributes: { id: `c${i}`, name: `Item ${i}` },
+            })),
+            meta: { commodities: 36, total: 36, page: 1, per_page: 100, total_pages: 1 },
+          })
+        ),
+        msw.get(api("/g/household/commodities/values"), () =>
+          HttpResponse.json({
+            data: {
+              attributes: {
+                global_total: 12345.67,
+                location_totals: [],
+                area_totals: [],
+              },
+            },
+          })
+        ),
+        // Regression guard for #1679: if the dashboard fetch slips past
+        // the readSlugFromUrl ?g= fallback (or the GroupProvider's
+        // slug-slot update lands late), the http wrapper won't rewrite
+        // `/commodities` → `/g/household/commodities` and will hit the
+        // un-prefixed paths. Returning 404 on the bare paths flips the
+        // query to `isError`, so the items-value assertion below fails
+        // loudly rather than silently masking the race.
+        msw.get(api("/commodities"), () => new HttpResponse(null, { status: 404 })),
+        msw.get(api("/commodities/values"), () => new HttpResponse(null, { status: 404 }))
+      )
+      const original = window.location
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        writable: true,
+        value: { ...original, pathname: "/profile", search: "?g=household" },
+      })
+      try {
+        renderProfile("/profile?g=household")
+        await waitFor(() => {
+          expect(screen.getByTestId("profile-stat-items-value")).toHaveTextContent("36")
+        })
+        expect(screen.getByTestId("profile-stat-est-value-value").textContent).toMatch(/\$/)
+      } finally {
+        Object.defineProperty(window, "location", {
+          configurable: true,
+          writable: true,
+          value: original,
+        })
+      }
+    })
   })
 })


### PR DESCRIPTION
## Summary

Closes #1679.

The four-tile snapshot on `/profile` (Items / Active warranties / Expiring soon / Est. value, added in #1672) rendered the `—` placeholder for **all** stats on a freshly seeded admin account that owned a populated `Default` group. The same numbers resolved fine on `/g/{slug}` — the bug was in the `/profile` fetch path, not in the underlying queries.

## Root cause

`GroupProvider` auto-fills `?g=<default>` on path-clean routes via `setSearchParams`. The moment that lands, `currentGroup` resolves and `useDashboardData`'s `enabled` flips `false → true`, which schedules the commodities + values fetches in the same commit. The slug-mirror `useEffect` that writes the active slug into `lib/group-context.ts`'s slot runs **after** that — so the very first fetch issued by the snapshot lands against the un-rewritten `/commodities` / `/commodities/values` paths and 404s. React Query parks the query in `isError`, which trips the `statsReady` guard, and the four tiles stay on `—` until something else nudges the dashboard query (route change, hard reload, etc.).

The same fetch on `/g/{slug}/dashboard` works because `getCurrentGroupSlug()` already reads the slug from `window.location.pathname` (`/g/<slug>/...`) before falling back to the slot — closing the same effect race for path-shaped routes.

## Fix

Extend `readSlugFromUrl` in `frontend/src/lib/group-context.ts` to also pick up `?g=<slug>` from `window.location.search`. BrowserRouter's `setSearchParams` calls `history.replaceState` synchronously, so the moment auto-fill lands the URL is already authoritative — the fetch no longer depends on `useEffect` timing. Path-shape (`/g/<slug>/*`) still wins over `?g=`, matching the previous precedence.

## Test plan

- [x] `npx vitest run` — **987 passed / 4 skipped** (135 files). Includes:
  - `src/lib/__tests__/http.test.ts` — two new cases pinning `?g=` fallback and confirming path-shape still wins when both are present.
  - `src/pages/__tests__/ProfilePage.test.tsx` — bare `/profile` resolves the four-tile snapshot to the default group instead of `—`. MemoryRouter doesn't mirror its history to `window.location`, so the test pins `window.location.search` directly (same pattern the existing http URL-slug tests already use).
- [x] `npx eslint src` — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run i18n:check` — catalogs in sync.
- [x] `npx prettier --check src` — clean.
- [ ] CI Playwright lane (existing `e2e/tests/profile.spec.ts > Profile page — read-only landing` already asserts `profile-stats` visibility; this PR doesn't change those expectations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now supports reading group context from URL query parameters (`?g=<slug>`) in addition to path-based routing, enabling flexible URL handling for path-clean routes.

* **Bug Fixes**
  * Resolved an issue with ProfilePage stat tiles failing to populate correctly when accessed via clean paths with group query parameters.

* **Tests**
  * Added regression tests for query parameter group-slug sourcing and validation of path-based slug precedence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->