### PR TITLE
[#1787] Fix admin RLS bypass: dedicated inventario_admin role

### DIFF
--- a/go/registry/postgres/admin_rls_bypass_test.go
+++ b/go/registry/postgres/admin_rls_bypass_test.go
@@ -1,0 +1,216 @@
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres"
+)
+
+// TestAdminCrossTenantQueries_NonBypassAppRole is the regression test for
+// issue #1787. The cross-tenant admin endpoints (admin groups list/detail,
+// admin tenants list/detail, admin users list, admin group members list)
+// used to issue `SET LOCAL row_security = off` while connected as a
+// non-BYPASSRLS role. PostgreSQL answers any query that WOULD be filtered
+// by an RLS policy with SQLSTATE 42501 in that situation, so every one of
+// those endpoints returned HTTP 500 on a standard deployment.
+//
+// The fix routes the admin registry methods through store.DoAsAdmin, which
+// runs the transaction under the dedicated `inventario_admin` role created
+// by the bootstrap SQL with the BYPASSRLS attribute.
+//
+// The default test harness connects as a superuser, which bypasses RLS
+// regardless and would therefore mask the bug. This test deliberately
+// connects as a freshly-created, non-superuser, non-BYPASSRLS login role
+// that is merely a *member* of inventario_app / inventario_background_worker
+// / inventario_admin — exactly the production role model — so it exercises
+// the genuinely broken scenario.
+func TestAdminCrossTenantQueries_NonBypassAppRole(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+
+	// Seed two tenants, each with a user and a group, via the standard
+	// (superuser) harness so the schema is bootstrapped and migrated.
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	seededUser := getTestUser(c, registrySet)
+	tenantA := seededUser.TenantID
+
+	// A second tenant + user + group so the cross-tenant listings have
+	// rows the admin caller is not a member of.
+	secondTenant, err := registrySet.TenantRegistry.Create(ctx, models.Tenant{
+		Name:   "Second Organization",
+		Slug:   "second-org",
+		Status: models.TenantStatusActive,
+	})
+	c.Assert(err, qt.IsNil)
+
+	secondUser, err := registrySet.UserRegistry.Create(ctx, models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: secondTenant.ID},
+		Email:               "owner@second-org.com",
+		Name:                "Second Owner",
+		IsActive:            true,
+	})
+	c.Assert(err, qt.IsNil)
+
+	secondSlug, err := models.GenerateGroupSlug()
+	c.Assert(err, qt.IsNil)
+	secondGroup, err := registrySet.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: secondTenant.ID},
+		Name:                "Second Group",
+		Slug:                secondSlug,
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           secondUser.ID,
+		GroupCurrency:       models.Currency("USD"),
+	})
+	c.Assert(err, qt.IsNil)
+
+	// A membership in the second tenant's group so ListByGroupWithUsersAdmin
+	// has a cross-tenant row to join.
+	_, err = registrySet.GroupMembershipRegistry.Create(ctx, models.GroupMembership{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: secondTenant.ID},
+		GroupID:             secondGroup.ID,
+		MemberUserID:        secondUser.ID,
+		Role:                models.GroupRoleOwner,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// Build a FactorySet on a connection that authenticates as a
+	// non-BYPASSRLS login role — the production role model.
+	adminFactory := newNonBypassAppFactory(c, dsn)
+
+	// Each of these calls used to fail with SQLSTATE 42501. Under the
+	// inventario_admin role they must succeed and see BOTH tenants.
+
+	c.Run("groups list crosses tenants", func(c *qt.C) {
+		items, total, err := adminFactory.LocationGroupRegistry.ListAdmin(ctx, registry.AdminGroupListOptions{})
+		c.Assert(err, qt.IsNil)
+		c.Assert(total >= 2, qt.IsTrue,
+			qt.Commentf("expected groups from both tenants, got total=%d", total))
+		c.Assert(len(items) >= 2, qt.IsTrue)
+	})
+
+	c.Run("group detail loads a foreign-tenant group", func(c *qt.C) {
+		detail, err := adminFactory.LocationGroupRegistry.GetAdmin(ctx, secondGroup.ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(detail, qt.IsNotNil)
+		c.Assert(detail.Group.ID, qt.Equals, secondGroup.ID)
+	})
+
+	c.Run("tenants list crosses tenants", func(c *qt.C) {
+		items, total, err := adminFactory.TenantRegistry.ListAdmin(ctx, registry.AdminTenantListOptions{})
+		c.Assert(err, qt.IsNil)
+		c.Assert(total >= 2, qt.IsTrue,
+			qt.Commentf("expected at least 2 tenants, got total=%d", total))
+		c.Assert(len(items) >= 2, qt.IsTrue)
+	})
+
+	c.Run("tenant detail loads computed counts", func(c *qt.C) {
+		detail, err := adminFactory.TenantRegistry.GetAdmin(ctx, secondTenant.ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(detail, qt.IsNotNil)
+		c.Assert(detail.UserCount, qt.Equals, 1)
+		c.Assert(detail.GroupCount, qt.Equals, 1)
+	})
+
+	c.Run("users list crosses tenants", func(c *qt.C) {
+		items, total, err := adminFactory.UserRegistry.ListAdminByTenant(ctx, secondTenant.ID, registry.AdminUserListOptions{})
+		c.Assert(err, qt.IsNil)
+		c.Assert(total, qt.Equals, 1)
+		c.Assert(items, qt.HasLen, 1)
+		c.Assert(items[0].User.ID, qt.Equals, secondUser.ID)
+	})
+
+	c.Run("active session count crosses tenants", func(c *qt.C) {
+		count, err := adminFactory.UserRegistry.CountSessionsByUser(ctx, secondUser.ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(count, qt.Equals, 0)
+	})
+
+	c.Run("group members list crosses tenants", func(c *qt.C) {
+		members, err := adminFactory.GroupMembershipRegistry.ListByGroupWithUsersAdmin(ctx, secondGroup.ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(members, qt.HasLen, 1)
+		c.Assert(members[0].User.ID, qt.Equals, secondUser.ID)
+	})
+
+	// Sanity check: tenant A's group is also visible — the admin surface
+	// is genuinely cross-tenant, not just scoped to the second tenant.
+	c.Run("group detail loads tenant A group too", func(c *qt.C) {
+		groups, err := registrySet.LocationGroupRegistry.ListByTenant(ctx, tenantA)
+		c.Assert(err, qt.IsNil)
+		c.Assert(len(groups) >= 1, qt.IsTrue)
+		detail, err := adminFactory.LocationGroupRegistry.GetAdmin(ctx, groups[0].ID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(detail.Group.ID, qt.Equals, groups[0].ID)
+	})
+}
+
+// newNonBypassAppFactory creates a PostgreSQL FactorySet whose connection
+// authenticates as a non-superuser, non-BYPASSRLS login role. The role is a
+// member of inventario_app, inventario_background_worker and
+// inventario_admin — i.e. it can SET ROLE to any of them but bypasses RLS
+// only while inventario_admin is the *active* role. This mirrors the
+// production deployment and is the only configuration in which the #1787
+// bug reproduces.
+func newNonBypassAppFactory(c *qt.C, superuserDSN string) *registry.FactorySet {
+	c.Helper()
+
+	const (
+		appLoginRole = "inventario_app_test_login"
+		appLoginPass = "app_test_login_pw"
+	)
+
+	// Create / refresh the non-bypass login role via the superuser pool.
+	adminPool, err := getOrCreatePool(superuserDSN)
+	c.Assert(err, qt.IsNil)
+
+	setupSQL := fmt.Sprintf(`
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '%[1]s') THEN
+        CREATE ROLE %[1]s WITH LOGIN PASSWORD '%[2]s'
+            NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;
+    ELSE
+        ALTER ROLE %[1]s WITH LOGIN PASSWORD '%[2]s'
+            NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;
+    END IF;
+    -- Defensive: this login role MUST NOT carry BYPASSRLS itself,
+    -- otherwise the test would silently stop reproducing #1787.
+    ALTER ROLE %[1]s WITH NOBYPASSRLS;
+END $$;
+GRANT inventario_app TO %[1]s;
+GRANT inventario_background_worker TO %[1]s;
+GRANT inventario_admin TO %[1]s;
+`, appLoginRole, appLoginPass)
+
+	_, err = adminPool.Exec(c.Context(), setupSQL)
+	c.Assert(err, qt.IsNil)
+
+	// Build a DSN for the non-bypass login role, reusing host / database /
+	// query params from the superuser DSN.
+	u, err := url.Parse(superuserDSN)
+	c.Assert(err, qt.IsNil)
+	u.User = url.UserPassword(appLoginRole, appLoginPass)
+
+	pool, err := pgxpool.New(c.Context(), u.String())
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(pool.Close)
+
+	sqlDB := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	c.Cleanup(func() { _ = sqlDB.Close() })
+
+	return postgres.NewFactorySet(sqlDB)
+}

--- a/go/registry/postgres/group_memberships.go
+++ b/go/registry/postgres/group_memberships.go
@@ -690,23 +690,18 @@ func (r *GroupMembershipRegistry) ListByGroupWithUsers(ctx context.Context, grou
 
 // ListByGroupWithUsersAdmin is the cross-tenant twin of
 // ListByGroupWithUsers, backing the #1756 admin membership editor. The
-// system-admin caller is not tenant-scoped, so the join runs under
-// `SET LOCAL row_security = off` — the same defense-in-depth RLS bypass
-// LocationGroupRegistry.GetAdmin / ListAdmin use. The membership rows
-// already run via the background-worker role (bypass policy on
-// group_memberships); the explicit `row_security = off` additionally
-// covers the JOINed users table so a group in ANY tenant lists fine.
+// system-admin caller is not tenant-scoped, so the membership↔users
+// join runs inside store.DoAsAdmin — under the inventario_admin role,
+// whose BYPASSRLS attribute skips the tenant-isolation policies on both
+// group_memberships and the JOINed users table, so a group in ANY
+// tenant lists fine.
 func (r *GroupMembershipRegistry) ListByGroupWithUsersAdmin(ctx context.Context, groupID string) ([]*models.MembershipWithUser, error) {
 	if groupID == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
 	}
 
 	var out []*models.MembershipWithUser
-	reg := r.newSQLRegistry()
-	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
-			return errxtrace.Wrap("failed to disable row_security for admin members listing", execErr)
-		}
+	err := store.DoAsAdmin(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
 		var loadErr error
 		out, loadErr = r.loadMembersWithUsersTx(ctx, tx, groupID)
 		return loadErr
@@ -722,13 +717,14 @@ func (r *GroupMembershipRegistry) ListByGroupWithUsersAdmin(ctx context.Context,
 // and its admin twin so the two surfaces ship an identical row shape.
 // The query rows are never RLS-scoped at this layer — the registry runs
 // in service mode on the background-worker role, which bypasses the
-// tenant-isolation policy. The only difference between the two callers
-// is whether the admin twin additionally issues `SET LOCAL row_security
-// = off` first as documented defense-in-depth covering the JOINed users
-// table; the non-admin caller is tenant-gated upstream by the
-// requireGroupMembership HTTP middleware. The JOIN matches tenant_id on
-// both sides as a further defense-in-depth guard against cross-tenant
-// leakage.
+// tenant-isolation policy. The two callers differ only in the role the
+// surrounding tx runs under: ListByGroupWithUsers stays on the
+// background-worker role (and is tenant-gated upstream by the
+// requireGroupMembership HTTP middleware), while ListByGroupWithUsersAdmin
+// runs under store.DoAsAdmin / inventario_admin (BYPASSRLS) so the
+// JOINed users table is also reachable cross-tenant. The JOIN matches
+// tenant_id on both sides as a further defense-in-depth guard against
+// cross-tenant leakage.
 func (r *GroupMembershipRegistry) loadMembersWithUsersTx(ctx context.Context, tx *sqlx.Tx, groupID string) ([]*models.MembershipWithUser, error) {
 	type row struct {
 		// membership fields

--- a/go/registry/postgres/location_groups.go
+++ b/go/registry/postgres/location_groups.go
@@ -220,14 +220,12 @@ func (r *LocationGroupRegistry) ListByTenant(ctx context.Context, tenantID strin
 // member_count from a correlated subquery on group_memberships.
 //
 // The endpoint crosses tenants by design — a system admin lists every
-// tenant's groups. This registry runs in service mode as the
-// inventario_background_worker role, which already carries `using=true`
-// bypass policies on location_groups / group_memberships, so the
-// cross-tenant read works regardless of RLS. The `SET LOCAL row_security =
-// off` on the tx is defense-in-depth: it makes the intentional cross-tenant
-// read explicit at the call site and, on the bypass role, is effectively a
-// no-op rather than the primary guard. Same rationale as
-// TenantRegistry.ListAdmin / UserRegistry.ListAdminByTenant.
+// tenant's groups. The query runs inside store.DoAsAdmin, i.e. under the
+// inventario_admin role, which carries the BYPASSRLS attribute so the
+// per-tenant isolation policies on location_groups / group_memberships /
+// tenants are skipped for this transaction only. Normal inventario_app
+// traffic never assumes that role and stays RLS-enforced. Same rationale
+// as TenantRegistry.ListAdmin / UserRegistry.ListAdminByTenant.
 //
 // Total is post-filter, pre-pagination.
 func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.AdminGroupListOptions) ([]*registry.AdminGroupListItem, int, error) {
@@ -277,12 +275,7 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 		items []*registry.AdminGroupListItem
 		total int
 	)
-	reg := r.newSQLRegistry()
-	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
-			return errxtrace.Wrap("failed to disable row_security for admin group listing", execErr)
-		}
-
+	err := store.DoAsAdmin(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
 		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s AS g %s", groupsTable, where)
 		if scanErr := tx.QueryRowContext(ctx, countQuery, args...).Scan(&total); scanErr != nil {
 			return errxtrace.Wrap("failed to count admin groups", scanErr)
@@ -299,7 +292,7 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 		// tenants is JOINed (not a correlated subquery) so each row carries
 		// the owning-tenant chip — the cross-tenant admin list renders the
 		// tenant name per row without an FE N+1 lookup. Same tx, so the JOIN
-		// is read under the same `SET LOCAL row_security = off`.
+		// is read under the same inventario_admin (BYPASSRLS) role.
 		//
 		// LEFT JOIN, not INNER: AdminGroupListItem.Tenant is *models.Tenant
 		// (nullable by contract). An INNER JOIN would silently DROP a group
@@ -357,20 +350,16 @@ func (r *LocationGroupRegistry) ListAdmin(ctx context.Context, opts registry.Adm
 
 // GetAdmin returns a single group detail row with the computed
 // member_count plus the owning tenant (joined so the detail handler can
-// render the tenant chip in one round-trip). Runs under
-// `SET LOCAL row_security = off` for the same defense-in-depth
-// cross-tenant rationale as ListAdmin.
+// render the tenant chip in one round-trip). Runs under the
+// inventario_admin (BYPASSRLS) role for the same cross-tenant rationale
+// as ListAdmin.
 func (r *LocationGroupRegistry) GetAdmin(ctx context.Context, groupID string) (*registry.AdminGroupDetail, error) {
 	if groupID == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "GroupID"))
 	}
 
 	var detail *registry.AdminGroupDetail
-	reg := r.newSQLRegistry()
-	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
-			return errxtrace.Wrap("failed to disable row_security for admin group detail", execErr)
-		}
+	err := store.DoAsAdmin(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
 		var loadErr error
 		detail, loadErr = r.loadAdminGroupDetailTx(ctx, tx, groupID)
 		return loadErr
@@ -393,7 +382,8 @@ func (r *LocationGroupRegistry) GetAdmin(ctx context.Context, groupID string) (*
 // so the post-delete row carries exactly the shape the detail handler
 // renders without a second round-trip. Returns (nil, nil) when the group
 // id doesn't exist — callers map that to ErrNotFound. The caller is
-// responsible for the `SET LOCAL row_security = off` on the tx.
+// responsible for running the tx under the inventario_admin (BYPASSRLS)
+// role via store.DoAsAdmin.
 func (r *LocationGroupRegistry) loadAdminGroupDetailTx(ctx context.Context, tx *sqlx.Tx, groupID string) (*registry.AdminGroupDetail, error) {
 	groupsTable := r.tableNames.LocationGroups()
 	membershipsTable := r.tableNames.GroupMemberships()
@@ -478,15 +468,10 @@ func (r *LocationGroupRegistry) MarkPendingDeletionAdmin(ctx context.Context, gr
 		alreadyPending bool
 		detail         *registry.AdminGroupDetail
 	)
-	err := store.DoAsBackgroundWorker(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
-		// Defense-in-depth: like ListAdmin / GetAdmin, make the intentional
-		// cross-tenant write explicit at the call site. On the background-
-		// worker role (which carries RLS bypass policies on location_groups)
-		// this is effectively a no-op rather than the primary guard.
-		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
-			return errxtrace.Wrap("failed to disable row_security for admin group soft-delete", execErr)
-		}
-
+	err := store.DoAsAdmin(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// Cross-tenant admin write: the system admin soft-deletes a group
+		// in any tenant. Runs under the inventario_admin (BYPASSRLS) role
+		// like ListAdmin / GetAdmin.
 		var currentStatus string
 		selectQuery := fmt.Sprintf("SELECT status FROM %s WHERE id = $1 FOR UPDATE", groupsTable)
 		scanErr := tx.QueryRowContext(ctx, selectQuery, groupID).Scan(&currentStatus)

--- a/go/registry/postgres/store/utils.go
+++ b/go/registry/postgres/store/utils.go
@@ -37,6 +37,10 @@ func setBackgroundWorkerRole(ctx context.Context, tx *sqlx.Tx) error {
 	return setRole(ctx, tx, "inventario_background_worker")
 }
 
+func setAdminRole(ctx context.Context, tx *sqlx.Tx) error {
+	return setRole(ctx, tx, "inventario_admin")
+}
+
 func setUserContext(ctx context.Context, tx *sqlx.Tx, userID string) error {
 	// Escape single quotes in userID for safety
 	escapedUserID := strings.ReplaceAll(userID, "'", "''")
@@ -100,6 +104,32 @@ func beginServiceTx(ctx context.Context, dbx *sqlx.DB) (*sqlx.Tx, error) {
 	if err != nil {
 		tx.Rollback()
 		return nil, errxtrace.Wrap("failed to set background worker role", err)
+	}
+
+	return tx, nil
+}
+
+// beginAdminTx begins a transaction that has SET LOCAL ROLE to
+// inventario_admin. That role carries the BYPASSRLS attribute, so RLS
+// policies are skipped entirely for the duration of the transaction —
+// the cross-tenant admin surfaces (#1787) need to read and write rows
+// in every tenant regardless of the per-tenant isolation policies.
+//
+// Crucially, BYPASSRLS lives ONLY on inventario_admin, never on
+// inventario_app: a plain app request is still bound by the
+// tenant-isolation policies because it never assumes this role. The
+// override is scoped to the transaction by SET LOCAL ROLE and is
+// reset automatically on commit or rollback.
+func beginAdminTx(ctx context.Context, dbx *sqlx.DB) (*sqlx.Tx, error) {
+	tx, err := dbx.Beginx()
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to begin transaction", err)
+	}
+
+	err = setAdminRole(ctx, tx)
+	if err != nil {
+		tx.Rollback()
+		return nil, errxtrace.Wrap("failed to set admin role", err)
 	}
 
 	return tx, nil
@@ -174,6 +204,42 @@ func DoAsBackgroundWorker(ctx context.Context, dbx *sqlx.DB, fn func(context.Con
 
 	if err = fn(ctx, tx); err != nil {
 		return errxtrace.Wrap("background-worker operation failed", err)
+	}
+	return nil
+}
+
+// DoAsAdmin runs fn inside a transaction that has SET LOCAL ROLE to
+// inventario_admin (a BYPASSRLS role), committing on nil return and
+// rolling back otherwise. It is the entry point for the cross-tenant
+// system-admin surfaces (#1787): listing every tenant's groups,
+// loading a group/tenant/user detail row in another tenant, editing a
+// group's membership as a system administrator, etc.
+//
+// Why a dedicated role rather than `SET LOCAL row_security = off`:
+// Postgres raises SQLSTATE 42501 ("query would be affected by
+// row-level security policy") when a query that WOULD be filtered by
+// an RLS policy runs with row_security=off under a role that can
+// neither own the table nor bypass RLS. inventario_app and
+// inventario_background_worker are both non-bypass roles, so the old
+// admin code tripped 42501 on every PostgreSQL deployment. Switching
+// the active role to inventario_admin — which has BYPASSRLS — makes
+// the cross-tenant reads/writes succeed without weakening the
+// per-tenant isolation that normal inventario_app traffic relies on.
+//
+// New callers should be rare and gated behind RequireSystemAdmin.
+func DoAsAdmin(ctx context.Context, dbx *sqlx.DB, fn func(context.Context, *sqlx.Tx) error) (err error) {
+	tx, err := beginAdminTx(ctx, dbx)
+	if err != nil {
+		return errxtrace.Wrap("failed to begin admin transaction", err)
+	}
+	defer func() {
+		if rbErr := RollbackOrCommit(tx, err); rbErr != nil && err == nil {
+			err = errxtrace.Wrap("failed to finish admin transaction", rbErr)
+		}
+	}()
+
+	if err = fn(ctx, tx); err != nil {
+		return errxtrace.Wrap("admin operation failed", err)
 	}
 	return nil
 }

--- a/go/registry/postgres/tenants.go
+++ b/go/registry/postgres/tenants.go
@@ -209,22 +209,12 @@ func (r *TenantRegistry) GetBySlug(ctx context.Context, slug string) (*models.Te
 // `/api/v1/admin/tenants` listing (#1746) along with per-row computed
 // user_count and group_count.
 //
-// The `tenants` table has no RLS enabled (it IS the tenant boundary), so
-// the cross-tenant read works through the existing NonRLSRepository
-// without a role switch — the correlated COUNT subqueries on the
-// RLS-enabled `users` / `location_groups` tables rely on the connection
-// role's bypass (table-owner or BYPASSRLS attribute) to produce the
-// cross-tenant counts the admin UI needs.
-//
-// `SET LOCAL row_security = off` on the tx is a fail-loud guard: per
-// the postgres semantics, queries against an RLS-protected table by a
-// non-bypass role with row_security=off ERROR out rather than silently
-// filtering. If the connection role's bypass is ever revoked this
-// endpoint will start 5xx-ing loudly instead of returning honest-looking
-// "0" counts that mask a misconfiguration. That matches the issue
-// spec's "Endpoints bypass RLS via SET LOCAL row_security = off inside
-// the handler's tx" — the bypass narrative is "fail loud on
-// misconfiguration", not "produce rows the role couldn't otherwise see".
+// The `tenants` table has no RLS enabled (it IS the tenant boundary),
+// but the correlated COUNT subqueries hit the RLS-enabled `users` /
+// `location_groups` tables. To make those counts cross-tenant the whole
+// query runs inside store.DoAsAdmin — under the inventario_admin role,
+// which carries the BYPASSRLS attribute. inventario_app traffic never
+// assumes that role, so per-tenant isolation is unaffected.
 //
 // Two queries are issued under the same tx so total + page rows stay
 // consistent with one another. The COUNT/page split exists because
@@ -266,18 +256,7 @@ func (r *TenantRegistry) ListAdmin(ctx context.Context, opts registry.AdminTenan
 		items []*registry.AdminTenantListItem
 		total int
 	)
-	reg := r.newSQLRegistry()
-	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		// SET LOCAL row_security = off scopes the override to this tx.
-		// Postgres semantics: with row_security=off, any non-bypass role
-		// querying an RLS-protected table ERRORs instead of silently
-		// filtering. That's the fail-loud guard — if this connection
-		// role ever loses its bypass we want a 5xx, not a quietly empty
-		// page. See the function godoc for the full reasoning.
-		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
-			return errxtrace.Wrap("failed to disable row_security for admin tenant listing", execErr)
-		}
-
+	err := store.DoAsAdmin(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
 		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s AS t %s", tenantsTable, where)
 		if err := tx.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
 			return errxtrace.Wrap("failed to count admin tenants", err)
@@ -341,10 +320,10 @@ func (r *TenantRegistry) ListAdmin(ctx context.Context, opts registry.AdminTenan
 }
 
 // GetAdmin returns a single tenant detail row with the same computed
-// counts the listing surfaces. Runs one tx with row_security=off plus
-// COUNT subqueries instead of materialising the full user / group
-// row sets — keeps the detail endpoint O(constant) regardless of
-// tenant size.
+// counts the listing surfaces. Runs one tx under the inventario_admin
+// (BYPASSRLS) role with COUNT subqueries instead of materialising the
+// full user / group row sets — keeps the detail endpoint O(constant)
+// regardless of tenant size.
 func (r *TenantRegistry) GetAdmin(ctx context.Context, tenantID string) (*registry.AdminTenantListItem, error) {
 	if tenantID == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "TenantID"))
@@ -360,11 +339,7 @@ func (r *TenantRegistry) GetAdmin(ctx context.Context, tenantID string) (*regist
 		groupCount int
 		found      bool
 	)
-	reg := r.newSQLRegistry()
-	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
-			return errxtrace.Wrap("failed to disable row_security for admin tenant detail", execErr)
-		}
+	err := store.DoAsAdmin(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
 		query := fmt.Sprintf(`
 			SELECT t.*,
 				(SELECT COUNT(*) FROM %s AS u WHERE u.tenant_id = t.id) AS _user_count,

--- a/go/registry/postgres/users.go
+++ b/go/registry/postgres/users.go
@@ -335,13 +335,11 @@ func (r *UserRegistry) ListSystemAdmins(ctx context.Context) ([]*models.User, er
 // computed from a correlated subquery on group_memberships.
 //
 // The endpoint crosses tenants by design — the admin caller may not be
-// a member of the target tenant. The postgres UserRegistry uses
-// NonRLSRepository (no role switch); the cross-tenant read relies on
-// the connection role's bypass (table-owner or BYPASSRLS). `SET LOCAL
-// row_security = off` on the tx is a fail-loud guard — if the bypass
-// is ever revoked, the query ERRORs instead of silently filtering, so
-// a misconfiguration surfaces as a 5xx rather than a quietly empty
-// admin page (see TenantRegistry.ListAdmin for the same rationale).
+// a member of the target tenant. The query runs inside store.DoAsAdmin,
+// under the inventario_admin role, whose BYPASSRLS attribute skips the
+// tenant-isolation policy on `users` and `group_memberships` for this
+// transaction only. inventario_app traffic never assumes that role and
+// stays RLS-enforced (see TenantRegistry.ListAdmin for the same model).
 //
 // Total is post-filter, pre-pagination, matching TenantRegistry.ListAdmin.
 func (r *UserRegistry) ListAdminByTenant(ctx context.Context, tenantID string, opts registry.AdminUserListOptions) ([]*registry.AdminUserListItem, int, error) {
@@ -387,12 +385,7 @@ func (r *UserRegistry) ListAdminByTenant(ctx context.Context, tenantID string, o
 		items []*registry.AdminUserListItem
 		total int
 	)
-	reg := r.newSQLRegistry()
-	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
-			return errxtrace.Wrap("failed to disable row_security for admin user listing", execErr)
-		}
-
+	err := store.DoAsAdmin(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
 		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s AS u %s", usersTable, where)
 		if scanErr := tx.QueryRowContext(ctx, countQuery, args...).Scan(&total); scanErr != nil {
 			return errxtrace.Wrap("failed to count admin users", scanErr)
@@ -457,11 +450,10 @@ func (r *UserRegistry) ListAdminByTenant(ctx context.Context, tenantID string, o
 // user that are neither revoked nor expired. Backs the
 // `active_session_count` field on the admin user-detail endpoint
 // (#1746). The lookup crosses tenants intentionally — the admin caller
-// may not be a member of the target user's tenant — and runs under the
-// default connection role, which bypasses RLS on refresh_tokens. SET
-// LOCAL row_security = off is the same fail-loud guard the other admin
-// listings carry: if the role's bypass is revoked the query ERRORs
-// instead of silently returning 0 (see TenantRegistry.ListAdmin).
+// may not be a member of the target user's tenant — and runs inside
+// store.DoAsAdmin, under the inventario_admin (BYPASSRLS) role, so the
+// refresh_tokens RLS policy is skipped for this transaction only (see
+// TenantRegistry.ListAdmin for the same model).
 //
 // Note on the handler contract: admin handler degrades a CountSessionsByUser
 // failure to 0 + a separate audit row (admin.get_user_sessions, success=false)
@@ -474,11 +466,7 @@ func (r *UserRegistry) CountSessionsByUser(ctx context.Context, userID string) (
 	}
 
 	var count int
-	reg := r.newSQLRegistry()
-	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		if _, execErr := tx.ExecContext(ctx, "SET LOCAL row_security = off"); execErr != nil {
-			return errxtrace.Wrap("failed to disable row_security for active-session count", execErr)
-		}
+	err := store.DoAsAdmin(ctx, r.dbx, func(ctx context.Context, tx *sqlx.Tx) error {
 		query := fmt.Sprintf(
 			`SELECT COUNT(*) FROM %s WHERE user_id = $1 AND revoked_at IS NULL AND expires_at > $2`,
 			r.tableNames.RefreshTokens(),

--- a/go/schema/bootstrap/_sqldata/001_initial.sql
+++ b/go/schema/bootstrap/_sqldata/001_initial.sql
@@ -76,6 +76,37 @@ BEGIN
     END IF;
 END $$;
 
+-- Create the cross-tenant admin role.
+--
+-- inventario_admin is the ONLY role with the BYPASSRLS attribute. The
+-- system-admin surfaces (/api/v1/admin/...) read and write rows across
+-- every tenant; the application assumes this role via a transaction-scoped
+-- `SET LOCAL ROLE inventario_admin` (see store.DoAsAdmin) and resets it on
+-- commit/rollback. BYPASSRLS deliberately lives nowhere else: inventario_app
+-- and inventario_background_worker stay non-bypass so ordinary request
+-- traffic remains fully RLS-enforced and tenant-isolated.
+--
+-- The pre-existing admin code disabled RLS with `SET LOCAL row_security =
+-- off` instead. Postgres rejects that with SQLSTATE 42501 for a role that
+-- can neither own the table nor bypass RLS, so every admin group/tenant/user
+-- query 500'd on a standard deployment. BYPASSRLS is the supported fix.
+--
+-- This block is re-run on every (idempotent) bootstrap, so existing
+-- databases that were bootstrapped before this change pick up the new role
+-- automatically — no separate manual migration step is required.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'inventario_admin') THEN
+        CREATE ROLE inventario_admin WITH NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION BYPASSRLS;
+        RAISE NOTICE 'Created role inventario_admin';
+    ELSE
+        -- Ensure the attribute is present even if the role pre-existed
+        -- without it (e.g. created manually by an operator).
+        ALTER ROLE inventario_admin WITH BYPASSRLS;
+        RAISE NOTICE 'Role inventario_admin already exists; ensured BYPASSRLS';
+    END IF;
+END $$;
+
 -- Grant schema usage role to the operational user (only if different from role name)
 DO $$
 BEGIN
@@ -103,6 +134,25 @@ DO $$
     END IF;
 END $$;
 
+-- Grant the cross-tenant admin role to the login users that the
+-- application connects as. A login user can only `SET ROLE inventario_admin`
+-- if it is a member of that role; membership alone does NOT make ordinary
+-- queries bypass RLS — BYPASSRLS only takes effect once the role is the
+-- session's *active* role, which the app does exclusively inside the
+-- transaction-scoped store.DoAsAdmin helper.
+DO $$
+BEGIN
+    IF '{{.Username}}' != 'inventario_admin' THEN
+        GRANT inventario_admin TO {{.Username}};
+        RAISE NOTICE 'Granted inventario_admin role to {{.Username}}';
+    END IF;
+    IF '{{.UsernameForBackgroundWorker}}' != 'inventario_admin'
+       AND '{{.UsernameForBackgroundWorker}}' != '{{.Username}}' THEN
+        GRANT inventario_admin TO {{.UsernameForBackgroundWorker}};
+        RAISE NOTICE 'Granted inventario_admin role to {{.UsernameForBackgroundWorker}}';
+    END IF;
+END $$;
+
 -- App role gets only usage
 GRANT USAGE ON SCHEMA public TO inventario_app;
 
@@ -111,6 +161,9 @@ GRANT USAGE, CREATE ON SCHEMA public TO inventario_migrator;
 
 -- Background worker role gets schema privileges
 GRANT USAGE ON SCHEMA public TO inventario_background_worker;
+
+-- Admin role gets schema usage
+GRANT USAGE ON SCHEMA public TO inventario_admin;
 
 -- Default privileges for objects created by migrator role
 ALTER DEFAULT PRIVILEGES FOR ROLE inventario_migrator IN SCHEMA public
@@ -125,6 +178,13 @@ ALTER DEFAULT PRIVILEGES FOR ROLE inventario_migrator IN SCHEMA public
 
 ALTER DEFAULT PRIVILEGES FOR ROLE inventario_migrator IN SCHEMA public
     GRANT USAGE, SELECT ON SEQUENCES TO inventario_background_worker;
+
+-- Default privileges for objects created by migrator role for the admin role
+ALTER DEFAULT PRIVILEGES FOR ROLE inventario_migrator IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO inventario_admin;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE inventario_migrator IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO inventario_admin;
 
 -- Default privileges for objects created by the current user (whoever runs this bootstrap)
 -- This ensures that tables created during migrations get the correct permissions
@@ -142,6 +202,13 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
     GRANT USAGE, SELECT ON SEQUENCES TO inventario_background_worker;
 
+-- Default privileges for objects created by the current user for the admin role
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO inventario_admin;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO inventario_admin;
+
 -- Grant permissions on all existing tables to inventario_app
 -- This is needed for any tables that already exist
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO inventario_app;
@@ -155,6 +222,9 @@ ALTER DEFAULT PRIVILEGES FOR ROLE inventario_migrator IN SCHEMA public
 ALTER DEFAULT PRIVILEGES FOR ROLE inventario_background_worker IN SCHEMA public
     GRANT EXECUTE ON FUNCTIONS TO inventario_app;
 
+ALTER DEFAULT PRIVILEGES FOR ROLE inventario_migrator IN SCHEMA public
+    GRANT EXECUTE ON FUNCTIONS TO inventario_admin;
+
 -- Grant privileges on existing objects to both roles
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO inventario_migrator;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO inventario_migrator;
@@ -167,4 +237,11 @@ GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO inventario_app;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO inventario_background_worker;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO inventario_background_worker;
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO inventario_background_worker;
+
+-- Cross-tenant admin role gets the same DML reach as the app role across
+-- all existing objects. RLS bypass comes from the BYPASSRLS attribute on
+-- the role itself, not from any policy, so no per-table policy is needed.
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO inventario_admin;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO inventario_admin;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO inventario_admin;
 


### PR DESCRIPTION
## Problem

The admin cross-tenant endpoints for groups returned HTTP 500 on **every** PostgreSQL deployment using the standard bootstrap roles:

- `GET /api/v1/admin/groups`
- `GET /api/v1/admin/groups/{groupID}`
- `POST /api/v1/admin/groups/{groupID}/members` and the role-change / remove twins (these call `GetAdmin` first, so they 500'd transitively)

```
ERROR: query would be affected by row-level security policy for table "location_groups" (SQLSTATE 42501)
ERROR: query would be affected by row-level security policy for table "group_memberships" (SQLSTATE 42501)
```

### Root cause

The admin read/write paths issued `SET LOCAL row_security = off` inside their transaction while connected as a **non-bypass role** (`inventario_app` / `inventario_background_worker`). PostgreSQL answers any query that *would* be filtered by an RLS policy with `SQLSTATE 42501` when `row_security` is off and the active role can neither own the table nor bypass RLS. The bootstrap roles are created `NOSUPERUSER ...` with no `BYPASSRLS`, and tables are owned by `inventario_migrator` — so the app roles can neither own nor bypass, and the admin queries failed loudly on a standard install.

The same root cause affected `/api/v1/admin/tenants` and `/api/v1/admin/users`, whose registry methods carried the same `SET LOCAL row_security = off`. A silent empty result there would have been worse than the loud 500 — both are fixed consistently.

## Approach: a dedicated `inventario_admin` BYPASSRLS role

Granting `BYPASSRLS` to `inventario_app` was rejected — that attribute would make the role bypass RLS for **every** query, app-wide, collapsing the per-tenant isolation the whole multi-tenant model relies on.

Instead this PR introduces a dedicated role used **only** for admin transactions:

- **Bootstrap SQL** (`001_initial.sql`) creates `inventario_admin` as a `NOLOGIN` role with the `BYPASSRLS` attribute, grants it the same DML reach as `inventario_app`, and grants the role *to* the operational and background-worker login users so they can `SET ROLE` to it. `BYPASSRLS` lives **only** on `inventario_admin` — `inventario_app` and `inventario_background_worker` stay non-bypass, so ordinary request traffic remains fully RLS-enforced. Merely being a *member* of `inventario_admin` does not bypass RLS: the attribute only takes effect once the role is the session's *active* role.
- **`store.DoAsAdmin` / `beginAdminTx`** run a transaction under a transaction-scoped `SET LOCAL ROLE inventario_admin`, which resets automatically on commit/rollback and never leaks past the request. This mirrors the existing `DoAsBackgroundWorker` pattern.
- The seven admin registry methods now route through `store.DoAsAdmin` and the `SET LOCAL row_security = off` lines are removed: `LocationGroupRegistry.ListAdmin` / `GetAdmin` / `MarkPendingDeletionAdmin`, `TenantRegistry.ListAdmin` / `GetAdmin`, `UserRegistry.ListAdminByTenant` / `CountSessionsByUser`, `GroupMembershipRegistry.ListByGroupWithUsersAdmin`.

## Existing deployments

The bootstrap SQL is idempotent and re-runs on every startup (the `inventario-bootstrap` compose service, `scripts/bootstrap.sh`). Existing already-bootstrapped databases therefore pick up `inventario_admin` automatically — no separate manual migration step is required. The new block also `ALTER`s the role to ensure `BYPASSRLS` if it pre-existed without it. No docker-compose change is needed: the bootstrap path already runs as the privileged `POSTGRES_USER` superuser.

## Tests

Adds `TestAdminCrossTenantQueries_NonBypassAppRole`. The default postgres test harness connects as a **superuser**, which bypasses RLS regardless and would mask the bug — so the test deliberately creates a fresh non-superuser, non-`BYPASSRLS` login role (a member of `inventario_app` / `inventario_background_worker` / `inventario_admin`, i.e. the exact production role model) and proves all four admin cross-tenant surfaces succeed against it.

Verified the test **reproduces** `SQLSTATE 42501` when run against the pre-fix code, and **passes** with the fix.

- `go test -p 1 ./registry/postgres/...` — all green (incl. the new test, 8 subtests)
- `go test ./schema/bootstrap/...` — green, incl. `TestMigrator_Apply_Idempotent_HappyPath`
- `go build ./...`, `gofmt`, `nolintguard`, `qtlint`, `golangci-lint` on the changed packages — all clean

Closes #1787


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for cross-tenant admin registry operations to verify functionality across tenant boundaries.

* **Database Schema**
  * Introduced new admin role to support system-wide administrative operations.

* **Refactor**
  * Updated admin query execution mechanisms to use centralized role-based transaction handling for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->