### PR TITLE
security(middleware): cap rejectTenantBody body read at 1 MiB; skip multipart (#1826)

### DIFF
--- a/go/apiserver/security_middleware.go
+++ b/go/apiserver/security_middleware.go
@@ -89,43 +89,103 @@ func rejectTenantQueryParam(w http.ResponseWriter, r *http.Request) bool {
 	return false
 }
 
+// tenantScanMaxBodyBytes is the maximum number of body bytes rejectTenantBody
+// will read from a non-multipart request. It applies only to bodies that are
+// actually scanned (multipart/* is skipped entirely — see rejectTenantBody);
+// it is NOT a global request-body cap. The value is intentionally much
+// larger than every per-handler text-body cap in the codebase today
+// (feedbackMaxRequestBodyBytes ≈ 53 KB; createInviteMaxBodyBytes = 4 KB;
+// PasswordResetRateLimitMiddleware = 4 KB) so legitimate JSON / form
+// payloads never trip it, while still being small enough that an attacker
+// cannot force gigabyte-scale allocations per concurrent request.
+const tenantScanMaxBodyBytes = 1 * 1024 * 1024 // 1 MiB
+
 // rejectTenantBody checks the request body of mutating requests for
-// tenant-identifying fields. It reads and restores the body so downstream
-// handlers still see it. Returns true — having written a 4xx — when a
-// violation (or a body-read failure) was found; false when the body is
-// clean or the method is not body-bearing.
+// tenant-identifying fields. Behaviour, in order:
 //
-// The check is intentionally a cheap, case-insensitive substring scan
-// rather than a JSON parser — it is belt-and-suspenders defense-in-depth,
-// not a contract validator. After lowercasing the body it matches:
-//   - snake_case "tenant_id" (also catches snake_case form-encoded
+//  1. Method gate: only POST/PUT/PATCH bodies are scanned. Anything else
+//     passes through untouched (returns false).
+//
+//  2. Multipart skip: when Content-Type starts with "multipart/", the body
+//     is skipped entirely without being read. Multipart payloads are
+//     mostly binary file bytes that (a) can be gigabytes large and (b)
+//     can randomly contain the substrings this scan looks for, producing
+//     false-positive 403s. No handler in the codebase binds a tenant ID
+//     from a multipart field, and the header / query / non-multipart-body
+//     scans still catch the realistic injection paths.
+//
+//  3. Size cap: the body is read through io.LimitReader with a cap of
+//     tenantScanMaxBodyBytes+1. If the read length exceeds the cap, the
+//     middleware writes a 413 and short-circuits. io.LimitReader is used
+//     in preference to http.MaxBytesReader to keep response-writing under
+//     the middleware's sole control: MaxBytesReader writes to the
+//     ResponseWriter when the limit is exceeded, which would race the
+//     middleware's own http.Error call and risk a double-write. This is
+//     the same idiom PasswordResetRateLimitMiddleware uses in
+//     rate_limit_middleware.go for the same reason.
+//
+//  4. Substring scan: the read body is lowercased and checked against a
+//     small set of quote-anchored substrings. This is intentionally a
+//     cheap, case-insensitive scan rather than a JSON parser — it is
+//     belt-and-suspenders defense-in-depth, not a contract validator.
+//     The patterns matched are:
+//     - snake_case "tenant_id" (also catches snake_case form-encoded
 //     bodies such as "tenant_id=…");
-//   - the double-quoted form "\"tenant\"" — a JSON object key cannot
-//     legitimately read free text without those surrounding quotes, so
-//     the quote anchors make this match key-shaped occurrences only;
-//   - the single-quoted form "'tenant'" — pre-existing pattern that
+//     - the double-quoted form "\"tenant\"" — a JSON object key cannot
+//     legitimately read free text without those surrounding quotes,
+//     so the quote anchors make this match key-shaped occurrences
+//     only;
+//     - the single-quoted form "'tenant'" — pre-existing pattern that
 //     covers non-JSON formats (YAML / JS-embedded) and is left in
 //     place for back-compat. It can over-fire on free text that
 //     contains 'tenant' in single quotes; accepted as a known
 //     belt-and-suspenders limitation;
-//   - the camelCase JSON-key forms "\"tenantId\"" / "\"tenantID\""
-//     (covered by the lowercased "\"tenantid\"" substring, quoted to
-//     avoid flagging the bare word "tenantid" inside free text).
+//     - the camelCase JSON-key forms "\"tenantId\"" / "\"tenantID\""
+//     (covered by the lowercased "\"tenantid\"" substring, quoted
+//     to avoid flagging the bare word "tenantid" inside free text).
+//     Only the double-quoted "\"tenantid\"" form is added — extending
+//     the single-quoted variant would introduce a new false-positive
+//     surface for description-style strings such as "...'tenantid'..."
+//     without adding any coverage against JSON, which is the format
+//     every current Inventario handler decodes. On a hit the middleware
+//     writes a 403.
 //
-// Only the double-quoted "\"tenantid\"" form is added — extending the
-// single-quoted variant would introduce a new false-positive surface
-// for description-style strings such as "...'tenantid'..." without
-// adding any coverage against JSON, which is the format every current
-// Inventario handler decodes.
+//  5. Body restoration: the buffered bytes are written back to r.Body
+//     via io.NopCloser so downstream handlers can re-read.
+//
+// Returns true — having written a 4xx — when a violation, a body-read
+// failure, or an oversize-body event occurred; false when the body is
+// clean, the method is not body-bearing, or the content type is multipart.
 func rejectTenantBody(w http.ResponseWriter, r *http.Request) bool {
 	if r.Method != http.MethodPost && r.Method != http.MethodPut && r.Method != http.MethodPatch {
 		return false
 	}
 
-	body, err := io.ReadAll(r.Body)
+	contentType := r.Header.Get("Content-Type")
+	if strings.HasPrefix(strings.ToLower(contentType), "multipart/") {
+		return false
+	}
+
+	// Bound the read so a malicious client cannot force unbounded
+	// allocation here. See tenantScanMaxBodyBytes and the doc comment
+	// above for the LimitReader-vs-MaxBytesReader rationale.
+	body, err := io.ReadAll(io.LimitReader(r.Body, tenantScanMaxBodyBytes+1))
+	_ = r.Body.Close() // mirrors PasswordResetRateLimitMiddleware; r.Body is replaced below
 	if err != nil {
 		slog.Error("Failed to read request body for security validation", "error", err)
 		http.Error(w, "Failed to read request body", http.StatusBadRequest)
+		return true
+	}
+	if int64(len(body)) > tenantScanMaxBodyBytes {
+		slog.Error("Security violation: request body exceeds tenant-scan size cap",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"content_type", contentType,
+			"content_length", r.ContentLength,
+			"user_agent", r.UserAgent(),
+			"remote_addr", r.RemoteAddr,
+		)
+		http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
 		return true
 	}
 	// Restore body for downstream handlers.
@@ -139,7 +199,7 @@ func rejectTenantBody(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 	slog.Error("Security violation: user-provided tenant ID in request body",
-		"content_type", r.Header.Get("Content-Type"),
+		"content_type", contentType,
 		"body_preview", truncateString(string(body), 200),
 		"user_agent", r.UserAgent(),
 		"remote_addr", r.RemoteAddr,

--- a/go/apiserver/security_middleware.go
+++ b/go/apiserver/security_middleware.go
@@ -89,15 +89,22 @@ func rejectTenantQueryParam(w http.ResponseWriter, r *http.Request) bool {
 	return false
 }
 
-// tenantScanMaxBodyBytes is the maximum number of body bytes rejectTenantBody
-// will read from a non-multipart request. It applies only to bodies that are
-// actually scanned (multipart/* is skipped entirely — see rejectTenantBody);
-// it is NOT a global request-body cap. The value is intentionally much
-// larger than every per-handler text-body cap in the codebase today
-// (feedbackMaxRequestBodyBytes ≈ 53 KB; createInviteMaxBodyBytes = 4 KB;
-// PasswordResetRateLimitMiddleware = 4 KB) so legitimate JSON / form
-// payloads never trip it, while still being small enough that an attacker
-// cannot force gigabyte-scale allocations per concurrent request.
+// tenantScanMaxBodyBytes is the maximum non-multipart request-body size
+// that rejectTenantBody will accept and scan. It applies only to bodies
+// that are actually scanned (multipart/* is skipped entirely — see
+// rejectTenantBody); it is NOT a global request-body cap. The
+// implementation actually reads up to tenantScanMaxBodyBytes+1 bytes via
+// io.LimitReader so that a body of exactly this size still passes (it is
+// buffered in full) but a body one byte larger trips the cap and
+// short-circuits with 413 — the +1 is a sentinel read for overflow
+// detection, not part of the contract.
+//
+// The value is intentionally much larger than every per-handler text-body
+// cap in the codebase today (feedbackMaxRequestBodyBytes ≈ 53 KB;
+// createInviteMaxBodyBytes = 4 KB; PasswordResetRateLimitMiddleware =
+// 4 KB) so legitimate JSON / form payloads never trip it, while still
+// being small enough that an attacker cannot force gigabyte-scale
+// allocations per concurrent request.
 const tenantScanMaxBodyBytes = 1 * 1024 * 1024 // 1 MiB
 
 // rejectTenantBody checks the request body of mutating requests for
@@ -199,7 +206,12 @@ func rejectTenantBody(w http.ResponseWriter, r *http.Request) bool {
 	// here, so the immutable reader is more accurate.
 	r.Body = io.NopCloser(bytes.NewReader(body))
 
-	bodyLower := strings.ToLower(string(body))
+	// Convert []byte→string ONCE — the body can be up to
+	// tenantScanMaxBodyBytes (1 MiB) on every POST/PUT/PATCH and a second
+	// conversion in the violation-logging branch would double the
+	// per-request allocation cost on a hot path.
+	bodyStr := string(body)
+	bodyLower := strings.ToLower(bodyStr)
 	if !strings.Contains(bodyLower, "tenant_id") &&
 		!strings.Contains(bodyLower, "\"tenant\"") &&
 		!strings.Contains(bodyLower, "'tenant'") &&
@@ -208,7 +220,7 @@ func rejectTenantBody(w http.ResponseWriter, r *http.Request) bool {
 	}
 	slog.Error("Security violation: user-provided tenant ID in request body",
 		"content_type", contentType,
-		"body_preview", truncateString(string(body), 200),
+		"body_preview", truncateString(bodyStr, 200),
 		"user_agent", r.UserAgent(),
 		"remote_addr", r.RemoteAddr,
 		"method", r.Method,

--- a/go/apiserver/security_middleware.go
+++ b/go/apiserver/security_middleware.go
@@ -125,12 +125,17 @@ const tenantScanMaxBodyBytes = 1 * 1024 * 1024 // 1 MiB
 //     rate_limit_middleware.go for the same reason.
 //
 //  4. Substring scan: the read body is lowercased and checked against a
-//     small set of quote-anchored substrings. This is intentionally a
-//     cheap, case-insensitive scan rather than a JSON parser — it is
-//     belt-and-suspenders defense-in-depth, not a contract validator.
-//     The patterns matched are:
-//     - snake_case "tenant_id" (also catches snake_case form-encoded
-//     bodies such as "tenant_id=…");
+//     small mixed set of quote-anchored and unanchored substrings. This
+//     is intentionally a cheap, case-insensitive scan rather than a JSON
+//     parser — it is belt-and-suspenders defense-in-depth, not a contract
+//     validator. The patterns matched are:
+//     - snake_case "tenant_id" — UNANCHORED on purpose so it catches
+//     form-encoded bodies such as "tenant_id=…", where the key is not
+//     wrapped in quotes. This can over-fire if a free-text value
+//     happens to contain the literal substring "tenant_id"; accepted
+//     as a known belt-and-suspenders limitation because no handler
+//     currently binds a "tenant_id" field anyway, so the cost of a
+//     spurious 403 is bounded;
 //     - the double-quoted form "\"tenant\"" — a JSON object key cannot
 //     legitimately read free text without those surrounding quotes,
 //     so the quote anchors make this match key-shaped occurrences
@@ -138,8 +143,8 @@ const tenantScanMaxBodyBytes = 1 * 1024 * 1024 // 1 MiB
 //     - the single-quoted form "'tenant'" — pre-existing pattern that
 //     covers non-JSON formats (YAML / JS-embedded) and is left in
 //     place for back-compat. It can over-fire on free text that
-//     contains 'tenant' in single quotes; accepted as a known
-//     belt-and-suspenders limitation;
+//     contains 'tenant' in single quotes; same accepted trade-off as
+//     the snake_case form;
 //     - the camelCase JSON-key forms "\"tenantId\"" / "\"tenantID\""
 //     (covered by the lowercased "\"tenantid\"" substring, quoted
 //     to avoid flagging the bare word "tenantid" inside free text).
@@ -188,8 +193,11 @@ func rejectTenantBody(w http.ResponseWriter, r *http.Request) bool {
 		http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
 		return true
 	}
-	// Restore body for downstream handlers.
-	r.Body = io.NopCloser(bytes.NewBuffer(body))
+	// Restore body for downstream handlers. bytes.NewReader (read-only)
+	// matches PasswordResetRateLimitMiddleware's restoration pattern in
+	// rate_limit_middleware.go — the slice is never written to again
+	// here, so the immutable reader is more accurate.
+	r.Body = io.NopCloser(bytes.NewReader(body))
 
 	bodyLower := strings.ToLower(string(body))
 	if !strings.Contains(bodyLower, "tenant_id") &&

--- a/go/apiserver/security_middleware_test.go
+++ b/go/apiserver/security_middleware_test.go
@@ -1,8 +1,11 @@
 package apiserver_test
 
 import (
+	"bytes"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"strings"
 	"testing"
 
@@ -10,6 +13,11 @@ import (
 
 	"github.com/denisvmedia/inventario/apiserver"
 )
+
+// tenantScanCap mirrors the unexported tenantScanMaxBodyBytes constant in
+// security_middleware.go. Kept literal here so the test asserts the
+// observable contract (1 MiB) without leaking the implementation symbol.
+const tenantScanCap = 1 * 1024 * 1024
 
 // TestValidateNoUserProvidedTenantID_AdminSubtreeQueryExemption verifies the
 // narrow exemption added for #1748: the /api/v1/admin/* subtree is exempt
@@ -189,4 +197,208 @@ func TestValidateNoUserProvidedTenantID_AdminSubtreeBodyCheckEnforced(t *testing
 	handler.ServeHTTP(rr, req)
 
 	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+}
+
+// buildJSONPadded constructs a JSON document of EXACTLY size bytes that
+// (when scanned for tenant_id substrings) contains no positive match.
+// The shape is {"x":"<padding>"}; padding is ASCII 'a' bytes.
+func buildJSONPadded(size int) []byte {
+	const prefix = `{"x":"`
+	const suffix = `"}`
+	if size < len(prefix)+len(suffix) {
+		// Fall back to an empty object if the requested size is smaller
+		// than the wrapper itself; callers in this test request >= cap-1.
+		return []byte(`{}`)
+	}
+	padLen := size - len(prefix) - len(suffix)
+	buf := make([]byte, 0, size)
+	buf = append(buf, prefix...)
+	for range padLen {
+		buf = append(buf, 'a')
+	}
+	buf = append(buf, suffix...)
+	return buf
+}
+
+// buildMultipartBody constructs a multipart/form-data body of approximately
+// totalSize bytes, optionally prefixed by extra named form fields. Each
+// extraFieldName is added as a separate form-data part containing the
+// fixed string "ignored"; this lets callers force a specific field-name
+// substring (e.g. "tenant_id") into the body to test the multipart-skip
+// path. Returns the body and the Content-Type header value (which carries
+// the boundary).
+func buildMultipartBody(totalSize int, extraFieldNames ...string) ([]byte, string) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	for _, name := range extraFieldNames {
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", `form-data; name="`+name+`"`)
+		part, _ := w.CreatePart(h)
+		_, _ = part.Write([]byte("ignored"))
+	}
+
+	// Add a file part and pad it out to reach approximately totalSize.
+	fh := make(textproto.MIMEHeader)
+	fh.Set("Content-Disposition", `form-data; name="file"; filename="big.bin"`)
+	fh.Set("Content-Type", "application/octet-stream")
+	part, _ := w.CreatePart(fh)
+	// Pad to (approximately) totalSize. We aim a bit shy so that closing
+	// the writer (which appends a trailing boundary) does not over-shoot
+	// dramatically; for the assertions in this test the exact size does
+	// not matter, only that it is well above tenantScanCap.
+	padLen := max(
+		// leave headroom for boundaries
+		totalSize-buf.Len()-256, 0)
+	pad := make([]byte, padLen)
+	for i := range pad {
+		pad[i] = 'A'
+	}
+	_, _ = part.Write(pad)
+	_ = w.Close()
+
+	return buf.Bytes(), w.FormDataContentType()
+}
+
+// TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap covers the
+// rejectTenantBody size-cap and multipart-skip behaviour added for #1826.
+//
+// Cases:
+//
+//	(a) JSON well below cap     -> 200
+//	(b) JSON exactly at cap     -> 200
+//	(c) JSON one byte over cap  -> 413
+//	(d) Form one byte over cap  -> 413
+//	(e) Multipart over cap, no tenant_id substring -> 200 (multipart skip)
+//	(f) Multipart over cap, with tenant_id field name -> 200 (anti-regression)
+//	(g) JSON with tenant_id under cap -> 403 (scan still fires)
+//	(h) GET with huge body      -> 200 (method gate first; no read)
+func TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap(t *testing.T) {
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := apiserver.ValidateNoUserProvidedTenantID()(downstream)
+
+	multipartClean, multipartCleanCT := buildMultipartBody(2 * tenantScanCap)
+	multipartWithTenant, multipartWithTenantCT := buildMultipartBody(2*tenantScanCap, "tenant_id")
+
+	tests := []struct {
+		name           string
+		method         string
+		target         string
+		contentType    string
+		body           []byte
+		wantStatus     int
+		wantBodyPrefix string // optional; only checked when non-empty
+	}{
+		{
+			name:        "json well below cap is allowed",
+			method:      http.MethodPost,
+			target:      "/api/v1/areas",
+			contentType: "application/json",
+			body:        buildJSONPadded(1024),
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "json exactly at cap is allowed",
+			method:      http.MethodPost,
+			target:      "/api/v1/areas",
+			contentType: "application/json",
+			body:        buildJSONPadded(tenantScanCap),
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:           "json one byte over cap is rejected with 413",
+			method:         http.MethodPost,
+			target:         "/api/v1/areas",
+			contentType:    "application/json",
+			body:           buildJSONPadded(tenantScanCap + 1),
+			wantStatus:     http.StatusRequestEntityTooLarge,
+			wantBodyPrefix: "Request body too large",
+		},
+		{
+			name:           "form-encoded one byte over cap is rejected with 413",
+			method:         http.MethodPost,
+			target:         "/api/v1/areas",
+			contentType:    "application/x-www-form-urlencoded",
+			body:           append([]byte("x="), bytes.Repeat([]byte("a"), tenantScanCap)...),
+			wantStatus:     http.StatusRequestEntityTooLarge,
+			wantBodyPrefix: "Request body too large",
+		},
+		{
+			name:        "multipart well over cap with no tenant_id is allowed (skip)",
+			method:      http.MethodPost,
+			target:      "/api/v1/files",
+			contentType: multipartCleanCT,
+			body:        multipartClean,
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "multipart well over cap with tenant_id field name is allowed (skip)",
+			method:      http.MethodPost,
+			target:      "/api/v1/files",
+			contentType: multipartWithTenantCT,
+			body:        multipartWithTenant,
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "json with tenant_id under cap is still rejected with 403",
+			method:      http.MethodPost,
+			target:      "/api/v1/areas",
+			contentType: "application/json",
+			body:        []byte(`{"tenant_id":"x"}`),
+			wantStatus:  http.StatusForbidden,
+		},
+		{
+			name:        "GET with huge body is passed through (method gate)",
+			method:      http.MethodGet,
+			target:      "/api/v1/areas",
+			contentType: "application/json",
+			body:        buildJSONPadded(tenantScanCap + 1),
+			wantStatus:  http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			req := httptest.NewRequest(tc.method, tc.target, bytes.NewReader(tc.body))
+			if tc.contentType != "" {
+				req.Header.Set("Content-Type", tc.contentType)
+			}
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			c.Assert(rr.Code, qt.Equals, tc.wantStatus)
+			if tc.wantBodyPrefix != "" {
+				c.Assert(strings.HasPrefix(rr.Body.String(), tc.wantBodyPrefix), qt.IsTrue,
+					qt.Commentf("body=%q", rr.Body.String()))
+			}
+		})
+	}
+}
+
+// TestValidateNoUserProvidedTenantID_RejectTenantBody_HugeBodyNoOOM proves
+// the LimitReader actually bounds the read: sending a 10 MiB non-multipart
+// body must complete with a 413 response and no allocation blow-up. The
+// fact that this test runs in a normal unit-test environment without
+// exhausting memory is the proof.
+func TestValidateNoUserProvidedTenantID_RejectTenantBody_HugeBodyNoOOM(t *testing.T) {
+	c := qt.New(t)
+
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := apiserver.ValidateNoUserProvidedTenantID()(downstream)
+
+	const giant = 10 * 1024 * 1024 // 10 MiB
+	body := bytes.Repeat([]byte("a"), giant)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/areas", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusRequestEntityTooLarge)
 }

--- a/go/apiserver/security_middleware_test.go
+++ b/go/apiserver/security_middleware_test.go
@@ -19,6 +19,16 @@ import (
 // observable contract (1 MiB) without leaking the implementation symbol.
 const tenantScanCap = 1 * 1024 * 1024
 
+// Expected response bodies for the middleware's three short-circuit paths.
+// http.Error always appends "\n" after the message, so these mirror what
+// the wire-level response body looks like to a client. Kept as literal
+// strings (rather than re-exporting from the apiserver package) so the
+// test asserts the observable contract.
+const (
+	tenantSizeCapBody   = "Request body too large\n"
+	tenantViolationBody = "Security violation: tenant information cannot be provided by user\n"
+)
+
 // TestValidateNoUserProvidedTenantID_AdminSubtreeQueryExemption verifies the
 // narrow exemption added for #1748: the /api/v1/admin/* subtree is exempt
 // from the query-parameter "tenant" check (so the documented ?tenantID=
@@ -301,14 +311,17 @@ func TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap(t *testing.T) {
 	multipartClean, multipartCleanCT := buildMultipartBody(t, 2*tenantScanCap)
 	multipartWithTenant, multipartWithTenantCT := buildMultipartBody(t, 2*tenantScanCap, "tenant_id")
 
+	// Every case sets contentType and wantBody explicitly — empty
+	// strings are the literal expected values, not "skip this assertion"
+	// sentinels. Project rule: no conditionals in tests.
 	tests := []struct {
-		name           string
-		method         string
-		target         string
-		contentType    string
-		body           []byte
-		wantStatus     int
-		wantBodyPrefix string // optional; only checked when non-empty
+		name        string
+		method      string
+		target      string
+		contentType string
+		body        []byte
+		wantStatus  int
+		wantBody    string // exact response body the client receives
 	}{
 		{
 			name:        "json well below cap is allowed",
@@ -317,6 +330,7 @@ func TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap(t *testing.T) {
 			contentType: "application/json",
 			body:        buildJSONPadded(1024),
 			wantStatus:  http.StatusOK,
+			wantBody:    "", // downstream only WriteHeaders, no body
 		},
 		{
 			name:        "json exactly at cap is allowed",
@@ -325,25 +339,26 @@ func TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap(t *testing.T) {
 			contentType: "application/json",
 			body:        buildJSONPadded(tenantScanCap),
 			wantStatus:  http.StatusOK,
+			wantBody:    "",
 		},
 		{
-			name:           "json one byte over cap is rejected with 413",
-			method:         http.MethodPost,
-			target:         "/api/v1/areas",
-			contentType:    "application/json",
-			body:           buildJSONPadded(tenantScanCap + 1),
-			wantStatus:     http.StatusRequestEntityTooLarge,
-			wantBodyPrefix: "Request body too large",
+			name:        "json one byte over cap is rejected with 413",
+			method:      http.MethodPost,
+			target:      "/api/v1/areas",
+			contentType: "application/json",
+			body:        buildJSONPadded(tenantScanCap + 1),
+			wantStatus:  http.StatusRequestEntityTooLarge,
+			wantBody:    tenantSizeCapBody,
 		},
 		{
 			// Body is exactly cap+1: "x=" (2 bytes) + cap-1 padding 'a's.
-			name:           "form-encoded one byte over cap is rejected with 413",
-			method:         http.MethodPost,
-			target:         "/api/v1/areas",
-			contentType:    "application/x-www-form-urlencoded",
-			body:           append([]byte("x="), bytes.Repeat([]byte("a"), tenantScanCap-1)...),
-			wantStatus:     http.StatusRequestEntityTooLarge,
-			wantBodyPrefix: "Request body too large",
+			name:        "form-encoded one byte over cap is rejected with 413",
+			method:      http.MethodPost,
+			target:      "/api/v1/areas",
+			contentType: "application/x-www-form-urlencoded",
+			body:        append([]byte("x="), bytes.Repeat([]byte("a"), tenantScanCap-1)...),
+			wantStatus:  http.StatusRequestEntityTooLarge,
+			wantBody:    tenantSizeCapBody,
 		},
 		{
 			name:        "multipart well over cap with no tenant_id is allowed (skip)",
@@ -352,6 +367,7 @@ func TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap(t *testing.T) {
 			contentType: multipartCleanCT,
 			body:        multipartClean,
 			wantStatus:  http.StatusOK,
+			wantBody:    "",
 		},
 		{
 			name:        "multipart well over cap with tenant_id field name is allowed (skip)",
@@ -360,6 +376,7 @@ func TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap(t *testing.T) {
 			contentType: multipartWithTenantCT,
 			body:        multipartWithTenant,
 			wantStatus:  http.StatusOK,
+			wantBody:    "",
 		},
 		{
 			name:        "json with tenant_id under cap is still rejected with 403",
@@ -368,6 +385,7 @@ func TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap(t *testing.T) {
 			contentType: "application/json",
 			body:        []byte(`{"tenant_id":"x"}`),
 			wantStatus:  http.StatusForbidden,
+			wantBody:    tenantViolationBody,
 		},
 		{
 			name:        "GET with huge body is passed through (method gate)",
@@ -376,6 +394,7 @@ func TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap(t *testing.T) {
 			contentType: "application/json",
 			body:        buildJSONPadded(tenantScanCap + 1),
 			wantStatus:  http.StatusOK,
+			wantBody:    "",
 		},
 	}
 
@@ -384,17 +403,12 @@ func TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap(t *testing.T) {
 			c := qt.New(t)
 
 			req := httptest.NewRequest(tc.method, tc.target, bytes.NewReader(tc.body))
-			if tc.contentType != "" {
-				req.Header.Set("Content-Type", tc.contentType)
-			}
+			req.Header.Set("Content-Type", tc.contentType)
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)
 
 			c.Assert(rr.Code, qt.Equals, tc.wantStatus)
-			if tc.wantBodyPrefix != "" {
-				c.Assert(strings.HasPrefix(rr.Body.String(), tc.wantBodyPrefix), qt.IsTrue,
-					qt.Commentf("body=%q", rr.Body.String()))
-			}
+			c.Assert(rr.Body.String(), qt.Equals, tc.wantBody)
 		})
 	}
 }

--- a/go/apiserver/security_middleware_test.go
+++ b/go/apiserver/security_middleware_test.go
@@ -226,23 +226,34 @@ func buildJSONPadded(size int) []byte {
 // fixed string "ignored"; this lets callers force a specific field-name
 // substring (e.g. "tenant_id") into the body to test the multipart-skip
 // path. Returns the body and the Content-Type header value (which carries
-// the boundary).
-func buildMultipartBody(totalSize int, extraFieldNames ...string) ([]byte, string) {
+// the boundary). Any writer error fails the test immediately — a panic
+// from the multipart pipeline would otherwise surface as a confusing
+// goroutine trace rather than a clear test failure.
+func buildMultipartBody(tb testing.TB, totalSize int, extraFieldNames ...string) ([]byte, string) {
+	tb.Helper()
 	var buf bytes.Buffer
 	w := multipart.NewWriter(&buf)
 
 	for _, name := range extraFieldNames {
 		h := make(textproto.MIMEHeader)
 		h.Set("Content-Disposition", `form-data; name="`+name+`"`)
-		part, _ := w.CreatePart(h)
-		_, _ = part.Write([]byte("ignored"))
+		part, err := w.CreatePart(h)
+		if err != nil {
+			tb.Fatalf("buildMultipartBody: CreatePart(%q) failed: %v", name, err)
+		}
+		if _, err := part.Write([]byte("ignored")); err != nil {
+			tb.Fatalf("buildMultipartBody: write ignored value for %q failed: %v", name, err)
+		}
 	}
 
 	// Add a file part and pad it out to reach approximately totalSize.
 	fh := make(textproto.MIMEHeader)
 	fh.Set("Content-Disposition", `form-data; name="file"; filename="big.bin"`)
 	fh.Set("Content-Type", "application/octet-stream")
-	part, _ := w.CreatePart(fh)
+	part, err := w.CreatePart(fh)
+	if err != nil {
+		tb.Fatalf("buildMultipartBody: CreatePart(file) failed: %v", err)
+	}
 	// Pad to (approximately) totalSize. We aim a bit shy so that closing
 	// the writer (which appends a trailing boundary) does not over-shoot
 	// dramatically; for the assertions in this test the exact size does
@@ -254,8 +265,12 @@ func buildMultipartBody(totalSize int, extraFieldNames ...string) ([]byte, strin
 	for i := range pad {
 		pad[i] = 'A'
 	}
-	_, _ = part.Write(pad)
-	_ = w.Close()
+	if _, err := part.Write(pad); err != nil {
+		tb.Fatalf("buildMultipartBody: pad write failed: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		tb.Fatalf("buildMultipartBody: writer Close failed: %v", err)
+	}
 
 	return buf.Bytes(), w.FormDataContentType()
 }
@@ -279,8 +294,8 @@ func TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap(t *testing.T) {
 	})
 	handler := apiserver.ValidateNoUserProvidedTenantID()(downstream)
 
-	multipartClean, multipartCleanCT := buildMultipartBody(2 * tenantScanCap)
-	multipartWithTenant, multipartWithTenantCT := buildMultipartBody(2*tenantScanCap, "tenant_id")
+	multipartClean, multipartCleanCT := buildMultipartBody(t, 2*tenantScanCap)
+	multipartWithTenant, multipartWithTenantCT := buildMultipartBody(t, 2*tenantScanCap, "tenant_id")
 
 	tests := []struct {
 		name           string
@@ -317,11 +332,12 @@ func TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap(t *testing.T) {
 			wantBodyPrefix: "Request body too large",
 		},
 		{
+			// Body is exactly cap+1: "x=" (2 bytes) + cap-1 padding 'a's.
 			name:           "form-encoded one byte over cap is rejected with 413",
 			method:         http.MethodPost,
 			target:         "/api/v1/areas",
 			contentType:    "application/x-www-form-urlencoded",
-			body:           append([]byte("x="), bytes.Repeat([]byte("a"), tenantScanCap)...),
+			body:           append([]byte("x="), bytes.Repeat([]byte("a"), tenantScanCap-1)...),
 			wantStatus:     http.StatusRequestEntityTooLarge,
 			wantBodyPrefix: "Request body too large",
 		},

--- a/go/apiserver/security_middleware_test.go
+++ b/go/apiserver/security_middleware_test.go
@@ -199,15 +199,19 @@ func TestValidateNoUserProvidedTenantID_AdminSubtreeBodyCheckEnforced(t *testing
 	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
 }
 
-// buildJSONPadded constructs a JSON document of EXACTLY size bytes that
-// (when scanned for tenant_id substrings) contains no positive match.
-// The shape is {"x":"<padding>"}; padding is ASCII 'a' bytes.
+// buildJSONPadded constructs a JSON document that (when scanned for
+// tenant_id substrings) contains no positive match. The shape is
+// {"x":"<padding>"} with ASCII 'a' bytes as padding. The returned slice
+// is EXACTLY `size` bytes long when `size >= len(prefix)+len(suffix)`
+// (the only regime any caller in this test exercises); below that
+// threshold it returns the literal `{}` (2 bytes) as a sentinel so
+// degenerate inputs cannot produce malformed output.
 func buildJSONPadded(size int) []byte {
 	const prefix = `{"x":"`
 	const suffix = `"}`
 	if size < len(prefix)+len(suffix) {
-		// Fall back to an empty object if the requested size is smaller
-		// than the wrapper itself; callers in this test request >= cap-1.
+		// Out-of-contract sentinel — callers here always request a size
+		// well above the wrapper width, so this branch is purely defensive.
 		return []byte(`{}`)
 	}
 	padLen := size - len(prefix) - len(suffix)


### PR DESCRIPTION
## Summary

`rejectTenantBody` in `go/apiserver/security_middleware.go` read the entire request body via unbounded `io.ReadAll` for every POST/PUT/PATCH. The middleware is `r.Use`-mounted on the whole `/api/v1/*` tree (`apiserver.go:224`), so a client could force arbitrary in-memory allocation by sending a large body to **any** mutating endpoint — long before per-handler caps (`createInviteMaxBodyBytes` 4 KB, `feedbackMaxRequestBodyBytes` ≈ 53 KB, `PasswordResetRateLimitMiddleware` 4 KB) kick in.

Per #1826 this is **informational** defense-in-depth — Inventario is typically reverse-proxied behind a sized ingress in production. This PR closes the residual gap.

## What this change does

- **`tenantScanMaxBodyBytes = 1 MiB`** — ~20× headroom over the largest per-handler text-body cap (`feedbackMaxRequestBodyBytes` ≈ 53 KB), small enough that an attacker cannot force gigabyte-scale allocations per concurrent request.
- **`io.LimitReader(r.Body, cap+1)`** — not `http.MaxBytesReader`. `MaxBytesReader` would write a 413 to the `ResponseWriter` itself, racing the middleware's own `http.Error` and risking a double-write. Same idiom `PasswordResetRateLimitMiddleware` uses for the same reason; the rationale is now on-file in the doc comment for both call sites.
- **413 "Request body too large"** on overflow, with a security-event `slog.Error` mirroring the existing in-file convention (`method`/`path`/`content_type`/`content_length`/`user_agent`/`remote_addr`).
- **Skip the scan for `multipart/*`**. Multipart payloads are mostly binary file bytes — gigabyte-class and capable of false-positive matches on the `tenant_id` substring. Verified in `uploads.go` and surrounding handlers that no handler in the codebase binds a tenant ID from a multipart field, so this is a safe relaxation. Header / query / non-multipart body scans still catch the realistic injection paths.
- **`r.Body.Close()`** after the bounded read (mirrors `PasswordResetRateLimitMiddleware`).
- **Doc comment** rewritten to enumerate the control flow in order: method gate → multipart skip → LimitReader cap + 413 → substring scan → body restoration.

## Why this shape

- #1826 explicitly scopes the fix as "a generous but bounded `MaxBytesReader` wrap, large enough to cover legitimate flows like commodity imports". Commodity imports go through `multipart/form-data` (XML inside) — they are now skipped entirely instead of needing the cap raised to accommodate them. JSON / form-encoded bodies, which the tenant-id substring scan is actually defending against, get a 1 MiB cap with substantial margin.
- The substring set the body scan looks for is **unchanged** (`tenant_id`, `"tenant"`, `'tenant'`) — that surface was just fixed in #1825 for camelCase variants and is not in scope here.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./apiserver/... -run 'Tenant|TenantBody|SizeCap|RejectTenantBody|HugeBodyNoOOM' -count=1 -race` green
- [x] `golangci-lint run --timeout=5m ./apiserver/...` → `0 issues.`
- [x] `nolintguard` and `qtlint` clean on `./apiserver/...`
- [x] New `TestValidateNoUserProvidedTenantID_RejectTenantBody_SizeCap` covers:
  - JSON well below cap → 200
  - JSON exactly at cap → 200
  - JSON one byte over cap → 413
  - Form-encoded one byte over cap → 413
  - Multipart over cap, clean body → 200 (skip)
  - Multipart over cap, `tenant_id` field name → 200 (skip, anti-regression of the field-name false-positive)
  - JSON with `tenant_id` under cap → 403 (existing scan still fires)
  - GET with huge body → 200 (method gate first; no read)
- [x] `TestValidateNoUserProvidedTenantID_RejectTenantBody_HugeBodyNoOOM` sends a 10 MiB body and asserts 413 — the fact that this runs in a normal unit-test environment without exhausting memory is the proof that `LimitReader` actually bounds the read.

Fixes #1826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a 1 MiB request-body scan cap; oversized requests now return 413.
  * Body scanning limited to POST/PUT/PATCH; other methods bypass scanning.
  * Multipart content types are exempt from body scanning.
  * Request body is safely restored for downstream handlers and violation logging improved.

* **Tests**
  * Added tests for size-cap enforcement, multipart behavior, method gating, and protection against very large payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->