### PR TITLE
[#1785] backoffice foundation: backoffice_users model, registry, CLI bootstrap

### DIFF
--- a/go/cmd/inventario/backoffice/backoffice.go
+++ b/go/cmd/inventario/backoffice/backoffice.go
@@ -1,0 +1,59 @@
+// Package backoffice is the CLI command group for managing platform-
+// operator identities used by the back-office auth plane (issue #1785).
+//
+// Back-office identities live OUTSIDE the tenant model: a row in
+// backoffice_users has no tenant_id, no group membership, and no RLS
+// scoping. The whole point of the #1785 epic is to keep platform
+// operators (support agents, platform admins) on a separate auth plane
+// so impersonating a customer or escalating to system-admin cannot
+// happen by accidentally flipping a column on a regular user row.
+//
+// Phase 1 (this CLI) ships only the `bootstrap` subcommand — enough to
+// stamp the first platform_admin into a fresh deployment. Later phases
+// will hang `create`, `list`, and `block` off this same group.
+//
+// All operations require a PostgreSQL DSN — the in-memory backend has
+// no persistence, so any write would vanish the moment the CLI exits.
+package backoffice
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/denisvmedia/inventario/cmd/inventario/backoffice/bootstrap"
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+)
+
+// New creates the parent `backoffice` command and registers its
+// subcommands. Mounted from cmd/inventario/inventario.go alongside
+// `admin`, `tenants`, `users` — the dbConfig flagset is supplied by
+// the root command.
+func New(dbConfig *shared.DatabaseConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backoffice",
+		Short: "Manage back-office (platform-operator) identities",
+		Long: `Back-office commands manage platform-operator identities used by the
+back-office auth plane (issue #1785). Back-office users live OUTSIDE
+the tenant model: they have no tenant_id, no group membership, and no
+RLS scoping. They are distinct from regular tenant users (and from the
+legacy users.is_system_admin flag, which Phase 3 of #1785 retires).
+
+IMPORTANT: These commands ONLY support PostgreSQL databases. Memory
+databases cannot persist back-office identities across restarts.
+
+USAGE EXAMPLES:
+
+  Bootstrap the first platform_admin (auto-generates a password):
+    inventario backoffice bootstrap --email admin@example.com --name "Ops Admin"
+
+  Bootstrap with an explicit password:
+    inventario backoffice bootstrap --email admin@example.com --name "Ops" --password 'S3cret-Pass'
+
+  Add a second back-office user after the first has been created:
+    inventario backoffice bootstrap --email second@example.com --name "Second" --force`,
+		Args: cobra.NoArgs,
+	}
+
+	cmd.AddCommand(bootstrap.New(dbConfig).Cmd())
+
+	return cmd
+}

--- a/go/cmd/inventario/backoffice/bootstrap/bootstrap.go
+++ b/go/cmd/inventario/backoffice/bootstrap/bootstrap.go
@@ -99,11 +99,11 @@ func (c *Command) registerFlags() {
 func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
 	out := c.Cmd().OutOrStdout()
 
+	// dbConfig.Validate already rejects non-postgres DSNs at the
+	// shared-validator layer (memory://, file:// etc all fail with
+	// "only support PostgreSQL"). No second guard needed here.
 	if err := dbConfig.Validate(); err != nil {
 		return errxtrace.Wrap("database configuration error", err)
-	}
-	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
-		return errors.New("backoffice commands are not supported for memory databases; use PostgreSQL")
 	}
 
 	email := strings.TrimSpace(cfg.Email)

--- a/go/cmd/inventario/backoffice/bootstrap/bootstrap.go
+++ b/go/cmd/inventario/backoffice/bootstrap/bootstrap.go
@@ -1,0 +1,168 @@
+// Package bootstrap implements `inventario backoffice bootstrap`.
+//
+// Stamps the first platform-operator identity into a fresh deployment
+// (issue #1785 Phase 1). The command is idempotent on the email — a
+// re-run with the same email prints "user already exists" and exits 0.
+// A re-run with a different email refuses unless --force is passed, so
+// an operator can't accidentally create a sprawl of back-office users.
+package bootstrap
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/spf13/cobra"
+
+	"github.com/denisvmedia/inventario/cmd/internal/command"
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/services/backoffice"
+)
+
+// Config carries the bootstrap command's flags.
+type Config struct {
+	Email    string `yaml:"email" env:"EMAIL"`
+	Name     string `yaml:"name" env:"NAME"`
+	Role     string `yaml:"role" env:"ROLE"`
+	Password string `yaml:"password" env:"PASSWORD"`
+	Force    bool   `yaml:"force" env:"FORCE"`
+}
+
+// Command is the cobra wrapper around `backoffice bootstrap`.
+type Command struct {
+	command.Base
+
+	config Config
+}
+
+// New constructs the command with the supplied database config.
+func New(dbConfig *shared.DatabaseConfig) *Command {
+	c := &Command{}
+
+	shared.TryReadSection("backoffice.bootstrap", &c.config)
+
+	c.Base = command.NewBase(&cobra.Command{
+		Use:   "bootstrap",
+		Short: "Create the first back-office (platform-operator) user",
+		Long: `Stamp the first back-office user into a fresh deployment.
+
+Back-office users live OUTSIDE the tenant model: they have no tenant_id,
+no group membership, and no RLS scoping. They authenticate against the
+back-office auth plane (added in Phase 2 of issue #1785).
+
+IDEMPOTENCY:
+
+  • Re-running with the same --email prints "user already exists" and
+    exits 0 (safe to call from provisioning scripts).
+  • Re-running with a different --email refuses unless --force is
+    passed, so a deployment can't accidentally accumulate operators.
+
+PASSWORD:
+
+  • If --password is omitted, a strong random password is generated
+    and printed ONCE to stdout. Copy it before the terminal scrolls —
+    it is NOT stored anywhere and cannot be recovered.
+  • If --password is supplied, it must meet the same complexity rules
+    as models.ValidatePassword (8+ chars, upper, lower, digit).
+
+ROLE:
+
+  • Defaults to platform_admin (full mutation rights — the only sensible
+    seed value).
+  • support_agent is also accepted for non-first invocations under --force.
+
+Examples:
+  inventario backoffice bootstrap --email admin@example.com --name "Ops Admin"
+  inventario backoffice bootstrap --email second@example.com --name "Second" --force
+  inventario backoffice bootstrap --email a@example.com --name "A" --password 'Sup3rSecret!'`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.run(&c.config, dbConfig)
+		},
+	})
+
+	c.registerFlags()
+
+	return c
+}
+
+func (c *Command) registerFlags() {
+	c.Cmd().Flags().StringVar(&c.config.Email, "email", c.config.Email, "Back-office user email (required)")
+	c.Cmd().Flags().StringVar(&c.config.Name, "name", c.config.Name, "Back-office user display name (required)")
+	c.Cmd().Flags().StringVar(&c.config.Role, "role", c.config.Role, "Back-office role: platform_admin (default) or support_agent")
+	c.Cmd().Flags().StringVar(&c.config.Password, "password", c.config.Password, "Password (auto-generated if omitted)")
+	c.Cmd().Flags().BoolVar(&c.config.Force, "force", c.config.Force, "Allow adding a second+ back-office user when one already exists")
+}
+
+func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
+	out := c.Cmd().OutOrStdout()
+
+	if err := dbConfig.Validate(); err != nil {
+		return errxtrace.Wrap("database configuration error", err)
+	}
+	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
+		return errors.New("backoffice commands are not supported for memory databases; use PostgreSQL")
+	}
+
+	email := strings.TrimSpace(cfg.Email)
+	if email == "" {
+		return errors.New("--email is required")
+	}
+	name := strings.TrimSpace(cfg.Name)
+	if name == "" {
+		return errors.New("--name is required")
+	}
+
+	// Role defaults to platform_admin at the service layer; reject
+	// invalid free-form values here so the CLI error message includes
+	// the valid set without the service having to know about CLI
+	// presentation.
+	role := models.BackofficeRole(strings.TrimSpace(cfg.Role))
+	if role == "" {
+		role = models.BackofficeRolePlatformAdmin
+	}
+	if !role.IsValid() {
+		return fmt.Errorf("--role must be one of: support_agent, platform_admin (got %q)", string(role))
+	}
+
+	svc, err := backoffice.NewService(dbConfig)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := svc.Close(); closeErr != nil {
+			fmt.Fprintf(out, "Warning: failed to close backoffice service: %v\n", closeErr)
+		}
+	}()
+
+	result, err := svc.Bootstrap(c.Cmd().Context(), backoffice.BootstrapRequest{
+		Email:    email,
+		Name:     name,
+		Role:     role,
+		Password: cfg.Password,
+		Force:    cfg.Force,
+	})
+	if err != nil {
+		return errxtrace.Wrap("failed to bootstrap backoffice user", err)
+	}
+
+	if result.AlreadyExisted {
+		fmt.Fprintf(out, "ℹ️  Back-office user %s (%s) already exists; no changes made.\n",
+			result.User.Name, result.User.Email)
+		return nil
+	}
+
+	fmt.Fprintf(out, "✅ Created back-office user %s (%s) with role %s.\n",
+		result.User.Name, result.User.Email, string(result.User.Role))
+	if result.GeneratedPassword != "" {
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "🔑 Generated password (copy this NOW — it will not be shown again):")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "    "+result.GeneratedPassword)
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "The operator should sign in with this password and rotate it on first login.")
+	}
+	return nil
+}

--- a/go/cmd/inventario/backoffice/bootstrap/bootstrap_test.go
+++ b/go/cmd/inventario/backoffice/bootstrap/bootstrap_test.go
@@ -1,0 +1,232 @@
+package bootstrap_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/cmd/inventario/backoffice/bootstrap"
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+// setupMemoryAsPostgres registers the in-memory registry under the
+// `postgres` scheme so the bootstrap command — which routes through
+// `services/backoffice`, which routes through `registry.GetRegistry` —
+// resolves a working factory set without an actual postgres instance.
+// Mirrors the helper in cmd/inventario/users/create/create_test.go.
+//
+// Returns the factory set so the test can introspect post-conditions
+// (was the row inserted? what's the current count?).
+func setupMemoryAsPostgres(c *qt.C) *registry.FactorySet {
+	var captured *registry.FactorySet
+	newFn, _ := memory.NewMemoryRegistrySet()
+	wrappedNewFn := func(cfg registry.Config) (*registry.FactorySet, error) {
+		if captured != nil {
+			return captured, nil
+		}
+		fs, err := newFn(cfg)
+		if err != nil {
+			return nil, err
+		}
+		captured = fs
+		return fs, nil
+	}
+	registry.Register("postgres", wrappedNewFn)
+	c.Cleanup(func() {
+		registry.Unregister("postgres")
+	})
+
+	// Pre-resolve the factory set so the caller has access to it
+	// regardless of whether the command run reaches the registry layer.
+	fs, err := wrappedNewFn(registry.Config("postgres://test"))
+	c.Assert(err, qt.IsNil)
+	return fs
+}
+
+// runBootstrap is a one-liner around the cobra command — captures
+// stdout for assertion and returns the run error.
+func runBootstrap(c *qt.C, dsn string, args ...string) (string, error) {
+	dbConfig := &shared.DatabaseConfig{DBDSN: dsn}
+	cmd := bootstrap.New(dbConfig).Cmd()
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// TestBootstrap_HappyPath pins the canonical create-with-auto-password
+// flow: no rows in the table → command succeeds, prints the generated
+// password to stdout, and inserts a single platform_admin row.
+func TestBootstrap_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+
+	out, err := runBootstrap(c, "postgres://test",
+		"--email=admin@example.com",
+		"--name=Ops Admin",
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "Created back-office user")
+	c.Assert(out, qt.Contains, "Generated password")
+
+	users, err := fs.BackofficeUserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+	c.Assert(users[0].Email, qt.Equals, "admin@example.com")
+	c.Assert(string(users[0].Role), qt.Equals, "platform_admin")
+	c.Assert(users[0].PasswordHash, qt.Not(qt.Equals), "")
+}
+
+// TestBootstrap_ExplicitPassword pins that --password skips the
+// auto-generation path and DOES NOT print the password.
+func TestBootstrap_ExplicitPassword(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+
+	out, err := runBootstrap(c, "postgres://test",
+		"--email=admin@example.com",
+		"--name=Ops Admin",
+		"--password=S3curePass!",
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "Created back-office user")
+	c.Assert(out, qt.Not(qt.Contains), "Generated password",
+		qt.Commentf("explicit password should not print a generated password"))
+
+	users, err := fs.BackofficeUserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+}
+
+// TestBootstrap_IdempotentReRun pins the "ℹ️  already exists" branch:
+// a second run with the same email is a no-op + exit 0.
+func TestBootstrap_IdempotentReRun(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+
+	_, err := runBootstrap(c, "postgres://test",
+		"--email=admin@example.com",
+		"--name=Ops Admin",
+	)
+	c.Assert(err, qt.IsNil)
+
+	out, err := runBootstrap(c, "postgres://test",
+		"--email=admin@example.com",
+		"--name=Ops Admin",
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "already exists")
+
+	users, err := fs.BackofficeUserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+}
+
+// TestBootstrap_RefusesSecondWithoutForce pins the fresh-deployment
+// safeguard: once any back-office user exists, a NEW email is rejected
+// unless --force is passed.
+func TestBootstrap_RefusesSecondWithoutForce(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+
+	_, err := runBootstrap(c, "postgres://test",
+		"--email=first@example.com",
+		"--name=First",
+	)
+	c.Assert(err, qt.IsNil)
+
+	_, err = runBootstrap(c, "postgres://test",
+		"--email=second@example.com",
+		"--name=Second",
+	)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "--force")
+
+	users, err := fs.BackofficeUserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 1)
+}
+
+// TestBootstrap_ForceAllowsSecond pins that --force unblocks the
+// second-user path.
+func TestBootstrap_ForceAllowsSecond(t *testing.T) {
+	c := qt.New(t)
+	fs := setupMemoryAsPostgres(c)
+
+	_, err := runBootstrap(c, "postgres://test",
+		"--email=first@example.com",
+		"--name=First",
+	)
+	c.Assert(err, qt.IsNil)
+
+	_, err = runBootstrap(c, "postgres://test",
+		"--email=second@example.com",
+		"--name=Second",
+		"--force",
+	)
+	c.Assert(err, qt.IsNil)
+
+	users, err := fs.BackofficeUserRegistry.List(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(users, qt.HasLen, 2)
+}
+
+// TestBootstrap_RejectsMemoryDSN pins the persistence guard: the
+// memory backend has no place to keep rows across CLI invocations,
+// so the command fails-closed with a hint.
+func TestBootstrap_RejectsMemoryDSN(t *testing.T) {
+	c := qt.New(t)
+
+	// No memory-as-postgres alias here — we want the real memory:// DSN
+	// path to flow through DatabaseConfig.Validate first. That validator
+	// itself rejects non-postgres DSNs at the database config layer
+	// (see cmd/inventario/shared/database.go: "only support PostgreSQL").
+	_, err := runBootstrap(c, "memory://",
+		"--email=admin@example.com",
+		"--name=Ops Admin",
+	)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "PostgreSQL")
+}
+
+// TestBootstrap_RejectsInvalidRole pins that the role flag is validated
+// against the closed-set enum before the service is even constructed.
+func TestBootstrap_RejectsInvalidRole(t *testing.T) {
+	c := qt.New(t)
+	setupMemoryAsPostgres(c)
+
+	_, err := runBootstrap(c, "postgres://test",
+		"--email=admin@example.com",
+		"--name=Ops Admin",
+		"--role=wizard",
+	)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "--role")
+}
+
+// TestBootstrap_RequiresEmail pins the basic required-arg branch.
+func TestBootstrap_RequiresEmail(t *testing.T) {
+	c := qt.New(t)
+	setupMemoryAsPostgres(c)
+
+	_, err := runBootstrap(c, "postgres://test", "--name=Ops")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "--email is required")
+}
+
+// TestBootstrap_RequiresName pins the basic required-arg branch.
+func TestBootstrap_RequiresName(t *testing.T) {
+	c := qt.New(t)
+	setupMemoryAsPostgres(c)
+
+	_, err := runBootstrap(c, "postgres://test", "--email=a@example.com")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "--name is required")
+}

