### PR TITLE
[#1778] Reject non-access JWTs on the authenticated access path

### DIFF
--- a/go/apiserver/admin_impersonation.go
+++ b/go/apiserver/admin_impersonation.go
@@ -633,8 +633,12 @@ func (api *adminImpersonationAPI) signImpersonationToken(target *models.User, ad
 		"impersonated_by": adminID,
 		"imp":             true,
 		"is_system_admin": false,
-		"iat":             issuedAt.Unix(),
-		"exp":             expiresAt.Unix(),
+		// The impersonation token is consumed on the standard access path
+		// by JWTMiddleware, so it must carry token_type=access like any
+		// other access token (#1778). The imp=true claim is unchanged.
+		"token_type": accessTokenType,
+		"iat":        issuedAt.Unix(),
+		"exp":        expiresAt.Unix(),
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString(api.jwtSecret)
@@ -650,6 +654,7 @@ func (api *adminImpersonationAPI) signAdminAccessToken(admin *models.User, rti s
 		"jti":             uuid.New().String(),
 		"user_id":         admin.ID,
 		"is_system_admin": admin.IsSystemAdmin,
+		"token_type":      accessTokenType,
 		"iat":             now.Unix(),
 		"exp":             now.Add(accessTokenExpiration).Unix(),
 	}

--- a/go/apiserver/admin_impersonation_test.go
+++ b/go/apiserver/admin_impersonation_test.go
@@ -47,6 +47,7 @@ func makeImpersonationToken(c *qt.C, cl impersonateClaims) string {
 		"impersonated_by": cl.adminUserID,
 		"imp":             true,
 		"is_system_admin": false,
+		"token_type":      "access",
 		"iat":             time.Now().Add(-time.Minute).Unix(),
 		"exp":             cl.expiresAt.Unix(),
 	})

--- a/go/apiserver/admin_users_test.go
+++ b/go/apiserver/admin_users_test.go
@@ -424,10 +424,11 @@ func mintAccessTokenForUser(t *testing.T, userID string, iatOffset time.Duration
 	t.Helper()
 	iat := time.Now().Add(iatOffset)
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user_id": userID,
-		"jti":     "test-jti-" + userID,
-		"iat":     iat.Unix(),
-		"exp":     iat.Add(24 * time.Hour).Unix(),
+		"user_id":    userID,
+		"jti":        "test-jti-" + userID,
+		"token_type": "access",
+		"iat":        iat.Unix(),
+		"exp":        iat.Add(24 * time.Hour).Unix(),
 	})
 	signed, err := token.SignedString(testJWTSecret)
 	if err != nil {
@@ -578,6 +579,12 @@ func createTestJWTTokenWithClaims(t *testing.T, claims jwt.MapClaims) string {
 	t.Helper()
 	if _, ok := claims["exp"]; !ok {
 		claims["exp"] = time.Now().Add(24 * time.Hour).Unix()
+	}
+	// Default to an access token so the forged token clears the
+	// token-type enforcement in validateJWTToken (#1778). Callers can
+	// override token_type explicitly to test the rejection path.
+	if _, ok := claims["token_type"]; !ok {
+		claims["token_type"] = "access"
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	signed, err := token.SignedString(testJWTSecret)

--- a/go/apiserver/api_security_test.go
+++ b/go/apiserver/api_security_test.go
@@ -82,8 +82,9 @@ func TestAPISecurity_CrossTenantExportAttempt(t *testing.T) {
 
 	// Create JWT token for tenant 2 user
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user_id": u2.ID,
-		"exp":     time.Now().Add(time.Hour).Unix(),
+		"user_id":    u2.ID,
+		"token_type": "access",
+		"exp":        time.Now().Add(time.Hour).Unix(),
 	})
 	tokenString, err := token.SignedString(jwtSecret)
 	c.Assert(err, qt.IsNil)
@@ -195,8 +196,9 @@ func TestAPISecurity_InvalidUserContexts(t *testing.T) {
 
 			// Create JWT token
 			token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-				"user_id": user.ID,
-				"exp":     time.Now().Add(time.Hour).Unix(),
+				"user_id":    user.ID,
+				"token_type": "access",
+				"exp":        time.Now().Add(time.Hour).Unix(),
 			})
 			tokenString, err := token.SignedString(jwtSecret)
 			c.Assert(err, qt.IsNil)

--- a/go/apiserver/apiserver_test.go
+++ b/go/apiserver/apiserver_test.go
@@ -93,11 +93,14 @@ func getRegistrySetFromParams(params apiserver.Params, user *models.User) *regis
 	return must.Must(params.FactorySet.CreateUserRegistrySet(ctx))
 }
 
