### PR TITLE
design-mocks: sync mirror with upstream inventario-design (+ admin surface)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,11 @@ Support for multiple database backends via DSN:
 - React 19 with TypeScript (strict)
 - shadcn/ui components (Radix primitives) for consistent UI
 
+### Git Worktrees
+- **All git worktrees MUST be created inside the main project under `.claude/worktrees/<name>/`.** This is a hard requirement, not a suggestion — never create a worktree as a sibling directory of the repository (e.g. `../inventario-1748`) or anywhere else outside `.claude/worktrees/`.
+- Example: `git worktree add .claude/worktrees/issue-1748-admin-groups -b feat/1748-admin-groups-endpoints master`.
+- Keeping every worktree under `.claude/worktrees/` ensures tooling (SocratiCode indexing, linters, the file watcher) resolves a single canonical project root and that stray worktrees are never indexed or linted as if they were separate projects.
+
 ### Pointer Allocation Style
 - When code needs a pointer copy of an existing value, prefer the direct `new(value)` form at the use site (for example, `m.users[user.ID] = new(user)`) instead of copy-then-address patterns through intermediate locals.
 - Do not introduce `ptrTo`, `toPtr`, or similar helper wrappers whose only purpose is manufacturing pointers; prefer the direct allocation form unless the helper adds real behavior beyond pointer construction.

--- a/design-mocks/CLAUDE.md
+++ b/design-mocks/CLAUDE.md
@@ -666,9 +666,11 @@ areaName("area-id")           // "Cabinet"
 
 | Do | Don't |
 |---|---|
-| `radix-ui` (umbrella) for all UI primitives | `@base-ui/react` — removed; not wired |
+| `radix-ui` (umbrella) for all UI primitives | `@base-ui/react` — **never add this**; it is not in package.json and must stay out |
 | `cmdk` for `<Command>` / searchable lists | Any other headless combobox library |
 | Add new primitives only from `radix-ui` or shadcn CLI | Pull in a competing primitive library for a single use case |
+
+> **Why no `@base-ui/react`:** The project uses `radix-ui` (the official shadcn/new-york primitive set). `@base-ui/react` is a separate, incompatible library that was considered but never wired. Keeping both would create two conflicting primitive sources, inflate the bundle, and confuse future contributors. If a specific primitive is ever needed that `radix-ui` cannot provide, file an explicit decision record here before installing anything.
 
 ### Interactions
 

--- a/design-mocks/package-lock.json
+++ b/design-mocks/package-lock.json
@@ -37,9 +37,8 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.2.0",
-        "playwright": "^1.59.1",
         "typescript": "~5.9.3",
-        "vite": "^7.3.3"
+        "vite": "^7.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2939,64 +2938,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -4100,57 +4041,10 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4766,9 +4660,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/design-mocks/package.json
+++ b/design-mocks/package.json
@@ -39,8 +39,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
-    "playwright": "^1.59.1",
     "typescript": "~5.9.3",
-    "vite": "^7.3.3"
+    "vite": "^7.3.1"
   }
 }

--- a/design-mocks/src/App.tsx
+++ b/design-mocks/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { OnboardingTour, RestartTourButton, TOUR_STEPS } from "@/components/OnboardingTour"
 import { useOnboarding } from "@/hooks/use-onboarding"
 import { SidebarProvider, SidebarTrigger, SidebarInset } from "@/components/ui/sidebar"
@@ -23,6 +23,13 @@ import { UIShowcaseView } from "@/views/UIShowcaseView"
 import { TagsView } from "@/views/TagsView"
 import { PlansView } from "@/views/PlansView"
 import { AuthView } from "@/views/AuthView"
+import { TenantsView } from "@/views/admin/TenantsView"
+import { TenantDetailView } from "@/views/admin/TenantDetailView"
+import { UserDetailView } from "@/views/admin/UserDetailView"
+import { GroupsView } from "@/views/admin/GroupsView"
+import { GroupDetailView } from "@/views/admin/GroupDetailView"
+import { ImpersonationBannerMock } from "@/views/admin/ImpersonationBannerMock"
+import { adminUserById } from "@/data/mock"
 import {
   NotFoundView,
   NoLocationGroupView,
@@ -33,6 +40,8 @@ import {
 } from "@/views/EmptyStatesView"
 import { InviteBanner } from "@/components/InviteBanner"
 import { ModeToggle } from "@/components/mode-toggle"
+import { CommandPalette, useCommandPalette } from "@/components/CommandPalette"
+import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog"
 import { Separator } from "@/components/ui/separator"
 import {
   Package,
@@ -55,7 +64,12 @@ import {
   Shield,
   Palette,
   Zap,
+  Search,
+  Building2,
+  UserCog,
 } from "lucide-react"
+import { Kbd, KbdGroup } from "@/components/ui/kbd"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 
 type View =
   | "dashboard"
@@ -82,6 +96,11 @@ type View =
   | "state-no-area"
   | "state-maintenance"
   | "state-no-group-onboarding"
+  | "admin-tenants"
+  | "admin-tenant-detail"
+  | "admin-user-detail"
+  | "admin-groups"
+  | "admin-group-detail"
 
 const VIEW_TITLES: Record<View, string> = {
   dashboard: "Dashboard",
@@ -108,6 +127,11 @@ const VIEW_TITLES: Record<View, string> = {
   "state-no-area": "No Area",
   "state-maintenance": "Maintenance",
   "state-no-group-onboarding": "Get Started",
+  "admin-tenants": "Tenants",
+  "admin-tenant-detail": "Tenant Detail",
+  "admin-user-detail": "User Detail",
+  "admin-groups": "Groups",
+  "admin-group-detail": "Group Detail",
 }
 
 const VIEW_ICONS: Record<View, React.ElementType> = {
@@ -135,6 +159,11 @@ const VIEW_ICONS: Record<View, React.ElementType> = {
   "state-no-area": LayoutGrid,
   "state-maintenance": Wrench,
   "state-no-group-onboarding": Layers,
+  "admin-tenants": Building2,
+  "admin-tenant-detail": Building2,
+  "admin-user-detail": UserCog,
+  "admin-groups": Layers,
+  "admin-group-detail": Layers,
 }
 
 
@@ -145,7 +174,40 @@ export function App() {
   const [activeGroupId, setActiveGroupId] = useState("g1")
   const [insuranceReportItemId, setInsuranceReportItemId] = useState<string | undefined>()
   const [insuranceReportLocationId, setInsuranceReportLocationId] = useState<string | undefined>()
+  const [selectedTenantId, setSelectedTenantId] = useState<string | null>(null)
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null)
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null)
+  const [impersonatingUserId, setImpersonatingUserId] = useState<string | null>(null)
+  // Remember which admin view a detail page was opened from, so "Back"
+  // returns to the originating context (tenant detail vs. a list view).
+  const [userDetailBackTo, setUserDetailBackTo] = useState<View>("admin-tenants")
+  const [groupDetailBackTo, setGroupDetailBackTo] = useState<View>("admin-groups")
   const onboarding = useOnboarding()
+  const palette = useCommandPalette()
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
+
+  // Global keyboard shortcuts
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      // Cmd/Ctrl+/ → shortcuts dialog
+      if (e.key === "/" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        setShortcutsOpen((o) => !o)
+        return
+      }
+      // Cmd/Ctrl+N → add item
+      if (e.key === "n" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        setAddDialogOpen(true)
+        return
+      }
+      // G+x two-key nav (only when no input focused)
+      const tag = (document.activeElement as HTMLElement)?.tagName?.toLowerCase()
+      if (tag === "input" || tag === "textarea" || (document.activeElement as HTMLElement)?.isContentEditable) return
+    }
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [])
 
   const fullscreenViews: View[] = ["auth", "image-viewer", "pdf-viewer", "insurance-report"]
   const isFullscreen = fullscreenViews.includes(view)
@@ -172,6 +234,7 @@ export function App() {
   }
 
   const ViewIcon = VIEW_ICONS[view]
+  const impersonatingUser = impersonatingUserId ? adminUserById(impersonatingUserId) : undefined
 
   return (
     <SidebarProvider>
@@ -183,6 +246,14 @@ export function App() {
         onGroupChange={setActiveGroupId}
       />
       <SidebarInset>
+        {/* Impersonation banner — non-dismissible, sits above the topbar */}
+        {impersonatingUser && (
+          <ImpersonationBannerMock
+            userName={impersonatingUser.name}
+            userEmail={impersonatingUser.email}
+            onEnd={() => setImpersonatingUserId(null)}
+          />
+        )}
         {/* Topbar */}
         <header className="flex h-12 items-center gap-2 border-b border-border px-4 sticky top-0 bg-background z-10" data-tour="welcome">
           <SidebarTrigger className="-ml-1" />
@@ -209,6 +280,22 @@ export function App() {
                 )
               })}
             </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => palette.setOpen(true)}
+                  className="hidden sm:flex items-center gap-2 h-8 px-3 rounded-md border border-border bg-background text-muted-foreground text-sm hover:bg-muted hover:text-foreground transition-colors"
+                >
+                  <Search className="size-3.5 shrink-0" />
+                  <span className="text-xs">Search…</span>
+                  <KbdGroup className="ml-1">
+                    <Kbd className="text-[10px] h-4 min-w-4 px-1">⌘</Kbd>
+                    <Kbd className="text-[10px] h-4 min-w-4 px-1">K</Kbd>
+                  </KbdGroup>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Open command palette</TooltipContent>
+            </Tooltip>
             <RestartTourButton onRestart={onboarding.restart} />
             <ModeToggle />
           </div>
