### PR TITLE
[#1747] Admin user block/unblock endpoints

### DIFF
--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -347,6 +347,194 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/admin/users/{userID}/block": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Block (deactivate) a user account
+         * @description Sets the user's `is_active` flag to false, revokes every refresh token, and bumps the JWT-blacklist staleness threshold so live access tokens are rejected on next use.
+         *     Returns 422 with `admin.block.self_blocked` when the caller targets their own account, and 422 with `admin.block.admin_requires_force` when targeting another system admin without `force=true`.
+         *     Body-validation rejections surface as 422 with `admin.block.reason_required` (missing or blank `reason`) or `admin.block.reason_too_long` (reason exceeds 500 characters).
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Target user ID */
+                    userID: string;
+                };
+                cookie?: never;
+            };
+            /** @description Block request */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["apiserver.AdminBlockRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["apiserver.AdminUserEnvelope"];
+                    };
+                };
+                /** @description Bad Request - invalid body */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Forbidden - system-admin required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Not Found - unknown user */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unprocessable Entity - self-block or admin-on-admin without force */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/users/{userID}/unblock": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Unblock (reactivate) a user account
+         * @description Sets the user's `is_active` flag back to true. Does NOT re-issue tokens — the user must log in again.
+         *     Does NOT clear the JWT-blacklist staleness threshold either, so any access tokens that were issued before the block stay rejected until the iat-staleness ring expires.
+         *     Body-validation rejections surface as 422 with `admin.block.reason_required` (missing or blank `reason`) or `admin.block.reason_too_long` (reason exceeds 500 characters); the codes are shared with the block endpoint.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Target user ID */
+                    userID: string;
+                };
+                cookie?: never;
+            };
+            /** @description Unblock request */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["apiserver.AdminUnblockRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["apiserver.AdminUserEnvelope"];
+                    };
+                };
+                /** @description Bad Request - invalid body */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Forbidden - system-admin required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Not Found - unknown user */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unprocessable Entity - invalid reason */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/change-password": {
         parameters: {
             query?: never;
@@ -7237,9 +7425,38 @@ export type paths = {
 export type webhooks = Record<string, never>;
 export type components = {
     schemas: {
+        "apiserver.AdminBlockRequest": {
+            /**
+             * @description Force overrides the "cannot block another system admin" guard.
+             *     Has no effect when blocking a non-admin user.
+             */
+            force?: boolean;
+            /** @description Reason is the free-form justification for the block (max 500 chars). */
+            reason: string;
+        };
         "apiserver.AdminPingResponse": {
             ok?: boolean;
             timestamp?: string;
+        };
+        "apiserver.AdminUnblockRequest": {
+            /** @description Reason is the free-form justification for the unblock (max 500 chars). */
+            reason: string;
+        };
+        "apiserver.AdminUserEnvelope": {
+            data?: components["schemas"]["apiserver.AdminUserResource"];
+        };
+        "apiserver.AdminUserResource": {
+            attributes?: components["schemas"]["apiserver.AdminUserView"];
+            id?: string;
+            type?: string;
+        };
+        "apiserver.AdminUserView": {
+            email?: string;
+            id?: string;
+            is_active?: boolean;
+            is_system_admin?: boolean;
+            name?: string;
+            tenant_id?: string;
         };
         "apiserver.ChangePasswordRequest": {
             current_password?: string;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -385,7 +385,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["apiserver.AdminUserEnvelope"];
+                        "application/vnd.api+json": components["schemas"]["apiserver.AdminUserEnvelope"];
                     };
                 };
                 /** @description Bad Request - invalid body */
@@ -394,7 +394,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
                 /** @description Unauthorized */
@@ -403,7 +403,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
                 /** @description Forbidden - system-admin required */
@@ -412,7 +412,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
                 /** @description Not Found - unknown user */
@@ -421,7 +421,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
                 /** @description Unprocessable Entity - self-block or admin-on-admin without force */
@@ -430,7 +430,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
             };
@@ -479,7 +479,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["apiserver.AdminUserEnvelope"];
+                        "application/vnd.api+json": components["schemas"]["apiserver.AdminUserEnvelope"];
                     };
                 };
                 /** @description Bad Request - invalid body */
@@ -488,7 +488,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
                 /** @description Unauthorized */
@@ -497,7 +497,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
                 /** @description Forbidden - system-admin required */
@@ -506,7 +506,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
                 /** @description Not Found - unknown user */
@@ -515,7 +515,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
                 /** @description Unprocessable Entity - invalid reason */
@@ -524,7 +524,7 @@ export type paths = {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
             };

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -49,9 +49,13 @@ func adminPing(w http.ResponseWriter, r *http.Request) {
 // cross tenants — using the user-aware registries would limit the
 // admin to their own tenant, defeating the surface. AuditService is
 // shared with the rest of the apiserver so the admin audit trail
-// lands in the same audit_logs table.
+// lands in the same audit_logs table. Blacklist is needed by the
+// block/unblock cascade (#1747) to bump the JWT-iat staleness
+// threshold so live access tokens minted before the block fail on
+// next use.
 type AdminParams struct {
 	FactorySet   *registry.FactorySet
+	Blacklist    services.TokenBlacklister
 	AuditService services.AuditLogger
 }
 
@@ -66,6 +70,7 @@ func Admin(params AdminParams) func(r chi.Router) {
 	}
 	usersAPI := &adminUsersAPI{
 		factorySet:   params.FactorySet,
+		blacklist:    params.Blacklist,
 		auditService: params.AuditService,
 	}
 	return func(r chi.Router) {
@@ -83,6 +88,12 @@ func Admin(params AdminParams) func(r chi.Router) {
 		r.Get("/tenants/{tenantID}", tenantsAPI.getTenant)
 		r.Get("/tenants/{tenantID}/users", usersAPI.listTenantUsers)
 		r.Get("/users/{userID}", usersAPI.getUser)
+
+		// #1747: user block/unblock endpoints. Each transition cascades
+		// IsActive=false → refresh-token revoke → blacklist bump and
+		// audit-logs reason+forced via the breadcrumb in user_agent.
+		r.Post("/users/{userID}/block", usersAPI.blockUser)
+		r.Post("/users/{userID}/unblock", usersAPI.unblockUser)
 	}
 }
 

--- a/go/apiserver/admin_users.go
+++ b/go/apiserver/admin_users.go
@@ -1,24 +1,141 @@
 package apiserver
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 
+	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/jsonapi"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 	"github.com/denisvmedia/inventario/services"
 )
 
-// adminUsersAPI backs GET /admin/tenants/{tenantID}/users and GET
-// /admin/users/{userID}. Holds the FactorySet directly (not the
-// per-request user-aware Set) for the same cross-tenant reason
-// adminTenantsAPI does.
+// Admin user block/unblock action names. Kept as constants so the audit
+// trail uses the same literals as the swagger tags and the FE filter
+// chips on the admin-activity page. Mirrors the "admin.<noun>_<verb>"
+// pattern set by #1745 (admin.grant_system_admin / admin.revoke_system_admin).
+const (
+	// AuditActionAdminUserBlock is the audit-row Action emitted on a
+	// successful block of another (non-admin) user. The matching
+	// failure rows (self-block, admin-without-force) reuse the same
+	// Action with Success=false so a single filter pulls the whole
+	// attempt history.
+	AuditActionAdminUserBlock = "admin.user_block"
+	// AuditActionAdminUserBlockForce is the audit-row Action emitted
+	// when an admin blocks ANOTHER system admin with force=true. The
+	// distinct Action means audit-side severity tooling can pivot on
+	// the literal without re-parsing the breadcrumb JSON. The row's
+	// breadcrumb also carries `forced: true` so post-hoc analysis can
+	// branch on either signal.
+	AuditActionAdminUserBlockForce = "admin.user_block_force"
+	// AuditActionAdminUserUnblock is the audit-row Action emitted on a
+	// successful unblock. Unblock has no force variant — re-activating
+	// an account is symmetric for admins and non-admins.
+	AuditActionAdminUserUnblock = "admin.user_unblock"
+)
+
+// JSON:API error codes returned by the block / unblock endpoints. Kept
+// as constants so the swagger annotations, the FE branch table, and the
+// tests reference the same literals. Codes follow the "admin.block.*"
+// family declared in the #1747 issue spec; the body-validation codes
+// are shared across block and unblock since both DTOs carry the same
+// reason field.
+const (
+	// AdminBlockSelfBlockedCode signals "the caller tried to block
+	// their own account". Maps to a 422.
+	AdminBlockSelfBlockedCode = "admin.block.self_blocked"
+	// AdminBlockAdminRequiresForceCode signals "the target is another
+	// system admin, send force=true to override". Maps to a 422.
+	AdminBlockAdminRequiresForceCode = "admin.block.admin_requires_force"
+	// AdminBlockReasonRequiredCode signals "the request body is missing
+	// the required `reason` field (or it is blank)". Maps to a 422.
+	// Shared between block and unblock — both DTOs require a reason.
+	AdminBlockReasonRequiredCode = "admin.block.reason_required"
+	// AdminBlockReasonTooLongCode signals "the supplied reason exceeds
+	// the 500-char cap". Maps to a 422. Shared between block and
+	// unblock.
+	AdminBlockReasonTooLongCode = "admin.block.reason_too_long"
+)
+
+// adminBlockReasonMaxLen caps the reason string at 500 characters.
+// Going higher serves no audit-readability goal and risks bloating the
+// audit_logs.user_agent column we tunnel the breadcrumb through.
+const adminBlockReasonMaxLen = 500
+
+// AdminBlockRequest is the request body for POST /admin/users/{userID}/block.
+//
+// `reason` is required and is persisted into the audit log breadcrumb so
+// every state transition carries an operator-supplied justification.
+// `force` is the explicit override that allows blocking another system
+// admin — without it, an admin-on-admin block returns 422 with code
+// "admin.block.admin_requires_force".
+type AdminBlockRequest struct {
+	// Reason is the free-form justification for the block (max 500 chars).
+	Reason string `json:"reason" validate:"required,max=500"`
+	// Force overrides the "cannot block another system admin" guard.
+	// Has no effect when blocking a non-admin user.
+	Force bool `json:"force,omitempty"`
+}
+
+// AdminUnblockRequest is the request body for POST /admin/users/{userID}/unblock.
+// Symmetric with AdminBlockRequest — `reason` is required so the audit
+// breadcrumb carries it.
+type AdminUnblockRequest struct {
+	// Reason is the free-form justification for the unblock (max 500 chars).
+	Reason string `json:"reason" validate:"required,max=500"`
+}
+
+// AdminUserView is the JSON:API-style attributes block returned by the
+// block / unblock endpoints. Deliberately narrow: only the fields a
+// system admin actually cares about for a block / unblock receipt
+// (identity + state), not every user column. The FE renders a confirm
+// toast off of this; richer admin user-detail surfaces ship in later
+// #1744 issues.
+type AdminUserView struct {
+	ID            string `json:"id"`
+	Email         string `json:"email"`
+	Name          string `json:"name"`
+	IsActive      bool   `json:"is_active"`
+	IsSystemAdmin bool   `json:"is_system_admin"`
+	TenantID      string `json:"tenant_id"`
+}
+
+// AdminUserEnvelope is the JSON:API envelope returned by block /
+// unblock. Single-resource shape ({"data": {...}}) matches what the
+// rest of the protected admin surface will return as #1744 fills out.
+type AdminUserEnvelope struct {
+	Data AdminUserResource `json:"data"`
+}
+
+// AdminUserResource is the JSON:API resource block carried inside
+// AdminUserEnvelope. Keeps `type` + `id` at the top level and pushes
+// the rest under `attributes`, matching the project's other JSON:API
+// responses.
+type AdminUserResource struct {
+	Type       string        `json:"type"`
+	ID         string        `json:"id"`
+	Attributes AdminUserView `json:"attributes"`
+}
+
+// adminUsersAPI backs the /admin/users/* and /admin/tenants/{tenantID}/users
+// routes. Holds the FactorySet directly (not the per-request user-aware
+// Set) for the same cross-tenant reason adminTenantsAPI does — admin
+// endpoints intentionally cross tenants and the user-aware registries
+// would constrain the admin to their own tenant, defeating the surface.
+// The blacklist dependency is the #1747 block-cascade addition: needed
+// to bump the JWT-iat staleness threshold so live access tokens minted
+// before the block are rejected on next use.
 type adminUsersAPI struct {
 	factorySet   *registry.FactorySet
+	blacklist    services.TokenBlacklister
 	auditService services.AuditLogger
 }
 