-// createTestJWTToken creates a JWT token for testing
+// createTestJWTToken creates an access JWT token for testing. It carries
+// token_type=access so it survives the token-type enforcement in
+// validateJWTToken (#1778), matching real access tokens.
 func createTestJWTToken(userID string) string {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user_id": userID,
-		"exp":     time.Now().Add(24 * time.Hour).Unix(),
+		"user_id":    userID,
+		"token_type": "access",
+		"exp":        time.Now().Add(24 * time.Hour).Unix(),
 	})
 
 	tokenString, err := token.SignedString(testJWTSecret)

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -27,6 +27,12 @@ import (
 const (
 	// accessTokenExpiration defines how long access JWT tokens remain valid.
 	accessTokenExpiration = 15 * time.Minute
+	// accessTokenType is the "token_type" claim stamped into every access
+	// JWT (regular, restored-admin, and impersonation). validateJWTToken
+	// only admits tokens carrying this type, so special-purpose JWTs signed
+	// with the same secret — notably the step-1 mfa_token (mfaTokenType) —
+	// cannot be replayed on the authenticated access path (#1778).
+	accessTokenType = "access"
 	// refreshTokenExpiration defines how long refresh tokens remain valid.
 	refreshTokenExpiration = 30 * 24 * time.Hour
 	// refreshTokenCookieName is the name of the httpOnly cookie carrying the refresh token.
@@ -1197,6 +1203,7 @@ func (api *AuthAPI) issueAccessToken(user *models.User, rti string) (string, tim
 		"jti":             uuid.New().String(),
 		"user_id":         user.ID,
 		"is_system_admin": user.IsSystemAdmin,
+		"token_type":      accessTokenType,
 		"exp":             expiresAt.Unix(),
 		"iat":             time.Now().Unix(),
 	}

--- a/go/apiserver/auth_mfa_test.go
+++ b/go/apiserver/auth_mfa_test.go
@@ -119,10 +119,11 @@ func (f *authMFAFixture) call(t *testing.T, method, path string, body any) *http
 func (f *authMFAFixture) bearerToken(t *testing.T) string {
 	t.Helper()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"jti":     uuid.New().String(),
-		"user_id": f.user.ID,
-		"iat":     time.Now().Unix(),
-		"exp":     time.Now().Add(5 * time.Minute).Unix(),
+		"jti":        uuid.New().String(),
+		"user_id":    f.user.ID,
+		"token_type": "access",
+		"iat":        time.Now().Unix(),
+		"exp":        time.Now().Add(5 * time.Minute).Unix(),
 	})
 	signed, err := token.SignedString(f.jwtSecret)
 	if err != nil {

--- a/go/apiserver/auth_security_test.go
+++ b/go/apiserver/auth_security_test.go
@@ -344,9 +344,10 @@ func TestAuthSecurity_JWTTokenSecurity(t *testing.T) {
 		{
 			name: "valid token",
 			tokenClaims: jwt.MapClaims{
-				"user_id": "user-123",
-				"role":    "user",
-				"exp":     time.Now().Add(time.Hour).Unix(),
+				"user_id":    "user-123",
+				"role":       "user",
+				"token_type": "access",
+				"exp":        time.Now().Add(time.Hour).Unix(),
 			},
 			secret:      jwtSecret,
 			expectValid: true,
@@ -509,9 +510,10 @@ func TestAuthSecurity_UserStatusValidation(t *testing.T) {
 
 			// Create valid token for the user
 			token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-				"user_id": tt.userID,
-				"role":    "user",
-				"exp":     time.Now().Add(time.Hour).Unix(),
+				"user_id":    tt.userID,
+				"role":       "user",
+				"token_type": "access",
+				"exp":        time.Now().Add(time.Hour).Unix(),
 			})
 			tokenString, err := token.SignedString(jwtSecret)
 			c.Assert(err, qt.IsNil)

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -948,9 +948,10 @@ func TestAuthAPI_GetCurrentUser(t *testing.T) {
 
 		// Create valid JWT token
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"user_id": "user-123",
-			"role":    "user",
-			"exp":     time.Now().Add(24 * time.Hour).Unix(),
+			"user_id":    "user-123",
+			"role":       "user",
+			"token_type": "access",
+			"exp":        time.Now().Add(24 * time.Hour).Unix(),
 		})
 		tokenString, err := token.SignedString(jwtSecret)
 		c.Assert(err, qt.IsNil)
@@ -1012,9 +1013,10 @@ func TestAuthAPI_UpdateCurrentUser(t *testing.T) {
 		t.Helper()
 		c := qt.New(t)
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"user_id": "user-123",
-			"role":    "user",
-			"exp":     time.Now().Add(24 * time.Hour).Unix(),
+			"user_id":    "user-123",
+			"role":       "user",
+			"token_type": "access",
+			"exp":        time.Now().Add(24 * time.Hour).Unix(),
 		})
 		tokenString, err := token.SignedString(jwtSecret)
 		c.Assert(err, qt.IsNil)
@@ -1428,10 +1430,11 @@ func TestAuthAPI_ChangePassword(t *testing.T) {
 		t.Helper()
 		c := qt.New(t)
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"user_id": "user-123",
-			"role":    "user",
-			"exp":     time.Now().Add(24 * time.Hour).Unix(),
-			"jti":     "test-change-pw-jti",
+			"user_id":    "user-123",
+			"role":       "user",
+			"token_type": "access",
+			"exp":        time.Now().Add(24 * time.Hour).Unix(),
+			"jti":        "test-change-pw-jti",
 		})
 		tokenString, err := token.SignedString(jwtSecret)
 		c.Assert(err, qt.IsNil)