@@ -223,7 +310,7 @@ export function App() {
           {view === "items" && <ItemsView onItemClick={setSelectedItemId} onAddItem={() => setAddDialogOpen(true)} />}
           {view === "warranties" && <WarrantiesView onItemClick={setSelectedItemId} />}
           {view === "tags" && <TagsView />}
-          {view === "settings" && <SettingsView onNavigate={(v) => setView(v as View)} />}
+          {view === "settings" && <SettingsView onNavigate={(v) => setView(v as View)} onOpenShortcuts={() => setShortcutsOpen(true)} />}
           {view === "group-settings" && (
             <GroupSettingsView
               activeGroupId={activeGroupId}
@@ -268,6 +355,61 @@ export function App() {
           {view === "state-no-location" && <NoLocationView />}
           {view === "state-no-area" && <NoAreaView />}
           {view === "state-maintenance" && <MaintenanceView />}
+
+          {/* Admin views */}
+          {view === "admin-tenants" && (
+            <TenantsView
+              onSelectTenant={(id) => {
+                setSelectedTenantId(id)
+                setView("admin-tenant-detail")
+              }}
+            />
+          )}
+          {view === "admin-tenant-detail" && selectedTenantId && (
+            <TenantDetailView
+              tenantId={selectedTenantId}
+              onBack={() => setView("admin-tenants")}
+              onSelectUser={(id) => {
+                setSelectedUserId(id)
+                setUserDetailBackTo("admin-tenant-detail")
+                setView("admin-user-detail")
+              }}
+              onSelectGroup={(id) => {
+                setSelectedGroupId(id)
+                setGroupDetailBackTo("admin-tenant-detail")
+                setView("admin-group-detail")
+              }}
+            />
+          )}
+          {view === "admin-user-detail" && selectedUserId && (
+            <UserDetailView
+              key={selectedUserId}
+              userId={selectedUserId}
+              onBack={() => setView(userDetailBackTo)}
+              onSelectGroup={(id) => {
+                setSelectedGroupId(id)
+                setGroupDetailBackTo("admin-user-detail")
+                setView("admin-group-detail")
+              }}
+              onImpersonate={(id) => setImpersonatingUserId(id)}
+            />
+          )}
+          {view === "admin-groups" && (
+            <GroupsView
+              onSelectGroup={(id) => {
+                setSelectedGroupId(id)
+                setGroupDetailBackTo("admin-groups")
+                setView("admin-group-detail")
+              }}
+            />
+          )}
+          {view === "admin-group-detail" && selectedGroupId && (
+            <GroupDetailView
+              key={selectedGroupId}
+              groupId={selectedGroupId}
+              onBack={() => setView(groupDetailBackTo)}
+            />
+          )}
         </main>
       </SidebarInset>
 
@@ -292,6 +434,17 @@ export function App() {
           onSkip={onboarding.skip}
         />
       )}
+
+      <CommandPalette
+        open={palette.open}
+        onOpenChange={palette.setOpen}
+        onNavigate={(v) => setView(v as View)}
+        onItemClick={setSelectedItemId}
+      />
+      <KeyboardShortcutsDialog
+        open={shortcutsOpen}
+        onOpenChange={setShortcutsOpen}
+      />
     </SidebarProvider>
   )
 }

--- a/design-mocks/src/components/AddItemDialog.tsx
+++ b/design-mocks/src/components/AddItemDialog.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/select"
 import { Upload, X, FileText, Image, File, Plus, Image as ImageIcon, Receipt, BookOpen, Sparkles, Camera, ScanText, CircleCheck as CheckCircle2, CircleAlert as AlertCircle, ChevronDown, TriangleAlert, RefreshCw, ServerCrash } from "lucide-react"
 import { CATEGORIES, MOCK_LOCATIONS, MOCK_AREAS, CURRENCIES, type ItemCategory, type FileCategory } from "@/data/mock"
-import { cn, makeId } from "@/lib/utils"
+import { cn } from "@/lib/utils"
 import { CurrencyCombobox } from "@/components/CurrencyCombobox"
 
 // ─── Brand / model data ───────────────────────────────────────
@@ -385,7 +385,7 @@ export function AddItemDialog({ open, onClose, defaultAreaId }: AddItemDialogPro
 
   function addFilesToList(files: File[], setter: React.Dispatch<React.SetStateAction<AttachedFileDraft[]>>, category: FileCategory) {
     const drafts: AttachedFileDraft[] = files.map((f) => ({
-      id: makeId(),
+      id: crypto.randomUUID(),
       name: f.name,
       size: formatFileSize(f.size),
       mimeType: f.type,
@@ -734,7 +734,7 @@ function AiPhotoStep({ phase, photos, setPhotos, filledName, filledBrand, filled
 }) {
   function handlePhotoFiles(files: File[]) {
     const previews = files.map((f) => ({
-      id: makeId(),
+      id: crypto.randomUUID(),
       name: f.name,
       preview: URL.createObjectURL(f),
     }))
@@ -1312,7 +1312,7 @@ function ExtrasStep({ notes, setNotes, tagInput, setTagInput, tags, setTags, add
           <button
             type="button"
             className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-            onClick={() => setUrls((prev: any[]) => [...prev, { id: makeId(), label: "", url: "" }])}
+            onClick={() => setUrls((prev: any[]) => [...prev, { id: crypto.randomUUID(), label: "", url: "" }])}
           >
             <Plus className="size-3" />Add
           </button>
@@ -1344,7 +1344,7 @@ function ExtrasStep({ notes, setNotes, tagInput, setTagInput, tags, setTags, add
           <button
             type="button"
             className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-            onClick={() => setSupplyLinks((prev: any[]) => [...prev, { id: makeId(), label: "", url: "" }])}
+            onClick={() => setSupplyLinks((prev: any[]) => [...prev, { id: crypto.randomUUID(), label: "", url: "" }])}
           >
             <Plus className="size-3" />Add
           </button>

--- a/design-mocks/src/components/AppSidebar.tsx
+++ b/design-mocks/src/components/AppSidebar.tsx
@@ -18,6 +18,7 @@ import {
   LogOut,
   SlidersHorizontal,
   ChevronsUpDown,
+  Building2,
 } from "lucide-react"
 import {
   Sidebar,
@@ -72,6 +73,11 @@ const MANAGE_ITEMS = [
 const PERSONAL_ITEMS = [
   { id: "profile", label: "Profile", icon: User },
   { id: "settings", label: "Preferences", icon: Settings },
+]
+
+const ADMIN_ITEMS = [
+  { id: "admin-tenants", label: "Tenants", icon: Building2 },
+  { id: "admin-groups", label: "Groups", icon: Layers },
 ]
 
 const STATE_ITEMS = [
@@ -176,6 +182,31 @@ export function AppSidebar({ activeView, onNavigate, onAddItem, activeGroupId, o
                 <SidebarMenuItem key={item.id}>
                   <SidebarMenuButton
                     isActive={activeView === item.id}
+                    tooltip={item.label}
+                    onClick={() => handleNavigate(item.id)}
+                  >
+                    <item.icon className="size-4" />
+                    <span>{item.label}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <SidebarGroup>
+          <SidebarGroupLabel>Admin</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {ADMIN_ITEMS.map((item) => (
+                <SidebarMenuItem key={item.id}>
+                  <SidebarMenuButton
+                    isActive={
+                      activeView === item.id ||
+                      (item.id === "admin-tenants" &&
+                        (activeView === "admin-tenant-detail" || activeView === "admin-user-detail")) ||
+                      (item.id === "admin-groups" && activeView === "admin-group-detail")
+                    }
                     tooltip={item.label}
                     onClick={() => handleNavigate(item.id)}
                   >

--- a/design-mocks/src/components/CommandPalette.tsx
+++ b/design-mocks/src/components/CommandPalette.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useState } from "react"
+import {
+  LayoutDashboard,
+  Package,
+  ShieldCheck,
+  Tag,
+  FolderOpen,
+  MapPin,
+  Users,
+  Settings,
+  HardDriveDownload,
+  Zap,
+  User,
+  ArrowRight,
+  Box,
+  FileText,
+  Image,
+} from "lucide-react"
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command"
+import { Badge } from "@/components/ui/badge"
+import { MOCK_ITEMS, MOCK_LOCATIONS, MOCK_FILES } from "@/data/mock"
+
+const NAV_ITEMS = [
+  { id: "dashboard", label: "Dashboard", icon: LayoutDashboard, description: "Overview & stats" },
+  { id: "items", label: "All Items", icon: Package, description: "Browse inventory" },
+  { id: "warranties", label: "Warranties", icon: ShieldCheck, description: "Track warranties" },
+  { id: "tags", label: "Tags", icon: Tag, description: "Manage labels" },
+  { id: "files", label: "Files", icon: FolderOpen, description: "Attachments & documents" },
+  { id: "locations", label: "Locations", icon: MapPin, description: "Rooms & areas" },
+  { id: "members", label: "Members", icon: Users, description: "Shared access" },
+  { id: "backup", label: "Backup & Restore", icon: HardDriveDownload, description: "Export your data" },
+  { id: "plans", label: "Plans & Pricing", icon: Zap, description: "Upgrade your plan" },
+  { id: "settings", label: "Preferences", icon: Settings, description: "App settings" },
+  { id: "profile", label: "Profile", icon: User, description: "Your account" },
+] as const
+
+const FILE_ICON_MAP: Record<string, React.ElementType> = {
+  "application/pdf": FileText,
+}
+
+function getFileIcon(mimeType: string): React.ElementType {
+  if (mimeType.startsWith("image/")) return Image
+  return FILE_ICON_MAP[mimeType] ?? FileText
+}
+
+interface CommandPaletteProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onNavigate: (view: string) => void
+  onItemClick: (id: string) => void
+}
+
+export function CommandPalette({ open, onOpenChange, onNavigate, onItemClick }: CommandPaletteProps) {
+  const recentItems = MOCK_ITEMS.slice(0, 5)
+  const recentFiles = (MOCK_FILES ?? []).slice(0, 4)
+  const locations = MOCK_LOCATIONS.slice(0, 6)
+
+  function select(fn: () => void) {
+    onOpenChange(false)
+    // slight delay so the dialog closes before state update
+    setTimeout(fn, 50)
+  }
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange} title="Command palette" description="Navigate, search items, files, and locations">
+      <CommandInput placeholder="Search or jump to…" />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+
+        {/* Navigate */}
+        <CommandGroup heading="Navigate">
+          {NAV_ITEMS.map((item) => (
+            <CommandItem
+              key={item.id}
+              value={`navigate ${item.label} ${item.description}`}
+              onSelect={() => select(() => onNavigate(item.id))}
+              className="gap-3"
+            >
+              <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted">
+                <item.icon className="size-3.5 text-muted-foreground" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <span className="font-medium text-sm">{item.label}</span>
+                <span className="ml-2 text-xs text-muted-foreground">{item.description}</span>
+              </div>
+              <ArrowRight className="size-3 text-muted-foreground/40 shrink-0" />
+            </CommandItem>
+          ))}
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        {/* Recent items */}
+        <CommandGroup heading="Recent Items">
+          {recentItems.map((item) => (
+            <CommandItem
+              key={item.id}
+              value={`item ${item.name} ${item.brand} ${item.model} ${item.category}`}
+              onSelect={() => select(() => onItemClick(item.id))}
+              className="gap-3"
+            >
+              <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted">
+                <Box className="size-3.5 text-muted-foreground" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <span className="font-medium text-sm truncate">{item.name}</span>
+                {item.brand && (
+                  <span className="ml-2 text-xs text-muted-foreground">{item.brand}</span>
+                )}
+              </div>
+              <Badge variant="outline" className="text-[10px] h-4 px-1.5 shrink-0 capitalize">
+                {item.category}
+              </Badge>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        {/* Recent files */}
+        {recentFiles.length > 0 && (
+          <>
+            <CommandGroup heading="Recent Files">
+              {recentFiles.map((file) => {
+                const FileIcon = getFileIcon(file.mimeType)
+                return (
+                  <CommandItem
+                    key={file.id}
+                    value={`file ${file.name} ${file.category}`}
+                    onSelect={() => select(() => onNavigate("files"))}
+                    className="gap-3"
+                  >
+                    <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted">
+                      <FileIcon className="size-3.5 text-muted-foreground" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <span className="font-medium text-sm truncate">{file.name}</span>
+                      <span className="ml-2 text-xs text-muted-foreground">{file.size}</span>
+                    </div>
+                    <Badge variant="outline" className="text-[10px] h-4 px-1.5 shrink-0 capitalize">
+                      {file.category}
+                    </Badge>
+                  </CommandItem>
+                )
+              })}
+            </CommandGroup>
+            <CommandSeparator />
+          </>
+        )}
+
+        {/* Locations */}
+        <CommandGroup heading="Locations">
+          {locations.map((loc) => (
+            <CommandItem
+              key={loc.id}
+              value={`location ${loc.name}`}
+              onSelect={() => select(() => onNavigate("locations"))}
+              className="gap-3"
+            >
+              <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-sm leading-none">
+                {loc.icon}
+              </div>
+              <span className="font-medium text-sm">{loc.name}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  )
+}
+
+// Hook to wire the Cmd/Ctrl+K shortcut
+export function useCommandPalette() {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        setOpen((o) => !o)
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [])
+
+  return { open, setOpen }
+}

--- a/design-mocks/src/components/ErrorBoundary.tsx
+++ b/design-mocks/src/components/ErrorBoundary.tsx
@@ -1,0 +1,94 @@
+import { Component } from "react"
+import { TriangleAlert as AlertTriangle, RefreshCcw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface Props {
+  children: React.ReactNode
+}
+
+interface State {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("[ErrorBoundary]", error, info.componentStack)
+  }
+
+  private handleReload = () => {
+    window.location.reload()
+  }
+
+  private handleReset = () => {
+    this.setState({ error: null })
+  }
+
+  render() {
+    const { error } = this.state
+    if (!error) return this.props.children
+
+    const isDev = import.meta.env.DEV
+
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center p-6">
+        <div className="w-full max-w-lg">
+          {/* Icon */}
+          <div className="flex justify-center mb-6">
+            <div className="flex size-16 items-center justify-center rounded-2xl bg-destructive/10">
+              <AlertTriangle className="size-8 text-destructive" />
+            </div>
+          </div>
+
+          {/* Heading */}
+          <div className="text-center mb-8">
+            <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight mb-2">
+              Something went wrong
+            </h1>
+            <p className="text-muted-foreground text-sm leading-relaxed max-w-sm mx-auto">
+              An unexpected error occurred. Your data is safe — this is a display
+              issue. Try reloading the page.
+            </p>
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center justify-center gap-3 mb-8">
+            <Button onClick={this.handleReload} className="gap-2">
+              <RefreshCcw className="size-4" />
+              Reload page
+            </Button>
+            <Button variant="outline" onClick={this.handleReset}>
+              Try again
+            </Button>
+          </div>
+
+          {/* Dev-only stack trace */}
+          {isDev && (
+            <div className="rounded-xl border border-destructive/30 bg-destructive/5 overflow-hidden">
+              <div className="px-4 py-2.5 border-b border-destructive/20 flex items-center gap-2">
+                <span className="text-xs font-semibold uppercase tracking-widest text-destructive/70">
+                  Dev — Error details
+                </span>
+              </div>
+              <div className="p-4 space-y-3 max-h-72 overflow-y-auto">
+                <p className="font-mono text-xs font-semibold text-destructive break-all">
+                  {error.message}
+                </p>
+                {error.stack && (
+                  <pre className="font-mono text-[11px] text-muted-foreground whitespace-pre-wrap break-all leading-relaxed">
+                    {error.stack}
+                  </pre>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+}

--- a/design-mocks/src/components/FileDetail.tsx
+++ b/design-mocks/src/components/FileDetail.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
-import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -46,7 +45,8 @@ import {
   Layers,
 } from "lucide-react"
 import { FilePreviewDialog } from "@/components/FilePreviewDialog"
-import { FILE_TAGS, FILE_CATEGORY_CONFIG, type AttachedFile, type FileCategory } from "@/data/mock"
+import { FILE_TAGS, FILE_CATEGORY_CONFIG, resolveTags, type AttachedFile, type FileCategory } from "@/data/mock"
+import { TagPill } from "@/components/TagPill"
 import { cn } from "@/lib/utils"
 
 type MimeGroup = "pdf" | "image" | "archive" | "other"
@@ -227,7 +227,7 @@ export function FileDetailSheet({ file, onClose, onDelete }: FileDetailSheetProp
 
   const group = file ? mimeGroup(file.mimeType) : "other"
   const Icon = FILE_ICONS[group]
-  const fileTags = file ? FILE_TAGS.filter((t) => file.tags.includes(t.id)) : []
+  const fileTags = file ? resolveTags(file.tags) : []
 
   function handleDelete() {
     if (!file) return
@@ -274,9 +274,7 @@ export function FileDetailSheet({ file, onClose, onDelete }: FileDetailSheetProp
                 {fileTags.length > 0 && (
                   <div className="flex flex-wrap gap-1.5 pt-1">
                     {fileTags.map((tag) => (
-                      <Badge key={tag.id} variant="secondary" className="h-5 px-1.5 text-xs">
-                        <span className={tag.color}>#{tag.label}</span>
-                      </Badge>
+                      <TagPill key={tag.id} tag={tag} size="sm" />
                     ))}
                   </div>
                 )}
@@ -366,9 +364,7 @@ export function FileDetailSheet({ file, onClose, onDelete }: FileDetailSheetProp
                       value={
                         <div className="flex flex-wrap gap-1 mt-0.5">
                           {fileTags.map((tag) => (
-                            <Badge key={tag.id} variant="secondary" className="h-5 px-1.5 text-xs">
-                              {tag.label}
-                            </Badge>
+                            <TagPill key={tag.id} tag={tag} size="xs" />
                           ))}
                         </div>
                       }

--- a/design-mocks/src/components/ItemDetail.tsx
+++ b/design-mocks/src/components/ItemDetail.tsx
@@ -27,7 +27,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog"
-import { ShieldCheck, ShieldAlert, ShieldOff, Shield, ExternalLink, MapPin, Calendar, Hash, Tag, Pencil, Trash2, DollarSign, FileText, Image as ImageIcon, File, Upload, X, ArrowLeft, Plus, Paperclip, ChartBar as FileBarChart2, Package, CircleDot, TriangleAlert as AlertTriangle, Link as LinkIcon, Layers } from "lucide-react"
+import { ShieldCheck, ShieldAlert, ShieldOff, Shield, ExternalLink, MapPin, Calendar, Hash, Tag, Pencil, Trash2, DollarSign, FileText, Image as ImageIcon, File, Upload, ArrowLeft, Paperclip, ChartBar as FileBarChart2, Package, CircleDot, TriangleAlert as AlertTriangle, Link as LinkIcon, Layers } from "lucide-react"
 import { WarrantyBadge } from "@/components/WarrantyBadge"
 import { FilePreviewDialog } from "@/components/FilePreviewDialog"
 import {
@@ -43,7 +43,8 @@ import {
 import {
   MOCK_ITEMS,
   MOCK_FILES,
-  FILE_TAGS,
+  MOCK_TAGS,
+  resolveTags,
   CATEGORIES,
   MOCK_LOCATIONS,
   MOCK_AREAS,
@@ -58,6 +59,7 @@ import {
   WARRANTY_STATUS_CONFIG,
   COMMODITY_STATUS_CONFIG,
 } from "@/data/mock"
+import { TagPill } from "@/components/TagPill"
 import { cn } from "@/lib/utils"
 
 interface ItemDetailProps {
@@ -330,7 +332,7 @@ function ItemFilesTab({ item }: { item: InventoryItem }) {
             {(activeCategory !== "image" && nonPhotos.length > 0) && (
               <ul className="flex flex-col gap-1.5">
                 {nonPhotos.map((f) => {
-                  const tagObjs = f.tags.map((tid) => FILE_TAGS.find((t) => t.id === tid)).filter(Boolean)
+                  const tagObjs = resolveTags(f.tags)
                   return (
                     <li key={f.id} className="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2.5">
                       {fileIcon(f.mimeType)}
@@ -348,8 +350,8 @@ function ItemFilesTab({ item }: { item: InventoryItem }) {
                         </div>
                         <div className="flex items-center gap-2 mt-0.5">
                           <span className="text-xs text-muted-foreground">{f.size}</span>
-                          {tagObjs.map((t) => t && (
-                            <span key={t.id} className={`text-xs ${t.color}`}>{t.label}</span>
+                          {tagObjs.map((t) => (
+                            <TagPill key={t.id} tag={t} size="xs" />
                           ))}
                         </div>
                       </div>
@@ -443,17 +445,16 @@ function ItemEditForm({ item, onCancel }: { item: InventoryItem; onCancel: () =>
   const [warrantyNotes, setWarrantyNotes] = useState(item.warranty.notes)
 
   const [notes, setNotes] = useState(item.notes)
-  const [tagInput, setTagInput] = useState("")
   const [tags, setTags] = useState<string[]>(item.tags)
 
   const availableAreas = selectedLocationId
     ? MOCK_AREAS.filter((a) => a.locationId === selectedLocationId)
     : []
 
-  function addTag(raw: string) {
-    const newTags = raw.split(",").map((t) => t.trim().toLowerCase()).filter((t) => t && !tags.includes(t))
-    if (newTags.length) setTags((prev) => [...prev, ...newTags])
-    setTagInput("")
+  const itemTagPalette = MOCK_TAGS.filter((t) => t.id.startsWith("i"))
+
+  function toggleTag(id: string) {
+    setTags((prev) => prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id])
   }
 
   return (
@@ -553,28 +554,30 @@ function ItemEditForm({ item, onCancel }: { item: InventoryItem; onCancel: () =>
 
         <div className="flex flex-col gap-1.5">
           <Label>Tags</Label>
-          <div className="flex gap-2">
-            <Input
-              placeholder="e.g. kitchen — comma to add"
-              value={tagInput}
-              onChange={(e) => setTagInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === ",") { e.preventDefault(); addTag(tagInput) }
-              }}
-            />
-            <Button type="button" variant="outline" size="sm" onClick={() => addTag(tagInput)} disabled={!tagInput.trim()}>
-              <Plus className="size-3.5" />
-            </Button>
+          <div className="flex flex-wrap gap-1.5">
+            {itemTagPalette.map((tag) => {
+              const active = tags.includes(tag.id)
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => toggleTag(tag.id)}
+                  className={cn(
+                    "rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
+                    active
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "border-border bg-background text-muted-foreground hover:border-primary/50"
+                  )}
+                >
+                  #{tag.label}
+                </button>
+              )
+            })}
           </div>
           {tags.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-1">
-              {tags.map((t) => (
-                <Badge key={t} variant="secondary" className="gap-1 h-5 text-xs">
-                  {t}
-                  <button type="button" onClick={() => setTags((prev) => prev.filter((x) => x !== t))}>
-                    <X className="size-3" />
-                  </button>
-                </Badge>
+              {resolveTags(tags).map((tag) => (
+                <TagPill key={tag.id} tag={tag} size="xs" onRemove={() => toggleTag(tag.id)} />
               ))}
             </div>
           )}
@@ -877,8 +880,8 @@ function ItemDetailContent({ item, onOpenInsuranceReport }: { item: InventoryIte
                 label="Tags"
                 value={
                   <div className="flex flex-wrap gap-1 mt-0.5">
-                    {item.tags.map((tag) => (
-                      <Badge key={tag} variant="secondary" className="h-5 px-1.5 text-xs">{tag}</Badge>
+                    {resolveTags(item.tags).map((tag) => (
+                      <TagPill key={tag.id} tag={tag} size="xs" />
                     ))}
                   </div>
                 }

--- a/design-mocks/src/components/ItemsPanel.tsx
+++ b/design-mocks/src/components/ItemsPanel.tsx
@@ -43,11 +43,13 @@ import {
   warrantyStatus,
   areaName,
   COMMODITY_STATUS_CONFIG,
+  resolveTags,
   type InventoryItem,
   type ItemCategory,
   type WarrantyStatus,
   type CommodityStatus,
 } from "@/data/mock"
+import { TagPill } from "@/components/TagPill"
 import { cn } from "@/lib/utils"
 
 const PAGE_SIZE = 8
@@ -465,10 +467,8 @@ export function ItemsPanel({
                   </div>
                   {item.tags.length > 0 && (
                     <div className="mt-2 flex flex-wrap gap-1">
-                      {item.tags.slice(0, 3).map((tag) => (
-                        <Badge key={tag} variant="secondary" className="h-4 px-1.5 text-[10px]">
-                          {tag}
-                        </Badge>
+                      {resolveTags(item.tags).slice(0, 3).map((tag) => (
+                        <TagPill key={tag.id} tag={tag} size="xs" />
                       ))}
                     </div>
                   )}

--- a/design-mocks/src/components/KeyboardShortcutsDialog.tsx
+++ b/design-mocks/src/components/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,228 @@
+import { Command } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { Kbd, KbdGroup } from "@/components/ui/kbd"
+import { Separator } from "@/components/ui/separator"
+import { ScrollArea } from "@/components/ui/scroll-area"
+
+interface ShortcutRowProps {
+  label: string
+  keys: React.ReactNode
+}
+
+function ShortcutRow({ label, keys }: ShortcutRowProps) {
+  return (
+    <div className="flex items-center justify-between py-2">
+      <span className="text-sm text-foreground">{label}</span>
+      <div className="shrink-0">{keys}</div>
+    </div>
+  )
+}
+
+function ShortcutSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-0.5">
+      <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-1 pt-1">
+        {title}
+      </p>
+      <div className="divide-y divide-border">{children}</div>
+    </div>
+  )
+}
+
+// Platform-aware modifier key label
+const isMac = typeof navigator !== "undefined" && /mac/i.test(navigator.platform)
+const Mod = () =>
+  isMac ? (
+    <Kbd>
+      <Command className="size-3" />
+    </Kbd>
+  ) : (
+    <Kbd>Ctrl</Kbd>
+  )
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function KeyboardShortcutsDialog({ open, onOpenChange }: KeyboardShortcutsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <div className="flex size-7 items-center justify-center rounded-lg bg-primary/10">
+              <Command className="size-4 text-primary" />
+            </div>
+            Keyboard Shortcuts
+          </DialogTitle>
+          <DialogDescription>
+            All available shortcuts across Inventario.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="max-h-[60vh] pr-1">
+          <div className="space-y-4 pb-2">
+
+            <ShortcutSection title="Global">
+              <ShortcutRow
+                label="Open command palette"
+                keys={
+                  <KbdGroup>
+                    <Mod />
+                    <Kbd>K</Kbd>
+                  </KbdGroup>
+                }
+              />
+              <ShortcutRow
+                label="Keyboard shortcuts"
+                keys={
+                  <KbdGroup>
+                    <Mod />
+                    <Kbd>/</Kbd>
+                  </KbdGroup>
+                }
+              />
+              <ShortcutRow
+                label="Toggle sidebar"
+                keys={
+                  <KbdGroup>
+                    <Mod />
+                    <Kbd>B</Kbd>
+                  </KbdGroup>
+                }
+              />
+              <ShortcutRow
+                label="Add new item"
+                keys={
+                  <KbdGroup>
+                    <Mod />
+                    <Kbd>N</Kbd>
+                  </KbdGroup>
+                }
+              />
+              <ShortcutRow
+                label="Close dialog / panel"
+                keys={<Kbd>Esc</Kbd>}
+              />
+            </ShortcutSection>
+
+            <Separator />
+
+            <ShortcutSection title="Navigation">
+              <ShortcutRow
+                label="Go to Dashboard"
+                keys={
+                  <KbdGroup>
+                    <Kbd>G</Kbd>
+                    <Kbd>D</Kbd>
+                  </KbdGroup>
+                }
+              />
+              <ShortcutRow
+                label="Go to All Items"
+                keys={
+                  <KbdGroup>
+                    <Kbd>G</Kbd>
+                    <Kbd>I</Kbd>
+                  </KbdGroup>
+                }
+              />
+              <ShortcutRow
+                label="Go to Warranties"
+                keys={
+                  <KbdGroup>
+                    <Kbd>G</Kbd>
+                    <Kbd>W</Kbd>
+                  </KbdGroup>
+                }
+              />
+              <ShortcutRow
+                label="Go to Files"
+                keys={
+                  <KbdGroup>
+                    <Kbd>G</Kbd>
+                    <Kbd>F</Kbd>
+                  </KbdGroup>
+                }
+              />
+              <ShortcutRow
+                label="Go to Locations"
+                keys={
+                  <KbdGroup>
+                    <Kbd>G</Kbd>
+                    <Kbd>L</Kbd>
+                  </KbdGroup>
+                }
+              />
+              <ShortcutRow
+                label="Go to Settings"
+                keys={
+                  <KbdGroup>
+                    <Kbd>G</Kbd>
+                    <Kbd>S</Kbd>
+                  </KbdGroup>
+                }
+              />
+            </ShortcutSection>
+
+            <Separator />
+
+            <ShortcutSection title="Items list">
+              <ShortcutRow
+                label="Search / filter"
+                keys={<Kbd>/</Kbd>}
+              />
+              <ShortcutRow
+                label="Select item"
+                keys={<Kbd>Enter</Kbd>}
+              />
+              <ShortcutRow
+                label="Move focus up"
+                keys={<Kbd>↑</Kbd>}
+              />
+              <ShortcutRow
+                label="Move focus down"
+                keys={<Kbd>↓</Kbd>}
+              />
+            </ShortcutSection>
+
+            <Separator />
+
+            <ShortcutSection title="Item detail panel">
+              <ShortcutRow
+                label="Close panel"
+                keys={<Kbd>Esc</Kbd>}
+              />
+              <ShortcutRow
+                label="Edit item"
+                keys={
+                  <KbdGroup>
+                    <Mod />
+                    <Kbd>E</Kbd>
+                  </KbdGroup>
+                }
+              />
+              <ShortcutRow
+                label="Generate insurance report"
+                keys={
+                  <KbdGroup>
+                    <Mod />
+                    <Kbd>R</Kbd>
+                  </KbdGroup>
+                }
+              />
+            </ShortcutSection>
+
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/design-mocks/src/components/LocationDialog.tsx
+++ b/design-mocks/src/components/LocationDialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog"
-import { cn, makeId } from "@/lib/utils"
+import { cn } from "@/lib/utils"
 import type { Location } from "@/data/mock"
 
 const LOCATION_ICONS = ["🏠", "🏡", "🏢", "🏗️", "🏚️", "🚗", "🌿", "🌊", "⛺", "🏕️", "🔑", "📦"]
@@ -64,7 +64,7 @@ export function LocationDialog({ open, onClose, location, onSave }: LocationDial
 
   function addFiles(files: File[]) {
     const drafts: AttachedFileDraft[] = files.map((f) => ({
-      id: makeId(),
+      id: crypto.randomUUID(),
       name: f.name,
       size: formatSize(f.size),
       mimeType: f.type,

--- a/design-mocks/src/components/SkeletonPatterns.tsx
+++ b/design-mocks/src/components/SkeletonPatterns.tsx
@@ -1,0 +1,198 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import { Separator } from "@/components/ui/separator"
+
+// ─── Stat card skeleton ───────────────────────────────────────────────────────
+// Used in: Dashboard stat row, Items header stats
+export function StatCardSkeleton() {
+  return (
+    <div className="rounded-xl border border-border bg-card px-4 py-3 flex items-center gap-3">
+      <Skeleton className="size-8 rounded-lg shrink-0" />
+      <div className="space-y-1.5 flex-1">
+        <Skeleton className="h-3 w-16 rounded" />
+        <Skeleton className="h-5 w-10 rounded" />
+      </div>
+    </div>
+  )
+}
+
+export function StatCardSkeletonRow({ count = 3 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <StatCardSkeleton key={i} />
+      ))}
+    </div>
+  )
+}
+
+// ─── Table row skeleton ───────────────────────────────────────────────────────
+// Used in: Items list, Warranties list, Members list
+export function TableRowSkeleton() {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 border-b border-border last:border-0">
+      <Skeleton className="size-9 rounded-lg shrink-0" />
+      <div className="flex-1 space-y-1.5">
+        <Skeleton className="h-3.5 w-40 rounded" />
+        <Skeleton className="h-3 w-24 rounded" />
+      </div>
+      <Skeleton className="h-5 w-16 rounded-full shrink-0" />
+      <Skeleton className="h-5 w-14 rounded-full shrink-0" />
+      <Skeleton className="size-7 rounded-md shrink-0" />
+    </div>
+  )
+}
+
+export function TableSkeleton({ rows = 6 }: { rows?: number }) {
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
+      {/* fake header */}
+      <div className="flex items-center gap-3 px-4 py-2.5 bg-muted/50 border-b border-border">
+        <Skeleton className="h-3 w-6 rounded" />
+        <Skeleton className="h-3 w-24 rounded" />
+        <div className="flex-1" />
+        <Skeleton className="h-3 w-16 rounded" />
+        <Skeleton className="h-3 w-14 rounded" />
+        <Skeleton className="size-5 rounded-md" />
+      </div>
+      {Array.from({ length: rows }).map((_, i) => (
+        <TableRowSkeleton key={i} />
+      ))}
+    </div>
+  )
+}
+
+// ─── Tile / card skeleton ─────────────────────────────────────────────────────
+// Used in: Items grid view, Files grid view
+export function TileSkeleton() {
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden">
+      {/* image area */}
+      <Skeleton className="w-full aspect-[4/3] rounded-none" />
+      <div className="p-3 space-y-2">
+        <Skeleton className="h-4 w-3/4 rounded" />
+        <Skeleton className="h-3 w-1/2 rounded" />
+        <div className="flex items-center gap-1.5 pt-0.5">
+          <Skeleton className="h-4 w-12 rounded-full" />
+          <Skeleton className="h-4 w-14 rounded-full" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function TileGridSkeleton({ count = 8 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <TileSkeleton key={i} />
+      ))}
+    </div>
+  )
+}
+
+// ─── Detail panel skeleton ────────────────────────────────────────────────────
+// Used in: ItemDetail (Sheet), FileDetail (Sheet)
+export function DetailPanelSkeleton() {
+  return (
+    <div className="flex flex-col gap-5 p-6">
+      {/* header: image + title */}
+      <div className="flex items-start gap-4">
+        <Skeleton className="size-16 rounded-xl shrink-0" />
+        <div className="flex-1 space-y-2 pt-1">
+          <Skeleton className="h-5 w-40 rounded" />
+          <Skeleton className="h-3.5 w-28 rounded" />
+          <div className="flex gap-1.5 pt-1">
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="h-5 w-20 rounded-full" />
+          </div>
+        </div>
+      </div>
+
+      <Separator />
+
+      {/* stat row */}
+      <div className="grid grid-cols-2 gap-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-lg border border-border p-3 space-y-1.5">
+            <Skeleton className="h-3 w-16 rounded" />
+            <Skeleton className="h-4 w-20 rounded" />
+          </div>
+        ))}
+      </div>
+
+      <Separator />
+
+      {/* tab bar */}
+      <div className="flex gap-1">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-20 rounded-md" />
+        ))}
+      </div>
+
+      {/* body lines */}
+      <div className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex justify-between items-center py-2 border-b border-border last:border-0">
+            <Skeleton className="h-3.5 w-24 rounded" />
+            <Skeleton className={`h-3.5 rounded ${i % 2 === 0 ? "w-32" : "w-20"}`} />
+          </div>
+        ))}
+      </div>
+
+      {/* action buttons */}
+      <div className="flex gap-2 pt-2">
+        <Skeleton className="h-9 flex-1 rounded-md" />
+        <Skeleton className="size-9 rounded-md shrink-0" />
+      </div>
+    </div>
+  )
+}
+
+// ─── Showcase wrapper used in UIShowcaseView ──────────────────────────────────
+export function SkeletonShowcase() {
+  return (
+    <div className="space-y-10">
+
+      {/* Stat cards */}
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3">
+          Stat card skeleton
+        </p>
+        <StatCardSkeletonRow count={3} />
+      </div>
+
+      <Separator />
+
+      {/* Table rows */}
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3">
+          Table / row skeleton (6 rows)
+        </p>
+        <TableSkeleton rows={6} />
+      </div>
+
+      <Separator />
+
+      {/* Tiles */}
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3">
+          Tile / grid skeleton (8 cards)
+        </p>
+        <TileGridSkeleton count={8} />
+      </div>
+
+      <Separator />
+
+      {/* Detail panel */}
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3">
+          Detail-panel skeleton (Sheet / slide-over)
+        </p>
+        <div className="rounded-xl border border-border bg-card max-w-sm overflow-hidden">
+          <DetailPanelSkeleton />
+        </div>
+      </div>
+
+    </div>
+  )
+}

--- a/design-mocks/src/components/TagPill.tsx
+++ b/design-mocks/src/components/TagPill.tsx
@@ -1,0 +1,40 @@
+import { Hash, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { Tag } from "@/data/mock"
+
+interface TagPillProps {
+  tag: Tag
+  size?: "sm" | "xs"
+  onRemove?: () => void
+  className?: string
+}
+
+export function TagPill({ tag, size = "sm", onRemove, className }: TagPillProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border font-medium select-none",
+        size === "xs"
+          ? "h-4 px-1.5 text-[10px]"
+          : "h-5 px-2 text-xs",
+        tag.bg,
+        tag.color,
+        tag.border,
+        className
+      )}
+    >
+      <Hash className={cn("shrink-0", size === "xs" ? "size-2.5" : "size-3")} />
+      {tag.label}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onRemove() }}
+          className="ml-0.5 opacity-60 hover:opacity-100 transition-opacity"
+          aria-label={`Remove tag ${tag.label}`}
+        >
+          <X className={size === "xs" ? "size-2.5" : "size-3"} />
+        </button>
+      )}
+    </span>
+  )
+}

--- a/design-mocks/src/components/ui/skeleton.tsx
+++ b/design-mocks/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn("animate-pulse rounded-md bg-accent", className)}
       {...props}
     />
   )

--- a/design-mocks/src/data/mock.ts
+++ b/design-mocks/src/data/mock.ts
@@ -43,11 +43,18 @@ export interface Area {
   icon: string
 }
 
-export interface FileTag {
+// Unified tag entity — used for both inventory items and attached files.
+// `color` is a Tailwind text-color class from the design token palette.
+export interface Tag {
   id: string
   label: string
-  color: string
+  color: string   // e.g. "text-chart-1"
+  bg: string      // e.g. "bg-chart-1/15"
+  border: string  // e.g. "border-chart-1/30"
 }
+
+/** @deprecated Use Tag instead */
+export type FileTag = Tag
 
 export type FileCategory = "image" | "invoice" | "document" | "other"
 
@@ -194,7 +201,7 @@ export const MOCK_ITEMS: InventoryItem[] = [
     supplyLinks: [{ label: "Descaler tablets", url: "#" }, { label: "Drum cleaner", url: "#" }],
     notes: "Uses Miele UltraTabs. Run maintenance cycle monthly.",
     imageUrl: null,
-    tags: ["laundry", "white-goods"],
+    tags: ["i1", "i2"],
   },
   {
     id: "2",
@@ -219,7 +226,7 @@ export const MOCK_ITEMS: InventoryItem[] = [
     supplyLinks: [{ label: "USB-C charger 140W", url: "#" }, { label: "Screen cleaner kit", url: "#" }],
     notes: "M1 Pro chip. 16GB RAM / 1TB SSD.",
     imageUrl: null,
-    tags: ["work", "apple"],
+    tags: ["i3", "i4"],
   },
   {
     id: "3",
@@ -244,7 +251,7 @@ export const MOCK_ITEMS: InventoryItem[] = [
     supplyLinks: [{ label: "Water filter DA29-00020B", url: "#" }, { label: "Ice maker assembly", url: "#" }],
     notes: "Change water filter every 6 months.",
     imageUrl: null,
-    tags: ["kitchen", "samsung"],
+    tags: ["i5", "i6"],
   },
   {
     id: "4",
@@ -269,7 +276,7 @@ export const MOCK_ITEMS: InventoryItem[] = [
     supplyLinks: [{ label: "HEPA filter", url: "#" }, { label: "Replacement battery", url: "#" }],
     notes: "Clean filter every 3 months.",
     imageUrl: null,
-    tags: ["cleaning"],
+    tags: ["i7"],
   },
   {
     id: "5",
@@ -294,7 +301,7 @@ export const MOCK_ITEMS: InventoryItem[] = [
     supplyLinks: [{ label: "Replacement ear cushions", url: "#" }, { label: "USB-C cable", url: "#" }],
     notes: "Best noise-cancelling on the market.",
     imageUrl: null,
-    tags: ["audio", "sony"],
+    tags: ["i8", "i9"],
     statusNote: "Sold on eBay",
     statusDate: "2026-02-14",
     salePrice: 210,
@@ -322,7 +329,7 @@ export const MOCK_ITEMS: InventoryItem[] = [
     supplyLinks: [{ label: "Finish Quantum pods", url: "#" }, { label: "Dishwasher cleaner", url: "#" }],
     notes: "Run dishwasher cleaner monthly.",
     imageUrl: null,
-    tags: ["kitchen", "bosch"],
+    tags: ["i5", "i10"],
   },
   {
     id: "7",
@@ -347,7 +354,7 @@ export const MOCK_ITEMS: InventoryItem[] = [
     supplyLinks: [{ label: "HDMI 2.1 cable", url: "#" }],
     notes: '65" OLED, G-Sync Compatible.',
     imageUrl: null,
-    tags: ["living-room", "lg"],
+    tags: ["i11", "i12"],
   },
   {
     id: "8",
@@ -372,7 +379,7 @@ export const MOCK_ITEMS: InventoryItem[] = [
     supplyLinks: [{ label: "20V MAX battery", url: "#" }, { label: "Drill bit set", url: "#" }],
     notes: "Left battery needs replacement.",
     imageUrl: null,
-    tags: ["tools", "dewalt"],
+    tags: ["i13", "i14"],
   },
   {
     id: "9",
@@ -397,19 +404,101 @@ export const MOCK_ITEMS: InventoryItem[] = [
     supplyLinks: [{ label: "Replacement blade", url: "#" }],
     notes: "Use only 165mm blades.",
     imageUrl: null,
-    tags: ["tools", "makita"],
+    tags: ["i13", "i15", "i7"],
+  },
+  {
+    id: "10",
+    name: "Nespresso Vertuo",
+    shortName: "Coffee Maker",
+    brand: "Nespresso",
+    model: "Vertuo Next",
+    category: "appliance",
+    status: "in_use",
+    draft: false,
+    count: 1,
+    areaId: "a1",
+    purchasedAt: "2023-09-01",
+    purchasePrice: 199,
+    purchaseCurrency: "USD",
+    currentValue: 150,
+    serialNumber: "NES-VN-23-009",
+    extraSerialNumbers: [],
+    partNumbers: [],
+    urls: [],
+    warranty: { expiresAt: daysFromNow(300), receiptUrl: null, notes: "2-year Nespresso warranty." },
+    supplyLinks: [{ label: "Vertuo pods", url: "#" }],
+    notes: "Descale every 3 months.",
+    imageUrl: null,
+    tags: ["i5", "i7", "i2"],
+  },
+  {
+    id: "11",
+    name: "Bose QuietComfort 45",
+    shortName: "BQ45",
+    brand: "Bose",
+    model: "QC45",
+    category: "electronics",
+    status: "in_use",
+    draft: false,
+    count: 1,
+    areaId: "a3",
+    purchasedAt: "2022-07-15",
+    purchasePrice: 329,
+    purchaseCurrency: "USD",
+    currentValue: 200,
+    serialNumber: "BOSE-QC45-22-887",
+    extraSerialNumbers: [],
+    partNumbers: [],
+    urls: [],
+    warranty: { expiresAt: daysFromNow(-90), receiptUrl: null, notes: "1-year Bose warranty." },
+    supplyLinks: [{ label: "Replacement ear cushions", url: "#" }],
+    notes: "Charge every 2–3 days with regular use.",
+    imageUrl: null,
+    tags: ["i8", "i3", "i11"],
   },
 ]
 
-// ─── File tags ────────────────────────────────────────────────
-export const FILE_TAGS: FileTag[] = [
-  { id: "t1", label: "Invoice", color: "text-chart-1" },
-  { id: "t2", label: "Warranty", color: "text-status-active" },
-  { id: "t3", label: "Manual", color: "text-chart-3" },
-  { id: "t4", label: "Photo", color: "text-status-expiring" },
-  { id: "t5", label: "Certificate", color: "text-chart-2" },
-  { id: "t6", label: "Backup", color: "text-muted-foreground" },
+// ─── Unified tag palette ──────────────────────────────────────
+// Single source of truth for both item tags and file tags.
+// color/bg/border are design-token-based Tailwind classes.
+export const MOCK_TAGS: Tag[] = [
+  // File/document tags (t1–t6) — kept with same IDs for backwards compat
+  { id: "t1", label: "Invoice",     color: "text-chart-1",         bg: "bg-chart-1/15",        border: "border-chart-1/30" },
+  { id: "t2", label: "Warranty",    color: "text-status-active",   bg: "bg-status-active/15",  border: "border-status-active/30" },
+  { id: "t3", label: "Manual",      color: "text-chart-3",         bg: "bg-chart-3/15",        border: "border-chart-3/30" },
+  { id: "t4", label: "Photo",       color: "text-status-expiring", bg: "bg-status-expiring/15",border: "border-status-expiring/30" },
+  { id: "t5", label: "Certificate", color: "text-chart-2",         bg: "bg-chart-2/15",        border: "border-chart-2/30" },
+  { id: "t6", label: "Backup",      color: "text-muted-foreground",bg: "bg-muted",             border: "border-border" },
+  // Item / inventory tags (i1–i12)
+  { id: "i1",  label: "laundry",    color: "text-chart-3",         bg: "bg-chart-3/15",        border: "border-chart-3/30" },
+  { id: "i2",  label: "white-goods",color: "text-chart-1",         bg: "bg-chart-1/15",        border: "border-chart-1/30" },
+  { id: "i3",  label: "work",       color: "text-chart-2",         bg: "bg-chart-2/15",        border: "border-chart-2/30" },
+  { id: "i4",  label: "apple",      color: "text-muted-foreground",bg: "bg-muted",             border: "border-border" },
+  { id: "i5",  label: "kitchen",    color: "text-status-expiring", bg: "bg-status-expiring/15",border: "border-status-expiring/30" },
+  { id: "i6",  label: "samsung",    color: "text-chart-4",         bg: "bg-chart-4/15",        border: "border-chart-4/30" },
+  { id: "i7",  label: "cleaning",   color: "text-status-active",   bg: "bg-status-active/15",  border: "border-status-active/30" },
+  { id: "i8",  label: "audio",      color: "text-chart-1",         bg: "bg-chart-1/15",        border: "border-chart-1/30" },
+  { id: "i9",  label: "sony",       color: "text-chart-5",         bg: "bg-chart-5/15",        border: "border-chart-5/30" },
+  { id: "i10", label: "bosch",      color: "text-chart-3",         bg: "bg-chart-3/15",        border: "border-chart-3/30" },
+  { id: "i11", label: "living-room",color: "text-chart-2",         bg: "bg-chart-2/15",        border: "border-chart-2/30" },
+  { id: "i12", label: "lg",         color: "text-chart-4",         bg: "bg-chart-4/15",        border: "border-chart-4/30" },
+  { id: "i13", label: "tools",      color: "text-chart-5",         bg: "bg-chart-5/15",        border: "border-chart-5/30" },
+  { id: "i14", label: "dewalt",     color: "text-status-expiring", bg: "bg-status-expiring/15",border: "border-status-expiring/30" },
+  { id: "i15", label: "makita",     color: "text-chart-1",         bg: "bg-chart-1/15",        border: "border-chart-1/30" },
 ]
+
+/** @deprecated Use MOCK_TAGS instead */
+export const FILE_TAGS: Tag[] = MOCK_TAGS.filter((t) => t.id.startsWith("t"))
+
+// Helper: look up a Tag by ID, returns undefined if not found
+export function findTag(id: string): Tag | undefined {
+  return MOCK_TAGS.find((t) => t.id === id)
+}
+
+// Helper: resolve an array of tag IDs to Tag objects (omits unknown IDs)
+export function resolveTags(ids: string[]): Tag[] {
+  return ids.flatMap((id) => { const t = findTag(id); return t ? [t] : [] })
+}
 
 // ─── Files ────────────────────────────────────────────────────
 export const MOCK_FILES: AttachedFile[] = [
@@ -540,3 +629,221 @@ export const CURRENCIES = [
   { code: "SAR", name: "Saudi Riyal", symbol: "﷼" },
   { code: "AED", name: "UAE Dirham", symbol: "د.إ" },
 ]
+
+// ══════════════════════════════════════════════════════════════
+// Admin — tenants, users, sessions, groups (mock-only)
+// ══════════════════════════════════════════════════════════════
+
+export type TenantStatus = "active" | "suspended" | "trial" | "archived"
+export type TenantPlan = "free" | "starter" | "business" | "enterprise"
+export type GroupStatus = "active" | "pending_deletion"
+
+export interface UserSession {
+  id: string
+  device: string
+  ip: string
+  location: string
+  lastActive: string // ISO datetime
+  current: boolean
+}
+
+export interface AdminUser {
+  id: string
+  tenantId: string
+  name: string
+  email: string
+  avatarInitials: string
+  role: MemberRole
+  isActive: boolean
+  lastLogin: string | null // ISO datetime
+  createdAt: string
+  sessions: UserSession[]
+  groupMemberships: { groupId: string; role: MemberRole }[]
+}
+
+export interface AdminGroup {
+  id: string
+  tenantId: string
+  name: string
+  status: GroupStatus
+  currency: string
+  memberCount: number
+  createdAt: string
+  members: { userId: string; role: MemberRole }[]
+}
+
+export interface Tenant {
+  id: string
+  name: string
+  slug: string
+  domain: string
+  status: TenantStatus
+  plan: TenantPlan
+  userCount: number
+  groupCount: number
+  createdAt: string
+}
+
+export const TENANT_STATUS_CONFIG: Record<
+  TenantStatus,
+  { label: string; color: string; bg: string }
+> = {
+  active: { label: "Active", color: "text-status-active", bg: "bg-status-active/10" },
+  trial: { label: "Trial", color: "text-chart-3", bg: "bg-chart-3/10" },
+  suspended: { label: "Suspended", color: "text-status-expired", bg: "bg-status-expired/10" },
+  archived: { label: "Archived", color: "text-status-none", bg: "bg-status-none/10" },
+}
+
+export const TENANT_PLAN_CONFIG: Record<TenantPlan, { label: string }> = {
+  free: { label: "Free" },
+  starter: { label: "Starter" },
+  business: { label: "Business" },
+  enterprise: { label: "Enterprise" },
+}
+
+export const GROUP_STATUS_CONFIG: Record<
+  GroupStatus,
+  { label: string; color: string; bg: string }
+> = {
+  active: { label: "Active", color: "text-status-active", bg: "bg-status-active/10" },
+  pending_deletion: { label: "Pending Deletion", color: "text-status-expired", bg: "bg-status-expired/10" },
+}
+
+// ─── Tenants ─────────────────────────────────────────────────
+export const MOCK_TENANTS: Tenant[] = [
+  { id: "tn1",  name: "Northwind Estates",     slug: "northwind",     domain: "northwind.inventario.app",    status: "active",    plan: "business",   userCount: 24, groupCount: 6, createdAt: "2023-02-11" },
+  { id: "tn2",  name: "Harbor & Co",           slug: "harbor-co",     domain: "harbor.inventario.app",       status: "active",    plan: "enterprise", userCount: 88, groupCount: 14, createdAt: "2022-09-30" },
+  { id: "tn3",  name: "Cedar Valley Homes",    slug: "cedar-valley",  domain: "cedarvalley.inventario.app",  status: "trial",     plan: "starter",    userCount: 5,  groupCount: 2, createdAt: "2026-04-28" },
+  { id: "tn4",  name: "Atlas Property Group",  slug: "atlas-pg",      domain: "atlas.inventario.app",        status: "active",    plan: "business",   userCount: 41, groupCount: 9, createdAt: "2023-07-19" },
+  { id: "tn5",  name: "Birchwood Rentals",     slug: "birchwood",     domain: "birchwood.inventario.app",    status: "suspended", plan: "starter",    userCount: 12, groupCount: 3, createdAt: "2024-01-05" },
+  { id: "tn6",  name: "Sterling Logistics",    slug: "sterling",      domain: "sterling.inventario.app",     status: "active",    plan: "enterprise", userCount: 130, groupCount: 22, createdAt: "2021-11-22" },
+  { id: "tn7",  name: "Maple Lane Storage",    slug: "maple-lane",    domain: "maplelane.inventario.app",    status: "active",    plan: "free",       userCount: 3,  groupCount: 1, createdAt: "2025-03-14" },
+  { id: "tn8",  name: "Ironclad Workshops",    slug: "ironclad",      domain: "ironclad.inventario.app",     status: "trial",     plan: "starter",    userCount: 7,  groupCount: 2, createdAt: "2026-05-02" },
+  { id: "tn9",  name: "Greenfield Coop",       slug: "greenfield",    domain: "greenfield.inventario.app",   status: "active",    plan: "business",   userCount: 33, groupCount: 7, createdAt: "2023-05-08" },
+  { id: "tn10", name: "Pinecrest Holdings",    slug: "pinecrest",     domain: "pinecrest.inventario.app",    status: "archived",  plan: "free",       userCount: 2,  groupCount: 1, createdAt: "2022-04-17" },
+  { id: "tn11", name: "Lakeside Ventures",     slug: "lakeside",      domain: "lakeside.inventario.app",     status: "active",    plan: "business",   userCount: 19, groupCount: 5, createdAt: "2024-08-29" },
+  { id: "tn12", name: "Summit Facilities",     slug: "summit-fac",    domain: "summit.inventario.app",       status: "active",    plan: "enterprise", userCount: 64, groupCount: 11, createdAt: "2022-12-03" },
+  { id: "tn13", name: "Willow Park Mgmt",      slug: "willow-park",   domain: "willowpark.inventario.app",   status: "suspended", plan: "business",   userCount: 28, groupCount: 6, createdAt: "2023-10-11" },
+  { id: "tn14", name: "Redbrick Realty",       slug: "redbrick",      domain: "redbrick.inventario.app",     status: "active",    plan: "starter",    userCount: 9,  groupCount: 3, createdAt: "2025-01-20" },
+  { id: "tn15", name: "Copperline Studios",    slug: "copperline",    domain: "copperline.inventario.app",   status: "trial",     plan: "starter",    userCount: 4,  groupCount: 1, createdAt: "2026-05-12" },
+  { id: "tn16", name: "Oakhaven Trust",        slug: "oakhaven",      domain: "oakhaven.inventario.app",     status: "active",    plan: "business",   userCount: 37, groupCount: 8, createdAt: "2023-03-27" },
+  { id: "tn17", name: "Brightwater Group",     slug: "brightwater",   domain: "brightwater.inventario.app",  status: "active",    plan: "enterprise", userCount: 102, groupCount: 18, createdAt: "2022-06-14" },
+  { id: "tn18", name: "Stonebridge Estates",   slug: "stonebridge",   domain: "stonebridge.inventario.app",  status: "active",    plan: "free",       userCount: 6,  groupCount: 2, createdAt: "2025-09-01" },
+  { id: "tn19", name: "Hollow Creek Storage",  slug: "hollow-creek",  domain: "hollowcreek.inventario.app",  status: "archived",  plan: "starter",    userCount: 8,  groupCount: 2, createdAt: "2021-08-23" },
+  { id: "tn20", name: "Vantage Property Co",   slug: "vantage",       domain: "vantage.inventario.app",      status: "active",    plan: "business",   userCount: 45, groupCount: 10, createdAt: "2024-02-16" },
+  { id: "tn21", name: "Foxglove Rentals",      slug: "foxglove",      domain: "foxglove.inventario.app",     status: "trial",     plan: "free",       userCount: 3,  groupCount: 1, createdAt: "2026-05-15" },
+  { id: "tn22", name: "Driftwood Holdings",    slug: "driftwood",     domain: "driftwood.inventario.app",    status: "active",    plan: "enterprise", userCount: 71, groupCount: 13, createdAt: "2023-01-09" },
+]
+
+// ─── Admin users — generated per tenant ──────────────────────
+const ADMIN_FIRST = ["Alex", "Jordan", "Riley", "Morgan", "Casey", "Taylor", "Sam", "Jamie", "Quinn", "Avery", "Drew", "Reese"]
+const ADMIN_LAST = ["Hartley", "Velez", "Okafor", "Lindqvist", "Marsh", "Delgado", "Novak", "Bauer", "Cho", "Ferreira"]
+const DEVICES = ["MacBook Pro · Chrome", "iPhone 15 · Safari", "Windows 11 · Edge", "iPad Air · Safari", "Linux · Firefox"]
+const CITIES = ["Berlin, DE", "Austin, US", "Prague, CZ", "London, GB", "Toronto, CA", "Lisbon, PT"]
+
+function pick<T>(arr: T[], n: number): T {
+  return arr[n % arr.length]
+}
+
+function buildAdminUsers(): AdminUser[] {
+  const users: AdminUser[] = []
+  let seq = 0
+  for (const tenant of MOCK_TENANTS) {
+    const count = Math.min(6, Math.max(2, Math.round(tenant.userCount / 8)))
+    for (let i = 0; i < count; i++) {
+      seq++
+      const first = pick(ADMIN_FIRST, seq * 3 + i)
+      const last = pick(ADMIN_LAST, seq + i * 2)
+      const role: MemberRole = i === 0 ? "owner" : i === 1 ? "admin" : i % 2 === 0 ? "user" : "viewer"
+      const isActive = !(seq % 9 === 0)
+      const sessionCount = isActive ? (i % 3) + 1 : 0
+      const sessions: UserSession[] = Array.from({ length: sessionCount }, (_, s) => ({
+        id: `se-${seq}-${s}`,
+        device: pick(DEVICES, seq + s),
+        ip: `${20 + ((seq + s) % 200)}.${(seq * 7 + s) % 250}.${(s * 13) % 250}.${(seq + s * 3) % 250}`,
+        location: pick(CITIES, seq + s * 2),
+        lastActive: daysFromNow(-(s * 2) - (seq % 5)) + "T" + String(8 + ((seq + s) % 12)).padStart(2, "0") + ":" + String((seq * 7) % 60).padStart(2, "0") + ":00",
+        current: s === 0,
+      }))
+      users.push({
+        id: `au-${seq}`,
+        tenantId: tenant.id,
+        name: `${first} ${last}`,
+        email: `${first.toLowerCase()}.${last.toLowerCase()}@${tenant.slug}.com`,
+        avatarInitials: first[0] + last[0],
+        role,
+        isActive,
+        lastLogin: isActive ? daysFromNow(-(seq % 14)) + "T09:" + String((seq * 11) % 60).padStart(2, "0") + ":00" : daysFromNow(-60 - (seq % 90)) + "T09:00:00",
+        createdAt: tenant.createdAt,
+        sessions,
+        groupMemberships: [],
+      })
+    }
+  }
+  return users
+}
+
+export const MOCK_ADMIN_USERS: AdminUser[] = buildAdminUsers()
+
+// ─── Admin groups — generated per tenant ─────────────────────
+const GROUP_NAMES = ["Main Residence", "Downtown Office", "Warehouse A", "Storage Unit 12", "Garage Workshop", "Coastal Retreat", "North Wing", "Field Depot", "Annex Building", "Records Vault"]
+
+function buildAdminGroups(): AdminGroup[] {
+  const groups: AdminGroup[] = []
+  let seq = 0
+  for (const tenant of MOCK_TENANTS) {
+    const tenantUsers = MOCK_ADMIN_USERS.filter((u) => u.tenantId === tenant.id)
+    const count = Math.min(5, Math.max(1, Math.round(tenant.groupCount / 2)))
+    for (let i = 0; i < count; i++) {
+      seq++
+      const status: GroupStatus = seq % 11 === 0 ? "pending_deletion" : "active"
+      const memberSlice = tenantUsers.slice(0, Math.min(tenantUsers.length, (i % 3) + 2))
+      // Intentional: a member's group-membership role is assigned per group and
+      // is distinct from the user's tenant-level identity role. A user who is a
+      // "viewer" at the tenant level can legitimately be an "owner" of a group.
+      const members = memberSlice.map((u, mi) => ({
+        userId: u.id,
+        role: (mi === 0 ? "owner" : mi === 1 ? "admin" : mi % 2 === 0 ? "user" : "viewer") as MemberRole,
+      }))
+      const group: AdminGroup = {
+        id: `ag-${seq}`,
+        tenantId: tenant.id,
+        name: pick(GROUP_NAMES, seq + i),
+        status,
+        currency: pick(["USD", "EUR", "GBP", "CZK", "CHF"], seq),
+        memberCount: members.length,
+        createdAt: daysFromNow(-(seq * 17) - 30),
+        members,
+      }
+      groups.push(group)
+      for (const m of members) {
+        const u = MOCK_ADMIN_USERS.find((x) => x.id === m.userId)
+        if (u) u.groupMemberships.push({ groupId: group.id, role: m.role })
+      }
+    }
+  }
+  return groups
+}
+
+export const MOCK_ADMIN_GROUPS: AdminGroup[] = buildAdminGroups()
+
+// ─── Admin lookup helpers ────────────────────────────────────
+export function tenantById(id: string): Tenant | undefined {
+  return MOCK_TENANTS.find((t) => t.id === id)
+}
+
+export function adminUserById(id: string): AdminUser | undefined {
+  return MOCK_ADMIN_USERS.find((u) => u.id === id)
+}
+
+export function adminGroupById(id: string): AdminGroup | undefined {
+  return MOCK_ADMIN_GROUPS.find((g) => g.id === id)
+}
+
+export function usersByTenant(tenantId: string): AdminUser[] {
+  return MOCK_ADMIN_USERS.filter((u) => u.tenantId === tenantId)
+}
+
+export function groupsByTenant(tenantId: string): AdminGroup[] {
+  return MOCK_ADMIN_GROUPS.filter((g) => g.tenantId === tenantId)
+}

--- a/design-mocks/src/lib/utils.ts
+++ b/design-mocks/src/lib/utils.ts
@@ -4,15 +4,3 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
-
-// `crypto.randomUUID` is undefined outside a secure context (HTTPS or
-// `localhost` / `127.0.0.1`). Plain-HTTP dev hosts (e.g. tailscale
-// hostnames) hit the unbounded form and crash on mount. The fallback
-// yields enough entropy for in-memory list keys — these ids never
-// leave the client.
-export function makeId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID()
-  }
-  return `id-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
-}

--- a/design-mocks/src/main.tsx
+++ b/design-mocks/src/main.tsx
@@ -4,11 +4,14 @@ import { createRoot } from "react-dom/client"
 import "./index.css"
 import App from "./App.tsx"
 import { ThemeProvider } from "@/components/theme-provider.tsx"
+import { ErrorBoundary } from "@/components/ErrorBoundary.tsx"
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ThemeProvider>
-      <App />
-    </ThemeProvider>
+    <ErrorBoundary>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </ErrorBoundary>
   </StrictMode>
 )

--- a/design-mocks/src/views/FileBrowserView.tsx
+++ b/design-mocks/src/views/FileBrowserView.tsx
@@ -39,8 +39,9 @@ import {
   PaginationEllipsis,
 } from "@/components/ui/pagination"
 import { FileDetailSheet } from "@/components/FileDetail"
-import { cn, makeId } from "@/lib/utils"
-import { MOCK_FILES, FILE_TAGS, type AttachedFile, type FileCategory } from "@/data/mock"
+import { cn } from "@/lib/utils"
+import { MOCK_FILES, FILE_TAGS, resolveTags, type AttachedFile, type FileCategory } from "@/data/mock"
+import { TagPill } from "@/components/TagPill"
 
 const PAGE_SIZE = 12
 
@@ -180,7 +181,7 @@ function UploadDialog({ open, onClose }: UploadDialogProps) {
     setPendingFiles((prev) => [
       ...prev,
       ...arr.map((f) => ({
-        id: makeId(),
+        id: crypto.randomUUID(),
         file: f,
         name: f.name.replace(/\.[^.]+$/, ""),
         category: guessCategoryFromMime(f.type),
@@ -701,7 +702,7 @@ export function FileBrowserView({ onOpenFile: _onOpenFile }: FileBrowserViewProp
               const group = mimeGroup(file.mimeType)
               const Icon = FILE_ICONS[group]
               const isSelected = selectedFile?.id === file.id
-              const fileTags = FILE_TAGS.filter((t) => file.tags.includes(t.id))
+              const fileTags = resolveTags(file.tags)
               const catTab = CATEGORY_TABS.find((t) => t.id === file.category)
               const CatIcon = catTab?.icon ?? File
               const dateStr = new Date(file.uploadedAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
@@ -722,7 +723,7 @@ export function FileBrowserView({ onOpenFile: _onOpenFile }: FileBrowserViewProp
                       <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
                         <span className="text-xs text-muted-foreground truncate">{file.attachedTo.name}</span>
                         {fileTags.map((tag) => (
-                          <span key={tag.id} className={cn("text-[10px] font-medium", tag.color)}>#{tag.label}</span>
+                          <TagPill key={tag.id} tag={tag} size="xs" />
                         ))}
                       </div>
                     </div>
@@ -753,7 +754,7 @@ export function FileBrowserView({ onOpenFile: _onOpenFile }: FileBrowserViewProp
                           <span className={cn("text-[10px] font-medium", catTab?.color ?? "text-muted-foreground")}>{catTab?.label ?? file.category}</span>
                         </div>
                         {fileTags.map((tag) => (
-                          <span key={tag.id} className={cn("text-[10px] font-medium", tag.color)}>#{tag.label}</span>
+                          <TagPill key={tag.id} tag={tag} size="xs" />
                         ))}
                       </div>
                     </div>
@@ -773,7 +774,7 @@ export function FileBrowserView({ onOpenFile: _onOpenFile }: FileBrowserViewProp
             const group = mimeGroup(file.mimeType)
             const Icon = FILE_ICONS[group]
             const isSelected = selectedFile?.id === file.id
-            const fileTags = FILE_TAGS.filter((t) => file.tags.includes(t.id))
+            const fileTags = resolveTags(file.tags)
             const catTab = CATEGORY_TABS.find((t) => t.id === file.category)
             const CatIcon = catTab?.icon ?? File
             return (
@@ -820,9 +821,7 @@ export function FileBrowserView({ onOpenFile: _onOpenFile }: FileBrowserViewProp
                   </p>
                   <div className="flex items-center gap-x-2 gap-y-0.5 mt-1.5 flex-wrap">
                     {fileTags.map((tag) => (
-                      <span key={tag.id} className={cn("text-[10px] font-medium", tag.color)}>
-                        #{tag.label}
-                      </span>
+                      <TagPill key={tag.id} tag={tag} size="xs" />
                     ))}
                     <span className="text-[10px] text-muted-foreground ml-auto">{file.size}</span>
                   </div>

--- a/design-mocks/src/views/MembersView.tsx
+++ b/design-mocks/src/views/MembersView.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { UserPlus, MoveHorizontal as MoreHorizontal, Shield, User, Mail, Crown, Trash2, Check, X, Users, Clock, Plus, Building2, Eye } from "lucide-react"
+import { UserPlus, Ellipsis, Shield, User, Mail, Crown, Trash2, Check, X, Users, Clock, Plus, Building2, Eye } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
@@ -218,7 +218,7 @@ export function MembersView({ activeGroupId }: MembersViewProps) {
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <Button variant="ghost" size="icon" className="size-7">
-                            <MoreHorizontal className="size-4" />
+                            <Ellipsis className="size-4" />
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
@@ -389,7 +389,7 @@ function MemberRow({
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" size="icon" className="size-7">
-              <MoreHorizontal className="size-4" />
+              <Ellipsis className="size-4" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">

--- a/design-mocks/src/views/SettingsView.tsx
+++ b/design-mocks/src/views/SettingsView.tsx
@@ -34,9 +34,10 @@ const SECTIONS = [
 
 interface SettingsViewProps {
   onNavigate?: (view: string) => void
+  onOpenShortcuts?: () => void
 }
 
-export function SettingsView({ onNavigate }: SettingsViewProps) {
+export function SettingsView({ onNavigate, onOpenShortcuts }: SettingsViewProps) {
   const [active, setActive] = useState<SettingsSection>("appearance")
 
   return (
@@ -86,7 +87,7 @@ export function SettingsView({ onNavigate }: SettingsViewProps) {
               {active === "notifications" && <NotificationsSection />}
               {active === "privacy" && <PrivacySection />}
               {active === "data" && <DataSection />}
-              {active === "help" && <HelpSection />}
+              {active === "help" && <HelpSection onOpenShortcuts={onOpenShortcuts} />}
             </div>
           </div>
         </div>
@@ -450,27 +451,30 @@ function DataSection() {
   )
 }
 
-function HelpSection() {
+function HelpSection({ onOpenShortcuts }: { onOpenShortcuts?: () => void }) {
+  const ROWS = [
+    { label: "Documentation", description: "Browse guides and tutorials", action: undefined },
+    { label: "Keyboard shortcuts", description: "View all available shortcuts", action: onOpenShortcuts },
+    { label: "What's new", description: "See latest features and updates", badge: "v1.2", action: undefined },
+    { label: "Send feedback", description: "Help us improve Inventario", action: undefined },
+    { label: "Contact support", description: "Get help from the team", action: undefined },
+  ]
+
   return (
     <div>
       <SectionTitle>Help & Support</SectionTitle>
       <div className="space-y-4">
         <div className="rounded-xl border border-border divide-y divide-border">
-          {[
-            { label: "Documentation", description: "Browse guides and tutorials" },
-            { label: "Keyboard shortcuts", description: "View all available shortcuts" },
-            { label: "What's new", description: "See latest features and updates", badge: "v1.2" },
-            { label: "Send feedback", description: "Help us improve Inventario" },
-            { label: "Contact support", description: "Get help from the team" },
-          ].map((row) => (
+          {ROWS.map((row) => (
             <button
               key={row.label}
+              onClick={row.action}
               className="flex w-full items-center justify-between p-4 text-left hover:bg-muted/50 transition-colors"
             >
               <div>
                 <div className="flex items-center gap-2">
                   <p className="text-sm font-medium">{row.label}</p>
-                  {row.badge && (
+                  {"badge" in row && row.badge && (
                     <Badge variant="secondary" className="text-[10px] h-4 px-1.5">
                       {row.badge}
                     </Badge>

--- a/design-mocks/src/views/TagsView.tsx
+++ b/design-mocks/src/views/TagsView.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react"
-import { Tag, Plus, Pencil, Trash2, Hash, Package, Search, X, Check } from "lucide-react"
+import { Tag as TagIcon, Plus, Pencil, Trash2, Hash, Package, Search, X, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
@@ -14,72 +14,25 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { cn } from "@/lib/utils"
-import { MOCK_ITEMS } from "@/data/mock"
+import { MOCK_ITEMS, MOCK_TAGS, type Tag } from "@/data/mock"
+import { TagPill } from "@/components/TagPill"
 
 // ─── Tag color palette ────────────────────────────────────────
 
-const TAG_COLORS = [
-  { id: "amber",   dot: "bg-chart-1",        pill: "bg-chart-1/15 text-chart-1 border-chart-1/30" },
-  { id: "green",   dot: "bg-status-active",   pill: "bg-status-active/15 text-status-active border-status-active/30" },
-  { id: "blue",    dot: "bg-chart-3",         pill: "bg-chart-3/15 text-chart-3 border-chart-3/30" },
-  { id: "orange",  dot: "bg-chart-4",         pill: "bg-chart-4/15 text-chart-4 border-chart-4/30" },
-  { id: "red",     dot: "bg-chart-5",         pill: "bg-chart-5/15 text-chart-5 border-chart-5/30" },
-  { id: "muted",   dot: "bg-muted-foreground",pill: "bg-muted text-muted-foreground border-border" },
+const TAG_COLORS: Array<{ id: string; dot: string; color: string; bg: string; border: string }> = [
+  { id: "amber",   dot: "bg-chart-1",          color: "text-chart-1",         bg: "bg-chart-1/15",        border: "border-chart-1/30" },
+  { id: "green",   dot: "bg-status-active",     color: "text-status-active",   bg: "bg-status-active/15",  border: "border-status-active/30" },
+  { id: "blue",    dot: "bg-chart-3",           color: "text-chart-3",         bg: "bg-chart-3/15",        border: "border-chart-3/30" },
+  { id: "orange",  dot: "bg-chart-4",           color: "text-chart-4",         bg: "bg-chart-4/15",        border: "border-chart-4/30" },
+  { id: "red",     dot: "bg-chart-5",           color: "text-chart-5",         bg: "bg-chart-5/15",        border: "border-chart-5/30" },
+  { id: "muted",   dot: "bg-muted-foreground",  color: "text-muted-foreground",bg: "bg-muted",             border: "border-border" },
 ]
 
-interface TagDef {
-  id: string
-  label: string
-  colorId: string
-}
+// Seed initial state from MOCK_TAGS that are item tags (i-prefix)
+const INITIAL_TAGS: Tag[] = MOCK_TAGS.filter((t) => t.id.startsWith("i"))
 
-// Seed from items
-const seedTags = (): TagDef[] => {
-  const seen = new Set<string>()
-  const result: TagDef[] = []
-  const colors = TAG_COLORS.map((c) => c.id)
-  MOCK_ITEMS.forEach((item) => {
-    item.tags.forEach((t) => {
-      if (!seen.has(t)) {
-        seen.add(t)
-        result.push({ id: t, label: t, colorId: colors[result.length % colors.length] })
-      }
-    })
-  })
-  return result
-}
-
-const INITIAL_TAGS = seedTags()
-
-function itemCountForTag(tag: string) {
-  return MOCK_ITEMS.filter((item) => item.tags.includes(tag)).length
-}
-
-// ─── Tag pill (display) ───────────────────────────────────────
-
-function TagPill({ tag, onRemove }: { tag: TagDef; onRemove?: () => void }) {
-  const color = TAG_COLORS.find((c) => c.id === tag.colorId) ?? TAG_COLORS[5]
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium select-none",
-        color.pill
-      )}
-    >
-      <Hash className="size-2.5 shrink-0" />
-      {tag.label}
-      {onRemove && (
-        <button
-          type="button"
-          onClick={onRemove}
-          className="ml-0.5 rounded-full opacity-60 hover:opacity-100 transition-opacity"
-          aria-label="Remove tag"
-        >
-          <X className="size-2.5" />
-        </button>
-      )}
-    </span>
-  )
+function itemCountForTag(tagId: string) {
+  return MOCK_ITEMS.filter((item) => item.tags.includes(tagId)).length
 }
 
 // ─── Color picker dot row ─────────────────────────────────────
@@ -106,15 +59,18 @@ function ColorPicker({ value, onChange }: { value: string; onChange: (id: string
 
 // ─── Inline edit row ──────────────────────────────────────────
 
-function EditRow({ tag, onSave, onCancel }: { tag: TagDef; onSave: (t: TagDef) => void; onCancel: () => void }) {
+function EditRow({ tag, onSave, onCancel }: { tag: Tag; onSave: (t: Tag) => void; onCancel: () => void }) {
   const [label, setLabel] = useState(tag.label)
-  const [colorId, setColorId] = useState(tag.colorId)
+  // find closest colorId by matching bg class
+  const initialColorId = TAG_COLORS.find((c) => c.bg === tag.bg)?.id ?? TAG_COLORS[0].id
+  const [colorId, setColorId] = useState(initialColorId)
   const inputRef = useRef<HTMLInputElement>(null)
 
   function submit() {
     const trimmed = label.trim().toLowerCase().replace(/\s+/g, "-")
     if (!trimmed) return
-    onSave({ ...tag, label: trimmed, colorId })
+    const c = TAG_COLORS.find((x) => x.id === colorId) ?? TAG_COLORS[0]
+    onSave({ ...tag, label: trimmed, color: c.color, bg: c.bg, border: c.border })
   }
 
   return (
@@ -147,7 +103,7 @@ function EditRow({ tag, onSave, onCancel }: { tag: TagDef; onSave: (t: TagDef) =
 
 // ─── Create row ───────────────────────────────────────────────
 
-function CreateRow({ existingLabels, onCreate }: { existingLabels: Set<string>; onCreate: (t: Omit<TagDef, "id">) => void }) {
+function CreateRow({ existingLabels, onCreate }: { existingLabels: Set<string>; onCreate: (t: Omit<Tag, "id">) => void }) {
   const [open, setOpen] = useState(false)
   const [label, setLabel] = useState("")
   const [colorId, setColorId] = useState(TAG_COLORS[0].id)
@@ -155,7 +111,8 @@ function CreateRow({ existingLabels, onCreate }: { existingLabels: Set<string>; 
   function submit() {
     const trimmed = label.trim().toLowerCase().replace(/\s+/g, "-")
     if (!trimmed || existingLabels.has(trimmed)) return
-    onCreate({ label: trimmed, colorId })
+    const c = TAG_COLORS.find((x) => x.id === colorId) ?? TAG_COLORS[0]
+    onCreate({ label: trimmed, color: c.color, bg: c.bg, border: c.border })
     setLabel("")
     setColorId(TAG_COLORS[0].id)
     setOpen(false)
@@ -201,7 +158,7 @@ function CreateRow({ existingLabels, onCreate }: { existingLabels: Set<string>; 
 // ─── Main view ────────────────────────────────────────────────
 
 export function TagsView() {
-  const [tags, setTags] = useState<TagDef[]>(INITIAL_TAGS)
+  const [tags, setTags] = useState<Tag[]>(INITIAL_TAGS)
   const [search, setSearch] = useState("")
   const [editingId, setEditingId] = useState<string | null>(null)
   const [deleteId, setDeleteId] = useState<string | null>(null)
@@ -212,12 +169,12 @@ export function TagsView() {
 
   const existingLabels = new Set(tags.map((t) => t.label))
 
-  function addTag(partial: Omit<TagDef, "id">) {
-    const id = partial.label.replace(/\s+/g, "-") + "-" + Date.now()
+  function addTag(partial: Omit<Tag, "id">) {
+    const id = "u-" + partial.label.replace(/\s+/g, "-") + "-" + Date.now()
     setTags((prev) => [...prev, { ...partial, id }])
   }
 
-  function saveTag(updated: TagDef) {
+  function saveTag(updated: Tag) {
     setTags((prev) => prev.map((t) => (t.id === updated.id ? updated : t)))
     setEditingId(null)
   }
@@ -230,21 +187,24 @@ export function TagsView() {
 
   const totalTagged = MOCK_ITEMS.filter((item) => item.tags.length > 0).length
 
+  // For the dot color in the row, find the closest TAG_COLORS entry
+  function dotClass(tag: Tag) {
+    return TAG_COLORS.find((c) => c.bg === tag.bg)?.dot ?? "bg-muted-foreground"
+  }
+
   return (
     <div className="flex flex-col gap-6 p-6 max-w-2xl mx-auto w-full">
 
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">Tags</h1>
-          <p className="mt-1 text-muted-foreground">Organise your inventory with custom labels.</p>
-        </div>
+      <div>
+        <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">Tags</h1>
+        <p className="mt-1 text-muted-foreground">Organise your inventory with custom labels.</p>
       </div>
 
       {/* Stats row */}
       <div className="grid grid-cols-3 gap-3">
         {[
-          { label: "Total tags", value: tags.length, icon: Tag },
+          { label: "Total tags", value: tags.length, icon: TagIcon },
           { label: "Tagged items", value: totalTagged, icon: Package },
           { label: "Untagged items", value: MOCK_ITEMS.length - totalTagged, icon: Hash },
         ].map(({ label, value, icon: Icon }) => (
@@ -282,7 +242,7 @@ export function TagsView() {
 
       {/* Tag list */}
       <div className="rounded-xl border border-border bg-card overflow-hidden">
-        <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+        <div className="px-4 py-3 border-b border-border">
           <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
             {search ? `${filtered.length} result${filtered.length !== 1 ? "s" : ""}` : `${tags.length} tag${tags.length !== 1 ? "s" : ""}`}
           </p>
@@ -290,7 +250,7 @@ export function TagsView() {
 
         {filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 py-16">
-            <Tag className="size-8 text-muted-foreground/30" />
+            <TagIcon className="size-8 text-muted-foreground/30" />
             <p className="text-sm text-muted-foreground">
               {search ? "No tags match your search." : "No tags yet. Create your first tag below."}
             </p>
@@ -299,7 +259,6 @@ export function TagsView() {
           <ul className="divide-y divide-border">
             {filtered.map((tag) => {
               const count = itemCountForTag(tag.id)
-              const color = TAG_COLORS.find((c) => c.id === tag.colorId) ?? TAG_COLORS[5]
               const isEditing = editingId === tag.id
 
               return (
@@ -312,12 +271,10 @@ export function TagsView() {
                     />
                   ) : (
                     <div className="flex items-center gap-3 group">
-                      <div className={cn("size-2.5 rounded-full shrink-0", color.dot)} />
+                      <div className={cn("size-2.5 rounded-full shrink-0", dotClass(tag))} />
                       <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 min-w-0">
-                          <span className="text-sm font-medium truncate"># {tag.label}</span>
-                        </div>
-                        <p className="text-xs text-muted-foreground mt-0.5">
+                        <TagPill tag={tag} size="sm" />
+                        <p className="text-xs text-muted-foreground mt-1">
                           {count === 0
                             ? "No items"
                             : `${count} item${count !== 1 ? "s" : ""}`}

--- a/design-mocks/src/views/UIShowcaseView.tsx
+++ b/design-mocks/src/views/UIShowcaseView.tsx
@@ -16,6 +16,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Skeleton } from "@/components/ui/skeleton"
+import { SkeletonShowcase } from "@/components/SkeletonPatterns"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import {
   Select,
@@ -578,7 +579,7 @@ export function UIShowcaseView() {
             <Spinner className="size-4" />
             <Spinner className="size-6" />
           </DemoRow>
-          <DemoRow label="Skeleton">
+          <DemoRow label="Skeleton primitives">
             <div className="w-full space-y-2">
               <Skeleton className="h-5 w-1/2" />
               <Skeleton className="h-4 w-3/4" />
@@ -593,6 +594,16 @@ export function UIShowcaseView() {
             </div>
           </DemoRow>
         </div>
+      </Section>
+
+      <Separator />
+
+      {/* ── SKELETON PATTERNS ────────────────────────────────── */}
+      <Section
+        title="Skeleton Patterns"
+        subtitle="Loading state patterns for stat cards, tables, grids, and detail panels"
+      >
+        <SkeletonShowcase />
       </Section>
 
       <Separator />

--- a/design-mocks/src/views/admin/GroupDetailView.tsx
+++ b/design-mocks/src/views/admin/GroupDetailView.tsx
@@ -1,0 +1,411 @@
+import { useMemo, useState } from "react"
+import {
+  Layers,
+  UserPlus,
+  Trash2,
+  Ellipsis,
+  TriangleAlert,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { cn } from "@/lib/utils"
+import {
+  adminGroupById,
+  adminUserById,
+  CURRENCIES,
+  type GroupStatus,
+  type MemberRole,
+} from "@/data/mock"
+import {
+  AdminBackButton,
+  TenantChip,
+  GroupStatusBadge,
+  ADMIN_ROLE_CONFIG,
+} from "./admin-shared"
+
+interface GroupMemberRow {
+  id: string
+  name: string
+  email: string
+  avatarInitials: string
+  role: MemberRole
+}
+
+interface GroupDetailViewProps {
+  groupId: string
+  onBack?: () => void
+}
+
+const ROLE_OPTIONS: MemberRole[] = ["viewer", "user", "admin", "owner"]
+
+export function GroupDetailView({ groupId, onBack }: GroupDetailViewProps) {
+  const group = adminGroupById(groupId)
+
+  const initialMembers = useMemo<GroupMemberRow[]>(() => {
+    if (!group) return []
+    return group.members.flatMap((m) => {
+      const u = adminUserById(m.userId)
+      return u
+        ? [{ id: u.id, name: u.name, email: u.email, avatarInitials: u.avatarInitials, role: m.role }]
+        : []
+    })
+  }, [group])
+
+  const [members, setMembers] = useState<GroupMemberRow[]>(initialMembers)
+  const [status, setStatus] = useState<GroupStatus>(group?.status ?? "active")
+  const [addOpen, setAddOpen] = useState(false)
+  const [addName, setAddName] = useState("")
+  const [addEmail, setAddEmail] = useState("")
+  const [addRole, setAddRole] = useState<MemberRole>("user")
+  const [removeTarget, setRemoveTarget] = useState<GroupMemberRow | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  if (!group) {
+    return (
+      <div className="flex flex-col gap-6 p-6 max-w-3xl mx-auto w-full">
+        <AdminBackButton label="Back" onClick={onBack} />
+        <div className="flex flex-col items-center justify-center gap-3 py-24">
+          <Layers className="size-8 text-muted-foreground/30" />
+          <p className="text-sm text-muted-foreground">Group not found.</p>
+        </div>
+      </div>
+    )
+  }
+
+  const currency = CURRENCIES.find((c) => c.code === group.currency)
+
+  function addMember() {
+    if (!addName.trim() || !addEmail.trim()) return
+    const initials = addName
+      .trim()
+      .split(/\s+/)
+      .slice(0, 2)
+      .map((w) => w[0]?.toUpperCase() ?? "")
+      .join("")
+    setMembers((prev) => [
+      ...prev,
+      {
+        id: `new-${Date.now()}`,
+        name: addName.trim(),
+        email: addEmail.trim(),
+        avatarInitials: initials || "?",
+        role: addRole,
+      },
+    ])
+    setAddName("")
+    setAddEmail("")
+    setAddRole("user")
+    setAddOpen(false)
+  }
+
+  function changeRole(memberId: string, role: MemberRole) {
+    setMembers((prev) => prev.map((m) => (m.id === memberId ? { ...m, role } : m)))
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-3xl mx-auto w-full">
+      <AdminBackButton label="Back" onClick={onBack} />
+
+      {/* Header card */}
+      <div className="rounded-xl border border-border bg-card p-6">
+        <div className="flex items-start gap-4">
+          <div className="flex size-12 items-center justify-center rounded-xl bg-primary/10 shrink-0">
+            <Layers className="size-6 text-primary" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-2xl font-semibold tracking-tight">{group.name}</h1>
+              <GroupStatusBadge status={status} />
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <TenantChip tenantId={group.tenantId} />
+              <span>
+                {group.currency}
+                {currency ? ` · ${currency.name}` : ""}
+              </span>
+              <span>· {members.length} members</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Members */}
+      <div>
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-base font-semibold">Members</h2>
+          <Button size="sm" className="gap-1.5" onClick={() => setAddOpen(true)}>
+            <UserPlus className="size-3.5" />
+            Add member
+          </Button>
+        </div>
+        <div className="rounded-xl border border-border bg-card overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="pl-4">Member</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead className="w-10 pr-4" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {members.length === 0 && (
+                <TableRow className="hover:bg-transparent">
+                  <TableCell colSpan={3} className="h-24 text-center text-sm text-muted-foreground">
+                    No members in this group.
+                  </TableCell>
+                </TableRow>
+              )}
+              {members.map((member) => (
+                <TableRow key={member.id} className="hover:bg-transparent">
+                  <TableCell className="pl-4 py-3.5">
+                    <div className="flex items-center gap-2.5">
+                      <div className="flex size-8 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground shrink-0">
+                        {member.avatarInitials}
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium truncate">{member.name}</p>
+                        <p className="text-xs text-muted-foreground truncate">{member.email}</p>
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell className="py-3.5">
+                    <Select
+                      value={member.role}
+                      onValueChange={(v) => changeRole(member.id, v as MemberRole)}
+                    >
+                      <SelectTrigger size="sm" className="w-40">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {ROLE_OPTIONS.map((role) => {
+                          const cfg = ADMIN_ROLE_CONFIG[role]
+                          const Icon = cfg.icon
+                          return (
+                            <SelectItem key={role} value={role}>
+                              <Icon className="size-3.5 text-muted-foreground shrink-0" />
+                              {cfg.label}
+                            </SelectItem>
+                          )
+                        })}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell className="pr-4 py-3.5 text-right">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="icon" className="size-7" aria-label="Member actions">
+                          <Ellipsis className="size-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          className="text-destructive focus:text-destructive"
+                          onClick={() => setRemoveTarget(member)}
+                        >
+                          <Trash2 className="size-4 mr-2" />
+                          Remove from group
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+
+      {/* Danger zone */}
+      <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-5">
+        <div className="flex items-start gap-3">
+          <div className="flex size-9 items-center justify-center rounded-lg bg-destructive/10 shrink-0">
+            <TriangleAlert className="size-4 text-destructive" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="text-sm font-semibold">Danger zone</h3>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              {status === "pending_deletion"
+                ? "This group is queued for deletion. It will be permanently removed after the retention window."
+                : "Soft-delete this group. It enters a pending-deletion state and is removed after the retention window."}
+            </p>
+          </div>
+        </div>
+        <div className="mt-4">
+          <Button
+            size="sm"
+            variant="destructive"
+            className="gap-1.5"
+            disabled={status === "pending_deletion"}
+            onClick={() => setConfirmDelete(true)}
+          >
+            <Trash2 className="size-3.5" />
+            {status === "pending_deletion" ? "Deletion pending" : "Delete group"}
+          </Button>
+        </div>
+      </div>
+
+      {/* Add member dialog */}
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <div className="flex size-7 items-center justify-center rounded-lg bg-primary/10">
+                <UserPlus className="size-4 text-primary" />
+              </div>
+              Add member
+            </DialogTitle>
+            <DialogDescription>Add a person to {group.name}.</DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-4 py-2">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="add-member-name">Full name</Label>
+              <Input
+                id="add-member-name"
+                placeholder="e.g. Jordan Velez"
+                value={addName}
+                onChange={(e) => setAddName(e.target.value)}
+                autoFocus
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="add-member-email">Email address</Label>
+              <Input
+                id="add-member-email"
+                type="email"
+                placeholder="colleague@example.com"
+                value={addEmail}
+                onChange={(e) => setAddEmail(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="add-member-role">Role</Label>
+              <Select value={addRole} onValueChange={(v) => setAddRole(v as MemberRole)}>
+                <SelectTrigger id="add-member-role">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(["viewer", "user", "admin"] as MemberRole[]).map((role) => {
+                    const cfg = ADMIN_ROLE_CONFIG[role]
+                    const Icon = cfg.icon
+                    return (
+                      <SelectItem key={role} value={role}>
+                        <Icon className="size-3.5 text-muted-foreground shrink-0" />
+                        {cfg.label}
+                      </SelectItem>
+                    )
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter className="gap-2">
+            <Button variant="outline" onClick={() => setAddOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              className="gap-2"
+              onClick={addMember}
+              disabled={!addName.trim() || !addEmail.trim()}
+            >
+              <UserPlus className="size-4" />
+              Add member
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Remove member confirmation */}
+      <AlertDialog open={!!removeTarget} onOpenChange={(open) => !open && setRemoveTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove member?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <span className="font-medium text-foreground">{removeTarget?.name}</span> will lose access to{" "}
+              <span className="font-medium text-foreground">{group.name}</span>. They can be re-added later.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={cn("bg-destructive text-destructive-foreground hover:bg-destructive/90")}
+              onClick={() => {
+                if (removeTarget) {
+                  setMembers((prev) => prev.filter((m) => m.id !== removeTarget.id))
+                  setRemoveTarget(null)
+                }
+              }}
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Soft-delete confirmation */}
+      <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this group?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <span className="font-medium text-foreground">{group.name}</span> will be moved to a
+              pending-deletion state. Members lose access immediately and the group is permanently
+              removed after the retention window.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={cn("bg-destructive text-destructive-foreground hover:bg-destructive/90")}
+              onClick={() => {
+                setStatus("pending_deletion")
+                setConfirmDelete(false)
+              }}
+            >
+              Delete group
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/design-mocks/src/views/admin/GroupsView.tsx
+++ b/design-mocks/src/views/admin/GroupsView.tsx
@@ -1,0 +1,239 @@
+import { useMemo, useState } from "react"
+import { Layers, Search, X } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination"
+import { MOCK_ADMIN_GROUPS, MOCK_TENANTS } from "@/data/mock"
+import { TenantChip, GroupStatusBadge, fmtDate } from "./admin-shared"
+
+const PAGE_SIZE = 8
+
+interface GroupsViewProps {
+  onSelectGroup?: (groupId: string) => void
+}
+
+export function GroupsView({ onSelectGroup }: GroupsViewProps) {
+  const [search, setSearch] = useState("")
+  const [tenantFilter, setTenantFilter] = useState<string>("all")
+  const [statusFilter, setStatusFilter] = useState<string>("all")
+  const [page, setPage] = useState(1)
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return MOCK_ADMIN_GROUPS.filter((g) => {
+      if (q && !g.name.toLowerCase().includes(q)) return false
+      if (tenantFilter !== "all" && g.tenantId !== tenantFilter) return false
+      if (statusFilter !== "all" && g.status !== statusFilter) return false
+      return true
+    })
+  }, [search, tenantFilter, statusFilter])
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const currentPage = Math.min(page, pageCount)
+  const rows = filtered.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+
+  function resetPage() {
+    setPage(1)
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full">
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10 shrink-0">
+          <Layers className="size-5 text-primary" />
+        </div>
+        <div>
+          <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">Groups</h1>
+          <p className="mt-1 text-muted-foreground">
+            Every inventory group across all tenants.
+          </p>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="relative flex-1">
+          <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value)
+              resetPage()
+            }}
+            placeholder="Search groups…"
+            className="pl-8"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => {
+                setSearch("")
+                resetPage()
+              }}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Clear search"
+            >
+              <X className="size-3.5" />
+            </button>
+          )}
+        </div>
+        <Select
+          value={tenantFilter}
+          onValueChange={(v) => {
+            setTenantFilter(v)
+            resetPage()
+          }}
+        >
+          <SelectTrigger className="sm:w-52">
+            <SelectValue placeholder="All tenants" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All tenants</SelectItem>
+            {MOCK_TENANTS.map((t) => (
+              <SelectItem key={t.id} value={t.id}>
+                {t.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={statusFilter}
+          onValueChange={(v) => {
+            setStatusFilter(v)
+            resetPage()
+          }}
+        >
+          <SelectTrigger className="sm:w-44">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="active">Active</SelectItem>
+            <SelectItem value="pending_deletion">Pending Deletion</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-xl border border-border bg-card overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="pl-4">Group</TableHead>
+              <TableHead>Tenant</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Currency</TableHead>
+              <TableHead className="text-right">Members</TableHead>
+              <TableHead className="pr-4">Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 && (
+              <TableRow className="hover:bg-transparent">
+                <TableCell colSpan={6} className="h-32 text-center">
+                  <div className="flex flex-col items-center justify-center gap-2">
+                    <Layers className="size-8 text-muted-foreground/30" />
+                    <p className="text-sm text-muted-foreground">No groups match your filters.</p>
+                  </div>
+                </TableCell>
+              </TableRow>
+            )}
+            {rows.map((group) => (
+              <TableRow
+                key={group.id}
+                className="cursor-pointer"
+                onClick={() => onSelectGroup?.(group.id)}
+              >
+                <TableCell className="pl-4 py-3.5 text-sm font-medium">{group.name}</TableCell>
+                <TableCell className="py-3.5">
+                  <TenantChip tenantId={group.tenantId} />
+                </TableCell>
+                <TableCell className="py-3.5">
+                  <GroupStatusBadge status={group.status} />
+                </TableCell>
+                <TableCell className="py-3.5 text-sm text-muted-foreground">{group.currency}</TableCell>
+                <TableCell className="py-3.5 text-right text-sm tabular-nums">{group.memberCount}</TableCell>
+                <TableCell className="pr-4 py-3.5 text-sm text-muted-foreground">
+                  {fmtDate(group.createdAt)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {filtered.length > 0 && (
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-xs text-muted-foreground">
+            Showing{" "}
+            <span className="font-medium text-foreground">
+              {(currentPage - 1) * PAGE_SIZE + 1}–{Math.min(currentPage * PAGE_SIZE, filtered.length)}
+            </span>{" "}
+            of <span className="font-medium text-foreground">{filtered.length}</span>
+          </p>
+          <Pagination className="mx-0 w-auto justify-end">
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    setPage((p) => Math.max(1, p - 1))
+                  }}
+                  className={currentPage === 1 ? "pointer-events-none opacity-50" : undefined}
+                />
+              </PaginationItem>
+              {Array.from({ length: pageCount }, (_, i) => i + 1).map((p) => (
+                <PaginationItem key={p}>
+                  <PaginationLink
+                    href="#"
+                    isActive={p === currentPage}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      setPage(p)
+                    }}
+                  >
+                    {p}
+                  </PaginationLink>
+                </PaginationItem>
+              ))}
+              <PaginationItem>
+                <PaginationNext
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    setPage((p) => Math.min(pageCount, p + 1))
+                  }}
+                  className={currentPage === pageCount ? "pointer-events-none opacity-50" : undefined}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/design-mocks/src/views/admin/ImpersonationBannerMock.tsx
+++ b/design-mocks/src/views/admin/ImpersonationBannerMock.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from "react"
+import { UserCog, LogOut } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface ImpersonationBannerMockProps {
+  /** Display name of the user currently being impersonated. */
+  userName: string
+  /** Email of the impersonated user — shown as secondary context. */
+  userEmail: string
+  /** Total countdown duration in seconds. Defaults to 30 minutes. */
+  durationSeconds?: number
+  /** Called when the admin ends the impersonated session (button or expiry). */
+  onEnd: () => void
+}
+
+function formatMMSS(totalSeconds: number): string {
+  const safe = Math.max(0, totalSeconds)
+  const mm = String(Math.floor(safe / 60)).padStart(2, "0")
+  const ss = String(safe % 60).padStart(2, "0")
+  return `${mm}:${ss}`
+}
+
+/**
+ * Persistent, non-dismissible top banner shown while an admin is impersonating
+ * a user. Sits above the topbar and counts down a session timer. The only way
+ * to dismiss it is the "End impersonation" button (or the timer reaching zero).
+ */
+export function ImpersonationBannerMock({
+  userName,
+  userEmail,
+  durationSeconds = 30 * 60,
+  onEnd,
+}: ImpersonationBannerMockProps) {
+  const [remaining, setRemaining] = useState(durationSeconds)
+
+  // Keep the latest onEnd in a ref so the mount-once interval below never
+  // tears down/recreates when App re-renders (which would drift the timer).
+  const onEndRef = useRef(onEnd)
+  useEffect(() => {
+    onEndRef.current = onEnd
+  }, [onEnd])
+
+  // Reset the countdown when a new impersonation session starts.
+  useEffect(() => {
+    setRemaining(durationSeconds)
+  }, [durationSeconds, userName])
+
+  // Mount-once ticking interval — never depends on changing props.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRemaining((prev) => (prev <= 0 ? 0 : prev - 1))
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  // End the session when the timer hits zero — done in a separate effect so we
+  // never trigger a cross-component update from inside the setState updater.
+  useEffect(() => {
+    if (remaining === 0) onEndRef.current()
+  }, [remaining])
+
+  const low = remaining <= 60
+
+  return (
+    <div className="flex h-10 items-center gap-3 border-b border-accent/40 bg-accent/15 px-4 text-sm">
+      <div className="flex size-6 items-center justify-center rounded-md bg-accent text-accent-foreground shrink-0">
+        <UserCog className="size-3.5" />
+      </div>
+      <div className="flex min-w-0 flex-1 items-baseline gap-2">
+        <span className="font-semibold text-foreground truncate">
+          Impersonating {userName}
+        </span>
+        <span className="hidden text-xs text-muted-foreground truncate sm:inline">
+          {userEmail}
+        </span>
+      </div>
+      <div className="flex items-center gap-1.5 shrink-0">
+        <span className="text-xs text-muted-foreground hidden sm:inline">Session ends in</span>
+        <span
+          className={cn(
+            "font-mono text-xs font-semibold tabular-nums",
+            low ? "text-status-expired" : "text-foreground"
+          )}
+        >
+          {formatMMSS(remaining)}
+        </span>
+      </div>
+      <Button
+        size="xs"
+        variant="outline"
+        className="gap-1.5 shrink-0 border-accent-foreground/20 bg-background"
+        onClick={onEnd}
+      >
+        <LogOut className="size-3" />
+        End impersonation
+      </Button>
+    </div>
+  )
+}

--- a/design-mocks/src/views/admin/TenantDetailView.tsx
+++ b/design-mocks/src/views/admin/TenantDetailView.tsx
@@ -1,0 +1,222 @@
+import { Building2, Globe, Hash, Users, Layers } from "lucide-react"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  tenantById,
+  usersByTenant,
+  groupsByTenant,
+  TENANT_PLAN_CONFIG,
+  CURRENCIES,
+} from "@/data/mock"
+import {
+  AdminBackButton,
+  TenantStatusBadge,
+  GroupStatusBadge,
+  AccountStateBadge,
+  RoleBadge,
+  fmtDateTime,
+} from "./admin-shared"
+
+interface TenantDetailViewProps {
+  tenantId: string
+  onBack?: () => void
+  onSelectUser?: (userId: string) => void
+  onSelectGroup?: (groupId: string) => void
+}
+
+export function TenantDetailView({
+  tenantId,
+  onBack,
+  onSelectUser,
+  onSelectGroup,
+}: TenantDetailViewProps) {
+  const tenant = tenantById(tenantId)
+
+  if (!tenant) {
+    return (
+      <div className="flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full">
+        <AdminBackButton label="Back to tenants" onClick={onBack} />
+        <div className="flex flex-col items-center justify-center gap-3 py-24">
+          <Building2 className="size-8 text-muted-foreground/30" />
+          <p className="text-sm text-muted-foreground">Tenant not found.</p>
+        </div>
+      </div>
+    )
+  }
+
+  const users = usersByTenant(tenant.id)
+  const groups = groupsByTenant(tenant.id)
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full">
+      <AdminBackButton label="Back to tenants" onClick={onBack} />
+
+      {/* Header card */}
+      <div className="rounded-xl border border-border bg-card p-6">
+        <div className="flex items-start gap-4">
+          <div className="flex size-12 items-center justify-center rounded-xl bg-primary/10 shrink-0">
+            <Building2 className="size-6 text-primary" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-2xl font-semibold tracking-tight">{tenant.name}</h1>
+              <TenantStatusBadge status={tenant.status} />
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground">
+              <span className="inline-flex items-center gap-1.5">
+                <Hash className="size-3.5" />
+                <span className="font-mono text-xs">{tenant.slug}</span>
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Globe className="size-3.5" />
+                {tenant.domain}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {[
+            { label: "Plan", value: TENANT_PLAN_CONFIG[tenant.plan].label },
+            { label: "Users", value: String(tenant.userCount) },
+            { label: "Groups", value: String(tenant.groupCount) },
+            {
+              label: "Created",
+              value: new Date(tenant.createdAt).toLocaleDateString("en-US", {
+                month: "short",
+                year: "numeric",
+              }),
+            },
+          ].map((s) => (
+            <div key={s.label} className="rounded-lg border border-border bg-muted/40 px-3 py-2.5">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {s.label}
+              </p>
+              <p className="mt-0.5 text-sm font-semibold">{s.value}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <Tabs defaultValue="users">
+        <TabsList>
+          <TabsTrigger value="users">
+            <Users className="size-3.5" />
+            Users
+          </TabsTrigger>
+          <TabsTrigger value="groups">
+            <Layers className="size-3.5" />
+            Groups
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Users tab */}
+        <TabsContent value="users">
+          <div className="rounded-xl border border-border bg-card overflow-hidden">
+            <Table>
+              <TableHeader>
+                <TableRow className="hover:bg-transparent">
+                  <TableHead className="pl-4">Name</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead className="pr-4">Last login</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.length === 0 && (
+                  <TableRow className="hover:bg-transparent">
+                    <TableCell colSpan={5} className="h-24 text-center text-sm text-muted-foreground">
+                      No users in this tenant.
+                    </TableCell>
+                  </TableRow>
+                )}
+                {users.map((user) => (
+                  <TableRow
+                    key={user.id}
+                    className="cursor-pointer"
+                    onClick={() => onSelectUser?.(user.id)}
+                  >
+                    <TableCell className="pl-4 py-3.5">
+                      <div className="flex items-center gap-2.5">
+                        <div className="flex size-7 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground shrink-0">
+                          {user.avatarInitials}
+                        </div>
+                        <span className="text-sm font-medium">{user.name}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="py-3.5 text-sm text-muted-foreground">{user.email}</TableCell>
+                    <TableCell className="py-3.5">
+                      <RoleBadge role={user.role} />
+                    </TableCell>
+                    <TableCell className="py-3.5">
+                      <AccountStateBadge active={user.isActive} />
+                    </TableCell>
+                    <TableCell className="pr-4 py-3.5 text-sm text-muted-foreground">
+                      {fmtDateTime(user.lastLogin)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </TabsContent>
+
+        {/* Groups tab */}
+        <TabsContent value="groups">
+          <div className="rounded-xl border border-border bg-card overflow-hidden">
+            <Table>
+              <TableHeader>
+                <TableRow className="hover:bg-transparent">
+                  <TableHead className="pl-4">Group</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Currency</TableHead>
+                  <TableHead className="text-right pr-4">Members</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {groups.length === 0 && (
+                  <TableRow className="hover:bg-transparent">
+                    <TableCell colSpan={4} className="h-24 text-center text-sm text-muted-foreground">
+                      No groups in this tenant.
+                    </TableCell>
+                  </TableRow>
+                )}
+                {groups.map((group) => {
+                  const currency = CURRENCIES.find((c) => c.code === group.currency)
+                  return (
+                    <TableRow
+                      key={group.id}
+                      className="cursor-pointer"
+                      onClick={() => onSelectGroup?.(group.id)}
+                    >
+                      <TableCell className="pl-4 py-3.5 text-sm font-medium">{group.name}</TableCell>
+                      <TableCell className="py-3.5">
+                        <GroupStatusBadge status={group.status} />
+                      </TableCell>
+                      <TableCell className="py-3.5 text-sm text-muted-foreground">
+                        {group.currency}
+                        {currency ? ` · ${currency.name}` : ""}
+                      </TableCell>
+                      <TableCell className="pr-4 py-3.5 text-right text-sm tabular-nums">
+                        {group.memberCount}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/design-mocks/src/views/admin/TenantsView.tsx
+++ b/design-mocks/src/views/admin/TenantsView.tsx
@@ -1,0 +1,224 @@
+import { useMemo, useState } from "react"
+import { Building2, Search, X, Users, Layers, ShieldCheck, Activity } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination"
+import { MOCK_TENANTS, TENANT_PLAN_CONFIG } from "@/data/mock"
+import { TenantStatusBadge, fmtDate } from "./admin-shared"
+
+const PAGE_SIZE = 8
+
+interface TenantsViewProps {
+  onSelectTenant?: (tenantId: string) => void
+}
+
+export function TenantsView({ onSelectTenant }: TenantsViewProps) {
+  const [search, setSearch] = useState("")
+  const [page, setPage] = useState(1)
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return MOCK_TENANTS
+    return MOCK_TENANTS.filter(
+      (t) =>
+        t.name.toLowerCase().includes(q) ||
+        t.slug.toLowerCase().includes(q) ||
+        t.domain.toLowerCase().includes(q)
+    )
+  }, [search])
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const currentPage = Math.min(page, pageCount)
+  const rows = filtered.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+
+  const stats = useMemo(
+    () => [
+      { label: "Tenants", value: MOCK_TENANTS.length, icon: Building2 },
+      {
+        label: "Active",
+        value: MOCK_TENANTS.filter((t) => t.status === "active").length,
+        icon: Activity,
+      },
+      { label: "Total users", value: MOCK_TENANTS.reduce((s, t) => s + t.userCount, 0), icon: Users },
+      { label: "Total groups", value: MOCK_TENANTS.reduce((s, t) => s + t.groupCount, 0), icon: Layers },
+    ],
+    []
+  )
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full">
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10 shrink-0">
+          <ShieldCheck className="size-5 text-primary" />
+        </div>
+        <div>
+          <h1 className="scroll-m-20 text-3xl font-semibold tracking-tight">Tenants</h1>
+          <p className="mt-1 text-muted-foreground">
+            Organisations using Inventario across the platform.
+          </p>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        {stats.map((s) => (
+          <div key={s.label} className="rounded-xl border border-border bg-card px-4 py-3 flex items-center gap-3">
+            <div className="flex size-8 items-center justify-center rounded-lg bg-muted shrink-0">
+              <s.icon className="size-4 text-muted-foreground" />
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">{s.label}</p>
+              <p className="text-lg font-semibold leading-tight">{s.value}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value)
+            setPage(1)
+          }}
+          placeholder="Search by name, slug or domain…"
+          className="pl-8"
+        />
+        {search && (
+          <button
+            type="button"
+            onClick={() => {
+              setSearch("")
+              setPage(1)
+            }}
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Clear search"
+          >
+            <X className="size-3.5" />
+          </button>
+        )}
+      </div>
+
+      {/* Table */}
+      <div className="rounded-xl border border-border bg-card overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="pl-4">Name</TableHead>
+              <TableHead>Domain</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Plan</TableHead>
+              <TableHead className="text-right">Users</TableHead>
+              <TableHead className="text-right">Groups</TableHead>
+              <TableHead className="pr-4">Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 && (
+              <TableRow className="hover:bg-transparent">
+                <TableCell colSpan={7} className="h-32 text-center">
+                  <div className="flex flex-col items-center justify-center gap-2">
+                    <Building2 className="size-8 text-muted-foreground/30" />
+                    <p className="text-sm text-muted-foreground">No tenants match your search.</p>
+                  </div>
+                </TableCell>
+              </TableRow>
+            )}
+            {rows.map((tenant) => (
+              <TableRow
+                key={tenant.id}
+                className="cursor-pointer"
+                onClick={() => onSelectTenant?.(tenant.id)}
+              >
+                <TableCell className="pl-4 py-3.5">
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium">{tenant.name}</span>
+                    <span className="font-mono text-xs text-muted-foreground">{tenant.slug}</span>
+                  </div>
+                </TableCell>
+                <TableCell className="py-3.5 text-sm text-muted-foreground">{tenant.domain}</TableCell>
+                <TableCell className="py-3.5">
+                  <TenantStatusBadge status={tenant.status} />
+                </TableCell>
+                <TableCell className="py-3.5 text-sm">{TENANT_PLAN_CONFIG[tenant.plan].label}</TableCell>
+                <TableCell className="py-3.5 text-right text-sm tabular-nums">{tenant.userCount}</TableCell>
+                <TableCell className="py-3.5 text-right text-sm tabular-nums">{tenant.groupCount}</TableCell>
+                <TableCell className="pr-4 py-3.5 text-sm text-muted-foreground">
+                  {fmtDate(tenant.createdAt)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {filtered.length > 0 && (
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-xs text-muted-foreground">
+            Showing{" "}
+            <span className="font-medium text-foreground">
+              {(currentPage - 1) * PAGE_SIZE + 1}–{Math.min(currentPage * PAGE_SIZE, filtered.length)}
+            </span>{" "}
+            of <span className="font-medium text-foreground">{filtered.length}</span>
+          </p>
+          <Pagination className="mx-0 w-auto justify-end">
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    setPage((p) => Math.max(1, p - 1))
+                  }}
+                  className={currentPage === 1 ? "pointer-events-none opacity-50" : undefined}
+                />
+              </PaginationItem>
+              {Array.from({ length: pageCount }, (_, i) => i + 1).map((p) => (
+                <PaginationItem key={p}>
+                  <PaginationLink
+                    href="#"
+                    isActive={p === currentPage}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      setPage(p)
+                    }}
+                  >
+                    {p}
+                  </PaginationLink>
+                </PaginationItem>
+              ))}
+              <PaginationItem>
+                <PaginationNext
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    setPage((p) => Math.min(pageCount, p + 1))
+                  }}
+                  className={currentPage === pageCount ? "pointer-events-none opacity-50" : undefined}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/design-mocks/src/views/admin/UserDetailView.tsx
+++ b/design-mocks/src/views/admin/UserDetailView.tsx
@@ -1,0 +1,260 @@
+import { useState } from "react"
+import {
+  User,
+  Monitor,
+  Ban,
+  CircleCheck,
+  UserCog,
+  Layers,
+  ChevronRight,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { cn } from "@/lib/utils"
+import { adminUserById, tenantById, adminGroupById } from "@/data/mock"
+import {
+  AdminBackButton,
+  AccountStateBadge,
+  RoleBadge,
+  TenantChip,
+  fmtDateTime,
+  relativeFromNow,
+} from "./admin-shared"
+
+interface UserDetailViewProps {
+  userId: string
+  onBack?: () => void
+  onSelectGroup?: (groupId: string) => void
+  onImpersonate?: (userId: string) => void
+}
+
+export function UserDetailView({
+  userId,
+  onBack,
+  onSelectGroup,
+  onImpersonate,
+}: UserDetailViewProps) {
+  const user = adminUserById(userId)
+  const [active, setActive] = useState(user?.isActive ?? true)
+  const [confirmBlock, setConfirmBlock] = useState(false)
+  // Sessions are local state so blocking can revoke them (mock of the
+  // real "sign out of all sessions" behaviour). Not restored on unblock —
+  // matches the backend, which does not re-issue tokens.
+  const [sessions, setSessions] = useState(user?.sessions ?? [])
+
+  if (!user) {
+    return (
+      <div className="flex flex-col gap-6 p-6 max-w-3xl mx-auto w-full">
+        <AdminBackButton label="Back" onClick={onBack} />
+        <div className="flex flex-col items-center justify-center gap-3 py-24">
+          <User className="size-8 text-muted-foreground/30" />
+          <p className="text-sm text-muted-foreground">User not found.</p>
+        </div>
+      </div>
+    )
+  }
+
+  const tenant = tenantById(user.tenantId)
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-3xl mx-auto w-full">
+      <AdminBackButton label="Back" onClick={onBack} />
+
+      {/* Identity card */}
+      <div className="rounded-xl border border-border bg-card p-6">
+        <div className="flex items-start gap-4">
+          <div className="flex size-14 items-center justify-center rounded-full bg-primary text-primary-foreground text-lg font-semibold shrink-0">
+            {user.avatarInitials}
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-2xl font-semibold tracking-tight">{user.name}</h1>
+              <AccountStateBadge active={active} />
+            </div>
+            <p className="mt-0.5 text-sm text-muted-foreground">{user.email}</p>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <TenantChip tenantId={user.tenantId} />
+              <RoleBadge role={user.role} />
+            </div>
+          </div>
+        </div>
+
+        <Separator className="my-5" />
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            className="gap-1.5"
+            disabled={!active}
+            onClick={() => onImpersonate?.(user.id)}
+          >
+            <UserCog className="size-3.5" />
+            Impersonate
+          </Button>
+          {active ? (
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5 text-destructive hover:bg-destructive/10 hover:text-destructive"
+              onClick={() => setConfirmBlock(true)}
+            >
+              <Ban className="size-3.5" />
+              Block user
+            </Button>
+          ) : (
+            <Button size="sm" variant="outline" className="gap-1.5" onClick={() => setActive(true)}>
+              <CircleCheck className="size-3.5" />
+              Unblock user
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Sessions */}
+      <div>
+        <div className="mb-3 flex items-center gap-2">
+          <Monitor className="size-4 text-muted-foreground" />
+          <h2 className="text-base font-semibold">Sessions</h2>
+          <Badge variant="secondary" className="h-5 text-xs">
+            {sessions.length}
+          </Badge>
+        </div>
+        <div className="rounded-xl border border-border bg-card overflow-hidden">
+          {sessions.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-2 py-12">
+              <Monitor className="size-7 text-muted-foreground/30" />
+              <p className="text-sm text-muted-foreground">No active sessions.</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow className="hover:bg-transparent">
+                  <TableHead className="pl-4">Device</TableHead>
+                  <TableHead>IP address</TableHead>
+                  <TableHead>Location</TableHead>
+                  <TableHead className="pr-4">Last active</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sessions.map((s) => (
+                  <TableRow key={s.id} className="hover:bg-transparent">
+                    <TableCell className="pl-4 py-3.5">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium">{s.device}</span>
+                        {s.current && (
+                          <Badge
+                            variant="outline"
+                            className="h-5 text-xs border-current/20 font-medium text-status-active bg-status-active/10"
+                          >
+                            Current
+                          </Badge>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="py-3.5 font-mono text-xs text-muted-foreground">{s.ip}</TableCell>
+                    <TableCell className="py-3.5 text-sm text-muted-foreground">{s.location}</TableCell>
+                    <TableCell className="pr-4 py-3.5 text-sm text-muted-foreground">
+                      {relativeFromNow(s.lastActive)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      </div>
+
+      {/* Group memberships */}
+      <div>
+        <div className="mb-3 flex items-center gap-2">
+          <Layers className="size-4 text-muted-foreground" />
+          <h2 className="text-base font-semibold">Group memberships</h2>
+          <Badge variant="secondary" className="h-5 text-xs">
+            {user.groupMemberships.length}
+          </Badge>
+        </div>
+        <div className="rounded-xl border border-border bg-card divide-y divide-border overflow-hidden">
+          {user.groupMemberships.length === 0 && (
+            <div className="flex flex-col items-center justify-center gap-2 py-12">
+              <Layers className="size-7 text-muted-foreground/30" />
+              <p className="text-sm text-muted-foreground">Not a member of any group.</p>
+            </div>
+          )}
+          {user.groupMemberships.map((m) => {
+            const group = adminGroupById(m.groupId)
+            if (!group) return null
+            return (
+              <button
+                key={m.groupId}
+                onClick={() => onSelectGroup?.(m.groupId)}
+                className="flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors hover:bg-muted/50"
+              >
+                <div className="flex size-8 items-center justify-center rounded-lg bg-muted shrink-0">
+                  <Layers className="size-4 text-muted-foreground" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">{group.name}</p>
+                  <p className="text-xs text-muted-foreground">{group.currency}</p>
+                </div>
+                <RoleBadge role={m.role} />
+                <ChevronRight className="size-4 text-muted-foreground shrink-0" />
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Meta */}
+      <p className="text-xs text-muted-foreground">
+        Member of <span className="font-medium text-foreground">{tenant?.name}</span> · last login{" "}
+        {fmtDateTime(user.lastLogin)}
+      </p>
+
+      {/* Block confirmation */}
+      <AlertDialog open={confirmBlock} onOpenChange={setConfirmBlock}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Block this user?</AlertDialogTitle>
+            <AlertDialogDescription>
+              <span className="font-medium text-foreground">{user.name}</span> will be signed out of all
+              sessions and cannot sign in until unblocked. This does not delete their data.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={cn("bg-destructive text-destructive-foreground hover:bg-destructive/90")}
+              onClick={() => {
+                setActive(false)
+                setSessions([])
+                setConfirmBlock(false)
+              }}
+            >
+              Block user
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/design-mocks/src/views/admin/admin-shared.tsx
+++ b/design-mocks/src/views/admin/admin-shared.tsx
@@ -1,0 +1,131 @@
+import { Building2, Shield, User, Crown, Eye, ArrowLeft } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import {
+  tenantById,
+  TENANT_STATUS_CONFIG,
+  GROUP_STATUS_CONFIG,
+  type TenantStatus,
+  type GroupStatus,
+  type MemberRole,
+} from "@/data/mock"
+
+// ─── Tenant chip ──────────────────────────────────────────────
+// Compact, non-interactive tenant indicator used inside admin tables.
+export function TenantChip({ tenantId, className }: { tenantId: string; className?: string }) {
+  const tenant = tenantById(tenantId)
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground select-none",
+        className
+      )}
+    >
+      <Building2 className="size-3 shrink-0" />
+      <span className="truncate max-w-32">{tenant?.name ?? "Unknown tenant"}</span>
+    </span>
+  )
+}
+
+// ─── Status badges ────────────────────────────────────────────
+export function TenantStatusBadge({ status }: { status: TenantStatus }) {
+  const cfg = TENANT_STATUS_CONFIG[status]
+  return (
+    <Badge variant="outline" className={cn("h-5 text-xs border-current/20 font-medium", cfg.color, cfg.bg)}>
+      {cfg.label}
+    </Badge>
+  )
+}
+
+export function GroupStatusBadge({ status }: { status: GroupStatus }) {
+  const cfg = GROUP_STATUS_CONFIG[status]
+  return (
+    <Badge variant="outline" className={cn("h-5 text-xs border-current/20 font-medium", cfg.color, cfg.bg)}>
+      {cfg.label}
+    </Badge>
+  )
+}
+
+// ─── Active / blocked badge ───────────────────────────────────
+export function AccountStateBadge({ active }: { active: boolean }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "h-5 text-xs border-current/20 font-medium gap-1",
+        active ? "text-status-active bg-status-active/10" : "text-status-expired bg-status-expired/10"
+      )}
+    >
+      <span className={cn("size-1.5 rounded-full", active ? "bg-status-active" : "bg-status-expired")} />
+      {active ? "Active" : "Blocked"}
+    </Badge>
+  )
+}
+
+// ─── Role badge — mirrors MembersView role styling ────────────
+export const ADMIN_ROLE_CONFIG: Record<
+  MemberRole,
+  { label: string; icon: React.ElementType; badgeClass: string }
+> = {
+  viewer: { label: "Viewer", icon: Eye, badgeClass: "bg-muted text-muted-foreground border-0" },
+  user: { label: "User", icon: User, badgeClass: "bg-chart-3/10 text-chart-3 border-0" },
+  admin: { label: "Administrator", icon: Shield, badgeClass: "bg-primary/10 text-primary border-0" },
+  owner: { label: "Owner", icon: Crown, badgeClass: "bg-accent text-accent-foreground border-0" },
+}
+
+export function RoleBadge({ role }: { role: MemberRole }) {
+  const cfg = ADMIN_ROLE_CONFIG[role]
+  const Icon = cfg.icon
+  return (
+    <Badge variant="secondary" className={cn("gap-1 h-5 text-xs", cfg.badgeClass)}>
+      <Icon className="size-3" />
+      {cfg.label}
+    </Badge>
+  )
+}
+
+// ─── Back button — matches EditProfileView / PlansView onBack ─
+export function AdminBackButton({ label, onClick }: { label: string; onClick?: () => void }) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="gap-1.5 -ml-2 self-start text-muted-foreground hover:text-foreground"
+      onClick={onClick}
+    >
+      <ArrowLeft className="size-4" />
+      {label}
+    </Button>
+  )
+}
+
+// ─── Date formatting helpers ──────────────────────────────────
+export function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+}
+
+export function fmtDateTime(iso: string | null): string {
+  if (!iso) return "Never"
+  // toLocaleString (not toLocaleDateString) — some runtimes ignore the
+  // hour/minute fields on toLocaleDateString, dropping the time portion.
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+export function relativeFromNow(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime()
+  // Clamp future timestamps (mock session data can land later-today) to
+  // "just now" instead of rendering a negative "-Xm ago".
+  if (diffMs < 60000) return "just now"
+  const mins = Math.round(diffMs / 60000)
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.round(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  const days = Math.round(hrs / 24)
+  return `${days}d ago`
+}

--- a/design-mocks/vite.config.ts
+++ b/design-mocks/vite.config.ts
@@ -11,4 +11,10 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    // Allow remote preview of the design mock over Tailscale MagicDNS
+    // (*.ts.net) only — keeps Vite's host-check protection on for every
+    // other host. Plain IP / localhost access is permitted by Vite by default.
+    allowedHosts: [".ts.net"],
+  },
 })


### PR DESCRIPTION
## What

Re-syncs the `design-mocks/` **read-only mirror** with the current state of [`inventario-design`](https://github.com/denisvmedia/inventario-design) (upstream), which had drifted behind.

This is the backport of [`inventario-design` PR #15](https://github.com/denisvmedia/inventario-design/pull/15) — the design deliverable of #1751 (Phase B of the admin umbrella #1744).

## Headline: net-new admin surface

Six layout-complete mock views under `design-mocks/src/views/admin/`:

| View | Contents |
|---|---|
| `TenantsView` | Paginated tenants table + search + stats |
| `TenantDetailView` | Header + Users / Groups tabs |
| `UserDetailView` | Identity, sessions, group memberships, block / unblock, impersonate |
| `GroupsView` | Cross-tenant list with tenant chip + status badge |
| `GroupDetailView` | Header, members table (add / remove / role-change), soft-delete danger zone |
| `ImpersonationBannerMock` | Persistent non-dismissible banner with countdown |
| `admin-shared.tsx` | Shared chips / status badges / back button / date helpers |

Wired into the mock's `view` state machine (`admin-*` states) and a new "Admin" sidebar group.

## Rest of the mirror sync

The mirror had fallen behind upstream beyond the admin work, so this also brings:

- New components: `CommandPalette`, `KeyboardShortcutsDialog`, `ErrorBoundary`, `SkeletonPatterns`, `TagPill`
- Unified `Tag` model in `mock.ts`
- Assorted view/component refinements (`ItemDetail`, `TagsView`, `SettingsView`, `FileBrowserView`, …)

32 files changed. `design-mocks/` is now byte-identical to upstream `inventario-design`.

## Verification

`npm run typecheck` and `npm run build` both pass clean in `design-mocks/`.

## Notes

- `design-mocks/` is a read-only mirror per [AGENTS.md](../blob/master/AGENTS.md); this PR only updates that mirror — no `frontend/` code changes.
- The #1751 acceptance criterion about a `devdocs/frontend/design-deviations.md` entry is **deferred to Phase C**: that file tracks where the real `frontend/` diverges from the mock, and no `frontend/` admin implementation exists yet (issues #1752–#1757). The entry belongs with whichever frontend PR first ships — or intentionally deviates from — the admin surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin dashboard (tenants, groups, users) with impersonation banner and countdown
  * Command palette (⌘/Ctrl+K) and global shortcuts (open palette, shortcuts dialog)
  * Keyboard shortcuts dialog and Settings integration
  * Skeleton loading patterns and improved tag display

* **Bug Fixes**
  * Error boundary to surface runtime errors gracefully

* **Documentation**
  * Clarified design/engineering guide on allowed UI primitives
  * Added Git worktree workflow guidance

* **Chores**
  * Vite dev server preview configuration updated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->