### PR TITLE
[#1749] Admin group membership endpoints (add / remove / role-change)

### DIFF
--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -59,6 +59,255 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/admin/groups/{groupID}/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Add a member to a group (admin)
+         * @description Adds a user to a group with the given role, bypassing the per-group admin check. The membership cap is still enforced — a user already at the cap is rejected with 422.
+         *     Returns 422 with `admin.member.tenant_mismatch` when the target user's tenant differs from the group's tenant, `admin.member.invalid_role` for a missing or invalid role, and `admin.member.user_required` for a missing userID.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group ID */
+                    groupID: string;
+                };
+                cookie?: never;
+            };
+            /** @description Add-member request */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["apiserver.AdminAddMemberRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["apiserver.AdminMemberEnvelope"];
+                    };
+                };
+                /** @description Bad Request - invalid body */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Forbidden - system-admin required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Not Found - unknown group or user */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unprocessable Entity - tenant mismatch, cap reached, duplicate, or invalid role */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/groups/{groupID}/members/{userID}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Remove a member from a group (admin)
+         * @description Removes a user from a group, bypassing the per-group admin check. The ≥1-owner and ≥1-member invariants still apply — removing the last owner returns 422, removing the last member returns 422 with `group.last_member`.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group ID */
+                    groupID: string;
+                    /** @description User ID of the member to remove */
+                    userID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Forbidden - system-admin required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Not Found - user is not a member of the group */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unprocessable Entity - removing the last owner or last member */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /**
+         * Change a member's role (admin)
+         * @description Changes a group member's role, bypassing the per-group admin check. Demoting the sole owner is rejected with 422 (`ErrLastOwner`). Returns 422 with `admin.member.invalid_role` for a missing or invalid role.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group ID */
+                    groupID: string;
+                    /** @description User ID of the member */
+                    userID: string;
+                };
+                cookie?: never;
+            };
+            /** @description Role-change request */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["apiserver.AdminUpdateMemberRoleRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["apiserver.AdminMemberEnvelope"];
+                    };
+                };
+                /** @description Bad Request - invalid body */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Forbidden - system-admin required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Not Found - user is not a member of the group */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unprocessable Entity - demoting the last owner or invalid role */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/admin/tenants": {
         parameters: {
             query?: never;
@@ -7425,6 +7674,12 @@ export type paths = {
 export type webhooks = Record<string, never>;
 export type components = {
     schemas: {
+        "apiserver.AdminAddMemberRequest": {
+            /** @description Role is the group role granted to the user: viewer|user|admin|owner. */
+            role?: components["schemas"]["models.GroupRole"];
+            /** @description UserID is the ID of the user being added to the group. */
+            userID?: string;
+        };
         "apiserver.AdminBlockRequest": {
             /**
              * @description Force overrides the "cannot block another system admin" guard.
@@ -7434,6 +7689,21 @@ export type components = {
             /** @description Reason is the free-form justification for the block (max 500 chars). */
             reason: string;
         };
+        "apiserver.AdminMemberEnvelope": {
+            data?: components["schemas"]["apiserver.AdminMemberResource"];
+        };
+        "apiserver.AdminMemberResource": {
+            attributes?: components["schemas"]["apiserver.AdminMemberView"];
+            id?: string;
+            type?: string;
+        };
+        "apiserver.AdminMemberView": {
+            group_id?: string;
+            joined_at?: string;
+            member_user_id?: string;
+            role?: string;
+            tenant_id?: string;
+        };
         "apiserver.AdminPingResponse": {
             ok?: boolean;
             timestamp?: string;
@@ -7441,6 +7711,10 @@ export type components = {
         "apiserver.AdminUnblockRequest": {
             /** @description Reason is the free-form justification for the unblock (max 500 chars). */
             reason: string;
+        };
+        "apiserver.AdminUpdateMemberRoleRequest": {
+            /** @description Role is the new group role: viewer|user|admin|owner. */
+            role?: components["schemas"]["models.GroupRole"];
         };
         "apiserver.AdminUserEnvelope": {
             data?: components["schemas"]["apiserver.AdminUserResource"];

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -7676,9 +7676,9 @@ export type components = {
     schemas: {
         "apiserver.AdminAddMemberRequest": {
             /** @description Role is the group role granted to the user: viewer|user|admin|owner. */
-            role?: components["schemas"]["models.GroupRole"];
+            role: components["schemas"]["models.GroupRole"];
             /** @description UserID is the ID of the user being added to the group. */
-            userID?: string;
+            userID: string;
         };
         "apiserver.AdminBlockRequest": {
             /**
@@ -7701,7 +7701,7 @@ export type components = {
             group_id?: string;
             joined_at?: string;
             member_user_id?: string;
-            role?: string;
+            role?: components["schemas"]["models.GroupRole"];
             tenant_id?: string;
         };
         "apiserver.AdminPingResponse": {
@@ -7714,7 +7714,7 @@ export type components = {
         };
         "apiserver.AdminUpdateMemberRoleRequest": {
             /** @description Role is the new group role: viewer|user|admin|owner. */
-            role?: components["schemas"]["models.GroupRole"];
+            role: components["schemas"]["models.GroupRole"];
         };
         "apiserver.AdminUserEnvelope": {
             data?: components["schemas"]["apiserver.AdminUserResource"];

--- a/go/apiserver/admin_group_members.go
+++ b/go/apiserver/admin_group_members.go
@@ -61,9 +61,9 @@ const (
 // step.
 type AdminAddMemberRequest struct {
 	// UserID is the ID of the user being added to the group.
-	UserID string `json:"userID"`
+	UserID string `json:"userID" validate:"required"`
 	// Role is the group role granted to the user: viewer|user|admin|owner.
-	Role models.GroupRole `json:"role"`
+	Role models.GroupRole `json:"role" validate:"required"`
 }
 
 // AdminUpdateMemberRoleRequest is the request body for
@@ -72,7 +72,7 @@ type AdminAddMemberRequest struct {
 // remove + add, not a patch.
 type AdminUpdateMemberRoleRequest struct {
 	// Role is the new group role: viewer|user|admin|owner.
-	Role models.GroupRole `json:"role"`
+	Role models.GroupRole `json:"role" validate:"required"`
 }
 
 // AdminMemberView is the JSON:API-style attributes block returned by
@@ -80,11 +80,11 @@ type AdminUpdateMemberRoleRequest struct {
 // identity (group, user, role) plus the synthetic joined_at. Richer
 // member detail (avatar / email) lives on the per-group members surface.
 type AdminMemberView struct {
-	GroupID      string `json:"group_id"`
-	MemberUserID string `json:"member_user_id"`
-	Role         string `json:"role"`
-	TenantID     string `json:"tenant_id"`
-	JoinedAt     string `json:"joined_at"`
+	GroupID      string           `json:"group_id"`
+	MemberUserID string           `json:"member_user_id"`
+	Role         models.GroupRole `json:"role"`
+	TenantID     string           `json:"tenant_id"`
+	JoinedAt     string           `json:"joined_at"`
 }
 
 // AdminMemberEnvelope is the JSON:API envelope returned by add /
@@ -356,7 +356,7 @@ func (api *adminGroupMembersAPI) writeMemberEnvelope(w http.ResponseWriter, stat
 			Attributes: AdminMemberView{
 				GroupID:      m.GroupID,
 				MemberUserID: m.MemberUserID,
-				Role:         string(m.Role),
+				Role:         m.Role,
 				TenantID:     m.TenantID,
 				JoinedAt:     m.JoinedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
 			},

--- a/go/apiserver/admin_group_members.go
+++ b/go/apiserver/admin_group_members.go
@@ -1,0 +1,425 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// Admin group-membership audit action names (#1749). Kept as constants
+// so the audit trail, the swagger annotations, and the tests reference
+// the same literals. Mirrors the "admin.<noun>_<verb>" family set by
+// #1745 (admin.grant_system_admin) and #1747 (admin.user_block).
+const (
+	// AuditActionAdminMemberAdd is the audit-row Action emitted when a
+	// system admin adds a user to a group. Failed attempts (tenant
+	// mismatch, cap hit, duplicate) reuse the same Action with
+	// Success=false so a single filter pulls the whole attempt history.
+	AuditActionAdminMemberAdd = "admin.group_member_add"
+	// AuditActionAdminMemberRemove is the audit-row Action emitted when
+	// a system admin removes a member from a group.
+	AuditActionAdminMemberRemove = "admin.group_member_remove"
+	// AuditActionAdminMemberRoleChange is the audit-row Action emitted
+	// when a system admin changes a member's role.
+	AuditActionAdminMemberRoleChange = "admin.group_member_role_change"
+)
+
+// JSON:API error codes returned by the admin group-membership
+// endpoints. Kept as constants so the swagger annotations, the FE
+// branch table, and the tests reference the same literals. Codes follow
+// the "admin.member.*" family — distinct from the per-group "group.*"
+// codes the non-admin members surface uses so the admin FE can branch
+// without colliding.
+const (
+	// adminMemberTenantMismatchCode signals "the target user belongs to
+	// a different tenant than the group". Maps to a 422. Referenced by
+	// toJSONAPIError in errors.go.
+	adminMemberTenantMismatchCode = "admin.member.tenant_mismatch"
+	// adminMemberInvalidRoleCode signals "the request body's `role`
+	// field is missing or not one of viewer|user|admin|owner". Maps to
+	// a 422.
+	adminMemberInvalidRoleCode = "admin.member.invalid_role"
+	// adminMemberUserRequiredCode signals "the add-member body is
+	// missing the required `userID` field". Maps to a 422.
+	adminMemberUserRequiredCode = "admin.member.user_required"
+)
+
+// AdminAddMemberRequest is the request body for
+// POST /admin/groups/{groupID}/members.
+//
+// `userID` is the user to admit; `role` is the role they are admitted
+// with. Both are required — there is no invite-token flow here, an
+// admin add is direct, so the role cannot be deferred to an acceptance
+// step.
+type AdminAddMemberRequest struct {
+	// UserID is the ID of the user being added to the group.
+	UserID string `json:"userID"`
+	// Role is the group role granted to the user: viewer|user|admin|owner.
+	Role models.GroupRole `json:"role"`
+}
+
+// AdminUpdateMemberRoleRequest is the request body for
+// PATCH /admin/groups/{groupID}/members/{userID}. Only the role is
+// mutable — moving a membership to a different group or user is a
+// remove + add, not a patch.
+type AdminUpdateMemberRoleRequest struct {
+	// Role is the new group role: viewer|user|admin|owner.
+	Role models.GroupRole `json:"role"`
+}
+
+// AdminMemberView is the JSON:API-style attributes block returned by
+// the add / role-change endpoints. Narrow on purpose: the membership
+// identity (group, user, role) plus the synthetic joined_at. Richer
+// member detail (avatar / email) lives on the per-group members surface.
+type AdminMemberView struct {
+	GroupID      string `json:"group_id"`
+	MemberUserID string `json:"member_user_id"`
+	Role         string `json:"role"`
+	TenantID     string `json:"tenant_id"`
+	JoinedAt     string `json:"joined_at"`
+}
+
+// AdminMemberEnvelope is the JSON:API envelope returned by add /
+// role-change. Single-resource shape ({"data": {...}}) matches the rest
+// of the admin surface (AdminUserEnvelope).
+type AdminMemberEnvelope struct {
+	Data AdminMemberResource `json:"data"`
+}
+
+// AdminMemberResource is the JSON:API resource block carried inside
+// AdminMemberEnvelope.
+type AdminMemberResource struct {
+	Type       string          `json:"type"`
+	ID         string          `json:"id"`
+	Attributes AdminMemberView `json:"attributes"`
+}
+
+// adminGroupMembersAPI backs the /admin/groups/{groupID}/members
+// routes. Holds the FactorySet directly for the cross-tenant lookups
+// the add path needs (resolve group + user from any tenant) and the
+// GroupService so the membership writes route through the same
+// invariant-bearing methods the per-group members surface uses.
+type adminGroupMembersAPI struct {
+	factorySet   *registry.FactorySet
+	groupService *services.GroupService
+	auditService services.AuditLogger
+}
+
+// addMember admits a user to a group on behalf of a system
+// administrator, bypassing the per-group requireGroupAdmin middleware
+// but still enforcing the per-user membership cap (the registry's
+// atomic CreateUnderCap path) and the cross-tenant safety check.
+//
+// @Summary Add a member to a group (admin)
+// @Description Adds a user to a group with the given role, bypassing the per-group admin check. The membership cap is still enforced — a user already at the cap is rejected with 422.
+// @Description Returns 422 with `admin.member.tenant_mismatch` when the target user's tenant differs from the group's tenant, `admin.member.invalid_role` for a missing or invalid role, and `admin.member.user_required` for a missing userID.
+// @Tags admin
+// @Accept json
+// @Produce json-api
+// @Param groupID path string true "Group ID"
+// @Param data body AdminAddMemberRequest true "Add-member request"
+// @Success 201 {object} AdminMemberEnvelope "Created"
+// @Failure 400 {object} jsonapi.Errors "Bad Request - invalid body"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 404 {object} jsonapi.Errors "Not Found - unknown group or user"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - tenant mismatch, cap reached, duplicate, or invalid role"
+// @Router /admin/groups/{groupID}/members [post]
+func (api *adminGroupMembersAPI) addMember(w http.ResponseWriter, r *http.Request) {
+	groupID := chi.URLParam(r, "groupID")
+	if strings.TrimSpace(groupID) == "" {
+		_ = renderEntityError(w, r, registry.ErrNotFound)
+		return
+	}
+
+	req, ok := api.decodeAddMemberRequest(w, r)
+	if !ok {
+		return
+	}
+
+	// Resolve the group first so a typo in the URL surfaces as 404
+	// rather than a confusing tenant-mismatch or membership error.
+	group, err := api.factorySet.LocationGroupRegistry.Get(r.Context(), groupID)
+	if err != nil {
+		// The group lookup failed, so its tenant is unknown — pass an
+		// empty tenant for the failed-add audit row but keep the
+		// already-validated target user ID so the row records who the
+		// admin tried to add.
+		api.auditAdd(r, "", groupID, req.UserID, req.Role, err)
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	// Resolve the target user across tenants — the admin caller is not
+	// scoped to the group's tenant, so the user may live anywhere.
+	target, err := api.factorySet.UserRegistry.Get(r.Context(), req.UserID)
+	if err != nil {
+		api.auditAdd(r, group.TenantID, groupID, req.UserID, req.Role, err)
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	membership, err := api.groupService.AdminAddMember(
+		r.Context(), group.ID, group.TenantID, target.ID, target.TenantID, req.Role,
+	)
+	if err != nil {
+		api.auditAdd(r, group.TenantID, group.ID, target.ID, req.Role, err)
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	api.auditAdd(r, group.TenantID, group.ID, target.ID, req.Role, nil)
+	api.writeMemberEnvelope(w, http.StatusCreated, membership)
+}
+
+// removeMember removes a member from a group on behalf of a system
+// administrator. Wraps GroupService.RemoveMember, so the ≥1-owner and
+// ≥1-member invariants (ErrLastOwner / ErrLastMember) are enforced
+// unchanged — the same business rule the per-group leave path obeys.
+//
+// @Summary Remove a member from a group (admin)
+// @Description Removes a user from a group, bypassing the per-group admin check. The ≥1-owner and ≥1-member invariants still apply — removing the last owner returns 422, removing the last member returns 422 with `group.last_member`.
+// @Tags admin
+// @Produce json-api
+// @Param groupID path string true "Group ID"
+// @Param userID path string true "User ID of the member to remove"
+// @Success 204 "No Content"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 404 {object} jsonapi.Errors "Not Found - user is not a member of the group"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - removing the last owner or last member"
+// @Router /admin/groups/{groupID}/members/{userID} [delete]
+func (api *adminGroupMembersAPI) removeMember(w http.ResponseWriter, r *http.Request) {
+	groupID := chi.URLParam(r, "groupID")
+	userID := chi.URLParam(r, "userID")
+	if strings.TrimSpace(groupID) == "" || strings.TrimSpace(userID) == "" {
+		_ = renderEntityError(w, r, registry.ErrNotFound)
+		return
+	}
+
+	// Resolve the group up front so the audit row carries the group's
+	// tenant ID and a typo in the URL surfaces as a clean 404.
+	group, err := api.factorySet.LocationGroupRegistry.Get(r.Context(), groupID)
+	if err != nil {
+		api.auditRemove(r, "", groupID, userID, err)
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	if err := api.groupService.RemoveMember(r.Context(), group.ID, userID); err != nil {
+		api.auditRemove(r, group.TenantID, group.ID, userID, err)
+		// ErrNotGroupMember means "no such membership" — surface it as a
+		// 404 so the admin FE renders a "not a member" message rather
+		// than a generic 500. Other sentinels (ErrLastOwner /
+		// ErrLastMember) flow through toJSONAPIError as 422.
+		if errors.Is(err, services.ErrNotGroupMember) {
+			_ = renderEntityError(w, r, registry.ErrNotFound)
+			return
+		}
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	api.auditRemove(r, group.TenantID, group.ID, userID, nil)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// updateMemberRole changes a member's role on behalf of a system
+// administrator. Wraps GroupService.UpdateMemberRole, so the ≥1-owner
+// invariant (ErrLastOwner — demoting the sole owner) is enforced under
+// the same per-group lock the per-group role-change path uses.
+//
+// @Summary Change a member's role (admin)
+// @Description Changes a group member's role, bypassing the per-group admin check. Demoting the sole owner is rejected with 422 (`ErrLastOwner`). Returns 422 with `admin.member.invalid_role` for a missing or invalid role.
+// @Tags admin
+// @Accept json
+// @Produce json-api
+// @Param groupID path string true "Group ID"
+// @Param userID path string true "User ID of the member"
+// @Param data body AdminUpdateMemberRoleRequest true "Role-change request"
+// @Success 200 {object} AdminMemberEnvelope "OK"
+// @Failure 400 {object} jsonapi.Errors "Bad Request - invalid body"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 404 {object} jsonapi.Errors "Not Found - user is not a member of the group"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - demoting the last owner or invalid role"
+// @Router /admin/groups/{groupID}/members/{userID} [patch]
+func (api *adminGroupMembersAPI) updateMemberRole(w http.ResponseWriter, r *http.Request) {
+	groupID := chi.URLParam(r, "groupID")
+	userID := chi.URLParam(r, "userID")
+	if strings.TrimSpace(groupID) == "" || strings.TrimSpace(userID) == "" {
+		_ = renderEntityError(w, r, registry.ErrNotFound)
+		return
+	}
+
+	req, ok := api.decodeUpdateRoleRequest(w, r)
+	if !ok {
+		return
+	}
+
+	// Resolve the group up front so the audit row carries the group's
+	// tenant ID and a typo in the URL surfaces as a clean 404.
+	group, err := api.factorySet.LocationGroupRegistry.Get(r.Context(), groupID)
+	if err != nil {
+		api.auditRoleChange(r, "", groupID, userID, req.Role, err)
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	membership, err := api.groupService.UpdateMemberRole(r.Context(), group.ID, userID, req.Role)
+	if err != nil {
+		api.auditRoleChange(r, group.TenantID, group.ID, userID, req.Role, err)
+		if errors.Is(err, services.ErrNotGroupMember) {
+			_ = renderEntityError(w, r, registry.ErrNotFound)
+			return
+		}
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	api.auditRoleChange(r, group.TenantID, group.ID, userID, req.Role, nil)
+	api.writeMemberEnvelope(w, http.StatusOK, membership)
+}
+
+// decodeAddMemberRequest parses + validates the POST body. Writes the
+// right error response and returns ok=false on failure so the caller
+// can early-return without decode-error noise.
+func (api *adminGroupMembersAPI) decodeAddMemberRequest(w http.ResponseWriter, r *http.Request) (AdminAddMemberRequest, bool) {
+	var req AdminAddMemberRequest
+	if r.Body == nil {
+		_ = badRequest(w, r, errors.New("missing request body"))
+		return req, false
+	}
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		_ = badRequest(w, r, err)
+		return req, false
+	}
+	if !decoderAtEOF(dec) {
+		_ = badRequest(w, r, errors.New("invalid JSON body — trailing tokens"))
+		return req, false
+	}
+	req.UserID = strings.TrimSpace(req.UserID)
+	if req.UserID == "" {
+		_ = codedUnprocessableEntityError(w, r, errors.New("userID is required"), adminMemberUserRequiredCode)
+		return req, false
+	}
+	if err := req.Role.Validate(); err != nil {
+		_ = codedUnprocessableEntityError(w, r, err, adminMemberInvalidRoleCode)
+		return req, false
+	}
+	return req, true
+}
+
+// decodeUpdateRoleRequest mirrors decodeAddMemberRequest for the PATCH
+// shape. Kept separate so the two swagger DTOs stay narrow and a future
+// expansion of either body doesn't entangle them.
+func (api *adminGroupMembersAPI) decodeUpdateRoleRequest(w http.ResponseWriter, r *http.Request) (AdminUpdateMemberRoleRequest, bool) {
+	var req AdminUpdateMemberRoleRequest
+	if r.Body == nil {
+		_ = badRequest(w, r, errors.New("missing request body"))
+		return req, false
+	}
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		_ = badRequest(w, r, err)
+		return req, false
+	}
+	if !decoderAtEOF(dec) {
+		_ = badRequest(w, r, errors.New("invalid JSON body — trailing tokens"))
+		return req, false
+	}
+	if err := req.Role.Validate(); err != nil {
+		_ = codedUnprocessableEntityError(w, r, err, adminMemberInvalidRoleCode)
+		return req, false
+	}
+	return req, true
+}
+
+// writeMemberEnvelope encodes a *models.GroupMembership into the
+// AdminMemberEnvelope JSON:API shape and writes it on the response.
+func (api *adminGroupMembersAPI) writeMemberEnvelope(w http.ResponseWriter, status int, m *models.GroupMembership) {
+	envelope := AdminMemberEnvelope{
+		Data: AdminMemberResource{
+			Type: "group_memberships",
+			ID:   m.ID,
+			Attributes: AdminMemberView{
+				GroupID:      m.GroupID,
+				MemberUserID: m.MemberUserID,
+				Role:         string(m.Role),
+				TenantID:     m.TenantID,
+				JoinedAt:     m.JoinedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			},
+		},
+	}
+	w.Header().Set("Content-Type", "application/vnd.api+json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(envelope); err != nil {
+		// Headers (and the status) have already been flushed; logging
+		// the encode failure keeps the operator-side trail honest
+		// instead of silently dropping it.
+		slog.Error("admin member envelope: failed to encode response", "membership_id", m.ID, "error", err)
+	}
+}
+
+// auditAdd records an admin.group_member_add audit row. The group's
+// tenant is the audit TenantID; the subject is the membership target
+// user. Best-effort — nil-safe for the case where AuditService was not
+// wired in. `tenantID` is the group's tenant ("" when the group lookup
+// failed and the tenant is therefore unknown).
+func (api *adminGroupMembersAPI) auditAdd(r *http.Request, tenantID, groupID, userID string, role models.GroupRole, opErr error) {
+	api.logMemberEvent(r, AuditActionAdminMemberAdd, tenantID, groupID, userID, role, opErr)
+}
+
+// auditRemove records an admin.group_member_remove audit row.
+func (api *adminGroupMembersAPI) auditRemove(r *http.Request, tenantID, groupID, userID string, opErr error) {
+	api.logMemberEvent(r, AuditActionAdminMemberRemove, tenantID, groupID, userID, "", opErr)
+}
+
+// auditRoleChange records an admin.group_member_role_change audit row.
+func (api *adminGroupMembersAPI) auditRoleChange(r *http.Request, tenantID, groupID, userID string, role models.GroupRole, opErr error) {
+	api.logMemberEvent(r, AuditActionAdminMemberRoleChange, tenantID, groupID, userID, role, opErr)
+}
+
+// logMemberEvent is the shared audit-row writer for the three
+// group-membership admin actions. The subject is the target user; the
+// group's tenant lands in the audit TenantID column; the group ID and
+// (when present) the role land in the Extra breadcrumb so audit
+// consumers can correlate "who changed whose membership in which group"
+// without re-parsing free text.
+func (api *adminGroupMembersAPI) logMemberEvent(
+	r *http.Request,
+	action, tenantID, groupID, userID string,
+	role models.GroupRole,
+	opErr error,
+) {
+	if api.auditService == nil {
+		return
+	}
+	extra := map[string]any{"group_id": groupID}
+	if role != "" {
+		extra["role"] = string(role)
+	}
+	ev := services.AdminEvent{
+		Action:      action,
+		ActorID:     actorIDFromRequest(r),
+		TenantID:    nullableString(tenantID),
+		SubjectType: stringPtr("user"),
+		SubjectID:   nullableString(userID),
+		Success:     opErr == nil,
+		Request:     r,
+		ErrMsg:      strPtrFromErr(opErr),
+		Extra:       extra,
+	}
+	api.auditService.LogAdmin(r.Context(), ev)
+}

--- a/go/apiserver/admin_group_members_test.go
+++ b/go/apiserver/admin_group_members_test.go
@@ -1,0 +1,350 @@
+package apiserver_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/internal/checkers"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// Admin group-membership handler tests (#1749). Every AC in the issue
+// spec maps to one (or more) of the tests below: add / remove /
+// role-change, each invariant violation surfacing its sentinel, the
+// cross-tenant rejection, and the audit-log breadcrumbs. The tests
+// reuse the admin_users_test.go helpers (newAdminEnv,
+// createTestUserDirect, doAdminJSONRequest) so the per-test setup stays
+// one line.
+
+// createAdminTestGroup creates a group directly via the registry, with
+// no members. Callers seed memberships with addMembershipRow so the
+// invariant tests have full control over the group's owner / member
+// counts.
+func createAdminTestGroup(c *qt.C, params apiserver.Params, tenantID string) *models.LocationGroup {
+	c.Helper()
+	slug := must.Must(models.GenerateGroupSlug())
+	return must.Must(params.FactorySet.LocationGroupRegistry.Create(context.Background(), models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Name:                "Admin Test Group",
+		Slug:                slug,
+		Status:              models.LocationGroupStatusActive,
+		GroupCurrency:       models.Currency("USD"),
+	}))
+}
+
+// addMembershipRow inserts a membership row directly via the registry,
+// bypassing the service so the test can construct a group with an exact
+// owner / member composition.
+func addMembershipRow(c *qt.C, params apiserver.Params, tenantID, groupID, userID string, role models.GroupRole) {
+	c.Helper()
+	must.Must(params.FactorySet.GroupMembershipRegistry.Create(context.Background(), models.GroupMembership{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		GroupID:             groupID,
+		MemberUserID:        userID,
+		Role:                role,
+	}))
+}
+
+// findAuditRow returns the first audit row with the given action, or
+// nil when none exists.
+func findAuditRow(c *qt.C, params apiserver.Params, action string) *models.AuditLog {
+	c.Helper()
+	rows := must.Must(params.FactorySet.AuditLogRegistry.List(context.Background()))
+	for i := range rows {
+		if rows[i].Action == action {
+			return rows[i]
+		}
+	}
+	return nil
+}
+
+func TestAdminAddMember_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "newmember@example.com", true, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/groups/"+group.ID+"/members",
+		env.admin.ID, map[string]any{"userID": target.ID, "role": "user"})
+	c.Assert(rr.Code, qt.Equals, http.StatusCreated)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.type"), "group_memberships")
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.group_id"), group.ID)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.member_user_id"), target.ID)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.role"), "user")
+
+	// The membership row is persisted with a synthetic joined_at.
+	m := must.Must(env.params.FactorySet.GroupMembershipRegistry.GetByGroupAndUser(context.Background(), group.ID, target.ID))
+	c.Assert(m.Role, qt.Equals, models.GroupRoleUser)
+	c.Assert(m.JoinedAt.IsZero(), qt.IsFalse)
+}
+
+func TestAdminAddMember_AuditRow(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "newmember@example.com", true, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/groups/"+group.ID+"/members",
+		env.admin.ID, map[string]any{"userID": target.ID, "role": "admin"})
+	c.Assert(rr.Code, qt.Equals, http.StatusCreated)
+
+	row := findAuditRow(c, env.params, apiserver.AuditActionAdminMemberAdd)
+	c.Assert(row, qt.IsNotNil)
+	c.Assert(row.UserID, qt.IsNotNil)
+	c.Assert(*row.UserID, qt.Equals, env.admin.ID)
+	c.Assert(row.EntityID, qt.IsNotNil)
+	c.Assert(*row.EntityID, qt.Equals, target.ID)
+	// The audit row must carry the group's tenant ID (#1749 requires
+	// admin user ID + group ID + tenant ID on every membership event).
+	c.Assert(row.TenantID, qt.IsNotNil)
+	c.Assert(*row.TenantID, qt.Equals, group.TenantID)
+	c.Assert(row.Success, qt.IsTrue)
+}
+
+func TestAdminAddMember_CrossTenantRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+
+	// A user in a different tenant.
+	otherTenant := must.Must(env.params.FactorySet.TenantRegistry.Create(context.Background(), models.Tenant{
+		Name:   "Other Org",
+		Slug:   "other-org",
+		Status: models.TenantStatusActive,
+	}))
+	target := createTestUserDirect(c, env.params, otherTenant.ID, "outsider@example.com", true, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/groups/"+group.ID+"/members",
+		env.admin.ID, map[string]any{"userID": target.ID, "role": "user"})
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), "admin.member.tenant_mismatch")
+}
+
+func TestAdminAddMember_CapReached(t *testing.T) {
+	c := qt.New(t)
+	if services.MaxGroupMembershipsPerUser() <= 0 {
+		c.Skip("cap disabled")
+	}
+	env := newAdminEnv(c)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "capped@example.com", true, false)
+
+	// Fill the target's membership quota up to the cap.
+	for range services.MaxGroupMembershipsPerUser() {
+		g := createAdminTestGroup(c, env.params, env.admin.TenantID)
+		addMembershipRow(c, env.params, env.admin.TenantID, g.ID, target.ID, models.GroupRoleUser)
+	}
+	overflow := createAdminTestGroup(c, env.params, env.admin.TenantID)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/groups/"+overflow.ID+"/members",
+		env.admin.ID, map[string]any{"userID": target.ID, "role": "user"})
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+}
+
+func TestAdminAddMember_AlreadyMemberRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "dup@example.com", true, false)
+	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, target.ID, models.GroupRoleUser)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/groups/"+group.ID+"/members",
+		env.admin.ID, map[string]any{"userID": target.ID, "role": "admin"})
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+}
+
+func TestAdminAddMember_InvalidRoleRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "badrole@example.com", true, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/groups/"+group.ID+"/members",
+		env.admin.ID, map[string]any{"userID": target.ID, "role": "superuser"})
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), "admin.member.invalid_role")
+}
+
+func TestAdminAddMember_MissingUserIDRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/groups/"+group.ID+"/members",
+		env.admin.ID, map[string]any{"role": "user"})
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), "admin.member.user_required")
+}
+
+func TestAdminAddMember_UnknownGroupReturns404(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	target := createTestUserDirect(c, env.params, env.admin.TenantID, "nogroup@example.com", true, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/groups/does-not-exist/members",
+		env.admin.ID, map[string]any{"userID": target.ID, "role": "user"})
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+func TestAdminAddMember_NonAdminForbidden(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := newParams() // not promoted
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+	group := createAdminTestGroup(c, params, user.TenantID)
+	target := createTestUserDirect(c, params, user.TenantID, "nope@example.com", true, false)
+
+	rr := doAdminJSONRequest(t, handler, http.MethodPost,
+		"/api/v1/admin/groups/"+group.ID+"/members",
+		user.ID, map[string]any{"userID": target.ID, "role": "user"})
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+	c.Assert(rr.Body.String(), qt.Contains, "admin.forbidden")
+}
+
+func TestAdminRemoveMember_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	owner := createTestUserDirect(c, env.params, env.admin.TenantID, "owner@example.com", true, false)
+	member := createTestUserDirect(c, env.params, env.admin.TenantID, "member@example.com", true, false)
+	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, owner.ID, models.GroupRoleOwner)
+	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodDelete,
+		"/api/v1/admin/groups/"+group.ID+"/members/"+member.ID,
+		env.admin.ID, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusNoContent)
+
+	_, err := env.params.FactorySet.GroupMembershipRegistry.GetByGroupAndUser(context.Background(), group.ID, member.ID)
+	c.Assert(err, qt.IsNotNil)
+
+	row := findAuditRow(c, env.params, apiserver.AuditActionAdminMemberRemove)
+	c.Assert(row, qt.IsNotNil)
+	c.Assert(row.TenantID, qt.IsNotNil)
+	c.Assert(*row.TenantID, qt.Equals, group.TenantID)
+	c.Assert(row.Success, qt.IsTrue)
+}
+
+func TestAdminRemoveMember_LastOwnerRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	owner := createTestUserDirect(c, env.params, env.admin.TenantID, "soleowner@example.com", true, false)
+	member := createTestUserDirect(c, env.params, env.admin.TenantID, "plainmember@example.com", true, false)
+	// One owner + one non-owner: removing the owner trips ErrLastOwner
+	// (the ≥1-member invariant is still satisfied).
+	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, owner.ID, models.GroupRoleOwner)
+	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodDelete,
+		"/api/v1/admin/groups/"+group.ID+"/members/"+owner.ID,
+		env.admin.ID, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+}
+
+func TestAdminRemoveMember_LastMemberRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	member := createTestUserDirect(c, env.params, env.admin.TenantID, "lonely@example.com", true, false)
+	// A single non-owner member: removing them trips ErrLastMember
+	// (the owner check would pass vacuously).
+	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodDelete,
+		"/api/v1/admin/groups/"+group.ID+"/members/"+member.ID,
+		env.admin.ID, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), "group.last_member")
+}
+
+func TestAdminRemoveMember_NotAMemberReturns404(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	stranger := createTestUserDirect(c, env.params, env.admin.TenantID, "stranger@example.com", true, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodDelete,
+		"/api/v1/admin/groups/"+group.ID+"/members/"+stranger.ID,
+		env.admin.ID, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+func TestAdminUpdateMemberRole_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	owner := createTestUserDirect(c, env.params, env.admin.TenantID, "owner2@example.com", true, false)
+	member := createTestUserDirect(c, env.params, env.admin.TenantID, "promoteme@example.com", true, false)
+	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, owner.ID, models.GroupRoleOwner)
+	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPatch,
+		"/api/v1/admin/groups/"+group.ID+"/members/"+member.ID,
+		env.admin.ID, map[string]any{"role": "admin"})
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.role"), "admin")
+
+	m := must.Must(env.params.FactorySet.GroupMembershipRegistry.GetByGroupAndUser(context.Background(), group.ID, member.ID))
+	c.Assert(m.Role, qt.Equals, models.GroupRoleAdmin)
+
+	row := findAuditRow(c, env.params, apiserver.AuditActionAdminMemberRoleChange)
+	c.Assert(row, qt.IsNotNil)
+	c.Assert(row.TenantID, qt.IsNotNil)
+	c.Assert(*row.TenantID, qt.Equals, group.TenantID)
+	c.Assert(row.Success, qt.IsTrue)
+}
+
+func TestAdminUpdateMemberRole_LastOwnerDemotionRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	owner := createTestUserDirect(c, env.params, env.admin.TenantID, "demoteme@example.com", true, false)
+	member := createTestUserDirect(c, env.params, env.admin.TenantID, "bystander@example.com", true, false)
+	// Sole owner: demoting them to user would leave the group ownerless.
+	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, owner.ID, models.GroupRoleOwner)
+	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPatch,
+		"/api/v1/admin/groups/"+group.ID+"/members/"+owner.ID,
+		env.admin.ID, map[string]any{"role": "user"})
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+}
+
+func TestAdminUpdateMemberRole_InvalidRoleRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	member := createTestUserDirect(c, env.params, env.admin.TenantID, "rolecheck@example.com", true, false)
+	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPatch,
+		"/api/v1/admin/groups/"+group.ID+"/members/"+member.ID,
+		env.admin.ID, map[string]any{"role": "godmode"})
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), "admin.member.invalid_role")
+}
+
+func TestAdminUpdateMemberRole_NotAMemberReturns404(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	stranger := createTestUserDirect(c, env.params, env.admin.TenantID, "ghost@example.com", true, false)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPatch,
+		"/api/v1/admin/groups/"+group.ID+"/members/"+stranger.ID,
+		env.admin.ID, map[string]any{"role": "admin"})
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -57,6 +57,14 @@ type AdminParams struct {
 	FactorySet   *registry.FactorySet
 	Blacklist    services.TokenBlacklister
 	AuditService services.AuditLogger
+	// GroupService backs the #1749 group-membership admin endpoints
+	// (add / remove / role-change). The same instance the rest of the
+	// apiserver uses — its registries are the tenant-scoped (not
+	// user-aware) FactorySet ones, which is exactly what the admin
+	// surface needs to cross tenants. Reusing the service keeps the
+	// membership invariants (cap, ≥1 owner, ≥1 member) single-sourced
+	// instead of forking a parallel code path for admins.
+	GroupService *services.GroupService
 }
 
 // Admin returns the router configurator for /api/v1/admin/*. Mounted
