### PR TITLE
[#1735] Add enum constraints to JSON:API request data.type across loans/services/supplies

### DIFF
--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -7386,7 +7386,11 @@ export type components = {
         };
         "jsonapi.CommodityLoanReturnRequestDataWrapper": {
             attributes?: components["schemas"]["jsonapi.CommodityLoanReturnRequestData"];
-            type?: string;
+            /**
+             * @example commodity_loans
+             * @enum {string}
+             */
+            type?: "commodity_loans";
         };
         "jsonapi.CommodityLoanUpdateRequest": {
             data?: components["schemas"]["jsonapi.CommodityLoanUpdateRequestDataWrapper"];
@@ -7564,7 +7568,11 @@ export type components = {
         };
         "jsonapi.CommodityServiceReturnRequestDataWrapper": {
             attributes?: components["schemas"]["jsonapi.CommodityServiceReturnRequestData"];
-            type?: string;
+            /**
+             * @example commodity_services
+             * @enum {string}
+             */
+            type?: "commodity_services";
         };
         "jsonapi.CommodityServiceUpdateRequest": {
             data?: components["schemas"]["jsonapi.CommodityServiceUpdateRequestDataWrapper"];

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -7360,7 +7360,11 @@ export type components = {
         "jsonapi.CommodityLoanRequestDataWrapper": {
             attributes?: components["schemas"]["jsonapi.CommodityLoanRequestData"];
             id?: string;
-            type?: string;
+            /**
+             * @example commodity_loans
+             * @enum {string}
+             */
+            type?: "commodity_loans";
         };
         "jsonapi.CommodityLoanResponse": {
             data?: components["schemas"]["jsonapi.CommodityLoanResponseData"];
@@ -7401,7 +7405,11 @@ export type components = {
         "jsonapi.CommodityLoanUpdateRequestDataWrapper": {
             attributes?: components["schemas"]["jsonapi.CommodityLoanUpdateRequestData"];
             id?: string;
-            type?: string;
+            /**
+             * @example commodity_loans
+             * @enum {string}
+             */
+            type?: "commodity_loans";
         };
         "jsonapi.CommodityLoansMeta": {
             /**
@@ -7528,7 +7536,11 @@ export type components = {
         "jsonapi.CommodityServiceRequestDataWrapper": {
             attributes?: components["schemas"]["jsonapi.CommodityServiceRequestData"];
             id?: string;
-            type?: string;
+            /**
+             * @example commodity_services
+             * @enum {string}
+             */
+            type?: "commodity_services";
         };
         "jsonapi.CommodityServiceResponse": {
             data?: components["schemas"]["jsonapi.CommodityServiceResponseData"];
@@ -7568,7 +7580,11 @@ export type components = {
         "jsonapi.CommodityServiceUpdateRequestDataWrapper": {
             attributes?: components["schemas"]["jsonapi.CommodityServiceUpdateRequestData"];
             id?: string;
-            type?: string;
+            /**
+             * @example commodity_services
+             * @enum {string}
+             */
+            type?: "commodity_services";
         };
         "jsonapi.CommodityServicesMeta": {
             /**
@@ -8361,7 +8377,11 @@ export type components = {
         };
         "jsonapi.SupplyLinkReorderRequestData": {
             attributes?: components["schemas"]["jsonapi.SupplyLinkReorderRequestAttributes"];
-            type?: string;
+            /**
+             * @example commodity_supply_links_reorder
+             * @enum {string}
+             */
+            type?: "commodity_supply_links_reorder";
         };
         "jsonapi.SupplyLinkRequest": {
             data?: components["schemas"]["jsonapi.SupplyLinkRequestDataWrapper"];
@@ -8374,7 +8394,11 @@ export type components = {
         "jsonapi.SupplyLinkRequestDataWrapper": {
             attributes?: components["schemas"]["jsonapi.SupplyLinkRequestData"];
             id?: string;
-            type?: string;
+            /**
+             * @example commodity_supply_links
+             * @enum {string}
+             */
+            type?: "commodity_supply_links";
         };
         "jsonapi.SupplyLinkResponse": {
             data?: components["schemas"]["jsonapi.SupplyLinkResponseData"];
@@ -8399,7 +8423,11 @@ export type components = {
         "jsonapi.SupplyLinkUpdateRequestDataWrapper": {
             attributes?: components["schemas"]["jsonapi.SupplyLinkUpdateRequestData"];
             id?: string;
-            type?: string;
+            /**
+             * @example commodity_supply_links
+             * @enum {string}
+             */
+            type?: "commodity_supply_links";
         };
         "jsonapi.SupplyLinksMeta": {
             /**

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -7324,7 +7324,11 @@ const docTemplate = `{
                     "$ref": "#/definitions/jsonapi.CommodityLoanReturnRequestData"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_loans"
+                    ],
+                    "example": "commodity_loans"
                 }
             }
         },
@@ -7642,7 +7646,11 @@ const docTemplate = `{
                     "$ref": "#/definitions/jsonapi.CommodityServiceReturnRequestData"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_services"
+                    ],
+                    "example": "commodity_services"
                 }
             }
         },

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -7267,7 +7267,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_loans"
+                    ],
+                    "example": "commodity_loans"
                 }
             }
         },
@@ -7361,7 +7365,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_loans"
+                    ],
+                    "example": "commodity_loans"
                 }
             }
         },
@@ -7571,7 +7579,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_services"
+                    ],
+                    "example": "commodity_services"
                 }
             }
         },
@@ -7675,7 +7687,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_services"
+                    ],
+                    "example": "commodity_services"
                 }
             }
         },
@@ -9241,7 +9257,11 @@ const docTemplate = `{
                     "$ref": "#/definitions/jsonapi.SupplyLinkReorderRequestAttributes"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_supply_links_reorder"
+                    ],
+                    "example": "commodity_supply_links_reorder"
                 }
             }
         },
@@ -9277,7 +9297,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_supply_links"
+                    ],
+                    "example": "commodity_supply_links"
                 }
             }
         },
@@ -9339,7 +9363,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_supply_links"
+                    ],
+                    "example": "commodity_supply_links"
                 }
             }
         },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -7260,7 +7260,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_loans"
+                    ],
+                    "example": "commodity_loans"
                 }
             }
         },
@@ -7354,7 +7358,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_loans"
+                    ],
+                    "example": "commodity_loans"
                 }
             }
         },
@@ -7564,7 +7572,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_services"
+                    ],
+                    "example": "commodity_services"
                 }
             }
         },
@@ -7668,7 +7680,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_services"
+                    ],
+                    "example": "commodity_services"
                 }
             }
         },
@@ -9234,7 +9250,11 @@
                     "$ref": "#/definitions/jsonapi.SupplyLinkReorderRequestAttributes"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_supply_links_reorder"
+                    ],
+                    "example": "commodity_supply_links_reorder"
                 }
             }
         },
@@ -9270,7 +9290,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_supply_links"
+                    ],
+                    "example": "commodity_supply_links"
                 }
             }
         },
@@ -9332,7 +9356,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_supply_links"
+                    ],
+                    "example": "commodity_supply_links"
                 }
             }
         },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -7317,7 +7317,11 @@
                     "$ref": "#/definitions/jsonapi.CommodityLoanReturnRequestData"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_loans"
+                    ],
+                    "example": "commodity_loans"
                 }
             }
         },
@@ -7635,7 +7639,11 @@
                     "$ref": "#/definitions/jsonapi.CommodityServiceReturnRequestData"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "commodity_services"
+                    ],
+                    "example": "commodity_services"
                 }
             }
         },

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -708,6 +708,9 @@ definitions:
       id:
         type: string
       type:
+        enum:
+        - commodity_loans
+        example: commodity_loans
         type: string
     type: object
   jsonapi.CommodityLoanResponse:
@@ -772,6 +775,9 @@ definitions:
       id:
         type: string
       type:
+        enum:
+        - commodity_loans
+        example: commodity_loans
         type: string
     type: object
   jsonapi.CommodityLoansMeta:
@@ -941,6 +947,9 @@ definitions:
       id:
         type: string
       type:
+        enum:
+        - commodity_services
+        example: commodity_services
         type: string
     type: object
   jsonapi.CommodityServiceResponse:
@@ -1008,6 +1017,9 @@ definitions:
       id:
         type: string
       type:
+        enum:
+        - commodity_services
+        example: commodity_services
         type: string
     type: object
   jsonapi.CommodityServicesMeta:
@@ -2123,6 +2135,9 @@ definitions:
       attributes:
         $ref: '#/definitions/jsonapi.SupplyLinkReorderRequestAttributes'
       type:
+        enum:
+        - commodity_supply_links_reorder
+        example: commodity_supply_links_reorder
         type: string
     type: object
   jsonapi.SupplyLinkRequest:
@@ -2146,6 +2161,9 @@ definitions:
       id:
         type: string
       type:
+        enum:
+        - commodity_supply_links
+        example: commodity_supply_links
         type: string
     type: object
   jsonapi.SupplyLinkResponse:
@@ -2186,6 +2204,9 @@ definitions:
       id:
         type: string
       type:
+        enum:
+        - commodity_supply_links
+        example: commodity_supply_links
         type: string
     type: object
   jsonapi.SupplyLinksMeta:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -745,6 +745,9 @@ definitions:
       attributes:
         $ref: '#/definitions/jsonapi.CommodityLoanReturnRequestData'
       type:
+        enum:
+        - commodity_loans
+        example: commodity_loans
         type: string
     type: object
   jsonapi.CommodityLoanUpdateRequest:
@@ -988,6 +991,9 @@ definitions:
       attributes:
         $ref: '#/definitions/jsonapi.CommodityServiceReturnRequestData'
       type:
+        enum:
+        - commodity_services
+        example: commodity_services
         type: string
     type: object
   jsonapi.CommodityServiceUpdateRequest:

--- a/go/jsonapi/commodity_loans.go
+++ b/go/jsonapi/commodity_loans.go
@@ -83,7 +83,7 @@ type CommodityLoanRequest struct {
 
 type CommodityLoanRequestDataWrapper struct {
 	ID         string                   `json:"id,omitempty"`
-	Type       string                   `json:"type"`
+	Type       string                   `json:"type" example:"commodity_loans" enums:"commodity_loans"`
 	Attributes CommodityLoanRequestData `json:"attributes"`
 }
 
@@ -158,7 +158,7 @@ type CommodityLoanUpdateRequest struct {
 
 type CommodityLoanUpdateRequestDataWrapper struct {
 	ID         string                         `json:"id"`
-	Type       string                         `json:"type"`
+	Type       string                         `json:"type" example:"commodity_loans" enums:"commodity_loans"`
 	Attributes CommodityLoanUpdateRequestData `json:"attributes"`
 }
 

--- a/go/jsonapi/commodity_loans.go
+++ b/go/jsonapi/commodity_loans.go
@@ -250,7 +250,7 @@ type CommodityLoanReturnRequest struct {
 }
 
 type CommodityLoanReturnRequestDataWrapper struct {
-	Type       string                         `json:"type"`
+	Type       string                         `json:"type" example:"commodity_loans" enums:"commodity_loans"`
 	Attributes CommodityLoanReturnRequestData `json:"attributes"`
 }
 

--- a/go/jsonapi/commodity_services.go
+++ b/go/jsonapi/commodity_services.go
@@ -82,7 +82,7 @@ type CommodityServiceRequest struct {
 
 type CommodityServiceRequestDataWrapper struct {
 	ID         string                      `json:"id,omitempty"`
-	Type       string                      `json:"type"`
+	Type       string                      `json:"type" example:"commodity_services" enums:"commodity_services"`
 	Attributes CommodityServiceRequestData `json:"attributes"`
 }
 
@@ -159,7 +159,7 @@ type CommodityServiceUpdateRequest struct {
 
 type CommodityServiceUpdateRequestDataWrapper struct {
 	ID         string                            `json:"id"`
-	Type       string                            `json:"type"`
+	Type       string                            `json:"type" example:"commodity_services" enums:"commodity_services"`
 	Attributes CommodityServiceUpdateRequestData `json:"attributes"`
 }
 

--- a/go/jsonapi/commodity_services.go
+++ b/go/jsonapi/commodity_services.go
@@ -231,7 +231,7 @@ type CommodityServiceReturnRequest struct {
 }
 
 type CommodityServiceReturnRequestDataWrapper struct {
-	Type       string                            `json:"type"`
+	Type       string                            `json:"type" example:"commodity_services" enums:"commodity_services"`
 	Attributes CommodityServiceReturnRequestData `json:"attributes"`
 }
 

--- a/go/jsonapi/commodity_supply_links.go
+++ b/go/jsonapi/commodity_supply_links.go
@@ -85,7 +85,7 @@ type SupplyLinkRequest struct {
 
 type SupplyLinkRequestDataWrapper struct {
 	ID         string                `json:"id,omitempty"`
-	Type       string                `json:"type"`
+	Type       string                `json:"type" example:"commodity_supply_links" enums:"commodity_supply_links"`
 	Attributes SupplyLinkRequestData `json:"attributes"`
 }
 
@@ -147,7 +147,7 @@ type SupplyLinkUpdateRequest struct {
 
 type SupplyLinkUpdateRequestDataWrapper struct {
 	ID         string                      `json:"id"`
-	Type       string                      `json:"type"`
+	Type       string                      `json:"type" example:"commodity_supply_links" enums:"commodity_supply_links"`
 	Attributes SupplyLinkUpdateRequestData `json:"attributes"`
 }
 
@@ -210,7 +210,7 @@ type SupplyLinkReorderRequest struct {
 }
 
 type SupplyLinkReorderRequestData struct {
-	Type       string                             `json:"type"`
+	Type       string                             `json:"type" example:"commodity_supply_links_reorder" enums:"commodity_supply_links_reorder"`
 	Attributes SupplyLinkReorderRequestAttributes `json:"attributes"`
 }
 


### PR DESCRIPTION
Closes #1735.

## Summary

Spec-only sweep: every JSON:API request data-wrapper in `commodity_loans.go` / `commodity_services.go` / `commodity_supply_links.go` now declares its accepted `data.type` value as both `enum` and `example` instead of leaving it as a free-form `string`. Runtime enforcement was already in place at the handler layer (`validation.In("commodity_loans")` etc., returning 422 on mismatch) — this PR is a Swagger/OpenAPI alignment so generated clients (frontend `api.d.ts`, swagger-ui) see the exact contract.

## What's in

Source edits — single struct-tag widening per type, mirroring the pattern already used on the matching read wrappers (e.g. `CommodityLoanData.Type`):

| Wrapper | `data.type` enum value |
| --- | --- |
| `CommodityLoanRequestDataWrapper` | `commodity_loans` |
| `CommodityLoanUpdateRequestDataWrapper` | `commodity_loans` |
| `CommodityLoanReturnRequestDataWrapper` | `commodity_loans` |
| `CommodityServiceRequestDataWrapper` | `commodity_services` |
| `CommodityServiceUpdateRequestDataWrapper` | `commodity_services` |
| `CommodityServiceReturnRequestDataWrapper` | `commodity_services` |
| `SupplyLinkRequestDataWrapper` | `commodity_supply_links` |
| `SupplyLinkUpdateRequestDataWrapper` | `commodity_supply_links` |
| `SupplyLinkReorderRequestData` | `commodity_supply_links_reorder` |

The first commit covers the seven wrappers explicitly listed in the issue body. The follow-up commit folds in the two `*ReturnRequestDataWrapper` variants in the same files — they share an existing `validation.In(...)` runtime guard with an enum value already in this PR (no new schema, zero coordination cost), and were the only remaining bare `json:"type"` tags in the three touched files. Skipping them would have left `api.d.ts` interleaving narrowed and free-form `type` fields for the same subsystem — the exact inconsistency the issue set out to eliminate.

Generated artifacts regenerated via `make swagger` (covers both `go tool swag init` and `npm run codegen`):

- `go/docs/{docs.go,swagger.json,swagger.yaml}`
- `frontend/src/types/api.d.ts`

## Behavioural impact

- **Server**: none. 422 on type mismatch was already returned before this PR.
- **Generated TS clients**: `api.d.ts` now narrows `type?: string` → `type?: "commodity_loans"` (etc.). FE callers currently passing a free-form string may see new compile-time errors — this is the desired tightening.

## Test plan

- [x] `golangci-lint run ./jsonapi/...` — 0 issues
- [x] `go test -short ./jsonapi/... ./apiserver/...` — green (handler-level type validators pin the new enums end-to-end)
- [x] `npx tsc --noEmit` (frontend) — green
- [x] CodeRabbit + senior-reviewer pass — green; reviewer's strong recommendation to fold in the two Return wrappers applied
- [ ] CI runs the full Go + frontend + e2e matrix

Refs #1733 (where the original CodeRabbit thread surfaced this).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Constrained API request "type" fields to fixed allowed values for commodity loans, commodity services, and commodity supply links to improve schema strictness.

* **Documentation**
  * Updated API/OpenAPI documentation and examples to reflect the new fixed request type values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->