### PR TITLE
[#1002] Add tests for EmailVerificationRegistry (memory and PostgreSQL)

### DIFF
--- a/go/registry/memory/email_verifications_test.go
+++ b/go/registry/memory/email_verifications_test.go
@@ -1,0 +1,220 @@
+package memory_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+// newTestEmailVerification builds a valid EmailVerification with the given
+// token. The memory backend has no FK constraints, so the tenant/user IDs are
+// arbitrary — but realistic values keep the tests readable.
+func newTestEmailVerification(token string) models.EmailVerification {
+	return models.EmailVerification{
+		UserID:    "user-1",
+		TenantID:  "tenant-1",
+		Email:     "user@example.com",
+		Token:     token,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+}
+
+func TestEmailVerificationRegistry_Create_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	created, err := r.Create(ctx, newTestEmailVerification("token-happy"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created, qt.IsNotNil)
+	c.Assert(created.ID, qt.Not(qt.Equals), "")
+	c.Assert(created.UUID, qt.Not(qt.Equals), "")
+	c.Assert(created.Token, qt.Equals, "token-happy")
+	c.Assert(created.CreatedAt.IsZero(), qt.IsFalse)
+}
+
+func TestEmailVerificationRegistry_Create_MissingFields(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		mut  func(*models.EmailVerification)
+	}{
+		{"user_id empty", func(ev *models.EmailVerification) { ev.UserID = "" }},
+		{"tenant_id empty", func(ev *models.EmailVerification) { ev.TenantID = "" }},
+		{"token empty", func(ev *models.EmailVerification) { ev.Token = "" }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			r := memory.NewEmailVerificationRegistry()
+			ev := newTestEmailVerification("token-missing")
+			tc.mut(&ev)
+			_, err := r.Create(ctx, ev)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(errors.Is(err, registry.ErrFieldRequired), qt.IsTrue)
+		})
+	}
+}
+
+func TestEmailVerificationRegistry_Get(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	created, err := r.Create(ctx, newTestEmailVerification("token-get"))
+	c.Assert(err, qt.IsNil)
+
+	fetched, err := r.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.ID, qt.Equals, created.ID)
+	c.Assert(fetched.Token, qt.Equals, "token-get")
+}
+
+func TestEmailVerificationRegistry_Get_NotFound(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	_, err := r.Get(ctx, "no-such-id")
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
+func TestEmailVerificationRegistry_List(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	_, err := r.Create(ctx, newTestEmailVerification("token-list-1"))
+	c.Assert(err, qt.IsNil)
+	_, err = r.Create(ctx, newTestEmailVerification("token-list-2"))
+	c.Assert(err, qt.IsNil)
+
+	all, err := r.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(all, qt.HasLen, 2)
+}
+
+func TestEmailVerificationRegistry_GetByToken(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	created, err := r.Create(ctx, newTestEmailVerification("token-by-token"))
+	c.Assert(err, qt.IsNil)
+
+	fetched, err := r.GetByToken(ctx, "token-by-token")
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.ID, qt.Equals, created.ID)
+
+	_, err = r.GetByToken(ctx, "missing-token")
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
+func TestEmailVerificationRegistry_GetByUserID(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	ev := newTestEmailVerification("token-by-user")
+	ev.UserID = "user-target"
+	_, err := r.Create(ctx, ev)
+	c.Assert(err, qt.IsNil)
+
+	found, err := r.GetByUserID(ctx, "user-target")
+	c.Assert(err, qt.IsNil)
+	c.Assert(found, qt.HasLen, 1)
+	c.Assert(found[0].UserID, qt.Equals, "user-target")
+
+	empty, err := r.GetByUserID(ctx, "user-unknown")
+	c.Assert(err, qt.IsNil)
+	c.Assert(empty, qt.HasLen, 0)
+}
+
+func TestEmailVerificationRegistry_Update(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	created, err := r.Create(ctx, newTestEmailVerification("token-update"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.VerifiedAt, qt.IsNil)
+
+	verifiedAt := time.Now()
+	created.VerifiedAt = &verifiedAt
+	_, err = r.Update(ctx, *created)
+	c.Assert(err, qt.IsNil)
+
+	reloaded, err := r.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(reloaded.VerifiedAt, qt.IsNotNil)
+	c.Assert(reloaded.IsVerified(), qt.IsTrue)
+}
+
+func TestEmailVerificationRegistry_Delete(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	created, err := r.Create(ctx, newTestEmailVerification("token-delete"))
+	c.Assert(err, qt.IsNil)
+
+	err = r.Delete(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+
+	_, err = r.Get(ctx, created.ID)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
+// TestEmailVerificationRegistry_DeleteExpired pins that DeleteExpired removes
+// only records whose ExpiresAt is in the past and keeps future-dated ones.
+func TestEmailVerificationRegistry_DeleteExpired(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	expired := newTestEmailVerification("token-expired")
+	expired.ExpiresAt = time.Now().Add(-1 * time.Hour)
+	_, err := r.Create(ctx, expired)
+	c.Assert(err, qt.IsNil)
+
+	future := newTestEmailVerification("token-future")
+	future.ExpiresAt = time.Now().Add(1 * time.Hour)
+	futureCreated, err := r.Create(ctx, future)
+	c.Assert(err, qt.IsNil)
+
+	err = r.DeleteExpired(ctx)
+	c.Assert(err, qt.IsNil)
+
+	all, err := r.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(all, qt.HasLen, 1)
+	c.Assert(all[0].ID, qt.Equals, futureCreated.ID)
+}
+
+func TestEmailVerificationRegistry_Count(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	count, err := r.Count(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+
+	_, err = r.Create(ctx, newTestEmailVerification("token-count-1"))
+	c.Assert(err, qt.IsNil)
+	_, err = r.Create(ctx, newTestEmailVerification("token-count-2"))
+	c.Assert(err, qt.IsNil)
+
+	count, err = r.Count(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 2)
+}

--- a/go/registry/postgres/email_verifications_test.go
+++ b/go/registry/postgres/email_verifications_test.go
@@ -15,8 +15,9 @@ import (
 // newTestEmailVerification builds a valid EmailVerification for the postgres
 // backend. The user/tenant IDs must reference real rows (FK constraints
 // fk_email_verification_user / fk_email_verification_tenant), and token must be
-// unique per record (UNIQUE index). UUID is left empty so the DB default
-// (gen_random_uuid()) fills it.
+// unique per record (UNIQUE index). UUID is left empty so the registry layer
+// fills it: store.NonRLSRepository.Create generates one server-side, with the
+// DB gen_random_uuid() default as a fallback.
 func newTestEmailVerification(user *models.User, token string) models.EmailVerification {
 	return models.EmailVerification{
 		UserID:    user.ID,

--- a/go/registry/postgres/email_verifications_test.go
+++ b/go/registry/postgres/email_verifications_test.go
@@ -1,0 +1,252 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// newTestEmailVerification builds a valid EmailVerification for the postgres
+// backend. The user/tenant IDs must reference real rows (FK constraints
+// fk_email_verification_user / fk_email_verification_tenant), and token must be
+// unique per record (UNIQUE index). UUID is left empty so the DB default
+// (gen_random_uuid()) fills it.
+func newTestEmailVerification(user *models.User, token string) models.EmailVerification {
+	return models.EmailVerification{
+		UserID:    user.ID,
+		TenantID:  user.TenantID,
+		Email:     "verify@test-org.com",
+		Token:     token,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+}
+
+func TestEmailVerificationRegistry_Create_HappyPath(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	created, err := registrySet.EmailVerificationRegistry.Create(ctx, newTestEmailVerification(user, "token-happy"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created, qt.IsNotNil)
+	c.Assert(created.ID, qt.Not(qt.Equals), "")
+	c.Assert(created.UUID, qt.Not(qt.Equals), "")
+	c.Assert(created.Token, qt.Equals, "token-happy")
+	c.Assert(created.CreatedAt.IsZero(), qt.IsFalse)
+}
+
+func TestEmailVerificationRegistry_Create_MissingFields(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	cases := []struct {
+		name string
+		mut  func(*models.EmailVerification)
+	}{
+		{"user_id empty", func(ev *models.EmailVerification) { ev.UserID = "" }},
+		{"tenant_id empty", func(ev *models.EmailVerification) { ev.TenantID = "" }},
+		{"token empty", func(ev *models.EmailVerification) { ev.Token = "" }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			ev := newTestEmailVerification(user, "token-missing")
+			tc.mut(&ev)
+			_, err := registrySet.EmailVerificationRegistry.Create(ctx, ev)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(errors.Is(err, registry.ErrFieldRequired), qt.IsTrue)
+		})
+	}
+}
+
+func TestEmailVerificationRegistry_Get(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	created, err := registrySet.EmailVerificationRegistry.Create(ctx, newTestEmailVerification(user, "token-get"))
+	c.Assert(err, qt.IsNil)
+
+	fetched, err := registrySet.EmailVerificationRegistry.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.ID, qt.Equals, created.ID)
+	c.Assert(fetched.Token, qt.Equals, "token-get")
+}
+
+func TestEmailVerificationRegistry_Get_NotFound(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	_, err := registrySet.EmailVerificationRegistry.Get(ctx, "no-such-id")
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
+func TestEmailVerificationRegistry_List(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	_, err := registrySet.EmailVerificationRegistry.Create(ctx, newTestEmailVerification(user, "token-list-1"))
+	c.Assert(err, qt.IsNil)
+	_, err = registrySet.EmailVerificationRegistry.Create(ctx, newTestEmailVerification(user, "token-list-2"))
+	c.Assert(err, qt.IsNil)
+
+	all, err := registrySet.EmailVerificationRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(all, qt.HasLen, 2)
+}
+
+func TestEmailVerificationRegistry_GetByToken(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	created, err := registrySet.EmailVerificationRegistry.Create(ctx, newTestEmailVerification(user, "token-by-token"))
+	c.Assert(err, qt.IsNil)
+
+	fetched, err := registrySet.EmailVerificationRegistry.GetByToken(ctx, "token-by-token")
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.ID, qt.Equals, created.ID)
+
+	_, err = registrySet.EmailVerificationRegistry.GetByToken(ctx, "missing-token")
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
+func TestEmailVerificationRegistry_GetByUserID(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	_, err := registrySet.EmailVerificationRegistry.Create(ctx, newTestEmailVerification(user, "token-by-user"))
+	c.Assert(err, qt.IsNil)
+
+	found, err := registrySet.EmailVerificationRegistry.GetByUserID(ctx, user.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(found, qt.HasLen, 1)
+	c.Assert(found[0].UserID, qt.Equals, user.ID)
+
+	empty, err := registrySet.EmailVerificationRegistry.GetByUserID(ctx, "user-unknown")
+	c.Assert(err, qt.IsNil)
+	c.Assert(empty, qt.HasLen, 0)
+}
+
+func TestEmailVerificationRegistry_Update(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	created, err := registrySet.EmailVerificationRegistry.Create(ctx, newTestEmailVerification(user, "token-update"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.VerifiedAt, qt.IsNil)
+
+	verifiedAt := time.Now()
+	created.VerifiedAt = &verifiedAt
+	_, err = registrySet.EmailVerificationRegistry.Update(ctx, *created)
+	c.Assert(err, qt.IsNil)
+
+	reloaded, err := registrySet.EmailVerificationRegistry.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(reloaded.VerifiedAt, qt.IsNotNil)
+	c.Assert(reloaded.IsVerified(), qt.IsTrue)
+}
+
+func TestEmailVerificationRegistry_Delete(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	created, err := registrySet.EmailVerificationRegistry.Create(ctx, newTestEmailVerification(user, "token-delete"))
+	c.Assert(err, qt.IsNil)
+
+	err = registrySet.EmailVerificationRegistry.Delete(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+
+	_, err = registrySet.EmailVerificationRegistry.Get(ctx, created.ID)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
+// TestEmailVerificationRegistry_DeleteExpired pins that DeleteExpired removes
+// only records whose ExpiresAt is in the past and keeps future-dated ones.
+func TestEmailVerificationRegistry_DeleteExpired(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	expired := newTestEmailVerification(user, "token-expired")
+	expired.ExpiresAt = time.Now().Add(-1 * time.Hour)
+	_, err := registrySet.EmailVerificationRegistry.Create(ctx, expired)
+	c.Assert(err, qt.IsNil)
+
+	future := newTestEmailVerification(user, "token-future")
+	future.ExpiresAt = time.Now().Add(1 * time.Hour)
+	futureCreated, err := registrySet.EmailVerificationRegistry.Create(ctx, future)
+	c.Assert(err, qt.IsNil)
+
+	err = registrySet.EmailVerificationRegistry.DeleteExpired(ctx)
+	c.Assert(err, qt.IsNil)
+
+	all, err := registrySet.EmailVerificationRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(all, qt.HasLen, 1)
+	c.Assert(all[0].ID, qt.Equals, futureCreated.ID)
+}
+
+func TestEmailVerificationRegistry_Count(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	count, err := registrySet.EmailVerificationRegistry.Count(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+
+	_, err = registrySet.EmailVerificationRegistry.Create(ctx, newTestEmailVerification(user, "token-count-1"))
+	c.Assert(err, qt.IsNil)
+	_, err = registrySet.EmailVerificationRegistry.Create(ctx, newTestEmailVerification(user, "token-count-2"))
+	c.Assert(err, qt.IsNil)
+
+	count, err = registrySet.EmailVerificationRegistry.Count(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 2)
+}


### PR DESCRIPTION
## Summary

Adds unit/integration tests for `EmailVerificationRegistry`, which had no
coverage for either implementation introduced by PR #1001.

- `go/registry/memory/email_verifications_test.go`
- `go/registry/postgres/email_verifications_test.go`

## Coverage

Table-driven tests (`frankban/quicktest`) covering both the memory and
PostgreSQL implementations:

- `Create` — happy path; missing `UserID` / `TenantID` / `Token` return `ErrFieldRequired`
- `Get` / `List` — basic retrieval; unknown ID returns `ErrNotFound`
- `GetByToken` — found; not found returns `ErrNotFound`
- `GetByUserID` — found; empty result for an unknown user
- `Update` — marks the record verified (`VerifiedAt`) and confirms it persisted
- `Delete` — removes the record
- `DeleteExpired` — removes only past-dated records, keeps future-dated ones
- `Count` — count before and after inserts

## Notes

- PostgreSQL tests skip when `POSTGRES_TEST_DSN` is unset, following the
  existing `skipIfNoPostgreSQL` pattern; the postgres CI job runs them
  against a real database.
- PostgreSQL tests use the seeded tenant/user from `getTestUser` so the
  `fk_email_verification_user` / `fk_email_verification_tenant` foreign keys
  are satisfied, and each record uses a distinct token to respect the
  `email_verifications_token_idx` unique index.

Closes #1002


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for email verification workflows across storage backends. Covers successful creation and required-field validation, retrieval by ID and token (including not-found cases), listing and counting records, lookup by user, updating verification status, deletion, and expiration-handling to ensure expired entries are removed while future-dated entries remain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->