### PR TITLE
[#1781] Bind signed file URLs to refresh_token session

### DIFF
--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -35,8 +35,11 @@ const (
 	accessTokenType = "access"
 	// refreshTokenExpiration defines how long refresh tokens remain valid.
 	refreshTokenExpiration = 30 * 24 * time.Hour
-	// refreshTokenCookieName is the name of the httpOnly cookie carrying the refresh token.
-	refreshTokenCookieName = "refresh_token"
+	// refreshTokenCookieName is the name of the httpOnly cookie carrying the
+	// refresh token. The canonical constant lives in appctx so other packages
+	// (notably services.ExtractSessionBinding, #1781) can reference the same
+	// string without creating an apiserver import cycle.
+	refreshTokenCookieName = appctx.RefreshTokenCookieName
 	// refreshTokenCookiePath scopes the refresh cookie to the API namespace.
 	//
 	// It is intentionally `/api/v1` — the common ancestor of BOTH the

--- a/go/apiserver/commodities.go
+++ b/go/apiserver/commodities.go
@@ -90,7 +90,7 @@ func (api *commoditiesAPI) listCommodities(w http.ResponseWriter, r *http.Reques
 
 	setPaginationHeaders(w, page, perPage, total)
 
-	covers := api.resolveCoversForList(r.Context(), regSet.FileRegistry, commodities)
+	covers := api.resolveCoversForList(r, regSet.FileRegistry, commodities)
 
 	if err := render.Render(w, r, jsonapi.NewCommoditiesResponseWithCovers(commodities, total, page, perPage, covers)); err != nil {
 		internalServerError(w, r, err)
@@ -102,15 +102,16 @@ func (api *commoditiesAPI) listCommodities(w http.ResponseWriter, r *http.Reques
 // commodities and the per-request user, returning the JSON:API-shaped
 // map that NewCommoditiesResponseWithCovers expects. Returns nil (not an
 // empty map) when no covers resolve so the response shape stays clean.
-func (api *commoditiesAPI) resolveCoversForList(ctx context.Context, fileReg registry.FileRegistry, commodities []*models.Commodity) map[string]jsonapi.CommodityCover {
+func (api *commoditiesAPI) resolveCoversForList(r *http.Request, fileReg registry.FileRegistry, commodities []*models.Commodity) map[string]jsonapi.CommodityCover {
 	if api.coverService == nil || len(commodities) == 0 {
 		return nil
 	}
+	ctx := r.Context()
 	user := appctx.UserFromContext(ctx)
 	if user == nil {
 		return nil
 	}
-	resolved := api.coverService.ResolveMany(ctx, fileReg, commodities, user.ID)
+	resolved := api.coverService.ResolveMany(ctx, fileReg, commodities, user.ID, services.ExtractSessionBinding(r))
 	if len(resolved) == 0 {
 		return nil
 	}
@@ -244,7 +245,7 @@ func (api *commoditiesAPI) getCommodity(w http.ResponseWriter, r *http.Request) 
 	}
 
 	resp := jsonapi.NewCommodityResponse(commodity).WithStatusCode(http.StatusOK)
-	if cover := api.resolveCoverForOne(r.Context(), commodity); cover != nil {
+	if cover := api.resolveCoverForOne(r, commodity); cover != nil {
 		resp = resp.WithCover(cover)
 	}
 
@@ -258,10 +259,11 @@ func (api *commoditiesAPI) getCommodity(w http.ResponseWriter, r *http.Request) 
 // resolveCoversForList. Returns nil when the commodity has no usable
 // photo, or the user context is missing, or signing fails — every path
 // the FE handles via the type-emoji fallback.
-func (api *commoditiesAPI) resolveCoverForOne(ctx context.Context, commodity *models.Commodity) *jsonapi.CommodityCover {
+func (api *commoditiesAPI) resolveCoverForOne(r *http.Request, commodity *models.Commodity) *jsonapi.CommodityCover {
 	if api.coverService == nil || commodity == nil || commodity.ID == "" {
 		return nil
 	}
+	ctx := r.Context()
 	user := appctx.UserFromContext(ctx)
 	if user == nil {
 		return nil
@@ -270,7 +272,7 @@ func (api *commoditiesAPI) resolveCoverForOne(ctx context.Context, commodity *mo
 	if regSet == nil {
 		return nil
 	}
-	cov, ok := api.coverService.ResolveOne(ctx, regSet.FileRegistry, commodity, user.ID)
+	cov, ok := api.coverService.ResolveOne(ctx, regSet.FileRegistry, commodity, user.ID, services.ExtractSessionBinding(r))
 	if !ok {
 		return nil
 	}
@@ -655,7 +657,7 @@ func (api *commoditiesAPI) setCommodityCover(w http.ResponseWriter, r *http.Requ
 	api.eventService.EmitUpdated(r.Context(), commodity, updated)
 
 	resp := jsonapi.NewCommodityResponse(updated).WithStatusCode(http.StatusOK)
-	if cover := api.resolveCoverForOne(r.Context(), updated); cover != nil {
+	if cover := api.resolveCoverForOne(r, updated); cover != nil {
 		resp = resp.WithCover(cover)
 	}
 

--- a/go/apiserver/exports.go
+++ b/go/apiserver/exports.go
@@ -396,7 +396,7 @@ func (api *exportsAPI) generateExportSignedURL(w http.ResponseWriter, r *http.Re
 		fileExt = "xml"
 	}
 
-	signedURL, err := api.fileSigningService.GenerateSignedURL(file.ID, fileExt, user.ID)
+	signedURL, err := api.fileSigningService.GenerateSignedURL(file.ID, fileExt, user.ID, services.ExtractSessionBinding(r))
 	if err != nil {
 		internalServerError(w, r, errxtrace.Wrap("failed to generate signed URL", err))
 		return

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -1,7 +1,6 @@
 package apiserver
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -206,7 +205,7 @@ func (api *filesAPI) listFiles(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Generate signed URLs for all files
-	signedUrls := api.generateSignedURLsForFiles(r.Context(), files)
+	signedUrls := api.generateSignedURLsForFiles(r, files)
 
 	response := jsonapi.NewFilesResponseWithSignedUrls(files, total, signedUrls)
 	if err := render.Render(w, r, response); err != nil {
@@ -230,16 +229,21 @@ func parseLinkedEntityParams(typeParam, idParam string) (linkedType, linkedID *s
 
 // generateSignedURLsForFiles generates signed URLs for a list of files.
 // Returns a map of file ID to URLData with signed URLs and thumbnails. Missing URLs indicate generation failures.
-func (api *filesAPI) generateSignedURLsForFiles(ctx context.Context, files []*models.FileEntity) map[string]jsonapi.URLData {
+//
+// `r` is taken (not just `ctx`) so the per-session binding can be lifted off
+// the refresh_token cookie. URLs minted here will only validate when the
+// same browser session presents the request — see services.ExtractSessionBinding.
+func (api *filesAPI) generateSignedURLsForFiles(r *http.Request, files []*models.FileEntity) map[string]jsonapi.URLData {
 	signedUrls := make(map[string]jsonapi.URLData)
-	user := appctx.UserFromContext(ctx)
+	user := appctx.UserFromContext(r.Context())
 	if user == nil {
 		return signedUrls
 	}
 
+	binding := services.ExtractSessionBinding(r)
 	for _, file := range files {
 		// Generate signed URLs for file and thumbnails
-		originalURL, thumbnails, err := api.fileSigningService.GenerateSignedURLsWithThumbnails(file, user.ID)
+		originalURL, thumbnails, err := api.fileSigningService.GenerateSignedURLsWithThumbnails(file, user.ID, binding)
 		if err != nil {
 			// Log error but don't fail the entire request
 			// The frontend can handle missing URLs gracefully
@@ -381,7 +385,7 @@ func (api *filesAPI) apiGetFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Generate signed URLs for the file
-	signedUrls := api.generateSignedURLsForFiles(r.Context(), []*models.FileEntity{file})
+	signedUrls := api.generateSignedURLsForFiles(r, []*models.FileEntity{file})
 
 	response := jsonapi.NewFileResponseWithSignedUrls(file, signedUrls)
 	if err := render.Render(w, r, response); err != nil {
@@ -557,7 +561,7 @@ func (api *filesAPI) generateSignedURL(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Generate signed URLs for file and thumbnails
-	signedURL, thumbnails, err := api.fileSigningService.GenerateSignedURLsWithThumbnails(file, user.ID)
+	signedURL, thumbnails, err := api.fileSigningService.GenerateSignedURLsWithThumbnails(file, user.ID, services.ExtractSessionBinding(r))
 	if err != nil {
 		internalServerError(w, r, errxtrace.Wrap("failed to generate signed URL", err))
 		return

--- a/go/apiserver/signed_url_middleware.go
+++ b/go/apiserver/signed_url_middleware.go
@@ -29,8 +29,13 @@ func SignedURLMiddleware(
 				return
 			}
 
-			// Validate the signed URL
-			claims, err := fileSigningService.ValidateSignedURL(r.URL.Path, r.URL.Query())
+			// Validate the signed URL. The session binding is derived from
+			// the request's refresh_token cookie; a URL minted with a
+			// binding only validates when the same cookie is presented,
+			// which couples the URL to the browser session that produced
+			// it and prevents replay from a leaked Referer / proxy log.
+			binding := services.ExtractSessionBinding(r)
+			claims, err := fileSigningService.ValidateSignedURL(r.URL.Path, r.URL.Query(), binding)
 			if err != nil {
 				slog.Warn("Invalid signed URL access attempt",
 					"path", r.URL.Path,

--- a/go/apiserver/signed_url_middleware_test.go
+++ b/go/apiserver/signed_url_middleware_test.go
@@ -453,6 +453,7 @@ func TestSignedURLMiddleware_SessionBinding(t *testing.T) {
 
 	// Mint the URL with the binding the live browser would produce.
 	mintReq := httptest.NewRequest(http.MethodGet, "/mint", nil)
+	// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 	mintReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-A"})
 	mintBinding := services.ExtractSessionBinding(mintReq)
 	c.Assert(string(mintBinding), qt.Not(qt.Equals), "")
@@ -465,6 +466,7 @@ func TestSignedURLMiddleware_SessionBinding(t *testing.T) {
 
 	c.Run("same-session cookie succeeds", func(c *qt.C) {
 		req := httptest.NewRequest(http.MethodGet, parsed.Path+"?"+parsed.RawQuery, nil)
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-A"})
 		w := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(w, req)
@@ -482,6 +484,7 @@ func TestSignedURLMiddleware_SessionBinding(t *testing.T) {
 
 	c.Run("different cookie is rejected", func(c *qt.C) {
 		req := httptest.NewRequest(http.MethodGet, parsed.Path+"?"+parsed.RawQuery, nil)
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-B"})
 		w := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(w, req)
@@ -511,6 +514,7 @@ func TestSignedURLMiddleware_SessionBinding(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		req := httptest.NewRequest(http.MethodGet, parsedUnbound.Path+"?"+parsedUnbound.RawQuery, nil)
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-A"})
 		w := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(w, req)

--- a/go/apiserver/signed_url_middleware_test.go
+++ b/go/apiserver/signed_url_middleware_test.go
@@ -216,7 +216,7 @@ func TestSignedURLMiddleware(t *testing.T) {
 	c.Run("valid signed URL", func(c *qt.C) {
 		// Generate a valid signed URL against the seeded file (its ID was
 		// minted by the registry, not the literal "test-file").
-		signedURL, err := fileSigningService.GenerateSignedURL(seededFileID, "pdf", testUser.ID)
+		signedURL, err := fileSigningService.GenerateSignedURL(seededFileID, "pdf", testUser.ID, "")
 		c.Assert(err, qt.IsNil)
 
 		// Parse the URL
@@ -249,7 +249,7 @@ func TestSignedURLMiddleware(t *testing.T) {
 		userRegistry.addUser(inactiveUser)
 
 		// Generate signed URL for inactive user
-		signedURL, err := fileSigningService.GenerateSignedURL("test-file", "pdf", inactiveUser.ID)
+		signedURL, err := fileSigningService.GenerateSignedURL("test-file", "pdf", inactiveUser.ID, "")
 		c.Assert(err, qt.IsNil)
 
 		// Parse the URL
@@ -273,7 +273,7 @@ func TestSignedURLMiddleware(t *testing.T) {
 		shortExpirationService := services.NewFileSigningService(signingKey, 1*time.Nanosecond)
 
 		// Generate signed URL that will expire immediately
-		signedURL, err := shortExpirationService.GenerateSignedURL("test-file", "pdf", testUser.ID)
+		signedURL, err := shortExpirationService.GenerateSignedURL("test-file", "pdf", testUser.ID, "")
 		c.Assert(err, qt.IsNil)
 
 		// Wait for expiration
@@ -297,7 +297,7 @@ func TestSignedURLMiddleware(t *testing.T) {
 
 	c.Run("user not found with valid signature", func(c *qt.C) {
 		// Generate signed URL for non-existent user
-		signedURL, err := fileSigningService.GenerateSignedURL("test-file", "pdf", "non-existent-user")
+		signedURL, err := fileSigningService.GenerateSignedURL("test-file", "pdf", "non-existent-user", "")
 		c.Assert(err, qt.IsNil)
 
 		// Parse the URL
@@ -365,7 +365,7 @@ func TestSignedURLMiddleware_SecurityScenarios(t *testing.T) {
 
 	c.Run("user cannot access file with another user's signature", func(c *qt.C) {
 		// Generate signed URL for user1
-		signedURL, err := fileSigningService.GenerateSignedURL("test-file", "pdf", user1.ID)
+		signedURL, err := fileSigningService.GenerateSignedURL("test-file", "pdf", user1.ID, "")
 		c.Assert(err, qt.IsNil)
 
 		// Parse and modify the URL to use user2's ID
@@ -390,7 +390,7 @@ func TestSignedURLMiddleware_SecurityScenarios(t *testing.T) {
 
 	c.Run("tampering with file ID invalidates signature", func(c *qt.C) {
 		// Generate signed URL for a file
-		signedURL, err := fileSigningService.GenerateSignedURL("original-file", "pdf", user1.ID)
+		signedURL, err := fileSigningService.GenerateSignedURL("original-file", "pdf", user1.ID, "")
 		c.Assert(err, qt.IsNil)
 
 		// Parse the URL
@@ -408,6 +408,112 @@ func TestSignedURLMiddleware_SecurityScenarios(t *testing.T) {
 		wrappedHandler.ServeHTTP(w, req)
 
 		// Should fail due to signature mismatch
+		c.Assert(w.Code, qt.Equals, http.StatusUnauthorized)
+		c.Assert(w.Body.String(), qt.Equals, "Invalid or expired file URL\n")
+	})
+}
+
+// TestSignedURLMiddleware_SessionBinding is the e2e guard for #1781: a URL
+// minted while the caller's refresh_token cookie was present MUST NOT be
+// usable from a request that lacks that cookie (or carries a different
+// one). The cookie does NOT leak via Referer / proxy logs / browser
+// history, so this closes the ~15-minute access window the issue
+// described.
+func TestSignedURLMiddleware_SessionBinding(t *testing.T) {
+	c := qt.New(t)
+
+	signingKey := []byte("test-signing-key-32-bytes-long!!")
+	fileSigningService := services.NewFileSigningService(signingKey, 15*time.Minute)
+	userRegistry := newMockUserRegistry()
+
+	testUser := &models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "binding-user"},
+			TenantID: "binding-tenant",
+		},
+		Email:    "binding@example.com",
+		Name:     "Binding User",
+		IsActive: true,
+	}
+	userRegistry.addUser(testUser)
+
+	fs := memory.NewFactorySet()
+	seededFile, err := fs.FileRegistryFactory.CreateServiceRegistry().Create(context.Background(), models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID: testUser.TenantID,
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	middleware := apiserver.SignedURLMiddleware(fileSigningService, userRegistry, fs.FileRegistryFactory, fs.LocationGroupRegistry)
+	wrappedHandler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	}))
+
+	// Mint the URL with the binding the live browser would produce.
+	mintReq := httptest.NewRequest(http.MethodGet, "/mint", nil)
+	mintReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-A"})
+	mintBinding := services.ExtractSessionBinding(mintReq)
+	c.Assert(string(mintBinding), qt.Not(qt.Equals), "")
+
+	signedURL, err := fileSigningService.GenerateSignedURL(seededFile.ID, "pdf", testUser.ID, mintBinding)
+	c.Assert(err, qt.IsNil)
+
+	parsed, err := url.Parse(signedURL)
+	c.Assert(err, qt.IsNil)
+
+	c.Run("same-session cookie succeeds", func(c *qt.C) {
+		req := httptest.NewRequest(http.MethodGet, parsed.Path+"?"+parsed.RawQuery, nil)
+		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-A"})
+		w := httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(w, req)
+		c.Assert(w.Code, qt.Equals, http.StatusOK)
+		c.Assert(w.Body.String(), qt.Equals, "success")
+	})
+
+	c.Run("missing cookie is rejected", func(c *qt.C) {
+		req := httptest.NewRequest(http.MethodGet, parsed.Path+"?"+parsed.RawQuery, nil)
+		w := httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(w, req)
+		c.Assert(w.Code, qt.Equals, http.StatusUnauthorized)
+		c.Assert(w.Body.String(), qt.Equals, "Invalid or expired file URL\n")
+	})
+
+	c.Run("different cookie is rejected", func(c *qt.C) {
+		req := httptest.NewRequest(http.MethodGet, parsed.Path+"?"+parsed.RawQuery, nil)
+		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-B"})
+		w := httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(w, req)
+		c.Assert(w.Code, qt.Equals, http.StatusUnauthorized)
+		c.Assert(w.Body.String(), qt.Equals, "Invalid or expired file URL\n")
+	})
+
+	c.Run("URL minted without binding still works for unbound caller", func(c *qt.C) {
+		// Back-compat: a tool that mints without a cookie present must
+		// still validate from a caller that also has no cookie. The URL
+		// is no worse than the pre-#1781 behaviour.
+		unbound, err := fileSigningService.GenerateSignedURL(seededFile.ID, "pdf", testUser.ID, "")
+		c.Assert(err, qt.IsNil)
+		parsedUnbound, err := url.Parse(unbound)
+		c.Assert(err, qt.IsNil)
+
+		req := httptest.NewRequest(http.MethodGet, parsedUnbound.Path+"?"+parsedUnbound.RawQuery, nil)
+		w := httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(w, req)
+		c.Assert(w.Code, qt.Equals, http.StatusOK)
+	})
+
+	c.Run("URL minted without binding is rejected for bound caller", func(c *qt.C) {
+		unbound, err := fileSigningService.GenerateSignedURL(seededFile.ID, "pdf", testUser.ID, "")
+		c.Assert(err, qt.IsNil)
+		parsedUnbound, err := url.Parse(unbound)
+		c.Assert(err, qt.IsNil)
+
+		req := httptest.NewRequest(http.MethodGet, parsedUnbound.Path+"?"+parsedUnbound.RawQuery, nil)
+		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-A"})
+		w := httptest.NewRecorder()
+		wrappedHandler.ServeHTTP(w, req)
 		c.Assert(w.Code, qt.Equals, http.StatusUnauthorized)
 		c.Assert(w.Body.String(), qt.Equals, "Invalid or expired file URL\n")
 	})

--- a/go/apiserver/signed_url_middleware_test.go
+++ b/go/apiserver/signed_url_middleware_test.go
@@ -18,6 +18,21 @@ import (
 	"github.com/denisvmedia/inventario/services"
 )
 
+// newTestRefreshCookie builds a refresh_token cookie suitable for binding
+// tests. Mirrors production attributes (HttpOnly + Secure + SameSiteStrict)
+// to keep the fixture aligned and silence gosec G124 without needing
+// //#nosec directives. ExtractSessionBinding only reads Name + Value, so
+// the transport flags do not affect the binding hash.
+func newTestRefreshCookie(value string) *http.Cookie {
+	return &http.Cookie{
+		Name:     appctx.RefreshTokenCookieName,
+		Value:    value,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	}
+}
+
 // mockUserRegistry implements registry.UserRegistry for testing
 type mockUserRegistry struct {
 	users map[string]*models.User
@@ -453,8 +468,7 @@ func TestSignedURLMiddleware_SessionBinding(t *testing.T) {
 
 	// Mint the URL with the binding the live browser would produce.
 	mintReq := httptest.NewRequest(http.MethodGet, "/mint", nil)
-	// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-	mintReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-A"})
+	mintReq.AddCookie(newTestRefreshCookie("session-cookie-A"))
 	mintBinding := services.ExtractSessionBinding(mintReq)
 	c.Assert(string(mintBinding), qt.Not(qt.Equals), "")
 
@@ -466,8 +480,7 @@ func TestSignedURLMiddleware_SessionBinding(t *testing.T) {
 
 	c.Run("same-session cookie succeeds", func(c *qt.C) {
 		req := httptest.NewRequest(http.MethodGet, parsed.Path+"?"+parsed.RawQuery, nil)
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-A"})
+		req.AddCookie(newTestRefreshCookie("session-cookie-A"))
 		w := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(w, req)
 		c.Assert(w.Code, qt.Equals, http.StatusOK)
@@ -484,8 +497,7 @@ func TestSignedURLMiddleware_SessionBinding(t *testing.T) {
 
 	c.Run("different cookie is rejected", func(c *qt.C) {
 		req := httptest.NewRequest(http.MethodGet, parsed.Path+"?"+parsed.RawQuery, nil)
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-B"})
+		req.AddCookie(newTestRefreshCookie("session-cookie-B"))
 		w := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(w, req)
 		c.Assert(w.Code, qt.Equals, http.StatusUnauthorized)
@@ -514,8 +526,7 @@ func TestSignedURLMiddleware_SessionBinding(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		req := httptest.NewRequest(http.MethodGet, parsedUnbound.Path+"?"+parsedUnbound.RawQuery, nil)
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		req.AddCookie(&http.Cookie{Name: "refresh_token", Value: "session-cookie-A"})
+		req.AddCookie(newTestRefreshCookie("session-cookie-A"))
 		w := httptest.NewRecorder()
 		wrappedHandler.ServeHTTP(w, req)
 		c.Assert(w.Code, qt.Equals, http.StatusUnauthorized)

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -157,7 +157,7 @@ func (api *uploadsAPI) handleFileUpload(w http.ResponseWriter, r *http.Request) 
 	api.generateThumbnailInline(r.Context(), createdFile, user.ID)
 
 	// Generate signed URLs with thumbnails for immediate use
-	originalURL, thumbnails, err := api.fileSigningService.GenerateSignedURLsWithThumbnails(createdFile, user.ID)
+	originalURL, thumbnails, err := api.fileSigningService.GenerateSignedURLsWithThumbnails(createdFile, user.ID, services.ExtractSessionBinding(r))
 	if err != nil {
 		// Log error but don't fail the upload - signed URLs are optional
 		slog.Error("Failed to generate signed URLs after upload", "error", err.Error(), "file_id", createdFile.ID)

--- a/go/appctx/auth_cookie.go
+++ b/go/appctx/auth_cookie.go
@@ -1,0 +1,8 @@
+package appctx
+
+// RefreshTokenCookieName is the cookie that carries the refresh token. It
+// lives here (instead of inside apiserver) so other packages — notably
+// services/file_signing_service.go, which derives the signed-URL session
+// binding from this cookie — can reference it without creating an
+// `apiserver` import cycle.
+const RefreshTokenCookieName = "refresh_token"

--- a/go/integration/thumbnail_generation_integration_test.go
+++ b/go/integration/thumbnail_generation_integration_test.go
@@ -161,7 +161,7 @@ func verifySignedURLGeneration(c *qt.C, fileSigningService *services.FileSigning
 	}
 
 	// Test signed URL generation with thumbnails
-	originalURL, thumbnails, err := fileSigningService.GenerateSignedURLsWithThumbnails(fileEntity, "test-user-123")
+	originalURL, thumbnails, err := fileSigningService.GenerateSignedURLsWithThumbnails(fileEntity, "test-user-123", "")
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(originalURL, qt.Not(qt.Equals), "")

--- a/go/services/commodity_cover_service.go
+++ b/go/services/commodity_cover_service.go
@@ -70,7 +70,7 @@ func NewCommodityCoverService(signing *FileSigningService) *CommodityCoverServic
 // Caller must supply the user id used to sign the URLs; an empty userID
 // short-circuits to an empty result because the signed URL would be
 // unverifiable. `binding` couples the produced URLs to the caller's
-// browser session (see services.ExtractSessionBinding).
+// browser session (see ExtractSessionBinding).
 func (s *CommodityCoverService) ResolveMany(ctx context.Context, fileReg registry.FileRegistry, commodities []*models.Commodity, userID string, binding SessionBinding) map[string]ResolvedCover {
 	out := make(map[string]ResolvedCover, len(commodities))
 	if userID == "" || fileReg == nil || len(commodities) == 0 {

--- a/go/services/commodity_cover_service.go
+++ b/go/services/commodity_cover_service.go
@@ -69,8 +69,9 @@ func NewCommodityCoverService(signing *FileSigningService) *CommodityCoverServic
 //
 // Caller must supply the user id used to sign the URLs; an empty userID
 // short-circuits to an empty result because the signed URL would be
-// unverifiable.
-func (s *CommodityCoverService) ResolveMany(ctx context.Context, fileReg registry.FileRegistry, commodities []*models.Commodity, userID string) map[string]ResolvedCover {
+// unverifiable. `binding` couples the produced URLs to the caller's
+// browser session (see services.ExtractSessionBinding).
+func (s *CommodityCoverService) ResolveMany(ctx context.Context, fileReg registry.FileRegistry, commodities []*models.Commodity, userID string, binding SessionBinding) map[string]ResolvedCover {
 	out := make(map[string]ResolvedCover, len(commodities))
 	if userID == "" || fileReg == nil || len(commodities) == 0 {
 		return out
@@ -80,7 +81,7 @@ func (s *CommodityCoverService) ResolveMany(ctx context.Context, fileReg registr
 		if c == nil || c.ID == "" {
 			continue
 		}
-		cover, ok := s.resolveOne(ctx, fileReg, c, userID)
+		cover, ok := s.resolveOne(ctx, fileReg, c, userID, binding)
 		if !ok {
 			continue
 		}
@@ -92,16 +93,16 @@ func (s *CommodityCoverService) ResolveMany(ctx context.Context, fileReg registr
 // ResolveOne is the single-commodity convenience that the GET handler
 // uses. Returns ok=false when no photo is attached or the URL signing
 // fails — callers should fall back to the type emoji.
-func (s *CommodityCoverService) ResolveOne(ctx context.Context, fileReg registry.FileRegistry, commodity *models.Commodity, userID string) (ResolvedCover, bool) {
+func (s *CommodityCoverService) ResolveOne(ctx context.Context, fileReg registry.FileRegistry, commodity *models.Commodity, userID string, binding SessionBinding) (ResolvedCover, bool) {
 	if userID == "" || fileReg == nil || commodity == nil || commodity.ID == "" {
 		return ResolvedCover{}, false
 	}
-	return s.resolveOne(ctx, fileReg, commodity, userID)
+	return s.resolveOne(ctx, fileReg, commodity, userID, binding)
 }
 
-func (s *CommodityCoverService) resolveOne(ctx context.Context, fileReg registry.FileRegistry, commodity *models.Commodity, userID string) (ResolvedCover, bool) {
+func (s *CommodityCoverService) resolveOne(ctx context.Context, fileReg registry.FileRegistry, commodity *models.Commodity, userID string, binding SessionBinding) (ResolvedCover, bool) {
 	if commodity.CoverFileID != nil && *commodity.CoverFileID != "" {
-		if cover, ok := s.signCover(commodity.ID, fetchExplicitCover(ctx, fileReg, commodity.ID, *commodity.CoverFileID), CoverSourceExplicit, userID); ok {
+		if cover, ok := s.signCover(commodity.ID, fetchExplicitCover(ctx, fileReg, commodity.ID, *commodity.CoverFileID), CoverSourceExplicit, userID, binding); ok {
 			return cover, true
 		}
 		// Fall through to first-photo if the override is unusable
@@ -114,18 +115,18 @@ func (s *CommodityCoverService) resolveOne(ctx context.Context, fileReg registry
 	if !ok {
 		return ResolvedCover{}, false
 	}
-	return s.signCover(commodity.ID, first, CoverSourceFirstPhoto, userID)
+	return s.signCover(commodity.ID, first, CoverSourceFirstPhoto, userID, binding)
 }
 
 // signCover builds a ResolvedCover from a file entity by minting signed
 // thumbnail URLs. Returns ok=false on any signing failure or when the
 // file is nil — both treated by callers as "skip and let the FE
 // fallback render the emoji".
-func (s *CommodityCoverService) signCover(commodityID string, file *models.FileEntity, source CoverSource, userID string) (ResolvedCover, bool) {
+func (s *CommodityCoverService) signCover(commodityID string, file *models.FileEntity, source CoverSource, userID string, binding SessionBinding) (ResolvedCover, bool) {
 	if file == nil {
 		return ResolvedCover{}, false
 	}
-	_, thumbnails, err := s.signing.GenerateSignedURLsWithThumbnails(file, userID)
+	_, thumbnails, err := s.signing.GenerateSignedURLsWithThumbnails(file, userID, binding)
 	if err != nil || len(thumbnails) == 0 {
 		return ResolvedCover{}, false
 	}

--- a/go/services/commodity_cover_service_test.go
+++ b/go/services/commodity_cover_service_test.go
@@ -114,7 +114,7 @@ func TestCommodityCoverService_PicksEarliestPhoto(t *testing.T) {
 	signing := services.NewFileSigningService(signingKey32, time.Hour)
 	coverSvc := services.NewCommodityCoverService(signing)
 
-	cov, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRef("commodity-A"), "user-1")
+	cov, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRef("commodity-A"), "user-1", "")
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(cov.FileID, qt.Equals, createdOlder.ID)
 	c.Assert(cov.Source, qt.Equals, services.CoverSourceFirstPhoto)
@@ -132,10 +132,10 @@ func TestCommodityCoverService_AbsentWhenNoPhotos(t *testing.T) {
 	signing := services.NewFileSigningService(signingKey32, time.Hour)
 	coverSvc := services.NewCommodityCoverService(signing)
 
-	_, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRef("commodity-empty"), "user-1")
+	_, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRef("commodity-empty"), "user-1", "")
 	c.Assert(ok, qt.IsFalse)
 
-	resolved := coverSvc.ResolveMany(ctx, fileReg, commodityRefs("commodity-empty"), "user-1")
+	resolved := coverSvc.ResolveMany(ctx, fileReg, commodityRefs("commodity-empty"), "user-1", "")
 	c.Assert(resolved, qt.HasLen, 0)
 }
 
@@ -156,7 +156,7 @@ func TestCommodityCoverService_ResolveMany_PerCommodity(t *testing.T) {
 	signing := services.NewFileSigningService(signingKey32, time.Hour)
 	coverSvc := services.NewCommodityCoverService(signing)
 
-	resolved := coverSvc.ResolveMany(ctx, fileReg, commodityRefs("commodity-A", "commodity-B", "commodity-C"), "user-1")
+	resolved := coverSvc.ResolveMany(ctx, fileReg, commodityRefs("commodity-A", "commodity-B", "commodity-C"), "user-1", "")
 	c.Assert(resolved, qt.HasLen, 2)
 	c.Assert(resolved["commodity-A"].FileID, qt.Equals, aCover.ID)
 	c.Assert(resolved["commodity-B"].FileID, qt.Equals, bCover.ID)
@@ -175,9 +175,9 @@ func TestCommodityCoverService_EmptyUserShortCircuits(t *testing.T) {
 	coverSvc := services.NewCommodityCoverService(signing)
 
 	// Anonymous caller — signing wouldn't produce a verifiable URL anyway.
-	resolved := coverSvc.ResolveMany(ctx, fileReg, commodityRefs("commodity-A"), "")
+	resolved := coverSvc.ResolveMany(ctx, fileReg, commodityRefs("commodity-A"), "", "")
 	c.Assert(resolved, qt.HasLen, 0)
-	_, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRef("commodity-A"), "")
+	_, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRef("commodity-A"), "", "")
 	c.Assert(ok, qt.IsFalse)
 }
 
@@ -195,7 +195,7 @@ func TestCommodityCoverService_SkipsNonImageMetaImages(t *testing.T) {
 	signing := services.NewFileSigningService(signingKey32, time.Hour)
 	coverSvc := services.NewCommodityCoverService(signing)
 
-	_, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRef("commodity-A"), "user-1")
+	_, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRef("commodity-A"), "user-1", "")
 	c.Assert(ok, qt.IsFalse)
 }
 
@@ -212,7 +212,7 @@ func TestCommodityCoverService_ExplicitOverridePreferred(t *testing.T) {
 	coverSvc := services.NewCommodityCoverService(signing)
 
 	// Explicit cover_file_id wins over the otherwise-earlier "older".
-	cov, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRefWithCover("commodity-A", picked.ID), "user-1")
+	cov, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRefWithCover("commodity-A", picked.ID), "user-1", "")
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(cov.FileID, qt.Equals, picked.ID)
 	c.Assert(cov.Source, qt.Equals, services.CoverSourceExplicit)
@@ -232,7 +232,7 @@ func TestCommodityCoverService_StaleOverrideFallsBack(t *testing.T) {
 	// Stale override — file id doesn't exist. Resolver falls back to
 	// the first-photo path so a deleted-image race never blanks out the
 	// cover slot until the user re-picks.
-	cov, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRefWithCover("commodity-A", "no-such-file"), "user-1")
+	cov, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRefWithCover("commodity-A", "no-such-file"), "user-1", "")
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(cov.FileID, qt.Equals, older.ID)
 	c.Assert(cov.Source, qt.Equals, services.CoverSourceFirstPhoto)
@@ -253,6 +253,6 @@ func TestCommodityCoverService_OverrideFromOtherCommodityRejected(t *testing.T) 
 	signing := services.NewFileSigningService(signingKey32, time.Hour)
 	coverSvc := services.NewCommodityCoverService(signing)
 
-	_, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRefWithCover("commodity-B", other.ID), "user-1")
+	_, ok := coverSvc.ResolveOne(ctx, fileReg, commodityRefWithCover("commodity-B", other.ID), "user-1", "")
 	c.Assert(ok, qt.IsFalse)
 }

--- a/go/services/file_signing_service.go
+++ b/go/services/file_signing_service.go
@@ -48,8 +48,10 @@ type SessionBinding string
 // The binding is the first 16 bytes of SHA-256(cookie value), base64url-
 // encoded. The relevant security property is preimage resistance over a
 // high-entropy cookie value (a real refresh token is 32 random bytes), so
-// 16 bytes is overkill — it also keeps the URL compact. The HMAC still
-// supplies the full 32 bytes of secret entropy.
+// 16 bytes is overkill — it also keeps the binding identifier itself
+// short, which matters for log volume and `fmt.Sprintf` of the HMAC
+// message but not for the URL (binding is never written into the URL).
+// The HMAC still supplies the full 32 bytes of secret entropy.
 //
 // Impersonation caveat: during an impersonation session the cookie value
 // is `imp:<jti>`, where the JTI is also a claim on the visible access

--- a/go/services/file_signing_service.go
+++ b/go/services/file_signing_service.go
@@ -130,19 +130,51 @@ func (s *FileSigningService) GenerateSignedURL(fileID, fileExt, userID string, b
 	return signedURL, nil
 }
 
-// GenerateSignedURLsWithThumbnails generates signed URLs for a file and its thumbnails
-func (s *FileSigningService) GenerateSignedURLsWithThumbnails(file *models.FileEntity, userID string, binding SessionBinding) (string, map[string]string, error) {
+// GenerateSignedURLsWithThumbnails mints a signed URL for the original
+// file and best-effort signed URLs for any pre-computed thumbnails the
+// FE may want to render alongside it.
+//
+// Parameters:
+//   - file: the FileEntity being exposed. `file.ID` is the routing key,
+//     `file.Ext` provides the sanity-check extension for the original
+//     URL, and `file.MIMEType` decides whether thumbnails are minted
+//     at all (only image/jpeg and image/png are eligible — every other
+//     MIME type returns an empty `thumbnails` map).
+//   - userID: the user the URLs are minted for; folded into the HMAC so
+//     a foreign-user replay fails validation.
+//   - binding: the SessionBinding from the request that authorized this
+//     signing call (see ExtractSessionBinding). Pass "" to produce
+//     unbound URLs; otherwise downstream validators must present the
+//     same binding to consume them.
+//
+// Return values:
+//   - original: the signed URL for the full-resolution file. Always
+//     populated when err is nil.
+//   - thumbnails: keyed by size name ("small", "medium"). Only carries
+//     entries for sizes that could be signed; a missing entry simply
+//     means no thumbnail is available at that size and callers should
+//     fall back to `original`. Non-nil but empty when the file has no
+//     eligible MIME type.
+//   - err: non-nil only when the *original* URL cannot be signed.
+//     Per-thumbnail signing errors are swallowed by design — a missing
+//     thumbnail URL is recoverable on the client; an unsigned original
+//     is not.
+func (s *FileSigningService) GenerateSignedURLsWithThumbnails(
+	file *models.FileEntity,
+	userID string,
+	binding SessionBinding,
+) (original string, thumbnails map[string]string, err error) {
 	// Get file extension (remove leading dot if present)
 	fileExt := strings.TrimPrefix(file.Ext, ".")
 
 	// Generate signed URL for the original file
-	originalURL, err := s.GenerateSignedURL(file.ID, fileExt, userID, binding)
+	original, err = s.GenerateSignedURL(file.ID, fileExt, userID, binding)
 	if err != nil {
 		return "", nil, errxtrace.Wrap("failed to generate original file URL", err)
 	}
 
 	// Generate thumbnail URLs if it's a supported image format
-	thumbnails := make(map[string]string)
+	thumbnails = make(map[string]string)
 	if mimekit.IsImage(file.MIMEType) && (strings.HasPrefix(file.MIMEType, "image/jpeg") || strings.HasPrefix(file.MIMEType, "image/png")) {
 		thumbnailSizes := map[string]int{
 			"small":  150,
@@ -150,16 +182,18 @@ func (s *FileSigningService) GenerateSignedURLsWithThumbnails(file *models.FileE
 		}
 
 		for sizeName := range thumbnailSizes {
-			thumbnailURL, err := s.generateThumbnailSignedURL(file.ID, sizeName, userID, binding)
-			if err != nil {
-				// Don't fail if thumbnail URL generation fails - thumbnail might not exist
+			thumbnailURL, thumbErr := s.generateThumbnailSignedURL(file.ID, sizeName, userID, binding)
+			if thumbErr != nil {
+				// Don't fail if thumbnail URL generation fails — thumbnail
+				// may not exist yet (deferred generation) or be unsupported
+				// at this size. The client falls back to `original`.
 				continue
 			}
 			thumbnails[sizeName] = thumbnailURL
 		}
 	}
 
-	return originalURL, thumbnails, nil
+	return original, thumbnails, nil
 }
 
 // generateThumbnailSignedURL creates a signed URL for thumbnail access

--- a/go/services/file_signing_service.go
+++ b/go/services/file_signing_service.go
@@ -107,24 +107,11 @@ func (s *FileSigningService) GenerateSignedURL(fileID, fileExt, userID string, b
 	// Create the base URL path for original files
 	basePath := fmt.Sprintf("/api/v1/files/download/files/%s", fileID)
 
-	// Create the message to sign. Format is
-	//     GET|path|fileID|userID|exp[|binding]
-	// where the trailing |binding segment is omitted entirely when the
-	// binding is empty. Two reasons:
-	//
-	//  1. Rolling-deploy backwards compatibility: URLs minted by the
-	//     pre-#1781 code carried no binding segment. With conditional
-	//     encoding, the new validator constructs the same OLD-format
-	//     message when no cookie is present, so existing in-flight
-	//     unbound URLs keep validating through the deploy window
-	//     instead of all 401-ing for the FileURLExpiration TTL.
-	//  2. Symmetry: a URL minted as "unbound" should look textually
-	//     identical to what the pre-binding world produced, so the
-	//     fallback path has no extra surface.
-	//
-	// The bound case (binding != "") still appends |binding, which is
-	// what the binding matrix tests exercise.
-	message := buildSignedURLMessage(basePath, fileID, userID, expTimestamp, binding)
+	// Create the message to sign: method + path + fileID + userID + expiration + binding.
+	// The |binding segment is unconditional — pre-#1781 URLs are not
+	// supported on this code path; in-flight unbound URLs are expected
+	// to 401 after a deploy and be re-fetched by the FE.
+	message := fmt.Sprintf("GET|%s|%s|%s|%d|%s", basePath, fileID, userID, expTimestamp, binding)
 
 	// Generate HMAC signature
 	signature, err := s.generateSignature(message)
@@ -141,17 +128,6 @@ func (s *FileSigningService) GenerateSignedURL(fileID, fileExt, userID string, b
 		url.QueryEscape(fileID))
 
 	return signedURL, nil
-}
-
-// buildSignedURLMessage assembles the HMAC message. The `|binding` suffix
-// is conditionally appended so unbound URLs share their wire format with
-// pre-#1781 code — see GenerateSignedURL for the rolling-deploy rationale.
-func buildSignedURLMessage(basePath, fileID, userID string, expTimestamp int64, binding SessionBinding) string {
-	message := fmt.Sprintf("GET|%s|%s|%s|%d", basePath, fileID, userID, expTimestamp)
-	if binding != "" {
-		message += "|" + string(binding)
-	}
-	return message
 }
 
 // GenerateSignedURLsWithThumbnails generates signed URLs for a file and its thumbnails
@@ -205,8 +181,8 @@ func (s *FileSigningService) generateThumbnailSignedURL(fileID, sizeName, userID
 	// Create the base URL path for thumbnails
 	basePath := fmt.Sprintf("/api/v1/files/download/thumbnails/%s/%s", fileID, sizeName)
 
-	// See GenerateSignedURL for the conditional |binding suffix rationale.
-	message := buildSignedURLMessage(basePath, fileID, userID, expTimestamp, binding)
+	// Create the message to sign: method + path + fileID + userID + expiration + binding
+	message := fmt.Sprintf("GET|%s|%s|%s|%d|%s", basePath, fileID, userID, expTimestamp, binding)
 
 	// Generate HMAC signature
 	signature, err := s.generateSignature(message)
@@ -266,10 +242,8 @@ func (s *FileSigningService) ValidateSignedURL(path string, queryParams url.Valu
 		return nil, errors.New("signed URL has expired")
 	}
 
-	// Recreate the message that was signed. See GenerateSignedURL for the
-	// conditional |binding suffix rationale (matters for rolling-deploy
-	// compatibility against pre-#1781 URLs).
-	message := buildSignedURLMessage(path, fileID, userID, expTimestamp, binding)
+	// Recreate the message that was signed
+	message := fmt.Sprintf("GET|%s|%s|%s|%d|%s", path, fileID, userID, expTimestamp, binding)
 
 	// Validate the signature
 	if !s.validateSignature(message, signature) {

--- a/go/services/file_signing_service.go
+++ b/go/services/file_signing_service.go
@@ -15,14 +15,10 @@ import (
 
 	errxtrace "github.com/go-extras/errx/stacktrace"
 
+	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/internal/mimekit"
 	"github.com/denisvmedia/inventario/models"
 )
-
-// refreshTokenCookieName is the cookie that carries the refresh token. It is
-// duplicated from apiserver/auth.go to keep services/ free of an apiserver
-// import (would be a cycle). Keep this in sync if the cookie is ever renamed.
-const refreshTokenCookieName = "refresh_token"
 
 // FileSigningService provides secure file URL signing functionality
 type FileSigningService struct {
@@ -50,14 +46,21 @@ type SessionBinding string
 // unbound (backwards-compatible for non-browser clients without cookies).
 //
 // The binding is the first 16 bytes of SHA-256(cookie value), base64url-
-// encoded. 16 bytes is plenty of collision resistance for an identifier
-// that only has to discriminate concurrent sessions; the HMAC still
+// encoded. The relevant security property is preimage resistance over a
+// high-entropy cookie value (a real refresh token is 32 random bytes), so
+// 16 bytes is overkill — it also keeps the URL compact. The HMAC still
 // supplies the full 32 bytes of secret entropy.
+//
+// Impersonation caveat: during an impersonation session the cookie value
+// is `imp:<jti>`, where the JTI is also a claim on the visible access
+// token. The binding therefore degrades to "knowledge of the access
+// token" for impersonation; a separate leak of both the URL and the
+// bearer is required to replay. See #1781 follow-up for tighter binding.
 func ExtractSessionBinding(r *http.Request) SessionBinding {
 	if r == nil {
 		return ""
 	}
-	cookie, err := r.Cookie(refreshTokenCookieName)
+	cookie, err := r.Cookie(appctx.RefreshTokenCookieName)
 	if err != nil || cookie == nil || cookie.Value == "" {
 		return ""
 	}

--- a/go/services/file_signing_service.go
+++ b/go/services/file_signing_service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -17,6 +18,11 @@ import (
 	"github.com/denisvmedia/inventario/internal/mimekit"
 	"github.com/denisvmedia/inventario/models"
 )
+
+// refreshTokenCookieName is the cookie that carries the refresh token. It is
+// duplicated from apiserver/auth.go to keep services/ free of an apiserver
+// import (would be a cycle). Keep this in sync if the cookie is ever renamed.
+const refreshTokenCookieName = "refresh_token"
 
 // FileSigningService provides secure file URL signing functionality
 type FileSigningService struct {
@@ -32,6 +38,33 @@ func NewFileSigningService(signingKey []byte, expiration time.Duration) *FileSig
 	}
 }
 
+// SessionBinding is the per-session identifier woven into the signed URL.
+// It is derived from the refresh_token cookie (see ExtractSessionBinding)
+// and folded into the HMAC message; it is NOT carried as a query parameter
+// so it cannot leak via Referer / proxy logs / browser history alongside
+// the URL itself.
+type SessionBinding string
+
+// ExtractSessionBinding derives the binding from the request's refresh_token
+// cookie. Returns "" when the cookie is missing or empty — the URL is then
+// unbound (backwards-compatible for non-browser clients without cookies).
+//
+// The binding is the first 16 bytes of SHA-256(cookie value), base64url-
+// encoded. 16 bytes is plenty of collision resistance for an identifier
+// that only has to discriminate concurrent sessions; the HMAC still
+// supplies the full 32 bytes of secret entropy.
+func ExtractSessionBinding(r *http.Request) SessionBinding {
+	if r == nil {
+		return ""
+	}
+	cookie, err := r.Cookie(refreshTokenCookieName)
+	if err != nil || cookie == nil || cookie.Value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(cookie.Value))
+	return SessionBinding(base64.RawURLEncoding.EncodeToString(sum[:16]))
+}
+
 // SignedURLClaims contains the claims for a signed file URL
 type SignedURLClaims struct {
 	FileID    string    // File ID being accessed
@@ -41,7 +74,11 @@ type SignedURLClaims struct {
 
 // GenerateSignedURL creates a signed URL for file access
 // The URL format will be: /files/{fileID}.{ext}?sig={signature}&exp={timestamp}&uid={userID}
-func (s *FileSigningService) GenerateSignedURL(fileID, fileExt, userID string) (string, error) {
+//
+// `binding` is the SessionBinding from the request that authorized this
+// signing call. An empty binding produces an unbound URL — validators must
+// be invoked with an empty binding to accept it.
+func (s *FileSigningService) GenerateSignedURL(fileID, fileExt, userID string, binding SessionBinding) (string, error) {
 	if fileID == "" {
 		return "", errors.New("file ID is required")
 	}
@@ -59,8 +96,8 @@ func (s *FileSigningService) GenerateSignedURL(fileID, fileExt, userID string) (
 	// Create the base URL path for original files
 	basePath := fmt.Sprintf("/api/v1/files/download/files/%s", fileID)
 
-	// Create the message to sign: method + path + fileID + userID + expiration
-	message := fmt.Sprintf("GET|%s|%s|%s|%d", basePath, fileID, userID, expTimestamp)
+	// Create the message to sign: method + path + fileID + userID + expiration + binding
+	message := fmt.Sprintf("GET|%s|%s|%s|%d|%s", basePath, fileID, userID, expTimestamp, binding)
 
 	// Generate HMAC signature
 	signature, err := s.generateSignature(message)
@@ -80,12 +117,12 @@ func (s *FileSigningService) GenerateSignedURL(fileID, fileExt, userID string) (
 }
 
 // GenerateSignedURLsWithThumbnails generates signed URLs for a file and its thumbnails
-func (s *FileSigningService) GenerateSignedURLsWithThumbnails(file *models.FileEntity, userID string) (string, map[string]string, error) {
+func (s *FileSigningService) GenerateSignedURLsWithThumbnails(file *models.FileEntity, userID string, binding SessionBinding) (string, map[string]string, error) {
 	// Get file extension (remove leading dot if present)
 	fileExt := strings.TrimPrefix(file.Ext, ".")
 
 	// Generate signed URL for the original file
-	originalURL, err := s.GenerateSignedURL(file.ID, fileExt, userID)
+	originalURL, err := s.GenerateSignedURL(file.ID, fileExt, userID, binding)
 	if err != nil {
 		return "", nil, errxtrace.Wrap("failed to generate original file URL", err)
 	}
@@ -99,7 +136,7 @@ func (s *FileSigningService) GenerateSignedURLsWithThumbnails(file *models.FileE
 		}
 
 		for sizeName := range thumbnailSizes {
-			thumbnailURL, err := s.generateThumbnailSignedURL(file.ID, sizeName, userID)
+			thumbnailURL, err := s.generateThumbnailSignedURL(file.ID, sizeName, userID, binding)
 			if err != nil {
 				// Don't fail if thumbnail URL generation fails - thumbnail might not exist
 				continue
@@ -112,7 +149,7 @@ func (s *FileSigningService) GenerateSignedURLsWithThumbnails(file *models.FileE
 }
 
 // generateThumbnailSignedURL creates a signed URL for thumbnail access
-func (s *FileSigningService) generateThumbnailSignedURL(fileID, sizeName, userID string) (string, error) {
+func (s *FileSigningService) generateThumbnailSignedURL(fileID, sizeName, userID string, binding SessionBinding) (string, error) {
 	if fileID == "" {
 		return "", errors.New("file ID is required")
 	}
@@ -130,8 +167,8 @@ func (s *FileSigningService) generateThumbnailSignedURL(fileID, sizeName, userID
 	// Create the base URL path for thumbnails
 	basePath := fmt.Sprintf("/api/v1/files/download/thumbnails/%s/%s", fileID, sizeName)
 
-	// Create the message to sign: method + path + fileID + userID + expiration
-	message := fmt.Sprintf("GET|%s|%s|%s|%d", basePath, fileID, userID, expTimestamp)
+	// Create the message to sign: method + path + fileID + userID + expiration + binding
+	message := fmt.Sprintf("GET|%s|%s|%s|%d|%s", basePath, fileID, userID, expTimestamp, binding)
 
 	// Generate HMAC signature
 	signature, err := s.generateSignature(message)
@@ -150,8 +187,13 @@ func (s *FileSigningService) generateThumbnailSignedURL(fileID, sizeName, userID
 	return signedURL, nil
 }
 
-// ValidateSignedURL validates a signed URL and returns the claims if valid
-func (s *FileSigningService) ValidateSignedURL(path string, queryParams url.Values) (*SignedURLClaims, error) {
+// ValidateSignedURL validates a signed URL and returns the claims if valid.
+//
+// `binding` is derived from the validating request's refresh_token cookie
+// (see ExtractSessionBinding). The signature only matches when the binding
+// at validate time equals the binding the URL was minted with — that is
+// what couples a URL to the session that produced it.
+func (s *FileSigningService) ValidateSignedURL(path string, queryParams url.Values, binding SessionBinding) (*SignedURLClaims, error) {
 	// Extract required parameters
 	signature := queryParams.Get("sig")
 	if signature == "" {
@@ -187,7 +229,7 @@ func (s *FileSigningService) ValidateSignedURL(path string, queryParams url.Valu
 	}
 
 	// Recreate the message that was signed
-	message := fmt.Sprintf("GET|%s|%s|%s|%d", path, fileID, userID, expTimestamp)
+	message := fmt.Sprintf("GET|%s|%s|%s|%d|%s", path, fileID, userID, expTimestamp, binding)
 
 	// Validate the signature
 	if !s.validateSignature(message, signature) {

--- a/go/services/file_signing_service.go
+++ b/go/services/file_signing_service.go
@@ -77,12 +77,18 @@ type SignedURLClaims struct {
 	ExpiresAt time.Time // Expiration time
 }
 
-// GenerateSignedURL creates a signed URL for file access
-// The URL format will be: /files/{fileID}.{ext}?sig={signature}&exp={timestamp}&uid={userID}
+// GenerateSignedURL creates a signed URL for file access.
+//
+// The emitted URL is `/api/v1/files/download/files/{fileID}?sig=…&exp=…&uid=…&fid=…`
+// — no extension is embedded; chi routes off the path segment alone and
+// the streamer reads MIME / extension from the FileEntity. `fileExt` is
+// validated for non-emptiness as a sanity check but does not appear in
+// the path.
 //
 // `binding` is the SessionBinding from the request that authorized this
-// signing call. An empty binding produces an unbound URL — validators must
-// be invoked with an empty binding to accept it.
+// signing call. An empty binding produces an unbound URL — validators
+// must be invoked with an empty binding to accept it. The binding is
+// folded into the HMAC message only and never written into the URL.
 func (s *FileSigningService) GenerateSignedURL(fileID, fileExt, userID string, binding SessionBinding) (string, error) {
 	if fileID == "" {
 		return "", errors.New("file ID is required")
@@ -101,8 +107,24 @@ func (s *FileSigningService) GenerateSignedURL(fileID, fileExt, userID string, b
 	// Create the base URL path for original files
 	basePath := fmt.Sprintf("/api/v1/files/download/files/%s", fileID)
 
-	// Create the message to sign: method + path + fileID + userID + expiration + binding
-	message := fmt.Sprintf("GET|%s|%s|%s|%d|%s", basePath, fileID, userID, expTimestamp, binding)
+	// Create the message to sign. Format is
+	//     GET|path|fileID|userID|exp[|binding]
+	// where the trailing |binding segment is omitted entirely when the
+	// binding is empty. Two reasons:
+	//
+	//  1. Rolling-deploy backwards compatibility: URLs minted by the
+	//     pre-#1781 code carried no binding segment. With conditional
+	//     encoding, the new validator constructs the same OLD-format
+	//     message when no cookie is present, so existing in-flight
+	//     unbound URLs keep validating through the deploy window
+	//     instead of all 401-ing for the FileURLExpiration TTL.
+	//  2. Symmetry: a URL minted as "unbound" should look textually
+	//     identical to what the pre-binding world produced, so the
+	//     fallback path has no extra surface.
+	//
+	// The bound case (binding != "") still appends |binding, which is
+	// what the binding matrix tests exercise.
+	message := buildSignedURLMessage(basePath, fileID, userID, expTimestamp, binding)
 
 	// Generate HMAC signature
 	signature, err := s.generateSignature(message)
@@ -119,6 +141,17 @@ func (s *FileSigningService) GenerateSignedURL(fileID, fileExt, userID string, b
 		url.QueryEscape(fileID))
 
 	return signedURL, nil
+}
+
+// buildSignedURLMessage assembles the HMAC message. The `|binding` suffix
+// is conditionally appended so unbound URLs share their wire format with
+// pre-#1781 code — see GenerateSignedURL for the rolling-deploy rationale.
+func buildSignedURLMessage(basePath, fileID, userID string, expTimestamp int64, binding SessionBinding) string {
+	message := fmt.Sprintf("GET|%s|%s|%s|%d", basePath, fileID, userID, expTimestamp)
+	if binding != "" {
+		message += "|" + string(binding)
+	}
+	return message
 }
 
 // GenerateSignedURLsWithThumbnails generates signed URLs for a file and its thumbnails
@@ -172,8 +205,8 @@ func (s *FileSigningService) generateThumbnailSignedURL(fileID, sizeName, userID
 	// Create the base URL path for thumbnails
 	basePath := fmt.Sprintf("/api/v1/files/download/thumbnails/%s/%s", fileID, sizeName)
 
-	// Create the message to sign: method + path + fileID + userID + expiration + binding
-	message := fmt.Sprintf("GET|%s|%s|%s|%d|%s", basePath, fileID, userID, expTimestamp, binding)
+	// See GenerateSignedURL for the conditional |binding suffix rationale.
+	message := buildSignedURLMessage(basePath, fileID, userID, expTimestamp, binding)
 
 	// Generate HMAC signature
 	signature, err := s.generateSignature(message)
@@ -233,8 +266,10 @@ func (s *FileSigningService) ValidateSignedURL(path string, queryParams url.Valu
 		return nil, errors.New("signed URL has expired")
 	}
 
-	// Recreate the message that was signed
-	message := fmt.Sprintf("GET|%s|%s|%s|%d|%s", path, fileID, userID, expTimestamp, binding)
+	// Recreate the message that was signed. See GenerateSignedURL for the
+	// conditional |binding suffix rationale (matters for rolling-deploy
+	// compatibility against pre-#1781 URLs).
+	message := buildSignedURLMessage(path, fileID, userID, expTimestamp, binding)
 
 	// Validate the signature
 	if !s.validateSignature(message, signature) {

--- a/go/services/file_signing_service_test.go
+++ b/go/services/file_signing_service_test.go
@@ -1,6 +1,9 @@
 package services_test
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -722,6 +725,57 @@ func TestFileSigningService_SessionBindingMatrix(t *testing.T) {
 		c.Assert(err, qt.IsNotNil)
 		c.Assert(err.Error(), qt.Equals, "invalid signature")
 	})
+}
+
+// TestFileSigningService_PreBindingURLStillValidates locks in the
+// rolling-deploy backwards compatibility property: a URL produced by the
+// pre-#1781 message format (no |binding segment) MUST still validate on
+// the post-#1781 code when no cookie is presented. Without this, every
+// in-flight signed URL would 401 on the new pods for FileURLExpiration
+// after deploy.
+//
+// We emulate the old mint by computing the signature over the OLD
+// message format ourselves and assembling the same wire format
+// GenerateSignedURL emits, then validate with the current code.
+func TestFileSigningService_PreBindingURLStillValidates(t *testing.T) {
+	c := qt.New(t)
+
+	signingKey := []byte("test-signing-key-32-bytes-long!!")
+	service := services.NewFileSigningService(signingKey, 15*time.Minute)
+
+	const (
+		fileID   = "file-legacy"
+		userID   = "user-legacy"
+		basePath = "/api/v1/files/download/files/file-legacy"
+	)
+	exp := time.Now().Add(10 * time.Minute).Unix()
+
+	// Pre-#1781 message format — no trailing |binding segment.
+	oldMessage := "GET|" + basePath + "|" + fileID + "|" + userID + "|" + strconv.FormatInt(exp, 10)
+
+	h := hmac.New(sha256.New, signingKey)
+	_, err := h.Write([]byte(oldMessage))
+	c.Assert(err, qt.IsNil)
+	oldSig := base64.URLEncoding.EncodeToString(h.Sum(nil))
+
+	q := url.Values{}
+	q.Set("sig", oldSig)
+	q.Set("exp", strconv.FormatInt(exp, 10))
+	q.Set("uid", userID)
+	q.Set("fid", fileID)
+
+	// Validator with no cookie → must accept the OLD-format signature.
+	claims, err := service.ValidateSignedURL(basePath, q, "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(claims, qt.IsNotNil)
+	c.Assert(claims.FileID, qt.Equals, fileID)
+	c.Assert(claims.UserID, qt.Equals, userID)
+
+	// Validator WITH a cookie must NOT accept the OLD-format signature —
+	// that would let a bound caller replay an unbound URL.
+	_, err = service.ValidateSignedURL(basePath, q, "session-A")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Equals, "invalid signature")
 }
 
 // TestFileSigningService_ThumbnailsCarryBinding ensures the thumbnail URL

--- a/go/services/file_signing_service_test.go
+++ b/go/services/file_signing_service_test.go
@@ -560,14 +560,17 @@ func TestExtractSessionBinding(t *testing.T) {
 
 	c.Run("empty cookie value returns empty", func(c *qt.C) {
 		r := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		r.AddCookie(&http.Cookie{Name: "refresh_token", Value: ""})
 		c.Assert(services.ExtractSessionBinding(r), qt.Equals, services.SessionBinding(""))
 	})
 
 	c.Run("present cookie produces stable, non-empty binding", func(c *qt.C) {
 		r1 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		r1.AddCookie(&http.Cookie{Name: "refresh_token", Value: "the-cookie-value"})
 		r2 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		r2.AddCookie(&http.Cookie{Name: "refresh_token", Value: "the-cookie-value"})
 
 		b1 := services.ExtractSessionBinding(r1)
@@ -579,8 +582,10 @@ func TestExtractSessionBinding(t *testing.T) {
 
 	c.Run("different cookies produce different bindings", func(c *qt.C) {
 		r1 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		r1.AddCookie(&http.Cookie{Name: "refresh_token", Value: "cookie-A"})
 		r2 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		r2.AddCookie(&http.Cookie{Name: "refresh_token", Value: "cookie-B"})
 
 		c.Assert(services.ExtractSessionBinding(r1), qt.Not(qt.Equals), services.ExtractSessionBinding(r2))
@@ -588,7 +593,9 @@ func TestExtractSessionBinding(t *testing.T) {
 
 	c.Run("other cookies do not contribute", func(c *qt.C) {
 		r := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		r.AddCookie(&http.Cookie{Name: "session", Value: "looks-juicy"})
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		r.AddCookie(&http.Cookie{Name: "access_token", Value: "also-juicy"})
 		c.Assert(services.ExtractSessionBinding(r), qt.Equals, services.SessionBinding(""))
 	})
@@ -683,6 +690,7 @@ func TestFileSigningService_SessionBindingMatrix(t *testing.T) {
 		c := qt.New(t)
 
 		mintReq := httptest.NewRequest(http.MethodGet, "/sign", nil)
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		mintReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: "round-trip-cookie"})
 		mintBinding := services.ExtractSessionBinding(mintReq)
 		c.Assert(string(mintBinding), qt.Not(qt.Equals), "")
@@ -694,6 +702,7 @@ func TestFileSigningService_SessionBindingMatrix(t *testing.T) {
 
 		// Same cookie at validate time → success.
 		sameReq := httptest.NewRequest(http.MethodGet, parsed.Path+"?"+parsed.RawQuery, nil)
+		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
 		sameReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: "round-trip-cookie"})
 		_, err = service.ValidateSignedURL(parsed.Path, parsed.Query(), services.ExtractSessionBinding(sameReq))
 		c.Assert(err, qt.IsNil)

--- a/go/services/file_signing_service_test.go
+++ b/go/services/file_signing_service_test.go
@@ -1,6 +1,8 @@
 package services_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"testing"
@@ -62,7 +64,7 @@ func TestFileSigningService_GenerateSignedURL(t *testing.T) {
 
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
-			signedURL, err := service.GenerateSignedURL(tt.fileID, tt.fileExt, tt.userID)
+			signedURL, err := service.GenerateSignedURL(tt.fileID, tt.fileExt, tt.userID, "")
 
 			if tt.expectError {
 				c.Assert(err, qt.IsNotNil)
@@ -85,6 +87,13 @@ func TestFileSigningService_GenerateSignedURL(t *testing.T) {
 				c.Assert(query.Get("sig"), qt.Not(qt.Equals), "")
 				c.Assert(query.Get("exp"), qt.Not(qt.Equals), "")
 				c.Assert(query.Get("uid"), qt.Equals, tt.userID)
+
+				// The binding MUST NOT leak as a query parameter — it
+				// is folded into the HMAC only. If a future change ever
+				// surfaces it in the URL the leak this issue closes
+				// (#1781) reopens immediately.
+				c.Assert(query.Get("binding"), qt.Equals, "")
+				c.Assert(query.Get("sb"), qt.Equals, "")
 
 				// Check expiration is in the future
 				expStr := query.Get("exp")
@@ -109,7 +118,7 @@ func TestFileSigningService_ValidateSignedURL_ValidCases(t *testing.T) {
 	fileID := "test-file-123"
 	fileExt := "pdf"
 	userID := "user-456"
-	signedURL, err := service.GenerateSignedURL(fileID, fileExt, userID)
+	signedURL, err := service.GenerateSignedURL(fileID, fileExt, userID, "")
 	c.Assert(err, qt.IsNil)
 
 	// Parse the URL to get path and query parameters
@@ -130,7 +139,7 @@ func TestFileSigningService_ValidateSignedURL_ValidCases(t *testing.T) {
 
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
-			claims, err := service.ValidateSignedURL(tt.path, tt.query)
+			claims, err := service.ValidateSignedURL(tt.path, tt.query, "")
 
 			c.Assert(err, qt.IsNil)
 			c.Assert(claims, qt.IsNotNil)
@@ -152,7 +161,7 @@ func TestFileSigningService_ValidateSignedURL_ErrorCases(t *testing.T) {
 	fileID := "test-file-123"
 	fileExt := "pdf"
 	userID := "user-456"
-	signedURL, err := service.GenerateSignedURL(fileID, fileExt, userID)
+	signedURL, err := service.GenerateSignedURL(fileID, fileExt, userID, "")
 	c.Assert(err, qt.IsNil)
 
 	// Parse the URL to get path and query parameters
@@ -211,7 +220,7 @@ func TestFileSigningService_ValidateSignedURL_ErrorCases(t *testing.T) {
 
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
-			claims, err := service.ValidateSignedURL(tt.path, tt.query)
+			claims, err := service.ValidateSignedURL(tt.path, tt.query, "")
 
 			c.Assert(err, qt.IsNotNil)
 			c.Assert(err.Error(), qt.Contains, tt.errorMsg)
@@ -263,7 +272,7 @@ func TestFileSigningService_ExtractFileIDFromPath_ValidPaths(t *testing.T) {
 			query.Set("uid", "test-user")
 			query.Set("fid", "test-file-id")
 
-			_, err := service.ValidateSignedURL(tt.path, query)
+			_, err := service.ValidateSignedURL(tt.path, query, "")
 
 			// Valid paths should fail with "invalid signature" error, not path format error
 			c.Assert(err, qt.IsNotNil)
@@ -305,7 +314,7 @@ func TestFileSigningService_ExtractFileIDFromPath_InvalidPaths(t *testing.T) {
 			query.Set("exp", strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10))
 			query.Set("uid", "test-user")
 
-			_, err := service.ValidateSignedURL(tt.path, query)
+			_, err := service.ValidateSignedURL(tt.path, query, "")
 
 			// Invalid paths should fail, but we don't care about the specific error message
 			// as it could be path format or other validation errors
@@ -325,8 +334,8 @@ func TestFileSigningService_SecurityProperties(t *testing.T) {
 		otherKey := []byte("different-key-32-bytes-long!!!")
 		otherService := services.NewFileSigningService(otherKey, expiration)
 
-		url1, err1 := service.GenerateSignedURL("file-123", "pdf", "user-456")
-		url2, err2 := otherService.GenerateSignedURL("file-123", "pdf", "user-456")
+		url1, err1 := service.GenerateSignedURL("file-123", "pdf", "user-456", "")
+		url2, err2 := otherService.GenerateSignedURL("file-123", "pdf", "user-456", "")
 
 		c.Assert(err1, qt.IsNil)
 		c.Assert(err2, qt.IsNil)
@@ -335,19 +344,19 @@ func TestFileSigningService_SecurityProperties(t *testing.T) {
 		// URL from service1 should not validate with service2
 		parsed, err := url.Parse(url1)
 		c.Assert(err, qt.IsNil)
-		_, err = otherService.ValidateSignedURL(parsed.Path, parsed.Query())
+		_, err = otherService.ValidateSignedURL(parsed.Path, parsed.Query(), "")
 		c.Assert(err, qt.IsNotNil)
 		c.Assert(err.Error(), qt.Equals, "invalid signature")
 	})
 
 	c.Run("signatures with different timestamps are different", func(c *qt.C) {
-		url1, err1 := service.GenerateSignedURL("file-123", "pdf", "user-456")
+		url1, err1 := service.GenerateSignedURL("file-123", "pdf", "user-456", "")
 		c.Assert(err1, qt.IsNil)
 
 		// Wait a full second to ensure different timestamp (Unix timestamp has 1-second resolution)
 		time.Sleep(1100 * time.Millisecond)
 
-		url2, err2 := service.GenerateSignedURL("file-123", "pdf", "user-456")
+		url2, err2 := service.GenerateSignedURL("file-123", "pdf", "user-456", "")
 		c.Assert(err2, qt.IsNil)
 
 		// URLs should be different due to different timestamps
@@ -356,13 +365,13 @@ func TestFileSigningService_SecurityProperties(t *testing.T) {
 		// But both should validate successfully
 		parsed1, err := url.Parse(url1)
 		c.Assert(err, qt.IsNil)
-		claims1, err := service.ValidateSignedURL(parsed1.Path, parsed1.Query())
+		claims1, err := service.ValidateSignedURL(parsed1.Path, parsed1.Query(), "")
 		c.Assert(err, qt.IsNil)
 		c.Assert(claims1, qt.IsNotNil)
 
 		parsed2, err := url.Parse(url2)
 		c.Assert(err, qt.IsNil)
-		claims2, err := service.ValidateSignedURL(parsed2.Path, parsed2.Query())
+		claims2, err := service.ValidateSignedURL(parsed2.Path, parsed2.Query(), "")
 		c.Assert(err, qt.IsNil)
 		c.Assert(claims2, qt.IsNotNil)
 	})
@@ -443,7 +452,7 @@ func TestFileSigningService_GenerateSignedURLsWithThumbnails(t *testing.T) {
 				},
 			}
 
-			originalURL, thumbnails, err := service.GenerateSignedURLsWithThumbnails(fileEntity, tt.userID)
+			originalURL, thumbnails, err := service.GenerateSignedURLsWithThumbnails(fileEntity, tt.userID, "")
 
 			c.Assert(err, qt.IsNil)
 			c.Assert(originalURL, qt.Not(qt.Equals), "")
@@ -521,7 +530,7 @@ func TestFileSigningService_GetThumbnailPath(t *testing.T) {
 				},
 			}
 
-			_, thumbnails, err := service.GenerateSignedURLsWithThumbnails(fileEntity, "user-id")
+			_, thumbnails, err := service.GenerateSignedURLsWithThumbnails(fileEntity, "user-id", "")
 			c.Assert(err, qt.IsNil)
 
 			switch tt.sizeName {
@@ -531,5 +540,185 @@ func TestFileSigningService_GetThumbnailPath(t *testing.T) {
 				c.Assert(thumbnails["medium"], qt.Contains, tt.expected)
 			}
 		})
+	}
+}
+
+// TestExtractSessionBinding covers the helper that lifts the binding off
+// the incoming request: nil request, no cookie, empty cookie, and a real
+// cookie should all behave per spec.
+func TestExtractSessionBinding(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("nil request returns empty", func(c *qt.C) {
+		c.Assert(services.ExtractSessionBinding(nil), qt.Equals, services.SessionBinding(""))
+	})
+
+	c.Run("missing cookie returns empty", func(c *qt.C) {
+		r := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		c.Assert(services.ExtractSessionBinding(r), qt.Equals, services.SessionBinding(""))
+	})
+
+	c.Run("empty cookie value returns empty", func(c *qt.C) {
+		r := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		r.AddCookie(&http.Cookie{Name: "refresh_token", Value: ""})
+		c.Assert(services.ExtractSessionBinding(r), qt.Equals, services.SessionBinding(""))
+	})
+
+	c.Run("present cookie produces stable, non-empty binding", func(c *qt.C) {
+		r1 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		r1.AddCookie(&http.Cookie{Name: "refresh_token", Value: "the-cookie-value"})
+		r2 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		r2.AddCookie(&http.Cookie{Name: "refresh_token", Value: "the-cookie-value"})
+
+		b1 := services.ExtractSessionBinding(r1)
+		b2 := services.ExtractSessionBinding(r2)
+
+		c.Assert(string(b1), qt.Not(qt.Equals), "")
+		c.Assert(b1, qt.Equals, b2)
+	})
+
+	c.Run("different cookies produce different bindings", func(c *qt.C) {
+		r1 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		r1.AddCookie(&http.Cookie{Name: "refresh_token", Value: "cookie-A"})
+		r2 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		r2.AddCookie(&http.Cookie{Name: "refresh_token", Value: "cookie-B"})
+
+		c.Assert(services.ExtractSessionBinding(r1), qt.Not(qt.Equals), services.ExtractSessionBinding(r2))
+	})
+
+	c.Run("other cookies do not contribute", func(c *qt.C) {
+		r := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+		r.AddCookie(&http.Cookie{Name: "session", Value: "looks-juicy"})
+		r.AddCookie(&http.Cookie{Name: "access_token", Value: "also-juicy"})
+		c.Assert(services.ExtractSessionBinding(r), qt.Equals, services.SessionBinding(""))
+	})
+}
+
+// TestFileSigningService_SessionBindingMatrix is the heart of #1781: the
+// signature MUST only verify when the binding presented at validate time
+// equals the binding the URL was minted with.
+func TestFileSigningService_SessionBindingMatrix(t *testing.T) {
+	signingKey := []byte("test-signing-key-32-bytes-long!!")
+	expiration := 15 * time.Minute
+	service := services.NewFileSigningService(signingKey, expiration)
+
+	const fileID = "file-1"
+	const fileExt = "pdf"
+	const userID = "user-1"
+
+	type row struct {
+		name        string
+		mintWith    services.SessionBinding
+		validateAs  services.SessionBinding
+		expectValid bool
+	}
+
+	rows := []row{
+		{
+			name:        "bound mint, same binding validates",
+			mintWith:    "session-A",
+			validateAs:  "session-A",
+			expectValid: true,
+		},
+		{
+			name:        "bound mint, different binding rejected",
+			mintWith:    "session-A",
+			validateAs:  "session-B",
+			expectValid: false,
+		},
+		{
+			name:        "bound mint, empty binding rejected",
+			mintWith:    "session-A",
+			validateAs:  "",
+			expectValid: false,
+		},
+		{
+			name:        "unbound mint, empty binding validates (back-compat)",
+			mintWith:    "",
+			validateAs:  "",
+			expectValid: true,
+		},
+		{
+			name:        "unbound mint, any binding rejected",
+			mintWith:    "",
+			validateAs:  "session-A",
+			expectValid: false,
+		},
+	}
+
+	for _, r := range rows {
+		t.Run(r.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			signed, err := service.GenerateSignedURL(fileID, fileExt, userID, r.mintWith)
+			c.Assert(err, qt.IsNil)
+
+			parsed, err := url.Parse(signed)
+			c.Assert(err, qt.IsNil)
+
+			// The binding must never appear in the URL — that is the
+			// whole point of binding via cookie.
+			c.Assert(parsed.Query().Get("binding"), qt.Equals, "")
+			c.Assert(parsed.Query().Get("sb"), qt.Equals, "")
+
+			claims, err := service.ValidateSignedURL(parsed.Path, parsed.Query(), r.validateAs)
+			if r.expectValid {
+				c.Assert(err, qt.IsNil)
+				c.Assert(claims, qt.IsNotNil)
+				c.Assert(claims.FileID, qt.Equals, fileID)
+				c.Assert(claims.UserID, qt.Equals, userID)
+			} else {
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err.Error(), qt.Equals, "invalid signature")
+				c.Assert(claims, qt.IsNil)
+			}
+		})
+	}
+}
+
+// TestFileSigningService_ThumbnailsCarryBinding ensures the thumbnail URL
+// path also inherits the binding so a leaked thumbnail URL can't be used
+// from a foreign session either.
+func TestFileSigningService_ThumbnailsCarryBinding(t *testing.T) {
+	c := qt.New(t)
+
+	signingKey := []byte("test-signing-key-32-bytes-long!!")
+	service := services.NewFileSigningService(signingKey, 15*time.Minute)
+
+	fileEntity := &models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			EntityID: models.EntityID{ID: "img-1"},
+		},
+		Type: models.FileTypeImage,
+		File: &models.File{
+			Path:         "img-1",
+			OriginalPath: "img-1.png",
+			Ext:          ".png",
+			MIMEType:     "image/png",
+		},
+	}
+
+	originalURL, thumbnails, err := service.GenerateSignedURLsWithThumbnails(fileEntity, "user-1", "session-A")
+	c.Assert(err, qt.IsNil)
+	c.Assert(thumbnails, qt.HasLen, 2)
+
+	// Original URL must reject foreign binding.
+	parsed, err := url.Parse(originalURL)
+	c.Assert(err, qt.IsNil)
+	_, err = service.ValidateSignedURL(parsed.Path, parsed.Query(), "session-B")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Equals, "invalid signature")
+
+	// Each thumbnail URL must also reject foreign binding.
+	for size, raw := range thumbnails {
+		parsed, err := url.Parse(raw)
+		c.Assert(err, qt.IsNil, qt.Commentf("thumbnail %q failed to parse", size))
+		_, err = service.ValidateSignedURL(parsed.Path, parsed.Query(), "session-B")
+		c.Assert(err, qt.IsNotNil, qt.Commentf("thumbnail %q should reject foreign binding", size))
+		c.Assert(err.Error(), qt.Equals, "invalid signature")
+
+		// And accept the original binding.
+		_, err = service.ValidateSignedURL(parsed.Path, parsed.Query(), "session-A")
+		c.Assert(err, qt.IsNil, qt.Commentf("thumbnail %q should accept original binding", size))
 	}
 }

--- a/go/services/file_signing_service_test.go
+++ b/go/services/file_signing_service_test.go
@@ -10,9 +10,26 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/services"
 )
+
+// newTestRefreshCookie builds a refresh_token cookie suitable for binding
+// tests. Production cookies are emitted by apiserver.writeRefreshCookie with
+// the same attributes; setting them here keeps the test fixture aligned and
+// silences gosec G124 without sprinkling //#nosec directives. The transport
+// security flags do not affect ExtractSessionBinding's behaviour — the
+// helper only reads Name + Value.
+func newTestRefreshCookie(value string) *http.Cookie {
+	return &http.Cookie{
+		Name:     appctx.RefreshTokenCookieName,
+		Value:    value,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	}
+}
 
 func TestFileSigningService_GenerateSignedURL(t *testing.T) {
 	c := qt.New(t)
@@ -560,18 +577,15 @@ func TestExtractSessionBinding(t *testing.T) {
 
 	c.Run("empty cookie value returns empty", func(c *qt.C) {
 		r := httptest.NewRequest(http.MethodGet, "/whatever", nil)
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		r.AddCookie(&http.Cookie{Name: "refresh_token", Value: ""})
+		r.AddCookie(newTestRefreshCookie(""))
 		c.Assert(services.ExtractSessionBinding(r), qt.Equals, services.SessionBinding(""))
 	})
 
 	c.Run("present cookie produces stable, non-empty binding", func(c *qt.C) {
 		r1 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		r1.AddCookie(&http.Cookie{Name: "refresh_token", Value: "the-cookie-value"})
+		r1.AddCookie(newTestRefreshCookie("the-cookie-value"))
 		r2 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		r2.AddCookie(&http.Cookie{Name: "refresh_token", Value: "the-cookie-value"})
+		r2.AddCookie(newTestRefreshCookie("the-cookie-value"))
 
 		b1 := services.ExtractSessionBinding(r1)
 		b2 := services.ExtractSessionBinding(r2)
@@ -582,21 +596,19 @@ func TestExtractSessionBinding(t *testing.T) {
 
 	c.Run("different cookies produce different bindings", func(c *qt.C) {
 		r1 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		r1.AddCookie(&http.Cookie{Name: "refresh_token", Value: "cookie-A"})
+		r1.AddCookie(newTestRefreshCookie("cookie-A"))
 		r2 := httptest.NewRequest(http.MethodGet, "/whatever", nil)
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		r2.AddCookie(&http.Cookie{Name: "refresh_token", Value: "cookie-B"})
+		r2.AddCookie(newTestRefreshCookie("cookie-B"))
 
 		c.Assert(services.ExtractSessionBinding(r1), qt.Not(qt.Equals), services.ExtractSessionBinding(r2))
 	})
 
 	c.Run("other cookies do not contribute", func(c *qt.C) {
 		r := httptest.NewRequest(http.MethodGet, "/whatever", nil)
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		r.AddCookie(&http.Cookie{Name: "session", Value: "looks-juicy"})
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		r.AddCookie(&http.Cookie{Name: "access_token", Value: "also-juicy"})
+		// #nosec G124 -- intentionally different cookie names; transport security irrelevant.
+		r.AddCookie(&http.Cookie{Name: "session", Value: "looks-juicy", Secure: true, HttpOnly: true, SameSite: http.SameSiteStrictMode})
+		// #nosec G124 -- intentionally different cookie names; transport security irrelevant.
+		r.AddCookie(&http.Cookie{Name: "access_token", Value: "also-juicy", Secure: true, HttpOnly: true, SameSite: http.SameSiteStrictMode})
 		c.Assert(services.ExtractSessionBinding(r), qt.Equals, services.SessionBinding(""))
 	})
 }
@@ -690,8 +702,7 @@ func TestFileSigningService_SessionBindingMatrix(t *testing.T) {
 		c := qt.New(t)
 
 		mintReq := httptest.NewRequest(http.MethodGet, "/sign", nil)
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		mintReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: "round-trip-cookie"})
+		mintReq.AddCookie(newTestRefreshCookie("round-trip-cookie"))
 		mintBinding := services.ExtractSessionBinding(mintReq)
 		c.Assert(string(mintBinding), qt.Not(qt.Equals), "")
 
@@ -702,8 +713,7 @@ func TestFileSigningService_SessionBindingMatrix(t *testing.T) {
 
 		// Same cookie at validate time → success.
 		sameReq := httptest.NewRequest(http.MethodGet, parsed.Path+"?"+parsed.RawQuery, nil)
-		// #nosec G124 -- test request cookie; transport security is irrelevant to the assertion.
-		sameReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: "round-trip-cookie"})
+		sameReq.AddCookie(newTestRefreshCookie("round-trip-cookie"))
 		_, err = service.ValidateSignedURL(parsed.Path, parsed.Query(), services.ExtractSessionBinding(sameReq))
 		c.Assert(err, qt.IsNil)
 
@@ -740,8 +750,10 @@ func TestFileSigningService_ThumbnailsCarryBinding(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(thumbnails, qt.HasLen, 2)
 
-	// Original URL must reject foreign binding.
+	// Original URL must accept the mint binding and reject foreign ones.
 	parsed, err := url.Parse(originalURL)
+	c.Assert(err, qt.IsNil)
+	_, err = service.ValidateSignedURL(parsed.Path, parsed.Query(), "session-A")
 	c.Assert(err, qt.IsNil)
 	_, err = service.ValidateSignedURL(parsed.Path, parsed.Query(), "session-B")
 	c.Assert(err, qt.IsNotNil)

--- a/go/services/file_signing_service_test.go
+++ b/go/services/file_signing_service_test.go
@@ -674,6 +674,35 @@ func TestFileSigningService_SessionBindingMatrix(t *testing.T) {
 			}
 		})
 	}
+
+	// Extra row driven through the real ExtractSessionBinding helper, so a
+	// future encoding-change regression in the helper (e.g. swapping
+	// RawURLEncoding for URLEncoding, or shifting the truncation width)
+	// cannot pass while the literal-string matrix above still does.
+	t.Run("round-trip via ExtractSessionBinding helper", func(t *testing.T) {
+		c := qt.New(t)
+
+		mintReq := httptest.NewRequest(http.MethodGet, "/sign", nil)
+		mintReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: "round-trip-cookie"})
+		mintBinding := services.ExtractSessionBinding(mintReq)
+		c.Assert(string(mintBinding), qt.Not(qt.Equals), "")
+
+		signed, err := service.GenerateSignedURL(fileID, fileExt, userID, mintBinding)
+		c.Assert(err, qt.IsNil)
+		parsed, err := url.Parse(signed)
+		c.Assert(err, qt.IsNil)
+
+		// Same cookie at validate time → success.
+		sameReq := httptest.NewRequest(http.MethodGet, parsed.Path+"?"+parsed.RawQuery, nil)
+		sameReq.AddCookie(&http.Cookie{Name: "refresh_token", Value: "round-trip-cookie"})
+		_, err = service.ValidateSignedURL(parsed.Path, parsed.Query(), services.ExtractSessionBinding(sameReq))
+		c.Assert(err, qt.IsNil)
+
+		// No cookie at validate time → rejected.
+		_, err = service.ValidateSignedURL(parsed.Path, parsed.Query(), services.ExtractSessionBinding(httptest.NewRequest(http.MethodGet, "/x", nil)))
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "invalid signature")
+	})
 }
 
 // TestFileSigningService_ThumbnailsCarryBinding ensures the thumbnail URL

--- a/go/services/file_signing_service_test.go
+++ b/go/services/file_signing_service_test.go
@@ -1,9 +1,6 @@
 package services_test
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -725,57 +722,6 @@ func TestFileSigningService_SessionBindingMatrix(t *testing.T) {
 		c.Assert(err, qt.IsNotNil)
 		c.Assert(err.Error(), qt.Equals, "invalid signature")
 	})
-}
-
-// TestFileSigningService_PreBindingURLStillValidates locks in the
-// rolling-deploy backwards compatibility property: a URL produced by the
-// pre-#1781 message format (no |binding segment) MUST still validate on
-// the post-#1781 code when no cookie is presented. Without this, every
-// in-flight signed URL would 401 on the new pods for FileURLExpiration
-// after deploy.
-//
-// We emulate the old mint by computing the signature over the OLD
-// message format ourselves and assembling the same wire format
-// GenerateSignedURL emits, then validate with the current code.
-func TestFileSigningService_PreBindingURLStillValidates(t *testing.T) {
-	c := qt.New(t)
-
-	signingKey := []byte("test-signing-key-32-bytes-long!!")
-	service := services.NewFileSigningService(signingKey, 15*time.Minute)
-
-	const (
-		fileID   = "file-legacy"
-		userID   = "user-legacy"
-		basePath = "/api/v1/files/download/files/file-legacy"
-	)
-	exp := time.Now().Add(10 * time.Minute).Unix()
-
-	// Pre-#1781 message format — no trailing |binding segment.
-	oldMessage := "GET|" + basePath + "|" + fileID + "|" + userID + "|" + strconv.FormatInt(exp, 10)
-
-	h := hmac.New(sha256.New, signingKey)
-	_, err := h.Write([]byte(oldMessage))
-	c.Assert(err, qt.IsNil)
-	oldSig := base64.URLEncoding.EncodeToString(h.Sum(nil))
-
-	q := url.Values{}
-	q.Set("sig", oldSig)
-	q.Set("exp", strconv.FormatInt(exp, 10))
-	q.Set("uid", userID)
-	q.Set("fid", fileID)
-
-	// Validator with no cookie → must accept the OLD-format signature.
-	claims, err := service.ValidateSignedURL(basePath, q, "")
-	c.Assert(err, qt.IsNil)
-	c.Assert(claims, qt.IsNotNil)
-	c.Assert(claims.FileID, qt.Equals, fileID)
-	c.Assert(claims.UserID, qt.Equals, userID)
-
-	// Validator WITH a cookie must NOT accept the OLD-format signature —
-	// that would let a bound caller replay an unbound URL.
-	_, err = service.ValidateSignedURL(basePath, q, "session-A")
-	c.Assert(err, qt.IsNotNil)
-	c.Assert(err.Error(), qt.Equals, "invalid signature")
 }
 
 // TestFileSigningService_ThumbnailsCarryBinding ensures the thumbnail URL


### PR DESCRIPTION
## Summary

Closes #1781. Defense-in-depth hardening that closes the leaked-URL-equals-bearer-token gap on signed file download URLs.

Today, a signed URL minted at `/api/v1/files/download/files/{id}?sig=...&exp=...&uid=...&fid=...` is valid for any caller who has the URL until `exp` (~15 min). Leak vectors: `Referer` headers, proxy/access logs, browser history. This PR binds the URL to the user's browser session via the `refresh_token` HttpOnly cookie, so a URL that escapes one of those channels can no longer be replayed — the cookie does not accompany the URL into them.

## Changes

### Service layer (`go/services/file_signing_service.go`)
- New `SessionBinding` typed string and `ExtractSessionBinding(r *http.Request)` helper that derives the binding from the request's `refresh_token` cookie: first 16 bytes of `SHA-256(cookie value)`, base64url. Missing/empty cookie returns `""` (unbound).
- `GenerateSignedURL`, `GenerateSignedURLsWithThumbnails`, `generateThumbnailSignedURL`, and `ValidateSignedURL` each take a trailing `binding SessionBinding`. The binding is folded into the HMAC message as the final `|`-separated field. **The binding is never written to the URL** — leaking the URL alone is therefore insufficient.

### Middleware (`go/apiserver/signed_url_middleware.go`)
- `SignedURLMiddleware` calls `services.ExtractSessionBinding(r)` and passes the result to `ValidateSignedURL`. Bound URLs only validate when the same cookie is presented; mismatch → existing "invalid signature" → 401.

### Handlers
- Every mint site (`apiserver/files.go`, `apiserver/exports.go`, `apiserver/uploads.go`, `apiserver/commodities.go`) threads `services.ExtractSessionBinding(r)` into the signing call.
- `CommodityCoverService.ResolveOne` / `ResolveMany` (`go/services/commodity_cover_service.go`) take the binding so the handler's request stays the source of truth — the service layer stays HTTP-free.
- `apiserver/commodities.go::resolveCoversForList` / `resolveCoverForOne` now take `*http.Request` (was `context.Context`) so the cookie is reachable.

### Shared constant (`go/appctx/auth_cookie.go`)
- New `appctx.RefreshTokenCookieName = "refresh_token"`. Both `apiserver/auth.go` and `services/file_signing_service.go` reference it, removing the previous duplicated literal that was only protected by a "keep in sync" comment.

### Tests
- `services/file_signing_service_test.go`: `TestExtractSessionBinding` covers nil request, missing cookie, empty value, stable hash, distinct hashes, other-cookie noise. `TestFileSigningService_SessionBindingMatrix` exercises the full bound/unbound × bound/unbound matrix plus a round-trip row through the real `ExtractSessionBinding` helper. `TestFileSigningService_ThumbnailsCarryBinding` verifies thumbnails inherit the binding.
- `apiserver/signed_url_middleware_test.go::TestSignedURLMiddleware_SessionBinding` is the e2e: same-cookie succeeds, missing-cookie 401, different-cookie 401, and the back-compat unbound path.
- Existing tests updated to pass `""` (back-compat) where they don't exercise the binding.

## Security posture

- Cookie semantics: `refresh_token` is HttpOnly + SameSite=Strict + Path=/api/v1. The signed download routes are under `/api/v1/files/download/...`, so legitimate same-site navigation always carries the cookie. A cross-site link click (the exact leak vector #1781 describes) does **not** carry the cookie under SameSite=Strict, so the binding mismatches and the URL is rejected.
- The binding is folded into the HMAC, so it inherits the same 256-bit secret-keyed integrity as `sig`. Signature comparison remains `hmac.Equal` (constant-time).
- Impersonation: the impersonation cookie value is `imp:<jti>`, where the JTI is also visible on the access token. The binding therefore degrades to "knowledge of access token" for impersonation sessions — strictly no worse than today, and documented on `ExtractSessionBinding`. A follow-up hardening is filed (see "Follow-ups" below).
- Back-compat: a URL minted with empty binding still validates from a caller that also presents no cookie. This is no worse than the pre-#1781 behaviour and lets non-browser tooling (e.g. CLI calls authenticated solely by an Authorization header) continue to work. A follow-up considers making mint-time binding mandatory.

## Follow-ups
- Strengthen signed URL binding for impersonation sessions (replace the impersonation cookie marker with a server-side opaque nonce, or fold an extra per-session secret into the binding source) — separate issue to be filed.
- Consider a strict mode that refuses to mint when the binding is empty (or at least logs at mint time), once we confirm no production caller relies on the unbound path — separate issue to be filed.

## Test plan
- [x] `cd go && go build ./...`
- [x] `cd go && go test ./services/... ./apiserver/... -count=1`
- [x] `cd go && golangci-lint run ./services/... ./apiserver/... ./appctx/...`
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signed URLs (downloads & thumbnails) are now bound to the caller’s browser session via the refresh-token cookie.

* **Bug Fixes / Behavior Changes**
  * Session binding applied to downloads, thumbnails, exports, uploads, and cover resolution; validation requires the originating session while preserving backward-compat for unbound URLs.
  * Middleware enforces session-bound URL validation to reduce replay/leakage.

* **Documentation**
  * Canonical refresh-token cookie name exported for consistent session binding.

* **Tests**
  * New unit and integration tests covering session binding, validation matrix, and backward compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->