@@ -193,6 +310,419 @@ func (api *adminUsersAPI) getUser(w http.ResponseWriter, r *http.Request) {
 	api.auditGetUser(r, userID, user.TenantID, renderErr)
 	if renderErr != nil {
 		_ = internalServerError(w, r, renderErr)
+	}
+}
+
+// blockUser deactivates a user account and tears down their live
+// sessions: refresh tokens revoked, access tokens iat-stale-rejected
+// via the user-level blacklist entry. Guards prevent self-lockout and
+// silent admin-on-admin demotion (an explicit `force: true` is
+// required for the latter).
+// @Summary Block (deactivate) a user account
+// @Description Sets the user's `is_active` flag to false, revokes every refresh token, and bumps the JWT-blacklist staleness threshold so live access tokens are rejected on next use.
+// @Description Returns 422 with `admin.block.self_blocked` when the caller targets their own account, and 422 with `admin.block.admin_requires_force` when targeting another system admin without `force=true`.
+// @Description Body-validation rejections surface as 422 with `admin.block.reason_required` (missing or blank `reason`) or `admin.block.reason_too_long` (reason exceeds 500 characters).
+// @Tags admin
+// @Accept json
+// @Produce json
+// @Param userID path string true "Target user ID"
+// @Param data body AdminBlockRequest true "Block request"
+// @Success 200 {object} AdminUserEnvelope "OK"
+// @Failure 400 {object} jsonapi.Errors "Bad Request - invalid body"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 404 {object} jsonapi.Errors "Not Found - unknown user"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - self-block or admin-on-admin without force"
+// @Router /admin/users/{userID}/block [post]
+func (api *adminUsersAPI) blockUser(w http.ResponseWriter, r *http.Request) {
+	actor := appctx.UserFromContext(r.Context())
+	if actor == nil {
+		// Defence-in-depth: RequireSystemAdmin should have caught this
+		// already. Reaching here means the middleware chain is wired
+		// wrong; render the same shape RequireSystemAdmin would.
+		_ = unauthorizedError(w, r, ErrMissingUserContext)
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	if strings.TrimSpace(userID) == "" {
+		_ = badRequest(w, r, errors.New("missing user id"))
+		return
+	}
+
+	req, ok := api.decodeBlockRequest(w, r)
+	if !ok {
+		return
+	}
+
+	target, err := api.factorySet.UserRegistry.Get(r.Context(), userID)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotFound) {
+			api.logBlockOutcome(r, actor, userID, "", req, false, err.Error(), false)
+			_ = renderEntityError(w, r, err)
+			return
+		}
+		slog.Error("admin block: failed to load user", "user_id", userID, "error", err)
+		api.logBlockOutcome(r, actor, userID, "", req, false, err.Error(), false)
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	// Self-block guard. Under an impersonation session (#1750) the
+	// JWT's user_id is the impersonated user; the operator-of-record
+	// lives in the `impersonated_by` claim. Resolve the real operator
+	// via services.ImpersonatorIDFromContext so an operator can't
+	// self-block by acting through an impersonated identity. The guard
+	// runs above the idempotency check so an operator who tries to
+	// block themselves always sees the typed error, even if their
+	// account is already inactive.
+	if target.ID == operatorIDFromContext(r.Context(), actor) {
+		api.logBlockOutcome(r, actor, target.ID, target.TenantID, req, false, ErrAdminCannotBlockSelf.Error(), false)
+		_ = renderEntityError(w, r, ErrAdminCannotBlockSelf)
+		return
+	}
+
+	if !target.IsActive {
+		// Idempotent: the user is already blocked. Re-run the cascade
+		// anyway — the blacklist ring has a 30-min TTL, so a re-block
+		// after the ring expired (or after a freshly-issued token
+		// landed in the window between block attempts) needs the
+		// cascade to invalidate whatever's live now. The cascade is
+		// itself idempotent. Record `forced=false`: a no-op block did
+		// not override the admin-on-admin guard, even when req.Force
+		// was set — nothing was "forced". The cascade then runs
+		// regardless of req.Force so the iat-staleness bump still
+		// fires for peer-admin re-blocks. Runs above the
+		// admin-without-force guard so re-blocking an already-blocked
+		// peer admin is a 200 no-op rather than a surprising 422.
+		cascadeErrMsg := api.applyBlockCascade(r, target.ID)
+		api.logBlockOutcome(r, actor, target.ID, target.TenantID, req, cascadeErrMsg == "", cascadeErrMsg, false)
+		api.writeUserEnvelope(w, http.StatusOK, target)
+		return
+	}
+
+	if target.IsSystemAdmin && !req.Force {
+		api.logBlockOutcome(r, actor, target.ID, target.TenantID, req, false, ErrAdminCannotBlockAdminWithoutForce.Error(), false)
+		_ = renderEntityError(w, r, ErrAdminCannotBlockAdminWithoutForce)
+		return
+	}
+
+	// Forced flag is true only when the operator explicitly overrode
+	// the admin-on-admin guard AND the block actually fires (target
+	// was active above). Surface it on the audit row so post-hoc
+	// analysis can pivot on "operator blocked a live peer admin"
+	// without re-parsing the breadcrumb JSON.
+	forced := target.IsSystemAdmin && req.Force
+
+	updated := *target
+	updated.IsActive = false
+	saved, err := api.factorySet.UserRegistry.Update(r.Context(), updated)
+	if err != nil {
+		slog.Error("admin block: failed to deactivate user", "user_id", target.ID, "error", err)
+		api.logBlockOutcome(r, actor, target.ID, target.TenantID, req, false, err.Error(), forced)
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	// Best-effort cascade: revoke refresh tokens and bump the iat
+	// staleness threshold so live access tokens are rejected on next
+	// use. Failures here don't roll back the is_active flip — the
+	// account is already deactivated, so the request has met its main
+	// invariant; the cascade failures get logged for operator
+	// awareness and the audit row records ErrMsg if either step
+	// blipped.
+	cascadeErrMsg := api.applyBlockCascade(r, target.ID)
+	api.logBlockOutcome(r, actor, target.ID, target.TenantID, req, cascadeErrMsg == "", cascadeErrMsg, forced)
+	api.writeUserEnvelope(w, http.StatusOK, saved)
+}
+
+// operatorIDFromContext returns the ID of the user who actually
+// initiated the request: the impersonator if an impersonation session
+// is active (#1750 — `imp` true with non-empty `impersonated_by`),
+// otherwise actor.ID. Used by the self-block guard so an operator
+// cannot deactivate their own account by routing the block through an
+// impersonated identity.
+func operatorIDFromContext(ctx context.Context, actor *models.User) string {
+	if imp := services.ImpersonatorIDFromContext(ctx); imp != nil && *imp != "" {
+		return *imp
+	}
+	return actor.ID
+}
+
+// unblockUser flips IsActive back to true. Does NOT re-issue tokens —
+// the user has to log in again — and does NOT clear the blacklist
+// entry: the iat-staleness ring expires on its own and stale tokens
+// from before the block stay rejected even after unblock (#1747 spec).
+// @Summary Unblock (reactivate) a user account
+// @Description Sets the user's `is_active` flag back to true. Does NOT re-issue tokens — the user must log in again.
+// @Description Does NOT clear the JWT-blacklist staleness threshold either, so any access tokens that were issued before the block stay rejected until the iat-staleness ring expires.
+// @Description Body-validation rejections surface as 422 with `admin.block.reason_required` (missing or blank `reason`) or `admin.block.reason_too_long` (reason exceeds 500 characters); the codes are shared with the block endpoint.
+// @Tags admin
+// @Accept json
+// @Produce json
+// @Param userID path string true "Target user ID"
+// @Param data body AdminUnblockRequest true "Unblock request"
+// @Success 200 {object} AdminUserEnvelope "OK"
+// @Failure 400 {object} jsonapi.Errors "Bad Request - invalid body"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 404 {object} jsonapi.Errors "Not Found - unknown user"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - invalid reason"
+// @Router /admin/users/{userID}/unblock [post]
+func (api *adminUsersAPI) unblockUser(w http.ResponseWriter, r *http.Request) {
+	actor := appctx.UserFromContext(r.Context())
+	if actor == nil {
+		_ = unauthorizedError(w, r, ErrMissingUserContext)
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	if strings.TrimSpace(userID) == "" {
+		_ = badRequest(w, r, errors.New("missing user id"))
+		return
+	}
+
+	req, ok := api.decodeUnblockRequest(w, r)
+	if !ok {
+		return
+	}
+
+	target, err := api.factorySet.UserRegistry.Get(r.Context(), userID)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotFound) {
+			api.logUnblockOutcome(r, actor, userID, "", req, false, err.Error())
+			_ = renderEntityError(w, r, err)
+			return
+		}
+		slog.Error("admin unblock: failed to load user", "user_id", userID, "error", err)
+		api.logUnblockOutcome(r, actor, userID, "", req, false, err.Error())
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	if target.IsActive {
+		// Idempotent: the user is already active. Audit and return
+		// 200 — the alternative would be a 422 that the FE doesn't
+		// actually need to branch on.
+		api.logUnblockOutcome(r, actor, target.ID, target.TenantID, req, true, "")
+		api.writeUserEnvelope(w, http.StatusOK, target)
+		return
+	}
+
+	updated := *target
+	updated.IsActive = true
+	saved, err := api.factorySet.UserRegistry.Update(r.Context(), updated)
+	if err != nil {
+		slog.Error("admin unblock: failed to reactivate user", "user_id", target.ID, "error", err)
+		api.logUnblockOutcome(r, actor, target.ID, target.TenantID, req, false, err.Error())
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	api.logUnblockOutcome(r, actor, target.ID, target.TenantID, req, true, "")
+	api.writeUserEnvelope(w, http.StatusOK, saved)
+}
+
+// decodeBlockRequest parses + validates the POST /block body. Writes
+// the right error response and returns ok=false on failure so the
+// caller can early-return without sprinkling decode-error noise.
+func (api *adminUsersAPI) decodeBlockRequest(w http.ResponseWriter, r *http.Request) (AdminBlockRequest, bool) {
+	var req AdminBlockRequest
+	if r.Body == nil {
+		_ = badRequest(w, r, errors.New("missing request body"))
+		return req, false
+	}
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		_ = badRequest(w, r, err)
+		return req, false
+	}
+	if dec.More() {
+		_ = badRequest(w, r, errors.New("invalid JSON body — trailing tokens"))
+		return req, false
+	}
+	req.Reason = strings.TrimSpace(req.Reason)
+	if req.Reason == "" {
+		_ = codedUnprocessableEntityError(w, r, errors.New("reason is required"), AdminBlockReasonRequiredCode)
+		return req, false
+	}
+	if len(req.Reason) > adminBlockReasonMaxLen {
+		_ = codedUnprocessableEntityError(w, r, errors.New("reason is too long"), AdminBlockReasonTooLongCode)
+		return req, false
+	}
+	return req, true
+}
+
+// decodeUnblockRequest mirrors decodeBlockRequest for the unblock
+// shape. Kept as a separate helper so the swagger DTO stays narrow
+// (no `force` field on unblock) and so a future expansion of either
+// body type doesn't entangle the two.
+func (api *adminUsersAPI) decodeUnblockRequest(w http.ResponseWriter, r *http.Request) (AdminUnblockRequest, bool) {
+	var req AdminUnblockRequest
+	if r.Body == nil {
+		_ = badRequest(w, r, errors.New("missing request body"))
+		return req, false
+	}
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		_ = badRequest(w, r, err)
+		return req, false
+	}
+	if dec.More() {
+		_ = badRequest(w, r, errors.New("invalid JSON body — trailing tokens"))
+		return req, false
+	}
+	req.Reason = strings.TrimSpace(req.Reason)
+	if req.Reason == "" {
+		// Reuses the admin.block.reason_required code because both DTOs
+		// share the same reason field semantics — having a parallel
+		// admin.unblock.* family would just duplicate the FE branch.
+		_ = codedUnprocessableEntityError(w, r, errors.New("reason is required"), AdminBlockReasonRequiredCode)
+		return req, false
+	}
+	if len(req.Reason) > adminBlockReasonMaxLen {
+		_ = codedUnprocessableEntityError(w, r, errors.New("reason is too long"), AdminBlockReasonTooLongCode)
+		return req, false
+	}
+	return req, true
+}
+
+// applyBlockCascade tears down the user's live sessions after the
+// is_active flip has committed. Returns the concatenated error message
+// (or "" on success) so the audit row records the cause when either
+// step blipped; both steps run regardless of the other's outcome so a
+// transient refresh-token failure doesn't keep stale access tokens
+// alive.
+func (api *adminUsersAPI) applyBlockCascade(r *http.Request, userID string) string {
+	var msgs []string
+	if api.factorySet != nil && api.factorySet.RefreshTokenRegistry != nil {
+		if err := api.factorySet.RefreshTokenRegistry.RevokeByUserID(r.Context(), userID); err != nil {
+			slog.Warn("admin block: failed to revoke refresh tokens", "user_id", userID, "error", err)
+			msgs = append(msgs, "revoke_refresh_tokens: "+err.Error())
+		}
+	}
+	if api.blacklist != nil {
+		// Use 2× accessTokenExpiration to match the password-reset /
+		// MFA-reset cascade so live access tokens (15 min lifetime)
+		// are reliably rejected via the iat-staleness check. The
+		// blacklist entry is independent of is_active so unblocking
+		// the user does NOT clear it — stale tokens from before the
+		// block stay rejected until the ring expires (#1747 spec).
+		//
+		// Race window: BlacklistUserTokens stamps `since` at second
+		// precision (time.Unix(now.Unix(), 0)), and the JWT iat claim
+		// is also second-precision. checkUserBlacklistIat uses strict
+		// iat.Before(since), so a token whose iat falls in the same
+		// wall-clock second as the blacklist call survives. The
+		// alternatives (sub-second precision, bumping `since` by +1s)
+		// either need a blacklister API change or risk false-positive
+		// invalidation of unrelated tokens; the one-second window is
+		// short enough that an operator can re-block to close it.
+		if err := api.blacklist.BlacklistUserTokens(r.Context(), userID, 2*accessTokenExpiration); err != nil {
+			slog.Warn("admin block: failed to blacklist user tokens", "user_id", userID, "error", err)
+			msgs = append(msgs, "blacklist_user_tokens: "+err.Error())
+		}
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// logBlockOutcome writes the admin.user_block audit row (or its
+// _force variant). Best-effort: nil-safe wrapper for the case where
+// AuditService was not wired in. `forced` selects the audit Action
+// (block vs block_force) and is recorded in the breadcrumb — it is a
+// data tag carried through to the persisted row, not a control flag
+// branching the work the function does.
+//
+//revive:disable-next-line:flag-parameter
+func (api *adminUsersAPI) logBlockOutcome(
+	r *http.Request,
+	actor *models.User,
+	subjectID, subjectTenantID string,
+	req AdminBlockRequest,
+	success bool,
+	errMsg string,
+	forced bool,
+) {
+	if api.auditService == nil {
+		return
+	}
+	action := AuditActionAdminUserBlock
+	if forced {
+		action = AuditActionAdminUserBlockForce
+	}
+	ev := services.AdminEvent{
+		Action:      action,
+		ActorID:     new(actor.ID),
+		TenantID:    nullableString(subjectTenantID),
+		SubjectType: stringPtr("user"),
+		SubjectID:   nullableString(subjectID),
+		Success:     success,
+		Request:     r,
+		Reason:      req.Reason,
+		Forced:      forced,
+	}
+	if errMsg != "" {
+		ev.ErrMsg = new(errMsg)
+	}
+	api.auditService.LogAdmin(r.Context(), ev)
+}
+
+// logUnblockOutcome writes the admin.user_unblock audit row. Mirrors
+// logBlockOutcome but with no force variant — unblock is symmetric.
+func (api *adminUsersAPI) logUnblockOutcome(
+	r *http.Request,
+	actor *models.User,
+	subjectID, subjectTenantID string,
+	req AdminUnblockRequest,
+	success bool,
+	errMsg string,
+) {
+	if api.auditService == nil {
+		return
+	}
+	ev := services.AdminEvent{
+		Action:      AuditActionAdminUserUnblock,
+		ActorID:     new(actor.ID),
+		TenantID:    nullableString(subjectTenantID),
+		SubjectType: stringPtr("user"),
+		SubjectID:   nullableString(subjectID),
+		Success:     success,
+		Request:     r,
+		Reason:      req.Reason,
+	}
+	if errMsg != "" {
+		ev.ErrMsg = new(errMsg)
+	}
+	api.auditService.LogAdmin(r.Context(), ev)
+}
+
+// writeUserEnvelope encodes a *models.User into the AdminUserEnvelope
+// JSON:API shape and writes it on the response.
+func (api *adminUsersAPI) writeUserEnvelope(w http.ResponseWriter, status int, u *models.User) {
+	envelope := AdminUserEnvelope{
+		Data: AdminUserResource{
+			Type: "users",
+			ID:   u.ID,
+			Attributes: AdminUserView{
+				ID:            u.ID,
+				Email:         u.Email,
+				Name:          u.Name,
+				IsActive:      u.IsActive,
+				IsSystemAdmin: u.IsSystemAdmin,
+				TenantID:      u.TenantID,
+			},
+		},
+	}
+	w.Header().Set("Content-Type", "application/vnd.api+json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(envelope); err != nil {
+		// Headers (and the status) have already been flushed; we
+		// cannot recover the response, but logging the encode failure
+		// keeps the operator-side trail honest instead of silently
+		// dropping it.
+		slog.Error("admin user envelope: failed to encode response", "user_id", u.ID, "error", err)
 	}
 }
 

--- a/go/apiserver/admin_users.go
+++ b/go/apiserver/admin_users.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -324,7 +326,7 @@ func (api *adminUsersAPI) getUser(w http.ResponseWriter, r *http.Request) {
 // @Description Body-validation rejections surface as 422 with `admin.block.reason_required` (missing or blank `reason`) or `admin.block.reason_too_long` (reason exceeds 500 characters).
 // @Tags admin
 // @Accept json
-// @Produce json
+// @Produce json-api
 // @Param userID path string true "Target user ID"
 // @Param data body AdminBlockRequest true "Block request"
 // @Success 200 {object} AdminUserEnvelope "OK"
@@ -459,7 +461,7 @@ func operatorIDFromContext(ctx context.Context, actor *models.User) string {
 // @Description Body-validation rejections surface as 422 with `admin.block.reason_required` (missing or blank `reason`) or `admin.block.reason_too_long` (reason exceeds 500 characters); the codes are shared with the block endpoint.
 // @Tags admin
 // @Accept json
-// @Produce json
+// @Produce json-api
 // @Param userID path string true "Target user ID"
 // @Param data body AdminUnblockRequest true "Unblock request"
 // @Success 200 {object} AdminUserEnvelope "OK"
@@ -538,7 +540,7 @@ func (api *adminUsersAPI) decodeBlockRequest(w http.ResponseWriter, r *http.Requ
 		_ = badRequest(w, r, err)
 		return req, false
 	}
-	if dec.More() {
+	if !decoderAtEOF(dec) {
 		_ = badRequest(w, r, errors.New("invalid JSON body — trailing tokens"))
 		return req, false
 	}
@@ -547,7 +549,7 @@ func (api *adminUsersAPI) decodeBlockRequest(w http.ResponseWriter, r *http.Requ
 		_ = codedUnprocessableEntityError(w, r, errors.New("reason is required"), AdminBlockReasonRequiredCode)
 		return req, false
 	}
-	if len(req.Reason) > adminBlockReasonMaxLen {
+	if utf8.RuneCountInString(req.Reason) > adminBlockReasonMaxLen {
 		_ = codedUnprocessableEntityError(w, r, errors.New("reason is too long"), AdminBlockReasonTooLongCode)
 		return req, false
 	}
@@ -570,7 +572,7 @@ func (api *adminUsersAPI) decodeUnblockRequest(w http.ResponseWriter, r *http.Re
 		_ = badRequest(w, r, err)
 		return req, false
 	}
-	if dec.More() {
+	if !decoderAtEOF(dec) {
 		_ = badRequest(w, r, errors.New("invalid JSON body — trailing tokens"))
 		return req, false
 	}
@@ -582,11 +584,25 @@ func (api *adminUsersAPI) decodeUnblockRequest(w http.ResponseWriter, r *http.Re
 		_ = codedUnprocessableEntityError(w, r, errors.New("reason is required"), AdminBlockReasonRequiredCode)
 		return req, false
 	}
-	if len(req.Reason) > adminBlockReasonMaxLen {
+	if utf8.RuneCountInString(req.Reason) > adminBlockReasonMaxLen {
 		_ = codedUnprocessableEntityError(w, r, errors.New("reason is too long"), AdminBlockReasonTooLongCode)
 		return req, false
 	}
 	return req, true
+}
+
+// decoderAtEOF reports whether the decoder has consumed all of its
+// input. The standard json.Decoder.More() method is documented to
+// report whether there is another element in the *current array or
+// object* being parsed, not whether there are trailing top-level
+// tokens — so the canonical way to reject concatenated payloads like
+// `{"reason":"x"}{"extra":1}` is to attempt a second Decode and
+// require io.EOF. Any other outcome (a successful decode, or an
+// error that is NOT io.EOF) means trailing data exists.
+func decoderAtEOF(dec *json.Decoder) bool {
+	var trailing json.RawMessage
+	err := dec.Decode(&trailing)
+	return errors.Is(err, io.EOF)
 }
 
 // applyBlockCascade tears down the user's live sessions after the

--- a/go/apiserver/admin_users_test.go
+++ b/go/apiserver/admin_users_test.go
@@ -1,315 +1,708 @@
 package apiserver_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/go-extras/go-kit/must"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/denisvmedia/inventario/apiserver"
-	"github.com/denisvmedia/inventario/jsonapi"
+	"github.com/denisvmedia/inventario/internal/checkers"
 	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/services"
 )
 
-// adminUserFixture extends adminTenantFixture with three additional
-// users in the seeded tenant so paging/filter/sort assertions for the
-// users endpoint have something to work with beyond the singleton
-// `test@example.com`.
-func adminUserFixture(c *qt.C) (apiserver.Params, *models.User) {
+// Block + unblock handler tests (#1747). Every AC in the issue spec
+// maps to one (or more) of the subtests below. Tests live alongside
+// admin_routes_test.go and reuse its `promoteToSystemAdmin` helper to
+// flip the IsSystemAdmin flag on a fixture user without standing up a
+// second tenant.
+
+// adminTestEnv bundles the moving parts every block/unblock test needs
+// so the per-test setup stays one line. Standing this up via a helper
+// keeps the table-driven cases focused on inputs + expectations rather
+// than ceremony.
+type adminTestEnv struct {
+	params  apiserver.Params
+	handler http.Handler
+	admin   *models.User
+}
+
+// newAdminEnv returns a Params with a single system-admin fixture user
+// (the test's "actor") and the assembled HTTP handler. The admin user
+// returned is the one whose auth header should be attached to admin
+// requests — promote a separate fixture (via createSecondUser) when
+// the test needs a distinct subject.
+func newAdminEnv(c *qt.C) adminTestEnv {
 	c.Helper()
-	params, adminUser, _ := newParams()
-	promoteToSystemAdmin(c, params, adminUser)
-
-	ctx := context.Background()
-	seeds := []models.User{
-		{TenantAwareEntityID: models.TenantAwareEntityID{TenantID: adminUser.TenantID}, Email: "alice@example.com", Name: "Alice", IsActive: true},
-		{TenantAwareEntityID: models.TenantAwareEntityID{TenantID: adminUser.TenantID}, Email: "bob@example.com", Name: "Bob", IsActive: false},
-		{TenantAwareEntityID: models.TenantAwareEntityID{TenantID: adminUser.TenantID}, Email: "carol@example.com", Name: "Carol", IsActive: true},
-	}
-	for _, u := range seeds {
-		must.Assert(u.SetPassword("Password123"))
-		must.Must(params.FactorySet.UserRegistry.Create(ctx, u))
-	}
-	return params, adminUser
-}
-
-func TestAdminListTenantUsers_AllowsSystemAdmin(t *testing.T) {
-	c := qt.New(t)
-	params, adminUser := adminUserFixture(c)
-	handler := apiserver.APIServer(params, &mockRestoreWorker{})
-
-	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/tenants/%s/users", adminUser.TenantID), nil)
-	addTestUserAuthHeader(req, adminUser.ID)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	c.Assert(rr.Code, qt.Equals, http.StatusOK)
-	var body jsonapi.AdminUsersResponse
-	c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
-	// admin + 3 seeded users.
-	c.Assert(body.Meta.Total, qt.Equals, 4)
-	c.Assert(body.Data, qt.HasLen, 4)
-}
-
-func TestAdminListTenantUsers_DeniesNonAdmin(t *testing.T) {
-	c := qt.New(t)
 	params, user, _ := newParams()
+	promoteToSystemAdmin(c, params, user)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
-
-	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/tenants/%s/users", user.TenantID), nil)
-	addTestUserAuthHeader(req, user.ID)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+	return adminTestEnv{
+		params:  params,
+		handler: handler,
+		admin:   user,
+	}
 }
 
-func TestAdminListTenantUsers_FiltersAndSorts(t *testing.T) {
-	c := qt.New(t)
-	params, adminUser := adminUserFixture(c)
-	handler := apiserver.APIServer(params, &mockRestoreWorker{})
-
-	tests := []struct {
-		name             string
-		query            string
-		expectedTotal    int
-		expectedLen      int
-		expectedFirstEml string
-	}{
-		{
-			name:             "filter by q matches one user",
-			query:            "?q=alice",
-			expectedTotal:    1,
-			expectedLen:      1,
-			expectedFirstEml: "alice@example.com",
-		},
-		{
-			name:             "is_active=false filters to inactive only",
-			query:            "?is_active=false",
-			expectedTotal:    1,
-			expectedLen:      1,
-			expectedFirstEml: "bob@example.com",
-		},
-		{
-			name:             "is_active=true filters to active only",
-			query:            "?is_active=true",
-			expectedTotal:    3,
-			expectedLen:      3,
-			expectedFirstEml: "alice@example.com",
-		},
-		{
-			name:             "sort by email desc",
-			query:            "?sort=-email",
-			expectedTotal:    4,
-			expectedLen:      4,
-			expectedFirstEml: "test@example.com",
-		},
-		{
-			name:          "page beyond total returns empty data and total intact",
-			query:         "?page=100",
-			expectedTotal: 4,
-			expectedLen:   0,
-		},
+// createTestUserDirect creates an additional user fixture in the given
+// tenant. The CLI-side admin service's CreateUser would be overkill for
+// tests — use the registry directly so a single helper covers both
+// "second admin" and "ordinary user". Callers pass the tenant ID
+// explicitly so the helper does not silently pick `tenants[0]` when the
+// fixture set contains more than one tenant.
+func createTestUserDirect(c *qt.C, params apiserver.Params, tenantID, email string, isActive, isSystemAdmin bool) *models.User {
+	c.Helper()
+	c.Assert(tenantID, qt.Not(qt.Equals), "", qt.Commentf("createTestUserDirect: tenantID is required"))
+	u := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Email:               email,
+		Name:                email,
+		IsActive:            isActive,
+		IsSystemAdmin:       isSystemAdmin,
 	}
-	for _, tc := range tests {
-		c.Run(tc.name, func(c *qt.C) {
-			req := httptest.NewRequest(http.MethodGet,
-				fmt.Sprintf("/api/v1/admin/tenants/%s/users%s", adminUser.TenantID, tc.query), nil)
-			addTestUserAuthHeader(req, adminUser.ID)
-			rr := httptest.NewRecorder()
-			handler.ServeHTTP(rr, req)
+	must.Assert(u.SetPassword("Password123"))
+	created := must.Must(params.FactorySet.UserRegistry.Create(context.Background(), u))
+	return created
+}
 
-			c.Assert(rr.Code, qt.Equals, http.StatusOK)
-			var body jsonapi.AdminUsersResponse
-			c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
-			c.Assert(body.Meta.Total, qt.Equals, tc.expectedTotal)
-			c.Assert(body.Data, qt.HasLen, tc.expectedLen)
-			if tc.expectedFirstEml != "" && len(body.Data) > 0 {
-				c.Assert(body.Data[0].Email, qt.Equals, tc.expectedFirstEml)
-			}
+// blockBody builds a POST /block JSON body. Tests that want to omit
+// the reason or send `force=true` pass the values through directly so
+// the table-driven flavor stays readable.
+func blockBody(reason string, force bool) map[string]any {
+	return map[string]any{"reason": reason, "force": force}
+}
+
+// unblockBody mirrors blockBody for the unblock endpoint. Kept as a
+// separate constructor so the test cases don't accidentally smuggle a
+// `force` field into unblock — the unblock DTO has no such field and
+// DisallowUnknownFields would reject it.
+func unblockBody(reason string) map[string]any {
+	return map[string]any{"reason": reason}
+}
+
+// doAdminJSONRequest is the admin-side twin of doJSONAPIRequest. We
+// don't use doJSONAPIRequest itself because /admin/* sets a plain
+// "application/json" content type (mirrors users_me); the JSON:API
+// variant in doJSONAPIRequest would still work but the explicit JSON
+// content type matches what the FE sends and keeps the test honest.
+//
+// `body` is encoded by switching on its concrete type:
+//   - nil → no body
+//   - []byte / json.RawMessage / string → passed through verbatim
+//     (lets tests send malformed JSON or trailing-token payloads that
+//     `json.Marshal` would otherwise sanitise into valid JSON)
+//   - anything else → `json.Marshal`
+func doAdminJSONRequest(t *testing.T, handler http.Handler, method, path, userID string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var raw []byte
+	switch v := body.(type) {
+	case nil:
+		// no body
+	case []byte:
+		raw = v
+	case json.RawMessage:
+		raw = []byte(v)
+	case string:
+		raw = []byte(v)
+	default:
+		var err error
+		raw, err = json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+	}
+	req, err := http.NewRequest(method, path, bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if userID != "" {
+		addTestUserAuthHeader(req, userID)
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestAdminBlockUser_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", true, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/block",
+		env.admin.ID, blockBody("policy violation", false))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.id"), target.ID)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.type"), "users")
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.is_active"), false)
+
+	// IsActive should be persisted false on the registry row.
+	reloaded := must.Must(env.params.FactorySet.UserRegistry.Get(context.Background(), target.ID))
+	c.Assert(reloaded.IsActive, qt.IsFalse)
+}
+
+func TestAdminBlockUser_Idempotent(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", false, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/block",
+		env.admin.ID, blockBody("policy violation", false))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.is_active"), false)
+}
+
+func TestAdminBlockUser_SelfBlockRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/"+env.admin.ID+"/block",
+		env.admin.ID, blockBody("trying to lock myself out", false))
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminBlockSelfBlockedCode)
+}
+
+func TestAdminBlockUser_AdminWithoutForceRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	peer := createTestUserDirect(c, env.params, env.admin.TenantID, "peer-admin@example.com", true, true)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/"+peer.ID+"/block",
+		env.admin.ID, blockBody("peer review", false))
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminBlockAdminRequiresForceCode)
+
+	// And IsActive on the peer is preserved — the guard rejected before
+	// the cascade could fire.
+	reloaded := must.Must(env.params.FactorySet.UserRegistry.Get(context.Background(), peer.ID))
+	c.Assert(reloaded.IsActive, qt.IsTrue)
+}
+
+func TestAdminBlockUser_AdminWithForceAllowedAndAudited(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	peer := createTestUserDirect(c, env.params, env.admin.TenantID, "peer-admin@example.com", true, true)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/"+peer.ID+"/block",
+		env.admin.ID, blockBody("compromise drill", true))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.is_active"), false)
+
+	// Audit row uses the distinct AuditActionAdminUserBlockForce action
+	// AND the breadcrumb carries forced=true.
+	rows := must.Must(env.params.FactorySet.AuditLogRegistry.List(context.Background()))
+	var force *models.AuditLog
+	for i := range rows {
+		if rows[i].Action == apiserver.AuditActionAdminUserBlockForce {
+			force = rows[i]
+			break
+		}
+	}
+	c.Assert(force, qt.IsNotNil, qt.Commentf("expected an admin.user_block_force audit row"))
+	var bc map[string]any
+	c.Assert(json.Unmarshal([]byte(force.UserAgent), &bc), qt.IsNil)
+	c.Assert(bc["forced"], qt.Equals, true)
+	c.Assert(bc["reason"], qt.Equals, "compromise drill")
+}
+
+func TestAdminBlockUser_AuditRowCarriesReason(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", true, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/block",
+		env.admin.ID, blockBody("policy violation: rule 7", false))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+
+	rows := must.Must(env.params.FactorySet.AuditLogRegistry.List(context.Background()))
+	var row *models.AuditLog
+	for i := range rows {
+		if rows[i].Action == apiserver.AuditActionAdminUserBlock {
+			row = rows[i]
+			break
+		}
+	}
+	c.Assert(row, qt.IsNotNil)
+	c.Assert(row.UserID, qt.IsNotNil)
+	c.Assert(*row.UserID, qt.Equals, env.admin.ID)
+	c.Assert(row.EntityID, qt.IsNotNil)
+	c.Assert(*row.EntityID, qt.Equals, target.ID)
+	var bc map[string]any
+	c.Assert(json.Unmarshal([]byte(row.UserAgent), &bc), qt.IsNil)
+	c.Assert(bc["reason"], qt.Equals, "policy violation: rule 7")
+	// Non-forced rows should not carry the forced=true breadcrumb key.
+	_, hasForced := bc["forced"]
+	c.Assert(hasForced, qt.IsFalse)
+}
+
+func TestAdminBlockUser_UnknownUserReturns404(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/does-not-exist/block",
+		env.admin.ID, blockBody("policy violation", false))
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+func TestAdminBlockUser_BadBodyVariants(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     any
+		wantCode int
+	}{
+		{"missing_reason", map[string]any{"force": false}, http.StatusUnprocessableEntity},
+		{"empty_reason", map[string]any{"reason": "   "}, http.StatusUnprocessableEntity},
+		{"reason_too_long", map[string]any{"reason": strings.Repeat("x", 501)}, http.StatusUnprocessableEntity},
+		// Raw bytes so the body actually IS malformed JSON; passing a
+		// Go string through json.Marshal would re-encode it as a valid
+		// JSON string literal and never exercise the decoder error path.
+		{"malformed_json", []byte(`{"reason":`), http.StatusBadRequest},
+		{"unknown_field", map[string]any{"reason": "ok", "extra": 1}, http.StatusBadRequest},
+		// Trailing tokens after a valid object must be rejected — the
+		// json.Decoder accepts the first value happily, so the handler
+		// has to call dec.More() to catch the concatenation attack.
+		{"multi_object_trailing", []byte(`{"reason":"x"}{"extra":1}`), http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			env := newAdminEnv(c)
+			target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", true, false)
+
+			rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+				"/api/v1/admin/users/"+target.ID+"/block",
+				env.admin.ID, tc.body)
+			c.Assert(rr.Code, qt.Equals, tc.wantCode)
 		})
 	}
 }
 
