### PR TITLE
[#1791] Drop legacy imp==true allowance in validateJWTToken

### DIFF
--- a/go/apiserver/jwt_middleware.go
+++ b/go/apiserver/jwt_middleware.go
@@ -68,29 +68,22 @@ func validateJWTToken(ctx context.Context, tokenString string, jwtSecret []byte,
 	}
 
 	// Enforce the token type so only genuine access tokens reach
-	// authenticated endpoints (#1778). Every JWT the apiserver mints is
-	// signed with the same jwtSecret, so a valid signature + unexpired
-	// exp is NOT enough to prove a token was meant for the access path.
-	// Without this check the step-1 mfa_token — handed out before the TOTP
-	// code is verified — could be replayed verbatim as a Bearer token,
-	// fully bypassing the second factor for its ~5-minute TTL.
+	// authenticated endpoints (#1778, tightened in #1791). Every JWT the
+	// apiserver mints is signed with the same jwtSecret, so a valid
+	// signature + unexpired exp is NOT enough to prove a token was meant
+	// for the access path. Without this check the step-1 mfa_token —
+	// handed out before the TOTP code is verified — could be replayed
+	// verbatim as a Bearer token, fully bypassing the second factor for
+	// its ~5-minute TTL.
 	//
-	// A token is admitted only if:
-	//   - token_type == accessTokenType ("access"), stamped by every access
-	//     token mint (issueAccessToken / signAdminAccessToken /
-	//     signImpersonationToken); or
-	//   - it carries imp == true. This explicit allowance keeps
-	//     impersonation tokens issued *before* this change (which lack the
-	//     token_type claim) working for their short TTL across a deploy.
-	//     Steady-state impersonation tokens already pass via token_type, so
-	//     the imp arm is removable once #1778 has shipped — tracked by #1791.
-	//
-	// Everything else — a missing token_type, the mfa_challenge type, or
+	// Admission rule: token_type == accessTokenType ("access"). Every
+	// access-token mint (issueAccessToken, signAdminAccessToken,
+	// signImpersonationToken) stamps it, so impersonation tokens are
+	// included. Anything else — missing token_type, mfa_challenge, or
 	// any future special-purpose JWT — is rejected, which makes
 	// JWTMiddleware respond 401.
 	tokenType, _ := claims["token_type"].(string)
-	imp, _ := claims["imp"].(bool)
-	if tokenType != accessTokenType && !imp {
+	if tokenType != accessTokenType {
 		return nil, fmt.Errorf("invalid token type")
 	}
 

--- a/go/apiserver/jwt_middleware_test.go
+++ b/go/apiserver/jwt_middleware_test.go
@@ -92,30 +92,8 @@ func TestJWTMiddleware(t *testing.T) {
 			},
 		},
 		{
-			// #1778: an impersonation token issued before the token_type
-			// change lacks the claim but carries imp=true. The explicit
-			// imp allowance keeps such in-flight tokens working across a
-			// deploy.
-			name: "legacy impersonation token (imp=true, no token_type)",
-			setupRequest: func(req *http.Request) {
-				token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-					"user_id": "user-123",
-					"imp":     true,
-					"exp":     time.Now().Add(24 * time.Hour).Unix(),
-				})
-				tokenString, _ := token.SignedString(jwtSecret)
-				req.Header.Set("Authorization", "Bearer "+tokenString)
-			},
-			checkContext: func(t *testing.T, r *http.Request) {
-				c := qt.New(t)
-				user := appctx.UserFromContext(r.Context())
-				c.Assert(user, qt.IsNotNil)
-				c.Assert(user.ID, qt.Equals, "user-123")
-			},
-		},
-		{
-			// Steady-state impersonation token: carries both imp=true and
-			// token_type=access. Accepted via the token_type check.
+			// Steady-state impersonation token: carries imp=true and
+			// token_type=access (stamped by signImpersonationToken).
 			name: "impersonation token with imp=true and token_type=access",
 			setupRequest: func(req *http.Request) {
 				token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
@@ -254,6 +232,25 @@ func TestJWTMiddleware(t *testing.T) {
 				token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 					"user_id": "user-123",
 					"role":    "user",
+					"exp":     time.Now().Add(24 * time.Hour).Unix(),
+				})
+				tokenString, _ := token.SignedString(jwtSecret)
+				req.Header.Set("Authorization", "Bearer "+tokenString)
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			// #1791: the legacy imp=true rollout-window allowance was
+			// dropped. A token shaped like a pre-#1778 impersonation
+			// token (imp=true, no token_type) must now be rejected, like
+			// any other token missing token_type=access. Steady-state
+			// impersonation tokens stamp token_type=access and are
+			// covered by the success case above.
+			name: "legacy impersonation token without token_type is rejected",
+			setupRequest: func(req *http.Request) {
+				token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+					"user_id": "user-123",
+					"imp":     true,
 					"exp":     time.Now().Add(24 * time.Hour).Unix(),
 				})
 				tokenString, _ := token.SignedString(jwtSecret)


### PR DESCRIPTION
Closes #1791.

## Summary

After PR #1792 (which fixed #1778) shipped on 2026-05-22 and the >30-minute impersonation-token TTL window closed, the `imp == true` rollout-window arm in `validateJWTToken` is dead code. This PR tightens admission to the steady-state rule.

## Change

- **`go/apiserver/jwt_middleware.go`** — admission rule simplifies to `tokenType != accessTokenType { return ... }`. The unused `imp` local is removed. Comment block rewritten to drop the rollout-window phrasing; the load-bearing WHY (mfa_token replay protection introduced in #1778, tightened here) is preserved and now points at #1791.
- **`go/apiserver/jwt_middleware_test.go`** — the "legacy impersonation token (imp=true, no token_type)" success case is removed and replaced by a symmetric failure case ("legacy impersonation token without token_type is rejected", 401). The steady-state impersonation case ("imp=true and token_type=access") remains green — `signImpersonationToken` stamps both, so impersonation tokens continue to admit via the `token_type` channel.

## Why it's safe to drop now

- #1792 merged 2026-05-22 17:49 UTC; impersonation TTL ≤ 30 min; today is 2026-05-23 — every pre-#1792 token has been expired for hours.
- All four JWT minters that sign with `jwtSecret` were audited: `issueAccessToken`, `signAdminAccessToken`, `signImpersonationToken` all stamp `token_type: "access"`; `issueMFAToken` stamps `mfa_challenge` (the original #1778 victim) and MUST keep being rejected.
- All readers of the `imp` claim downstream (`audit_service.go`, `auth.go`, `admin_impersonation.go`) operate on already-admitted tokens — they never relied on the `imp` arm for admission. The refresh and `/end` endpoints inspect the bearer via their own `jwt.Parse` callers and never transit `validateJWTToken`.

## Test plan

- [x] `gofmt -l ./apiserver/` — no output
- [x] `go build ./...` — clean
- [x] `go vet ./apiserver/...` — clean
- [x] `golangci-lint run --fix ./apiserver/...` — `0 issues.`
- [x] `golangci-lint run` (full repo) — `0 issues.`
- [x] `go test ./apiserver/... -count=1` — `ok`
- [x] Verbose run confirms `impersonation_token_with_imp=true_and_token_type=access` still PASSES as a success case (steady-state impersonation still works) and `legacy_impersonation_token_without_token_type_is_rejected` PASSES as a 401 failure case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened JWT token validation for API authentication. Impersonation tokens now must include proper token type designation. Tokens that do not meet updated requirements will receive 401 Unauthorized responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->