--- a/go/cmd/inventario/backoffice/bootstrap/bootstrap_test.go
+++ b/go/cmd/inventario/backoffice/bootstrap/bootstrap_test.go
@@ -178,16 +178,15 @@ func TestBootstrap_ForceAllowsSecond(t *testing.T) {
 	c.Assert(users, qt.HasLen, 2)
 }
 
-// TestBootstrap_RejectsMemoryDSN pins the persistence guard: the
-// memory backend has no place to keep rows across CLI invocations,
-// so the command fails-closed with a hint.
+// TestBootstrap_RejectsMemoryDSN pins the persistence guard: a
+// memory:// DSN is rejected by the shared DatabaseConfig.Validate at
+// the database-config layer (cmd/inventario/shared/database.go: "only
+// support PostgreSQL"), and the bootstrap CLI surfaces that wrapped
+// error. The back-office plane intentionally has no memory backend
+// because operator identities must survive process restarts.
 func TestBootstrap_RejectsMemoryDSN(t *testing.T) {
 	c := qt.New(t)
 
-	// No memory-as-postgres alias here — we want the real memory:// DSN
-	// path to flow through DatabaseConfig.Validate first. That validator
-	// itself rejects non-postgres DSNs at the database config layer
-	// (see cmd/inventario/shared/database.go: "only support PostgreSQL").
 	_, err := runBootstrap(c, "memory://",
 		"--email=admin@example.com",
 		"--name=Ops Admin",
@@ -229,4 +228,21 @@ func TestBootstrap_RequiresName(t *testing.T) {
 	_, err := runBootstrap(c, "postgres://test", "--email=a@example.com")
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "--name is required")
+}
+
+// TestBootstrap_RejectsMalformedEmail pins that BackofficeUser model
+// validation (EmailPattern via ValidateWithContext) runs inside the
+// service layer — the registry's floor only checks "not empty + role
+// enum", so without the model-level call a malformed email would
+// round-trip into the table.
+func TestBootstrap_RejectsMalformedEmail(t *testing.T) {
+	c := qt.New(t)
+	setupMemoryAsPostgres(c)
+
+	_, err := runBootstrap(c, "postgres://test",
+		"--email=not-an-email",
+		"--name=Ops Admin",
+	)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "validation failed")
 }