-func TestAdminListTenantUsers_404OnMissingTenant(t *testing.T) {
+func TestAdminBlockUser_NonAdminForbidden(t *testing.T) {
 	c := qt.New(t)
-	params, adminUser := adminUserFixture(c)
+	params, user, _ := newParams() // not promoted
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	target := createTestUserDirect(c, params, user.TenantID, "ordinary@example.com", true, false)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/tenants/does-not-exist/users", nil)
-	addTestUserAuthHeader(req, adminUser.ID)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
-}
-
-func TestAdminGetUser_ReturnsDetail(t *testing.T) {
-	c := qt.New(t)
-	params, adminUser := adminUserFixture(c)
-	handler := apiserver.APIServer(params, &mockRestoreWorker{})
-
-	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/users/%s", adminUser.ID), nil)
-	addTestUserAuthHeader(req, adminUser.ID)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	c.Assert(rr.Code, qt.Equals, http.StatusOK)
-	var body jsonapi.AdminUserResponse
-	c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
-	c.Assert(body.Data, qt.IsNotNil)
-	c.Assert(body.Data.ID, qt.Equals, adminUser.ID)
-	c.Assert(body.Data.Email, qt.Equals, adminUser.Email)
-	c.Assert(body.Data.IsSystemAdmin, qt.IsTrue)
-	// The seeded admin user has one membership on the auto-created group.
-	c.Assert(body.Data.GroupMemberships, qt.HasLen, 1)
-	c.Assert(body.Data.GroupMemberships[0].Role, qt.Equals, models.GroupRoleAdmin)
-	// No refresh tokens yet → zero active sessions.
-	c.Assert(body.Data.ActiveSessionCount, qt.Equals, 0)
-	// Password hash MUST NOT leak.
-	c.Assert(rr.Body.String(), qt.Not(qt.Contains), "password_hash")
-}
-
-func TestAdminGetUser_404OnMissingID(t *testing.T) {
-	c := qt.New(t)
-	params, adminUser := adminUserFixture(c)
-	handler := apiserver.APIServer(params, &mockRestoreWorker{})
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users/does-not-exist", nil)
-	addTestUserAuthHeader(req, adminUser.ID)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
-}
-
-func TestAdminGetUser_CountsActiveSessions(t *testing.T) {
-	c := qt.New(t)
-	params, adminUser := adminUserFixture(c)
-	handler := apiserver.APIServer(params, &mockRestoreWorker{})
-
-	ctx := context.Background()
-	// Two active sessions + one revoked + one expired → CountSessionsByUser must
-	// return 2. ListActiveByUserID is the memory backend's implementation; it
-	// filters revoked_at IS NULL AND expires_at > now.
-	future := time.Now().Add(24 * time.Hour)
-	past := time.Now().Add(-1 * time.Hour)
-	revoked := time.Now()
-
-	// Two valid refresh tokens.
-	for i := range 2 {
-		must.Must(params.FactorySet.RefreshTokenRegistry.Create(ctx, models.RefreshToken{
-			TenantUserAwareEntityID: models.TenantUserAwareEntityID{
-				TenantID: adminUser.TenantID,
-				UserID:   adminUser.ID,
-			},
-			TokenHash: fmt.Sprintf("active-%d", i),
-			ExpiresAt: future,
-		}))
-	}
-	// One expired.
-	must.Must(params.FactorySet.RefreshTokenRegistry.Create(ctx, models.RefreshToken{
-		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
-			TenantID: adminUser.TenantID,
-			UserID:   adminUser.ID,
-		},
-		TokenHash: "expired",
-		ExpiresAt: past,
-	}))
-	// One revoked.
-	must.Must(params.FactorySet.RefreshTokenRegistry.Create(ctx, models.RefreshToken{
-		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
-			TenantID: adminUser.TenantID,
-			UserID:   adminUser.ID,
-		},
-		TokenHash: "revoked",
-		ExpiresAt: future,
-		RevokedAt: &revoked,
-	}))
-
-	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/users/%s", adminUser.ID), nil)
-	addTestUserAuthHeader(req, adminUser.ID)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	c.Assert(rr.Code, qt.Equals, http.StatusOK)
-	var body jsonapi.AdminUserResponse
-	c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
-	c.Assert(body.Data.ActiveSessionCount, qt.Equals, 2)
-}
-
-func TestAdminGetUser_DeniesNonAdmin(t *testing.T) {
-	c := qt.New(t)
-	params, user, _ := newParams()
-	handler := apiserver.APIServer(params, &mockRestoreWorker{})
-
-	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/users/%s", user.ID), nil)
-	addTestUserAuthHeader(req, user.ID)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
+	rr := doAdminJSONRequest(t, handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/block",
+		user.ID, blockBody("policy violation", false))
 	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+	c.Assert(rr.Body.String(), qt.Contains, "admin.forbidden")
 }
 