@@ -1631,11 +1634,12 @@ func TestCheckTokenBlacklist_IatBased(t *testing.T) {
 		t.Helper()
 		c := qt.New(t)
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"user_id": "user-iat-test",
-			"role":    "user",
-			"exp":     time.Now().Add(24 * time.Hour).Unix(),
-			"iat":     iat.Unix(),
-			"jti":     "jti-" + iat.String(),
+			"user_id":    "user-iat-test",
+			"role":       "user",
+			"token_type": "access",
+			"exp":        time.Now().Add(24 * time.Hour).Unix(),
+			"iat":        iat.Unix(),
+			"jti":        "jti-" + iat.String(),
 		})
 		tokenString, err := token.SignedString(jwtSecret)
 		c.Assert(err, qt.IsNil)

--- a/go/apiserver/csrf_middleware_test.go
+++ b/go/apiserver/csrf_middleware_test.go
@@ -54,8 +54,9 @@ func makeCSRFTestUser(t *testing.T, jwtSecret []byte) (*models.User, string) {
 		IsActive: true,
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user_id": user.ID,
-		"exp":     time.Now().Add(time.Hour).Unix(),
+		"user_id":    user.ID,
+		"token_type": "access",
+		"exp":        time.Now().Add(time.Hour).Unix(),
 	})
 	tokenString, err := token.SignedString(jwtSecret)
 	if err != nil {

--- a/go/apiserver/group_slug_resolver_test.go
+++ b/go/apiserver/group_slug_resolver_test.go
@@ -137,10 +137,13 @@ func TestGroupSlugResolver_StaleUserToken(t *testing.T) {
 
 	params, _, testGroup := newParams()
 
-	// Build a JWT for a user that does not exist in the registry.
+	// Build a JWT for a user that does not exist in the registry. The token
+	// carries token_type=access so the 401 comes from the stale-user guard
+	// under test, not from the token-type enforcement (#1778).
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user_id": "user-does-not-exist",
-		"exp":     time.Now().Add(24 * time.Hour).Unix(),
+		"user_id":    "user-does-not-exist",
+		"token_type": "access",
+		"exp":        time.Now().Add(24 * time.Hour).Unix(),
 	})
 	tokenString := must.Must(token.SignedString(testJWTSecret))
 

