### PR TITLE
[#1814] Postgres NonRLSRepository-backed Update returns ErrNotFound for unknown ID

### DIFF
--- a/go/registry/memory/email_verifications_test.go
+++ b/go/registry/memory/email_verifications_test.go
@@ -159,6 +159,17 @@ func TestEmailVerificationRegistry_Update(t *testing.T) {
 	c.Assert(reloaded.IsVerified(), qt.IsTrue)
 }
 
+func TestEmailVerificationRegistry_Update_NotFound(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	ev := newTestEmailVerification("token-update-missing")
+	ev.ID = "no-such-id"
+	_, err := r.Update(ctx, ev)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
 func TestEmailVerificationRegistry_Delete(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()

--- a/go/registry/memory/password_resets_test.go
+++ b/go/registry/memory/password_resets_test.go
@@ -1,0 +1,33 @@
+package memory_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+// TestPasswordResetRegistry_Update_NotFound pins parity with the postgres
+// backend: Update against an unknown ID returns registry.ErrNotFound rather
+// than silently succeeding. See #1814.
+func TestPasswordResetRegistry_Update_NotFound(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewPasswordResetRegistry()
+
+	pr := models.PasswordReset{
+		UserID:    "user-1",
+		TenantID:  "tenant-1",
+		Token:     "token-update-missing",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	pr.ID = "no-such-id"
+	_, err := r.Update(ctx, pr)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}

--- a/go/registry/postgres/audit_logs.go
+++ b/go/registry/postgres/audit_logs.go
@@ -101,6 +101,9 @@ func (r *AuditLogRegistry) Update(ctx context.Context, entry models.AuditLog) (*
 
 	reg := r.newSQLRegistry()
 	if err := reg.Update(ctx, entry, nil); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "AuditLog", "entity_id", entry.GetID()))
+		}
 		return nil, errxtrace.Wrap("failed to update audit log entry", err)
 	}
 

--- a/go/registry/postgres/email_verifications.go
+++ b/go/registry/postgres/email_verifications.go
@@ -85,6 +85,9 @@ func (r *EmailVerificationRegistry) Update(ctx context.Context, ev models.EmailV
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
 	}
 	if err := r.newRepo().Update(ctx, ev, nil); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "EmailVerification", "entity_id", ev.GetID()))
+		}
 		return nil, errxtrace.Wrap("failed to update email verification", err)
 	}
 	return &ev, nil

--- a/go/registry/postgres/email_verifications_test.go
+++ b/go/registry/postgres/email_verifications_test.go
@@ -183,6 +183,23 @@ func TestEmailVerificationRegistry_Update(t *testing.T) {
 	c.Assert(reloaded.IsVerified(), qt.IsTrue)
 }
 
+// TestEmailVerificationRegistry_Update_NotFound pins parity with the memory
+// backend: Update against an unknown ID returns registry.ErrNotFound rather
+// than silently succeeding with a zero-row UPDATE. See #1814.
+func TestEmailVerificationRegistry_Update_NotFound(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	ev := newTestEmailVerification(user, "token-update-missing")
+	ev.ID = "no-such-id"
+	_, err := registrySet.EmailVerificationRegistry.Update(ctx, ev)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
 func TestEmailVerificationRegistry_Delete(t *testing.T) {
 	registrySet, cleanup := setupTestRegistrySet(t)
 	defer cleanup()

--- a/go/registry/postgres/password_resets.go
+++ b/go/registry/postgres/password_resets.go
@@ -85,6 +85,9 @@ func (r *PasswordResetRegistry) Update(ctx context.Context, pr models.PasswordRe
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
 	}
 	if err := r.newRepo().Update(ctx, pr, nil); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "PasswordReset", "entity_id", pr.GetID()))
+		}
 		return nil, errxtrace.Wrap("failed to update password reset", err)
 	}
 	return &pr, nil

