### PR TITLE
[#1681] Use medium date style for print page header

### DIFF
--- a/frontend/src/pages/commodities/CommodityPrintPage.tsx
+++ b/frontend/src/pages/commodities/CommodityPrintPage.tsx
@@ -119,8 +119,8 @@ export function CommodityPrintPage() {
                   {type ? t(`commodities:type.${type}`) : ""}
                 </p>
               </div>
-              <p className="text-xs text-muted-foreground">
-                {formatDate(new Date(), { style: "short" })}
+              <p className="text-xs text-muted-foreground" data-testid="commodity-print-header-date">
+                {formatDate(new Date(), { style: "medium" })}
               </p>
             </header>
 

--- a/frontend/src/pages/commodities/CommodityPrintPage.tsx
+++ b/frontend/src/pages/commodities/CommodityPrintPage.tsx
@@ -119,7 +119,10 @@ export function CommodityPrintPage() {
                   {type ? t(`commodities:type.${type}`) : ""}
                 </p>
               </div>
-              <p className="text-xs text-muted-foreground" data-testid="commodity-print-header-date">
+              <p
+                className="text-xs text-muted-foreground"
+                data-testid="commodity-print-header-date"
+              >
                 {formatDate(new Date(), { style: "medium" })}
               </p>
             </header>

--- a/frontend/src/pages/commodities/__tests__/CommodityPrintPage.test.tsx
+++ b/frontend/src/pages/commodities/__tests__/CommodityPrintPage.test.tsx
@@ -82,6 +82,7 @@ describe("<CommodityPrintPage />", () => {
     expect(screen.getByText(/garage/i)).toBeInTheDocument()
     expect(screen.getByText(/\$2,400\.00/)).toBeInTheDocument()
     expect(screen.getByText(/daily driver/i)).toBeInTheDocument()
+    expect(screen.getByTestId("commodity-print-header-date").textContent).toMatch(/\b20\d{2}\b/)
   })
 
   it("calls window.print when the Print button is clicked", async () => {


### PR DESCRIPTION
## Summary

- Swap the print-friendly item view header date from Intl `short` (`5/15/26`, 2-digit year, ambiguous on a printed artefact) to `medium` (e.g. `May 19, 2026`) so the header matches the body's already-`medium` purchase-date.
- One-line `data-testid="commodity-print-header-date"` on the header `<p>` so the new test can pin to it without coupling to locale-specific formatting.
- One new vitest assertion verifying the header text contains a 4-digit year (`/\b20\d{2}\b/`), scoped to the new test id.

## Why

Issue #1681 — within `/g/:slug/commodities/:id/print` the same surface used two different date formats (`5/15/26` in the header, `May 15, 2024` in the body). For a printable page that may live in a filing cabinet, the 2-digit-year form is the wrong choice. The body already does the right thing via `formatDate(..., { style: "medium" })`; this aligns the header with it.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test -- src/pages/commodities/__tests__/CommodityPrintPage.test.tsx` — 3/3 pass
- [ ] CI green
- [x] Manual check via the existing axe test — no a11y regression from the added `data-testid`

## Notes / Out of scope

There are four other `style: "short"` callers in the codebase (`CommoditiesListPage.tsx:1181`, `CommodityDetailPage.tsx:1030/1285/1296`); those are on-screen ephemeral surfaces, not print artefacts, and stay out of this PR per #1681's stated scope.

Closes #1681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Commodity print header now displays the current date in a more complete (medium) format for clearer readability.

* **Tests**
  * Added a test to validate the commodity print header shows a proper four-digit year.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->