### PR TITLE
[#1812] Accept the Bearer auth scheme case-insensitively

### DIFF
--- a/go/apiserver/admin_impersonation.go
+++ b/go/apiserver/admin_impersonation.go
@@ -321,8 +321,8 @@ func (api *adminImpersonationAPI) issueAndRespond(w http.ResponseWriter, r *http
 // is NOT an error here — that case yields (claims, nil) and is handled
 // downstream as the 422 "not active" business-rule outcome.
 func (api *adminImpersonationAPI) parseImpersonationEndToken(authHeader string) (jwt.MapClaims, error) {
-	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
-	if tokenString == authHeader || tokenString == "" {
+	tokenString, ok := parseBearerToken(authHeader)
+	if !ok {
 		return nil, ErrImpersonationTokenInvalid
 	}
 	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -417,14 +417,36 @@ func (api *AuthAPI) refresh(w http.ResponseWriter, r *http.Request) {
 	writeLoginResponse(w, accessTokenString, csrfToken, user)
 }
 
+// parseBearerToken extracts the token portion of an Authorization header that
+// uses the Bearer scheme. Per RFC 7235 §2.1, auth-scheme names are
+// case-insensitive, so `Bearer`, `bearer`, `BEARER`, `BeArEr` all match. The
+// token is trimmed of surrounding whitespace; an empty token (e.g. `Bearer `
+// with nothing after the space) is rejected. Returns (token, true) on a
+// well-formed Bearer header; ("", false) when the header is empty, lacks a
+// space-separated scheme, uses a non-Bearer scheme, or carries no token.
+func parseBearerToken(authHeader string) (string, bool) {
+	scheme, token, ok := strings.Cut(authHeader, " ")
+	if !ok {
+		return "", false
+	}
+	if !strings.EqualFold(scheme, "Bearer") {
+		return "", false
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
 // userIDFromAccessTokenHeader parses the Bearer token in authHeader and returns
 // the user ID stored in the "user_id" claim.  Expired tokens are accepted so
 // that logout can retrieve the user ID even when the access token has already
 // lapsed.  Returns ("", false) when the header is absent, malformed, or has an
 // invalid signature.
 func (api *AuthAPI) userIDFromAccessTokenHeader(authHeader string) (string, bool) {
-	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
-	if tokenString == authHeader {
+	tokenString, ok := parseBearerToken(authHeader)
+	if !ok {
 		return "", false
 	}
 	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
@@ -457,8 +479,8 @@ func (api *AuthAPI) userIDFromAccessTokenHeader(authHeader string) (string, bool
 // cannot verify is treated as "not an impersonation token" so the
 // regular cookie-based refresh path handles (and rejects) it.
 func (api *AuthAPI) accessTokenIsImpersonation(authHeader string) bool {
-	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
-	if tokenString == authHeader || tokenString == "" {
+	tokenString, ok := parseBearerToken(authHeader)
+	if !ok {
 		return false
 	}
 	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
@@ -495,8 +517,8 @@ func (api *AuthAPI) accessTokenIsImpersonation(authHeader string) bool {
 // header is absent/malformed, the signature is invalid, or the token is
 // not an impersonation token.
 func (api *AuthAPI) impersonationClaimsFromAccessTokenHeader(authHeader string) (jwt.MapClaims, bool) {
-	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
-	if tokenString == authHeader || tokenString == "" {
+	tokenString, ok := parseBearerToken(authHeader)
+	if !ok {
 		return nil, false
 	}
 	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
@@ -526,8 +548,8 @@ func (api *AuthAPI) blacklistAccessToken(ctx context.Context, authHeader string)
 	if api.blacklistService == nil {
 		return
 	}
-	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
-	if tokenString == authHeader {
+	tokenString, ok := parseBearerToken(authHeader)
+	if !ok {
 		return
 	}
 	// Parse with signature verification. We allow tokens that are already expired

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -791,6 +791,83 @@ func TestAuthAPI_Refresh(t *testing.T) {
 	})
 }
 
+// TestAuthAPI_Refresh_BearerSchemeIsCaseInsensitive is the #1812 regression
+// test for accessTokenIsImpersonation. The refresh endpoint reads the
+// Authorization header to detect impersonation access tokens (which it must
+// reject). Before #1812 the scheme match was case-sensitive on the exact
+// prefix `"Bearer "`, so an FE that sent `Authorization: bearer <token>` —
+// permitted by RFC 7235 §2.1 — would bypass the impersonation guard and
+// silently receive a fresh admin access token. This test asserts that a
+// lower-case scheme is correctly classified as an impersonation token and
+// rejected with 401 ErrImpersonationTokenCannotRefresh.
+func TestAuthAPI_Refresh_BearerSchemeIsCaseInsensitive(t *testing.T) {
+	jwtSecret := []byte("test-secret-32-bytes-minimum-length")
+	const (
+		userID   = "user-refresh-imp"
+		tenantID = "test-tenant-id"
+	)
+
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{userID: {
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: userID},
+			TenantID: tenantID,
+		},
+		Email:    "imp@example.com",
+		Name:     "Imp Refresh User",
+		IsActive: true,
+	}}}
+	refreshReg := &mockRefreshTokenRegistryForAuth{tokensByHash: map[string]*models.RefreshToken{}}
+
+	// Mint an impersonation access token. accessTokenIsImpersonation reads only
+	// the `imp` claim, so the rest of the claims can be minimal.
+	impToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"user_id":         userID,
+		"token_type":      "access",
+		"imp":             true,
+		"impersonated_by": "admin-user",
+		"jti":             "imp-jti",
+		"exp":             time.Now().Add(15 * time.Minute).Unix(),
+	})
+	impTokenString, err := impToken.SignedString(jwtSecret)
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+
+	cases := []struct {
+		name        string
+		authHeader  string
+		description string
+	}{
+		{"lower-case bearer", "bearer " + impTokenString, "RFC 7235 §2.1 case-insensitive scheme"},
+		{"upper-case BEARER", "BEARER " + impTokenString, "RFC 7235 §2.1 case-insensitive scheme"},
+		{"mixed-case BeArEr", "BeArEr " + impTokenString, "RFC 7235 §2.1 case-insensitive scheme"},
+		{"canonical Bearer", "Bearer " + impTokenString, "baseline sanity"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			req := httptest.NewRequest("POST", "/refresh", nil)
+			req.Header.Set("Authorization", tc.authHeader)
+			resp := httptest.NewRecorder()
+
+			router := chi.NewRouter()
+			apiserver.Auth(apiserver.AuthParams{
+				UserRegistry:         userReg,
+				RefreshTokenRegistry: refreshReg,
+				JWTSecret:            jwtSecret,
+			})(router)
+			router.ServeHTTP(resp, req)
+
+			// All four header forms must be classified as impersonation tokens
+			// and rejected with 401 carrying the dedicated error message.
+			c.Assert(resp.Code, qt.Equals, http.StatusUnauthorized)
+			c.Assert(strings.TrimSpace(resp.Body.String()), qt.Equals, apiserver.ErrImpersonationTokenCannotRefresh.Error())
+		})
+	}
+}
+
 // legacyRefreshCookieDeleted reports whether the response includes a
 // Set-Cookie header that deletes the refresh_token cookie pinned at the
 // legacy /api/v1/auth path. http.SetCookie with MaxAge=-1 renders as

--- a/go/apiserver/auth_test.go
+++ b/go/apiserver/auth_test.go
@@ -834,14 +834,13 @@ func TestAuthAPI_Refresh_BearerSchemeIsCaseInsensitive(t *testing.T) {
 	}
 
 	cases := []struct {
-		name        string
-		authHeader  string
-		description string
+		name       string
+		authHeader string
 	}{
-		{"lower-case bearer", "bearer " + impTokenString, "RFC 7235 §2.1 case-insensitive scheme"},
-		{"upper-case BEARER", "BEARER " + impTokenString, "RFC 7235 §2.1 case-insensitive scheme"},
-		{"mixed-case BeArEr", "BeArEr " + impTokenString, "RFC 7235 §2.1 case-insensitive scheme"},
-		{"canonical Bearer", "Bearer " + impTokenString, "baseline sanity"},
+		{"lower-case bearer", "bearer " + impTokenString},
+		{"upper-case BEARER", "BEARER " + impTokenString},
+		{"mixed-case BeArEr", "BeArEr " + impTokenString},
+		{"canonical Bearer", "Bearer " + impTokenString},
 	}
 
 	for _, tc := range cases {

--- a/go/apiserver/jwt_middleware.go
+++ b/go/apiserver/jwt_middleware.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -23,14 +22,17 @@ import (
 // full-scope access tokens in URLs leak via Referer headers, proxy/access
 // logs and browser history. Genuine browser file/thumbnail downloads use
 // HMAC-signed URLs (SignedURLMiddleware), not JWTs.
+//
+// The Bearer auth-scheme name is matched case-insensitively per RFC 7235 §2.1
+// (delegated to parseBearerToken).
 func extractTokenFromRequest(r *http.Request) (string, error) {
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
 		return "", fmt.Errorf("authorization header required")
 	}
 
-	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
-	if tokenString == authHeader {
+	tokenString, ok := parseBearerToken(authHeader)
+	if !ok {
 		return "", fmt.Errorf("bearer token required")
 	}
 	return tokenString, nil

--- a/go/apiserver/jwt_middleware_test.go
+++ b/go/apiserver/jwt_middleware_test.go
@@ -92,6 +92,49 @@ func TestJWTMiddleware(t *testing.T) {
 			},
 		},
 		{
+			// #1812 regression: RFC 7235 §2.1 makes auth-scheme names
+			// case-insensitive. Lower-case `bearer` must be accepted.
+			name: "lower-case bearer scheme is accepted",
+			setupRequest: func(req *http.Request) {
+				token := createToken("user-123")
+				req.Header.Set("Authorization", "bearer "+token)
+			},
+			checkContext: func(t *testing.T, r *http.Request) {
+				c := qt.New(t)
+				user := appctx.UserFromContext(r.Context())
+				c.Assert(user, qt.IsNotNil)
+				c.Assert(user.ID, qt.Equals, "user-123")
+			},
+		},
+		{
+			// #1812 regression: upper-case BEARER scheme is accepted.
+			name: "upper-case BEARER scheme is accepted",
+			setupRequest: func(req *http.Request) {
+				token := createToken("user-123")
+				req.Header.Set("Authorization", "BEARER "+token)
+			},
+			checkContext: func(t *testing.T, r *http.Request) {
+				c := qt.New(t)
+				user := appctx.UserFromContext(r.Context())
+				c.Assert(user, qt.IsNotNil)
+				c.Assert(user.ID, qt.Equals, "user-123")
+			},
+		},
+		{
+			// #1812 regression: mixed-case BeArEr scheme is accepted.
+			name: "mixed-case BeArEr scheme is accepted",
+			setupRequest: func(req *http.Request) {
+				token := createToken("user-123")
+				req.Header.Set("Authorization", "BeArEr "+token)
+			},
+			checkContext: func(t *testing.T, r *http.Request) {
+				c := qt.New(t)
+				user := appctx.UserFromContext(r.Context())
+				c.Assert(user, qt.IsNotNil)
+				c.Assert(user.ID, qt.Equals, "user-123")
+			},
+		},
+		{
 			// Steady-state impersonation token: carries imp=true and
 			// token_type=access (stamped by signImpersonationToken).
 			name: "impersonation token with imp=true and token_type=access",
@@ -255,6 +298,44 @@ func TestJWTMiddleware(t *testing.T) {
 				})
 				tokenString, _ := token.SignedString(jwtSecret)
 				req.Header.Set("Authorization", "Bearer "+tokenString)
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			// #1812 regression: a single space with no scheme/no token is
+			// rejected. extractTokenFromRequest must not admit `" "` as a
+			// valid Bearer header.
+			name: "single space authorization header is rejected",
+			setupRequest: func(req *http.Request) {
+				req.Header.Set("Authorization", " ")
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			// #1812 regression: a Basic scheme — a different RFC 7235 auth
+			// scheme — must be rejected even when it carries what looks
+			// like a JWT after the space.
+			name: "non-Bearer scheme is rejected",
+			setupRequest: func(req *http.Request) {
+				req.Header.Set("Authorization", "Basic some.jwt.like.thing")
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			// #1812 regression: a bare `Bearer` with no space and no token
+			// is rejected.
+			name: "Bearer with no token is rejected",
+			setupRequest: func(req *http.Request) {
+				req.Header.Set("Authorization", "Bearer")
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			// #1812 regression: `Bearer ` with a trailing space but no
+			// actual token is rejected.
+			name: "Bearer with trailing space and empty token is rejected",
+			setupRequest: func(req *http.Request) {
+				req.Header.Set("Authorization", "Bearer ")
 			},
 			expectedStatus: http.StatusUnauthorized,
 		},


### PR DESCRIPTION
## Summary

Closes #1812.

`Authorization` header parsing rejected the `Bearer` auth scheme unless its name was exactly capitalised. Per [RFC 7235 §2.1](https://datatracker.ietf.org/doc/html/rfc7235#section-2.1) the auth-scheme name is **case-insensitive**, so `Authorization: bearer …`, `BEARER …`, mixed-case, etc. must all be accepted. Pre-fix, anything other than `Bearer ` produced a `401 bearer token required`.

## Changes

- New helper `parseBearerToken(authHeader string) (token string, ok bool)` in `go/apiserver/auth.go`:
  - Splits on the first space (`strings.Cut`), rejects single-token headers.
  - Matches scheme via `strings.EqualFold(scheme, "Bearer")` — RFC 7235 §2.1 case-insensitivity.
  - Trims whitespace from the token; rejects empty.
- Replaces the previous `strings.TrimPrefix(authHeader, "Bearer ")` pattern at 6 sites:
  - `jwt_middleware.go::extractTokenFromRequest`
  - `auth.go::userIDFromAccessTokenHeader`
  - `auth.go::accessTokenIsImpersonation`
  - `auth.go::impersonationClaimsFromAccessTokenHeader`
  - `auth.go::blacklistAccessToken`
  - `admin_impersonation.go::parseImpersonationEndToken`

The issue body listed 3 files, but `auth.go` has 5 sites — all were affected by the same bug, so all 6 are fixed.

Existing error/return semantics are preserved at each site:
- `extractTokenFromRequest` still returns `fmt.Errorf("bearer token required")` → 401.
- The four `auth.go` helpers still return their typed `(zero, false)` tuples.
- `parseImpersonationEndToken` still returns `ErrImpersonationTokenInvalid`.

### Strict-improvement note

Three sites (`extractTokenFromRequest`, `userIDFromAccessTokenHeader`, `blacklistAccessToken`) previously had no explicit empty-token guard — they relied on downstream `jwt.Parse("")` to fail. The helper now short-circuits at parse time. Outward HTTP behaviour for legitimate clients is unchanged; an empty token still produces the same 401/early-return.

## Tests

`go/apiserver/jwt_middleware_test.go` (regression for `extractTokenFromRequest` via the full middleware path):

- ✅ `bearer <token>` — accepted
- ✅ `BEARER <token>` — accepted
- ✅ `BeArEr <token>` — accepted
- ✅ `Bearer <token>` — accepted (baseline sanity)
- ❌ `Basic <token>` — rejected
- ❌ `Bearer` (no space) — rejected
- ❌ `Bearer ` (no token after space) — rejected
- ❌ ` ` (single space) — rejected

`go/apiserver/auth_test.go::TestAuthAPI_Refresh_BearerSchemeIsCaseInsensitive` exercises `accessTokenIsImpersonation` through the `/auth/refresh` handler with `bearer`/`BEARER`/`BeArEr`/`Bearer` impersonation tokens — all four are classified as impersonation and rejected with `ErrImpersonationTokenCannotRefresh`.

## Verification

```
make lint-go     # 0 issues
make test-go     # all PASS
```

## Test plan

- [x] `make lint-go` passes
- [x] `make test-go` passes
- [x] New regression cases for lower/upper/mixed-case `Bearer` exercised through middleware
- [x] Negative cases (`Basic`, bare `Bearer`, empty, single space) still rejected
- [x] No swagger / migration / codegen impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization header Bearer scheme matching is now case-insensitive (RFC 7235 compliant).
  * Improved validation and consistent error handling for malformed, missing, or empty Bearer tokens across authentication endpoints.

* **Tests**
  * Added tests covering case-insensitive Bearer scheme variants and rejection of malformed or empty Authorization headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->