@@ -71,6 +79,11 @@ func Admin(params AdminParams) func(r chi.Router) {
 	usersAPI := &adminUsersAPI{
 		factorySet:   params.FactorySet,
 		blacklist:    params.Blacklist,
+		auditService: params.AuditService,
+	}
+	groupMembersAPI := &adminGroupMembersAPI{
+		factorySet:   params.FactorySet,
+		groupService: params.GroupService,
 		auditService: params.AuditService,
 	}
 	return func(r chi.Router) {
@@ -94,6 +107,15 @@ func Admin(params AdminParams) func(r chi.Router) {
 		// audit-logs reason+forced via the breadcrumb in user_agent.
 		r.Post("/users/{userID}/block", usersAPI.blockUser)
 		r.Post("/users/{userID}/unblock", usersAPI.unblockUser)
+
+		// #1749: group-membership admin endpoints. add / remove /
+		// role-change route through GroupService so the per-group
+		// invariants (cap, ≥1 owner, ≥1 member) stay single-sourced,
+		// bypassing only the per-group requireGroupAdmin middleware —
+		// the RequireSystemAdmin gate above is authorization enough.
+		r.Post("/groups/{groupID}/members", groupMembersAPI.addMember)
+		r.Delete("/groups/{groupID}/members/{userID}", groupMembersAPI.removeMember)
+		r.Patch("/groups/{groupID}/members/{userID}", groupMembersAPI.updateMemberRole)
 	}
 }
 

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -72,6 +72,14 @@ type AdminParams struct {
 // CSRF) and the RequireSystemAdmin gate. Later admin issues hang their
 // endpoints off the same chi.Router this closure receives.
 func Admin(params AdminParams) func(r chi.Router) {
+	// Fail fast on a misconfigured wiring: the #1749 group-membership
+	// endpoints dereference GroupService on every request, so a nil
+	// here would otherwise surface as a confusing per-request panic
+	// rather than a clear startup failure.
+	if params.GroupService == nil {
+		panic("apiserver.Admin requires non-nil AdminParams.GroupService")
+	}
+
 	tenantsAPI := &adminTenantsAPI{
 		factorySet:   params.FactorySet,
 		auditService: params.AuditService,

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -360,6 +360,7 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			FactorySet:   params.FactorySet,
 			Blacklist:    blacklist,
 			AuditService: auditSvc,
+			GroupService: groupService,
 		}))
 		// The former /api/v1/users admin CRUD was removed together with the
 		// tenant-level `users.role` column. Per-group user management lives

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -170,6 +170,21 @@ func adminBlockGuardError(err error) jsonapi.Error {
 	}
 }
 