--- a/go/apiserver/jwt_middleware.go
+++ b/go/apiserver/jwt_middleware.go
@@ -38,8 +38,10 @@ func extractTokenFromRequest(r *http.Request) (string, error) {
 }
 
 // validateJWTToken validates the JWT token and returns the claims.
-// If blacklist is non-nil, it additionally checks whether the token's JTI or
-// the user have been revoked.
+// It enforces the token's expiration, its token_type (so only access tokens
+// reach authenticated endpoints — see the token_type block below for #1778),
+// and, if blacklist is non-nil, whether the token's JTI or the user have been
+// revoked.
 func validateJWTToken(ctx context.Context, tokenString string, jwtSecret []byte, blacklist services.TokenBlacklister) (jwt.MapClaims, error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -64,6 +66,33 @@ func validateJWTToken(ctx context.Context, tokenString string, jwtSecret []byte,
 		return nil, fmt.Errorf("invalid expiration claim format")
 	} else if int64(expFloat) <= time.Now().Unix() {
 		return nil, fmt.Errorf("token expired")
+	}
+
+	// Enforce the token type so only genuine access tokens reach
+	// authenticated endpoints (#1778). Every JWT the apiserver mints is
+	// signed with the same jwtSecret, so a valid signature + unexpired
+	// exp is NOT enough to prove a token was meant for the access path.
+	// Without this check the step-1 mfa_token — handed out before the TOTP
+	// code is verified — could be replayed verbatim as a Bearer token,
+	// fully bypassing the second factor for its ~5-minute TTL.
+	//
+	// A token is admitted only if:
+	//   - token_type == accessTokenType ("access"), stamped by every access
+	//     token mint (issueAccessToken / signAdminAccessToken /
+	//     signImpersonationToken); or
+	//   - it carries imp == true. This explicit allowance keeps
+	//     impersonation tokens issued *before* this change (which lack the
+	//     token_type claim) working for their short TTL across a deploy.
+	//     Steady-state impersonation tokens already pass via token_type, so
+	//     the imp arm is removable once #1778 has shipped — tracked by #1791.
+	//
+	// Everything else — a missing token_type, the mfa_challenge type, or
+	// any future special-purpose JWT — is rejected, which makes
+	// JWTMiddleware / FileAccessMiddleware respond 401.
+	tokenType, _ := claims["token_type"].(string)
+	imp, _ := claims["imp"].(bool)
+	if tokenType != accessTokenType && !imp {
+		return nil, fmt.Errorf("invalid token type")
 	}
 
 	// Check blacklist when a blacklister is configured.

--- a/go/apiserver/jwt_middleware_test.go
+++ b/go/apiserver/jwt_middleware_test.go
@@ -45,12 +45,15 @@ func TestJWTMiddleware(t *testing.T) {
 		},
 	}
 
-	// Helper function to create a valid JWT token
+	// Helper function to create a valid JWT token. Carries token_type=access
+	// to match real access tokens — validateJWTToken rejects tokens without
+	// it (#1778).
 	createToken := func(userID string) string {
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"user_id": userID,
-			"role":    "user",
-			"exp":     time.Now().Add(24 * time.Hour).Unix(),
+			"user_id":    userID,
+			"role":       "user",
+			"token_type": "access",
+			"exp":        time.Now().Add(24 * time.Hour).Unix(),
 		})
 		tokenString, _ := token.SignedString(jwtSecret)
 		return tokenString