--- a/go/registry/postgres/password_resets_test.go
+++ b/go/registry/postgres/password_resets_test.go
@@ -1,0 +1,35 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// TestPasswordResetRegistry_Update_NotFound pins parity with the memory
+// backend: Update against an unknown ID returns registry.ErrNotFound rather
+// than silently succeeding with a zero-row UPDATE. See #1814.
+func TestPasswordResetRegistry_Update_NotFound(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	pr := models.PasswordReset{
+		UserID:    user.ID,
+		TenantID:  user.TenantID,
+		Token:     "token-update-missing",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	pr.ID = "no-such-id"
+	_, err := registrySet.PasswordResetRegistry.Update(ctx, pr)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}

--- a/go/registry/postgres/tenants.go
+++ b/go/registry/postgres/tenants.go
@@ -145,6 +145,9 @@ func (r *TenantRegistry) Update(ctx context.Context, tenant models.Tenant) (*mod
 
 	err := reg.Update(ctx, tenant, nil)
 	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "Tenant", "entity_id", tenant.GetID()))
+		}
 		return nil, errxtrace.Wrap("failed to update tenant", err)
 	}
 

--- a/go/registry/postgres/users.go
+++ b/go/registry/postgres/users.go
@@ -154,6 +154,9 @@ func (r *UserRegistry) Update(ctx context.Context, user models.User) (*models.Us
 
 	err := reg.Update(ctx, user, nil)
 	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "User", "entity_id", user.GetID()))
+		}
 		return nil, errxtrace.Wrap("failed to update user", err)
 	}
 


### PR DESCRIPTION
## Summary

Pin parity between memory and postgres backends for `Update` against a non-existent ID across every `NonRLSRepository`-backed registry. The postgres `NonRLSRepository.Update` already does a `ScanOneByField` existence check and returns `store.ErrNotFound` on miss, but each registry's `Update` was wrapping that result with `errxtrace.Wrap("failed to update <thing>")` — so the chain technically satisfied `errors.Is(err, registry.ErrNotFound)` but the error message read `"failed to update X: failed to scan entity: not found"` instead of a clean classification.

Translate the not-found case explicitly in each registry's `Update`, mirroring the surrounding `Get` / `GetByToken` pattern.

## Changes

- `go/registry/postgres/email_verifications.go` — classify `store.ErrNotFound` -> `registry.ErrNotFound` in `Update`.
- `go/registry/postgres/password_resets.go` — same.
- `go/registry/postgres/users.go` — same.
- `go/registry/postgres/tenants.go` — same.
- `go/registry/postgres/audit_logs.go` — same.
- `go/registry/memory/email_verifications_test.go` — new `TestEmailVerificationRegistry_Update_NotFound` parity test.
- `go/registry/postgres/email_verifications_test.go` — same.
- `go/registry/memory/password_resets_test.go` — new test file with `TestPasswordResetRegistry_Update_NotFound` parity test.
- `go/registry/postgres/password_resets_test.go` — same.

## Audit notes

The five `NonRLSRepository`-backed registries are: `EmailVerificationRegistry`, `PasswordResetRegistry`, `UserRegistry`, `TenantRegistry`, `AuditLogRegistry`. All five now translate `store.ErrNotFound` explicitly. Parity tests added for the two named in #1814 (email verifications and password resets). `users`/`tenants`/`audit_logs` had no existing test files; the registry-layer fix is the audit deliverable per the issue scope — adding bare parity-only test files for them is out of scope.

## Test plan

- [x] `go test ./registry/memory/ -count=1` — all pass.
- [x] `POSTGRES_TEST_DSN=... go test ./registry/postgres/ -count=1` — all pass (~5min).
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `go tool nolintguard ./...` — clean.
- [x] `go tool qtlint ./...` — clean.
- [x] `go test ./...` — no failures across the full module.

Fixes #1814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed error handling when attempting to update non-existent records across data backends, now returning consistent not-found responses.

* **Tests**
  * Added comprehensive test coverage for update operations on non-existent records across in-memory and database backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->