+// adminMemberTenantMismatchError maps the #1749 cross-tenant
+// add-member rejection (services.ErrTenantMismatch) to its 422 + code
+// wire shape. Extracted as a free function — like adminBlockGuardError
+// — so the toJSONAPIError switch stays under the gocyclo budget while
+// keeping the mapping explicit and grep-friendly.
+func adminMemberTenantMismatchError(err error) jsonapi.Error {
+	return jsonapi.Error{
+		Err:            err,
+		UserError:      errormarshal.Marshal(err),
+		HTTPStatusCode: http.StatusUnprocessableEntity,
+		StatusText:     "Unprocessable Entity",
+		Code:           adminMemberTenantMismatchCode,
+	}
+}
+
 func toJSONAPIError(err error) jsonapi.Error {
 	switch {
 	case errors.Is(err, registry.ErrCannotDelete):
@@ -202,22 +217,27 @@ func toJSONAPIError(err error) jsonapi.Error {
 		// Resending a legacy token-only invite (no captured email)
 		// is a business-rule violation: 422, not 500.
 		return NewUnprocessableEntityError(err)
-	case errors.Is(err, services.ErrCommodityNotTrackable):
+	case errors.Is(err, services.ErrCommodityNotTrackable),
+		errors.Is(err, services.ErrClosedLoanFieldImmutable):
 		// #1554: a bundle commodity (count > 1) cannot carry a per-
-		// instance event (lend / service / warranty). Surface as 422
-		// so the FE renders the same "split into separate items" hint
-		// the create-form banner uses.
-		return NewUnprocessableEntityError(err)
-	case errors.Is(err, services.ErrClosedLoanFieldImmutable):
-		// #1511: due_back_at / returned_at are frozen on closed loans
-		// (date-of-record after the loan ends). Surface as 422 so the
-		// FE can render a toast that names the offending field — the
-		// dialog already disables the date inputs, so this only fires
-		// against a hand-crafted request.
+		// instance event (lend / service / warranty) — the FE renders
+		// the "split into separate items" hint the create-form banner
+		// uses. #1511: due_back_at / returned_at are frozen on closed
+		// loans (date-of-record after the loan ends). Both are
+		// business-rule violations: 422, not 500.
 		return NewUnprocessableEntityError(err)
 	case errors.Is(err, services.ErrInvalidConfirmation),
 		errors.Is(err, services.ErrInvalidPassword):
 		return NewUnprocessableEntityError(err)
+	case errors.Is(err, services.ErrTenantMismatch):
+		// #1749: an admin add-member request named a user whose tenant
+		// differs from the group's tenant. A membership crosses no
+		// tenant boundary, so this is a business-rule violation, not a
+		// server bug. 422 + the JSON:API code lets the admin FE render
+		// targeted copy ("that user belongs to a different tenant")
+		// instead of a generic 422 toast. Extracted into a helper so
+		// the switch stays under the gocyclo budget.
+		return adminMemberTenantMismatchError(err)
 	case errors.Is(err, services.ErrTooManyGroupMemberships):
 		// Per-user group-membership cap reached (#1388). Same shape as
 		// the other invite/membership business-rule violations below —

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -6904,6 +6904,10 @@ const docTemplate = `{
     "definitions": {
         "apiserver.AdminAddMemberRequest": {
             "type": "object",
+            "required": [
+                "role",
+                "userID"
+            ],
             "properties": {
                 "role": {
                     "description": "Role is the group role granted to the user: viewer|user|admin|owner.",
@@ -6971,7 +6975,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "role": {
-                    "type": "string"
+                    "$ref": "#/definitions/models.GroupRole"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -7004,6 +7008,9 @@ const docTemplate = `{
         },
         "apiserver.AdminUpdateMemberRoleRequest": {
             "type": "object",
+            "required": [
+                "role"
+            ],
             "properties": {
                 "role": {
                     "description": "Role is the new group role: viewer|user|admin|owner.",

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -54,6 +54,210 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/groups/{groupID}/members": {
+            "post": {
+                "description": "Adds a user to a group with the given role, bypassing the per-group admin check. The membership cap is still enforced — a user already at the cap is rejected with 422.\nReturns 422 with ` + "`" + `admin.member.tenant_mismatch` + "`" + ` when the target user's tenant differs from the group's tenant, ` + "`" + `admin.member.invalid_role` + "`" + ` for a missing or invalid role, and ` + "`" + `admin.member.user_required` + "`" + ` for a missing userID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Add a member to a group (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "groupID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Add-member request",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminAddMemberRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminMemberEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown group or user",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - tenant mismatch, cap reached, duplicate, or invalid role",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/groups/{groupID}/members/{userID}": {
+            "delete": {
+                "description": "Removes a user from a group, bypassing the per-group admin check. The ≥1-owner and ≥1-member invariants still apply — removing the last owner returns 422, removing the last member returns 422 with ` + "`" + `group.last_member` + "`" + `.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Remove a member from a group (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "groupID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User ID of the member to remove",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - user is not a member of the group",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - removing the last owner or last member",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Changes a group member's role, bypassing the per-group admin check. Demoting the sole owner is rejected with 422 (` + "`" + `ErrLastOwner` + "`" + `). Returns 422 with ` + "`" + `admin.member.invalid_role` + "`" + ` for a missing or invalid role.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Change a member's role (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "groupID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User ID of the member",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Role-change request",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminUpdateMemberRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminMemberEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - user is not a member of the group",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - demoting the last owner or invalid role",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/tenants": {
             "get": {
                 "description": "Returns every tenant with computed user_count and group_count. Pagination via ?page\u0026per_page; ?q matches name/slug/domain (ILIKE); ?sort=\u003cfield\u003e with optional ` + "`" + `-` + "`" + ` prefix for desc, or explicit ?order=asc|desc.",
@@ -6698,6 +6902,23 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "apiserver.AdminAddMemberRequest": {
+            "type": "object",
+            "properties": {
+                "role": {
+                    "description": "Role is the group role granted to the user: viewer|user|admin|owner.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.GroupRole"
+                        }
+                    ]
+                },
+                "userID": {
+                    "description": "UserID is the ID of the user being added to the group.",
+                    "type": "string"
+                }
+            }
+        },
         "apiserver.AdminBlockRequest": {
             "type": "object",
             "required": [
@@ -6712,6 +6933,48 @@ const docTemplate = `{
                     "description": "Reason is the free-form justification for the block (max 500 chars).",
                     "type": "string",
                     "maxLength": 500
+                }
+            }
+        },
+        "apiserver.AdminMemberEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/apiserver.AdminMemberResource"
+                }
+            }
+        },
+        "apiserver.AdminMemberResource": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/apiserver.AdminMemberView"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.AdminMemberView": {
+            "type": "object",
+            "properties": {
+                "group_id": {
+                    "type": "string"
+                },
+                "joined_at": {
+                    "type": "string"
+                },
+                "member_user_id": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
                 }
             }
         },
@@ -6736,6 +6999,19 @@ const docTemplate = `{
                     "description": "Reason is the free-form justification for the unblock (max 500 chars).",
                     "type": "string",
                     "maxLength": 500
+                }
+            }
+        },
+        "apiserver.AdminUpdateMemberRoleRequest": {
+            "type": "object",
+            "properties": {
+                "role": {
+                    "description": "Role is the new group role: viewer|user|admin|owner.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.GroupRole"
+                        }
+                    ]
                 }
             }
         },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -47,6 +47,210 @@
                 }
             }
         },
+        "/admin/groups/{groupID}/members": {
+            "post": {
+                "description": "Adds a user to a group with the given role, bypassing the per-group admin check. The membership cap is still enforced — a user already at the cap is rejected with 422.\nReturns 422 with `admin.member.tenant_mismatch` when the target user's tenant differs from the group's tenant, `admin.member.invalid_role` for a missing or invalid role, and `admin.member.user_required` for a missing userID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Add a member to a group (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "groupID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Add-member request",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminAddMemberRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminMemberEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown group or user",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - tenant mismatch, cap reached, duplicate, or invalid role",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/groups/{groupID}/members/{userID}": {
+            "delete": {
+                "description": "Removes a user from a group, bypassing the per-group admin check. The ≥1-owner and ≥1-member invariants still apply — removing the last owner returns 422, removing the last member returns 422 with `group.last_member`.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Remove a member from a group (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "groupID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User ID of the member to remove",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - user is not a member of the group",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - removing the last owner or last member",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Changes a group member's role, bypassing the per-group admin check. Demoting the sole owner is rejected with 422 (`ErrLastOwner`). Returns 422 with `admin.member.invalid_role` for a missing or invalid role.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Change a member's role (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "groupID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User ID of the member",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Role-change request",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminUpdateMemberRoleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.AdminMemberEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - user is not a member of the group",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - demoting the last owner or invalid role",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/tenants": {
             "get": {
                 "description": "Returns every tenant with computed user_count and group_count. Pagination via ?page\u0026per_page; ?q matches name/slug/domain (ILIKE); ?sort=\u003cfield\u003e with optional `-` prefix for desc, or explicit ?order=asc|desc.",
@@ -6691,6 +6895,23 @@
         }
     },
     "definitions": {
+        "apiserver.AdminAddMemberRequest": {
+            "type": "object",
+            "properties": {
+                "role": {
+                    "description": "Role is the group role granted to the user: viewer|user|admin|owner.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.GroupRole"
+                        }
+                    ]
+                },
+                "userID": {
+                    "description": "UserID is the ID of the user being added to the group.",
+                    "type": "string"
+                }
+            }
+        },
         "apiserver.AdminBlockRequest": {
             "type": "object",
             "required": [
@@ -6705,6 +6926,48 @@
                     "description": "Reason is the free-form justification for the block (max 500 chars).",
                     "type": "string",
                     "maxLength": 500
+                }
+            }
+        },
+        "apiserver.AdminMemberEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/apiserver.AdminMemberResource"
+                }
+            }
+        },
+        "apiserver.AdminMemberResource": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/apiserver.AdminMemberView"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.AdminMemberView": {
+            "type": "object",
+            "properties": {
+                "group_id": {
+                    "type": "string"
+                },
+                "joined_at": {
+                    "type": "string"
+                },
+                "member_user_id": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
                 }
             }
         },
