### PR TITLE
fix(frontend): retune size-limit gate for rolldown 1.0 chunking

### DIFF
--- a/frontend/.size-limit.json
+++ b/frontend/.size-limit.json
@@ -1,12 +1,8 @@
 [
   {
-    "name": "Initial JS (main + jsx-runtime + button chunk)",
-    "path": [
-      "dist/assets/index-*.js",
-      "dist/assets/jsx-runtime-*.js",
-      "dist/assets/button-*.js"
-    ],
-    "limit": "200 KB",
+    "name": "Initial JS (entry chunk — all eager code)",
+    "path": "dist/assets/index-*.js",
+    "limit": "230 KB",
     "gzip": true
   },
   {


### PR DESCRIPTION
## Problem

PR #1802 (vite 8.0.11 → 8.0.14) was auto-merged by the Dependabot
workflow, but it left the **Frontend Bundle Size** gate red on `master`.

vite 8.0.14 bumps rolldown `1.0.0-rc.18` → `1.0.2` (stable). Stable
rolldown changed its default chunking: the ~27 small eager chunks that
rc.18 emitted (`jsx-runtime`, `button`, `createLucideIcon`, `AuthContext`,
`GroupContext`, `i18next`, vendor `dist-*.js`, …) are now inlined into the
single entry chunk.

The old `.size-limit.json` gate globbed `index-* + jsx-runtime-* + button-*`.
Under rc.18 that captured only **159 kB** of a real **228 kB** eager payload
(the other ~25 preloaded chunks were never counted). The 200 kB limit was
calibrated against that undercount. With one entry chunk the glob now
honestly measures the whole eager bundle — **216 kB** — which trips the
stale 200 kB limit.

## Evidence

| | master @8.0.11 | @8.0.14 |
|---|---|---|
| Chunks referenced by `index.html` (eager) | entry + 27 preloads | entry only |
| **Real initial JS (gzip)** | **228 kB** | **216 kB** |
| Total `dist/assets` | 5588 KB | 5500 KB |

Initial load is actually ~12 kB **smaller** and the total bundle shrank —
the re-chunking is a net win, not a regression. Lazy route chunks are
untouched (the "Lazy real pages" budget still passes at 3.84 kB).

## Fix

`.size-limit.json` — first budget: drop the now-dead `jsx-runtime-*` /
`button-*` globs (those chunks no longer exist), track `index-*.js` alone,
and raise the limit 200 → 230 kB. 230 kB is honest about the entry-inlined
layout yet still stricter than master's de-facto 228 kB eager footprint.

Verified locally on the post-merge tree: `npm run size` green
(216.53 / 230), plus `tsc -b`, `vite build`, `eslint`, `vitest` (1084/1084).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for bundle size tracking. JavaScript bundle size limit increased from 200 KB to 230 KB.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->