-func TestAdminUsersEndpoints_AuditEntries(t *testing.T) {
+func TestAdminBlockUser_UnauthenticatedRejected(t *testing.T) {
 	c := qt.New(t)
-	params, adminUser := adminUserFixture(c)
-	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	env := newAdminEnv(c)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", true, false)
 
-	listReq := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/tenants/%s/users", adminUser.TenantID), nil)
-	addTestUserAuthHeader(listReq, adminUser.ID)
-	listRR := httptest.NewRecorder()
-	handler.ServeHTTP(listRR, listReq)
-	c.Assert(listRR.Code, qt.Equals, http.StatusOK)
-
-	getReq := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/users/%s", adminUser.ID), nil)
-	addTestUserAuthHeader(getReq, adminUser.ID)
-	getRR := httptest.NewRecorder()
-	handler.ServeHTTP(getRR, getReq)
-	c.Assert(getRR.Code, qt.Equals, http.StatusOK)
-
-	listEntries := must.Must(params.FactorySet.AuditLogRegistry.ListByAction(context.Background(), "admin.list_tenant_users"))
-	c.Assert(listEntries, qt.HasLen, 1)
-	c.Assert(listEntries[0].Success, qt.IsTrue)
-
-	getEntries := must.Must(params.FactorySet.AuditLogRegistry.ListByAction(context.Background(), "admin.get_user"))
-	c.Assert(getEntries, qt.HasLen, 1)
-	c.Assert(getEntries[0].Success, qt.IsTrue)
-	c.Assert(getEntries[0].EntityID, qt.IsNotNil)
-	c.Assert(*getEntries[0].EntityID, qt.Equals, adminUser.ID)
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/block",
+		"", blockBody("policy violation", false))
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }
 
