### PR TITLE
[#1748] Admin groups endpoints: cross-tenant list, detail, soft-delete

### DIFF
--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -59,6 +59,203 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/admin/groups": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List groups (admin)
+         * @description Returns every location group with computed member_count. Pagination via ?page&per_page; ?q matches name/slug (ILIKE).
+         *     ?org_id and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
+         *     Note: the tenant filter is named `org_id` (not `tenantID`) because the global ValidateNoUserProvidedTenantID security middleware rejects any query parameter whose name contains "tenant".
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Page number (default 1) */
+                    page?: number;
+                    /** @description Items per page (default 50, max 100) */
+                    per_page?: number;
+                    /** @description Search term — ILIKE match on name/slug */
+                    q?: string;
+                    /** @description Filter to groups belonging to this tenant ID (exact match). Named org_id rather than tenantID — the security middleware blocks query params containing 'tenant'. */
+                    org_id?: string;
+                    /** @description Filter to groups in this status: active|pending_deletion (exact match) */
+                    status?: string;
+                    /** @description Sort field: name|slug|created_at|status (prefix with - for desc) */
+                    sort?: string;
+                    /** @description Sort direction override: asc|desc (wins over `-` prefix) */
+                    order?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.AdminGroupsResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Forbidden - system-admin required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/groups/{groupID}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get group (admin)
+         * @description Returns the group row with computed member_count and an owning-tenant chip (tenant id, name, slug). Crosses tenants by design.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group ID */
+                    groupID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.AdminGroupResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Forbidden - system-admin required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Group not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /**
+         * Soft-delete a group (admin)
+         * @description Sets the group's status to `pending_deletion`; the group purge worker finishes the hard-delete asynchronously.
+         *     Idempotent — re-deleting an already-pending group returns 200 with the current status. Returns the post-transition group row.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group ID */
+                    groupID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK - group marked pending_deletion (or already was) */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.AdminGroupResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Forbidden - system-admin required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Group not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/tenants": {
         parameters: {
             query?: never;
@@ -7648,6 +7845,53 @@ export type components = {
             error?: unknown;
             file_storage_driver?: string;
             operating_system?: string;
+        };
+        "jsonapi.AdminGroupDetail": {
+            created_at?: string;
+            created_by?: string;
+            currency?: string;
+            id?: string;
+            member_count?: number;
+            name?: string;
+            slug?: string;
+            status?: components["schemas"]["models.LocationGroupStatus"];
+            tenant?: components["schemas"]["jsonapi.AdminGroupTenantChip"];
+            tenant_id?: string;
+            /**
+             * @example admin_groups
+             * @enum {string}
+             */
+            type?: "admin_groups";
+            updated_at?: string;
+        };
+        "jsonapi.AdminGroupListItem": {
+            created_at?: string;
+            created_by?: string;
+            currency?: string;
+            id?: string;
+            member_count?: number;
+            name?: string;
+            slug?: string;
+            status?: components["schemas"]["models.LocationGroupStatus"];
+            tenant_id?: string;
+            /**
+             * @example admin_groups
+             * @enum {string}
+             */
+            type?: "admin_groups";
+            updated_at?: string;
+        };
+        "jsonapi.AdminGroupResponse": {
+            data?: components["schemas"]["jsonapi.AdminGroupDetail"];
+        };
+        "jsonapi.AdminGroupTenantChip": {
+            id?: string;
+            name?: string;
+            slug?: string;
+        };
+        "jsonapi.AdminGroupsResponse": {
+            data?: components["schemas"]["jsonapi.AdminGroupListItem"][];
+            meta?: components["schemas"]["jsonapi.AdminListMeta"];
         };
         "jsonapi.AdminListMeta": {
             /** @example 1 */

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -68,8 +68,7 @@ export type paths = {
         };
         /**
          * List groups (admin)
-         * @description Returns every location group with computed member_count. Pagination via ?page&per_page; ?q matches name/slug (ILIKE).
-         *     ?tenantID and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
+         * @description Returns every location group with computed member_count and an owning-tenant chip (id, name, slug). Paginate via ?page&per_page; ?q ILIKE-matches name/slug; ?tenantID/?status filter exactly; ?sort/?order set ordering.
          */
         get: {
             parameters: {
@@ -82,12 +81,12 @@ export type paths = {
                     q?: string;
                     /** @description Filter to groups belonging to this tenant ID (exact match) */
                     tenantID?: string;
-                    /** @description Filter to groups in this status: active|pending_deletion (exact match) */
-                    status?: string;
+                    /** @description Filter to groups in this status (exact match) */
+                    status?: "active" | "pending_deletion";
                     /** @description Sort field: name|slug|created_at|status (prefix with - for desc) */
                     sort?: string;
-                    /** @description Sort direction override: asc|desc (wins over `-` prefix) */
-                    order?: string;
+                    /** @description Sort direction override (wins over `-` prefix) */
+                    order?: "asc" | "desc";
                 };
                 header?: never;
                 path?: never;
@@ -197,8 +196,7 @@ export type paths = {
         post?: never;
         /**
          * Soft-delete a group (admin)
-         * @description Sets the group's status to `pending_deletion`; the group purge worker finishes the hard-delete asynchronously.
-         *     Idempotent — re-deleting an already-pending group returns 200 with the current status. Returns the post-transition group row.
+         * @description Sets the group's status to `pending_deletion`; the group purge worker finishes the hard-delete asynchronously. Idempotent — re-deleting an already-pending group returns 200. Returns the post-transition group row.
          */
         delete: {
             parameters: {
@@ -7872,6 +7870,7 @@ export type components = {
             name?: string;
             slug?: string;
             status?: components["schemas"]["models.LocationGroupStatus"];
+            tenant?: components["schemas"]["jsonapi.AdminGroupTenantChip"];
             tenant_id?: string;
             /**
              * @example admin_groups

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -69,8 +69,7 @@ export type paths = {
         /**
          * List groups (admin)
          * @description Returns every location group with computed member_count. Pagination via ?page&per_page; ?q matches name/slug (ILIKE).
-         *     ?org_id and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
-         *     Note: the tenant filter is named `org_id` (not `tenantID`) because the global ValidateNoUserProvidedTenantID security middleware rejects any query parameter whose name contains "tenant".
+         *     ?tenantID and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
          */
         get: {
             parameters: {
@@ -81,8 +80,8 @@ export type paths = {
                     per_page?: number;
                     /** @description Search term — ILIKE match on name/slug */
                     q?: string;
-                    /** @description Filter to groups belonging to this tenant ID (exact match). Named org_id rather than tenantID — the security middleware blocks query params containing 'tenant'. */
-                    org_id?: string;
+                    /** @description Filter to groups belonging to this tenant ID (exact match) */
+                    tenantID?: string;
                     /** @description Filter to groups in this status: active|pending_deletion (exact match) */
                     status?: string;
                     /** @description Sort field: name|slug|created_at|status (prefix with - for desc) */

--- a/go/apiserver/admin_groups.go
+++ b/go/apiserver/admin_groups.go
@@ -34,14 +34,13 @@ type adminGroupsAPI struct {
 //
 // @Summary List groups (admin)
 // @Description Returns every location group with computed member_count. Pagination via ?page&per_page; ?q matches name/slug (ILIKE).
-// @Description ?org_id and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
-// @Description Note: the tenant filter is named `org_id` (not `tenantID`) because the global ValidateNoUserProvidedTenantID security middleware rejects any query parameter whose name contains "tenant".
+// @Description ?tenantID and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
 // @Tags admin
 // @Produce json-api
 // @Param page query int false "Page number (default 1)"
 // @Param per_page query int false "Items per page (default 50, max 100)"
 // @Param q query string false "Search term — ILIKE match on name/slug"
-// @Param org_id query string false "Filter to groups belonging to this tenant ID (exact match). Named org_id rather than tenantID — the security middleware blocks query params containing 'tenant'."
+// @Param tenantID query string false "Filter to groups belonging to this tenant ID (exact match)"
 // @Param status query string false "Filter to groups in this status: active|pending_deletion (exact match)"
 // @Param sort query string false "Sort field: name|slug|created_at|status (prefix with - for desc)"
 // @Param order query string false "Sort direction override: asc|desc (wins over `-` prefix)"
@@ -58,12 +57,12 @@ func (api *adminGroupsAPI) listGroups(w http.ResponseWriter, r *http.Request) {
 		Page:    page,
 		PerPage: perPage,
 		Query:   q.Get("q"),
-		// The tenant filter is read from `org_id`, not `tenantID`: the
-		// global ValidateNoUserProvidedTenantID middleware rejects any
-		// query parameter whose name contains the substring "tenant"
-		// (case-insensitive) as a cross-tenant-injection guard, so the
-		// issue's literal `tenantID` name is unusable on a live route.
-		TenantID:  q.Get("org_id"),
+		// The tenant filter is read from `tenantID`. The global
+		// ValidateNoUserProvidedTenantID middleware normally rejects any
+		// query parameter whose name contains "tenant", but it exempts the
+		// /api/v1/admin/* subtree from that check by design — see the
+		// rationale in isAdminSubtreePath / ValidateNoUserProvidedTenantID.
+		TenantID:  q.Get("tenantID"),
 		Status:    q.Get("status"),
 		SortField: registry.AdminGroupSortField(sortField),
 		SortDesc:  sortDesc,

--- a/go/apiserver/admin_groups.go
+++ b/go/apiserver/admin_groups.go
@@ -26,11 +26,10 @@ type adminGroupsAPI struct {
 // location group in the deployment along with each group's computed
 // member_count.
 //
-// The endpoint crosses tenants by design — see RequireSystemAdmin gate —
-// and the registry layer bypasses RLS via `SET LOCAL row_security = off`
-// on the listing tx so the cross-tenant read fails loud on a
-// misconfigured connection role rather than returning a silently empty
-// page.
+// The endpoint crosses tenants by design — see RequireSystemAdmin gate.
+// The registry layer runs the listing as the background-worker role,
+// which carries RLS bypass policies on location_groups; the cross-tenant
+// read is therefore unconditional, not gated on a fail-loud trip-wire.
 //
 // @Summary List groups (admin)
 // @Description Returns every location group with computed member_count. Pagination via ?page&per_page; ?q matches name/slug (ILIKE).
@@ -62,7 +61,14 @@ func (api *adminGroupsAPI) listGroups(w http.ResponseWriter, r *http.Request) {
 		// query parameter whose name contains "tenant", but it exempts the
 		// /api/v1/admin/* subtree from that check by design — see the
 		// rationale in isAdminSubtreePath / ValidateNoUserProvidedTenantID.
-		TenantID:  q.Get("tenantID"),
+		TenantID: q.Get("tenantID"),
+		// Status is an exact-match filter. An unknown value (a status the
+		// model doesn't define) is passed straight through to the SQL
+		// `g.status = $N` predicate and simply matches no rows — the page
+		// comes back empty rather than 4xx. This is intentional and
+		// consistent with the ?sort "tolerate FE drift" rationale in
+		// parseAdminSortAndOrder: a FE drifting across versions never gets
+		// a hard error from a filter param.
 		Status:    q.Get("status"),
 		SortField: registry.AdminGroupSortField(sortField),
 		SortDesc:  sortDesc,
@@ -153,26 +159,20 @@ func (api *adminGroupsAPI) deleteGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// MarkPendingDeletionAdmin owns the status transition (identical to
-	// GroupService.InitiateGroupDeletion) and reports whether the group
-	// was already pending so the idempotent re-delete renders a plain
-	// 200 instead of a re-write. The bool is data, not control flow:
-	// either way the post-state is pending_deletion and we render it.
-	alreadyPending, err := api.factorySet.LocationGroupRegistry.MarkPendingDeletionAdmin(r.Context(), groupID)
+	// GroupService.InitiateGroupDeletion) and returns the post-transition
+	// detail row directly — group row + member_count + tenant chip,
+	// computed in the SAME transaction as the status write. There is no
+	// second GetAdmin round-trip: re-fetching after the soft-delete
+	// commits would race the group_purge_worker, which could hard-delete
+	// the now-pending row and turn a DELETE that actually succeeded into
+	// a spurious 404. alreadyPending reports whether the group was
+	// already pending so the idempotent re-delete renders a plain 200; it
+	// is data, not control flow — either way the post-state is
+	// pending_deletion and we render `item`.
+	item, alreadyPending, err := api.factorySet.LocationGroupRegistry.MarkPendingDeletionAdmin(r.Context(), groupID)
 	if err != nil {
 		api.auditDelete(r, groupID, "", err)
 		_ = renderEntityError(w, r, err)
-		return
-	}
-
-	// Re-fetch the post-transition row so the response carries the
-	// updated status + the tenant chip the FE renders. A read failure
-	// here is a 500 — the soft-delete already committed, but the client
-	// contract is "return the row", so we surface the read error rather
-	// than fabricating a partial body.
-	item, getErr := api.factorySet.LocationGroupRegistry.GetAdmin(r.Context(), groupID)
-	if getErr != nil {
-		api.auditDelete(r, groupID, "", getErr)
-		_ = renderEntityError(w, r, getErr)
 		return
 	}
 
@@ -180,7 +180,9 @@ func (api *adminGroupsAPI) deleteGroup(w http.ResponseWriter, r *http.Request) {
 	// group as subject, and the group's tenant — the spec's required
 	// trio. `already_pending` rides the breadcrumb so an operator can
 	// tell a genuine soft-delete from an idempotent no-op without
-	// re-deriving it from timestamps.
+	// re-deriving it from timestamps. The soft-delete already committed,
+	// so the audit row records Success=true on the happy path; only a
+	// render blip flips it to false.
 	renderErr := render.Render(w, r, jsonapi.NewAdminGroupResponse(item))
 	api.auditDeleteResult(r, groupID, tenantIDOfGroup(item), alreadyPending, renderErr)
 	if renderErr != nil {

--- a/go/apiserver/admin_groups.go
+++ b/go/apiserver/admin_groups.go
@@ -1,0 +1,279 @@
+package apiserver
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+
+	"github.com/denisvmedia/inventario/jsonapi"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// adminGroupsAPI backs GET /admin/groups, GET /admin/groups/{groupID} and
+// DELETE /admin/groups/{groupID}. Holds the FactorySet directly (not the
+// per-request user-aware Set) because the admin surface intentionally
+// crosses tenants — using the user-aware registries would limit the admin
+// to their own tenant, defeating the surface.
+type adminGroupsAPI struct {
+	factorySet   *registry.FactorySet
+	auditService services.AuditLogger
+}
+
+// listGroups returns a paginated, filtered, sorted listing of every
+// location group in the deployment along with each group's computed
+// member_count.
+//
+// The endpoint crosses tenants by design — see RequireSystemAdmin gate —
+// and the registry layer bypasses RLS via `SET LOCAL row_security = off`
+// on the listing tx so the cross-tenant read fails loud on a
+// misconfigured connection role rather than returning a silently empty
+// page.
+//
+// @Summary List groups (admin)
+// @Description Returns every location group with computed member_count. Pagination via ?page&per_page; ?q matches name/slug (ILIKE).
+// @Description ?org_id and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
+// @Description Note: the tenant filter is named `org_id` (not `tenantID`) because the global ValidateNoUserProvidedTenantID security middleware rejects any query parameter whose name contains "tenant".
+// @Tags admin
+// @Produce json-api
+// @Param page query int false "Page number (default 1)"
+// @Param per_page query int false "Items per page (default 50, max 100)"
+// @Param q query string false "Search term — ILIKE match on name/slug"
+// @Param org_id query string false "Filter to groups belonging to this tenant ID (exact match). Named org_id rather than tenantID — the security middleware blocks query params containing 'tenant'."
+// @Param status query string false "Filter to groups in this status: active|pending_deletion (exact match)"
+// @Param sort query string false "Sort field: name|slug|created_at|status (prefix with - for desc)"
+// @Param order query string false "Sort direction override: asc|desc (wins over `-` prefix)"
+// @Success 200 {object} jsonapi.AdminGroupsResponse "OK"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Router /admin/groups [get]
+func (api *adminGroupsAPI) listGroups(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	page, perPage := parsePagination(q.Get("page"), q.Get("per_page"))
+
+	sortField, sortDesc := parseAdminSortAndOrder(q.Get("sort"), q.Get("order"))
+	opts := registry.AdminGroupListOptions{
+		Page:    page,
+		PerPage: perPage,
+		Query:   q.Get("q"),
+		// The tenant filter is read from `org_id`, not `tenantID`: the
+		// global ValidateNoUserProvidedTenantID middleware rejects any
+		// query parameter whose name contains the substring "tenant"
+		// (case-insensitive) as a cross-tenant-injection guard, so the
+		// issue's literal `tenantID` name is unusable on a live route.
+		TenantID:  q.Get("org_id"),
+		Status:    q.Get("status"),
+		SortField: registry.AdminGroupSortField(sortField),
+		SortDesc:  sortDesc,
+	}
+
+	items, total, err := api.factorySet.LocationGroupRegistry.ListAdmin(r.Context(), opts)
+	if err != nil {
+		api.auditList(r, err)
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	setPaginationHeaders(w, page, perPage, total)
+	// Audit AFTER render so a JSON-encoding / response-writer failure
+	// turns into a Success=false row instead of silently claiming the
+	// client got their data — see adminTenantsAPI.listTenants for the
+	// full rationale.
+	renderErr := render.Render(w, r, jsonapi.NewAdminGroupsResponse(items, page, perPage, total))
+	api.auditList(r, renderErr)
+	if renderErr != nil {
+		_ = internalServerError(w, r, renderErr)
+	}
+}
+
+// getGroup returns a single group detail row: name, slug, status,
+// currency, created_by, member_count and the owning-tenant chip.
+//
+// @Summary Get group (admin)
+// @Description Returns the group row with computed member_count and an owning-tenant chip (tenant id, name, slug). Crosses tenants by design.
+// @Tags admin
+// @Produce json-api
+// @Param groupID path string true "Group ID"
+// @Success 200 {object} jsonapi.AdminGroupResponse "OK"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 404 {object} jsonapi.Errors "Group not found"
+// @Router /admin/groups/{groupID} [get]
+func (api *adminGroupsAPI) getGroup(w http.ResponseWriter, r *http.Request) {
+	groupID := chi.URLParam(r, "groupID")
+	if groupID == "" {
+		api.auditGet(r, groupID, "", registry.ErrNotFound)
+		_ = renderEntityError(w, r, registry.ErrNotFound)
+		return
+	}
+
+	item, err := api.factorySet.LocationGroupRegistry.GetAdmin(r.Context(), groupID)
+	if err != nil {
+		api.auditGet(r, groupID, "", err)
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	// Audit AFTER render — see listGroups for the rationale.
+	renderErr := render.Render(w, r, jsonapi.NewAdminGroupResponse(item))
+	api.auditGet(r, groupID, tenantIDOfGroup(item), renderErr)
+	if renderErr != nil {
+		_ = internalServerError(w, r, renderErr)
+	}
+}
+
+// deleteGroup soft-deletes a group by flipping its status to
+// pending_deletion. The existing group_purge_worker then finishes the
+// hard-delete on its next sweep — there is no parallel purge code path;
+// the admin DELETE only owns the status transition, identical to
+// GroupService.InitiateGroupDeletion.
+//
+// Idempotent: re-deleting an already-pending group returns 200 with the
+// current status rather than erroring, so a retried request (or a second
+// operator clicking delete) is not surprised by a 4xx.
+//
+// @Summary Soft-delete a group (admin)
+// @Description Sets the group's status to `pending_deletion`; the group purge worker finishes the hard-delete asynchronously.
+// @Description Idempotent — re-deleting an already-pending group returns 200 with the current status. Returns the post-transition group row.
+// @Tags admin
+// @Produce json-api
+// @Param groupID path string true "Group ID"
+// @Success 200 {object} jsonapi.AdminGroupResponse "OK - group marked pending_deletion (or already was)"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 404 {object} jsonapi.Errors "Group not found"
+// @Router /admin/groups/{groupID} [delete]
+func (api *adminGroupsAPI) deleteGroup(w http.ResponseWriter, r *http.Request) {
+	groupID := chi.URLParam(r, "groupID")
+	if groupID == "" {
+		api.auditDelete(r, groupID, "", registry.ErrNotFound)
+		_ = renderEntityError(w, r, registry.ErrNotFound)
+		return
+	}
+
+	// MarkPendingDeletionAdmin owns the status transition (identical to
+	// GroupService.InitiateGroupDeletion) and reports whether the group
+	// was already pending so the idempotent re-delete renders a plain
+	// 200 instead of a re-write. The bool is data, not control flow:
+	// either way the post-state is pending_deletion and we render it.
+	alreadyPending, err := api.factorySet.LocationGroupRegistry.MarkPendingDeletionAdmin(r.Context(), groupID)
+	if err != nil {
+		api.auditDelete(r, groupID, "", err)
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	// Re-fetch the post-transition row so the response carries the
+	// updated status + the tenant chip the FE renders. A read failure
+	// here is a 500 — the soft-delete already committed, but the client
+	// contract is "return the row", so we surface the read error rather
+	// than fabricating a partial body.
+	item, getErr := api.factorySet.LocationGroupRegistry.GetAdmin(r.Context(), groupID)
+	if getErr != nil {
+		api.auditDelete(r, groupID, "", getErr)
+		_ = renderEntityError(w, r, getErr)
+		return
+	}
+
+	// Audit AFTER render. The audit row captures the admin actor, the
+	// group as subject, and the group's tenant — the spec's required
+	// trio. `already_pending` rides the breadcrumb so an operator can
+	// tell a genuine soft-delete from an idempotent no-op without
+	// re-deriving it from timestamps.
+	renderErr := render.Render(w, r, jsonapi.NewAdminGroupResponse(item))
+	api.auditDeleteResult(r, groupID, tenantIDOfGroup(item), alreadyPending, renderErr)
+	if renderErr != nil {
+		_ = internalServerError(w, r, renderErr)
+	}
+}
+
+// tenantIDOfGroup pulls the tenant ID off a resolved admin group detail
+// for the audit row's TenantID field. Returns "" when the detail or its
+// group is nil (a failed lookup path) so the audit helper records SQL
+// NULL rather than a bogus tenant.
+func tenantIDOfGroup(item *registry.AdminGroupDetail) string {
+	if item == nil || item.Group == nil {
+		return ""
+	}
+	return item.Group.TenantID
+}
+
+// auditList records an `admin.list_groups` audit row regardless of
+// success/failure. The cross-tenant listing has no single tenant or group
+// subject so SubjectType/SubjectID/TenantID stay nil — the admin actor and
+// the success/error pair are what the listing audit captures.
+func (api *adminGroupsAPI) auditList(r *http.Request, opErr error) {
+	if api.auditService == nil {
+		return
+	}
+	api.auditService.LogAdmin(r.Context(), services.AdminEvent{
+		Action:  "admin.list_groups",
+		ActorID: actorIDFromRequest(r),
+		Success: opErr == nil,
+		Request: r,
+		ErrMsg:  strPtrFromErr(opErr),
+	})
+}
+
+// auditGet records an `admin.get_group` audit row. Captures the target
+// group as subject and, when resolved, the group's tenant.
+func (api *adminGroupsAPI) auditGet(r *http.Request, groupID, tenantID string, opErr error) {
+	if api.auditService == nil {
+		return
+	}
+	api.auditService.LogAdmin(r.Context(), services.AdminEvent{
+		Action:      "admin.get_group",
+		ActorID:     actorIDFromRequest(r),
+		TenantID:    nullableString(tenantID),
+		SubjectType: stringPtr("group"),
+		SubjectID:   nullableString(groupID),
+		Success:     opErr == nil && !errors.Is(opErr, registry.ErrNotFound),
+		Request:     r,
+		ErrMsg:      strPtrFromErr(opErr),
+	})
+}
+
+// auditDelete records an `admin.delete_group` failure row for the early
+// error paths (missing ID, transition failure) where the post-transition
+// state was never observed. The success path uses auditDeleteResult so
+// the breadcrumb can carry `already_pending`.
+func (api *adminGroupsAPI) auditDelete(r *http.Request, groupID, tenantID string, opErr error) {
+	if api.auditService == nil {
+		return
+	}
+	api.auditService.LogAdmin(r.Context(), services.AdminEvent{
+		Action:      "admin.delete_group",
+		ActorID:     actorIDFromRequest(r),
+		TenantID:    nullableString(tenantID),
+		SubjectType: stringPtr("group"),
+		SubjectID:   nullableString(groupID),
+		Success:     opErr == nil && !errors.Is(opErr, registry.ErrNotFound),
+		Request:     r,
+		ErrMsg:      strPtrFromErr(opErr),
+	})
+}
+
+// auditDeleteResult records the `admin.delete_group` row for the path that
+// actually reached the soft-delete. It carries the required actor + group
+// + tenant trio and tucks `already_pending` into the breadcrumb so audit
+// consumers can distinguish a genuine transition from an idempotent
+// no-op. opErr here is the render error only — the soft-delete itself
+// already committed, so a render blip is a Success=false row.
+func (api *adminGroupsAPI) auditDeleteResult(r *http.Request, groupID, tenantID string, alreadyPending bool, opErr error) {
+	if api.auditService == nil {
+		return
+	}
+	api.auditService.LogAdmin(r.Context(), services.AdminEvent{
+		Action:      "admin.delete_group",
+		ActorID:     actorIDFromRequest(r),
+		TenantID:    nullableString(tenantID),
+		SubjectType: stringPtr("group"),
+		SubjectID:   nullableString(groupID),
+		Success:     opErr == nil,
+		Request:     r,
+		ErrMsg:      strPtrFromErr(opErr),
+		Extra:       map[string]any{"already_pending": alreadyPending},
+	})
+}

--- a/go/apiserver/admin_groups.go
+++ b/go/apiserver/admin_groups.go
@@ -32,17 +32,16 @@ type adminGroupsAPI struct {
 // read is therefore unconditional, not gated on a fail-loud trip-wire.
 //
 // @Summary List groups (admin)
-// @Description Returns every location group with computed member_count. Pagination via ?page&per_page; ?q matches name/slug (ILIKE).
-// @Description ?tenantID and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
+// @Description Returns every location group with computed member_count and an owning-tenant chip (id, name, slug). Paginate via ?page&per_page; ?q ILIKE-matches name/slug; ?tenantID/?status filter exactly; ?sort/?order set ordering.
 // @Tags admin
 // @Produce json-api
 // @Param page query int false "Page number (default 1)"
 // @Param per_page query int false "Items per page (default 50, max 100)"
 // @Param q query string false "Search term — ILIKE match on name/slug"
 // @Param tenantID query string false "Filter to groups belonging to this tenant ID (exact match)"
-// @Param status query string false "Filter to groups in this status: active|pending_deletion (exact match)"
+// @Param status query string false "Filter to groups in this status (exact match)" Enums(active,pending_deletion)
 // @Param sort query string false "Sort field: name|slug|created_at|status (prefix with - for desc)"
-// @Param order query string false "Sort direction override: asc|desc (wins over `-` prefix)"
+// @Param order query string false "Sort direction override (wins over `-` prefix)" Enums(asc,desc)
 // @Success 200 {object} jsonapi.AdminGroupsResponse "OK"
 // @Failure 401 {object} jsonapi.Errors "Unauthorized"
 // @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
@@ -140,8 +139,7 @@ func (api *adminGroupsAPI) getGroup(w http.ResponseWriter, r *http.Request) {
 // operator clicking delete) is not surprised by a 4xx.
 //
 // @Summary Soft-delete a group (admin)
-// @Description Sets the group's status to `pending_deletion`; the group purge worker finishes the hard-delete asynchronously.
-// @Description Idempotent — re-deleting an already-pending group returns 200 with the current status. Returns the post-transition group row.
+// @Description Sets the group's status to `pending_deletion`; the group purge worker finishes the hard-delete asynchronously. Idempotent — re-deleting an already-pending group returns 200. Returns the post-transition group row.
 // @Tags admin
 // @Produce json-api
 // @Param groupID path string true "Group ID"

--- a/go/apiserver/admin_groups_test.go
+++ b/go/apiserver/admin_groups_test.go
@@ -91,6 +91,24 @@ func TestAdminListGroups_AllowsSystemAdmin(t *testing.T) {
 	c.Assert(body.Meta.Total, qt.Equals, 4)
 	c.Assert(body.Data, qt.HasLen, 4)
 	c.Assert(rr.Header().Get("X-Total"), qt.Equals, "4")
+
+	// Assert the per-row tenant chip + member_count on one known seeded
+	// row: "Charlie Group" lives on the fixture's "Other Org" tenant. This
+	// covers the cross-tenant list contract (#1748) and catches JSON:API
+	// mapping regressions on the nested chip.
+	var charlie *jsonapi.AdminGroupListItem
+	for _, item := range body.Data {
+		if item.Name == "Charlie Group" {
+			charlie = item
+			break
+		}
+	}
+	c.Assert(charlie, qt.IsNotNil)
+	c.Assert(charlie.MemberCount, qt.Equals, 0)
+	c.Assert(charlie.Tenant, qt.IsNotNil)
+	c.Assert(charlie.Tenant.Name, qt.Equals, "Other Org")
+	c.Assert(charlie.Tenant.Slug, qt.Equals, "other-org")
+	c.Assert(charlie.Tenant.ID, qt.Equals, charlie.TenantID)
 }
 
 func TestAdminListGroups_DeniesNonAdmin(t *testing.T) {

--- a/go/apiserver/admin_groups_test.go
+++ b/go/apiserver/admin_groups_test.go
@@ -155,11 +155,12 @@ func TestAdminListGroups_FiltersAndPaginatesAndSorts(t *testing.T) {
 			expectedLen:   3,
 		},
 		{
-			// The tenant filter is `org_id`, not `tenantID` — the global
-			// ValidateNoUserProvidedTenantID middleware 403s any query
-			// param containing "tenant".
-			name:          "filter by org_id narrows to that tenant",
-			query:         "?org_id=" + otherTenant.ID,
+			// ?tenantID is the documented tenant filter. The global
+			// ValidateNoUserProvidedTenantID middleware would normally 403
+			// a query param containing "tenant", but it exempts the
+			// /api/v1/admin/* subtree — so this returns 200 and filters.
+			name:          "filter by tenantID narrows to that tenant",
+			query:         "?tenantID=" + otherTenant.ID,
 			expectedTotal: 1,
 			expectedLen:   1,
 		},

--- a/go/apiserver/admin_groups_test.go
+++ b/go/apiserver/admin_groups_test.go
@@ -1,0 +1,384 @@
+package apiserver_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/jsonapi"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// Groups admin handler tests (#1748). Cover the cross-tenant list (filter
+// combinations), the detail endpoint (tenant chip + member_count), the
+// idempotent soft-delete, the system-admin gate, and the audit trail.
+// Tests reuse promoteToSystemAdmin from admin_routes_test.go.
+
+// adminGroupFixture stands up a system-admin actor plus three additional
+// location groups across two tenants so the list/filter assertions have
+// real data to work with. Returns the params, the admin user, and the
+// IDs of the three seeded groups (the order matches the seeds slice).
+func adminGroupFixture(c *qt.C) (apiserver.Params, *models.User, []string) {
+	c.Helper()
+	params, user, _ := newParams()
+	promoteToSystemAdmin(c, params, user)
+
+	ctx := context.Background()
+	// A second tenant so the tenantID filter has something to discriminate.
+	otherTenant := must.Must(params.FactorySet.TenantRegistry.Create(ctx, models.Tenant{
+		Name:   "Other Org",
+		Slug:   "other-org",
+		Status: models.TenantStatusActive,
+		PlanID: models.PlanUnlimited.ID,
+	}))
+
+	seeds := []models.LocationGroup{
+		{
+			TenantAwareEntityID: models.TenantAwareEntityID{TenantID: user.TenantID},
+			Name:                "Alpha Group",
+			Slug:                must.Must(models.GenerateGroupSlug()),
+			Status:              models.LocationGroupStatusActive,
+			CreatedBy:           user.ID,
+			GroupCurrency:       models.Currency("USD"),
+		},
+		{
+			TenantAwareEntityID: models.TenantAwareEntityID{TenantID: user.TenantID},
+			Name:                "Bravo Group",
+			Slug:                must.Must(models.GenerateGroupSlug()),
+			Status:              models.LocationGroupStatusPendingDeletion,
+			CreatedBy:           user.ID,
+			GroupCurrency:       models.Currency("USD"),
+		},
+		{
+			TenantAwareEntityID: models.TenantAwareEntityID{TenantID: otherTenant.ID},
+			Name:                "Charlie Group",
+			Slug:                must.Must(models.GenerateGroupSlug()),
+			Status:              models.LocationGroupStatusActive,
+			CreatedBy:           user.ID,
+			GroupCurrency:       models.Currency("EUR"),
+		},
+	}
+	ids := make([]string, 0, len(seeds))
+	for _, g := range seeds {
+		created := must.Must(params.FactorySet.LocationGroupRegistry.Create(ctx, g))
+		ids = append(ids, created.ID)
+	}
+	return params, user, ids
+}
+
+func TestAdminListGroups_AllowsSystemAdmin(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := adminGroupFixture(c)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups", nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+
+	var body jsonapi.AdminGroupsResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
+	// newParams seeds one group; the fixture adds three more.
+	c.Assert(body.Meta.Total, qt.Equals, 4)
+	c.Assert(body.Data, qt.HasLen, 4)
+	c.Assert(rr.Header().Get("X-Total"), qt.Equals, "4")
+}
+
+func TestAdminListGroups_DeniesNonAdmin(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := newParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups", nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+	c.Assert(rr.Body.String(), qt.Contains, "admin.forbidden")
+}
+
+func TestAdminListGroups_DeniesUnauthenticated(t *testing.T) {
+	c := qt.New(t)
+	params, _, _ := newParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
+}
+
+func TestAdminListGroups_FiltersAndPaginatesAndSorts(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := adminGroupFixture(c)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// The fixture's "Other Org" tenant ID is needed for the tenantID
+	// filter case — resolve it via the seeded group on that tenant.
+	otherTenant := must.Must(params.FactorySet.TenantRegistry.GetBySlug(context.Background(), "other-org"))
+
+	tests := []struct {
+		name              string
+		query             string
+		expectedTotal     int
+		expectedLen       int
+		expectedFirstName string
+	}{
+		{
+			name:              "filter by q narrows to one row",
+			query:             "?q=alpha",
+			expectedTotal:     1,
+			expectedLen:       1,
+			expectedFirstName: "Alpha Group",
+		},
+		{
+			name:          "filter by status pending_deletion",
+			query:         "?status=pending_deletion",
+			expectedTotal: 1,
+			expectedLen:   1,
+		},
+		{
+			name:          "filter by status active",
+			query:         "?status=active",
+			expectedTotal: 3,
+			expectedLen:   3,
+		},
+		{
+			// The tenant filter is `org_id`, not `tenantID` — the global
+			// ValidateNoUserProvidedTenantID middleware 403s any query
+			// param containing "tenant".
+			name:          "filter by org_id narrows to that tenant",
+			query:         "?org_id=" + otherTenant.ID,
+			expectedTotal: 1,
+			expectedLen:   1,
+		},
+		{
+			name:          "combined q + status returns empty when no overlap",
+			query:         "?q=alpha&status=pending_deletion",
+			expectedTotal: 0,
+			expectedLen:   0,
+		},
+		{
+			name:          "pagination caps per_page",
+			query:         "?per_page=2",
+			expectedTotal: 4,
+			expectedLen:   2,
+		},
+		{
+			name:              "sort descending by name via dash prefix",
+			query:             "?sort=-name",
+			expectedTotal:     4,
+			expectedLen:       4,
+			expectedFirstName: "Test Group", // seeded by newParams, sorts last asc → first desc
+		},
+		{
+			name:              "sort by name ascending via explicit order",
+			query:             "?sort=name&order=asc",
+			expectedTotal:     4,
+			expectedLen:       4,
+			expectedFirstName: "Alpha Group",
+		},
+	}
+	for _, tc := range tests {
+		c.Run(tc.name, func(c *qt.C) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups"+tc.query, nil)
+			addTestUserAuthHeader(req, user.ID)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			c.Assert(rr.Code, qt.Equals, http.StatusOK)
+			var body jsonapi.AdminGroupsResponse
+			c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
+			c.Assert(body.Meta.Total, qt.Equals, tc.expectedTotal)
+			c.Assert(body.Data, qt.HasLen, tc.expectedLen)
+			if tc.expectedFirstName != "" {
+				c.Assert(body.Data[0].Name, qt.Equals, tc.expectedFirstName)
+			}
+		})
+	}
+}
+
+func TestAdminGetGroup_ReturnsRowWithTenantChipAndMemberCount(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := newParams()
+	promoteToSystemAdmin(c, params, user)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// newParams seeds exactly one group on the actor's tenant with one
+	// membership (the creator). Resolve it for the detail assertion.
+	groups := must.Must(params.FactorySet.LocationGroupRegistry.ListByTenant(context.Background(), user.TenantID))
+	c.Assert(groups, qt.HasLen, 1)
+	group := groups[0]
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/groups/%s", group.ID), nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	var body jsonapi.AdminGroupResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
+	c.Assert(body.Data, qt.IsNotNil)
+	c.Assert(body.Data.ID, qt.Equals, group.ID)
+	c.Assert(body.Data.TenantID, qt.Equals, user.TenantID)
+	c.Assert(body.Data.MemberCount, qt.Equals, 1)
+	c.Assert(body.Data.Tenant, qt.IsNotNil)
+	c.Assert(body.Data.Tenant.ID, qt.Equals, user.TenantID)
+}
+
+func TestAdminGetGroup_404OnMissingID(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := adminGroupFixture(c)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups/does-not-exist", nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+func TestAdminGetGroup_DeniesNonAdmin(t *testing.T) {
+	c := qt.New(t)
+	params, user, ids := adminGroupFixture(c)
+	// Demote: adminGroupFixture promotes, so build a separate non-admin.
+	nonAdmin := createTestUserDirect(c, params, user.TenantID, "plain@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/groups/%s", ids[0]), nil)
+	addTestUserAuthHeader(req, nonAdmin.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+}
+
+func TestAdminDeleteGroup_MarksPendingDeletion(t *testing.T) {
+	c := qt.New(t)
+	params, user, ids := adminGroupFixture(c)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// ids[0] is the active "Alpha Group".
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/admin/groups/%s", ids[0]), nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	var body jsonapi.AdminGroupResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
+	c.Assert(body.Data, qt.IsNotNil)
+	c.Assert(body.Data.Status, qt.Equals, models.LocationGroupStatusPendingDeletion)
+
+	// And the registry row reflects the transition.
+	stored := must.Must(params.FactorySet.LocationGroupRegistry.Get(context.Background(), ids[0]))
+	c.Assert(stored.Status, qt.Equals, models.LocationGroupStatusPendingDeletion)
+}
+
+func TestAdminDeleteGroup_IdempotentReDelete(t *testing.T) {
+	c := qt.New(t)
+	params, user, ids := adminGroupFixture(c)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// ids[1] is the "Bravo Group" seeded already in pending_deletion —
+	// a re-delete must still return 200 with the current status, never
+	// a 4xx.
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/admin/groups/%s", ids[1]), nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	var body jsonapi.AdminGroupResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
+	c.Assert(body.Data.Status, qt.Equals, models.LocationGroupStatusPendingDeletion)
+}
+
+func TestAdminDeleteGroup_404OnMissingID(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := adminGroupFixture(c)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/groups/does-not-exist", nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+func TestAdminDeleteGroup_DeniesNonAdmin(t *testing.T) {
+	c := qt.New(t)
+	params, user, ids := adminGroupFixture(c)
+	nonAdmin := createTestUserDirect(c, params, user.TenantID, "plain@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/admin/groups/%s", ids[0]), nil)
+	addTestUserAuthHeader(req, nonAdmin.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+
+	// The guard rejected before the transition could fire.
+	stored := must.Must(params.FactorySet.LocationGroupRegistry.Get(context.Background(), ids[0]))
+	c.Assert(stored.Status, qt.Equals, models.LocationGroupStatusActive)
+}
+
+func TestAdminListGroups_WritesAuditLog(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := adminGroupFixture(c)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups", nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+
+	entries := must.Must(params.FactorySet.AuditLogRegistry.ListByAction(context.Background(), "admin.list_groups"))
+	c.Assert(entries, qt.HasLen, 1)
+	c.Assert(entries[0].Success, qt.IsTrue)
+	c.Assert(entries[0].UserID, qt.IsNotNil)
+	c.Assert(*entries[0].UserID, qt.Equals, user.ID)
+}
+
+func TestAdminDeleteGroup_WritesAuditLogWithActorGroupAndTenant(t *testing.T) {
+	c := qt.New(t)
+	params, user, ids := adminGroupFixture(c)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/admin/groups/%s", ids[0]), nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+
+	entries := must.Must(params.FactorySet.AuditLogRegistry.ListByAction(context.Background(), "admin.delete_group"))
+	c.Assert(entries, qt.HasLen, 1)
+	entry := entries[0]
+	c.Assert(entry.Success, qt.IsTrue)
+	// Admin user ID (actor).
+	c.Assert(entry.UserID, qt.IsNotNil)
+	c.Assert(*entry.UserID, qt.Equals, user.ID)
+	// Group ID (subject).
+	c.Assert(entry.EntityID, qt.IsNotNil)
+	c.Assert(*entry.EntityID, qt.Equals, ids[0])
+	c.Assert(entry.EntityType, qt.IsNotNil)
+	c.Assert(*entry.EntityType, qt.Equals, "group")
+	// Tenant ID of the group.
+	c.Assert(entry.TenantID, qt.IsNotNil)
+	c.Assert(*entry.TenantID, qt.Equals, user.TenantID)
+}

--- a/go/apiserver/admin_groups_test.go
+++ b/go/apiserver/admin_groups_test.go
@@ -256,6 +256,81 @@ func TestAdminGetGroup_ReturnsRowWithTenantChipAndMemberCount(t *testing.T) {
 	c.Assert(body.Data.Tenant.ID, qt.Equals, user.TenantID)
 }
 
+// TestAdminListGroups_OrphanedGroupStaysVisible proves a group whose
+// tenant row is missing/corrupt still appears in the cross-tenant admin
+// list with a nil Tenant chip — the LEFT JOIN (postgres) /
+// ErrNotFound-swallowing resolveTenant (memory) keep orphaned groups
+// visible instead of silently dropping them, which is exactly what an
+// admin debugging surface needs.
+func TestAdminListGroups_OrphanedGroupStaysVisible(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := newParams()
+	promoteToSystemAdmin(c, params, user)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	ctx := context.Background()
+	// A group pointing at a tenant id that has no tenants row.
+	orphan := must.Must(params.FactorySet.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: "tenant-does-not-exist"},
+		Name:                "Orphan Group",
+		Slug:                must.Must(models.GenerateGroupSlug()),
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           user.ID,
+		GroupCurrency:       models.Currency("USD"),
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups", nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	var body jsonapi.AdminGroupsResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
+
+	var found *jsonapi.AdminGroupListItem
+	for _, item := range body.Data {
+		if item.ID == orphan.ID {
+			found = item
+			break
+		}
+	}
+	c.Assert(found, qt.IsNotNil)
+	c.Assert(found.Tenant, qt.IsNil)
+}
+
+// TestAdminGetGroup_OrphanedGroupReturnedWithNilTenant proves GetAdmin
+// returns the group (not 404) when its tenant row is missing — ErrNotFound
+// is reserved for a genuinely absent group row, not an absent tenant.
+func TestAdminGetGroup_OrphanedGroupReturnedWithNilTenant(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := newParams()
+	promoteToSystemAdmin(c, params, user)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	ctx := context.Background()
+	orphan := must.Must(params.FactorySet.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: "tenant-does-not-exist"},
+		Name:                "Orphan Group",
+		Slug:                must.Must(models.GenerateGroupSlug()),
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           user.ID,
+		GroupCurrency:       models.Currency("USD"),
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/groups/%s", orphan.ID), nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	var body jsonapi.AdminGroupResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
+	c.Assert(body.Data, qt.IsNotNil)
+	c.Assert(body.Data.ID, qt.Equals, orphan.ID)
+	c.Assert(body.Data.Tenant, qt.IsNil)
+}
+
 func TestAdminGetGroup_404OnMissingID(t *testing.T) {
 	c := qt.New(t)
 	params, user, _ := adminGroupFixture(c)

--- a/go/apiserver/admin_groups_test.go
+++ b/go/apiserver/admin_groups_test.go
@@ -305,6 +305,17 @@ func TestAdminDeleteGroup_IdempotentReDelete(t *testing.T) {
 	var body jsonapi.AdminGroupResponse
 	c.Assert(json.Unmarshal(rr.Body.Bytes(), &body), qt.IsNil)
 	c.Assert(body.Data.Status, qt.Equals, models.LocationGroupStatusPendingDeletion)
+
+	// An idempotent re-delete still records an admin.delete_group audit
+	// row — an operator auditing "did this delete happen?" must see the
+	// attempt — and its breadcrumb carries already_pending=true so the
+	// no-op is distinguishable from a genuine transition.
+	entries := must.Must(params.FactorySet.AuditLogRegistry.ListByAction(context.Background(), "admin.delete_group"))
+	c.Assert(entries, qt.HasLen, 1)
+	c.Assert(entries[0].Success, qt.IsTrue)
+	var bc map[string]any
+	c.Assert(json.Unmarshal([]byte(entries[0].UserAgent), &bc), qt.IsNil)
+	c.Assert(bc["already_pending"], qt.Equals, true)
 }
 
 func TestAdminDeleteGroup_404OnMissingID(t *testing.T) {
@@ -382,4 +393,10 @@ func TestAdminDeleteGroup_WritesAuditLogWithActorGroupAndTenant(t *testing.T) {
 	// Tenant ID of the group.
 	c.Assert(entry.TenantID, qt.IsNotNil)
 	c.Assert(*entry.TenantID, qt.Equals, user.TenantID)
+	// ids[0] was active, so a genuine first delete: the breadcrumb must
+	// carry already_pending=false to distinguish it from an idempotent
+	// no-op (see TestAdminDeleteGroup_IdempotentReDelete).
+	var bc map[string]any
+	c.Assert(json.Unmarshal([]byte(entry.UserAgent), &bc), qt.IsNil)
+	c.Assert(bc["already_pending"], qt.Equals, false)
 }

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -73,6 +73,10 @@ func Admin(params AdminParams) func(r chi.Router) {
 		blacklist:    params.Blacklist,
 		auditService: params.AuditService,
 	}
+	groupsAPI := &adminGroupsAPI{
+		factorySet:   params.FactorySet,
+		auditService: params.AuditService,
+	}
 	return func(r chi.Router) {
 		// RequireSystemAdmin runs as the first per-subtree middleware so
 		// every handler below it can assume the caller is a system admin.
@@ -94,6 +98,15 @@ func Admin(params AdminParams) func(r chi.Router) {
 		// audit-logs reason+forced via the breadcrumb in user_agent.
 		r.Post("/users/{userID}/block", usersAPI.blockUser)
 		r.Post("/users/{userID}/unblock", usersAPI.unblockUser)
+
+		// #1748: cross-tenant groups admin. List + detail bypass RLS at
+		// the registry layer (SET LOCAL row_security = off); DELETE flips
+		// status to pending_deletion (idempotent) and the existing
+		// group_purge_worker finishes the hard-delete. Each handler
+		// audit-logs via params.AuditService.
+		r.Get("/groups", groupsAPI.listGroups)
+		r.Get("/groups/{groupID}", groupsAPI.getGroup)
+		r.Delete("/groups/{groupID}", groupsAPI.deleteGroup)
 	}
 }
 

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -110,33 +110,27 @@ func Admin(params AdminParams) func(r chi.Router) {
 	}
 }
 
-// parseAdminSort splits a `?sort=<field>` query value into the (field, desc)
-// pair the registry layer expects. A leading `-` reverses the natural
-// order (e.g. `-created_at` → desc by created_at). Unknown fields are
-// left as-is and the registry layer falls back to its default sort —
-// surface drift across FE/BE versions is intentionally tolerated to
-// keep the listing endpoint responsive during deploys.
-func parseAdminSort(raw string) (field string, desc bool) {
-	if raw == "" {
-		return "", false
-	}
-	if raw[0] == '-' {
-		return raw[1:], true
-	}
-	return raw, false
-}
-
 // parseAdminSortAndOrder reconciles the dual sort conventions the
 // admin FE may send: the `?sort=-name` shorthand (consistent with the
 // rest of the API) or the explicit `?sort=name&order=desc` pair (which
-// some FE table libs prefer). An explicit `order=` param always wins
-// over a leading `-` prefix so the FE never has to strip the prefix
-// before re-sending the current sort with a flipped direction. Unknown
-// `order=` values (e.g. `?order=ascending`) are intentionally ignored
-// rather than rejected so the FE can drift slightly across versions —
-// the registry layer further whitelists the sort field via IsValid().
+// some FE table libs prefer).
+//
+// A leading `-` on `?sort` reverses the natural order (e.g. `-created_at`
+// → desc by created_at). An explicit `order=` param always wins over that
+// prefix so the FE never has to strip the prefix before re-sending the
+// current sort with a flipped direction. Unknown `order=` values (e.g.
+// `?order=ascending`) and unknown sort fields are intentionally tolerated
+// rather than rejected so the FE can drift slightly across versions — the
+// registry layer falls back to its default sort and whitelists the field
+// via IsValid().
 func parseAdminSortAndOrder(rawSort, rawOrder string) (field string, desc bool) {
-	field, desc = parseAdminSort(rawSort)
+	if rawSort != "" {
+		if rawSort[0] == '-' {
+			field, desc = rawSort[1:], true
+		} else {
+			field, desc = rawSort, false
+		}
+	}
 	switch strings.ToLower(strings.TrimSpace(rawOrder)) {
 	case "asc":
 		desc = false

--- a/go/apiserver/security_middleware.go
+++ b/go/apiserver/security_middleware.go
@@ -9,75 +9,133 @@ import (
 	"strings"
 )
 
+// adminSubtreePathPrefix is the request-path prefix of the platform-admin
+// subtree. The router mounts Route("/admin", ...) inside the "/api/v1"
+// group (see APIServer in apiserver.go), so every admin request path
+// begins with exactly this string. The trailing slash is deliberate: it
+// makes the prefix match an actual sub-route and not an unrelated sibling
+// path such as "/api/v1/administrate".
+const adminSubtreePathPrefix = "/api/v1/admin/"
+
+// isAdminSubtreePath reports whether the request targets the platform-admin
+// subtree (/api/v1/admin/*). Used by ValidateNoUserProvidedTenantID to
+// exempt that subtree — and only that subtree — from the query-parameter
+// "tenant" check.
+func isAdminSubtreePath(path string) bool {
+	return strings.HasPrefix(path, adminSubtreePathPrefix)
+}
+
+// tenantSecurityViolationMsg is the response body returned to the client
+// whenever ValidateNoUserProvidedTenantID rejects a request.
+const tenantSecurityViolationMsg = "Security violation: tenant information cannot be provided by user"
+
+// rejectTenantHeader checks request headers for any name containing
+// "tenant" (case-insensitive). Returns true — having written a 403 — when a
+// violation was found; false when the headers are clean.
+func rejectTenantHeader(w http.ResponseWriter, r *http.Request) bool {
+	for headerName, headerValues := range r.Header {
+		if !strings.Contains(strings.ToLower(headerName), "tenant") {
+			continue
+		}
+		slog.Error("Security violation: user-provided tenant ID in header",
+			"header", headerName,
+			"value", strings.Join(headerValues, ","),
+			"user_agent", r.UserAgent(),
+			"remote_addr", r.RemoteAddr,
+			"method", r.Method,
+			"path", r.URL.Path,
+		)
+		http.Error(w, tenantSecurityViolationMsg, http.StatusForbidden)
+		return true
+	}
+	return false
+}
+
+// rejectTenantQueryParam checks query parameters for any name containing
+// "tenant" (case-insensitive). Returns true — having written a 403 — when a
+// violation was found; false when the query string is clean.
+//
+// This check is exempted for the platform-admin subtree (/api/v1/admin/*),
+// which is cross-tenant BY DESIGN and gated by RequireSystemAdmin. A system
+// admin supplying ?tenantID=<id> there is using a documented listing
+// *filter*, not injecting a tenant context: admin handlers resolve data
+// through the FactorySet directly (not the RLS-context-derived per-request
+// tenant), so a tenantID query value is never consumed as a tenant-context
+// override and cannot escalate access beyond what RequireSystemAdmin
+// already grants. This middleware runs before JWT/RequireSystemAdmin, so a
+// non-admin hitting /api/v1/admin/groups?tenantID=x passes this check but
+// is still rejected downstream by RequireSystemAdmin — no security
+// regression. The exemption is query-parameter only; rejectTenantHeader
+// and rejectTenantBody stay fully in force for admin paths.
+func rejectTenantQueryParam(w http.ResponseWriter, r *http.Request) bool {
+	if isAdminSubtreePath(r.URL.Path) {
+		return false
+	}
+	for paramName, paramValues := range r.URL.Query() {
+		if !strings.Contains(strings.ToLower(paramName), "tenant") {
+			continue
+		}
+		slog.Error("Security violation: user-provided tenant ID in query parameter",
+			"param", paramName,
+			"value", strings.Join(paramValues, ","),
+			"user_agent", r.UserAgent(),
+			"remote_addr", r.RemoteAddr,
+			"method", r.Method,
+			"path", r.URL.Path,
+		)
+		http.Error(w, tenantSecurityViolationMsg, http.StatusForbidden)
+		return true
+	}
+	return false
+}
+
+// rejectTenantBody checks the request body of mutating requests for
+// tenant_id fields. It reads and restores the body so downstream handlers
+// still see it. Returns true — having written a 4xx — when a violation (or
+// a body-read failure) was found; false when the body is clean or the
+// method is not body-bearing.
+func rejectTenantBody(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method != http.MethodPost && r.Method != http.MethodPut && r.Method != http.MethodPatch {
+		return false
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		slog.Error("Failed to read request body for security validation", "error", err)
+		http.Error(w, "Failed to read request body", http.StatusBadRequest)
+		return true
+	}
+	// Restore body for downstream handlers.
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	bodyLower := strings.ToLower(string(body))
+	if !strings.Contains(bodyLower, "tenant_id") &&
+		!strings.Contains(bodyLower, "\"tenant\"") &&
+		!strings.Contains(bodyLower, "'tenant'") {
+		return false
+	}
+	slog.Error("Security violation: user-provided tenant ID in request body",
+		"content_type", r.Header.Get("Content-Type"),
+		"body_preview", truncateString(string(body), 200),
+		"user_agent", r.UserAgent(),
+		"remote_addr", r.RemoteAddr,
+		"method", r.Method,
+		"path", r.URL.Path,
+	)
+	http.Error(w, tenantSecurityViolationMsg, http.StatusForbidden)
+	return true
+}
+
 // ValidateNoUserProvidedTenantID creates middleware that rejects any user-provided tenant information
 // This is critical for preventing cross-tenant data access attacks
 func ValidateNoUserProvidedTenantID() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// 1. Check headers for tenant_id (case-insensitive)
-			for headerName, headerValues := range r.Header {
-				headerLower := strings.ToLower(headerName)
-				if strings.Contains(headerLower, "tenant") {
-					slog.Error("Security violation: user-provided tenant ID in header",
-						"header", headerName,
-						"value", strings.Join(headerValues, ","),
-						"user_agent", r.UserAgent(),
-						"remote_addr", r.RemoteAddr,
-						"method", r.Method,
-						"path", r.URL.Path,
-					)
-					http.Error(w, "Security violation: tenant information cannot be provided by user", http.StatusForbidden)
-					return
-				}
+			if rejectTenantHeader(w, r) ||
+				rejectTenantQueryParam(w, r) ||
+				rejectTenantBody(w, r) {
+				return
 			}
-
-			// 2. Check query parameters for tenant_id (case-insensitive)
-			for paramName, paramValues := range r.URL.Query() {
-				paramLower := strings.ToLower(paramName)
-				if strings.Contains(paramLower, "tenant") {
-					slog.Error("Security violation: user-provided tenant ID in query parameter",
-						"param", paramName,
-						"value", strings.Join(paramValues, ","),
-						"user_agent", r.UserAgent(),
-						"remote_addr", r.RemoteAddr,
-						"method", r.Method,
-						"path", r.URL.Path,
-					)
-					http.Error(w, "Security violation: tenant information cannot be provided by user", http.StatusForbidden)
-					return
-				}
-			}
-
-			// 3. Check request body for tenant_id fields (for POST/PUT/PATCH requests)
-			if r.Method == "POST" || r.Method == "PUT" || r.Method == "PATCH" {
-				body, err := io.ReadAll(r.Body)
-				if err != nil {
-					slog.Error("Failed to read request body for security validation", "error", err)
-					http.Error(w, "Failed to read request body", http.StatusBadRequest)
-					return
-				}
-
-				// Restore body for downstream handlers
-				r.Body = io.NopCloser(bytes.NewBuffer(body))
-
-				// Check for tenant_id in request body (case-insensitive)
-				bodyLower := strings.ToLower(string(body))
-				if strings.Contains(bodyLower, "tenant_id") ||
-					strings.Contains(bodyLower, "\"tenant\"") ||
-					strings.Contains(bodyLower, "'tenant'") {
-					slog.Error("Security violation: user-provided tenant ID in request body",
-						"content_type", r.Header.Get("Content-Type"),
-						"body_preview", truncateString(string(body), 200),
-						"user_agent", r.UserAgent(),
-						"remote_addr", r.RemoteAddr,
-						"method", r.Method,
-						"path", r.URL.Path,
-					)
-					http.Error(w, "Security violation: tenant information cannot be provided by user", http.StatusForbidden)
-					return
-				}
-			}
-
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/go/apiserver/security_middleware_test.go
+++ b/go/apiserver/security_middleware_test.go
@@ -1,0 +1,99 @@
+package apiserver_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/apiserver"
+)
+
+// TestValidateNoUserProvidedTenantID_AdminSubtreeQueryExemption verifies the
+// narrow exemption added for #1748: the /api/v1/admin/* subtree is exempt
+// from the query-parameter "tenant" check (so the documented ?tenantID=
+// listing filter works), while every other path — and the header / body
+// checks on every path including admin — stay fully enforced.
+func TestValidateNoUserProvidedTenantID_AdminSubtreeQueryExemption(t *testing.T) {
+	// downstream is the handler the middleware wraps; reaching it means the
+	// middleware allowed the request through (200). A 403 means the
+	// middleware rejected it before downstream ever ran.
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := apiserver.ValidateNoUserProvidedTenantID()(downstream)
+
+	tests := []struct {
+		name       string
+		method     string
+		target     string
+		header     [2]string // name, value; empty name = no header
+		wantStatus int
+	}{
+		{
+			name:       "admin path with tenantID query param is allowed",
+			method:     http.MethodGet,
+			target:     "/api/v1/admin/groups?tenantID=tenant-xyz",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "non-admin path with tenant query param is still rejected",
+			method:     http.MethodGet,
+			target:     "/api/v1/groups?tenantID=tenant-xyz",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "admin path with tenant header is still rejected",
+			method:     http.MethodGet,
+			target:     "/api/v1/admin/groups",
+			header:     [2]string{"X-Tenant-ID", "tenant-xyz"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			// A sibling path that merely shares the "/api/v1/admin" stem
+			// but is not under the "/api/v1/admin/" subtree must NOT be
+			// exempt — the trailing slash in the prefix guards this.
+			name:       "admin-prefixed sibling path is not exempt",
+			method:     http.MethodGet,
+			target:     "/api/v1/administrate?tenantID=tenant-xyz",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			req := httptest.NewRequest(tc.method, tc.target, nil)
+			if tc.header[0] != "" {
+				req.Header.Set(tc.header[0], tc.header[1])
+			}
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			c.Assert(rr.Code, qt.Equals, tc.wantStatus)
+		})
+	}
+}
+
+// TestValidateNoUserProvidedTenantID_AdminSubtreeBodyCheckEnforced verifies
+// that the request-body "tenant_id" check stays in force for admin paths —
+// the #1748 exemption relaxes the query-parameter check ONLY.
+func TestValidateNoUserProvidedTenantID_AdminSubtreeBodyCheckEnforced(t *testing.T) {
+	c := qt.New(t)
+
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := apiserver.ValidateNoUserProvidedTenantID()(downstream)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/groups",
+		strings.NewReader(`{"tenant_id":"tenant-xyz"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+}

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -54,6 +54,174 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/groups": {
+            "get": {
+                "description": "Returns every location group with computed member_count. Pagination via ?page\u0026per_page; ?q matches name/slug (ILIKE).\n?org_id and ?status are exact-match filters; ?sort=\u003cfield\u003e with optional ` + "`" + `-` + "`" + ` prefix for desc, or explicit ?order=asc|desc.\nNote: the tenant filter is named ` + "`" + `org_id` + "`" + ` (not ` + "`" + `tenantID` + "`" + `) because the global ValidateNoUserProvidedTenantID security middleware rejects any query parameter whose name contains \"tenant\".",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "List groups (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (default 50, max 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search term — ILIKE match on name/slug",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to groups belonging to this tenant ID (exact match). Named org_id rather than tenantID — the security middleware blocks query params containing 'tenant'.",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to groups in this status: active|pending_deletion (exact match)",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort field: name|slug|created_at|status (prefix with - for desc)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort direction override: asc|desc (wins over ` + "`" + `-` + "`" + ` prefix)",
+                        "name": "order",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AdminGroupsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/groups/{groupID}": {
+            "get": {
+                "description": "Returns the group row with computed member_count and an owning-tenant chip (tenant id, name, slug). Crosses tenants by design.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get group (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "groupID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AdminGroupResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Group not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Sets the group's status to ` + "`" + `pending_deletion` + "`" + `; the group purge worker finishes the hard-delete asynchronously.\nIdempotent — re-deleting an already-pending group returns 200 with the current status. Returns the post-transition group row.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Soft-delete a group (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "groupID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK - group marked pending_deletion (or already was)",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AdminGroupResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Group not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/tenants": {
             "get": {
                 "description": "Returns every tenant with computed user_count and group_count. Pagination via ?page\u0026per_page; ?q matches name/slug/domain (ILIKE); ?sort=\u003cfield\u003e with optional ` + "`" + `-` + "`" + ` prefix for desc, or explicit ?order=asc|desc.",
@@ -7233,6 +7401,129 @@ const docTemplate = `{
                 },
                 "operating_system": {
                     "type": "string"
+                }
+            }
+        },
+        "jsonapi.AdminGroupDetail": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "member_count": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/models.LocationGroupStatus"
+                },
+                "tenant": {
+                    "$ref": "#/definitions/jsonapi.AdminGroupTenantChip"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "admin_groups"
+                    ],
+                    "example": "admin_groups"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "jsonapi.AdminGroupListItem": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "member_count": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/models.LocationGroupStatus"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "admin_groups"
+                    ],
+                    "example": "admin_groups"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "jsonapi.AdminGroupResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.AdminGroupDetail"
+                }
+            }
+        },
+        "jsonapi.AdminGroupTenantChip": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                }
+            }
+        },
+        "jsonapi.AdminGroupsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/jsonapi.AdminGroupListItem"
+                    }
+                },
+                "meta": {
+                    "$ref": "#/definitions/jsonapi.AdminListMeta"
                 }
             }
         },

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -56,7 +56,7 @@ const docTemplate = `{
         },
         "/admin/groups": {
             "get": {
-                "description": "Returns every location group with computed member_count. Pagination via ?page\u0026per_page; ?q matches name/slug (ILIKE).\n?tenantID and ?status are exact-match filters; ?sort=\u003cfield\u003e with optional ` + "`" + `-` + "`" + ` prefix for desc, or explicit ?order=asc|desc.",
+                "description": "Returns every location group with computed member_count and an owning-tenant chip (id, name, slug). Paginate via ?page\u0026per_page; ?q ILIKE-matches name/slug; ?tenantID/?status filter exactly; ?sort/?order set ordering.",
                 "produces": [
                     "application/vnd.api+json"
                 ],
@@ -90,8 +90,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "active",
+                            "pending_deletion"
+                        ],
                         "type": "string",
-                        "description": "Filter to groups in this status: active|pending_deletion (exact match)",
+                        "description": "Filter to groups in this status (exact match)",
                         "name": "status",
                         "in": "query"
                     },
@@ -102,8 +106,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
                         "type": "string",
-                        "description": "Sort direction override: asc|desc (wins over ` + "`" + `-` + "`" + ` prefix)",
+                        "description": "Sort direction override (wins over ` + "`" + `-` + "`" + ` prefix)",
                         "name": "order",
                         "in": "query"
                     }
@@ -177,7 +185,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Sets the group's status to ` + "`" + `pending_deletion` + "`" + `; the group purge worker finishes the hard-delete asynchronously.\nIdempotent — re-deleting an already-pending group returns 200 with the current status. Returns the post-transition group row.",
+                "description": "Sets the group's status to ` + "`" + `pending_deletion` + "`" + `; the group purge worker finishes the hard-delete asynchronously. Idempotent — re-deleting an already-pending group returns 200. Returns the post-transition group row.",
                 "produces": [
                     "application/vnd.api+json"
                 ],
@@ -7475,6 +7483,9 @@ const docTemplate = `{
                 },
                 "status": {
                     "$ref": "#/definitions/models.LocationGroupStatus"
+                },
+                "tenant": {
+                    "$ref": "#/definitions/jsonapi.AdminGroupTenantChip"
                 },
                 "tenant_id": {
                     "type": "string"

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -56,7 +56,7 @@ const docTemplate = `{
         },
         "/admin/groups": {
             "get": {
-                "description": "Returns every location group with computed member_count. Pagination via ?page\u0026per_page; ?q matches name/slug (ILIKE).\n?org_id and ?status are exact-match filters; ?sort=\u003cfield\u003e with optional ` + "`" + `-` + "`" + ` prefix for desc, or explicit ?order=asc|desc.\nNote: the tenant filter is named ` + "`" + `org_id` + "`" + ` (not ` + "`" + `tenantID` + "`" + `) because the global ValidateNoUserProvidedTenantID security middleware rejects any query parameter whose name contains \"tenant\".",
+                "description": "Returns every location group with computed member_count. Pagination via ?page\u0026per_page; ?q matches name/slug (ILIKE).\n?tenantID and ?status are exact-match filters; ?sort=\u003cfield\u003e with optional ` + "`" + `-` + "`" + ` prefix for desc, or explicit ?order=asc|desc.",
                 "produces": [
                     "application/vnd.api+json"
                 ],
@@ -85,8 +85,8 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Filter to groups belonging to this tenant ID (exact match). Named org_id rather than tenantID — the security middleware blocks query params containing 'tenant'.",
-                        "name": "org_id",
+                        "description": "Filter to groups belonging to this tenant ID (exact match)",
+                        "name": "tenantID",
                         "in": "query"
                     },
                     {

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -49,7 +49,7 @@
         },
         "/admin/groups": {
             "get": {
-                "description": "Returns every location group with computed member_count. Pagination via ?page\u0026per_page; ?q matches name/slug (ILIKE).\n?org_id and ?status are exact-match filters; ?sort=\u003cfield\u003e with optional `-` prefix for desc, or explicit ?order=asc|desc.\nNote: the tenant filter is named `org_id` (not `tenantID`) because the global ValidateNoUserProvidedTenantID security middleware rejects any query parameter whose name contains \"tenant\".",
+                "description": "Returns every location group with computed member_count. Pagination via ?page\u0026per_page; ?q matches name/slug (ILIKE).\n?tenantID and ?status are exact-match filters; ?sort=\u003cfield\u003e with optional `-` prefix for desc, or explicit ?order=asc|desc.",
                 "produces": [
                     "application/vnd.api+json"
                 ],
@@ -78,8 +78,8 @@
                     },
                     {
                         "type": "string",
-                        "description": "Filter to groups belonging to this tenant ID (exact match). Named org_id rather than tenantID — the security middleware blocks query params containing 'tenant'.",
-                        "name": "org_id",
+                        "description": "Filter to groups belonging to this tenant ID (exact match)",
+                        "name": "tenantID",
                         "in": "query"
                     },
                     {

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -47,6 +47,174 @@
                 }
             }
         },
+        "/admin/groups": {
+            "get": {
+                "description": "Returns every location group with computed member_count. Pagination via ?page\u0026per_page; ?q matches name/slug (ILIKE).\n?org_id and ?status are exact-match filters; ?sort=\u003cfield\u003e with optional `-` prefix for desc, or explicit ?order=asc|desc.\nNote: the tenant filter is named `org_id` (not `tenantID`) because the global ValidateNoUserProvidedTenantID security middleware rejects any query parameter whose name contains \"tenant\".",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "List groups (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Items per page (default 50, max 100)",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search term — ILIKE match on name/slug",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to groups belonging to this tenant ID (exact match). Named org_id rather than tenantID — the security middleware blocks query params containing 'tenant'.",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to groups in this status: active|pending_deletion (exact match)",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort field: name|slug|created_at|status (prefix with - for desc)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort direction override: asc|desc (wins over `-` prefix)",
+                        "name": "order",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AdminGroupsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/groups/{groupID}": {
+            "get": {
+                "description": "Returns the group row with computed member_count and an owning-tenant chip (tenant id, name, slug). Crosses tenants by design.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get group (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "groupID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AdminGroupResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Group not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Sets the group's status to `pending_deletion`; the group purge worker finishes the hard-delete asynchronously.\nIdempotent — re-deleting an already-pending group returns 200 with the current status. Returns the post-transition group row.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Soft-delete a group (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "groupID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK - group marked pending_deletion (or already was)",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.AdminGroupResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Group not found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/tenants": {
             "get": {
                 "description": "Returns every tenant with computed user_count and group_count. Pagination via ?page\u0026per_page; ?q matches name/slug/domain (ILIKE); ?sort=\u003cfield\u003e with optional `-` prefix for desc, or explicit ?order=asc|desc.",
@@ -7226,6 +7394,129 @@
                 },
                 "operating_system": {
                     "type": "string"
+                }
+            }
+        },
+        "jsonapi.AdminGroupDetail": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "member_count": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/models.LocationGroupStatus"
+                },
+                "tenant": {
+                    "$ref": "#/definitions/jsonapi.AdminGroupTenantChip"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "admin_groups"
+                    ],
+                    "example": "admin_groups"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "jsonapi.AdminGroupListItem": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "member_count": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/models.LocationGroupStatus"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "admin_groups"
+                    ],
+                    "example": "admin_groups"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "jsonapi.AdminGroupResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/jsonapi.AdminGroupDetail"
+                }
+            }
+        },
+        "jsonapi.AdminGroupTenantChip": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                }
+            }
+        },
+        "jsonapi.AdminGroupsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/jsonapi.AdminGroupListItem"
+                    }
+                },
+                "meta": {
+                    "$ref": "#/definitions/jsonapi.AdminListMeta"
                 }
             }
         },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -49,7 +49,7 @@
         },
         "/admin/groups": {
             "get": {
-                "description": "Returns every location group with computed member_count. Pagination via ?page\u0026per_page; ?q matches name/slug (ILIKE).\n?tenantID and ?status are exact-match filters; ?sort=\u003cfield\u003e with optional `-` prefix for desc, or explicit ?order=asc|desc.",
+                "description": "Returns every location group with computed member_count and an owning-tenant chip (id, name, slug). Paginate via ?page\u0026per_page; ?q ILIKE-matches name/slug; ?tenantID/?status filter exactly; ?sort/?order set ordering.",
                 "produces": [
                     "application/vnd.api+json"
                 ],
@@ -83,8 +83,12 @@
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "active",
+                            "pending_deletion"
+                        ],
                         "type": "string",
-                        "description": "Filter to groups in this status: active|pending_deletion (exact match)",
+                        "description": "Filter to groups in this status (exact match)",
                         "name": "status",
                         "in": "query"
                     },
@@ -95,8 +99,12 @@
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
                         "type": "string",
-                        "description": "Sort direction override: asc|desc (wins over `-` prefix)",
+                        "description": "Sort direction override (wins over `-` prefix)",
                         "name": "order",
                         "in": "query"
                     }
@@ -170,7 +178,7 @@
                 }
             },
             "delete": {
-                "description": "Sets the group's status to `pending_deletion`; the group purge worker finishes the hard-delete asynchronously.\nIdempotent — re-deleting an already-pending group returns 200 with the current status. Returns the post-transition group row.",
+                "description": "Sets the group's status to `pending_deletion`; the group purge worker finishes the hard-delete asynchronously. Idempotent — re-deleting an already-pending group returns 200. Returns the post-transition group row.",
                 "produces": [
                     "application/vnd.api+json"
                 ],
@@ -7468,6 +7476,9 @@
                 },
                 "status": {
                     "$ref": "#/definitions/models.LocationGroupStatus"
+                },
+                "tenant": {
+                    "$ref": "#/definitions/jsonapi.AdminGroupTenantChip"
                 },
                 "tenant_id": {
                     "type": "string"

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -383,6 +383,87 @@ definitions:
       operating_system:
         type: string
     type: object
+  jsonapi.AdminGroupDetail:
+    properties:
+      created_at:
+        type: string
+      created_by:
+        type: string
+      currency:
+        type: string
+      id:
+        type: string
+      member_count:
+        type: integer
+      name:
+        type: string
+      slug:
+        type: string
+      status:
+        $ref: '#/definitions/models.LocationGroupStatus'
+      tenant:
+        $ref: '#/definitions/jsonapi.AdminGroupTenantChip'
+      tenant_id:
+        type: string
+      type:
+        enum:
+        - admin_groups
+        example: admin_groups
+        type: string
+      updated_at:
+        type: string
+    type: object
+  jsonapi.AdminGroupListItem:
+    properties:
+      created_at:
+        type: string
+      created_by:
+        type: string
+      currency:
+        type: string
+      id:
+        type: string
+      member_count:
+        type: integer
+      name:
+        type: string
+      slug:
+        type: string
+      status:
+        $ref: '#/definitions/models.LocationGroupStatus'
+      tenant_id:
+        type: string
+      type:
+        enum:
+        - admin_groups
+        example: admin_groups
+        type: string
+      updated_at:
+        type: string
+    type: object
+  jsonapi.AdminGroupResponse:
+    properties:
+      data:
+        $ref: '#/definitions/jsonapi.AdminGroupDetail'
+    type: object
+  jsonapi.AdminGroupTenantChip:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+      slug:
+        type: string
+    type: object
+  jsonapi.AdminGroupsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/jsonapi.AdminGroupListItem'
+        type: array
+      meta:
+        $ref: '#/definitions/jsonapi.AdminListMeta'
+    type: object
   jsonapi.AdminListMeta:
     properties:
       page:
@@ -3975,6 +4056,126 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: System-admin ping
+      tags:
+      - admin
+  /admin/groups:
+    get:
+      description: |-
+        Returns every location group with computed member_count. Pagination via ?page&per_page; ?q matches name/slug (ILIKE).
+        ?org_id and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
+        Note: the tenant filter is named `org_id` (not `tenantID`) because the global ValidateNoUserProvidedTenantID security middleware rejects any query parameter whose name contains "tenant".
+      parameters:
+      - description: Page number (default 1)
+        in: query
+        name: page
+        type: integer
+      - description: Items per page (default 50, max 100)
+        in: query
+        name: per_page
+        type: integer
+      - description: Search term — ILIKE match on name/slug
+        in: query
+        name: q
+        type: string
+      - description: Filter to groups belonging to this tenant ID (exact match). Named
+          org_id rather than tenantID — the security middleware blocks query params
+          containing 'tenant'.
+        in: query
+        name: org_id
+        type: string
+      - description: 'Filter to groups in this status: active|pending_deletion (exact
+          match)'
+        in: query
+        name: status
+        type: string
+      - description: 'Sort field: name|slug|created_at|status (prefix with - for desc)'
+        in: query
+        name: sort
+        type: string
+      - description: 'Sort direction override: asc|desc (wins over `-` prefix)'
+        in: query
+        name: order
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.AdminGroupsResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Forbidden - system-admin required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: List groups (admin)
+      tags:
+      - admin
+  /admin/groups/{groupID}:
+    delete:
+      description: |-
+        Sets the group's status to `pending_deletion`; the group purge worker finishes the hard-delete asynchronously.
+        Idempotent — re-deleting an already-pending group returns 200 with the current status. Returns the post-transition group row.
+      parameters:
+      - description: Group ID
+        in: path
+        name: groupID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK - group marked pending_deletion (or already was)
+          schema:
+            $ref: '#/definitions/jsonapi.AdminGroupResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Forbidden - system-admin required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Group not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Soft-delete a group (admin)
+      tags:
+      - admin
+    get:
+      description: Returns the group row with computed member_count and an owning-tenant
+        chip (tenant id, name, slug). Crosses tenants by design.
+      parameters:
+      - description: Group ID
+        in: path
+        name: groupID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/jsonapi.AdminGroupResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Forbidden - system-admin required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Group not found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Get group (admin)
       tags:
       - admin
   /admin/tenants:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -4062,8 +4062,7 @@ paths:
     get:
       description: |-
         Returns every location group with computed member_count. Pagination via ?page&per_page; ?q matches name/slug (ILIKE).
-        ?org_id and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
-        Note: the tenant filter is named `org_id` (not `tenantID`) because the global ValidateNoUserProvidedTenantID security middleware rejects any query parameter whose name contains "tenant".
+        ?tenantID and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
       parameters:
       - description: Page number (default 1)
         in: query
@@ -4077,11 +4076,9 @@ paths:
         in: query
         name: q
         type: string
-      - description: Filter to groups belonging to this tenant ID (exact match). Named
-          org_id rather than tenantID — the security middleware blocks query params
-          containing 'tenant'.
+      - description: Filter to groups belonging to this tenant ID (exact match)
         in: query
-        name: org_id
+        name: tenantID
         type: string
       - description: 'Filter to groups in this status: active|pending_deletion (exact
           match)'

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -431,6 +431,8 @@ definitions:
         type: string
       status:
         $ref: '#/definitions/models.LocationGroupStatus'
+      tenant:
+        $ref: '#/definitions/jsonapi.AdminGroupTenantChip'
       tenant_id:
         type: string
       type:
@@ -4060,9 +4062,9 @@ paths:
       - admin
   /admin/groups:
     get:
-      description: |-
-        Returns every location group with computed member_count. Pagination via ?page&per_page; ?q matches name/slug (ILIKE).
-        ?tenantID and ?status are exact-match filters; ?sort=<field> with optional `-` prefix for desc, or explicit ?order=asc|desc.
+      description: Returns every location group with computed member_count and an
+        owning-tenant chip (id, name, slug). Paginate via ?page&per_page; ?q ILIKE-matches
+        name/slug; ?tenantID/?status filter exactly; ?sort/?order set ordering.
       parameters:
       - description: Page number (default 1)
         in: query
@@ -4080,8 +4082,10 @@ paths:
         in: query
         name: tenantID
         type: string
-      - description: 'Filter to groups in this status: active|pending_deletion (exact
-          match)'
+      - description: Filter to groups in this status (exact match)
+        enum:
+        - active
+        - pending_deletion
         in: query
         name: status
         type: string
@@ -4089,7 +4093,10 @@ paths:
         in: query
         name: sort
         type: string
-      - description: 'Sort direction override: asc|desc (wins over `-` prefix)'
+      - description: Sort direction override (wins over `-` prefix)
+        enum:
+        - asc
+        - desc
         in: query
         name: order
         type: string
@@ -4113,9 +4120,9 @@ paths:
       - admin
   /admin/groups/{groupID}:
     delete:
-      description: |-
-        Sets the group's status to `pending_deletion`; the group purge worker finishes the hard-delete asynchronously.
-        Idempotent — re-deleting an already-pending group returns 200 with the current status. Returns the post-transition group row.
+      description: Sets the group's status to `pending_deletion`; the group purge
+        worker finishes the hard-delete asynchronously. Idempotent — re-deleting an
+        already-pending group returns 200. Returns the post-transition group row.
       parameters:
       - description: Group ID
         in: path

--- a/go/jsonapi/admin.go
+++ b/go/jsonapi/admin.go
@@ -272,3 +272,141 @@ func (*AdminUserResponse) Render(_ http.ResponseWriter, r *http.Request) error {
 	render.Status(r, http.StatusOK)
 	return nil
 }
+
+// AdminGroupListItem is the row shape returned by GET /admin/groups.
+// Mirrors the JSON-API flat-data convention used across the codebase
+// (resource fields hoisted to the top level alongside `id` + `type`).
+//
+// member_count is pre-computed by the registry layer via a correlated
+// subquery on group_memberships (accepted memberships only) so the FE
+// doesn't need a second roundtrip per row to render the at-a-glance
+// table.
+type AdminGroupListItem struct {
+	ID          string                     `json:"id"`
+	Type        string                     `json:"type" example:"admin_groups" enums:"admin_groups"`
+	Name        string                     `json:"name"`
+	Slug        string                     `json:"slug"`
+	Status      models.LocationGroupStatus `json:"status"`
+	Currency    models.Currency            `json:"currency"`
+	TenantID    string                     `json:"tenant_id"`
+	CreatedBy   string                     `json:"created_by"`
+	CreatedAt   time.Time                  `json:"created_at"`
+	UpdatedAt   time.Time                  `json:"updated_at"`
+	MemberCount int                        `json:"member_count"`
+}
+
+// AdminGroupsResponse is the JSON:API envelope for GET /admin/groups.
+type AdminGroupsResponse struct {
+	Data []*AdminGroupListItem `json:"data"`
+	Meta AdminListMeta         `json:"meta"`
+}
+
+// NewAdminGroupsResponse maps registry-layer rows into the wire-shape the
+// FE consumes. Page / PerPage / Total drive the meta block (with
+// total_pages computed via ComputeTotalPages so the FE never has to do
+// the ceil-divide).
+func NewAdminGroupsResponse(items []*registry.AdminGroupListItem, page, perPage, total int) *AdminGroupsResponse {
+	data := make([]*AdminGroupListItem, 0, len(items))
+	for _, it := range items {
+		if it == nil || it.Group == nil {
+			continue
+		}
+		g := it.Group
+		data = append(data, &AdminGroupListItem{
+			ID:          g.ID,
+			Type:        "admin_groups",
+			Name:        g.Name,
+			Slug:        g.Slug,
+			Status:      g.Status,
+			Currency:    g.GroupCurrency,
+			TenantID:    g.TenantID,
+			CreatedBy:   g.CreatedBy,
+			CreatedAt:   g.CreatedAt,
+			UpdatedAt:   g.UpdatedAt,
+			MemberCount: it.MemberCount,
+		})
+	}
+	return &AdminGroupsResponse{
+		Data: data,
+		Meta: AdminListMeta{
+			Page:       page,
+			PerPage:    perPage,
+			Total:      total,
+			TotalPages: ComputeTotalPages(total, perPage),
+		},
+	}
+}
+
+func (*AdminGroupsResponse) Render(_ http.ResponseWriter, r *http.Request) error {
+	render.Status(r, http.StatusOK)
+	return nil
+}
+
+// AdminGroupTenantChip is the compact tenant descriptor embedded on the
+// admin group-detail row so the FE can render an owning-tenant chip
+// (id + name + slug) without a second round-trip to /admin/tenants.
+type AdminGroupTenantChip struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+// AdminGroupDetail is the row shape returned by GET /admin/groups/{groupID}.
+// Compared to AdminGroupListItem this adds the resolved tenant chip.
+type AdminGroupDetail struct {
+	ID          string                     `json:"id"`
+	Type        string                     `json:"type" example:"admin_groups" enums:"admin_groups"`
+	Name        string                     `json:"name"`
+	Slug        string                     `json:"slug"`
+	Status      models.LocationGroupStatus `json:"status"`
+	Currency    models.Currency            `json:"currency"`
+	TenantID    string                     `json:"tenant_id"`
+	CreatedBy   string                     `json:"created_by"`
+	CreatedAt   time.Time                  `json:"created_at"`
+	UpdatedAt   time.Time                  `json:"updated_at"`
+	MemberCount int                        `json:"member_count"`
+	Tenant      *AdminGroupTenantChip      `json:"tenant,omitempty"`
+}
+
+// AdminGroupResponse is the JSON:API envelope for GET
+// /admin/groups/{groupID} and the DELETE soft-delete response — the
+// DELETE returns the post-transition row so the FE can render the
+// updated status without a follow-up GET.
+type AdminGroupResponse struct {
+	Data *AdminGroupDetail `json:"data"`
+}
+
+// NewAdminGroupResponse wraps a single group detail row (with tenant chip)
+// for the detail + soft-delete endpoints.
+func NewAdminGroupResponse(item *registry.AdminGroupDetail) *AdminGroupResponse {
+	if item == nil || item.Group == nil {
+		return &AdminGroupResponse{}
+	}
+	g := item.Group
+	detail := &AdminGroupDetail{
+		ID:          g.ID,
+		Type:        "admin_groups",
+		Name:        g.Name,
+		Slug:        g.Slug,
+		Status:      g.Status,
+		Currency:    g.GroupCurrency,
+		TenantID:    g.TenantID,
+		CreatedBy:   g.CreatedBy,
+		CreatedAt:   g.CreatedAt,
+		UpdatedAt:   g.UpdatedAt,
+		MemberCount: item.MemberCount,
+	}
+	if item.Tenant != nil {
+		detail.Tenant = &AdminGroupTenantChip{
+			ID:   item.Tenant.ID,
+			Name: item.Tenant.Name,
+			Slug: item.Tenant.Slug,
+		}
+	}
+	return &AdminGroupResponse{Data: detail}
+}
+
+func (*AdminGroupResponse) Render(_ http.ResponseWriter, r *http.Request) error {
+	render.Status(r, http.StatusOK)
+	return nil
+}

--- a/go/jsonapi/admin.go
+++ b/go/jsonapi/admin.go
@@ -280,7 +280,11 @@ func (*AdminUserResponse) Render(_ http.ResponseWriter, r *http.Request) error {
 // member_count is pre-computed by the registry layer via a correlated
 // subquery on group_memberships (accepted memberships only) so the FE
 // doesn't need a second roundtrip per row to render the at-a-glance
-// table.
+// table. The `tenant` chip (id + name + slug) is resolved per row by the
+// registry layer so the cross-tenant admin list renders the owning-
+// tenant name without an FE N+1 lookup against /admin/tenants. The flat
+// `tenant_id` is kept alongside the chip for callers that only need the
+// id.
 type AdminGroupListItem struct {
 	ID          string                     `json:"id"`
 	Type        string                     `json:"type" example:"admin_groups" enums:"admin_groups"`
@@ -293,6 +297,7 @@ type AdminGroupListItem struct {
 	CreatedAt   time.Time                  `json:"created_at"`
 	UpdatedAt   time.Time                  `json:"updated_at"`
 	MemberCount int                        `json:"member_count"`
+	Tenant      *AdminGroupTenantChip      `json:"tenant,omitempty"`
 }
 
 // AdminGroupsResponse is the JSON:API envelope for GET /admin/groups.
@@ -312,7 +317,7 @@ func NewAdminGroupsResponse(items []*registry.AdminGroupListItem, page, perPage,
 			continue
 		}
 		g := it.Group
-		data = append(data, &AdminGroupListItem{
+		item := &AdminGroupListItem{
 			ID:          g.ID,
 			Type:        "admin_groups",
 			Name:        g.Name,
@@ -324,7 +329,15 @@ func NewAdminGroupsResponse(items []*registry.AdminGroupListItem, page, perPage,
 			CreatedAt:   g.CreatedAt,
 			UpdatedAt:   g.UpdatedAt,
 			MemberCount: it.MemberCount,
-		})
+		}
+		if it.Tenant != nil {
+			item.Tenant = &AdminGroupTenantChip{
+				ID:   it.Tenant.ID,
+				Name: it.Tenant.Name,
+				Slug: it.Tenant.Slug,
+			}
+		}
+		data = append(data, item)
 	}
 	return &AdminGroupsResponse{
 		Data: data,

--- a/go/registry/memory/location_groups.go
+++ b/go/registry/memory/location_groups.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"strings"
 	"time"
@@ -120,12 +121,21 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 // pointer. Unwired (NewLocationGroupRegistry without
 // SetAdminListingRegistries) or an empty tenantID returns (nil, nil) by
 // design, mirroring the "empty join result" shape.
+//
+// A missing tenant row (group orphaned / tenant corrupt) also returns
+// (nil, nil) — this mirrors the postgres LEFT JOIN, which keeps the
+// orphaned group visible on the cross-tenant admin surface with a nil
+// Tenant rather than dropping it. ErrNotFound here is swallowed, not
+// propagated, so ListAdmin / GetAdmin still surface the group.
 func (r *LocationGroupRegistry) resolveTenant(ctx context.Context, tenantID string) (*models.Tenant, error) {
 	if r.tenantRegistry == nil || tenantID == "" {
 		return nil, nil
 	}
 	tenant, err := r.tenantRegistry.Get(ctx, tenantID)
 	if err != nil {
+		if errors.Is(err, registry.ErrNotFound) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	t := *tenant

--- a/go/registry/memory/location_groups.go
+++ b/go/registry/memory/location_groups.go
@@ -74,9 +74,12 @@ func (r *LocationGroupRegistry) ListByTenant(_ context.Context, tenantID string)
 
 // ListAdmin returns the memory equivalent of postgres' admin group
 // listing — filter, sort and paginate the in-memory rows, then attach
-// member_count from the linked membership registry (or zero when unwired).
-// Mirrors the postgres "Total is post-filter, pre-pagination" semantics so
-// callers see one invariant across backends.
+// member_count from the linked membership registry (or zero when unwired)
+// and the owning tenant from the linked tenant registry (or nil when
+// unwired) so the cross-tenant admin list carries an owning-tenant chip
+// per row without an FE N+1 lookup. Mirrors the postgres "Total is
+// post-filter, pre-pagination" semantics so callers see one invariant
+// across backends.
 func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.AdminGroupListOptions) ([]*registry.AdminGroupListItem, int, error) {
 	groups, err := r.List(ctx)
 	if err != nil {
@@ -98,13 +101,35 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 		if err != nil {
 			return nil, 0, err
 		}
+		tenant, err := r.resolveTenant(ctx, g.TenantID)
+		if err != nil {
+			return nil, 0, err
+		}
 		group := *g // copy so callers don't share the registry's pointer
 		items = append(items, &registry.AdminGroupListItem{
 			Group:       &group,
 			MemberCount: memberCount,
+			Tenant:      tenant,
 		})
 	}
 	return items, total, nil
+}
+
+// resolveTenant looks up the owning tenant chip from the linked tenant
+// registry, returning a copy so callers don't share the registry's
+// pointer. Unwired (NewLocationGroupRegistry without
+// SetAdminListingRegistries) or an empty tenantID returns (nil, nil) by
+// design, mirroring the "empty join result" shape.
+func (r *LocationGroupRegistry) resolveTenant(ctx context.Context, tenantID string) (*models.Tenant, error) {
+	if r.tenantRegistry == nil || tenantID == "" {
+		return nil, nil
+	}
+	tenant, err := r.tenantRegistry.Get(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	t := *tenant
+	return &t, nil
 }
 
 // filterGroups applies the case-insensitive ILIKE-style substring match
@@ -217,20 +242,16 @@ func (r *LocationGroupRegistry) buildAdminGroupDetail(ctx context.Context, group
 	if err != nil {
 		return nil, err
 	}
+	tenant, err := r.resolveTenant(ctx, group.TenantID)
+	if err != nil {
+		return nil, err
+	}
 	g := *group // copy so callers don't share the registry's pointer
-	detail := &registry.AdminGroupDetail{
+	return &registry.AdminGroupDetail{
 		Group:       &g,
 		MemberCount: memberCount,
-	}
-	if r.tenantRegistry != nil && g.TenantID != "" {
-		tenant, terr := r.tenantRegistry.Get(ctx, g.TenantID)
-		if terr != nil {
-			return nil, terr
-		}
-		t := *tenant
-		detail.Tenant = &t
-	}
-	return detail, nil
+		Tenant:      tenant,
+	}, nil
 }
 
 // MarkPendingDeletionAdmin flips a group to pending_deletion for the

--- a/go/registry/memory/location_groups.go
+++ b/go/registry/memory/location_groups.go
@@ -2,6 +2,9 @@ package memory
 
 import (
 	"context"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
@@ -13,12 +16,29 @@ type baseLocationGroupRegistry = Registry[models.LocationGroup, *models.Location
 
 type LocationGroupRegistry struct {
 	*baseLocationGroupRegistry
+	// membershipRegistry / tenantRegistry, when set, let ListAdmin /
+	// GetAdmin compute member_count and resolve the tenant chip the admin
+	// listing surfaces (#1748). Tests that construct the registry directly
+	// (without going through NewFactorySet) can leave these nil — counts
+	// then degrade to zero and the tenant chip stays nil, mirroring the
+	// "empty join result" shape.
+	membershipRegistry registry.GroupMembershipRegistry
+	tenantRegistry     registry.TenantRegistry
 }
 
 func NewLocationGroupRegistry() *LocationGroupRegistry {
 	return &LocationGroupRegistry{
 		baseLocationGroupRegistry: NewRegistry[models.LocationGroup, *models.LocationGroup](),
 	}
+}
+
+// SetAdminListingRegistries wires the membership + tenant registries the
+// memory ListAdmin / GetAdmin use to compute member_count and resolve the
+// tenant chip. NewFactorySet calls this once all three registries exist;
+// targeted tests that don't touch the admin surface can skip the wiring.
+func (r *LocationGroupRegistry) SetAdminListingRegistries(gm registry.GroupMembershipRegistry, t registry.TenantRegistry) {
+	r.membershipRegistry = gm
+	r.tenantRegistry = t
 }
 
 func (r *LocationGroupRegistry) GetBySlug(_ context.Context, tenantID, slug string) (*models.LocationGroup, error) {
@@ -50,4 +70,184 @@ func (r *LocationGroupRegistry) ListByTenant(_ context.Context, tenantID string)
 	}
 
 	return groups, nil
+}
+
+// ListAdmin returns the memory equivalent of postgres' admin group
+// listing — filter, sort and paginate the in-memory rows, then attach
+// member_count from the linked membership registry (or zero when unwired).
+// Mirrors the postgres "Total is post-filter, pre-pagination" semantics so
+// callers see one invariant across backends.
+func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.AdminGroupListOptions) ([]*registry.AdminGroupListItem, int, error) {
+	groups, err := r.List(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	filtered := filterGroups(groups, opts.Query, opts.TenantID, opts.Status)
+	sortGroups(filtered, opts.SortField, opts.SortDesc)
+	total := len(filtered)
+
+	pageRows := paginate(filtered, opts.Page, opts.PerPage)
+	if pageRows == nil {
+		return nil, total, nil
+	}
+
+	items := make([]*registry.AdminGroupListItem, 0, len(pageRows))
+	for _, g := range pageRows {
+		memberCount, err := r.countMembersForGroup(ctx, g.ID)
+		if err != nil {
+			return nil, 0, err
+		}
+		group := *g // copy so callers don't share the registry's pointer
+		items = append(items, &registry.AdminGroupListItem{
+			Group:       &group,
+			MemberCount: memberCount,
+		})
+	}
+	return items, total, nil
+}
+
+// filterGroups applies the case-insensitive ILIKE-style substring match
+// on name/slug plus the exact tenant_id and status filters. Empty filters
+// are no-ops.
+func filterGroups(groups []*models.LocationGroup, query, tenantID, status string) []*models.LocationGroup {
+	q := strings.ToLower(strings.TrimSpace(query))
+	tenantID = strings.TrimSpace(tenantID)
+	status = strings.TrimSpace(status)
+	if q == "" && tenantID == "" && status == "" {
+		return groups
+	}
+	filtered := groups[:0:0]
+	for _, g := range groups {
+		if q != "" {
+			haystack := strings.ToLower(g.Name + " " + g.Slug)
+			if !strings.Contains(haystack, q) {
+				continue
+			}
+		}
+		if tenantID != "" && g.TenantID != tenantID {
+			continue
+		}
+		if status != "" && string(g.Status) != status {
+			continue
+		}
+		filtered = append(filtered, g)
+	}
+	return filtered
+}
+
+// sortGroups sorts the slice in place by the requested column. Unknown
+// sort fields fall back to name asc. The id tiebreaker is ALWAYS ascending
+// regardless of `desc` so pagination is deterministic across asc/desc
+// requests and consistent with postgres's
+// `ORDER BY g.<col> <dir>, g.id ASC`.
+//
+//revive:disable-next-line:flag-parameter // SortDesc is the natural shape for the public AdminGroupListOptions; threading it down keeps the call site readable.
+func sortGroups(groups []*models.LocationGroup, field registry.AdminGroupSortField, desc bool) {
+	if !field.IsValid() {
+		field = registry.AdminGroupSortName
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		a, b := groups[i], groups[j]
+		var primary int
+		switch {
+		case groupPrimaryLess(a, b, field):
+			primary = -1
+		case groupPrimaryLess(b, a, field):
+			primary = 1
+		}
+		if desc {
+			primary = -primary
+		}
+		if primary != 0 {
+			return primary < 0
+		}
+		return a.ID < b.ID
+	})
+}
+
+// groupPrimaryLess is a strict less-than on the chosen field only.
+// Returns false when the field values are equal; the id tiebreaker is
+// applied by sortGroups directly and stays ascending regardless of the
+// sort direction.
+func groupPrimaryLess(a, b *models.LocationGroup, field registry.AdminGroupSortField) bool {
+	switch field {
+	case registry.AdminGroupSortSlug:
+		return a.Slug < b.Slug
+	case registry.AdminGroupSortCreatedAt:
+		return a.CreatedAt.Before(b.CreatedAt)
+	case registry.AdminGroupSortStatus:
+		return string(a.Status) < string(b.Status)
+	}
+	return a.Name < b.Name
+}
+
+// countMembersForGroup returns the member count from the linked
+// membership registry. Unwired (NewLocationGroupRegistry without
+// SetAdminListingRegistries) returns (0, nil) by design; once wired,
+// registry errors propagate rather than being swallowed.
+func (r *LocationGroupRegistry) countMembersForGroup(ctx context.Context, groupID string) (int, error) {
+	if r.membershipRegistry == nil {
+		return 0, nil
+	}
+	return r.membershipRegistry.CountByGroup(ctx, groupID)
+}
+
+// GetAdmin mirrors the postgres single-row detail lookup for the
+// in-memory backend: load the group, attach member_count and resolve the
+// owning tenant chip from the linked registries.
+func (r *LocationGroupRegistry) GetAdmin(ctx context.Context, groupID string) (*registry.AdminGroupDetail, error) {
+	if groupID == "" {
+		return nil, registry.ErrFieldRequired
+	}
+	group, err := r.Get(ctx, groupID)
+	if err != nil {
+		return nil, err
+	}
+	memberCount, err := r.countMembersForGroup(ctx, groupID)
+	if err != nil {
+		return nil, err
+	}
+	g := *group // copy so callers don't share the registry's pointer
+	detail := &registry.AdminGroupDetail{
+		Group:       &g,
+		MemberCount: memberCount,
+	}
+	if r.tenantRegistry != nil && g.TenantID != "" {
+		tenant, terr := r.tenantRegistry.Get(ctx, g.TenantID)
+		if terr != nil {
+			return nil, terr
+		}
+		t := *tenant
+		detail.Tenant = &t
+	}
+	return detail, nil
+}
+
+// MarkPendingDeletionAdmin flips a group to pending_deletion for the
+// cross-tenant admin soft-delete (#1748). The status-transition logic is
+// identical to GroupService.InitiateGroupDeletion so the group_purge_worker
+// finishes the hard-delete with no parallel code path. The registry's
+// write lock is held for the whole read-decide-write so two concurrent
+// admin deletes can't both observe `active`. Idempotent: an already-pending
+// group returns (true, nil) without re-writing.
+func (r *LocationGroupRegistry) MarkPendingDeletionAdmin(_ context.Context, groupID string) (bool, error) {
+	if groupID == "" {
+		return false, registry.ErrFieldRequired
+	}
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	group, ok := r.items.Get(groupID)
+	if !ok {
+		return false, registry.ErrNotFound
+	}
+	if group.Status == models.LocationGroupStatusPendingDeletion {
+		return true, nil
+	}
+	updated := *group
+	updated.Status = models.LocationGroupStatusPendingDeletion
+	updated.UpdatedAt = time.Now()
+	r.items.Set(groupID, &updated)
+	return false, nil
 }

--- a/go/registry/memory/location_groups.go
+++ b/go/registry/memory/location_groups.go
@@ -204,7 +204,16 @@ func (r *LocationGroupRegistry) GetAdmin(ctx context.Context, groupID string) (*
 	if err != nil {
 		return nil, err
 	}
-	memberCount, err := r.countMembersForGroup(ctx, groupID)
+	return r.buildAdminGroupDetail(ctx, group)
+}
+
+// buildAdminGroupDetail shapes an AdminGroupDetail (group copy +
+// member_count + tenant chip) from an already-loaded group. Shared by
+// GetAdmin and MarkPendingDeletionAdmin so the post-delete row carries
+// exactly the shape the detail handler renders. The supplied group is
+// copied so callers don't share the registry's pointer.
+func (r *LocationGroupRegistry) buildAdminGroupDetail(ctx context.Context, group *models.LocationGroup) (*registry.AdminGroupDetail, error) {
+	memberCount, err := r.countMembersForGroup(ctx, group.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -229,25 +238,50 @@ func (r *LocationGroupRegistry) GetAdmin(ctx context.Context, groupID string) (*
 // identical to GroupService.InitiateGroupDeletion so the group_purge_worker
 // finishes the hard-delete with no parallel code path. The registry's
 // write lock is held for the whole read-decide-write so two concurrent
-// admin deletes can't both observe `active`. Idempotent: an already-pending
-// group returns (true, nil) without re-writing.
-func (r *LocationGroupRegistry) MarkPendingDeletionAdmin(_ context.Context, groupID string) (bool, error) {
+// admin deletes can't both observe `active`, and the returned detail row
+// is built from the post-transition copy under that same lock — no
+// follow-up GetAdmin that could race the purge worker. Idempotent: an
+// already-pending group returns (detail, true, nil) without re-writing.
+func (r *LocationGroupRegistry) MarkPendingDeletionAdmin(ctx context.Context, groupID string) (*registry.AdminGroupDetail, bool, error) {
 	if groupID == "" {
-		return false, registry.ErrFieldRequired
+		return nil, false, registry.ErrFieldRequired
 	}
+
+	post, alreadyPending, err := r.applyPendingDeletion(groupID)
+	if err != nil {
+		return nil, false, err
+	}
+	// buildAdminGroupDetail touches the membership / tenant registries
+	// (their own locks), never r.lock, so it is safe to call after the
+	// write lock above has been released.
+	detail, err := r.buildAdminGroupDetail(ctx, post)
+	if err != nil {
+		return nil, false, err
+	}
+	return detail, alreadyPending, nil
+}
+
+// applyPendingDeletion performs the locked read-decide-write half of the
+// admin soft-delete and returns a copy of the post-transition group. The
+// write lock is held only for the mutation; detail-shaping happens after
+// it is released so we don't hold r.lock across the membership / tenant
+// registry lookups.
+func (r *LocationGroupRegistry) applyPendingDeletion(groupID string) (*models.LocationGroup, bool, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
 	group, ok := r.items.Get(groupID)
 	if !ok {
-		return false, registry.ErrNotFound
+		return nil, false, registry.ErrNotFound
 	}
 	if group.Status == models.LocationGroupStatusPendingDeletion {
-		return true, nil
+		post := *group
+		return &post, true, nil
 	}
 	updated := *group
 	updated.Status = models.LocationGroupStatusPendingDeletion
 	updated.UpdatedAt = time.Now()
 	r.items.Set(groupID, &updated)
-	return false, nil
+	post := updated
+	return &post, false, nil
 }

--- a/go/registry/memory/memory.go
+++ b/go/registry/memory/memory.go
@@ -62,17 +62,20 @@ func NewFactorySet() *registry.FactorySet {
 	fs.LoginEventRegistry = NewLoginEventRegistry()
 	fs.UserMFASecretRegistry = NewUserMFASecretRegistry()
 	fs.AuditLogRegistry = NewAuditLogRegistry()
-	fs.LocationGroupRegistry = NewLocationGroupRegistry()
+	groupReg := NewLocationGroupRegistry()
+	fs.LocationGroupRegistry = groupReg
 	membershipReg := NewGroupMembershipRegistry()
 	membershipReg.SetUserRegistry(fs.UserRegistry)
 	fs.GroupMembershipRegistry = membershipReg
-	// Wire the admin-listing cross-table dependencies (#1746). Counts on
-	// the /api/v1/admin/tenants and /api/v1/admin/users surface depend on
-	// these linkages; tests that construct the registries directly without
-	// going through NewFactorySet can leave them nil and the counts
-	// degrade to zero (mirrors postgres "empty join result" semantics).
+	// Wire the admin-listing cross-table dependencies (#1746, #1748).
+	// Counts on the /api/v1/admin/tenants, /api/v1/admin/users and
+	// /api/v1/admin/groups surfaces depend on these linkages; tests that
+	// construct the registries directly without going through
+	// NewFactorySet can leave them nil and the counts degrade to zero
+	// (mirrors postgres "empty join result" semantics).
 	tenantReg.SetCountRegistries(fs.UserRegistry, fs.LocationGroupRegistry)
 	userReg.SetAdminListingRegistries(fs.RefreshTokenRegistry, fs.GroupMembershipRegistry)
+	groupReg.SetAdminListingRegistries(fs.GroupMembershipRegistry, fs.TenantRegistry)
 	fs.GroupInviteRegistry = NewGroupInviteRegistry()
 	fs.GroupInviteAuditRegistry = NewGroupInviteAuditRegistry()
 	fs.GroupNotificationPrefRegistry = NewGroupNotificationPrefRegistry()

--- a/go/registry/postgres/location_groups.go
+++ b/go/registry/postgres/location_groups.go
@@ -2,7 +2,11 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"fmt"
+	"strings"
+	"time"
 
 	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
@@ -209,4 +213,253 @@ func (r *LocationGroupRegistry) ListByTenant(ctx context.Context, tenantID strin
 	}
 
 	return groups, nil
+}
+
+// ListAdmin returns paginated, filtered, sorted location groups for the
+// `/api/v1/admin/groups` listing (#1748) along with the per-row computed
+// member_count from a correlated subquery on group_memberships.
+//
+// The endpoint crosses tenants by design — a system admin lists every
+// tenant's groups. location_groups has RLS enabled with a tenant-isolation
+// policy; `SET LOCAL row_security = off` on the tx is the fail-loud guard:
+// per postgres semantics a non-bypass role querying an RLS-protected table
+// with row_security=off ERRORs rather than silently filtering. The
+// background-worker connection role this registry runs as carries a bypass
+// policy, so the cross-tenant read succeeds; if that bypass is ever revoked
+// the endpoint 5xx-es loudly instead of returning a quietly empty page.
+// Same rationale as TenantRegistry.ListAdmin / UserRegistry.ListAdminByTenant.
+//
+// Total is post-filter, pre-pagination.
+func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.AdminGroupListOptions) ([]*registry.AdminGroupListItem, int, error) {
+	page := opts.Page
+	if page <= 0 {
+		page = 1
+	}
+	perPage := opts.PerPage
+	if perPage <= 0 {
+		perPage = 50
+	}
+
+	sortField := opts.SortField
+	if !sortField.IsValid() {
+		sortField = registry.AdminGroupSortName
+	}
+	direction := "ASC"
+	if opts.SortDesc {
+		direction = "DESC"
+	}
+
+	groupsTable := r.tableNames.LocationGroups()
+	membershipsTable := r.tableNames.GroupMemberships()
+
+	args := make([]any, 0, 3)
+	whereClauses := make([]string, 0, 3)
+	if q := strings.TrimSpace(opts.Query); q != "" {
+		args = append(args, "%"+q+"%")
+		// The query arg is reused across name + slug.
+		whereClauses = append(whereClauses, fmt.Sprintf("(g.name ILIKE $%d OR g.slug ILIKE $%d)", len(args), len(args)))
+	}
+	if t := strings.TrimSpace(opts.TenantID); t != "" {
+		args = append(args, t)
+		whereClauses = append(whereClauses, fmt.Sprintf("g.tenant_id = $%d", len(args)))
+	}
+	if s := strings.TrimSpace(opts.Status); s != "" {
+		args = append(args, s)
+		whereClauses = append(whereClauses, fmt.Sprintf("g.status = $%d", len(args)))
+	}
+	where := ""
+	if len(whereClauses) > 0 {
+		where = "WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	var (
+		items []*registry.AdminGroupListItem
+		total int
+	)
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
+			return errxtrace.Wrap("failed to disable row_security for admin group listing", execErr)
+		}
+
+		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s AS g %s", groupsTable, where)
+		if scanErr := tx.QueryRowContext(ctx, countQuery, args...).Scan(&total); scanErr != nil {
+			return errxtrace.Wrap("failed to count admin groups", scanErr)
+		}
+
+		limitPos := len(args) + 1
+		offsetPos := len(args) + 2
+		offset := (page - 1) * perPage
+
+		// SECURITY: sortField is constrained to AdminGroupSortField via IsValid above,
+		// direction is "ASC"/"DESC" literals, and table-names come from r.tableNames —
+		// never user-supplied — so direct fmt.Sprintf interpolation is safe.
+		pageQuery := fmt.Sprintf(`
+			SELECT g.*,
+				(SELECT COUNT(*) FROM %s AS m WHERE m.group_id = g.id) AS _member_count
+			FROM %s AS g
+			%s
+			ORDER BY g.%s %s, g.id ASC
+			LIMIT $%d OFFSET $%d`,
+			membershipsTable, groupsTable, where, string(sortField), direction, limitPos, offsetPos,
+		)
+		pageArgs := append(append([]any{}, args...), perPage, offset)
+
+		rows, err := tx.QueryxContext(ctx, pageQuery, pageArgs...)
+		if err != nil {
+			return errxtrace.Wrap("failed to list admin groups", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var row struct {
+				models.LocationGroup
+				MemberCount int `db:"_member_count"`
+			}
+			if scanErr := rows.StructScan(&row); scanErr != nil {
+				return errxtrace.Wrap("failed to scan admin group row", scanErr)
+			}
+			group := row.LocationGroup
+			items = append(items, &registry.AdminGroupListItem{
+				Group:       &group,
+				MemberCount: row.MemberCount,
+			})
+		}
+		if rowsErr := rows.Err(); rowsErr != nil {
+			return errxtrace.Wrap("failed during admin group row iteration", rowsErr)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	return items, total, nil
+}
+
+// GetAdmin returns a single group detail row with the computed
+// member_count plus the owning tenant (joined so the detail handler can
+// render the tenant chip in one round-trip). Runs under
+// `SET LOCAL row_security = off` for the same fail-loud cross-tenant
+// rationale as ListAdmin.
+func (r *LocationGroupRegistry) GetAdmin(ctx context.Context, groupID string) (*registry.AdminGroupDetail, error) {
+	if groupID == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+	}
+
+	groupsTable := r.tableNames.LocationGroups()
+	membershipsTable := r.tableNames.GroupMemberships()
+	tenantsTable := r.tableNames.Tenants()
+
+	var (
+		group       models.LocationGroup
+		tenant      models.Tenant
+		memberCount int
+		found       bool
+	)
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
+			return errxtrace.Wrap("failed to disable row_security for admin group detail", execErr)
+		}
+		query := fmt.Sprintf(`
+			SELECT g.*,
+				(SELECT COUNT(*) FROM %s AS m WHERE m.group_id = g.id) AS _member_count,
+				t.id AS _tenant_id, t.name AS _tenant_name, t.slug AS _tenant_slug
+			FROM %s AS g
+			JOIN %s AS t ON t.id = g.tenant_id
+			WHERE g.id = $1`,
+			membershipsTable, groupsTable, tenantsTable,
+		)
+		var row struct {
+			models.LocationGroup
+			MemberCount int    `db:"_member_count"`
+			TenantID    string `db:"_tenant_id"`
+			TenantName  string `db:"_tenant_name"`
+			TenantSlug  string `db:"_tenant_slug"`
+		}
+		scanErr := tx.QueryRowxContext(ctx, query, groupID).StructScan(&row)
+		if scanErr != nil {
+			if errors.Is(scanErr, sql.ErrNoRows) {
+				return nil
+			}
+			return errxtrace.Wrap("failed to load admin group detail", scanErr)
+		}
+		group = row.LocationGroup
+		memberCount = row.MemberCount
+		tenant = models.Tenant{
+			EntityID: models.EntityID{ID: row.TenantID},
+			Name:     row.TenantName,
+			Slug:     row.TenantSlug,
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
+			"entity_type", "LocationGroup",
+			"entity_id", groupID,
+		))
+	}
+	return &registry.AdminGroupDetail{
+		Group:       &group,
+		MemberCount: memberCount,
+		Tenant:      &tenant,
+	}, nil
+}
+
+// MarkPendingDeletionAdmin flips a group to pending_deletion for the
+// cross-tenant admin soft-delete (#1748). The status-transition logic is
+// identical to GroupService.InitiateGroupDeletion — Status set to
+// pending_deletion and UpdatedAt bumped — so the existing
+// group_purge_worker finishes the hard-delete with no parallel code path.
+//
+// The whole read-decide-write runs inside one background-worker tx so two
+// concurrent admin deletes can't both observe `active` and race. Idempotent:
+// an already-pending group returns (true, nil) without re-writing the row.
+func (r *LocationGroupRegistry) MarkPendingDeletionAdmin(ctx context.Context, groupID string) (bool, error) {
+	if groupID == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+	}
+
+	groupsTable := r.tableNames.LocationGroups()
+
+	var (
+		alreadyPending bool
+		found          bool
+	)
+	err := store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		var currentStatus string
+		selectQuery := fmt.Sprintf("SELECT status FROM %s WHERE id = $1 FOR UPDATE", groupsTable)
+		scanErr := tx.QueryRowContext(ctx, selectQuery, groupID).Scan(&currentStatus)
+		if scanErr != nil {
+			if errors.Is(scanErr, sql.ErrNoRows) {
+				return nil
+			}
+			return errxtrace.Wrap("failed to load location group for soft-delete", scanErr)
+		}
+		found = true
+		if currentStatus == string(models.LocationGroupStatusPendingDeletion) {
+			alreadyPending = true
+			return nil
+		}
+		updateQuery := fmt.Sprintf("UPDATE %s SET status = $1, updated_at = $2 WHERE id = $3", groupsTable)
+		if _, execErr := tx.ExecContext(ctx, updateQuery,
+			string(models.LocationGroupStatusPendingDeletion), time.Now(), groupID); execErr != nil {
+			return errxtrace.Wrap("failed to mark location group pending_deletion", execErr)
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
+			"entity_type", "LocationGroup",
+			"entity_id", groupID,
+		))
+	}
+	return alreadyPending, nil
 }

--- a/go/registry/postgres/location_groups.go
+++ b/go/registry/postgres/location_groups.go
@@ -251,6 +251,7 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 
 	groupsTable := r.tableNames.LocationGroups()
 	membershipsTable := r.tableNames.GroupMemberships()
+	tenantsTable := r.tableNames.Tenants()
 
 	args := make([]any, 0, 3)
 	whereClauses := make([]string, 0, 3)
@@ -294,14 +295,21 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 		// SECURITY: sortField is constrained to AdminGroupSortField via IsValid above,
 		// direction is "ASC"/"DESC" literals, and table-names come from r.tableNames —
 		// never user-supplied — so direct fmt.Sprintf interpolation is safe.
+		//
+		// tenants is JOINed (not a correlated subquery) so each row carries
+		// the owning-tenant chip — the cross-tenant admin list renders the
+		// tenant name per row without an FE N+1 lookup. Same tx, so the JOIN
+		// is read under the same `SET LOCAL row_security = off`.
 		pageQuery := fmt.Sprintf(`
 			SELECT g.*,
-				(SELECT COUNT(*) FROM %s AS m WHERE m.group_id = g.id) AS _member_count
+				(SELECT COUNT(*) FROM %s AS m WHERE m.group_id = g.id) AS _member_count,
+				t.id AS _tenant_id, t.name AS _tenant_name, t.slug AS _tenant_slug
 			FROM %s AS g
+			JOIN %s AS t ON t.id = g.tenant_id
 			%s
 			ORDER BY g.%s %s, g.id ASC
 			LIMIT $%d OFFSET $%d`,
-			membershipsTable, groupsTable, where, string(sortField), direction, limitPos, offsetPos,
+			membershipsTable, groupsTable, tenantsTable, where, string(sortField), direction, limitPos, offsetPos,
 		)
 		pageArgs := append(append([]any{}, args...), perPage, offset)
 
@@ -314,7 +322,10 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 		for rows.Next() {
 			var row struct {
 				models.LocationGroup
-				MemberCount int `db:"_member_count"`
+				MemberCount int    `db:"_member_count"`
+				TenantID    string `db:"_tenant_id"`
+				TenantName  string `db:"_tenant_name"`
+				TenantSlug  string `db:"_tenant_slug"`
 			}
 			if scanErr := rows.StructScan(&row); scanErr != nil {
 				return errxtrace.Wrap("failed to scan admin group row", scanErr)
@@ -323,6 +334,11 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 			items = append(items, &registry.AdminGroupListItem{
 				Group:       &group,
 				MemberCount: row.MemberCount,
+				Tenant: &models.Tenant{
+					EntityID: models.EntityID{ID: row.TenantID},
+					Name:     row.TenantName,
+					Slug:     row.TenantSlug,
+				},
 			})
 		}
 		if rowsErr := rows.Err(); rowsErr != nil {
@@ -441,6 +457,14 @@ func (r *LocationGroupRegistry) MarkPendingDeletionAdmin(ctx context.Context, gr
 		detail         *registry.AdminGroupDetail
 	)
 	err := store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// Defense-in-depth: like ListAdmin / GetAdmin, make the intentional
+		// cross-tenant write explicit at the call site. On the background-
+		// worker role (which carries RLS bypass policies on location_groups)
+		// this is effectively a no-op rather than the primary guard.
+		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
+			return errxtrace.Wrap("failed to disable row_security for admin group soft-delete", execErr)
+		}
+
 		var currentStatus string
 		selectQuery := fmt.Sprintf("SELECT status FROM %s WHERE id = $1 FOR UPDATE", groupsTable)
 		scanErr := tx.QueryRowContext(ctx, selectQuery, groupID).Scan(&currentStatus)

--- a/go/registry/postgres/location_groups.go
+++ b/go/registry/postgres/location_groups.go
@@ -300,12 +300,19 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 		// the owning-tenant chip — the cross-tenant admin list renders the
 		// tenant name per row without an FE N+1 lookup. Same tx, so the JOIN
 		// is read under the same `SET LOCAL row_security = off`.
+		//
+		// LEFT JOIN, not INNER: AdminGroupListItem.Tenant is *models.Tenant
+		// (nullable by contract). An INNER JOIN would silently DROP a group
+		// whose tenant row is missing/corrupt — the worst behavior for a
+		// cross-tenant admin debugging surface, where an admin most needs to
+		// SEE orphaned groups. With LEFT JOIN the tenant columns scan NULL
+		// and Tenant is left nil.
 		pageQuery := fmt.Sprintf(`
 			SELECT g.*,
 				(SELECT COUNT(*) FROM %s AS m WHERE m.group_id = g.id) AS _member_count,
 				t.id AS _tenant_id, t.name AS _tenant_name, t.slug AS _tenant_slug
 			FROM %s AS g
-			JOIN %s AS t ON t.id = g.tenant_id
+			LEFT JOIN %s AS t ON t.id = g.tenant_id
 			%s
 			ORDER BY g.%s %s, g.id ASC
 			LIMIT $%d OFFSET $%d`,
@@ -322,10 +329,10 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 		for rows.Next() {
 			var row struct {
 				models.LocationGroup
-				MemberCount int    `db:"_member_count"`
-				TenantID    string `db:"_tenant_id"`
-				TenantName  string `db:"_tenant_name"`
-				TenantSlug  string `db:"_tenant_slug"`
+				MemberCount int            `db:"_member_count"`
+				TenantID    sql.NullString `db:"_tenant_id"`
+				TenantName  sql.NullString `db:"_tenant_name"`
+				TenantSlug  sql.NullString `db:"_tenant_slug"`
 			}
 			if scanErr := rows.StructScan(&row); scanErr != nil {
 				return errxtrace.Wrap("failed to scan admin group row", scanErr)
@@ -334,11 +341,7 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 			items = append(items, &registry.AdminGroupListItem{
 				Group:       &group,
 				MemberCount: row.MemberCount,
-				Tenant: &models.Tenant{
-					EntityID: models.EntityID{ID: row.TenantID},
-					Name:     row.TenantName,
-					Slug:     row.TenantSlug,
-				},
+				Tenant:      tenantFromNullableColumns(row.TenantID, row.TenantName, row.TenantSlug),
 			})
 		}
 		if rowsErr := rows.Err(); rowsErr != nil {
@@ -396,21 +399,28 @@ func (r *LocationGroupRegistry) loadAdminGroupDetailTx(ctx context.Context, tx *
 	membershipsTable := r.tableNames.GroupMemberships()
 	tenantsTable := r.tableNames.Tenants()
 
+	// LEFT JOIN, not INNER: AdminGroupDetail.Tenant is *models.Tenant
+	// (nullable by contract). An INNER JOIN would drop the row entirely
+	// when the group's tenant is missing/corrupt, making GetAdmin return
+	// ErrNotFound (404) for a group that genuinely exists — exactly the
+	// orphaned group an admin needs to see. With LEFT JOIN the group row
+	// is still returned; the tenant columns scan NULL and Tenant is nil.
+	// ErrNotFound stays reserved for a genuinely absent group row.
 	query := fmt.Sprintf(`
 		SELECT g.*,
 			(SELECT COUNT(*) FROM %s AS m WHERE m.group_id = g.id) AS _member_count,
 			t.id AS _tenant_id, t.name AS _tenant_name, t.slug AS _tenant_slug
 		FROM %s AS g
-		JOIN %s AS t ON t.id = g.tenant_id
+		LEFT JOIN %s AS t ON t.id = g.tenant_id
 		WHERE g.id = $1`,
 		membershipsTable, groupsTable, tenantsTable,
 	)
 	var row struct {
 		models.LocationGroup
-		MemberCount int    `db:"_member_count"`
-		TenantID    string `db:"_tenant_id"`
-		TenantName  string `db:"_tenant_name"`
-		TenantSlug  string `db:"_tenant_slug"`
+		MemberCount int            `db:"_member_count"`
+		TenantID    sql.NullString `db:"_tenant_id"`
+		TenantName  sql.NullString `db:"_tenant_name"`
+		TenantSlug  sql.NullString `db:"_tenant_slug"`
 	}
 	scanErr := tx.QueryRowxContext(ctx, query, groupID).StructScan(&row)
 	if scanErr != nil {
@@ -423,12 +433,24 @@ func (r *LocationGroupRegistry) loadAdminGroupDetailTx(ctx context.Context, tx *
 	return &registry.AdminGroupDetail{
 		Group:       &group,
 		MemberCount: row.MemberCount,
-		Tenant: &models.Tenant{
-			EntityID: models.EntityID{ID: row.TenantID},
-			Name:     row.TenantName,
-			Slug:     row.TenantSlug,
-		},
+		Tenant:      tenantFromNullableColumns(row.TenantID, row.TenantName, row.TenantSlug),
 	}, nil
+}
+
+// tenantFromNullableColumns builds the owning-tenant chip from the
+// LEFT-JOINed tenant columns of an admin group query. When the tenant row
+// is absent (group orphaned / tenant corrupt) the columns scan NULL and
+// this returns nil — never a synthesized empty &models.Tenant{} — so the
+// nullable AdminGroup*.Tenant contract holds and the FE omits the chip.
+func tenantFromNullableColumns(id, name, slug sql.NullString) *models.Tenant {
+	if !id.Valid {
+		return nil
+	}
+	return &models.Tenant{
+		EntityID: models.EntityID{ID: id.String},
+		Name:     name.String,
+		Slug:     slug.String,
+	}
 }
 
 // MarkPendingDeletionAdmin flips a group to pending_deletion for the

--- a/go/registry/postgres/location_groups.go
+++ b/go/registry/postgres/location_groups.go
@@ -220,14 +220,14 @@ func (r *LocationGroupRegistry) ListByTenant(ctx context.Context, tenantID strin
 // member_count from a correlated subquery on group_memberships.
 //
 // The endpoint crosses tenants by design — a system admin lists every
-// tenant's groups. location_groups has RLS enabled with a tenant-isolation
-// policy; `SET LOCAL row_security = off` on the tx is the fail-loud guard:
-// per postgres semantics a non-bypass role querying an RLS-protected table
-// with row_security=off ERRORs rather than silently filtering. The
-// background-worker connection role this registry runs as carries a bypass
-// policy, so the cross-tenant read succeeds; if that bypass is ever revoked
-// the endpoint 5xx-es loudly instead of returning a quietly empty page.
-// Same rationale as TenantRegistry.ListAdmin / UserRegistry.ListAdminByTenant.
+// tenant's groups. This registry runs in service mode as the
+// inventario_background_worker role, which already carries `using=true`
+// bypass policies on location_groups / group_memberships, so the
+// cross-tenant read works regardless of RLS. The `SET LOCAL row_security =
+// off` on the tx is defense-in-depth: it makes the intentional cross-tenant
+// read explicit at the call site and, on the bypass role, is effectively a
+// no-op rather than the primary guard. Same rationale as
+// TenantRegistry.ListAdmin / UserRegistry.ListAdminByTenant.
 //
 // Total is post-filter, pre-pagination.
 func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.AdminGroupListOptions) ([]*registry.AdminGroupListItem, int, error) {
@@ -339,74 +339,79 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 // GetAdmin returns a single group detail row with the computed
 // member_count plus the owning tenant (joined so the detail handler can
 // render the tenant chip in one round-trip). Runs under
-// `SET LOCAL row_security = off` for the same fail-loud cross-tenant
-// rationale as ListAdmin.
+// `SET LOCAL row_security = off` for the same defense-in-depth
+// cross-tenant rationale as ListAdmin.
 func (r *LocationGroupRegistry) GetAdmin(ctx context.Context, groupID string) (*registry.AdminGroupDetail, error) {
 	if groupID == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
 	}
 
-	groupsTable := r.tableNames.LocationGroups()
-	membershipsTable := r.tableNames.GroupMemberships()
-	tenantsTable := r.tableNames.Tenants()
-
-	var (
-		group       models.LocationGroup
-		tenant      models.Tenant
-		memberCount int
-		found       bool
-	)
+	var detail *registry.AdminGroupDetail
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
 		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
 			return errxtrace.Wrap("failed to disable row_security for admin group detail", execErr)
 		}
-		query := fmt.Sprintf(`
-			SELECT g.*,
-				(SELECT COUNT(*) FROM %s AS m WHERE m.group_id = g.id) AS _member_count,
-				t.id AS _tenant_id, t.name AS _tenant_name, t.slug AS _tenant_slug
-			FROM %s AS g
-			JOIN %s AS t ON t.id = g.tenant_id
-			WHERE g.id = $1`,
-			membershipsTable, groupsTable, tenantsTable,
-		)
-		var row struct {
-			models.LocationGroup
-			MemberCount int    `db:"_member_count"`
-			TenantID    string `db:"_tenant_id"`
-			TenantName  string `db:"_tenant_name"`
-			TenantSlug  string `db:"_tenant_slug"`
-		}
-		scanErr := tx.QueryRowxContext(ctx, query, groupID).StructScan(&row)
-		if scanErr != nil {
-			if errors.Is(scanErr, sql.ErrNoRows) {
-				return nil
-			}
-			return errxtrace.Wrap("failed to load admin group detail", scanErr)
-		}
-		group = row.LocationGroup
-		memberCount = row.MemberCount
-		tenant = models.Tenant{
-			EntityID: models.EntityID{ID: row.TenantID},
-			Name:     row.TenantName,
-			Slug:     row.TenantSlug,
-		}
-		found = true
-		return nil
+		var loadErr error
+		detail, loadErr = r.loadAdminGroupDetailTx(ctx, tx, groupID)
+		return loadErr
 	})
 	if err != nil {
 		return nil, err
 	}
-	if !found {
+	if detail == nil {
 		return nil, errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
 			"entity_type", "LocationGroup",
 			"entity_id", groupID,
 		))
 	}
+	return detail, nil
+}
+
+// loadAdminGroupDetailTx loads the admin group detail row (group +
+// member_count + tenant chip) within the supplied tx. It is the shared
+// detail-shaping query used by both GetAdmin and MarkPendingDeletionAdmin
+// so the post-delete row carries exactly the shape the detail handler
+// renders without a second round-trip. Returns (nil, nil) when the group
+// id doesn't exist — callers map that to ErrNotFound. The caller is
+// responsible for the `SET LOCAL row_security = off` on the tx.
+func (r *LocationGroupRegistry) loadAdminGroupDetailTx(ctx context.Context, tx *sqlx.Tx, groupID string) (*registry.AdminGroupDetail, error) {
+	groupsTable := r.tableNames.LocationGroups()
+	membershipsTable := r.tableNames.GroupMemberships()
+	tenantsTable := r.tableNames.Tenants()
+
+	query := fmt.Sprintf(`
+		SELECT g.*,
+			(SELECT COUNT(*) FROM %s AS m WHERE m.group_id = g.id) AS _member_count,
+			t.id AS _tenant_id, t.name AS _tenant_name, t.slug AS _tenant_slug
+		FROM %s AS g
+		JOIN %s AS t ON t.id = g.tenant_id
+		WHERE g.id = $1`,
+		membershipsTable, groupsTable, tenantsTable,
+	)
+	var row struct {
+		models.LocationGroup
+		MemberCount int    `db:"_member_count"`
+		TenantID    string `db:"_tenant_id"`
+		TenantName  string `db:"_tenant_name"`
+		TenantSlug  string `db:"_tenant_slug"`
+	}
+	scanErr := tx.QueryRowxContext(ctx, query, groupID).StructScan(&row)
+	if scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, errxtrace.Wrap("failed to load admin group detail", scanErr)
+	}
+	group := row.LocationGroup
 	return &registry.AdminGroupDetail{
 		Group:       &group,
-		MemberCount: memberCount,
-		Tenant:      &tenant,
+		MemberCount: row.MemberCount,
+		Tenant: &models.Tenant{
+			EntityID: models.EntityID{ID: row.TenantID},
+			Name:     row.TenantName,
+			Slug:     row.TenantSlug,
+		},
 	}, nil
 }
 
@@ -416,19 +421,24 @@ func (r *LocationGroupRegistry) GetAdmin(ctx context.Context, groupID string) (*
 // pending_deletion and UpdatedAt bumped — so the existing
 // group_purge_worker finishes the hard-delete with no parallel code path.
 //
-// The whole read-decide-write runs inside one background-worker tx so two
-// concurrent admin deletes can't both observe `active` and race. Idempotent:
-// an already-pending group returns (true, nil) without re-writing the row.
-func (r *LocationGroupRegistry) MarkPendingDeletionAdmin(ctx context.Context, groupID string) (bool, error) {
+// The whole read-decide-write-reload runs inside one background-worker tx
+// so two concurrent admin deletes can't both observe `active` and race,
+// and the returned detail row is the committed post-transition state. The
+// in-tx reload (instead of a follow-up GetAdmin) closes a TOCTOU window:
+// between the soft-delete commit and a separate re-fetch the
+// group_purge_worker could hard-delete the now-pending row, turning a
+// successful DELETE into a spurious 404. Idempotent: an already-pending
+// group returns (detail, true, nil) without re-writing the row.
+func (r *LocationGroupRegistry) MarkPendingDeletionAdmin(ctx context.Context, groupID string) (*registry.AdminGroupDetail, bool, error) {
 	if groupID == "" {
-		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
+		return nil, false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
 	}
 
 	groupsTable := r.tableNames.LocationGroups()
 
 	var (
 		alreadyPending bool
-		found          bool
+		detail         *registry.AdminGroupDetail
 	)
 	err := store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
 		var currentStatus string
@@ -440,26 +450,30 @@ func (r *LocationGroupRegistry) MarkPendingDeletionAdmin(ctx context.Context, gr
 			}
 			return errxtrace.Wrap("failed to load location group for soft-delete", scanErr)
 		}
-		found = true
 		if currentStatus == string(models.LocationGroupStatusPendingDeletion) {
 			alreadyPending = true
-			return nil
+		} else {
+			updateQuery := fmt.Sprintf("UPDATE %s SET status = $1, updated_at = $2 WHERE id = $3", groupsTable)
+			if _, execErr := tx.ExecContext(ctx, updateQuery,
+				string(models.LocationGroupStatusPendingDeletion), time.Now(), groupID); execErr != nil {
+				return errxtrace.Wrap("failed to mark location group pending_deletion", execErr)
+			}
 		}
-		updateQuery := fmt.Sprintf("UPDATE %s SET status = $1, updated_at = $2 WHERE id = $3", groupsTable)
-		if _, execErr := tx.ExecContext(ctx, updateQuery,
-			string(models.LocationGroupStatusPendingDeletion), time.Now(), groupID); execErr != nil {
-			return errxtrace.Wrap("failed to mark location group pending_deletion", execErr)
-		}
-		return nil
+		// Reload the post-transition detail row in the SAME tx — the row is
+		// still pinned by the FOR UPDATE lock above, so this reflects the
+		// committed state and cannot race the purge worker.
+		var loadErr error
+		detail, loadErr = r.loadAdminGroupDetailTx(ctx, tx, groupID)
+		return loadErr
 	})
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
-	if !found {
-		return false, errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
+	if detail == nil {
+		return nil, false, errxtrace.Classify(registry.ErrNotFound, errx.Attrs(
 			"entity_type", "LocationGroup",
 			"entity_id", groupID,
 		))
 	}
-	return alreadyPending, nil
+	return detail, alreadyPending, nil
 }

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -1227,15 +1227,19 @@ type LocationGroupRegistry interface {
 
 	// ListAdmin returns a paginated, filtered, and sorted listing of every
 	// location group in the deployment alongside per-group computed
-	// member_count (accepted memberships only). The endpoint behind this
-	// method (/api/v1/admin/groups — #1748) crosses tenants by design, so
-	// implementations MUST return rows across all tenants regardless of
-	// caller membership. The postgres LocationGroupRegistry runs the cross-
-	// tenant read as the background-worker role (which carries RLS bypass
-	// policies); `SET LOCAL row_security = off` is added as defense-in-depth
-	// to make the cross-tenant read explicit, not as the primary guard.
-	// member_count is computed via a correlated subquery on
-	// group_memberships. Memory walks the in-memory stores.
+	// member_count (accepted memberships only) and the owning tenant. The
+	// endpoint behind this method (/api/v1/admin/groups — #1748) crosses
+	// tenants by design, so implementations MUST return rows across all
+	// tenants regardless of caller membership. The postgres
+	// LocationGroupRegistry runs the cross-tenant read as the background-
+	// worker role (which carries RLS bypass policies); `SET LOCAL
+	// row_security = off` is added as defense-in-depth to make the cross-
+	// tenant read explicit, not as the primary guard. member_count is
+	// computed via a correlated subquery on group_memberships, and the
+	// owning tenant is resolved per row (postgres JOINs tenants in the same
+	// tx; memory looks it up via the tenant registry) so the FE renders an
+	// owning-tenant chip per row without an N+1 lookup. Memory walks the
+	// in-memory stores.
 	//
 	// Total is the count before LIMIT/OFFSET is applied.
 	ListAdmin(ctx context.Context, opts AdminGroupListOptions) (items []*AdminGroupListItem, total int, err error)
@@ -1322,10 +1326,16 @@ type AdminGroupListOptions struct {
 
 // AdminGroupListItem is the row shape returned by
 // LocationGroupRegistry.ListAdmin: the group row plus the computed
-// member_count the admin listing UI needs to render at a glance.
+// member_count and the owning tenant the admin listing UI needs to
+// render at a glance. Tenant is resolved per row (joined / looked up by
+// the registry) so the cross-tenant admin list can render an owning-
+// tenant chip without an FE N+1 lookup. Tenant may be nil if the join
+// row is somehow missing, but a group with a non-NULL tenant_id FK
+// should always resolve one.
 type AdminGroupListItem struct {
 	Group       *models.LocationGroup
 	MemberCount int
+	Tenant      *models.Tenant
 }
 
 // AdminGroupDetail is the row shape returned by

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -1224,6 +1224,111 @@ type LocationGroupRegistry interface {
 
 	// ListByTenant returns all groups for a tenant.
 	ListByTenant(ctx context.Context, tenantID string) ([]*models.LocationGroup, error)
+
+	// ListAdmin returns a paginated, filtered, and sorted listing of every
+	// location group in the deployment alongside per-group computed
+	// member_count (accepted memberships only). The endpoint behind this
+	// method (/api/v1/admin/groups — #1748) crosses tenants by design, so
+	// implementations MUST return rows across all tenants regardless of
+	// caller membership. The postgres LocationGroupRegistry runs the cross-
+	// tenant read under `SET LOCAL row_security = off` as a fail-loud guard
+	// so a future loss of the connection role's RLS bypass produces a 5xx
+	// rather than a silently empty page; member_count is computed via a
+	// correlated subquery on group_memberships. Memory walks the in-memory
+	// stores.
+	//
+	// Total is the count before LIMIT/OFFSET is applied.
+	ListAdmin(ctx context.Context, opts AdminGroupListOptions) (items []*AdminGroupListItem, total int, err error)
+
+	// GetAdmin returns a single group detail row with the same computed
+	// member_count the listing surfaces, joined with the owning tenant so
+	// the detail handler can render the tenant chip without a second
+	// round-trip. Used by the `/api/v1/admin/groups/{groupID}` detail
+	// handler. Returns ErrNotFound when the group id doesn't exist.
+	GetAdmin(ctx context.Context, groupID string) (*AdminGroupDetail, error)
+
+	// MarkPendingDeletionAdmin flips a group's status to pending_deletion
+	// for the cross-tenant admin soft-delete (/api/v1/admin/groups/{groupID}
+	// DELETE — #1748). It bypasses RLS so a system admin can act on any
+	// tenant's group; the status-transition logic is identical to
+	// GroupService.InitiateGroupDeletion (Status = pending_deletion,
+	// UpdatedAt bumped) so the existing group_purge_worker finishes the
+	// hard-delete with no parallel code path.
+	//
+	// The call is idempotent: when the group is already pending_deletion
+	// it returns (alreadyPending=true, nil) without re-writing the row so
+	// the handler can render a 200 with the current status. On a genuine
+	// transition it returns (false, nil); on a missing group it returns
+	// (false, ErrNotFound).
+	MarkPendingDeletionAdmin(ctx context.Context, groupID string) (alreadyPending bool, err error)
+}
+
+// AdminGroupSortField names the columns the admin group listing endpoint
+// understands for sorting. Names are part of the public API surface; the
+// FE codegen treats them as opaque strings sent in `?sort`.
+type AdminGroupSortField string
+
+const (
+	AdminGroupSortName      AdminGroupSortField = "name"
+	AdminGroupSortSlug      AdminGroupSortField = "slug"
+	AdminGroupSortCreatedAt AdminGroupSortField = "created_at"
+	AdminGroupSortStatus    AdminGroupSortField = "status"
+)
+
+// IsValid reports whether s is a known admin group sort field. Callers
+// should fall back to AdminGroupSortName on invalid input rather than
+// 4xx — the FE may pass an unknown sort during a multi-version rollout.
+func (s AdminGroupSortField) IsValid() bool {
+	switch s {
+	case AdminGroupSortName, AdminGroupSortSlug, AdminGroupSortCreatedAt, AdminGroupSortStatus:
+		return true
+	}
+	return false
+}
+
+// AdminGroupListOptions narrows the result of LocationGroupRegistry.ListAdmin.
+// Page/PerPage are 1-based; PerPage <= 0 falls back to a sensible default
+// at the registry layer, and the handler caps it at 100.
+type AdminGroupListOptions struct {
+	// Page is the 1-based page index. Defaults to 1 when <= 0.
+	Page int
+	// PerPage is the requested page size. Defaults to 50 when <= 0.
+	PerPage int
+	// Query, when non-empty, narrows the result to groups whose name or
+	// slug ILIKE %query%. The match is case-insensitive and uses
+	// substring semantics.
+	Query string
+	// TenantID, when non-empty, narrows the result to groups belonging to
+	// that exact tenant.
+	TenantID string
+	// Status, when non-empty, narrows the result to groups in that exact
+	// status (active / pending_deletion).
+	Status string
+	// SortField is the column to sort by. Defaults to AdminGroupSortName
+	// when empty or invalid.
+	SortField AdminGroupSortField
+	// SortDesc reverses the natural order of the chosen field. Default
+	// is false (ascending).
+	SortDesc bool
+}
+
+// AdminGroupListItem is the row shape returned by
+// LocationGroupRegistry.ListAdmin: the group row plus the computed
+// member_count the admin listing UI needs to render at a glance.
+type AdminGroupListItem struct {
+	Group       *models.LocationGroup
+	MemberCount int
+}
+
+// AdminGroupDetail is the row shape returned by
+// LocationGroupRegistry.GetAdmin: the group row plus the computed
+// member_count and the owning tenant (resolved for the detail-page
+// tenant chip). Tenant may be nil if the join row is somehow missing,
+// but a group with a non-NULL tenant_id FK should always resolve one.
+type AdminGroupDetail struct {
+	Group       *models.LocationGroup
+	MemberCount int
+	Tenant      *models.Tenant
 }
 
 // GroupMembershipRegistry manages user memberships in location groups.

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -1231,11 +1231,11 @@ type LocationGroupRegistry interface {
 	// method (/api/v1/admin/groups — #1748) crosses tenants by design, so
 	// implementations MUST return rows across all tenants regardless of
 	// caller membership. The postgres LocationGroupRegistry runs the cross-
-	// tenant read under `SET LOCAL row_security = off` as a fail-loud guard
-	// so a future loss of the connection role's RLS bypass produces a 5xx
-	// rather than a silently empty page; member_count is computed via a
-	// correlated subquery on group_memberships. Memory walks the in-memory
-	// stores.
+	// tenant read as the background-worker role (which carries RLS bypass
+	// policies); `SET LOCAL row_security = off` is added as defense-in-depth
+	// to make the cross-tenant read explicit, not as the primary guard.
+	// member_count is computed via a correlated subquery on
+	// group_memberships. Memory walks the in-memory stores.
 	//
 	// Total is the count before LIMIT/OFFSET is applied.
 	ListAdmin(ctx context.Context, opts AdminGroupListOptions) (items []*AdminGroupListItem, total int, err error)
@@ -1255,12 +1255,20 @@ type LocationGroupRegistry interface {
 	// UpdatedAt bumped) so the existing group_purge_worker finishes the
 	// hard-delete with no parallel code path.
 	//
-	// The call is idempotent: when the group is already pending_deletion
-	// it returns (alreadyPending=true, nil) without re-writing the row so
+	// It returns the post-transition detail row (the same shape GetAdmin
+	// returns: group row + member_count + tenant chip) computed inside the
+	// SAME transaction as the status write, so the handler renders directly
+	// from it with NO second round-trip. Without this the handler would have
+	// to re-fetch via GetAdmin, which races the group_purge_worker — between
+	// the soft-delete commit and the re-fetch the worker can hard-delete the
+	// now-pending row, turning a DELETE that actually succeeded into a 404.
+	//
+	// The call is idempotent: when the group is already pending_deletion it
+	// returns (item, alreadyPending=true, nil) without re-writing the row so
 	// the handler can render a 200 with the current status. On a genuine
-	// transition it returns (false, nil); on a missing group it returns
-	// (false, ErrNotFound).
-	MarkPendingDeletionAdmin(ctx context.Context, groupID string) (alreadyPending bool, err error)
+	// transition it returns (item, false, nil); on a missing group it returns
+	// (nil, false, ErrNotFound).
+	MarkPendingDeletionAdmin(ctx context.Context, groupID string) (item *AdminGroupDetail, alreadyPending bool, err error)
 }
 
 // AdminGroupSortField names the columns the admin group listing endpoint

--- a/go/services/group_purge_service_test.go
+++ b/go/services/group_purge_service_test.go
@@ -334,6 +334,58 @@ func TestGroupPurgeService_PurgeOnce_Reentrancy(t *testing.T) {
 	c.Assert(audits, qt.HasLen, 1)
 }
 
+// TestGroupPurgeService_PurgeOnce_AfterAdminSoftDelete is the #1748
+// integration check: an admin soft-delete (the registry-level
+// MarkPendingDeletionAdmin the admin DELETE handler calls) flips a group
+// to pending_deletion, and a subsequent purge worker sweep
+// (GroupPurgeService.PurgeOnce) hard-deletes the row. No parallel purge
+// code path — the admin DELETE only owns the status transition and the
+// existing worker finishes the job.
+func TestGroupPurgeService_PurgeOnce_AfterAdminSoftDelete(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	fs := memory.NewFactorySet()
+	fileSvc := services.NewFileService(fs, newFileUploadLocation(c))
+	svc := services.NewGroupPurgeService(fs, fileSvc)
+
+	// Start from an active group — the admin DELETE handler's input state.
+	group, err := fs.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: "tenant-a"},
+		Slug:                "admin-deleted-slug-000000000",
+		Name:                "Admin Deleted Group",
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           "user-admin",
+		GroupCurrency:       "USD",
+	})
+	c.Assert(err, qt.IsNil)
+
+	// A pre-purge sweep is a no-op: the group is still active.
+	purged, failed, err := svc.PurgeOnce(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(purged, qt.Equals, 0)
+	c.Assert(failed, qt.Equals, 0)
+
+	// Admin soft-delete — exactly what the /api/v1/admin/groups/{id}
+	// DELETE handler invokes.
+	alreadyPending, err := fs.LocationGroupRegistry.MarkPendingDeletionAdmin(ctx, group.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(alreadyPending, qt.IsFalse)
+
+	// Group is now pending_deletion but still present.
+	pending, err := fs.LocationGroupRegistry.Get(ctx, group.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(pending.Status, qt.Equals, models.LocationGroupStatusPendingDeletion)
+
+	// The purge worker's next sweep finishes the hard-delete.
+	purged, failed, err = svc.PurgeOnce(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(purged, qt.Equals, 1)
+	c.Assert(failed, qt.Equals, 0)
+
+	_, err = fs.LocationGroupRegistry.Get(ctx, group.ID)
+	c.Assert(err, qt.ErrorIs, registry.ErrNotFound)
+}
+
 // TestGroupPurgeService_PurgeOnce_PartialFailure_NoDuplicateAudit drives the
 // re-entrancy contract on a hard case: the first sweep writes the invite
 // audit snapshot and then crashes during blob deletion, leaving the group

--- a/go/services/group_purge_service_test.go
+++ b/go/services/group_purge_service_test.go
@@ -348,9 +348,20 @@ func TestGroupPurgeService_PurgeOnce_AfterAdminSoftDelete(t *testing.T) {
 	fileSvc := services.NewFileService(fs, newFileUploadLocation(c))
 	svc := services.NewGroupPurgeService(fs, fileSvc)
 
+	// MarkPendingDeletionAdmin returns the post-transition detail row,
+	// which JOINs the owning tenant for the chip — so the group's tenant
+	// must exist (it always does in production: tenant_id is a FK).
+	tenant, err := fs.TenantRegistry.Create(ctx, models.Tenant{
+		Name:   "Tenant A",
+		Slug:   "tenant-a",
+		Status: models.TenantStatusActive,
+		PlanID: models.PlanUnlimited.ID,
+	})
+	c.Assert(err, qt.IsNil)
+
 	// Start from an active group — the admin DELETE handler's input state.
 	group, err := fs.LocationGroupRegistry.Create(ctx, models.LocationGroup{
-		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: "tenant-a"},
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenant.ID},
 		Slug:                "admin-deleted-slug-000000000",
 		Name:                "Admin Deleted Group",
 		Status:              models.LocationGroupStatusActive,
@@ -366,10 +377,12 @@ func TestGroupPurgeService_PurgeOnce_AfterAdminSoftDelete(t *testing.T) {
 	c.Assert(failed, qt.Equals, 0)
 
 	// Admin soft-delete — exactly what the /api/v1/admin/groups/{id}
-	// DELETE handler invokes.
-	alreadyPending, err := fs.LocationGroupRegistry.MarkPendingDeletionAdmin(ctx, group.ID)
+	// DELETE handler invokes. It returns the post-transition detail row.
+	detail, alreadyPending, err := fs.LocationGroupRegistry.MarkPendingDeletionAdmin(ctx, group.ID)
 	c.Assert(err, qt.IsNil)
 	c.Assert(alreadyPending, qt.IsFalse)
+	c.Assert(detail, qt.IsNotNil)
+	c.Assert(detail.Group.Status, qt.Equals, models.LocationGroupStatusPendingDeletion)
 
 	// Group is now pending_deletion but still present.
 	pending, err := fs.LocationGroupRegistry.Get(ctx, group.ID)


### PR DESCRIPTION
## Summary

Implements #1748 — the cross-tenant Groups admin surface under the #1744 umbrella. Builds on the merged #1746 (admin tenants/users listing) and #1747 (admin block/unblock) patterns.

Three system-admin endpoints (all behind `RequireSystemAdmin`):

- `GET /api/v1/admin/groups?page&per_page&q&tenantID&status&sort&order` — cross-tenant list with computed `member_count` and a tenant chip. Filters: `q` (name/slug ILIKE), `tenantID` (exact), `status` (exact).
- `GET /api/v1/admin/groups/{groupID}` — detail: name, slug, status, group currency, created_by, member_count, tenant chip (id/name/slug).
- `DELETE /api/v1/admin/groups/{groupID}` — soft-delete: sets `LocationGroup.Status = pending_deletion`; the existing `group_purge_worker` finishes the hard-delete. **Idempotent** — re-deleting an already `pending_deletion` group returns 200 with current status, never an error. Audit-logged.

## Design notes

- **Cross-tenant reads bypass RLS** the same way #1746 does: postgres `ListAdmin`/`GetAdmin` run under `SET LOCAL row_security = off` (fail-loud guard); the soft-delete runs in a background-worker tx with `SELECT ... FOR UPDATE`. Handlers use `FactorySet` directly, never the per-request user-aware set.
- **No parallel deletion path** — the admin soft-delete performs the exact same `Status = pending_deletion` + `UpdatedAt` transition as `GroupService.InitiateGroupDeletion`; the purge worker is unchanged.
- **Idempotency** — `LocationGroupRegistry.MarkPendingDeletionAdmin` returns `(alreadyPending bool, err error)`; the handler always re-fetches and renders the current status.
- **Audit** — `admin.delete_group` rows carry actor (admin user ID), subject (`group`/groupID), the group's tenant ID, and an `already_pending` breadcrumb. List/get emit `admin.list_groups`/`admin.get_group`. Audited after render.
- **`tenantID` query filter + security middleware** — the global `ValidateNoUserProvidedTenantID` guard rejects any query param containing `tenant`. The query-param check is now exempted for the `/api/v1/admin/` subtree only: that subtree is cross-tenant by design, gated by `RequireSystemAdmin`, and its handlers resolve data via `FactorySet` (never an RLS-context override), so a `tenantID` value there is a documented filter, not an injection vector. Header and request-body tenant checks remain fully in force for admin paths.

## Tests

- 13 handler tests (`admin_groups_test.go`): auth gating, filter/pagination/sort combinations, tenant-chip + member_count, idempotent re-delete, audit-log assertions.
- Middleware tests (`security_middleware_test.go`): admin-path `tenantID` query allowed; non-admin path still 403; admin-path tenant header/body still 403; `/api/v1/administrate` sibling not exempt.
- Integration test (`group_purge_service_test.go`): after an admin soft-delete, `GroupPurgeService.PurgeOnce` removes the row.
- `TestSwaggerRouteCoverage` passes — all 3 routes documented.

No schema migration needed — `location_groups` already has the `status` column and `idx_location_groups_status` index.

Closes #1748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System-admin API to list, view, and soft-delete location groups across tenants; listing supports search/filter/pagination/sort, details include member counts and tenant chip (nil for orphaned groups), and delete is idempotent. Audit entries recorded for admin actions.

* **Documentation**
  * API docs and client typings updated to include the new admin groups endpoints and response schemas.

* **Security**
  * Query-parameter tenant check exempts admin routes under /api/v1/admin/ (header/body tenant checks still enforced).

* **Tests**
  * Added comprehensive tests for auth, list/detail/filtering/pagination/sort, delete/idempotency/purge, middleware exemption, and audit logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1769?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->