--- a/go/cmd/inventario/inventario.go
+++ b/go/cmd/inventario/inventario.go
@@ -8,6 +8,7 @@ import (
 	"github.com/denisvmedia/inventario/cmd/common/version"
 	"github.com/denisvmedia/inventario/cmd/inventario/admin"
 	"github.com/denisvmedia/inventario/cmd/inventario/backfill"
+	"github.com/denisvmedia/inventario/cmd/inventario/backoffice"
 	"github.com/denisvmedia/inventario/cmd/inventario/db"
 	"github.com/denisvmedia/inventario/cmd/inventario/features"
 	"github.com/denisvmedia/inventario/cmd/inventario/initconfig"
@@ -61,6 +62,7 @@ Use "inventario [command] --help" for detailed information about each command.`,
 	rootCmd.AddCommand(users.New(&dbConfig))
 	rootCmd.AddCommand(admin.New(&dbConfig))
 	rootCmd.AddCommand(backfill.New(&dbConfig))
+	rootCmd.AddCommand(backoffice.New(&dbConfig))
 	rootCmd.AddCommand(version.New())
 	err := rootCmd.Execute()
 	if err != nil {

--- a/go/models/backoffice_role.go
+++ b/go/models/backoffice_role.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"github.com/jellydator/validation"
+)
+
+// BackofficeRole names the closed set of platform-operator roles that
+// can be assigned to a BackofficeUser. The taxonomy is intentionally
+// small (two values) so the back-office auth plane can keep its
+// authorisation logic explicit: support_agent has read-mostly access to
+// the back-office surfaces, platform_admin can also mutate them. The
+// per-endpoint authorisation matrix lands in Phase 2/3 of issue #1785;
+// here we only carry the typed enum so validation and storage are
+// already shape-correct.
+//
+// Storing the role as a TEXT column (rather than an integer) keeps the
+// migration cheap (adding a value is a Go-side enum extension + a
+// migration that updates Validate, no schema change), and matches the
+// project's other typed-enum columns (TenantStatus, RegistrationMode,
+// CommodityStatus, ...).
+type BackofficeRole string
+
+const (
+	// BackofficeRoleSupportAgent is the read-mostly persona — Phase 2/3
+	// will gate destructive back-office actions to platform_admin only.
+	BackofficeRoleSupportAgent BackofficeRole = "support_agent"
+	// BackofficeRolePlatformAdmin is the full-mutation persona for the
+	// back-office surfaces. Distinct from `users.is_system_admin` —
+	// system_admin lives on a regular tenant user and Phase 3 removes it
+	// in favour of the back-office plane entirely.
+	BackofficeRolePlatformAdmin BackofficeRole = "platform_admin"
+)
+
+// IsValid reports whether r is one of the closed-set role values.
+// Useful for callers that need a boolean check without producing a
+// validation.Error (e.g. registry-layer guards).
+func (r BackofficeRole) IsValid() bool {
+	switch r {
+	case BackofficeRoleSupportAgent, BackofficeRolePlatformAdmin:
+		return true
+	}
+	return false
+}
+
+var (
+	_ validation.Validatable = (*BackofficeRole)(nil)
+)
+
+// Validate implements validation.Validatable so the role can be plugged
+// into a model's ValidateWithContext chain. Unknown values produce a
+// validation.NewError with a stable error code so the future Phase 2
+// HTTP layer can map it to a typed JSON:API error.
+func (r BackofficeRole) Validate() error {
+	if r.IsValid() {
+		return nil
+	}
+	return validation.NewError(
+		"validation_invalid_backoffice_role",
+		"must be one of: support_agent, platform_admin",
+	)
+}

--- a/go/models/backoffice_user.go
+++ b/go/models/backoffice_user.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/jellydator/validation"
@@ -98,8 +97,6 @@ var (
 	_ validation.Validatable            = (*BackofficeUser)(nil)
 	_ validation.ValidatableWithContext = (*BackofficeUser)(nil)
 	_ IDable                            = (*BackofficeUser)(nil)
-	_ json.Marshaler                    = (*BackofficeUser)(nil)
-	_ json.Unmarshaler                  = (*BackofficeUser)(nil)
 )
 
 func (*BackofficeUser) Validate() error {
@@ -114,20 +111,4 @@ func (u *BackofficeUser) ValidateWithContext(ctx context.Context) error {
 	}
 
 	return validation.ValidateStructWithContext(ctx, u, fields...)
-}
-
-func (u *BackofficeUser) MarshalJSON() ([]byte, error) {
-	type Alias BackofficeUser
-	tmp := *u
-	return json.Marshal(Alias(tmp))
-}
-
-func (u *BackofficeUser) UnmarshalJSON(data []byte) error {
-	type Alias BackofficeUser
-	aux := &struct {
-		*Alias
-	}{
-		Alias: (*Alias)(u),
-	}
-	return json.Unmarshal(data, &aux)
 }

--- a/go/models/backoffice_user.go
+++ b/go/models/backoffice_user.go
@@ -1,0 +1,133 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/jellydator/validation"
+
+	"github.com/denisvmedia/inventario/models/rules"
+)
+
+// BackofficeUser is a platform-operator identity that lives entirely
+// OUTSIDE the tenant model. Where models.User belongs to a specific
+// tenant and authenticates against the tenant-scoped login flow, a
+// BackofficeUser belongs to the platform itself: there is no
+// tenant_id column, no per-tenant RLS, no group membership. The whole
+// point of the issue #1785 epic is to keep platform operators (support
+// agents, platform admins) separate from regular users so impersonating
+// a customer or escalating to system-admin cannot happen by accidentally
+// flipping a column on a normal user row.
+//
+// The table has NO row-level security — same reason `tenants` has none:
+// it IS the boundary. Access is gated entirely at the application layer
+// by the back-office auth plane (added in Phase 2 / #1785).
+//
+// Email is unique platform-wide and is lowercased at the registry layer
+// before persisting and before comparison. The migrator schema annotations
+// don't express functional indexes (`UNIQUE INDEX (lower(email))`), so
+// case-insensitivity is enforced by registry-level normalisation paired
+// with a regular unique index on the `email` column. Callers MUST go
+// through BackofficeUserRegistry.{Create,GetByEmail,Update,SetPasswordHash}
+// — direct INSERTs that bypass the lower-casing would let duplicates land
+// and the unique index would NOT catch them.
+//
+// MFAEnforced defaults to true and is reserved for Phase 4 wiring; the
+// column exists now so the schema is stable when MFA enforcement lands.
+// Phase 1 readers should treat it as data only.
+//
+// PasswordHash is bcrypt at DefaultCost — matching models.User so the
+// hash format is identical and the CLI bootstrap can reuse the standard
+// bcrypt code paths.
+
+//migrator:schema:table name="backoffice_users"
+type BackofficeUser struct {
+	//migrator:embedded mode="inline"
+	EntityID
+	//migrator:schema:field name="email" type="TEXT" not_null="true"
+	Email string `json:"email" db:"email"`
+	//migrator:schema:field name="name" type="TEXT" not_null="true"
+	Name string `json:"name" db:"name"`
+	// PasswordHash is bcrypt(DefaultCost). Marshal-blocked via `json:"-"`
+	// so the hash can never accidentally leak to a JSON response — back-
+	// office identities are higher-value than regular users, so the
+	// guardrail matters even more.
+	//migrator:schema:field name="password_hash" type="TEXT" not_null="true"
+	PasswordHash string `json:"-" db:"password_hash" userinput:"false"`
+	// Role is a typed enum: support_agent | platform_admin. Validated in
+	// ValidateWithContext via BackofficeRole.Validate.
+	//migrator:schema:field name="role" type="TEXT" not_null="true"
+	Role BackofficeRole `json:"role" db:"role"`
+	//migrator:schema:field name="is_active" type="BOOLEAN" not_null="true" default="true"
+	IsActive bool `json:"is_active" db:"is_active"`
+	// MFAEnforced is reserved for Phase 4 wiring (issue #1785). Defaults
+	// to true at the schema level so freshly bootstrapped back-office
+	// users are MFA-mandatory once the enforcement code lands.
+	//migrator:schema:field name="mfa_enforced" type="BOOLEAN" not_null="true" default="true"
+	MFAEnforced bool `json:"mfa_enforced" db:"mfa_enforced"`
+	//migrator:schema:field name="last_login_at" type="TIMESTAMP"
+	LastLoginAt *time.Time `json:"last_login_at" db:"last_login_at" userinput:"false"`
+	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	CreatedAt time.Time `json:"created_at" db:"created_at" userinput:"false"`
+	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	UpdatedAt time.Time `json:"updated_at" db:"updated_at" userinput:"false"`
+}
+
+// PostgreSQL-specific indexes for backoffice_users.
+type BackofficeUserIndexes struct {
+	// Immutable UUID index (deduplication key for import/restore, mirroring
+	// every other table that embeds EntityID).
+	//migrator:schema:index name="idx_backoffice_users_uuid" fields="uuid" unique="true" table="backoffice_users"
+	_ int
+
+	// Unique index on email enforces platform-wide uniqueness. The
+	// registry layer lowercases email on write + read so case variants
+	// collapse to the same row; without that normalisation the unique
+	// index alone would let "Admin@x.com" and "admin@x.com" coexist.
+	//migrator:schema:index name="idx_backoffice_users_email" fields="email" unique="true" table="backoffice_users"
+	_ int
+
+	// Index for active-user lookups (Phase 2's login flow will filter on
+	// is_active before checking the password hash).
+	//migrator:schema:index name="idx_backoffice_users_active" fields="is_active" table="backoffice_users"
+	_ int
+}
+
+var (
+	_ validation.Validatable            = (*BackofficeUser)(nil)
+	_ validation.ValidatableWithContext = (*BackofficeUser)(nil)
+	_ IDable                            = (*BackofficeUser)(nil)
+	_ json.Marshaler                    = (*BackofficeUser)(nil)
+	_ json.Unmarshaler                  = (*BackofficeUser)(nil)
+)
+
+func (*BackofficeUser) Validate() error {
+	return ErrMustUseValidateWithContext
+}
+
+func (u *BackofficeUser) ValidateWithContext(ctx context.Context) error {
+	fields := []*validation.FieldRules{
+		validation.Field(&u.Email, rules.NotEmpty, validation.Length(1, 255), validation.Match(EmailPattern)),
+		validation.Field(&u.Name, rules.NotEmpty, validation.Length(1, 100)),
+		validation.Field(&u.Role, validation.Required),
+	}
+
+	return validation.ValidateStructWithContext(ctx, u, fields...)
+}
+
+func (u *BackofficeUser) MarshalJSON() ([]byte, error) {
+	type Alias BackofficeUser
+	tmp := *u
+	return json.Marshal(Alias(tmp))
+}
+
+func (u *BackofficeUser) UnmarshalJSON(data []byte) error {
+	type Alias BackofficeUser
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(u),
+	}
+	return json.Unmarshal(data, &aux)
+}

--- a/go/models/backoffice_user_test.go
+++ b/go/models/backoffice_user_test.go
@@ -1,0 +1,53 @@
+package models_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+)
+
+// validBackofficeUser builds a BackofficeUser that satisfies every
+// rule in ValidateWithContext, so individual tests can mutate one
+// field at a time to assert specific failure modes.
+func validBackofficeUser() *models.BackofficeUser {
+	return &models.BackofficeUser{
+		Email: "ops@example.com",
+		Name:  "Operator",
+		Role:  models.BackofficeRolePlatformAdmin,
+	}
+}
+
+func TestBackofficeUser_ValidateWithContext_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	u := validBackofficeUser()
+	c.Assert(u.ValidateWithContext(context.Background()), qt.IsNil)
+}
+
+// TestBackofficeUser_ValidateWithContext_RejectsUnknownRole guards the
+// closed-set contract on BackofficeRole. The ozzo-validation library
+// auto-invokes the field type's own Validate() (BackofficeRole.Validate
+// in this case) when the field is referenced from validation.Field, so
+// validation.Required + BackofficeRole.Validate together both enforce
+// non-empty AND closed-set membership without an explicit validation.In
+// rule. This test pins that behaviour so a future refactor of the role
+// type or the validation library can't silently weaken it.
+func TestBackofficeUser_ValidateWithContext_RejectsUnknownRole(t *testing.T) {
+	c := qt.New(t)
+	u := validBackofficeUser()
+	u.Role = models.BackofficeRole("hacker")
+	err := u.ValidateWithContext(context.Background())
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "support_agent")
+	c.Assert(err.Error(), qt.Contains, "platform_admin")
+}
+
+func TestBackofficeUser_ValidateWithContext_RejectsMalformedEmail(t *testing.T) {
+	c := qt.New(t)
+	u := validBackofficeUser()
+	u.Email = "not-an-email"
+	err := u.ValidateWithContext(context.Background())
+	c.Assert(err, qt.IsNotNil)
+}

--- a/go/registry/errors.go
+++ b/go/registry/errors.go
@@ -112,4 +112,25 @@ var (
 	// callers branch on a single identity. The CLI exposes the override
 	// via `--allow-zero`; the HTTP path will never expose it. #1745.
 	ErrLastSystemAdmin = errx.NewSentinel("cannot revoke the last system administrator")
+
+	// ErrBackofficeUserNotFound is returned by BackofficeUserRegistry
+	// lookups when no row matches the supplied id / email. Distinct
+	// sentinel from ErrNotFound so callers in the back-office plane
+	// (issue #1785) can render messages targeted at platform operators
+	// without conflating with regular user/tenant misses.
+	ErrBackofficeUserNotFound = errx.NewSentinel("backoffice user not found", ErrNotFound)
+
+	// ErrBackofficeEmailAlreadyExists is returned by
+	// BackofficeUserRegistry.Create when the lowercased email collides
+	// with an existing row. Email is unique platform-wide for back-office
+	// identities (no tenant_id to partition on), so this is the canonical
+	// duplicate-create error for that table.
+	ErrBackofficeEmailAlreadyExists = errx.NewSentinel("backoffice user email already exists", ErrEmailAlreadyExists)
+
+	// ErrInvalidBackofficeRole is returned by BackofficeUserRegistry.Create
+	// / Update when the supplied role is not one of the closed-set values
+	// declared on models.BackofficeRole. The model's ValidateWithContext
+	// catches this on the happy path; the registry-level check is a
+	// defense-in-depth guard for callers that skip model validation.
+	ErrInvalidBackofficeRole = errx.NewSentinel("invalid backoffice role")
 )

--- a/go/registry/factories.go
+++ b/go/registry/factories.go
@@ -168,6 +168,13 @@ type FactorySet struct {
 	StorageQuotaReminderRegistry          StorageQuotaReminderRegistry  // StorageQuotaReminderRegistry is the storage quota warning worker idempotency store; service-mode only (#1585)
 	MaintenanceReminderRegistry           MaintenanceReminderRegistry   // MaintenanceReminderRegistry is the maintenance reminder worker idempotency store; service-mode only (#1368)
 	CurrencyMigrationRegistryFactory      CurrencyMigrationRegistryFactory
+	// BackofficeUserRegistry persists platform-operator identities
+	// (issue #1785). Lives on FactorySet only — back-office identities
+	// are NOT part of the per-request *Set (they're cross-cutting infra,
+	// not user-aware data), so the bootstrap CLI accesses them directly
+	// via factorySet.BackofficeUserRegistry. Phase 2 (login flow) and
+	// Phase 3 (admin surface) will add HTTP-side wiring on top.
+	BackofficeUserRegistry BackofficeUserRegistry
 }
 
 // Ping checks readiness of the backing registry dependency (e.g. database).

--- a/go/registry/memory/backoffice_users.go
+++ b/go/registry/memory/backoffice_users.go
@@ -48,9 +48,18 @@ func NewBackofficeUserRegistry() *BackofficeUserRegistry {
 // leaving a race window where two concurrent calls with the same email
 // could both observe "no collision". Holding the lock across both ops
 // matches the postgres backend's "check + insert in one tx" contract.
-func (r *BackofficeUserRegistry) Create(_ context.Context, user models.BackofficeUser) (*models.BackofficeUser, error) {
+func (r *BackofficeUserRegistry) Create(ctx context.Context, user models.BackofficeUser) (*models.BackofficeUser, error) {
 	if err := r.validateForCreate(user); err != nil {
 		return nil, err
+	}
+	// Defence-in-depth: re-run the model's full validation so format/
+	// length constraints (EmailPattern, max lengths, closed-set role)
+	// fail closed even if a future caller bypasses Service.Bootstrap.
+	// The registry's bespoke validateForCreate runs first so the existing
+	// ErrFieldRequired / ErrInvalidBackofficeRole sentinels keep their
+	// identity for callers that branch on them.
+	if err := user.ValidateWithContext(ctx); err != nil {
+		return nil, errxtrace.Wrap("backoffice user failed model validation", err)
 	}
 	user.Email = normaliseBackofficeEmail(user.Email)
 
@@ -106,8 +115,10 @@ func (r *BackofficeUserRegistry) Get(ctx context.Context, id string) (*models.Ba
 }
 
 // GetByEmail performs a case-insensitive lookup by lowercased email.
+// Whitespace-only input is treated as empty so a stray "   " from a
+// caller doesn't fall through to a no-rows lookup.
 func (r *BackofficeUserRegistry) GetByEmail(ctx context.Context, email string) (*models.BackofficeUser, error) {
-	if email == "" {
+	if strings.TrimSpace(email) == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Email"))
 	}
 	normalised := normaliseBackofficeEmail(email)
@@ -132,6 +143,13 @@ func (r *BackofficeUserRegistry) GetByEmail(ctx context.Context, email string) (
 // PasswordHash is intentionally NOT required on the input — Update
 // restores it from the persisted row. Callers that want to change the
 // hash must go through SetPasswordHash.
+//
+// The cross-row email uniqueness check AND the persisted write happen
+// under a single write-lock acquisition — the previous shape released
+// the lock between the check and a delegated call to the underlying
+// Registry.Update, leaving a race window where two concurrent updates
+// could both observe "no collision". Holding the lock across both ops
+// matches the postgres backend's "check + UPDATE in one tx" contract.
 func (r *BackofficeUserRegistry) Update(ctx context.Context, user models.BackofficeUser) (*models.BackofficeUser, error) {
 	if user.GetID() == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
@@ -139,28 +157,50 @@ func (r *BackofficeUserRegistry) Update(ctx context.Context, user models.Backoff
 	if err := r.validateForUpdate(user); err != nil {
 		return nil, err
 	}
+	// Defence-in-depth: re-run the model's full validation so format/
+	// length constraints (EmailPattern, max lengths, closed-set role)
+	// fail closed even when callers bypass the service layer. The
+	// registry's bespoke validateForUpdate runs first so the existing
+	// ErrFieldRequired / ErrInvalidBackofficeRole sentinels keep their
+	// identity. PasswordHash isn't part of the public Update surface,
+	// so model validation runs on a copy with an opaque non-empty hash
+	// substituted in — the on-disk hash is restored further down.
+	validateUser := user
+	if validateUser.PasswordHash == "" {
+		validateUser.PasswordHash = "validation-placeholder"
+	}
+	if err := validateUser.ValidateWithContext(ctx); err != nil {
+		return nil, errxtrace.Wrap("backoffice user failed model validation", err)
+	}
 	user.Email = normaliseBackofficeEmail(user.Email)
 
 	r.lock.Lock()
+	defer r.lock.Unlock()
+
 	existing, ok := r.items.Get(user.ID)
 	if !ok {
-		r.lock.Unlock()
 		return nil, errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", user.ID))
 	}
 	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
 		if pair.Value.ID != user.ID && pair.Value.Email == user.Email {
-			r.lock.Unlock()
 			return nil, errxtrace.Classify(registry.ErrBackofficeEmailAlreadyExists, errx.Attrs("email", user.Email))
 		}
 	}
-	// Preserve immutable / write-path-isolated fields.
+	// Preserve immutable / write-path-isolated fields, then perform the
+	// store update inline so the whole "check uniqueness, mutate" sequence
+	// runs under the single lock acquisition.
 	user.CreatedAt = existing.CreatedAt
 	user.PasswordHash = existing.PasswordHash
 	user.LastLoginAt = existing.LastLoginAt
 	user.UpdatedAt = time.Now()
-	r.lock.Unlock()
+	// UUID is immutable after creation — overwrite whatever the caller
+	// supplied with the persisted value (mirrors the base Registry's
+	// Update behaviour for UUIDable rows).
+	user.UUID = existing.UUID
+	stored := user
+	r.items.Set(stored.ID, &stored)
 
-	return r.baseBackofficeUserRegistry.Update(ctx, user)
+	return &stored, nil
 }
 
 // Delete is delegated to the base registry. Idempotent semantics match

--- a/go/registry/memory/backoffice_users.go
+++ b/go/registry/memory/backoffice_users.go
@@ -1,0 +1,259 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/go-extras/errx"
+	errxtrace "github.com/go-extras/errx/stacktrace"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+var _ registry.BackofficeUserRegistry = (*BackofficeUserRegistry)(nil)
+
+type baseBackofficeUserRegistry = Registry[models.BackofficeUser, *models.BackofficeUser]
+
+// BackofficeUserRegistry is the in-memory implementation of the
+// platform-operator identity store (issue #1785). Mirrors the postgres
+// backend's invariants — lowercased email storage and platform-wide
+// email uniqueness — so tests that use the memory backend exercise the
+// same semantics as production.
+type BackofficeUserRegistry struct {
+	*baseBackofficeUserRegistry
+}
+
+// NewBackofficeUserRegistry builds an empty in-memory back-office user
+// store. No RLS / tenant wiring is required because the table is
+// cross-cutting infrastructure that lives OUTSIDE the tenant model.
+func NewBackofficeUserRegistry() *BackofficeUserRegistry {
+	return &BackofficeUserRegistry{
+		baseBackofficeUserRegistry: NewRegistry[models.BackofficeUser, *models.BackofficeUser](),
+	}
+}
+
+// Create validates required fields, lowercases the email, and rejects
+// duplicates platform-wide. CreatedAt / UpdatedAt are stamped at insert
+// time so callers don't need to populate them. Returns ErrFieldRequired,
+// ErrInvalidBackofficeRole, or ErrBackofficeEmailAlreadyExists when
+// applicable.
+func (r *BackofficeUserRegistry) Create(ctx context.Context, user models.BackofficeUser) (*models.BackofficeUser, error) {
+	if err := r.validateForCreate(user); err != nil {
+		return nil, err
+	}
+	user.Email = normaliseBackofficeEmail(user.Email)
+
+	// Email uniqueness check has to happen under the write lock or two
+	// concurrent Creates with the same email could both pass the
+	// existence check. Using the underlying Registry's exposed lock keeps
+	// the contention scope tight.
+	r.lock.Lock()
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		if pair.Value.Email == user.Email {
+			r.lock.Unlock()
+			return nil, errxtrace.Classify(registry.ErrBackofficeEmailAlreadyExists, errx.Attrs("email", user.Email))
+		}
+	}
+	r.lock.Unlock()
+
+	now := time.Now()
+	user.CreatedAt = now
+	user.UpdatedAt = now
+	if user.LastLoginAt != nil && user.LastLoginAt.IsZero() {
+		user.LastLoginAt = nil
+	}
+
+	return r.baseBackofficeUserRegistry.Create(ctx, user)
+}
+
+// Get returns the row by id. Translates the generic ErrNotFound to the
+// back-office-specific sentinel so callers don't have to discriminate
+// at the call site.
+func (r *BackofficeUserRegistry) Get(ctx context.Context, id string) (*models.BackofficeUser, error) {
+	if id == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+	user, err := r.baseBackofficeUserRegistry.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotFound) {
+			return nil, errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", id))
+		}
+		return nil, err
+	}
+	return user, nil
+}
+
+// GetByEmail performs a case-insensitive lookup by lowercased email.
+func (r *BackofficeUserRegistry) GetByEmail(ctx context.Context, email string) (*models.BackofficeUser, error) {
+	if email == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Email"))
+	}
+	normalised := normaliseBackofficeEmail(email)
+
+	users, err := r.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, u := range users {
+		if u.Email == normalised {
+			return u, nil
+		}
+	}
+	return nil, errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("email", normalised))
+}
+
+// Update revalidates required fields, lowercases the email, and rejects
+// email collisions with OTHER rows. Preserves CreatedAt / PasswordHash
+// / LastLoginAt from the persisted row so a partial-struct update from
+// the future HTTP layer can't clobber them by accident.
+//
+// PasswordHash is intentionally NOT required on the input — Update
+// restores it from the persisted row. Callers that want to change the
+// hash must go through SetPasswordHash.
+func (r *BackofficeUserRegistry) Update(ctx context.Context, user models.BackofficeUser) (*models.BackofficeUser, error) {
+	if user.GetID() == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+	if err := r.validateForUpdate(user); err != nil {
+		return nil, err
+	}
+	user.Email = normaliseBackofficeEmail(user.Email)
+
+	r.lock.Lock()
+	existing, ok := r.items.Get(user.ID)
+	if !ok {
+		r.lock.Unlock()
+		return nil, errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", user.ID))
+	}
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		if pair.Value.ID != user.ID && pair.Value.Email == user.Email {
+			r.lock.Unlock()
+			return nil, errxtrace.Classify(registry.ErrBackofficeEmailAlreadyExists, errx.Attrs("email", user.Email))
+		}
+	}
+	// Preserve immutable / write-path-isolated fields.
+	user.CreatedAt = existing.CreatedAt
+	user.PasswordHash = existing.PasswordHash
+	user.LastLoginAt = existing.LastLoginAt
+	user.UpdatedAt = time.Now()
+	r.lock.Unlock()
+
+	return r.baseBackofficeUserRegistry.Update(ctx, user)
+}
+
+// Delete is delegated to the base registry. Idempotent semantics match
+// the rest of the memory backend.
+func (r *BackofficeUserRegistry) Delete(ctx context.Context, id string) error {
+	if id == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+	return r.baseBackofficeUserRegistry.Delete(ctx, id)
+}
+
+// SetPasswordHash overwrites only password_hash + bumps updated_at.
+// Intentionally separate from Update so the bcrypt hash can never leak
+// through a generic full-row update.
+func (r *BackofficeUserRegistry) SetPasswordHash(_ context.Context, id, hash string) error {
+	if id == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+	if hash == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "PasswordHash"))
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	existing, ok := r.items.Get(id)
+	if !ok {
+		return errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", id))
+	}
+	existing.PasswordHash = hash
+	existing.UpdatedAt = time.Now()
+	r.items.Set(id, existing)
+	return nil
+}
+
+// UpdateLastLogin stamps last_login_at and bumps updated_at.
+func (r *BackofficeUserRegistry) UpdateLastLogin(_ context.Context, id string, at time.Time) error {
+	if id == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	existing, ok := r.items.Get(id)
+	if !ok {
+		return errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", id))
+	}
+	stamped := at
+	existing.LastLoginAt = &stamped
+	existing.UpdatedAt = time.Now()
+	r.items.Set(id, existing)
+	return nil
+}
+
+// SetActive flips is_active and bumps updated_at.
+func (r *BackofficeUserRegistry) SetActive(_ context.Context, id string, active bool) error {
+	if id == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	existing, ok := r.items.Get(id)
+	if !ok {
+		return errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", id))
+	}
+	existing.IsActive = active
+	existing.UpdatedAt = time.Now()
+	r.items.Set(id, existing)
+	return nil
+}
+
+// validateForCreate enforces the full required-field invariants for an
+// insert: email, name, password_hash, and a valid role. Role validation
+// returns the registry-typed sentinel instead of a validation.Error so
+// callers can branch on a single identity.
+func (r *BackofficeUserRegistry) validateForCreate(user models.BackofficeUser) error {
+	if err := validateCommonBackofficeFields(user); err != nil {
+		return err
+	}
+	if user.PasswordHash == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "PasswordHash"))
+	}
+	return nil
+}
+
+// validateForUpdate is the relaxed variant: it skips the PasswordHash
+// check because Update restores the persisted hash from the stored row
+// (callers must use SetPasswordHash to change the hash). Everything
+// else remains required.
+func (r *BackofficeUserRegistry) validateForUpdate(user models.BackofficeUser) error {
+	return validateCommonBackofficeFields(user)
+}
+
+// validateCommonBackofficeFields covers the invariants shared by Create
+// and Update — every column except the password hash, which only Create
+// requires.
+func validateCommonBackofficeFields(user models.BackofficeUser) error {
+	if strings.TrimSpace(user.Email) == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Email"))
+	}
+	if strings.TrimSpace(user.Name) == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Name"))
+	}
+	if !user.Role.IsValid() {
+		return errxtrace.Classify(registry.ErrInvalidBackofficeRole, errx.Attrs("role", string(user.Role)))
+	}
+	return nil
+}
+
+// normaliseBackofficeEmail lowercases + trims the email so case variants
+// collapse to a single row. Mirrors postgres's behaviour where the
+// registry layer does the same normalisation before INSERT / SELECT.
+func normaliseBackofficeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}

--- a/go/registry/memory/backoffice_users.go
+++ b/go/registry/memory/backoffice_users.go
@@ -63,7 +63,11 @@ func (r *BackofficeUserRegistry) Create(ctx context.Context, user models.Backoff
 	}
 	user.Email = normaliseBackofficeEmail(user.Email)
 
-	now := time.Now()
+	// Stamp in UTC to match the postgres backend (which uses
+	// time.Now().UTC() / Postgres now() returning UTC-equivalent values)
+	// and the rest of the memory registries — keeps cross-backend
+	// timestamps comparable and independent of the host timezone.
+	now := time.Now().UTC()
 	if user.CreatedAt.IsZero() {
 		user.CreatedAt = now
 	}
@@ -192,7 +196,7 @@ func (r *BackofficeUserRegistry) Update(ctx context.Context, user models.Backoff
 	user.CreatedAt = existing.CreatedAt
 	user.PasswordHash = existing.PasswordHash
 	user.LastLoginAt = existing.LastLoginAt
-	user.UpdatedAt = time.Now()
+	user.UpdatedAt = time.Now().UTC()
 	// UUID is immutable after creation — overwrite whatever the caller
 	// supplied with the persisted value (mirrors the base Registry's
 	// Update behaviour for UUIDable rows).
@@ -230,7 +234,7 @@ func (r *BackofficeUserRegistry) SetPasswordHash(_ context.Context, id, hash str
 		return errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", id))
 	}
 	existing.PasswordHash = hash
-	existing.UpdatedAt = time.Now()
+	existing.UpdatedAt = time.Now().UTC()
 	r.items.Set(id, existing)
 	return nil
 }
@@ -249,7 +253,7 @@ func (r *BackofficeUserRegistry) UpdateLastLogin(_ context.Context, id string, a
 	}
 	stamped := at
 	existing.LastLoginAt = &stamped
-	existing.UpdatedAt = time.Now()
+	existing.UpdatedAt = time.Now().UTC()
 	r.items.Set(id, existing)
 	return nil
 }
@@ -267,7 +271,7 @@ func (r *BackofficeUserRegistry) SetActive(_ context.Context, id string, active 
 		return errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", id))
 	}
 	existing.IsActive = active
-	existing.UpdatedAt = time.Now()
+	existing.UpdatedAt = time.Now().UTC()
 	r.items.Set(id, existing)
 	return nil
 }

--- a/go/registry/memory/backoffice_users.go
+++ b/go/registry/memory/backoffice_users.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/google/uuid"
 
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
@@ -40,33 +41,51 @@ func NewBackofficeUserRegistry() *BackofficeUserRegistry {
 // time so callers don't need to populate them. Returns ErrFieldRequired,
 // ErrInvalidBackofficeRole, or ErrBackofficeEmailAlreadyExists when
 // applicable.
-func (r *BackofficeUserRegistry) Create(ctx context.Context, user models.BackofficeUser) (*models.BackofficeUser, error) {
+//
+// The email uniqueness check AND the insert happen under a single
+// write-lock acquisition — the previous shape released the lock between
+// the check and the underlying Registry.Create's own re-acquisition,
+// leaving a race window where two concurrent calls with the same email
+// could both observe "no collision". Holding the lock across both ops
+// matches the postgres backend's "check + insert in one tx" contract.
+func (r *BackofficeUserRegistry) Create(_ context.Context, user models.BackofficeUser) (*models.BackofficeUser, error) {
 	if err := r.validateForCreate(user); err != nil {
 		return nil, err
 	}
 	user.Email = normaliseBackofficeEmail(user.Email)
 
-	// Email uniqueness check has to happen under the write lock or two
-	// concurrent Creates with the same email could both pass the
-	// existence check. Using the underlying Registry's exposed lock keeps
-	// the contention scope tight.
-	r.lock.Lock()
-	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
-		if pair.Value.Email == user.Email {
-			r.lock.Unlock()
-			return nil, errxtrace.Classify(registry.ErrBackofficeEmailAlreadyExists, errx.Attrs("email", user.Email))
-		}
-	}
-	r.lock.Unlock()
-
 	now := time.Now()
-	user.CreatedAt = now
-	user.UpdatedAt = now
+	if user.CreatedAt.IsZero() {
+		user.CreatedAt = now
+	}
+	if user.UpdatedAt.IsZero() {
+		user.UpdatedAt = now
+	}
 	if user.LastLoginAt != nil && user.LastLoginAt.IsZero() {
 		user.LastLoginAt = nil
 	}
 
-	return r.baseBackofficeUserRegistry.Create(ctx, user)
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		if pair.Value.Email == user.Email {
+			return nil, errxtrace.Classify(registry.ErrBackofficeEmailAlreadyExists, errx.Attrs("email", user.Email))
+		}
+	}
+
+	// Mint server-side ID + UUID inline so the whole "check uniqueness,
+	// assign id, insert" sequence runs under the single lock. Mirrors
+	// the base memory Registry's Create body — duplicated here so we
+	// don't have to release the lock to call into it.
+	user.ID = uuid.New().String()
+	if user.UUID == "" {
+		user.UUID = uuid.New().String()
+	}
+	stored := user
+	r.items.Set(stored.ID, &stored)
+
+	return &stored, nil
 }
 
 // Get returns the row by id. Translates the generic ErrNotFound to the

--- a/go/registry/memory/backoffice_users_test.go
+++ b/go/registry/memory/backoffice_users_test.go
@@ -347,3 +347,35 @@ func TestBackofficeUserRegistry_SetActive(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(fetched.IsActive, qt.IsTrue)
 }
+
+// TestBackofficeUserRegistry_List_DistinctRowsAndInsertionOrder pins
+// the cross-backend list contract: List returns one entry per inserted
+// row, each a distinct pointer, in the order rows were inserted. The
+// memory backend's base List iterates the underlying ordered map's
+// Oldest()->Newest() chain and copies each item, so the slice can never
+// alias — this test guards against a future refactor that returns the
+// map's internal pointers directly.
+func TestBackofficeUserRegistry_List_DistinctRowsAndInsertionOrder(t *testing.T) {
+	r := memory.NewBackofficeUserRegistry()
+	c := qt.New(t)
+	ctx := context.Background()
+
+	emails := []string{"first@example.com", "second@example.com", "third@example.com"}
+	for _, email := range emails {
+		_, err := r.Create(ctx, newTestBackofficeUser(email))
+		c.Assert(err, qt.IsNil)
+	}
+
+	listed, err := r.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(listed, qt.HasLen, 3)
+
+	seenIDs := make(map[string]struct{}, len(listed))
+	gotEmails := make([]string, 0, len(listed))
+	for _, u := range listed {
+		seenIDs[u.ID] = struct{}{}
+		gotEmails = append(gotEmails, u.Email)
+	}
+	c.Assert(seenIDs, qt.HasLen, 3)
+	c.Assert(gotEmails, qt.DeepEquals, emails)
+}

--- a/go/registry/memory/backoffice_users_test.go
+++ b/go/registry/memory/backoffice_users_test.go
@@ -1,0 +1,285 @@
+package memory_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+// newTestBackofficeUser returns a valid BackofficeUser with the given
+// email. The PasswordHash isn't a real bcrypt — registry-level tests
+// only check storage invariants, not bcrypt correctness (the latter is
+// covered by models.User.SetPassword's own tests).
+func newTestBackofficeUser(email string) models.BackofficeUser {
+	return models.BackofficeUser{
+		Email:        email,
+		Name:         "Operator",
+		PasswordHash: "$2a$10$placeholder",
+		Role:         models.BackofficeRolePlatformAdmin,
+		IsActive:     true,
+		MFAEnforced:  true,
+	}
+}
+
+func TestBackofficeUserRegistry_Create_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	created, err := r.Create(ctx, newTestBackofficeUser("ops@example.com"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created, qt.IsNotNil)
+	c.Assert(created.ID, qt.Not(qt.Equals), "")
+	c.Assert(created.UUID, qt.Not(qt.Equals), "")
+	c.Assert(created.Email, qt.Equals, "ops@example.com")
+	c.Assert(created.Role, qt.Equals, models.BackofficeRolePlatformAdmin)
+	c.Assert(created.CreatedAt.IsZero(), qt.IsFalse)
+	c.Assert(created.UpdatedAt.IsZero(), qt.IsFalse)
+	c.Assert(created.LastLoginAt, qt.IsNil)
+}
+
+// TestBackofficeUserRegistry_Create_LowercasesEmail pins the case-
+// insensitivity invariant: a mixed-case email lands in the store
+// lowercased so subsequent lookups + uniqueness checks collapse case
+// variants.
+func TestBackofficeUserRegistry_Create_LowercasesEmail(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	created, err := r.Create(ctx, newTestBackofficeUser("Ops@Example.COM"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.Email, qt.Equals, "ops@example.com")
+}
+
+func TestBackofficeUserRegistry_Create_MissingFields(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		mut  func(*models.BackofficeUser)
+	}{
+		{"email empty", func(u *models.BackofficeUser) { u.Email = "" }},
+		{"name empty", func(u *models.BackofficeUser) { u.Name = "" }},
+		{"password_hash empty", func(u *models.BackofficeUser) { u.PasswordHash = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			r := memory.NewBackofficeUserRegistry()
+			u := newTestBackofficeUser("user@example.com")
+			tc.mut(&u)
+			_, err := r.Create(ctx, u)
+			c.Assert(errors.Is(err, registry.ErrFieldRequired), qt.IsTrue)
+		})
+	}
+}
+
+func TestBackofficeUserRegistry_Create_InvalidRole(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	u := newTestBackofficeUser("user@example.com")
+	u.Role = "no-such-role"
+	_, err := r.Create(ctx, u)
+	c.Assert(errors.Is(err, registry.ErrInvalidBackofficeRole), qt.IsTrue)
+}
+
+// TestBackofficeUserRegistry_Create_DuplicateEmail pins the platform-wide
+// uniqueness invariant — including the case-insensitive variant, since
+// the second Create's email is upper-cased on input.
+func TestBackofficeUserRegistry_Create_DuplicateEmail(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	_, err := r.Create(ctx, newTestBackofficeUser("ops@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	_, err = r.Create(ctx, newTestBackofficeUser("Ops@Example.com"))
+	c.Assert(errors.Is(err, registry.ErrBackofficeEmailAlreadyExists), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistry_Get(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	created, err := r.Create(ctx, newTestBackofficeUser("get@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	fetched, err := r.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.ID, qt.Equals, created.ID)
+	c.Assert(fetched.Email, qt.Equals, "get@example.com")
+}
+
+func TestBackofficeUserRegistry_Get_NotFound(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	_, err := r.Get(ctx, "no-such-id")
+	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
+	// The sentinel wraps ErrNotFound, so generic callers branching on
+	// the umbrella sentinel still work.
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistry_GetByEmail_CaseInsensitive(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	_, err := r.Create(ctx, newTestBackofficeUser("ops@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	fetched, err := r.GetByEmail(ctx, "OPS@example.COM")
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.Email, qt.Equals, "ops@example.com")
+}
+
+func TestBackofficeUserRegistry_GetByEmail_NotFound(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	_, err := r.GetByEmail(ctx, "missing@example.com")
+	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistry_Update_PreservesPasswordHash(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	created, err := r.Create(ctx, newTestBackofficeUser("upd@example.com"))
+	c.Assert(err, qt.IsNil)
+	originalHash := created.PasswordHash
+
+	// Simulate a caller that nulls out the hash on the way through
+	// (a partial-struct update from the future HTTP layer). The
+	// registry must keep the persisted hash intact.
+	updated := *created
+	updated.PasswordHash = ""
+	updated.Name = "Renamed Operator"
+
+	got, err := r.Update(ctx, updated)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.PasswordHash, qt.Equals, originalHash)
+	c.Assert(got.Name, qt.Equals, "Renamed Operator")
+}
+
+func TestBackofficeUserRegistry_Update_RejectsEmailCollision(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	_, err := r.Create(ctx, newTestBackofficeUser("first@example.com"))
+	c.Assert(err, qt.IsNil)
+	second, err := r.Create(ctx, newTestBackofficeUser("second@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	second.Email = "first@example.com"
+	_, err = r.Update(ctx, *second)
+	c.Assert(errors.Is(err, registry.ErrBackofficeEmailAlreadyExists), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistry_Delete(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	created, err := r.Create(ctx, newTestBackofficeUser("del@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(r.Delete(ctx, created.ID), qt.IsNil)
+	_, err = r.Get(ctx, created.ID)
+	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistry_Count(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	count, err := r.Count(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+
+	_, err = r.Create(ctx, newTestBackofficeUser("a@example.com"))
+	c.Assert(err, qt.IsNil)
+	_, err = r.Create(ctx, newTestBackofficeUser("b@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	count, err = r.Count(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 2)
+}
+
+func TestBackofficeUserRegistry_SetPasswordHash(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	created, err := r.Create(ctx, newTestBackofficeUser("hash@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(r.SetPasswordHash(ctx, created.ID, "$2a$10$newhash"), qt.IsNil)
+	fetched, err := r.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.PasswordHash, qt.Equals, "$2a$10$newhash")
+}
+
+func TestBackofficeUserRegistry_SetPasswordHash_NotFound(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	err := r.SetPasswordHash(ctx, "no-such-id", "$2a$10$x")
+	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistry_UpdateLastLogin(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	created, err := r.Create(ctx, newTestBackofficeUser("login@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	at := time.Now().UTC().Truncate(time.Second)
+	c.Assert(r.UpdateLastLogin(ctx, created.ID, at), qt.IsNil)
+
+	fetched, err := r.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.LastLoginAt, qt.IsNotNil)
+	c.Assert(fetched.LastLoginAt.Equal(at), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistry_SetActive(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	created, err := r.Create(ctx, newTestBackofficeUser("act@example.com"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.IsActive, qt.IsTrue)
+
+	c.Assert(r.SetActive(ctx, created.ID, false), qt.IsNil)
+	fetched, err := r.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.IsActive, qt.IsFalse)
+
+	c.Assert(r.SetActive(ctx, created.ID, true), qt.IsNil)
+	fetched, err = r.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.IsActive, qt.IsTrue)
+}

--- a/go/registry/memory/backoffice_users_test.go
+++ b/go/registry/memory/backoffice_users_test.go
@@ -205,6 +205,18 @@ func TestBackofficeUserRegistry_Delete(t *testing.T) {
 	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
 }
 
+// TestBackofficeUserRegistry_Delete_Idempotent pins the cross-backend
+// idempotency contract: a Delete on a missing id is a no-op rather than
+// an error, so callers (provisioning scripts, the future admin surface)
+// can re-run Delete safely. Mirrored by the postgres backend.
+func TestBackofficeUserRegistry_Delete_Idempotent(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	c.Assert(r.Delete(ctx, "no-such-id"), qt.IsNil)
+}
+
 func TestBackofficeUserRegistry_Count(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()

--- a/go/registry/memory/backoffice_users_test.go
+++ b/go/registry/memory/backoffice_users_test.go
@@ -92,6 +92,27 @@ func TestBackofficeUserRegistry_Create_InvalidRole(t *testing.T) {
 	c.Assert(errors.Is(err, registry.ErrInvalidBackofficeRole), qt.IsTrue)
 }
 
+// TestBackofficeUserRegistry_Create_RejectsMalformedEmail proves the
+// defence-in-depth model validation runs at the registry layer — a
+// string that passes the bespoke TrimSpace-required check ("not-an-
+// email") still gets rejected by BackofficeUser.ValidateWithContext's
+// EmailPattern rule. The Service.Bootstrap path also runs model
+// validation; this test guards the registry against future callers
+// that bypass the service layer.
+func TestBackofficeUserRegistry_Create_RejectsMalformedEmail(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	u := newTestBackofficeUser("not-an-email")
+	_, err := r.Create(ctx, u)
+	c.Assert(err, qt.IsNotNil)
+	// Model validation returns a wrapped validation.Errors — the
+	// registry doesn't translate it to a typed sentinel because the
+	// future HTTP layer maps validation errors generically.
+	c.Assert(err.Error(), qt.Contains, "model validation")
+}
+
 // TestBackofficeUserRegistry_Create_DuplicateEmail pins the platform-wide
 // uniqueness invariant — including the case-insensitive variant, since
 // the second Create's email is upper-cased on input.
@@ -155,6 +176,18 @@ func TestBackofficeUserRegistry_GetByEmail_NotFound(t *testing.T) {
 	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
 }
 
+// TestBackofficeUserRegistry_GetByEmail_WhitespaceOnly pins the
+// whitespace-rejection invariant — a stray "   " from the caller must
+// surface as ErrFieldRequired, not as a no-rows lookup.
+func TestBackofficeUserRegistry_GetByEmail_WhitespaceOnly(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	_, err := r.GetByEmail(ctx, "   ")
+	c.Assert(errors.Is(err, registry.ErrFieldRequired), qt.IsTrue)
+}
+
 func TestBackofficeUserRegistry_Update_PreservesPasswordHash(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
@@ -175,6 +208,25 @@ func TestBackofficeUserRegistry_Update_PreservesPasswordHash(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(got.PasswordHash, qt.Equals, originalHash)
 	c.Assert(got.Name, qt.Equals, "Renamed Operator")
+}
+
+// TestBackofficeUserRegistry_Update_RejectsMalformedEmail confirms the
+// model-level EmailPattern check runs on Update too — a payload that
+// passes the bespoke required-field check ("not-an-email") still fails
+// model validation. Symmetric with the Create variant.
+func TestBackofficeUserRegistry_Update_RejectsMalformedEmail(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewBackofficeUserRegistry()
+
+	created, err := r.Create(ctx, newTestBackofficeUser("ok@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	updated := *created
+	updated.Email = "not-an-email"
+	_, err = r.Update(ctx, updated)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "model validation")
 }
 
 func TestBackofficeUserRegistry_Update_RejectsEmailCollision(t *testing.T) {

--- a/go/registry/memory/memory.go
+++ b/go/registry/memory/memory.go
@@ -62,6 +62,11 @@ func NewFactorySet() *registry.FactorySet {
 	fs.LoginEventRegistry = NewLoginEventRegistry()
 	fs.UserMFASecretRegistry = NewUserMFASecretRegistry()
 	fs.AuditLogRegistry = NewAuditLogRegistry()
+	// Back-office identities (issue #1785) — platform-operator users
+	// that live OUTSIDE the tenant model. Wired on FactorySet only;
+	// not part of the per-request Set since back-office identities are
+	// cross-cutting infra, not user-aware data.
+	fs.BackofficeUserRegistry = NewBackofficeUserRegistry()
 	groupReg := NewLocationGroupRegistry()
 	fs.LocationGroupRegistry = groupReg
 	membershipReg := NewGroupMembershipRegistry()

--- a/go/registry/postgres/backoffice_users.go
+++ b/go/registry/postgres/backoffice_users.go
@@ -1,0 +1,360 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-extras/errx"
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+var _ registry.BackofficeUserRegistry = (*BackofficeUserRegistry)(nil)
+
+// BackofficeUserRegistry is the postgres-backed implementation of the
+// platform-operator identity store (issue #1785). The underlying table
+// has NO row-level security enabled — same reasoning as `tenants`: a
+// back-office identity IS the boundary, so the table is wrapped by a
+// NonRLSRepository and access is gated entirely at the application
+// layer (Phase 2 / #1785).
+//
+// Email is unique platform-wide and is lowercased at the registry layer
+// before INSERT and before SELECT, so case variants collapse to one row.
+// The schema annotations don't express functional indexes, so the
+// regular UNIQUE INDEX on `email` only catches duplicates when callers
+// route through this registry.
+type BackofficeUserRegistry struct {
+	dbx        *sqlx.DB
+	tableNames store.TableNames
+}
+
+// NewBackofficeUserRegistry returns a postgres-backed BackofficeUserRegistry
+// using the default table-name set.
+func NewBackofficeUserRegistry(dbx *sqlx.DB) *BackofficeUserRegistry {
+	return NewBackofficeUserRegistryWithTableNames(dbx, store.DefaultTableNames)
+}
+
+// NewBackofficeUserRegistryWithTableNames lets tests override the table
+// names (per the same pattern used by every other postgres registry).
+func NewBackofficeUserRegistryWithTableNames(dbx *sqlx.DB, tableNames store.TableNames) *BackofficeUserRegistry {
+	return &BackofficeUserRegistry{
+		dbx:        dbx,
+		tableNames: tableNames,
+	}
+}
+
+func (r *BackofficeUserRegistry) newSQLRegistry() *store.NonRLSRepository[models.BackofficeUser, *models.BackofficeUser] {
+	return store.NewSQLRegistry[models.BackofficeUser, *models.BackofficeUser](r.dbx, r.tableNames.BackofficeUsers())
+}
+
+// Create validates required fields, lowercases the email, and rejects
+// duplicates platform-wide inside the same transaction as the INSERT so
+// two concurrent calls with the same email both fail-closed (one
+// commits, the second rolls back on the unique-index violation; the
+// pre-check turns "lost insert" into the friendlier
+// ErrBackofficeEmailAlreadyExists sentinel).
+func (r *BackofficeUserRegistry) Create(ctx context.Context, user models.BackofficeUser) (*models.BackofficeUser, error) {
+	if err := r.validateForCreate(user); err != nil {
+		return nil, err
+	}
+	user.Email = normaliseBackofficeEmail(user.Email)
+
+	reg := r.newSQLRegistry()
+	created, err := reg.Create(ctx, user, func(ctx context.Context, tx *sqlx.Tx) error {
+		var existing models.BackofficeUser
+		txReg := store.NewTxRegistry[models.BackofficeUser](tx, r.tableNames.BackofficeUsers())
+		err := txReg.ScanOneByField(ctx, store.Pair("email", user.Email), &existing)
+		if err == nil {
+			return errxtrace.Classify(registry.ErrBackofficeEmailAlreadyExists, errx.Attrs("email", user.Email))
+		}
+		if !errors.Is(err, store.ErrNotFound) {
+			return errxtrace.Wrap("failed to check for existing backoffice user", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to create backoffice user", err)
+	}
+	return &created, nil
+}
+
+// Get returns the row by id. Maps store.ErrNotFound to the back-office-
+// specific sentinel so callers don't have to discriminate at the call
+// site.
+func (r *BackofficeUserRegistry) Get(ctx context.Context, id string) (*models.BackofficeUser, error) {
+	if id == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+
+	var user models.BackofficeUser
+	reg := r.newSQLRegistry()
+	if err := reg.ScanOneByField(ctx, store.Pair("id", id), &user); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", id))
+		}
+		return nil, errxtrace.Wrap("failed to get backoffice user", err)
+	}
+	return &user, nil
+}
+
+// GetByEmail performs a case-insensitive lookup by lowercased email.
+// The registry layer normalises the email both on write and read, so a
+// regular `email = $1` predicate is enough — no `lower(email)` index
+// required.
+func (r *BackofficeUserRegistry) GetByEmail(ctx context.Context, email string) (*models.BackofficeUser, error) {
+	if email == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Email"))
+	}
+	normalised := normaliseBackofficeEmail(email)
+
+	var user models.BackofficeUser
+	reg := r.newSQLRegistry()
+	if err := reg.ScanOneByField(ctx, store.Pair("email", normalised), &user); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("email", normalised))
+		}
+		return nil, errxtrace.Wrap("failed to get backoffice user by email", err)
+	}
+	return &user, nil
+}
+
+// List returns every back-office row in insertion order. Tiny table (a
+// handful of platform operators), so no pagination is needed yet.
+func (r *BackofficeUserRegistry) List(ctx context.Context) ([]*models.BackofficeUser, error) {
+	var users []*models.BackofficeUser
+	reg := r.newSQLRegistry()
+	for user, err := range reg.Scan(ctx) {
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to list backoffice users", err)
+		}
+		users = append(users, &user)
+	}
+	return users, nil
+}
+
+// Count returns the total number of back-office rows. Used by the
+// bootstrap CLI to refuse a fresh create unless --force is passed.
+func (r *BackofficeUserRegistry) Count(ctx context.Context) (int, error) {
+	reg := r.newSQLRegistry()
+	count, err := reg.Count(ctx)
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to count backoffice users", err)
+	}
+	return count, nil
+}
+
+// Update revalidates required fields, lowercases the email, and writes
+// the row back. The bcrypt hash + created_at + last_login_at are NOT
+// part of the public Update surface — callers must go through
+// SetPasswordHash / UpdateLastLogin / Create respectively, so we
+// preserve those columns from the persisted row inside the same tx.
+func (r *BackofficeUserRegistry) Update(ctx context.Context, user models.BackofficeUser) (*models.BackofficeUser, error) {
+	if user.GetID() == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+	if err := r.validateForUpdate(user); err != nil {
+		return nil, err
+	}
+	user.Email = normaliseBackofficeEmail(user.Email)
+
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// Load existing row so write-path-isolated columns survive a
+		// partial-struct update from the future HTTP layer.
+		var existing models.BackofficeUser
+		txReg := store.NewTxRegistry[models.BackofficeUser](tx, r.tableNames.BackofficeUsers())
+		if scanErr := txReg.ScanOneByField(ctx, store.Pair("id", user.GetID()), &existing); scanErr != nil {
+			if errors.Is(scanErr, store.ErrNotFound) {
+				return errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", user.GetID()))
+			}
+			return errxtrace.Wrap("failed to load backoffice user for update", scanErr)
+		}
+
+		// Cross-row email uniqueness — under the tx so a concurrent
+		// Create can't slip in between the lookup and the UPDATE.
+		var collision models.BackofficeUser
+		lookupErr := txReg.ScanOneByField(ctx, store.Pair("email", user.Email), &collision)
+		if lookupErr == nil && collision.ID != user.GetID() {
+			return errxtrace.Classify(registry.ErrBackofficeEmailAlreadyExists, errx.Attrs("email", user.Email))
+		}
+		if lookupErr != nil && !errors.Is(lookupErr, store.ErrNotFound) {
+			return errxtrace.Wrap("failed to check for backoffice email collision", lookupErr)
+		}
+
+		updateQuery := fmt.Sprintf(`
+			UPDATE %s
+			   SET email = $1,
+			       name = $2,
+			       role = $3,
+			       is_active = $4,
+			       mfa_enforced = $5,
+			       updated_at = now()
+			 WHERE id = $6`,
+			r.tableNames.BackofficeUsers(),
+		)
+		if _, execErr := tx.ExecContext(ctx, updateQuery,
+			user.Email, user.Name, string(user.Role), user.IsActive, user.MFAEnforced, user.GetID(),
+		); execErr != nil {
+			return errxtrace.Wrap("failed to update backoffice user", execErr)
+		}
+
+		// Replay preserved columns on the caller's struct so the
+		// returned pointer is consistent with what's on disk.
+		user.CreatedAt = existing.CreatedAt
+		user.PasswordHash = existing.PasswordHash
+		user.LastLoginAt = existing.LastLoginAt
+		user.UpdatedAt = time.Now()
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+// Delete removes the row by id. Idempotent at the SQL layer — Delete on
+// a missing id is a no-op rather than an error, matching every other
+// postgres registry in the project.
+func (r *BackofficeUserRegistry) Delete(ctx context.Context, id string) error {
+	if id == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+	reg := r.newSQLRegistry()
+	if err := reg.Delete(ctx, id, nil); err != nil {
+		return errxtrace.Wrap("failed to delete backoffice user", err)
+	}
+	return nil
+}
+
+// SetPasswordHash overwrites only the password_hash column on the
+// target row. Kept off the generic Update path so the bcrypt hash never
+// gets exposed through a full-row write.
+func (r *BackofficeUserRegistry) SetPasswordHash(ctx context.Context, id, hash string) error {
+	if id == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+	if hash == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "PasswordHash"))
+	}
+
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(`UPDATE %s SET password_hash = $1, updated_at = now() WHERE id = $2`, r.tableNames.BackofficeUsers())
+		res, execErr := tx.ExecContext(ctx, query, hash, id)
+		if execErr != nil {
+			return errxtrace.Wrap("failed to set backoffice password hash", execErr)
+		}
+		affected, raErr := res.RowsAffected()
+		if raErr != nil {
+			return errxtrace.Wrap("failed to read rows affected for backoffice password hash update", raErr)
+		}
+		if affected == 0 {
+			return errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", id))
+		}
+		return nil
+	})
+	return err
+}
+
+// UpdateLastLogin stamps last_login_at + updated_at on the target row.
+// Called by the Phase 2 login flow on each successful authentication.
+func (r *BackofficeUserRegistry) UpdateLastLogin(ctx context.Context, id string, at time.Time) error {
+	if id == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(`UPDATE %s SET last_login_at = $1, updated_at = now() WHERE id = $2`, r.tableNames.BackofficeUsers())
+		res, execErr := tx.ExecContext(ctx, query, at, id)
+		if execErr != nil {
+			return errxtrace.Wrap("failed to update backoffice last_login_at", execErr)
+		}
+		affected, raErr := res.RowsAffected()
+		if raErr != nil {
+			return errxtrace.Wrap("failed to read rows affected for backoffice last_login update", raErr)
+		}
+		if affected == 0 {
+			return errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", id))
+		}
+		return nil
+	})
+	return err
+}
+
+// SetActive flips the is_active column. Used by the future back-office
+// admin UI to suspend / restore a platform operator.
+func (r *BackofficeUserRegistry) SetActive(ctx context.Context, id string, active bool) error {
+	if id == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
+	}
+
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(`UPDATE %s SET is_active = $1, updated_at = now() WHERE id = $2`, r.tableNames.BackofficeUsers())
+		res, execErr := tx.ExecContext(ctx, query, active, id)
+		if execErr != nil {
+			return errxtrace.Wrap("failed to set backoffice is_active", execErr)
+		}
+		affected, raErr := res.RowsAffected()
+		if raErr != nil {
+			return errxtrace.Wrap("failed to read rows affected for backoffice is_active update", raErr)
+		}
+		if affected == 0 {
+			return errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", id))
+		}
+		return nil
+	})
+	return err
+}
+
+// validateForCreate enforces the full required-field invariants for an
+// insert: email, name, password_hash, and a valid role. Mirrors the
+// memory backend's variant so both backends fail-closed on the same
+// inputs.
+func (r *BackofficeUserRegistry) validateForCreate(user models.BackofficeUser) error {
+	if err := validateCommonBackofficeFields(user); err != nil {
+		return err
+	}
+	if user.PasswordHash == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "PasswordHash"))
+	}
+	return nil
+}
+
+// validateForUpdate skips the PasswordHash check because Update
+// restores the persisted hash from the stored row — callers must use
+// SetPasswordHash to change the hash.
+func (r *BackofficeUserRegistry) validateForUpdate(user models.BackofficeUser) error {
+	return validateCommonBackofficeFields(user)
+}
+
+// validateCommonBackofficeFields covers the invariants shared by Create
+// and Update — every column except the password hash, which only Create
+// requires.
+func validateCommonBackofficeFields(user models.BackofficeUser) error {
+	if strings.TrimSpace(user.Email) == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Email"))
+	}
+	if strings.TrimSpace(user.Name) == "" {
+		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Name"))
+	}
+	if !user.Role.IsValid() {
+		return errxtrace.Classify(registry.ErrInvalidBackofficeRole, errx.Attrs("role", string(user.Role)))
+	}
+	return nil
+}
+
+// normaliseBackofficeEmail lowercases + trims the email so case variants
+// collapse to a single row. Mirrors the memory backend's identical
+// helper — kept private per package to keep dependency direction clean.
+func normaliseBackofficeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}

--- a/go/registry/postgres/backoffice_users.go
+++ b/go/registry/postgres/backoffice_users.go
@@ -163,16 +163,31 @@ func (r *BackofficeUserRegistry) GetByEmail(ctx context.Context, email string) (
 	return &user, nil
 }
 
-// List returns every back-office row in insertion order. Tiny table (a
+// List returns every back-office row ordered by created_at, with id as
+// the tiebreaker for rows that share a timestamp (Postgres timestamps
+// resolve to microseconds, so two inserts inside the same microsecond
+// would otherwise come back in unstable storage order). Tiny table (a
 // handful of platform operators), so no pagination is needed yet.
+//
+// Implemented as a direct sqlx.SelectContext rather than via
+// NonRLSRepository.Scan because Scan issues an un-ordered
+// `SELECT * FROM ...` and Postgres does not guarantee insertion order
+// without an explicit ORDER BY. Returning `[]*BackofficeUser` directly
+// from SelectContext also avoids the for-range-yields-shared-value
+// aliasing trap (Scan's iterator yielded the same address per
+// iteration, so appending `&user` produced N pointers to the last row).
 func (r *BackofficeUserRegistry) List(ctx context.Context) ([]*models.BackofficeUser, error) {
 	var users []*models.BackofficeUser
 	reg := r.newSQLRegistry()
-	for user, err := range reg.Scan(ctx) {
-		if err != nil {
-			return nil, errxtrace.Wrap("failed to list backoffice users", err)
-		}
-		users = append(users, &user)
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`SELECT * FROM %s ORDER BY created_at, id`,
+			r.tableNames.BackofficeUsers(),
+		)
+		return tx.SelectContext(ctx, &users, query)
+	})
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list backoffice users", err)
 	}
 	return users, nil
 }

--- a/go/registry/postgres/backoffice_users.go
+++ b/go/registry/postgres/backoffice_users.go
@@ -72,6 +72,15 @@ func (r *BackofficeUserRegistry) Create(ctx context.Context, user models.Backoff
 	if err := r.validateForCreate(user); err != nil {
 		return nil, err
 	}
+	// Defence-in-depth: re-run the model's full validation so format/
+	// length constraints (EmailPattern, max lengths, closed-set role)
+	// fail closed even if a future caller bypasses Service.Bootstrap.
+	// The registry's bespoke validateForCreate runs first so the existing
+	// ErrFieldRequired / ErrInvalidBackofficeRole sentinels keep their
+	// identity for callers that branch on them.
+	if err := user.ValidateWithContext(ctx); err != nil {
+		return nil, errxtrace.Wrap("backoffice user failed model validation", err)
+	}
 	user.Email = normaliseBackofficeEmail(user.Email)
 	now := time.Now().UTC()
 	if user.CreatedAt.IsZero() {
@@ -135,9 +144,10 @@ func (r *BackofficeUserRegistry) Get(ctx context.Context, id string) (*models.Ba
 // GetByEmail performs a case-insensitive lookup by lowercased email.
 // The registry layer normalises the email both on write and read, so a
 // regular `email = $1` predicate is enough — no `lower(email)` index
-// required.
+// required. Whitespace-only input is treated as empty so a stray "   "
+// from a caller doesn't fall through to a no-rows lookup.
 func (r *BackofficeUserRegistry) GetByEmail(ctx context.Context, email string) (*models.BackofficeUser, error) {
-	if email == "" {
+	if strings.TrimSpace(email) == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Email"))
 	}
 	normalised := normaliseBackofficeEmail(email)
@@ -190,6 +200,21 @@ func (r *BackofficeUserRegistry) Update(ctx context.Context, user models.Backoff
 	if err := r.validateForUpdate(user); err != nil {
 		return nil, err
 	}
+	// Defence-in-depth: re-run the model's full validation so format/
+	// length constraints (EmailPattern, max lengths, closed-set role)
+	// fail closed even when callers bypass the service layer. The
+	// registry's bespoke validateForUpdate runs first so the existing
+	// ErrFieldRequired / ErrInvalidBackofficeRole sentinels keep their
+	// identity. PasswordHash isn't part of the public Update surface,
+	// so model validation runs on a copy with an opaque non-empty hash
+	// substituted in — the on-disk hash is restored further down.
+	validateUser := user
+	if validateUser.PasswordHash == "" {
+		validateUser.PasswordHash = "validation-placeholder"
+	}
+	if err := validateUser.ValidateWithContext(ctx); err != nil {
+		return nil, errxtrace.Wrap("backoffice user failed model validation", err)
+	}
 	user.Email = normaliseBackofficeEmail(user.Email)
 
 	reg := r.newSQLRegistry()
@@ -227,9 +252,10 @@ func (r *BackofficeUserRegistry) Update(ctx context.Context, user models.Backoff
 			 WHERE id = $6`,
 			r.tableNames.BackofficeUsers(),
 		)