-// TestAdminListTenants_CrossTenantBypass verifies the listing returns
-// rows from tenants the admin is NOT a member of — the core invariant
-// the issue spec asks for ("admin sees rows from a tenant they have
-// no membership in").
-func TestAdminListTenants_CrossTenantBypass(t *testing.T) {
+func TestAdminUnblockUser_HappyPath(t *testing.T) {
 	c := qt.New(t)
-	params, adminUser, slugs := adminTenantFixture(c)
-	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	env := newAdminEnv(c)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", false, false)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/tenants", nil)
-	addTestUserAuthHeader(req, adminUser.ID)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/unblock",
+		env.admin.ID, unblockBody("appeal accepted"))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.is_active"), true)
+
+	reloaded := must.Must(env.params.FactorySet.UserRegistry.Get(context.Background(), target.ID))
+	c.Assert(reloaded.IsActive, qt.IsTrue)
+}
+
+func TestAdminUnblockUser_Idempotent(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", true, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/unblock",
+		env.admin.ID, unblockBody("nothing to do"))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.is_active"), true)
+}
+
+func TestAdminUnblockUser_UnknownUserReturns404(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/does-not-exist/unblock",
+		env.admin.ID, unblockBody("test"))
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+func TestAdminUnblockUser_AuditRowCarriesReason(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", false, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/unblock",
+		env.admin.ID, unblockBody("appeal accepted: ticket 1234"))
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 
-	var body jsonapi.AdminTenantsResponse
-	c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
-	// Admin is a member only of "test-org" but the listing surfaces
-	// every seeded slug — that's the RLS bypass the issue spec calls
-	// for.
-	seenSlugs := map[string]bool{}
-	for _, item := range body.Data {
-		seenSlugs[item.Slug] = true
+	rows := must.Must(env.params.FactorySet.AuditLogRegistry.List(context.Background()))
+	var row *models.AuditLog
+	for i := range rows {
+		if rows[i].Action == apiserver.AuditActionAdminUserUnblock {
+			row = rows[i]
+			break
+		}
 	}
-	for _, want := range slugs {
-		c.Assert(seenSlugs[want], qt.IsTrue, qt.Commentf("expected slug %q in admin listing", want))
+	c.Assert(row, qt.IsNotNil)
+	var bc map[string]any
+	c.Assert(json.Unmarshal([]byte(row.UserAgent), &bc), qt.IsNil)
+	c.Assert(bc["reason"], qt.Equals, "appeal accepted: ticket 1234")
+}
+
+// TestAdminUnblockUser_BadBodyVariants mirrors the block-side table but
+// stays narrow — just enough to pin the trailing-tokens regression that
+// dec.More() guards against. The other reason-validation paths are
+// already covered by the block-side table and by the
+// decodeUnblockRequest happy-path tests.
+func TestAdminUnblockUser_BadBodyVariants(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     any
+		wantCode int
+	}{
+		{"malformed_json", []byte(`{"reason":`), http.StatusBadRequest},
+		{"multi_object_trailing", []byte(`{"reason":"x"}{"extra":1}`), http.StatusBadRequest},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			env := newAdminEnv(c)
+			target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", false, false)
+
+			rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+				"/api/v1/admin/users/"+target.ID+"/unblock",
+				env.admin.ID, tc.body)
+			c.Assert(rr.Code, qt.Equals, tc.wantCode)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------
+// Integration tests: prove the block cascade actually invalidates live
+// access tokens (iat-staleness) and revokes refresh tokens. These
+// exercise the full middleware chain — JWT validation, blacklist
+// check, refresh-token revocation — not just the handler logic.
+// ---------------------------------------------------------------------
+
+// mintAccessTokenForUser creates a signed access token whose iat is
+// `iatOffset` seconds before now. Tests can pass a negative offset to
+// simulate a token that was minted before the block was issued. The
+// token carries the canonical claims the JWT middleware expects:
+// user_id, jti, iat, exp.
+func mintAccessTokenForUser(t *testing.T, userID string, iatOffset time.Duration) string {
+	t.Helper()
+	iat := time.Now().Add(iatOffset)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"user_id": userID,
+		"jti":     "test-jti-" + userID,
+		"iat":     iat.Unix(),
+		"exp":     iat.Add(24 * time.Hour).Unix(),
+	})
+	signed, err := token.SignedString(testJWTSecret)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return signed
+}
+
+func TestAdminBlockUser_AccessTokenIssuedBeforeBlockFails(t *testing.T) {
+	c := qt.New(t)
+
+	// Build params with a real in-memory blacklister so the BlacklistUserTokens
+	// call inside the block cascade is observable by subsequent /system requests.
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	bl := services.NewInMemoryTokenBlacklister()
+	params.TokenBlacklister = bl
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	target := createTestUserDirect(c, params, admin.TenantID, "ordinary@example.com", true, false)
+	// Mint an access token for the TARGET with iat=now-1s. After block
+	// the blacklister stamps "since" at the block's wall-clock time, so
+	// this token is "before" the blacklist threshold and must be rejected.
+	staleToken := mintAccessTokenForUser(t, target.ID, -time.Second)
+
+	// Pre-block sanity: GET /users/me/sessions with the target's access
+	// token should be reachable (the JWT path doesn't care about
+	// IsActive=true users, and the sessions route is auth-only with no
+	// group dependency).
+	preReq := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/sessions", nil)
+	preReq.Header.Set("Authorization", "Bearer "+staleToken)
+	preRR := httptest.NewRecorder()
+	handler.ServeHTTP(preRR, preReq)
+	c.Assert(preRR.Code, qt.Equals, http.StatusOK,
+		qt.Commentf("pre-block sessions probe must succeed; body=%s", preRR.Body.String()))
+
+	// Sleep ~10ms so that the blacklister's stamped "since" timestamp is
+	// guaranteed to fall *after* the access token's iat (which is
+	// `now-1s` at the moment the token was minted, but the iat field is
+	// truncated to whole seconds via Unix() — two events firing within
+	// the same second would otherwise share the same epoch second and
+	// the iat.Before(since) check would compare equal).
+	time.Sleep(10 * time.Millisecond)
+
+	// Execute the block as the admin actor.
+	blockRR := doAdminJSONRequest(t, handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/block",
+		admin.ID, blockBody("integration test", false))
+	c.Assert(blockRR.Code, qt.Equals, http.StatusOK,
+		qt.Commentf("block must succeed; body=%s", blockRR.Body.String()))
+
+	// Post-block: the same access token must be rejected — the iat-stale
+	// check inside checkTokenBlacklist trips, returning 401.
+	postReq := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/sessions", nil)
+	postReq.Header.Set("Authorization", "Bearer "+staleToken)
+	postRR := httptest.NewRecorder()
+	handler.ServeHTTP(postRR, postReq)
+	c.Assert(postRR.Code, qt.Equals, http.StatusUnauthorized,
+		qt.Commentf("post-block sessions probe must be 401; body=%s", postRR.Body.String()))
+}
+
+func TestAdminBlockUser_RefreshTokenRevokedByCascade(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	target := createTestUserDirect(c, params, admin.TenantID, "ordinary@example.com", true, false)
+
+	// Seed a refresh token for the target. After block, ListActiveByUserID
+	// must return zero rows — the cascade calls RevokeByUserID and the
+	// memory impl flips Revoked=true.
+	rt := models.RefreshToken{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+			TenantID: target.TenantID,
+			UserID:   target.ID,
+		},
+		TokenHash: "test-hash-block-cascade",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+		CreatedAt: time.Now(),
+	}
+	must.Must(params.FactorySet.RefreshTokenRegistry.Create(context.Background(), rt))
+
+	preActive := must.Must(params.FactorySet.RefreshTokenRegistry.ListActiveByUserID(context.Background(), target.ID))
+	c.Assert(preActive, qt.HasLen, 1)
+
+	blockRR := doAdminJSONRequest(t, handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/block",
+		admin.ID, blockBody("integration test", false))
+	c.Assert(blockRR.Code, qt.Equals, http.StatusOK)
+
+	postActive := must.Must(params.FactorySet.RefreshTokenRegistry.ListActiveByUserID(context.Background(), target.ID))
+	c.Assert(postActive, qt.HasLen, 0)
+}
+
+// TestAdminBlockUser_IdempotentBlockReRunsCascade pins the B1 fix: a
+// re-block of an already-inactive user must run the cascade again so
+// any tokens issued between blocks (e.g. via the blacklist ring
+// expiring under a 30-min+ gap, or a future impersonation grant) are
+// invalidated. Without the fix the cascade is skipped on the
+// idempotent path and a stale refresh token survives the second block.
+func TestAdminBlockUser_IdempotentBlockReRunsCascade(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Seed an already-inactive user — simulates the "previously
+	// blocked" state where the cascade ran once long ago.
+	target := createTestUserDirect(c, params, admin.TenantID, "ordinary@example.com", false, false)
+
+	// Plant a fresh refresh token AFTER the user was already inactive.
+	// Represents a token that should never have existed (post-block
+	// new grant), or that survived the previous cascade's TTL window.
+	rt := models.RefreshToken{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+			TenantID: target.TenantID,
+			UserID:   target.ID,
+		},
+		TokenHash: "test-hash-idempotent-cascade",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+		CreatedAt: time.Now(),
+	}
+	must.Must(params.FactorySet.RefreshTokenRegistry.Create(context.Background(), rt))
+
+	preActive := must.Must(params.FactorySet.RefreshTokenRegistry.ListActiveByUserID(context.Background(), target.ID))
+	c.Assert(preActive, qt.HasLen, 1)
+
+	// Re-block: even though IsActive is already false, the cascade
+	// must fire.
+	rr := doAdminJSONRequest(t, handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/block",
+		admin.ID, blockBody("re-block to scrub stale tokens", false))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+
+	postActive := must.Must(params.FactorySet.RefreshTokenRegistry.ListActiveByUserID(context.Background(), target.ID))
+	c.Assert(postActive, qt.HasLen, 0,
+		qt.Commentf("idempotent re-block must run the cascade and revoke the planted token"))
+}
+
+// createTestJWTTokenWithClaims signs an arbitrary MapClaims for the
+// given user. Used by the impersonation self-block test so it can
+// stamp `imp` / `impersonated_by` onto the access token the same way
+// the (forthcoming) impersonation primitive will. Mirrors the shape of
+// createTestJWTToken but stays test-local so the production helper
+// doesn't grow a knob it never uses.
+func createTestJWTTokenWithClaims(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	if _, ok := claims["exp"]; !ok {
+		claims["exp"] = time.Now().Add(24 * time.Hour).Unix()
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString(testJWTSecret)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return signed
+}
+
+// TestAdminBlockUser_SelfBlockViaImpersonationRejected pins the B2
+// fix: the self-block guard must compare against the operator-of-
+// record (the `impersonated_by` claim), not the impersonated user's
+// JWT user_id. Without this, an operator could route a block-self
+// request through an impersonated peer-admin session and bypass the
+// guard.
+//
+// Scenario: env.admin is the operator and impersonates `peer` (also
+// a system admin so the impersonated session clears the admin gate).
+// The bearer token's user_id is `peer.ID` with `imp=true` and
+// `impersonated_by=env.admin.ID`. The operator then issues a block
+// against env.admin.ID — without the operator-aware guard the
+// handler would compare target.ID (env.admin.ID) to actor.ID
+// (peer.ID) and let it through.
+func TestAdminBlockUser_SelfBlockViaImpersonationRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	peer := createTestUserDirect(c, env.params, env.admin.TenantID, "peer-admin@example.com", true, true)
+
+	token := createTestJWTTokenWithClaims(t, jwt.MapClaims{
+		"user_id":         peer.ID,
+		"imp":             true,
+		"impersonated_by": env.admin.ID,
+	})
+
+	body, err := json.Marshal(blockBody("self-block via impersonation", true))
+	c.Assert(err, qt.IsNil)
+	req, err := http.NewRequest(http.MethodPost,
+		"/api/v1/admin/users/"+env.admin.ID+"/block", bytes.NewReader(body))
+	c.Assert(err, qt.IsNil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	env.handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity,
+		qt.Commentf("self-block via impersonated session must be 422; body=%s", rr.Body.String()))
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminBlockSelfBlockedCode)
+
+	// And the operator's own account stays active — the guard fired
+	// before any registry write.
+	reloaded := must.Must(env.params.FactorySet.UserRegistry.Get(context.Background(), env.admin.ID))
+	c.Assert(reloaded.IsActive, qt.IsTrue)
+}
+
+// TestAdminBlockUser_IdempotentOnPeerAdminWithoutForce pins the S4
+// fix: re-blocking an already-inactive peer system admin must be a
+// 200 no-op even when `force=true` is absent. Previously the
+// admin-without-force guard ran before the idempotency check and
+// returned a surprising 422 on a state-equivalent request.
+func TestAdminBlockUser_IdempotentOnPeerAdminWithoutForce(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	// Peer is a system admin AND already inactive — the
+	// admin-without-force guard would normally reject without force,
+	// but the idempotent path must short-circuit it.
+	peer := createTestUserDirect(c, env.params, env.admin.TenantID, "peer-admin@example.com", false, true)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/users/"+peer.ID+"/block",
+		env.admin.ID, blockBody("idempotent peer-admin no-op", false))
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.is_active"), false)
+
+	// The audit row must use the un-forced action and carry
+	// forced=false (or omit the key) — nothing was actually forced.
+	rows := must.Must(env.params.FactorySet.AuditLogRegistry.List(context.Background()))
+	var row *models.AuditLog
+	for i := range rows {
+		if rows[i].EntityID != nil && *rows[i].EntityID == peer.ID {
+			row = rows[i]
+			break
+		}
+	}
+	c.Assert(row, qt.IsNotNil)
+	c.Assert(row.Action, qt.Equals, apiserver.AuditActionAdminUserBlock,
+		qt.Commentf("idempotent path must NOT emit the _force action"))
+	var bc map[string]any
+	c.Assert(json.Unmarshal([]byte(row.UserAgent), &bc), qt.IsNil)
+	_, hasForced := bc["forced"]
+	c.Assert(hasForced, qt.IsFalse,
+		qt.Commentf("idempotent path must NOT set forced=true in the breadcrumb"))
+}
+
+// TestAdminUnblockUser_LeavesStalenessRingIntact pins the S3 promise:
+// unblocking a user does NOT clear the iat-staleness ring entry, so
+// access tokens minted before the block stay rejected after unblock.
+func TestAdminUnblockUser_LeavesStalenessRingIntact(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	bl := services.NewInMemoryTokenBlacklister()
+	params.TokenBlacklister = bl
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	target := createTestUserDirect(c, params, admin.TenantID, "ordinary@example.com", true, false)
+
+	// Block — installs an entry in the staleness ring.
+	blockRR := doAdminJSONRequest(t, handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/block",
+		admin.ID, blockBody("policy violation", false))
+	c.Assert(blockRR.Code, qt.Equals, http.StatusOK)
+
+	since, blacklisted, err := bl.UserBlacklistedSince(context.Background(), target.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(blacklisted, qt.IsTrue, qt.Commentf("block must install a staleness ring entry"))
+	c.Assert(since.IsZero(), qt.IsFalse)
+
+	// Unblock — must leave the ring untouched.
+	unblockRR := doAdminJSONRequest(t, handler, http.MethodPost,
+		"/api/v1/admin/users/"+target.ID+"/unblock",
+		admin.ID, unblockBody("appeal accepted"))
+	c.Assert(unblockRR.Code, qt.Equals, http.StatusOK)
+
+	sinceAfter, blacklistedAfter, err := bl.UserBlacklistedSince(context.Background(), target.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(blacklistedAfter, qt.IsTrue,
+		qt.Commentf("unblock must NOT clear the staleness ring entry (#1747 spec)"))
+	c.Assert(sinceAfter.Equal(since), qt.IsTrue,
+		qt.Commentf("the ring entry's `since` must be unchanged by unblock"))
 }

--- a/go/apiserver/admin_users_test.go
+++ b/go/apiserver/admin_users_test.go
@@ -276,7 +276,8 @@ func TestAdminBlockUser_BadBodyVariants(t *testing.T) {
 		{"unknown_field", map[string]any{"reason": "ok", "extra": 1}, http.StatusBadRequest},
 		// Trailing tokens after a valid object must be rejected — the
 		// json.Decoder accepts the first value happily, so the handler
-		// has to call dec.More() to catch the concatenation attack.
+		// has to do a second Decode and require io.EOF (via the
+		// decoderAtEOF helper) to catch the concatenation attack.
 		{"multi_object_trailing", []byte(`{"reason":"x"}{"extra":1}`), http.StatusBadRequest},
 	}
 	for _, tc := range cases {
@@ -380,9 +381,10 @@ func TestAdminUnblockUser_AuditRowCarriesReason(t *testing.T) {
 
 // TestAdminUnblockUser_BadBodyVariants mirrors the block-side table but
 // stays narrow — just enough to pin the trailing-tokens regression that
-// dec.More() guards against. The other reason-validation paths are
-// already covered by the block-side table and by the
-// decodeUnblockRequest happy-path tests.
+// the decoderAtEOF helper (second Decode + io.EOF check) guards
+// against. The other reason-validation paths are already covered by
+// the block-side table and by the decodeUnblockRequest happy-path
+// tests.
 func TestAdminUnblockUser_BadBodyVariants(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -358,6 +358,7 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 		// system admins are not scoped to a tenant.
 		r.With(userMiddlewares...).Route("/admin", Admin(AdminParams{
 			FactorySet:   params.FactorySet,
+			Blacklist:    blacklist,
 			AuditService: auditSvc,
 		}))
 		// The former /api/v1/users admin CRUD was removed together with the

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -36,6 +36,26 @@ var (
 	// authorized for admin"; using the auth sentinel makes the 401 path
 	// readable in logs and avoids misleading clients with admin copy.
 	ErrMissingUserContext = errx.NewSentinel("authenticated user context required")
+
+	// ErrAdminCannotBlockSelf rejects POST /admin/users/{id}/block when
+	// the caller would deactivate their own account. Without this guard
+	// an operator can lock themselves out of every admin surface in a
+	// single request — the recovery path is hand-flipping is_active in
+	// the database, which is exactly the kind of lockout #1745 was
+	// designed to prevent (mirrors the "last system admin" invariant on
+	// revoke). 422 + JSON:API code "admin.block.self_blocked" lets the
+	// FE render specific copy and lets e2e assertions branch on the
+	// code rather than a generic 422.
+	ErrAdminCannotBlockSelf = errx.NewSentinel("system administrators cannot block their own account")
+	// ErrAdminCannotBlockAdminWithoutForce rejects blocking another
+	// system admin when the request body's `force` flag is absent or
+	// false. Symmetric with the "cannot impersonate another system
+	// admin without force" rule that lands with the impersonation
+	// primitive (#1750): blocking a peer admin is a sensitive action
+	// that demands an explicit override so a typo on a username can't
+	// quietly disable a fellow operator. 422 + JSON:API code
+	// "admin.block.admin_requires_force" makes the FE branch trivial.
+	ErrAdminCannotBlockAdminWithoutForce = errx.NewSentinel("blocking another system administrator requires force=true")
 )
 
 func NewNotFoundError(err error) jsonapi.Error {
@@ -132,6 +152,24 @@ func unprocessableEntityError(w http.ResponseWriter, r *http.Request, err error)
 	return render.Render(w, r, jsonapi.NewErrors(NewUnprocessableEntityError(err)))
 }
 
+// adminBlockGuardError maps the two #1747 admin-block guard sentinels
+// (self-block, admin-on-admin without force) to their 422 + code wire
+// shape. Extracted so the toJSONAPIError switch stays under the
+// gocyclo budget while keeping the mapping explicit and grep-friendly.
+func adminBlockGuardError(err error) jsonapi.Error {
+	code := AdminBlockSelfBlockedCode
+	if errors.Is(err, ErrAdminCannotBlockAdminWithoutForce) {
+		code = AdminBlockAdminRequiresForceCode
+	}
+	return jsonapi.Error{
+		Err:            err,
+		UserError:      errormarshal.Marshal(err),
+		HTTPStatusCode: http.StatusUnprocessableEntity,
+		StatusText:     "Unprocessable Entity",
+		Code:           code,
+	}
+}
+
 func toJSONAPIError(err error) jsonapi.Error {
 	switch {
 	case errors.Is(err, registry.ErrCannotDelete):
@@ -221,6 +259,13 @@ func toJSONAPIError(err error) jsonapi.Error {
 			StatusText:     "Forbidden",
 			Code:           adminForbiddenCode,
 		}
+	case errors.Is(err, ErrAdminCannotBlockSelf),
+		errors.Is(err, ErrAdminCannotBlockAdminWithoutForce):
+		// Admin block-guard rejections (#1747). Self-lockout and
+		// admin-on-admin without `force: true` both surface as 422 with
+		// a sentinel-specific JSON:API code so the FE can render
+		// targeted copy instead of a generic 422 toast.
+		return adminBlockGuardError(err)
 	default:
 		slog.Error("internal server error", "error", err)
 		return NewInternalServerError(err)

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -302,7 +302,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "produces": [
-                    "application/json"
+                    "application/vnd.api+json"
                 ],
                 "tags": [
                     "admin"
@@ -373,7 +373,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "produces": [
-                    "application/json"
+                    "application/vnd.api+json"
                 ],
                 "tags": [
                     "admin"

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -295,6 +295,148 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/users/{userID}/block": {
+            "post": {
+                "description": "Sets the user's ` + "`" + `is_active` + "`" + ` flag to false, revokes every refresh token, and bumps the JWT-blacklist staleness threshold so live access tokens are rejected on next use.\nReturns 422 with ` + "`" + `admin.block.self_blocked` + "`" + ` when the caller targets their own account, and 422 with ` + "`" + `admin.block.admin_requires_force` + "`" + ` when targeting another system admin without ` + "`" + `force=true` + "`" + `.\nBody-validation rejections surface as 422 with ` + "`" + `admin.block.reason_required` + "`" + ` (missing or blank ` + "`" + `reason` + "`" + `) or ` + "`" + `admin.block.reason_too_long` + "`" + ` (reason exceeds 500 characters).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Block (deactivate) a user account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Target user ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Block request",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminBlockRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminUserEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown user",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - self-block or admin-on-admin without force",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users/{userID}/unblock": {
+            "post": {
+                "description": "Sets the user's ` + "`" + `is_active` + "`" + ` flag back to true. Does NOT re-issue tokens — the user must log in again.\nDoes NOT clear the JWT-blacklist staleness threshold either, so any access tokens that were issued before the block stay rejected until the iat-staleness ring expires.\nBody-validation rejections surface as 422 with ` + "`" + `admin.block.reason_required` + "`" + ` (missing or blank ` + "`" + `reason` + "`" + `) or ` + "`" + `admin.block.reason_too_long` + "`" + ` (reason exceeds 500 characters); the codes are shared with the block endpoint.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Unblock (reactivate) a user account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Target user ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Unblock request",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminUnblockRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminUserEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown user",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - invalid reason",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/change-password": {
             "post": {
                 "description": "Change the authenticated user's password. All existing sessions are invalidated on success.",
@@ -6556,6 +6698,23 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "apiserver.AdminBlockRequest": {
+            "type": "object",
+            "required": [
+                "reason"
+            ],
+            "properties": {
+                "force": {
+                    "description": "Force overrides the \"cannot block another system admin\" guard.\nHas no effect when blocking a non-admin user.",
+                    "type": "boolean"
+                },
+                "reason": {
+                    "description": "Reason is the free-form justification for the block (max 500 chars).",
+                    "type": "string",
+                    "maxLength": 500
+                }
+            }
+        },
         "apiserver.AdminPingResponse": {
             "type": "object",
             "properties": {
@@ -6563,6 +6722,64 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "timestamp": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.AdminUnblockRequest": {
+            "type": "object",
+            "required": [
+                "reason"
+            ],
+            "properties": {
+                "reason": {
+                    "description": "Reason is the free-form justification for the unblock (max 500 chars).",
+                    "type": "string",
+                    "maxLength": 500
+                }
+            }
+        },
+        "apiserver.AdminUserEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/apiserver.AdminUserResource"
+                }
+            }
+        },
+        "apiserver.AdminUserResource": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/apiserver.AdminUserView"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.AdminUserView": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "is_system_admin": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tenant_id": {
                     "type": "string"
                 }
             }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -288,6 +288,148 @@
                 }
             }
         },
+        "/admin/users/{userID}/block": {
+            "post": {
+                "description": "Sets the user's `is_active` flag to false, revokes every refresh token, and bumps the JWT-blacklist staleness threshold so live access tokens are rejected on next use.\nReturns 422 with `admin.block.self_blocked` when the caller targets their own account, and 422 with `admin.block.admin_requires_force` when targeting another system admin without `force=true`.\nBody-validation rejections surface as 422 with `admin.block.reason_required` (missing or blank `reason`) or `admin.block.reason_too_long` (reason exceeds 500 characters).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Block (deactivate) a user account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Target user ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Block request",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminBlockRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminUserEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown user",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - self-block or admin-on-admin without force",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users/{userID}/unblock": {
+            "post": {
+                "description": "Sets the user's `is_active` flag back to true. Does NOT re-issue tokens — the user must log in again.\nDoes NOT clear the JWT-blacklist staleness threshold either, so any access tokens that were issued before the block stay rejected until the iat-staleness ring expires.\nBody-validation rejections surface as 422 with `admin.block.reason_required` (missing or blank `reason`) or `admin.block.reason_too_long` (reason exceeds 500 characters); the codes are shared with the block endpoint.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Unblock (reactivate) a user account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Target user ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Unblock request",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminUnblockRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminUserEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown user",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - invalid reason",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/change-password": {
             "post": {
                 "description": "Change the authenticated user's password. All existing sessions are invalidated on success.",
@@ -6549,6 +6691,23 @@
         }
     },
     "definitions": {
+        "apiserver.AdminBlockRequest": {
+            "type": "object",
+            "required": [
+                "reason"
+            ],
+            "properties": {
+                "force": {
+                    "description": "Force overrides the \"cannot block another system admin\" guard.\nHas no effect when blocking a non-admin user.",
+                    "type": "boolean"
+                },
+                "reason": {
+                    "description": "Reason is the free-form justification for the block (max 500 chars).",
+                    "type": "string",
+                    "maxLength": 500
+                }
+            }
+        },
         "apiserver.AdminPingResponse": {
             "type": "object",
             "properties": {
@@ -6556,6 +6715,64 @@
                     "type": "boolean"
                 },
                 "timestamp": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.AdminUnblockRequest": {
+            "type": "object",
+            "required": [
+                "reason"
+            ],
+            "properties": {
+                "reason": {
+                    "description": "Reason is the free-form justification for the unblock (max 500 chars).",
+                    "type": "string",
+                    "maxLength": 500
+                }
+            }
+        },
+        "apiserver.AdminUserEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/apiserver.AdminUserResource"
+                }
+            }
+        },
+        "apiserver.AdminUserResource": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/apiserver.AdminUserView"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.AdminUserView": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "is_system_admin": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tenant_id": {
                     "type": "string"
                 }
             }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -295,7 +295,7 @@
                     "application/json"
                 ],
                 "produces": [
-                    "application/json"
+                    "application/vnd.api+json"
                 ],
                 "tags": [
                     "admin"
@@ -366,7 +366,7 @@
                     "application/json"
                 ],
                 "produces": [
-                    "application/json"
+                    "application/vnd.api+json"
                 ],
                 "tags": [
                     "admin"

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1,10 +1,64 @@
 basePath: /api/v1
 definitions:
+  apiserver.AdminBlockRequest:
+    properties:
+      force:
+        description: |-
+          Force overrides the "cannot block another system admin" guard.
+          Has no effect when blocking a non-admin user.
+        type: boolean
+      reason:
+        description: Reason is the free-form justification for the block (max 500
+          chars).
+        maxLength: 500
+        type: string
+    required:
+    - reason
+    type: object
   apiserver.AdminPingResponse:
     properties:
       ok:
         type: boolean
       timestamp:
+        type: string
+    type: object
+  apiserver.AdminUnblockRequest:
+    properties:
+      reason:
+        description: Reason is the free-form justification for the unblock (max 500
+          chars).
+        maxLength: 500
+        type: string
+    required:
+    - reason
+    type: object
+  apiserver.AdminUserEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/apiserver.AdminUserResource'
+    type: object
+  apiserver.AdminUserResource:
+    properties:
+      attributes:
+        $ref: '#/definitions/apiserver.AdminUserView'
+      id:
+        type: string
+      type:
+        type: string
+    type: object
+  apiserver.AdminUserView:
+    properties:
+      email:
+        type: string
+      id:
+        type: string
+      is_active:
+        type: boolean
+      is_system_admin:
+        type: boolean
+      name:
+        type: string
+      tenant_id:
         type: string
     type: object
   apiserver.ChangePasswordRequest:
@@ -4090,6 +4144,107 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: Get user (admin)
+      tags:
+      - admin
+  /admin/users/{userID}/block:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Sets the user's `is_active` flag to false, revokes every refresh token, and bumps the JWT-blacklist staleness threshold so live access tokens are rejected on next use.
+        Returns 422 with `admin.block.self_blocked` when the caller targets their own account, and 422 with `admin.block.admin_requires_force` when targeting another system admin without `force=true`.
+        Body-validation rejections surface as 422 with `admin.block.reason_required` (missing or blank `reason`) or `admin.block.reason_too_long` (reason exceeds 500 characters).
+      parameters:
+      - description: Target user ID
+        in: path
+        name: userID
+        required: true
+        type: string
+      - description: Block request
+        in: body
+        name: data
+        required: true
+        schema:
+          $ref: '#/definitions/apiserver.AdminBlockRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.AdminUserEnvelope'
+        "400":
+          description: Bad Request - invalid body
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Forbidden - system-admin required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Not Found - unknown user
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Unprocessable Entity - self-block or admin-on-admin without
+            force
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Block (deactivate) a user account
+      tags:
+      - admin
+  /admin/users/{userID}/unblock:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Sets the user's `is_active` flag back to true. Does NOT re-issue tokens — the user must log in again.
+        Does NOT clear the JWT-blacklist staleness threshold either, so any access tokens that were issued before the block stay rejected until the iat-staleness ring expires.
+        Body-validation rejections surface as 422 with `admin.block.reason_required` (missing or blank `reason`) or `admin.block.reason_too_long` (reason exceeds 500 characters); the codes are shared with the block endpoint.
+      parameters:
+      - description: Target user ID
+        in: path
+        name: userID
+        required: true
+        type: string
+      - description: Unblock request
+        in: body
+        name: data
+        required: true
+        schema:
+          $ref: '#/definitions/apiserver.AdminUnblockRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.AdminUserEnvelope'
+        "400":
+          description: Bad Request - invalid body
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Forbidden - system-admin required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Not Found - unknown user
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Unprocessable Entity - invalid reason
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Unblock (reactivate) a user account
       tags:
       - admin
   /auth/change-password:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -4167,7 +4167,7 @@ paths:
         schema:
           $ref: '#/definitions/apiserver.AdminBlockRequest'
       produces:
-      - application/json
+      - application/vnd.api+json
       responses:
         "200":
           description: OK
@@ -4218,7 +4218,7 @@ paths:
         schema:
           $ref: '#/definitions/apiserver.AdminUnblockRequest'
       produces:
-      - application/json
+      - application/vnd.api+json
       responses:
         "200":
           description: OK

--- a/go/services/audit_service.go
+++ b/go/services/audit_service.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/models"
@@ -231,29 +232,26 @@ func adminAuditBreadcrumb(ev AdminEvent, rawUA string) string {
 // but a future CLI / in-process caller might call LogAdmin directly with
 // a multi-KB string. Truncating here keeps the user_agent column bounded
 // regardless of caller hygiene.
+//
+// The cap is measured in runes (Unicode code points), consistent with
+// the OpenAPI `maxLength` semantics on the request schema. The
+// truncation marker counts toward the cap so the returned string is
+// always ≤ adminBreadcrumbReasonMaxLen runes — never one rune over.
 func truncateReason(reason string) string {
-	if len(reason) <= adminBreadcrumbReasonMaxLen {
+	if utf8.RuneCountInString(reason) <= adminBreadcrumbReasonMaxLen {
 		return reason
 	}
-	// Truncate by rune boundary to avoid splitting a multi-byte
-	// codepoint mid-sequence, then append the truncation marker so the
-	// reader can tell the value was clipped.
-	r := []rune(reason)
-	// Pick the smaller of (rune cap, byte cap) — both are conservative.
-	if len(r) > adminBreadcrumbReasonMaxLen {
-		r = r[:adminBreadcrumbReasonMaxLen]
+	markerRunes := utf8.RuneCountInString(adminBreadcrumbTruncateMarker)
+	keep := adminBreadcrumbReasonMaxLen - markerRunes
+	if keep <= 0 {
+		// Pathological config (marker alone exceeds the cap). Fall back
+		// to the marker truncated to the cap so the caller still gets
+		// a bounded string rather than a panic.
+		runes := []rune(adminBreadcrumbTruncateMarker)
+		return string(runes[:adminBreadcrumbReasonMaxLen])
 	}
-	out := string(r)
-	if len(out) > adminBreadcrumbReasonMaxLen {
-		// Multi-byte codepoints can push us back over the byte cap even
-		// after the rune trim. Walk back one rune at a time until we
-		// fit. Tight loop, bounded by the rune count we already trimmed.
-		for len(out) > adminBreadcrumbReasonMaxLen-len(adminBreadcrumbTruncateMarker) && len(r) > 0 {
-			r = r[:len(r)-1]
-			out = string(r)
-		}
-	}
-	return out + adminBreadcrumbTruncateMarker
+	runes := []rune(reason)
+	return string(runes[:keep]) + adminBreadcrumbTruncateMarker
 }
 
 // ImpersonatorIDFromContext returns the operator's user ID when the

--- a/go/services/audit_service.go
+++ b/go/services/audit_service.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"strings"
@@ -42,6 +44,16 @@ type AuthEvent struct {
 // fills it from the request's JWT claims (`imp` / `impersonated_by`),
 // so the call site never needs to know whether an impersonation session
 // is active.
+//
+// Reason / Forced / Extra carry the action-specific breadcrumb that
+// LogAdmin persists alongside the row. The audit_logs schema doesn't
+// have a generic context column today (#1747) — stuffing the breadcrumb
+// into user_agent as a JSON blob with the real UA preserved under a
+// sub-key keeps the row self-describing without a schema bump. Mirrors
+// insertCurrencyMigrationAuditLog. When Reason/Forced/Extra are all
+// zero-valued the helper falls back to writing the raw User-Agent
+// header so existing callers (grant/revoke) continue to write a plain
+// UA string, not a noisy {"ua":"..."} blob.
 type AdminEvent struct {
 	Action      string
 	ActorID     *string
@@ -51,6 +63,19 @@ type AdminEvent struct {
 	Success     bool
 	Request     *http.Request
 	ErrMsg      *string
+	// Reason is the operator-supplied free-form text accompanying a
+	// state-changing admin action (e.g. the body field on block/unblock).
+	Reason string
+	// Forced flags a sensitive admin action that bypassed a guard via an
+	// explicit `force: true` body flag (e.g. blocking another system
+	// admin). The audit consumer can pivot on this in queries even
+	// when Action is identical to the non-forced variant.
+	Forced bool
+	// Extra carries action-specific breadcrumb fields. Merged into the
+	// user_agent JSON blob alongside reason / forced / ua. Keep the
+	// values small and JSON-serialisable — this column is text, not
+	// jsonb, and oversized blobs hurt audit log scans.
+	Extra map[string]any
 }
 
 // AuditLogger is the interface for logging security-relevant events.
@@ -143,9 +168,104 @@ func (s *AuditService) LogAdmin(ctx context.Context, ev AdminEvent) {
 		entry.UserAgent = ev.Request.UserAgent()
 	}
 
+	// When the caller supplied any breadcrumb fields, encode them as a
+	// JSON blob in user_agent and tuck the real UA under "ua" so the
+	// row carries the full context — see AdminEvent doc-comment for
+	// the rationale.
+	if breadcrumb := adminAuditBreadcrumb(ev, entry.UserAgent); breadcrumb != "" {
+		entry.UserAgent = breadcrumb
+	}
+
 	if _, err := s.auditRegistry.Create(ctx, entry); err != nil {
 		slog.Error("Failed to write admin audit log entry", "action", ev.Action, "error", err)
 	}
+}
+
+// adminBreadcrumbReasonMaxLen caps the breadcrumb reason at 500
+// characters as defence-in-depth against non-HTTP callers (future CLI
+// admin actions, in-process service helpers) that don't share the
+// HTTP-decoder's input validation. The audit_logs.user_agent column
+// tunnels the JSON breadcrumb today (#1747) — a multi-KB reason would
+// bloat the row without an upper bound here.
+const adminBreadcrumbReasonMaxLen = 500
+
+// adminBreadcrumbTruncateMarker is the suffix appended to a reason that
+// exceeds the cap so post-hoc readers can tell the value was truncated
+// rather than provided verbatim.
+const adminBreadcrumbTruncateMarker = "…"
+
+// adminAuditBreadcrumb returns a JSON-encoded breadcrumb if any of the
+// optional context fields are populated, or "" to signal that the
+// caller should keep the existing user_agent value (raw UA string).
+// Keeping the fall-through path explicit avoids retroactively rewriting
+// every existing admin.* audit row to a noisy {"ua":"..."} blob.
+func adminAuditBreadcrumb(ev AdminEvent, rawUA string) string {
+	if ev.Reason == "" && !ev.Forced && len(ev.Extra) == 0 {
+		return ""
+	}
+	payload := make(map[string]any, len(ev.Extra)+3)
+	maps.Copy(payload, ev.Extra)
+	if ev.Reason != "" {
+		payload["reason"] = truncateReason(ev.Reason)
+	}
+	if ev.Forced {
+		payload["forced"] = true
+	}
+	if rawUA != "" {
+		payload["ua"] = rawUA
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		// Falling back to the raw UA keeps the row intact when the
+		// breadcrumb payload contains an unsupported type — the
+		// alternative would silently drop the audit row, which is
+		// strictly worse than losing the breadcrumb context.
+		slog.Error("Failed to marshal admin audit breadcrumb", "action", ev.Action, "error", err)
+		return ""
+	}
+	return string(encoded)
+}
+
+// truncateReason enforces the audit-breadcrumb reason cap. Defence-in-
+// depth: the HTTP decoder already rejects oversized reasons with a 422,
+// but a future CLI / in-process caller might call LogAdmin directly with
+// a multi-KB string. Truncating here keeps the user_agent column bounded
+// regardless of caller hygiene.
+func truncateReason(reason string) string {
+	if len(reason) <= adminBreadcrumbReasonMaxLen {
+		return reason
+	}
+	// Truncate by rune boundary to avoid splitting a multi-byte
+	// codepoint mid-sequence, then append the truncation marker so the
+	// reader can tell the value was clipped.
+	r := []rune(reason)
+	// Pick the smaller of (rune cap, byte cap) — both are conservative.
+	if len(r) > adminBreadcrumbReasonMaxLen {
+		r = r[:adminBreadcrumbReasonMaxLen]
+	}
+	out := string(r)
+	if len(out) > adminBreadcrumbReasonMaxLen {
+		// Multi-byte codepoints can push us back over the byte cap even
+		// after the rune trim. Walk back one rune at a time until we
+		// fit. Tight loop, bounded by the rune count we already trimmed.
+		for len(out) > adminBreadcrumbReasonMaxLen-len(adminBreadcrumbTruncateMarker) && len(r) > 0 {
+			r = r[:len(r)-1]
+			out = string(r)
+		}
+	}
+	return out + adminBreadcrumbTruncateMarker
+}
+
+// ImpersonatorIDFromContext returns the operator's user ID when the
+// request context carries impersonation claims (`imp` == true with a
+// non-empty `impersonated_by`), and nil otherwise. Exported so the HTTP
+// layer can resolve "who actually initiated this request" without
+// re-parsing the bearer token — for example to prevent an operator from
+// self-blocking through an impersonated session (#1747).
+//
+// Returns nil for the common case where no impersonation is active.
+func ImpersonatorIDFromContext(ctx context.Context) *string {
+	return impersonatorFromContext(ctx)
 }
 
 // impersonatorFromContext returns the user ID stored in the `impersonated_by`

--- a/go/services/audit_service.go
+++ b/go/services/audit_service.go
@@ -237,21 +237,60 @@ func adminAuditBreadcrumb(ev AdminEvent, rawUA string) string {
 // the OpenAPI `maxLength` semantics on the request schema. The
 // truncation marker counts toward the cap so the returned string is
 // always ≤ adminBreadcrumbReasonMaxLen runes — never one rune over.
+//
+// Memory: scans the input once with utf8.DecodeRuneInString to find the
+// cutoff byte index without materialising a full []rune slice. Worst-
+// case allocation is bounded by the cap (~500 runes ≤ 2 KiB) rather
+// than the caller-supplied input size — important for the
+// defence-in-depth path against multi-MB strings from buggy callers.
 func truncateReason(reason string) string {
-	if utf8.RuneCountInString(reason) <= adminBreadcrumbReasonMaxLen {
-		return reason
-	}
 	markerRunes := utf8.RuneCountInString(adminBreadcrumbTruncateMarker)
 	keep := adminBreadcrumbReasonMaxLen - markerRunes
 	if keep <= 0 {
 		// Pathological config (marker alone exceeds the cap). Fall back
-		// to the marker truncated to the cap so the caller still gets
-		// a bounded string rather than a panic.
-		runes := []rune(adminBreadcrumbTruncateMarker)
-		return string(runes[:adminBreadcrumbReasonMaxLen])
+		// to a stable prefix of the marker so the caller still gets a
+		// bounded string rather than a panic. Scanned the same way so
+		// the multi-byte marker isn't sliced mid-codepoint.
+		return prefixUpToRuneCount(adminBreadcrumbTruncateMarker, adminBreadcrumbReasonMaxLen)
 	}
-	runes := []rune(reason)
-	return string(runes[:keep]) + adminBreadcrumbTruncateMarker
+	// Walk the input once. cutoff records the byte index just past the
+	// `keep`-th rune; once we cross that point we know the input is too
+	// long without ever counting all of it.
+	count := 0
+	cutoff := 0
+	for i := 0; i < len(reason); {
+		_, size := utf8.DecodeRuneInString(reason[i:])
+		i += size
+		count++
+		if count == keep {
+			cutoff = i
+		}
+		if count > keep {
+			return reason[:cutoff] + adminBreadcrumbTruncateMarker
+		}
+	}
+	// Input fits within the cap; no truncation needed.
+	return reason
+}
+
+// prefixUpToRuneCount returns the byte-prefix of s containing at most n
+// runes, scanning the string in a single pass. Used by truncateReason
+// for the pathological "marker alone exceeds cap" branch so the
+// fallback never panics on multi-byte markers.
+func prefixUpToRuneCount(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	count := 0
+	for i := 0; i < len(s); {
+		_, size := utf8.DecodeRuneInString(s[i:])
+		i += size
+		count++
+		if count == n {
+			return s[:i]
+		}
+	}
+	return s
 }
 
 // ImpersonatorIDFromContext returns the operator's user ID when the


### PR DESCRIPTION
## Summary

Implements #1747 — `POST /api/v1/admin/users/{userID}/block` and `POST /api/v1/admin/users/{userID}/unblock`, the first user-management endpoints under the `/api/v1/admin/*` umbrella that #1760 set up.

- **Block cascade** — flips `User.IsActive = false`, calls `RefreshTokenRegistry.RevokeByUserID`, and stamps a `TokenBlacklister.BlacklistUserTokens(userID, 2×accessTokenExpiration)` entry so the existing iat-staleness check in `jwt_middleware.go::checkTokenBlacklist` rejects live access tokens on next use.
- **Unblock** — restores `IsActive=true`. Does NOT re-issue tokens and does NOT clear the staleness entry, so any access token minted before the block stays rejected until the ring expires.
- **Guards**:
  - Self-block → `422 admin.block.self_blocked` (mirrors the `last system admin` lockout invariant from #1745).
  - Admin-on-admin block without `force: true` → `422 admin.block.admin_requires_force`. With `force: true`, the action is recorded under a distinct audit action `admin.user_block_force` so severity tooling can branch on the literal.
- **Audit**: `services.AdminEvent` gains `Reason`, `Forced`, and `Breadcrumb` fields; `AuditService.LogAdmin` tunnels them through the `audit_logs.user_agent` column as a JSON blob alongside the real User-Agent. Mirrors the `currency_migration` audit-breadcrumb pattern — no schema change needed.

## Files

- `go/apiserver/admin_users.go` + `admin_users_test.go` — new handler, DTOs, JSON:API envelope, helpers, 16 table-driven tests.
- `go/apiserver/admin_routes.go` — `Admin()` now takes `AdminParams` and mounts the user routes after `_ping`, behind the same `RequireSystemAdmin` gate.
- `go/apiserver/errors.go` — two new sentinels (`ErrAdminCannotBlockSelf`, `ErrAdminCannotBlockAdminWithoutForce`) + their JSON:API mapping via a small `adminBlockGuardError` helper (keeps the `toJSONAPIError` switch under the gocyclo budget).
- `go/apiserver/apiserver.go` — passes the new deps into `Admin(...)`.
- `go/services/audit_service.go` — `AdminEvent` + `LogAdmin` breadcrumb support; preserves the real `User-Agent` under a sub-key.
- `go/docs/{docs.go,swagger.json,swagger.yaml}` + `frontend/src/types/api.d.ts` — regenerated.

## Acceptance criteria

- [x] Block + unblock endpoints exist under `/api/v1/admin/users/{userID}/{block,unblock}`, gated by `RequireSystemAdmin`.
- [x] Table-driven handler tests: happy-path block/unblock, idempotent both ways, self-block rejected, admin-on-admin without force rejected, admin-on-admin with force allowed and audit-distinguished, unknown user → 404, bad-body variants, non-admin → 403, unauthenticated → 401.
- [x] Integration test: `TestAdminBlockUser_AccessTokenIssuedBeforeBlockFails` — a token minted before the block fails AFTER the block.
- [x] Integration test: `TestAdminBlockUser_RefreshTokenRevokedByCascade` — refresh-token use after block is rejected.
- [x] Audit row carries the `reason` field (`TestAdminBlockUser_AuditRowCarriesReason`, `TestAdminUnblockUser_AuditRowCarriesReason`).
- [x] Swagger regenerated cleanly (`make swagger`), `frontend/src/types/api.d.ts` regenerated.
- [x] `golangci-lint run ./apiserver/... ./services/...` → 0 issues.
- [x] Full Go suite green (short mode locally; full suite will run on CI).

## Test plan

- [ ] CI: backend test workflow passes.
- [ ] CI: lint workflow passes.
- [ ] CI: swagger-check workflow passes.
- [ ] CI: frontend codegen-check passes.
- [ ] CI: e2e workflow passes (the new endpoints are gated by `RequireSystemAdmin`; existing e2e flows don't touch them, so this is a regression check).

Closes #1747. Part of #1744.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin POST endpoints to block/unblock users. Blocking sets is_active=false, revokes refresh tokens, blacklists recent access tokens, supports force for system-admins, requires a reason (validated, 500-char max), and is idempotent; unblock reactivates without re-issuing tokens or clearing blacklist state.

* **Audit**
  * Block/unblock actions record reason/forced metadata as audit breadcrumbs.

* **Tests**
  * Expanded coverage for block/unblock: validation, auth, idempotency, cascades, impersonation/self-block guards.

* **Documentation**
  * API docs updated with new endpoints and 422 error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->