### PR TITLE
[#1780] Replace ?token= JWT-in-URL with signed download URLs

### DIFF
--- a/frontend/src/components/exports/ExportRow.tsx
+++ b/frontend/src/components/exports/ExportRow.tsx
@@ -13,14 +13,16 @@ import { Link } from "react-router-dom"
 import { ExportStatusBadge } from "@/components/exports/ExportStatusBadge"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { type Export, isExportTerminal, useExportDownloadHref } from "@/features/export/api"
+import { type Export, isExportTerminal } from "@/features/export/api"
+import { useDownloadExport } from "@/features/export/hooks"
+import { useAppToast } from "@/hooks/useAppToast"
 import { formatBytes, formatDateTime } from "@/lib/intl"
+import { parseServerError } from "@/lib/server-error"
 import { cn } from "@/lib/utils"
 
 export interface ExportRowProps {
   export: Export
   detailHref: string
-  groupSlug: string
   onDelete: () => void
   onRestore?: () => void
 }
@@ -33,23 +35,25 @@ function totalItemCount(e: Export): number {
 
 // Mock-spec row: tinted leading icon tile + (title row + date + stats
 // line + error footer) + hover-revealed action cluster. The download CTA
-// stays an `<a>` so the browser streams the JWT-protected file natively;
-// the token is appended as `?token=…` (BE accepts that in addition to
-// Authorization headers).
-export function ExportRow({
-  export: exp,
-  detailHref,
-  groupSlug,
-  onDelete,
-  onRestore,
-}: ExportRowProps) {
+// is a real button: clicking it mints a short-lived server-signed URL
+// (no JWT in the URL, #1780) and triggers a native browser download.
+export function ExportRow({ export: exp, detailHref, onDelete, onRestore }: ExportRowProps) {
   const { t } = useTranslation(["exports"])
+  const toast = useAppToast()
+  const downloadMutation = useDownloadExport()
   const isDeleted = !!exp.deleted_at
   const isTerminal = isExportTerminal(exp.status)
   const isCompleted = exp.status === "completed"
   const isFailed = exp.status === "failed"
   const isInFlight = exp.status === "in_progress" || exp.status === "pending"
-  const downloadHref = useExportDownloadHref(exp.id, groupSlug)
+
+  async function onDownload() {
+    try {
+      await downloadMutation.mutateAsync(exp.id)
+    } catch (err) {
+      toast.error(t("exports:errors.downloadFailed", { error: parseServerError(err, String(err)) }))
+    }
+  }
   const scopeLabel =
     exp.type === "selected_items"
       ? t("exports:detail.scopeSelectedItems", { count: exp.selected_items?.length ?? 0 })
@@ -171,16 +175,20 @@ export function ExportRow({
             </Button>
           )}
           <Button
-            asChild
+            type="button"
             size="sm"
             variant="outline"
-            aria-disabled={!downloadHref}
-            className={cn("flex-1 gap-1.5 sm:flex-none", !downloadHref && "pointer-events-none")}
+            onClick={onDownload}
+            disabled={downloadMutation.isPending}
+            data-testid={`export-row-${exp.id}-download`}
+            className="flex-1 gap-1.5 sm:flex-none"
           >
-            <a href={downloadHref ?? "#"} data-testid={`export-row-${exp.id}-download`}>
+            {downloadMutation.isPending ? (
+              <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+            ) : (
               <Download className="size-3.5" aria-hidden="true" />
-              {t("exports:actions.download")}
-            </a>
+            )}
+            {t("exports:actions.download")}
           </Button>
         </div>
       )}

--- a/frontend/src/features/export/__tests__/api.test.ts
+++ b/frontend/src/features/export/__tests__/api.test.ts
@@ -5,7 +5,7 @@ import {
   createExport,
   createRestore,
   deleteExport,
-  exportDownloadPath,
+  fetchExportDownloadUrl,
   getExport,
   getRestore,
   importBackup,
@@ -266,17 +266,26 @@ describe("features/export/api", () => {
     expect(isRestoreTerminal("pending")).toBe(false)
   })
 
-  it("exportDownloadPath builds the absolute /api/v1/g/<slug>/ download URL", () => {
-    expect(exportDownloadPath("e1", "household", null)).toBe(
-      "/api/v1/g/household/exports/e1/download"
+  it("fetchExportDownloadUrl GETs /exports/:id/signed-url and returns attributes.url", async () => {
+    server.use(
+      http.get(apiUrl("/g/g1/exports/e1/signed-url"), () =>
+        HttpResponse.json({
+          id: "f1",
+          type: "urls",
+          attributes: { url: "/api/v1/files/download/files/f1?sig=abc&exp=123&uid=u&fid=f1" },
+        })
+      )
     )
+    const url = await fetchExportDownloadUrl("g1", "e1")
+    expect(url).toBe("/api/v1/files/download/files/f1?sig=abc&exp=123&uid=u&fid=f1")
   })
 
-  it("exportDownloadPath appends the access token as ?token= for <a href> downloads", () => {
-    // The BE accepts JWT via Authorization or ?token=; <a href> doesn't
-    // send Authorization, so the wrapper has to attach the token.
-    expect(exportDownloadPath("e1", "household", "tok-abc")).toBe(
-      "/api/v1/g/household/exports/e1/download?token=tok-abc"
+  it("fetchExportDownloadUrl throws when the signed-url response has no attributes.url", async () => {
+    server.use(
+      http.get(apiUrl("/g/g1/exports/e1/signed-url"), () =>
+        HttpResponse.json({ id: "f1", type: "urls", attributes: {} })
+      )
     )
+    await expect(fetchExportDownloadUrl("g1", "e1")).rejects.toThrow(/attributes\.url/)
   })
 })

--- a/frontend/src/features/export/api.ts
+++ b/frontend/src/features/export/api.ts
@@ -1,9 +1,7 @@
 // Pure data-layer functions for the exports / imports / restores feature
 // slice. Hooks live in `./hooks.ts`. Backed by the `/exports`, `/exports/{id}`,
-// `/exports/{id}/restores`, `/exports/import` and `/uploads/restores` surfaces.
-import { useMemo } from "react"
-
-import { getAccessToken } from "@/lib/auth-storage"
+// `/exports/{id}/restores`, `/exports/{id}/signed-url`, `/exports/import` and
+// `/uploads/restores` surfaces.
 import { http } from "@/lib/http"
 import type { Schema } from "@/types"
 
@@ -170,30 +168,30 @@ export async function deleteExport(id: string): Promise<void> {
   await http.del<void>(`/exports/${encodeURIComponent(id)}`)
 }
 
-// Internal builder. The BE accepts JWT either as `Authorization: Bearer
-// …` or as `?token=…` (see go/apiserver/jwt_middleware.go). Plain
-// `<a href>` clicks do not send Authorization (the access token lives
-// in localStorage), so we append the token as a query param so the
-// browser's native download UX still works. The token leaks into
-// referer / browser history — acceptable for short-lived JWTs but
-// callers must not surface this URL outside of the download CTA.
-export function exportDownloadPath(id: string, slug: string, accessToken: string | null): string {
-  const path = `/api/v1/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(id)}/download`
-  if (!accessToken) return path
-  return `${path}?token=${encodeURIComponent(accessToken)}`
-}
+// Downloads no longer put a JWT in the URL (#1780). Instead we ask the BE
+// to mint a short-lived HMAC-signed, app-absolute download URL via an
+// authenticated request; the browser then navigates to that signed URL,
+// which streams the file with `Content-Disposition: attachment`. No
+// session token ever appears in referer / history / proxy logs.
+type SignedFileURLResponse = Schema<"jsonapi.SignedFileURLResponse">
 
-// React hook variant that pulls the current access token from storage.
-// Returns null when either the id or slug is missing so callers can
-// gate the download CTA on a usable href.
-export function useExportDownloadHref(
-  id: string | undefined,
-  slug: string | undefined
-): string | null {
-  return useMemo(() => {
-    if (!id || !slug) return null
-    return exportDownloadPath(id, slug, getAccessToken())
-  }, [id, slug])
+// fetchExportDownloadUrl performs an authenticated GET to mint a
+// short-lived signed download URL for a completed export. The returned
+// string is an app-absolute URL (`/api/v1/...`) ready to navigate to.
+// It is a GET because minting the URL is side-effect-free — and because
+// the group-scoped write gate is admin-only for non-GET methods, so a
+// GET keeps export downloads available to every group member.
+// Throws on a malformed response or a BE error (404 when the export is
+// deleted, not completed, or has no backing file entity).
+export async function fetchExportDownloadUrl(slug: string, id: string): Promise<string> {
+  const body = await http.get<SignedFileURLResponse>(
+    `/g/${encodeURIComponent(slug)}/exports/${encodeURIComponent(id)}/signed-url`
+  )
+  const url = body.attributes?.url
+  if (!url) {
+    throw new Error("Malformed signed-url response: missing attributes.url")
+  }
+  return url
 }
 
 export interface UploadRestoreFileResult {

--- a/frontend/src/features/export/hooks.ts
+++ b/frontend/src/features/export/hooks.ts
@@ -13,6 +13,7 @@ import {
   createExport,
   createRestore,
   deleteExport,
+  fetchExportDownloadUrl,
   getExport,
   getRestore,
   importBackup,
@@ -164,6 +165,32 @@ export function useImportBackup() {
   return useMutation<Export, Error, ImportBackupRequest>({
     mutationFn: (req) => importBackup(req),
     onSuccess: () => invalidate.all(),
+  })
+}
+
+// Triggers a native browser download of a signed URL. The signed-url
+// response carries `Content-Disposition: attachment`, so navigating a
+// transient anchor to it streams the file without unloading the SPA.
+function triggerBrowserDownload(url: string): void {
+  const a = document.createElement("a")
+  a.href = url
+  a.rel = "noopener"
+  a.download = ""
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+}
+
+// useDownloadExport mints a short-lived signed download URL for a
+// completed export (authenticated request — no JWT in the URL, #1780)
+// and triggers a native browser download of it. No cache invalidation:
+// minting a signed URL does not mutate any exports/restores state.
+export function useDownloadExport() {
+  const { currentGroup } = useCurrentGroup()
+  const slug = currentGroup?.slug ?? ""
+  return useMutation<string, Error, string>({
+    mutationFn: (exportId) => fetchExportDownloadUrl(slug, exportId),
+    onSuccess: (url) => triggerBrowserDownload(url),
   })
 }
 

--- a/frontend/src/i18n/locales/en/exports.json
+++ b/frontend/src/i18n/locales/en/exports.json
@@ -37,6 +37,7 @@
   "errors": {
     "createFailed": "Could not create export: {{error}}",
     "deleteFailed": "Could not delete export: {{error}}",
+    "downloadFailed": "Could not download export: {{error}}",
     "importFailed": "Could not import backup: {{error}}",
     "loadFailed": "Could not load exports: {{error}}",
     "restoreCreateFailed": "Could not start restore: {{error}}",

--- a/frontend/src/pages/exports/ExportDetailPage.tsx
+++ b/frontend/src/pages/exports/ExportDetailPage.tsx
@@ -8,7 +8,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
-import { type Export, isExportTerminal } from "@/features/export/api"
+import { type Export } from "@/features/export/api"
 import {
   useDeleteExport,
   useDownloadExport,
@@ -41,7 +41,6 @@ export function ExportDetailPage() {
 
   const exp = exportQuery.data
   const isCompleted = exp?.status === "completed"
-  const isTerminal = isExportTerminal(exp?.status)
   const isDeleted = !!exp?.deleted_at
 
   async function onDelete() {
@@ -129,7 +128,7 @@ export function ExportDetailPage() {
             type="button"
             variant="outline"
             onClick={onDownload}
-            disabled={!isTerminal || !isCompleted || isDeleted || downloadMutation.isPending}
+            disabled={!isCompleted || isDeleted || downloadMutation.isPending}
             data-testid="export-detail-download"
           >
             {downloadMutation.isPending ? (

--- a/frontend/src/pages/exports/ExportDetailPage.tsx
+++ b/frontend/src/pages/exports/ExportDetailPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Download, RotateCcw, Trash2 } from "lucide-react"
+import { ArrowLeft, Download, Loader2, RotateCcw, Trash2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { Link, useNavigate, useParams } from "react-router-dom"
 
@@ -8,8 +8,13 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
-import { type Export, isExportTerminal, useExportDownloadHref } from "@/features/export/api"
-import { useDeleteExport, useExport, useExportRestores } from "@/features/export/hooks"
+import { type Export, isExportTerminal } from "@/features/export/api"
+import {
+  useDeleteExport,
+  useDownloadExport,
+  useExport,
+  useExportRestores,
+} from "@/features/export/hooks"
 import { useGroupMigrationLock } from "@/features/currency-migration/lock"
 import { useCurrentGroup } from "@/features/group/GroupContext"
 import { useAppToast } from "@/hooks/useAppToast"
@@ -32,7 +37,7 @@ export function ExportDetailPage() {
   const exportQuery = useExport(exportId, { enabled: groupReady && !!exportId })
   const restoresQuery = useExportRestores(exportId, { enabled: groupReady && !!exportId })
   const deleteMutation = useDeleteExport()
-  const downloadHref = useExportDownloadHref(exportId, slug)
+  const downloadMutation = useDownloadExport()
 
   const exp = exportQuery.data
   const isCompleted = exp?.status === "completed"
@@ -58,6 +63,15 @@ export function ExportDetailPage() {
       // restore in progress") instead of the bare HTTP wrapper.
       const message = parseServerError(err, String(err))
       toast.error(t("exports:errors.deleteFailed", { error: message }))
+    }
+  }
+
+  async function onDownload() {
+    if (!exp) return
+    try {
+      await downloadMutation.mutateAsync(exp.id)
+    } catch (err) {
+      toast.error(t("exports:errors.downloadFailed", { error: parseServerError(err, String(err)) }))
     }
   }
 
@@ -112,15 +126,18 @@ export function ExportDetailPage() {
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <Button
-            asChild
+            type="button"
             variant="outline"
-            disabled={!isTerminal || !isCompleted || isDeleted || !downloadHref}
-            aria-disabled={!isTerminal || !isCompleted || isDeleted || !downloadHref}
+            onClick={onDownload}
+            disabled={!isTerminal || !isCompleted || isDeleted || downloadMutation.isPending}
+            data-testid="export-detail-download"
           >
-            <a href={downloadHref ?? "#"} data-testid="export-detail-download">
+            {downloadMutation.isPending ? (
+              <Loader2 className="mr-1.5 size-4 animate-spin" aria-hidden="true" />
+            ) : (
               <Download className="mr-1.5 size-4" aria-hidden="true" />
-              {t("exports:actions.download")}
-            </a>
+            )}
+            {t("exports:actions.download")}
           </Button>
           <Button
             asChild

--- a/frontend/src/pages/exports/ExportsListPage.tsx
+++ b/frontend/src/pages/exports/ExportsListPage.tsx
@@ -179,7 +179,6 @@ export function ExportsListPage() {
               <ExportRow
                 export={exp}
                 detailHref={exportUrl(slug, exp.id)}
-                groupSlug={slug}
                 onDelete={() => onDelete(exp)}
                 onRestore={migrationLock.locked ? undefined : () => setRestoreTarget(exp)}
               />

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -4672,6 +4672,64 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/g/{groupSlug}/exports/{id}/signed-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get signed URL for export download
+         * @description Return a secure HMAC-signed URL for downloading a completed
+         *     export file without putting a JWT in the URL. Minting the URL
+         *     is side-effect-free, so this is a GET available to any group
+         *     member (the same audience as the export download route). The
+         *     signed URL targets the file-download route and is consumed by
+         *     the frontend export-download CTA.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Group slug */
+                    groupSlug: string;
+                    /** @description Export ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Signed URL */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.SignedFileURLResponse"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/g/{groupSlug}/files": {
         parameters: {
             query?: never;

--- a/go/apiserver/exports.go
+++ b/go/apiserver/exports.go
@@ -342,15 +342,17 @@ func (api *exportsAPI) generateExportSignedURL(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Check if export is deleted
+	// Check if export is deleted. Render a JSON:API 404 (not http.NotFound's
+	// plain-text body) so the frontend's JSON http wrapper parses a
+	// structured error instead of throwing on a non-JSON response.
 	if exp.IsDeleted() {
-		http.NotFound(w, r)
+		renderEntityError(w, r, ErrNotFound)
 		return
 	}
 
 	// Only completed exports can be downloaded
 	if exp.Status != models.ExportStatusCompleted {
-		http.NotFound(w, r)
+		renderEntityError(w, r, ErrNotFound)
 		return
 	}
 
@@ -359,7 +361,7 @@ func (api *exportsAPI) generateExportSignedURL(w http.ResponseWriter, r *http.Re
 	// (see go/backup/export/service.go), so a nil FileID here is an old
 	// record that simply cannot be served via a signed URL.
 	if exp.FileID == nil || *exp.FileID == "" {
-		http.NotFound(w, r)
+		renderEntityError(w, r, ErrNotFound)
 		return
 	}
 
@@ -381,7 +383,20 @@ func (api *exportsAPI) generateExportSignedURL(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	signedURL, err := api.fileSigningService.GenerateSignedURL(file.ID, strings.TrimPrefix(file.Ext, "."), user.ID)
+	// GenerateSignedURL requires a non-empty extension purely as a sanity
+	// check — it never appears in the signed path, which keys on the file
+	// ID. Fall back to the original path's extension, then to "xml" (export
+	// artifacts are XML), so minting never 500s on a FileEntity whose Ext
+	// happens to be empty.
+	fileExt := strings.TrimPrefix(file.Ext, ".")
+	if fileExt == "" {
+		fileExt = strings.TrimPrefix(path.Ext(file.OriginalPath), ".")
+	}
+	if fileExt == "" {
+		fileExt = "xml"
+	}
+
+	signedURL, err := api.fileSigningService.GenerateSignedURL(file.ID, fileExt, user.ID)
 	if err != nil {
 		internalServerError(w, r, errxtrace.Wrap("failed to generate signed URL", err))
 		return

--- a/go/apiserver/exports.go
+++ b/go/apiserver/exports.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -31,8 +32,9 @@ func exportFromContext(ctx context.Context) *models.Export {
 }
 
 type exportsAPI struct {
-	uploadLocation string
-	entityService  *services.EntityService
+	uploadLocation     string
+	entityService      *services.EntityService
+	fileSigningService *services.FileSigningService
 }
 
 // listExports lists all exports.
@@ -311,6 +313,86 @@ func (api *exportsAPI) downloadExport(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// generateExportSignedURL returns a signed URL for downloading an export file.
+// @Summary Get signed URL for export download
+// @Description Return a secure HMAC-signed URL for downloading a completed
+// @Description export file without putting a JWT in the URL. Minting the URL
+// @Description is side-effect-free, so this is a GET available to any group
+// @Description member (the same audience as the export download route). The
+// @Description signed URL targets the file-download route and is consumed by
+// @Description the frontend export-download CTA.
+// @Tags exports
+// @Produce json-api
+// @Param groupSlug path string true "Group slug"
+// @Param id path string true "Export ID"
+// @Success 200 {object} jsonapi.SignedFileURLResponse "Signed URL"
+// @Failure 404 {object} jsonapi.Errors "Not Found"
+// @Router /g/{groupSlug}/exports/{id}/signed-url [get].
+func (api *exportsAPI) generateExportSignedURL(w http.ResponseWriter, r *http.Request) {
+	// Get user-aware settings registry from context
+	registrySet := RegistrySetFromContext(r.Context())
+	if registrySet == nil {
+		http.Error(w, "Registry set not found in context", http.StatusInternalServerError)
+		return
+	}
+
+	exp := exportFromContext(r.Context())
+	if exp == nil {
+		unprocessableEntityError(w, r, errors.New("export not found in context"))
+		return
+	}
+
+	// Check if export is deleted
+	if exp.IsDeleted() {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Only completed exports can be downloaded
+	if exp.Status != models.ExportStatusCompleted {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Legacy FilePath-only exports have no FileEntity to sign. Completed
+	// exports produced by the current export service always set FileID
+	// (see go/backup/export/service.go), so a nil FileID here is an old
+	// record that simply cannot be served via a signed URL.
+	if exp.FileID == nil || *exp.FileID == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	user := GetUserFromRequest(r)
+	if user == nil {
+		http.Error(w, "User context required", http.StatusInternalServerError)
+		return
+	}
+
+	// Load the file entity backing the export
+	file, err := registrySet.FileRegistry.Get(r.Context(), *exp.FileID)
+	if err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
+
+	if file.File == nil {
+		renderEntityError(w, r, ErrNotFound)
+		return
+	}
+
+	signedURL, err := api.fileSigningService.GenerateSignedURL(file.ID, strings.TrimPrefix(file.Ext, "."), user.ID)
+	if err != nil {
+		internalServerError(w, r, errxtrace.Wrap("failed to generate signed URL", err))
+		return
+	}
+
+	if err := render.Render(w, r, jsonapi.NewSignedFileURLResponse(file.ID, signedURL)); err != nil {
+		internalServerError(w, r, errxtrace.Wrap("failed to render response", err))
+		return
+	}
+}
+
 // importExport imports an XML export file and creates an export record
 // @Summary Import XML export
 // @Description Import an uploaded XML export file and create an export record
@@ -411,8 +493,9 @@ func exportCtx() func(next http.Handler) http.Handler {
 // Exports sets up the exports API routes.
 func Exports(params Params, restoreStatus RestoreStatusQuerier) func(r chi.Router) {
 	api := &exportsAPI{
-		uploadLocation: params.UploadLocation,
-		entityService:  params.EntityService,
+		uploadLocation:     params.UploadLocation,
+		entityService:      params.EntityService,
+		fileSigningService: services.NewFileSigningService(params.FileSigningKey, params.FileURLExpiration),
 	}
 
 	return func(r chi.Router) {
@@ -425,6 +508,7 @@ func Exports(params Params, restoreStatus RestoreStatusQuerier) func(r chi.Route
 			r.Get("/", api.apiGetExport)
 			r.Delete("/", api.deleteExport)
 			r.Get("/download", api.downloadExport)
+			r.Get("/signed-url", api.generateExportSignedURL)
 			r.Route("/restores", ExportRestores(restoreStatus, params.FeatureCurrencyMigration))
 		})
 	}

--- a/go/apiserver/exports_test.go
+++ b/go/apiserver/exports_test.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/go-chi/chi/v5"
@@ -569,4 +571,242 @@ func TestExportCreate_NonWhitespaceTooLongDescription_Rejects(t *testing.T) {
 
 	c.Assert(w.Code, qt.Equals, http.StatusUnprocessableEntity,
 		qt.Commentf("expected 422 for 501-char description, body: %s", w.Body.String()))
+}
+
+// TestGenerateExportSignedURL covers GET /exports/{id}/signed-url (#1780).
+// The endpoint lets the frontend download a completed export without
+// putting a JWT in the URL: it returns an HMAC-signed URL targeting the
+// file-download route. Minting the URL is a side-effect-free read, so it
+// is a GET (see TestGenerateExportSignedURL_NonAdminMemberAllowed for the
+// authz rationale). Cases: completed export with FileID → 200 + signed
+// URL; deleted, non-completed, and nil-FileID exports → 404.
+func TestGenerateExportSignedURL(t *testing.T) {
+	type setupResult struct {
+		exportID string
+		fileID   string
+	}
+
+	// makeExport seeds a file entity + an export and returns their IDs.
+	// status, deleted and withFile control which 404 branch is exercised.
+	makeExport := func(ctx context.Context, registrySet *registry.Set, status models.ExportStatus, deleted, withFile bool) setupResult {
+		var fileID *string
+		var resolvedFileID string
+		if withFile {
+			file := must.Must(registrySet.FileRegistry.Create(ctx, models.FileEntity{
+				Title: "export-file",
+				Type:  models.FileTypeDocument,
+				File: &models.File{
+					Path:         "exports/export",
+					OriginalPath: "exports/export.xml",
+					Ext:          ".xml",
+					MIMEType:     "application/xml",
+				},
+			}))
+			resolvedFileID = file.ID
+			fileID = &file.ID
+		}
+
+		exp := must.Must(registrySet.ExportRegistry.Create(ctx, models.Export{
+			Type:        models.ExportTypeFullDatabase,
+			Description: "Signed URL test export",
+			Status:      status,
+			FileID:      fileID,
+		}))
+
+		if deleted {
+			must.Assert(registrySet.ExportRegistry.Delete(ctx, exp.ID))
+		}
+
+		return setupResult{exportID: exp.ID, fileID: resolvedFileID}
+	}
+
+	tests := []struct {
+		name           string
+		status         models.ExportStatus
+		deleted        bool
+		withFile       bool
+		expectedStatus int
+	}{
+		{
+			name:           "completed export with file id returns signed url",
+			status:         models.ExportStatusCompleted,
+			withFile:       true,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "deleted export returns 404",
+			status:         models.ExportStatusCompleted,
+			deleted:        true,
+			withFile:       true,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "non-completed export returns 404",
+			status:         models.ExportStatusPending,
+			withFile:       true,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "export with nil file id returns 404",
+			status:         models.ExportStatusCompleted,
+			withFile:       false,
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			factorySet := memory.NewFactorySet()
+
+			testUser := models.User{
+				TenantAwareEntityID: models.TenantAwareEntityID{TenantID: "test-tenant-id"},
+				Email:               "test+signed-url@example.com",
+				Name:                "Test User",
+				IsActive:            true,
+			}
+			must.Assert(testUser.SetPassword("Password123"))
+			createdUser := must.Must(factorySet.UserRegistry.Create(context.Background(), testUser))
+
+			ctx := appctx.WithUser(context.Background(), createdUser)
+			registrySet := must.Must(factorySet.CreateUserRegistrySet(ctx))
+
+			seeded := makeExport(ctx, registrySet, tt.status, tt.deleted, tt.withFile)
+
+			r := chi.NewRouter()
+			r.Use(render.SetContentType(render.ContentTypeJSON))
+			r.Use(apiserver.JWTMiddleware(testJWTSecret, factorySet.UserRegistry, nil))
+			r.Use(apiserver.RegistrySetMiddleware(factorySet))
+
+			params := apiserver.Params{
+				FactorySet:        factorySet,
+				UploadLocation:    "memory://",
+				EntityService:     services.NewEntityService(factorySet, "memory://"),
+				JWTSecret:         testJWTSecret,
+				FileSigningKey:    []byte("test-file-signing-key-32-bytes-minimum"),
+				FileURLExpiration: 15 * time.Minute,
+			}
+			mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+			r.Route("/exports", apiserver.Exports(params, mockRestoreWorker))
+
+			req := httptest.NewRequest("GET", "/exports/"+seeded.exportID+"/signed-url", nil)
+			addTestUserAuthHeader(req, createdUser.ID)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			c.Assert(w.Code, qt.Equals, tt.expectedStatus,
+				qt.Commentf("body: %s", w.Body.String()))
+
+			if tt.expectedStatus != http.StatusOK {
+				return
+			}
+
+			var response jsonapi.SignedFileURLResponse
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			c.Assert(err, qt.IsNil)
+
+			c.Assert(response.ID, qt.Equals, seeded.fileID)
+			c.Assert(response.Attributes.URL, qt.Not(qt.Equals), "")
+
+			parsed, err := url.Parse(response.Attributes.URL)
+			c.Assert(err, qt.IsNil)
+			c.Assert(parsed.Path, qt.Equals, "/api/v1/files/download/files/"+seeded.fileID)
+
+			query := parsed.Query()
+			c.Assert(query.Get("sig"), qt.Not(qt.Equals), "")
+			c.Assert(query.Get("exp"), qt.Not(qt.Equals), "")
+			c.Assert(query.Get("uid"), qt.Equals, createdUser.ID)
+			c.Assert(query.Get("fid"), qt.Equals, seeded.fileID)
+		})
+	}
+}
+
+// TestGenerateExportSignedURL_NonAdminMemberAllowed is the #1780 authz
+// regression test. The /exports router is mounted behind the
+// method-conditional structuralWriteGate (requireGroupRoleForWrite with
+// GroupRoleAdmin): non-GET requests require admin, GET/HEAD/OPTIONS fall
+// through to any group member. The signed-url endpoint is a GET precisely
+// so a non-admin member can still obtain an export download URL — the same
+// audience as GET /exports/{id}/download.
+//
+// This runs against the full apiserver.APIServer router (not a hand-wired
+// sub-router) so the structuralWriteGate is genuinely in the chain. The
+// test asserts both directions:
+//   - a non-admin member gets 200 from GET /exports/{id}/signed-url; and
+//   - the same member gets 403 from POST /exports, proving the gate is
+//     actually mounted and the 200 above is meaningful, not a gate bypass.
+func TestGenerateExportSignedURL_NonAdminMemberAllowed(t *testing.T) {
+	c := qt.New(t)
+
+	params, _, testGroup := newParams()
+
+	// Create a second user and add them to the group as a non-admin
+	// (viewer) member — the audience the regression locked out.
+	tenantID := testGroup.TenantID
+	memberTemplate := models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		Email:               "viewer+signed-url@example.com",
+		Name:                "Viewer Member",
+		IsActive:            true,
+	}
+	must.Assert(memberTemplate.SetPassword("Password123"))
+	memberUser := must.Must(params.FactorySet.UserRegistry.Create(context.Background(), memberTemplate))
+	must.Must(params.FactorySet.GroupMembershipRegistry.Create(context.Background(), models.GroupMembership{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID},
+		GroupID:             testGroup.ID,
+		MemberUserID:        memberUser.ID,
+		Role:                models.GroupRoleViewer,
+	}))
+
+	// Seed a completed export with a backing file entity, scoped to the
+	// group, using a registry set bound to the member's user+group ctx.
+	ctx := createTestUserContextWithGroup(memberUser.ID, tenantID, testGroup.ID)
+	rs := must.Must(params.FactorySet.CreateUserRegistrySet(ctx))
+	file := must.Must(rs.FileRegistry.Create(ctx, models.FileEntity{
+		Title: "export-file",
+		Type:  models.FileTypeDocument,
+		File: &models.File{
+			Path:         "exports/export",
+			OriginalPath: "exports/export.xml",
+			Ext:          ".xml",
+			MIMEType:     "application/xml",
+		},
+	}))
+	exp := must.Must(rs.ExportRegistry.Create(ctx, models.Export{
+		Type:        models.ExportTypeFullDatabase,
+		Description: "Signed URL test export",
+		Status:      models.ExportStatusCompleted,
+		FileID:      &file.ID,
+	}))
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// The non-admin member can mint a signed URL via the GET endpoint.
+	rr := doJSONAPIRequest(t, handler, http.MethodGet,
+		"/api/v1/g/"+testGroup.Slug+"/exports/"+exp.ID+"/signed-url", memberUser.ID, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK,
+		qt.Commentf("non-admin member must reach the signed-url GET; body: %s", rr.Body.String()))
+
+	var response jsonapi.SignedFileURLResponse
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &response), qt.IsNil)
+	c.Assert(response.ID, qt.Equals, file.ID)
+	c.Assert(response.Attributes.URL, qt.Not(qt.Equals), "")
+
+	// Proof the structuralWriteGate is actually in the chain: the same
+	// non-admin member is blocked (403) from a genuine write on the
+	// gated /exports router. If this were 200/201 the test above would
+	// be meaningless (gate not mounted).
+	rr = doJSONAPIRequest(t, handler, http.MethodPost,
+		"/api/v1/g/"+testGroup.Slug+"/exports", memberUser.ID, map[string]any{
+			"data": map[string]any{
+				"type": "exports",
+				"attributes": map[string]any{
+					"type":        string(models.ExportTypeFullDatabase),
+					"description": "should be blocked for non-admin",
+				},
+			},
+		})
+	c.Assert(rr.Code, qt.Equals, http.StatusForbidden,
+		qt.Commentf("non-admin member must be blocked by structuralWriteGate on POST /exports; body: %s", rr.Body.String()))
 }

--- a/go/apiserver/jwt_middleware.go
+++ b/go/apiserver/jwt_middleware.go
@@ -17,22 +17,21 @@ import (
 	"github.com/denisvmedia/inventario/services"
 )
 
-// extractTokenFromRequest extracts JWT token from Authorization header or query parameter
+// extractTokenFromRequest extracts the JWT token from the Authorization
+// Bearer header. The token is taken ONLY from the header — a previously
+// supported `?token=` query-parameter fallback was removed (#1780) because
+// full-scope access tokens in URLs leak via Referer headers, proxy/access
+// logs and browser history. Genuine browser file/thumbnail downloads use
+// HMAC-signed URLs (SignedURLMiddleware), not JWTs.
 func extractTokenFromRequest(r *http.Request) (string, error) {
-	// Try to get token from Authorization header first
 	authHeader := r.Header.Get("Authorization")
-	if authHeader != "" {
-		tokenString := strings.TrimPrefix(authHeader, "Bearer ")
-		if tokenString == authHeader {
-			return "", fmt.Errorf("bearer token required")
-		}
-		return tokenString, nil
+	if authHeader == "" {
+		return "", fmt.Errorf("authorization header required")
 	}
 
-	// If no Authorization header, try to get token from query parameter
-	tokenString := r.URL.Query().Get("token")
-	if tokenString == "" {
-		return "", fmt.Errorf("authorization header or token query parameter required")
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+	if tokenString == authHeader {
+		return "", fmt.Errorf("bearer token required")
 	}
 	return tokenString, nil
 }
@@ -88,7 +87,7 @@ func validateJWTToken(ctx context.Context, tokenString string, jwtSecret []byte,
 	//
 	// Everything else — a missing token_type, the mfa_challenge type, or
 	// any future special-purpose JWT — is rejected, which makes
-	// JWTMiddleware / FileAccessMiddleware respond 401.
+	// JWTMiddleware respond 401.
 	tokenType, _ := claims["token_type"].(string)
 	imp, _ := claims["imp"].(bool)
 	if tokenType != accessTokenType && !imp {
@@ -230,11 +229,5 @@ func JWTMiddleware(jwtSecret []byte, userRegistry registry.UserRegistry, blackli
 
 // RequireAuth is an alias for JWTMiddleware.
 func RequireAuth(jwtSecret []byte, userRegistry registry.UserRegistry, blacklist services.TokenBlacklister) func(http.Handler) http.Handler {
-	return JWTMiddleware(jwtSecret, userRegistry, blacklist)
-}
-
-// FileAccessMiddleware creates middleware specifically for file access that supports both
-// Authorization header and query parameter authentication for direct browser access.
-func FileAccessMiddleware(jwtSecret []byte, userRegistry registry.UserRegistry, blacklist services.TokenBlacklister) func(http.Handler) http.Handler {
 	return JWTMiddleware(jwtSecret, userRegistry, blacklist)
 }

--- a/go/apiserver/jwt_middleware_test.go
+++ b/go/apiserver/jwt_middleware_test.go
@@ -261,6 +261,21 @@ func TestJWTMiddleware(t *testing.T) {
 			},
 			expectedStatus: http.StatusUnauthorized,
 		},
+		{
+			// #1780 regression test: a valid access token passed via the
+			// `?token=` query parameter (with NO Authorization header) must
+			// be rejected. The query-parameter fallback was removed because
+			// full-scope JWTs in URLs leak via Referer headers, proxy/access
+			// logs and browser history.
+			name: "valid token via ?token= query param without header is rejected",
+			setupRequest: func(req *http.Request) {
+				token := createToken("user-123")
+				q := req.URL.Query()
+				q.Set("token", token)
+				req.URL.RawQuery = q.Encode()
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
 	}
 
 	// Test successful authentication cases
@@ -325,6 +340,68 @@ func TestJWTMiddleware(t *testing.T) {
 			c.Assert(resp.Code, qt.Equals, tt.expectedStatus)
 		})
 	}
+}
+
+// TestJWTMiddleware_QueryParamTokenRejected is a focused #1780 regression
+// test: it asserts that a valid access token supplied ONLY via the
+// `?token=` query parameter is rejected with 401, while the same token in
+// the Authorization Bearer header is still accepted.
+func TestJWTMiddleware_QueryParamTokenRejected(t *testing.T) {
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+
+	testUser := &models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "user-123"},
+			TenantID: "test-tenant-id",
+		},
+		Email:    "test@example.com",
+		Name:     "Test User",
+		IsActive: true,
+	}
+
+	userRegistry := &mockUserRegistryForAuth{
+		users: map[string]*models.User{"user-123": testUser},
+	}
+
+	createToken := func(userID string) string {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"user_id":    userID,
+			"role":       "user",
+			"token_type": "access",
+			"exp":        time.Now().Add(24 * time.Hour).Unix(),
+		})
+		tokenString, _ := token.SignedString(jwtSecret)
+		return tokenString
+	}
+
+	middleware := apiserver.JWTMiddleware(jwtSecret, userRegistry, nil)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	wrappedHandler := middleware(handler)
+
+	t.Run("token via query param without Authorization header is rejected", func(t *testing.T) {
+		c := qt.New(t)
+
+		token := createToken("user-123")
+		req := httptest.NewRequest("GET", "/test?token="+token, nil)
+		resp := httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(resp, req)
+
+		c.Assert(resp.Code, qt.Equals, http.StatusUnauthorized)
+	})
+
+	t.Run("token via Authorization header still works", func(t *testing.T) {
+		c := qt.New(t)
+
+		token := createToken("user-123")
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(resp, req)
+
+		c.Assert(resp.Code, qt.Equals, http.StatusOK)
+	})
 }
 
 func TestRequireAuth(t *testing.T) {

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -4099,6 +4099,48 @@ const docTemplate = `{
                 }
             }
         },
+        "/g/{groupSlug}/exports/{id}/signed-url": {
+            "get": {
+                "description": "Return a secure HMAC-signed URL for downloading a completed\nexport file without putting a JWT in the URL. Minting the URL\nis side-effect-free, so this is a GET available to any group\nmember (the same audience as the export download route). The\nsigned URL targets the file-download route and is consumed by\nthe frontend export-download CTA.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Get signed URL for export download",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Signed URL",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.SignedFileURLResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/g/{groupSlug}/files": {
             "get": {
                 "description": "get files with optional filtering",

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -4092,6 +4092,48 @@
                 }
             }
         },
+        "/g/{groupSlug}/exports/{id}/signed-url": {
+            "get": {
+                "description": "Return a secure HMAC-signed URL for downloading a completed\nexport file without putting a JWT in the URL. Minting the URL\nis side-effect-free, so this is a GET available to any group\nmember (the same audience as the export download route). The\nsigned URL targets the file-download route and is consumed by\nthe frontend export-download CTA.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "exports"
+                ],
+                "summary": "Get signed URL for export download",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group slug",
+                        "name": "groupSlug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Export ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Signed URL",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.SignedFileURLResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/g/{groupSlug}/files": {
             "get": {
                 "description": "get files with optional filtering",

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -6953,6 +6953,40 @@ paths:
       summary: Get export restore operation
       tags:
       - exports
+  /g/{groupSlug}/exports/{id}/signed-url:
+    get:
+      description: |-
+        Return a secure HMAC-signed URL for downloading a completed
+        export file without putting a JWT in the URL. Minting the URL
+        is side-effect-free, so this is a GET available to any group
+        member (the same audience as the export download route). The
+        signed URL targets the file-download route and is consumed by
+        the frontend export-download CTA.
+      parameters:
+      - description: Group slug
+        in: path
+        name: groupSlug
+        required: true
+        type: string
+      - description: Export ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: Signed URL
+          schema:
+            $ref: '#/definitions/jsonapi.SignedFileURLResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Get signed URL for export download
+      tags:
+      - exports
   /g/{groupSlug}/exports/import:
     post:
       consumes:


### PR DESCRIPTION
## Summary

Fixes #1780. The full-scope session access-token JWT was both **accepted** by the backend from a `?token=` URL query parameter and **emitted** by the frontend export-download CTA into a live `<a href>`. Full-scope JWTs in URLs leak via `Referer` headers, proxy/access logs and browser history — any holder of the leaked token can call the tenant API as the victim until it expires.

## Changes

### Backend
- `extractTokenFromRequest` now reads the JWT **only** from the `Authorization: Bearer` header. The `?token=` query-parameter fallback is removed, so every authenticated route rejects tokens supplied in the URL.
- Removed the unused `FileAccessMiddleware` alias — its sole purpose was query-parameter auth, which no longer exists.
- Added `GET /g/{groupSlug}/exports/{id}/signed-url`, which mints a short-lived, single-purpose HMAC-signed download URL (the existing `FileSigningService` / `SignedURLMiddleware` machinery) for a completed export. It is a `GET` because minting the URL is side-effect-free — which also keeps export downloads available to **every group member**, matching the pre-existing `GET /download` audience (the group write gate is admin-only for non-GET methods).

### Frontend
- The export-download CTA is now a button: on click it requests a signed URL via an authenticated call, then triggers a native browser download of that URL. No session token ever appears in the URL, `Referer`, or browser history.

### Generated
- Regenerated swagger docs (`go/docs/*`) and frontend API types (`frontend/src/types/api.d.ts`).

## Security posture

The minted signed URL carries only `fid` / `uid` / `exp` / HMAC `sig` — no session JWT. It is short-TTL, single-purpose (downloads exactly one file for one user within one expiry window), and validated by `SignedURLMiddleware`, which independently re-checks tenant ownership. Leaking it exposes at most a time-boxed download of an already-owned export file, not API access.

The existing `GET /download` route is unchanged; it simply no longer accepts `?token=` (it still works with an `Authorization` header).

## Notes

- Completed exports created by the current export/import services always set `FileID`, so the new endpoint serves them. A legacy completed export with a nil `FileID` (predating the file-entity system) returns `404` from `/signed-url`; the unchanged `GET /download` route still serves such records via its `FilePath` fallback.
- The remaining `?token=` query parameters in the codebase (email verification, password reset, invites) are distinct single-use non-JWT tokens and are unaffected.

## Testing

- Backend: `go test ./apiserver/...` green, including new `TestGenerateExportSignedURL` (200 / 404 cases), `TestGenerateExportSignedURL_NonAdminMemberAllowed` (a non-admin group member can mint a download URL), and a `?token=`-rejection regression test in `jwt_middleware_test.go`. `golangci-lint` / `nolintguard` / `qtlint` clean.
- Frontend: `tsc`, `eslint`, `vitest` (export feature/page/component suites) and `codegen:check` all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-minted signed download URLs for exports; UI download controls now use a download action, show a spinner while in-flight, and disable appropriately

* **Security Improvements**
  * JWTs are accepted only via the Authorization header (query-parameter tokens rejected)

* **Bug Fixes**
  * Download failures surface translated toast errors

* **Tests**
  * Added tests for signed-URL behavior and JWT query-param rejection

* **Documentation**
  * OpenAPI/docs updated to include the signed URL endpoint

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->