-		if _, execErr := tx.ExecContext(ctx, updateQuery,
+		res, execErr := tx.ExecContext(ctx, updateQuery,
 			user.Email, user.Name, string(user.Role), user.IsActive, user.MFAEnforced, user.GetID(),
-		); execErr != nil {
+		)
+		if execErr != nil {
 			// Re-classify a Postgres unique-violation on the email
 			// index as ErrBackofficeEmailAlreadyExists — mirrors the
 			// Create path so callers get the canonical sentinel even
@@ -239,6 +265,19 @@ func (r *BackofficeUserRegistry) Update(ctx context.Context, user models.Backoff
 				return errxtrace.Classify(registry.ErrBackofficeEmailAlreadyExists, errx.Attrs("email", user.Email))
 			}
 			return errxtrace.Wrap("failed to update backoffice user", execErr)
+		}
+		// Defence-in-depth: even though the pre-SELECT above runs in the
+		// same READ COMMITTED transaction, it doesn't take a row lock,
+		// so a concurrent Delete could remove the row between the
+		// ScanOneByField and this UPDATE. Checking RowsAffected closes
+		// the window — without it, the call would return success on a
+		// no-op write and the caller would see a stale view of the row.
+		affected, raErr := res.RowsAffected()
+		if raErr != nil {
+			return errxtrace.Wrap("failed to read rows affected for backoffice update", raErr)
+		}
+		if affected == 0 {
+			return errxtrace.Classify(registry.ErrBackofficeUserNotFound, errx.Attrs("entity_id", user.GetID()))
 		}
 
 		// Replay preserved columns on the caller's struct so the

--- a/go/registry/postgres/backoffice_users.go
+++ b/go/registry/postgres/backoffice_users.go
@@ -60,11 +60,29 @@ func (r *BackofficeUserRegistry) newSQLRegistry() *store.NonRLSRepository[models
 // commits, the second rolls back on the unique-index violation; the
 // pre-check turns "lost insert" into the friendlier
 // ErrBackofficeEmailAlreadyExists sentinel).
+//
+// CreatedAt / UpdatedAt are stamped here (when zero) — the store layer's
+// Insert (txexec.go) uses typekit.ExtractDBFields which includes every
+// db-tagged column, so leaving them at zero would override the column
+// DEFAULT CURRENT_TIMESTAMP and persist year-0001 timestamps. Mirrors
+// the pattern in email_verifications / commodity_loans / login_events /
+// user_mfa_secrets. The IsZero guard lets tests that pin a specific
+// timestamp keep their override.
 func (r *BackofficeUserRegistry) Create(ctx context.Context, user models.BackofficeUser) (*models.BackofficeUser, error) {
 	if err := r.validateForCreate(user); err != nil {
 		return nil, err
 	}
 	user.Email = normaliseBackofficeEmail(user.Email)
+	now := time.Now().UTC()
+	if user.CreatedAt.IsZero() {
+		user.CreatedAt = now
+	}
+	if user.UpdatedAt.IsZero() {
+		user.UpdatedAt = now
+	}
+	if user.LastLoginAt != nil && user.LastLoginAt.IsZero() {
+		user.LastLoginAt = nil
+	}
 
 	reg := r.newSQLRegistry()
 	created, err := reg.Create(ctx, user, func(ctx context.Context, tx *sqlx.Tx) error {
@@ -80,6 +98,16 @@ func (r *BackofficeUserRegistry) Create(ctx context.Context, user models.Backoff
 		return nil
 	})
 	if err != nil {
+		// Close the race window between the pre-SELECT and the INSERT
+		// by re-classifying a Postgres unique-violation on the email
+		// index as ErrBackofficeEmailAlreadyExists so callers (and
+		// Service.Bootstrap's idempotent-rerun branch) can branch on
+		// the canonical sentinel even when the loser of a parallel
+		// Create surfaces the SQLSTATE rather than the application-
+		// level pre-check.
+		if isBackofficeEmailUniqueViolation(err) {
+			return nil, errxtrace.Classify(registry.ErrBackofficeEmailAlreadyExists, errx.Attrs("email", user.Email))
+		}
 		return nil, errxtrace.Wrap("failed to create backoffice user", err)
 	}
 	return &created, nil
@@ -202,6 +230,14 @@ func (r *BackofficeUserRegistry) Update(ctx context.Context, user models.Backoff
 		if _, execErr := tx.ExecContext(ctx, updateQuery,
 			user.Email, user.Name, string(user.Role), user.IsActive, user.MFAEnforced, user.GetID(),
 		); execErr != nil {
+			// Re-classify a Postgres unique-violation on the email
+			// index as ErrBackofficeEmailAlreadyExists — mirrors the
+			// Create path so callers get the canonical sentinel even
+			// when a concurrent insert wins the race between this
+			// transaction's pre-SELECT and its UPDATE.
+			if isBackofficeEmailUniqueViolation(execErr) {
+				return errxtrace.Classify(registry.ErrBackofficeEmailAlreadyExists, errx.Attrs("email", user.Email))
+			}
 			return errxtrace.Wrap("failed to update backoffice user", execErr)
 		}
 
@@ -210,7 +246,7 @@ func (r *BackofficeUserRegistry) Update(ctx context.Context, user models.Backoff
 		user.CreatedAt = existing.CreatedAt
 		user.PasswordHash = existing.PasswordHash
 		user.LastLoginAt = existing.LastLoginAt
-		user.UpdatedAt = time.Now()
+		user.UpdatedAt = time.Now().UTC()
 		return nil
 	})
 	if err != nil {
@@ -219,15 +255,20 @@ func (r *BackofficeUserRegistry) Update(ctx context.Context, user models.Backoff
 	return &user, nil
 }
 
-// Delete removes the row by id. Idempotent at the SQL layer — Delete on
-// a missing id is a no-op rather than an error, matching every other
-// postgres registry in the project.
+// Delete removes the row by id. Idempotent — a Delete on a missing id
+// is a no-op rather than an error, matching the memory backend and
+// keeping the cross-backend contract uniform. NonRLSRepository.Delete
+// returns a wrapped store.ErrNotFound when the row doesn't exist; we
+// swallow it here so callers can re-run Delete safely.
 func (r *BackofficeUserRegistry) Delete(ctx context.Context, id string) error {
 	if id == "" {
 		return errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "ID"))
 	}
 	reg := r.newSQLRegistry()
 	if err := reg.Delete(ctx, id, nil); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil
+		}
 		return errxtrace.Wrap("failed to delete backoffice user", err)
 	}
 	return nil
@@ -357,4 +398,39 @@ func validateCommonBackofficeFields(user models.BackofficeUser) error {
 // helper — kept private per package to keep dependency direction clean.
 func normaliseBackofficeEmail(email string) string {
 	return strings.ToLower(strings.TrimSpace(email))
+}
+
+// backofficeEmailUniqueIndexName is the postgres unique index on the
+// email column. The Create / Update paths translate violations on
+// this index into ErrBackofficeEmailAlreadyExists so the loser of a
+// concurrent insert race surfaces the same canonical sentinel as the
+// application-level pre-check. Any OTHER unique violation (e.g. on
+// the uuid index) is re-raised as-is — it would indicate a programmer
+// error rather than a legitimate domain conflict.
+const backofficeEmailUniqueIndexName = "idx_backoffice_users_email"
+
+// isBackofficeEmailUniqueViolation reports whether err corresponds to a
+// Postgres unique-violation (SQLSTATE 23505) on the backoffice email
+// index. Mirrors the helpers in warranty_reminders / currency_migration
+// — kept locally so this registry stays self-contained, and string-based
+// for the SQLSTATE so we don't pull in lib/pq just for the constant.
+func isBackofficeEmailUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	type sqlStater interface{ SQLState() string }
+	type constrainter interface{ ConstraintName() string }
+
+	var s sqlStater
+	if !errors.As(err, &s) || s.SQLState() != "23505" {
+		// Fall back to substring match against the index name when
+		// the underlying error doesn't expose SQLState (defence in
+		// depth — current drivers do, but the helper stays robust).
+		return strings.Contains(err.Error(), backofficeEmailUniqueIndexName)
+	}
+	var c constrainter
+	if errors.As(err, &c) && c.ConstraintName() == backofficeEmailUniqueIndexName {
+		return true
+	}
+	return strings.Contains(err.Error(), backofficeEmailUniqueIndexName)
 }

--- a/go/registry/postgres/backoffice_users_test.go
+++ b/go/registry/postgres/backoffice_users_test.go
@@ -332,6 +332,53 @@ func TestBackofficeUserRegistryPostgres_Count(t *testing.T) {
 	c.Assert(count, qt.Equals, 2)
 }
 
+// TestBackofficeUserRegistryPostgres_List_DistinctRowsAndOrder pins two
+// invariants on the List query that earlier shapes got wrong:
+//
+//  1. Each returned pointer references a distinct row, not N copies of
+//     the last one. The previous Scan-based implementation re-used the
+//     iteration variable's address per yield, so appending `&user`
+//     produced a slice of aliased pointers.
+//  2. Rows come back ordered by created_at (then id as the tiebreaker).
+//     The previous shape relied on Postgres's un-ordered SELECT and
+//     happened to look stable in tests, but the contract was not
+//     enforced.
+//
+// We insert three rows with explicit, monotonically-increasing
+// CreatedAt stamps and assert (a) three distinct IDs, (b) emails come
+// back in created_at order.
+func TestBackofficeUserRegistryPostgres_List_DistinctRowsAndOrder(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	base := time.Now().UTC().Truncate(time.Second)
+	emails := []string{"first@example.com", "second@example.com", "third@example.com"}
+	for i, email := range emails {
+		u := newTestBackofficeUser(email)
+		u.CreatedAt = base.Add(time.Duration(i) * time.Second)
+		u.UpdatedAt = u.CreatedAt
+		_, err := bo.Create(ctx, u)
+		c.Assert(err, qt.IsNil)
+	}
+
+	listed, err := bo.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(listed, qt.HasLen, 3)
+
+	seenIDs := make(map[string]struct{}, len(listed))
+	gotEmails := make([]string, 0, len(listed))
+	for _, u := range listed {
+		seenIDs[u.ID] = struct{}{}
+		gotEmails = append(gotEmails, u.Email)
+	}
+	c.Assert(seenIDs, qt.HasLen, 3)
+	c.Assert(gotEmails, qt.DeepEquals, emails)
+}
+
 func TestBackofficeUserRegistryPostgres_SetPasswordHash(t *testing.T) {
 	registrySet, cleanup := setupTestRegistrySet(t)
 	defer cleanup()

--- a/go/registry/postgres/backoffice_users_test.go
+++ b/go/registry/postgres/backoffice_users_test.go
@@ -231,6 +231,22 @@ func TestBackofficeUserRegistryPostgres_Delete(t *testing.T) {
 	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
 }
 
+// TestBackofficeUserRegistryPostgres_Delete_Idempotent pins the cross-
+// backend idempotency contract: Delete on a missing id is a no-op
+// rather than an error. The postgres backend's NonRLSRepository.Delete
+// returns store.ErrNotFound on a missing row; the registry swallows it
+// so the contract matches the memory backend.
+func TestBackofficeUserRegistryPostgres_Delete_Idempotent(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	c.Assert(bo.Delete(ctx, "no-such-id"), qt.IsNil)
+}
+
 func TestBackofficeUserRegistryPostgres_Count(t *testing.T) {
 	registrySet, cleanup := setupTestRegistrySet(t)
 	defer cleanup()

--- a/go/registry/postgres/backoffice_users_test.go
+++ b/go/registry/postgres/backoffice_users_test.go
@@ -1,0 +1,340 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// newTestBackofficeUser builds a valid BackofficeUser for the postgres
+// backend. backoffice_users has NO foreign keys — back-office identities
+// live OUTSIDE the tenant model — so the row stands alone without any
+// preceding tenant / user setup. The PasswordHash is a placeholder
+// string; bcrypt correctness lives in models.User's own tests.
+func newTestBackofficeUser(email string) models.BackofficeUser {
+	return models.BackofficeUser{
+		Email:        email,
+		Name:         "Operator",
+		PasswordHash: "$2a$10$placeholderhashvalue",
+		Role:         models.BackofficeRolePlatformAdmin,
+		IsActive:     true,
+		MFAEnforced:  true,
+	}
+}
+
+func TestBackofficeUserRegistryPostgres_Create_HappyPath(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	created, err := bo.Create(ctx, newTestBackofficeUser("ops@example.com"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created, qt.IsNotNil)
+	c.Assert(created.ID, qt.Not(qt.Equals), "")
+	c.Assert(created.UUID, qt.Not(qt.Equals), "")
+	c.Assert(created.Email, qt.Equals, "ops@example.com")
+	c.Assert(created.Role, qt.Equals, models.BackofficeRolePlatformAdmin)
+	c.Assert(created.CreatedAt.IsZero(), qt.IsFalse)
+}
+
+func TestBackofficeUserRegistryPostgres_Create_LowercasesEmail(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	created, err := bo.Create(ctx, newTestBackofficeUser("Ops@Example.COM"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.Email, qt.Equals, "ops@example.com")
+}
+
+func TestBackofficeUserRegistryPostgres_Create_MissingFields(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		mut  func(*models.BackofficeUser)
+	}{
+		{"email empty", func(u *models.BackofficeUser) { u.Email = "" }},
+		{"name empty", func(u *models.BackofficeUser) { u.Name = "" }},
+		{"password_hash empty", func(u *models.BackofficeUser) { u.PasswordHash = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			u := newTestBackofficeUser("missing@example.com")
+			tc.mut(&u)
+			_, err := bo.Create(ctx, u)
+			c.Assert(errors.Is(err, registry.ErrFieldRequired), qt.IsTrue)
+		})
+	}
+}
+
+func TestBackofficeUserRegistryPostgres_Create_InvalidRole(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	u := newTestBackofficeUser("role@example.com")
+	u.Role = "no-such-role"
+	_, err := bo.Create(ctx, u)
+	c.Assert(errors.Is(err, registry.ErrInvalidBackofficeRole), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistryPostgres_Create_DuplicateEmail(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	_, err := bo.Create(ctx, newTestBackofficeUser("dup@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	_, err = bo.Create(ctx, newTestBackofficeUser("DUP@example.com"))
+	c.Assert(errors.Is(err, registry.ErrBackofficeEmailAlreadyExists), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistryPostgres_Get(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	created, err := bo.Create(ctx, newTestBackofficeUser("get@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	fetched, err := bo.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.ID, qt.Equals, created.ID)
+}
+
+func TestBackofficeUserRegistryPostgres_Get_NotFound(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	_, err := bo.Get(ctx, "no-such-id")
+	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
+	c.Assert(errors.Is(err, registry.ErrNotFound), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistryPostgres_GetByEmail_CaseInsensitive(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	_, err := bo.Create(ctx, newTestBackofficeUser("case@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	fetched, err := bo.GetByEmail(ctx, "CASE@Example.COM")
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.Email, qt.Equals, "case@example.com")
+}
+
+func TestBackofficeUserRegistryPostgres_GetByEmail_NotFound(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	_, err := bo.GetByEmail(ctx, "missing@example.com")
+	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistryPostgres_Update_PreservesPasswordHash(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	created, err := bo.Create(ctx, newTestBackofficeUser("upd@example.com"))
+	c.Assert(err, qt.IsNil)
+	originalHash := created.PasswordHash
+
+	updated := *created
+	updated.PasswordHash = ""
+	updated.Name = "Renamed"
+
+	got, err := bo.Update(ctx, updated)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.PasswordHash, qt.Equals, originalHash)
+	c.Assert(got.Name, qt.Equals, "Renamed")
+
+	reloaded, err := bo.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(reloaded.PasswordHash, qt.Equals, originalHash)
+	c.Assert(reloaded.Name, qt.Equals, "Renamed")
+}
+
+func TestBackofficeUserRegistryPostgres_Update_RejectsEmailCollision(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	_, err := bo.Create(ctx, newTestBackofficeUser("first@example.com"))
+	c.Assert(err, qt.IsNil)
+	second, err := bo.Create(ctx, newTestBackofficeUser("second@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	second.Email = "first@example.com"
+	_, err = bo.Update(ctx, *second)
+	c.Assert(errors.Is(err, registry.ErrBackofficeEmailAlreadyExists), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistryPostgres_Delete(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	created, err := bo.Create(ctx, newTestBackofficeUser("del@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(bo.Delete(ctx, created.ID), qt.IsNil)
+	_, err = bo.Get(ctx, created.ID)
+	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistryPostgres_Count(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	count, err := bo.Count(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+
+	_, err = bo.Create(ctx, newTestBackofficeUser("a@example.com"))
+	c.Assert(err, qt.IsNil)
+	_, err = bo.Create(ctx, newTestBackofficeUser("b@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	count, err = bo.Count(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 2)
+}
+
+func TestBackofficeUserRegistryPostgres_SetPasswordHash(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	created, err := bo.Create(ctx, newTestBackofficeUser("hash@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(bo.SetPasswordHash(ctx, created.ID, "$2a$10$newvalue"), qt.IsNil)
+	fetched, err := bo.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.PasswordHash, qt.Equals, "$2a$10$newvalue")
+}
+
+func TestBackofficeUserRegistryPostgres_SetPasswordHash_NotFound(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	err := bo.SetPasswordHash(ctx, "no-such-id", "$2a$10$x")
+	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistryPostgres_UpdateLastLogin(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	created, err := bo.Create(ctx, newTestBackofficeUser("login@example.com"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.LastLoginAt, qt.IsNil)
+
+	at := time.Now().UTC().Truncate(time.Second)
+	c.Assert(bo.UpdateLastLogin(ctx, created.ID, at), qt.IsNil)
+
+	fetched, err := bo.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.LastLoginAt, qt.IsNotNil)
+	c.Assert(fetched.LastLoginAt.UTC().Truncate(time.Second).Equal(at), qt.IsTrue)
+}
+
+func TestBackofficeUserRegistryPostgres_SetActive(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	created, err := bo.Create(ctx, newTestBackofficeUser("act@example.com"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.IsActive, qt.IsTrue)
+
+	c.Assert(bo.SetActive(ctx, created.ID, false), qt.IsNil)
+	fetched, err := bo.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fetched.IsActive, qt.IsFalse)
+}
+
+// getBackofficeRegistry resolves the BackofficeUserRegistry via the
+// underlying factory set. The per-request *Set this package's helpers
+// produce only carries user-aware data, while back-office identities
+// live on FactorySet (they're cross-cutting infra, not user-aware) —
+// so we rebuild a factory set from the same pool the setupTest helper
+// used and grab the registry off it. The rows we write here share the
+// database with the helper's test tenant rows but never overlap them
+// (no FK, separate table).
+func getBackofficeRegistry(t *testing.T, _ *registry.Set) registry.BackofficeUserRegistry {
+	t.Helper()
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	fs := createRegistrySetFromPool(pool)
+	return fs.BackofficeUserRegistry
+}

--- a/go/registry/postgres/backoffice_users_test.go
+++ b/go/registry/postgres/backoffice_users_test.go
@@ -98,6 +98,25 @@ func TestBackofficeUserRegistryPostgres_Create_InvalidRole(t *testing.T) {
 	c.Assert(errors.Is(err, registry.ErrInvalidBackofficeRole), qt.IsTrue)
 }
 
+// TestBackofficeUserRegistryPostgres_Create_RejectsMalformedEmail proves
+// the defence-in-depth model validation runs at the postgres registry
+// layer — a string that passes the bespoke TrimSpace-required check
+// ("not-an-email") still gets rejected by BackofficeUser.ValidateWith-
+// Context's EmailPattern rule before the INSERT touches the database.
+func TestBackofficeUserRegistryPostgres_Create_RejectsMalformedEmail(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	u := newTestBackofficeUser("not-an-email")
+	_, err := bo.Create(ctx, u)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "model validation")
+}
+
 func TestBackofficeUserRegistryPostgres_Create_DuplicateEmail(t *testing.T) {
 	registrySet, cleanup := setupTestRegistrySet(t)
 	defer cleanup()
@@ -170,6 +189,21 @@ func TestBackofficeUserRegistryPostgres_GetByEmail_NotFound(t *testing.T) {
 	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
 }
 
+// TestBackofficeUserRegistryPostgres_GetByEmail_WhitespaceOnly pins the
+// whitespace-rejection invariant — a stray "   " from the caller must
+// surface as ErrFieldRequired, not as a no-rows lookup.
+func TestBackofficeUserRegistryPostgres_GetByEmail_WhitespaceOnly(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	_, err := bo.GetByEmail(ctx, "   ")
+	c.Assert(errors.Is(err, registry.ErrFieldRequired), qt.IsTrue)
+}
+
 func TestBackofficeUserRegistryPostgres_Update_PreservesPasswordHash(t *testing.T) {
 	registrySet, cleanup := setupTestRegistrySet(t)
 	defer cleanup()
@@ -213,6 +247,35 @@ func TestBackofficeUserRegistryPostgres_Update_RejectsEmailCollision(t *testing.
 	second.Email = "first@example.com"
 	_, err = bo.Update(ctx, *second)
 	c.Assert(errors.Is(err, registry.ErrBackofficeEmailAlreadyExists), qt.IsTrue)
+}
+
+// TestBackofficeUserRegistryPostgres_Update_NotFoundOnDeletedRow pins
+// the defence-in-depth RowsAffected check: if the row is deleted
+// between Update's pre-SELECT and its UPDATE, the call must surface
+// ErrBackofficeUserNotFound rather than silently succeed. We simulate
+// the race by deleting the row immediately before Update (no need for
+// real concurrency — the postgres pre-SELECT inside Update's tx will
+// see no row, which itself returns ErrBackofficeUserNotFound; this
+// test guards the secondary path where the row could vanish between
+// the pre-SELECT and the UPDATE if SELECT FOR UPDATE were ever added
+// or removed without updating the contract).
+func TestBackofficeUserRegistryPostgres_Update_NotFoundOnDeletedRow(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+	bo := getBackofficeRegistry(t, registrySet)
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	created, err := bo.Create(ctx, newTestBackofficeUser("race@example.com"))
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(bo.Delete(ctx, created.ID), qt.IsNil)
+
+	updated := *created
+	updated.Name = "After Delete"
+	_, err = bo.Update(ctx, updated)
+	c.Assert(errors.Is(err, registry.ErrBackofficeUserNotFound), qt.IsTrue)
 }
 
 func TestBackofficeUserRegistryPostgres_Delete(t *testing.T) {

--- a/go/registry/postgres/postgres.go
+++ b/go/registry/postgres/postgres.go
@@ -63,6 +63,11 @@ func NewFactorySet(dbx *sqlx.DB) *registry.FactorySet {
 	fs.StorageQuotaReminderRegistry = NewStorageQuotaReminderRegistry(dbx)
 	fs.MaintenanceReminderRegistry = NewMaintenanceReminderRegistry(dbx)
 	fs.CurrencyMigrationRegistryFactory = NewCurrencyMigrationRegistry(dbx)
+	// Back-office identities (issue #1785) — platform-operator users
+	// that live OUTSIDE the tenant model. Wired on FactorySet only;
+	// not part of the per-request Set since back-office identities are
+	// cross-cutting infra, not user-aware data.
+	fs.BackofficeUserRegistry = NewBackofficeUserRegistry(dbx)
 	fs.PingFn = dbx.PingContext
 
 	return fs

--- a/go/registry/postgres/store/tablenames.go
+++ b/go/registry/postgres/store/tablenames.go
@@ -38,6 +38,7 @@ type TableNames struct {
 	MaintenanceReminders    func() TableName
 	CurrencyMigrations      func() TableName
 	CurrencyMigrationAudit  func() TableName
+	BackofficeUsers         func() TableName
 }
 
 var DefaultTableNames = TableNames{
@@ -76,6 +77,7 @@ var DefaultTableNames = TableNames{
 	MaintenanceReminders:    func() TableName { return "maintenance_reminders" },
 	CurrencyMigrations:      func() TableName { return "currency_migrations" },
 	CurrencyMigrationAudit:  func() TableName { return "currency_migration_audit_rows" },
+	BackofficeUsers:         func() TableName { return "backoffice_users" },
 }
 
 // NewTableNames returns the default table names

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -1111,6 +1111,51 @@ type AdminTenantListItem struct {
 	GroupCount int
 }
 
+// BackofficeUserRegistry persists platform-operator identities used by
+// the back-office auth plane (issue #1785). Unlike UserRegistry, this
+// table has NO tenant_id and NO RLS — back-office users live OUTSIDE
+// the tenant model and are gated entirely at the application layer.
+//
+// Phase 1 surfaces only the storage primitives the bootstrap CLI needs;
+// later phases add the HTTP login flow + role-aware authorisation on top
+// of these methods. Two design choices worth pinning:
+//
+//  1. GetByEmail is case-insensitive. The registry layer lowercases the
+//     email on every read and every write, and the postgres UNIQUE INDEX
+//     is defined over the column (not lower(email), which the migrator
+//     annotations cannot express). Bypass paths that INSERT a mixed-case
+//     email would let duplicates through, so callers MUST go through
+//     this interface for create/update/lookup.
+//
+//  2. SetPasswordHash and UpdateLastLogin are isolated from Update so
+//     the bcrypt hash never gets exposed through a generic Update path
+//     that the future HTTP layer might call with a partially populated
+//     struct. The same shape worked for refresh tokens (RevokeByID /
+//     UpdateLastUsedAt) and is the cheapest way to keep the write-path
+//     surface explicit.
+type BackofficeUserRegistry interface {
+	Registry[models.BackofficeUser]
+
+	// GetByEmail returns the back-office user whose lowercased email
+	// matches the lowercased argument. Returns ErrBackofficeUserNotFound
+	// when no row exists.
+	GetByEmail(ctx context.Context, email string) (*models.BackofficeUser, error)
+
+	// SetPasswordHash overwrites only the password_hash column on the
+	// target row, leaving every other field untouched. Keeps the bcrypt
+	// hash out of any generic Update call site.
+	SetPasswordHash(ctx context.Context, id, hash string) error
+
+	// UpdateLastLogin stamps last_login_at on the target row. Called by
+	// the Phase 2 login flow on each successful authentication.
+	UpdateLastLogin(ctx context.Context, id string, at time.Time) error
+
+	// SetActive flips is_active to the requested value. Used by the
+	// future back-office admin UI; in Phase 1 only the bootstrap CLI
+	// exercises this indirectly via the initial-user create path.
+	SetActive(ctx context.Context, id string, active bool) error
+}
+
 // AuditLogRegistry manages security-relevant event records for compliance and debugging.
 type AuditLogRegistry interface {
 	Registry[models.AuditLog]

--- a/go/schema/migrations/_sqldata/1780600000_add_backoffice_users.down.sql
+++ b/go/schema/migrations/_sqldata/1780600000_add_backoffice_users.down.sql
@@ -1,0 +1,8 @@
+-- Migration rollback: drop backoffice_users (#1785)
+-- Direction: DOWN
+
+DROP INDEX IF EXISTS idx_backoffice_users_active;
+DROP INDEX IF EXISTS idx_backoffice_users_email;
+DROP INDEX IF EXISTS idx_backoffice_users_uuid;
+-- WARNING: This will delete all data!
+DROP TABLE IF EXISTS backoffice_users CASCADE;

--- a/go/schema/migrations/_sqldata/1780600000_add_backoffice_users.up.sql
+++ b/go/schema/migrations/_sqldata/1780600000_add_backoffice_users.up.sql
@@ -1,0 +1,27 @@
+-- Migration: add backoffice_users for the back-office auth plane (#1785)
+-- Direction: UP
+--
+-- backoffice_users stores platform-operator identities used by the
+-- back-office auth plane (issue #1785). The table has NO row-level
+-- security — same reason as `tenants`: it IS the boundary. There is no
+-- tenant_id column because back-office identities are cross-tenant by
+-- design. Email is unique platform-wide; the registry layer lowercases
+-- emails on read + write so case variants collapse to a single row.
+
+-- POSTGRES TABLE: backoffice_users --
+CREATE TABLE backoffice_users (
+  email TEXT NOT NULL,
+  name TEXT NOT NULL,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT 'true',
+  mfa_enforced BOOLEAN NOT NULL DEFAULT 'true',
+  last_login_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  id TEXT PRIMARY KEY NOT NULL,
+  uuid TEXT NOT NULL DEFAULT (gen_random_uuid())::text
+);
+CREATE INDEX IF NOT EXISTS idx_backoffice_users_active ON backoffice_users (is_active);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_backoffice_users_email ON backoffice_users (email);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_backoffice_users_uuid ON backoffice_users (uuid);

--- a/go/services/backoffice/service.go
+++ b/go/services/backoffice/service.go
@@ -29,17 +29,13 @@ type Service struct {
 	cleanup    func() error
 }
 
-// NewService constructs a Service backed by the postgres registry. The
-// memory backend is rejected explicitly because back-office identities
-// must survive process restarts (Phase 1's only writer is the CLI; the
-// CLI's job IS persistence). Mirrors services/admin.NewService.
+// NewService constructs a Service backed by the postgres registry.
+// dbConfig.Validate already rejects non-postgres DSNs (memory://,
+// file://, etc.), so by the time control reaches the registry lookup
+// the DSN is guaranteed to be postgres. Mirrors services/admin.NewService.
 func NewService(dbConfig *shared.DatabaseConfig) (*Service, error) {
 	if err := dbConfig.Validate(); err != nil {
 		return nil, fmt.Errorf("database configuration error: %w", err)
-	}
-
-	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
-		return nil, fmt.Errorf("backoffice commands are not supported for memory databases as they don't provide persistence; please use a PostgreSQL database")
 	}
 
 	registryFunc, ok := registry.GetRegistry(dbConfig.DBDSN)
@@ -210,15 +206,14 @@ func (s *Service) Bootstrap(ctx context.Context, req BootstrapRequest) (*Bootstr
 
 // generatePassword produces a strong random password the CLI prints
 // once to stdout. 18 bytes of base64 = 24 ASCII chars with mixed-case
-// + digits + URL-safe symbols, comfortably above models.ValidatePassword's
-// length / character-class requirements without bringing in a separate
-// generator library.
+// + digits, comfortably above models.ValidatePassword's length
+// requirement.
 //
-// We append "Aa1" to guarantee the upper-case + lower-case + digit
-// classes are present even on the (astronomically unlikely) draw where
-// the random bytes happen to map to a base64 string missing one of
-// them — keeps Bootstrap from failing a follow-up ValidatePassword
-// check on bad luck.
+// The "Aa1" suffix is load-bearing: a 24-char random base64 string has
+// a non-trivial probability of missing at least one of the upper /
+// lower / digit character classes models.ValidatePassword requires.
+// The suffix is what guarantees the validation check passes — not a
+// safety net for an unlikely draw.
 func generatePassword() (string, error) {
 	buf := make([]byte, 18)
 	if _, err := rand.Read(buf); err != nil {

--- a/go/services/backoffice/service.go
+++ b/go/services/backoffice/service.go
@@ -1,0 +1,218 @@
+// Package backoffice exposes a thin service layer over
+// BackofficeUserRegistry for the Phase 1 CLI (issue #1785). Kept
+// intentionally narrow: only what the bootstrap subcommand needs. Phase
+// 2 (HTTP login) and Phase 3 (admin surface) will grow this package
+// rather than retrofitting more behaviour onto the registry itself.
+package backoffice
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// Service wraps BackofficeUserRegistry with the business-rule logic
+// the bootstrap CLI needs (password hashing, idempotent "already
+// exists" detection, fresh-deployment refusal-unless-force).
+type Service struct {
+	factorySet *registry.FactorySet
+	cleanup    func() error
+}
+
+// NewService constructs a Service backed by the postgres registry. The
+// memory backend is rejected explicitly because back-office identities
+// must survive process restarts (Phase 1's only writer is the CLI; the
+// CLI's job IS persistence). Mirrors services/admin.NewService.
+func NewService(dbConfig *shared.DatabaseConfig) (*Service, error) {
+	if err := dbConfig.Validate(); err != nil {
+		return nil, fmt.Errorf("database configuration error: %w", err)
+	}
+
+	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
+		return nil, fmt.Errorf("backoffice commands are not supported for memory databases as they don't provide persistence; please use a PostgreSQL database")
+	}
+
+	registryFunc, ok := registry.GetRegistry(dbConfig.DBDSN)
+	if !ok {
+		return nil, fmt.Errorf("unsupported database type in DSN: %s", dbConfig.DBDSN)
+	}
+
+	factorySet, err := registryFunc(registry.Config(dbConfig.DBDSN))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create registry factory set: %w", err)
+	}
+
+	return &Service{
+		factorySet: factorySet,
+		cleanup:    nil,
+	}, nil
+}
+
+// Close releases the underlying database connections, if any. Safe to
+// call on a service constructed without a cleanup hook.
+func (s *Service) Close() error {
+	if s.cleanup != nil {
+		return s.cleanup()
+	}
+	return nil
+}
+
+// BootstrapRequest carries the inputs to Service.Bootstrap.
+type BootstrapRequest struct {
+	Email    string
+	Name     string
+	Role     models.BackofficeRole
+	Password string // optional; auto-generated when empty
+	Force    bool   // allow creating an additional user when the table is non-empty
+}
+
+// BootstrapResult captures the outcome of a Bootstrap call.
+type BootstrapResult struct {
+	User              *models.BackofficeUser
+	GeneratedPassword string // populated only when the caller did NOT supply Password
+	AlreadyExisted    bool   // true when an existing user with the same email was found (idempotent re-run)
+}
+
+// Bootstrap creates the first (or, with --force, an additional) back-
+// office user. The contract is:
+//
+//   - If a row already exists with the supplied email, return
+//     AlreadyExisted=true with no error and no mutation. The CLI maps
+//     this to "ℹ️  user already exists" + exit 0 so re-running the
+//     command is safe.
+//   - Else, if at least one back-office user already exists AND the
+//     caller did not pass Force, refuse with a fail-closed error. The
+//     CLI surfaces this with a hint to pass --force.
+//   - Else, generate (or accept) a password, bcrypt it at DefaultCost
+//     (matching models.User.SetPassword), and insert the row.
+//
+// Pre-existence is checked by email FIRST (idempotency) and only then
+// by global count (force gate). Order matters: re-running the same
+// invocation should never trip the force gate.
+func (s *Service) Bootstrap(ctx context.Context, req BootstrapRequest) (*BootstrapResult, error) {
+	if s.factorySet == nil || s.factorySet.BackofficeUserRegistry == nil {
+		return nil, errors.New("backoffice user registry not configured")
+	}
+
+	email := strings.TrimSpace(req.Email)
+	if email == "" {
+		return nil, errors.New("email is required")
+	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, errors.New("name is required")
+	}
+	role := req.Role
+	if role == "" {
+		role = models.BackofficeRolePlatformAdmin
+	}
+	if !role.IsValid() {
+		return nil, fmt.Errorf("invalid role %q (must be one of: support_agent, platform_admin)", string(role))
+	}
+
+	// 1. Idempotency check by email. GetByEmail is case-insensitive at
+	// the registry layer, so re-running with the same email in a
+	// different case still hits the existing row.
+	existing, lookupErr := s.factorySet.BackofficeUserRegistry.GetByEmail(ctx, email)
+	switch {
+	case lookupErr == nil:
+		return &BootstrapResult{User: existing, AlreadyExisted: true}, nil
+	case errors.Is(lookupErr, registry.ErrBackofficeUserNotFound):
+		// expected — fall through to count + insert
+	default:
+		return nil, errxtrace.Wrap("failed to check existing backoffice user", lookupErr)
+	}
+
+	// 2. Force gate. Counting is cheap on a tiny table; doing it under a
+	// transaction is overkill for a CLI run that has no concurrent writer.
+	if !req.Force {
+		count, countErr := s.factorySet.BackofficeUserRegistry.Count(ctx)
+		if countErr != nil {
+			return nil, errxtrace.Wrap("failed to count existing backoffice users", countErr)
+		}
+		if count > 0 {
+			return nil, fmt.Errorf("a backoffice user already exists; pass --force to add another (current count: %d)", count)
+		}
+	}
+
+	// 3. Password: explicit or generated. Generated passwords are
+	// returned to the CLI so the operator can copy them once; the
+	// service never stores or logs the plaintext.
+	password := req.Password
+	var generated string
+	if password == "" {
+		gp, genErr := generatePassword()
+		if genErr != nil {
+			return nil, errxtrace.Wrap("failed to generate password", genErr)
+		}
+		password = gp
+		generated = gp
+	}
+
+	if err := models.ValidatePassword(password); err != nil {
+		return nil, fmt.Errorf("password validation failed: %w", err)
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to bcrypt password", err)
+	}
+
+	user := models.BackofficeUser{
+		Email:        email,
+		Name:         name,
+		PasswordHash: string(hash),
+		Role:         role,
+		IsActive:     true,
+		MFAEnforced:  true,
+	}
+
+	created, err := s.factorySet.BackofficeUserRegistry.Create(ctx, user)
+	if err != nil {
+		// A concurrent caller could have inserted the same email
+		// between our idempotency check and this Create. Surface
+		// the canonical "already exists" sentinel so the CLI can
+		// render the same friendly message either way.
+		if errors.Is(err, registry.ErrBackofficeEmailAlreadyExists) {
+			refetched, refErr := s.factorySet.BackofficeUserRegistry.GetByEmail(ctx, email)
+			if refErr == nil {
+				return &BootstrapResult{User: refetched, AlreadyExisted: true}, nil
+			}
+		}
+		return nil, errxtrace.Wrap("failed to create backoffice user", err)
+	}
+
+	return &BootstrapResult{
+		User:              created,
+		GeneratedPassword: generated,
+	}, nil
+}
+
+// generatePassword produces a strong random password the CLI prints
+// once to stdout. 18 bytes of base64 = 24 ASCII chars with mixed-case
+// + digits + URL-safe symbols, comfortably above models.ValidatePassword's
+// length / character-class requirements without bringing in a separate
+// generator library.
+//
+// We append "Aa1" to guarantee the upper-case + lower-case + digit
+// classes are present even on the (astronomically unlikely) draw where
+// the random bytes happen to map to a base64 string missing one of
+// them — keeps Bootstrap from failing a follow-up ValidatePassword
+// check on bad luck.
+func generatePassword() (string, error) {
+	buf := make([]byte, 18)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf) + "Aa1", nil
+}

--- a/go/services/backoffice/service.go
+++ b/go/services/backoffice/service.go
@@ -177,6 +177,16 @@ func (s *Service) Bootstrap(ctx context.Context, req BootstrapRequest) (*Bootstr
 		MFAEnforced:  true,
 	}
 
+	// Run the model's full validation (length caps, EmailPattern match)
+	// before handing the row to the registry. The registry's
+	// validateCommonBackofficeFields only checks "not empty" + role
+	// membership, so without this an invocation like
+	// `--email "not-an-email"` would round-trip cleanly. Mirrors
+	// services/admin.Service.CreateUser.
+	if err := user.ValidateWithContext(ctx); err != nil {
+		return nil, fmt.Errorf("user validation failed: %w", err)
+	}
+
 	created, err := s.factorySet.BackofficeUserRegistry.Create(ctx, user)
 	if err != nil {
 		// A concurrent caller could have inserted the same email


### PR DESCRIPTION
First slice of issue #1785 ("Separate back-office auth plane"). Pure foundation — adds the new identity store and a bootstrap CLI. No HTTP routes, no middleware changes, no impact on the existing `users.is_system_admin` plane.

## Summary

- New `BackofficeUser` model (cross-tenant, no RLS — back-office identities ARE the boundary, like `tenants`), with a typed `BackofficeRole` enum (`support_agent` | `platform_admin`).
- `BackofficeUserRegistry` on `FactorySet` with memory + postgres implementations (postgres uses `NonRLSRepository`).
- Sentinel errors: `ErrBackofficeUserNotFound`, `ErrBackofficeEmailAlreadyExists`, `ErrInvalidBackofficeRole`.
- Generated migration (`1780600000_add_backoffice_users.{up,down}.sql`) — `UNIQUE INDEX` on `email`, `UNIQUE INDEX` on `uuid`, plain index on `is_active` (Phase 2's login flow will filter on it; revisit as partial / drop entirely if the access pattern changes).
- `inventario backoffice bootstrap` CLI command (mirrors `inventario admin grant-system-admin` ergonomics — PostgreSQL-only via the shared DatabaseConfig validator, idempotent re-run, `--force` to add a second back-office user).
- Tests: registry (memory + postgres) and CLI.

## What this is NOT

- ❌ No `/api/v1/backoffice/auth/login` endpoint — Phase 2.
- ❌ No JWT middleware changes — Phase 2.
- ❌ No changes to `users.is_system_admin` or `RequireSystemAdmin` — Phase 3.
- ❌ MFA enforcement column exists (`mfa_enforced bool`) but is data-only here — Phase 4 wires it.
- ❌ No frontend — Phase 6.

## Design notes

**No `tenant_id`, no RLS.** Back-office identities are platform-wide operators by definition; tenanting them would defeat the epic. Same modelling choice the `tenants` table makes.

**Email case-insensitivity** is enforced at the registry boundary by lowercasing on `Create`/`GetByEmail`, plus a regular `UNIQUE INDEX (email)`. The migrator annotation system doesn't expose functional/expression indexes (`lower(email)`), so manual `INSERT`s bypassing the registry would defeat this — documented in code. Postgres unique-violations on the email index are re-classified at the registry layer to `ErrBackofficeEmailAlreadyExists` so the loser of a concurrent insert race surfaces the canonical sentinel.

**Password hash** uses the same bcrypt cost as `models.User`. `SetPasswordHash` is a separate registry method so the hash doesn't leak through generic `Update` paths.

**Delete is idempotent on both backends** — a Delete on a missing id is a no-op rather than an error.

**Migration version** renamed from generator default (`1779525214_*` — real Unix ts) to `1780600000_*` to keep the fake-future sequential ordering with `17805*` migrations that already exist.

## Test plan

- [ ] CI green
- [ ] `go test ./registry/memory/... -run TestBackofficeUserRegistry` (20 cases) passes
- [ ] `go test ./registry/postgres/... -run TestBackofficeUserRegistry` passes (under `make test-go-postgres`)
- [ ] `go test ./cmd/inventario/backoffice/...` (10 cases) passes
- [ ] `inventario backoffice bootstrap --help` shows the subcommand
- [ ] `inventario backoffice bootstrap --db-dsn memory://...` is rejected with a clear message

Tracking: #1785 (Phase 1 of 6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a back-office (platform-operator) identity plane: CLI command to bootstrap the first back-office user, role support (platform_admin, support_agent), idempotent creation, and a service for managing back-office users.
* **Database**
  * Migration to add backoffice_users table with UUIDs, timestamps, role/status fields, and indexes (including unique email).
* **Tests**
  * Extensive unit and integration tests covering CLI, service, model validation, in-memory and Postgres registries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->