### PR TITLE
[#1779] Reject client-supplied file path in createFile

### DIFF
--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -9349,8 +9349,6 @@ export type components = {
             linked_entity_meta?: string;
             /** @description commodity, export, or empty */
             linked_entity_type?: string;
-            /** @description Only for updates */
-            path?: string;
             tags?: string[];
             title?: string;
         };

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -324,9 +324,15 @@ func (api *filesAPI) createFile(w http.ResponseWriter, r *http.Request) {
 		LinkedEntityMeta: input.Data.Attributes.LinkedEntityMeta,
 		CreatedAt:        now,
 		UpdatedAt:        now,
+		// The blob Path/OriginalPath are intentionally left empty here.
+		// This is a metadata-only create endpoint; the physical blob key
+		// is populated server-side by the upload flow (/uploads/file)
+		// once a real blob exists. A client-supplied path must never be
+		// honored — it would let a caller point a row in their own tenant
+		// at another tenant's blob key in the flat blob namespace (#1779).
 		File: &models.File{
-			Path:         input.Data.Attributes.Path,
-			OriginalPath: input.Data.Attributes.Path,
+			Path:         "",
+			OriginalPath: "",
 			Ext:          "",
 			MIMEType:     "",
 		},

--- a/go/apiserver/security_test.go
+++ b/go/apiserver/security_test.go
@@ -197,6 +197,112 @@ func TestSecurityIDRejection(t *testing.T) {
 	}
 }
 
+// TestSecurityFileCreatePathNotHonored verifies that a client-supplied
+// `data.attributes.path` on POST /files is ignored. The create endpoint is
+// metadata-only; the blob key is populated server-side by the upload flow.
+// Honoring a client path would let an attacker create a row in their own
+// tenant pointing at another tenant's blob key in the flat blob namespace,
+// then leak its content via a signed download URL (#1779).
+//
+// The `path` field has been removed from jsonapi.FileRequestData, so the
+// hostile value is injected via a raw JSON body to exercise the real decode
+// path (an unknown key must be silently dropped, not honored).
+func TestSecurityFileCreatePathNotHonored(t *testing.T) {
+	c := qt.New(t)
+
+	factorySet := memory.NewFactorySet()
+	testUser := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			TenantID: "test-tenant-id",
+		},
+		Email:    "test@example.com",
+		Name:     "Test User",
+		IsActive: true,
+	}
+	err := testUser.SetPassword("TestPassword123")
+	c.Assert(err, qt.IsNil)
+	createdUser, err := factorySet.UserRegistry.Create(context.Background(), testUser)
+	c.Assert(err, qt.IsNil)
+
+	group := createTestGroupForUser(factorySet, createdUser.TenantID, createdUser.ID)
+
+	testCases := []struct {
+		name        string
+		hostilePath string
+	}{
+		{
+			name:        "cross-tenant thumbnail blob key is not honored",
+			hostilePath: "thumbnails/00000000-0000-0000-0000-000000000000_medium.jpg",
+		},
+		{
+			name:        "path traversal value is not honored",
+			hostilePath: "../../etc/passwd",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			r := chi.NewRouter()
+			r.Use(render.SetContentType(render.ContentTypeJSON))
+
+			params := apiserver.Params{
+				FactorySet:     factorySet,
+				UploadLocation: "memory://",
+				JWTSecret:      testJWTSecret,
+			}
+
+			withTestGroup := func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					next.ServeHTTP(w, r.WithContext(appctx.WithGroup(r.Context(), group)))
+				})
+			}
+
+			r.With(apiserver.RequireAuth(testJWTSecret, factorySet.UserRegistry, nil)).With(withTestGroup).With(apiserver.RegistrySetMiddleware(factorySet)).Route("/files", apiserver.Files(params))
+
+			// Raw JSON body: the hostile `path` key is no longer part of the
+			// FileRequestData struct, so it must be decoded-and-dropped.
+			rawBody := map[string]any{
+				"data": map[string]any{
+					"type": "files",
+					"attributes": map[string]any{
+						"title":       "Hostile File",
+						"description": "attempts to point at another tenant's blob",
+						"tags":        []string{"test"},
+						"path":        tc.hostilePath,
+					},
+				},
+			}
+			requestBodyBytes, err := json.Marshal(rawBody)
+			c.Assert(err, qt.IsNil)
+
+			req := httptest.NewRequest("POST", "/files", bytes.NewReader(requestBodyBytes))
+			req.Header.Set("Content-Type", "application/json")
+			addTestUserAuthHeader(req, createdUser.ID)
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			c.Assert(w.Code, qt.Equals, http.StatusCreated)
+
+			var resp struct {
+				Attributes struct {
+					Path         string `json:"path"`
+					OriginalPath string `json:"original_path"`
+				} `json:"attributes"`
+			}
+			err = json.Unmarshal(w.Body.Bytes(), &resp)
+			c.Assert(err, qt.IsNil)
+
+			// The client-supplied path must not be honored: both blob-key
+			// fields come back empty, to be filled server-side on upload.
+			c.Assert(resp.Attributes.Path, qt.Equals, "")
+			c.Assert(resp.Attributes.OriginalPath, qt.Equals, "")
+		})
+	}
+}
+
 // TestSecurityServerGeneratedIDs tests that server-generated IDs are always used
 func TestSecurityServerGeneratedIDs(t *testing.T) {
 	c := qt.New(t)

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -9756,10 +9756,6 @@ const docTemplate = `{
                     "description": "commodity, export, or empty",
                     "type": "string"
                 },
-                "path": {
-                    "description": "Only for updates",
-                    "type": "string"
-                },
                 "tags": {
                     "type": "array",
                     "items": {

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -9749,10 +9749,6 @@
                     "description": "commodity, export, or empty",
                     "type": "string"
                 },
-                "path": {
-                    "description": "Only for updates",
-                    "type": "string"
-                },
                 "tags": {
                     "type": "array",
                     "items": {

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -1770,9 +1770,6 @@ definitions:
       linked_entity_type:
         description: commodity, export, or empty
         type: string
-      path:
-        description: Only for updates
-        type: string
       tags:
         items:
           type: string

--- a/go/jsonapi/files.go
+++ b/go/jsonapi/files.go
@@ -230,12 +230,14 @@ func (fr *FileRequest) ValidateWithContext(ctx context.Context) error {
 	return validation.ValidateStructWithContext(ctx, fr, fields...)
 }
 
-// FileRequestData contains the attributes for creating/updating a file.
+// FileRequestData contains the attributes for creating a file entity.
+// It is metadata-only: the blob path is never accepted from the client.
+// The physical blob key is populated server-side by the upload flow
+// (/uploads/file). See updateFile for the separate update request struct.
 type FileRequestData struct {
 	Title            string   `json:"title"`
 	Description      string   `json:"description"`
 	Tags             []string `json:"tags"`
-	Path             string   `json:"path,omitempty"`               // Only for updates
 	LinkedEntityType string   `json:"linked_entity_type,omitempty"` // commodity, export, or empty
 	LinkedEntityID   string   `json:"linked_entity_id,omitempty"`   // ID of linked entity
 	LinkedEntityMeta string   `json:"linked_entity_meta,omitempty"` // metadata about the link


### PR DESCRIPTION
## Summary

Fixes #1779.

`createFile` (`POST /g/{slug}/files`) copied the client-controlled `path`
attribute straight into both `File.Path` **and** `File.OriginalPath` with no
sanitization. Combined with the flat, tenant-shared blob namespace (blob keys
carry no tenant prefix), a normal authenticated user could:

1. `POST /g/{slug}/files` with `attributes.path` set to another tenant's blob
   key — the new row belongs to the attacker's own tenant, so it passes every
   tenant/group check.
2. Request a signed download URL — `downloadOriginalFile` resolves the row
   (attacker's tenant, passes) and streams the blob at `OriginalPath`, which is
   the victim tenant's content.

`SignedURLMiddleware`'s `file.TenantID == user.TenantID` check does not help:
the row genuinely belongs to the attacker. The unverified surface is the blob
*key*, not the row.

## Fix

- Remove the `path` field from `jsonapi.FileRequestData` — the create-request
  attributes struct. `createFile` is metadata-only; it has no physical blob
  yet, so it must not accept a blob key. Updates use the separate
  `FileUpdateRequestFileData` struct, which is untouched (its `Path` is the
  user-facing display filename, sanitized via `CleanFilename`, and is never a
  blob key).
- `createFile` now sets `File.Path` / `File.OriginalPath` to empty. The blob
  key is only ever written server-side by the `/uploads/file` flow once a real
  blob exists.
- Regenerated swagger to drop the `path` property from the `FileRequestData`
  schema.

Removing the field makes the fix enforced at the type level — a future caller
cannot re-introduce the assignment without a compile error.

## Scope

`updateFile` was confirmed safe: it writes only `File.Path` (the display
filename, run through `CleanFilename`, which strips `/`, `\`, `.`) and never
`File.OriginalPath` (the blob key). No change needed there.

The blob namespace is still flat. Tenant/group-prefixing blob keys —
defence-in-depth so a leaked or guessed `OriginalPath` cannot cross tenants
even if it were honored — is deliberately out of scope for this issue and
tracked separately in #1793.

## Testing

- New `TestSecurityFileCreatePathNotHonored`: posts a create request with a
  hostile raw-JSON `data.attributes.path` (a cross-tenant thumbnail blob key
  and a `../../etc/passwd` traversal value) and asserts the created file's
  `path` and `original_path` come back empty. Raw JSON is used so the unknown
  key exercises the real decode-and-drop path. Verified to fail when the
  vulnerable code is restored.
- `go build ./...`, `go test ./apiserver/... ./jsonapi/...`, `go vet`, and
  `golangci-lint` on the touched packages — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File creation requests no longer accept custom file paths; paths are now managed server-side during the upload process.

* **Tests**
  * Added security test to verify client-supplied file paths are not persisted during file creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->