@@ -59,9 +62,10 @@ func TestJWTMiddleware(t *testing.T) {
 	// Helper function to create an expired JWT token
 	createExpiredToken := func(userID string) string {
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"user_id": userID,
-			"role":    "user",
-			"exp":     time.Now().Add(-1 * time.Hour).Unix(), // Expired 1 hour ago
+			"user_id":    userID,
+			"role":       "user",
+			"token_type": "access",
+			"exp":        time.Now().Add(-1 * time.Hour).Unix(), // Expired 1 hour ago
 		})
 		tokenString, _ := token.SignedString(jwtSecret)
 		return tokenString
@@ -85,6 +89,49 @@ func TestJWTMiddleware(t *testing.T) {
 				c.Assert(user, qt.IsNotNil)
 				c.Assert(user.ID, qt.Equals, "user-123")
 				c.Assert(user.Email, qt.Equals, "test@example.com")
+			},
+		},
+		{
+			// #1778: an impersonation token issued before the token_type
+			// change lacks the claim but carries imp=true. The explicit
+			// imp allowance keeps such in-flight tokens working across a
+			// deploy.
+			name: "legacy impersonation token (imp=true, no token_type)",
+			setupRequest: func(req *http.Request) {
+				token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+					"user_id": "user-123",
+					"imp":     true,
+					"exp":     time.Now().Add(24 * time.Hour).Unix(),
+				})
+				tokenString, _ := token.SignedString(jwtSecret)
+				req.Header.Set("Authorization", "Bearer "+tokenString)
+			},
+			checkContext: func(t *testing.T, r *http.Request) {
+				c := qt.New(t)
+				user := appctx.UserFromContext(r.Context())
+				c.Assert(user, qt.IsNotNil)
+				c.Assert(user.ID, qt.Equals, "user-123")
+			},
+		},
+		{
+			// Steady-state impersonation token: carries both imp=true and
+			// token_type=access. Accepted via the token_type check.
+			name: "impersonation token with imp=true and token_type=access",
+			setupRequest: func(req *http.Request) {
+				token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+					"user_id":    "user-123",
+					"imp":        true,
+					"token_type": "access",
+					"exp":        time.Now().Add(24 * time.Hour).Unix(),
+				})
+				tokenString, _ := token.SignedString(jwtSecret)
+				req.Header.Set("Authorization", "Bearer "+tokenString)
+			},
+			checkContext: func(t *testing.T, r *http.Request) {
+				c := qt.New(t)
+				user := appctx.UserFromContext(r.Context())
+				c.Assert(user, qt.IsNotNil)
+				c.Assert(user.ID, qt.Equals, "user-123")
 			},
 		},
 	}
@@ -172,6 +219,43 @@ func TestJWTMiddleware(t *testing.T) {
 				req.Header.Set("Authorization", "Bearer "+token)
 			},
 			expectedStatus: http.StatusForbidden,
+		},
+		{
+			// #1778 regression test: the step-1 mfa_token is signed with
+			// the same secret as access tokens. Replaying it verbatim as a
+			// Bearer token must be rejected — otherwise an attacker with
+			// only username+password (no TOTP code) bypasses the second
+			// factor for the token's ~5-minute TTL.
+			name: "mfa_token replayed as access token is rejected",
+			setupRequest: func(req *http.Request) {
+				token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+					"jti":        "mfa-jti",
+					"user_id":    "user-123",
+					"tenant_id":  "test-tenant-id",
+					"token_type": "mfa_challenge",
+					"exp":        time.Now().Add(5 * time.Minute).Unix(),
+					"iat":        time.Now().Unix(),
+				})
+				tokenString, _ := token.SignedString(jwtSecret)
+				req.Header.Set("Authorization", "Bearer "+tokenString)
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			// A token missing the token_type claim entirely is rejected:
+			// genuine access tokens always stamp it, so its absence means
+			// the token was not minted for the access path (#1778).
+			name: "token without token_type claim is rejected",
+			setupRequest: func(req *http.Request) {
+				token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+					"user_id": "user-123",
+					"role":    "user",
+					"exp":     time.Now().Add(24 * time.Hour).Unix(),
+				})
+				tokenString, _ := token.SignedString(jwtSecret)
+				req.Header.Set("Authorization", "Bearer "+tokenString)
+			},
+			expectedStatus: http.StatusUnauthorized,
 		},
 	}
 

