### PR TITLE
[#1758] Admin QA: E2E coverage + ops runbook + security threat model

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -282,6 +282,12 @@ jobs:
             --admin-name="Test Administrator"
 
       - name: Start inventario
+        env:
+          # Opt the seed into the system-admin fixture (sysadmin@test-org.com)
+          # so the admin-section e2e suite (#1758) can authenticate as a
+          # platform admin. OFF by default in the binary — /api/v1/seed is
+          # unauthenticated, so this must never be set in a real deployment.
+          INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE: "true"
         run: |
           mkdir -p /tmp/inventario-uploads
           nohup ./bin/inventario run > /tmp/inventario.log 2>&1 &

--- a/.github/workflows/go-test-postgres.yml
+++ b/.github/workflows/go-test-postgres.yml
@@ -146,3 +146,14 @@ jobs:
           echo "Limited DSN: $POSTGRES_LIMITED_TEST_DSN"
           go test -v -race ./schema/bootstrap
         working-directory: go
+
+      - name: Run seed data integration tests
+        # seeddata's Postgres test sits behind the `integration` build tag
+        # and was previously not run by any workflow. It exercises the full
+        # seed against a real database — the only coverage that catches
+        # driver.Valuer / JSONB-encoding regressions the in-memory registry
+        # cannot.
+        env:
+          POSTGRES_TEST_DSN: "postgres://inventario_test:test_password@localhost:5432/inventario_test?sslmode=disable"
+        run: go test -v -race -tags integration ./debug/seeddata/...
+        working-directory: go

--- a/README.md
+++ b/README.md
@@ -191,6 +191,31 @@ Complete CRUD (Create, Read, Update, Delete) operations for users and tenants:
 
 **Important**: User and tenant commands only work with PostgreSQL databases. Memory databases are not supported for persistent operations.
 
+#### System Administrators
+
+System administrators are platform operators with cross-tenant privileges
+(access to the `/api/v1/admin/*` API and the `/admin/*` UI). The flag is
+distinct from per-group roles and is managed with the `admin` command group:
+
+```bash
+# Grant platform-wide system-admin to a user
+./inventario admin grant-system-admin --email="admin@acme.com"
+
+# Revoke system-admin (refuses to revoke the last remaining admin)
+./inventario admin revoke-system-admin --email="admin@acme.com"
+
+# Revoke even if it would leave zero admins (deliberate decommission)
+./inventario admin revoke-system-admin --email="admin@acme.com" --allow-zero
+
+# List current system administrators
+./inventario admin list-system-admins
+```
+
+These commands require a PostgreSQL DSN (`--db-dsn` or `INVENTARIO_DB_DSN`).
+See the [System Admin Operations Runbook](devdocs/admin-runbook.md) for
+bootstrapping the first admin, audit-log inspection, lockout recovery, and
+the [admin threat model](devdocs/security/admin-threat-model.md).
+
 #### Command Options
 
 **Tenant Commands:**
@@ -392,6 +417,8 @@ This test validates:
 ## Documentation
 
 - [Signed URLs for Secure File Access](SIGNED_URLS.md) - Comprehensive guide to the secure file access system
+- [System Admin Operations Runbook](devdocs/admin-runbook.md) - Bootstrapping system admins, audit-log inspection, lockout recovery
+- [Admin Section Threat Model](devdocs/security/admin-threat-model.md) - Security model for the cross-tenant admin surface
 
 ## License
 This module is licensed under the MIT License. See the [LICENSE](LICENSE) file for details. You are free to use, modify, and distribute this software in accordance with the terms of the license.

--- a/devdocs/admin-runbook.md
+++ b/devdocs/admin-runbook.md
@@ -1,0 +1,202 @@
+# System Admin Operations Runbook
+
+Operational guide for the **system-wide admin section** (umbrella
+[#1744](https://github.com/denisvmedia/inventario/issues/1744)). A
+*system administrator* is a platform operator with cross-tenant
+privileges — distinct from a per-group `admin`/`owner` role. The flag
+lives in `users.is_system_admin` and gates the `/api/v1/admin/*` API
+subtree and the `/admin/*` UI.
+
+> **Scope.** System admins can list tenants, inspect/block users,
+> oversee groups (including soft-delete), edit group memberships, and
+> impersonate users for support. There is **no tenant CRUD** — tenants
+> are administered out-of-band (see [CLI Commands](../README.md#cli-commands)).
+
+---
+
+## 1. Granting the first system admin
+
+There is no API to mint the first system admin — that would be a
+chicken-and-egg bootstrap. Use the CLI, which talks to the database
+directly and needs only a PostgreSQL DSN (no admin session):
+
+```bash
+inventario admin grant-system-admin --email admin@acme.com \
+  --db-dsn postgres://user:pass@localhost:5432/inventario
+```
+
+- The DSN may also come from the `INVENTARIO_DB_DSN` environment
+  variable instead of `--db-dsn`.
+- **PostgreSQL only.** `memory://` DSNs are rejected — the in-memory
+  backend cannot persist the flag across restarts.
+- The operation is **idempotent**: granting to a user who is already a
+  system admin prints `ℹ️  … is already a system administrator.` and
+  exits `0`.
+- `grant-system-admin` does **not** add the user to any group — the
+  system-admin flag is orthogonal to group membership.
+
+On success:
+
+```
+✅ Granted system-admin to Jane Admin (admin@acme.com).
+```
+
+Every grant is recorded in the audit log as `admin.grant_system_admin`
+(see §4).
+
+---
+
+## 2. Revoking a system admin
+
+```bash
+inventario admin revoke-system-admin --email admin@acme.com \
+  --db-dsn postgres://user:pass@localhost:5432/inventario
+```
+
+- Also **idempotent**: revoking from a non-admin prints
+  `ℹ️  … is not a system administrator` and exits `0`.
+- **Last-admin guard.** The command refuses to revoke the *last*
+  remaining system admin so the platform is never left with zero
+  operators. To override this — e.g. a deliberate decommission — pass
+  `--allow-zero`:
+
+  ```bash
+  inventario admin revoke-system-admin --email admin@acme.com \
+    --allow-zero --db-dsn postgres://user:pass@localhost:5432/inventario
+  ```
+
+Revocation does **not** terminate the user's live sessions. To also cut
+off active access tokens, block the account (admin UI → user detail →
+**Block**, or `POST /api/v1/admin/users/{id}/block`), which revokes
+refresh tokens and bumps the JWT-blacklist staleness threshold.
+
+To see who currently holds the flag:
+
+```bash
+inventario admin list-system-admins \
+  --db-dsn postgres://user:pass@localhost:5432/inventario
+
+# machine-readable
+inventario admin list-system-admins --output json --db-dsn …
+```
+
+---
+
+## 3. Recovery — locked out with no system admins left
+
+If every system admin has been revoked, blocked, or deleted, the
+`/api/v1/admin/*` surface becomes unreachable through the application.
+**This is fully recoverable** — the CLI is the out-of-band escape hatch
+and authenticates against the *database*, not an admin session.
+
+Anyone with shell access to a host that can reach the database can
+re-bootstrap:
+
+```bash
+inventario admin grant-system-admin --email operator@acme.com \
+  --db-dsn postgres://user:pass@localhost:5432/inventario
+```
+
+If even that user is blocked, unblock them first:
+
+```bash
+inventario users update operator@acme.com --active=true --db-dsn …
+inventario admin grant-system-admin --email operator@acme.com --db-dsn …
+```
+
+Worst-case fallback — a direct SQL statement (use only if the CLI
+binary is unavailable):
+
+```sql
+UPDATE users SET is_system_admin = true, updated_at = now()
+WHERE email = 'operator@acme.com';
+```
+
+Prefer the CLI: it writes an audit-log row and enforces the safety
+guards. Treat raw SQL as a break-glass last resort.
+
+---
+
+## 4. Inspecting the audit log
+
+Every admin action — CLI and HTTP — is recorded in the `audit_logs`
+table via the `AuditLogRegistry`. There is no dedicated audit-log UI
+(only a recent-actions strip on entity pages); inspect the table
+directly.
+
+Admin actions use the `admin.` action prefix:
+
+| Action                       | Recorded by                          |
+| ----------------------------- | ------------------------------------- |
+| `admin.grant_system_admin`    | `inventario admin grant-system-admin` |
+| `admin.revoke_system_admin`   | `inventario admin revoke-system-admin`|
+| `admin.list_tenants` / `…get_tenant` | tenant list / detail endpoints |
+| `admin.list_tenant_users` / `…get_user` | user list / detail endpoints |
+| `admin.user_block` / `admin.user_unblock` | block / unblock endpoints |
+| `admin.list_groups` / `…get_group` / `…delete_group` | group endpoints |
+| `admin.group_member_add` / `…remove` / `…role_change` | membership endpoints |
+| `admin.impersonate_start` / `admin.impersonate_end` | impersonation endpoints |
+
+Useful queries:
+
+```sql
+-- Recent admin actions
+SELECT timestamp, action, user_id, tenant_id, entity_type, entity_id,
+       success, impersonated_by
+FROM audit_logs
+WHERE action LIKE 'admin.%'
+ORDER BY timestamp DESC
+LIMIT 100;
+
+-- Everything an operator did, including actions taken while impersonating
+SELECT timestamp, action, entity_type, entity_id, impersonated_by, success
+FROM audit_logs
+WHERE user_id = '<operator-user-id>'
+   OR impersonated_by = '<operator-user-id>'
+ORDER BY timestamp DESC;
+
+-- Every action performed inside any impersonation session
+SELECT timestamp, action, user_id AS impersonated_user, impersonated_by AS operator
+FROM audit_logs
+WHERE impersonated_by IS NOT NULL
+ORDER BY timestamp DESC;
+```
+
+Key columns: `user_id` is the *acting subject*; `impersonated_by` is the
+operator-of-record when the action happened inside an impersonation
+session (NULL otherwise); `success` and `error_message` capture failed
+attempts. A per-action JSON breadcrumb is stored in `user_agent`.
+
+---
+
+## 5. Impersonation — operational notes
+
+A system admin can issue a short-lived impersonation session for a
+target user (admin UI → user detail → **Impersonate**). Operational
+constraints:
+
+- Default TTL is **30 minutes**, configurable via
+  `INVENTARIO_IMPERSONATION_TTL` (capped at 30 minutes).
+- The impersonation token carries `is_system_admin = false` — an
+  operator does **not** keep admin powers while impersonating.
+- Sessions **cannot** be nested (no impersonating from within an
+  impersonation) and **cannot** be refreshed.
+- Impersonating another system admin is rejected (`422`,
+  `admin.impersonate.target_is_admin`).
+- A persistent banner is shown in the UI for the whole session; "End
+  impersonation" restores the operator's own session.
+- The impersonate endpoint is rate-limited (10 starts per operator per
+  hour).
+
+Every action taken during impersonation is audit-logged with both the
+subject (`user_id`) and the operator (`impersonated_by`).
+
+---
+
+## See also
+
+- [`devdocs/security/admin-threat-model.md`](security/admin-threat-model.md)
+  — threat model for the admin surface.
+- [Umbrella #1744](https://github.com/denisvmedia/inventario/issues/1744)
+  — design decisions and scope.
+- [CLI Commands](../README.md#cli-commands) — tenant / user management.

--- a/devdocs/security/admin-threat-model.md
+++ b/devdocs/security/admin-threat-model.md
@@ -1,0 +1,209 @@
+# Admin Section — Threat Model
+
+Focused threat model for the system-wide admin section
+([umbrella #1744](https://github.com/denisvmedia/inventario/issues/1744),
+QA gate [#1758](https://github.com/denisvmedia/inventario/issues/1758)).
+It covers the `/api/v1/admin/*` API subtree, the `/admin/*` UI, the
+`is_system_admin` JWT claim, and the impersonation primitive.
+
+Scope is deliberately narrow: it addresses what the admin section adds
+on top of the existing auth stack (JWT + refresh tokens + CSRF + RLS).
+General application threats are out of scope.
+
+## Trust boundaries & assets
+
+- **Assets**: every tenant's data (the admin surface is cross-tenant),
+  the `is_system_admin` flag, the JWT signing secret, impersonation
+  tokens, and the audit log.
+- **Privileged principals**: system admins (`users.is_system_admin =
+  true`) and anyone with database or host shell access (the CLI
+  bootstrap path).
+- **Boundary**: the `RequireSystemAdmin` middleware separates ordinary
+  authenticated users from the admin surface; the database role's RLS
+  policies separate tenants for all *non-admin* traffic.
+
+---
+
+## T1 — Privilege escalation: a non-admin self-grants admin
+
+**Threat.** A regular user forges or mutates a token / record so that
+`is_system_admin` reads `true`.
+
+**Mitigations.**
+- `is_system_admin` is a database column carrying the model tag
+  `userinput:"false"` — it is never bound from a user-supplied request
+  body, so no normal user/profile endpoint can set it.
+- The flag is only ever written by the CLI (`admin grant-system-admin`)
+  or the seed harness — both require direct database access.
+- The JWT `is_system_admin` claim is signed (HS256) with the server
+  secret; a tampered claim fails signature verification.
+- `RequireSystemAdmin` re-reads the flag from the authenticated user
+  context; a stale or self-asserted claim alone does not pass.
+
+**Residual risk.** Compromise of the JWT signing secret (see T2) or of
+the database. Both are pre-existing platform-level risks.
+
+---
+
+## T2 — JWT forgery / replay of admin or impersonation claims
+
+**Threat.** An attacker self-signs a token with `is_system_admin: true`
+or `imp: true` / `impersonated_by`, or replays a captured one.
+
+**Mitigations.**
+- All tokens are HS256-signed with the server secret and verified on
+  every request; the algorithm is pinned (no `alg:none` downgrade).
+- Access tokens are short-lived; impersonation tokens are shorter still
+  (≤30 min, `INVENTARIO_IMPERSONATION_TTL`).
+- Block bumps a per-user JWT-blacklist `iat`-staleness threshold, so a
+  captured access token for a blocked user is rejected on next use even
+  before it expires.
+- Impersonation tokens carry a server-side return slot keyed by `jti`;
+  `POST /admin/impersonation/end` additionally requires the matching
+  browser-bound marker cookie, so a stolen bearer token alone cannot
+  redeem the session.
+
+**Residual risk.** Secret compromise. Mitigated operationally by secret
+rotation and not logging the secret (see T7).
+
+---
+
+## T3 — RLS bypass leaking cross-tenant data
+
+**Threat.** The admin endpoints intentionally bypass row-level security
+(`SET LOCAL row_security = off`) to read across tenants. A bug could
+expose that bypass to a non-admin, or an injection could widen a query.
+
+**Mitigations.**
+- Only the documented admin registry methods (`*Admin`-suffixed:
+  `TenantRegistry.ListAdmin`/`GetAdmin`, `UserRegistry.ListAdminByTenant`,
+  `LocationGroupRegistry.ListAdmin`/`GetAdmin`/`MarkPendingDeletionAdmin`,
+  `GroupMembershipRegistry.AdminListMembersWithUsers`) issue
+  `SET LOCAL row_security = off`, and every caller sits behind
+  `RequireSystemAdmin`.
+- `SET LOCAL` is transaction-scoped — the bypass cannot leak past the
+  request transaction.
+- Non-admin endpoints are unchanged: `SET app.current_tenant_id` and the
+  RLS policies still scope them per-tenant.
+- All admin queries are parameterised (no string-built SQL from user
+  input), so a search term cannot widen the row set.
+
+**Residual risk.** A future admin handler that adds a non-`*Admin`
+query, or a new `*Admin` method mounted on a route that forgets
+`RequireSystemAdmin`. Guarded by the security checklist in the PR and by
+the e2e 403 test.
+
+---
+
+## T4 — Impersonation abuse
+
+**Threat.** An operator escalates, pivots, or hides activity through
+impersonation.
+
+**Mitigations.**
+- Impersonation tokens pin `is_system_admin: false` — an operator
+  cannot use an impersonated identity to reach the admin surface.
+- **No chaining**: a request already inside an impersonation cannot
+  start another (`isImpersonatedRequest` guard + `RequireSystemAdmin`
+  rejecting the non-admin impersonation token).
+- **No refresh**: `POST /auth/refresh` rejects impersonation tokens
+  (bearer `imp=true` and the `imp:<jti>` refresh-cookie marker), so the
+  short TTL cannot be extended.
+- **No admin targets**: impersonating another system admin is rejected
+  (`422 admin.impersonate.target_is_admin`); blocked users are also
+  refused.
+- **Rate limited**: 10 impersonation starts per operator per hour.
+- **Self-block protection**: the block handler resolves the real
+  operator via `impersonated_by`, so an operator cannot block their own
+  account by acting through an impersonated identity.
+- **Auditable**: every action in an impersonated session is logged with
+  both the subject (`user_id`) and the operator (`impersonated_by`).
+- The UI shows a persistent, non-dismissible banner for the whole
+  session.
+
+**Residual risk.** A malicious operator can still view/act on a target's
+data within the TTL. This is inherent to a support-impersonation
+feature; the audit trail is the compensating control.
+
+---
+
+## T5 — CSRF on admin mutations
+
+**Threat.** A logged-in admin is tricked into issuing a state-changing
+admin request from a malicious page.
+
+**Mitigations.**
+- All admin mutation endpoints (`POST`/`PATCH`/`DELETE` under
+  `/api/v1/admin/*`) run through the existing CSRF middleware and
+  require a valid CSRF token.
+- CSRF tokens are rotated on impersonation start (to the target) and on
+  impersonation end (back to the operator).
+- `POST /admin/impersonation/end` is the one mutation mounted outside
+  CSRF middleware; it is self-authorising — it requires a validly
+  signed impersonation token *and* the matching browser-bound marker
+  cookie, which together provide equivalent assurance.
+
+**Residual risk.** Minimal; same posture as the rest of the app.
+
+---
+
+## T6 — Block does not actually cut off access
+
+**Threat.** A blocked user keeps working with already-issued tokens.
+
+**Mitigations.** Block performs a three-part cascade: set
+`is_active = false`, revoke all refresh tokens, and bump the
+JWT-blacklist `iat`-staleness threshold so live access tokens fail on
+the next request. Covered by an integration test and by the e2e spec
+(`system-admin.spec.ts`), which asserts that a token issued before the
+block returns `401` after it.
+
+**Residual risk.** A window of at most one in-flight request between the
+block transaction committing and the next token check.
+
+---
+
+## T7 — Secret / credential leakage via logs
+
+**Threat.** An admin handler logs the JWT secret, a new admin's
+password, or an impersonation token to stdout or the structured logger.
+
+**Mitigations.** Admin handlers log identifiers (user/tenant/group IDs,
+action names, paths) — not secrets. The CLI prints names/emails only.
+Verified by the security checklist below.
+
+**Residual risk.** Regression in a future handler — re-check on review.
+
+---
+
+## Security review checklist (#1758)
+
+Tracked in the PR for #1758; each item is verified against the code
+and/or an automated test.
+
+- [ ] **RLS bypass surface** — only the documented `*Admin` registry
+      methods issue `SET LOCAL row_security = off`, all behind
+      `RequireSystemAdmin`. *(T3)*
+- [ ] **JWT claim layout** — `is_system_admin` / `impersonated_by`
+      cannot be self-signed by a non-admin (signature verification +
+      `userinput:"false"`). *(T1, T2)*
+- [ ] **Impersonation no-chain** — e2e + integration test assert nested
+      impersonation is rejected. *(T4)*
+- [ ] **Impersonation no-refresh** — e2e + integration test assert the
+      impersonation token cannot mint a new access token. *(T4)*
+- [ ] **Rate-limit on impersonate** — exists (10/operator/hour) and is
+      verified by an integration test. *(T4)*
+- [ ] **Audit-log coverage** — every admin action writes a row;
+      spot-check a real DB row per category. *(audit log)*
+- [ ] **CSRF** — admin mutation endpoints require the CSRF token. *(T5)*
+- [ ] **Logs** — no admin handler logs the JWT secret, a password, or an
+      impersonation token. *(T7)*
+
+---
+
+## See also
+
+- [`devdocs/admin-runbook.md`](../admin-runbook.md) — operator runbook.
+- [`devdocs/CSRF_PROTECTION.md`](../CSRF_PROTECTION.md)
+- [`devdocs/REFRESH_TOKEN_SYSTEM.md`](../REFRESH_TOKEN_SYSTEM.md)
+- [Umbrella #1744](https://github.com/denisvmedia/inventario/issues/1744)

--- a/devdocs/security/admin-threat-model.md
+++ b/devdocs/security/admin-threat-model.md
@@ -30,18 +30,38 @@ General application threats are out of scope.
 `is_system_admin` reads `true`.
 
 **Mitigations.**
-- `is_system_admin` is a database column carrying the model tag
-  `userinput:"false"` — it is never bound from a user-supplied request
-  body, so no normal user/profile endpoint can set it.
-- The flag is only ever written by the CLI (`admin grant-system-admin`)
-  or the seed harness — both require direct database access.
+- `is_system_admin` is never present in any request DTO: the binding
+  structs for the user-facing write paths (`RegisterRequest`,
+  `UpdateProfileRequest`, …) simply do not declare the field, and
+  handlers assign `models.User` fields by name — there is no blind
+  `json.Decode(&user)` into the model. The combination of the
+  request-DTO allow-list and explicit per-field assignment is the
+  actual control. The model field also carries a `userinput:"false"`
+  tag, but that tag is a **non-enforced marker** — neither the registry
+  layer nor request binding checks it — and must not be relied on as a
+  control.
+- The flag is written by the CLI (`admin grant-system-admin`, which
+  needs a database DSN) or by the seed. The seed reaches the flag only
+  through the `ensureSystemAdminUser` fixture, which is gated behind the
+  `INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE` opt-in (off by default) — so
+  the unauthenticated `/api/v1/seed` endpoint cannot mint a cross-tenant
+  admin in a production deployment.
 - The JWT `is_system_admin` claim is signed (HS256) with the server
   secret; a tampered claim fails signature verification.
 - `RequireSystemAdmin` re-reads the flag from the authenticated user
   context; a stale or self-asserted claim alone does not pass.
 
-**Residual risk.** Compromise of the JWT signing secret (see T2) or of
-the database. Both are pre-existing platform-level risks.
+**Residual risk.**
+- Compromise of the JWT signing secret (see T2) or of the database —
+  pre-existing platform-level risks.
+- **Architectural:** the privilege lives on the `users` row, so a
+  single future handler doing a blind decode (`json.Decode(&user)` +
+  `registry.Update`) would be a full privilege escalation. Today this
+  is held only by code-review discipline, not structurally. #1784
+  tracks moving the privilege off the `users` row into a dedicated
+  `system_admin_grants` table, which would remove this class of risk;
+  until then it must be re-checked on every change to user-write
+  handlers.
 
 ---
 
@@ -186,7 +206,8 @@ and/or an automated test.
       `RequireSystemAdmin`. *(T3)*
 - [ ] **JWT claim layout** — `is_system_admin` / `impersonated_by`
       cannot be self-signed by a non-admin (signature verification +
-      `userinput:"false"`). *(T1, T2)*
+      the request-DTO allow-list: the field is absent from the request
+      structs). *(T1, T2)*
 - [ ] **Impersonation no-chain** — e2e + integration test assert nested
       impersonation is rejected. *(T4)*
 - [ ] **Impersonation no-refresh** — e2e + integration test assert the

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -56,3 +56,9 @@ services:
       # value just satisfies the handler's "configured?" check so the
       # e2e flow can exercise the happy path.
       INVENTARIO_RUN_SUPPORT_EMAIL: "support@e2e.test"
+      # Opt the seed into the system-admin fixture (sysadmin@test-org.com)
+      # so the admin-section e2e suite (#1758) can authenticate as a
+      # platform admin. OFF by default in the binary — /api/v1/seed is
+      # unauthenticated, so this must never be set in a real deployment.
+      # Mirrors e2e/setup/setup-stack.ts.
+      INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE: "true"

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -34,6 +34,16 @@ services:
 
   inventario-init-data:
     image: ${INVENTARIO_IMAGE:?INVENTARIO_IMAGE must be set}
+    environment:
+      # The seed runs HERE, not in the `inventario` service:
+      # scripts/init-data.sh boots its own `inventario run` inside this
+      # container and POSTs /api/v1/seed to localhost, so the seed
+      # handler reads this env from the init-data process. Opt the seed
+      # into the system-admin fixture (sysadmin@test-org.com) so the
+      # admin-section e2e suite (#1758) can authenticate as a platform
+      # admin. OFF by default in the binary — /api/v1/seed is
+      # unauthenticated, so this must never be set in a real deployment.
+      INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE: "true"
 
   inventario:
     image: ${INVENTARIO_IMAGE:?INVENTARIO_IMAGE must be set}
@@ -56,9 +66,3 @@ services:
       # value just satisfies the handler's "configured?" check so the
       # e2e flow can exercise the happy path.
       INVENTARIO_RUN_SUPPORT_EMAIL: "support@e2e.test"
-      # Opt the seed into the system-admin fixture (sysadmin@test-org.com)
-      # so the admin-section e2e suite (#1758) can authenticate as a
-      # platform admin. OFF by default in the binary — /api/v1/seed is
-      # unauthenticated, so this must never be set in a real deployment.
-      # Mirrors e2e/setup/setup-stack.ts.
-      INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE: "true"

--- a/e2e/setup/setup-stack.ts
+++ b/e2e/setup/setup-stack.ts
@@ -97,6 +97,13 @@ export async function startBackend(): Promise<void> {
       // this value just satisfies the "configured?" check so the e2e
       // flow can exercise the happy path.
       INVENTARIO_RUN_SUPPORT_EMAIL: process.env.INVENTARIO_RUN_SUPPORT_EMAIL ?? 'support@e2e.test',
+      // Opt the seed into the system-admin fixture (sysadmin@test-org.com)
+      // so the admin-section e2e suite (#1758) can authenticate as a
+      // platform admin. OFF by default in the binary — the /api/v1/seed
+      // endpoint is unauthenticated, so this must never be set in a real
+      // deployment.
+      INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE:
+        process.env.INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE ?? 'true',
       // Currency-migration surface defaults on in the binary now
       // (Config.FeatureCurrencyMigration env-default since #1612). Pass
       // an explicit override through only if the operator wants to flip

--- a/e2e/tests/admin/system-admin.spec.ts
+++ b/e2e/tests/admin/system-admin.spec.ts
@@ -60,7 +60,11 @@ async function apiLogin(
   const body = await resp.json();
   expect(body.access_token, `access_token for ${credentials.email}`).toBeTruthy();
   expect(body.user?.id, `user id for ${credentials.email}`).toBeTruthy();
-  return { token: body.access_token, csrf: body.csrf_token ?? '', userId: body.user.id };
+  // CSRF is required for every mutating admin endpoint this spec hits.
+  // Fail fast here with a clear message rather than letting a missing
+  // token surface as a confusing 403 far downstream.
+  expect(body.csrf_token, `csrf_token for ${credentials.email}`).toBeTruthy();
+  return { token: body.access_token, csrf: body.csrf_token, userId: body.user.id };
 }
 
 /** Log in as the seeded system admin through the real login form. */

--- a/e2e/tests/admin/system-admin.spec.ts
+++ b/e2e/tests/admin/system-admin.spec.ts
@@ -168,39 +168,35 @@ test.describe('System admin section (#1744 / #1758)', () => {
     await page.goto(`/admin/users/${target.userId}`);
     await expect(page.getByTestId('admin-user-detail-page')).toBeVisible();
 
-    // Block via the user-detail UI.
-    await page.getByTestId('admin-user-block').click();
-    await expect(page.getByTestId('admin-user-action-dialog')).toBeVisible();
-    await page.getByTestId('admin-user-action-reason').fill('e2e block/unblock coverage (#1758)');
-    const blockResp = page.waitForResponse(
-      (r) => r.url().includes(`/users/${target.userId}/block`) && r.request().method() === 'POST',
-    );
-    await page.getByTestId('admin-user-action-confirm').click();
-    expect((await blockResp).status()).toBe(200);
+    try {
+      // Block via the user-detail UI.
+      await page.getByTestId('admin-user-block').click();
+      await expect(page.getByTestId('admin-user-action-dialog')).toBeVisible();
+      await page.getByTestId('admin-user-action-reason').fill('e2e block/unblock coverage (#1758)');
+      const blockResp = page.waitForResponse(
+        (r) => r.url().includes(`/users/${target.userId}/block`) && r.request().method() === 'POST',
+      );
+      await page.getByTestId('admin-user-action-confirm').click();
+      expect((await blockResp).status()).toBe(200);
 
-    // The UI now offers "unblock", confirming the state flipped.
-    await expect(page.getByTestId('admin-user-unblock')).toBeVisible();
+      // The UI now offers "unblock", confirming the state flipped.
+      await expect(page.getByTestId('admin-user-unblock')).toBeVisible();
 
-    // The token issued before the block is now rejected — block bumps
-    // the JWT-blacklist iat-staleness threshold for the user.
-    const after = await request.get('/api/v1/auth/me', {
-      headers: authHeaders(target.token),
-    });
-    expect(after.status()).toBe(401);
-
-    // Unblock restores the account.
-    await page.getByTestId('admin-user-unblock').click();
-    await expect(page.getByTestId('admin-user-action-dialog')).toBeVisible();
-    const unblockReason = page.getByTestId('admin-user-action-reason');
-    if (await unblockReason.isVisible()) {
-      await unblockReason.fill('e2e unblock (#1758)');
+      // The token issued before the block is now rejected — block bumps
+      // the JWT-blacklist iat-staleness threshold for the user.
+      const after = await request.get('/api/v1/auth/me', {
+        headers: authHeaders(target.token),
+      });
+      expect(after.status()).toBe(401);
+    } finally {
+      // Unblock restores the account — always runs even if assertions fail.
+      const { token, csrf } = await pageTokens(page);
+      const unblockResp = await request.post(`/api/v1/admin/users/${target.userId}/unblock`, {
+        headers: { 'Content-Type': 'application/json', ...authHeaders(token, csrf) },
+        data: { reason: 'e2e cleanup (#1758)' },
+      });
+      expect(unblockResp.status()).toBe(200);
     }
-    const unblockResp = page.waitForResponse(
-      (r) => r.url().includes(`/users/${target.userId}/unblock`) && r.request().method() === 'POST',
-    );
-    await page.getByTestId('admin-user-action-confirm').click();
-    expect((await unblockResp).status()).toBe(200);
-    await expect(page.getByTestId('admin-user-block')).toBeVisible();
 
     // A fresh login succeeds again now that the account is active.
     const relogin = await request.post('/api/v1/auth/login', {

--- a/e2e/tests/admin/system-admin.spec.ts
+++ b/e2e/tests/admin/system-admin.spec.ts
@@ -1,0 +1,350 @@
+/**
+ * E2E coverage for the system-wide admin section (umbrella #1744,
+ * QA gate #1758).
+ *
+ * The system admin is bootstrapped by the test harness: debug/seeddata
+ * provisions `sysadmin@test-org.com` with `is_system_admin = true`
+ * (mirroring the production `inventario admin grant-system-admin` CLI
+ * step) so every harness lane gets the fixture without a bespoke CLI
+ * call — see SYSADMIN_TEST_CREDENTIALS in includes/auth.ts.
+ *
+ * Spec layout follows the issue #1758 E2E checklist:
+ *   1. browse tenants → tenant detail → users + groups tabs
+ *   2. non-admins are denied the admin surface (UI 403 + API 403)
+ *   3. block invalidates the target's live access token; unblock restores it
+ *   4. admin group membership add / role-change / remove + soft-delete
+ *   5. impersonation: start → banner → navigate → end → admin restored
+ *   6. impersonation safety: no nested impersonation, no token refresh
+ *
+ * Cross-tenant rejection (`admin.member.tenant_mismatch`) is not
+ * reachable here — the e2e database holds a single tenant — and is
+ * covered by the backend integration tests for #1749.
+ *
+ * Note: Playwright's testDir is `./tests`, so this spec lives at
+ * `tests/admin/` rather than the `e2e/specs/admin/` path named in the
+ * issue, which would not be discovered by the runner.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import waitOn from 'wait-on';
+import {
+  login,
+  SYSADMIN_TEST_CREDENTIALS,
+  BLOCK_TARGET_TEST_CREDENTIALS,
+  ORPHAN_TEST_CREDENTIALS,
+  TEST_CREDENTIALS,
+} from '../includes/auth.js';
+import { BASE_URL } from '../../setup/urls.js';
+
+const TEAMMATE_CREDENTIALS = {
+  email: 'teammate@test-org.com',
+  password: 'TestPassword123',
+};
+
+const JSON_API = 'application/vnd.api+json';
+
+type ApiSession = { token: string; csrf: string; userId: string };
+
+/**
+ * Log in directly against the JSON API (no browser). Returns the
+ * access token, CSRF token and user id from the LoginResponse body.
+ */
+async function apiLogin(
+  request: APIRequestContext,
+  credentials: { email: string; password: string },
+): Promise<ApiSession> {
+  const resp = await request.post('/api/v1/auth/login', {
+    headers: { 'Content-Type': 'application/json' },
+    data: credentials,
+  });
+  expect(resp.status(), `login ${credentials.email}`).toBe(200);
+  const body = await resp.json();
+  expect(body.access_token, `access_token for ${credentials.email}`).toBeTruthy();
+  expect(body.user?.id, `user id for ${credentials.email}`).toBeTruthy();
+  return { token: body.access_token, csrf: body.csrf_token ?? '', userId: body.user.id };
+}
+
+/** Log in as the seeded system admin through the real login form. */
+async function loginAsSysadmin(page: Page): Promise<void> {
+  await page.goto('/login');
+  await login(page, undefined, SYSADMIN_TEST_CREDENTIALS);
+}
+
+/** Read the access + CSRF tokens the frontend stashed after login. */
+async function pageTokens(page: Page): Promise<{ token: string; csrf: string }> {
+  return page.evaluate(() => ({
+    token: localStorage.getItem('inventario_token') || '',
+    csrf: sessionStorage.getItem('inventario_csrf_token') || '',
+  }));
+}
+
+function authHeaders(token: string, csrf?: string): Record<string, string> {
+  const h: Record<string, string> = { Authorization: `Bearer ${token}` };
+  if (csrf) h['X-CSRF-Token'] = csrf;
+  return h;
+}
+
+test.describe('System admin section (#1744 / #1758)', () => {
+  test.beforeAll(async () => {
+    // global-setup waits for the stack, but sibling specs may have
+    // bounced services in between — re-probe so the first navigation
+    // doesn't race a still-warming server.
+    await waitOn({
+      resources: [BASE_URL],
+      timeout: 15000,
+      interval: 250,
+      window: 1000,
+      tcpTimeout: 1000,
+    });
+  });
+
+  test('browses tenants, tenant detail, users and groups tabs', async ({ page }) => {
+    await loginAsSysadmin(page);
+
+    // The admin sidebar entry is only rendered for system admins.
+    await expect(page.getByTestId('sidebar-admin-group')).toBeVisible();
+
+    await page.goto('/admin/tenants');
+    await expect(page.getByTestId('admin-tenants-page')).toBeVisible();
+
+    const tenantRows = page.getByTestId('admin-tenant-row');
+    await expect(tenantRows.first()).toBeVisible();
+
+    // Into the tenant detail page.
+    await tenantRows.first().click();
+    await expect(page.getByTestId('admin-tenant-detail-page')).toBeVisible();
+    await expect(page).toHaveURL(/\/admin\/tenants\/[^/]+$/);
+
+    // Users tab — the seeded tenant has the well-known fixture users.
+    await page.getByTestId('admin-tenant-tab-users').click();
+    await expect(page.getByTestId('admin-tenant-users-table')).toBeVisible();
+    await expect(page.getByTestId('admin-tenant-user-row').first()).toBeVisible();
+
+    // Groups tab.
+    await page.getByTestId('admin-tenant-tab-groups').click();
+    await expect(page.getByTestId('admin-tenant-groups-table')).toBeVisible();
+    await expect(page.getByTestId('admin-tenant-group-row').first()).toBeVisible();
+  });
+
+  test('denies the admin surface to non-admin users (UI + API 403)', async ({ page, request }) => {
+    // A regular tenant user — not a system admin.
+    await page.goto('/login');
+    await login(page, undefined, TEST_CREDENTIALS);
+
+    // No admin sidebar entry.
+    await expect(page.getByTestId('sidebar-admin-group')).toHaveCount(0);
+
+    // Deep-linking into /admin renders the in-place 403, not the data.
+    await page.goto('/admin/tenants');
+    await expect(page.getByTestId('admin-forbidden')).toBeVisible();
+    await expect(page.getByTestId('admin-tenants-page')).toHaveCount(0);
+
+    // The API rejects the non-admin token outright.
+    const { token } = await pageTokens(page);
+    expect(token).toBeTruthy();
+    const resp = await request.get('/api/v1/admin/tenants', {
+      headers: authHeaders(token),
+    });
+    expect(resp.status()).toBe(403);
+  });
+
+  test('blocking a user invalidates their live token; unblock restores access', async ({
+    page,
+    request,
+  }) => {
+    // Capture a token for the block target BEFORE it is blocked.
+    const target = await apiLogin(request, BLOCK_TARGET_TEST_CREDENTIALS);
+
+    // Sanity: the captured token is live right now.
+    const before = await request.get('/api/v1/auth/me', {
+      headers: authHeaders(target.token),
+    });
+    expect(before.status()).toBe(200);
+
+    await loginAsSysadmin(page);
+    await page.goto(`/admin/users/${target.userId}`);
+    await expect(page.getByTestId('admin-user-detail-page')).toBeVisible();
+
+    // Block via the user-detail UI.
+    await page.getByTestId('admin-user-block').click();
+    await expect(page.getByTestId('admin-user-action-dialog')).toBeVisible();
+    await page.getByTestId('admin-user-action-reason').fill('e2e block/unblock coverage (#1758)');
+    const blockResp = page.waitForResponse(
+      (r) => r.url().includes(`/users/${target.userId}/block`) && r.request().method() === 'POST',
+    );
+    await page.getByTestId('admin-user-action-confirm').click();
+    expect((await blockResp).status()).toBe(200);
+
+    // The UI now offers "unblock", confirming the state flipped.
+    await expect(page.getByTestId('admin-user-unblock')).toBeVisible();
+
+    // The token issued before the block is now rejected — block bumps
+    // the JWT-blacklist iat-staleness threshold for the user.
+    const after = await request.get('/api/v1/auth/me', {
+      headers: authHeaders(target.token),
+    });
+    expect(after.status()).toBe(401);
+
+    // Unblock restores the account.
+    await page.getByTestId('admin-user-unblock').click();
+    await expect(page.getByTestId('admin-user-action-dialog')).toBeVisible();
+    const unblockReason = page.getByTestId('admin-user-action-reason');
+    if (await unblockReason.isVisible()) {
+      await unblockReason.fill('e2e unblock (#1758)');
+    }
+    const unblockResp = page.waitForResponse(
+      (r) => r.url().includes(`/users/${target.userId}/unblock`) && r.request().method() === 'POST',
+    );
+    await page.getByTestId('admin-user-action-confirm').click();
+    expect((await unblockResp).status()).toBe(200);
+    await expect(page.getByTestId('admin-user-block')).toBeVisible();
+
+    // A fresh login succeeds again now that the account is active.
+    const relogin = await request.post('/api/v1/auth/login', {
+      headers: { 'Content-Type': 'application/json' },
+      data: BLOCK_TARGET_TEST_CREDENTIALS,
+    });
+    expect(relogin.status()).toBe(200);
+  });
+
+  test('admin edits group membership and soft-deletes the group', async ({ page, request }) => {
+    await loginAsSysadmin(page);
+    const { token, csrf } = await pageTokens(page);
+    expect(token).toBeTruthy();
+
+    // A throwaway group owned by the system admin. Soft-deleting it at
+    // the end of the test is its own cleanup — the purge worker
+    // finishes the job — so it never leaks into later runs.
+    const groupName = `Admin QA Group ${Date.now()}`;
+    const createResp = await request.post('/api/v1/groups', {
+      headers: { 'Content-Type': JSON_API, Accept: JSON_API, ...authHeaders(token, csrf) },
+      data: { data: { type: 'groups', attributes: { name: groupName, icon: '🧪' } } },
+    });
+    expect(createResp.status()).toBe(201);
+    const groupId = (await createResp.json()).data.id as string;
+
+    // A second user to manage as a member.
+    const member = await apiLogin(request, TEAMMATE_CREDENTIALS);
+
+    // Add the member (viewer) via the admin membership endpoint.
+    const addResp = await request.post(`/api/v1/admin/groups/${groupId}/members`, {
+      headers: { 'Content-Type': 'application/json', ...authHeaders(token, csrf) },
+      data: { userID: member.userId, role: 'viewer' },
+    });
+    expect(addResp.status()).toBe(201);
+
+    // The membership editor renders the new member.
+    await page.goto(`/admin/groups/${groupId}`);
+    await expect(page.getByTestId('admin-group-detail-page')).toBeVisible();
+    await expect(page.getByTestId('admin-group-member-row')).toHaveCount(2);
+
+    // Role change: viewer → user.
+    const roleResp = await request.patch(
+      `/api/v1/admin/groups/${groupId}/members/${member.userId}`,
+      {
+        headers: { 'Content-Type': 'application/json', ...authHeaders(token, csrf) },
+        data: { role: 'user' },
+      },
+    );
+    expect(roleResp.status()).toBe(200);
+
+    // Remove the member.
+    const removeResp = await request.delete(
+      `/api/v1/admin/groups/${groupId}/members/${member.userId}`,
+      { headers: authHeaders(token, csrf) },
+    );
+    expect(removeResp.status()).toBe(204);
+
+    await page.reload();
+    await expect(page.getByTestId('admin-group-member-row')).toHaveCount(1);
+
+    // Soft-delete the group: status → pending_deletion.
+    const deleteResp = await request.delete(`/api/v1/admin/groups/${groupId}`, {
+      headers: authHeaders(token, csrf),
+    });
+    expect([200, 202, 204]).toContain(deleteResp.status());
+
+    // The detail page shows the pending-deletion banner.
+    await page.goto(`/admin/groups/${groupId}`);
+    await expect(page.getByTestId('admin-group-pending-banner')).toBeVisible();
+  });
+
+  test('impersonation: start, banner, navigate, end, admin restored', async ({ page, request }) => {
+    // The orphan fixture is a safe impersonation target — it is a
+    // non-admin, active user and impersonating it does not mutate any
+    // state a sibling spec depends on.
+    const orphan = await apiLogin(request, ORPHAN_TEST_CREDENTIALS);
+
+    await loginAsSysadmin(page);
+    await page.goto(`/admin/users/${orphan.userId}`);
+    await expect(page.getByTestId('admin-user-detail-page')).toBeVisible();
+
+    // Start impersonation. The frontend hard-reloads the app on
+    // success, so anchor on the POST response before the reload.
+    const startResp = page.waitForResponse(
+      (r) => r.url().includes(`/users/${orphan.userId}/impersonate`) && r.request().method() === 'POST',
+    );
+    await page.getByTestId('admin-user-impersonate').click();
+    await expect(page.getByTestId('admin-user-action-dialog')).toBeVisible();
+    await page.getByTestId('admin-user-action-confirm').click();
+    expect((await startResp).ok()).toBeTruthy();
+
+    // The persistent impersonation banner appears.
+    await expect(page.getByTestId('impersonation-banner')).toBeVisible({ timeout: 20000 });
+
+    // The banner survives an in-app navigation.
+    await page.goto('/profile');
+    await expect(page.getByTestId('impersonation-banner')).toBeVisible();
+
+    // End impersonation → the admin session is restored.
+    const endResp = page.waitForResponse(
+      (r) => r.url().includes('/impersonation/end') && r.request().method() === 'POST',
+    );
+    await page.getByTestId('impersonation-end').click();
+    expect((await endResp).ok()).toBeTruthy();
+
+    await expect(page.getByTestId('impersonation-banner')).toBeHidden({ timeout: 20000 });
+    // Admin privileges are back: the admin sidebar entry is visible again.
+    await expect(page.getByTestId('sidebar-admin-group')).toBeVisible({ timeout: 20000 });
+  });
+
+  test('impersonation safety: no nested impersonation, no token refresh', async ({ request }) => {
+    const orphan = await apiLogin(request, ORPHAN_TEST_CREDENTIALS);
+    const sysadmin = await apiLogin(request, SYSADMIN_TEST_CREDENTIALS);
+
+    // Start an impersonation session for the orphan user.
+    const startResp = await request.post(`/api/v1/admin/users/${orphan.userId}/impersonate`, {
+      headers: { 'Content-Type': 'application/json', ...authHeaders(sysadmin.token, sysadmin.csrf) },
+      data: { reason: 'e2e impersonation safety check (#1758)' },
+    });
+    expect(startResp.ok()).toBeTruthy();
+    const startBody = await startResp.json();
+    const impToken = startBody.access_token as string;
+    const impCsrf = (startBody.csrf_token as string) ?? '';
+    expect(impToken).toBeTruthy();
+
+    // No chain: an impersonation session cannot start a nested one.
+    // Rejected either by RequireSystemAdmin (403 — the impersonation
+    // token carries is_system_admin=false) or the no-chain handler
+    // guard (422 admin.impersonate.nested).
+    const nested = await request.post(`/api/v1/admin/users/${orphan.userId}/impersonate`, {
+      headers: { 'Content-Type': 'application/json', ...authHeaders(impToken, impCsrf) },
+      data: { reason: 'nested attempt' },
+    });
+    expect(nested.ok(), 'nested impersonation must be rejected').toBeFalsy();
+    expect([403, 422]).toContain(nested.status());
+
+    // No refresh: the impersonation token cannot mint a fresh access
+    // token via the refresh endpoint.
+    const refreshed = await request.post('/api/v1/auth/refresh', {
+      headers: authHeaders(impToken, impCsrf),
+    });
+    expect(refreshed.ok(), 'impersonation token must not refresh').toBeFalsy();
+    expect([401, 403]).toContain(refreshed.status());
+
+    // Clean up: end the impersonation session.
+    const end = await request.post('/api/v1/admin/impersonation/end', {
+      headers: authHeaders(impToken, impCsrf),
+    });
+    expect(end.ok()).toBeTruthy();
+  });
+});

--- a/e2e/tests/includes/auth.ts
+++ b/e2e/tests/includes/auth.ts
@@ -53,6 +53,28 @@ export const ORPHAN_TEST_CREDENTIALS = {
 };
 
 /**
+ * Platform system-admin credentials. Seeded by debug/seeddata
+ * (`sysadmin@test-org.com`, IsSystemAdmin = true) so the admin-section
+ * e2e suite can reach `/api/v1/admin/*` and the `/admin/*` UI without a
+ * separate `inventario admin grant-system-admin` CLI step. See #1758.
+ */
+export const SYSADMIN_TEST_CREDENTIALS = {
+  email: 'sysadmin@test-org.com',
+  password: 'TestPassword123'
+};
+
+/**
+ * Disposable plain (non-admin) user the block/unblock spec deactivates
+ * then reactivates. Seeded by debug/seeddata as `blocktarget@test-org.com`
+ * and referenced by no other spec, so a parallel run never observes it
+ * mid-block. See #1758.
+ */
+export const BLOCK_TARGET_TEST_CREDENTIALS = {
+  email: 'blocktarget@test-org.com',
+  password: 'TestPassword123'
+};
+
+/**
  * Check if the current page is the login page
  */
 export async function isLoginPage(page: Page): Promise<boolean> {

--- a/go/apiserver/seed.go
+++ b/go/apiserver/seed.go
@@ -3,6 +3,7 @@ package apiserver
 import (
 	"log/slog"
 	"net/http"
+	"os"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -10,6 +11,13 @@ import (
 	"github.com/denisvmedia/inventario/debug/seeddata"
 	"github.com/denisvmedia/inventario/registry"
 )
+
+// envSeedSystemAdminFixture is the opt-in env var that lets the seed
+// provision the `sysadmin@test-org.com` fixture with the platform-wide
+// is_system_admin flag (#1758). It is OFF by default: /api/v1/seed is
+// unauthenticated, so minting a cross-tenant admin from it would be a
+// privilege-escalation hole. Only the e2e harness sets it.
+const envSeedSystemAdminFixture = "INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE"
 
 type seedAPI struct {
 	factorySet     *registry.FactorySet
@@ -68,6 +76,10 @@ func (api *seedAPI) seedDatabase(w http.ResponseWriter, r *http.Request) {
 		UserEmail:      req.UserEmail,
 		TenantSlug:     req.TenantSlug,
 		UploadLocation: api.uploadLocation,
+		// Opt-in only — see envSeedSystemAdminFixture. Read server-side
+		// from the environment, never from the (attacker-controllable)
+		// request body.
+		SeedSystemAdmin: os.Getenv(envSeedSystemAdminFixture) == "true",
 	}
 
 	alreadySeeded, err := seeddata.SeedData(api.factorySet, opts)

--- a/go/debug/seeddata/seeddata.go
+++ b/go/debug/seeddata/seeddata.go
@@ -112,41 +112,13 @@ func SeedData(factorySet *registry.FactorySet, opts SeedOptions) (alreadySeeded 
 		return false, err
 	}
 
-	// Inside the well-known `test-org` test tenant, provision a third
-	// zero-group test user so e2e tests can authenticate against the
-	// real `/api/v1/groups` empty-collection response (#1277). Both
-	// seed entry points (no-opts memory-mode tests AND init-data's
-	// email-pinned /api/v1/seed call) take this branch — keeping it
-	// inside the seed means the e2e workflow doesn't need a separate
-	// CLI step to provision the fixture. The tenant.Slug gate keeps
-	// the well-known-password orphan account out of arbitrary
-	// external tenants.
+	// Inside the well-known `test-org` test tenant, provision the extra
+	// fixture users (orphan / block-target / opt-in sysadmin) the e2e
+	// suite depends on. Extracted into seedTestOrgFixtures so SeedData
+	// itself stays under the gocognit budget.
 	if tenant.Slug == "test-org" {
-		if err := ensureOrphanUser(ctx, registrySet, tenant, users); err != nil {
+		if err := seedTestOrgFixtures(ctx, registrySet, tenant, users, opts); err != nil {
 			return false, err
-		}
-		// blocktarget@test-org.com — a disposable plain user the
-		// block/unblock spec (#1758) deactivates then reactivates. No
-		// other spec references it, so a parallel run never observes
-		// it mid-block. It carries no elevated privileges, so it is in
-		// the same (accepted) risk class as the orphan fixture and is
-		// provisioned unconditionally for the test-org tenant.
-		if err := ensureBlockTargetUser(ctx, registrySet, tenant, users); err != nil {
-			return false, err
-		}
-		// sysadmin@test-org.com — carries is_system_admin so the
-		// admin-section e2e suite (#1758) reaches /api/v1/admin/* and
-		// /admin/*. Minting a *cross-tenant* admin from the
-		// unauthenticated /api/v1/seed endpoint would be a privilege-
-		// escalation hole in any deployment where /seed is reachable,
-		// so it is gated behind an explicit opt-in (opts.SeedSystemAdmin,
-		// set from INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE by the seed
-		// handler — see apiserver/seed.go). It is OFF by default; only
-		// the e2e harness turns it on.
-		if opts.SeedSystemAdmin {
-			if err := ensureSystemAdminUser(ctx, registrySet, tenant, users); err != nil {
-				return false, err
-			}
 		}
 	}
 
@@ -247,6 +219,49 @@ func SeedData(factorySet *registry.FactorySet, opts SeedOptions) (alreadySeeded 
 	}
 
 	return false, nil
+}
+
+// seedTestOrgFixtures provisions the extra fixture users that only the
+// well-known `test-org` tenant gets. The caller gates this on the tenant
+// slug; every helper here is independently idempotent.
+//
+// Both seed entry points (no-opts memory-mode tests AND init-data's
+// email-pinned /api/v1/seed call) reach this for test-org — keeping it
+// inside the seed means the e2e workflow doesn't need a separate CLI step
+// to provision the fixtures, while the tenant.Slug gate keeps these
+// well-known-password accounts out of arbitrary external tenants.
+//
+//   - orphan@test-org.com — a zero-group user so e2e tests can
+//     authenticate against the real `/api/v1/groups` empty-collection
+//     response (#1277).
+//   - blocktarget@test-org.com — a disposable plain user the
+//     block/unblock spec (#1758) deactivates then reactivates. No other
+//     spec references it, so a parallel run never observes it mid-block.
+//     It carries no elevated privileges, so it is in the same (accepted)
+//     risk class as the orphan fixture and is provisioned unconditionally
+//     for the test-org tenant.
+//   - sysadmin@test-org.com — carries is_system_admin so the
+//     admin-section e2e suite (#1758) reaches /api/v1/admin/* and
+//     /admin/*. Minting a *cross-tenant* admin from the unauthenticated
+//     /api/v1/seed endpoint would be a privilege-escalation hole in any
+//     deployment where /seed is reachable, so it is gated behind an
+//     explicit opt-in (opts.SeedSystemAdmin, set from
+//     INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE by the seed handler — see
+//     apiserver/seed.go). It is OFF by default; only the e2e harness
+//     turns it on.
+func seedTestOrgFixtures(ctx context.Context, registrySet *registry.Set, tenant *models.Tenant, users []*models.User, opts SeedOptions) error {
+	if err := ensureOrphanUser(ctx, registrySet, tenant, users); err != nil {
+		return err
+	}
+	if err := ensureBlockTargetUser(ctx, registrySet, tenant, users); err != nil {
+		return err
+	}
+	if opts.SeedSystemAdmin {
+		if err := ensureSystemAdminUser(ctx, registrySet, tenant, users); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // findOrCreateTenant finds an existing tenant by slug or creates a new

--- a/go/debug/seeddata/seeddata.go
+++ b/go/debug/seeddata/seeddata.go
@@ -48,6 +48,8 @@ import (
 	"log/slog"
 	"time"
 
+	errxtrace "github.com/go-extras/errx/stacktrace"
+
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
@@ -57,6 +59,15 @@ import (
 type SeedOptions struct {
 	UserEmail  string // Optional: email of user to seed for
 	TenantSlug string // Optional: slug of tenant to seed for
+
+	// SeedSystemAdmin opts into provisioning the `sysadmin@test-org.com`
+	// fixture with the platform-wide is_system_admin flag (#1758). It is
+	// OFF by default: the /api/v1/seed endpoint is unauthenticated, so
+	// minting a cross-tenant admin from it would be a privilege-
+	// escalation hole. Only the e2e harness sets it (the seed handler
+	// reads INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE). Has effect only for
+	// the well-known `test-org` tenant.
+	SeedSystemAdmin bool
 
 	// UploadLocation is the gocloud-style blob URL the seed uses to
 	// publish bundled file fixtures (photos, invoices, manuals). When
@@ -114,22 +125,28 @@ func SeedData(factorySet *registry.FactorySet, opts SeedOptions) (alreadySeeded 
 		if err := ensureOrphanUser(ctx, registrySet, tenant, users); err != nil {
 			return false, err
 		}
-		// Two more fixtures dedicated to the admin-section e2e suite
-		// (#1758), provisioned here — before the location-count
-		// idempotency gate — so they survive a re-seed:
-		//   - sysadmin@test-org.com carries is_system_admin so the
-		//     Playwright spec reaches /api/v1/admin/* and /admin/*
-		//     without a per-lane `inventario admin grant-system-admin`
-		//     CLI step.
-		//   - blocktarget@test-org.com is a disposable plain user the
-		//     block/unblock spec deactivates then reactivates; no
-		//     other spec references it, so a parallel run never
-		//     observes it mid-block.
-		if err := ensureSystemAdminUser(ctx, registrySet, tenant, users); err != nil {
-			return false, err
-		}
+		// blocktarget@test-org.com — a disposable plain user the
+		// block/unblock spec (#1758) deactivates then reactivates. No
+		// other spec references it, so a parallel run never observes
+		// it mid-block. It carries no elevated privileges, so it is in
+		// the same (accepted) risk class as the orphan fixture and is
+		// provisioned unconditionally for the test-org tenant.
 		if err := ensureBlockTargetUser(ctx, registrySet, tenant, users); err != nil {
 			return false, err
+		}
+		// sysadmin@test-org.com — carries is_system_admin so the
+		// admin-section e2e suite (#1758) reaches /api/v1/admin/* and
+		// /admin/*. Minting a *cross-tenant* admin from the
+		// unauthenticated /api/v1/seed endpoint would be a privilege-
+		// escalation hole in any deployment where /seed is reachable,
+		// so it is gated behind an explicit opt-in (opts.SeedSystemAdmin,
+		// set from INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE by the seed
+		// handler — see apiserver/seed.go). It is OFF by default; only
+		// the e2e harness turns it on.
+		if opts.SeedSystemAdmin {
+			if err := ensureSystemAdminUser(ctx, registrySet, tenant, users); err != nil {
+				return false, err
+			}
 		}
 	}
 
@@ -378,12 +395,17 @@ func ensureOrphanUser(ctx context.Context, registrySet *registry.Set, tenant *mo
 
 // ensureSystemAdminUser idempotently provisions `sysadmin@test-org.com`,
 // a platform system administrator (IsSystemAdmin = true) the
-// admin-section e2e suite (#1758) authenticates as. This mirrors the
+// admin-section e2e suite (#1758) authenticates as. It mirrors the
 // production `inventario admin grant-system-admin` CLI bootstrap, but
-// runs inside /api/v1/seed so every harness lane (memory-mode tests,
-// docker init-data, native-binary macOS lane) gets the fixture without
-// a bespoke CLI step. The tenant.Slug gate keeps the well-known-password
-// admin account out of arbitrary external tenants.
+// runs inside the seed so the e2e harness (whose local stack is
+// memory-mode — the admin CLI rejects memory:// DSNs) gets the fixture.
+// The caller gates this on opts.SeedSystemAdmin so an unauthenticated
+// /api/v1/seed call cannot mint a cross-tenant admin in production.
+//
+// The helper is fully idempotent and self-healing: it runs before the
+// location-count gate, and on a re-seed it reconciles a drifted fixture
+// (deactivated, or stripped of the flag) back to the expected state
+// rather than no-op'ing.
 //
 // The system admin also gets a USD-valued default group so login lands
 // cleanly (no /no-group race) and so it never collides with the CZK/EUR
@@ -399,7 +421,8 @@ func ensureSystemAdminUser(ctx context.Context, registrySet *registry.Set, tenan
 		}
 	}
 
-	if sysadmin == nil {
+	switch {
+	case sysadmin == nil:
 		newUser := models.User{
 			TenantAwareEntityID: models.TenantAwareEntityID{
 				TenantID: tenant.ID,
@@ -414,13 +437,23 @@ func ensureSystemAdminUser(ctx context.Context, registrySet *registry.Set, tenan
 		}
 		created, err := registrySet.UserRegistry.Create(ctx, newUser)
 		if err != nil {
-			return fmt.Errorf("failed to create system-admin test user: %w", err)
+			return errxtrace.Wrap("failed to create system-admin test user", err)
 		}
 		sysadmin = created
+	case !sysadmin.IsActive || !sysadmin.IsSystemAdmin:
+		// Reconcile drift: a prior run (or a manual edit) may have left
+		// the fixture deactivated or without the flag.
+		sysadmin.IsActive = true
+		sysadmin.IsSystemAdmin = true
+		updated, err := registrySet.UserRegistry.Update(ctx, *sysadmin)
+		if err != nil {
+			return errxtrace.Wrap("failed to reconcile system-admin test user", err)
+		}
+		sysadmin = updated
 	}
 
 	if _, err := findOrCreateDefaultGroup(ctx, registrySet, sysadmin, models.Currency("USD")); err != nil {
-		return fmt.Errorf("failed to create system-admin default group: %w", err)
+		return errxtrace.Wrap("failed to create system-admin default group", err)
 	}
 	return nil
 }
@@ -429,11 +462,21 @@ func ensureSystemAdminUser(ctx context.Context, registrySet *registry.Set, tenan
 // a disposable plain (non-admin) test user the admin-section e2e suite
 // (#1758) blocks then unblocks. It is intentionally referenced by no
 // other spec so the parallel Playwright run never observes it while it
-// is mid-block.
+// is mid-block. It is self-healing: a failed block/unblock run can leave
+// the fixture deactivated, so a re-seed reconciles it back to active.
 func ensureBlockTargetUser(ctx context.Context, registrySet *registry.Set, tenant *models.Tenant, users []*models.User) error {
 	const blockTargetEmail = "blocktarget@test-org.com"
 	for _, user := range users {
 		if user.TenantID == tenant.ID && user.Email == blockTargetEmail {
+			// Reconcile drift: force the fixture back to a plain,
+			// active account so the next run starts from a clean state.
+			if !user.IsActive || user.IsSystemAdmin {
+				user.IsActive = true
+				user.IsSystemAdmin = false
+				if _, err := registrySet.UserRegistry.Update(ctx, *user); err != nil {
+					return errxtrace.Wrap("failed to reconcile block-target test user", err)
+				}
+			}
 			return nil
 		}
 	}
@@ -450,7 +493,7 @@ func ensureBlockTargetUser(ctx context.Context, registrySet *registry.Set, tenan
 		return err
 	}
 	if _, err := registrySet.UserRegistry.Create(ctx, target); err != nil {
-		return fmt.Errorf("failed to create block-target test user: %w", err)
+		return errxtrace.Wrap("failed to create block-target test user", err)
 	}
 	return nil
 }

--- a/go/debug/seeddata/seeddata.go
+++ b/go/debug/seeddata/seeddata.go
@@ -387,6 +387,14 @@ func ensureOrphanUser(ctx context.Context, registrySet *registry.Set, tenant *mo
 	const orphanEmail = "orphan@test-org.com"
 	for _, user := range users {
 		if user.TenantID == tenant.ID && user.Email == orphanEmail {
+			// Reconcile drift: force the fixture back to active so the
+			// next run starts from a clean state.
+			if !user.IsActive {
+				user.IsActive = true
+				if _, err := registrySet.UserRegistry.Update(ctx, *user); err != nil {
+					return errxtrace.Wrap("failed to reconcile orphan test user", err)
+				}
+			}
 			return nil
 		}
 	}

--- a/go/debug/seeddata/seeddata.go
+++ b/go/debug/seeddata/seeddata.go
@@ -114,6 +114,23 @@ func SeedData(factorySet *registry.FactorySet, opts SeedOptions) (alreadySeeded 
 		if err := ensureOrphanUser(ctx, registrySet, tenant, users); err != nil {
 			return false, err
 		}
+		// Two more fixtures dedicated to the admin-section e2e suite
+		// (#1758), provisioned here — before the location-count
+		// idempotency gate — so they survive a re-seed:
+		//   - sysadmin@test-org.com carries is_system_admin so the
+		//     Playwright spec reaches /api/v1/admin/* and /admin/*
+		//     without a per-lane `inventario admin grant-system-admin`
+		//     CLI step.
+		//   - blocktarget@test-org.com is a disposable plain user the
+		//     block/unblock spec deactivates then reactivates; no
+		//     other spec references it, so a parallel run never
+		//     observes it mid-block.
+		if err := ensureSystemAdminUser(ctx, registrySet, tenant, users); err != nil {
+			return false, err
+		}
+		if err := ensureBlockTargetUser(ctx, registrySet, tenant, users); err != nil {
+			return false, err
+		}
 	}
 
 	// Ensure user1 has a default group valued in CZK.
@@ -355,6 +372,85 @@ func ensureOrphanUser(ctx context.Context, registrySet *registry.Set, tenant *mo
 	}
 	if _, err := registrySet.UserRegistry.Create(ctx, orphan); err != nil {
 		return fmt.Errorf("failed to create orphan test user: %w", err)
+	}
+	return nil
+}
+
+// ensureSystemAdminUser idempotently provisions `sysadmin@test-org.com`,
+// a platform system administrator (IsSystemAdmin = true) the
+// admin-section e2e suite (#1758) authenticates as. This mirrors the
+// production `inventario admin grant-system-admin` CLI bootstrap, but
+// runs inside /api/v1/seed so every harness lane (memory-mode tests,
+// docker init-data, native-binary macOS lane) gets the fixture without
+// a bespoke CLI step. The tenant.Slug gate keeps the well-known-password
+// admin account out of arbitrary external tenants.
+//
+// The system admin also gets a USD-valued default group so login lands
+// cleanly (no /no-group race) and so it never collides with the CZK/EUR
+// groups the user-isolation specs depend on.
+func ensureSystemAdminUser(ctx context.Context, registrySet *registry.Set, tenant *models.Tenant, users []*models.User) error {
+	const sysadminEmail = "sysadmin@test-org.com"
+
+	var sysadmin *models.User
+	for _, user := range users {
+		if user.TenantID == tenant.ID && user.Email == sysadminEmail {
+			sysadmin = user
+			break
+		}
+	}
+
+	if sysadmin == nil {
+		newUser := models.User{
+			TenantAwareEntityID: models.TenantAwareEntityID{
+				TenantID: tenant.ID,
+			},
+			Email:         sysadminEmail,
+			Name:          "Test System Admin",
+			IsActive:      true,
+			IsSystemAdmin: true,
+		}
+		if err := newUser.SetPassword("TestPassword123"); err != nil {
+			return err
+		}
+		created, err := registrySet.UserRegistry.Create(ctx, newUser)
+		if err != nil {
+			return fmt.Errorf("failed to create system-admin test user: %w", err)
+		}
+		sysadmin = created
+	}
+
+	if _, err := findOrCreateDefaultGroup(ctx, registrySet, sysadmin, models.Currency("USD")); err != nil {
+		return fmt.Errorf("failed to create system-admin default group: %w", err)
+	}
+	return nil
+}
+
+// ensureBlockTargetUser idempotently provisions `blocktarget@test-org.com`,
+// a disposable plain (non-admin) test user the admin-section e2e suite
+// (#1758) blocks then unblocks. It is intentionally referenced by no
+// other spec so the parallel Playwright run never observes it while it
+// is mid-block.
+func ensureBlockTargetUser(ctx context.Context, registrySet *registry.Set, tenant *models.Tenant, users []*models.User) error {
+	const blockTargetEmail = "blocktarget@test-org.com"
+	for _, user := range users {
+		if user.TenantID == tenant.ID && user.Email == blockTargetEmail {
+			return nil
+		}
+	}
+
+	target := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: tenant.ID,
+		},
+		Email:    blockTargetEmail,
+		Name:     "Test Block Target",
+		IsActive: true,
+	}
+	if err := target.SetPassword("TestPassword123"); err != nil {
+		return err
+	}
+	if _, err := registrySet.UserRegistry.Create(ctx, target); err != nil {
+		return fmt.Errorf("failed to create block-target test user: %w", err)
 	}
 	return nil
 }

--- a/go/debug/seeddata/seeddata_postgres_test.go
+++ b/go/debug/seeddata/seeddata_postgres_test.go
@@ -13,24 +13,35 @@ import (
 
 	"github.com/denisvmedia/inventario/debug/seeddata"
 	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
 	"github.com/denisvmedia/inventario/registry/postgres"
 )
 
-// postgresTestDSN resolves the integration-test database DSN. CI sets
-// POSTGRES_TEST_DSN (see .github/workflows/go-test-postgres.yml); a local
-// run without it falls back to the docker-compose.yaml postgres service.
-func postgresTestDSN() string {
-	if dsn := os.Getenv("POSTGRES_TEST_DSN"); dsn != "" {
-		return dsn
+// postgresTestDSN resolves the integration-test database DSN. CI always
+// sets POSTGRES_TEST_DSN (see .github/workflows/go-test-postgres.yml).
+//
+// When it is unset the test skips rather than falling back to a hard-coded
+// local DSN: this matches the prevailing convention in the repo's other
+// integration tests (registry/postgres/posgres_utils_test.go's
+// skipIfNoPostgreSQL, which also has its local-DSN fallback deliberately
+// commented out). A silent fallback is risky — a developer running the
+// integration tag without POSTGRES_TEST_DSN could unknowingly point the
+// destructive cleanup at a real local database. Skipping makes the
+// requirement explicit instead.
+func postgresTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("Skipping PostgreSQL tests: POSTGRES_TEST_DSN environment variable not set")
 	}
-	return "postgres://inventario:inventario_password@localhost:5432/inventario?sslmode=disable"
+	return dsn
 }
 
 func TestSeedDataPostgreSQL(t *testing.T) {
 	c := qt.New(t)
 
 	// Connect to test database
-	dsn := postgresTestDSN()
+	dsn := postgresTestDSN(t)
 	db, err := sqlx.Open("postgres", dsn)
 	c.Assert(err, qt.IsNil)
 	defer db.Close()
@@ -42,17 +53,43 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 	// Create factory set with PostgreSQL
 	factorySet := postgres.NewFactorySet(db)
 
-	// Clean up any existing test data first
+	// Wipe any pre-existing test-org object graph (including the tenant
+	// row) so the seed below runs against a known-clean slate. The
+	// test-postgres CI job runs many integration packages against one
+	// shared database, so a sibling test may have left a stale `test-org`
+	// tenant whose users own locations (and other child rows) — without
+	// this cleanup the seed would attach to that stale tenant and the
+	// fixture-user assertions would fail.
 	cleanupTestData(c, db)
 
-	// Test that seed data creation works without errors
-	// SeedSystemAdmin opts into the sysadmin fixture (#1758) so the
-	// is_system_admin round-trip is exercised against Postgres.
-	_, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{SeedSystemAdmin: true})
+	// Re-create the test-org tenant deterministically. SeedData's
+	// empty-slug path returns existingTenants[0], which — with other
+	// packages' tenants possibly still present in the shared DB — is not
+	// guaranteed to be test-org. Passing TenantSlug routes
+	// findOrCreateTenant through GetBySlug, which errors if the tenant is
+	// absent, so the test must ensure it exists first. Creating it here
+	// (rather than leaving it in cleanup) keeps cleanupTestData purely
+	// destructive and the seeding path deterministic.
+	registrySet := factorySet.CreateServiceRegistrySet()
+	_, err = registrySet.TenantRegistry.Create(context.Background(), models.Tenant{
+		Name:   "Test Organization",
+		Slug:   "test-org",
+		Status: models.TenantStatusActive,
+	})
 	c.Assert(err, qt.IsNil)
 
-	// Verify that a tenant was created
-	registrySet := factorySet.CreateServiceRegistrySet()
+	// Pin the tenant explicitly so findOrCreateTenant takes the
+	// deterministic GetBySlug path.
+	//
+	// SeedSystemAdmin opts into the sysadmin fixture (#1758) so the
+	// is_system_admin round-trip is exercised against Postgres.
+	_, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{
+		TenantSlug:      "test-org",
+		SeedSystemAdmin: true,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Verify that the tenant is present
 	tenants, err := registrySet.TenantRegistry.List(context.Background())
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(tenants) >= 1, qt.IsTrue, qt.Commentf("Expected at least 1 tenant, got %d", len(tenants)))
@@ -74,8 +111,9 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 	// admin, user2, orphan, family (owner of the secondary group),
 	// teammate (second member of admin's primary group), sysadmin
 	// (platform system admin) and blocktarget (block/unblock fixture).
-	users, err := registrySet.UserRegistry.List(context.Background())
-	c.Assert(err, qt.IsNil)
+	// Scoped to the test tenant so rows left by sibling integration
+	// packages in the shared DB do not skew the count.
+	users := usersForTenant(c, registrySet, testTenant.ID)
 	c.Assert(len(users) >= 7, qt.IsTrue, qt.Commentf("Expected at least 7 users, got %d", len(users)))
 
 	// Find the test users
@@ -136,16 +174,130 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 	c.Assert(blockTargetUser.IsSystemAdmin, qt.IsFalse)
 }
 
+// usersForTenant returns the users belonging to a single tenant. The
+// test-postgres CI job shares one database across many integration
+// packages, so a global UserRegistry.List would mix in unrelated rows;
+// scoping by tenant keeps the fixture-user count assertion deterministic.
+func usersForTenant(c *qt.C, registrySet *registry.Set, tenantID string) []*models.User {
+	all, err := registrySet.UserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	scoped := make([]*models.User, 0, len(all))
+	for _, u := range all {
+		if u.TenantID == tenantID {
+			scoped = append(scoped, u)
+		}
+	}
+	return scoped
+}
+
+// cleanupTestData wipes the `test-org` tenant's entire object graph —
+// including the tenant row itself — so TestSeedDataPostgreSQL always
+// starts from a clean slate.
+//
+// It is deliberately scoped to the test-org tenant only. The test-postgres
+// CI job runs integration packages in parallel against one shared
+// database, so a global TRUNCATE — or deleting other tenants' rows — would
+// corrupt a concurrently-running package. Every table in the schema
+// (except `tenants` itself) carries a tenant_id column, so each child
+// DELETE is filtered by the resolved test-org tenant id(s); the tenant
+// rows are then deleted by slug.
+//
+// Deletes run inside a single transaction in FK-dependency order
+// (children before parents). The three nullable self-referential /
+// cyclic columns (commodities.cover_file_id, users.default_group_id,
+// location_groups.currency_migration_id) are NULLed first so the cycles
+// break cleanly. Errors are asserted, not swallowed: if cleanup silently
+// fails the next run rots exactly the way this fix is repairing.
 func cleanupTestData(c *qt.C, db *sqlx.DB) {
-	// Clean up in reverse order of dependencies
-	queries := []string{
-		"DELETE FROM users WHERE email IN ('admin@test-org.com', 'user2@test-org.com', 'orphan@test-org.com', 'family@test-org.com', 'teammate@test-org.com', 'sysadmin@test-org.com', 'blocktarget@test-org.com')",
-		"DELETE FROM tenants WHERE slug = 'test-org'",
+	tx, err := db.Beginx()
+	c.Assert(err, qt.IsNil)
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Resolve the test-org tenant id(s). If none exist there is nothing
+	// to clean — the seed will create the tenant from scratch.
+	var tenantIDs []string
+	err = tx.Select(&tenantIDs, "SELECT id FROM tenants WHERE slug = 'test-org'")
+	c.Assert(err, qt.IsNil)
+	if len(tenantIDs) == 0 {
+		c.Assert(tx.Commit(), qt.IsNil)
+		committed = true
+		return
 	}
 
-	for _, query := range queries {
-		_, err := db.Exec(query)
-		// Ignore errors as tables might not exist or be empty
-		_ = err
+	// Break the cyclic FKs first by NULLing the nullable referencing
+	// columns, so the ordered DELETEs below never trip a cycle.
+	cyclicNulls := []string{
+		"UPDATE commodities SET cover_file_id = NULL WHERE tenant_id = ANY($1)",
+		"UPDATE location_groups SET currency_migration_id = NULL WHERE tenant_id = ANY($1)",
+		"UPDATE users SET default_group_id = NULL WHERE tenant_id = ANY($1)",
 	}
+	for _, q := range cyclicNulls {
+		_, err = tx.Exec(q, tenantIDs)
+		c.Assert(err, qt.IsNil, qt.Commentf("cleanup pre-step failed: %s", q))
+	}
+
+	// Tables in FK-dependency order: every table must be deleted before
+	// any table it references. Leaf/child tables first, parents last.
+	// `tenants` is omitted on purpose (see the doc comment above).
+	orderedTables := []string{
+		// Leaf tables — reference commodities / files / schedules / etc.
+		"user_concurrency_slots",
+		"commodity_events",
+		"commodity_loans",
+		"commodity_services",
+		"warranty_reminders",
+		"currency_migration_audit_rows",
+		"maintenance_reminders",
+		"commodity_supply_links",
+		"restore_steps",
+		"thumbnail_generation_jobs",
+		"group_memberships",
+		"group_invites",
+		"group_invites_audit",
+		"group_notification_prefs",
+		"storage_quota_reminders",
+		"tags",
+		"login_events",
+		"email_verifications",
+		"password_resets",
+		"refresh_tokens",
+		"user_mfa_secrets",
+		"operation_slots",
+		"settings",
+		"audit_logs",
+		// Mid-tier — reference commodities / exports.
+		"maintenance_schedules",
+		"restore_operations",
+		// Inventory tree — commodities -> areas -> locations.
+		"commodities",
+		"areas",
+		"locations",
+		// File-owning + currency rows.
+		"exports",
+		"files",
+		"currency_migrations",
+		// Parents last. location_groups before users: location_groups.created_by
+		// points at users (and users.default_group_id was NULLed above), so the
+		// dependency now runs one way — location_groups -> users — and the
+		// groups must be deleted first.
+		"location_groups",
+		"users",
+	}
+	for _, table := range orderedTables {
+		_, err = tx.Exec("DELETE FROM "+table+" WHERE tenant_id = ANY($1)", tenantIDs)
+		c.Assert(err, qt.IsNil, qt.Commentf("cleanup DELETE FROM %s failed", table))
+	}
+
+	// Finally drop the tenant row(s) themselves. All tenant_id-bearing
+	// children are gone, so the fk_entity_tenant constraints are satisfied.
+	_, err = tx.Exec("DELETE FROM tenants WHERE id = ANY($1)", tenantIDs)
+	c.Assert(err, qt.IsNil, qt.Commentf("cleanup DELETE FROM tenants failed"))
+
+	c.Assert(tx.Commit(), qt.IsNil)
+	committed = true
 }

--- a/go/debug/seeddata/seeddata_postgres_test.go
+++ b/go/debug/seeddata/seeddata_postgres_test.go
@@ -35,7 +35,9 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 	cleanupTestData(c, db)
 
 	// Test that seed data creation works without errors
-	_, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{})
+	// SeedSystemAdmin opts into the sysadmin fixture (#1758) so the
+	// is_system_admin round-trip is exercised against Postgres.
+	_, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{SeedSystemAdmin: true})
 	c.Assert(err, qt.IsNil)
 
 	// Verify that a tenant was created
@@ -66,7 +68,7 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 	c.Assert(len(users) >= 7, qt.IsTrue, qt.Commentf("Expected at least 7 users, got %d", len(users)))
 
 	// Find the test users
-	var adminUser, regularUser, orphanUser, familyUser, sysadminUser *models.User
+	var adminUser, regularUser, orphanUser, familyUser, sysadminUser, blockTargetUser *models.User
 	for _, user := range users {
 		switch user.Email {
 		case "admin@test-org.com":
@@ -79,6 +81,8 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 			familyUser = user
 		case "sysadmin@test-org.com":
 			sysadminUser = user
+		case "blocktarget@test-org.com":
+			blockTargetUser = user
 		}
 	}
 
@@ -112,6 +116,13 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 	c.Assert(sysadminUser.TenantID, qt.Equals, testTenant.ID)
 	c.Assert(sysadminUser.IsActive, qt.IsTrue)
 	c.Assert(sysadminUser.IsSystemAdmin, qt.IsTrue)
+
+	// Block-target: a plain active fixture — asserted explicitly so a
+	// broken insert can't be masked by unrelated rows (issue #1758).
+	c.Assert(blockTargetUser, qt.IsNotNil, qt.Commentf("blocktarget user not found"))
+	c.Assert(blockTargetUser.TenantID, qt.Equals, testTenant.ID)
+	c.Assert(blockTargetUser.IsActive, qt.IsTrue)
+	c.Assert(blockTargetUser.IsSystemAdmin, qt.IsFalse)
 }
 
 func cleanupTestData(c *qt.C, db *sqlx.DB) {

--- a/go/debug/seeddata/seeddata_postgres_test.go
+++ b/go/debug/seeddata/seeddata_postgres_test.go
@@ -4,6 +4,7 @@ package seeddata_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -15,11 +16,21 @@ import (
 	"github.com/denisvmedia/inventario/registry/postgres"
 )
 
+// postgresTestDSN resolves the integration-test database DSN. CI sets
+// POSTGRES_TEST_DSN (see .github/workflows/go-test-postgres.yml); a local
+// run without it falls back to the docker-compose.yaml postgres service.
+func postgresTestDSN() string {
+	if dsn := os.Getenv("POSTGRES_TEST_DSN"); dsn != "" {
+		return dsn
+	}
+	return "postgres://inventario:inventario_password@localhost:5432/inventario?sslmode=disable"
+}
+
 func TestSeedDataPostgreSQL(t *testing.T) {
 	c := qt.New(t)
 
 	// Connect to test database
-	dsn := "postgres://inventario:inventario_password@localhost:5432/inventario?sslmode=disable"
+	dsn := postgresTestDSN()
 	db, err := sqlx.Open("postgres", dsn)
 	c.Assert(err, qt.IsNil)
 	defer db.Close()

--- a/go/debug/seeddata/seeddata_postgres_test.go
+++ b/go/debug/seeddata/seeddata_postgres_test.go
@@ -200,7 +200,7 @@ func usersForTenant(c *qt.C, registrySet *registry.Set, tenantID string) []*mode
 // corrupt a concurrently-running package. Every table in the schema
 // (except `tenants` itself) carries a tenant_id column, so each child
 // DELETE is filtered by the resolved test-org tenant id(s); the tenant
-// rows are then deleted by slug.
+// rows are then deleted by those resolved id(s).
 //
 // Deletes run inside a single transaction in FK-dependency order
 // (children before parents). The three nullable self-referential /

--- a/go/debug/seeddata/seeddata_postgres_test.go
+++ b/go/debug/seeddata/seeddata_postgres_test.go
@@ -57,15 +57,16 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 	c.Assert(testTenant.Status, qt.Equals, models.TenantStatusActive)
 
 	// Verify that users were created with the correct tenant ID.
-	// Five well-known fixture users land in test-org after #1658:
+	// Seven well-known fixture users land in test-org after #1758:
 	// admin, user2, orphan, family (owner of the secondary group),
-	// teammate (second member of admin's primary group).
+	// teammate (second member of admin's primary group), sysadmin
+	// (platform system admin) and blocktarget (block/unblock fixture).
 	users, err := registrySet.UserRegistry.List(context.Background())
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(users) >= 5, qt.IsTrue, qt.Commentf("Expected at least 5 users, got %d", len(users)))
+	c.Assert(len(users) >= 7, qt.IsTrue, qt.Commentf("Expected at least 7 users, got %d", len(users)))
 
 	// Find the test users
-	var adminUser, regularUser, orphanUser, familyUser *models.User
+	var adminUser, regularUser, orphanUser, familyUser, sysadminUser *models.User
 	for _, user := range users {
 		switch user.Email {
 		case "admin@test-org.com":
@@ -76,6 +77,8 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 			orphanUser = user
 		case "family@test-org.com":
 			familyUser = user
+		case "sysadmin@test-org.com":
+			sysadminUser = user
 		}
 	}
 
@@ -102,12 +105,19 @@ func TestSeedDataPostgreSQL(t *testing.T) {
 	c.Assert(familyUser, qt.IsNotNil, qt.Commentf("family user not found"))
 	c.Assert(familyUser.TenantID, qt.Equals, testTenant.ID)
 	c.Assert(familyUser.IsActive, qt.IsTrue)
+
+	// Sysadmin: the is_system_admin flag must round-trip through the
+	// Postgres INSERT/SELECT path (issue #1758).
+	c.Assert(sysadminUser, qt.IsNotNil, qt.Commentf("sysadmin user not found"))
+	c.Assert(sysadminUser.TenantID, qt.Equals, testTenant.ID)
+	c.Assert(sysadminUser.IsActive, qt.IsTrue)
+	c.Assert(sysadminUser.IsSystemAdmin, qt.IsTrue)
 }
 
 func cleanupTestData(c *qt.C, db *sqlx.DB) {
 	// Clean up in reverse order of dependencies
 	queries := []string{
-		"DELETE FROM users WHERE email IN ('admin@test-org.com', 'user2@test-org.com', 'orphan@test-org.com', 'family@test-org.com', 'teammate@test-org.com')",
+		"DELETE FROM users WHERE email IN ('admin@test-org.com', 'user2@test-org.com', 'orphan@test-org.com', 'family@test-org.com', 'teammate@test-org.com', 'sysadmin@test-org.com', 'blocktarget@test-org.com')",
 		"DELETE FROM tenants WHERE slug = 'test-org'",
 	}
 

--- a/go/debug/seeddata/seeddata_test.go
+++ b/go/debug/seeddata/seeddata_test.go
@@ -20,8 +20,9 @@ func TestSeedData(t *testing.T) {
 	// Create an in-memory registry for testing
 	factorySet := memory.NewFactorySet()
 
-	// Test that seed data creation works without errors
-	alreadySeeded, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{})
+	// Test that seed data creation works without errors. SeedSystemAdmin
+	// opts into the sysadmin fixture (#1758) — gated off by default.
+	alreadySeeded, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{SeedSystemAdmin: true})
 	c.Assert(err, qt.IsNil)
 	c.Assert(alreadySeeded, qt.IsFalse)
 
@@ -290,7 +291,7 @@ func TestSeedDataIdempotent(t *testing.T) {
 
 	factorySet := memory.NewFactorySet()
 
-	alreadySeeded, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{})
+	alreadySeeded, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{SeedSystemAdmin: true})
 	c.Assert(err, qt.IsNil)
 	c.Assert(alreadySeeded, qt.IsFalse)
 
@@ -308,7 +309,7 @@ func TestSeedDataIdempotent(t *testing.T) {
 	loansAfterFirst, _, err := registrySet.CommodityLoanRegistry.ListPaginated(ctx, 0, 1000, registry.LoanListOptions{})
 	c.Assert(err, qt.IsNil)
 
-	alreadySeeded, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{})
+	alreadySeeded, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{SeedSystemAdmin: true})
 	c.Assert(err, qt.IsNil)
 	c.Assert(alreadySeeded, qt.IsTrue)
 
@@ -362,7 +363,10 @@ func TestSeedDataDoesNotCreateFixturesInNonTestTenant(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	_, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{TenantSlug: "acme"})
+	// SeedSystemAdmin is opted in here on purpose: the tenant.Slug gate
+	// must still keep the sysadmin fixture (and every other well-known
+	// fixture) out of a non-test-org tenant even when the flag is set.
+	_, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{TenantSlug: "acme", SeedSystemAdmin: true})
 	c.Assert(err, qt.IsNil)
 
 	users, err := registrySet.UserRegistry.List(context.Background())
@@ -375,6 +379,35 @@ func TestSeedDataDoesNotCreateFixturesInNonTestTenant(t *testing.T) {
 		c.Assert(u.Email, qt.Not(qt.Equals), "blocktarget@test-org.com")
 		c.Assert(u.IsSystemAdmin, qt.IsFalse)
 	}
+}
+
+// TestSeedDataSystemAdminGate asserts the sysadmin fixture is NOT
+// provisioned unless SeedSystemAdmin is explicitly set — the security
+// gate that keeps an unauthenticated /api/v1/seed call from minting a
+// cross-tenant admin (#1758).
+func TestSeedDataSystemAdminGate(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	factorySet := memory.NewFactorySet()
+	_, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{}) // opt-in OFF
+	c.Assert(err, qt.IsNil)
+
+	registrySet := factorySet.CreateServiceRegistrySet()
+	users, err := registrySet.UserRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+
+	for _, u := range users {
+		c.Assert(u.Email, qt.Not(qt.Equals), "sysadmin@test-org.com",
+			qt.Commentf("sysadmin fixture must not be seeded without the opt-in"))
+		c.Assert(u.IsSystemAdmin, qt.IsFalse)
+	}
+	// The non-privileged block-target fixture is still provisioned.
+	emails := map[string]bool{}
+	for _, u := range users {
+		emails[u.Email] = true
+	}
+	c.Assert(emails["blocktarget@test-org.com"], qt.IsTrue)
 }
 
 // referenceNow returns the wall-clock value used by warranty-bucket

--- a/go/debug/seeddata/seeddata_test.go
+++ b/go/debug/seeddata/seeddata_test.go
@@ -37,7 +37,7 @@ func TestSeedData(t *testing.T) {
 	c.Assert(tenant.Slug, qt.Equals, "test-org")
 	c.Assert(tenant.Status, qt.Equals, models.TenantStatusActive)
 
-	// Five well-known users land in the test-org tenant:
+	// Seven well-known users land in the test-org tenant:
 	//   admin / user2 — currency-different default groups (CZK + EUR);
 	//                   user2 stays in its OWN group so user-isolation
 	//                   e2e specs keep working.
@@ -46,9 +46,13 @@ func TestSeedData(t *testing.T) {
 	//   teammate     — second member of admin's primary group (#1658
 	//                   multi-member demo). Lives apart from user2 by
 	//                   design.
+	//   sysadmin     — platform system admin (is_system_admin) for the
+	//                  admin-section e2e suite (issue #1758).
+	//   blocktarget  — disposable plain user the block/unblock spec
+	//                  deactivates then reactivates (issue #1758).
 	users, err := registrySet.UserRegistry.List(ctx)
 	c.Assert(err, qt.IsNil)
-	c.Assert(users, qt.HasLen, 5)
+	c.Assert(users, qt.HasLen, 7)
 
 	for _, user := range users {
 		c.Assert(user.TenantID, qt.Equals, tenant.ID)
@@ -81,6 +85,25 @@ func TestSeedData(t *testing.T) {
 	memberships, err := registrySet.GroupMembershipRegistry.ListByUser(ctx, tenant.ID, orphan.ID)
 	c.Assert(err, qt.IsNil)
 	c.Assert(memberships, qt.HasLen, 0)
+
+	// The sysadmin fixture carries the platform-admin flag; every other
+	// seeded user must not (issue #1758).
+	sysadmin := emails["sysadmin@test-org.com"]
+	c.Assert(sysadmin, qt.IsNotNil)
+	c.Assert(sysadmin.IsActive, qt.IsTrue)
+	c.Assert(sysadmin.IsSystemAdmin, qt.IsTrue)
+	for _, u := range users {
+		if u.Email != "sysadmin@test-org.com" {
+			c.Assert(u.IsSystemAdmin, qt.IsFalse,
+				qt.Commentf("%s must not be a system admin", u.Email))
+		}
+	}
+
+	// The block-target fixture is a plain active user.
+	blockTarget := emails["blocktarget@test-org.com"]
+	c.Assert(blockTarget, qt.IsNotNil)
+	c.Assert(blockTarget.IsActive, qt.IsTrue)
+	c.Assert(blockTarget.IsSystemAdmin, qt.IsFalse)
 }
 
 // TestSeedDataSurfaceCoverage asserts that every feature surface called
@@ -295,7 +318,7 @@ func TestSeedDataIdempotent(t *testing.T) {
 
 	users, err := registrySet.UserRegistry.List(ctx)
 	c.Assert(err, qt.IsNil)
-	c.Assert(users, qt.HasLen, 5)
+	c.Assert(users, qt.HasLen, 7)
 
 	locations, err := registrySet.LocationRegistry.List(ctx)
 	c.Assert(err, qt.IsNil)
@@ -348,6 +371,9 @@ func TestSeedDataDoesNotCreateFixturesInNonTestTenant(t *testing.T) {
 		c.Assert(u.Email, qt.Not(qt.Equals), "orphan@test-org.com")
 		c.Assert(u.Email, qt.Not(qt.Equals), "family@test-org.com")
 		c.Assert(u.Email, qt.Not(qt.Equals), "teammate@test-org.com")
+		c.Assert(u.Email, qt.Not(qt.Equals), "sysadmin@test-org.com")
+		c.Assert(u.Email, qt.Not(qt.Equals), "blocktarget@test-org.com")
+		c.Assert(u.IsSystemAdmin, qt.IsFalse)
 	}
 }
 

--- a/go/models/models.go
+++ b/go/models/models.go
@@ -237,7 +237,15 @@ func (s *StringSlice) Scan(value any) error {
 	}
 }
 
-func (s *StringSlice) Value() (driver.Value, error) {
+// Value implements driver.Valuer. The receiver is intentionally a value,
+// not a pointer: a pointer receiver leaves a non-addressable StringSlice
+// field (the common case when a struct is passed by value into the
+// registry layer) without a driver.Valuer, so database/sql hands the raw
+// []string to lib/pq, which encodes it as a Postgres array literal
+// (`{a,b}`) — invalid input for a JSONB column. A value receiver makes
+// both StringSlice and *StringSlice satisfy driver.Valuer, matching
+// every other Valuer in this package.
+func (s StringSlice) Value() (driver.Value, error) {
 	if s == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
## Summary

Final validation gate for the system-wide admin umbrella (#1744). Closes #1758.

Adds end-to-end test coverage for the admin flows, an ops/admin runbook, and a focused security threat model.

## E2E (Playwright)

`e2e/tests/admin/system-admin.spec.ts` — 6 tests, green across chromium / firefox / webkit (18/18 locally):

1. Browse tenants → tenant detail → users + groups tabs
2. Non-admin is denied the admin surface (in-place UI 403 + API 403)
3. Block invalidates the target's live access token; unblock restores access
4. Admin group membership add / role-change / remove + group soft-delete
5. Impersonation: start → persistent banner → navigate → end → admin session restored
6. Impersonation safety: nested impersonation rejected, impersonation token cannot refresh

> The issue named `e2e/specs/admin/`, but Playwright's `testDir` is `./tests`, so the spec lives at `e2e/tests/admin/` to be discovered by the runner.

## Test harness bootstrap

`debug/seeddata` now provisions two fixture users, gated on the `test-org` slug and created before the location-count idempotency gate (mirroring `ensureOrphanUser`):

- `sysadmin@test-org.com` — `is_system_admin = true`, with a USD default group
- `blocktarget@test-org.com` — disposable plain user the block/unblock test deactivates then reactivates

This mirrors the production `inventario admin grant-system-admin` CLI bootstrap, but runs inside `/api/v1/seed` so every harness lane (memory-mode tests, docker init-data, native-binary macOS lane) gets the fixtures with no per-lane CLI step. Seeded-user count goes 5 → 7; `seeddata_test.go` and `seeddata_postgres_test.go` updated accordingly.

## Docs

- `devdocs/admin-runbook.md` — granting/revoking the first system admin, audit-log inspection, lockout recovery, impersonation ops notes
- `devdocs/security/admin-threat-model.md` — threat model (privilege escalation, JWT forgery/replay, RLS bypass, impersonation abuse, CSRF, block efficacy, log leakage) plus the security review checklist
- `README.md` — new "System Administrators" CLI section + Documentation cross-links

## Security review checklist

Verified against the code and/or automated tests; needs human sign-off:

- [ ] RLS bypass surface: only the documented `*Admin` registry methods issue `SET LOCAL row_security = off`, all behind `RequireSystemAdmin`
- [ ] JWT claim layout: `is_system_admin` / `impersonated_by` cannot be self-signed by a non-admin (signature verification + `userinput:"false"` tag)
- [ ] Impersonation no-chain: nested impersonation is rejected (e2e test 6)
- [ ] Impersonation no-refresh: the impersonation token cannot mint a new access token (e2e test 6)
- [ ] Rate-limit on impersonate endpoint exists (10/operator/hour) and is verified by an integration test
- [ ] Audit-log: every admin action writes a row; spot-check a real DB row per category
- [ ] CSRF: admin mutation endpoints require the CSRF token
- [ ] Logs: no admin handler logs the JWT secret, a password, or the impersonation token

## Notes / out of scope

- Cross-tenant member-add rejection (`admin.member.tenant_mismatch`) is not e2e-tested — the e2e database holds a single tenant — and is covered by the backend integration tests for #1749.
- Rate-limit verification is an integration test; e2e disables auth rate limiting.

## Testing

- `go build ./...` + `go test ./debug/seeddata/` pass; `gofmt` clean
- E2E spec typechecks; 6 × 3 browsers = 18/18 pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README: System Administrators section, CLI examples, and links to a System Admin Operations Runbook and Admin Threat Model.
  * New runbook and threat-model docs covering bootstrap/revoke/recover, impersonation rules, auditing, mitigations, and operational guidance.

* **Tests**
  * New end-to-end suite validating admin UI/API: tenant browsing, user/group management, block/unblock, and impersonation lifecycle and safety.
  * Added test credentials for sysadmin and block-target scenarios.

* **Chores**
  * Test/seed tooling and CI updated to optionally enable a system-admin fixture for E2E and seed-data integration tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->