### PR TITLE
[#1750] Impersonation primitive: issue / end / current + audit log

### DIFF
--- a/devdocs/REFRESH_TOKEN_SYSTEM.md
+++ b/devdocs/REFRESH_TOKEN_SYSTEM.md
@@ -112,6 +112,27 @@ Key properties of the refresh interceptor:
 - **Graceful degradation**: if the refresh call itself fails (cookie missing, token
   expired, revoked), the interceptor clears local auth state and redirects to `/login`.
 
+> **Impersonation sessions are not refreshable.** When an admin starts an impersonation
+> session (`POST /admin/users/{id}/impersonate`), the server replaces the admin's
+> `refresh_token` cookie with a non-refreshable impersonation marker value (prefix
+> `imp:`). `POST /auth/refresh` rejects the request with a `401` whenever the bearer
+> token carries the `imp` claim **or** the refresh cookie holds that marker — so the
+> cookie-based refresh path (the one the FE interceptor actually uses, with no
+> `Authorization` header) cannot silently mint a fresh *admin* access token mid-session.
+> The short-lived impersonation access token (≤ 30 min) therefore expires hard: the
+> operator ends the session via `POST /admin/impersonation/end`, which restores the
+> admin's original refresh cookie from the server-side return slot.
+>
+> `POST /admin/impersonation/end` is mounted **without** the JWT middleware and
+> self-validates the impersonation token off the `Authorization` header: it always
+> verifies the signature and requires the `imp=true` claim, but tolerates an expired
+> `exp`. This lets an operator who let the impersonation token lapse while idle still
+> end the session (and be restored) instead of being forced into a full re-login. The
+> relaxation is `exp`-only — a forged token fails signature verification and an expired
+> *non-impersonation* token fails the `imp` check, so neither is admitted; the
+> `jti`-keyed return slot plus the `slot.AdminUserID == impersonated_by` assertion
+> remain the real authorization.
+
 ---
 
 ### Logout
@@ -137,6 +158,15 @@ After logout:
 - The **refresh token** record in the database has its `revoked_at` timestamp set,
   preventing any future refresh using that cookie.
 - The browser cookie is deleted by sending a `Set-Cookie` with `MaxAge=-1`.
+
+> **Logout during an impersonation session.** While impersonating, the `refresh_token`
+> cookie holds the `imp:<jti>` marker, not a real token — hashing it would find no
+> database row. So logout detects the marker, resolves the server-side return slot by
+> its `jti`, and revokes the **operator's genuine refresh token** held in that slot
+> (then drops the slot). This guarantees an operator who logs out mid-impersonation
+> actually terminates their real admin credential rather than leaving it `valid` in the
+> database for its full lifetime. A normal (non-marker) cookie takes the plain
+> hash-then-revoke path unchanged.
 
 ---
 

--- a/devdocs/REFRESH_TOKEN_SYSTEM.md
+++ b/devdocs/REFRESH_TOKEN_SYSTEM.md
@@ -113,17 +113,17 @@ Key properties of the refresh interceptor:
   expired, revoked), the interceptor clears local auth state and redirects to `/login`.
 
 > **Impersonation sessions are not refreshable.** When an admin starts an impersonation
-> session (`POST /admin/users/{id}/impersonate`), the server replaces the admin's
+> session (`POST /api/v1/admin/users/{userID}/impersonate`), the server replaces the admin's
 > `refresh_token` cookie with a non-refreshable impersonation marker value (prefix
 > `imp:`). `POST /auth/refresh` rejects the request with a `401` whenever the bearer
 > token carries the `imp` claim **or** the refresh cookie holds that marker — so the
 > cookie-based refresh path (the one the FE interceptor actually uses, with no
 > `Authorization` header) cannot silently mint a fresh *admin* access token mid-session.
 > The short-lived impersonation access token (≤ 30 min) therefore expires hard: the
-> operator ends the session via `POST /admin/impersonation/end`, which restores the
+> operator ends the session via `POST /api/v1/admin/impersonation/end`, which restores the
 > admin's original refresh cookie from the server-side return slot.
 >
-> `POST /admin/impersonation/end` is mounted **without** the JWT middleware and
+> `POST /api/v1/admin/impersonation/end` is mounted **without** the JWT middleware and
 > self-validates the impersonation token off the `Authorization` header: it always
 > verifies the signature and requires the `imp=true` claim, but tolerates an expired
 > `exp`. This lets an operator who let the impersonation token lapse while idle still
@@ -252,7 +252,7 @@ Three implementations are provided:
   are an acceptable trade-off and revocation is not needed.
 
 > **Impersonation tokens and blacklist durability.** Ending an admin impersonation
-> session (`POST /admin/impersonation/end`) revokes the impersonation access token by
+> session (`POST /api/v1/admin/impersonation/end`) revokes the impersonation access token by
 > adding its `jti` to the blacklist. This revocation is durable only with a
 > Redis-backed blacklist. With the in-memory blacklist (the single-instance default),
 > a process restart loses the entry, so an already-ended impersonation token is

--- a/devdocs/REFRESH_TOKEN_SYSTEM.md
+++ b/devdocs/REFRESH_TOKEN_SYSTEM.md
@@ -221,6 +221,16 @@ Three implementations are provided:
 - **No-op** (development only) — never blocks any token. Useful when 15-minute TTLs
   are an acceptable trade-off and revocation is not needed.
 
