### PR TITLE
[#1221] Reject invite-based registration on email mismatch

### DIFF
--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -7609,7 +7609,7 @@ export type paths = {
         put?: never;
         /**
          * Accept invite
-         * @description Accepts a single-use invite link and joins the group as a user. Requires authentication. If the invite has an invitee email, the user's email must match (case-insensitive); else 422 with code `invite.email_mismatch`.
+         * @description Accepts a single-use invite link and joins the group with the role stored on the invite. Requires auth. If invitee_email is set, user email must match (trimmed, case-insensitive); else 422 `invite.email_mismatch`.
          */
         post: {
             parameters: {
@@ -7650,7 +7650,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Invite expired, already used, user already a member, or user email does not match invitee email */
+                /** @description Invite expired, already used, user already a member, or user email (trim + case-insensitive) does not match invitee email */
                 422: {
                     headers: {
                         [name: string]: unknown;
@@ -7705,7 +7705,7 @@ export type paths = {
                         };
                     };
                 };
-                /** @description Bad Request - invalid body, expired/used invite, invalid password, or registration email doesn't match invitee email */
+                /** @description Bad Request - invalid body, expired/used invite, invalid password, or registration email (trim + case-insensitive) does not match invitee email */
                 400: {
                     headers: {
                         [name: string]: unknown;
@@ -8437,9 +8437,12 @@ export type components = {
              *     logging in. See issue #1219 §7 and #1285.
              *
              *     When the invite carries `invitee_email` (the #1533 email-flow path),
-             *     the registration `email` must match it case-insensitively, otherwise
-             *     the request is rejected with 400. Legacy token-only invites
-             *     (invitee_email == nil) keep working unchanged. See #1221.
+             *     the registration `email` must match it after trim + case-insensitive
+             *     normalization, otherwise the request is rejected with 400. A
+             *     whitespace-only invitee_email (only reachable via direct registry
+             *     write — the JSON-API binder strips whitespace) is treated as
+             *     invalid and rejected. Legacy token-only invites (invitee_email ==
+             *     nil) keep working unchanged. See #1221.
              */
             invite_token?: string;
             name?: string;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -7609,7 +7609,7 @@ export type paths = {
         put?: never;
         /**
          * Accept invite
-         * @description Accepts a single-use invite link and joins the group as a user. Requires authentication.
+         * @description Accepts a single-use invite link and joins the group as a user. Requires authentication. If the invite has an invitee email, the user's email must match (case-insensitive); else 422 with code `invite.email_mismatch`.
          */
         post: {
             parameters: {
@@ -7650,7 +7650,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Invite expired, already used, or user already a member */
+                /** @description Invite expired, already used, user already a member, or user email does not match invitee email */
                 422: {
                     headers: {
                         [name: string]: unknown;
@@ -7705,7 +7705,7 @@ export type paths = {
                         };
                     };
                 };
-                /** @description Bad Request - invalid body, expired/used invite, or invalid password */
+                /** @description Bad Request - invalid body, expired/used invite, invalid password, or registration email doesn't match invitee email */
                 400: {
                     headers: {
                         [name: string]: unknown;
@@ -8435,6 +8435,11 @@ export type components = {
              *     (the invite itself vouches for the user). The token is NOT consumed
              *     here — the caller must POST /api/v1/invites/{token}/accept after
              *     logging in. See issue #1219 §7 and #1285.
+             *
+             *     When the invite carries `invitee_email` (the #1533 email-flow path),
+             *     the registration `email` must match it case-insensitively, otherwise
+             *     the request is rejected with 400. Legacy token-only invites
+             *     (invitee_email == nil) keep working unchanged. See #1221.
              */
             invite_token?: string;
             name?: string;

--- a/go/apiserver/errors.go
+++ b/go/apiserver/errors.go
@@ -255,6 +255,27 @@ func adminMemberTenantMismatchError(err error) jsonapi.Error {
 	}
 }
 
+// inviteAcceptRejectionError maps the invite-accept business-rule
+// sentinels (expired, already used, already a member, #1221 email
+// mismatch) to their 422 wire shape. The email-mismatch case carries
+// the JSON:API code `invite.email_mismatch` so the FE can distinguish
+// it from generic invite-state errors; the other three keep the bare
+// 422 they had pre-#1221. Extracted as a free function so the
+// toJSONAPIError switch stays under the gocyclo budget while keeping
+// the mapping explicit and grep-friendly.
+func inviteAcceptRejectionError(err error) jsonapi.Error {
+	if errors.Is(err, services.ErrInviteEmailMismatch) {
+		return jsonapi.Error{
+			Err:            err,
+			UserError:      errormarshal.Marshal(err),
+			HTTPStatusCode: http.StatusUnprocessableEntity,
+			StatusText:     "Unprocessable Entity",
+			Code:           "invite.email_mismatch",
+		}
+	}
+	return NewUnprocessableEntityError(err)
+}
+
 // adminImpersonationGuardError maps the #1750 impersonation guard
 // sentinels (target-is-admin, target-blocked, nested, not-active) to
 // their 422 + code wire shape. Extracted as a free function — like
@@ -403,14 +424,20 @@ func toJSONAPIError(err error) jsonapi.Error {
 		return NewUnprocessableEntityError(err)
 	case errors.Is(err, services.ErrInviteExpired),
 		errors.Is(err, services.ErrInviteAlreadyUsed),
-		errors.Is(err, services.ErrAlreadyMember):
+		errors.Is(err, services.ErrAlreadyMember),
+		errors.Is(err, services.ErrInviteEmailMismatch):
 		// Business-rule violations on the invite accept path: the token
 		// is syntactically valid but cannot be redeemed right now.
 		// Swagger on POST /invites/{token}/accept advertises 422 for
 		// exactly these conditions; without this mapping they fall into
 		// the default branch and surface as 500, which would mislead
 		// clients (and e2e assertions) into treating them as server bugs.
-		return NewUnprocessableEntityError(err)
+		// The #1221 email-mismatch sentinel carries an extra JSON:API
+		// `code` so the FE can render targeted copy ("this invite is
+		// for a different email address") — handled by a helper that
+		// keeps the wire shape sentinel-specific while collapsing the
+		// switch arm so gocyclo stays under budget.
+		return inviteAcceptRejectionError(err)
 	case errors.Is(err, registry.ErrGroupCurrencyNotSet):
 		return NewBadRequestError(err)
 	case errors.Is(err, services.ErrRateLimitExceeded):

--- a/go/apiserver/groups.go
+++ b/go/apiserver/groups.go
@@ -1086,7 +1086,7 @@ func (api *groupsAPI) getInviteInfo(w http.ResponseWriter, r *http.Request) {
 
 // acceptInvite accepts an invite and joins the group.
 // @Summary Accept invite
-// @Description Accepts a single-use invite link and joins the group as a user. Requires authentication.
+// @Description Accepts a single-use invite link and joins the group as a user. Requires authentication. If the invite has an invitee email, the user's email must match (case-insensitive); else 422 with code `invite.email_mismatch`.
 // @Tags invites
 // @Accept json-api
 // @Produce json-api
@@ -1094,7 +1094,7 @@ func (api *groupsAPI) getInviteInfo(w http.ResponseWriter, r *http.Request) {
 // @Success 201 {object} jsonapi.GroupMembershipResponse "Created"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 404 {object} jsonapi.Errors "Invite not found"
-// @Failure 422 {object} jsonapi.Errors "Invite expired, already used, or user already a member"
+// @Failure 422 {object} jsonapi.Errors "Invite expired, already used, user already a member, or user email does not match invitee email"
 // @Router /invites/{token}/accept [post].
 func (api *groupsAPI) acceptInvite(w http.ResponseWriter, r *http.Request) {
 	token := chi.URLParam(r, "token")
@@ -1109,7 +1109,7 @@ func (api *groupsAPI) acceptInvite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	membership, err := api.groupService.AcceptInvite(r.Context(), token, user.ID, user.TenantID)
+	membership, err := api.groupService.AcceptInvite(r.Context(), token, user.ID, user.Email, user.TenantID)
 	if err != nil {
 		renderEntityError(w, r, err)
 		return

--- a/go/apiserver/groups.go
+++ b/go/apiserver/groups.go
@@ -1086,7 +1086,7 @@ func (api *groupsAPI) getInviteInfo(w http.ResponseWriter, r *http.Request) {
 
 // acceptInvite accepts an invite and joins the group.
 // @Summary Accept invite
-// @Description Accepts a single-use invite link and joins the group as a user. Requires authentication. If the invite has an invitee email, the user's email must match (case-insensitive); else 422 with code `invite.email_mismatch`.
+// @Description Accepts a single-use invite link and joins the group with the role stored on the invite. Requires auth. If invitee_email is set, user email must match (trimmed, case-insensitive); else 422 `invite.email_mismatch`.
 // @Tags invites
 // @Accept json-api
 // @Produce json-api
@@ -1094,7 +1094,7 @@ func (api *groupsAPI) getInviteInfo(w http.ResponseWriter, r *http.Request) {
 // @Success 201 {object} jsonapi.GroupMembershipResponse "Created"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 404 {object} jsonapi.Errors "Invite not found"
-// @Failure 422 {object} jsonapi.Errors "Invite expired, already used, user already a member, or user email does not match invitee email"
+// @Failure 422 {object} jsonapi.Errors "Invite expired, already used, user already a member, or user email (trim + case-insensitive) does not match invitee email"
 // @Router /invites/{token}/accept [post].
 func (api *groupsAPI) acceptInvite(w http.ResponseWriter, r *http.Request) {
 	token := chi.URLParam(r, "token")

--- a/go/apiserver/registration.go
+++ b/go/apiserver/registration.go
@@ -57,6 +57,11 @@ type RegisterRequest struct {
 	// (the invite itself vouches for the user). The token is NOT consumed
 	// here — the caller must POST /api/v1/invites/{token}/accept after
 	// logging in. See issue #1219 §7 and #1285.
+	//
+	// When the invite carries `invitee_email` (the #1533 email-flow path),
+	// the registration `email` must match it case-insensitively, otherwise
+	// the request is rejected with 400. Legacy token-only invites
+	// (invitee_email == nil) keep working unchanged. See #1221.
 	InviteToken string `json:"invite_token,omitempty"`
 }
 
@@ -100,6 +105,8 @@ func resolveRegistrationMode(ctx context.Context) models.RegistrationMode {
 //   - invite_token present & valid → account created ACTIVE; no verification
 //     email; caller must separately POST /invites/{token}/accept to join the
 //     group (see #1219 §7). Allowed even when RegistrationMode is closed.
+//     If the invite carries `invitee_email`, the registration `email` must
+//     match it (case-insensitive); mismatch → 400 (#1221).
 //   - closed    → 403 Forbidden; registration is disabled.
 //   - approval  → account created (inactive); admin must activate; no verification email sent.
 //   - open      → account created (inactive); verification email sent; activates on token click.
@@ -111,7 +118,7 @@ func resolveRegistrationMode(ctx context.Context) models.RegistrationMode {
 // @Produce json
 // @Param data body RegisterRequest true "Registration data (optionally including invite_token)"
 // @Success 200 {object} map[string]string "OK - registration accepted"
-// @Failure 400 {string} string "Bad Request - invalid body, expired/used invite, or invalid password"
+// @Failure 400 {string} string "Bad Request - invalid body, expired/used invite, invalid password, or registration email doesn't match invitee email"
 // @Failure 403 {string} string "Forbidden - registrations are closed and no valid invite was supplied"
 // @Failure 500 {string} string "Internal Server Error"
 // @Failure 503 {string} string "Service Unavailable - registration mode is misconfigured or invite-based registration is not wired"
@@ -129,8 +136,9 @@ func (api *RegistrationAPI) handleRegister(w http.ResponseWriter, r *http.Reques
 	// Resolve invite before enforcing registration mode so a valid invite can
 	// bypass the closed-mode gate (#1219 §7). Invalid/expired/used tokens are
 	// rejected with distinguishable 400 errors so the FE can surface a useful
-	// message to the user.
-	inviteBypass, regErr := api.resolveInvite(r, req.InviteToken)
+	// message to the user. The registration email is passed in so the
+	// #1221 email-match check can run on email-flow invites.
+	inviteBypass, regErr := api.resolveInvite(r, req.InviteToken, req.Email)
 	if regErr != nil {
 		http.Error(w, regErr.userMessage, regErr.status)
 		return
@@ -238,7 +246,13 @@ type registrationError struct {
 // (false, nil) when no token was supplied, and (false, err) when a token was
 // supplied but is invalid. The invite is NOT consumed — the caller must POST
 // /api/v1/invites/{token}/accept after logging in.
-func (api *RegistrationAPI) resolveInvite(r *http.Request, token string) (bool, *registrationError) {
+//
+// callerEmail is the registration email from the request body; when the
+// invite was created with an invitee_email (the #1533 email-flow path),
+// callerEmail must match it case-insensitively or the invite is rejected
+// (#1221). Legacy token-only invites (invitee_email == nil) ignore
+// callerEmail — the admin handed the URL to whoever they meant to invite.
+func (api *RegistrationAPI) resolveInvite(r *http.Request, token, callerEmail string) (bool, *registrationError) {
 	if token == "" {
 		return false, nil
 	}
@@ -270,6 +284,22 @@ func (api *RegistrationAPI) resolveInvite(r *http.Request, token string) (bool, 
 	}
 	if invite.IsUsed() {
 		return false, &registrationError{status: http.StatusBadRequest, userMessage: "This invite link has already been used"}
+	}
+	// #1221: an invite minted via the email-flow (#1533) is bound to a
+	// specific address — the user must register with that address. We
+	// trim+lowercase both sides defensively even though handleRegister
+	// already normalizes req.Email, because the function is logically
+	// reusable from other entry points. Legacy copy-paste invites
+	// (invitee_email == nil) skip this check.
+	if invite.InviteeEmail != nil {
+		inviteEmail := strings.ToLower(strings.TrimSpace(*invite.InviteeEmail))
+		caller := strings.ToLower(strings.TrimSpace(callerEmail))
+		if inviteEmail != "" && inviteEmail != caller {
+			return false, &registrationError{
+				status:      http.StatusBadRequest,
+				userMessage: "This invite is for a different email address. Please register with the email address the invite was sent to.",
+			}
+		}
 	}
 	return true, nil
 }

--- a/go/apiserver/registration.go
+++ b/go/apiserver/registration.go
@@ -59,9 +59,12 @@ type RegisterRequest struct {
 	// logging in. See issue #1219 §7 and #1285.
 	//
 	// When the invite carries `invitee_email` (the #1533 email-flow path),
-	// the registration `email` must match it case-insensitively, otherwise
-	// the request is rejected with 400. Legacy token-only invites
-	// (invitee_email == nil) keep working unchanged. See #1221.
+	// the registration `email` must match it after trim + case-insensitive
+	// normalization, otherwise the request is rejected with 400. A
+	// whitespace-only invitee_email (only reachable via direct registry
+	// write — the JSON-API binder strips whitespace) is treated as
+	// invalid and rejected. Legacy token-only invites (invitee_email ==
+	// nil) keep working unchanged. See #1221.
 	InviteToken string `json:"invite_token,omitempty"`
 }
 
@@ -106,7 +109,7 @@ func resolveRegistrationMode(ctx context.Context) models.RegistrationMode {
 //     email; caller must separately POST /invites/{token}/accept to join the
 //     group (see #1219 §7). Allowed even when RegistrationMode is closed.
 //     If the invite carries `invitee_email`, the registration `email` must
-//     match it (case-insensitive); mismatch → 400 (#1221).
+//     match it (trim + case-insensitive); mismatch → 400 (#1221).
 //   - closed    → 403 Forbidden; registration is disabled.
 //   - approval  → account created (inactive); admin must activate; no verification email sent.
 //   - open      → account created (inactive); verification email sent; activates on token click.
@@ -118,7 +121,7 @@ func resolveRegistrationMode(ctx context.Context) models.RegistrationMode {
 // @Produce json
 // @Param data body RegisterRequest true "Registration data (optionally including invite_token)"
 // @Success 200 {object} map[string]string "OK - registration accepted"
-// @Failure 400 {string} string "Bad Request - invalid body, expired/used invite, invalid password, or registration email doesn't match invitee email"
+// @Failure 400 {string} string "Bad Request - invalid body, expired/used invite, invalid password, or registration email (trim + case-insensitive) does not match invitee email"
 // @Failure 403 {string} string "Forbidden - registrations are closed and no valid invite was supplied"
 // @Failure 500 {string} string "Internal Server Error"
 // @Failure 503 {string} string "Service Unavailable - registration mode is misconfigured or invite-based registration is not wired"
@@ -302,7 +305,13 @@ func (api *RegistrationAPI) resolveInvite(r *http.Request, token, callerEmail st
 	if invite.InviteeEmail != nil {
 		inviteEmail := strings.ToLower(strings.TrimSpace(*invite.InviteeEmail))
 		caller := strings.ToLower(strings.TrimSpace(callerEmail))
-		if inviteEmail != caller {
+		// Fail closed on a whitespace-only invitee_email: an empty ==
+		// empty match would silently redeem a malformed invite for any
+		// caller (including a buggy/malicious one that submits an
+		// empty email). The JSON-API binder in createInvite already
+		// strips whitespace, so reaching this branch implies a direct
+		// registry write — refuse to bypass closed-mode for it.
+		if inviteEmail == "" || inviteEmail != caller {
 			return false, &registrationError{
 				status:      http.StatusBadRequest,
 				userMessage: "This invite is for a different email address. Please register with the email address the invite was sent to.",

--- a/go/apiserver/registration.go
+++ b/go/apiserver/registration.go
@@ -290,11 +290,19 @@ func (api *RegistrationAPI) resolveInvite(r *http.Request, token, callerEmail st
 	// trim+lowercase both sides defensively even though handleRegister
 	// already normalizes req.Email, because the function is logically
 	// reusable from other entry points. Legacy copy-paste invites
-	// (invitee_email == nil) skip this check.
+	// (invitee_email == nil) skip this check. The duplicate-of-AcceptInvite
+	// check is intentional: this endpoint speaks plain `http.Error` with
+	// 4xx statuses (no JSON-API envelope), so it can't reuse
+	// validateInviteForAccept's sentinel-classified errors directly. Both
+	// paths normalize identically so they agree on what "match" means.
+	// An invitee_email that normalizes to empty (impossible via the
+	// JSON-API binder, only via a direct registry write) is treated as
+	// fail-closed — the comparison just falls through to "not equal" and
+	// rejects every caller, rather than silently bypassing the gate.
 	if invite.InviteeEmail != nil {
 		inviteEmail := strings.ToLower(strings.TrimSpace(*invite.InviteeEmail))
 		caller := strings.ToLower(strings.TrimSpace(callerEmail))
-		if inviteEmail != "" && inviteEmail != caller {
+		if inviteEmail != caller {
 			return false, &registrationError{
 				status:      http.StatusBadRequest,
 				userMessage: "This invite is for a different email address. Please register with the email address the invite was sent to.",

--- a/go/apiserver/registration_invite_test.go
+++ b/go/apiserver/registration_invite_test.go
@@ -59,6 +59,19 @@ func (f *inviteFixture) mintInvite(c *qt.C) string {
 	return invite.Token
 }
 
+// mintInviteForEmail returns a fresh single-use invite token whose
+// invitee_email is bound to the given address (the #1533 email-flow
+// shape). #1221 requires the registering/accepting user's email to
+// match this value (case-insensitive).
+func (f *inviteFixture) mintInviteForEmail(c *qt.C, email string) string {
+	invite, err := f.groupService.CreateInviteWithEmail(
+		context.Background(), inviteTestTenantID, f.group.ID, f.creatorID,
+		models.GroupRoleUser, &email, 0,
+	)
+	c.Assert(err, qt.IsNil)
+	return invite.Token
+}
+
 // mintExpiredInvite produces a token whose ExpiresAt is already in the past.
 // It creates the invite via the service (which forbids past expiry) and then
 // back-dates it directly via the registry.
@@ -359,4 +372,116 @@ func TestHandleRegister_OpenModeWithoutInviteStillWorks(t *testing.T) {
 		created = u
 	}
 	c.Assert(created.IsActive, qt.IsFalse, qt.Commentf("open-mode registration without invite must stay pending email verification"))
+}
+
+// closedModeInviteWithMatchingEmail — #1221: invite was minted via the
+// email-flow (invitee_email != nil) and the registration email matches.
+// The user is created ACTIVE just like the unconstrained invite path.
+// Case-insensitivity is exercised explicitly by registering with a
+// mixed-case variant of the invitee email.
+func TestHandleRegister_ClosedModeInviteWithMatchingEmailCreatesActiveUser(t *testing.T) {
+	c := qt.New(t)
+
+	f := newInviteFixture(c)
+	userReg := &registrationUserRegistry{mockUserRegistryForAuth: &mockUserRegistryForAuth{users: map[string]*models.User{}}}
+	r := newRegistrationRouterWithInvites(apiserver.RegistrationParams{
+		UserRegistry:         userReg,
+		VerificationRegistry: memory.NewEmailVerificationRegistry(),
+		GroupService:         f.groupService,
+		RateLimiter:          services.NewInMemoryAuthRateLimiter(),
+	}, models.RegistrationModeClosed)
+
+	token := f.mintInviteForEmail(c, "match@example.com")
+	// Mixed-case input proves the comparison is case-insensitive — the
+	// handler lower-cases req.Email before resolveInvite runs.
+	w := postRegister(c, r, map[string]string{
+		"email":        "Match@Example.com",
+		"name":         "Matching Invitee",
+		"password":     "Password123",
+		"invite_token": token,
+	})
+
+	c.Assert(w.Code, qt.Equals, http.StatusOK)
+	c.Assert(userReg.users, qt.HasLen, 1)
+	var created *models.User
+	for _, u := range userReg.users {
+		created = u
+	}
+	c.Assert(created, qt.IsNotNil)
+	c.Assert(created.Email, qt.Equals, "match@example.com")
+	c.Assert(created.IsActive, qt.IsTrue,
+		qt.Commentf("invite-based registration with matching email must mark user active"))
+}
+
+// closedModeInviteWithMismatchEmail — #1221: invite was minted via the
+// email-flow (invitee_email != nil) but the registration email is for
+// someone else. Rejected with 400 and a useful message; no user is
+// created. The invite stays unconsumed so the legitimate invitee can
+// still redeem it.
+func TestHandleRegister_ClosedModeInviteWithMismatchEmailRejected(t *testing.T) {
+	c := qt.New(t)
+
+	f := newInviteFixture(c)
+	userReg := &registrationUserRegistry{mockUserRegistryForAuth: &mockUserRegistryForAuth{users: map[string]*models.User{}}}
+	r := newRegistrationRouterWithInvites(apiserver.RegistrationParams{
+		UserRegistry:         userReg,
+		VerificationRegistry: memory.NewEmailVerificationRegistry(),
+		GroupService:         f.groupService,
+		RateLimiter:          services.NewInMemoryAuthRateLimiter(),
+	}, models.RegistrationModeClosed)
+
+	token := f.mintInviteForEmail(c, "intended@example.com")
+	w := postRegister(c, r, map[string]string{
+		"email":        "other@example.com",
+		"name":         "Wrong Invitee",
+		"password":     "Password123",
+		"invite_token": token,
+	})
+
+	c.Assert(w.Code, qt.Equals, http.StatusBadRequest)
+	c.Assert(w.Body.String(), qt.Contains, "different email")
+	c.Assert(userReg.users, qt.HasLen, 0,
+		qt.Commentf("mismatched-email invite registration must not create a user"))
+
+	// Invite must remain unconsumed so the legitimate invitee can still use it.
+	invite, err := f.invites.GetByToken(context.Background(), token)
+	c.Assert(err, qt.IsNil)
+	c.Assert(invite.IsUsed(), qt.IsFalse)
+}
+
+// closedModeLegacyInviteIgnoresEmail — #1221 regression guard: a legacy
+// token-only invite (invitee_email == nil, the copy-paste flow) keeps
+// working as it did before the email-match check landed. The admin
+// generated a URL they handed to the intended person — there's no
+// invitee_email to compare against, so any email registers fine.
+func TestHandleRegister_ClosedModeLegacyInviteIgnoresEmail(t *testing.T) {
+	c := qt.New(t)
+
+	f := newInviteFixture(c)
+	userReg := &registrationUserRegistry{mockUserRegistryForAuth: &mockUserRegistryForAuth{users: map[string]*models.User{}}}
+	r := newRegistrationRouterWithInvites(apiserver.RegistrationParams{
+		UserRegistry:         userReg,
+		VerificationRegistry: memory.NewEmailVerificationRegistry(),
+		GroupService:         f.groupService,
+		RateLimiter:          services.NewInMemoryAuthRateLimiter(),
+	}, models.RegistrationModeClosed)
+
+	// mintInvite() builds a token-only invite (invitee_email == nil).
+	token := f.mintInvite(c)
+	w := postRegister(c, r, map[string]string{
+		"email":        "whoever@example.com",
+		"name":         "Whoever",
+		"password":     "Password123",
+		"invite_token": token,
+	})
+
+	c.Assert(w.Code, qt.Equals, http.StatusOK)
+	c.Assert(userReg.users, qt.HasLen, 1)
+	var created *models.User
+	for _, u := range userReg.users {
+		created = u
+	}
+	c.Assert(created.Email, qt.Equals, "whoever@example.com")
+	c.Assert(created.IsActive, qt.IsTrue,
+		qt.Commentf("legacy invite path must still mark user active"))
 }

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -6869,7 +6869,7 @@ const docTemplate = `{
         },
         "/invites/{token}/accept": {
             "post": {
-                "description": "Accepts a single-use invite link and joins the group as a user. Requires authentication. If the invite has an invitee email, the user's email must match (case-insensitive); else 422 with code ` + "`" + `invite.email_mismatch` + "`" + `.",
+                "description": "Accepts a single-use invite link and joins the group with the role stored on the invite. Requires auth. If invitee_email is set, user email must match (trimmed, case-insensitive); else 422 ` + "`" + `invite.email_mismatch` + "`" + `.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -6909,7 +6909,7 @@ const docTemplate = `{
                         }
                     },
                     "422": {
-                        "description": "Invite expired, already used, user already a member, or user email does not match invitee email",
+                        "description": "Invite expired, already used, user already a member, or user email (trim + case-insensitive) does not match invitee email",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -6952,7 +6952,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Bad Request - invalid body, expired/used invite, invalid password, or registration email doesn't match invitee email",
+                        "description": "Bad Request - invalid body, expired/used invite, invalid password, or registration email (trim + case-insensitive) does not match invitee email",
                         "schema": {
                             "type": "string"
                         }
@@ -7811,7 +7811,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "invite_token": {
-                    "description": "InviteToken, when present and valid, allows registration even if\nRegistrationMode is closed and suppresses the email-verification step\n(the invite itself vouches for the user). The token is NOT consumed\nhere — the caller must POST /api/v1/invites/{token}/accept after\nlogging in. See issue #1219 §7 and #1285.\n\nWhen the invite carries ` + "`" + `invitee_email` + "`" + ` (the #1533 email-flow path),\nthe registration ` + "`" + `email` + "`" + ` must match it case-insensitively, otherwise\nthe request is rejected with 400. Legacy token-only invites\n(invitee_email == nil) keep working unchanged. See #1221.",
+                    "description": "InviteToken, when present and valid, allows registration even if\nRegistrationMode is closed and suppresses the email-verification step\n(the invite itself vouches for the user). The token is NOT consumed\nhere — the caller must POST /api/v1/invites/{token}/accept after\nlogging in. See issue #1219 §7 and #1285.\n\nWhen the invite carries ` + "`" + `invitee_email` + "`" + ` (the #1533 email-flow path),\nthe registration ` + "`" + `email` + "`" + ` must match it after trim + case-insensitive\nnormalization, otherwise the request is rejected with 400. A\nwhitespace-only invitee_email (only reachable via direct registry\nwrite — the JSON-API binder strips whitespace) is treated as\ninvalid and rejected. Legacy token-only invites (invitee_email ==\nnil) keep working unchanged. See #1221.",
                     "type": "string"
                 },
                 "name": {

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -6869,7 +6869,7 @@ const docTemplate = `{
         },
         "/invites/{token}/accept": {
             "post": {
-                "description": "Accepts a single-use invite link and joins the group as a user. Requires authentication.",
+                "description": "Accepts a single-use invite link and joins the group as a user. Requires authentication. If the invite has an invitee email, the user's email must match (case-insensitive); else 422 with code ` + "`" + `invite.email_mismatch` + "`" + `.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -6909,7 +6909,7 @@ const docTemplate = `{
                         }
                     },
                     "422": {
-                        "description": "Invite expired, already used, or user already a member",
+                        "description": "Invite expired, already used, user already a member, or user email does not match invitee email",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -6952,7 +6952,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Bad Request - invalid body, expired/used invite, or invalid password",
+                        "description": "Bad Request - invalid body, expired/used invite, invalid password, or registration email doesn't match invitee email",
                         "schema": {
                             "type": "string"
                         }
@@ -7811,7 +7811,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "invite_token": {
-                    "description": "InviteToken, when present and valid, allows registration even if\nRegistrationMode is closed and suppresses the email-verification step\n(the invite itself vouches for the user). The token is NOT consumed\nhere — the caller must POST /api/v1/invites/{token}/accept after\nlogging in. See issue #1219 §7 and #1285.",
+                    "description": "InviteToken, when present and valid, allows registration even if\nRegistrationMode is closed and suppresses the email-verification step\n(the invite itself vouches for the user). The token is NOT consumed\nhere — the caller must POST /api/v1/invites/{token}/accept after\nlogging in. See issue #1219 §7 and #1285.\n\nWhen the invite carries ` + "`" + `invitee_email` + "`" + ` (the #1533 email-flow path),\nthe registration ` + "`" + `email` + "`" + ` must match it case-insensitively, otherwise\nthe request is rejected with 400. Legacy token-only invites\n(invitee_email == nil) keep working unchanged. See #1221.",
                     "type": "string"
                 },
                 "name": {

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -6862,7 +6862,7 @@
         },
         "/invites/{token}/accept": {
             "post": {
-                "description": "Accepts a single-use invite link and joins the group as a user. Requires authentication.",
+                "description": "Accepts a single-use invite link and joins the group as a user. Requires authentication. If the invite has an invitee email, the user's email must match (case-insensitive); else 422 with code `invite.email_mismatch`.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -6902,7 +6902,7 @@
                         }
                     },
                     "422": {
-                        "description": "Invite expired, already used, or user already a member",
+                        "description": "Invite expired, already used, user already a member, or user email does not match invitee email",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -6945,7 +6945,7 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request - invalid body, expired/used invite, or invalid password",
+                        "description": "Bad Request - invalid body, expired/used invite, invalid password, or registration email doesn't match invitee email",
                         "schema": {
                             "type": "string"
                         }
@@ -7804,7 +7804,7 @@
                     "type": "string"
                 },
                 "invite_token": {
-                    "description": "InviteToken, when present and valid, allows registration even if\nRegistrationMode is closed and suppresses the email-verification step\n(the invite itself vouches for the user). The token is NOT consumed\nhere — the caller must POST /api/v1/invites/{token}/accept after\nlogging in. See issue #1219 §7 and #1285.",
+                    "description": "InviteToken, when present and valid, allows registration even if\nRegistrationMode is closed and suppresses the email-verification step\n(the invite itself vouches for the user). The token is NOT consumed\nhere — the caller must POST /api/v1/invites/{token}/accept after\nlogging in. See issue #1219 §7 and #1285.\n\nWhen the invite carries `invitee_email` (the #1533 email-flow path),\nthe registration `email` must match it case-insensitively, otherwise\nthe request is rejected with 400. Legacy token-only invites\n(invitee_email == nil) keep working unchanged. See #1221.",
                     "type": "string"
                 },
                 "name": {

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -6862,7 +6862,7 @@
         },
         "/invites/{token}/accept": {
             "post": {
-                "description": "Accepts a single-use invite link and joins the group as a user. Requires authentication. If the invite has an invitee email, the user's email must match (case-insensitive); else 422 with code `invite.email_mismatch`.",
+                "description": "Accepts a single-use invite link and joins the group with the role stored on the invite. Requires auth. If invitee_email is set, user email must match (trimmed, case-insensitive); else 422 `invite.email_mismatch`.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -6902,7 +6902,7 @@
                         }
                     },
                     "422": {
-                        "description": "Invite expired, already used, user already a member, or user email does not match invitee email",
+                        "description": "Invite expired, already used, user already a member, or user email (trim + case-insensitive) does not match invitee email",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -6945,7 +6945,7 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request - invalid body, expired/used invite, invalid password, or registration email doesn't match invitee email",
+                        "description": "Bad Request - invalid body, expired/used invite, invalid password, or registration email (trim + case-insensitive) does not match invitee email",
                         "schema": {
                             "type": "string"
                         }
@@ -7804,7 +7804,7 @@
                     "type": "string"
                 },
                 "invite_token": {
-                    "description": "InviteToken, when present and valid, allows registration even if\nRegistrationMode is closed and suppresses the email-verification step\n(the invite itself vouches for the user). The token is NOT consumed\nhere — the caller must POST /api/v1/invites/{token}/accept after\nlogging in. See issue #1219 §7 and #1285.\n\nWhen the invite carries `invitee_email` (the #1533 email-flow path),\nthe registration `email` must match it case-insensitively, otherwise\nthe request is rejected with 400. Legacy token-only invites\n(invitee_email == nil) keep working unchanged. See #1221.",
+                    "description": "InviteToken, when present and valid, allows registration even if\nRegistrationMode is closed and suppresses the email-verification step\n(the invite itself vouches for the user). The token is NOT consumed\nhere — the caller must POST /api/v1/invites/{token}/accept after\nlogging in. See issue #1219 §7 and #1285.\n\nWhen the invite carries `invitee_email` (the #1533 email-flow path),\nthe registration `email` must match it after trim + case-insensitive\nnormalization, otherwise the request is rejected with 400. A\nwhitespace-only invitee_email (only reachable via direct registry\nwrite — the JSON-API binder strips whitespace) is treated as\ninvalid and rejected. Legacy token-only invites (invitee_email ==\nnil) keep working unchanged. See #1221.",
                     "type": "string"
                 },
                 "name": {

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -362,9 +362,12 @@ definitions:
           logging in. See issue #1219 §7 and #1285.
 
           When the invite carries `invitee_email` (the #1533 email-flow path),
-          the registration `email` must match it case-insensitively, otherwise
-          the request is rejected with 400. Legacy token-only invites
-          (invitee_email == nil) keep working unchanged. See #1221.
+          the registration `email` must match it after trim + case-insensitive
+          normalization, otherwise the request is rejected with 400. A
+          whitespace-only invitee_email (only reachable via direct registry
+          write — the JSON-API binder strips whitespace) is treated as
+          invalid and rejected. Legacy token-only invites (invitee_email ==
+          nil) keep working unchanged. See #1221.
         type: string
       name:
         type: string
@@ -8897,9 +8900,9 @@ paths:
     post:
       consumes:
       - application/vnd.api+json
-      description: Accepts a single-use invite link and joins the group as a user.
-        Requires authentication. If the invite has an invitee email, the user's email
-        must match (case-insensitive); else 422 with code `invite.email_mismatch`.
+      description: Accepts a single-use invite link and joins the group with the role
+        stored on the invite. Requires auth. If invitee_email is set, user email must
+        match (trimmed, case-insensitive); else 422 `invite.email_mismatch`.
       parameters:
       - description: Invite token
         in: path
@@ -8923,7 +8926,7 @@ paths:
             $ref: '#/definitions/jsonapi.Errors'
         "422":
           description: Invite expired, already used, user already a member, or user
-            email does not match invitee email
+            email (trim + case-insensitive) does not match invitee email
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: Accept invite
@@ -8954,7 +8957,8 @@ paths:
             type: object
         "400":
           description: Bad Request - invalid body, expired/used invite, invalid password,
-            or registration email doesn't match invitee email
+            or registration email (trim + case-insensitive) does not match invitee
+            email
           schema:
             type: string
         "403":

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -360,6 +360,11 @@ definitions:
           (the invite itself vouches for the user). The token is NOT consumed
           here — the caller must POST /api/v1/invites/{token}/accept after
           logging in. See issue #1219 §7 and #1285.
+
+          When the invite carries `invitee_email` (the #1533 email-flow path),
+          the registration `email` must match it case-insensitively, otherwise
+          the request is rejected with 400. Legacy token-only invites
+          (invitee_email == nil) keep working unchanged. See #1221.
         type: string
       name:
         type: string
@@ -8893,7 +8898,8 @@ paths:
       consumes:
       - application/vnd.api+json
       description: Accepts a single-use invite link and joins the group as a user.
-        Requires authentication.
+        Requires authentication. If the invite has an invitee email, the user's email
+        must match (case-insensitive); else 422 with code `invite.email_mismatch`.
       parameters:
       - description: Invite token
         in: path
@@ -8916,7 +8922,8 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "422":
-          description: Invite expired, already used, or user already a member
+          description: Invite expired, already used, user already a member, or user
+            email does not match invitee email
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: Accept invite
@@ -8946,8 +8953,8 @@ paths:
               type: string
             type: object
         "400":
-          description: Bad Request - invalid body, expired/used invite, or invalid
-            password
+          description: Bad Request - invalid body, expired/used invite, invalid password,
+            or registration email doesn't match invitee email
           schema:
             type: string
         "403":

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -907,9 +907,12 @@ func (s *GroupService) AcceptInvite(ctx context.Context, token, userID, userEmai
 //   - #1221: if the invite carries an invitee_email (the #1533
 //     email-flow path), the accepting user's email must match it
 //     case-insensitively. Legacy token-only invites (invitee_email ==
-//     nil) and email-flow invites whose stored address normalizes to
-//     empty bypass the email check — the admin vouched for whoever
-//     they handed the URL to.
+//     nil) bypass the email check — the admin vouched for whoever they
+//     handed the URL to. An invitee_email that normalizes to the empty
+//     string (only possible via a direct registry write — the JSON-API
+//     binder in createInvite rejects whitespace-only input) is treated
+//     as fail-closed: no caller email matches, so the invite is
+//     unredeemable. Trusting it would silently bypass the gate.
 //
 // Extracted as a free function so AcceptInvite stays under the gocyclo
 // budget while keeping every rejection sentinel grep-friendly.
@@ -927,9 +930,6 @@ func validateInviteForAccept(invite *models.GroupInvite, userEmail, expectedTena
 		return nil
 	}
 	inviteEmail := strings.ToLower(strings.TrimSpace(*invite.InviteeEmail))
-	if inviteEmail == "" {
-		return nil
-	}
 	caller := strings.ToLower(strings.TrimSpace(userEmail))
 	if inviteEmail != caller {
 		return errxtrace.Classify(ErrInviteEmailMismatch)

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,7 +35,13 @@ var (
 	// ErrInviteNotByEmail is returned when the resend path is called on an
 	// invite created via the legacy token-only flow (invitee_email is nil
 	// — there's no address to resend to).
-	ErrInviteNotByEmail    = errx.NewSentinel("invite was not created with an email address")
+	ErrInviteNotByEmail = errx.NewSentinel("invite was not created with an email address")
+	// ErrInviteEmailMismatch is returned when an invite was addressed to a
+	// specific email (invitee_email != nil, the #1533 email-flow path) and
+	// the registering or accepting user's email doesn't match. Legacy
+	// copy-paste invites (invitee_email == nil) skip this check — the
+	// admin handed the URL to whoever they meant to invite. See #1221.
+	ErrInviteEmailMismatch = errx.NewSentinel("user email does not match invitee email on invite")
 	ErrAlreadyMember       = errx.NewSentinel("user is already a member of this group")
 	ErrNotGroupMember      = errx.NewSentinel("user is not a member of this group")
 	ErrNotGroupAdmin       = errx.NewSentinel("user is not an admin of this group")
@@ -785,24 +792,20 @@ func (s *GroupService) GetInviteInfo(ctx context.Context, token string) (*models
 // the invite's tenant, otherwise we'd create a cross-tenant membership (which
 // in memory silently violates isolation and on PostgreSQL fails RLS with a
 // confusing error).
-func (s *GroupService) AcceptInvite(ctx context.Context, token, userID, expectedTenantID string) (*models.GroupMembership, error) {
+//
+// When the invite was created with an invitee_email (the #1533 email-flow
+// path), userEmail must match invitee_email case-insensitively; otherwise
+// ErrInviteEmailMismatch is returned. Legacy token-only invites
+// (invitee_email == nil) ignore userEmail — the admin handed the URL to
+// whoever they meant to invite. See #1221.
+func (s *GroupService) AcceptInvite(ctx context.Context, token, userID, userEmail, expectedTenantID string) (*models.GroupMembership, error) {
 	invite, err := s.inviteRegistry.GetByToken(ctx, token)
 	if err != nil {
 		return nil, err
 	}
 
-	if invite.TenantID != expectedTenantID {
-		// Don't leak the distinction between "token not found" and
-		// "token belongs to another tenant".
-		return nil, errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "GroupInvite"))
-	}
-
-	if invite.IsExpired() {
-		return nil, errxtrace.Classify(ErrInviteExpired)
-	}
-
-	if invite.IsUsed() {
-		return nil, errxtrace.Classify(ErrInviteAlreadyUsed)
+	if err := validateInviteForAccept(invite, userEmail, expectedTenantID); err != nil {
+		return nil, err
 	}
 
 	// Check if already a member. Distinguish real failures from NotFound.
@@ -892,6 +895,46 @@ func (s *GroupService) AcceptInvite(ctx context.Context, token, userID, expected
 	s.ensureDefaultGroupBestEffort(ctx, userID)
 
 	return created, nil
+}
+
+// validateInviteForAccept enforces the pre-redemption invariants of the
+// AcceptInvite flow:
+//
+//   - tenant match (cross-tenant tokens are masked as not-found so we
+//     don't leak the distinction);
+//   - invite is not expired;
+//   - invite is not already used;
+//   - #1221: if the invite carries an invitee_email (the #1533
+//     email-flow path), the accepting user's email must match it
+//     case-insensitively. Legacy token-only invites (invitee_email ==
+//     nil) and email-flow invites whose stored address normalizes to
+//     empty bypass the email check — the admin vouched for whoever
+//     they handed the URL to.
+//
+// Extracted as a free function so AcceptInvite stays under the gocyclo
+// budget while keeping every rejection sentinel grep-friendly.
+func validateInviteForAccept(invite *models.GroupInvite, userEmail, expectedTenantID string) error {
+	if invite.TenantID != expectedTenantID {
+		return errxtrace.Classify(registry.ErrNotFound, errx.Attrs("entity_type", "GroupInvite"))
+	}
+	if invite.IsExpired() {
+		return errxtrace.Classify(ErrInviteExpired)
+	}
+	if invite.IsUsed() {
+		return errxtrace.Classify(ErrInviteAlreadyUsed)
+	}
+	if invite.InviteeEmail == nil {
+		return nil
+	}
+	inviteEmail := strings.ToLower(strings.TrimSpace(*invite.InviteeEmail))
+	if inviteEmail == "" {
+		return nil
+	}
+	caller := strings.ToLower(strings.TrimSpace(userEmail))
+	if inviteEmail != caller {
+		return errxtrace.Classify(ErrInviteEmailMismatch)
+	}
+	return nil
 }
 
 // RevokeInviteForGroup verifies the invite belongs to the given group, then deletes it.

--- a/go/services/group_service.go
+++ b/go/services/group_service.go
@@ -905,14 +905,16 @@ func (s *GroupService) AcceptInvite(ctx context.Context, token, userID, userEmai
 //   - invite is not expired;
 //   - invite is not already used;
 //   - #1221: if the invite carries an invitee_email (the #1533
-//     email-flow path), the accepting user's email must match it
-//     case-insensitively. Legacy token-only invites (invitee_email ==
-//     nil) bypass the email check — the admin vouched for whoever they
-//     handed the URL to. An invitee_email that normalizes to the empty
-//     string (only possible via a direct registry write — the JSON-API
-//     binder in createInvite rejects whitespace-only input) is treated
-//     as fail-closed: no caller email matches, so the invite is
-//     unredeemable. Trusting it would silently bypass the gate.
+//     email-flow path), the accepting user's email must match it after
+//     trim + case-insensitive normalization. Legacy token-only invites
+//     (invitee_email == nil) bypass the email check — the admin
+//     vouched for whoever they handed the URL to. An invitee_email
+//     that normalizes to the empty string (only possible via a direct
+//     registry write — the JSON-API binder in createInvite rejects
+//     whitespace-only input) is unconditionally rejected: even a
+//     caller whose userEmail also normalizes to "" must not match,
+//     otherwise a malformed invite would be redeemable for any
+//     blank-email caller.
 //
 // Extracted as a free function so AcceptInvite stays under the gocyclo
 // budget while keeping every rejection sentinel grep-friendly.
@@ -931,7 +933,13 @@ func validateInviteForAccept(invite *models.GroupInvite, userEmail, expectedTena
 	}
 	inviteEmail := strings.ToLower(strings.TrimSpace(*invite.InviteeEmail))
 	caller := strings.ToLower(strings.TrimSpace(userEmail))
-	if inviteEmail != caller {
+	// Fail closed on a whitespace-only invitee_email: even if the
+	// caller also normalizes to empty, an empty == empty match would
+	// silently redeem a malformed invite. The JSON-API binder in
+	// createInvite already rejects whitespace input, so reaching this
+	// branch implies a direct registry write (or future bypass) — we
+	// refuse to redeem it.
+	if inviteEmail == "" || inviteEmail != caller {
 		return errxtrace.Classify(ErrInviteEmailMismatch)
 	}
 	return nil

--- a/go/services/group_service_test.go
+++ b/go/services/group_service_test.go
@@ -1111,6 +1111,47 @@ func TestGroupService_AcceptInvite_LegacyInviteIgnoresUserEmail(t *testing.T) {
 	c.Assert(mem.MemberUserID, qt.Equals, "user-2")
 }
 
+// TestGroupService_AcceptInvite_WhitespaceOnlyInviteeEmailRejected — #1221
+// fail-closed guard: an invite whose invitee_email is set but normalizes
+// to "" (only reachable via a direct registry write — the JSON-API
+// binder strips whitespace) must NOT be redeemable, even by a caller
+// whose userEmail is also empty/whitespace. Otherwise a malformed
+// invite would be a free wildcard.
+func TestGroupService_AcceptInvite_WhitespaceOnlyInviteeEmailRejected(t *testing.T) {
+	c := qt.New(t)
+	// Build the service with an explicit invite registry handle so the
+	// test can patch invitee_email to whitespace — simulating a
+	// corrupted row that bypassed the binder.
+	invites := memory.NewGroupInviteRegistry()
+	svc := services.NewGroupService(
+		memory.NewLocationGroupRegistry(),
+		memory.NewGroupMembershipRegistry(),
+		invites,
+	)
+	ctx := context.Background()
+
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
+	c.Assert(err, qt.IsNil)
+
+	validEmail := "real@example.com"
+	invite, err := svc.CreateInviteWithEmail(
+		ctx, "tenant-1", group.ID, "user-1",
+		models.GroupRoleUser, &validEmail, 0,
+	)
+	c.Assert(err, qt.IsNil)
+	whitespace := "   "
+	invite.InviteeEmail = &whitespace
+	_, err = invites.Update(ctx, *invite)
+	c.Assert(err, qt.IsNil)
+
+	// A caller passing an exactly-equal whitespace string must still
+	// be rejected — the fail-closed branch makes any whitespace-only
+	// invitee_email unredeemable.
+	_, err = svc.AcceptInvite(ctx, invite.Token, "user-2", "   ", "tenant-1")
+	c.Assert(err, qt.ErrorIs, services.ErrInviteEmailMismatch)
+	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-2"), qt.IsFalse)
+}
+
 func TestGroupService_ResendInvite(t *testing.T) {
 	c := qt.New(t)
 	svc := newTestGroupService()

--- a/go/services/group_service_test.go
+++ b/go/services/group_service_test.go
@@ -576,14 +576,16 @@ func TestGroupService_InviteFlow(t *testing.T) {
 	c.Assert(fetchedInvite.ID, qt.Equals, invite.ID)
 	c.Assert(fetchedGroup.ID, qt.Equals, group.ID)
 
-	// Accept invite (legacy token-only invite — userEmail is ignored).
-	membership, err := svc.AcceptInvite(ctx, invite.Token, "user-2", "", "tenant-1")
+	// Accept invite (legacy token-only invite — userEmail is ignored;
+	// pass a non-empty value so the test guards against a regression
+	// that accidentally tightened the nil-check to a non-empty check).
+	membership, err := svc.AcceptInvite(ctx, invite.Token, "user-2", "any-email@example.com", "tenant-1")
 	c.Assert(err, qt.IsNil)
 	c.Assert(membership.MemberUserID, qt.Equals, "user-2")
 	c.Assert(membership.Role, qt.Equals, models.GroupRoleUser)
 
 	// Cannot accept the same invite again
-	_, err = svc.AcceptInvite(ctx, invite.Token, "user-3", "", "tenant-1")
+	_, err = svc.AcceptInvite(ctx, invite.Token, "user-3", "any-email@example.com", "tenant-1")
 	c.Assert(err, qt.IsNotNil)
 
 	// Verify user-2 is now a member
@@ -641,8 +643,10 @@ func TestGroupService_RevokeInviteForGroup_CannotRevokeUsed(t *testing.T) {
 	invite, err := svc.CreateInvite(ctx, "tenant-1", group.ID, "user-1", 24*time.Hour)
 	c.Assert(err, qt.IsNil)
 
-	// Accept the invite (legacy token-only invite — userEmail is ignored).
-	_, err = svc.AcceptInvite(ctx, invite.Token, "user-2", "", "tenant-1")
+	// Accept the invite (legacy token-only invite — userEmail is ignored;
+	// pass a non-empty value as a regression guard, matching the basic
+	// invite-flow test above).
+	_, err = svc.AcceptInvite(ctx, invite.Token, "user-2", "any-email@example.com", "tenant-1")
 	c.Assert(err, qt.IsNil)
 
 	// Cannot revoke a used invite
@@ -1050,6 +1054,14 @@ func TestGroupService_AcceptInvite_EmailMismatchRejected(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, services.ErrInviteEmailMismatch)
 	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-2"), qt.IsFalse,
 		qt.Commentf("rejected accept must not create a membership"))
+
+	// The invite must stay unconsumed so the legitimate invitee can
+	// still redeem it (the CAS MarkUsed runs only after every
+	// pre-redemption check passes).
+	fresh, _, err := svc.GetInviteInfo(ctx, invite.Token)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fresh.IsUsed(), qt.IsFalse,
+		qt.Commentf("email-mismatch rejection must leave the invite unconsumed"))
 }
 
 // TestGroupService_AcceptInvite_EmailMatchAccepted — #1221: matching

--- a/go/services/group_service_test.go
+++ b/go/services/group_service_test.go
@@ -576,14 +576,14 @@ func TestGroupService_InviteFlow(t *testing.T) {
 	c.Assert(fetchedInvite.ID, qt.Equals, invite.ID)
 	c.Assert(fetchedGroup.ID, qt.Equals, group.ID)
 
-	// Accept invite
-	membership, err := svc.AcceptInvite(ctx, invite.Token, "user-2", "tenant-1")
+	// Accept invite (legacy token-only invite — userEmail is ignored).
+	membership, err := svc.AcceptInvite(ctx, invite.Token, "user-2", "", "tenant-1")
 	c.Assert(err, qt.IsNil)
 	c.Assert(membership.MemberUserID, qt.Equals, "user-2")
 	c.Assert(membership.Role, qt.Equals, models.GroupRoleUser)
 
 	// Cannot accept the same invite again
-	_, err = svc.AcceptInvite(ctx, invite.Token, "user-3", "tenant-1")
+	_, err = svc.AcceptInvite(ctx, invite.Token, "user-3", "", "tenant-1")
 	c.Assert(err, qt.IsNotNil)
 
 	// Verify user-2 is now a member
@@ -641,8 +641,8 @@ func TestGroupService_RevokeInviteForGroup_CannotRevokeUsed(t *testing.T) {
 	invite, err := svc.CreateInvite(ctx, "tenant-1", group.ID, "user-1", 24*time.Hour)
 	c.Assert(err, qt.IsNil)
 
-	// Accept the invite
-	_, err = svc.AcceptInvite(ctx, invite.Token, "user-2", "tenant-1")
+	// Accept the invite (legacy token-only invite — userEmail is ignored).
+	_, err = svc.AcceptInvite(ctx, invite.Token, "user-2", "", "tenant-1")
 	c.Assert(err, qt.IsNil)
 
 	// Cannot revoke a used invite
@@ -738,7 +738,7 @@ func TestGroupService_EnsureDefaultGroup_AcceptInviteAsBrandNewUser(t *testing.T
 	invite, err := svc.CreateInvite(ctx, "tenant-1", group.ID, owner.ID, 24*time.Hour)
 	c.Assert(err, qt.IsNil)
 
-	_, err = svc.AcceptInvite(ctx, invite.Token, invitee.ID, "tenant-1")
+	_, err = svc.AcceptInvite(ctx, invite.Token, invitee.ID, invitee.Email, "tenant-1")
 	c.Assert(err, qt.IsNil)
 
 	stored, err := users.Get(ctx, invitee.ID)
@@ -1020,9 +1020,83 @@ func TestGroupService_AcceptInvite_UsesInviteRole(t *testing.T) {
 	)
 	c.Assert(err, qt.IsNil)
 
-	mem, err := svc.AcceptInvite(ctx, invite.Token, "user-2", "tenant-1")
+	// The invite was minted with invitee_email = email, so the accepting
+	// user must supply that same address (#1221).
+	mem, err := svc.AcceptInvite(ctx, invite.Token, "user-2", email, "tenant-1")
 	c.Assert(err, qt.IsNil)
 	c.Assert(mem.Role, qt.Equals, models.GroupRoleViewer)
+}
+
+// TestGroupService_AcceptInvite_EmailMismatchRejected — #1221: an
+// invite minted via the email-flow (invitee_email != nil) refuses an
+// AcceptInvite call from a different address. No membership is created
+// and the invite stays unconsumed.
+func TestGroupService_AcceptInvite_EmailMismatchRejected(t *testing.T) {
+	c := qt.New(t)
+	svc := newTestGroupService()
+	ctx := context.Background()
+
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
+	c.Assert(err, qt.IsNil)
+
+	inviteeEmail := "intended@example.com"
+	invite, err := svc.CreateInviteWithEmail(
+		ctx, "tenant-1", group.ID, "user-1",
+		models.GroupRoleUser, &inviteeEmail, 0,
+	)
+	c.Assert(err, qt.IsNil)
+
+	_, err = svc.AcceptInvite(ctx, invite.Token, "user-2", "someone-else@example.com", "tenant-1")
+	c.Assert(err, qt.ErrorIs, services.ErrInviteEmailMismatch)
+	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-2"), qt.IsFalse,
+		qt.Commentf("rejected accept must not create a membership"))
+}
+
+// TestGroupService_AcceptInvite_EmailMatchAccepted — #1221: matching
+// email succeeds, and the match is case-insensitive (passing the
+// invitee_email in upper-case must still match the stored lower-case
+// form).
+func TestGroupService_AcceptInvite_EmailMatchAccepted(t *testing.T) {
+	c := qt.New(t)
+	svc := newTestGroupService()
+	ctx := context.Background()
+
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
+	c.Assert(err, qt.IsNil)
+
+	inviteeEmail := "invitee@example.com"
+	invite, err := svc.CreateInviteWithEmail(
+		ctx, "tenant-1", group.ID, "user-1",
+		models.GroupRoleUser, &inviteeEmail, 0,
+	)
+	c.Assert(err, qt.IsNil)
+
+	// Pass the email in upper-case to prove the comparison is case-folded.
+	mem, err := svc.AcceptInvite(ctx, invite.Token, "user-2", "INVITEE@EXAMPLE.COM", "tenant-1")
+	c.Assert(err, qt.IsNil)
+	c.Assert(mem.MemberUserID, qt.Equals, "user-2")
+	c.Assert(svc.IsGroupMember(ctx, group.ID, "user-2"), qt.IsTrue)
+}
+
+// TestGroupService_AcceptInvite_LegacyInviteIgnoresUserEmail — #1221
+// regression guard: a legacy token-only invite (invitee_email == nil,
+// the copy-paste flow) accepts any userEmail. The admin handed the URL
+// to whoever they meant — there's no email on file to compare against.
+func TestGroupService_AcceptInvite_LegacyInviteIgnoresUserEmail(t *testing.T) {
+	c := qt.New(t)
+	svc := newTestGroupService()
+	ctx := context.Background()
+
+	group, err := svc.CreateGroup(ctx, "tenant-1", "user-1", "Group", "", "", "")
+	c.Assert(err, qt.IsNil)
+
+	// CreateInvite (no email) is the legacy token-only entry point.
+	invite, err := svc.CreateInvite(ctx, "tenant-1", group.ID, "user-1", 0)
+	c.Assert(err, qt.IsNil)
+
+	mem, err := svc.AcceptInvite(ctx, invite.Token, "user-2", "whoever@example.com", "tenant-1")
+	c.Assert(err, qt.IsNil)
+	c.Assert(mem.MemberUserID, qt.Equals, "user-2")
 }
 
 func TestGroupService_ResendInvite(t *testing.T) {


### PR DESCRIPTION
Closes #1221.

## Decision

Issue #1221 asked three questions:

1. **Should invite-based registration skip email verification entirely?** — **Yes.** The admin's invite is the trust anchor; making the invitee re-prove ownership of an email the admin already vouched for is friction without security. This is the status quo since #1285, now confirmed and documented.
2. **Should it be configurable per-tenant?** — **No.** Per the project's "no premature configurability" convention, no `require_email_verification_on_invite` flag. Re-open if a concrete tenant actually asks.
3. **What about cases where the invited email differs from the registration email?** — **Reject.** When an invite carries `invitee_email` (the #1533 email-flow path), both `POST /api/v1/register` (with `invite_token`) and `POST /api/v1/invites/{token}/accept` now require the user's email to match `invitee_email` (case-insensitive, trimmed). Legacy copy-paste invites (`invitee_email == nil`) keep working unchanged — the admin handed the URL to whoever they meant.

## Summary

- New sentinel `services.ErrInviteEmailMismatch` mapped to 422 + JSON:API code `invite.email_mismatch` so the FE can render targeted copy.
- `GroupService.AcceptInvite` widened to `(ctx, token, userID, userEmail, expectedTenantID)`. All 4 production / 5 test call sites updated.
- `validateInviteForAccept` extracted as a free function (keeps `AcceptInvite` under the gocyclo budget; one source of truth for the four pre-redemption invariants: tenant / expired / used / email-match).
- Registration handler's `resolveInvite` performs the same check at the unauthenticated entry point. The two paths are intentionally separate — registration speaks plain `http.Error` (400), accept speaks JSON:API (422). Both normalize identically.
- Fail-closed on a whitespace-only `invitee_email`: only possible via direct registry write (the JSON-API binder in `createInvite` strips it), but the runtime check still rejects rather than silently bypassing.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — 63 packages, 0 fails
- [x] `golangci-lint run ./...` — 0 issues
- [x] New unit tests cover: matching email (case-fold proof), mismatch, and legacy `invitee_email == nil` regression guard — at both the handler layer (`registration_invite_test.go`) and the service layer (`group_service_test.go`).
- [x] Email-mismatch service test asserts `invite.IsUsed() == false` post-rejection — the CAS MarkUsed only fires when every pre-redemption check passes.
- [x] No migrations touched (handler/service-only change).
- [ ] e2e (`register-via-invite.spec.ts`) uses email-less invites, so no e2e changes required; the existing tests continue to exercise the legacy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invites can be bound to an email: accepting or registering with an email-bound invite now requires a case-insensitive, trimmed email match; legacy token-only invites remain unaffected.

* **Behavior Changes**
  * Mismatched emails are rejected (invite acceptance returns 422 with an email-mismatch code; registration returns 400). Whitespace-only invitee emails are treated as invalid.

* **Tests**
  * Added coverage for matching, mismatch, legacy-token, and whitespace-only invite flows.

* **Documentation**
  * API docs updated to reflect the above behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->