--- a/go/apiserver/jwt_middleware_test.go
+++ b/go/apiserver/jwt_middleware_test.go
@@ -193,11 +193,15 @@ func TestJWTMiddleware(t *testing.T) {
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
+			// token_type=access is set so the token clears the #1778
+			// token-type gate and the 401 is genuinely attributable to the
+			// missing user_id claim — the branch this case is meant to cover.
 			name: "token without user_id claim",
 			setupRequest: func(req *http.Request) {
 				token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-					"role": "user",
-					"exp":  time.Now().Add(24 * time.Hour).Unix(),
+					"role":       "user",
+					"token_type": "access",
+					"exp":        time.Now().Add(24 * time.Hour).Unix(),
 				})
 				tokenString, _ := token.SignedString(jwtSecret)
 				req.Header.Set("Authorization", "Bearer "+tokenString)


### PR DESCRIPTION
## Summary

Fixes #1778 — a HIGH-severity MFA bypass.

The step-1 MFA challenge token (`mfa_token`) is signed with the **same `jwtSecret`** as regular access tokens. `validateJWTToken` only validated the signature, `exp` and the blacklist — it never inspected the `token_type` claim. An attacker who has a victim's username + password but **not** the TOTP second factor could take the `mfa_token` returned by step-1 login and replay it verbatim as `Authorization: Bearer <mfa_token>` against any authenticated endpoint, fully bypassing MFA for the token's ~5-minute TTL.

## Fix

- New `accessTokenType = "access"` constant.
- `token_type: "access"` is now stamped into every access-token mint: `issueAccessToken`, `signAdminAccessToken`, and `signImpersonationToken`.
- `validateJWTToken` (`go/apiserver/jwt_middleware.go`) admits a token only when `token_type == "access"` **or** it carries `imp == true`. Everything else — a missing `token_type`, the `mfa_challenge` type, or any future special-purpose JWT signed with `jwtSecret` — is rejected with 401.

The `imp == true` arm is a rollout-window allowance: impersonation tokens minted before this change lack the `token_type` claim and would otherwise be rejected mid-session. Steady-state impersonation tokens now carry `token_type: "access"` too, so the arm becomes removable once the release has shipped — tracked in #1791.

### Audit of other JWTs on `jwtSecret`

Per the issue's "needs research" note, every `jwt.NewWithClaims` / `SignedString` site under `go/` was audited. Exactly four JWTs are minted on `jwtSecret`: the three access-token mints above and `issueMFAToken` (`mfa_challenge`). Password-reset and email-verification tokens are random DB-stored strings, not JWTs; signed file URLs use a separate HMAC scheme; CSRF has its own service. No other replay of this class exists.

## Test plan

- New regression tests in `jwt_middleware_test.go`: an `mfa_challenge`-shaped token replayed as a Bearer token gets **401**; a token with no `token_type` gets **401**; a normal access token and both impersonation-token shapes (legacy `imp:true`/no `token_type`, and `imp:true`+`token_type:"access"`) are accepted.
- Suite-wide auth test helpers updated to stamp `token_type:"access"` so they exercise the real access path.
- `gofmt`, `go build ./...`, `go vet ./apiserver/...`, `golangci-lint run ./apiserver/...`, `go test ./apiserver/...` — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Access tokens now include an explicit token-type claim and are strictly validated; tokens with missing/invalid types are rejected. Impersonation tokens remain supported, including legacy and current formats.

* **Tests**
  * Expanded test coverage for token-type handling across access tokens, impersonation flows, replay/failure cases, and related authorization checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->