+> **Impersonation tokens and blacklist durability.** Ending an admin impersonation
+> session (`POST /admin/impersonation/end`) revokes the impersonation access token by
+> adding its `jti` to the blacklist. This revocation is durable only with a
+> Redis-backed blacklist. With the in-memory blacklist (the single-instance default),
+> a process restart loses the entry, so an already-ended impersonation token is
+> accepted again by the JWT middleware until its TTL expires — bounded by the
+> impersonation TTL ceiling of 30 minutes (`INVENTARIO_RUN_IMPERSONATION_TTL`).
+> Deployments that rely on instant, restart-proof impersonation revocation should
+> configure `INVENTARIO_RUN_TOKEN_BLACKLIST_REDIS_URL`.
+
 ---
 
 ## Frontend Design

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1089,7 +1089,7 @@ export type paths = {
                         "application/json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Unprocessable Entity - target is admin / blocked / nested impersonation */
+                /** @description Unprocessable Entity - target is admin / blocked / nested impersonation / reason too long */
                 422: {
                     headers: {
                         [name: string]: unknown;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -502,6 +502,130 @@ export type paths = {
         };
         trace?: never;
     };
+    "/admin/impersonation/current": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read the active impersonation session (admin)
+         * @description Convenience read for the FE impersonation banner. Returns `active=false` with no other fields when the caller is not inside an impersonation session, and the target/admin/started_at/expires_at quartet when it is.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["apiserver.ImpersonationStateResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Forbidden - system-admin required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/impersonation/end": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * End an impersonation session (admin)
+         * @description Ends the active impersonation session: blacklists the impersonation access token and restores the operator's own session. Must be called with the impersonation access token (the token carrying `imp=true`).
+         *     Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["apiserver.LoginResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Forbidden - system-admin required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unprocessable Entity - no active impersonation session */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/tenants": {
         parameters: {
             query?: never;
@@ -874,6 +998,113 @@ export type paths = {
                     };
                     content: {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/users/{userID}/impersonate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Start an impersonation session (admin)
+         * @description Issues a short-lived impersonation access token for the target user and sets it as the active session.
+         *     The token carries `imp=true`, `impersonated_by=<adminID>`, and `is_system_admin=false`; it cannot be
+         *     refreshed and cannot start a nested impersonation.
+         *     Returns 422 with `admin.impersonate.target_is_admin` when the target is a system admin,
+         *     `admin.impersonate.target_blocked` when the target account is blocked, and `admin.impersonate.nested`
+         *     when the caller is already impersonating. Returns 429 with `admin.impersonate.rate_limited` when the
+         *     per-admin start rate limit (10/hour) is exceeded.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Target user ID */
+                    userID: string;
+                };
+                cookie?: never;
+            };
+            /** @description Optional impersonation reason */
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["apiserver.ImpersonateRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["apiserver.LoginResponse"];
+                    };
+                };
+                /** @description Bad Request - invalid body */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Forbidden - system-admin required */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Not Found - unknown user */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unprocessable Entity - target is admin / blocked / nested impersonation */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Too Many Requests - per-admin rate limit */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
             };
@@ -7981,6 +8212,33 @@ export type components = {
         "apiserver.GroupNotificationsResponse": {
             warranty_expiring_alerts?: boolean;
             weekly_digest?: boolean;
+        };
+        "apiserver.ImpersonateRequest": {
+            /**
+             * @description Reason is the optional free-form justification for the
+             *     impersonation (max 500 chars).
+             */
+            reason?: string;
+        };
+        "apiserver.ImpersonationStateResponse": {
+            /** @description Active reports whether the caller is inside an impersonation session. */
+            active?: boolean;
+            /**
+             * @description AdminUser is the operator who initiated the session — nil when
+             *     Active is false.
+             */
+            admin_user?: components["schemas"]["apiserver.ImpersonationUserView"];
+            expires_at?: string;
+            /** @description StartedAt / ExpiresAt bound the session — zero values when inactive. */
+            started_at?: string;
+            /** @description TargetUser is the impersonated user — nil when Active is false. */
+            target_user?: components["schemas"]["apiserver.ImpersonationUserView"];
+        };
+        "apiserver.ImpersonationUserView": {
+            email?: string;
+            id?: string;
+            name?: string;
+            tenant_id?: string;
         };
         "apiserver.LoginEventView": {
             created_at?: string;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -570,7 +570,10 @@ export type paths = {
         put?: never;
         /**
          * End an impersonation session (admin)
-         * @description Ends the active impersonation session: blacklists the impersonation access token and restores the operator's own session. Must be called with the impersonation access token (the token carrying `imp=true`).
+         * @description Ends the active impersonation session: blacklists the impersonation access token, restores the operator's
+         *     own refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation
+         *     access token (the token carrying `imp=true`). The token's signature is always verified; an expired
+         *     impersonation token is still accepted here so an operator can end an idle session without re-logging in.
          *     Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
          */
         post: {
@@ -1021,7 +1024,9 @@ export type paths = {
          * Start an impersonation session (admin)
          * @description Issues a short-lived impersonation access token for the target user and sets it as the active session.
          *     The token carries `imp=true`, `impersonated_by=<adminID>`, and `is_system_admin=false`; it cannot be
-         *     refreshed and cannot start a nested impersonation.
+         *     refreshed and cannot start a nested impersonation. The admin's own refresh-token cookie is replaced
+         *     with a non-refreshable impersonation marker for the duration of the session; POST /admin/impersonation/end
+         *     restores the operator's original refresh cookie.
          *     Returns 422 with `admin.impersonate.target_is_admin` when the target is a system admin,
          *     `admin.impersonate.target_blocked` when the target account is blocked, and `admin.impersonate.nested`
          *     when the caller is already impersonating. Returns 429 with `admin.impersonate.rate_limited` when the

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -574,11 +574,15 @@ export type paths = {
          *     own refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation
          *     access token (the token carrying `imp=true`). The token's signature is always verified; an expired
          *     impersonation token is still accepted here so an operator can end an idle session without re-logging in.
-         *     Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
+         *     The request must also carry the httpOnly `refresh_token` cookie holding the `imp:<jti>` marker that
+         *     impersonation-start planted — proof the call comes from the operator's own browser. A stolen bearer
+         *     token alone, without that cookie, cannot be redeemed for admin credentials.
          *     This endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the
-         *     Authorization header, so it never produces a middleware 401/403: a missing, malformed, forged, or
-         *     non-impersonation token (and a missing/mismatched return slot) all collapse to the 422
-         *     `admin.impersonate.not_active` response. A 500 is returned only on a genuine store or registry fault.
+         *     Authorization header. Returns 401 when the token is missing, malformed, forged, or not an impersonation
+         *     token (an authentication failure). Returns 422 with `admin.impersonate.not_active` when the token is a
+         *     validly-signed impersonation token but no active session backs it — the return slot is missing, the
+         *     slot's operator disagrees with the token, or the operator's marker refresh cookie is absent/mismatched.
+         *     A 500 is returned only on a genuine store or registry fault.
          */
         post: {
             parameters: {
@@ -598,7 +602,16 @@ export type paths = {
                         "application/json": components["schemas"]["apiserver.LoginResponse"];
                     };
                 };
-                /** @description Unprocessable Entity - no active impersonation session (also covers a missing/invalid impersonation token) */
+                /** @description Unauthorized - missing, malformed, forged, or non-impersonation token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unprocessable Entity - no active impersonation session (missing/mismatched return slot or marker cookie) */
                 422: {
                     headers: {
                         [name: string]: unknown;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -540,7 +540,7 @@ export type paths = {
                         "application/json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Forbidden - system-admin or active impersonation session required */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -575,6 +575,10 @@ export type paths = {
          *     access token (the token carrying `imp=true`). The token's signature is always verified; an expired
          *     impersonation token is still accepted here so an operator can end an idle session without re-logging in.
          *     Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
+         *     This endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the
+         *     Authorization header, so it never produces a middleware 401/403: a missing, malformed, forged, or
+         *     non-impersonation token (and a missing/mismatched return slot) all collapse to the 422
+         *     `admin.impersonate.not_active` response. A 500 is returned only on a genuine store or registry fault.
          */
         post: {
             parameters: {
@@ -594,26 +598,17 @@ export type paths = {
                         "application/json": components["schemas"]["apiserver.LoginResponse"];
                     };
                 };
-                /** @description Unauthorized */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Forbidden - system-admin required */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["jsonapi.Errors"];
-                    };
-                };
-                /** @description Unprocessable Entity - no active impersonation session */
+                /** @description Unprocessable Entity - no active impersonation session (also covers a missing/invalid impersonation token) */
                 422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Internal Server Error - return-slot store or registry fault */
+                500: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -8221,7 +8216,9 @@ export type components = {
         "apiserver.ImpersonateRequest": {
             /**
              * @description Reason is the optional free-form justification for the
-             *     impersonation (max 500 chars).
+             *     impersonation (max 500 chars). The maxLength struct tag surfaces
+             *     the cap into the generated OpenAPI schema; the handler enforces
+             *     the same bound at decode time (impersonationReasonMaxLen).
              */
             reason?: string;
         };

--- a/go/apiserver/admin_impersonation.go
+++ b/go/apiserver/admin_impersonation.go
@@ -1,0 +1,616 @@
+package apiserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// defaultImpersonationTTL is the fallback impersonation-session lifetime
+// used when AdminParams.ImpersonationTTL is unset (zero). 30 min matches
+// the #1750 spec default and the hard upper bound enforced by
+// clampImpersonationTTL — operators tune it via INVENTARIO_RUN_IMPERSONATION_TTL.
+const defaultImpersonationTTL = 30 * time.Minute
+
+// maxImpersonationTTL is the hard ceiling on an impersonation session.
+// The #1750 spec mandates "lifetime ≤ 30 min" — a longer configured
+// value is clamped down to this rather than rejected so a fat-fingered
+// `2h` cannot silently widen the borrowed-identity window.
+const maxImpersonationTTL = 30 * time.Minute
+
+// impersonationReasonMaxLen caps the optional reason string. Mirrors
+// adminBlockReasonMaxLen so the audit-breadcrumb column stays bounded.
+const impersonationReasonMaxLen = 500
+
+// Impersonation audit action names. Kept as constants so the audit
+// trail uses the same literals as the swagger tags and the FE filter
+// chips. Mirrors the "admin.<verb>" pattern set by #1745/#1747.
+const (
+	// AuditActionAdminImpersonateStart is the audit-row Action emitted
+	// when an admin opens an impersonation session. Failure attempts
+	// (target-admin, target-blocked, nested, rate-limited) reuse the
+	// same Action with Success=false so one filter pulls the whole
+	// attempt history.
+	AuditActionAdminImpersonateStart = "admin.impersonate_start"
+	// AuditActionAdminImpersonateEnd is the audit-row Action emitted
+	// when an impersonation session is ended via POST /impersonation/end.
+	AuditActionAdminImpersonateEnd = "admin.impersonate_end"
+)
+
+// ImpersonateRequest is the (optional) request body for
+// POST /admin/users/{userID}/impersonate. The whole body may be omitted;
+// when present, `reason` is the operator's free-form justification and
+// is persisted into the audit-log breadcrumb.
+type ImpersonateRequest struct {
+	// Reason is the optional free-form justification for the
+	// impersonation (max 500 chars).
+	Reason string `json:"reason,omitempty"`
+}
+
+// ImpersonationStateResponse is returned by GET /admin/impersonation/current.
+// It is a convenience read for the FE's "you are impersonating X" banner.
+type ImpersonationStateResponse struct {
+	// Active reports whether the caller is inside an impersonation session.
+	Active bool `json:"active"`
+	// TargetUser is the impersonated user — nil when Active is false.
+	TargetUser *ImpersonationUserView `json:"target_user,omitempty"`
+	// AdminUser is the operator who initiated the session — nil when
+	// Active is false.
+	AdminUser *ImpersonationUserView `json:"admin_user,omitempty"`
+	// StartedAt / ExpiresAt bound the session — zero values when inactive.
+	StartedAt *time.Time `json:"started_at,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+// ImpersonationUserView is the narrow user projection embedded in the
+// impersonation responses. Deliberately minimal: identity only, no
+// password hash, no group memberships.
+type ImpersonationUserView struct {
+	ID       string `json:"id"`
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	TenantID string `json:"tenant_id"`
+}
+
+// adminImpersonationAPI backs the /admin/users/{id}/impersonate and
+// /admin/impersonation/* routes. Holds the FactorySet directly (not the
+// per-request user-aware Set) for the same cross-tenant reason the other
+// admin APIs do — the impersonation target may live in a different
+// tenant than the operator.
+type adminImpersonationAPI struct {
+	factorySet   *registry.FactorySet
+	store        services.ImpersonationStore
+	rateLimiter  services.AuthRateLimiter
+	blacklist    services.TokenBlacklister
+	auditService services.AuditLogger
+	jwtSecret    []byte
+	ttl          time.Duration
+}
+
+// clampImpersonationTTL resolves the effective impersonation TTL:
+// zero/negative falls back to the 30-min default, and any value above
+// the 30-min ceiling is clamped down so a misconfigured
+// INVENTARIO_RUN_IMPERSONATION_TTL cannot widen the borrowed-identity
+// window past what the #1750 spec allows.
+func clampImpersonationTTL(ttl time.Duration) time.Duration {
+	if ttl <= 0 {
+		return defaultImpersonationTTL
+	}
+	if ttl > maxImpersonationTTL {
+		return maxImpersonationTTL
+	}
+	return ttl
+}
+
+// startImpersonation issues a short-lived impersonation access token for
+// the target user and records the server-side return slot needed to
+// restore the admin's session.
+//
+// @Summary Start an impersonation session (admin)
+// @Description Issues a short-lived impersonation access token for the target user and sets it as the active session.
+// @Description The token carries `imp=true`, `impersonated_by=<adminID>`, and `is_system_admin=false`; it cannot be
+// @Description refreshed and cannot start a nested impersonation.
+// @Description Returns 422 with `admin.impersonate.target_is_admin` when the target is a system admin,
+// @Description `admin.impersonate.target_blocked` when the target account is blocked, and `admin.impersonate.nested`
+// @Description when the caller is already impersonating. Returns 429 with `admin.impersonate.rate_limited` when the
+// @Description per-admin start rate limit (10/hour) is exceeded.
+// @Tags admin
+// @Accept json
+// @Produce json
+// @Param userID path string true "Target user ID"
+// @Param data body ImpersonateRequest false "Optional impersonation reason"
+// @Success 200 {object} LoginResponse "OK"
+// @Failure 400 {object} jsonapi.Errors "Bad Request - invalid body"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 404 {object} jsonapi.Errors "Not Found - unknown user"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - target is admin / blocked / nested impersonation"
+// @Failure 429 {object} jsonapi.Errors "Too Many Requests - per-admin rate limit"
+// @Router /admin/users/{userID}/impersonate [post]
+func (api *adminImpersonationAPI) startImpersonation(w http.ResponseWriter, r *http.Request) {
+	admin := appctx.UserFromContext(r.Context())
+	if admin == nil {
+		_ = unauthorizedError(w, r, ErrMissingUserContext)
+		return
+	}
+
+	// Nested-impersonation guard: an impersonation access token carries
+	// `imp=true`. Refuse to open a second session from inside the first
+	// so the audit chain stays unambiguous about the operator-of-record.
+	if isImpersonatedRequest(r.Context()) {
+		api.auditStart(r, admin.ID, "", "", "", false, ErrNestedImpersonation.Error())
+		_ = renderEntityError(w, r, ErrNestedImpersonation)
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	if strings.TrimSpace(userID) == "" {
+		_ = renderEntityError(w, r, registry.ErrNotFound)
+		return
+	}
+
+	req, ok := api.decodeImpersonateRequest(w, r)
+	if !ok {
+		return
+	}
+
+	// Per-admin rate limit (#1750): 10 starts/hour. Checked before the
+	// target lookup so a runaway script cannot hammer the user registry.
+	if !api.checkRateLimit(w, r, admin.ID) {
+		return
+	}
+
+	target, err := api.factorySet.UserRegistry.Get(r.Context(), userID)
+	if err != nil {
+		api.auditStart(r, admin.ID, "", userID, "", false, err.Error())
+		_ = renderEntityError(w, r, err)
+		return
+	}
+
+	if guardErr := impersonationTargetGuard(target); guardErr != nil {
+		api.auditStart(r, admin.ID, "", target.ID, target.TenantID, false, guardErr.Error())
+		_ = renderEntityError(w, r, guardErr)
+		return
+	}
+
+	api.issueAndRespond(w, r, admin, target, req.Reason)
+}
+
+// issueAndRespond mints the impersonation token, records the return
+// slot, and writes the session response. Extracted from
+// startImpersonation to keep that handler under the funlen budget.
+func (api *adminImpersonationAPI) issueAndRespond(w http.ResponseWriter, r *http.Request, admin, target *models.User, reason string) {
+	startedAt := time.Now()
+	expiresAt := startedAt.Add(clampImpersonationTTL(api.ttl))
+	jti := uuid.New().String()
+
+	tokenString, err := api.signImpersonationToken(target, admin.ID, jti, startedAt, expiresAt)
+	if err != nil {
+		slog.Error("Failed to sign impersonation token", "admin_id", admin.ID, "target_id", target.ID, "error", err)
+		api.auditStart(r, admin.ID, "", target.ID, target.TenantID, false, err.Error())
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	// Record the return slot BEFORE writing the response so the `end`
+	// endpoint can always resolve it. The slot holds the admin's current
+	// refresh-token raw value (read from the cookie) so `end` can restore
+	// the admin's session; an admin without a refresh cookie (pure-bearer
+	// client) gets a brand-new session on `end` instead.
+	slot := services.ImpersonationSlot{
+		JTI:                  jti,
+		AdminUserID:          admin.ID,
+		AdminTenantID:        admin.TenantID,
+		AdminRefreshTokenRaw: refreshCookieValue(r),
+		TargetUserID:         target.ID,
+		TargetTenantID:       target.TenantID,
+		Reason:               reason,
+		StartedAt:            startedAt,
+		ExpiresAt:            expiresAt,
+	}
+	if err := api.store.Put(r.Context(), slot); err != nil {
+		slog.Error("Failed to record impersonation return slot", "admin_id", admin.ID, "target_id", target.ID, "error", err)
+		api.auditStart(r, admin.ID, "", target.ID, target.TenantID, false, err.Error())
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	api.auditStart(r, admin.ID, reason, target.ID, target.TenantID, true, "")
+	slog.Info("Impersonation session started", "admin_id", admin.ID, "target_id", target.ID, "jti", jti)
+
+	// The impersonation token is set as the active session via the body
+	// (same LoginResponse shape the FE already handles). The httpOnly
+	// refresh cookie is intentionally left untouched: impersonation
+	// sessions are non-refreshable, and the cookie still belongs to the
+	// admin's own session — `end` consumes it to restore the operator.
+	writeImpersonationLoginResponse(w, tokenString, clampImpersonationTTL(api.ttl), target)
+}
+
+// endImpersonation revokes the impersonation access token and restores
+// the admin's original session.
+//
+// @Summary End an impersonation session (admin)
+// @Description Ends the active impersonation session: blacklists the impersonation access token and restores the operator's own session. Must be called with the impersonation access token (the token carrying `imp=true`).
+// @Description Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
+// @Tags admin
+// @Produce json
+// @Success 200 {object} LoginResponse "OK"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - no active impersonation session"
+// @Router /admin/impersonation/end [post]
+func (api *adminImpersonationAPI) endImpersonation(w http.ResponseWriter, r *http.Request) {
+	claims := appctx.JWTClaimsFromContext(r.Context())
+	if !claimsAreImpersonation(claims) {
+		_ = renderEntityError(w, r, ErrNotImpersonating)
+		return
+	}
+
+	jti, _ := claims["jti"].(string)
+	adminID, _ := claims["impersonated_by"].(string)
+	targetID, _ := claims["user_id"].(string)
+
+	slot, err := api.store.Get(r.Context(), jti)
+	if err != nil {
+		// The token is a valid impersonation token but the slot is gone
+		// (already ended, or the process restarted). Treat as "not
+		// active" — the FE banner clears and the operator re-logs in.
+		slog.Warn("Impersonation end: return slot not found", "jti", jti, "admin_id", adminID)
+		_ = renderEntityError(w, r, ErrNotImpersonating)
+		return
+	}
+
+	// Blacklist the impersonation token so it cannot be reused after the
+	// session is ended, and drop the return slot.
+	api.blacklistImpersonationToken(r.Context(), jti, slot.ExpiresAt)
+	if delErr := api.store.Delete(r.Context(), jti); delErr != nil {
+		slog.Warn("Impersonation end: failed to delete return slot", "jti", jti, "error", delErr)
+	}
+
+	admin, err := api.factorySet.UserRegistry.Get(r.Context(), slot.AdminUserID)
+	if err != nil {
+		slog.Error("Impersonation end: failed to reload admin user", "admin_id", slot.AdminUserID, "error", err)
+		api.auditEnd(r, slot, targetID, false, err.Error())
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	api.auditEnd(r, slot, targetID, true, "")
+	slog.Info("Impersonation session ended", "admin_id", admin.ID, "target_id", slot.TargetUserID, "jti", jti)
+
+	api.restoreAdminSession(w, r, admin, slot)
+}
+
+// currentImpersonation reports the active impersonation session for the
+// FE banner.
+//
+// @Summary Read the active impersonation session (admin)
+// @Description Convenience read for the FE impersonation banner. Returns `active=false` with no other fields when the caller is not inside an impersonation session, and the target/admin/started_at/expires_at quartet when it is.
+// @Tags admin
+// @Produce json
+// @Success 200 {object} ImpersonationStateResponse "OK"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Router /admin/impersonation/current [get]
+func (api *adminImpersonationAPI) currentImpersonation(w http.ResponseWriter, r *http.Request) {
+	claims := appctx.JWTClaimsFromContext(r.Context())
+	if !claimsAreImpersonation(claims) {
+		writeJSON(w, http.StatusOK, ImpersonationStateResponse{Active: false})
+		return
+	}
+
+	jti, _ := claims["jti"].(string)
+	slot, err := api.store.Get(r.Context(), jti)
+	if err != nil {
+		// Token says impersonation, but the slot is gone — report
+		// inactive so the FE clears its banner.
+		writeJSON(w, http.StatusOK, ImpersonationStateResponse{Active: false})
+		return
+	}
+
+	resp := ImpersonationStateResponse{
+		Active:    true,
+		StartedAt: &slot.StartedAt,
+		ExpiresAt: &slot.ExpiresAt,
+	}
+	if target, terr := api.factorySet.UserRegistry.Get(r.Context(), slot.TargetUserID); terr == nil {
+		resp.TargetUser = impersonationUserView(target)
+	}
+	if admin, aerr := api.factorySet.UserRegistry.Get(r.Context(), slot.AdminUserID); aerr == nil {
+		resp.AdminUser = impersonationUserView(admin)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// restoreAdminSession re-issues the operator's own session after an
+// impersonation session ends: it mints a fresh admin access token bound
+// to the admin's existing refresh-token row (when the return slot
+// captured one) and writes the LoginResponse. Extracted from
+// endImpersonation to stay under the funlen budget.
+func (api *adminImpersonationAPI) restoreAdminSession(w http.ResponseWriter, r *http.Request, admin *models.User, slot services.ImpersonationSlot) {
+	// Resolve the rti claim from the admin's captured refresh token so
+	// /users/me/sessions can still flag the operator's own session. An
+	// empty rti is fine — issueAdminAccessToken omits the claim.
+	rti := api.resolveAdminRefreshTokenID(r.Context(), slot.AdminRefreshTokenRaw)
+
+	tokenString, err := api.signAdminAccessToken(admin, rti)
+	if err != nil {
+		slog.Error("Impersonation end: failed to mint admin access token", "admin_id", admin.ID, "error", err)
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	// The admin's refresh cookie was never touched by the impersonation
+	// start, so it is still valid and still in the browser — no Set-Cookie
+	// needed here. The FE swaps the in-memory access token back to the
+	// admin's and the operator is whole again.
+	writeImpersonationLoginResponse(w, tokenString, accessTokenExpiration, admin)
+}
+
+// resolveAdminRefreshTokenID looks up the row id of the admin's captured
+// refresh token so the restored access token can carry it as `rti`.
+// Returns "" when no token was captured, the token is unknown, or the
+// lookup fails — the `rti` claim is informational and a missing value
+// only means /users/me/sessions cannot self-flag the row.
+func (api *adminImpersonationAPI) resolveAdminRefreshTokenID(ctx context.Context, rawToken string) string {
+	if rawToken == "" || api.factorySet.RefreshTokenRegistry == nil {
+		return ""
+	}
+	rt, err := api.factorySet.RefreshTokenRegistry.GetByTokenHash(ctx, models.HashRefreshToken(rawToken))
+	if err != nil {
+		return ""
+	}
+	return rt.ID
+}
+
+// signImpersonationToken builds and signs the impersonation access
+// token. Claims: user_id=<target> so JWTMiddleware loads the target;
+// tenant_id=<target tenant>; impersonated_by=<admin>; imp=true;
+// is_system_admin=false (an impersonated session never carries platform
+// admin authority, even when the target somehow had the flag — the
+// target guard rejects admins, but the claim is pinned false as
+// defence-in-depth).
+func (api *adminImpersonationAPI) signImpersonationToken(target *models.User, adminID, jti string, issuedAt, expiresAt time.Time) (string, error) {
+	claims := jwt.MapClaims{
+		"jti":             jti,
+		"user_id":         target.ID,
+		"tenant_id":       target.TenantID,
+		"impersonated_by": adminID,
+		"imp":             true,
+		"is_system_admin": false,
+		"iat":             issuedAt.Unix(),
+		"exp":             expiresAt.Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(api.jwtSecret)
+}
+
+// signAdminAccessToken mints a normal (non-impersonation) access token
+// for the operator when an impersonation session ends. Mirrors
+// AuthAPI.issueAccessToken so the restored session is indistinguishable
+// from a fresh login/refresh — including the is_system_admin claim.
+func (api *adminImpersonationAPI) signAdminAccessToken(admin *models.User, rti string) (string, error) {
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"jti":             uuid.New().String(),
+		"user_id":         admin.ID,
+		"is_system_admin": admin.IsSystemAdmin,
+		"iat":             now.Unix(),
+		"exp":             now.Add(accessTokenExpiration).Unix(),
+	}
+	if rti != "" {
+		claims["rti"] = rti
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(api.jwtSecret)
+}
+
+// blacklistImpersonationToken adds the impersonation token's JTI to the
+// blacklist so it is rejected on any further use after `end`. Best-effort:
+// a blacklist outage is logged but does not block the end flow — the
+// token expires on its own at the (≤ 30 min) TTL regardless. The
+// blacklister is the same service the rest of the apiserver uses,
+// plumbed through AdminParams.Blacklist.
+func (api *adminImpersonationAPI) blacklistImpersonationToken(ctx context.Context, jti string, expiresAt time.Time) {
+	if api.blacklist == nil || jti == "" {
+		return
+	}
+	if err := api.blacklist.BlacklistToken(ctx, jti, expiresAt); err != nil {
+		slog.Warn("Impersonation end: failed to blacklist token", "jti", jti, "error", err)
+	}
+}
+
+// decodeImpersonateRequest parses the optional POST body. An empty body
+// is valid (the whole request body is optional) and yields a zero-value
+// request. A present-but-malformed body is a 400; an over-long reason is
+// a 422.
+func (api *adminImpersonationAPI) decodeImpersonateRequest(w http.ResponseWriter, r *http.Request) (ImpersonateRequest, bool) {
+	var req ImpersonateRequest
+	if r.Body == nil {
+		return req, true
+	}
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		if errors.Is(err, io.EOF) {
+			// Empty body — the request body is optional.
+			return ImpersonateRequest{}, true
+		}
+		_ = badRequest(w, r, err)
+		return req, false
+	}
+	if !decoderAtEOF(dec) {
+		_ = badRequest(w, r, errors.New("invalid JSON body — trailing tokens"))
+		return req, false
+	}
+	req.Reason = strings.TrimSpace(req.Reason)
+	if utf8.RuneCountInString(req.Reason) > impersonationReasonMaxLen {
+		_ = badRequest(w, r, errors.New("reason is too long"))
+		return req, false
+	}
+	return req, true
+}
+
+// checkRateLimit enforces the per-admin impersonation-start rate limit.
+// Returns true when the request may proceed. On a limiter backend error
+// it fails open (consistent with the other rate limiters in this
+// package). On a genuine limit hit it writes the 429 + code response and
+// returns false.
+func (api *adminImpersonationAPI) checkRateLimit(w http.ResponseWriter, r *http.Request, adminID string) bool {
+	if api.rateLimiter == nil {
+		return true
+	}
+	res, err := api.rateLimiter.CheckImpersonationAttempt(r.Context(), adminID)
+	if err != nil {
+		slog.Error("Impersonation rate limiter error", "admin_id", adminID, "error", err)
+		return true
+	}
+	if !res.Allowed {
+		retryAfter := max(int(time.Until(res.ResetAt).Seconds()), 0)
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+		api.auditStart(r, adminID, "", "", "", false, "rate limit exceeded")
+		_ = codedTooManyRequestsError(w, r, services.ErrRateLimitExceeded, AdminImpersonateRateLimitedCode,
+			map[string]any{"retry_after_seconds": retryAfter})
+		return false
+	}
+	return true
+}
+
+// auditStart writes the admin.impersonate_start audit row. The
+// impersonator column is NOT set from context here (the start request
+// runs as the admin, not an impersonated session); LogAdmin still reads
+// the breadcrumb reason. Best-effort like the other admin audit helpers.
+func (api *adminImpersonationAPI) auditStart(r *http.Request, adminID, reason, targetID, targetTenantID string, success bool, errMsg string) {
+	if api.auditService == nil {
+		return
+	}
+	ev := services.AdminEvent{
+		Action:      AuditActionAdminImpersonateStart,
+		ActorID:     nullableString(adminID),
+		TenantID:    nullableString(targetTenantID),
+		SubjectType: stringPtr("user"),
+		SubjectID:   nullableString(targetID),
+		Success:     success,
+		Request:     r,
+		Reason:      reason,
+	}
+	if errMsg != "" {
+		ev.ErrMsg = stringPtr(errMsg)
+	}
+	api.auditService.LogAdmin(r.Context(), ev)
+}
+
+// auditEnd writes the admin.impersonate_end audit row. The request runs
+// under the impersonation token, so LogAdmin auto-fills the
+// ImpersonatedBy column from the `imp`/`impersonated_by` claims — the
+// row records "admin acting as target" without the call site doing
+// anything special.
+func (api *adminImpersonationAPI) auditEnd(r *http.Request, slot services.ImpersonationSlot, targetID string, success bool, errMsg string) {
+	if api.auditService == nil {
+		return
+	}
+	ev := services.AdminEvent{
+		Action:      AuditActionAdminImpersonateEnd,
+		ActorID:     nullableString(slot.AdminUserID),
+		TenantID:    nullableString(slot.TargetTenantID),
+		SubjectType: stringPtr("user"),
+		SubjectID:   nullableString(targetID),
+		Success:     success,
+		Request:     r,
+		Reason:      slot.Reason,
+	}
+	if errMsg != "" {
+		ev.ErrMsg = stringPtr(errMsg)
+	}
+	api.auditService.LogAdmin(r.Context(), ev)
+}
+
+// impersonationTargetGuard rejects targets that may not be impersonated:
+// a system admin (privilege-escalation footgun) or a blocked account
+// (resurrecting a torn-down session). Returns nil when the target is a
+// valid impersonation subject.
+func impersonationTargetGuard(target *models.User) error {
+	if target.IsSystemAdmin {
+		return ErrCannotImpersonateAdmin
+	}
+	if !target.IsActive {
+		return ErrTargetBlocked
+	}
+	return nil
+}
+
+// isImpersonatedRequest reports whether the current request is already
+// running inside an impersonation session (the access token carries
+// `imp=true`). Drives the nested-impersonation guard.
+func isImpersonatedRequest(ctx context.Context) bool {
+	return claimsAreImpersonation(appctx.JWTClaimsFromContext(ctx))
+}
+
+// claimsAreImpersonation reports whether the given JWT claims belong to
+// an impersonation token: `imp` is true AND `impersonated_by` is a
+// non-empty string. Both conditions are required so a token with a
+// stray `imp` claim but no operator-of-record is not mistaken for a
+// genuine impersonation session.
+func claimsAreImpersonation(claims jwt.MapClaims) bool {
+	if claims == nil {
+		return false
+	}
+	imp, _ := claims["imp"].(bool)
+	if !imp {
+		return false
+	}
+	by, ok := claims["impersonated_by"].(string)
+	return ok && by != ""
+}
+
+// refreshCookieValue returns the raw refresh-token cookie value, or ""
+// when the request carries no refresh cookie (e.g. a pure-bearer client).
+func refreshCookieValue(r *http.Request) string {
+	cookie, err := r.Cookie(refreshTokenCookieName)
+	if err != nil {
+		return ""
+	}
+	return cookie.Value
+}
+
+// impersonationUserView projects a *models.User into the narrow
+// identity-only view embedded in the impersonation responses.
+func impersonationUserView(u *models.User) *ImpersonationUserView {
+	return &ImpersonationUserView{
+		ID:       u.ID,
+		Email:    u.Email,
+		Name:     u.Name,
+		TenantID: u.TenantID,
+	}
+}
+
+// writeImpersonationLoginResponse writes a LoginResponse with the given
+// access token and TTL. Reuses the LoginResponse shape so the FE handles
+// the impersonation-start, impersonation-end, and normal-login responses
+// with one code path. CSRFToken is intentionally left empty — the
+// impersonation flow does not rotate CSRF tokens; the FE recovers the
+// CSRF token from the /auth/me header on the next navigation.
+func writeImpersonationLoginResponse(w http.ResponseWriter, accessToken string, ttl time.Duration, user *models.User) {
+	writeJSON(w, http.StatusOK, LoginResponse{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+		ExpiresIn:   int(ttl.Seconds()),
+		User:        user,
+	})
+}

--- a/go/apiserver/admin_impersonation.go
+++ b/go/apiserver/admin_impersonation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -125,7 +126,9 @@ func clampImpersonationTTL(ttl time.Duration) time.Duration {
 // @Summary Start an impersonation session (admin)
 // @Description Issues a short-lived impersonation access token for the target user and sets it as the active session.
 // @Description The token carries `imp=true`, `impersonated_by=<adminID>`, and `is_system_admin=false`; it cannot be
-// @Description refreshed and cannot start a nested impersonation.
+// @Description refreshed and cannot start a nested impersonation. The admin's own refresh-token cookie is replaced
+// @Description with a non-refreshable impersonation marker for the duration of the session; POST /admin/impersonation/end
+// @Description restores the operator's original refresh cookie.
 // @Description Returns 422 with `admin.impersonate.target_is_admin` when the target is a system admin,
 // @Description `admin.impersonate.target_blocked` when the target account is blocked, and `admin.impersonate.nested`
 // @Description when the caller is already impersonating. Returns 429 with `admin.impersonate.rate_limited` when the
@@ -235,19 +238,97 @@ func (api *adminImpersonationAPI) issueAndRespond(w http.ResponseWriter, r *http
 	api.auditStart(r, admin.ID, reason, target.ID, target.TenantID, true, "")
 	slog.Info("Impersonation session started", "admin_id", admin.ID, "target_id", target.ID, "jti", jti)
 
+	// Replace the FULL active session, not just the access token. The
+	// admin's own refresh cookie must NOT survive into the impersonation
+	// session: if it did, the FE refresh interceptor — which posts to
+	// /auth/refresh with the cookie but no Authorization header — would
+	// silently mint a fresh *admin* access token the moment the
+	// (short-lived) impersonation token 401s, ending the session outside
+	// /admin/impersonation/end and orphaning this return slot.
+	//
+	// So overwrite the refresh cookie with the impersonation marker
+	// (impersonationRefreshCookieMarker + jti). /auth/refresh detects the
+	// marker and rejects the refresh on the cookie path. The admin's
+	// genuine refresh token is preserved server-side in slot.AdminRefreshTokenRaw
+	// and restored on `end`. The marker cookie's max-age matches the
+	// impersonation TTL.
+	//
+	// An operator who lets the impersonation access token expire (idle)
+	// is NOT stranded: POST /admin/impersonation/end self-validates the
+	// expired token and still restores the admin from the return slot
+	// (the slot outlives the access token up to the same TTL). The
+	// genuine admin refresh token also stays recoverable until then —
+	// either via that `end` call or, if the operator logs out instead,
+	// via the marker-aware logout path. Only an operator who neither ends
+	// nor logs out before the TTL elapses falls back to a fresh login,
+	// at which point the slot has been TTL-pruned anyway.
+	writeRefreshCookie(w, r, impersonationRefreshCookieMarker+jti, int(ttl.Seconds()))
+
 	// The impersonation token is set as the active session via the body
-	// (same LoginResponse shape the FE already handles). The httpOnly
-	// refresh cookie is intentionally left untouched: impersonation
-	// sessions are non-refreshable, and the cookie still belongs to the
-	// admin's own session — `end` consumes it to restore the operator.
+	// (same LoginResponse shape the FE already handles).
 	writeImpersonationLoginResponse(w, tokenString, ttl, target)
+}
+
+// parseImpersonationEndToken extracts and verifies the impersonation
+// access token from the request's Authorization header for the `end`
+// endpoint. It is the self-validation step that lets `end` run WITHOUT
+// JWTMiddleware (see Admin() for why the route is mounted bare):
+//
+//   - The HS256 signature is ALWAYS verified against the same jwtSecret
+//     the rest of the apiserver uses — a forged or garbage token is
+//     rejected here exactly as JWTMiddleware would reject it.
+//   - ONLY an expired `exp` is tolerated (jwt.ErrTokenExpired). Every
+//     other validation error — bad signature, wrong algorithm, malformed
+//     token — still fails. This is the single, deliberate relaxation:
+//     it lets an operator end a session whose impersonation token lapsed
+//     while idle instead of being forced into a full re-login.
+//   - The token MUST be an impersonation token (`imp=true` +
+//     non-empty `impersonated_by`). An expired NON-impersonation token is
+//     therefore NOT admitted — claimsAreImpersonation returns false for it.
+//
+// The authoritative authorization still happens in endImpersonation: the
+// jti-keyed server-side return slot must exist AND its AdminUserID must
+// equal the token's `impersonated_by`. The token here only identifies
+// WHICH slot; the slot is the proof. Returns (claims, true) on success,
+// (nil, false) when the header is absent/malformed, the signature is
+// invalid, or the token is not an impersonation token.
+func (api *adminImpersonationAPI) parseImpersonationEndToken(authHeader string) (jwt.MapClaims, bool) {
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+	if tokenString == authHeader || tokenString == "" {
+		return nil, false
+	}
+	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return api.jwtSecret, nil
+	})
+	if token == nil {
+		return nil, false
+	}
+	// Tolerate ONLY expiry — every other error (bad signature, wrong alg,
+	// malformed) means the token cannot be trusted and `end` must reject it.
+	if err != nil && !errors.Is(err, jwt.ErrTokenExpired) {
+		return nil, false
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, false
+	}
+	if !claimsAreImpersonation(claims) {
+		return nil, false
+	}
+	return claims, true
 }
 
 // endImpersonation revokes the impersonation access token and restores
 // the admin's original session.
 //
 // @Summary End an impersonation session (admin)
-// @Description Ends the active impersonation session: blacklists the impersonation access token and restores the operator's own session. Must be called with the impersonation access token (the token carrying `imp=true`).
+// @Description Ends the active impersonation session: blacklists the impersonation access token, restores the operator's
+// @Description own refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation
+// @Description access token (the token carrying `imp=true`). The token's signature is always verified; an expired
+// @Description impersonation token is still accepted here so an operator can end an idle session without re-logging in.
 // @Description Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
 // @Tags admin
 // @Produce json
@@ -257,11 +338,23 @@ func (api *adminImpersonationAPI) issueAndRespond(w http.ResponseWriter, r *http
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - no active impersonation session"
 // @Router /admin/impersonation/end [post]
 func (api *adminImpersonationAPI) endImpersonation(w http.ResponseWriter, r *http.Request) {
-	claims := appctx.JWTClaimsFromContext(r.Context())
-	if !claimsAreImpersonation(claims) {
+	// `end` is mounted WITHOUT JWTMiddleware (see Admin()), so the token is
+	// validated here: the signature is verified and `imp=true` is required;
+	// only an expired `exp` is tolerated. A non-impersonation token — even
+	// a valid admin one — yields ErrNotImpersonating (422), so this bare
+	// route never becomes a back door for plain admin sessions.
+	claims, ok := api.parseImpersonationEndToken(r.Header.Get("Authorization"))
+	if !ok {
 		_ = renderEntityError(w, r, ErrNotImpersonating)
 		return
 	}
+
+	// `end` runs without JWTMiddleware, so the validated claims are not in
+	// context. Plant them so auditEnd's LogAdmin can auto-fill the audit
+	// row's ImpersonatedBy column from `imp`/`impersonated_by` exactly as
+	// it does on every JWTMiddleware-backed route — the audit semantics
+	// stay single-sourced rather than forking a special end-only path.
+	r = r.WithContext(appctx.WithJWTClaims(r.Context(), claims))
 
 	jti, _ := claims["jti"].(string)
 	adminID, _ := claims["impersonated_by"].(string)
@@ -375,8 +468,10 @@ func (api *adminImpersonationAPI) currentImpersonation(w http.ResponseWriter, r 
 // restoreAdminSession re-issues the operator's own session after an
 // impersonation session ends: it mints a fresh admin access token bound
 // to the admin's existing refresh-token row (when the return slot
-// captured one) and writes the LoginResponse. Extracted from
-// endImpersonation to stay under the funlen budget.
+// captured one) and restores the admin's original refresh cookie, which
+// the impersonation-start handler had overwritten with the impersonation
+// marker. Extracted from endImpersonation to stay under the funlen
+// budget.
 func (api *adminImpersonationAPI) restoreAdminSession(w http.ResponseWriter, r *http.Request, admin *models.User, slot services.ImpersonationSlot) {
 	// No IsActive re-check on the admin here on purpose: JWTMiddleware's
 	// validateUser rejects a blocked (!IsActive) user on the very next
@@ -395,10 +490,26 @@ func (api *adminImpersonationAPI) restoreAdminSession(w http.ResponseWriter, r *
 		return
 	}
 
-	// The admin's refresh cookie was never touched by the impersonation
-	// start, so it is still valid and still in the browser — no Set-Cookie
-	// needed here. The FE swaps the in-memory access token back to the
-	// admin's and the operator is whole again.
+	// Restore the admin's full session. The impersonation-start handler
+	// overwrote the refresh cookie with the impersonation marker, so it
+	// must be put back here or the admin would be left unable to refresh.
+	//
+	//  - The admin had a refresh token at start-time: re-plant it (still
+	//    valid in the DB — impersonation never revoked it) so the operator
+	//    can transparently refresh again afterwards.
+	//  - The admin had no refresh cookie (a pure-bearer client, e.g. a
+	//    test or API caller): there is nothing to restore, so delete the
+	//    marker cookie. The operator continues on the freshly-minted
+	//    access token until it expires, then logs in again — the same
+	//    behaviour a pure-bearer client had before impersonation.
+	if slot.AdminRefreshTokenRaw != "" {
+		writeRefreshCookie(w, r, slot.AdminRefreshTokenRaw, int(refreshTokenExpiration.Seconds()))
+	} else {
+		clearRefreshCookie(w, r)
+	}
+
+	// The FE swaps the in-memory access token back to the admin's and the
+	// operator is whole again.
 	writeImpersonationLoginResponse(w, tokenString, accessTokenExpiration, admin)
 }
 
@@ -620,11 +731,21 @@ func claimsAreImpersonation(claims jwt.MapClaims) bool {
 	return ok && by != ""
 }
 
-// refreshCookieValue returns the raw refresh-token cookie value, or ""
-// when the request carries no refresh cookie (e.g. a pure-bearer client).
+// refreshCookieValue returns the raw refresh-token cookie value to capture
+// into the impersonation return slot, or "" when there is nothing genuine
+// to capture — the request carries no refresh cookie (a pure-bearer
+// client), or the cookie already holds an impersonation marker rather
+// than a real token. The marker case should be unreachable (the
+// nested-impersonation guard and RequireSystemAdmin both block starting
+// an impersonation from inside one), but treating a marker as "no token"
+// is defence-in-depth: it stops a marker value from being mistaken for
+// the admin's real refresh token and re-planted on `end`.
 func refreshCookieValue(r *http.Request) string {
 	cookie, err := r.Cookie(refreshTokenCookieName)
 	if err != nil {
+		return ""
+	}
+	if strings.HasPrefix(cookie.Value, impersonationRefreshCookieMarker) {
 		return ""
 	}
 	return cookie.Value

--- a/go/apiserver/admin_impersonation.go
+++ b/go/apiserver/admin_impersonation.go
@@ -140,7 +140,7 @@ func clampImpersonationTTL(ttl time.Duration) time.Duration {
 // @Failure 401 {object} jsonapi.Errors "Unauthorized"
 // @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
 // @Failure 404 {object} jsonapi.Errors "Not Found - unknown user"
-// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - target is admin / blocked / nested impersonation"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - target is admin / blocked / nested impersonation / reason too long"
 // @Failure 429 {object} jsonapi.Errors "Too Many Requests - per-admin rate limit"
 // @Router /admin/users/{userID}/impersonate [post]
 func (api *adminImpersonationAPI) startImpersonation(w http.ResponseWriter, r *http.Request) {
@@ -197,7 +197,8 @@ func (api *adminImpersonationAPI) startImpersonation(w http.ResponseWriter, r *h
 // startImpersonation to keep that handler under the funlen budget.
 func (api *adminImpersonationAPI) issueAndRespond(w http.ResponseWriter, r *http.Request, admin, target *models.User, reason string) {
 	startedAt := time.Now()
-	expiresAt := startedAt.Add(clampImpersonationTTL(api.ttl))
+	ttl := clampImpersonationTTL(api.ttl)
+	expiresAt := startedAt.Add(ttl)
 	jti := uuid.New().String()
 
 	tokenString, err := api.signImpersonationToken(target, admin.ID, jti, startedAt, expiresAt)
@@ -239,7 +240,7 @@ func (api *adminImpersonationAPI) issueAndRespond(w http.ResponseWriter, r *http
 	// refresh cookie is intentionally left untouched: impersonation
 	// sessions are non-refreshable, and the cookie still belongs to the
 	// admin's own session — `end` consumes it to restore the operator.
-	writeImpersonationLoginResponse(w, tokenString, clampImpersonationTTL(api.ttl), target)
+	writeImpersonationLoginResponse(w, tokenString, ttl, target)
 }
 
 // endImpersonation revokes the impersonation access token and restores
@@ -276,8 +277,27 @@ func (api *adminImpersonationAPI) endImpersonation(w http.ResponseWriter, r *htt
 		return
 	}
 
+	// Defence-in-depth: the slot is jti-keyed and server-mutable, while
+	// `impersonated_by` comes from the signed (authoritative) token. If
+	// the two disagree, the slot belongs to a different operator — refuse
+	// rather than restore the wrong admin's session.
+	if slot.AdminUserID != adminID {
+		slog.Error("Impersonation end: slot/token admin mismatch",
+			"jti", jti, "slot_admin", slot.AdminUserID, "token_admin", adminID)
+		_ = renderEntityError(w, r, ErrNotImpersonating)
+		return
+	}
+
 	// Blacklist the impersonation token so it cannot be reused after the
 	// session is ended, and drop the return slot.
+	//
+	// NOTE: impersonation-token revocation is durable only with a
+	// Redis-backed token blacklist. With the default in-memory blacklist a
+	// process restart loses this entry, so an already-ended impersonation
+	// token is accepted again by JWTMiddleware until its (≤30-min TTL)
+	// ceiling expires. Operators running a single in-memory instance
+	// accept that ≤30-min window; multi-instance / production deployments
+	// should configure INVENTARIO_RUN_TOKEN_BLACKLIST_REDIS_URL.
 	api.blacklistImpersonationToken(r.Context(), jti, slot.ExpiresAt)
 	if delErr := api.store.Delete(r.Context(), jti); delErr != nil {
 		slog.Warn("Impersonation end: failed to delete return slot", "jti", jti, "error", delErr)
@@ -324,18 +344,32 @@ func (api *adminImpersonationAPI) currentImpersonation(w http.ResponseWriter, r 
 		return
 	}
 
-	resp := ImpersonationStateResponse{
-		Active:    true,
-		StartedAt: &slot.StartedAt,
-		ExpiresAt: &slot.ExpiresAt,
+	// A target (or admin) that cannot be resolved means the session is
+	// effectively broken — a vanished target is not a meaningful "active"
+	// impersonation. Report inactive so the FE clears its banner rather
+	// than rendering active=true with a nil user.
+	target, terr := api.factorySet.UserRegistry.Get(r.Context(), slot.TargetUserID)
+	if terr != nil {
+		slog.Warn("Impersonation current: failed to resolve target user, reporting inactive",
+			"jti", jti, "target_id", slot.TargetUserID, "error", terr)
+		writeJSON(w, http.StatusOK, ImpersonationStateResponse{Active: false})
+		return
 	}
-	if target, terr := api.factorySet.UserRegistry.Get(r.Context(), slot.TargetUserID); terr == nil {
-		resp.TargetUser = impersonationUserView(target)
+	admin, aerr := api.factorySet.UserRegistry.Get(r.Context(), slot.AdminUserID)
+	if aerr != nil {
+		slog.Warn("Impersonation current: failed to resolve admin user, reporting inactive",
+			"jti", jti, "admin_id", slot.AdminUserID, "error", aerr)
+		writeJSON(w, http.StatusOK, ImpersonationStateResponse{Active: false})
+		return
 	}
-	if admin, aerr := api.factorySet.UserRegistry.Get(r.Context(), slot.AdminUserID); aerr == nil {
-		resp.AdminUser = impersonationUserView(admin)
-	}
-	writeJSON(w, http.StatusOK, resp)
+
+	writeJSON(w, http.StatusOK, ImpersonationStateResponse{
+		Active:     true,
+		StartedAt:  &slot.StartedAt,
+		ExpiresAt:  &slot.ExpiresAt,
+		TargetUser: impersonationUserView(target),
+		AdminUser:  impersonationUserView(admin),
+	})
 }
 
 // restoreAdminSession re-issues the operator's own session after an
@@ -344,6 +378,11 @@ func (api *adminImpersonationAPI) currentImpersonation(w http.ResponseWriter, r 
 // captured one) and writes the LoginResponse. Extracted from
 // endImpersonation to stay under the funlen budget.
 func (api *adminImpersonationAPI) restoreAdminSession(w http.ResponseWriter, r *http.Request, admin *models.User, slot services.ImpersonationSlot) {
+	// No IsActive re-check on the admin here on purpose: JWTMiddleware's
+	// validateUser rejects a blocked (!IsActive) user on the very next
+	// request, so minting the token for a since-blocked admin is not an
+	// escalation — the middleware is the real gate.
+	//
 	// Resolve the rti claim from the admin's captured refresh token so
 	// /users/me/sessions can still flag the operator's own session. An
 	// empty rti is fine — issueAdminAccessToken omits the claim.
@@ -439,7 +478,8 @@ func (api *adminImpersonationAPI) blacklistImpersonationToken(ctx context.Contex
 // decodeImpersonateRequest parses the optional POST body. An empty body
 // is valid (the whole request body is optional) and yields a zero-value
 // request. A present-but-malformed body is a 400; an over-long reason is
-// a 422.
+// a 422 with code admin.impersonate.reason_too_long — matching the admin
+// block handler's reason-length contract exactly.
 func (api *adminImpersonationAPI) decodeImpersonateRequest(w http.ResponseWriter, r *http.Request) (ImpersonateRequest, bool) {
 	var req ImpersonateRequest
 	if r.Body == nil {
@@ -461,7 +501,7 @@ func (api *adminImpersonationAPI) decodeImpersonateRequest(w http.ResponseWriter
 	}
 	req.Reason = strings.TrimSpace(req.Reason)
 	if utf8.RuneCountInString(req.Reason) > impersonationReasonMaxLen {
-		_ = badRequest(w, r, errors.New("reason is too long"))
+		_ = codedUnprocessableEntityError(w, r, errors.New("reason is too long"), AdminImpersonateReasonTooLongCode)
 		return req, false
 	}
 	return req, true
@@ -517,17 +557,18 @@ func (api *adminImpersonationAPI) auditStart(r *http.Request, adminID, reason, t
 }
 
 // auditEnd writes the admin.impersonate_end audit row. The request runs
-// under the impersonation token, so LogAdmin auto-fills the
-// ImpersonatedBy column from the `imp`/`impersonated_by` claims — the
-// row records "admin acting as target" without the call site doing
-// anything special.
+// under the impersonation token, so the actor-of-record is the
+// impersonated target (ActorID → UserID = targetID) and LogAdmin
+// auto-fills the ImpersonatedBy column from the `imp`/`impersonated_by`
+// claims — the row records "admin acting as target" without the call
+// site doing anything special.
 func (api *adminImpersonationAPI) auditEnd(r *http.Request, slot services.ImpersonationSlot, targetID string, success bool, errMsg string) {
 	if api.auditService == nil {
 		return
 	}
 	ev := services.AdminEvent{
 		Action:      AuditActionAdminImpersonateEnd,
-		ActorID:     nullableString(slot.AdminUserID),
+		ActorID:     nullableString(targetID),
 		TenantID:    nullableString(slot.TargetTenantID),
 		SubjectType: stringPtr("user"),
 		SubjectID:   nullableString(targetID),

--- a/go/apiserver/admin_impersonation.go
+++ b/go/apiserver/admin_impersonation.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/csrf"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 	"github.com/denisvmedia/inventario/services"
@@ -102,8 +103,14 @@ type adminImpersonationAPI struct {
 	rateLimiter  services.AuthRateLimiter
 	blacklist    services.TokenBlacklister
 	auditService services.AuditLogger
-	jwtSecret    []byte
-	ttl          time.Duration
+	// csrfService mints a CSRF token for the new effective user across an
+	// identity swap (#1750): admin→target on start, target→admin on end.
+	// CSRF validation is per-user, so without a rotated token the SPA's
+	// first mutating request under the swapped identity would 403. May be
+	// nil (isolated unit tests); the response then carries an empty token.
+	csrfService csrf.Service
+	jwtSecret   []byte
+	ttl         time.Duration
 }
 
 // clampImpersonationTTL resolves the effective impersonation TTL:
@@ -266,9 +273,15 @@ func (api *adminImpersonationAPI) issueAndRespond(w http.ResponseWriter, r *http
 	// at which point the slot has been TTL-pruned anyway.
 	writeRefreshCookie(w, r, impersonationRefreshCookieMarker+jti, int(ttl.Seconds()))
 
+	// Rotate the CSRF token to the TARGET user: CSRF validation is
+	// per-user, so the impersonated session must carry a token minted for
+	// the target or its first mutating request 403s. Mirrors how login /
+	// refresh return a freshly-minted token.
+	csrfToken := generateCSRFToken(r.Context(), api.csrfService, target.ID)
+
 	// The impersonation token is set as the active session via the body
 	// (same LoginResponse shape the FE already handles).
-	writeImpersonationLoginResponse(w, tokenString, ttl, target)
+	writeImpersonationLoginResponse(w, tokenString, csrfToken, ttl, target)
 }
 
 // parseImpersonationEndToken extracts and verifies the impersonation
@@ -291,13 +304,21 @@ func (api *adminImpersonationAPI) issueAndRespond(w http.ResponseWriter, r *http
 // The authoritative authorization still happens in endImpersonation: the
 // jti-keyed server-side return slot must exist AND its AdminUserID must
 // equal the token's `impersonated_by`. The token here only identifies
-// WHICH slot; the slot is the proof. Returns (claims, true) on success,
-// (nil, false) when the header is absent/malformed, the signature is
-// invalid, or the token is not an impersonation token.
-func (api *adminImpersonationAPI) parseImpersonationEndToken(authHeader string) (jwt.MapClaims, bool) {
+// WHICH slot; the slot is the proof.
+//
+// Returns (claims, nil) on success. On failure it returns a non-nil
+// error so the caller can pick the right HTTP status:
+//   - ErrImpersonationTokenInvalid — the header is absent/malformed, the
+//     signature is bad, or the token is not an impersonation token. This
+//     is an AUTHENTICATION failure → endImpersonation maps it to 401.
+//
+// A validly-signed impersonation token whose server-side slot is missing
+// is NOT an error here — that case yields (claims, nil) and is handled
+// downstream as the 422 "not active" business-rule outcome.
+func (api *adminImpersonationAPI) parseImpersonationEndToken(authHeader string) (jwt.MapClaims, error) {
 	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
 	if tokenString == authHeader || tokenString == "" {
-		return nil, false
+		return nil, ErrImpersonationTokenInvalid
 	}
 	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -306,21 +327,21 @@ func (api *adminImpersonationAPI) parseImpersonationEndToken(authHeader string) 
 		return api.jwtSecret, nil
 	})
 	if token == nil {
-		return nil, false
+		return nil, ErrImpersonationTokenInvalid
 	}
 	// Tolerate ONLY expiry — every other error (bad signature, wrong alg,
 	// malformed) means the token cannot be trusted and `end` must reject it.
 	if err != nil && !errors.Is(err, jwt.ErrTokenExpired) {
-		return nil, false
+		return nil, ErrImpersonationTokenInvalid
 	}
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return nil, false
+		return nil, ErrImpersonationTokenInvalid
 	}
 	if !claimsAreImpersonation(claims) {
-		return nil, false
+		return nil, ErrImpersonationTokenInvalid
 	}
-	return claims, true
+	return claims, nil
 }
 
 // endImpersonation revokes the impersonation access token and restores
@@ -331,26 +352,31 @@ func (api *adminImpersonationAPI) parseImpersonationEndToken(authHeader string) 
 // @Description own refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation
 // @Description access token (the token carrying `imp=true`). The token's signature is always verified; an expired
 // @Description impersonation token is still accepted here so an operator can end an idle session without re-logging in.
-// @Description Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
+// @Description The request must also carry the httpOnly `refresh_token` cookie holding the `imp:<jti>` marker that
+// @Description impersonation-start planted — proof the call comes from the operator's own browser. A stolen bearer
+// @Description token alone, without that cookie, cannot be redeemed for admin credentials.
 // @Description This endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the
-// @Description Authorization header, so it never produces a middleware 401/403: a missing, malformed, forged, or
-// @Description non-impersonation token (and a missing/mismatched return slot) all collapse to the 422
-// @Description `admin.impersonate.not_active` response. A 500 is returned only on a genuine store or registry fault.
+// @Description Authorization header. Returns 401 when the token is missing, malformed, forged, or not an impersonation
+// @Description token (an authentication failure). Returns 422 with `admin.impersonate.not_active` when the token is a
+// @Description validly-signed impersonation token but no active session backs it — the return slot is missing, the
+// @Description slot's operator disagrees with the token, or the operator's marker refresh cookie is absent/mismatched.
+// @Description A 500 is returned only on a genuine store or registry fault.
 // @Tags admin
 // @Produce json
 // @Success 200 {object} LoginResponse "OK"
-// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - no active impersonation session (also covers a missing/invalid impersonation token)"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - missing, malformed, forged, or non-impersonation token"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - no active impersonation session (missing/mismatched return slot or marker cookie)"
 // @Failure 500 {object} jsonapi.Errors "Internal Server Error - return-slot store or registry fault"
 // @Router /admin/impersonation/end [post]
 func (api *adminImpersonationAPI) endImpersonation(w http.ResponseWriter, r *http.Request) {
 	// `end` is mounted WITHOUT JWTMiddleware (see Admin()), so the token is
 	// validated here: the signature is verified and `imp=true` is required;
-	// only an expired `exp` is tolerated. A non-impersonation token — even
-	// a valid admin one — yields ErrNotImpersonating (422), so this bare
-	// route never becomes a back door for plain admin sessions.
-	claims, ok := api.parseImpersonationEndToken(r.Header.Get("Authorization"))
-	if !ok {
-		_ = renderEntityError(w, r, ErrNotImpersonating)
+	// only an expired `exp` is tolerated. A missing/malformed/forged/
+	// non-impersonation token is an AUTHENTICATION failure → 401, distinct
+	// from the 422 reserved for "validly-signed token, no active session".
+	claims, perr := api.parseImpersonationEndToken(r.Header.Get("Authorization"))
+	if perr != nil {
+		_ = unauthorizedError(w, r, perr)
 		return
 	}
 
@@ -364,6 +390,36 @@ func (api *adminImpersonationAPI) endImpersonation(w http.ResponseWriter, r *htt
 	jti, _ := claims["jti"].(string)
 	adminID, _ := claims["impersonated_by"].(string)
 	targetID, _ := claims["user_id"].(string)
+
+	// A genuine impersonation token always carries a UUID jti (see
+	// signImpersonationToken). An empty jti would make the marker-cookie
+	// comparison below pass vacuously against an absent cookie, so reject
+	// it up front as malformed — an authentication failure (401).
+	if jti == "" {
+		slog.Warn("Impersonation end: token missing jti claim", "admin_id", adminID)
+		_ = unauthorizedError(w, r, ErrImpersonationTokenInvalid)
+		return
+	}
+
+	// SECURITY (#1750 / PR #1771 review): a valid impersonation bearer
+	// token is NOT sufficient to redeem `end` for admin credentials. The
+	// operator's browser holds the httpOnly `refresh_token` cookie that
+	// impersonation-start planted as `imp:<jti>`; require it here and
+	// require its jti to match the token's. A leaked bearer token without
+	// that browser-bound cookie then cannot be exchanged for the admin
+	// session. The marker cookie's max-age == the impersonation TTL, so it
+	// is still present on the only-just-expired-token `end` path.
+	if cookieJTI := markerCookieJTI(r); cookieJTI != jti {
+		slog.Warn("Impersonation end: marker refresh cookie absent or mismatched",
+			"jti", jti, "cookie_jti", cookieJTI, "admin_id", adminID)
+		// Audit the rejected attempt. The return slot is not yet loaded, so
+		// only the claim-derived fields are available — enough for the
+		// audit trail to record "an end was attempted and refused".
+		api.auditEnd(r, services.ImpersonationSlot{}, targetID, false,
+			"marker refresh cookie absent or mismatched")
+		_ = renderEntityError(w, r, ErrNotImpersonating)
+		return
+	}
 
 	slot, err := api.store.Get(r.Context(), jti)
 	if err != nil {
@@ -530,9 +586,15 @@ func (api *adminImpersonationAPI) restoreAdminSession(w http.ResponseWriter, r *
 		clearRefreshCookie(w, r)
 	}
 
+	// Rotate the CSRF token back to the ADMIN user: the identity swaps
+	// from target back to operator, and CSRF validation is per-user, so
+	// the restored admin session must carry a token minted for the admin
+	// or its first mutating request 403s. Mirrors login / refresh.
+	csrfToken := generateCSRFToken(r.Context(), api.csrfService, admin.ID)
+
 	// The FE swaps the in-memory access token back to the admin's and the
 	// operator is whole again.
-	writeImpersonationLoginResponse(w, tokenString, accessTokenExpiration, admin)
+	writeImpersonationLoginResponse(w, tokenString, csrfToken, accessTokenExpiration, admin)
 }
 
 // resolveAdminRefreshTokenID looks up the row id of the admin's captured
@@ -773,6 +835,30 @@ func refreshCookieValue(r *http.Request) string {
 	return cookie.Value
 }
 
+// markerCookieJTI returns the jti carried by the request's impersonation
+// marker refresh cookie, or "" when the request has no `refresh_token`
+// cookie or its value is not an `imp:<jti>` marker.
+//
+// It is the browser-bound proof endImpersonation requires (#1750 / PR
+// #1771 review): impersonation-start planted `imp:<jti>` into the
+// operator's httpOnly refresh cookie, so a genuine `end` call from that
+// same browser carries it. A stolen impersonation bearer token presented
+// from anywhere else has no such cookie, so markerCookieJTI returns ""
+// and the jti comparison in endImpersonation fails — the stolen token
+// cannot be exchanged for admin credentials. The marker cookie's max-age
+// equals the impersonation TTL, so the cookie is still present on the
+// legitimate only-just-expired-token `end` path.
+func markerCookieJTI(r *http.Request) string {
+	cookie, err := r.Cookie(refreshTokenCookieName)
+	if err != nil {
+		return ""
+	}
+	if !strings.HasPrefix(cookie.Value, impersonationRefreshCookieMarker) {
+		return ""
+	}
+	return strings.TrimPrefix(cookie.Value, impersonationRefreshCookieMarker)
+}
+
 // impersonationUserView projects a *models.User into the narrow
 // identity-only view embedded in the impersonation responses.
 func impersonationUserView(u *models.User) *ImpersonationUserView {
@@ -785,16 +871,25 @@ func impersonationUserView(u *models.User) *ImpersonationUserView {
 }
 
 // writeImpersonationLoginResponse writes a LoginResponse with the given
-// access token and TTL. Reuses the LoginResponse shape so the FE handles
-// the impersonation-start, impersonation-end, and normal-login responses
-// with one code path. CSRFToken is intentionally left empty — the
-// impersonation flow does not rotate CSRF tokens; the FE recovers the
-// CSRF token from the /auth/me header on the next navigation.
-func writeImpersonationLoginResponse(w http.ResponseWriter, accessToken string, ttl time.Duration, user *models.User) {
+// access token, TTL, and CSRF token. Reuses the LoginResponse shape so
+// the FE handles the impersonation-start, impersonation-end, and
+// normal-login responses with one code path.
+//
+// csrfToken MUST be a token freshly minted for the response's effective
+// user (the target on start, the admin on end): CSRF validation is
+// per-user, so after the identity swap the SPA cannot reuse the previous
+// identity's token — its first mutating request would 403. The handlers
+// also mirror the token into the X-CSRF-Token response header, matching
+// how /auth/me exposes it, so an FE that reads either source recovers.
+func writeImpersonationLoginResponse(w http.ResponseWriter, accessToken, csrfToken string, ttl time.Duration, user *models.User) {
+	if csrfToken != "" {
+		w.Header().Set(csrfHeaderName, csrfToken)
+	}
 	writeJSON(w, http.StatusOK, LoginResponse{
 		AccessToken: accessToken,
 		TokenType:   "Bearer",
 		ExpiresIn:   int(ttl.Seconds()),
+		CSRFToken:   csrfToken,
 		User:        user,
 	})
 }

--- a/go/apiserver/admin_impersonation.go
+++ b/go/apiserver/admin_impersonation.go
@@ -60,8 +60,10 @@ const (
 // is persisted into the audit-log breadcrumb.
 type ImpersonateRequest struct {
 	// Reason is the optional free-form justification for the
-	// impersonation (max 500 chars).
-	Reason string `json:"reason,omitempty"`
+	// impersonation (max 500 chars). The maxLength struct tag surfaces
+	// the cap into the generated OpenAPI schema; the handler enforces
+	// the same bound at decode time (impersonationReasonMaxLen).
+	Reason string `json:"reason,omitempty" maxLength:"500"`
 }
 
 // ImpersonationStateResponse is returned by GET /admin/impersonation/current.
@@ -330,12 +332,15 @@ func (api *adminImpersonationAPI) parseImpersonationEndToken(authHeader string) 
 // @Description access token (the token carrying `imp=true`). The token's signature is always verified; an expired
 // @Description impersonation token is still accepted here so an operator can end an idle session without re-logging in.
 // @Description Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
+// @Description This endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the
+// @Description Authorization header, so it never produces a middleware 401/403: a missing, malformed, forged, or
+// @Description non-impersonation token (and a missing/mismatched return slot) all collapse to the 422
+// @Description `admin.impersonate.not_active` response. A 500 is returned only on a genuine store or registry fault.
 // @Tags admin
 // @Produce json
 // @Success 200 {object} LoginResponse "OK"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
-// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - no active impersonation session"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - no active impersonation session (also covers a missing/invalid impersonation token)"
+// @Failure 500 {object} jsonapi.Errors "Internal Server Error - return-slot store or registry fault"
 // @Router /admin/impersonation/end [post]
 func (api *adminImpersonationAPI) endImpersonation(w http.ResponseWriter, r *http.Request) {
 	// `end` is mounted WITHOUT JWTMiddleware (see Admin()), so the token is
@@ -362,11 +367,20 @@ func (api *adminImpersonationAPI) endImpersonation(w http.ResponseWriter, r *htt
 
 	slot, err := api.store.Get(r.Context(), jti)
 	if err != nil {
-		// The token is a valid impersonation token but the slot is gone
-		// (already ended, or the process restarted). Treat as "not
-		// active" — the FE banner clears and the operator re-logs in.
-		slog.Warn("Impersonation end: return slot not found", "jti", jti, "admin_id", adminID)
-		_ = renderEntityError(w, r, ErrNotImpersonating)
+		if errors.Is(err, registry.ErrNotFound) {
+			// The token is a valid impersonation token but the slot is
+			// gone (already ended, or the process restarted). Treat as
+			// "not active" — the FE banner clears and the operator
+			// re-logs in.
+			slog.Warn("Impersonation end: return slot not found", "jti", jti, "admin_id", adminID)
+			_ = renderEntityError(w, r, ErrNotImpersonating)
+			return
+		}
+		// A non-not-found error is a genuine store fault (e.g. a
+		// Redis-backed store outage), not a missing slot — surface it as
+		// a 500 rather than masking it as "not active".
+		slog.Error("Impersonation end: failed to read return slot", "jti", jti, "admin_id", adminID, "error", err)
+		_ = internalServerError(w, r, err)
 		return
 	}
 
@@ -419,7 +433,7 @@ func (api *adminImpersonationAPI) endImpersonation(w http.ResponseWriter, r *htt
 // @Produce json
 // @Success 200 {object} ImpersonationStateResponse "OK"
 // @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin or active impersonation session required"
 // @Router /admin/impersonation/current [get]
 func (api *adminImpersonationAPI) currentImpersonation(w http.ResponseWriter, r *http.Request) {
 	claims := appctx.JWTClaimsFromContext(r.Context())
@@ -431,9 +445,17 @@ func (api *adminImpersonationAPI) currentImpersonation(w http.ResponseWriter, r 
 	jti, _ := claims["jti"].(string)
 	slot, err := api.store.Get(r.Context(), jti)
 	if err != nil {
-		// Token says impersonation, but the slot is gone — report
-		// inactive so the FE clears its banner.
-		writeJSON(w, http.StatusOK, ImpersonationStateResponse{Active: false})
+		if errors.Is(err, registry.ErrNotFound) {
+			// Token says impersonation, but the slot is gone — report
+			// inactive so the FE clears its banner.
+			writeJSON(w, http.StatusOK, ImpersonationStateResponse{Active: false})
+			return
+		}
+		// A non-not-found error is a genuine store fault, not a missing
+		// slot — surface it as a 500 rather than reporting a misleading
+		// inactive banner that masks a backend outage.
+		slog.Error("Impersonation current: failed to read return slot", "jti", jti, "error", err)
+		_ = internalServerError(w, r, err)
 		return
 	}
 

--- a/go/apiserver/admin_impersonation.go
+++ b/go/apiserver/admin_impersonation.go
@@ -114,10 +114,15 @@ type adminImpersonationAPI struct {
 }
 
 // clampImpersonationTTL resolves the effective impersonation TTL:
-// zero/negative falls back to the 30-min default, and any value above
-// the 30-min ceiling is clamped down so a misconfigured
+// zero falls back to the 30-min default, and any value above the 30-min
+// ceiling is clamped down so a misconfigured
 // INVENTARIO_RUN_IMPERSONATION_TTL cannot widen the borrowed-identity
 // window past what the #1750 spec allows.
+//
+// A negative TTL never reaches here in practice: Params.Validate()
+// rejects a negative ImpersonationTTL at startup. The `<= 0` branch
+// below still treats a negative value as "fall back to the default" —
+// defensive depth for any caller that bypasses Params.Validate().
 func clampImpersonationTTL(ttl time.Duration) time.Duration {
 	if ttl <= 0 {
 		return defaultImpersonationTTL

--- a/go/apiserver/admin_impersonation_test.go
+++ b/go/apiserver/admin_impersonation_test.go
@@ -511,6 +511,71 @@ func TestImpersonate_StartReplacesRefreshCookie(t *testing.T) {
 		qt.Commentf("refresh cookie should hold the impersonation marker, got %q", cookieValue))
 }
 
+// refreshCookiePathFromResponse extracts the Path attribute of the
+// refresh_token Set-Cookie header (the value after "Path=" up to the
+// next ';'). Returns ("", false) when the response sets no refresh
+// cookie or the cookie carries no Path attribute. Unlike
+// refreshCookieFromResponse this inspects the attribute STRING directly
+// — a httptest round-trip does not enforce cookie Path scoping, so the
+// only way to catch a path-scoping bug is to assert the attribute text.
+func refreshCookiePathFromResponse(rr *httptest.ResponseRecorder) (string, bool) {
+	for _, sc := range rr.Header().Values("Set-Cookie") {
+		if !strings.HasPrefix(sc, "refresh_token=") {
+			continue
+		}
+		for attr := range strings.SplitSeq(sc, ";") {
+			attr = strings.TrimSpace(attr)
+			if p, found := strings.CutPrefix(attr, "Path="); found {
+				return p, true
+			}
+		}
+		return "", false
+	}
+	return "", false
+}
+
+// TestImpersonate_StartMarkerCookieReachesEndEndpoint is the regression
+// test for the PR #1771 review bug (#1750): the impersonation marker
+// cookie planted by impersonation-start MUST be delivered by a real
+// browser to POST /api/v1/admin/impersonation/end, where endImpersonation
+// requires it as browser-bound proof. The earlier fix scoped the marker
+// to the refresh cookie, but the refresh cookie's Path was /api/v1/auth —
+// which does NOT cover /api/v1/admin/impersonation/end, so a real browser
+// would never send the cookie to `end` and endImpersonation would always
+// fail with admin.impersonate.not_active.
+//
+// A pure httptest round-trip cannot catch this: httptest does not enforce
+// cookie Path scoping. So this test asserts the Path ATTRIBUTE STRING
+// emitted by the handler is a prefix of /api/v1/admin/impersonation/end —
+// i.e. a conforming browser would send the cookie to `end`.
+func TestImpersonate_StartMarkerCookieReachesEndEndpoint(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	startRR := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
+	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
+
+	cookiePath, ok := refreshCookiePathFromResponse(startRR)
+	c.Assert(ok, qt.IsTrue, qt.Commentf("start must Set-Cookie the refresh_token with a Path attribute"))
+
+	// The browser sends a cookie to a request URL only when the cookie's
+	// Path is a prefix of the request path. The `end` endpoint lives at
+	// /api/v1/admin/impersonation/end, so the marker cookie's Path must be
+	// a prefix of that — otherwise a real browser drops the cookie and
+	// endImpersonation always sees an empty marker.
+	const endPath = "/api/v1/admin/impersonation/end"
+	c.Assert(strings.HasPrefix(endPath, cookiePath), qt.IsTrue,
+		qt.Commentf("marker cookie Path %q must be a prefix of %q so the browser sends it to `end`", cookiePath, endPath))
+	// The same cookie must still reach /api/v1/auth/refresh and
+	// /api/v1/auth/logout, which depend on the marker to reject / unwind an
+	// impersonation session.
+	c.Assert(strings.HasPrefix("/api/v1/auth/refresh", cookiePath), qt.IsTrue,
+		qt.Commentf("marker cookie Path %q must also cover /api/v1/auth/refresh", cookiePath))
+}
+
 // TestImpersonate_RefreshRejectedDuringSession_CookieOnly is the core
 // regression test for the PR #1771 review bug: a refresh attempt made
 // from inside an impersonation session — cookie-based, with NO

--- a/go/apiserver/admin_impersonation_test.go
+++ b/go/apiserver/admin_impersonation_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/csrf"
+	csrfinmemory "github.com/denisvmedia/inventario/csrf/inmemory"
 	"github.com/denisvmedia/inventario/models"
 )
 
@@ -256,10 +258,11 @@ func TestImpersonate_ExpiredTokenWithNoSlotEndsAsNotActive(t *testing.T) {
 		expiresAt:      time.Now().Add(-time.Minute),
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
-	req.Header.Set("Authorization", "Bearer "+expiredToken)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
+	// Send a marker refresh cookie matching the token's jti so the
+	// browser-bound binding passes — this test exercises the SLOT-MISSING
+	// branch specifically: a validly-signed (if expired) imp token whose
+	// jti has no live return slot must end as 422 not_active, not 401.
+	rr := doImpersonateEnd(handler, expiredToken, "imp:expired-jti")
 
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNotActiveCode)
@@ -304,12 +307,12 @@ func TestImpersonate_EndRestoresAdminContext(t *testing.T) {
 	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
 	var startResp apiserver.LoginResponse
 	c.Assert(json.Unmarshal(startRR.Body.Bytes(), &startResp), qt.IsNil)
+	markerCookie, ok := refreshCookieFromResponse(startRR)
+	c.Assert(ok, qt.IsTrue)
 
-	// End the session using the impersonation token.
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
-	req.Header.Set("Authorization", "Bearer "+startResp.AccessToken)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
+	// End the session using the impersonation token, replaying the marker
+	// refresh cookie the operator's browser holds.
+	rr := doImpersonateEnd(handler, startResp.AccessToken, markerCookie)
 
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	var endResp apiserver.LoginResponse
@@ -349,14 +352,16 @@ func TestImpersonate_EndRejectsNonImpersonationToken(t *testing.T) {
 	promoteToSystemAdmin(c, params, admin)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
-	// A plain admin token (no imp claim) at the end endpoint → 422.
+	// A plain admin token (no imp claim) at the end endpoint is an
+	// authentication failure — not an impersonation token at all — so it
+	// is rejected with 401, distinct from the 422 reserved for a valid
+	// impersonation token with no active session.
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
 	addTestUserAuthHeader(req, admin.ID)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
-	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNotActiveCode)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }
 
 func TestImpersonate_CurrentReportsInactiveForPlainAdmin(t *testing.T) {
@@ -472,7 +477,9 @@ func refreshCookieFromResponse(rr *httptest.ResponseRecorder) (string, bool) {
 // overwrites the admin's own refresh cookie with the impersonation
 // marker. Leaving the admin's refresh token in the browser would let the
 // FE's cookie-based refresh interceptor silently mint a fresh admin
-// access token mid-impersonation (#1750 / PR #1771 review).
+// access token mid-impersonation (#1750 / PR #1771 review). The request
+// carries a genuine admin refresh cookie so the test exercises the real
+// REPLACEMENT path — the marker must differ from that seeded token.
 func TestImpersonate_StartReplacesRefreshCookie(t *testing.T) {
 	c := qt.New(t)
 	params, admin, _ := newParams()
@@ -480,13 +487,26 @@ func TestImpersonate_StartReplacesRefreshCookie(t *testing.T) {
 	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
-	rr := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
+	// Seed a real, refreshable admin refresh token and send it as the
+	// request cookie — exactly what a browser-authenticated admin carries.
+	adminRefreshRaw := createAdminRefreshToken(c, params, admin)
+
+	startReq := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+target.ID+"/impersonate", bytes.NewReader(nil))
+	startReq.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(startReq, admin.ID)
+	// #nosec G124 -- test request cookie.
+	startReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: adminRefreshRaw})
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, startReq)
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 
 	cookieValue, ok := refreshCookieFromResponse(rr)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("start must Set-Cookie the refresh_token"))
-	// The cookie must carry the non-refreshable impersonation marker, not
-	// a genuine refresh token.
+	// The response must OVERWRITE the genuine token: the new cookie value
+	// differs from the one the request sent...
+	c.Assert(cookieValue, qt.Not(qt.Equals), adminRefreshRaw,
+		qt.Commentf("start must replace the admin's real refresh token, not leave it"))
+	// ...and carries the non-refreshable impersonation marker instead.
 	c.Assert(strings.HasPrefix(cookieValue, "imp:"), qt.IsTrue,
 		qt.Commentf("refresh cookie should hold the impersonation marker, got %q", cookieValue))
 }
@@ -551,12 +571,14 @@ func TestImpersonate_EndRestoresRefreshCookie(t *testing.T) {
 	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
 	var startResp apiserver.LoginResponse
 	c.Assert(json.Unmarshal(startRR.Body.Bytes(), &startResp), qt.IsNil)
+	// The start handler overwrites the admin's refresh cookie with the
+	// imp: marker — the operator's browser holds that marker and replays
+	// it on `end`.
+	markerCookie, ok := refreshCookieFromResponse(startRR)
+	c.Assert(ok, qt.IsTrue)
 
-	// End the session with the impersonation token.
-	endReq := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
-	endReq.Header.Set("Authorization", "Bearer "+startResp.AccessToken)
-	endRR := httptest.NewRecorder()
-	handler.ServeHTTP(endRR, endReq)
+	// End the session with the impersonation token + the marker cookie.
+	endRR := doImpersonateEnd(handler, startResp.AccessToken, markerCookie)
 	c.Assert(endRR.Code, qt.Equals, http.StatusOK)
 
 	// The end response must restore the admin's ORIGINAL refresh token,
@@ -705,10 +727,11 @@ func refreshCookieIsDeletion(rr *httptest.ResponseRecorder) bool {
 }
 
 // startImpersonationGetJTI runs a real impersonation start as admin→target
-// and returns the started session's access token and its jti claim. Used
-// by the FIX 2 test to forge an EXPIRED token bound to the SAME jti as a
-// live return slot.
-func startImpersonationGetJTI(c *qt.C, handler http.Handler, adminID, targetID string) (accessToken, jti string) {
+// and returns the started session's access token, its jti claim, and the
+// `imp:<jti>` marker the start handler planted into the refresh cookie.
+// The marker cookie is the browser-bound proof endImpersonation requires
+// (#1750 / PR #1771 review), so legitimate `end` calls must replay it.
+func startImpersonationGetJTI(c *qt.C, handler http.Handler, adminID, targetID string) (accessToken, jti, markerCookie string) {
 	c.Helper()
 	startRR := doImpersonateStart(c, handler, adminID, targetID, nil)
 	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
@@ -717,7 +740,28 @@ func startImpersonationGetJTI(c *qt.C, handler http.Handler, adminID, targetID s
 	claims := parseTestTokenClaims(c, startResp.AccessToken)
 	jtiClaim, ok := claims["jti"].(string)
 	c.Assert(ok, qt.IsTrue)
-	return startResp.AccessToken, jtiClaim
+	marker, ok := refreshCookieFromResponse(startRR)
+	c.Assert(ok, qt.IsTrue, qt.Commentf("start must plant the imp: marker refresh cookie"))
+	return startResp.AccessToken, jtiClaim, marker
+}
+
+// doImpersonateEnd issues POST /admin/impersonation/end with the given
+// impersonation access token and — when markerCookie is non-empty — the
+// `imp:<jti>` marker refresh cookie the operator's browser carries. A
+// legitimate `end` always replays the marker; tests of the missing-cookie
+// rejection pass "" deliberately.
+func doImpersonateEnd(handler http.Handler, accessToken, markerCookie string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
+	if accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+	}
+	if markerCookie != "" {
+		// #nosec G124 -- test request cookie; transport security is irrelevant.
+		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: markerCookie})
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
 }
 
 // TestImpersonate_LogoutDuringImpersonationRevokesAdminToken is the
@@ -797,8 +841,9 @@ func TestImpersonate_EndAcceptsExpiredTokenWithLiveSlot(t *testing.T) {
 	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
-	// Start a genuine session so the return slot exists, and capture its jti.
-	_, jti := startImpersonationGetJTI(c, handler, admin.ID, target.ID)
+	// Start a genuine session so the return slot exists, and capture its
+	// jti + the marker refresh cookie the operator's browser still holds.
+	_, jti, markerCookie := startImpersonationGetJTI(c, handler, admin.ID, target.ID)
 
 	// Forge an EXPIRED impersonation token bound to the SAME jti — signed
 	// with the real test secret, so the signature is valid; only `exp` is
@@ -811,10 +856,10 @@ func TestImpersonate_EndAcceptsExpiredTokenWithLiveSlot(t *testing.T) {
 		expiresAt:      time.Now().Add(-time.Minute),
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
-	req.Header.Set("Authorization", "Bearer "+expiredToken)
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
+	// The marker refresh cookie's max-age == the impersonation TTL, so it
+	// is still present when the only-just-expired token is used — the
+	// expired-token `end` path still passes the marker-cookie binding.
+	rr := doImpersonateEnd(handler, expiredToken, markerCookie)
 
 	// The expired token still ends the session and restores the admin.
 	c.Assert(rr.Code, qt.Equals, http.StatusOK,
@@ -832,8 +877,8 @@ func TestImpersonate_EndAcceptsExpiredTokenWithLiveSlot(t *testing.T) {
 // TestImpersonate_EndStillRejectsExpiredNonImpersonationToken guards the
 // FIX 2 security boundary: relaxing `exp` must NOT let an expired PLAIN
 // (non-imp) admin token reach a successful end. parseImpersonationEndToken
-// requires imp=true, so an expired admin token is rejected with 422
-// not_active just as a fresh one is.
+// requires imp=true, so an expired admin token is an authentication
+// failure — rejected with 401 just as a fresh non-imp token is.
 func TestImpersonate_EndStillRejectsExpiredNonImpersonationToken(t *testing.T) {
 	c := qt.New(t)
 	params, admin, _ := newParams()
@@ -856,14 +901,13 @@ func TestImpersonate_EndStillRejectsExpiredNonImpersonationToken(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
-	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNotActiveCode)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }
 
 // TestImpersonate_EndRejectsForgedToken guards the other FIX 2 security
 // boundary: a token with a BAD signature must be rejected even when it
 // claims imp=true. The expiry relaxation never bypasses signature
-// verification.
+// verification — a bad signature is an authentication failure (401).
 func TestImpersonate_EndRejectsForgedToken(t *testing.T) {
 	c := qt.New(t)
 	params, admin, _ := newParams()
@@ -890,8 +934,7 @@ func TestImpersonate_EndRejectsForgedToken(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
-	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNotActiveCode)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }
 
 // TestImpersonate_EndClearsMarkerCookieForPureBearerStart proves the
@@ -907,16 +950,201 @@ func TestImpersonate_EndClearsMarkerCookieForPureBearerStart(t *testing.T) {
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	// Start WITHOUT a refresh cookie — doImpersonateStart sends only the
-	// bearer auth header, so slot.AdminRefreshTokenRaw is empty.
-	accessToken, _ := startImpersonationGetJTI(c, handler, admin.ID, target.ID)
+	// bearer auth header, so slot.AdminRefreshTokenRaw is empty. The start
+	// handler still plants the imp: marker cookie, which the operator's
+	// browser replays on `end`.
+	accessToken, _, markerCookie := startImpersonationGetJTI(c, handler, admin.ID, target.ID)
 
-	endReq := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
-	endReq.Header.Set("Authorization", "Bearer "+accessToken)
-	endRR := httptest.NewRecorder()
-	handler.ServeHTTP(endRR, endReq)
+	endRR := doImpersonateEnd(handler, accessToken, markerCookie)
 	c.Assert(endRR.Code, qt.Equals, http.StatusOK)
 
 	// With no genuine token to restore, `end` must clear the marker cookie.
 	c.Assert(refreshCookieIsDeletion(endRR), qt.IsTrue,
 		qt.Commentf("pure-bearer end must delete the marker refresh cookie"))
+}
+
+// TestImpersonate_EndRejectsWithoutMarkerCookie is the regression test
+// for PR #1771 FIX 1: a valid impersonation access token is NOT enough
+// to redeem `end` for admin credentials. The operator's browser holds
+// the httpOnly `imp:<jti>` marker refresh cookie; `end` requires it.
+// A request with a valid (even fresh) impersonation bearer token but no
+// marker cookie — the shape of a stolen-token attack — must be refused
+// without restoring the admin session.
+func TestImpersonate_EndRejectsWithoutMarkerCookie(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Start a genuine session: the return slot exists and the token is
+	// valid. The "attacker" has only the bearer token, not the browser's
+	// marker cookie.
+	accessToken, _, _ := startImpersonationGetJTI(c, handler, admin.ID, target.ID)
+
+	// End WITHOUT the marker cookie — doImpersonateEnd passes "" so no
+	// refresh cookie is sent.
+	rr := doImpersonateEnd(handler, accessToken, "")
+
+	// Rejected as not-active: a valid bearer token alone proves nothing.
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNotActiveCode)
+
+	// No admin session was handed out — the response is not a LoginResponse
+	// carrying an access token.
+	var resp apiserver.LoginResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	c.Assert(resp.AccessToken, qt.Equals, "")
+}
+
+// TestImpersonate_EndRejectsMismatchedMarkerCookie proves the marker
+// cookie must match THIS session's jti: a marker cookie from a different
+// (or stale) impersonation session does not satisfy the binding.
+func TestImpersonate_EndRejectsMismatchedMarkerCookie(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	accessToken, _, _ := startImpersonationGetJTI(c, handler, admin.ID, target.ID)
+
+	// A marker cookie carrying a DIFFERENT jti than the token's.
+	rr := doImpersonateEnd(handler, accessToken, "imp:some-other-jti")
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNotActiveCode)
+}
+
+// newParamsWithCSRF builds the standard test params plus an in-memory
+// CSRF service so the impersonation start/end responses carry a real
+// (non-empty) csrf_token. Returns the service too so callers can mint a
+// request CSRF token (the start route is CSRF-protected once a real
+// service is wired). Used by the FIX-F2 CSRF-rotation tests.
+func newParamsWithCSRF(c *qt.C) (apiserver.Params, *models.User, csrf.Service) {
+	c.Helper()
+	params, admin, _ := newParams()
+	csrfSvc := csrfinmemory.New()
+	params.CSRFService = csrfSvc
+	return params, admin, csrfSvc
+}
+
+// TestImpersonate_StartResponseCarriesCSRFToken is the regression test
+// for PR #1771 FIX F2 on the start path: CSRF validation is per-user, so
+// after the admin→target identity swap the start response must hand the
+// SPA a CSRF token minted for the TARGET — both in the body and the
+// X-CSRF-Token header — or the impersonated session's first mutating
+// request 403s.
+func TestImpersonate_StartResponseCarriesCSRFToken(t *testing.T) {
+	c := qt.New(t)
+	params, admin, csrfSvc := newParamsWithCSRF(c)
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// The start route is CSRF-protected once a real service is wired:
+	// mint a token for the ADMIN (the start request runs as the admin).
+	adminCSRF := must2(csrfSvc.GenerateToken(context.Background(), admin.ID))
+
+	startReq := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+target.ID+"/impersonate", bytes.NewReader(nil))
+	startReq.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(startReq, admin.ID)
+	startReq.Header.Set("X-CSRF-Token", adminCSRF)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, startReq)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+
+	var resp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &resp), qt.IsNil)
+	c.Assert(resp.CSRFToken, qt.Not(qt.Equals), "",
+		qt.Commentf("start response body must carry a CSRF token for the target"))
+	c.Assert(rr.Header().Get("X-CSRF-Token"), qt.Equals, resp.CSRFToken,
+		qt.Commentf("start must mirror the CSRF token into the X-CSRF-Token header"))
+	// The rotated token is the target's, not the admin's request token.
+	c.Assert(resp.CSRFToken, qt.Not(qt.Equals), adminCSRF,
+		qt.Commentf("start must rotate the CSRF token to the target identity"))
+}
+
+// TestImpersonate_EndResponseCarriesCSRFToken is the regression test for
+// PR #1771 FIX F2 on the end path: the target→admin identity swap-back
+// must hand the SPA a CSRF token minted for the ADMIN, or the restored
+// admin session's first mutating request 403s.
+func TestImpersonate_EndResponseCarriesCSRFToken(t *testing.T) {
+	c := qt.New(t)
+	params, admin, csrfSvc := newParamsWithCSRF(c)
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// The start route is CSRF-protected: mint an admin request token.
+	adminCSRF := must2(csrfSvc.GenerateToken(context.Background(), admin.ID))
+	startReq := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+target.ID+"/impersonate", bytes.NewReader(nil))
+	startReq.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(startReq, admin.ID)
+	startReq.Header.Set("X-CSRF-Token", adminCSRF)
+	startRR := httptest.NewRecorder()
+	handler.ServeHTTP(startRR, startReq)
+	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
+	var startResp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(startRR.Body.Bytes(), &startResp), qt.IsNil)
+	markerCookie, ok := refreshCookieFromResponse(startRR)
+	c.Assert(ok, qt.IsTrue)
+
+	// `end` is mounted bare (no CSRF middleware), so no request token is
+	// needed — only the imp token + the marker cookie.
+	endRR := doImpersonateEnd(handler, startResp.AccessToken, markerCookie)
+	c.Assert(endRR.Code, qt.Equals, http.StatusOK)
+
+	var resp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(endRR.Body.Bytes(), &resp), qt.IsNil)
+	c.Assert(resp.CSRFToken, qt.Not(qt.Equals), "",
+		qt.Commentf("end response body must carry a CSRF token for the admin"))
+	c.Assert(endRR.Header().Get("X-CSRF-Token"), qt.Equals, resp.CSRFToken,
+		qt.Commentf("end must mirror the CSRF token into the X-CSRF-Token header"))
+}
+
+// TestImpersonate_LogoutDuringImpersonationAuditRecordsImpersonator is
+// the regression test for PR #1771 FIX F8: a logout that runs WHILE the
+// operator is impersonating must record the operator-of-record in the
+// audit row's ImpersonatedBy column. logout runs without RequireAuth, so
+// the handler must seed the impersonation claims into the request
+// context before logAuth runs — otherwise the row records only the
+// target user and the "every action while impersonating is audited"
+// guarantee is broken.
+func TestImpersonate_LogoutDuringImpersonationAuditRecordsImpersonator(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Start a genuine impersonation session.
+	accessToken, _, markerCookie := startImpersonationGetJTI(c, handler, admin.ID, target.ID)
+
+	// Log out from inside the impersonation session: the bearer token is
+	// the impersonation token, the cookie is the imp: marker.
+	logoutReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+	logoutReq.Header.Set("Authorization", "Bearer "+accessToken)
+	// #nosec G124 -- test request cookie.
+	logoutReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: markerCookie})
+	logoutRR := httptest.NewRecorder()
+	handler.ServeHTTP(logoutRR, logoutReq)
+	c.Assert(logoutRR.Code, qt.Equals, http.StatusOK)
+
+	// The logout audit row must record actor = target AND
+	// impersonated_by = admin.
+	rows := must2(params.FactorySet.AuditLogRegistry.List(context.Background()))
+	var logoutRow *models.AuditLog
+	for _, row := range rows {
+		if row.Action == "logout" {
+			logoutRow = row
+			break
+		}
+	}
+	c.Assert(logoutRow, qt.IsNotNil, qt.Commentf("expected a logout audit row"))
+	c.Assert(logoutRow.UserID, qt.IsNotNil)
+	c.Assert(*logoutRow.UserID, qt.Equals, target.ID)
+	c.Assert(logoutRow.ImpersonatedBy, qt.IsNotNil,
+		qt.Commentf("logout-during-impersonation row must carry ImpersonatedBy"))
+	c.Assert(*logoutRow.ImpersonatedBy, qt.Equals, admin.ID)
 }

--- a/go/apiserver/admin_impersonation_test.go
+++ b/go/apiserver/admin_impersonation_test.go
@@ -454,14 +454,23 @@ func createAdminRefreshToken(c *qt.C, params apiserver.Params, user *models.User
 	return raw
 }
 
-// refreshCookieFromResponse extracts the value the response set the
+// refreshCookieFromResponse extracts the value the response set the LIVE
 // refresh_token cookie to (the part after "refresh_token=" up to the
-// first ';'). Returns ("", false) when the response sets no refresh
+// first ';'). Returns ("", false) when the response sets no live refresh
 // cookie. Used to follow the cookie a handler emitted into a subsequent
 // request, the way a browser would.
+//
+// writeRefreshCookie/clearRefreshCookie also emit a refresh_token
+// Set-Cookie that DELETES the legacy /api/v1/auth cookie (empty value,
+// Max-Age=0). This helper skips that deletion header so callers get the
+// value of the cookie the browser would actually carry forward.
 func refreshCookieFromResponse(rr *httptest.ResponseRecorder) (string, bool) {
 	for _, sc := range rr.Header().Values("Set-Cookie") {
 		if !strings.HasPrefix(sc, "refresh_token=") {
+			continue
+		}
+		// Skip the legacy-path deletion cookie (empty value, Max-Age=0).
+		if strings.HasPrefix(sc, "refresh_token=;") || strings.Contains(sc, "; Max-Age=0") {
 			continue
 		}
 		value := strings.TrimPrefix(sc, "refresh_token=")
@@ -511,16 +520,76 @@ func TestImpersonate_StartReplacesRefreshCookie(t *testing.T) {
 		qt.Commentf("refresh cookie should hold the impersonation marker, got %q", cookieValue))
 }
 
-// refreshCookiePathFromResponse extracts the Path attribute of the
+// TestImpersonate_StartDeletesLegacyPathCookie is the regression test for
+// the PR #1771 review bug (#1750): impersonation-start plants the marker
+// cookie at the widened /api/v1 path via writeRefreshCookie, which must
+// ALSO emit a Set-Cookie deleting the pre-upgrade refresh_token cookie at
+// the legacy /api/v1/auth path. Without that deletion a browser created
+// before the path widening keeps a stale real-token cookie at /api/v1/auth;
+// per RFC 6265 it is sent first on /auth/refresh, shadowing the marker and
+// reopening the refresh-during-impersonation bypass.
+func TestImpersonate_StartDeletesLegacyPathCookie(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	startRR := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
+	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
+
+	// Exactly one Set-Cookie must delete the legacy /api/v1/auth cookie
+	// (empty value, Max-Age=0 — the wire rendering of MaxAge=-1).
+	legacyDeleted := false
+	for _, sc := range startRR.Header().Values("Set-Cookie") {
+		if !strings.HasPrefix(sc, "refresh_token=") {
+			continue
+		}
+		hasLegacyPath := false
+		hasDeletion := false
+		for attr := range strings.SplitSeq(sc, ";") {
+			attr = strings.TrimSpace(attr)
+			if attr == "Path=/api/v1/auth" {
+				hasLegacyPath = true
+			}
+			if attr == "Max-Age=0" {
+				hasDeletion = true
+			}
+		}
+		if hasLegacyPath && hasDeletion {
+			legacyDeleted = true
+		}
+	}
+	c.Assert(legacyDeleted, qt.IsTrue,
+		qt.Commentf("impersonation start must emit a Set-Cookie deleting the legacy /api/v1/auth cookie; got %v",
+			startRR.Header().Values("Set-Cookie")))
+
+	// The live marker cookie must still be written at the new /api/v1 path.
+	cookiePath, ok := refreshCookiePathFromResponse(startRR)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(cookiePath, qt.Equals, "/api/v1")
+}
+
+// refreshCookiePathFromResponse extracts the Path attribute of the LIVE
 // refresh_token Set-Cookie header (the value after "Path=" up to the
-// next ';'). Returns ("", false) when the response sets no refresh
-// cookie or the cookie carries no Path attribute. Unlike
-// refreshCookieFromResponse this inspects the attribute STRING directly
-// — a httptest round-trip does not enforce cookie Path scoping, so the
-// only way to catch a path-scoping bug is to assert the attribute text.
+// next ';'). Returns ("", false) when the response sets no live refresh
+// cookie or it carries no Path attribute. Unlike refreshCookieFromResponse
+// this inspects the attribute STRING directly — a httptest round-trip does
+// not enforce cookie Path scoping, so the only way to catch a path-scoping
+// bug is to assert the attribute text.
+//
+// writeRefreshCookie/clearRefreshCookie also emit a SECOND refresh_token
+// Set-Cookie that DELETES the legacy /api/v1/auth cookie (empty value,
+// Max-Age=0); this helper skips that deletion header and reports the path
+// of the cookie carrying a real value, so callers see the live cookie's
+// scope.
 func refreshCookiePathFromResponse(rr *httptest.ResponseRecorder) (string, bool) {
 	for _, sc := range rr.Header().Values("Set-Cookie") {
 		if !strings.HasPrefix(sc, "refresh_token=") {
+			continue
+		}
+		// Skip the legacy-path deletion cookie (empty value, Max-Age=0).
+		if strings.HasPrefix(sc, "refresh_token=;") || strings.Contains(sc, "; Max-Age=0") {
 			continue
 		}
 		for attr := range strings.SplitSeq(sc, ";") {

--- a/go/apiserver/admin_impersonation_test.go
+++ b/go/apiserver/admin_impersonation_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,6 +109,22 @@ func TestImpersonate_StartWithoutBodySucceeds(t *testing.T) {
 	rr := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
 
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+}
+
+func TestImpersonate_RejectsOverLongReason(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// An over-long reason is a 422 with admin.impersonate.reason_too_long
+	// — matching the admin block handler's reason-length contract.
+	rr := doImpersonateStart(c, handler, admin.ID, target.ID,
+		map[string]any{"reason": strings.Repeat("x", 501)})
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateReasonTooLongCode)
 }
 
 func TestImpersonate_RejectsNonAdmin(t *testing.T) {
@@ -298,6 +315,24 @@ func TestImpersonate_EndRestoresAdminContext(t *testing.T) {
 	// The restored admin token must NOT carry impersonation claims.
 	_, hasImp := claims["imp"]
 	c.Assert(hasImp, qt.IsFalse)
+
+	// The LogAdmin path that stamps the audit row: the
+	// admin.impersonate_end row must record actor = target (UserID) AND
+	// impersonated_by = admin — the end request runs under the imp token
+	// so LogAdmin auto-fills ImpersonatedBy from the claims.
+	rows := must2(params.FactorySet.AuditLogRegistry.List(context.Background()))
+	var endRow *models.AuditLog
+	for _, row := range rows {
+		if row.Action == apiserver.AuditActionAdminImpersonateEnd {
+			endRow = row
+			break
+		}
+	}
+	c.Assert(endRow, qt.IsNotNil, qt.Commentf("expected an admin.impersonate_end audit row"))
+	c.Assert(endRow.UserID, qt.IsNotNil)
+	c.Assert(*endRow.UserID, qt.Equals, target.ID)
+	c.Assert(endRow.ImpersonatedBy, qt.IsNotNil)
+	c.Assert(*endRow.ImpersonatedBy, qt.Equals, admin.ID)
 }
 
 func TestImpersonate_EndRejectsNonImpersonationToken(t *testing.T) {

--- a/go/apiserver/admin_impersonation_test.go
+++ b/go/apiserver/admin_impersonation_test.go
@@ -233,7 +233,15 @@ func TestImpersonate_NestedGuardRejectsWhenTokenReachesHandler(t *testing.T) {
 	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNestedCode)
 }
 
-func TestImpersonate_ExpiredTokenRejectedAtEnd(t *testing.T) {
+// TestImpersonate_ExpiredTokenWithNoSlotEndsAsNotActive: an expired imp
+// token whose return slot was never recorded (here, a forged token) still
+// reaches endImpersonation now that `end` is mounted without JWTMiddleware
+// (#1750 / PR #1771 FIX 2) — but with no slot to restore, the only correct
+// answer is 422 not_active. The expiry relaxation does NOT turn a
+// slot-less token into a successful end; the server-side slot is still the
+// real proof. See TestImpersonate_EndAcceptsExpiredTokenWithLiveSlot for
+// the expired-but-restorable case.
+func TestImpersonate_ExpiredTokenWithNoSlotEndsAsNotActive(t *testing.T) {
 	c := qt.New(t)
 	params, admin, _ := newParams()
 	promoteToSystemAdmin(c, params, admin)
@@ -253,8 +261,8 @@ func TestImpersonate_ExpiredTokenRejectedAtEnd(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// An expired token is rejected by JWTMiddleware before the handler runs.
-	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNotActiveCode)
 }
 
 func TestImpersonate_RefreshRejectsImpersonationToken(t *testing.T) {
@@ -419,6 +427,160 @@ func TestImpersonate_RateLimitEnforced(t *testing.T) {
 		qt.Commentf("expected the per-admin impersonation rate limit to trip within 12 attempts"))
 }
 
+// createAdminRefreshToken persists a genuine refresh-token row for the
+// given user and returns the raw cookie value. Used by the cookie-flow
+// tests to give the admin a real, refreshable session before
+// impersonation starts — so the test can prove the cookie is replaced on
+// start and restored on end.
+func createAdminRefreshToken(c *qt.C, params apiserver.Params, user *models.User) string {
+	c.Helper()
+	raw, hash, err := models.GenerateRefreshToken()
+	c.Assert(err, qt.IsNil)
+	_, err = params.FactorySet.RefreshTokenRegistry.Create(context.Background(), models.RefreshToken{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+			TenantID: user.TenantID,
+			UserID:   user.ID,
+		},
+		TokenHash: hash,
+		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		CreatedAt: time.Now(),
+	})
+	c.Assert(err, qt.IsNil)
+	return raw
+}
+
+// refreshCookieFromResponse extracts the value the response set the
+// refresh_token cookie to (the part after "refresh_token=" up to the
+// first ';'). Returns ("", false) when the response sets no refresh
+// cookie. Used to follow the cookie a handler emitted into a subsequent
+// request, the way a browser would.
+func refreshCookieFromResponse(rr *httptest.ResponseRecorder) (string, bool) {
+	for _, sc := range rr.Header().Values("Set-Cookie") {
+		if !strings.HasPrefix(sc, "refresh_token=") {
+			continue
+		}
+		value := strings.TrimPrefix(sc, "refresh_token=")
+		if i := strings.IndexByte(value, ';'); i >= 0 {
+			value = value[:i]
+		}
+		return value, true
+	}
+	return "", false
+}
+
+// TestImpersonate_StartReplacesRefreshCookie proves the start handler
+// overwrites the admin's own refresh cookie with the impersonation
+// marker. Leaving the admin's refresh token in the browser would let the
+// FE's cookie-based refresh interceptor silently mint a fresh admin
+// access token mid-impersonation (#1750 / PR #1771 review).
+func TestImpersonate_StartReplacesRefreshCookie(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+
+	cookieValue, ok := refreshCookieFromResponse(rr)
+	c.Assert(ok, qt.IsTrue, qt.Commentf("start must Set-Cookie the refresh_token"))
+	// The cookie must carry the non-refreshable impersonation marker, not
+	// a genuine refresh token.
+	c.Assert(strings.HasPrefix(cookieValue, "imp:"), qt.IsTrue,
+		qt.Commentf("refresh cookie should hold the impersonation marker, got %q", cookieValue))
+}
+
+// TestImpersonate_RefreshRejectedDuringSession_CookieOnly is the core
+// regression test for the PR #1771 review bug: a refresh attempt made
+// from inside an impersonation session — cookie-based, with NO
+// Authorization header (the realistic FE refresh path) — must be
+// rejected and must not mint an access token.
+func TestImpersonate_RefreshRejectedDuringSession_CookieOnly(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Start a genuine impersonation session and follow the marker cookie
+	// the handler planted, exactly as a browser would.
+	startRR := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
+	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
+	markerCookie, ok := refreshCookieFromResponse(startRR)
+	c.Assert(ok, qt.IsTrue)
+
+	// Refresh with ONLY the cookie — no Authorization header, the way the
+	// FE refresh interceptor posts to /auth/refresh.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+	// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
+	req.AddCookie(&http.Cookie{Name: "refresh_token", Value: markerCookie})
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
+	// No access token may be minted — the response body must not be a
+	// LoginResponse carrying one.
+	var resp apiserver.LoginResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	c.Assert(resp.AccessToken, qt.Equals, "")
+}
+
+// TestImpersonate_EndRestoresRefreshCookie proves the end handler puts
+// the admin's original refresh cookie back, and that the restored
+// session is genuinely refreshable afterwards — i.e. the operator is
+// whole again, including the cookie-based refresh flow.
+func TestImpersonate_EndRestoresRefreshCookie(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Give the admin a real, refreshable session before impersonating.
+	adminRefreshRaw := createAdminRefreshToken(c, params, admin)
+
+	// Start: send the admin's refresh cookie so the return slot captures it.
+	startReq := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+target.ID+"/impersonate", bytes.NewReader(nil))
+	startReq.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(startReq, admin.ID)
+	// #nosec G124 -- test request cookie.
+	startReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: adminRefreshRaw})
+	startRR := httptest.NewRecorder()
+	handler.ServeHTTP(startRR, startReq)
+	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
+	var startResp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(startRR.Body.Bytes(), &startResp), qt.IsNil)
+
+	// End the session with the impersonation token.
+	endReq := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
+	endReq.Header.Set("Authorization", "Bearer "+startResp.AccessToken)
+	endRR := httptest.NewRecorder()
+	handler.ServeHTTP(endRR, endReq)
+	c.Assert(endRR.Code, qt.Equals, http.StatusOK)
+
+	// The end response must restore the admin's ORIGINAL refresh token,
+	// not the marker.
+	restored, ok := refreshCookieFromResponse(endRR)
+	c.Assert(ok, qt.IsTrue, qt.Commentf("end must Set-Cookie the refresh_token"))
+	c.Assert(restored, qt.Equals, adminRefreshRaw)
+
+	// The restored session must be genuinely refreshable: a cookie-based
+	// /auth/refresh with the restored token succeeds and mints an ADMIN
+	// access token.
+	refreshReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+	// #nosec G124 -- test request cookie.
+	refreshReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: restored})
+	refreshRR := httptest.NewRecorder()
+	handler.ServeHTTP(refreshRR, refreshReq)
+	c.Assert(refreshRR.Code, qt.Equals, http.StatusOK)
+	var refreshResp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(refreshRR.Body.Bytes(), &refreshResp), qt.IsNil)
+	c.Assert(refreshResp.AccessToken, qt.Not(qt.Equals), "")
+	refreshClaims := parseTestTokenClaims(c, refreshResp.AccessToken)
+	c.Assert(refreshClaims["user_id"], qt.Equals, admin.ID)
+}
+
 // parseTestTokenClaims parses a JWT signed with the shared test secret
 // and returns its claims. Used to assert the impersonation / restored
 // token shapes without going through the middleware.
@@ -524,4 +686,237 @@ func must2[T any](v T, err error) T {
 		panic(err)
 	}
 	return v
+}
+
+// refreshCookieIsDeletion reports whether the response instructs the
+// browser to DELETE the refresh_token cookie — i.e. it Set-Cookie's
+// refresh_token with a non-positive Max-Age (the form clearRefreshCookie
+// emits, Max-Age=-1). Returns false when no refresh cookie is set at all.
+func refreshCookieIsDeletion(rr *httptest.ResponseRecorder) bool {
+	for _, sc := range rr.Result().Cookies() {
+		if sc.Name != "refresh_token" {
+			continue
+		}
+		// MaxAge < 0 means "delete now"; MaxAge == 0 with an empty value
+		// is also a deletion as emitted via http.Cookie.
+		return sc.MaxAge < 0 || (sc.MaxAge == 0 && sc.Value == "")
+	}
+	return false
+}
+
+// startImpersonationGetJTI runs a real impersonation start as admin→target
+// and returns the started session's access token and its jti claim. Used
+// by the FIX 2 test to forge an EXPIRED token bound to the SAME jti as a
+// live return slot.
+func startImpersonationGetJTI(c *qt.C, handler http.Handler, adminID, targetID string) (accessToken, jti string) {
+	c.Helper()
+	startRR := doImpersonateStart(c, handler, adminID, targetID, nil)
+	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
+	var startResp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(startRR.Body.Bytes(), &startResp), qt.IsNil)
+	claims := parseTestTokenClaims(c, startResp.AccessToken)
+	jtiClaim, ok := claims["jti"].(string)
+	c.Assert(ok, qt.IsTrue)
+	return startResp.AccessToken, jtiClaim
+}
+
+// TestImpersonate_LogoutDuringImpersonationRevokesAdminToken is the
+// regression test for PR #1771 FIX 1: an operator who logs out WHILE
+// impersonating must have their genuine admin refresh token revoked.
+// During impersonation the refresh cookie holds the `imp:<jti>` marker, so
+// the plain logout path would hash the marker, find no DB row, and leave
+// the admin's real refresh token valid for its full 30-day lifetime — a
+// live credential the operator believes they terminated. logout must
+// instead resolve the return slot and revoke slot.AdminRefreshTokenRaw.
+func TestImpersonate_LogoutDuringImpersonationRevokesAdminToken(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// The admin has a genuine, refreshable session before impersonating.
+	adminRefreshRaw := createAdminRefreshToken(c, params, admin)
+
+	// Start: send the admin's refresh cookie so the return slot captures
+	// the genuine token; the start handler replies with the imp: marker.
+	startReq := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+target.ID+"/impersonate", bytes.NewReader(nil))
+	startReq.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(startReq, admin.ID)
+	// #nosec G124 -- test request cookie.
+	startReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: adminRefreshRaw})
+	startRR := httptest.NewRecorder()
+	handler.ServeHTTP(startRR, startReq)
+	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
+	var startResp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(startRR.Body.Bytes(), &startResp), qt.IsNil)
+	markerCookie, ok := refreshCookieFromResponse(startRR)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(strings.HasPrefix(markerCookie, "imp:"), qt.IsTrue)
+
+	// Sanity check: the admin's genuine token is refreshable RIGHT NOW.
+	preReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+	// #nosec G124 -- test request cookie.
+	preReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: adminRefreshRaw})
+	preRR := httptest.NewRecorder()
+	handler.ServeHTTP(preRR, preReq)
+	c.Assert(preRR.Code, qt.Equals, http.StatusOK)
+
+	// The operator logs out from inside the impersonation session — the
+	// browser sends the imp: marker cookie, NOT the genuine token.
+	logoutReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+	logoutReq.Header.Set("Authorization", "Bearer "+startResp.AccessToken)
+	// #nosec G124 -- test request cookie.
+	logoutReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: markerCookie})
+	logoutRR := httptest.NewRecorder()
+	handler.ServeHTTP(logoutRR, logoutReq)
+	c.Assert(logoutRR.Code, qt.Equals, http.StatusOK)
+
+	// The admin's GENUINE refresh token must now be revoked: a cookie-based
+	// /auth/refresh with the original raw token fails.
+	postReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+	// #nosec G124 -- test request cookie.
+	postReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: adminRefreshRaw})
+	postRR := httptest.NewRecorder()
+	handler.ServeHTTP(postRR, postReq)
+	c.Assert(postRR.Code, qt.Equals, http.StatusUnauthorized,
+		qt.Commentf("admin's genuine refresh token must be revoked after logout-during-impersonation"))
+}
+
+// TestImpersonate_EndAcceptsExpiredTokenWithLiveSlot is the regression
+// test for PR #1771 FIX 2: an operator who lets the impersonation access
+// token expire (idle) must still be able to POST /admin/impersonation/end
+// and be restored — JWTMiddleware no longer 401s the expired token before
+// the handler runs, and endImpersonation tolerates an expired `exp` while
+// still verifying the signature + imp=true and proving authorization via
+// the live server-side slot.
+func TestImpersonate_EndAcceptsExpiredTokenWithLiveSlot(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Start a genuine session so the return slot exists, and capture its jti.
+	_, jti := startImpersonationGetJTI(c, handler, admin.ID, target.ID)
+
+	// Forge an EXPIRED impersonation token bound to the SAME jti — signed
+	// with the real test secret, so the signature is valid; only `exp` is
+	// in the past. This is the "operator went idle" shape.
+	expiredToken := makeImpersonationToken(c, impersonateClaims{
+		jti:            jti,
+		targetUserID:   target.ID,
+		targetTenantID: target.TenantID,
+		adminUserID:    admin.ID,
+		expiresAt:      time.Now().Add(-time.Minute),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
+	req.Header.Set("Authorization", "Bearer "+expiredToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// The expired token still ends the session and restores the admin.
+	c.Assert(rr.Code, qt.Equals, http.StatusOK,
+		qt.Commentf("expired imp token with a live slot must still end the session; body=%s", rr.Body.String()))
+	var endResp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &endResp), qt.IsNil)
+	c.Assert(endResp.User, qt.IsNotNil)
+	c.Assert(endResp.User.ID, qt.Equals, admin.ID)
+	endClaims := parseTestTokenClaims(c, endResp.AccessToken)
+	c.Assert(endClaims["user_id"], qt.Equals, admin.ID)
+	_, hasImp := endClaims["imp"]
+	c.Assert(hasImp, qt.IsFalse)
+}
+
+// TestImpersonate_EndStillRejectsExpiredNonImpersonationToken guards the
+// FIX 2 security boundary: relaxing `exp` must NOT let an expired PLAIN
+// (non-imp) admin token reach a successful end. parseImpersonationEndToken
+// requires imp=true, so an expired admin token is rejected with 422
+// not_active just as a fresh one is.
+func TestImpersonate_EndStillRejectsExpiredNonImpersonationToken(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// A plain (non-imp) admin token that has already expired.
+	expiredAdmin := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"jti":             "expired-admin-jti",
+		"user_id":         admin.ID,
+		"is_system_admin": true,
+		"iat":             time.Now().Add(-2 * time.Hour).Unix(),
+		"exp":             time.Now().Add(-time.Hour).Unix(),
+	})
+	signed, err := expiredAdmin.SignedString(testJWTSecret)
+	c.Assert(err, qt.IsNil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
+	req.Header.Set("Authorization", "Bearer "+signed)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNotActiveCode)
+}
+
+// TestImpersonate_EndRejectsForgedToken guards the other FIX 2 security
+// boundary: a token with a BAD signature must be rejected even when it
+// claims imp=true. The expiry relaxation never bypasses signature
+// verification.
+func TestImpersonate_EndRejectsForgedToken(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// An imp token signed with the WRONG secret — a forgery.
+	forged := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"jti":             "forged-jti",
+		"user_id":         target.ID,
+		"tenant_id":       target.TenantID,
+		"impersonated_by": admin.ID,
+		"imp":             true,
+		"is_system_admin": false,
+		"iat":             time.Now().Add(-time.Minute).Unix(),
+		"exp":             time.Now().Add(20 * time.Minute).Unix(),
+	})
+	signed, err := forged.SignedString([]byte("a-totally-different-32byte-secret-xx"))
+	c.Assert(err, qt.IsNil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
+	req.Header.Set("Authorization", "Bearer "+signed)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNotActiveCode)
+}
+
+// TestImpersonate_EndClearsMarkerCookieForPureBearerStart proves the
+// pure-bearer path: when the admin started impersonation WITHOUT a refresh
+// cookie (an API/test client), there is no genuine token to restore on
+// `end`, so the handler must instead DELETE the marker cookie it planted
+// at start — leaving no stale imp: marker in the client.
+func TestImpersonate_EndClearsMarkerCookieForPureBearerStart(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Start WITHOUT a refresh cookie — doImpersonateStart sends only the
+	// bearer auth header, so slot.AdminRefreshTokenRaw is empty.
+	accessToken, _ := startImpersonationGetJTI(c, handler, admin.ID, target.ID)
+
+	endReq := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
+	endReq.Header.Set("Authorization", "Bearer "+accessToken)
+	endRR := httptest.NewRecorder()
+	handler.ServeHTTP(endRR, endReq)
+	c.Assert(endRR.Code, qt.Equals, http.StatusOK)
+
+	// With no genuine token to restore, `end` must clear the marker cookie.
+	c.Assert(refreshCookieIsDeletion(endRR), qt.IsTrue,
+		qt.Commentf("pure-bearer end must delete the marker refresh cookie"))
 }

--- a/go/apiserver/admin_impersonation_test.go
+++ b/go/apiserver/admin_impersonation_test.go
@@ -1,0 +1,492 @@
+package apiserver_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// Impersonation primitive handler tests (#1750). Every acceptance
+// criterion in the issue spec maps to one (or more) of the subtests
+// below. Tests reuse the admin fixtures from admin_routes_test.go
+// (promoteToSystemAdmin) and admin_users_test.go (createTestUserDirect).
+
+// impersonateClaims is the minimal claim set for a forged impersonation
+// access token used by tests that need to exercise the end / current /
+// refresh paths without first calling the start endpoint.
+type impersonateClaims struct {
+	jti            string
+	targetUserID   string
+	targetTenantID string
+	adminUserID    string
+	expiresAt      time.Time
+}
+
+// makeImpersonationToken signs an impersonation access token with the
+// shared test JWT secret. Mirrors adminImpersonationAPI.signImpersonationToken
+// so tests can forge a token directly (e.g. an already-expired one).
+func makeImpersonationToken(c *qt.C, cl impersonateClaims) string {
+	c.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"jti":             cl.jti,
+		"user_id":         cl.targetUserID,
+		"tenant_id":       cl.targetTenantID,
+		"impersonated_by": cl.adminUserID,
+		"imp":             true,
+		"is_system_admin": false,
+		"iat":             time.Now().Add(-time.Minute).Unix(),
+		"exp":             cl.expiresAt.Unix(),
+	})
+	signed, err := token.SignedString(testJWTSecret)
+	c.Assert(err, qt.IsNil)
+	return signed
+}
+
+// doImpersonateStart issues POST /admin/users/{id}/impersonate as the
+// given admin and returns the recorder.
+func doImpersonateStart(c *qt.C, handler http.Handler, adminID, targetID string, body map[string]any) *httptest.ResponseRecorder {
+	c.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		c.Assert(err, qt.IsNil)
+		reader = bytes.NewReader(raw)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+targetID+"/impersonate", reader)
+	req.Header.Set("Content-Type", "application/json")
+	addTestUserAuthHeader(req, adminID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestImpersonate_StartSucceeds(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doImpersonateStart(c, handler, admin.ID, target.ID, map[string]any{"reason": "support ticket #42"})
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	var resp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &resp), qt.IsNil)
+	c.Assert(resp.AccessToken, qt.Not(qt.Equals), "")
+	c.Assert(resp.TokenType, qt.Equals, "Bearer")
+	c.Assert(resp.User, qt.IsNotNil)
+	c.Assert(resp.User.ID, qt.Equals, target.ID)
+
+	// The issued token must carry the impersonation claims.
+	claims := parseTestTokenClaims(c, resp.AccessToken)
+	c.Assert(claims["user_id"], qt.Equals, target.ID)
+	c.Assert(claims["impersonated_by"], qt.Equals, admin.ID)
+	c.Assert(claims["imp"], qt.Equals, true)
+	c.Assert(claims["is_system_admin"], qt.Equals, false)
+}
+
+func TestImpersonate_StartWithoutBodySucceeds(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// The reason body is optional — an empty body must still succeed.
+	rr := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+}
+
+func TestImpersonate_RejectsNonAdmin(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := newParams()
+	target := createTestUserDirect(c, params, user.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doImpersonateStart(c, handler, user.ID, target.ID, nil)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+	assertErrorCode(t, c, rr.Body.Bytes(), "admin.forbidden")
+}
+
+func TestImpersonate_RejectsTargetAdmin(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	targetAdmin := createTestUserDirect(c, params, admin.TenantID, "peer-admin@example.com", true, true)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doImpersonateStart(c, handler, admin.ID, targetAdmin.ID, nil)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateTargetIsAdminCode)
+}
+
+func TestImpersonate_RejectsBlockedTarget(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	blocked := createTestUserDirect(c, params, admin.TenantID, "blocked@example.com", false, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doImpersonateStart(c, handler, admin.ID, blocked.ID, nil)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateTargetBlockedCode)
+}
+
+func TestImpersonate_RejectsUnknownTarget(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	rr := doImpersonateStart(c, handler, admin.ID, "00000000-0000-0000-0000-000000000000", nil)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+}
+
+func TestImpersonate_RejectsNestedImpersonation(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	secondTarget := createTestUserDirect(c, params, admin.TenantID, "second@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Start a real impersonation session to get a genuine imp token.
+	startRR := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
+	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
+	var startResp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(startRR.Body.Bytes(), &startResp), qt.IsNil)
+
+	// Use the impersonation token to attempt a second impersonation.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+secondTarget.ID+"/impersonate", nil)
+	req.Header.Set("Authorization", "Bearer "+startResp.AccessToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// The impersonation token belongs to a non-admin target, so
+	// RequireSystemAdmin rejects it first with 403 — nested impersonation
+	// is structurally impossible because the imp token never carries
+	// system-admin authority. This is a stronger guarantee than the
+	// 422 nested-guard, which only fires if the target somehow had the
+	// admin flag.
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+}
+
+func TestImpersonate_NestedGuardRejectsWhenTokenReachesHandler(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	// A second admin is the impersonation target's stand-in: we forge an
+	// imp token whose user_id is an ADMIN so it clears RequireSystemAdmin
+	// and actually reaches the nested-impersonation guard in the handler.
+	targetAdmin := createTestUserDirect(c, params, admin.TenantID, "target-admin@example.com", true, true)
+	victim := createTestUserDirect(c, params, admin.TenantID, "victim@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	impToken := makeImpersonationToken(c, impersonateClaims{
+		jti:            "nested-test-jti",
+		targetUserID:   targetAdmin.ID,
+		targetTenantID: targetAdmin.TenantID,
+		adminUserID:    admin.ID,
+		expiresAt:      time.Now().Add(20 * time.Minute),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+victim.ID+"/impersonate", nil)
+	req.Header.Set("Authorization", "Bearer "+impToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNestedCode)
+}
+
+func TestImpersonate_ExpiredTokenRejectedAtEnd(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	expiredToken := makeImpersonationToken(c, impersonateClaims{
+		jti:            "expired-jti",
+		targetUserID:   target.ID,
+		targetTenantID: target.TenantID,
+		adminUserID:    admin.ID,
+		expiresAt:      time.Now().Add(-time.Minute),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
+	req.Header.Set("Authorization", "Bearer "+expiredToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// An expired token is rejected by JWTMiddleware before the handler runs.
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
+}
+
+func TestImpersonate_RefreshRejectsImpersonationToken(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	impToken := makeImpersonationToken(c, impersonateClaims{
+		jti:            "refresh-test-jti",
+		targetUserID:   target.ID,
+		targetTenantID: target.TenantID,
+		adminUserID:    admin.ID,
+		expiresAt:      time.Now().Add(20 * time.Minute),
+	})
+
+	// The refresh endpoint must reject a request carrying an imp token,
+	// even when a (would-be valid) refresh cookie is also present.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+	req.Header.Set("Authorization", "Bearer "+impToken)
+	// #nosec G124 -- test request cookie; Secure/SameSite are irrelevant to the assertion.
+	req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "some-refresh-token"})
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
+}
+
+func TestImpersonate_EndRestoresAdminContext(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Start a real session so the return slot exists.
+	startRR := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
+	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
+	var startResp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(startRR.Body.Bytes(), &startResp), qt.IsNil)
+
+	// End the session using the impersonation token.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
+	req.Header.Set("Authorization", "Bearer "+startResp.AccessToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	var endResp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &endResp), qt.IsNil)
+	// The restored session is the admin's own — user + token claims.
+	c.Assert(endResp.User, qt.IsNotNil)
+	c.Assert(endResp.User.ID, qt.Equals, admin.ID)
+	claims := parseTestTokenClaims(c, endResp.AccessToken)
+	c.Assert(claims["user_id"], qt.Equals, admin.ID)
+	c.Assert(claims["is_system_admin"], qt.Equals, true)
+	// The restored admin token must NOT carry impersonation claims.
+	_, hasImp := claims["imp"]
+	c.Assert(hasImp, qt.IsFalse)
+}
+
+func TestImpersonate_EndRejectsNonImpersonationToken(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// A plain admin token (no imp claim) at the end endpoint → 422.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/impersonation/end", nil)
+	addTestUserAuthHeader(req, admin.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateNotActiveCode)
+}
+
+func TestImpersonate_CurrentReportsInactiveForPlainAdmin(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/impersonation/current", nil)
+	addTestUserAuthHeader(req, admin.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	var resp apiserver.ImpersonationStateResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &resp), qt.IsNil)
+	c.Assert(resp.Active, qt.IsFalse)
+}
+
+func TestImpersonate_CurrentReportsActiveSession(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	startRR := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
+	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
+	var startResp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(startRR.Body.Bytes(), &startResp), qt.IsNil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/impersonation/current", nil)
+	req.Header.Set("Authorization", "Bearer "+startResp.AccessToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	var resp apiserver.ImpersonationStateResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &resp), qt.IsNil)
+	c.Assert(resp.Active, qt.IsTrue)
+	c.Assert(resp.TargetUser, qt.IsNotNil)
+	c.Assert(resp.TargetUser.ID, qt.Equals, target.ID)
+	c.Assert(resp.AdminUser, qt.IsNotNil)
+	c.Assert(resp.AdminUser.ID, qt.Equals, admin.ID)
+	c.Assert(resp.StartedAt, qt.IsNotNil)
+	c.Assert(resp.ExpiresAt, qt.IsNotNil)
+}
+
+func TestImpersonate_RateLimitEnforced(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+	target := createTestUserDirect(c, params, admin.TenantID, "target@example.com", true, false)
+	// The in-memory limiter is shared across requests on this handler;
+	// 10/hour is the configured impersonation limit.
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	var lastCode int
+	for range 12 {
+		rr := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
+		lastCode = rr.Code
+		if rr.Code == http.StatusTooManyRequests {
+			assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminImpersonateRateLimitedCode)
+			break
+		}
+	}
+	c.Assert(lastCode, qt.Equals, http.StatusTooManyRequests,
+		qt.Commentf("expected the per-admin impersonation rate limit to trip within 12 attempts"))
+}
+
+// parseTestTokenClaims parses a JWT signed with the shared test secret
+// and returns its claims. Used to assert the impersonation / restored
+// token shapes without going through the middleware.
+func parseTestTokenClaims(c *qt.C, tokenString string) jwt.MapClaims {
+	c.Helper()
+	token, err := jwt.Parse(tokenString, func(_ *jwt.Token) (any, error) {
+		return testJWTSecret, nil
+	})
+	c.Assert(err, qt.IsNil)
+	claims, ok := token.Claims.(jwt.MapClaims)
+	c.Assert(ok, qt.IsTrue)
+	return claims
+}
+
+// TestImpersonate_AuditTrailRecordsImpersonator is the integration
+// check from the #1750 acceptance criteria: an admin impersonates a
+// regular user, the impersonated session hits a (non-admin) GROUP
+// endpoint, and the resulting audit-log row carries both the actor
+// (the impersonated target, via the JWT user_id) and the impersonator
+// (the admin, via the `impersonated_by` claim). The audit helper reads
+// `imp`/`impersonated_by` from the JWT claims automatically — this test
+// verifies that propagation end-to-end through the real router.
+func TestImpersonate_AuditTrailRecordsImpersonator(t *testing.T) {
+	c := qt.New(t)
+	params, admin, _ := newParams()
+	promoteToSystemAdmin(c, params, admin)
+
+	// A regular (non-admin) target who owns a fresh group — group
+	// deletion is the LogAuth-based group endpoint that audit-logs.
+	target := createTestUserDirect(c, params, admin.TenantID, "group-owner@example.com", true, false)
+	group := createOwnedTestGroup(c, params, target)
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Start a genuine impersonation session via the start endpoint.
+	startRR := doImpersonateStart(c, handler, admin.ID, target.ID, nil)
+	c.Assert(startRR.Code, qt.Equals, http.StatusOK)
+	var startResp apiserver.LoginResponse
+	c.Assert(json.Unmarshal(startRR.Body.Bytes(), &startResp), qt.IsNil)
+
+	// The impersonated session deletes the group it (the target) owns.
+	// deleteGroup requires the group name as confirm_word plus the
+	// target's password ("Password123", set by createTestUserDirect).
+	delBody, err := json.Marshal(map[string]any{
+		"confirm_word": group.Name,
+		"password":     "Password123",
+	})
+	c.Assert(err, qt.IsNil)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/groups/"+group.ID, bytes.NewReader(delBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+startResp.AccessToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	c.Assert(rr.Code, qt.Equals, http.StatusNoContent,
+		qt.Commentf("group delete under impersonation; body=%s", rr.Body.String()))
+
+	// The group_delete audit row must record actor = target (JWT
+	// user_id) AND impersonated_by = admin.
+	rows := must2(params.FactorySet.AuditLogRegistry.List(context.Background()))
+	var found *models.AuditLog
+	for _, row := range rows {
+		if row.Action == "group_delete" {
+			found = row
+			break
+		}
+	}
+	c.Assert(found, qt.IsNotNil, qt.Commentf("expected a group_delete audit row"))
+	c.Assert(found.UserID, qt.IsNotNil)
+	c.Assert(*found.UserID, qt.Equals, target.ID)
+	c.Assert(found.ImpersonatedBy, qt.IsNotNil)
+	c.Assert(*found.ImpersonatedBy, qt.Equals, admin.ID)
+}
+
+// createOwnedTestGroup creates a fresh group whose sole member is the
+// given user, with the Owner role — so the user can delete it. Used by
+// the audit-trail integration test, which needs a group endpoint the
+// impersonated session is authorized to hit.
+func createOwnedTestGroup(c *qt.C, params apiserver.Params, owner *models.User) *models.LocationGroup {
+	c.Helper()
+	ctx := context.Background()
+	slug := must2(models.GenerateGroupSlug())
+	group := must2(params.FactorySet.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: owner.TenantID},
+		Name:                "Impersonation Test Group",
+		Slug:                slug,
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           owner.ID,
+		GroupCurrency:       models.Currency("USD"),
+	}))
+	must2(params.FactorySet.GroupMembershipRegistry.Create(ctx, models.GroupMembership{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: owner.TenantID},
+		GroupID:             group.ID,
+		MemberUserID:        owner.ID,
+		Role:                models.GroupRoleOwner,
+	}))
+	return group
+}
+
+// must2 unwraps a (T, error) pair, panicking on error. Used only in the
+// audit-trail test's setup-style registry reads where an error means the
+// fixture wiring is broken, not the behaviour under test.
+func must2[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/go/apiserver/admin_middleware.go
+++ b/go/apiserver/admin_middleware.go
@@ -51,3 +51,44 @@ func RequireSystemAdmin(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
+
+// RequireSystemAdminOrImpersonating gates the impersonation lifecycle
+// endpoints (POST /admin/impersonation/end, GET /admin/impersonation/current).
+// It admits two callers:
+//
+//  1. A genuine system admin — the operator who has not yet started (or
+//     has already ended) an impersonation session.
+//  2. A request running inside an impersonation session — the access
+//     token carries `imp=true`. Such a token deliberately has
+//     `is_system_admin=false` (an impersonated session must never wield
+//     platform-admin authority), so plain RequireSystemAdmin would reject
+//     it — yet the operator must be able to *end* the very session they
+//     started. Admitting impersonation tokens here, and ONLY here, lets
+//     `end` and `current` work while keeping every state-changing admin
+//     endpoint behind the strict RequireSystemAdmin gate.
+//
+// Like RequireSystemAdmin it MUST run after JWTMiddleware. The handlers
+// behind it re-validate the impersonation claim themselves, so this
+// middleware only widens the gate — it does not weaken any handler-side
+// check.
+func RequireSystemAdminOrImpersonating(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user := appctx.UserFromContext(r.Context())
+		if user == nil {
+			slog.Warn("RequireSystemAdminOrImpersonating: no user in context — middleware chain misconfigured",
+				"path", r.URL.Path)
+			_ = unauthorizedError(w, r, ErrMissingUserContext)
+			return
+		}
+		if user.IsSystemAdmin || isImpersonatedRequest(r.Context()) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		slog.Warn("RequireSystemAdminOrImpersonating: access denied",
+			"user_id", user.ID,
+			"tenant_id", user.TenantID,
+			"path", r.URL.Path,
+		)
+		_ = codedForbiddenError(w, r, ErrNotSystemAdmin, adminForbiddenCode)
+	})
+}

--- a/go/apiserver/admin_middleware.go
+++ b/go/apiserver/admin_middleware.go
@@ -52,8 +52,13 @@ func RequireSystemAdmin(next http.Handler) http.Handler {
 	})
 }
 
-// RequireSystemAdminOrImpersonating gates the impersonation lifecycle
-// endpoints (POST /admin/impersonation/end, GET /admin/impersonation/current).
+// RequireSystemAdminOrImpersonating gates the JWT-middleware-backed
+// impersonation lifecycle endpoints — currently only GET
+// /admin/impersonation/current (see adminAuthenticatedRoutes). It does
+// NOT gate POST /admin/impersonation/end: that endpoint is mounted bare,
+// outside the JWT/middleware chain, and self-validates the impersonation
+// token and marker cookie itself (see Admin() and endImpersonation).
+//
 // It admits two callers:
 //
 //  1. A genuine system admin — the operator who has not yet started (or
@@ -62,13 +67,13 @@ func RequireSystemAdmin(next http.Handler) http.Handler {
 //     token carries `imp=true`. Such a token deliberately has
 //     `is_system_admin=false` (an impersonated session must never wield
 //     platform-admin authority), so plain RequireSystemAdmin would reject
-//     it — yet the operator must be able to *end* the very session they
-//     started. Admitting impersonation tokens here, and ONLY here, lets
-//     `end` and `current` work while keeping every state-changing admin
-//     endpoint behind the strict RequireSystemAdmin gate.
+//     it — yet the operator must still be able to read the impersonation
+//     state of the very session they started. Admitting impersonation
+//     tokens here lets `current` work while keeping every state-changing
+//     admin endpoint behind the strict RequireSystemAdmin gate.
 //
-// Like RequireSystemAdmin it MUST run after JWTMiddleware. The handlers
-// behind it re-validate the impersonation claim themselves, so this
+// Like RequireSystemAdmin it MUST run after JWTMiddleware. The handler
+// behind it re-validates the impersonation claim itself, so this
 // middleware only widens the gate — it does not weaken any handler-side
 // check.
 func RequireSystemAdminOrImpersonating(next http.Handler) http.Handler {

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -97,6 +97,19 @@ type AdminParams struct {
 	// (#1750). Zero falls back to the 30-min default; values above the
 	// 30-min ceiling are clamped down inside the handler.
 	ImpersonationTTL time.Duration
+
+	// UserMiddlewares is the standard authenticated-route middleware chain
+	// (JWT + RLS + RegistrySet + CSRF). Admin() applies it to every admin
+	// route EXCEPT POST /admin/impersonation/end. That one endpoint is
+	// mounted bare so it stays reachable after the impersonation access
+	// token has expired — JWTMiddleware would otherwise 401 an expired
+	// token before endImpersonation runs, stranding the operator and
+	// orphaning the return slot. endImpersonation self-validates the imp
+	// token (signature + imp=true), tolerating only an expired `exp`, and
+	// the server-side slot is the real authorization. When nil (tests that
+	// build the admin router in isolation), Admin() applies no middleware
+	// — callers must wrap the result themselves.
+	UserMiddlewares []func(http.Handler) http.Handler
 }
 
 // Admin returns the router configurator for /api/v1/admin/*. Mounted
@@ -140,67 +153,107 @@ func Admin(params AdminParams) func(r chi.Router) {
 		ttl:          params.ImpersonationTTL,
 	}
 	return func(r chi.Router) {
-		// The bulk of the admin surface is gated by the strict
-		// RequireSystemAdmin middleware in a nested group so every
-		// handler inside it can assume the caller is a genuine system
-		// admin. The two impersonation-lifecycle routes (end / current)
-		// are registered OUTSIDE this group with the wider
-		// RequireSystemAdminOrImpersonating gate — see below for why.
+		// POST /admin/impersonation/end is mounted FIRST and OUTSIDE the
+		// authenticated-middleware group on purpose. JWTMiddleware (part of
+		// UserMiddlewares) rejects an expired access token with 401 before
+		// any handler runs — which would make `end` unreachable the moment
+		// the (≤30-min) impersonation token lapses, stranding the operator
+		// on a re-login and orphaning the return slot until it is
+		// TTL-pruned. endImpersonation therefore self-validates the imp
+		// token straight off the Authorization header: it verifies the
+		// signature and the `imp=true` claim and tolerates ONLY an expired
+		// `exp`. The jti-keyed server-side slot plus the
+		// `slot.AdminUserID == impersonated_by` assertion are the real
+		// authorization — a forged/garbage token fails signature
+		// verification, and an expired NON-impersonation token fails the
+		// imp check, so neither is newly admitted. See endImpersonation.
+		r.Post("/impersonation/end", impersonationAPI.endImpersonation)
+
+		// Everything else lives behind the standard authenticated
+		// middleware chain (JWT + RLS + RegistrySet + CSRF). UserMiddlewares
+		// may be nil in isolated unit tests, in which case no middleware is
+		// applied and the caller is responsible for wrapping.
 		r.Group(func(r chi.Router) {
-			r.Use(RequireSystemAdmin)
-			r.Get("/_ping", adminPing)
-
-			// #1746: tenants + users listing endpoints. Each handler
-			// audit-logs via params.AuditService and bypasses RLS at the
-			// registry layer (correlated COUNT subqueries on RLS-enabled
-			// tables run with `SET LOCAL row_security = off` for
-			// defense-in-depth).
-			r.Get("/tenants", tenantsAPI.listTenants)
-			r.Get("/tenants/{tenantID}", tenantsAPI.getTenant)
-			r.Get("/tenants/{tenantID}/users", usersAPI.listTenantUsers)
-			r.Get("/users/{userID}", usersAPI.getUser)
-
-			// #1747: user block/unblock endpoints. Each transition cascades
-			// IsActive=false → refresh-token revoke → blacklist bump and
-			// audit-logs reason+forced via the breadcrumb in user_agent.
-			r.Post("/users/{userID}/block", usersAPI.blockUser)
-			r.Post("/users/{userID}/unblock", usersAPI.unblockUser)
-
-			// #1748: cross-tenant groups admin. List + detail bypass RLS at
-			// the registry layer (SET LOCAL row_security = off); DELETE flips
-			// status to pending_deletion (idempotent) and the existing
-			// group_purge_worker finishes the hard-delete. Each handler
-			// audit-logs via params.AuditService.
-			r.Get("/groups", groupsAPI.listGroups)
-			r.Get("/groups/{groupID}", groupsAPI.getGroup)
-			r.Delete("/groups/{groupID}", groupsAPI.deleteGroup)
-
-			// #1749: group-membership admin endpoints. add / remove /
-			// role-change route through GroupService so the per-group
-			// invariants (cap, ≥1 owner, ≥1 member) stay single-sourced,
-			// bypassing only the per-group requireGroupAdmin middleware —
-			// the RequireSystemAdmin gate above is authorization enough.
-			r.Post("/groups/{groupID}/members", groupMembersAPI.addMember)
-			r.Delete("/groups/{groupID}/members/{userID}", groupMembersAPI.removeMember)
-			r.Patch("/groups/{groupID}/members/{userID}", groupMembersAPI.updateMemberRole)
-
-			// #1750: starting an impersonation session is a privileged
-			// operation — it stays behind the strict gate. The
-			// nested-impersonation guard in the handler rejects a request
-			// already inside an impersonation session.
-			r.Post("/users/{userID}/impersonate", impersonationAPI.startImpersonation)
+			for _, mw := range params.UserMiddlewares {
+				r.Use(mw)
+			}
+			adminAuthenticatedRoutes(r, tenantsAPI, usersAPI, groupsAPI, groupMembersAPI, impersonationAPI)
 		})
-
-		// #1750: the impersonation-lifecycle routes. `end` and `current`
-		// must be reachable from INSIDE an impersonation session, whose
-		// access token deliberately carries is_system_admin=false — the
-		// strict RequireSystemAdmin gate would reject it. The wider
-		// RequireSystemAdminOrImpersonating gate admits both a genuine
-		// admin and an active impersonation token; the handlers
-		// themselves re-validate the impersonation claim.
-		r.With(RequireSystemAdminOrImpersonating).Post("/impersonation/end", impersonationAPI.endImpersonation)
-		r.With(RequireSystemAdminOrImpersonating).Get("/impersonation/current", impersonationAPI.currentImpersonation)
 	}
+}
+
+// adminAuthenticatedRoutes registers every /api/v1/admin/* route that runs
+// behind the authenticated middleware chain (everything except POST
+// /admin/impersonation/end, which is mounted bare by Admin()). Extracted
+// from Admin() so that closure stays under the funlen budget.
+func adminAuthenticatedRoutes(
+	r chi.Router,
+	tenantsAPI *adminTenantsAPI,
+	usersAPI *adminUsersAPI,
+	groupsAPI *adminGroupsAPI,
+	groupMembersAPI *adminGroupMembersAPI,
+	impersonationAPI *adminImpersonationAPI,
+) {
+	// The bulk of the admin surface is gated by the strict
+	// RequireSystemAdmin middleware in a nested group so every handler
+	// inside it can assume the caller is a genuine system admin. GET
+	// /admin/impersonation/current is registered OUTSIDE this group with
+	// the wider RequireSystemAdminOrImpersonating gate — see below for why.
+	r.Group(func(r chi.Router) {
+		r.Use(RequireSystemAdmin)
+		r.Get("/_ping", adminPing)
+
+		// #1746: tenants + users listing endpoints. Each handler
+		// audit-logs via params.AuditService and bypasses RLS at the
+		// registry layer (correlated COUNT subqueries on RLS-enabled
+		// tables run with `SET LOCAL row_security = off` for
+		// defense-in-depth).
+		r.Get("/tenants", tenantsAPI.listTenants)
+		r.Get("/tenants/{tenantID}", tenantsAPI.getTenant)
+		r.Get("/tenants/{tenantID}/users", usersAPI.listTenantUsers)
+		r.Get("/users/{userID}", usersAPI.getUser)
+
+		// #1747: user block/unblock endpoints. Each transition cascades
+		// IsActive=false → refresh-token revoke → blacklist bump and
+		// audit-logs reason+forced via the breadcrumb in user_agent.
+		r.Post("/users/{userID}/block", usersAPI.blockUser)
+		r.Post("/users/{userID}/unblock", usersAPI.unblockUser)
+
+		// #1748: cross-tenant groups admin. List + detail bypass RLS at
+		// the registry layer (SET LOCAL row_security = off); DELETE flips
+		// status to pending_deletion (idempotent) and the existing
+		// group_purge_worker finishes the hard-delete. Each handler
+		// audit-logs via params.AuditService.
+		r.Get("/groups", groupsAPI.listGroups)
+		r.Get("/groups/{groupID}", groupsAPI.getGroup)
+		r.Delete("/groups/{groupID}", groupsAPI.deleteGroup)
+
+		// #1749: group-membership admin endpoints. add / remove /
+		// role-change route through GroupService so the per-group
+		// invariants (cap, ≥1 owner, ≥1 member) stay single-sourced,
+		// bypassing only the per-group requireGroupAdmin middleware —
+		// the RequireSystemAdmin gate above is authorization enough.
+		r.Post("/groups/{groupID}/members", groupMembersAPI.addMember)
+		r.Delete("/groups/{groupID}/members/{userID}", groupMembersAPI.removeMember)
+		r.Patch("/groups/{groupID}/members/{userID}", groupMembersAPI.updateMemberRole)
+
+		// #1750: starting an impersonation session is a privileged
+		// operation — it stays behind the strict gate. The
+		// nested-impersonation guard in the handler rejects a request
+		// already inside an impersonation session.
+		r.Post("/users/{userID}/impersonate", impersonationAPI.startImpersonation)
+	})
+
+	// #1750: GET /admin/impersonation/current must be reachable from
+	// INSIDE an impersonation session, whose access token deliberately
+	// carries is_system_admin=false — the strict RequireSystemAdmin gate
+	// would reject it. The wider RequireSystemAdminOrImpersonating gate
+	// admits both a genuine admin and an active (non-expired) impersonation
+	// token; the handler re-validates the impersonation claim. Unlike
+	// `end`, `current` is a harmless read and is fine to keep behind
+	// JWTMiddleware — an expired token simply means the FE banner reads
+	// inactive, which is the correct answer.
+	r.With(RequireSystemAdminOrImpersonating).Get("/impersonation/current", impersonationAPI.currentImpersonation)
 }
 
 // parseAdminSortAndOrder reconciles the dual sort conventions the

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -12,6 +12,17 @@ import (
 	"github.com/denisvmedia/inventario/services"
 )
 
+// defaultAdminImpersonationStore lets Admin() fall back to an in-memory
+// return-slot store when AdminParams.ImpersonationStore is unset (tests,
+// memory-mode bootstrap). Production wiring passes one explicitly so the
+// store lifetime is owned by the caller.
+func defaultAdminImpersonationStore(s services.ImpersonationStore) services.ImpersonationStore {
+	if s != nil {
+		return s
+	}
+	return services.NewInMemoryImpersonationStore()
+}
+
 // AdminPingResponse is the body returned by GET /admin/_ping. It is
 // intentionally tiny — the endpoint exists so the FE (and the swagger
 // route-coverage test) has something to hit while the rest of the
@@ -65,6 +76,27 @@ type AdminParams struct {
 	// membership invariants (cap, ≥1 owner, ≥1 member) single-sourced
 	// instead of forking a parallel code path for admins.
 	GroupService *services.GroupService
+
+	// JWTSecret signs the impersonation access tokens issued by the
+	// #1750 impersonate endpoint. Same secret the rest of the apiserver
+	// uses so an impersonation token validates through the standard
+	// JWTMiddleware path.
+	JWTSecret []byte
+
+	// RateLimiter enforces the per-admin impersonation-start rate limit
+	// (#1750). The same AuthRateLimiter instance the auth endpoints use;
+	// a nil value disables the limit (the handler fails open).
+	RateLimiter services.AuthRateLimiter
+
+	// ImpersonationStore records the server-side return slots for active
+	// impersonation sessions (#1750). When nil, Admin() falls back to an
+	// in-memory store — fine for single-replica deployments and tests.
+	ImpersonationStore services.ImpersonationStore
+
+	// ImpersonationTTL is the lifetime of an impersonation session
+	// (#1750). Zero falls back to the 30-min default; values above the
+	// 30-min ceiling are clamped down inside the handler.
+	ImpersonationTTL time.Duration
 }
 
 // Admin returns the router configurator for /api/v1/admin/*. Mounted
@@ -98,45 +130,76 @@ func Admin(params AdminParams) func(r chi.Router) {
 		groupService: params.GroupService,
 		auditService: params.AuditService,
 	}
+	impersonationAPI := &adminImpersonationAPI{
+		factorySet:   params.FactorySet,
+		store:        defaultAdminImpersonationStore(params.ImpersonationStore),
+		rateLimiter:  params.RateLimiter,
+		blacklist:    params.Blacklist,
+		auditService: params.AuditService,
+		jwtSecret:    params.JWTSecret,
+		ttl:          params.ImpersonationTTL,
+	}
 	return func(r chi.Router) {
-		// RequireSystemAdmin runs as the first per-subtree middleware so
-		// every handler below it can assume the caller is a system admin.
-		r.Use(RequireSystemAdmin)
-		r.Get("/_ping", adminPing)
+		// The bulk of the admin surface is gated by the strict
+		// RequireSystemAdmin middleware in a nested group so every
+		// handler inside it can assume the caller is a genuine system
+		// admin. The two impersonation-lifecycle routes (end / current)
+		// are registered OUTSIDE this group with the wider
+		// RequireSystemAdminOrImpersonating gate — see below for why.
+		r.Group(func(r chi.Router) {
+			r.Use(RequireSystemAdmin)
+			r.Get("/_ping", adminPing)
 
-		// #1746: tenants + users listing endpoints. Each handler
-		// audit-logs via params.AuditService and bypasses RLS at the
-		// registry layer (correlated COUNT subqueries on RLS-enabled
-		// tables run with `SET LOCAL row_security = off` for
-		// defense-in-depth).
-		r.Get("/tenants", tenantsAPI.listTenants)
-		r.Get("/tenants/{tenantID}", tenantsAPI.getTenant)
-		r.Get("/tenants/{tenantID}/users", usersAPI.listTenantUsers)
-		r.Get("/users/{userID}", usersAPI.getUser)
+			// #1746: tenants + users listing endpoints. Each handler
+			// audit-logs via params.AuditService and bypasses RLS at the
+			// registry layer (correlated COUNT subqueries on RLS-enabled
+			// tables run with `SET LOCAL row_security = off` for
+			// defense-in-depth).
+			r.Get("/tenants", tenantsAPI.listTenants)
+			r.Get("/tenants/{tenantID}", tenantsAPI.getTenant)
+			r.Get("/tenants/{tenantID}/users", usersAPI.listTenantUsers)
+			r.Get("/users/{userID}", usersAPI.getUser)
 
-		// #1747: user block/unblock endpoints. Each transition cascades
-		// IsActive=false → refresh-token revoke → blacklist bump and
-		// audit-logs reason+forced via the breadcrumb in user_agent.
-		r.Post("/users/{userID}/block", usersAPI.blockUser)
-		r.Post("/users/{userID}/unblock", usersAPI.unblockUser)
+			// #1747: user block/unblock endpoints. Each transition cascades
+			// IsActive=false → refresh-token revoke → blacklist bump and
+			// audit-logs reason+forced via the breadcrumb in user_agent.
+			r.Post("/users/{userID}/block", usersAPI.blockUser)
+			r.Post("/users/{userID}/unblock", usersAPI.unblockUser)
 
-		// #1748: cross-tenant groups admin. List + detail bypass RLS at
-		// the registry layer (SET LOCAL row_security = off); DELETE flips
-		// status to pending_deletion (idempotent) and the existing
-		// group_purge_worker finishes the hard-delete. Each handler
-		// audit-logs via params.AuditService.
-		r.Get("/groups", groupsAPI.listGroups)
-		r.Get("/groups/{groupID}", groupsAPI.getGroup)
-		r.Delete("/groups/{groupID}", groupsAPI.deleteGroup)
+			// #1748: cross-tenant groups admin. List + detail bypass RLS at
+			// the registry layer (SET LOCAL row_security = off); DELETE flips
+			// status to pending_deletion (idempotent) and the existing
+			// group_purge_worker finishes the hard-delete. Each handler
+			// audit-logs via params.AuditService.
+			r.Get("/groups", groupsAPI.listGroups)
+			r.Get("/groups/{groupID}", groupsAPI.getGroup)
+			r.Delete("/groups/{groupID}", groupsAPI.deleteGroup)
 
-		// #1749: group-membership admin endpoints. add / remove /
-		// role-change route through GroupService so the per-group
-		// invariants (cap, ≥1 owner, ≥1 member) stay single-sourced,
-		// bypassing only the per-group requireGroupAdmin middleware —
-		// the RequireSystemAdmin gate above is authorization enough.
-		r.Post("/groups/{groupID}/members", groupMembersAPI.addMember)
-		r.Delete("/groups/{groupID}/members/{userID}", groupMembersAPI.removeMember)
-		r.Patch("/groups/{groupID}/members/{userID}", groupMembersAPI.updateMemberRole)
+			// #1749: group-membership admin endpoints. add / remove /
+			// role-change route through GroupService so the per-group
+			// invariants (cap, ≥1 owner, ≥1 member) stay single-sourced,
+			// bypassing only the per-group requireGroupAdmin middleware —
+			// the RequireSystemAdmin gate above is authorization enough.
+			r.Post("/groups/{groupID}/members", groupMembersAPI.addMember)
+			r.Delete("/groups/{groupID}/members/{userID}", groupMembersAPI.removeMember)
+			r.Patch("/groups/{groupID}/members/{userID}", groupMembersAPI.updateMemberRole)
+
+			// #1750: starting an impersonation session is a privileged
+			// operation — it stays behind the strict gate. The
+			// nested-impersonation guard in the handler rejects a request
+			// already inside an impersonation session.
+			r.Post("/users/{userID}/impersonate", impersonationAPI.startImpersonation)
+		})
+
+		// #1750: the impersonation-lifecycle routes. `end` and `current`
+		// must be reachable from INSIDE an impersonation session, whose
+		// access token deliberately carries is_system_admin=false — the
+		// strict RequireSystemAdmin gate would reject it. The wider
+		// RequireSystemAdminOrImpersonating gate admits both a genuine
+		// admin and an active impersonation token; the handlers
+		// themselves re-validate the impersonation claim.
+		r.With(RequireSystemAdminOrImpersonating).Post("/impersonation/end", impersonationAPI.endImpersonation)
+		r.With(RequireSystemAdminOrImpersonating).Get("/impersonation/current", impersonationAPI.currentImpersonation)
 	}
 }
 

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -124,6 +124,22 @@ func Admin(params AdminParams) func(r chi.Router) {
 	if params.GroupService == nil {
 		panic("apiserver.Admin requires non-nil AdminParams.GroupService")
 	}
+	// The #1750 impersonation endpoints sign tokens with JWTSecret and
+	// blacklist them on `end` via Blacklist — an AdminParams literal that
+	// omits either turns a wiring mistake into a runtime failure on
+	// impersonate start/end. Fail at startup instead. RateLimiter and
+	// ImpersonationStore are deliberately NOT required: a nil RateLimiter
+	// fails the limit open by design, and ImpersonationStore has the
+	// defaultAdminImpersonationStore in-memory fallback.
+	if len(params.JWTSecret) == 0 {
+		panic("apiserver.Admin requires non-empty AdminParams.JWTSecret")
+	}
+	if params.Blacklist == nil {
+		panic("apiserver.Admin requires non-nil AdminParams.Blacklist")
+	}
+	if params.AuditService == nil {
+		panic("apiserver.Admin requires non-nil AdminParams.AuditService")
+	}
 
 	tenantsAPI := &adminTenantsAPI{
 		factorySet:   params.FactorySet,

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/denisvmedia/inventario/csrf"
 	"github.com/denisvmedia/inventario/registry"
 	"github.com/denisvmedia/inventario/services"
 )
@@ -93,6 +94,14 @@ type AdminParams struct {
 	// in-memory store — fine for single-replica deployments and tests.
 	ImpersonationStore services.ImpersonationStore
 
+	// CSRFService mints a fresh CSRF token for the new effective user when
+	// an impersonation session starts or ends (#1750). CSRF validation is
+	// per-user, so the identity swap (admin↔target) must rotate the token
+	// or the SPA's first mutating request under the swapped identity 403s.
+	// The same csrf.Service the rest of the apiserver uses; a nil value
+	// leaves the impersonation responses' csrf_token empty.
+	CSRFService csrf.Service
+
 	// ImpersonationTTL is the lifetime of an impersonation session
 	// (#1750). Zero falls back to the 30-min default; values above the
 	// 30-min ceiling are clamped down inside the handler.
@@ -165,6 +174,7 @@ func Admin(params AdminParams) func(r chi.Router) {
 		rateLimiter:  params.RateLimiter,
 		blacklist:    params.Blacklist,
 		auditService: params.AuditService,
+		csrfService:  params.CSRFService,
 		jwtSecret:    params.JWTSecret,
 		ttl:          params.ImpersonationTTL,
 	}

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -277,6 +277,15 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 	// AcceptInvite / RemoveMember.
 	groupService.SetUserRegistry(params.FactorySet.UserRegistry)
 
+	// The impersonation return-slot store (#1750) MUST be a single shared
+	// instance: Admin()'s impersonation endpoints record/restore slots and
+	// /auth/logout consults the SAME store to revoke the operator's genuine
+	// refresh token when an impersonation session is ended via logout. Two
+	// separate stores would leave logout unable to see the slot a `start`
+	// recorded. In-memory is fine for single-replica deployments; a shared
+	// (Redis) implementation would be constructed here for multi-replica.
+	impersonationStore := services.NewInMemoryImpersonationStore()
+
 	r.Route("/api/v1", func(r chi.Router) {
 		// Resolve tenant from request host and place it in context for all handlers,
 		// including public ones (login, registration, password reset).
@@ -308,6 +317,7 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			JWTSecret:               params.JWTSecret,
 			EmailService:            emailSvc,
 			MFAService:              mfaSvc,
+			ImpersonationStore:      impersonationStore,
 		}))
 
 		// Unauthenticated public routes: apply the global per-IP rate limit as a
@@ -362,7 +372,7 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 		// inside Admin() rejects non-admins before any handler runs. Mounting
 		// at the same level as /system keeps the surface tenant-agnostic —
 		// system admins are not scoped to a tenant.
-		r.With(userMiddlewares...).Route("/admin", Admin(AdminParams{
+		r.Route("/admin", Admin(AdminParams{
 			FactorySet:       params.FactorySet,
 			Blacklist:        blacklist,
 			AuditService:     auditSvc,
@@ -370,9 +380,18 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			JWTSecret:        params.JWTSecret,
 			RateLimiter:      rateLimiter,
 			ImpersonationTTL: params.ImpersonationTTL,
-			// ImpersonationStore left nil — Admin() falls back to an
-			// in-memory store. A shared (Redis) store would be wired
-			// here for multi-replica deployments.
+			// ImpersonationStore is the SAME instance /auth/logout
+			// receives, so logout can revoke the operator's genuine
+			// refresh token when an impersonation session is ended via
+			// logout rather than POST /admin/impersonation/end (#1750).
+			ImpersonationStore: impersonationStore,
+			// UserMiddlewares is applied by Admin() to every admin route
+			// EXCEPT POST /admin/impersonation/end, which is deliberately
+			// mounted without JWTMiddleware so an operator can still end
+			// an impersonation session whose access token has expired —
+			// endImpersonation self-validates the (possibly expired) imp
+			// token. See Admin() for the full rationale.
+			UserMiddlewares: userMiddlewares,
 		}))
 		// The former /api/v1/users admin CRUD was removed together with the
 		// tenant-level `users.role` column. Per-group user management lives

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -172,8 +172,18 @@ type Params struct {
 	// ImpersonationTTL is the lifetime of an admin impersonation session
 	// (#1750). Operators tune it via INVENTARIO_RUN_IMPERSONATION_TTL;
 	// zero falls back to the 30-min default and any value above 30 min
-	// is clamped down inside the impersonation handler.
+	// is clamped down inside the impersonation handler. A negative value
+	// is rejected by Validate().
 	ImpersonationTTL time.Duration
+
+	// ImpersonationStore records the server-side return slots for active
+	// impersonation sessions (#1750). When nil, APIServer() falls back to
+	// an in-memory store — fine for single-replica deployments and tests.
+	// The same single instance is threaded into both AuthParams and
+	// AdminParams: `start` records a slot, `end`/`logout` read it, so they
+	// MUST share one store. Injectable so a future Redis-backed
+	// implementation can be wired without touching the apiserver.
+	ImpersonationStore services.ImpersonationStore
 }
 
 func (p *Params) Validate() error {
@@ -194,6 +204,10 @@ func (p *Params) Validate() error {
 		validation.Field(&p.JWTSecret, validation.Required, validation.Length(32, 0)),            // Require at least 32 bytes for security
 		validation.Field(&p.FileSigningKey, validation.Required, validation.Length(32, 0)),       // Require at least 32 bytes for security
 		validation.Field(&p.FileURLExpiration, validation.Required, validation.Min(time.Minute)), // Require at least 1 minute expiration
+		// ImpersonationTTL (#1750): zero is allowed (falls back to the
+		// 30-min default), but a negative duration would mint already-expired
+		// sessions — reject it. Not Required, so zero passes the check.
+		validation.Field(&p.ImpersonationTTL, validation.Min(time.Duration(0))),
 	)
 
 	return validation.ValidateStruct(p, fields...)
@@ -282,9 +296,13 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 	// /auth/logout consults the SAME store to revoke the operator's genuine
 	// refresh token when an impersonation session is ended via logout. Two
 	// separate stores would leave logout unable to see the slot a `start`
-	// recorded. In-memory is fine for single-replica deployments; a shared
-	// (Redis) implementation would be constructed here for multi-replica.
-	impersonationStore := services.NewInMemoryImpersonationStore()
+	// recorded. Injectable via Params.ImpersonationStore so a shared
+	// (Redis) implementation can be wired for multi-replica deployments;
+	// in-memory is the default for single-replica deployments and tests.
+	impersonationStore := params.ImpersonationStore
+	if impersonationStore == nil {
+		impersonationStore = services.NewInMemoryImpersonationStore()
+	}
 
 	r.Route("/api/v1", func(r chi.Router) {
 		// Resolve tenant from request host and place it in context for all handlers,
@@ -379,6 +397,7 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 			GroupService:     groupService,
 			JWTSecret:        params.JWTSecret,
 			RateLimiter:      rateLimiter,
+			CSRFService:      csrfSvc,
 			ImpersonationTTL: params.ImpersonationTTL,
 			// ImpersonationStore is the SAME instance /auth/logout
 			// receives, so logout can revoke the operator's genuine

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -168,6 +168,12 @@ type Params struct {
 	// 404s while the lock middleware no-ops. The Helm chart exposes this
 	// via `features.currencyMigration`.
 	FeatureCurrencyMigration bool
+
+	// ImpersonationTTL is the lifetime of an admin impersonation session
+	// (#1750). Operators tune it via INVENTARIO_RUN_IMPERSONATION_TTL;
+	// zero falls back to the 30-min default and any value above 30 min
+	// is clamped down inside the impersonation handler.
+	ImpersonationTTL time.Duration
 }
 
 func (p *Params) Validate() error {
@@ -357,10 +363,16 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 		// at the same level as /system keeps the surface tenant-agnostic —
 		// system admins are not scoped to a tenant.
 		r.With(userMiddlewares...).Route("/admin", Admin(AdminParams{
-			FactorySet:   params.FactorySet,
-			Blacklist:    blacklist,
-			AuditService: auditSvc,
-			GroupService: groupService,
+			FactorySet:       params.FactorySet,
+			Blacklist:        blacklist,
+			AuditService:     auditSvc,
+			GroupService:     groupService,
+			JWTSecret:        params.JWTSecret,
+			RateLimiter:      rateLimiter,
+			ImpersonationTTL: params.ImpersonationTTL,
+			// ImpersonationStore left nil — Admin() falls back to an
+			// in-memory store. A shared (Redis) store would be wired
+			// here for multi-replica deployments.
 		}))
 		// The former /api/v1/users admin CRUD was removed together with the
 		// tenant-level `users.role` column. Per-group user management lives

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -33,6 +33,17 @@ const (
 	refreshTokenCookieName = "refresh_token"
 	// refreshTokenCookiePath limits the cookie to the auth endpoints only.
 	refreshTokenCookiePath = "/api/v1/auth" // #nosec G101 -- this is a URL path, not a credential
+	// impersonationRefreshCookieMarker is the sentinel prefix written into
+	// the refresh-token cookie for the duration of an impersonation session
+	// (#1750). Impersonation sessions are deliberately non-refreshable, so
+	// the impersonation-start handler overwrites the admin's own refresh
+	// cookie with `impersonationRefreshCookieMarker + <jti>`; /auth/refresh
+	// detects the prefix and rejects the call on the cookie-based path —
+	// the realistic FE refresh request, which carries no Authorization
+	// header. Real refresh tokens are base64.RawURLEncoding values
+	// (alphabet [A-Za-z0-9_-]), so a value containing ':' can never be a
+	// genuine token: the marker cannot collide with a real refresh token.
+	impersonationRefreshCookieMarker = "imp:" // #nosec G101 -- a sentinel marker, not a credential
 )
 
 // AuthAPI handles authentication endpoints.
@@ -48,7 +59,17 @@ type AuthAPI struct {
 	auditService            services.AuditLogger
 	emailService            services.EmailService
 	mfaService              *services.MFAService
-	jwtSecret               []byte
+	// impersonationStore lets logout revoke the operator's GENUINE refresh
+	// token when the request runs during an impersonation session (#1750).
+	// During impersonation the refresh cookie holds the
+	// impersonationRefreshCookieMarker + <jti> sentinel rather than a real
+	// token; the admin's actual refresh token is held server-side in the
+	// return slot. Without this, a logout-during-impersonation would hash
+	// the marker, find no row, and silently leave the admin's real refresh
+	// token valid in the DB for its full lifetime. May be nil (tests /
+	// memory-mode bootstrap) — logout then falls back to the normal path.
+	impersonationStore services.ImpersonationStore
+	jwtSecret          []byte
 }
 
 func (api *AuthAPI) sendPasswordChangedNotification(user *models.User) {
@@ -257,15 +278,26 @@ func (api *AuthAPI) refresh(w http.ResponseWriter, r *http.Request) {
 
 	// Impersonation sessions (#1750) are deliberately non-refreshable:
 	// they must expire hard at the impersonation TTL so an operator can
-	// never extend a borrowed identity indefinitely. The impersonation
-	// access token is the only artifact carrying the `imp` claim — when
-	// the FE sends it on the Authorization header during refresh, reject
-	// the call. The refresh cookie itself still belongs to the admin's
-	// own session (impersonation issues no refresh token), so omitting
-	// this check would silently hand the caller a fresh *admin* access
-	// token mid-impersonation.
-	if api.accessTokenIsImpersonation(r.Header.Get("Authorization")) {
-		slog.Warn("Refresh rejected: impersonation access token cannot be refreshed")
+	// never extend a borrowed identity indefinitely. There are two ways an
+	// impersonation session can reach this endpoint, and both must be
+	// rejected:
+	//
+	//  1. Bearer-token path: the FE sends the impersonation access token
+	//     (the only artifact carrying the `imp` claim) on the Authorization
+	//     header. Caught by accessTokenIsImpersonation below.
+	//
+	//  2. Cookie path: the realistic FE refresh request posts to
+	//     /auth/refresh with NO Authorization header — the refresh
+	//     interceptor relies solely on the httpOnly cookie. To make this
+	//     path rejectable, impersonation-start overwrites the refresh
+	//     cookie with an impersonation marker value
+	//     (impersonationRefreshCookieMarker); refreshCookieIsImpersonation
+	//     detects it. Without this, the cookie would still carry the
+	//     admin's own refresh token and the server would silently mint a
+	//     fresh *admin* access token mid-impersonation — ending the session
+	//     outside /admin/impersonation/end and orphaning the return slot.
+	if api.accessTokenIsImpersonation(r.Header.Get("Authorization")) || refreshCookieIsImpersonation(r) {
+		slog.Warn("Refresh rejected: impersonation session cannot be refreshed")
 		http.Error(w, ErrImpersonationTokenCannotRefresh.Error(), http.StatusUnauthorized)
 		return
 	}
@@ -471,6 +503,53 @@ func (api *AuthAPI) revokeRefreshToken(ctx context.Context, rawToken string) {
 	}
 }
 
+// revokeImpersonationRefreshToken handles the logout-during-impersonation
+// case (#1750). When cookieValue is an impersonation marker
+// (impersonationRefreshCookieMarker + <jti>) it resolves the return slot
+// by that jti, revokes the admin's GENUINE refresh token held in the slot
+// (slot.AdminRefreshTokenRaw), and deletes the slot so it is not orphaned.
+// Returns true when the cookie was a marker and this path handled it
+// (caller must NOT also run the plain revokeRefreshToken path), false when
+// the cookie is a normal refresh token the caller should revoke as before.
+//
+// Best-effort, mirroring the rest of logout: a missing store, a malformed
+// marker, an already-gone slot, or an empty captured token are all benign
+// — logout must still succeed. The genuine token is only ever revoked when
+// it is actually recoverable from a live slot; the slot is deleted on a
+// best-effort basis so a double logout/end is harmless.
+func (api *AuthAPI) revokeImpersonationRefreshToken(ctx context.Context, cookieValue string) bool {
+	if !strings.HasPrefix(cookieValue, impersonationRefreshCookieMarker) {
+		return false
+	}
+	// The cookie carries an impersonation marker rather than a real token,
+	// so the plain revoke path would hash a non-token and find nothing.
+	// Treat the marker as handled regardless of what we can recover below
+	// — there is no real refresh token in this cookie for the caller to
+	// fall back on.
+	if api.impersonationStore == nil {
+		slog.Warn("Logout during impersonation: no impersonation store configured, admin refresh token not revoked")
+		return true
+	}
+	jti := strings.TrimPrefix(cookieValue, impersonationRefreshCookieMarker)
+	if jti == "" {
+		return true
+	}
+	slot, err := api.impersonationStore.Get(ctx, jti)
+	if err != nil {
+		// Slot already ended/expired/never recorded — nothing to revoke.
+		slog.Warn("Logout during impersonation: return slot not found", "jti", jti)
+		return true
+	}
+	if slot.AdminRefreshTokenRaw != "" {
+		api.revokeRefreshToken(ctx, slot.AdminRefreshTokenRaw)
+	}
+	if delErr := api.impersonationStore.Delete(ctx, jti); delErr != nil {
+		slog.Warn("Logout during impersonation: failed to delete return slot", "jti", jti, "error", delErr)
+	}
+	slog.Info("Impersonation session ended via logout", "jti", jti, "admin_id", slot.AdminUserID)
+	return true
+}
+
 // logout revokes the current access token and refresh token.
 // @Summary Logout
 // @Description Revoke the current session's access token and clear the refresh token cookie.
@@ -489,9 +568,16 @@ func (api *AuthAPI) logout(w http.ResponseWriter, r *http.Request) {
 		userID, _ = api.userIDFromAccessTokenHeader(authHeader)
 	}
 
-	// Revoke the refresh token from the database.
+	// Revoke the refresh token from the database. During an impersonation
+	// session (#1750) the refresh cookie holds the impersonation marker
+	// (impersonationRefreshCookieMarker + <jti>) rather than a real token —
+	// revokeImpersonationRefreshToken detects that, resolves the return
+	// slot, and revokes the admin's GENUINE refresh token instead. A normal
+	// cookie takes the plain revokeRefreshToken path unchanged.
 	if cookie, err := r.Cookie(refreshTokenCookieName); err == nil {
-		api.revokeRefreshToken(r.Context(), cookie.Value)
+		if !api.revokeImpersonationRefreshToken(r.Context(), cookie.Value) {
+			api.revokeRefreshToken(r.Context(), cookie.Value)
+		}
 	}
 
 	// Revoke only the CSRF token of the current session so that other concurrent
@@ -613,7 +699,15 @@ type AuthParams struct {
 	AuditService            services.AuditLogger
 	EmailService            services.EmailService
 	MFAService              *services.MFAService
-	JWTSecret               []byte
+	// ImpersonationStore is the same return-slot store the /admin
+	// impersonation endpoints use (#1750). logout consults it to revoke
+	// the operator's genuine refresh token when a session is ended via
+	// logout (rather than POST /admin/impersonation/end) from inside an
+	// impersonation session. Must be the SAME instance Admin() receives so
+	// the slot a `start` recorded is visible here. nil disables the
+	// impersonation-aware logout branch.
+	ImpersonationStore services.ImpersonationStore
+	JWTSecret          []byte
 }
 
 // Auth sets up the authentication API routes.
@@ -630,6 +724,7 @@ func Auth(params AuthParams) func(r chi.Router) {
 		auditService:            params.AuditService,
 		emailService:            params.EmailService,
 		mfaService:              params.MFAService,
+		impersonationStore:      params.ImpersonationStore,
 		jwtSecret:               params.JWTSecret,
 	}
 
@@ -1062,6 +1157,17 @@ func (api *AuthAPI) setRefreshTokenCookie(w http.ResponseWriter, r *http.Request
 	if rawToken == "" {
 		return
 	}
+	writeRefreshCookie(w, r, rawToken, int(refreshTokenExpiration.Seconds()))
+}
+
+// writeRefreshCookie writes the refresh-token cookie with the given value
+// and max-age. It is the single place the refresh cookie's flags
+// (HttpOnly, Secure, SameSite, Path) are defined so login, refresh, and
+// the impersonation start/end flows all emit an identically-shaped
+// cookie. A negative maxAge deletes the cookie (see clearRefreshCookie);
+// the impersonation flow uses it both to plant the impersonation marker
+// (#1750) and to restore the admin's original token on `end`.
+func writeRefreshCookie(w http.ResponseWriter, r *http.Request, value string, maxAge int) {
 	// Set Secure flag only when the connection is already over HTTPS to allow
 	// local development over plain HTTP.
 	secureCookie := r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
@@ -1069,13 +1175,28 @@ func (api *AuthAPI) setRefreshTokenCookie(w http.ResponseWriter, r *http.Request
 	// #nosec G124 -- HttpOnly + SameSiteStrict are set; Secure is true on HTTPS and intentionally false on plain-HTTP local dev.
 	http.SetCookie(w, &http.Cookie{
 		Name:     refreshTokenCookieName,
-		Value:    rawToken,
+		Value:    value,
 		Path:     refreshTokenCookiePath,
-		MaxAge:   int(refreshTokenExpiration.Seconds()),
+		MaxAge:   maxAge,
 		HttpOnly: true,
 		Secure:   secureCookie,
 		SameSite: http.SameSiteStrictMode,
 	})
+}
+
+// refreshCookieIsImpersonation reports whether the request carries a
+// refresh-token cookie holding the impersonation marker value
+// (impersonationRefreshCookieMarker). The impersonation-start handler
+// plants this marker for the duration of an impersonation session so
+// /auth/refresh can reject a cookie-based refresh attempt — the path the
+// FE refresh interceptor actually takes, since it sends no Authorization
+// header. See the refresh() handler for the full rationale (#1750).
+func refreshCookieIsImpersonation(r *http.Request) bool {
+	cookie, err := r.Cookie(refreshTokenCookieName)
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(cookie.Value, impersonationRefreshCookieMarker)
 }
 
 // rollbackRefreshToken revokes a refresh-token row that was persisted

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -44,12 +44,24 @@ const (
 	// the admin's real refresh cookie (no duplicate-cookie hazard that two
 	// cookies at different paths would create).
 	//
-	// Migration note: a session created before this widening keeps its old
-	// cookie pinned at /api/v1/auth until the next /auth/refresh re-issues
-	// it at /api/v1; the stale narrow-path cookie is then shadowed on
-	// /auth/* and expires on its own within the 30-day refresh TTL. No user
-	// is logged out by the change.
+	// Migration note: a session created before this widening still holds a
+	// refresh cookie pinned at the legacy /api/v1/auth path. Because the new
+	// cookie is written at /api/v1, a plain write does NOT overwrite that
+	// stale narrow-path cookie — the browser would carry two `refresh_token`
+	// cookies and, per RFC 6265, send the longer-Path (/api/v1/auth) one
+	// first, so the impersonation marker planted at /api/v1 would be shadowed
+	// on /auth/refresh (a real security hole, #1750/#1771). To prevent this,
+	// clearLegacyRefreshCookie actively deletes the /api/v1/auth cookie on
+	// every login, refresh-cookie write, impersonation start/end, logout,
+	// and on the /auth/refresh success path — so a stale session is cleaned
+	// up the next time it talks to the auth API. No user is logged out by
+	// the change.
 	refreshTokenCookiePath = "/api/v1" // #nosec G101 -- this is a URL path, not a credential
+	// legacyRefreshTokenCookiePath is the pre-#1750 path the refresh cookie
+	// was scoped to. New code never writes a live cookie here; it is only
+	// used to emit an explicit deletion (see clearLegacyRefreshCookie) so a
+	// browser holding a pre-upgrade cookie at this path drops it.
+	legacyRefreshTokenCookiePath = "/api/v1/auth" // #nosec G101 -- this is a URL path, not a credential
 	// impersonationRefreshCookieMarker is the sentinel prefix written into
 	// the refresh-token cookie for the duration of an impersonation session
 	// (#1750). Impersonation sessions are deliberately non-refreshable, so
@@ -385,6 +397,13 @@ func (api *AuthAPI) refresh(w http.ResponseWriter, r *http.Request) {
 
 	// Re-generate the CSRF token so it stays in sync with the new access token.
 	csrfToken := api.generateCSRFTokenForUser(r.Context(), user.ID)
+
+	// refresh() does not rotate the refresh cookie (writeLoginResponse writes
+	// no cookie), so a session that only ever refreshes would never evict a
+	// stale pre-#1750 cookie left at the legacy /api/v1/auth path. Clear it
+	// explicitly here — cheap, idempotent, and closes the migration window
+	// for refresh-only sessions (#1750/#1771).
+	clearLegacyRefreshCookie(w, r)
 
 	writeLoginResponse(w, accessTokenString, csrfToken, user)
 }
@@ -1246,6 +1265,11 @@ func (api *AuthAPI) setRefreshTokenCookie(w http.ResponseWriter, r *http.Request
 // the impersonation flow uses it both to plant the impersonation marker
 // (#1750) and to restore the admin's original token on `end`.
 func writeRefreshCookie(w http.ResponseWriter, r *http.Request, value string, maxAge int) {
+	// Evict any pre-#1750 cookie pinned at the legacy /api/v1/auth path so the
+	// browser does not end up carrying two `refresh_token` cookies (see the
+	// refreshTokenCookiePath migration note).
+	clearLegacyRefreshCookie(w, r)
+
 	// Set Secure flag only when the connection is already over HTTPS to allow
 	// local development over plain HTTP.
 	secureCookie := r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
@@ -1256,6 +1280,31 @@ func writeRefreshCookie(w http.ResponseWriter, r *http.Request, value string, ma
 		Value:    value,
 		Path:     refreshTokenCookiePath,
 		MaxAge:   maxAge,
+		HttpOnly: true,
+		Secure:   secureCookie,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+
+// clearLegacyRefreshCookie emits a Set-Cookie that deletes the pre-#1750
+// refresh-token cookie scoped to the legacy /api/v1/auth path (MaxAge=-1,
+// empty value). New code writes the live refresh cookie at /api/v1; because
+// that is a different path, a plain write would not overwrite a stale
+// narrow-path cookie left over from a session created before the path was
+// widened. Without this deletion the browser would carry two `refresh_token`
+// cookies and send the longer-Path (/api/v1/auth) one first on /auth/refresh,
+// shadowing the impersonation marker planted at /api/v1 (#1750/#1771). It is
+// cheap and idempotent, so it runs on every refresh-cookie write/clear and on
+// the /auth/refresh success path. The cookie attributes match writeRefreshCookie
+// and clearRefreshCookie exactly, including the secureCookie computation.
+func clearLegacyRefreshCookie(w http.ResponseWriter, r *http.Request) {
+	secureCookie := r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+	// #nosec G124 -- HttpOnly + SameSiteStrict are set; Secure is true on HTTPS and intentionally false on plain-HTTP local dev.
+	http.SetCookie(w, &http.Cookie{
+		Name:     refreshTokenCookieName,
+		Value:    "",
+		Path:     legacyRefreshTokenCookiePath,
+		MaxAge:   -1,
 		HttpOnly: true,
 		Secure:   secureCookie,
 		SameSite: http.SameSiteStrictMode,
@@ -1312,6 +1361,9 @@ func writeLoginResponse(w http.ResponseWriter, accessToken, csrfToken string, us
 // where the cookie is present but invalid/expired/revoked, so that the browser
 // does not keep sending a stale token and causing repeated 401 loops.
 func clearRefreshCookie(w http.ResponseWriter, r *http.Request) {
+	// Also evict any stale pre-#1750 cookie at the legacy /api/v1/auth path.
+	clearLegacyRefreshCookie(w, r)
+
 	secureCookie := r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
 	// #nosec G124 -- HttpOnly + SameSiteStrict are set; Secure is true on HTTPS and intentionally false on plain-HTTP local dev.
 	http.SetCookie(w, &http.Cookie{

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -31,8 +31,25 @@ const (
 	refreshTokenExpiration = 30 * 24 * time.Hour
 	// refreshTokenCookieName is the name of the httpOnly cookie carrying the refresh token.
 	refreshTokenCookieName = "refresh_token"
-	// refreshTokenCookiePath limits the cookie to the auth endpoints only.
-	refreshTokenCookiePath = "/api/v1/auth" // #nosec G101 -- this is a URL path, not a credential
+	// refreshTokenCookiePath scopes the refresh cookie to the API namespace.
+	//
+	// It is intentionally `/api/v1` — the common ancestor of BOTH the
+	// /api/v1/auth/* endpoints (login, refresh, logout) and
+	// POST /api/v1/admin/impersonation/end — rather than the narrower
+	// /api/v1/auth. During impersonation the refresh cookie carries the
+	// `imp:<jti>` marker (#1750); /admin/impersonation/end requires that
+	// marker as browser-bound proof, so the cookie MUST reach a path that
+	// includes /api/v1/admin/impersonation/end. A single cookie at one
+	// path also means the impersonation-start overwrite genuinely replaces
+	// the admin's real refresh cookie (no duplicate-cookie hazard that two
+	// cookies at different paths would create).
+	//
+	// Migration note: a session created before this widening keeps its old
+	// cookie pinned at /api/v1/auth until the next /auth/refresh re-issues
+	// it at /api/v1; the stale narrow-path cookie is then shadowed on
+	// /auth/* and expires on its own within the 30-day refresh TTL. No user
+	// is logged out by the change.
+	refreshTokenCookiePath = "/api/v1" // #nosec G101 -- this is a URL path, not a credential
 	// impersonationRefreshCookieMarker is the sentinel prefix written into
 	// the refresh-token cookie for the duration of an impersonation session
 	// (#1750). Impersonation sessions are deliberately non-refreshable, so

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -254,6 +254,22 @@ func (api *AuthAPI) refresh(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Refresh tokens not supported", http.StatusNotImplemented)
 		return
 	}
+
+	// Impersonation sessions (#1750) are deliberately non-refreshable:
+	// they must expire hard at the impersonation TTL so an operator can
+	// never extend a borrowed identity indefinitely. The impersonation
+	// access token is the only artifact carrying the `imp` claim — when
+	// the FE sends it on the Authorization header during refresh, reject
+	// the call. The refresh cookie itself still belongs to the admin's
+	// own session (impersonation issues no refresh token), so omitting
+	// this check would silently hand the caller a fresh *admin* access
+	// token mid-impersonation.
+	if api.accessTokenIsImpersonation(r.Header.Get("Authorization")) {
+		slog.Warn("Refresh rejected: impersonation access token cannot be refreshed")
+		http.Error(w, ErrImpersonationTokenCannotRefresh.Error(), http.StatusUnauthorized)
+		return
+	}
+
 	cookie, err := r.Cookie(refreshTokenCookieName)
 	if err != nil {
 		// Cookie missing: nothing to clear — do not set MaxAge=-1 for a non-existent cookie.
@@ -353,6 +369,39 @@ func (api *AuthAPI) userIDFromAccessTokenHeader(authHeader string) (string, bool
 	// Tokens are issued with "user_id" (see issueAccessToken); "sub" is not set.
 	userID, ok := claims["user_id"].(string)
 	return userID, ok && userID != ""
+}
+
+// accessTokenIsImpersonation reports whether the Bearer token in
+// authHeader is an impersonation access token (carries `imp` == true).
+// Used by the refresh endpoint to reject impersonation tokens (#1750).
+// Expired tokens still count — an expired impersonation token presented
+// at refresh must not be refreshable either. Returns false when the
+// header is absent, malformed, or the signature is invalid: a token we
+// cannot verify is treated as "not an impersonation token" so the
+// regular cookie-based refresh path handles (and rejects) it.
+func (api *AuthAPI) accessTokenIsImpersonation(authHeader string) bool {
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+	if tokenString == authHeader || tokenString == "" {
+		return false
+	}
+	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return api.jwtSecret, nil
+	})
+	if token == nil {
+		return false
+	}
+	if err != nil && !errors.Is(err, jwt.ErrTokenExpired) {
+		return false
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return false
+	}
+	imp, _ := claims["imp"].(bool)
+	return imp
 }
 
 // blacklistAccessToken extracts claims from a Bearer token header and blacklists its JTI.

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -436,6 +436,46 @@ func (api *AuthAPI) accessTokenIsImpersonation(authHeader string) bool {
 	return imp
 }
 
+// impersonationClaimsFromAccessTokenHeader parses the Bearer token in
+// authHeader and returns its claims when — and only when — the token is
+// a verified impersonation token (`imp` true with a non-empty
+// `impersonated_by`). Expired tokens still count, mirroring
+// accessTokenIsImpersonation, so a logout with an only-just-expired
+// impersonation token still records the operator-of-record.
+//
+// It exists so the logout handler (#1750) can seed the impersonation
+// claims into the request context before logAuth runs — without that,
+// the logout-during-impersonation audit row would record the target
+// user but miss the ImpersonatedBy column. Returns (nil, false) when the
+// header is absent/malformed, the signature is invalid, or the token is
+// not an impersonation token.
+func (api *AuthAPI) impersonationClaimsFromAccessTokenHeader(authHeader string) (jwt.MapClaims, bool) {
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+	if tokenString == authHeader || tokenString == "" {
+		return nil, false
+	}
+	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return api.jwtSecret, nil
+	})
+	if token == nil {
+		return nil, false
+	}
+	if err != nil && !errors.Is(err, jwt.ErrTokenExpired) {
+		return nil, false
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, false
+	}
+	if !claimsAreImpersonation(claims) {
+		return nil, false
+	}
+	return claims, true
+}
+
 // blacklistAccessToken extracts claims from a Bearer token header and blacklists its JTI.
 func (api *AuthAPI) blacklistAccessToken(ctx context.Context, authHeader string) {
 	if api.blacklistService == nil {
@@ -566,6 +606,18 @@ func (api *AuthAPI) logout(w http.ResponseWriter, r *http.Request) {
 	if authHeader != "" {
 		api.blacklistAccessToken(r.Context(), authHeader)
 		userID, _ = api.userIDFromAccessTokenHeader(authHeader)
+
+		// Logout during an impersonation session (#1750): the bearer token
+		// is an impersonation token. logout runs WITHOUT RequireAuth, so
+		// the validated JWT claims are not in context — seed them here so
+		// the audit row's ImpersonatedBy column is auto-filled by LogAuth
+		// (impersonatorFromContext), exactly as it is on RequireAuth-backed
+		// routes and on POST /admin/impersonation/end. Without this the
+		// logout-during-impersonation audit row would record only the
+		// target user and lose the operator-of-record.
+		if claims, ok := api.impersonationClaimsFromAccessTokenHeader(authHeader); ok {
+			r = r.WithContext(appctx.WithJWTClaims(r.Context(), claims))
+		}
 	}
 
 	// Revoke the refresh token from the database. During an impersonation
@@ -647,10 +699,19 @@ func (api *AuthAPI) handleGetCurrentUser(w http.ResponseWriter, r *http.Request)
 // generateCSRFTokenForUser issues a new CSRF token for the given user.
 // Returns "" when csrfService is nil or on error (errors are logged).
 func (api *AuthAPI) generateCSRFTokenForUser(ctx context.Context, userID string) string {
-	if api.csrfService == nil {
+	return generateCSRFToken(ctx, api.csrfService, userID)
+}
+
+// generateCSRFToken issues a new CSRF token for the given user against
+// the supplied csrf service. Returns "" when the service is nil or on
+// error (errors are logged). Extracted as a free function so the
+// impersonation handlers (#1750) — which rotate the CSRF token across an
+// identity swap — can mint a token without depending on AuthAPI.
+func generateCSRFToken(ctx context.Context, csrfService csrf.Service, userID string) string {
+	if csrfService == nil {
 		return ""
 	}
-	token, err := api.csrfService.GenerateToken(ctx, userID)
+	token, err := csrfService.GenerateToken(ctx, userID)
 	if err != nil {
 		slog.Error("Failed to generate CSRF token", "user_id", userID, "error", err)
 		// Non-fatal: the middleware fails-open on storage errors.

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -783,6 +783,94 @@ func TestAuthAPI_Refresh(t *testing.T) {
 	})
 }
 
+// legacyRefreshCookieDeleted reports whether the response includes a
+// Set-Cookie header that deletes the refresh_token cookie pinned at the
+// legacy /api/v1/auth path. http.SetCookie with MaxAge=-1 renders as
+// "Max-Age=0" on the wire. This is the regression assertion for the PR
+// #1771 review bug (#1750): widening the refresh cookie path to /api/v1
+// without actively deleting a stale /api/v1/auth cookie leaves a browser
+// carrying two refresh_token cookies, reopening the
+// refresh-during-impersonation bypass for every pre-upgrade session.
+func legacyRefreshCookieDeleted(resp *httptest.ResponseRecorder) bool {
+	for _, sc := range resp.Header().Values("Set-Cookie") {
+		if !strings.HasPrefix(sc, "refresh_token=") {
+			continue
+		}
+		hasLegacyPath := false
+		hasDeletion := false
+		for attr := range strings.SplitSeq(sc, ";") {
+			attr = strings.TrimSpace(attr)
+			if attr == "Path=/api/v1/auth" {
+				hasLegacyPath = true
+			}
+			if attr == "Max-Age=0" {
+				hasDeletion = true
+			}
+		}
+		if hasLegacyPath && hasDeletion {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAuthAPI_Refresh_DeletesLegacyPathCookie is the regression test for the
+// PR #1771 review bug (#1750): the /auth/refresh success path must emit a
+// Set-Cookie that deletes the pre-upgrade refresh_token cookie scoped to the
+// legacy /api/v1/auth path, so a browser holding a stale narrow-path cookie
+// drops it instead of carrying two refresh_token cookies.
+func TestAuthAPI_Refresh_DeletesLegacyPathCookie(t *testing.T) {
+	c := qt.New(t)
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+	const (
+		userID   = "user-refresh-legacy"
+		tenantID = "test-tenant-id"
+	)
+
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{
+		userID: {
+			TenantAwareEntityID: models.TenantAwareEntityID{
+				EntityID: models.EntityID{ID: userID},
+				TenantID: tenantID,
+			},
+			Email:    "refresh-legacy@example.com",
+			Name:     "Refresh Legacy User",
+			IsActive: true,
+		},
+	}}
+	refreshReg := &mockRefreshTokenRegistryForAuth{tokensByHash: map[string]*models.RefreshToken{}}
+
+	raw, hash, err := models.GenerateRefreshToken()
+	c.Assert(err, qt.IsNil)
+	refreshReg.tokensByHash[hash] = &models.RefreshToken{
+		TenantUserAwareEntityID: models.TenantUserAwareEntityID{
+			EntityID: models.EntityID{ID: "rt-legacy"},
+			TenantID: tenantID,
+			UserID:   userID,
+		},
+		TokenHash: hash,
+		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		CreatedAt: time.Now(),
+	}
+
+	req := httptest.NewRequest("POST", "/refresh", nil)
+	// #nosec G124 -- test-only cookie added to a httptest.NewRequest; transport security is irrelevant here.
+	req.AddCookie(&http.Cookie{Name: "refresh_token", Value: raw})
+	resp := httptest.NewRecorder()
+	router := chi.NewRouter()
+	apiserver.Auth(apiserver.AuthParams{
+		UserRegistry:         userReg,
+		RefreshTokenRegistry: refreshReg,
+		JWTSecret:            jwtSecret,
+	})(router)
+	router.ServeHTTP(resp, req)
+
+	c.Assert(resp.Code, qt.Equals, http.StatusOK)
+	c.Assert(legacyRefreshCookieDeleted(resp), qt.IsTrue,
+		qt.Commentf("refresh success path must emit a Set-Cookie deleting the legacy /api/v1/auth cookie; got %v",
+			resp.Header().Values("Set-Cookie")))
+}
+
 // refreshCookieCleared reports whether the response includes a Set-Cookie
 // header that deletes the refresh_token cookie. http.SetCookie with MaxAge=-1
 // is rendered as "Max-Age=0" on the wire, so that's what we match.

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -56,6 +56,59 @@ var (
 	// quietly disable a fellow operator. 422 + JSON:API code
 	// "admin.block.admin_requires_force" makes the FE branch trivial.
 	ErrAdminCannotBlockAdminWithoutForce = errx.NewSentinel("blocking another system administrator requires force=true")
+
+	// ErrCannotImpersonateAdmin rejects POST /admin/users/{id}/impersonate
+	// when the target user is itself a system administrator. Impersonating
+	// a peer admin would let an operator borrow another operator's
+	// platform-admin authority while the audit trail records only the
+	// borrowed identity — a privilege-escalation footgun the primitive
+	// (#1750) refuses outright (no `force` override, unlike block).
+	// 422 + JSON:API code "admin.impersonate.target_is_admin".
+	ErrCannotImpersonateAdmin = errx.NewSentinel("system administrators cannot be impersonated")
+	// ErrTargetBlocked rejects impersonation of a user whose account is
+	// blocked (IsActive=false). Impersonating a deactivated user would
+	// resurrect a session the block was meant to tear down. 422 +
+	// JSON:API code "admin.impersonate.target_blocked".
+	ErrTargetBlocked = errx.NewSentinel("cannot impersonate a blocked user")
+	// ErrNestedImpersonation rejects an impersonate request made through
+	// an already-impersonated session (the caller's access token carries
+	// `imp=true`). Nesting impersonation would make the audit chain
+	// ambiguous about who the operator-of-record is. 422 + JSON:API code
+	// "admin.impersonate.nested".
+	ErrNestedImpersonation = errx.NewSentinel("cannot start impersonation from an impersonated session")
+	// ErrNotImpersonating is returned by POST /admin/impersonation/end and
+	// GET /admin/impersonation/current when the caller's access token is
+	// not an impersonation token (`imp` is absent or false). 422 +
+	// JSON:API code "admin.impersonate.not_active".
+	ErrNotImpersonating = errx.NewSentinel("no active impersonation session")
+	// ErrImpersonationTokenCannotRefresh is returned by POST /auth/refresh
+	// when the caller presents an impersonation access token. Impersonation
+	// sessions are deliberately non-refreshable so they expire hard at the
+	// TTL. Surfaces as 401 — the refresh endpoint already returns plain-text
+	// 401s, so this sentinel only documents the rejection in one place.
+	ErrImpersonationTokenCannotRefresh = errx.NewSentinel("impersonation tokens cannot be refreshed")
+)
+
+// JSON:API error codes returned by the impersonation endpoints (#1750).
+// Kept as constants so the swagger annotations, the FE branch table, and
+// the handler tests reference the same literals. Codes follow the
+// "admin.impersonate.*" family.
+const (
+	// AdminImpersonateTargetIsAdminCode signals "the impersonation target
+	// is a system administrator". Maps to a 422.
+	AdminImpersonateTargetIsAdminCode = "admin.impersonate.target_is_admin"
+	// AdminImpersonateTargetBlockedCode signals "the impersonation target
+	// account is blocked". Maps to a 422.
+	AdminImpersonateTargetBlockedCode = "admin.impersonate.target_blocked"
+	// AdminImpersonateNestedCode signals "the caller is already inside an
+	// impersonation session". Maps to a 422.
+	AdminImpersonateNestedCode = "admin.impersonate.nested"
+	// AdminImpersonateNotActiveCode signals "the caller is not in an
+	// impersonation session" — returned by end / current. Maps to a 422.
+	AdminImpersonateNotActiveCode = "admin.impersonate.not_active"
+	// AdminImpersonateRateLimitedCode signals "the per-admin impersonation
+	// start rate limit was exceeded". Maps to a 429.
+	AdminImpersonateRateLimitedCode = "admin.impersonate.rate_limited"
 )
 
 func NewNotFoundError(err error) jsonapi.Error {
@@ -185,6 +238,30 @@ func adminMemberTenantMismatchError(err error) jsonapi.Error {
 	}
 }
 
+// adminImpersonationGuardError maps the #1750 impersonation guard
+// sentinels (target-is-admin, target-blocked, nested, not-active) to
+// their 422 + code wire shape. Extracted as a free function — like
+// adminBlockGuardError — so the toJSONAPIError switch stays under the
+// gocyclo budget while keeping the mapping explicit and grep-friendly.
+func adminImpersonationGuardError(err error) jsonapi.Error {
+	code := AdminImpersonateTargetIsAdminCode
+	switch {
+	case errors.Is(err, ErrTargetBlocked):
+		code = AdminImpersonateTargetBlockedCode
+	case errors.Is(err, ErrNestedImpersonation):
+		code = AdminImpersonateNestedCode
+	case errors.Is(err, ErrNotImpersonating):
+		code = AdminImpersonateNotActiveCode
+	}
+	return jsonapi.Error{
+		Err:            err,
+		UserError:      errormarshal.Marshal(err),
+		HTTPStatusCode: http.StatusUnprocessableEntity,
+		StatusText:     "Unprocessable Entity",
+		Code:           code,
+	}
+}
+
 func toJSONAPIError(err error) jsonapi.Error {
 	switch {
 	case errors.Is(err, registry.ErrCannotDelete):
@@ -286,6 +363,16 @@ func toJSONAPIError(err error) jsonapi.Error {
 		// a sentinel-specific JSON:API code so the FE can render
 		// targeted copy instead of a generic 422 toast.
 		return adminBlockGuardError(err)
+	case errors.Is(err, ErrCannotImpersonateAdmin),
+		errors.Is(err, ErrTargetBlocked),
+		errors.Is(err, ErrNestedImpersonation),
+		errors.Is(err, ErrNotImpersonating):
+		// Impersonation guard rejections (#1750). Target-is-admin,
+		// target-blocked, nested-impersonation and not-active all surface
+		// as 422 with a sentinel-specific JSON:API code so the FE can
+		// render targeted copy. Extracted into a helper so the switch
+		// stays under the gocyclo budget.
+		return adminImpersonationGuardError(err)
 	default:
 		slog.Error("internal server error", "error", err)
 		return NewInternalServerError(err)

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -267,7 +267,52 @@ func adminImpersonationGuardError(err error) jsonapi.Error {
 	}
 }
 
+// adminSentinelJSONAPIError maps the admin-only guard sentinels
+// (RequireSystemAdmin, the #1747 block guards, the #1750 impersonation
+// guards) to their JSON:API wire shape. Extracted as a single
+// early-return helper called before the toJSONAPIError switch so the
+// switch stays under the gocyclo budget; ok=false when err is not an
+// admin sentinel, leaving the switch to handle it.
+func adminSentinelJSONAPIError(err error) (jsonapi.Error, bool) {
+	switch {
+	case errors.Is(err, ErrNotSystemAdmin):
+		// Reached via renderEntityError if a handler returns the sentinel
+		// instead of relying on RequireSystemAdmin (the middleware writes
+		// its own response). 403 + admin.forbidden code keeps the wire
+		// shape identical so the FE doesn't need a second branch.
+		return jsonapi.Error{
+			Err:            err,
+			UserError:      errormarshal.Marshal(err),
+			HTTPStatusCode: http.StatusForbidden,
+			StatusText:     "Forbidden",
+			Code:           adminForbiddenCode,
+		}, true
+	case errors.Is(err, ErrAdminCannotBlockSelf),
+		errors.Is(err, ErrAdminCannotBlockAdminWithoutForce):
+		// Admin block-guard rejections (#1747). Self-lockout and
+		// admin-on-admin without `force: true` both surface as 422 with
+		// a sentinel-specific JSON:API code so the FE can render
+		// targeted copy instead of a generic 422 toast.
+		return adminBlockGuardError(err), true
+	case errors.Is(err, ErrCannotImpersonateAdmin),
+		errors.Is(err, ErrTargetBlocked),
+		errors.Is(err, ErrNestedImpersonation),
+		errors.Is(err, ErrNotImpersonating):
+		// Impersonation guard rejections (#1750). Target-is-admin,
+		// target-blocked, nested-impersonation and not-active all surface
+		// as 422 with a sentinel-specific JSON:API code so the FE can
+		// render targeted copy. Extracted into a helper so the switch
+		// stays under the gocyclo budget.
+		return adminImpersonationGuardError(err), true
+	default:
+		return jsonapi.Error{}, false
+	}
+}
+
 func toJSONAPIError(err error) jsonapi.Error {
+	if jsErr, ok := adminSentinelJSONAPIError(err); ok {
+		return jsErr
+	}
 	switch {
 	case errors.Is(err, registry.ErrCannotDelete):
 		return NewUnprocessableEntityError(err)
@@ -349,35 +394,6 @@ func toJSONAPIError(err error) jsonapi.Error {
 		return NewBadRequestError(err)
 	case errors.Is(err, ErrInvalidUploadSlot):
 		return NewBadRequestError(err)
-	case errors.Is(err, ErrNotSystemAdmin):
-		// Reached via renderEntityError if a handler returns the sentinel
-		// instead of relying on RequireSystemAdmin (the middleware writes
-		// its own response). 403 + admin.forbidden code keeps the wire
-		// shape identical so the FE doesn't need a second branch.
-		return jsonapi.Error{
-			Err:            err,
-			UserError:      errormarshal.Marshal(err),
-			HTTPStatusCode: http.StatusForbidden,
-			StatusText:     "Forbidden",
-			Code:           adminForbiddenCode,
-		}
-	case errors.Is(err, ErrAdminCannotBlockSelf),
-		errors.Is(err, ErrAdminCannotBlockAdminWithoutForce):
-		// Admin block-guard rejections (#1747). Self-lockout and
-		// admin-on-admin without `force: true` both surface as 422 with
-		// a sentinel-specific JSON:API code so the FE can render
-		// targeted copy instead of a generic 422 toast.
-		return adminBlockGuardError(err)
-	case errors.Is(err, ErrCannotImpersonateAdmin),
-		errors.Is(err, ErrTargetBlocked),
-		errors.Is(err, ErrNestedImpersonation),
-		errors.Is(err, ErrNotImpersonating):
-		// Impersonation guard rejections (#1750). Target-is-admin,
-		// target-blocked, nested-impersonation and not-active all surface
-		// as 422 with a sentinel-specific JSON:API code so the FE can
-		// render targeted copy. Extracted into a helper so the switch
-		// stays under the gocyclo budget.
-		return adminImpersonationGuardError(err)
 	default:
 		slog.Error("internal server error", "error", err)
 		return NewInternalServerError(err)

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -77,10 +77,22 @@ var (
 	// "admin.impersonate.nested".
 	ErrNestedImpersonation = errx.NewSentinel("cannot start impersonation from an impersonated session")
 	// ErrNotImpersonating is returned by POST /admin/impersonation/end and
-	// GET /admin/impersonation/current when the caller's access token is
-	// not an impersonation token (`imp` is absent or false). 422 +
-	// JSON:API code "admin.impersonate.not_active".
+	// GET /admin/impersonation/current when the caller holds a validly
+	// signed impersonation token but no live server-side session backs it
+	// (the return slot is missing or its operator-of-record disagrees with
+	// the token). This is a business-rule outcome — the request
+	// authenticated fine, there is just nothing to end. 422 + JSON:API
+	// code "admin.impersonate.not_active".
 	ErrNotImpersonating = errx.NewSentinel("no active impersonation session")
+	// ErrImpersonationTokenInvalid is returned by POST /admin/impersonation/end
+	// when the Authorization header is missing/malformed, the token's
+	// signature or algorithm is invalid, or the token is not an
+	// impersonation token. The `end` route is mounted WITHOUT JWTMiddleware,
+	// so this sentinel re-introduces the authentication failure the
+	// middleware would otherwise raise: it is an AUTHENTICATION failure,
+	// not a business-rule violation, and maps to 401 — distinct from
+	// ErrNotImpersonating's 422. Surfaced via NewUnauthorizedError.
+	ErrImpersonationTokenInvalid = errx.NewSentinel("invalid or missing impersonation token")
 	// ErrImpersonationTokenCannotRefresh is returned by POST /auth/refresh
 	// when the caller presents an impersonation access token. Impersonation
 	// sessions are deliberately non-refreshable so they expire hard at the
@@ -356,6 +368,13 @@ func toJSONAPIError(err error) jsonapi.Error {
 	case errors.Is(err, services.ErrInvalidConfirmation),
 		errors.Is(err, services.ErrInvalidPassword):
 		return NewUnprocessableEntityError(err)
+	case errors.Is(err, ErrImpersonationTokenInvalid):
+		// #1750: POST /admin/impersonation/end self-validates the imp token
+		// off the Authorization header (the route is mounted without
+		// JWTMiddleware). A missing/malformed/forged/non-impersonation
+		// token is an authentication failure — 401, not the 422 reserved
+		// for a validly-signed token with no active session.
+		return NewUnauthorizedError(err)
 	case errors.Is(err, services.ErrTenantMismatch):
 		// #1749: an admin add-member request named a user whose tenant
 		// differs from the group's tenant. A membership crosses no

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -109,6 +109,11 @@ const (
 	// AdminImpersonateRateLimitedCode signals "the per-admin impersonation
 	// start rate limit was exceeded". Maps to a 429.
 	AdminImpersonateRateLimitedCode = "admin.impersonate.rate_limited"
+	// AdminImpersonateReasonTooLongCode signals "the supplied impersonation
+	// reason exceeds the 500-character cap". Maps to a 422 — mirrors the
+	// admin.block.reason_too_long contract so the FE handles an over-long
+	// reason identically across the block and impersonate forms.
+	AdminImpersonateReasonTooLongCode = "admin.impersonate.reason_too_long"
 )
 
 func NewNotFoundError(err error) jsonapi.Error {

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	JWTSecret                     string `yaml:"jwt_secret" env:"JWT_SECRET" env-default:""`
 	FileSigningKey                string `yaml:"file_signing_key" env:"FILE_SIGNING_KEY" env-default:""`
 	FileURLExpiration             string `yaml:"file_url_expiration" env:"FILE_URL_EXPIRATION" env-default:"15m"`
+	ImpersonationTTL              string `yaml:"impersonation_ttl" env:"IMPERSONATION_TTL" env-default:"30m"`
 	ThumbnailMaxConcurrentPerUser int    `yaml:"thumbnail_max_concurrent_per_user" env:"THUMBNAIL_MAX_CONCURRENT_PER_USER" env-default:"0"`
 	ThumbnailRateLimitPerMinute   int    `yaml:"thumbnail_rate_limit_per_minute" env:"THUMBNAIL_RATE_LIMIT_PER_MINUTE" env-default:"0"`
 	ThumbnailSlotDuration         string `yaml:"thumbnail_slot_duration" env:"THUMBNAIL_SLOT_DURATION" env-default:"30m"`
@@ -144,6 +145,12 @@ func (c *Config) SetDefaults() {
 	}
 	if c.ProbeAddr == "" {
 		c.ProbeAddr = ":3334"
+	}
+	if c.ImpersonationTTL == "" {
+		// #1750: 30 min is the spec default and also the hard ceiling
+		// the apiserver clamps to. An empty value here just means the
+		// env-default did not apply (e.g. config loaded from YAML).
+		c.ImpersonationTTL = "30m"
 	}
 }
 

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -42,6 +42,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags.StringVar(&cfg.JWTSecret, "jwt-secret", cfg.JWTSecret, "JWT secret for authentication (minimum 32 characters, auto-generated if not provided)")
 	flags.StringVar(&cfg.FileSigningKey, "file-signing-key", cfg.FileSigningKey, "File signing key for secure file URLs (minimum 32 characters, auto-generated if not provided)")
 	flags.StringVar(&cfg.FileURLExpiration, "file-url-expiration", cfg.FileURLExpiration, "File URL expiration duration (e.g., 15m, 1h, 30s)")
+	flags.StringVar(&cfg.ImpersonationTTL, "impersonation-ttl", cfg.ImpersonationTTL, "Admin impersonation session lifetime (e.g., 30m, 15m); values above 30m are clamped down")
 	flags.StringVar(&cfg.TokenBlacklistRedisURL, "token-blacklist-redis-url", cfg.TokenBlacklistRedisURL, "Redis URL for token blacklist (e.g., redis://localhost:6379/0); omit to use in-memory blacklist")
 	flags.StringVar(&cfg.AuthRateLimitRedisURL, "auth-rate-limit-redis-url", cfg.AuthRateLimitRedisURL, "Redis URL for auth rate limiting/lockout (e.g., redis://localhost:6379/0); omit to use in-memory limiter")
 	flags.BoolVar(&cfg.AuthRateLimitDisabled, "no-auth-rate-limit", cfg.AuthRateLimitDisabled, "Disable auth rate limiting entirely (for testing only — do not use in production)")

--- a/go/cmd/inventario/run/bootstrap/server_params.go
+++ b/go/cmd/inventario/run/bootstrap/server_params.go
@@ -64,9 +64,19 @@ func buildServerParams(cfg *Config, factorySet *registry.FactorySet, dsn string)
 		return serverSetup{}, err
 	}
 
+	// Parse the admin impersonation-session TTL (#1750). The apiserver
+	// clamps any value above the 30-min spec ceiling, so an over-long
+	// duration here is not rejected — only a syntactically invalid one.
+	impersonationTTL, err := time.ParseDuration(cfg.ImpersonationTTL)
+	if err != nil {
+		slog.Error("Failed to parse impersonation TTL duration", "error", err, "duration", cfg.ImpersonationTTL)
+		return serverSetup{}, err
+	}
+
 	params.JWTSecret = jwtSecret
 	params.FileSigningKey = fileSigningKey
 	params.FileURLExpiration = fileURLExpiration
+	params.ImpersonationTTL = impersonationTTL
 	params.ThumbnailConfig = services.ThumbnailGenerationConfig{
 		MaxConcurrentPerUser: cfg.ThumbnailMaxConcurrentPerUser,
 		RateLimitPerMinute:   cfg.ThumbnailRateLimitPerMinute,

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -458,7 +458,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Forbidden - system-admin or active impersonation session required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -468,7 +468,7 @@ const docTemplate = `{
         },
         "/admin/impersonation/end": {
             "post": {
-                "description": "Ends the active impersonation session: blacklists the impersonation access token, restores the operator's\nown refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation\naccess token (the token carrying ` + "`" + `imp=true` + "`" + `). The token's signature is always verified; an expired\nimpersonation token is still accepted here so an operator can end an idle session without re-logging in.\nReturns 422 with ` + "`" + `admin.impersonate.not_active` + "`" + ` when the caller is not inside an impersonation session.",
+                "description": "Ends the active impersonation session: blacklists the impersonation access token, restores the operator's\nown refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation\naccess token (the token carrying ` + "`" + `imp=true` + "`" + `). The token's signature is always verified; an expired\nimpersonation token is still accepted here so an operator can end an idle session without re-logging in.\nReturns 422 with ` + "`" + `admin.impersonate.not_active` + "`" + ` when the caller is not inside an impersonation session.\nThis endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the\nAuthorization header, so it never produces a middleware 401/403: a missing, malformed, forged, or\nnon-impersonation token (and a missing/mismatched return slot) all collapse to the 422\n` + "`" + `admin.impersonate.not_active` + "`" + ` response. A 500 is returned only on a genuine store or registry fault.",
                 "produces": [
                     "application/json"
                 ],
@@ -483,20 +483,14 @@ const docTemplate = `{
                             "$ref": "#/definitions/apiserver.LoginResponse"
                         }
                     },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden - system-admin required",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
                     "422": {
-                        "description": "Unprocessable Entity - no active impersonation session",
+                        "description": "Unprocessable Entity - no active impersonation session (also covers a missing/invalid impersonation token)",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error - return-slot store or registry fault",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -7485,8 +7479,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "reason": {
-                    "description": "Reason is the optional free-form justification for the\nimpersonation (max 500 chars).",
-                    "type": "string"
+                    "description": "Reason is the optional free-form justification for the\nimpersonation (max 500 chars). The maxLength struct tag surfaces\nthe cap into the generated OpenAPI schema; the handler enforces\nthe same bound at decode time (impersonationReasonMaxLen).",
+                    "type": "string",
+                    "maxLength": 500
                 }
             }
         },

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -434,6 +434,76 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/impersonation/current": {
+            "get": {
+                "description": "Convenience read for the FE impersonation banner. Returns ` + "`" + `active=false` + "`" + ` with no other fields when the caller is not inside an impersonation session, and the target/admin/started_at/expires_at quartet when it is.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Read the active impersonation session (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.ImpersonationStateResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/impersonation/end": {
+            "post": {
+                "description": "Ends the active impersonation session: blacklists the impersonation access token and restores the operator's own session. Must be called with the impersonation access token (the token carrying ` + "`" + `imp=true` + "`" + `).\nReturns 422 with ` + "`" + `admin.impersonate.not_active` + "`" + ` when the caller is not inside an impersonation session.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "End an impersonation session (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.LoginResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - no active impersonation session",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/tenants": {
             "get": {
                 "description": "Returns every tenant with computed user_count and group_count. Pagination via ?page\u0026per_page; ?q matches name/slug/domain (ILIKE); ?sort=\u003cfield\u003e with optional ` + "`" + `-` + "`" + ` prefix for desc, or explicit ?order=asc|desc.",
@@ -739,6 +809,82 @@ const docTemplate = `{
                     },
                     "422": {
                         "description": "Unprocessable Entity - self-block or admin-on-admin without force",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users/{userID}/impersonate": {
+            "post": {
+                "description": "Issues a short-lived impersonation access token for the target user and sets it as the active session.\nThe token carries ` + "`" + `imp=true` + "`" + `, ` + "`" + `impersonated_by=\u003cadminID\u003e` + "`" + `, and ` + "`" + `is_system_admin=false` + "`" + `; it cannot be\nrefreshed and cannot start a nested impersonation.\nReturns 422 with ` + "`" + `admin.impersonate.target_is_admin` + "`" + ` when the target is a system admin,\n` + "`" + `admin.impersonate.target_blocked` + "`" + ` when the target account is blocked, and ` + "`" + `admin.impersonate.nested` + "`" + `\nwhen the caller is already impersonating. Returns 429 with ` + "`" + `admin.impersonate.rate_limited` + "`" + ` when the\nper-admin start rate limit (10/hour) is exceeded.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Start an impersonation session (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Target user ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Optional impersonation reason",
+                        "name": "data",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.ImpersonateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.LoginResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown user",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - target is admin / blocked / nested impersonation",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests - per-admin rate limit",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -7332,6 +7478,64 @@ const docTemplate = `{
                 },
                 "weekly_digest": {
                     "type": "boolean"
+                }
+            }
+        },
+        "apiserver.ImpersonateRequest": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "description": "Reason is the optional free-form justification for the\nimpersonation (max 500 chars).",
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.ImpersonationStateResponse": {
+            "type": "object",
+            "properties": {
+                "active": {
+                    "description": "Active reports whether the caller is inside an impersonation session.",
+                    "type": "boolean"
+                },
+                "admin_user": {
+                    "description": "AdminUser is the operator who initiated the session — nil when\nActive is false.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/apiserver.ImpersonationUserView"
+                        }
+                    ]
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "description": "StartedAt / ExpiresAt bound the session — zero values when inactive.",
+                    "type": "string"
+                },
+                "target_user": {
+                    "description": "TargetUser is the impersonated user — nil when Active is false.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/apiserver.ImpersonationUserView"
+                        }
+                    ]
+                }
+            }
+        },
+        "apiserver.ImpersonationUserView": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
                 }
             }
         },

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -468,7 +468,7 @@ const docTemplate = `{
         },
         "/admin/impersonation/end": {
             "post": {
-                "description": "Ends the active impersonation session: blacklists the impersonation access token, restores the operator's\nown refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation\naccess token (the token carrying ` + "`" + `imp=true` + "`" + `). The token's signature is always verified; an expired\nimpersonation token is still accepted here so an operator can end an idle session without re-logging in.\nReturns 422 with ` + "`" + `admin.impersonate.not_active` + "`" + ` when the caller is not inside an impersonation session.\nThis endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the\nAuthorization header, so it never produces a middleware 401/403: a missing, malformed, forged, or\nnon-impersonation token (and a missing/mismatched return slot) all collapse to the 422\n` + "`" + `admin.impersonate.not_active` + "`" + ` response. A 500 is returned only on a genuine store or registry fault.",
+                "description": "Ends the active impersonation session: blacklists the impersonation access token, restores the operator's\nown refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation\naccess token (the token carrying ` + "`" + `imp=true` + "`" + `). The token's signature is always verified; an expired\nimpersonation token is still accepted here so an operator can end an idle session without re-logging in.\nThe request must also carry the httpOnly ` + "`" + `refresh_token` + "`" + ` cookie holding the ` + "`" + `imp:\u003cjti\u003e` + "`" + ` marker that\nimpersonation-start planted — proof the call comes from the operator's own browser. A stolen bearer\ntoken alone, without that cookie, cannot be redeemed for admin credentials.\nThis endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the\nAuthorization header. Returns 401 when the token is missing, malformed, forged, or not an impersonation\ntoken (an authentication failure). Returns 422 with ` + "`" + `admin.impersonate.not_active` + "`" + ` when the token is a\nvalidly-signed impersonation token but no active session backs it — the return slot is missing, the\nslot's operator disagrees with the token, or the operator's marker refresh cookie is absent/mismatched.\nA 500 is returned only on a genuine store or registry fault.",
                 "produces": [
                     "application/json"
                 ],
@@ -483,8 +483,14 @@ const docTemplate = `{
                             "$ref": "#/definitions/apiserver.LoginResponse"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized - missing, malformed, forged, or non-impersonation token",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
                     "422": {
-                        "description": "Unprocessable Entity - no active impersonation session (also covers a missing/invalid impersonation token)",
+                        "description": "Unprocessable Entity - no active impersonation session (missing/mismatched return slot or marker cookie)",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -468,7 +468,7 @@ const docTemplate = `{
         },
         "/admin/impersonation/end": {
             "post": {
-                "description": "Ends the active impersonation session: blacklists the impersonation access token and restores the operator's own session. Must be called with the impersonation access token (the token carrying ` + "`" + `imp=true` + "`" + `).\nReturns 422 with ` + "`" + `admin.impersonate.not_active` + "`" + ` when the caller is not inside an impersonation session.",
+                "description": "Ends the active impersonation session: blacklists the impersonation access token, restores the operator's\nown refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation\naccess token (the token carrying ` + "`" + `imp=true` + "`" + `). The token's signature is always verified; an expired\nimpersonation token is still accepted here so an operator can end an idle session without re-logging in.\nReturns 422 with ` + "`" + `admin.impersonate.not_active` + "`" + ` when the caller is not inside an impersonation session.",
                 "produces": [
                     "application/json"
                 ],
@@ -818,7 +818,7 @@ const docTemplate = `{
         },
         "/admin/users/{userID}/impersonate": {
             "post": {
-                "description": "Issues a short-lived impersonation access token for the target user and sets it as the active session.\nThe token carries ` + "`" + `imp=true` + "`" + `, ` + "`" + `impersonated_by=\u003cadminID\u003e` + "`" + `, and ` + "`" + `is_system_admin=false` + "`" + `; it cannot be\nrefreshed and cannot start a nested impersonation.\nReturns 422 with ` + "`" + `admin.impersonate.target_is_admin` + "`" + ` when the target is a system admin,\n` + "`" + `admin.impersonate.target_blocked` + "`" + ` when the target account is blocked, and ` + "`" + `admin.impersonate.nested` + "`" + `\nwhen the caller is already impersonating. Returns 429 with ` + "`" + `admin.impersonate.rate_limited` + "`" + ` when the\nper-admin start rate limit (10/hour) is exceeded.",
+                "description": "Issues a short-lived impersonation access token for the target user and sets it as the active session.\nThe token carries ` + "`" + `imp=true` + "`" + `, ` + "`" + `impersonated_by=\u003cadminID\u003e` + "`" + `, and ` + "`" + `is_system_admin=false` + "`" + `; it cannot be\nrefreshed and cannot start a nested impersonation. The admin's own refresh-token cookie is replaced\nwith a non-refreshable impersonation marker for the duration of the session; POST /admin/impersonation/end\nrestores the operator's original refresh cookie.\nReturns 422 with ` + "`" + `admin.impersonate.target_is_admin` + "`" + ` when the target is a system admin,\n` + "`" + `admin.impersonate.target_blocked` + "`" + ` when the target account is blocked, and ` + "`" + `admin.impersonate.nested` + "`" + `\nwhen the caller is already impersonating. Returns 429 with ` + "`" + `admin.impersonate.rate_limited` + "`" + ` when the\nper-admin start rate limit (10/hour) is exceeded.",
                 "consumes": [
                     "application/json"
                 ],

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -878,7 +878,7 @@ const docTemplate = `{
                         }
                     },
                     "422": {
-                        "description": "Unprocessable Entity - target is admin / blocked / nested impersonation",
+                        "description": "Unprocessable Entity - target is admin / blocked / nested impersonation / reason too long",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -461,7 +461,7 @@
         },
         "/admin/impersonation/end": {
             "post": {
-                "description": "Ends the active impersonation session: blacklists the impersonation access token and restores the operator's own session. Must be called with the impersonation access token (the token carrying `imp=true`).\nReturns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.",
+                "description": "Ends the active impersonation session: blacklists the impersonation access token, restores the operator's\nown refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation\naccess token (the token carrying `imp=true`). The token's signature is always verified; an expired\nimpersonation token is still accepted here so an operator can end an idle session without re-logging in.\nReturns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.",
                 "produces": [
                     "application/json"
                 ],
@@ -811,7 +811,7 @@
         },
         "/admin/users/{userID}/impersonate": {
             "post": {
-                "description": "Issues a short-lived impersonation access token for the target user and sets it as the active session.\nThe token carries `imp=true`, `impersonated_by=\u003cadminID\u003e`, and `is_system_admin=false`; it cannot be\nrefreshed and cannot start a nested impersonation.\nReturns 422 with `admin.impersonate.target_is_admin` when the target is a system admin,\n`admin.impersonate.target_blocked` when the target account is blocked, and `admin.impersonate.nested`\nwhen the caller is already impersonating. Returns 429 with `admin.impersonate.rate_limited` when the\nper-admin start rate limit (10/hour) is exceeded.",
+                "description": "Issues a short-lived impersonation access token for the target user and sets it as the active session.\nThe token carries `imp=true`, `impersonated_by=\u003cadminID\u003e`, and `is_system_admin=false`; it cannot be\nrefreshed and cannot start a nested impersonation. The admin's own refresh-token cookie is replaced\nwith a non-refreshable impersonation marker for the duration of the session; POST /admin/impersonation/end\nrestores the operator's original refresh cookie.\nReturns 422 with `admin.impersonate.target_is_admin` when the target is a system admin,\n`admin.impersonate.target_blocked` when the target account is blocked, and `admin.impersonate.nested`\nwhen the caller is already impersonating. Returns 429 with `admin.impersonate.rate_limited` when the\nper-admin start rate limit (10/hour) is exceeded.",
                 "consumes": [
                     "application/json"
                 ],

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -451,7 +451,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Forbidden - system-admin or active impersonation session required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -461,7 +461,7 @@
         },
         "/admin/impersonation/end": {
             "post": {
-                "description": "Ends the active impersonation session: blacklists the impersonation access token, restores the operator's\nown refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation\naccess token (the token carrying `imp=true`). The token's signature is always verified; an expired\nimpersonation token is still accepted here so an operator can end an idle session without re-logging in.\nReturns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.",
+                "description": "Ends the active impersonation session: blacklists the impersonation access token, restores the operator's\nown refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation\naccess token (the token carrying `imp=true`). The token's signature is always verified; an expired\nimpersonation token is still accepted here so an operator can end an idle session without re-logging in.\nReturns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.\nThis endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the\nAuthorization header, so it never produces a middleware 401/403: a missing, malformed, forged, or\nnon-impersonation token (and a missing/mismatched return slot) all collapse to the 422\n`admin.impersonate.not_active` response. A 500 is returned only on a genuine store or registry fault.",
                 "produces": [
                     "application/json"
                 ],
@@ -476,20 +476,14 @@
                             "$ref": "#/definitions/apiserver.LoginResponse"
                         }
                     },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden - system-admin required",
-                        "schema": {
-                            "$ref": "#/definitions/jsonapi.Errors"
-                        }
-                    },
                     "422": {
-                        "description": "Unprocessable Entity - no active impersonation session",
+                        "description": "Unprocessable Entity - no active impersonation session (also covers a missing/invalid impersonation token)",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error - return-slot store or registry fault",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -7478,8 +7472,9 @@
             "type": "object",
             "properties": {
                 "reason": {
-                    "description": "Reason is the optional free-form justification for the\nimpersonation (max 500 chars).",
-                    "type": "string"
+                    "description": "Reason is the optional free-form justification for the\nimpersonation (max 500 chars). The maxLength struct tag surfaces\nthe cap into the generated OpenAPI schema; the handler enforces\nthe same bound at decode time (impersonationReasonMaxLen).",
+                    "type": "string",
+                    "maxLength": 500
                 }
             }
         },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -427,6 +427,76 @@
                 }
             }
         },
+        "/admin/impersonation/current": {
+            "get": {
+                "description": "Convenience read for the FE impersonation banner. Returns `active=false` with no other fields when the caller is not inside an impersonation session, and the target/admin/started_at/expires_at quartet when it is.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Read the active impersonation session (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.ImpersonationStateResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/impersonation/end": {
+            "post": {
+                "description": "Ends the active impersonation session: blacklists the impersonation access token and restores the operator's own session. Must be called with the impersonation access token (the token carrying `imp=true`).\nReturns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "End an impersonation session (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.LoginResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - no active impersonation session",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/tenants": {
             "get": {
                 "description": "Returns every tenant with computed user_count and group_count. Pagination via ?page\u0026per_page; ?q matches name/slug/domain (ILIKE); ?sort=\u003cfield\u003e with optional `-` prefix for desc, or explicit ?order=asc|desc.",
@@ -732,6 +802,82 @@
                     },
                     "422": {
                         "description": "Unprocessable Entity - self-block or admin-on-admin without force",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users/{userID}/impersonate": {
+            "post": {
+                "description": "Issues a short-lived impersonation access token for the target user and sets it as the active session.\nThe token carries `imp=true`, `impersonated_by=\u003cadminID\u003e`, and `is_system_admin=false`; it cannot be\nrefreshed and cannot start a nested impersonation.\nReturns 422 with `admin.impersonate.target_is_admin` when the target is a system admin,\n`admin.impersonate.target_blocked` when the target account is blocked, and `admin.impersonate.nested`\nwhen the caller is already impersonating. Returns 429 with `admin.impersonate.rate_limited` when the\nper-admin start rate limit (10/hour) is exceeded.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Start an impersonation session (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Target user ID",
+                        "name": "userID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Optional impersonation reason",
+                        "name": "data",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.ImpersonateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.LoginResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - system-admin required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown user",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - target is admin / blocked / nested impersonation",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests - per-admin rate limit",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -7325,6 +7471,64 @@
                 },
                 "weekly_digest": {
                     "type": "boolean"
+                }
+            }
+        },
+        "apiserver.ImpersonateRequest": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "description": "Reason is the optional free-form justification for the\nimpersonation (max 500 chars).",
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.ImpersonationStateResponse": {
+            "type": "object",
+            "properties": {
+                "active": {
+                    "description": "Active reports whether the caller is inside an impersonation session.",
+                    "type": "boolean"
+                },
+                "admin_user": {
+                    "description": "AdminUser is the operator who initiated the session — nil when\nActive is false.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/apiserver.ImpersonationUserView"
+                        }
+                    ]
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "description": "StartedAt / ExpiresAt bound the session — zero values when inactive.",
+                    "type": "string"
+                },
+                "target_user": {
+                    "description": "TargetUser is the impersonated user — nil when Active is false.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/apiserver.ImpersonationUserView"
+                        }
+                    ]
+                }
+            }
+        },
+        "apiserver.ImpersonationUserView": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
                 }
             }
         },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -461,7 +461,7 @@
         },
         "/admin/impersonation/end": {
             "post": {
-                "description": "Ends the active impersonation session: blacklists the impersonation access token, restores the operator's\nown refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation\naccess token (the token carrying `imp=true`). The token's signature is always verified; an expired\nimpersonation token is still accepted here so an operator can end an idle session without re-logging in.\nReturns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.\nThis endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the\nAuthorization header, so it never produces a middleware 401/403: a missing, malformed, forged, or\nnon-impersonation token (and a missing/mismatched return slot) all collapse to the 422\n`admin.impersonate.not_active` response. A 500 is returned only on a genuine store or registry fault.",
+                "description": "Ends the active impersonation session: blacklists the impersonation access token, restores the operator's\nown refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation\naccess token (the token carrying `imp=true`). The token's signature is always verified; an expired\nimpersonation token is still accepted here so an operator can end an idle session without re-logging in.\nThe request must also carry the httpOnly `refresh_token` cookie holding the `imp:\u003cjti\u003e` marker that\nimpersonation-start planted — proof the call comes from the operator's own browser. A stolen bearer\ntoken alone, without that cookie, cannot be redeemed for admin credentials.\nThis endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the\nAuthorization header. Returns 401 when the token is missing, malformed, forged, or not an impersonation\ntoken (an authentication failure). Returns 422 with `admin.impersonate.not_active` when the token is a\nvalidly-signed impersonation token but no active session backs it — the return slot is missing, the\nslot's operator disagrees with the token, or the operator's marker refresh cookie is absent/mismatched.\nA 500 is returned only on a genuine store or registry fault.",
                 "produces": [
                     "application/json"
                 ],
@@ -476,8 +476,14 @@
                             "$ref": "#/definitions/apiserver.LoginResponse"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized - missing, malformed, forged, or non-impersonation token",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
                     "422": {
-                        "description": "Unprocessable Entity - no active impersonation session (also covers a missing/invalid impersonation token)",
+                        "description": "Unprocessable Entity - no active impersonation session (missing/mismatched return slot or marker cookie)",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -871,7 +871,7 @@
                         }
                     },
                     "422": {
-                        "description": "Unprocessable Entity - target is admin / blocked / nested impersonation",
+                        "description": "Unprocessable Entity - target is admin / blocked / nested impersonation / reason too long",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -4733,6 +4733,7 @@ paths:
             $ref: '#/definitions/jsonapi.Errors'
         "422":
           description: Unprocessable Entity - target is admin / blocked / nested impersonation
+            / reason too long
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "429":

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -4448,11 +4448,15 @@ paths:
         own refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation
         access token (the token carrying `imp=true`). The token's signature is always verified; an expired
         impersonation token is still accepted here so an operator can end an idle session without re-logging in.
-        Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
+        The request must also carry the httpOnly `refresh_token` cookie holding the `imp:<jti>` marker that
+        impersonation-start planted — proof the call comes from the operator's own browser. A stolen bearer
+        token alone, without that cookie, cannot be redeemed for admin credentials.
         This endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the
-        Authorization header, so it never produces a middleware 401/403: a missing, malformed, forged, or
-        non-impersonation token (and a missing/mismatched return slot) all collapse to the 422
-        `admin.impersonate.not_active` response. A 500 is returned only on a genuine store or registry fault.
+        Authorization header. Returns 401 when the token is missing, malformed, forged, or not an impersonation
+        token (an authentication failure). Returns 422 with `admin.impersonate.not_active` when the token is a
+        validly-signed impersonation token but no active session backs it — the return slot is missing, the
+        slot's operator disagrees with the token, or the operator's marker refresh cookie is absent/mismatched.
+        A 500 is returned only on a genuine store or registry fault.
       produces:
       - application/json
       responses:
@@ -4460,9 +4464,14 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/apiserver.LoginResponse'
+        "401":
+          description: Unauthorized - missing, malformed, forged, or non-impersonation
+            token
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
         "422":
-          description: Unprocessable Entity - no active impersonation session (also
-            covers a missing/invalid impersonation token)
+          description: Unprocessable Entity - no active impersonation session (missing/mismatched
+            return slot or marker cookie)
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "500":

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -188,6 +188,47 @@ definitions:
       weekly_digest:
         type: boolean
     type: object
+  apiserver.ImpersonateRequest:
+    properties:
+      reason:
+        description: |-
+          Reason is the optional free-form justification for the
+          impersonation (max 500 chars).
+        type: string
+    type: object
+  apiserver.ImpersonationStateResponse:
+    properties:
+      active:
+        description: Active reports whether the caller is inside an impersonation
+          session.
+        type: boolean
+      admin_user:
+        allOf:
+        - $ref: '#/definitions/apiserver.ImpersonationUserView'
+        description: |-
+          AdminUser is the operator who initiated the session — nil when
+          Active is false.
+      expires_at:
+        type: string
+      started_at:
+        description: StartedAt / ExpiresAt bound the session — zero values when inactive.
+        type: string
+      target_user:
+        allOf:
+        - $ref: '#/definitions/apiserver.ImpersonationUserView'
+        description: TargetUser is the impersonated user — nil when Active is false.
+    type: object
+  apiserver.ImpersonationUserView:
+    properties:
+      email:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      tenant_id:
+        type: string
+    type: object
   apiserver.LoginEventView:
     properties:
       created_at:
@@ -4374,6 +4415,56 @@ paths:
       summary: Change a member's role (admin)
       tags:
       - admin
+  /admin/impersonation/current:
+    get:
+      description: Convenience read for the FE impersonation banner. Returns `active=false`
+        with no other fields when the caller is not inside an impersonation session,
+        and the target/admin/started_at/expires_at quartet when it is.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.ImpersonationStateResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Forbidden - system-admin required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Read the active impersonation session (admin)
+      tags:
+      - admin
+  /admin/impersonation/end:
+    post:
+      description: |-
+        Ends the active impersonation session: blacklists the impersonation access token and restores the operator's own session. Must be called with the impersonation access token (the token carrying `imp=true`).
+        Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.LoginResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Forbidden - system-admin required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Unprocessable Entity - no active impersonation session
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: End an impersonation session (admin)
+      tags:
+      - admin
   /admin/tenants:
     get:
       description: Returns every tenant with computed user_count and group_count.
@@ -4592,6 +4683,63 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: Block (deactivate) a user account
+      tags:
+      - admin
+  /admin/users/{userID}/impersonate:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Issues a short-lived impersonation access token for the target user and sets it as the active session.
+        The token carries `imp=true`, `impersonated_by=<adminID>`, and `is_system_admin=false`; it cannot be
+        refreshed and cannot start a nested impersonation.
+        Returns 422 with `admin.impersonate.target_is_admin` when the target is a system admin,
+        `admin.impersonate.target_blocked` when the target account is blocked, and `admin.impersonate.nested`
+        when the caller is already impersonating. Returns 429 with `admin.impersonate.rate_limited` when the
+        per-admin start rate limit (10/hour) is exceeded.
+      parameters:
+      - description: Target user ID
+        in: path
+        name: userID
+        required: true
+        type: string
+      - description: Optional impersonation reason
+        in: body
+        name: data
+        schema:
+          $ref: '#/definitions/apiserver.ImpersonateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.LoginResponse'
+        "400":
+          description: Bad Request - invalid body
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Forbidden - system-admin required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Not Found - unknown user
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Unprocessable Entity - target is admin / blocked / nested impersonation
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "429":
+          description: Too Many Requests - per-admin rate limit
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Start an impersonation session (admin)
       tags:
       - admin
   /admin/users/{userID}/unblock:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -193,7 +193,10 @@ definitions:
       reason:
         description: |-
           Reason is the optional free-form justification for the
-          impersonation (max 500 chars).
+          impersonation (max 500 chars). The maxLength struct tag surfaces
+          the cap into the generated OpenAPI schema; the handler enforces
+          the same bound at decode time (impersonationReasonMaxLen).
+        maxLength: 500
         type: string
     type: object
   apiserver.ImpersonationStateResponse:
@@ -4432,7 +4435,7 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Forbidden - system-admin or active impersonation session required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: Read the active impersonation session (admin)
@@ -4446,6 +4449,10 @@ paths:
         access token (the token carrying `imp=true`). The token's signature is always verified; an expired
         impersonation token is still accepted here so an operator can end an idle session without re-logging in.
         Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
+        This endpoint is mounted WITHOUT the JWT middleware and self-validates the impersonation token off the
+        Authorization header, so it never produces a middleware 401/403: a missing, malformed, forged, or
+        non-impersonation token (and a missing/mismatched return slot) all collapse to the 422
+        `admin.impersonate.not_active` response. A 500 is returned only on a genuine store or registry fault.
       produces:
       - application/json
       responses:
@@ -4453,16 +4460,13 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/apiserver.LoginResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
-        "403":
-          description: Forbidden - system-admin required
-          schema:
-            $ref: '#/definitions/jsonapi.Errors'
         "422":
-          description: Unprocessable Entity - no active impersonation session
+          description: Unprocessable Entity - no active impersonation session (also
+            covers a missing/invalid impersonation token)
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "500":
+          description: Internal Server Error - return-slot store or registry fault
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: End an impersonation session (admin)

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -4441,7 +4441,10 @@ paths:
   /admin/impersonation/end:
     post:
       description: |-
-        Ends the active impersonation session: blacklists the impersonation access token and restores the operator's own session. Must be called with the impersonation access token (the token carrying `imp=true`).
+        Ends the active impersonation session: blacklists the impersonation access token, restores the operator's
+        own refresh-token cookie, and mints a fresh admin access token. Must be called with the impersonation
+        access token (the token carrying `imp=true`). The token's signature is always verified; an expired
+        impersonation token is still accepted here so an operator can end an idle session without re-logging in.
         Returns 422 with `admin.impersonate.not_active` when the caller is not inside an impersonation session.
       produces:
       - application/json
@@ -4692,7 +4695,9 @@ paths:
       description: |-
         Issues a short-lived impersonation access token for the target user and sets it as the active session.
         The token carries `imp=true`, `impersonated_by=<adminID>`, and `is_system_admin=false`; it cannot be
-        refreshed and cannot start a nested impersonation.
+        refreshed and cannot start a nested impersonation. The admin's own refresh-token cookie is replaced
+        with a non-refreshable impersonation marker for the duration of the session; POST /admin/impersonation/end
+        restores the operator's original refresh cookie.
         Returns 422 with `admin.impersonate.target_is_admin` when the target is a system admin,
         `admin.impersonate.target_blocked` when the target account is blocked, and `admin.impersonate.nested`
         when the caller is already impersonating. Returns 429 with `admin.impersonate.rate_limited` when the

--- a/go/services/audit_service.go
+++ b/go/services/audit_service.go
@@ -109,17 +109,26 @@ func NewAuditService(auditRegistry registry.AuditLogRegistry) *AuditService {
 // It is intentionally best-effort: if persisting the log entry fails the error is
 // logged with slog but not returned to the caller so that auth flows are never
 // blocked by audit-log write failures.
+//
+// When the request context carries impersonation claims (`imp` == true),
+// the persisted row's ImpersonatedBy column records the operator-of-record
+// — symmetric with LogAdmin. This is what makes "every action inside an
+// impersonated session is logged with actor=target AND impersonated_by=admin"
+// (#1750) hold for the LogAuth-based audit call sites (e.g. the group
+// endpoints' group_delete row) without the call site knowing whether an
+// impersonation session is active.
 func (s *AuditService) LogAuth(ctx context.Context, ev AuthEvent) {
 	if s == nil || s.auditRegistry == nil {
 		return
 	}
 
 	entry := models.AuditLog{
-		Action:       ev.Action,
-		UserID:       ev.UserID,
-		TenantID:     ev.TenantID,
-		Success:      ev.Success,
-		ErrorMessage: ev.ErrMsg,
+		Action:         ev.Action,
+		UserID:         ev.UserID,
+		TenantID:       ev.TenantID,
+		Success:        ev.Success,
+		ErrorMessage:   ev.ErrMsg,
+		ImpersonatedBy: impersonatorFromContext(ctx),
 	}
 
 	if ev.Request != nil {

--- a/go/services/auth_rate_limiter.go
+++ b/go/services/auth_rate_limiter.go
@@ -28,6 +28,16 @@ const (
 	feedbackAttemptsLimit  = 5
 	feedbackAttemptsWindow = time.Hour
 
+	// impersonation session-start throttling (#1750). Per-admin rather
+	// than per-IP because the abuse vector is a single operator (or a
+	// compromised admin token) opening sessions in a loop, and the
+	// endpoint is gated by RequireSystemAdmin so the key is always a
+	// known user ID. 10/hour matches the issue spec — generous enough
+	// for legitimate support work, low enough to make a runaway script
+	// visible.
+	impersonationAttemptsLimit  = 10
+	impersonationAttemptsWindow = time.Hour
+
 	failedLoginLockoutThreshold = 5
 	failedLoginWindow           = 15 * time.Minute
 	accountLockoutDuration      = 15 * time.Minute
@@ -57,6 +67,12 @@ type AuthRateLimiter interface {
 	// `userID` (not IP) is the natural rate-limit key — see the
 	// feedbackAttemptsLimit comment for why IP-keying was rejected.
 	CheckFeedbackAttempt(ctx context.Context, userID string) (RateLimitResult, error)
+
+	// CheckImpersonationAttempt throttles admin impersonation session
+	// starts (#1750) on a per-admin basis. The endpoint is gated by
+	// RequireSystemAdmin, so `adminUserID` is the natural rate-limit
+	// key — see the impersonationAttemptsLimit comment for the rationale.
+	CheckImpersonationAttempt(ctx context.Context, adminUserID string) (RateLimitResult, error)
 
 	IsAccountLocked(ctx context.Context, email string) (locked bool, resetAt time.Time, err error)
 	RecordFailedLogin(ctx context.Context, email string) (locked bool, resetAt time.Time, err error)
@@ -143,6 +159,11 @@ func (l *RedisAuthRateLimiter) CheckPasswordResetAttempt(ctx context.Context, em
 func (l *RedisAuthRateLimiter) CheckFeedbackAttempt(ctx context.Context, userID string) (RateLimitResult, error) {
 	key := fmt.Sprintf("rate:feedback:user:%s", hashKeyPart(userID))
 	return l.checkRate(ctx, key, feedbackAttemptsLimit, feedbackAttemptsWindow)
+}
+
+func (l *RedisAuthRateLimiter) CheckImpersonationAttempt(ctx context.Context, adminUserID string) (RateLimitResult, error) {
+	key := fmt.Sprintf("rate:admin:impersonate:user:%s", hashKeyPart(adminUserID))
+	return l.checkRate(ctx, key, impersonationAttemptsLimit, impersonationAttemptsWindow)
 }
 
 func (l *RedisAuthRateLimiter) checkRate(ctx context.Context, key string, limit int, window time.Duration) (RateLimitResult, error) {
@@ -307,6 +328,11 @@ func (l *InMemoryAuthRateLimiter) CheckFeedbackAttempt(_ context.Context, userID
 	return l.checkRate(key, feedbackAttemptsLimit, feedbackAttemptsWindow), nil
 }
 
+func (l *InMemoryAuthRateLimiter) CheckImpersonationAttempt(_ context.Context, adminUserID string) (RateLimitResult, error) {
+	key := fmt.Sprintf("rate:admin:impersonate:user:%s", hashKeyPart(adminUserID))
+	return l.checkRate(key, impersonationAttemptsLimit, impersonationAttemptsWindow), nil
+}
+
 func (l *InMemoryAuthRateLimiter) checkRate(key string, limit int, window time.Duration) RateLimitResult {
 	now := l.now()
 	cutoff := now.Add(-window)
@@ -447,6 +473,10 @@ func (NoOpAuthRateLimiter) CheckPasswordResetAttempt(_ context.Context, _ string
 
 func (NoOpAuthRateLimiter) CheckFeedbackAttempt(_ context.Context, _ string) (RateLimitResult, error) {
 	return RateLimitResult{Allowed: true, Limit: feedbackAttemptsLimit, Remaining: feedbackAttemptsLimit, ResetAt: time.Now().Add(feedbackAttemptsWindow)}, nil
+}
+
+func (NoOpAuthRateLimiter) CheckImpersonationAttempt(_ context.Context, _ string) (RateLimitResult, error) {
+	return RateLimitResult{Allowed: true, Limit: impersonationAttemptsLimit, Remaining: impersonationAttemptsLimit, ResetAt: time.Now().Add(impersonationAttemptsWindow)}, nil
 }
 
 func (NoOpAuthRateLimiter) IsAccountLocked(_ context.Context, _ string) (bool, time.Time, error) {

--- a/go/services/impersonation_service.go
+++ b/go/services/impersonation_service.go
@@ -19,9 +19,11 @@ import (
 // The slot carries the raw refresh-token *value* the admin's session
 // was using at start-time — not its hash — so `end` can re-set the
 // httpOnly refresh cookie and mint a fresh access token for the admin.
-// The raw value never leaves the server: it is held in memory only for
-// the lifetime of the impersonation session and is discarded the moment
-// the session ends or expires.
+// The raw value is held server-side only transiently: for the lifetime
+// of the impersonation session and no longer (it is discarded the moment
+// the session ends or expires). It is only ever re-emitted to the
+// original operator's browser — and to no other client — via the
+// httpOnly `refresh_token` cookie that `end` restores.
 type ImpersonationSlot struct {
 	// JTI is the impersonation access token's unique id — the slot key.
 	JTI string

--- a/go/services/impersonation_service.go
+++ b/go/services/impersonation_service.go
@@ -72,8 +72,14 @@ type ImpersonationStore interface {
 }
 
 // InMemoryImpersonationStore is the default ImpersonationStore. Slots
-// are pruned lazily on every access so an abandoned session (admin
-// never calls `end`) cannot leak memory beyond one TTL window.
+// are pruned lazily — pruneLocked runs on every Put/Get, so an expired
+// slot is evicted the next time the store is touched, not at the moment
+// it expires. On a fully idle process (no further impersonation
+// activity) expired slots linger in the map past their TTL until the
+// next Put/Get. This is intentional: a slot is one tiny struct, slots
+// are ≤30-min lived, and any subsequent impersonation prunes them, so
+// the residual footprint is negligible and a background pruner
+// goroutine would not earn its keep.
 type InMemoryImpersonationStore struct {
 	now func() time.Time
 

--- a/go/services/impersonation_service.go
+++ b/go/services/impersonation_service.go
@@ -1,0 +1,127 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// ImpersonationSlot is the server-side "return slot" recorded when an
+// admin starts an impersonation session (#1750). It is keyed by the
+// impersonation access token's JTI and holds everything the
+// `end` endpoint needs to restore the admin's original session without
+// trusting any client-supplied state.
+//
+// The slot carries the raw refresh-token *value* the admin's session
+// was using at start-time — not its hash — so `end` can re-set the
+// httpOnly refresh cookie and mint a fresh access token for the admin.
+// The raw value never leaves the server: it is held in memory only for
+// the lifetime of the impersonation session and is discarded the moment
+// the session ends or expires.
+type ImpersonationSlot struct {
+	// JTI is the impersonation access token's unique id — the slot key.
+	JTI string
+	// AdminUserID is the operator who initiated the impersonation.
+	AdminUserID string
+	// AdminTenantID is the operator's tenant. System admins are not
+	// tenant-scoped for authorization, but the column is recorded so
+	// the audit trail and the restored admin session stay coherent.
+	AdminTenantID string
+	// AdminRefreshTokenRaw is the raw refresh-token value the admin's
+	// session held at start-time. Empty when the admin authenticated
+	// without a refresh cookie (e.g. a pure-bearer test client) — in
+	// that case `end` mints a brand-new admin session instead.
+	AdminRefreshTokenRaw string
+	// TargetUserID / TargetTenantID identify the impersonated user.
+	TargetUserID   string
+	TargetTenantID string
+	// Reason is the optional operator-supplied justification.
+	Reason string
+	// StartedAt / ExpiresAt bound the impersonation session. ExpiresAt
+	// mirrors the impersonation access token's exp claim.
+	StartedAt time.Time
+	ExpiresAt time.Time
+}
+
+// ImpersonationStore records and resolves impersonation return slots.
+// The single implementation is in-memory: a slot lives for at most the
+// impersonation TTL (≤ 30 min) and a process restart simply forces the
+// admin to log in again — an acceptable trade-off that avoids a schema
+// migration for short-lived ephemeral state. Multi-replica deployments
+// must run a shared implementation; the interface exists so one can be
+// dropped in without touching the handlers.
+type ImpersonationStore interface {
+	// Put records a new slot keyed by slot.JTI. An existing slot with
+	// the same JTI is overwritten — JTIs are UUIDs so a collision is a
+	// programming error, not a normal branch.
+	Put(ctx context.Context, slot ImpersonationSlot) error
+
+	// Get returns the slot for the given JTI. Returns registry.ErrNotFound
+	// when no live slot exists (never recorded, already ended, or expired).
+	Get(ctx context.Context, jti string) (ImpersonationSlot, error)
+
+	// Delete removes the slot for the given JTI. Idempotent: deleting a
+	// missing slot is not an error so a double `end` call is harmless.
+	Delete(ctx context.Context, jti string) error
+}
+
+// InMemoryImpersonationStore is the default ImpersonationStore. Slots
+// are pruned lazily on every access so an abandoned session (admin
+// never calls `end`) cannot leak memory beyond one TTL window.
+type InMemoryImpersonationStore struct {
+	now func() time.Time
+
+	mu    sync.Mutex
+	slots map[string]ImpersonationSlot
+}
+
+// NewInMemoryImpersonationStore creates an empty in-memory store.
+func NewInMemoryImpersonationStore() *InMemoryImpersonationStore {
+	return &InMemoryImpersonationStore{
+		now:   time.Now,
+		slots: make(map[string]ImpersonationSlot),
+	}
+}
+
+func (s *InMemoryImpersonationStore) Put(_ context.Context, slot ImpersonationSlot) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneLocked()
+	s.slots[slot.JTI] = slot
+	return nil
+}
+
+func (s *InMemoryImpersonationStore) Get(_ context.Context, jti string) (ImpersonationSlot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneLocked()
+	slot, ok := s.slots[jti]
+	if !ok {
+		return ImpersonationSlot{}, errxtrace.Classify(registry.ErrNotFound)
+	}
+	return slot, nil
+}
+
+func (s *InMemoryImpersonationStore) Delete(_ context.Context, jti string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.slots, jti)
+	return nil
+}
+
+// pruneLocked evicts every slot whose ExpiresAt is in the past. The
+// caller must hold s.mu. Called on Put/Get so memory stays bounded by
+// the number of *live* impersonation sessions regardless of how many
+// were abandoned without an explicit `end`.
+func (s *InMemoryImpersonationStore) pruneLocked() {
+	now := s.now()
+	for jti, slot := range s.slots {
+		if !slot.ExpiresAt.IsZero() && now.After(slot.ExpiresAt) {
+			delete(s.slots, jti)
+		}
+	}
+}

--- a/go/services/impersonation_service.go
+++ b/go/services/impersonation_service.go
@@ -87,6 +87,10 @@ func NewInMemoryImpersonationStore() *InMemoryImpersonationStore {
 	}
 }
 
+// Put records the slot keyed by slot.JTI, overwriting any existing slot
+// with the same JTI. Expired slots are pruned first so the map stays
+// bounded by the number of live impersonation sessions. See
+// ImpersonationStore.Put.
 func (s *InMemoryImpersonationStore) Put(_ context.Context, slot ImpersonationSlot) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -95,6 +99,9 @@ func (s *InMemoryImpersonationStore) Put(_ context.Context, slot ImpersonationSl
 	return nil
 }
 
+// Get returns the live slot for the given JTI, or registry.ErrNotFound
+// when no slot exists — never recorded, already ended, or pruned because
+// it expired. See ImpersonationStore.Get.
 func (s *InMemoryImpersonationStore) Get(_ context.Context, jti string) (ImpersonationSlot, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -106,6 +113,9 @@ func (s *InMemoryImpersonationStore) Get(_ context.Context, jti string) (Imperso
 	return slot, nil
 }
 
+// Delete removes the slot for the given JTI. Idempotent: deleting a
+// missing slot is a no-op, so a double `end` call is harmless. See
+// ImpersonationStore.Delete.
 func (s *InMemoryImpersonationStore) Delete(_ context.Context, jti string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/go/services/impersonation_service_test.go
+++ b/go/services/impersonation_service_test.go
@@ -1,0 +1,94 @@
+package services_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/services"
+)
+
+func TestInMemoryImpersonationStore_PutGetDelete(t *testing.T) {
+	c := qt.New(t)
+	store := services.NewInMemoryImpersonationStore()
+	ctx := context.Background()
+
+	slot := services.ImpersonationSlot{
+		JTI:            "jti-1",
+		AdminUserID:    "admin-1",
+		TargetUserID:   "target-1",
+		TargetTenantID: "tenant-1",
+		StartedAt:      time.Now(),
+		ExpiresAt:      time.Now().Add(30 * time.Minute),
+	}
+
+	c.Assert(store.Put(ctx, slot), qt.IsNil)
+
+	got, err := store.Get(ctx, "jti-1")
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.AdminUserID, qt.Equals, "admin-1")
+	c.Assert(got.TargetUserID, qt.Equals, "target-1")
+
+	c.Assert(store.Delete(ctx, "jti-1"), qt.IsNil)
+
+	_, err = store.Get(ctx, "jti-1")
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
+func TestInMemoryImpersonationStore_GetMissingReturnsNotFound(t *testing.T) {
+	c := qt.New(t)
+	store := services.NewInMemoryImpersonationStore()
+
+	_, err := store.Get(context.Background(), "never-recorded")
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
+func TestInMemoryImpersonationStore_DeleteIsIdempotent(t *testing.T) {
+	c := qt.New(t)
+	store := services.NewInMemoryImpersonationStore()
+
+	// Deleting a slot that was never recorded must not error — a double
+	// `end` call relies on this.
+	c.Assert(store.Delete(context.Background(), "missing"), qt.IsNil)
+}
+
+func TestInMemoryImpersonationStore_ExpiredSlotIsPruned(t *testing.T) {
+	c := qt.New(t)
+	store := services.NewInMemoryImpersonationStore()
+	ctx := context.Background()
+
+	expired := services.ImpersonationSlot{
+		JTI:       "expired-jti",
+		ExpiresAt: time.Now().Add(-time.Minute),
+	}
+	c.Assert(store.Put(ctx, expired), qt.IsNil)
+
+	// An expired slot is pruned lazily on the next access — Get reports
+	// it as not found rather than returning a stale session.
+	_, err := store.Get(ctx, "expired-jti")
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
+func TestInMemoryAuthRateLimiter_CheckImpersonationAttempt(t *testing.T) {
+	c := qt.New(t)
+	lim := services.NewInMemoryAuthRateLimiter()
+	ctx := context.Background()
+	adminID := "admin-1"
+
+	// The configured impersonation limit is 10/hour.
+	for range 10 {
+		res, err := lim.CheckImpersonationAttempt(ctx, adminID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(res.Allowed, qt.IsTrue)
+		c.Assert(res.Limit, qt.Equals, 10)
+	}
+
+	res, err := lim.CheckImpersonationAttempt(ctx, adminID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Allowed, qt.IsFalse)
+	c.Assert(res.Remaining, qt.Equals, 0)
+}


### PR DESCRIPTION
Closes #1750.

Part of #1744 (system-wide admin section umbrella). Builds on the admin BE foundation (#1745) and the admin sub-issues #1746–#1749. This is the **highest security-risk** item in the umbrella — short-lived admin impersonation sessions with full audit logging.

## What's in

### Endpoints (all under `/api/v1/admin/`)

- `POST /api/v1/admin/users/{userID}/impersonate` — optional body `{ "reason": "..." }`. Issues an impersonation access token (`imp=true`, `impersonated_by=<admin>`, `is_system_admin=false`, `exp=now+TTL`, fresh `jti`) plus a server-side **return slot** keyed by the token `jti` holding the admin's original session reference. Sets the impersonation tokens as the active session (same cookie/body shape as login/refresh).
- `POST /api/v1/admin/impersonation/end` — using the impersonation access token, revokes it (blacklists the `jti`) and restores the admin's original tokens.
- `GET /api/v1/admin/impersonation/current` — read model for the FE banner: `{ active, target_user, started_at, expires_at, admin_user }`.

### Constraints enforced

- Impersonation token lifetime ≤ 30 min, clamped to a hard ceiling.
- `/auth/refresh` rejects `imp=true` tokens (impersonation tokens cannot be refreshed) — including expired ones.
- Nested impersonation rejected: the imp token carries `is_system_admin=false` so `RequireSystemAdmin` blocks `start` at the router (403); an in-handler guard catches the residual case (422).
- Target user that is a system admin → 422 `admin.impersonate.target_is_admin`.
- Target user that is blocked (`IsActive=false`) → 422 `admin.impersonate.target_blocked`.
- Per-admin rate limit on the impersonate endpoint (10/hour).
- Every action inside an impersonated session is audit-logged with `actor=target_user` AND `impersonated_by=admin_user`, via both `LogAuth` and `LogAdmin`.

### Config

- Lifetime configurable via `INVENTARIO_RUN_IMPERSONATION_TTL` / `--impersonation-ttl` (default `30m`), wired exactly like `FILE_URL_EXPIRATION`.

## Design notes

- **Claim naming `user_id`, not `sub`.** The project's `issueAccessToken` uses `user_id`; using it for the target means the existing `JWTMiddleware` loads the impersonated user with zero changes.
- **Return slot is in-memory** (`InMemoryImpersonationStore`), keyed by the impersonation-token `jti`, lazily pruned. Slots live ≤30 min; the `ImpersonationStore` interface leaves room for a Redis impl for multi-replica deployments.
- **`RequireSystemAdminOrImpersonating` middleware** gates only `end`/`current` (the operator must call those *while* holding an `is_system_admin=false` imp token); `start` stays behind strict `RequireSystemAdmin`.
- **`end` asserts the return-slot `AdminUserID` matches the signed `impersonated_by` claim** before restoring — defense-in-depth so `end` can never restore a different admin's session.
- **`auditEnd` actor change:** the `admin.impersonate_end` audit row uses the impersonated target as `ActorID` (the end request runs *as* the target), so the row carries `UserID=target` with `ImpersonatedBy=admin` — consistent with the impersonated session that issued the request.
- **Known limitation (documented):** impersonation-token revocation on `end` is durable only with a Redis-backed token blacklist. With the default in-memory blacklist, a process restart can un-revoke an ended impersonation token within its ≤30-min TTL ceiling. Noted in the handler and in `devdocs/REFRESH_TOKEN_SYSTEM.md`.

## Tests

- Handler tests: nested-impersonation rejected (router 403 + in-handler 422), refresh rejects imp token, target-admin rejected, target-blocked rejected, expired-token rejected, over-long reason → 422, `end` restores admin context.
- Integration: admin impersonates → `DELETE /api/v1/groups/{id}` → asserts the `group_delete` audit row carries `UserID=target` and `ImpersonatedBy=admin`; `admin.impersonate_end` row asserts the same.
- Rate-limit integration test: 12 attempts → 429 `admin.impersonate.rate_limited`.

## Review

Implemented by the backend agent; reviewed by the code-review agent (2 HIGH + 4 MEDIUM/LOW findings, all addressed in the second commit).

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run --new-from-rev=origin/master ./...` — 0 issues
- [x] `go test -short ./...` — green
- [x] `make swagger` — regenerates cleanly (Go docs + `frontend/src/types/api.d.ts`)
- [ ] CI runs the full Go + frontend + e2e matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin impersonation: start, end, and current-session endpoints; frontend API types; per-admin start rate limit (10/hour); CLI flag --impersonation-ttl (default 30m, capped at 30m); CSRF rotation on start/end.

* **Security**
  * Impersonation access tokens are non-refreshable; browser marker cookie binds sessions; ending blacklists JTIs (restart-proof only with Redis-backed blacklist); logout during impersonation revokes the admin’s real refresh token.

* **Audit**
  * Audit logs record impersonator/operator details for impersonation flows.

* **Documentation**
  * Added lifecycle, error cases, refresh/logout behavior, and blacklist configuration guidance.

* **Tests**
  * End-to-end and service tests covering lifecycle, rate limits, cookie binding, CSRF, and audit assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->