@@ -6729,6 +6992,19 @@
                     "description": "Reason is the free-form justification for the unblock (max 500 chars).",
                     "type": "string",
                     "maxLength": 500
+                }
+            }
+        },
+        "apiserver.AdminUpdateMemberRoleRequest": {
+            "type": "object",
+            "properties": {
+                "role": {
+                    "description": "Role is the new group role: viewer|user|admin|owner.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.GroupRole"
+                        }
+                    ]
                 }
             }
         },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -6897,6 +6897,10 @@
     "definitions": {
         "apiserver.AdminAddMemberRequest": {
             "type": "object",
+            "required": [
+                "role",
+                "userID"
+            ],
             "properties": {
                 "role": {
                     "description": "Role is the group role granted to the user: viewer|user|admin|owner.",
@@ -6964,7 +6968,7 @@
                     "type": "string"
                 },
                 "role": {
-                    "type": "string"
+                    "$ref": "#/definitions/models.GroupRole"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -6997,6 +7001,9 @@
         },
         "apiserver.AdminUpdateMemberRoleRequest": {
             "type": "object",
+            "required": [
+                "role"
+            ],
             "properties": {
                 "role": {
                     "description": "Role is the new group role: viewer|user|admin|owner.",

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1,5 +1,15 @@
 basePath: /api/v1
 definitions:
+  apiserver.AdminAddMemberRequest:
+    properties:
+      role:
+        allOf:
+        - $ref: '#/definitions/models.GroupRole'
+        description: 'Role is the group role granted to the user: viewer|user|admin|owner.'
+      userID:
+        description: UserID is the ID of the user being added to the group.
+        type: string
+    type: object
   apiserver.AdminBlockRequest:
     properties:
       force:
@@ -14,6 +24,33 @@ definitions:
         type: string
     required:
     - reason
+    type: object
+  apiserver.AdminMemberEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/apiserver.AdminMemberResource'
+    type: object
+  apiserver.AdminMemberResource:
+    properties:
+      attributes:
+        $ref: '#/definitions/apiserver.AdminMemberView'
+      id:
+        type: string
+      type:
+        type: string
+    type: object
+  apiserver.AdminMemberView:
+    properties:
+      group_id:
+        type: string
+      joined_at:
+        type: string
+      member_user_id:
+        type: string
+      role:
+        type: string
+      tenant_id:
+        type: string
     type: object
   apiserver.AdminPingResponse:
     properties:
@@ -31,6 +68,13 @@ definitions:
         type: string
     required:
     - reason
+    type: object
+  apiserver.AdminUpdateMemberRoleRequest:
+    properties:
+      role:
+        allOf:
+        - $ref: '#/definitions/models.GroupRole'
+        description: 'Role is the new group role: viewer|user|admin|owner.'
     type: object
   apiserver.AdminUserEnvelope:
     properties:
@@ -3975,6 +4019,149 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: System-admin ping
+      tags:
+      - admin
+  /admin/groups/{groupID}/members:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Adds a user to a group with the given role, bypassing the per-group admin check. The membership cap is still enforced — a user already at the cap is rejected with 422.
+        Returns 422 with `admin.member.tenant_mismatch` when the target user's tenant differs from the group's tenant, `admin.member.invalid_role` for a missing or invalid role, and `admin.member.user_required` for a missing userID.
+      parameters:
+      - description: Group ID
+        in: path
+        name: groupID
+        required: true
+        type: string
+      - description: Add-member request
+        in: body
+        name: data
+        required: true
+        schema:
+          $ref: '#/definitions/apiserver.AdminAddMemberRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/apiserver.AdminMemberEnvelope'
+        "400":
+          description: Bad Request - invalid body
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Forbidden - system-admin required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Not Found - unknown group or user
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Unprocessable Entity - tenant mismatch, cap reached, duplicate,
+            or invalid role
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Add a member to a group (admin)
+      tags:
+      - admin
+  /admin/groups/{groupID}/members/{userID}:
+    delete:
+      description: Removes a user from a group, bypassing the per-group admin check.
+        The ≥1-owner and ≥1-member invariants still apply — removing the last owner
+        returns 422, removing the last member returns 422 with `group.last_member`.
+      parameters:
+      - description: Group ID
+        in: path
+        name: groupID
+        required: true
+        type: string
+      - description: User ID of the member to remove
+        in: path
+        name: userID
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Forbidden - system-admin required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Not Found - user is not a member of the group
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Unprocessable Entity - removing the last owner or last member
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Remove a member from a group (admin)
+      tags:
+      - admin
+    patch:
+      consumes:
+      - application/json
+      description: Changes a group member's role, bypassing the per-group admin check.
+        Demoting the sole owner is rejected with 422 (`ErrLastOwner`). Returns 422
+        with `admin.member.invalid_role` for a missing or invalid role.
+      parameters:
+      - description: Group ID
+        in: path
+        name: groupID
+        required: true
+        type: string
+      - description: User ID of the member
+        in: path
+        name: userID
+        required: true
+        type: string
+      - description: Role-change request
+        in: body
+        name: data
+        required: true
+        schema:
+          $ref: '#/definitions/apiserver.AdminUpdateMemberRoleRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.AdminMemberEnvelope'
+        "400":
+          description: Bad Request - invalid body
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Forbidden - system-admin required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Not Found - user is not a member of the group
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Unprocessable Entity - demoting the last owner or invalid role
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Change a member's role (admin)
       tags:
       - admin
   /admin/tenants:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -9,6 +9,9 @@ definitions:
       userID:
         description: UserID is the ID of the user being added to the group.
         type: string
+    required:
+    - role
+    - userID
     type: object
   apiserver.AdminBlockRequest:
     properties:
@@ -48,7 +51,7 @@ definitions:
       member_user_id:
         type: string
       role:
-        type: string
+        $ref: '#/definitions/models.GroupRole'
       tenant_id:
         type: string
     type: object
@@ -75,6 +78,8 @@ definitions:
         allOf:
         - $ref: '#/definitions/models.GroupRole'
         description: 'Role is the new group role: viewer|user|admin|owner.'
+    required:
+    - role
     type: object
   apiserver.AdminUserEnvelope:
     properties:

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -47,6 +47,16 @@ var (
 	// ErrTooManyGroupMemberships is returned when CreateGroup, AddMember
 	// or AcceptInvite would push a user past MaxGroupMembershipsPerUser.
 	ErrTooManyGroupMemberships = errx.NewSentinel("user already belongs to the maximum number of groups")
+	// ErrTenantMismatch is returned by AdminAddMember when the target
+	// user's tenant differs from the group's tenant (#1749). A group
+	// membership crosses no tenant boundary: on PostgreSQL the RLS
+	// policy on group_memberships keys on tenant_id, so a cross-tenant
+	// row would either fail the WITH CHECK clause or — worse, on the
+	// in-memory backend — silently violate isolation. The admin
+	// add-member path crosses tenants by construction (a system admin
+	// is not scoped to one tenant), so the check is explicit here
+	// rather than delegated to RLS.
+	ErrTenantMismatch = errx.NewSentinel("user and group belong to different tenants")
 )
 
 // DefaultMaxGroupMembershipsPerUser caps how many groups a single
@@ -447,6 +457,71 @@ func (s *GroupService) AddMember(ctx context.Context, tenantID, groupID, userID 
 		return nil, errxtrace.Classify(ErrTooManyGroupMemberships)
 	}
 	return created, err
+}
+
+// AdminAddMember mints a membership on behalf of a system administrator
+// (#1749). It is the admin-facing twin of AddMember, with two
+// differences that the admin surface requires:
+//
+//  1. Cross-tenant safety. The system-admin caller is not scoped to a
+//     tenant, so the group and the target user are resolved from a
+//     cross-tenant registry by the handler and their tenants are passed
+//     in explicitly. A mismatch is rejected with ErrTenantMismatch
+//     rather than being left for the PostgreSQL RLS WITH CHECK clause
+//     (which the in-memory backend does not enforce).
+//  2. Membership row tenant. The new row is stamped with groupTenantID
+//     (== the target user's tenant once the mismatch check passes), not
+//     with whatever tenant the caller happens to sit in.
+//
+// The membership write still routes through createMembershipUnderCap so
+// the per-user cap invariant (ErrTooManyGroupMemberships) stays
+// single-sourced — there is no parallel cap code path for admins.
+// JoinedAt is a synthetic now(): an admin add is direct, with no invite
+// token to carry an acceptance timestamp.
+func (s *GroupService) AdminAddMember(
+	ctx context.Context,
+	groupID, groupTenantID, userID, userTenantID string,
+	role models.GroupRole,
+) (*models.GroupMembership, error) {
+	if groupTenantID != userTenantID {
+		return nil, errxtrace.Classify(ErrTenantMismatch)
+	}
+
+	// Reject a duplicate up front. Only swallow NotFound — any other
+	// registry error must surface, otherwise we'd fall through and try
+	// to insert a second membership row.
+	existing, err := s.membershipRegistry.GetByGroupAndUser(ctx, groupID, userID)
+	if err == nil && existing != nil {
+		return nil, errxtrace.Classify(ErrAlreadyMember)
+	}
+	if err != nil && !errors.Is(err, registry.ErrNotFound) {
+		return nil, errxtrace.Wrap("failed to look up existing membership", err)
+	}
+
+	membership := models.GroupMembership{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: groupTenantID,
+		},
+		GroupID:      groupID,
+		MemberUserID: userID,
+		Role:         role,
+		JoinedAt:     time.Now(),
+	}
+
+	created, overCap, err := s.createMembershipUnderCap(ctx, membership, MaxGroupMembershipsPerUser())
+	if overCap {
+		return nil, errxtrace.Classify(ErrTooManyGroupMemberships)
+	}
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to create membership", err)
+	}
+
+	// Promote the freshly-created membership to the user's default if
+	// they don't have a valid one yet (#1592). Best-effort — see
+	// ensureDefaultGroupBestEffort.
+	s.ensureDefaultGroupBestEffort(ctx, userID)
+
+	return created, nil
 }
 
 // RemoveMember removes a user from a group. Enforces two


### PR DESCRIPTION
## Summary

Implements #1749 — three system-admin endpoints under `/api/v1/admin/*` for managing a group's members, bypassing the per-group `requireGroupAdmin` middleware while reusing the same `GroupService`/registry methods so the invariants stay single-sourced.

| Method | Route | Behaviour |
|--------|-------|-----------|
| `POST` | `/api/v1/admin/groups/{groupID}/members` | Direct add via `GroupMembershipRegistry.CreateUnderCap` |
| `DELETE` | `/api/v1/admin/groups/{groupID}/members/{userID}` | Wraps `DeleteWithMemberInvariants` |
| `PATCH` | `/api/v1/admin/groups/{groupID}/members/{userID}` | Wraps `UpdateRoleWithMemberInvariants` |

## Details

- **New `GroupService.AdminAddMember`** routes the write through `createMembershipUnderCap`, so the per-user cap (`ErrTooManyGroupMemberships`) is enforced by the same atomic path as `AddMember`/`CreateGroup` — no parallel invariant code.
- Admin-added members get a synthetic `joined_at = now()` — no invite-token flow.
- **Cross-tenant safety:** adding a user whose `tenant_id` differs from the group's tenant is rejected with the new typed `ErrTenantMismatch` sentinel, mapped to `422 admin.member.tenant_mismatch`.
- Remove / role-change delegate to `GroupService.RemoveMember` / `UpdateMemberRole`, surfacing `ErrLastOwner` / `ErrLastMember` unchanged.
- Every action audit-logs via `AuditService` with admin user ID + group ID + tenant ID, matching the #1746/#1747 pattern.
- Swagger annotations + regenerated FE API types (`frontend/src/types/api.d.ts`) included.

## Acceptance criteria

- [x] Three endpoints + Swagger + FE codegen.
- [x] Handler tests cover each invariant violation surfacing the correct sentinel (`ErrLastOwner`, `ErrLastMember`, `ErrTooManyGroupMemberships`, `ErrAlreadyMember`).
- [x] Cross-tenant add rejected with `ErrTenantMismatch`.
- [x] Audit-log entries for add / remove / role-change (with tenant ID).

## Testing

- `go build ./...` — pass
- `golangci-lint run ./apiserver/... ./services/...` — 0 issues
- `go test ./apiserver/... ./services/... ./registry/...` — pass
- Handler tests cover happy paths, each invariant, cross-tenant rejection, non-admin 403, 404s, invalid role, and audit-row contents.

No migration required — no model changed.

Closes #1749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can add members to groups, remove members, and change member roles via new admin group-membership endpoints.

* **Tests**
  * Added comprehensive tests covering add/remove/role-change flows, validation, audit logging, and edge-case invariants (e.g., last-owner/member protections).

* **Documentation**
  * API docs and schema definitions updated to document the new admin membership endpoints, request formats, responses, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->