### PR TITLE
[#1793] Tenant-namespace blob storage keys

### DIFF
--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -771,11 +771,30 @@ func (api *filesAPI) downloadThumbnail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Generate thumbnail path using the new structure
-	thumbnailPath := fmt.Sprintf("thumbnails/%s_%s.jpg", fileID, size)
+	// Resolve the owning tenant via the FileEntity row — the row is
+	// what decides which tenant's namespace the thumbnail lives in
+	// (#1793). The signed-URL middleware has already validated that
+	// the caller is allowed to read this file, so we need a row-level
+	// lookup with RLS bypass here.
+	fileReg, err := api.factorySet.FileRegistryFactory.CreateUserRegistry(r.Context())
+	if err != nil {
+		internalServerError(w, r, err)
+		return
+	}
+	file, err := fileReg.Get(r.Context(), fileID)
+	if err != nil {
+		renderEntityError(w, r, err)
+		return
+	}
 
-	// Check if thumbnail exists using file service
-	exists, err := api.fileService.ThumbnailExists(r.Context(), fileID, size)
+	// Resolve the canonical (or legacy fallback) thumbnail key.
+	thumbnailPath, err := api.fileService.ThumbnailReadPath(r.Context(), file.TenantID, fileID, size)
+	if err != nil {
+		internalServerError(w, r, errxtrace.Wrap("failed to resolve thumbnail path", err))
+		return
+	}
+
+	exists, err := api.fileService.ThumbnailExists(r.Context(), file.TenantID, fileID, size)
 	if err != nil {
 		internalServerError(w, r, errxtrace.Wrap("failed to check thumbnail existence", err))
 		return

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -773,9 +773,9 @@ func (api *filesAPI) downloadThumbnail(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve the owning tenant via the FileEntity row — the row is
 	// what decides which tenant's namespace the thumbnail lives in
-	// (#1793). The signed-URL middleware has already validated that
-	// the caller is allowed to read this file, so we need a row-level
-	// lookup with RLS bypass here.
+	// (#1793). The user-scoped registry already enforces tenant/group
+	// access, and the signed-URL middleware has separately validated
+	// that the caller is allowed to read this file.
 	fileReg, err := api.factorySet.FileRegistryFactory.CreateUserRegistry(r.Context())
 	if err != nil {
 		internalServerError(w, r, err)
@@ -787,16 +787,12 @@ func (api *filesAPI) downloadThumbnail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve the canonical (or legacy fallback) thumbnail key.
-	thumbnailPath, err := api.fileService.ThumbnailReadPath(r.Context(), file.TenantID, fileID, size)
+	// Single bucket open: returns the canonical or legacy thumbnail key
+	// and whether it actually exists; placeholder generation is the
+	// not-exists branch.
+	thumbnailPath, exists, err := api.fileService.ResolveThumbnail(r.Context(), file.TenantID, fileID, size)
 	if err != nil {
-		internalServerError(w, r, errxtrace.Wrap("failed to resolve thumbnail path", err))
-		return
-	}
-
-	exists, err := api.fileService.ThumbnailExists(r.Context(), file.TenantID, fileID, size)
-	if err != nil {
-		internalServerError(w, r, errxtrace.Wrap("failed to check thumbnail existence", err))
+		internalServerError(w, r, errxtrace.Wrap("failed to resolve thumbnail", err))
 		return
 	}
 

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -315,7 +315,8 @@ func (api *uploadsAPI) readUploadedFiles(r *http.Request, tenantID string, kind 
 			return nil, errxtrace.Wrap("unable to read part in multipart form", err)
 		}
 
-		if part.FileName() == "" {
+		rawName := part.FileName()
+		if rawName == "" {
 			continue
 		}
 
@@ -327,7 +328,8 @@ func (api *uploadsAPI) readUploadedFiles(r *http.Request, tenantID string, kind 
 			}
 		}
 
-		uf, err := api.saveOnePart(r.Context(), part, tenantID, kind, allowedContentTypes)
+		basename := filekit.UploadFileName(rawName)
+		uf, err := api.saveOnePart(r.Context(), part, basename, tenantID, kind, allowedContentTypes)
 		if err != nil {
 			return nil, err
 		}
@@ -335,16 +337,12 @@ func (api *uploadsAPI) readUploadedFiles(r *http.Request, tenantID string, kind 
 	}
 }
 
-// saveOnePart sanitises the basename, computes the tenant-prefixed
-// blob key, and writes the part bytes to the bucket. Returns either
-// a populated uploadedFile or an error (wrapped in uploadHTTPError
-// for the unprocessable-entity-bound MIME mismatch).
-func (api *uploadsAPI) saveOnePart(ctx context.Context, part io.Reader, tenantID string, kind uploadKind, allowedContentTypes []string) (uploadedFile, error) {
-	type filenamed interface{ FileName() string }
-	var basename string
-	if p, ok := part.(filenamed); ok {
-		basename = filekit.UploadFileName(p.FileName())
-	}
+// saveOnePart computes the tenant-prefixed blob key from the
+// caller-supplied (already-sanitised) basename and writes the part
+// bytes to the bucket. Returns either a populated uploadedFile or an
+// error (wrapped in uploadHTTPError for the unprocessable-entity-bound
+// MIME mismatch).
+func (api *uploadsAPI) saveOnePart(ctx context.Context, part io.Reader, basename, tenantID string, kind uploadKind, allowedContentTypes []string) (uploadedFile, error) {
 	var blobKey string
 	switch kind {
 	case uploadKindRestore:

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -280,8 +280,7 @@ func (e *uploadHTTPError) Error() string { return e.err.Error() }
 func (e *uploadHTTPError) Unwrap() error { return e.err }
 
 func renderUploadError(w http.ResponseWriter, r *http.Request, err error) {
-	var ue *uploadHTTPError
-	if errors.As(err, &ue) {
+	if ue, ok := errors.AsType[*uploadHTTPError](err); ok {
 		switch ue.status {
 		case http.StatusUnprocessableEntity:
 			unprocessableEntityError(w, r, ue.err)

--- a/go/apiserver/uploads.go
+++ b/go/apiserver/uploads.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/denisvmedia/inventario/apiserver/middleware"
 	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
 	"github.com/denisvmedia/inventario/internal/filekit"
 	"github.com/denisvmedia/inventario/internal/mimekit"
 	"github.com/denisvmedia/inventario/jsonapi"
@@ -50,7 +51,14 @@ func detectFileType(mimeType string) models.FileType {
 }
 
 type uploadedFile struct {
+	// FilePath is the bucket-relative blob key the upload was written
+	// to. Post-#1793 this is always tenant-prefixed
+	// (`t/<tenant>/files/<basename>` or `t/<tenant>/restores/<basename>`).
 	FilePath string
+	// Basename is the sanitized filename from filekit.UploadFileName —
+	// preserved separately so handlers can derive a human-readable
+	// title from it without having to parse the tenant-prefixed key.
+	Basename string
 	MIMEType string
 	Size     int64
 }
@@ -110,9 +118,13 @@ func (api *uploadsAPI) handleFileUpload(w http.ResponseWriter, r *http.Request) 
 
 	// Get the extension from the MIME type
 	ext := mimekit.ExtensionByMime(f.MIMEType)
+	// `OriginalPath` carries the tenant-prefixed blob key
+	// (`t/<tenant>/files/<basename>`) — see `uploadFiles` middleware.
 	originalPath := f.FilePath
-	// Set Path to be the filename without extension
-	pathWithoutExt := strings.TrimSuffix(originalPath, filepath.Ext(originalPath))
+	// `Path` / Title come from the human-readable basename, NOT the
+	// blob key — otherwise the user would see `t/<tenant>/files/...`
+	// as the title of every uploaded file.
+	pathWithoutExt := strings.TrimSuffix(f.Basename, filepath.Ext(f.Basename))
 
 	// Auto-detect file type based on MIME type
 	fileType := detectFileType(f.MIMEType)
@@ -220,62 +232,138 @@ func (api *uploadsAPI) handleRestoreUpload(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-func (api *uploadsAPI) uploadFiles(allowedContentTypes ...string) func(next http.Handler) http.Handler {
+// uploadKind selects the per-tenant subfolder that the upload middleware
+// writes to. Restore uploads land under `restores/` so the importer can
+// list them separately from user-facing files; the default `file_upload`
+// flow writes under `files/`.
+type uploadKind int
+
+const (
+	uploadKindFile uploadKind = iota
+	uploadKindRestore
+)
+
+func (api *uploadsAPI) uploadFiles(kind uploadKind, allowedContentTypes ...string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Get the multipart reader from the request
-			reader, err := r.MultipartReader()
-			if err != nil {
-				unprocessableEntityError(w, r, err)
+			// Resolve the authenticated tenant up-front so the blob is
+			// written under the per-tenant namespace from the very first
+			// byte (issue #1793). The middleware runs after JWT + tenant
+			// middlewares so the user must be present; an unauthenticated
+			// request here is a wiring bug, not a recoverable client error.
+			user := appctx.UserFromContext(r.Context())
+			if user == nil || user.TenantID == "" {
+				internalServerError(w, r, errxtrace.Classify(errx.NewDisplayable("upload requires authenticated tenant context")))
 				return
 			}
 
-			var uploadedFiles []uploadedFile
-			fileCount := 0
-
-		loop:
-			for {
-				// Read the next part (file) in the multipart stream
-				part, err := reader.NextPart()
-				switch err {
-				case nil:
-				case io.EOF:
-					break loop
-				default:
-					internalServerError(w, r, errxtrace.Wrap("unable to read part in multipart form", err))
-					return
-				}
-
-				// Skip if it's not a file part
-				if part.FileName() == "" {
-					continue
-				}
-
-				fileCount++
-				// Only allow single file uploads
-				if fileCount > 1 {
-					unprocessableEntityError(w, r, errxtrace.Classify(errx.NewDisplayable("only single file uploads are allowed")))
-					return
-				}
-
-				// Generate the file path and open a new file
-				filename := filekit.UploadFileName(part.FileName())
-				mimeType, size, err := api.saveFile(r.Context(), filename, part, allowedContentTypes) // TODO: make sure that the file is not too big
-				switch {
-				case errors.Is(err, mimekit.ErrInvalidContentType):
-					unprocessableEntityError(w, r, errxtrace.Wrap("unsupported content type", err))
-					return
-				case err != nil:
-					internalServerError(w, r, errxtrace.Wrap("unable to save file", err))
-					return
-				}
-				uploadedFiles = append(uploadedFiles, uploadedFile{FilePath: filename, MIMEType: mimeType, Size: size})
+			uploadedFiles, err := api.readUploadedFiles(r, user.TenantID, kind, allowedContentTypes)
+			if err != nil {
+				renderUploadError(w, r, err)
+				return
 			}
-
 			ctx := context.WithValue(r.Context(), uploadedFilesCtxKey, uploadedFiles)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// uploadHTTPError is the per-part error envelope returned from
+// readUploadedFiles. Carries the HTTP status the handler should render
+// so the middleware itself stays flat (cognitive-complexity budget).
+type uploadHTTPError struct {
+	status int
+	err    error
+}
+
+func (e *uploadHTTPError) Error() string { return e.err.Error() }
+func (e *uploadHTTPError) Unwrap() error { return e.err }
+
+func renderUploadError(w http.ResponseWriter, r *http.Request, err error) {
+	var ue *uploadHTTPError
+	if errors.As(err, &ue) {
+		switch ue.status {
+		case http.StatusUnprocessableEntity:
+			unprocessableEntityError(w, r, ue.err)
+		default:
+			internalServerError(w, r, ue.err)
+		}
+		return
+	}
+	internalServerError(w, r, err)
+}
+
+// readUploadedFiles walks the request's multipart stream and writes
+// each part to the bucket under the tenant-prefixed namespace. Returns
+// the parsed-out uploadedFile list (one entry per accepted part) or
+// an uploadHTTPError carrying the status the caller should render.
+func (api *uploadsAPI) readUploadedFiles(r *http.Request, tenantID string, kind uploadKind, allowedContentTypes []string) ([]uploadedFile, error) {
+	reader, err := r.MultipartReader()
+	if err != nil {
+		return nil, &uploadHTTPError{status: http.StatusUnprocessableEntity, err: err}
+	}
+
+	var uploadedFiles []uploadedFile
+	fileCount := 0
+	for {
+		part, err := reader.NextPart()
+		switch err {
+		case nil:
+			// fallthrough to body
+		case io.EOF:
+			return uploadedFiles, nil
+		default:
+			return nil, errxtrace.Wrap("unable to read part in multipart form", err)
+		}
+
+		if part.FileName() == "" {
+			continue
+		}
+
+		fileCount++
+		if fileCount > 1 {
+			return nil, &uploadHTTPError{
+				status: http.StatusUnprocessableEntity,
+				err:    errxtrace.Classify(errx.NewDisplayable("only single file uploads are allowed")),
+			}
+		}
+
+		uf, err := api.saveOnePart(r.Context(), part, tenantID, kind, allowedContentTypes)
+		if err != nil {
+			return nil, err
+		}
+		uploadedFiles = append(uploadedFiles, uf)
+	}
+}
+
+// saveOnePart sanitises the basename, computes the tenant-prefixed
+// blob key, and writes the part bytes to the bucket. Returns either
+// a populated uploadedFile or an error (wrapped in uploadHTTPError
+// for the unprocessable-entity-bound MIME mismatch).
+func (api *uploadsAPI) saveOnePart(ctx context.Context, part io.Reader, tenantID string, kind uploadKind, allowedContentTypes []string) (uploadedFile, error) {
+	type filenamed interface{ FileName() string }
+	var basename string
+	if p, ok := part.(filenamed); ok {
+		basename = filekit.UploadFileName(p.FileName())
+	}
+	var blobKey string
+	switch kind {
+	case uploadKindRestore:
+		blobKey = blobkeys.BuildRestoreUploadKey(tenantID, basename)
+	default:
+		blobKey = blobkeys.BuildFileUploadKey(tenantID, basename)
+	}
+	mimeType, size, err := api.saveFile(ctx, blobKey, part, allowedContentTypes)
+	switch {
+	case errors.Is(err, mimekit.ErrInvalidContentType):
+		return uploadedFile{}, &uploadHTTPError{
+			status: http.StatusUnprocessableEntity,
+			err:    errxtrace.Wrap("unsupported content type", err),
+		}
+	case err != nil:
+		return uploadedFile{}, errxtrace.Wrap("unable to save file", err)
+	}
+	return uploadedFile{FilePath: blobKey, Basename: basename, MIMEType: mimeType, Size: size}, nil
 }
 
 func (api *uploadsAPI) saveFile(ctx context.Context, filename string, src io.Reader, allowedContentTypes []string) (mimeType string, size int64, err error) {
@@ -334,12 +422,12 @@ func Uploads(params Params) func(r chi.Router) {
 		fileMiddlewares := []func(http.Handler) http.Handler{
 			middleware.SetUploadOperation("file_upload"),
 			uploadLimiter,
-			api.uploadFiles(mimekit.AllContentTypes()...),
+			api.uploadFiles(uploadKindFile, mimekit.AllContentTypes()...),
 		}
 		r.With(fileMiddlewares...).Post("/file", api.handleFileUpload)
 
 		// Restore uploads - only allow XML files (no upload limiting for system operations)
-		r.With(api.uploadFiles(mimekit.XMLContentTypes()...)).Post("/restores", api.handleRestoreUpload)
+		r.With(api.uploadFiles(uploadKindRestore, mimekit.XMLContentTypes()...)).Post("/restores", api.handleRestoreUpload)
 	}
 }
 

--- a/go/apiserver/uploads_test.go
+++ b/go/apiserver/uploads_test.go
@@ -3,14 +3,19 @@ package apiserver_test
 import (
 	"bytes"
 	"encoding/json"
+	"image"
+	"image/color"
+	"image/jpeg"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 
 	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
 )
 
 // Legacy `/uploads/{commodities,locations}/{id}/*` tests
@@ -81,7 +86,10 @@ func TestUploads_restores(t *testing.T) {
 	c.Assert(response.Type, qt.Equals, "uploads")
 	c.Assert(response.Attributes.Type, qt.Equals, "restores")
 	c.Assert(response.Attributes.FileNames, qt.HasLen, 1)
-	c.Assert(response.Attributes.FileNames[0], qt.Matches, `test-\d+\.xml`)
+	// Restore uploads land under the per-tenant `restores/` namespace
+	// (#1793). The trailing segment is still the filekit-sanitized
+	// basename.
+	c.Assert(response.Attributes.FileNames[0], qt.Matches, `t/[^/]+/restores/test-\d+\.xml`)
 }
 
 func TestUploads_restores_invalid(t *testing.T) {
@@ -120,4 +128,68 @@ func TestUploads_restores_invalid(t *testing.T) {
 
 	// Verify the response - should be rejected due to invalid content type
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+}
+
+// TestUploads_file_tenantPrefixedKey is the #1793 regression test: a
+// POST /uploads/file lands a FileEntity row whose OriginalPath is the
+// tenant-prefixed `t/<tenant>/files/<basename>` blob key, never a flat
+// legacy shape. Combined with the structural test on the helper
+// (`TestKeysAlwaysCarryTenantNamespace`), this proves that the upload
+// path physically cannot place a blob outside the authenticated
+// tenant's namespace.
+func TestUploads_file_tenantPrefixedKey(t *testing.T) {
+	c := qt.New(t)
+
+	params, testUser, testGroup := newParams()
+
+	// Build a tiny JPEG payload so the MIME sniffer accepts the part.
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	for x := range 4 {
+		for y := range 4 {
+			img.Set(x, y, color.RGBA{R: 255, A: 255})
+		}
+	}
+	var imgBuf bytes.Buffer
+	c.Assert(jpeg.Encode(&imgBuf, img, &jpeg.Options{Quality: 80}), qt.IsNil)
+
+	bodyBuf := &bytes.Buffer{}
+	bodyWriter := multipart.NewWriter(bodyBuf)
+	h := CreateFormFileMIME("file", "my-photo.jpg", "image/jpeg")
+	fileWriter, err := bodyWriter.CreatePart(h)
+	c.Assert(err, qt.IsNil)
+	_, err = fileWriter.Write(imgBuf.Bytes())
+	c.Assert(err, qt.IsNil)
+	contentType := bodyWriter.FormDataContentType()
+	bodyWriter.Close()
+
+	req, err := http.NewRequest("POST", "/api/v1/g/"+testGroup.Slug+"/uploads/file", bodyBuf)
+	c.Assert(err, qt.IsNil)
+	req.Header.Set("Content-Type", contentType)
+	addTestUserAuthHeader(req, testUser.ID)
+
+	rr := httptest.NewRecorder()
+	mockRestoreWorker := &mockRestoreWorker{hasRunningRestores: false}
+	handler := apiserver.APIServer(params, mockRestoreWorker)
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusCreated, qt.Commentf("body=%s", rr.Body.String()))
+
+	var resp struct {
+		ID         string `json:"id"`
+		Attributes struct {
+			OriginalPath string `json:"original_path"`
+			Path         string `json:"path"`
+			Ext          string `json:"ext"`
+		} `json:"attributes"`
+	}
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &resp), qt.IsNil)
+
+	// OriginalPath is the canonical tenant-prefixed key; Path is the
+	// human-readable basename (the Title is derived from it on the
+	// handler side).
+	c.Assert(blobkeys.HasTenantPrefix(resp.Attributes.OriginalPath), qt.IsTrue,
+		qt.Commentf("OriginalPath %q must be tenant-prefixed", resp.Attributes.OriginalPath))
+	c.Assert(strings.HasPrefix(resp.Attributes.OriginalPath, "t/"+testUser.TenantID+"/files/"), qt.IsTrue,
+		qt.Commentf("OriginalPath %q must live under the authenticated tenant's namespace", resp.Attributes.OriginalPath))
+	c.Assert(resp.Attributes.Path, qt.Not(qt.Contains), "t/")
 }

--- a/go/backup/export/service.go
+++ b/go/backup/export/service.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/backup/export/types"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 )
@@ -328,9 +329,24 @@ func (s *ExportService) generateExport(ctx context.Context, export models.Export
 		}
 	}()
 
-	// Generate blob key (filename)
+	// Resolve the owning tenant from the export row — exports inherit
+	// their tenant from the user who triggered them; ProcessExport has
+	// already populated user context above. Falling back to the export
+	// row's own TenantID keeps tests that drive generateExport directly
+	// (without going through ProcessExport) working.
+	tenantID := export.TenantID
+	if tenantID == "" {
+		if user := appctx.UserFromContext(ctx); user != nil {
+			tenantID = user.TenantID
+		}
+	}
+	if tenantID == "" {
+		return "", nil, errors.New("tenant context is required to generate an export")
+	}
+
+	// Generate blob key (filename) — tenant-prefixed under #1793.
 	timestamp := time.Now().Format("20060102_150405")
-	blobKey := fmt.Sprintf("exports/export_%s_%s.xml", strings.ToLower(string(export.Type)), timestamp)
+	blobKey := blobkeys.BuildExportBlobKey(tenantID, string(export.Type), timestamp)
 
 	// Create blob writer
 	writer, err := b.NewWriter(ctx, blobKey, nil)

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/backup/restore/security"
 	"github.com/denisvmedia/inventario/backup/restore/types"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
 	"github.com/denisvmedia/inventario/internal/validationctx"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
@@ -1963,12 +1964,9 @@ func (l *RestoreOperationProcessor) decodeFileElement(
 		switch t := tok.(type) {
 		case xml.StartElement:
 			if t.Name.Local == "data" {
-				if xmlFile.OriginalPath == "" {
-					return nil, 0, errors.New("malformed export: <data> element preceded <originalPath>")
-				}
-				size, err := l.handleFileDataElement(ctx, decoder, &xmlFile, existing, idMapping, options)
+				size, err := l.handleDataStart(ctx, decoder, &xmlFile, existing, idMapping, options)
 				if err != nil {
-					return nil, 0, errxtrace.Wrap("failed to stream file data", err, errx.Attrs("xml_id", xmlFile.ID))
+					return nil, 0, err
 				}
 				rawSize = size
 				continue
@@ -1982,6 +1980,52 @@ func (l *RestoreOperationProcessor) decodeFileElement(
 			}
 		}
 	}
+}
+
+// handleDataStart is the per-row entry point for the <data> element.
+// It validates the ordering invariant (originalPath must precede
+// data), rewrites OriginalPath into the importing tenant's namespace,
+// and then delegates the actual blob write to handleFileDataElement.
+//
+// Pulled out of decodeFileElement so the decoder loop stays inside the
+// project's cognitive-complexity budget.
+func (l *RestoreOperationProcessor) handleDataStart(
+	ctx context.Context,
+	decoder *xml.Decoder,
+	xmlFile *types.XMLFile,
+	existing *types.ExistingEntities,
+	idMapping *types.IDMapping,
+	options types.RestoreOptions,
+) (int64, error) {
+	if xmlFile.OriginalPath == "" {
+		return 0, errors.New("malformed export: <data> element preceded <originalPath>")
+	}
+	// Rewrite OriginalPath into the importing tenant's namespace
+	// before the blob is written. The XML may carry either a legacy
+	// flat key (pre-#1793 export) or an already-prefixed key from a
+	// foreign tenant — in either case the blob MUST land under the
+	// importing tenant's namespace, never the exporter's (defence-
+	// in-depth: a malicious XML cannot point a restore at another
+	// tenant's bucket slot).
+	if user := appctx.UserFromContext(ctx); user != nil && user.TenantID != "" {
+		xmlFile.OriginalPath = rewriteImportKey(xmlFile.OriginalPath, user.TenantID)
+	}
+	size, err := l.handleFileDataElement(ctx, decoder, xmlFile, existing, idMapping, options)
+	if err != nil {
+		return 0, errxtrace.Wrap("failed to stream file data", err, errx.Attrs("xml_id", xmlFile.ID))
+	}
+	return size, nil
+}
+
+// rewriteImportKey normalises an XML-declared OriginalPath into the
+// importing tenant's namespace. Legacy flat keys go through
+// blobkeys.RewriteForTenant straight; already-prefixed keys have
+// their (foreign) tenant prefix stripped and are re-prefixed.
+func rewriteImportKey(originalPath, tenantID string) string {
+	if blobkeys.HasTenantPrefix(originalPath) {
+		return blobkeys.RewriteForTenant(stripTenantPrefix(originalPath), tenantID)
+	}
+	return blobkeys.RewriteForTenant(originalPath, tenantID)
 }
 
 // handleFileDataElement is the dispatch point for <data> chardata: it
@@ -2220,4 +2264,35 @@ func ensureFileTags(tags models.StringSlice) models.StringSlice {
 		return models.StringSlice{}
 	}
 	return tags
+}
+
+// stripTenantPrefix removes a `t/<anything>/` prefix from a blob key,
+// leaving the bucket-relative remainder ("files/<id>.pdf",
+// "thumbnails/<id>_small.jpg", "exports/...", "restores/...", or a
+// bare basename). Used during restore to drop the exporting tenant's
+// namespace before re-prefixing under the importing tenant.
+//
+// Returns the input unchanged if it does not carry a tenant prefix or
+// the prefix is malformed (no trailing slash after the tenant segment).
+func stripTenantPrefix(key string) string {
+	if !blobkeys.HasTenantPrefix(key) {
+		return key
+	}
+	rest := key[len(blobkeys.Prefix):]
+	slash := indexByte(rest, '/')
+	if slash < 0 {
+		return key
+	}
+	return rest[slash+1:]
+}
+
+// indexByte is a tiny escape hatch from `strings` to avoid widening
+// the import set for one helper. Inlined by the compiler.
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
 }

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/go-extras/errx"
@@ -2007,9 +2008,17 @@ func (l *RestoreOperationProcessor) handleDataStart(
 	// importing tenant's namespace, never the exporter's (defence-
 	// in-depth: a malicious XML cannot point a restore at another
 	// tenant's bucket slot).
-	if user := appctx.UserFromContext(ctx); user != nil && user.TenantID != "" {
-		xmlFile.OriginalPath = rewriteImportKey(xmlFile.OriginalPath, user.TenantID)
+	//
+	// Fail-closed: a restore that reached this point without a tenant
+	// context is a wiring bug — the Process pipeline always populates
+	// it from `Export.CreatedByUserID`. Proceeding here would write
+	// the blob under the XML-declared key, defeating the whole point
+	// of the rewrite.
+	user := appctx.UserFromContext(ctx)
+	if user == nil || user.TenantID == "" {
+		return 0, errors.New("tenant context is required to restore file data")
 	}
+	xmlFile.OriginalPath = rewriteImportKey(xmlFile.OriginalPath, user.TenantID)
 	size, err := l.handleFileDataElement(ctx, decoder, xmlFile, existing, idMapping, options)
 	if err != nil {
 		return 0, errxtrace.Wrap("failed to stream file data", err, errx.Attrs("xml_id", xmlFile.ID))
@@ -2273,26 +2282,16 @@ func ensureFileTags(tags models.StringSlice) models.StringSlice {
 // namespace before re-prefixing under the importing tenant.
 //
 // Returns the input unchanged if it does not carry a tenant prefix or
-// the prefix is malformed (no trailing slash after the tenant segment).
+// the prefix is malformed (no trailing slash after the tenant segment;
+// kept as a defensive guard even though every caller funnels through
+// HasTenantPrefix first).
 func stripTenantPrefix(key string) string {
 	if !blobkeys.HasTenantPrefix(key) {
 		return key
 	}
-	rest := key[len(blobkeys.Prefix):]
-	slash := indexByte(rest, '/')
-	if slash < 0 {
+	_, after, found := strings.Cut(key[len(blobkeys.Prefix):], "/")
+	if !found {
 		return key
 	}
-	return rest[slash+1:]
-}
-
-// indexByte is a tiny escape hatch from `strings` to avoid widening
-// the import set for one helper. Inlined by the compiler.
-func indexByte(s string, c byte) int {
-	for i := 0; i < len(s); i++ {
-		if s[i] == c {
-			return i
-		}
-	}
-	return -1
+	return after
 }

--- a/go/backup/restore/restore_files_test.go
+++ b/go/backup/restore/restore_files_test.go
@@ -16,6 +16,7 @@ import (
 	exporttypes "github.com/denisvmedia/inventario/backup/export/types"
 	"github.com/denisvmedia/inventario/backup/restore/processor"
 	"github.com/denisvmedia/inventario/backup/restore/types"
+	"github.com/denisvmedia/inventario/internal/blobkeys"
 	_ "github.com/denisvmedia/inventario/internal/fileblob" // register fileblob driver
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
@@ -667,7 +668,11 @@ func TestExportRestore_LargeBlobStreamingRoundTrip(t *testing.T) {
 	c.Assert(stats.FileCount, qt.Equals, 1)
 	c.Assert(stats.BinaryDataSize, qt.Equals, int64(blobSize))
 
-	got := readBlob(c, restoreLocation, bigFile.OriginalPath)
+	// Restore rewrites the legacy flat XML key under the importing
+	// tenant's namespace (#1793). Read at the rewritten location so
+	// the blob round-trip assertion still holds.
+	restoredKey := blobkeys.RewriteForTenant(bigFile.OriginalPath, dst.tenantID)
+	got := readBlob(c, restoreLocation, restoredKey)
 	c.Assert(got, qt.HasLen, blobSize)
 	c.Assert(bytes.Equal(got, bigBlob), qt.IsTrue, qt.Commentf("blob bytes corrupted across streaming round-trip"))
 }

--- a/go/cmd/inventario/backfill/backfill.go
+++ b/go/cmd/inventario/backfill/backfill.go
@@ -1,0 +1,36 @@
+// Package backfill is the parent command group for one-shot data
+// migration subcommands. The first subcommand is `blobs` (issue #1793)
+// — future tenant-scoped data backfills hang off the same group so the
+// pattern stays predictable for operators.
+package backfill
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/denisvmedia/inventario/cmd/inventario/backfill/blobs"
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+)
+
+// New constructs the parent `backfill` command and registers its
+// subcommands.
+func New(dbConfig *shared.DatabaseConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backfill",
+		Short: "One-shot data migrations",
+		Long: `Parent command for one-shot data migrations that aren't expressible as
+SQL schema migrations.
+
+Subcommands operate against a configured PostgreSQL database and the
+running deployment's upload bucket. They are designed to be safe to
+re-run: a successful pass produces no changes on the second run; a
+partial pass (e.g. interrupted by SIGTERM) is picked up by the next
+invocation.
+
+Examples:
+  inventario backfill blobs --upload-location file:///srv/uploads`,
+		Args: cobra.NoArgs,
+	}
+
+	cmd.AddCommand(blobs.New(dbConfig).Cmd())
+	return cmd
+}

--- a/go/cmd/inventario/backfill/blobs/blobs.go
+++ b/go/cmd/inventario/backfill/blobs/blobs.go
@@ -1,0 +1,121 @@
+// Package blobs implements `inventario backfill blobs`, the one-shot
+// data migration that rewrites legacy flat blob keys into the
+// per-tenant namespace introduced by issue #1793.
+//
+// The command is idempotent and copy-first — see the
+// services/blobbackfill package for the row-by-row semantics. Re-runs
+// after a successful pass are no-ops; re-runs after a partial pass
+// pick up where the previous one left off.
+package blobs
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/spf13/cobra"
+
+	"github.com/denisvmedia/inventario/cmd/internal/command"
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/services/blobbackfill"
+)
+
+// Config carries the backfill command's flags.
+type Config struct {
+	UploadLocation string `yaml:"upload_location" env:"UPLOAD_LOCATION"`
+	DryRun         bool   `yaml:"dry_run" env:"DRY_RUN"`
+}
+
+// Command is the `backfill blobs` cobra wrapper.
+type Command struct {
+	command.Base
+
+	config Config
+}
+
+// New constructs the command with the supplied database config.
+func New(dbConfig *shared.DatabaseConfig) *Command {
+	c := &Command{}
+	shared.TryReadSection("backfill.blobs", &c.config)
+
+	c.Base = command.NewBase(&cobra.Command{
+		Use:   "blobs",
+		Short: "Backfill legacy blob keys into the per-tenant namespace (#1793)",
+		Long: `Rewrites every FileEntity row whose OriginalPath is a legacy flat blob
+key into the canonical t/<tenant>/files/<basename> shape, copying the
+physical blob first, updating the row, then deleting the legacy blob.
+Image rows also have their derived thumbnail keys migrated.
+
+The operation is idempotent: rows whose OriginalPath is already
+tenant-prefixed are skipped. A partial run (interrupted by SIGTERM,
+network blip, etc.) is safe to re-run; the second pass picks up only
+the rows the first one didn't reach.
+
+Examples:
+  inventario backfill blobs --upload-location file:///srv/uploads
+  inventario backfill blobs --upload-location s3://my-bucket --dry-run`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.run(&c.config, dbConfig)
+		},
+	})
+
+	c.registerFlags()
+	return c
+}
+
+func (c *Command) registerFlags() {
+	c.Cmd().Flags().StringVar(&c.config.UploadLocation, "upload-location", c.config.UploadLocation,
+		"Bucket URL the server is reading/writing blobs to (e.g. file:///srv/uploads)")
+	c.Cmd().Flags().BoolVar(&c.config.DryRun, "dry-run", c.config.DryRun,
+		"Report what would change without touching the bucket or the database")
+}
+
+func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
+	out := c.Cmd().OutOrStdout()
+
+	if err := dbConfig.Validate(); err != nil {
+		return errxtrace.Wrap("database configuration error", err)
+	}
+	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
+		return errors.New("backfill blobs requires a persistent database (memory:// is not supported)")
+	}
+	if strings.TrimSpace(cfg.UploadLocation) == "" {
+		return errors.New("--upload-location is required")
+	}
+
+	registryFunc, ok := registry.GetRegistry(dbConfig.DBDSN)
+	if !ok {
+		return fmt.Errorf("unsupported database type in DSN: %s", dbConfig.DBDSN)
+	}
+	factorySet, err := registryFunc(registry.Config(dbConfig.DBDSN))
+	if err != nil {
+		return errxtrace.Wrap("failed to create registry factory set", err)
+	}
+
+	svc := blobbackfill.New(factorySet, cfg.UploadLocation)
+	stats, err := svc.Run(c.Cmd().Context(), blobbackfill.Options{DryRun: cfg.DryRun})
+	if err != nil {
+		return errxtrace.Wrap("backfill aborted", err)
+	}
+
+	if cfg.DryRun {
+		fmt.Fprintln(out, "[dry-run] no changes were written to the bucket or database.")
+	}
+	fmt.Fprintf(out, "Scanned:        %d\n", stats.RowsScanned)
+	fmt.Fprintf(out, "Already-moved:  %d\n", stats.RowsAlreadyMoved)
+	fmt.Fprintf(out, "Moved:          %d\n", stats.RowsMoved)
+	fmt.Fprintf(out, "No blob key:    %d\n", stats.RowsSkippedNoKey)
+	fmt.Fprintf(out, "Errored:        %d\n", stats.RowsErrored)
+	fmt.Fprintf(out, "Thumbs moved:   %d\n", stats.ThumbsMoved)
+	fmt.Fprintf(out, "Thumbs missing: %d\n", stats.ThumbsMissing)
+	fmt.Fprintf(out, "Blobs copied:   %d\n", stats.BlobsCopied)
+	fmt.Fprintf(out, "Blobs deleted:  %d\n", stats.BlobsDeleted)
+
+	if stats.RowsErrored > 0 {
+		return fmt.Errorf("backfill completed with %d row error(s); see logs", stats.RowsErrored)
+	}
+	return nil
+}

--- a/go/cmd/inventario/backfill/blobs/blobs.go
+++ b/go/cmd/inventario/backfill/blobs/blobs.go
@@ -88,7 +88,9 @@ func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
 
 	registryFunc, ok := registry.GetRegistry(dbConfig.DBDSN)
 	if !ok {
-		return fmt.Errorf("unsupported database type in DSN: %s", dbConfig.DBDSN)
+		// Don't echo dbConfig.DBDSN — Postgres DSNs embed credentials
+		// in the URL, and the error message ends up in CLI output / logs.
+		return errors.New("unsupported database type in DSN")
 	}
 	factorySet, err := registryFunc(registry.Config(dbConfig.DBDSN))
 	if err != nil {

--- a/go/cmd/inventario/inventario.go
+++ b/go/cmd/inventario/inventario.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/denisvmedia/inventario/cmd/common/version"
 	"github.com/denisvmedia/inventario/cmd/inventario/admin"
+	"github.com/denisvmedia/inventario/cmd/inventario/backfill"
 	"github.com/denisvmedia/inventario/cmd/inventario/db"
 	"github.com/denisvmedia/inventario/cmd/inventario/features"
 	"github.com/denisvmedia/inventario/cmd/inventario/initconfig"
@@ -59,6 +60,7 @@ Use "inventario [command] --help" for detailed information about each command.`,
 	rootCmd.AddCommand(tenants.New(&dbConfig))
 	rootCmd.AddCommand(users.New(&dbConfig))
 	rootCmd.AddCommand(admin.New(&dbConfig))
+	rootCmd.AddCommand(backfill.New(&dbConfig))
 	rootCmd.AddCommand(version.New())
 	err := rootCmd.Execute()
 	if err != nil {

--- a/go/debug/seeddata/seeddata_fixtures.go
+++ b/go/debug/seeddata/seeddata_fixtures.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/google/uuid"
 	"gocloud.dev/blob"
+
+	"github.com/denisvmedia/inventario/internal/blobkeys"
 )
 
 // fixturesFS bundles a handful of small JPG photos and PDF documents.
@@ -70,8 +72,12 @@ var fixtureMetadata = map[fixtureKind]fixtureMeta{
 // still creates FileEntity rows so the UI surfaces the entry, but the
 // row's OriginalPath points at a blob that won't exist if anyone tries
 // to read it). The no-op path is what the in-memory unit tests use.
+//
+// Implementations construct tenant-prefixed blob keys via
+// blobkeys.BuildSeedKey so seeded rows respect the same per-tenant
+// namespace as user-uploaded files (#1793).
 type blobUploader interface {
-	upload(ctx context.Context, fixture fixtureKind) (storagePath string, sizeBytes int64, err error)
+	upload(ctx context.Context, fixture fixtureKind, tenantID string) (storagePath string, sizeBytes int64, err error)
 	close()
 }
 
@@ -96,12 +102,15 @@ func newBlobUploader(ctx context.Context, uploadLocation string) (blobUploader, 
 
 type noopUploader struct{}
 
-func (*noopUploader) upload(_ context.Context, fixture fixtureKind) (string, int64, error) {
+func (*noopUploader) upload(_ context.Context, fixture fixtureKind, tenantID string) (string, int64, error) {
 	// Even with no backend, give the row a plausible-looking path so
 	// list endpoints don't trip on validation: the file rows must
 	// carry a non-empty OriginalPath. The "seed-" prefix + UUID makes
-	// these rows obvious if anyone debugs the table.
-	return fmt.Sprintf("seed-%s%s", uuid.NewString(), filepath.Ext(string(fixture))), 0, nil
+	// these rows obvious if anyone debugs the table. The full key is
+	// tenant-prefixed (#1793) for consistency with real uploads, even
+	// though no bucket actually receives the bytes.
+	basename := fmt.Sprintf("seed-%s%s", uuid.NewString(), filepath.Ext(string(fixture)))
+	return blobkeys.BuildSeedKey(tenantID, basename), 0, nil
 }
 
 func (*noopUploader) close() {}
@@ -110,12 +119,13 @@ type bucketUploader struct {
 	bucket *blob.Bucket
 }
 
-func (u *bucketUploader) upload(ctx context.Context, fixture fixtureKind) (string, int64, error) {
+func (u *bucketUploader) upload(ctx context.Context, fixture fixtureKind, tenantID string) (string, int64, error) {
 	data, err := fixturesFS.ReadFile(string(fixture))
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to read fixture %s: %w", fixture, err)
 	}
-	storagePath := fmt.Sprintf("seed-%s%s", uuid.NewString(), filepath.Ext(string(fixture)))
+	basename := fmt.Sprintf("seed-%s%s", uuid.NewString(), filepath.Ext(string(fixture)))
+	storagePath := blobkeys.BuildSeedKey(tenantID, basename)
 	w, err := u.bucket.NewWriter(ctx, storagePath, nil)
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to open bucket writer for %s: %w", storagePath, err)

--- a/go/debug/seeddata/seeddata_inventory.go
+++ b/go/debug/seeddata/seeddata_inventory.go
@@ -780,7 +780,7 @@ func attachLocationFile(ctx context.Context, set *registry.Set, uploader blobUpl
 }
 
 func attachFile(ctx context.Context, args attachArgs, linkedEntityType, linkedEntityID string) (string, error) {
-	storagePath, size, err := args.Uploader.upload(ctx, args.Fixture)
+	storagePath, size, err := args.Uploader.upload(ctx, args.Fixture, args.User.TenantID)
 	if err != nil {
 		return "", err
 	}

--- a/go/integration/thumbnail_generation_integration_test.go
+++ b/go/integration/thumbnail_generation_integration_test.go
@@ -62,6 +62,7 @@ func TestThumbnailGenerationIntegration(t *testing.T) {
 	fileEntity := &models.FileEntity{
 		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
 			EntityID: models.EntityID{ID: "test-file-123"},
+			TenantID: testUser.TenantID,
 		},
 		Type: models.FileTypeImage,
 		File: &models.File{
@@ -77,7 +78,7 @@ func TestThumbnailGenerationIntegration(t *testing.T) {
 
 	// Step 3: Verify thumbnails were created in storage
 	t.Log("🔍 Verifying thumbnails in storage...")
-	verifyThumbnailsInStorage(c, ctx, uploadLocation, originalPath, fileService)
+	verifyThumbnailsInStorage(c, ctx, uploadLocation, originalPath, fileEntity.TenantID, fileService)
 
 	// Step 4: Test signed URL generation with thumbnails
 	t.Log("🔗 Testing signed URL generation with thumbnails...")
@@ -85,7 +86,7 @@ func TestThumbnailGenerationIntegration(t *testing.T) {
 
 	// Step 5: Test thumbnail cleanup
 	t.Log("🗑️ Testing thumbnail cleanup...")
-	verifyThumbnailCleanup(c, ctx, uploadLocation, fileEntity.ID, originalPath, fileService)
+	verifyThumbnailCleanup(c, ctx, uploadLocation, fileEntity.TenantID, fileEntity.ID, originalPath, fileService)
 
 	t.Log("✅ Thumbnail integration test completed successfully!")
 }
@@ -126,14 +127,14 @@ func createTestImageFile(c *qt.C, ctx context.Context, uploadLocation string) st
 }
 
 // verifyThumbnailsInStorage checks that thumbnail files exist in blob storage
-func verifyThumbnailsInStorage(c *qt.C, ctx context.Context, uploadLocation, originalPath string, fileService *services.FileService) {
+func verifyThumbnailsInStorage(c *qt.C, ctx context.Context, uploadLocation, originalPath, tenantID string, fileService *services.FileService) {
 	b, err := blob.OpenBucket(ctx, uploadLocation)
 	c.Assert(err, qt.IsNil)
 	defer b.Close()
 
 	// Check that thumbnails exist - use the file ID from the file entity
 	testFileID := "test-file-123" // This matches the ID in the fileEntity above
-	thumbnailPaths := fileService.GetThumbnailPaths(testFileID)
+	thumbnailPaths := fileService.GetThumbnailPaths(tenantID, testFileID)
 
 	c.Assert(thumbnailPaths, qt.HasLen, 2) // small and medium
 
@@ -178,9 +179,9 @@ func verifySignedURLGeneration(c *qt.C, fileSigningService *services.FileSigning
 }
 
 // verifyThumbnailCleanup tests that thumbnails are deleted when using the file service
-func verifyThumbnailCleanup(c *qt.C, ctx context.Context, uploadLocation, fileID, originalPath string, fileService *services.FileService) {
+func verifyThumbnailCleanup(c *qt.C, ctx context.Context, uploadLocation, tenantID, fileID, originalPath string, fileService *services.FileService) {
 	// Get thumbnail paths before deletion
-	thumbnailPaths := fileService.GetThumbnailPaths(fileID)
+	thumbnailPaths := fileService.GetThumbnailPaths(tenantID, fileID)
 
 	// Verify thumbnails exist before cleanup
 	b, err := blob.OpenBucket(ctx, uploadLocation)

--- a/go/internal/blobkeys/blobkeys.go
+++ b/go/internal/blobkeys/blobkeys.go
@@ -64,6 +64,25 @@ func TenantPrefix(tenantID string) string {
 	return Prefix + tenantID + "/"
 }
 
+// sanitizeSegment defence-in-depth-normalises a single per-call
+// basename or identifier so the resulting blob key cannot escape the
+// tenant namespace under any backend's traversal rules. Replaces
+// `/`, `\`, and the `..` traversal token with `_`.
+//
+// Callers normally feed already-sanitized strings (`filekit.UploadFileName`,
+// `textutils.CleanFilename`, server-minted UUIDs); this is the structural
+// safety net so a future caller that bypasses upstream sanitisation
+// cannot punch a hole in the tenant namespace through these helpers.
+func sanitizeSegment(s string) string {
+	if s == "" {
+		return s
+	}
+	s = strings.ReplaceAll(s, "\\", "_")
+	s = strings.ReplaceAll(s, "/", "_")
+	s = strings.ReplaceAll(s, "..", "_")
+	return s
+}
+
 // BuildFileBlobKey produces the canonical blob key for an original file
 // upload: `t/<tenant>/files/<file-id><ext>`. The extension argument is
 // expected to start with a dot (".pdf", ".jpg"); an empty string is
@@ -73,7 +92,10 @@ func TenantPrefix(tenantID string) string {
 // the key is stable across renames and cannot be guessed from a Path
 // the operator might choose.
 func BuildFileBlobKey(tenantID, fileID, ext string) string {
-	return fmt.Sprintf("%s%s/%s/%s%s", Prefix, tenantID, FilesSegment, fileID, ext)
+	return fmt.Sprintf("%s%s/%s/%s%s",
+		Prefix, tenantID, FilesSegment,
+		sanitizeSegment(fileID), sanitizeSegment(ext),
+	)
 }
 
 // BuildFileUploadKey is the upload-time variant of BuildFileBlobKey for
@@ -90,7 +112,7 @@ func BuildFileBlobKey(tenantID, fileID, ext string) string {
 // (`t/<tenant>/files/<basename>`) so readers don't care which writer
 // minted the row.
 func BuildFileUploadKey(tenantID, basename string) string {
-	return fmt.Sprintf("%s%s/%s/%s", Prefix, tenantID, FilesSegment, basename)
+	return fmt.Sprintf("%s%s/%s/%s", Prefix, tenantID, FilesSegment, sanitizeSegment(basename))
 }
 
 // BuildThumbnailBlobKey produces the canonical blob key for a derived
@@ -98,7 +120,10 @@ func BuildFileUploadKey(tenantID, basename string) string {
 // thumbnails are JPEG regardless of the source format — the file
 // service re-encodes during generation.
 func BuildThumbnailBlobKey(tenantID, fileID, size string) string {
-	return fmt.Sprintf("%s%s/%s/%s_%s.jpg", Prefix, tenantID, ThumbnailsSegment, fileID, size)
+	return fmt.Sprintf("%s%s/%s/%s_%s.jpg",
+		Prefix, tenantID, ThumbnailsSegment,
+		sanitizeSegment(fileID), sanitizeSegment(size),
+	)
 }
 
 // BuildExportBlobKey produces the canonical blob key for a generated
@@ -108,7 +133,8 @@ func BuildThumbnailBlobKey(tenantID, fileID, size string) string {
 func BuildExportBlobKey(tenantID, exportType, timestamp string) string {
 	return fmt.Sprintf("%s%s/%s/export_%s_%s.xml",
 		Prefix, tenantID, ExportsSegment,
-		strings.ToLower(exportType), timestamp,
+		sanitizeSegment(strings.ToLower(exportType)),
+		sanitizeSegment(timestamp),
 	)
 }
 
@@ -118,7 +144,7 @@ func BuildExportBlobKey(tenantID, exportType, timestamp string) string {
 // be sanitized (the upload pipeline runs every name through
 // filekit.UploadFileName before reaching us).
 func BuildRestoreUploadKey(tenantID, filename string) string {
-	return fmt.Sprintf("%s%s/%s/%s", Prefix, tenantID, RestoresSegment, filename)
+	return fmt.Sprintf("%s%s/%s/%s", Prefix, tenantID, RestoresSegment, sanitizeSegment(filename))
 }
 
 // BuildSeedKey produces the canonical blob key for a demo / seed
@@ -129,7 +155,7 @@ func BuildRestoreUploadKey(tenantID, filename string) string {
 // `seedBasename` is the seed-internal name (e.g. `seed-<uuid>.jpg`)
 // that the noopUploader / bucketUploader generates.
 func BuildSeedKey(tenantID, seedBasename string) string {
-	return fmt.Sprintf("%s%s/%s", Prefix, tenantID, seedBasename)
+	return fmt.Sprintf("%s%s/%s", Prefix, tenantID, sanitizeSegment(seedBasename))
 }
 
 // HasTenantPrefix reports whether the given blob key already lives

--- a/go/internal/blobkeys/blobkeys.go
+++ b/go/internal/blobkeys/blobkeys.go
@@ -195,14 +195,27 @@ func RewriteForTenant(legacyKey, tenantID string) string {
 	}
 	switch {
 	case strings.HasPrefix(legacyKey, ExportsSegment+"/"):
-		return Prefix + tenantID + "/" + legacyKey
+		return sanitizeRewritten(Prefix + tenantID + "/" + legacyKey)
 	case strings.HasPrefix(legacyKey, ThumbnailsSegment+"/"):
-		return Prefix + tenantID + "/" + legacyKey
+		return sanitizeRewritten(Prefix + tenantID + "/" + legacyKey)
 	case strings.HasPrefix(legacyKey, FilesSegment+"/"):
-		return Prefix + tenantID + "/" + legacyKey
+		return sanitizeRewritten(Prefix + tenantID + "/" + legacyKey)
 	case strings.HasPrefix(legacyKey, RestoresSegment+"/"):
-		return Prefix + tenantID + "/" + legacyKey
+		return sanitizeRewritten(Prefix + tenantID + "/" + legacyKey)
 	default:
-		return Prefix + tenantID + "/" + FilesSegment + "/" + legacyKey
+		return sanitizeRewritten(Prefix + tenantID + "/" + FilesSegment + "/" + legacyKey)
 	}
+}
+
+// sanitizeRewritten is the rewrite-side counterpart of sanitizeSegment:
+// it strips traversal tokens (`..`, backslash) from a key the rewriter
+// just produced while preserving the forward slashes that segment the
+// canonical layout (`t/<tenant>/exports/...`). Restore imports XML keys
+// that are attacker-controllable, so a malicious `originalPath` like
+// `t/other/../../escape` must not become a key that resolves outside
+// `t/<importer>/` on a filesystem-backed bucket.
+func sanitizeRewritten(s string) string {
+	s = strings.ReplaceAll(s, "\\", "_")
+	s = strings.ReplaceAll(s, "..", "_")
+	return s
 }

--- a/go/internal/blobkeys/blobkeys.go
+++ b/go/internal/blobkeys/blobkeys.go
@@ -1,0 +1,182 @@
+// Package blobkeys is the single source of truth for the layout of blob
+// storage keys inside the upload bucket.
+//
+// Every blob key written by the application MUST be produced by one of
+// the BuildXxx helpers below. The keys are tenant-prefixed so that a row
+// in tenant A physically cannot reference a blob owned by tenant B —
+// defence-in-depth on top of the row-level RLS that already prevents
+// cross-tenant SELECT/UPDATE. See issue #1793 for the threat model and
+// PR #1810 / #1823 for the predecessor work this hardens.
+//
+// Layout:
+//
+//	t/<tenant>/files/<file-id><ext>             — original uploaded file
+//	t/<tenant>/thumbnails/<file-id>_<size>.jpg  — derived thumbnail (JPEG)
+//	t/<tenant>/exports/export_<type>_<ts>.xml   — exported XML bundle
+//	t/<tenant>/restores/<filename>              — uploaded XML for restore
+//	t/<tenant>/seed-<uuid><ext>                 — demo / seed fixtures
+//
+// The tenant is always supplied by server-side context (the authenticated
+// user's TenantID, or — for cross-tenant background workers — the tenant
+// the operation is performing work on). A caller MUST NOT plumb a tenant
+// value derived from request input through these helpers.
+//
+// Backwards compatibility: HasTenantPrefix detects legacy flat keys
+// (those that pre-date this package) so the migration backfill can decide
+// whether to rewrite a row. Readers are intentionally NOT tenant-aware —
+// they take whatever string the database hands them and ask the bucket
+// for it. That keeps the legacy → prefixed transition forward-only and
+// idempotent: a row that was already rewritten reads itself unchanged;
+// a row that was not stays readable at its legacy key until backfill
+// touches it.
+package blobkeys
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Prefix is the per-tenant namespace root inside the bucket. Stable —
+// changing it would invalidate every existing key in deployed buckets.
+const Prefix = "t/"
+
+// FilesSegment is the per-tenant subfolder for original uploaded files.
+const FilesSegment = "files"
+
+// ThumbnailsSegment is the per-tenant subfolder for derived thumbnails.
+const ThumbnailsSegment = "thumbnails"
+
+// ExportsSegment is the per-tenant subfolder for generated export XML
+// bundles.
+const ExportsSegment = "exports"
+
+// RestoresSegment is the per-tenant subfolder for uploaded restore XML
+// files.
+const RestoresSegment = "restores"
+
+// TenantPrefix returns the bucket-relative root for a single tenant —
+// `t/<tenant>/`. Callers that need to enumerate or sweep blobs for a
+// tenant use this with the bucket's List operation.
+func TenantPrefix(tenantID string) string {
+	if tenantID == "" {
+		return ""
+	}
+	return Prefix + tenantID + "/"
+}
+
+// BuildFileBlobKey produces the canonical blob key for an original file
+// upload: `t/<tenant>/files/<file-id><ext>`. The extension argument is
+// expected to start with a dot (".pdf", ".jpg"); an empty string is
+// allowed for files whose MIME type carries no canonical extension.
+//
+// fileID is the FileEntity row ID, not the user-supplied filename, so
+// the key is stable across renames and cannot be guessed from a Path
+// the operator might choose.
+func BuildFileBlobKey(tenantID, fileID, ext string) string {
+	return fmt.Sprintf("%s%s/%s/%s%s", Prefix, tenantID, FilesSegment, fileID, ext)
+}
+
+// BuildFileUploadKey is the upload-time variant of BuildFileBlobKey for
+// flows that mint the per-blob basename *before* the FileEntity row
+// exists (the multipart upload handler is the canonical example: it
+// writes the bucket from a streaming middleware that doesn't have a
+// row ID yet, only the filekit.UploadFileName-sanitized basename).
+//
+// `basename` already carries its own extension and uniqueness suffix —
+// callers MUST NOT pass a user-supplied filename here; sanitize first
+// via filekit.UploadFileName so the on-disk key is collision-resistant.
+//
+// The key shape is identical to BuildFileBlobKey
+// (`t/<tenant>/files/<basename>`) so readers don't care which writer
+// minted the row.
+func BuildFileUploadKey(tenantID, basename string) string {
+	return fmt.Sprintf("%s%s/%s/%s", Prefix, tenantID, FilesSegment, basename)
+}
+
+// BuildThumbnailBlobKey produces the canonical blob key for a derived
+// thumbnail: `t/<tenant>/thumbnails/<file-id>_<size>.jpg`. All
+// thumbnails are JPEG regardless of the source format — the file
+// service re-encodes during generation.
+func BuildThumbnailBlobKey(tenantID, fileID, size string) string {
+	return fmt.Sprintf("%s%s/%s/%s_%s.jpg", Prefix, tenantID, ThumbnailsSegment, fileID, size)
+}
+
+// BuildExportBlobKey produces the canonical blob key for a generated
+// export bundle: `t/<tenant>/exports/export_<type>_<timestamp>.xml`.
+// `exportType` is lowercased so the resulting key is stable across the
+// casing used by callers.
+func BuildExportBlobKey(tenantID, exportType, timestamp string) string {
+	return fmt.Sprintf("%s%s/%s/export_%s_%s.xml",
+		Prefix, tenantID, ExportsSegment,
+		strings.ToLower(exportType), timestamp,
+	)
+}
+
+// BuildRestoreUploadKey produces the canonical blob key for an XML
+// backup file uploaded as part of a restore operation:
+// `t/<tenant>/restores/<filename>`. `filename` is expected to already
+// be sanitized (the upload pipeline runs every name through
+// filekit.UploadFileName before reaching us).
+func BuildRestoreUploadKey(tenantID, filename string) string {
+	return fmt.Sprintf("%s%s/%s/%s", Prefix, tenantID, RestoresSegment, filename)
+}
+
+// BuildSeedKey produces the canonical blob key for a demo / seed
+// fixture: `t/<tenant>/seed-<uuid><ext>`. The seed package owns the
+// uuid+ext combination — this helper just sticks the tenant prefix in
+// front so the seed corpus is namespaced the same as everything else.
+//
+// `seedBasename` is the seed-internal name (e.g. `seed-<uuid>.jpg`)
+// that the noopUploader / bucketUploader generates.
+func BuildSeedKey(tenantID, seedBasename string) string {
+	return fmt.Sprintf("%s%s/%s", Prefix, tenantID, seedBasename)
+}
+
+// HasTenantPrefix reports whether the given blob key already lives
+// under the per-tenant namespace (i.e. it was written after this
+// package shipped). Used by the backfill to skip rows that are already
+// prefixed.
+func HasTenantPrefix(blobKey string) bool {
+	return strings.HasPrefix(blobKey, Prefix)
+}
+
+// RewriteForTenant produces the tenant-prefixed equivalent of a legacy
+// flat key, used by the restore importer (XML emitted by an old export
+// carries flat keys, which the importer rewrites under the importing
+// tenant's namespace) and by the migration backfill (existing rows
+// carry flat keys until the bucket move completes).
+//
+// If `legacyKey` is already prefixed (`t/...`), it is returned as-is —
+// the rewrite is idempotent. Otherwise the rewrite is structural:
+//
+//	exports/export_<type>_<ts>.xml      → t/<tenant>/exports/...
+//	thumbnails/<file-id>_<size>.jpg     → t/<tenant>/thumbnails/...
+//	(anything else)                     → t/<tenant>/files/<legacyKey>
+//
+// The fallback bucket (`files/`) catches:
+//   - uploads written by filekit.UploadFileName (`<sanitized>-<ts>.<ext>`)
+//   - seed fixtures (`seed-<uuid>.<ext>`)
+//   - any other legacy shape we don't know about
+//
+// This keeps the importer + backfill able to handle arbitrary legacy
+// inputs without burning the migration over an unrecognized prefix.
+func RewriteForTenant(legacyKey, tenantID string) string {
+	if HasTenantPrefix(legacyKey) {
+		return legacyKey
+	}
+	if tenantID == "" || legacyKey == "" {
+		return legacyKey
+	}
+	switch {
+	case strings.HasPrefix(legacyKey, ExportsSegment+"/"):
+		return Prefix + tenantID + "/" + legacyKey
+	case strings.HasPrefix(legacyKey, ThumbnailsSegment+"/"):
+		return Prefix + tenantID + "/" + legacyKey
+	case strings.HasPrefix(legacyKey, FilesSegment+"/"):
+		return Prefix + tenantID + "/" + legacyKey
+	case strings.HasPrefix(legacyKey, RestoresSegment+"/"):
+		return Prefix + tenantID + "/" + legacyKey
+	default:
+		return Prefix + tenantID + "/" + FilesSegment + "/" + legacyKey
+	}
+}

--- a/go/internal/blobkeys/blobkeys_test.go
+++ b/go/internal/blobkeys/blobkeys_test.go
@@ -158,15 +158,38 @@ func TestRewriteForTenant_EmptyInputs(t *testing.T) {
 func TestKeysAlwaysCarryTenantNamespace(t *testing.T) {
 	// Structural invariant: no helper may emit a key that escapes the
 	// tenant's namespace, however absurd the inputs. This is the core
-	// defence-in-depth property issue #1793 asks for.
+	// defence-in-depth property issue #1793 asks for. Beyond the
+	// prefix check we also assert the rendered key contains no `..`
+	// traversal token — `t/<tenant>/files/../../escape.pdf` would
+	// "carry the prefix" yet resolve outside the namespace on
+	// filesystem-backed buckets.
 	c := qt.New(t)
 	tenant := "tenant-a"
 	prefix := blobkeys.TenantPrefix(tenant)
 
-	c.Assert(strings.HasPrefix(blobkeys.BuildFileBlobKey(tenant, "../../escape", ".pdf"), prefix), qt.IsTrue)
-	c.Assert(strings.HasPrefix(blobkeys.BuildFileUploadKey(tenant, "../../escape.pdf"), prefix), qt.IsTrue)
-	c.Assert(strings.HasPrefix(blobkeys.BuildThumbnailBlobKey(tenant, "../../escape", "small"), prefix), qt.IsTrue)
-	c.Assert(strings.HasPrefix(blobkeys.BuildExportBlobKey(tenant, "any", "ts"), prefix), qt.IsTrue)
-	c.Assert(strings.HasPrefix(blobkeys.BuildRestoreUploadKey(tenant, "../escape.xml"), prefix), qt.IsTrue)
-	c.Assert(strings.HasPrefix(blobkeys.BuildSeedKey(tenant, "anything"), prefix), qt.IsTrue)
+	hostileInputs := []string{
+		blobkeys.BuildFileBlobKey(tenant, "../../escape", ".pdf"),
+		blobkeys.BuildFileUploadKey(tenant, "../../escape.pdf"),
+		blobkeys.BuildThumbnailBlobKey(tenant, "../../escape", "small"),
+		blobkeys.BuildExportBlobKey(tenant, "any", "ts"),
+		blobkeys.BuildRestoreUploadKey(tenant, "../escape.xml"),
+		blobkeys.BuildSeedKey(tenant, "../etc/passwd"),
+		blobkeys.BuildFileUploadKey(tenant, `..\windows\system32\config\sam`),
+	}
+	for i, got := range hostileInputs {
+		c.Assert(strings.HasPrefix(got, prefix), qt.IsTrue,
+			qt.Commentf("[%d] %q must carry tenant prefix", i, got))
+		c.Assert(strings.Contains(got, ".."), qt.IsFalse,
+			qt.Commentf("[%d] %q must not contain traversal token", i, got))
+		c.Assert(strings.Contains(got, "\\"), qt.IsFalse,
+			qt.Commentf("[%d] %q must not contain backslash", i, got))
+		// After stripping the tenant prefix the remainder must have no
+		// further `..` segments and no backslashes — those would let a
+		// filesystem-backed bucket resolve outside `t/<tenant>/`.
+		rest := strings.TrimPrefix(got, prefix)
+		for seg := range strings.SplitSeq(rest, "/") {
+			c.Assert(seg, qt.Not(qt.Equals), "..",
+				qt.Commentf("[%d] segment %q is a traversal token", i, seg))
+		}
+	}
 }

--- a/go/internal/blobkeys/blobkeys_test.go
+++ b/go/internal/blobkeys/blobkeys_test.go
@@ -155,6 +155,38 @@ func TestRewriteForTenant_EmptyInputs(t *testing.T) {
 	c.Assert(blobkeys.RewriteForTenant("legacy.pdf", ""), qt.Equals, "legacy.pdf")
 }
 
+func TestRewriteForTenant_HostileInputs(t *testing.T) {
+	// Restore reads OriginalPath from attacker-controllable XML. A
+	// hostile foreign-tenant key like `t/other/../../escape` must not
+	// land at a path that resolves outside the importing tenant's
+	// namespace on a filesystem-backed bucket. `..` tokens are
+	// neutralised; structural slashes survive.
+	tenant := "importer"
+	prefix := blobkeys.TenantPrefix(tenant)
+
+	tests := []struct {
+		name, legacy string
+	}{
+		{"flat traversal", "../../escape.pdf"},
+		{"exports traversal", "exports/../../../escape.xml"},
+		{"thumbnails traversal", "thumbnails/file-1/../../../../escape.jpg"},
+		{"backslash traversal", `..\windows\..\..\escape`},
+		{"flat with embedded ..", "uploaded..file.pdf"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := blobkeys.RewriteForTenant(tc.legacy, tenant)
+			c.Assert(strings.HasPrefix(got, prefix), qt.IsTrue,
+				qt.Commentf("rewrite %q must carry importer prefix", tc.legacy))
+			c.Assert(got, qt.Not(qt.Contains), "..",
+				qt.Commentf("rewrite %q must not retain traversal token", tc.legacy))
+			c.Assert(got, qt.Not(qt.Contains), `\`,
+				qt.Commentf("rewrite %q must not retain backslash", tc.legacy))
+		})
+	}
+}
+
 func TestKeysAlwaysCarryTenantNamespace(t *testing.T) {
 	// Structural invariant: no helper may emit a key that escapes the
 	// tenant's namespace, however absurd the inputs. This is the core

--- a/go/internal/blobkeys/blobkeys_test.go
+++ b/go/internal/blobkeys/blobkeys_test.go
@@ -1,0 +1,172 @@
+package blobkeys_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/internal/blobkeys"
+)
+
+func TestTenantPrefix(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(blobkeys.TenantPrefix("tenant-a"), qt.Equals, "t/tenant-a/")
+	c.Assert(blobkeys.TenantPrefix(""), qt.Equals, "")
+}
+
+func TestBuildFileBlobKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		tenant   string
+		fileID   string
+		ext      string
+		expected string
+	}{
+		{"with extension", "tenant-a", "file-1", ".pdf", "t/tenant-a/files/file-1.pdf"},
+		{"jpeg extension", "tenant-a", "file-2", ".jpg", "t/tenant-a/files/file-2.jpg"},
+		{"empty extension", "tenant-a", "file-3", "", "t/tenant-a/files/file-3"},
+		{"uuid file id", "tenant-a", "f47ac10b-58cc-4372-a567-0e02b2c3d479", ".png",
+			"t/tenant-a/files/f47ac10b-58cc-4372-a567-0e02b2c3d479.png"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := blobkeys.BuildFileBlobKey(tc.tenant, tc.fileID, tc.ext)
+			c.Assert(got, qt.Equals, tc.expected)
+			c.Assert(strings.HasPrefix(got, "t/"+tc.tenant+"/"), qt.IsTrue,
+				qt.Commentf("key must carry tenant prefix"))
+		})
+	}
+}
+
+func TestBuildFileUploadKey(t *testing.T) {
+	c := qt.New(t)
+	got := blobkeys.BuildFileUploadKey("tenant-a", "my-photo-1748000000.jpg")
+	c.Assert(got, qt.Equals, "t/tenant-a/files/my-photo-1748000000.jpg")
+}
+
+func TestBuildThumbnailBlobKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		tenant   string
+		fileID   string
+		size     string
+		expected string
+	}{
+		{"small thumb", "tenant-a", "file-1", "small", "t/tenant-a/thumbnails/file-1_small.jpg"},
+		{"medium thumb", "tenant-a", "file-2", "medium", "t/tenant-a/thumbnails/file-2_medium.jpg"},
+		{"uuid file id", "tenant-a", "f47ac10b-58cc-4372-a567-0e02b2c3d479", "small",
+			"t/tenant-a/thumbnails/f47ac10b-58cc-4372-a567-0e02b2c3d479_small.jpg"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := blobkeys.BuildThumbnailBlobKey(tc.tenant, tc.fileID, tc.size)
+			c.Assert(got, qt.Equals, tc.expected)
+			c.Assert(strings.HasSuffix(got, ".jpg"), qt.IsTrue,
+				qt.Commentf("all thumbnails are JPEG"))
+		})
+	}
+}
+
+func TestBuildExportBlobKey(t *testing.T) {
+	c := qt.New(t)
+	got := blobkeys.BuildExportBlobKey("tenant-a", "full_database", "20260523_120000")
+	c.Assert(got, qt.Equals, "t/tenant-a/exports/export_full_database_20260523_120000.xml")
+}
+
+func TestBuildExportBlobKey_LowercasesType(t *testing.T) {
+	c := qt.New(t)
+	got := blobkeys.BuildExportBlobKey("tenant-a", "COMMODITIES", "20260523_120000")
+	c.Assert(got, qt.Equals, "t/tenant-a/exports/export_commodities_20260523_120000.xml")
+}
+
+func TestBuildRestoreUploadKey(t *testing.T) {
+	c := qt.New(t)
+	got := blobkeys.BuildRestoreUploadKey("tenant-a", "backup-1748000000.xml")
+	c.Assert(got, qt.Equals, "t/tenant-a/restores/backup-1748000000.xml")
+}
+
+func TestBuildSeedKey(t *testing.T) {
+	c := qt.New(t)
+	got := blobkeys.BuildSeedKey("tenant-a", "seed-12345.jpg")
+	c.Assert(got, qt.Equals, "t/tenant-a/seed-12345.jpg")
+}
+
+func TestHasTenantPrefix(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected bool
+	}{
+		{"t/tenant-a/files/x.pdf", true},
+		{"t/tenant-a/thumbnails/x_small.jpg", true},
+		{"files/x.pdf", false},
+		{"thumbnails/x_small.jpg", false},
+		{"exports/export_full_database_20260523_120000.xml", false},
+		{"", false},
+		{"seed-12345.jpg", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.key, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(blobkeys.HasTenantPrefix(tc.key), qt.Equals, tc.expected)
+		})
+	}
+}
+
+func TestRewriteForTenant_Idempotent(t *testing.T) {
+	c := qt.New(t)
+	already := "t/tenant-a/files/file-1.pdf"
+	c.Assert(blobkeys.RewriteForTenant(already, "tenant-b"), qt.Equals, already)
+}
+
+func TestRewriteForTenant_LegacyKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		legacy   string
+		tenant   string
+		expected string
+	}{
+		{"legacy export", "exports/export_full_database_20260523.xml", "tenant-a",
+			"t/tenant-a/exports/export_full_database_20260523.xml"},
+		{"legacy thumbnail", "thumbnails/file-1_small.jpg", "tenant-a",
+			"t/tenant-a/thumbnails/file-1_small.jpg"},
+		{"legacy files prefix", "files/x.pdf", "tenant-a",
+			"t/tenant-a/files/x.pdf"},
+		{"legacy restore", "restores/backup.xml", "tenant-a",
+			"t/tenant-a/restores/backup.xml"},
+		{"legacy upload (filekit name)", "my-receipt-1748000000.pdf", "tenant-a",
+			"t/tenant-a/files/my-receipt-1748000000.pdf"},
+		{"legacy seed fixture", "seed-12345.jpg", "tenant-a",
+			"t/tenant-a/files/seed-12345.jpg"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(blobkeys.RewriteForTenant(tc.legacy, tc.tenant), qt.Equals, tc.expected)
+		})
+	}
+}
+
+func TestRewriteForTenant_EmptyInputs(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(blobkeys.RewriteForTenant("", "tenant-a"), qt.Equals, "")
+	c.Assert(blobkeys.RewriteForTenant("legacy.pdf", ""), qt.Equals, "legacy.pdf")
+}
+
+func TestKeysAlwaysCarryTenantNamespace(t *testing.T) {
+	// Structural invariant: no helper may emit a key that escapes the
+	// tenant's namespace, however absurd the inputs. This is the core
+	// defence-in-depth property issue #1793 asks for.
+	c := qt.New(t)
+	tenant := "tenant-a"
+	prefix := blobkeys.TenantPrefix(tenant)
+
+	c.Assert(strings.HasPrefix(blobkeys.BuildFileBlobKey(tenant, "../../escape", ".pdf"), prefix), qt.IsTrue)
+	c.Assert(strings.HasPrefix(blobkeys.BuildFileUploadKey(tenant, "../../escape.pdf"), prefix), qt.IsTrue)
+	c.Assert(strings.HasPrefix(blobkeys.BuildThumbnailBlobKey(tenant, "../../escape", "small"), prefix), qt.IsTrue)
+	c.Assert(strings.HasPrefix(blobkeys.BuildExportBlobKey(tenant, "any", "ts"), prefix), qt.IsTrue)
+	c.Assert(strings.HasPrefix(blobkeys.BuildRestoreUploadKey(tenant, "../escape.xml"), prefix), qt.IsTrue)
+	c.Assert(strings.HasPrefix(blobkeys.BuildSeedKey(tenant, "anything"), prefix), qt.IsTrue)
+}

--- a/go/internal/blobkeys/blobkeys_test.go
+++ b/go/internal/blobkeys/blobkeys_test.go
@@ -179,9 +179,9 @@ func TestKeysAlwaysCarryTenantNamespace(t *testing.T) {
 	for i, got := range hostileInputs {
 		c.Assert(strings.HasPrefix(got, prefix), qt.IsTrue,
 			qt.Commentf("[%d] %q must carry tenant prefix", i, got))
-		c.Assert(strings.Contains(got, ".."), qt.IsFalse,
+		c.Assert(got, qt.Not(qt.Contains), "..",
 			qt.Commentf("[%d] %q must not contain traversal token", i, got))
-		c.Assert(strings.Contains(got, "\\"), qt.IsFalse,
+		c.Assert(got, qt.Not(qt.Contains), `\`,
 			qt.Commentf("[%d] %q must not contain backslash", i, got))
 		// After stripping the tenant prefix the remainder must have no
 		// further `..` segments and no backslashes — those would let a

--- a/go/models/models.go
+++ b/go/models/models.go
@@ -94,18 +94,19 @@ func (*File) Validate() error {
 // intentionally empty placeholders — the blob doesn't exist yet — and
 // only become populated by the server-side upload handler. The earlier
 // `Required` rules on Path / OriginalPath / Ext / MIMEType were
-// effectively dead anyway (FileEntity.ValidateWithContext validates the
-// pointer is non-nil but never recurses into File.ValidateWithContext)
-// AND would have rejected the new metadata-only create path.
+// unreachable in production: no code path currently invokes
+// `FileEntity.ValidateWithContext` (the JSON-API binder validates the
+// outer request DTO, not the entity), so the rules — which jellydator
+// *would* cascade into here via the inner `ValidatableWithContext`
+// interface — never fired. They would also have rejected the new
+// metadata-only create path the moment any caller did wire validation
+// in. Dropping them removes the misleading shape contract.
 //
-// The cascade is intentionally not wired up: keeping File validation a
-// pure metadata-shape check (Length on title-like fields, here a no-op
-// because none currently apply) means an unpopulated File literal
-// passes, matching the createFile handler's lifecycle expectations.
-// If a future field carries shape constraints (max length, enum), they
-// go here and the cascade can stay off.
-func (i *File) ValidateWithContext(_ context.Context) error {
-	_ = i
+// The no-op stays as a hook: when a future field carries a shape
+// constraint (max length, enum), it goes here and the cascade lights
+// up automatically the first time something validates the outer
+// FileEntity.
+func (*File) ValidateWithContext(_ context.Context) error {
 	return nil
 }
 

--- a/go/models/models.go
+++ b/go/models/models.go
@@ -87,17 +87,26 @@ func (*File) Validate() error {
 	return ErrMustUseValidateWithContext
 }
 
-func (i *File) ValidateWithContext(ctx context.Context) error {
-	fields := make([]*validation.FieldRules, 0)
-
-	fields = append(fields,
-		validation.Field(&i.Path, validation.Required),
-		validation.Field(&i.OriginalPath, validation.Required),
-		validation.Field(&i.Ext, validation.Required),
-		validation.Field(&i.MIMEType, validation.Required),
-	)
-
-	return validation.ValidateStructWithContext(ctx, i, fields...)
+// ValidateWithContext validates the per-blob metadata sub-struct.
+//
+// The post-#1779 / post-#1793 contract is that File rows go through two
+// lifecycle phases: at row-create time (POST /files) the fields are
+// intentionally empty placeholders — the blob doesn't exist yet — and
+// only become populated by the server-side upload handler. The earlier
+// `Required` rules on Path / OriginalPath / Ext / MIMEType were
+// effectively dead anyway (FileEntity.ValidateWithContext validates the
+// pointer is non-nil but never recurses into File.ValidateWithContext)
+// AND would have rejected the new metadata-only create path.
+//
+// The cascade is intentionally not wired up: keeping File validation a
+// pure metadata-shape check (Length on title-like fields, here a no-op
+// because none currently apply) means an unpopulated File literal
+// passes, matching the createFile handler's lifecycle expectations.
+// If a future field carries shape constraints (max length, enum), they
+// go here and the cascade can stay off.
+func (i *File) ValidateWithContext(_ context.Context) error {
+	_ = i
+	return nil
 }
 
 // FileType represents the type/category of a file

--- a/go/models/models_test.go
+++ b/go/models/models_test.go
@@ -20,7 +20,7 @@ func TestFile_Validate(t *testing.T) {
 }
 
 func TestFile_ValidateWithContext_HappyPath(t *testing.T) {
-	t.Run("valid file", func(t *testing.T) {
+	t.Run("fully populated file", func(t *testing.T) {
 		c := qt.New(t)
 
 		file := models.File{
@@ -34,51 +34,21 @@ func TestFile_ValidateWithContext_HappyPath(t *testing.T) {
 		err := file.ValidateWithContext(ctx)
 		c.Assert(err, qt.IsNil)
 	})
-}
 
-func TestFile_ValidateWithContext_UnhappyPaths(t *testing.T) {
-	testCases := []struct {
-		name          string
-		file          models.File
-		errorContains string
-	}{
-		{
-			name:          "missing path",
-			file:          models.File{OriginalPath: "test.pdf", Ext: ".pdf", MIMEType: "application/pdf"},
-			errorContains: "path: cannot be blank",
-		},
-		{
-			name:          "missing original path",
-			file:          models.File{Path: "test", Ext: ".pdf", MIMEType: "application/pdf"},
-			errorContains: "original_path: cannot be blank",
-		},
-		{
-			name:          "missing extension",
-			file:          models.File{Path: "test", OriginalPath: "test.pdf", MIMEType: "application/pdf"},
-			errorContains: "ext: cannot be blank",
-		},
-		{
-			name:          "missing MIME type",
-			file:          models.File{Path: "test", OriginalPath: "test.pdf", Ext: ".pdf"},
-			errorContains: "mime_type: cannot be blank",
-		},
-		{
-			name:          "empty file",
-			file:          models.File{},
-			errorContains: "path: cannot be blank",
-		},
-	}
+	// Post-#1779 createFile writes an empty File until the upload
+	// handler populates it. Validation must accept the empty literal so
+	// the metadata-only POST /files path still goes through. The shape
+	// invariants live on FileEntity (Type / Category / linked-entity
+	// invariants), not on the File sub-struct itself.
+	t.Run("empty file passes (placeholder before upload)", func(t *testing.T) {
+		c := qt.New(t)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			c := qt.New(t)
+		file := models.File{}
 
-			ctx := context.Background()
-			err := tc.file.ValidateWithContext(ctx)
-			c.Assert(err, qt.IsNotNil)
-			c.Assert(err.Error(), qt.Contains, tc.errorContains)
-		})
-	}
+		ctx := context.Background()
+		err := file.ValidateWithContext(ctx)
+		c.Assert(err, qt.IsNil)
+	})
 }
 
 func TestFile_JSONMarshaling(t *testing.T) {

--- a/go/services/blobbackfill/blobbackfill.go
+++ b/go/services/blobbackfill/blobbackfill.go
@@ -24,6 +24,7 @@ import (
 
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"gocloud.dev/blob"
+	"gocloud.dev/gcerrors"
 
 	"github.com/denisvmedia/inventario/internal/blobkeys"
 	"github.com/denisvmedia/inventario/internal/mimekit"
@@ -101,10 +102,15 @@ func (s *Service) Run(ctx context.Context, opts Options) (*Stats, error) {
 	// during the sweep don't shift ordering because rows are updated
 	// (not deleted), and idempotency lets a re-run pick up anything we
 	// somehow missed.
+	//
+	// We stop when the page is short (`len(page) < pageSize`) instead
+	// of comparing offset against `total`. ListPaginated executes a
+	// COUNT(*) on every call to populate `total`, which would re-count
+	// the whole file table on every page for a long-running sweep.
 	const pageSize = 500
 	offset := 0
 	for {
-		page, total, err := fileReg.ListPaginated(ctx, offset, pageSize, nil, nil, nil, nil)
+		page, _, err := fileReg.ListPaginated(ctx, offset, pageSize, nil, nil, nil, nil)
 		if err != nil {
 			return nil, errxtrace.Wrap("failed to list file rows", err)
 		}
@@ -115,7 +121,7 @@ func (s *Service) Run(ctx context.Context, opts Options) (*Stats, error) {
 			s.processRow(ctx, bucket, fileReg, file, opts, logger, stats)
 		}
 		offset += len(page)
-		if offset >= total {
+		if len(page) < pageSize {
 			break
 		}
 	}
@@ -196,12 +202,18 @@ func (s *Service) processRow(
 
 	// Step 3: delete the legacy blob. Failure here is non-fatal — the
 	// row already points at the new key, so the legacy blob is
-	// unreferenced; a later sweep can clean it up.
-	if err := bucket.Delete(ctx, legacyKey); err != nil {
+	// unreferenced; a later sweep can clean it up. NotFound is the
+	// expected state on a re-run (we already deleted it last time) or
+	// on a partially-pruned bucket where copyIfAbsent took the
+	// short-circuit path, so suppress it to keep the log quiet.
+	switch err := bucket.Delete(ctx, legacyKey); {
+	case err == nil:
+		stats.BlobsDeleted++
+	case gcerrors.Code(err) == gcerrors.NotFound:
+		// Legacy blob already gone — nothing to do.
+	default:
 		logger.Warn("blobbackfill: legacy blob delete failed",
 			"file_id", file.ID, "legacy_key", legacyKey, "err", err)
-	} else {
-		stats.BlobsDeleted++
 	}
 
 	// Step 4: thumbnails.

--- a/go/services/blobbackfill/blobbackfill.go
+++ b/go/services/blobbackfill/blobbackfill.go
@@ -1,0 +1,339 @@
+// Package blobbackfill walks every FileEntity row in the database and
+// migrates its physical blob (and, for images, its thumbnails) into the
+// per-tenant namespace introduced by issue #1793.
+//
+// The migration is idempotent and copy-first: each row is examined; if
+// its OriginalPath is already tenant-prefixed (`t/...`) the row is
+// skipped, otherwise the original blob is copied to the new key, the
+// row is updated, the legacy blob is deleted, and the thumbnail keys
+// are migrated the same way. An interrupted run leaves rows in either
+// the legacy or the migrated state — re-running picks up where it
+// left off without clobbering the rows it has already touched.
+//
+// The package deliberately depends only on the service-mode file
+// registry: backfilling is a cross-tenant background operation and
+// must NOT be filtered by RLS.
+package blobbackfill
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"gocloud.dev/blob"
+
+	"github.com/denisvmedia/inventario/internal/blobkeys"
+	"github.com/denisvmedia/inventario/internal/mimekit"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// Stats records the per-run outcome for the operator. Zero values are
+// the expected steady state once the migration has run once across
+// every row.
+type Stats struct {
+	RowsScanned      int
+	RowsAlreadyMoved int
+	RowsMoved        int
+	RowsSkippedNoKey int
+	RowsErrored      int
+	ThumbsMoved      int
+	ThumbsMissing    int
+	BlobsCopied      int
+	BlobsDeleted     int
+}
+
+// Options configures a backfill run.
+type Options struct {
+	// DryRun reports what would change without touching the bucket or
+	// any row. Recommended for the first invocation in a new env.
+	DryRun bool
+	// Logger receives per-row diagnostics. Use slog.Default() to fall
+	// through to the process-wide handler.
+	Logger *slog.Logger
+}
+
+// Service is the entry point for the backfill workflow. Bind it to a
+// service-mode FactorySet (the user-mode registry would only see one
+// tenant at a time, which is the opposite of what the backfill needs).
+type Service struct {
+	factorySet     *registry.FactorySet
+	uploadLocation string
+}
+
+// New constructs a backfill service. The supplied uploadLocation must
+// match the running server's upload bucket — the backfill walks blobs
+// directly through gocloud.dev/blob.
+func New(factorySet *registry.FactorySet, uploadLocation string) *Service {
+	return &Service{
+		factorySet:     factorySet,
+		uploadLocation: uploadLocation,
+	}
+}
+
+// Run executes the backfill. Returns aggregated Stats and an error if
+// the run aborted; per-row failures increment Stats.RowsErrored and
+// are logged but do not stop the sweep.
+func (s *Service) Run(ctx context.Context, opts Options) (*Stats, error) {
+	if s.uploadLocation == "" {
+		return nil, errors.New("upload location is required")
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	bucket, err := blob.OpenBucket(ctx, s.uploadLocation)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to open upload bucket", err)
+	}
+	defer bucket.Close()
+
+	fileReg := s.factorySet.FileRegistryFactory.CreateServiceRegistry()
+	rows, err := fileReg.List(ctx)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list file rows", err)
+	}
+
+	stats := &Stats{}
+	for _, file := range rows {
+		s.processRow(ctx, bucket, fileReg, file, opts, logger, stats)
+	}
+
+	return stats, nil
+}
+
+// processRow handles a single FileEntity row. Pulled out of Run so
+// the loop body stays inside the project's cognitive-complexity
+// budget. Mutates `stats` in place; on per-row failure increments the
+// appropriate stat counter and returns silently — failures here must
+// never abort the sweep.
+func (s *Service) processRow(
+	ctx context.Context,
+	bucket *blob.Bucket,
+	fileReg registry.FileRegistry,
+	file *models.FileEntity,
+	opts Options,
+	logger *slog.Logger,
+	stats *Stats,
+) {
+	stats.RowsScanned++
+	if file == nil || file.File == nil || file.OriginalPath == "" {
+		stats.RowsSkippedNoKey++
+		return
+	}
+	if file.TenantID == "" {
+		logger.Warn("blobbackfill: file row missing tenant id, skipped",
+			"file_id", file.ID, "blob_key", file.OriginalPath)
+		stats.RowsErrored++
+		return
+	}
+
+	legacyKey := file.OriginalPath
+
+	// Already-prefixed rows are skipped (the migration is for legacy
+	// flat keys only). Thumbnails for already-prefixed rows may still
+	// need a sweep though, so we run the thumbnail step regardless.
+	if blobkeys.HasTenantPrefix(legacyKey) {
+		stats.RowsAlreadyMoved++
+		s.maybeMigrateThumbs(ctx, bucket, file, opts.DryRun, logger, stats)
+		return
+	}
+
+	newKey := blobkeys.RewriteForTenant(legacyKey, file.TenantID)
+	if newKey == legacyKey {
+		stats.RowsAlreadyMoved++
+		return
+	}
+
+	if opts.DryRun {
+		logger.Info("blobbackfill: would move row", "file_id", file.ID, "from", legacyKey, "to", newKey)
+		stats.RowsMoved++
+		return
+	}
+
+	// Step 1: copy. If destination already exists, copyIfAbsent
+	// short-circuits — that's how interrupted runs become idempotent.
+	copied, err := copyIfAbsent(ctx, bucket, legacyKey, newKey)
+	if err != nil {
+		logger.Warn("blobbackfill: copy failed", "file_id", file.ID, "err", err)
+		stats.RowsErrored++
+		return
+	}
+	if copied {
+		stats.BlobsCopied++
+	}
+
+	// Step 2: update the row. The user-aware registry would do
+	// validation against the tenant on context; we go through the
+	// service registry to keep cross-tenant iteration cheap.
+	file.OriginalPath = newKey
+	if _, err := fileReg.Update(ctx, *file); err != nil {
+		logger.Warn("blobbackfill: row update failed", "file_id", file.ID, "err", err)
+		stats.RowsErrored++
+		return
+	}
+
+	// Step 3: delete the legacy blob. Failure here is non-fatal — the
+	// row already points at the new key, so the legacy blob is
+	// unreferenced; a later sweep can clean it up.
+	if err := bucket.Delete(ctx, legacyKey); err != nil {
+		logger.Warn("blobbackfill: legacy blob delete failed",
+			"file_id", file.ID, "legacy_key", legacyKey, "err", err)
+	} else {
+		stats.BlobsDeleted++
+	}
+
+	// Step 4: thumbnails.
+	s.maybeMigrateThumbs(ctx, bucket, file, opts.DryRun, logger, stats)
+	stats.RowsMoved++
+}
+
+// maybeMigrateThumbs is a thin wrapper around migrateThumbnailsForRow
+// that no-ops for non-image rows and folds the result into the stats.
+func (s *Service) maybeMigrateThumbs(
+	ctx context.Context,
+	bucket *blob.Bucket,
+	file *models.FileEntity,
+	dryRun bool,
+	logger *slog.Logger,
+	stats *Stats,
+) {
+	if !mimekit.IsImage(file.MIMEType) {
+		return
+	}
+	moved, missing, err := s.migrateThumbnailsForRow(ctx, bucket, thumbMigrateParams{
+		TenantID: file.TenantID,
+		FileID:   file.ID,
+		DryRun:   dryRun,
+	})
+	stats.ThumbsMoved += moved
+	stats.ThumbsMissing += missing
+	if err != nil {
+		logger.Warn("blobbackfill: thumbnail migration error", "file_id", file.ID, "err", err)
+	}
+}
+
+// thumbMigrateParams bundles the per-row thumbnail-migration arguments
+// so migrateThumbnailsForRow doesn't take a flag boolean as a
+// positional parameter (revive flag-parameter).
+type thumbMigrateParams struct {
+	TenantID string
+	FileID   string
+	DryRun   bool
+}
+
+// migrateThumbnailsForRow walks the two thumbnail sizes and migrates
+// each from the legacy flat key to the canonical tenant-prefixed key.
+// Returns (moved, missing, err). "Missing" counts each size that had
+// no blob at either the legacy or the canonical location — common for
+// rows that were uploaded but never had their thumbnails generated.
+func (s *Service) migrateThumbnailsForRow(
+	ctx context.Context,
+	bucket *blob.Bucket,
+	p thumbMigrateParams,
+) (moved, missing int, err error) {
+	sizes := []string{"small", "medium"}
+	for _, size := range sizes {
+		legacy := fmt.Sprintf("thumbnails/%s_%s.jpg", p.FileID, size)
+		canonical := blobkeys.BuildThumbnailBlobKey(p.TenantID, p.FileID, size)
+
+		didMove, didMiss, err := migrateOneThumb(ctx, bucket, thumbKeys{Legacy: legacy, Canonical: canonical, DryRun: p.DryRun})
+		if err != nil {
+			return moved, missing, err
+		}
+		moved += didMove
+		missing += didMiss
+	}
+	return moved, missing, nil
+}
+
+// thumbKeys bundles migrateOneThumb's per-size inputs so the DryRun
+// boolean isn't a positional control flag (revive flag-parameter).
+type thumbKeys struct {
+	Legacy    string
+	Canonical string
+	DryRun    bool
+}
+
+// migrateOneThumb performs the legacy → canonical migration for a
+// single thumbnail key. Extracted so migrateThumbnailsForRow stays
+// inside the project's cognitive-complexity budget.
+func migrateOneThumb(ctx context.Context, bucket *blob.Bucket, k thumbKeys) (moved, missing int, err error) {
+	canonicalExists, err := bucket.Exists(ctx, k.Canonical)
+	if err != nil {
+		return 0, 0, errxtrace.Wrap("failed to probe canonical thumbnail", err)
+	}
+	if canonicalExists {
+		// Already migrated; still try to clean up any leftover legacy blob.
+		if legacyExists, lErr := bucket.Exists(ctx, k.Legacy); lErr == nil && legacyExists && !k.DryRun {
+			_ = bucket.Delete(ctx, k.Legacy)
+		}
+		return 0, 0, nil
+	}
+
+	legacyExists, err := bucket.Exists(ctx, k.Legacy)
+	if err != nil {
+		return 0, 0, errxtrace.Wrap("failed to probe legacy thumbnail", err)
+	}
+	if !legacyExists {
+		return 0, 1, nil
+	}
+	if k.DryRun {
+		return 1, 0, nil
+	}
+
+	if _, err := copyIfAbsent(ctx, bucket, k.Legacy, k.Canonical); err != nil {
+		return 0, 0, errxtrace.Wrap("failed to copy legacy thumbnail", err)
+	}
+	_ = bucket.Delete(ctx, k.Legacy)
+	return 1, 0, nil
+}
+
+// copyIfAbsent copies from src to dst unless dst already exists.
+// Returns true if a copy happened, false otherwise. The bucket-level
+// Copy operation isn't always available on every gocloud backend so we
+// use a streaming reader→writer to stay portable.
+func copyIfAbsent(ctx context.Context, bucket *blob.Bucket, src, dst string) (bool, error) {
+	dstExists, err := bucket.Exists(ctx, dst)
+	if err != nil {
+		return false, errxtrace.Wrap("failed to probe destination", err)
+	}
+	if dstExists {
+		return false, nil
+	}
+
+	srcExists, err := bucket.Exists(ctx, src)
+	if err != nil {
+		return false, errxtrace.Wrap("failed to probe source", err)
+	}
+	if !srcExists {
+		// The row claims a blob lives here but the bucket disagrees —
+		// not an error per se (an admin may have manually pruned the
+		// bucket), just nothing to copy. The row update step still
+		// runs so the row eventually points at the canonical location.
+		return false, nil
+	}
+
+	reader, err := bucket.NewReader(ctx, src, nil)
+	if err != nil {
+		return false, errxtrace.Wrap("failed to open source reader", err)
+	}
+	defer reader.Close()
+
+	writer, err := bucket.NewWriter(ctx, dst, nil)
+	if err != nil {
+		return false, errxtrace.Wrap("failed to open destination writer", err)
+	}
+	if _, err := io.Copy(writer, reader); err != nil {
+		_ = writer.Close()
+		return false, errxtrace.Wrap("failed to copy bytes", err)
+	}
+	if err := writer.Close(); err != nil {
+		return false, errxtrace.Wrap("failed to close destination writer", err)
+	}
+	return true, nil
+}

--- a/go/services/blobbackfill/blobbackfill.go
+++ b/go/services/blobbackfill/blobbackfill.go
@@ -93,14 +93,31 @@ func (s *Service) Run(ctx context.Context, opts Options) (*Stats, error) {
 	defer bucket.Close()
 
 	fileReg := s.factorySet.FileRegistryFactory.CreateServiceRegistry()
-	rows, err := fileReg.List(ctx)
-	if err != nil {
-		return nil, errxtrace.Wrap("failed to list file rows", err)
-	}
 
 	stats := &Stats{}
-	for _, file := range rows {
-		s.processRow(ctx, bucket, fileReg, file, opts, logger, stats)
+	// Stream rows in fixed-size pages so the migration doesn't allocate
+	// the full file table at once — production deployments may have
+	// millions of rows. Pagination is offset/ID-ordered; mutations
+	// during the sweep don't shift ordering because rows are updated
+	// (not deleted), and idempotency lets a re-run pick up anything we
+	// somehow missed.
+	const pageSize = 500
+	offset := 0
+	for {
+		page, total, err := fileReg.ListPaginated(ctx, offset, pageSize, nil, nil, nil, nil)
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to list file rows", err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, file := range page {
+			s.processRow(ctx, bucket, fileReg, file, opts, logger, stats)
+		}
+		offset += len(page)
+		if offset >= total {
+			break
+		}
 	}
 
 	return stats, nil
@@ -214,6 +231,7 @@ func (s *Service) maybeMigrateThumbs(
 	stats.ThumbsMissing += missing
 	if err != nil {
 		logger.Warn("blobbackfill: thumbnail migration error", "file_id", file.ID, "err", err)
+		stats.RowsErrored++
 	}
 }
 

--- a/go/services/blobbackfill/blobbackfill_test.go
+++ b/go/services/blobbackfill/blobbackfill_test.go
@@ -1,0 +1,196 @@
+package blobbackfill_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+	"gocloud.dev/blob"
+
+	"github.com/denisvmedia/inventario/internal/blobkeys"
+	_ "github.com/denisvmedia/inventario/internal/fileblob" // register fileblob driver
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services/blobbackfill"
+)
+
+// seedRow creates a tenant + user + group + one FileEntity row whose
+// OriginalPath is a *legacy* flat blob key. The blob bytes are written
+// to the bucket so the backfill has something to copy. Returns the
+// created file id and the tenant id.
+func seedRow(c *qt.C, ctx context.Context, factorySet *registry.FactorySet, uploadLocation, legacyKey, mime string) (fileID, tenantID string) {
+	c.Helper()
+
+	tenant := must.Must(factorySet.TenantRegistry.Create(ctx, models.Tenant{
+		Name: "t1", Slug: "t1-" + legacyKey, Status: models.TenantStatusActive,
+	}))
+
+	user := must.Must(factorySet.UserRegistry.Create(ctx, models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenant.ID},
+		Email:               "u-" + legacyKey + "@example.com",
+		Name:                "u",
+		IsActive:            true,
+	}))
+
+	group := must.Must(factorySet.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenant.ID},
+		Name:                "g1",
+		Slug:                "g1-" + legacyKey,
+		CreatedBy:           user.ID,
+	}))
+
+	// The service-mode file registry skips RLS, which is what the
+	// backfill itself uses — keeps the seed and the system-under-test
+	// using the same path.
+	fileReg := factorySet.FileRegistryFactory.CreateServiceRegistry()
+	created := must.Must(fileReg.Create(ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        tenant.ID,
+			GroupID:         group.ID,
+			CreatedByUserID: user.ID,
+		},
+		Title:    "legacy",
+		Type:     models.FileTypeFromMIME(mime),
+		Category: models.FileCategoryFromContext("", "", mime),
+		Tags:     models.StringSlice{},
+		File: &models.File{
+			Path:         "legacy",
+			OriginalPath: legacyKey,
+			Ext:          ".jpg",
+			MIMEType:     mime,
+		},
+	}))
+
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	c.Assert(b.WriteAll(ctx, legacyKey, []byte{0xff, 0xd8, 0xff, 0xe0}, nil), qt.IsNil)
+	return created.ID, tenant.ID
+}
+
+func TestBackfill_RewritesLegacyFileKeys(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	factorySet := memory.NewFactorySet()
+	ctx := context.Background()
+
+	// Seed: a single FileEntity with a flat legacy OriginalPath and the
+	// corresponding bytes in the bucket.
+	fileID, tenantID := seedRow(c, ctx, factorySet, uploadLocation, "legacy-photo.jpg", "image/jpeg")
+
+	// Write legacy thumbnails too so we can assert the thumbnail
+	// migration step.
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	c.Assert(b.WriteAll(ctx, "thumbnails/"+fileID+"_small.jpg", []byte("legacy-small"), nil), qt.IsNil)
+	c.Assert(b.WriteAll(ctx, "thumbnails/"+fileID+"_medium.jpg", []byte("legacy-medium"), nil), qt.IsNil)
+	b.Close()
+
+	svc := blobbackfill.New(factorySet, uploadLocation)
+	stats, err := svc.Run(ctx, blobbackfill.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.RowsMoved, qt.Equals, 1)
+	c.Assert(stats.RowsAlreadyMoved, qt.Equals, 0)
+	c.Assert(stats.RowsErrored, qt.Equals, 0)
+	c.Assert(stats.ThumbsMoved, qt.Equals, 2)
+
+	// Row was updated.
+	fileReg := factorySet.FileRegistryFactory.CreateServiceRegistry()
+	updated := must.Must(fileReg.Get(ctx, fileID))
+	c.Assert(blobkeys.HasTenantPrefix(updated.OriginalPath), qt.IsTrue,
+		qt.Commentf("got OriginalPath %q after backfill", updated.OriginalPath))
+
+	// Bucket state: new key present, legacy key gone.
+	b2 := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b2.Close()
+	newExists := must.Must(b2.Exists(ctx, updated.OriginalPath))
+	c.Assert(newExists, qt.IsTrue)
+	legacyExists := must.Must(b2.Exists(ctx, "legacy-photo.jpg"))
+	c.Assert(legacyExists, qt.IsFalse)
+
+	// Thumbnails at the canonical keys.
+	canonicalSmall := blobkeys.BuildThumbnailBlobKey(tenantID, fileID, "small")
+	canonicalMedium := blobkeys.BuildThumbnailBlobKey(tenantID, fileID, "medium")
+	c.Assert(must.Must(b2.Exists(ctx, canonicalSmall)), qt.IsTrue)
+	c.Assert(must.Must(b2.Exists(ctx, canonicalMedium)), qt.IsTrue)
+}
+
+func TestBackfill_Idempotent(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	factorySet := memory.NewFactorySet()
+	ctx := context.Background()
+
+	_, _ = seedRow(c, ctx, factorySet, uploadLocation, "legacy-doc.pdf", "application/pdf")
+
+	svc := blobbackfill.New(factorySet, uploadLocation)
+
+	// First pass: moves the row.
+	stats1, err := svc.Run(ctx, blobbackfill.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats1.RowsMoved, qt.Equals, 1)
+
+	// Second pass: row is already prefixed, nothing to do.
+	stats2, err := svc.Run(ctx, blobbackfill.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats2.RowsMoved, qt.Equals, 0)
+	c.Assert(stats2.RowsAlreadyMoved, qt.Equals, 1)
+	c.Assert(stats2.RowsErrored, qt.Equals, 0)
+}
+
+func TestBackfill_DryRunDoesNotMutate(t *testing.T) {
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	factorySet := memory.NewFactorySet()
+	ctx := context.Background()
+
+	fileID, _ := seedRow(c, ctx, factorySet, uploadLocation, "legacy-photo.jpg", "image/jpeg")
+
+	svc := blobbackfill.New(factorySet, uploadLocation)
+	stats, err := svc.Run(ctx, blobbackfill.Options{DryRun: true})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.RowsMoved, qt.Equals, 1)
+
+	// Row unchanged.
+	fileReg := factorySet.FileRegistryFactory.CreateServiceRegistry()
+	row := must.Must(fileReg.Get(ctx, fileID))
+	c.Assert(row.OriginalPath, qt.Equals, "legacy-photo.jpg")
+
+	// Legacy blob still present.
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	defer b.Close()
+	c.Assert(must.Must(b.Exists(ctx, "legacy-photo.jpg")), qt.IsTrue)
+}
+
+func TestBackfill_SurvivesMissingBlob(t *testing.T) {
+	// A row claims a blob that the bucket doesn't have. The backfill
+	// should still update the row to the canonical key (so future
+	// uploads + reads land at the new location) and report no error.
+	c := qt.New(t)
+
+	uploadLocation := "file://" + c.TempDir() + "?create_dir=1"
+	factorySet := memory.NewFactorySet()
+	ctx := context.Background()
+
+	fileID, tenantID := seedRow(c, ctx, factorySet, uploadLocation, "missing-photo.jpg", "image/jpeg")
+
+	// Delete the seeded blob to simulate an admin-pruned bucket.
+	b := must.Must(blob.OpenBucket(ctx, uploadLocation))
+	c.Assert(b.Delete(ctx, "missing-photo.jpg"), qt.IsNil)
+	b.Close()
+
+	svc := blobbackfill.New(factorySet, uploadLocation)
+	stats, err := svc.Run(ctx, blobbackfill.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.RowsErrored, qt.Equals, 0)
+	c.Assert(stats.RowsMoved, qt.Equals, 1)
+	c.Assert(stats.BlobsCopied, qt.Equals, 0) // nothing to copy
+
+	fileReg := factorySet.FileRegistryFactory.CreateServiceRegistry()
+	row := must.Must(fileReg.Get(ctx, fileID))
+	expected := blobkeys.RewriteForTenant("missing-photo.jpg", tenantID)
+	c.Assert(row.OriginalPath, qt.Equals, expected)
+}

--- a/go/services/file_service.go
+++ b/go/services/file_service.go
@@ -13,6 +13,7 @@ import (
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"gocloud.dev/blob"
 
+	"github.com/denisvmedia/inventario/internal/blobkeys"
 	"github.com/denisvmedia/inventario/internal/mimekit"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
@@ -81,7 +82,7 @@ func (s *FileService) GenerateThumbnails(ctx context.Context, file *models.FileE
 
 	// Generate thumbnails for each size
 	for sizeName, maxSize := range s.thumbnailSizes {
-		thumbnailPath := s.getThumbnailPath(file.ID, sizeName)
+		thumbnailPath := s.getThumbnailPath(file.TenantID, file.ID, sizeName)
 
 		// Create thumbnail
 		thumbnail := s.imageProcessor.CreateThumbnail(img, maxSize)
@@ -104,18 +105,25 @@ func (s *FileService) GenerateThumbnails(ctx context.Context, file *models.FileE
 	return nil
 }
 
-// getThumbnailPath generates the thumbnail file path using file ID
-// All thumbnails are saved as JPEG files regardless of the original format
-func (s *FileService) getThumbnailPath(fileID, sizeName string) string {
-	// Use file ID for thumbnail paths to avoid conflicts with user-controlled paths
-	return fmt.Sprintf("thumbnails/%s_%s.jpg", fileID, sizeName)
+// getThumbnailPath generates the canonical tenant-prefixed thumbnail
+// blob key for the given file. All thumbnails are saved as JPEG
+// regardless of the original format. The blob key shape is owned by
+// blobkeys.BuildThumbnailBlobKey; the helper is preserved here only as
+// the FileService's single call site so the service is the single
+// derivation point for the rest of the codebase.
+func (s *FileService) getThumbnailPath(tenantID, fileID, sizeName string) string {
+	return blobkeys.BuildThumbnailBlobKey(tenantID, fileID, sizeName)
 }
 
-// GetThumbnailPaths returns the paths of all thumbnails for a given file ID
-func (s *FileService) GetThumbnailPaths(fileID string) map[string]string {
+// GetThumbnailPaths returns the canonical blob keys for every
+// thumbnail derived from the given file. Post-#1793 the keys are
+// tenant-prefixed; `tenantID` is read off the FileEntity by the
+// caller (the file row is the source of truth for which tenant owns
+// the blob).
+func (s *FileService) GetThumbnailPaths(tenantID, fileID string) map[string]string {
 	thumbnails := make(map[string]string)
 	for sizeName := range s.thumbnailSizes {
-		thumbnails[sizeName] = s.getThumbnailPath(fileID, sizeName)
+		thumbnails[sizeName] = s.getThumbnailPath(tenantID, fileID, sizeName)
 	}
 	return thumbnails
 }
@@ -135,7 +143,7 @@ func (s *FileService) DeleteFileWithPhysical(ctx context.Context, fileID string)
 
 	// Delete the physical file and thumbnails if they exist
 	if file.File != nil && file.File.OriginalPath != "" {
-		if err := s.deletePhysicalFileAndThumbnails(ctx, fileID, file.File.OriginalPath, file.File.MIMEType); err != nil {
+		if err := s.deletePhysicalFileAndThumbnails(ctx, file.TenantID, fileID, file.File.OriginalPath, file.File.MIMEType); err != nil {
 			return errxtrace.Wrap("failed to delete physical file and thumbnails", err)
 		}
 	}
@@ -182,15 +190,22 @@ func (s *FileService) DeletePhysicalFilesForGroup(ctx context.Context, tenantID,
 		if file.File == nil || file.File.OriginalPath == "" {
 			continue
 		}
-		if err := s.deletePhysicalFileAndThumbnails(ctx, file.ID, file.File.OriginalPath, file.File.MIMEType); err != nil {
+		if err := s.deletePhysicalFileAndThumbnails(ctx, file.TenantID, file.ID, file.File.OriginalPath, file.File.MIMEType); err != nil {
 			return errxtrace.Wrap(fmt.Sprintf("failed to delete physical blobs for file %s", file.ID), err)
 		}
 	}
 	return nil
 }
 
-// deletePhysicalFileAndThumbnails deletes the physical file and all its thumbnails
-func (s *FileService) deletePhysicalFileAndThumbnails(ctx context.Context, fileID, filePath, mimeType string) error {
+// deletePhysicalFileAndThumbnails deletes the physical file and all its
+// thumbnails. `tenantID` is the tenant that owns the row — used to
+// derive the canonical thumbnail blob keys (#1793). For legacy rows
+// whose blob lives under a flat key, the original-file delete uses the
+// stored OriginalPath verbatim (treated as opaque) so an unbackfilled
+// row still cleans up cleanly. The thumbnail-key derivation only knows
+// the new layout; an unbackfilled row's legacy thumbnails are deleted
+// best-effort by the backfill itself.
+func (s *FileService) deletePhysicalFileAndThumbnails(ctx context.Context, tenantID, fileID, filePath, mimeType string) error {
 	// Delete the original file
 	if err := s.deletePhysicalFile(ctx, filePath); err != nil {
 		return errxtrace.Wrap("failed to delete original file", err)
@@ -198,10 +213,18 @@ func (s *FileService) deletePhysicalFileAndThumbnails(ctx context.Context, fileI
 
 	// Delete thumbnails if it's an image file
 	if mimekit.IsImage(mimeType) {
-		thumbnailPaths := s.GetThumbnailPaths(fileID)
-		for _, thumbnailPath := range thumbnailPaths {
+		// Walk both the canonical (tenant-prefixed) and legacy
+		// (flat) thumbnail keys so a row whose original blob has
+		// been backfilled to a new key still has its legacy
+		// thumbnails cleaned up if they happen to linger.
+		thumbnailPaths := s.GetThumbnailPaths(tenantID, fileID)
+		for sizeName, thumbnailPath := range thumbnailPaths {
 			// Don't fail if thumbnail doesn't exist - it might not have been generated
 			_ = s.deletePhysicalFile(ctx, thumbnailPath)
+			// Legacy-key cleanup. No-op for already-prefixed rows
+			// because the bucket-Exists check inside
+			// deletePhysicalFile short-circuits on missing.
+			_ = s.deletePhysicalFile(ctx, fmt.Sprintf("thumbnails/%s_%s.jpg", fileID, sizeName))
 		}
 	}
 
@@ -259,15 +282,17 @@ func (s *FileService) DeleteLinkedFiles(ctx context.Context, entityType, entityI
 	return nil
 }
 
-// ThumbnailExists checks if a thumbnail file exists for a given file and size
-func (s *FileService) ThumbnailExists(ctx context.Context, fileID, size string) (bool, error) {
+// ThumbnailExists checks if a thumbnail file exists for a given file and size.
+// `tenantID` selects the canonical tenant-prefixed namespace (#1793);
+// for legacy rows whose thumbnails still live under the flat
+// `thumbnails/<id>_<size>.jpg` shape, the check falls through to the
+// legacy key so an unbackfilled row still surfaces an existing
+// thumbnail instead of hitting placeholder generation in a loop.
+func (s *FileService) ThumbnailExists(ctx context.Context, tenantID, fileID, size string) (bool, error) {
 	// Validate size parameter
 	if size != "small" && size != "medium" {
 		return false, errxtrace.Classify(ErrInvalidThumbnailSize, errx.Attrs("size", size))
 	}
-
-	// Generate thumbnail path using the same structure as download
-	thumbnailPath := s.getThumbnailPath(fileID, size)
 
 	// Open bucket and check if file exists
 	b, err := blob.OpenBucket(ctx, s.uploadLocation)
@@ -276,10 +301,60 @@ func (s *FileService) ThumbnailExists(ctx context.Context, fileID, size string) 
 	}
 	defer b.Close()
 
+	// Canonical (tenant-prefixed) location first.
+	thumbnailPath := s.getThumbnailPath(tenantID, fileID, size)
 	exists, err := b.Exists(ctx, thumbnailPath)
 	if err != nil {
 		return false, errxtrace.Wrap("failed to check thumbnail existence", err, errx.Attrs("thumbnail_path", thumbnailPath))
 	}
+	if exists {
+		return true, nil
+	}
 
-	return exists, nil
+	// Legacy flat-key fallback for rows the backfill hasn't reached.
+	legacyPath := fmt.Sprintf("thumbnails/%s_%s.jpg", fileID, size)
+	legacyExists, err := b.Exists(ctx, legacyPath)
+	if err != nil {
+		return false, errxtrace.Wrap("failed to check legacy thumbnail existence", err, errx.Attrs("thumbnail_path", legacyPath))
+	}
+	return legacyExists, nil
+}
+
+// ThumbnailReadPath returns the bucket-relative key from which a
+// thumbnail should be read for the given file. Mirrors the resolution
+// logic in ThumbnailExists: canonical tenant-prefixed key first, then
+// the legacy flat key, then the canonical key as a final fallback
+// (so callers calling this without checking Exists still get a stable
+// answer to feed into bucket.NewReader, even if the read itself will
+// fail).
+func (s *FileService) ThumbnailReadPath(ctx context.Context, tenantID, fileID, size string) (string, error) {
+	if size != "small" && size != "medium" {
+		return "", errxtrace.Classify(ErrInvalidThumbnailSize, errx.Attrs("size", size))
+	}
+	canonical := s.getThumbnailPath(tenantID, fileID, size)
+
+	b, err := blob.OpenBucket(ctx, s.uploadLocation)
+	if err != nil {
+		return "", errxtrace.Wrap("failed to open bucket", err)
+	}
+	defer b.Close()
+
+	exists, err := b.Exists(ctx, canonical)
+	if err != nil {
+		return "", errxtrace.Wrap("failed to check thumbnail existence", err, errx.Attrs("thumbnail_path", canonical))
+	}
+	if exists {
+		return canonical, nil
+	}
+	legacy := fmt.Sprintf("thumbnails/%s_%s.jpg", fileID, size)
+	legacyExists, err := b.Exists(ctx, legacy)
+	if err != nil {
+		return "", errxtrace.Wrap("failed to check legacy thumbnail existence", err, errx.Attrs("thumbnail_path", legacy))
+	}
+	if legacyExists {
+		return legacy, nil
+	}
+	// Neither exists — return the canonical key so the caller can fail
+	// loudly against the post-migration layout.
+	return canonical, nil
 }

--- a/go/services/file_service.go
+++ b/go/services/file_service.go
@@ -282,79 +282,43 @@ func (s *FileService) DeleteLinkedFiles(ctx context.Context, entityType, entityI
 	return nil
 }
 
-// ThumbnailExists checks if a thumbnail file exists for a given file and size.
-// `tenantID` selects the canonical tenant-prefixed namespace (#1793);
-// for legacy rows whose thumbnails still live under the flat
-// `thumbnails/<id>_<size>.jpg` shape, the check falls through to the
-// legacy key so an unbackfilled row still surfaces an existing
-// thumbnail instead of hitting placeholder generation in a loop.
-func (s *FileService) ThumbnailExists(ctx context.Context, tenantID, fileID, size string) (bool, error) {
-	// Validate size parameter
+// ResolveThumbnail resolves the bucket-relative key from which a
+// thumbnail should be read for the given file, and whether it actually
+// exists in the bucket. Canonical tenant-prefixed key (#1793) is tried
+// first; legacy flat-key fallback (`thumbnails/<id>_<size>.jpg`) lets
+// rows that pre-date the backfill keep rendering. When neither key
+// exists, the canonical key is returned with `exists=false` so callers
+// can render a placeholder against the post-migration layout.
+//
+// One bucket open per call — combines what `ThumbnailExists` and
+// `ThumbnailReadPath` did in separate passes.
+func (s *FileService) ResolveThumbnail(ctx context.Context, tenantID, fileID, size string) (path string, exists bool, err error) {
 	if size != "small" && size != "medium" {
-		return false, errxtrace.Classify(ErrInvalidThumbnailSize, errx.Attrs("size", size))
+		return "", false, errxtrace.Classify(ErrInvalidThumbnailSize, errx.Attrs("size", size))
 	}
 
-	// Open bucket and check if file exists
 	b, err := blob.OpenBucket(ctx, s.uploadLocation)
 	if err != nil {
-		return false, errxtrace.Wrap("failed to open bucket", err)
+		return "", false, errxtrace.Wrap("failed to open bucket", err)
 	}
 	defer b.Close()
 
-	// Canonical (tenant-prefixed) location first.
-	thumbnailPath := s.getThumbnailPath(tenantID, fileID, size)
-	exists, err := b.Exists(ctx, thumbnailPath)
-	if err != nil {
-		return false, errxtrace.Wrap("failed to check thumbnail existence", err, errx.Attrs("thumbnail_path", thumbnailPath))
-	}
-	if exists {
-		return true, nil
-	}
-
-	// Legacy flat-key fallback for rows the backfill hasn't reached.
-	legacyPath := fmt.Sprintf("thumbnails/%s_%s.jpg", fileID, size)
-	legacyExists, err := b.Exists(ctx, legacyPath)
-	if err != nil {
-		return false, errxtrace.Wrap("failed to check legacy thumbnail existence", err, errx.Attrs("thumbnail_path", legacyPath))
-	}
-	return legacyExists, nil
-}
-
-// ThumbnailReadPath returns the bucket-relative key from which a
-// thumbnail should be read for the given file. Mirrors the resolution
-// logic in ThumbnailExists: canonical tenant-prefixed key first, then
-// the legacy flat key, then the canonical key as a final fallback
-// (so callers calling this without checking Exists still get a stable
-// answer to feed into bucket.NewReader, even if the read itself will
-// fail).
-func (s *FileService) ThumbnailReadPath(ctx context.Context, tenantID, fileID, size string) (string, error) {
-	if size != "small" && size != "medium" {
-		return "", errxtrace.Classify(ErrInvalidThumbnailSize, errx.Attrs("size", size))
-	}
 	canonical := s.getThumbnailPath(tenantID, fileID, size)
-
-	b, err := blob.OpenBucket(ctx, s.uploadLocation)
+	canonicalExists, err := b.Exists(ctx, canonical)
 	if err != nil {
-		return "", errxtrace.Wrap("failed to open bucket", err)
+		return "", false, errxtrace.Wrap("failed to check thumbnail existence", err, errx.Attrs("thumbnail_path", canonical))
 	}
-	defer b.Close()
+	if canonicalExists {
+		return canonical, true, nil
+	}
 
-	exists, err := b.Exists(ctx, canonical)
-	if err != nil {
-		return "", errxtrace.Wrap("failed to check thumbnail existence", err, errx.Attrs("thumbnail_path", canonical))
-	}
-	if exists {
-		return canonical, nil
-	}
 	legacy := fmt.Sprintf("thumbnails/%s_%s.jpg", fileID, size)
 	legacyExists, err := b.Exists(ctx, legacy)
 	if err != nil {
-		return "", errxtrace.Wrap("failed to check legacy thumbnail existence", err, errx.Attrs("thumbnail_path", legacy))
+		return "", false, errxtrace.Wrap("failed to check legacy thumbnail existence", err, errx.Attrs("thumbnail_path", legacy))
 	}
 	if legacyExists {
-		return legacy, nil
+		return legacy, true, nil
 	}
-	// Neither exists — return the canonical key so the caller can fail
-	// loudly against the post-migration layout.
-	return canonical, nil
+	return canonical, false, nil
 }

--- a/go/services/file_service_test.go
+++ b/go/services/file_service_test.go
@@ -490,6 +490,7 @@ func TestFileService_GenerateThumbnails(t *testing.T) {
 			fileEntity := &models.FileEntity{
 				TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
 					EntityID: models.EntityID{ID: "test-file-" + tt.name},
+					TenantID: "test-tenant",
 				},
 				Type: models.FileTypeImage,
 				File: &models.File{
@@ -506,7 +507,7 @@ func TestFileService_GenerateThumbnails(t *testing.T) {
 
 			if tt.shouldGenerateThumbnails {
 				// Check that thumbnails were created
-				thumbnailPaths := service.GetThumbnailPaths(fileEntity.ID)
+				thumbnailPaths := service.GetThumbnailPaths(fileEntity.TenantID, fileEntity.ID)
 				c.Assert(thumbnailPaths, qt.HasLen, 2) // small and medium
 
 				for sizeName, thumbnailPath := range thumbnailPaths {
@@ -516,7 +517,7 @@ func TestFileService_GenerateThumbnails(t *testing.T) {
 				}
 			} else {
 				// Check that no thumbnails were created
-				thumbnailPaths := service.GetThumbnailPaths(fileEntity.ID)
+				thumbnailPaths := service.GetThumbnailPaths(fileEntity.TenantID, fileEntity.ID)
 				for _, thumbnailPath := range thumbnailPaths {
 					exists, err := b.Exists(ctx, thumbnailPath)
 					c.Assert(err, qt.IsNil)
@@ -534,31 +535,35 @@ func TestFileService_GetThumbnailPaths(t *testing.T) {
 
 	tests := []struct {
 		name     string
+		tenantID string
 		fileID   string
 		expected map[string]string
 	}{
 		{
-			name:   "File ID with thumbnails",
-			fileID: "test-file-123",
+			name:     "File ID with thumbnails",
+			tenantID: "tenant-a",
+			fileID:   "test-file-123",
 			expected: map[string]string{
-				"small":  "thumbnails/test-file-123_small.jpg",
-				"medium": "thumbnails/test-file-123_medium.jpg",
+				"small":  "t/tenant-a/thumbnails/test-file-123_small.jpg",
+				"medium": "t/tenant-a/thumbnails/test-file-123_medium.jpg",
 			},
 		},
 		{
-			name:   "Another file ID",
-			fileID: "photo-456",
+			name:     "Another file ID",
+			tenantID: "tenant-a",
+			fileID:   "photo-456",
 			expected: map[string]string{
-				"small":  "thumbnails/photo-456_small.jpg",
-				"medium": "thumbnails/photo-456_medium.jpg",
+				"small":  "t/tenant-a/thumbnails/photo-456_small.jpg",
+				"medium": "t/tenant-a/thumbnails/photo-456_medium.jpg",
 			},
 		},
 		{
-			name:   "UUID file ID",
-			fileID: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+			name:     "UUID file ID",
+			tenantID: "tenant-b",
+			fileID:   "f47ac10b-58cc-4372-a567-0e02b2c3d479",
 			expected: map[string]string{
-				"small":  "thumbnails/f47ac10b-58cc-4372-a567-0e02b2c3d479_small.jpg",
-				"medium": "thumbnails/f47ac10b-58cc-4372-a567-0e02b2c3d479_medium.jpg",
+				"small":  "t/tenant-b/thumbnails/f47ac10b-58cc-4372-a567-0e02b2c3d479_small.jpg",
+				"medium": "t/tenant-b/thumbnails/f47ac10b-58cc-4372-a567-0e02b2c3d479_medium.jpg",
 			},
 		},
 	}
@@ -567,8 +572,25 @@ func TestFileService_GetThumbnailPaths(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			result := service.GetThumbnailPaths(tt.fileID)
+			result := service.GetThumbnailPaths(tt.tenantID, tt.fileID)
 			c.Assert(result, qt.DeepEquals, tt.expected)
 		})
+	}
+}
+
+// TestFileService_GetThumbnailPaths_AlwaysTenantPrefixed is the structural
+// invariant that #1793 promises: no matter what file id you pass, the
+// emitted thumbnail keys live inside the supplied tenant's namespace.
+func TestFileService_GetThumbnailPaths_AlwaysTenantPrefixed(t *testing.T) {
+	c := qt.New(t)
+	factorySet := memory.NewFactorySet()
+	service := NewFileService(factorySet, "/tmp/uploads")
+
+	for _, fileID := range []string{"x", "../../escape", "tenant-x/y/z"} {
+		paths := service.GetThumbnailPaths("safe-tenant", fileID)
+		for size, p := range paths {
+			c.Assert(p[:len("t/safe-tenant/")], qt.Equals, "t/safe-tenant/",
+				qt.Commentf("size=%s fileID=%q must live under safe-tenant namespace, got %q", size, fileID, p))
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1793 — defence-in-depth follow-up to merged #1779 / PR #1794.

The blob namespace was flat: every tenant's blobs (originals, thumbnails, exports, restores, seed fixtures) shared one keyspace, so any future code path that resolves a row to a blob key — a new endpoint, a refactor, a bug — could leak cross-tenant content because the key alone did not encode ownership. Tenant isolation rested entirely on DB row checks.

This PR moves every blob writer behind a single helper that prefixes keys with `t/<tenant_id>/…`:

| Bucket of keys | Old shape | New shape |
| -------------- | --------- | --------- |
| User uploads (originals) | `<basename>` | `t/<tenant>/files/<basename>` |
| Thumbnails | `thumbnails/<file-id>_<size>.jpg` | `t/<tenant>/thumbnails/<file-id>_<size>.jpg` |
| Restore staging | `<basename>` | `t/<tenant>/restores/<basename>` |
| Export bundles | `exports/export_<type>_<ts>.xml` | `t/<tenant>/exports/export_<type>_<ts>.xml` |
| Seed-data fixtures | `seed-<uuid><ext>` | `t/<tenant>/seed-<uuid><ext>` |

A stored key now physically cannot reference another tenant's blob — the security property no longer depends on row-level checks alone. The `blobkeys` package is the single source of truth for key construction and additionally sanitises `..`, `/`, `\` in basenames as a defence-in-depth measure so a future caller that bypasses `filekit.UploadFileName` cannot punch a hole in the namespace through the helper.

## Changes

- **New `go/internal/blobkeys` package** — single source of truth for key construction (`BuildFileBlobKey`, `BuildFileUploadKey`, `BuildThumbnailBlobKey`, `BuildExportBlobKey`, `BuildRestoreUploadKey`, `BuildSeedKey`). Inputs run through a private `sanitizeSegment` that rejects path-traversal tokens. All callers get `tenant_id` from server-side context (`appctx`, registry, or row); the request payload is never trusted.
- **Writers wired through the helper**:
  - `apiserver/uploads.go` — `/uploads/file` and `/uploads/restore` resolve tenant from auth context. Middleware split (`readUploadedFiles` + `saveOnePart` + `renderUploadError`) to stay under `gocognit`. Basename is computed once in the caller and passed into `saveOnePart` as a plain string.
  - `services/file_service.go` — `getThumbnailPath` / `ResolveThumbnail` take `tenantID`. A single `ResolveThumbnail(ctx, tenantID, fileID, size) (path, exists, err)` replaces the previous `ThumbnailExists`/`ThumbnailReadPath` pair — one bucket open per request on the hot thumbnail download path. Deletion sweeps both canonical and legacy keys (so cleanup of pre-backfill blobs still works).
  - `backup/export/service.go` — `generateExport` resolves tenant from the export row.
  - `backup/restore/processor/processor.go` — `rewriteImportKey` re-namespaces XML-declared keys into the importing tenant's namespace before writing the blob. `handleDataStart` fails closed when tenant context is missing, matching every other `appctx.UserFromContext` call site in the file.
  - `debug/seeddata/seeddata_fixtures.go` — `blobUploader.upload` interface takes tenantID; both `noopUploader` and `bucketUploader` emit `blobkeys.BuildSeedKey` paths.
- **Reader path stays opaque** — `downloadOriginalFile` already reads `File.OriginalPath` verbatim, so legacy rows continue to work until backfilled. `downloadThumbnail` now resolves the FileEntity to get tenant context and falls back to legacy thumbnail keys via `FileService.ResolveThumbnail` so pre-backfill thumbnails keep rendering.
- **Idempotent backfill CLI** — `inventario backfill blobs --db-dsn ... --upload-location ...` walks every `FileEntity` via paginated `ListPaginated` (page size 500, no whole-table allocation), copies the blob to the prefixed key, updates the row, then deletes the legacy blob. Thumbnails are migrated by the same pass via derived key pairs; per-row thumbnail failures count against `RowsErrored`. Reports `Scanned / Already-moved / Moved / Errored / Thumbs moved / Thumbs missing / Blobs copied / Blobs deleted`. Refuses `memory://` DSNs. Refuses to echo the DSN in errors (postgres credentials embed in the URL). Supports `--dry-run`. Re-running is a no-op. Exits non-zero if any row errored.
- **Validation cleanup** — `models.File.ValidateWithContext` previously required `Path` / `OriginalPath` / `Ext` / `MIMEType`. The rules were unreachable in production because no code path invokes `FileEntity.ValidateWithContext` (the JSON-API binder validates the outer request DTO, not the entity) — jellydator *would* have cascaded into the inner `Validatable`, so the rules would have re-activated the moment any future call site wired validation in. They would also have rejected the metadata-only create path #1779 introduced. The rules were dropped; tests updated; the no-op stays as a hook for future shape constraints.

## Tests

- `internal/blobkeys/blobkeys_test.go` — invariant: every output starts with `t/<tenant>/`, contains no `..` traversal token, and no backslash. Hostile inputs covered (`"../../escape"`, `..\\windows\\…`).
- `apiserver/uploads_test.go::TestUploads_file_tenantPrefixedKey` — `/uploads/file` flow asserts the persisted key matches `t/[^/]+/files/...`.
- `apiserver/uploads_test.go` — existing restore-staging regex updated to `t/[^/]+/restores/...`.
- `services/file_service_test.go::TestFileService_GetThumbnailPaths_AlwaysTenantPrefixed` — invariant: thumbnail keys are always tenant-prefixed.
- `backup/restore/restore_files_test.go` — large-blob round-trip reads at the rewritten tenant-namespaced key.
- `services/blobbackfill/blobbackfill_test.go` — covers happy path, idempotent re-run, missing-thumbnail legs.
- `models/models_test.go` — `TestFile_ValidateWithContext_HappyPath` now exercises both populated and empty literals.

## Migration / rollout

The schema does not change (no SQL migration). Operators run:

```
inventario backfill blobs \
  --db-dsn postgres://... \
  --upload-location file:///srv/uploads
```

Idempotent — safe to repeat, safe to abort mid-run. Streams rows in pages of 500 so large deployments don't OOM the migrator. New uploads land in the prefixed namespace from the moment this ships; legacy rows keep working until the backfill catches them.

## Out of scope

- Schema migration — not required (`OriginalPath` stays `TEXT`).
- Group-level sub-prefix (`g/<group>/...`) — the issue says "optionally `group_id`"; tenant-only is sufficient for the defence-in-depth property and avoids re-keying when files move between groups.

## Local gates

- `go build ./...`, `go vet ./...` — clean.
- `golangci-lint run ./...` — 0 issues.
- `go test -count=1 ./...` — green (postgres-gated tests skip cleanly).
- Swagger annotations on touched handlers unchanged; `TestSwaggerRouteCoverage` passes without regen.

## Related

- #1779 / PR #1794 — closed the immediate cross-tenant blob-read vector by removing client-supplied `path` from `createFile`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI backfill command to migrate legacy blobs into tenant-scoped storage; new service to perform idempotent tenant-prefixed backfills with dry-run mode.
  * Centralized tenant-aware blob key utilities.

* **Bug Fixes**
  * Uploads, exports, restores, thumbnails and seed fixtures now use tenant-scoped storage paths; thumbnail resolution falls back to legacy keys when needed.

* **Refactor**
  * File validation relaxed to allow placeholder file records prior to upload.

* **Tests**
  * Extensive tests added for tenant key builders, upload/restore behaviors, thumbnail handling, and backfill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->