### PR TITLE
[#1785] backoffice: gate /api/v1/admin/* CRUD on RequireBackofficeAuth

### DIFF
--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -103,7 +103,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.AdminGroupsResponse"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -112,7 +112,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -163,7 +163,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.AdminGroupResponse"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -172,7 +172,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -219,7 +219,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.AdminGroupResponse"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -228,7 +228,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -285,7 +285,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.AdminGroupMembersResponse"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -294,7 +294,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -355,7 +355,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -364,7 +364,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -434,7 +434,7 @@ export type paths = {
                     };
                     content?: never;
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -443,7 +443,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -515,7 +515,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -524,7 +524,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -730,7 +730,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.AdminTenantsResponse"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -739,7 +739,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -790,7 +790,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.AdminTenantResponse"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -799,7 +799,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -872,7 +872,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.AdminUsersResponse"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -881,7 +881,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -941,7 +941,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.AdminUserResponse"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -950,7 +950,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -1028,7 +1028,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -1037,7 +1037,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;
@@ -1231,7 +1231,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -1240,7 +1240,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -10,8 +10,8 @@ export type paths = {
             cookie?: never;
         };
         /**
-         * System-admin ping
-         * @description Returns 200 when the caller has system-admin privileges. Probe endpoint for the admin surface (#1745).
+         * Back-office ping
+         * @description Returns 200 when the caller is authenticated on the back-office plane. Probe endpoint for the admin surface (#1745).
          */
         get: {
             parameters: {
@@ -31,7 +31,7 @@ export type paths = {
                         "application/json": components["schemas"]["apiserver.AdminPingResponse"];
                     };
                 };
-                /** @description Unauthorized */
+                /** @description Unauthorized - back-office authentication required */
                 401: {
                     headers: {
                         [name: string]: unknown;
@@ -40,7 +40,7 @@ export type paths = {
                         "application/json": components["schemas"]["jsonapi.Errors"];
                     };
                 };
-                /** @description Forbidden - system-admin required */
+                /** @description Account disabled */
                 403: {
                     headers: {
                         [name: string]: unknown;

--- a/go/apiserver/admin_group_members.go
+++ b/go/apiserver/admin_group_members.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 
+	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/jsonapi"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
@@ -136,8 +137,8 @@ type adminGroupMembersAPI struct {
 // @Produce json-api
 // @Param groupID path string true "Group ID"
 // @Success 200 {object} jsonapi.AdminGroupMembersResponse "OK"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Failure 404 {object} jsonapi.Errors "Not Found - unknown group"
 // @Router /admin/groups/{groupID}/members [get]
 func (api *adminGroupMembersAPI) listMembers(w http.ResponseWriter, r *http.Request) {
@@ -199,12 +200,20 @@ func (api *adminGroupMembersAPI) listMembers(w http.ResponseWriter, r *http.Requ
 // @Param data body AdminAddMemberRequest true "Add-member request"
 // @Success 201 {object} AdminMemberEnvelope "Created"
 // @Failure 400 {object} jsonapi.Errors "Bad Request - invalid body"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Failure 404 {object} jsonapi.Errors "Not Found - unknown group or user"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - tenant mismatch, cap reached, duplicate, or invalid role"
 // @Router /admin/groups/{groupID}/members [post]
 func (api *adminGroupMembersAPI) addMember(w http.ResponseWriter, r *http.Request) {
+	if appctx.AdminActorFromContext(r.Context()) == nil {
+		// Defence-in-depth: RequireBackofficeAuth should have caught this
+		// already. Mirrors the wiring-bug 401 in admin_users.go's
+		// block/unblock handlers — see actorIDFromRequest's doc-comment.
+		_ = unauthorizedError(w, r, ErrMissingUserContext)
+		return
+	}
+
 	groupID := chi.URLParam(r, "groupID")
 	if strings.TrimSpace(groupID) == "" {
 		_ = renderEntityError(w, r, registry.ErrNotFound)
@@ -272,12 +281,20 @@ func (api *adminGroupMembersAPI) addMember(w http.ResponseWriter, r *http.Reques
 // @Param groupID path string true "Group ID"
 // @Param userID path string true "User ID of the member to remove"
 // @Success 204 "No Content"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Failure 404 {object} jsonapi.Errors "Not Found - user is not a member of the group"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - removing the last owner or last member"
 // @Router /admin/groups/{groupID}/members/{userID} [delete]
 func (api *adminGroupMembersAPI) removeMember(w http.ResponseWriter, r *http.Request) {
+	if appctx.AdminActorFromContext(r.Context()) == nil {
+		// Defence-in-depth: RequireBackofficeAuth should have caught this
+		// already. Mirrors the wiring-bug 401 in admin_users.go's
+		// block/unblock handlers — see actorIDFromRequest's doc-comment.
+		_ = unauthorizedError(w, r, ErrMissingUserContext)
+		return
+	}
+
 	groupID := chi.URLParam(r, "groupID")
 	userID := chi.URLParam(r, "userID")
 	if strings.TrimSpace(groupID) == "" || strings.TrimSpace(userID) == "" {
@@ -336,12 +353,20 @@ func (api *adminGroupMembersAPI) removeMember(w http.ResponseWriter, r *http.Req
 // @Param data body AdminUpdateMemberRoleRequest true "Role-change request"
 // @Success 200 {object} AdminMemberEnvelope "OK"
 // @Failure 400 {object} jsonapi.Errors "Bad Request - invalid body"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Failure 404 {object} jsonapi.Errors "Not Found - user is not a member of the group"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - demoting the last owner or invalid role"
 // @Router /admin/groups/{groupID}/members/{userID} [patch]
 func (api *adminGroupMembersAPI) updateMemberRole(w http.ResponseWriter, r *http.Request) {
+	if appctx.AdminActorFromContext(r.Context()) == nil {
+		// Defence-in-depth: RequireBackofficeAuth should have caught this
+		// already. Mirrors the wiring-bug 401 in admin_users.go's
+		// block/unblock handlers — see actorIDFromRequest's doc-comment.
+		_ = unauthorizedError(w, r, ErrMissingUserContext)
+		return
+	}
+
 	groupID := chi.URLParam(r, "groupID")
 	userID := chi.URLParam(r, "userID")
 	if strings.TrimSpace(groupID) == "" || strings.TrimSpace(userID) == "" {

--- a/go/apiserver/admin_group_members_test.go
+++ b/go/apiserver/admin_group_members_test.go
@@ -67,12 +67,12 @@ func findAuditRow(c *qt.C, params apiserver.Params, action string) *models.Audit
 func TestAdminAddMember_HappyPath(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "newmember@example.com", true, false)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	target := createTestUserDirect(c, env.params, env.tenantID, "newmember@example.com", true, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/groups/"+group.ID+"/members",
-		env.admin.ID, map[string]any{"userID": target.ID, "role": "user"})
+		env.adminToken, map[string]any{"userID": target.ID, "role": "user"})
 	c.Assert(rr.Code, qt.Equals, http.StatusCreated)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.type"), "group_memberships")
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.group_id"), group.ID)
@@ -88,12 +88,12 @@ func TestAdminAddMember_HappyPath(t *testing.T) {
 func TestAdminAddMember_AuditRow(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "newmember@example.com", true, false)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	target := createTestUserDirect(c, env.params, env.tenantID, "newmember@example.com", true, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/groups/"+group.ID+"/members",
-		env.admin.ID, map[string]any{"userID": target.ID, "role": "admin"})
+		env.adminToken, map[string]any{"userID": target.ID, "role": "admin"})
 	c.Assert(rr.Code, qt.Equals, http.StatusCreated)
 
 	row := findAuditRow(c, env.params, apiserver.AuditActionAdminMemberAdd)
@@ -112,7 +112,7 @@ func TestAdminAddMember_AuditRow(t *testing.T) {
 func TestAdminAddMember_CrossTenantRejected(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
 
 	// A user in a different tenant.
 	otherTenant := must.Must(env.params.FactorySet.TenantRegistry.Create(context.Background(), models.Tenant{
@@ -124,7 +124,7 @@ func TestAdminAddMember_CrossTenantRejected(t *testing.T) {
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/groups/"+group.ID+"/members",
-		env.admin.ID, map[string]any{"userID": target.ID, "role": "user"})
+		env.adminToken, map[string]any{"userID": target.ID, "role": "user"})
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 	assertErrorCode(t, c, rr.Body.Bytes(), "admin.member.tenant_mismatch")
 }
@@ -135,43 +135,43 @@ func TestAdminAddMember_CapReached(t *testing.T) {
 		c.Skip("cap disabled")
 	}
 	env := newAdminEnv(c)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "capped@example.com", true, false)
+	target := createTestUserDirect(c, env.params, env.tenantID, "capped@example.com", true, false)
 
 	// Fill the target's membership quota up to the cap.
 	for range services.MaxGroupMembershipsPerUser() {
-		g := createAdminTestGroup(c, env.params, env.admin.TenantID)
-		addMembershipRow(c, env.params, env.admin.TenantID, g.ID, target.ID, models.GroupRoleUser)
+		g := createAdminTestGroup(c, env.params, env.tenantID)
+		addMembershipRow(c, env.params, env.tenantID, g.ID, target.ID, models.GroupRoleUser)
 	}
-	overflow := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	overflow := createAdminTestGroup(c, env.params, env.tenantID)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/groups/"+overflow.ID+"/members",
-		env.admin.ID, map[string]any{"userID": target.ID, "role": "user"})
+		env.adminToken, map[string]any{"userID": target.ID, "role": "user"})
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 }
 
 func TestAdminAddMember_AlreadyMemberRejected(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "dup@example.com", true, false)
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, target.ID, models.GroupRoleUser)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	target := createTestUserDirect(c, env.params, env.tenantID, "dup@example.com", true, false)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, target.ID, models.GroupRoleUser)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/groups/"+group.ID+"/members",
-		env.admin.ID, map[string]any{"userID": target.ID, "role": "admin"})
+		env.adminToken, map[string]any{"userID": target.ID, "role": "admin"})
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 }
 
 func TestAdminAddMember_InvalidRoleRejected(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "badrole@example.com", true, false)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	target := createTestUserDirect(c, env.params, env.tenantID, "badrole@example.com", true, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/groups/"+group.ID+"/members",
-		env.admin.ID, map[string]any{"userID": target.ID, "role": "superuser"})
+		env.adminToken, map[string]any{"userID": target.ID, "role": "superuser"})
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 	assertErrorCode(t, c, rr.Body.Bytes(), "admin.member.invalid_role")
 }
@@ -179,11 +179,11 @@ func TestAdminAddMember_InvalidRoleRejected(t *testing.T) {
 func TestAdminAddMember_MissingUserIDRejected(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/groups/"+group.ID+"/members",
-		env.admin.ID, map[string]any{"role": "user"})
+		env.adminToken, map[string]any{"role": "user"})
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 	assertErrorCode(t, c, rr.Body.Bytes(), "admin.member.user_required")
 }
@@ -191,40 +191,40 @@ func TestAdminAddMember_MissingUserIDRejected(t *testing.T) {
 func TestAdminAddMember_UnknownGroupReturns404(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "nogroup@example.com", true, false)
+	target := createTestUserDirect(c, env.params, env.tenantID, "nogroup@example.com", true, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/groups/does-not-exist/members",
-		env.admin.ID, map[string]any{"userID": target.ID, "role": "user"})
+		env.adminToken, map[string]any{"userID": target.ID, "role": "user"})
 	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
 }
 
-func TestAdminAddMember_NonAdminForbidden(t *testing.T) {
+func TestAdminAddMember_TenantTokenRejected(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := newParams() // not promoted
+	params, user, _ := newParams()
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 	group := createAdminTestGroup(c, params, user.TenantID)
 	target := createTestUserDirect(c, params, user.TenantID, "nope@example.com", true, false)
 
+	// Tenant JWT — RequireBackofficeAuth rejects at the audience guard.
 	rr := doAdminJSONRequest(t, handler, http.MethodPost,
 		"/api/v1/admin/groups/"+group.ID+"/members",
-		user.ID, map[string]any{"userID": target.ID, "role": "user"})
-	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
-	c.Assert(rr.Body.String(), qt.Contains, "admin.forbidden")
+		createTestJWTToken(user.ID), map[string]any{"userID": target.ID, "role": "user"})
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }
 
 func TestAdminRemoveMember_HappyPath(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	owner := createTestUserDirect(c, env.params, env.admin.TenantID, "owner@example.com", true, false)
-	member := createTestUserDirect(c, env.params, env.admin.TenantID, "member@example.com", true, false)
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, owner.ID, models.GroupRoleOwner)
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	owner := createTestUserDirect(c, env.params, env.tenantID, "owner@example.com", true, false)
+	member := createTestUserDirect(c, env.params, env.tenantID, "member@example.com", true, false)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, owner.ID, models.GroupRoleOwner)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, member.ID, models.GroupRoleUser)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodDelete,
 		"/api/v1/admin/groups/"+group.ID+"/members/"+member.ID,
-		env.admin.ID, nil)
+		env.adminToken, nil)
 	c.Assert(rr.Code, qt.Equals, http.StatusNoContent)
 
 	_, err := env.params.FactorySet.GroupMembershipRegistry.GetByGroupAndUser(context.Background(), group.ID, member.ID)
@@ -240,32 +240,32 @@ func TestAdminRemoveMember_HappyPath(t *testing.T) {
 func TestAdminRemoveMember_LastOwnerRejected(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	owner := createTestUserDirect(c, env.params, env.admin.TenantID, "soleowner@example.com", true, false)
-	member := createTestUserDirect(c, env.params, env.admin.TenantID, "plainmember@example.com", true, false)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	owner := createTestUserDirect(c, env.params, env.tenantID, "soleowner@example.com", true, false)
+	member := createTestUserDirect(c, env.params, env.tenantID, "plainmember@example.com", true, false)
 	// One owner + one non-owner: removing the owner trips ErrLastOwner
 	// (the ≥1-member invariant is still satisfied).
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, owner.ID, models.GroupRoleOwner)
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, owner.ID, models.GroupRoleOwner)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, member.ID, models.GroupRoleUser)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodDelete,
 		"/api/v1/admin/groups/"+group.ID+"/members/"+owner.ID,
-		env.admin.ID, nil)
+		env.adminToken, nil)
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 }
 
 func TestAdminRemoveMember_LastMemberRejected(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	member := createTestUserDirect(c, env.params, env.admin.TenantID, "lonely@example.com", true, false)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	member := createTestUserDirect(c, env.params, env.tenantID, "lonely@example.com", true, false)
 	// A single non-owner member: removing them trips ErrLastMember
 	// (the owner check would pass vacuously).
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, member.ID, models.GroupRoleUser)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodDelete,
 		"/api/v1/admin/groups/"+group.ID+"/members/"+member.ID,
-		env.admin.ID, nil)
+		env.adminToken, nil)
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 	assertErrorCode(t, c, rr.Body.Bytes(), "group.last_member")
 }
@@ -273,27 +273,27 @@ func TestAdminRemoveMember_LastMemberRejected(t *testing.T) {
 func TestAdminRemoveMember_NotAMemberReturns404(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	stranger := createTestUserDirect(c, env.params, env.admin.TenantID, "stranger@example.com", true, false)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	stranger := createTestUserDirect(c, env.params, env.tenantID, "stranger@example.com", true, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodDelete,
 		"/api/v1/admin/groups/"+group.ID+"/members/"+stranger.ID,
-		env.admin.ID, nil)
+		env.adminToken, nil)
 	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
 }
 
 func TestAdminUpdateMemberRole_HappyPath(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	owner := createTestUserDirect(c, env.params, env.admin.TenantID, "owner2@example.com", true, false)
-	member := createTestUserDirect(c, env.params, env.admin.TenantID, "promoteme@example.com", true, false)
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, owner.ID, models.GroupRoleOwner)
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	owner := createTestUserDirect(c, env.params, env.tenantID, "owner2@example.com", true, false)
+	member := createTestUserDirect(c, env.params, env.tenantID, "promoteme@example.com", true, false)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, owner.ID, models.GroupRoleOwner)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, member.ID, models.GroupRoleUser)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPatch,
 		"/api/v1/admin/groups/"+group.ID+"/members/"+member.ID,
-		env.admin.ID, map[string]any{"role": "admin"})
+		env.adminToken, map[string]any{"role": "admin"})
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.role"), "admin")
 
@@ -310,29 +310,29 @@ func TestAdminUpdateMemberRole_HappyPath(t *testing.T) {
 func TestAdminUpdateMemberRole_LastOwnerDemotionRejected(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	owner := createTestUserDirect(c, env.params, env.admin.TenantID, "demoteme@example.com", true, false)
-	member := createTestUserDirect(c, env.params, env.admin.TenantID, "bystander@example.com", true, false)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	owner := createTestUserDirect(c, env.params, env.tenantID, "demoteme@example.com", true, false)
+	member := createTestUserDirect(c, env.params, env.tenantID, "bystander@example.com", true, false)
 	// Sole owner: demoting them to user would leave the group ownerless.
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, owner.ID, models.GroupRoleOwner)
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, owner.ID, models.GroupRoleOwner)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, member.ID, models.GroupRoleUser)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPatch,
 		"/api/v1/admin/groups/"+group.ID+"/members/"+owner.ID,
-		env.admin.ID, map[string]any{"role": "user"})
+		env.adminToken, map[string]any{"role": "user"})
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 }
 
 func TestAdminUpdateMemberRole_InvalidRoleRejected(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	member := createTestUserDirect(c, env.params, env.admin.TenantID, "rolecheck@example.com", true, false)
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	member := createTestUserDirect(c, env.params, env.tenantID, "rolecheck@example.com", true, false)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, member.ID, models.GroupRoleUser)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPatch,
 		"/api/v1/admin/groups/"+group.ID+"/members/"+member.ID,
-		env.admin.ID, map[string]any{"role": "godmode"})
+		env.adminToken, map[string]any{"role": "godmode"})
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 	assertErrorCode(t, c, rr.Body.Bytes(), "admin.member.invalid_role")
 }
@@ -340,12 +340,12 @@ func TestAdminUpdateMemberRole_InvalidRoleRejected(t *testing.T) {
 func TestAdminUpdateMemberRole_NotAMemberReturns404(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	stranger := createTestUserDirect(c, env.params, env.admin.TenantID, "ghost@example.com", true, false)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	stranger := createTestUserDirect(c, env.params, env.tenantID, "ghost@example.com", true, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPatch,
 		"/api/v1/admin/groups/"+group.ID+"/members/"+stranger.ID,
-		env.admin.ID, map[string]any{"role": "admin"})
+		env.adminToken, map[string]any{"role": "admin"})
 	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
 }
 
@@ -357,14 +357,14 @@ func TestAdminUpdateMemberRole_NotAMemberReturns404(t *testing.T) {
 func TestAdminListMembers_HappyPath(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
-	owner := createTestUserDirect(c, env.params, env.admin.TenantID, "listowner@example.com", true, false)
-	member := createTestUserDirect(c, env.params, env.admin.TenantID, "listmember@example.com", true, false)
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, owner.ID, models.GroupRoleOwner)
-	addMembershipRow(c, env.params, env.admin.TenantID, group.ID, member.ID, models.GroupRoleUser)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
+	owner := createTestUserDirect(c, env.params, env.tenantID, "listowner@example.com", true, false)
+	member := createTestUserDirect(c, env.params, env.tenantID, "listmember@example.com", true, false)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, owner.ID, models.GroupRoleOwner)
+	addMembershipRow(c, env.params, env.tenantID, group.ID, member.ID, models.GroupRoleUser)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodGet,
-		"/api/v1/admin/groups/"+group.ID+"/members", env.admin.ID, nil)
+		"/api/v1/admin/groups/"+group.ID+"/members", env.adminToken, nil)
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathMatches("$.data", qt.HasLen), 2)
 	// joined_at ASC ordering: the owner was seeded first.
@@ -383,19 +383,19 @@ func TestAdminListMembers_UnknownGroupReturns404(t *testing.T) {
 	env := newAdminEnv(c)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodGet,
-		"/api/v1/admin/groups/does-not-exist/members", env.admin.ID, nil)
+		"/api/v1/admin/groups/does-not-exist/members", env.adminToken, nil)
 	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
 }
 
 func TestAdminListMembers_EmptyGroupReturns200(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	group := createAdminTestGroup(c, env.params, env.admin.TenantID)
+	group := createAdminTestGroup(c, env.params, env.tenantID)
 
 	// An existing group with no members is a 200 with an empty data
 	// array — not a 404.
 	rr := doAdminJSONRequest(t, env.handler, http.MethodGet,
-		"/api/v1/admin/groups/"+group.ID+"/members", env.admin.ID, nil)
+		"/api/v1/admin/groups/"+group.ID+"/members", env.adminToken, nil)
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathMatches("$.data", qt.HasLen), 0)
 }
@@ -417,21 +417,21 @@ func TestAdminListMembers_CrossTenant(t *testing.T) {
 	addMembershipRow(c, env.params, otherTenant.ID, group.ID, member.ID, models.GroupRoleOwner)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodGet,
-		"/api/v1/admin/groups/"+group.ID+"/members", env.admin.ID, nil)
+		"/api/v1/admin/groups/"+group.ID+"/members", env.adminToken, nil)
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathMatches("$.data", qt.HasLen), 1)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data[0].member_user_id"), member.ID)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data[0].user.email"), "crosstenant@example.com")
 }
 
-func TestAdminListMembers_NonAdminForbidden(t *testing.T) {
+func TestAdminListMembers_TenantTokenRejected(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := newParams() // not promoted
+	params, user, _ := newParams()
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 	group := createAdminTestGroup(c, params, user.TenantID)
 
+	// Tenant JWT — RequireBackofficeAuth rejects at the audience guard.
 	rr := doAdminJSONRequest(t, handler, http.MethodGet,
-		"/api/v1/admin/groups/"+group.ID+"/members", user.ID, nil)
-	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
-	c.Assert(rr.Body.String(), qt.Contains, "admin.forbidden")
+		"/api/v1/admin/groups/"+group.ID+"/members", createTestJWTToken(user.ID), nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }

--- a/go/apiserver/admin_groups.go
+++ b/go/apiserver/admin_groups.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 
+	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/jsonapi"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
@@ -44,8 +45,8 @@ type adminGroupsAPI struct {
 // @Param sort query string false "Sort field: name|slug|created_at|status (prefix with - for desc)"
 // @Param order query string false "Sort direction override (wins over `-` prefix)" Enums(asc,desc)
 // @Success 200 {object} jsonapi.AdminGroupsResponse "OK"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Router /admin/groups [get]
 func (api *adminGroupsAPI) listGroups(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
@@ -102,8 +103,8 @@ func (api *adminGroupsAPI) listGroups(w http.ResponseWriter, r *http.Request) {
 // @Produce json-api
 // @Param groupID path string true "Group ID"
 // @Success 200 {object} jsonapi.AdminGroupResponse "OK"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Failure 404 {object} jsonapi.Errors "Group not found"
 // @Router /admin/groups/{groupID} [get]
 func (api *adminGroupsAPI) getGroup(w http.ResponseWriter, r *http.Request) {
@@ -145,11 +146,19 @@ func (api *adminGroupsAPI) getGroup(w http.ResponseWriter, r *http.Request) {
 // @Produce json-api
 // @Param groupID path string true "Group ID"
 // @Success 200 {object} jsonapi.AdminGroupResponse "OK - group marked pending_deletion (or already was)"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Failure 404 {object} jsonapi.Errors "Group not found"
 // @Router /admin/groups/{groupID} [delete]
 func (api *adminGroupsAPI) deleteGroup(w http.ResponseWriter, r *http.Request) {
+	if appctx.AdminActorFromContext(r.Context()) == nil {
+		// Defence-in-depth: RequireBackofficeAuth should have caught this
+		// already. Mirrors the wiring-bug 401 in admin_users.go's
+		// block/unblock handlers — see actorIDFromRequest's doc-comment.
+		_ = unauthorizedError(w, r, ErrMissingUserContext)
+		return
+	}
+
 	groupID := chi.URLParam(r, "groupID")
 	if groupID == "" {
 		api.auditDelete(r, groupID, "", registry.ErrNotFound)

--- a/go/apiserver/admin_groups_test.go
+++ b/go/apiserver/admin_groups_test.go
@@ -18,17 +18,20 @@ import (
 
 // Groups admin handler tests (#1748). Cover the cross-tenant list (filter
 // combinations), the detail endpoint (tenant chip + member_count), the
-// idempotent soft-delete, the system-admin gate, and the audit trail.
-// Tests reuse promoteToSystemAdmin from admin_routes_test.go.
+// idempotent soft-delete, the back-office admin gate, and the audit trail.
+// After the #1785 Phase 3 migration the admin gate is RequireBackofficeAuth,
+// so the auth header is a back-office bearer minted by WithBackofficeAdmin.
 
-// adminGroupFixture stands up a system-admin actor plus three additional
-// location groups across two tenants so the list/filter assertions have
-// real data to work with. Returns the params, the admin user, and the
-// IDs of the three seeded groups (the order matches the seeds slice).
-func adminGroupFixture(c *qt.C) (apiserver.Params, *models.User, []string) {
+// adminGroupFixture stands up a back-office admin actor plus three
+// additional location groups across two tenants so the list/filter
+// assertions have real data to work with. Returns the params, the seed
+// tenant user (still useful as the `CreatedBy` fixture identity), the
+// back-office bearer token to attach, and the IDs of the three seeded
+// groups (the order matches the seeds slice).
+func adminGroupFixture(t *testing.T, c *qt.C) (apiserver.Params, *models.User, string, []string) {
 	c.Helper()
 	params, user, _ := newParams()
-	promoteToSystemAdmin(c, params, user)
+	_, adminToken := WithBackofficeAdmin(t, params)
 
 	ctx := context.Background()
 	// A second tenant so the tenantID filter has something to discriminate.
@@ -70,16 +73,16 @@ func adminGroupFixture(c *qt.C) (apiserver.Params, *models.User, []string) {
 		created := must.Must(params.FactorySet.LocationGroupRegistry.Create(ctx, g))
 		ids = append(ids, created.ID)
 	}
-	return params, user, ids
+	return params, user, adminToken, ids
 }
 
-func TestAdminListGroups_AllowsSystemAdmin(t *testing.T) {
+func TestAdminListGroups_AllowsBackofficeAdmin(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := adminGroupFixture(c)
+	params, _, adminToken, _ := adminGroupFixture(t, c)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups", nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -111,18 +114,18 @@ func TestAdminListGroups_AllowsSystemAdmin(t *testing.T) {
 	c.Assert(charlie.Tenant.ID, qt.Equals, charlie.TenantID)
 }
 
-func TestAdminListGroups_DeniesNonAdmin(t *testing.T) {
+func TestAdminListGroups_DeniesTenantUser(t *testing.T) {
 	c := qt.New(t)
 	params, user, _ := newParams()
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
+	// Tenant JWT — RequireBackofficeAuth rejects at the audience guard.
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups", nil)
 	addTestUserAuthHeader(req, user.ID)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
-	c.Assert(rr.Body.String(), qt.Contains, "admin.forbidden")
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }
 
 func TestAdminListGroups_DeniesUnauthenticated(t *testing.T) {
@@ -139,7 +142,7 @@ func TestAdminListGroups_DeniesUnauthenticated(t *testing.T) {
 
 func TestAdminListGroups_FiltersAndPaginatesAndSorts(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := adminGroupFixture(c)
+	params, _, adminToken, _ := adminGroupFixture(t, c)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	// The fixture's "Other Org" tenant ID is needed for the tenantID
@@ -212,7 +215,7 @@ func TestAdminListGroups_FiltersAndPaginatesAndSorts(t *testing.T) {
 	for _, tc := range tests {
 		c.Run(tc.name, func(c *qt.C) {
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups"+tc.query, nil)
-			addTestUserAuthHeader(req, user.ID)
+			addBackofficeAuthHeader(req, adminToken)
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)
 
@@ -231,7 +234,7 @@ func TestAdminListGroups_FiltersAndPaginatesAndSorts(t *testing.T) {
 func TestAdminGetGroup_ReturnsRowWithTenantChipAndMemberCount(t *testing.T) {
 	c := qt.New(t)
 	params, user, _ := newParams()
-	promoteToSystemAdmin(c, params, user)
+	_, adminToken := WithBackofficeAdmin(t, params)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	// newParams seeds exactly one group on the actor's tenant with one
@@ -241,7 +244,7 @@ func TestAdminGetGroup_ReturnsRowWithTenantChipAndMemberCount(t *testing.T) {
 	group := groups[0]
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/groups/%s", group.ID), nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -265,7 +268,7 @@ func TestAdminGetGroup_ReturnsRowWithTenantChipAndMemberCount(t *testing.T) {
 func TestAdminListGroups_OrphanedGroupStaysVisible(t *testing.T) {
 	c := qt.New(t)
 	params, user, _ := newParams()
-	promoteToSystemAdmin(c, params, user)
+	_, adminToken := WithBackofficeAdmin(t, params)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	ctx := context.Background()
@@ -280,7 +283,7 @@ func TestAdminListGroups_OrphanedGroupStaysVisible(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups", nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -305,7 +308,7 @@ func TestAdminListGroups_OrphanedGroupStaysVisible(t *testing.T) {
 func TestAdminGetGroup_OrphanedGroupReturnedWithNilTenant(t *testing.T) {
 	c := qt.New(t)
 	params, user, _ := newParams()
-	promoteToSystemAdmin(c, params, user)
+	_, adminToken := WithBackofficeAdmin(t, params)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	ctx := context.Background()
@@ -319,7 +322,7 @@ func TestAdminGetGroup_OrphanedGroupReturnedWithNilTenant(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/groups/%s", orphan.ID), nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -333,21 +336,22 @@ func TestAdminGetGroup_OrphanedGroupReturnedWithNilTenant(t *testing.T) {
 
 func TestAdminGetGroup_404OnMissingID(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := adminGroupFixture(c)
+	params, _, adminToken, _ := adminGroupFixture(t, c)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups/does-not-exist", nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
 }
 
-func TestAdminGetGroup_DeniesNonAdmin(t *testing.T) {
+func TestAdminGetGroup_DeniesTenantUser(t *testing.T) {
 	c := qt.New(t)
-	params, user, ids := adminGroupFixture(c)
-	// Demote: adminGroupFixture promotes, so build a separate non-admin.
+	params, user, _, ids := adminGroupFixture(t, c)
+	// A plain (non-admin) tenant user — RequireBackofficeAuth rejects
+	// the tenant token at the audience guard before any handler runs.
 	nonAdmin := createTestUserDirect(c, params, user.TenantID, "plain@example.com", true, false)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
@@ -356,17 +360,17 @@ func TestAdminGetGroup_DeniesNonAdmin(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }
 
 func TestAdminDeleteGroup_MarksPendingDeletion(t *testing.T) {
 	c := qt.New(t)
-	params, user, ids := adminGroupFixture(c)
+	params, _, adminToken, ids := adminGroupFixture(t, c)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	// ids[0] is the active "Alpha Group".
 	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/admin/groups/%s", ids[0]), nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -383,14 +387,14 @@ func TestAdminDeleteGroup_MarksPendingDeletion(t *testing.T) {
 
 func TestAdminDeleteGroup_IdempotentReDelete(t *testing.T) {
 	c := qt.New(t)
-	params, user, ids := adminGroupFixture(c)
+	params, _, adminToken, ids := adminGroupFixture(t, c)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	// ids[1] is the "Bravo Group" seeded already in pending_deletion —
 	// a re-delete must still return 200 with the current status, never
 	// a 4xx.
 	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/admin/groups/%s", ids[1]), nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -413,20 +417,20 @@ func TestAdminDeleteGroup_IdempotentReDelete(t *testing.T) {
 
 func TestAdminDeleteGroup_404OnMissingID(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := adminGroupFixture(c)
+	params, _, adminToken, _ := adminGroupFixture(t, c)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/groups/does-not-exist", nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
 }
 
-func TestAdminDeleteGroup_DeniesNonAdmin(t *testing.T) {
+func TestAdminDeleteGroup_DeniesTenantUser(t *testing.T) {
 	c := qt.New(t)
-	params, user, ids := adminGroupFixture(c)
+	params, user, _, ids := adminGroupFixture(t, c)
 	nonAdmin := createTestUserDirect(c, params, user.TenantID, "plain@example.com", true, false)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
@@ -435,7 +439,7 @@ func TestAdminDeleteGroup_DeniesNonAdmin(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 
 	// The guard rejected before the transition could fire.
 	stored := must.Must(params.FactorySet.LocationGroupRegistry.Get(context.Background(), ids[0]))
@@ -444,11 +448,12 @@ func TestAdminDeleteGroup_DeniesNonAdmin(t *testing.T) {
 
 func TestAdminListGroups_WritesAuditLog(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := adminGroupFixture(c)
+	params, _, adminToken, _ := adminGroupFixture(t, c)
+	admin := backofficeAdminForToken(t, params, adminToken)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/groups", nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
@@ -457,16 +462,17 @@ func TestAdminListGroups_WritesAuditLog(t *testing.T) {
 	c.Assert(entries, qt.HasLen, 1)
 	c.Assert(entries[0].Success, qt.IsTrue)
 	c.Assert(entries[0].UserID, qt.IsNotNil)
-	c.Assert(*entries[0].UserID, qt.Equals, user.ID)
+	c.Assert(*entries[0].UserID, qt.Equals, admin.ID)
 }
 
 func TestAdminDeleteGroup_WritesAuditLogWithActorGroupAndTenant(t *testing.T) {
 	c := qt.New(t)
-	params, user, ids := adminGroupFixture(c)
+	params, user, adminToken, ids := adminGroupFixture(t, c)
+	admin := backofficeAdminForToken(t, params, adminToken)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/admin/groups/%s", ids[0]), nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
@@ -475,15 +481,17 @@ func TestAdminDeleteGroup_WritesAuditLogWithActorGroupAndTenant(t *testing.T) {
 	c.Assert(entries, qt.HasLen, 1)
 	entry := entries[0]
 	c.Assert(entry.Success, qt.IsTrue)
-	// Admin user ID (actor).
+	// Back-office admin ID (actor) — RequireBackofficeAuth's actor is a
+	// BackofficeUser, NOT the tenant user the fixture also produces.
 	c.Assert(entry.UserID, qt.IsNotNil)
-	c.Assert(*entry.UserID, qt.Equals, user.ID)
+	c.Assert(*entry.UserID, qt.Equals, admin.ID)
 	// Group ID (subject).
 	c.Assert(entry.EntityID, qt.IsNotNil)
 	c.Assert(*entry.EntityID, qt.Equals, ids[0])
 	c.Assert(entry.EntityType, qt.IsNotNil)
 	c.Assert(*entry.EntityType, qt.Equals, "group")
-	// Tenant ID of the group.
+	// Tenant ID of the group's tenant (the actor's back-office identity
+	// is cross-tenant; the row's tenant is the target group's tenant).
 	c.Assert(entry.TenantID, qt.IsNotNil)
 	c.Assert(*entry.TenantID, qt.Equals, user.TenantID)
 	// ids[0] was active, so a genuine first delete: the breadcrumb must

--- a/go/apiserver/admin_middleware_test.go
+++ b/go/apiserver/admin_middleware_test.go
@@ -60,3 +60,27 @@ func TestAdmin_AcceptsBackofficeJWT(t *testing.T) {
 
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 }
+
+// TestImpersonation_RejectsBackofficeJWT is the mirror of
+// TestAdmin_RejectsTenantJWTAfterMigration for the legacy impersonation
+// subtree: the impersonation start endpoint stays on the tenant-side
+// JWTMiddleware (#1785 Phase 3 left the impersonation lifecycle gated by
+// RequireSystemAdmin until a back-office-native redesign lands).
+// JWTMiddleware rejects any token with `aud == "backoffice"` or a non-
+// empty `admin_id` claim — see jwt_middleware.go:104-109 — so a back-
+// office token cannot satisfy the impersonation route.
+func TestImpersonation_RejectsBackofficeJWT(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := newParams()
+	_, backofficeToken := WithBackofficeAdmin(t, params)
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/admin/users/"+user.ID+"/impersonate", nil)
+	addBackofficeAuthHeader(req, backofficeToken)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
+}

--- a/go/apiserver/admin_middleware_test.go
+++ b/go/apiserver/admin_middleware_test.go
@@ -1,0 +1,62 @@
+package apiserver_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/apiserver"
+)
+
+// Cross-plane regression tests for the #1785 Phase 3 migration. The
+// cross-tenant /api/v1/admin/* CRUD surface is now gated by
+// RequireBackofficeAuth (aud=backoffice, admin_id claim). These tests
+// pin the boundary: a tenant-side JWT — even one carrying
+// is_system_admin=true — MUST be rejected at /admin/_ping, and a
+// back-office JWT MUST be accepted.
+
+// TestAdmin_RejectsTenantJWTAfterMigration locks in the audience guard:
+// the legacy "tenant user with IsSystemAdmin=true" path no longer
+// reaches an admin handler. RequireBackofficeAuth rejects the tenant
+// token at the door because its `aud` (omitted by the tenant mint) is
+// not "backoffice". The response is plain-text 401 — the back-office
+// middleware emits its rejections via http.Error rather than the
+// JSON:API envelope, matching the rest of the back-office plane.
+func TestAdmin_RejectsTenantJWTAfterMigration(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := newParams()
+	// Flip is_system_admin on the tenant user — this would have admitted
+	// the request under the legacy RequireSystemAdmin gate. Under the
+	// back-office gate the flag is irrelevant: the audience guard fires
+	// first.
+	promoteToSystemAdmin(c, params, user)
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/_ping", nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
+}
+
+// TestAdmin_AcceptsBackofficeJWT is the positive side of the audience
+// guard: a token signed with the same JWT secret but carrying
+// aud=backoffice + admin_id reaches the admin handler and returns 200.
+func TestAdmin_AcceptsBackofficeJWT(t *testing.T) {
+	c := qt.New(t)
+	params, _, _ := newParams()
+	_, token := WithBackofficeAdmin(t, params)
+
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/_ping", nil)
+	addBackofficeAuthHeader(req, token)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+}

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -66,9 +66,14 @@ func adminPing(w http.ResponseWriter, r *http.Request) {
 // threshold so live access tokens minted before the block fail on
 // next use.
 type AdminParams struct {
-	FactorySet   *registry.FactorySet
-	Blacklist    services.TokenBlacklister
-	AuditService services.AuditLogger
+	FactorySet *registry.FactorySet
+	// BackofficeUserRegistry backs the RequireBackofficeAuth middleware
+	// that gates every cross-tenant admin route (issue #1785, Phase 3).
+	// Held separately from the tenant FactorySet entry so the
+	// middleware constructor can take only what it needs.
+	BackofficeUserRegistry registry.BackofficeUserRegistry
+	Blacklist              services.TokenBlacklister
+	AuditService           services.AuditLogger
 	// GroupService backs the #1749 group-membership admin endpoints
 	// (add / remove / role-change). The same instance the rest of the
 	// apiserver uses — its registries are the tenant-scoped (not
@@ -122,9 +127,15 @@ type AdminParams struct {
 }
 
 // Admin returns the router configurator for /api/v1/admin/*. Mounted
-// from apiserver.go behind the standard userMiddlewares (JWT + RLS +
-// CSRF) and the RequireSystemAdmin gate. Later admin issues hang their
-// endpoints off the same chi.Router this closure receives.
+// from apiserver.go. Cross-tenant CRUD endpoints (tenants, users,
+// groups, members) are gated by RequireBackofficeAuth so the operator
+// must hold a back-office JWT (aud=backoffice, admin_id claim). The
+// legacy impersonation subtree (start/current/end) remains on the
+// tenant-side RequireSystemAdmin gate because the impersonation
+// lifecycle (return-slot restore of the operator's tenant refresh
+// cookie, fresh tenant access token mint) is intrinsically tied to a
+// tenant operator identity; a back-office redesign of impersonation is
+// deferred to a later phase of issue #1785.
 func Admin(params AdminParams) func(r chi.Router) {
 	// Fail fast on a misconfigured wiring: the #1749 group-membership
 	// endpoints dereference GroupService on every request, so a nil
@@ -155,6 +166,12 @@ func Admin(params AdminParams) func(r chi.Router) {
 	// invariant here for a clear failure message.
 	if params.FactorySet == nil {
 		panic("apiserver.Admin requires non-nil AdminParams.FactorySet")
+	}
+	// BackofficeUserRegistry is mandatory for the new back-office gate
+	// (#1785 Phase 3). Fail at startup so a wiring miss surfaces here
+	// rather than as a per-request nil deref inside the middleware.
+	if params.BackofficeUserRegistry == nil {
+		panic("apiserver.Admin requires non-nil AdminParams.BackofficeUserRegistry")
 	}
 
 	tenantsAPI := &adminTenantsAPI{
@@ -187,15 +204,23 @@ func Admin(params AdminParams) func(r chi.Router) {
 	}
 	// Resolve the grants registry from the FactorySet — RequireSystemAdmin
 	// and RequireSystemAdminOrImpersonating are no longer static funcs
-	// (#1784) but instances bound to the deployment's grant store. The
-	// FactorySet nil-guard above runs before this dereference, so a missing
-	// wiring fails at startup with a clear message rather than NPE'ing here.
+	// (#1784) but instances bound to the deployment's grant store. Used
+	// by the legacy impersonation subtree below; the back-office gate
+	// replaces them for the CRUD subtree (#1785 Phase 3). The FactorySet
+	// nil-guard above runs before this dereference, so a missing wiring
+	// fails at startup with a clear message rather than NPE'ing here.
 	// A nil SystemAdminGrantRegistry inside a non-nil FactorySet is caught
 	// downstream by RequireSystemAdmin's own nil-check, which panics at
 	// construction time — fail-fast on a misconfigured deployment rather
 	// than letting the process boot and 500-on-every-admin-request.
 	requireSystemAdmin := RequireSystemAdmin(params.FactorySet.SystemAdminGrantRegistry)
 	requireSystemAdminOrImpersonating := RequireSystemAdminOrImpersonating(params.FactorySet.SystemAdminGrantRegistry)
+
+	backofficeAuth := RequireBackofficeAuth(
+		params.JWTSecret,
+		params.BackofficeUserRegistry,
+		params.Blacklist,
+	)
 
 	return func(r chi.Router) {
 		// POST /admin/impersonation/end is mounted FIRST and OUTSIDE the
@@ -214,90 +239,115 @@ func Admin(params AdminParams) func(r chi.Router) {
 		// imp check, so neither is newly admitted. See endImpersonation.
 		r.Post("/impersonation/end", impersonationAPI.endImpersonation)
 
-		// Everything else lives behind the standard authenticated
-		// middleware chain (JWT + RLS + RegistrySet + CSRF). UserMiddlewares
-		// may be nil in isolated unit tests, in which case no middleware is
-		// applied and the caller is responsible for wrapping.
+		// Cross-tenant CRUD subtree (#1785 Phase 3): gated by the
+		// back-office auth plane. RequireBackofficeAuth parses + validates
+		// a `aud=backoffice` JWT and attaches the back-office identity to
+		// the context via appctx.WithBackofficeUser. Handlers read it back
+		// via appctx.AdminActorFromContext for audit-row population.
+		// Distinct from the impersonation group below — RequireBackofficeAuth
+		// REJECTS tenant tokens (and vice versa), so the two groups are
+		// mutually exclusive on the wire.
+		r.Group(func(r chi.Router) {
+			r.Use(backofficeAuth)
+			adminBackofficeRoutes(r, tenantsAPI, usersAPI, groupsAPI, groupMembersAPI, impersonationAPI)
+		})
+
+		// Legacy impersonation subtree stays on the tenant-side JWT +
+		// RequireSystemAdmin gate. The impersonation start/end lifecycle
+		// captures and restores the operator's tenant refresh cookie and
+		// mints a tenant access token in `restoreAdminSession`; none of
+		// that has a back-office analogue yet. Redesign is deferred to a
+		// later phase of issue #1785. UserMiddlewares may be nil in
+		// isolated unit tests, in which case no middleware is applied and
+		// the caller is responsible for wrapping.
 		r.Group(func(r chi.Router) {
 			for _, mw := range params.UserMiddlewares {
 				r.Use(mw)
 			}
-			adminAuthenticatedRoutes(r, requireSystemAdmin, requireSystemAdminOrImpersonating,
-				tenantsAPI, usersAPI, groupsAPI, groupMembersAPI, impersonationAPI)
+			adminImpersonationRoutes(r, requireSystemAdmin, requireSystemAdminOrImpersonating, impersonationAPI)
 		})
 	}
 }
 
-// adminAuthenticatedRoutes registers every /api/v1/admin/* route that runs
-// behind the authenticated middleware chain (everything except POST
-// /admin/impersonation/end, which is mounted bare by Admin()). Extracted
-// from Admin() so that closure stays under the funlen budget. The two
-// admin gates are passed in already bound to the grants registry
-// (#1784) so this function stays unaware of which registry the
-// deployment uses.
-func adminAuthenticatedRoutes(
+// adminBackofficeRoutes registers every cross-tenant admin route that
+// is gated by RequireBackofficeAuth (issue #1785, Phase 3). The legacy
+// impersonation subtree lives in adminImpersonationRoutes — those routes
+// retain the tenant JWT + RequireSystemAdmin gate until a back-office
+// redesign of the impersonation lifecycle lands. Extracted from Admin()
+// so that closure stays under the funlen budget.
+//
+// Every handler in this group can assume appctx.AdminActorFromContext
+// returns non-nil — RequireBackofficeAuth populates it before
+// dispatching.
+func adminBackofficeRoutes(
 	r chi.Router,
-	requireSystemAdmin func(http.Handler) http.Handler,
-	requireSystemAdminOrImpersonating func(http.Handler) http.Handler,
 	tenantsAPI *adminTenantsAPI,
 	usersAPI *adminUsersAPI,
 	groupsAPI *adminGroupsAPI,
 	groupMembersAPI *adminGroupMembersAPI,
+	_ *adminImpersonationAPI, // reserved for a future back-office impersonation surface
+) {
+	r.Get("/_ping", adminPing)
+
+	// #1746: tenants + users listing endpoints. Each handler
+	// audit-logs via params.AuditService and bypasses RLS at the
+	// registry layer (correlated COUNT subqueries on RLS-enabled
+	// tables run with `SET LOCAL row_security = off` for
+	// defense-in-depth).
+	r.Get("/tenants", tenantsAPI.listTenants)
+	r.Get("/tenants/{tenantID}", tenantsAPI.getTenant)
+	r.Get("/tenants/{tenantID}/users", usersAPI.listTenantUsers)
+	r.Get("/users/{userID}", usersAPI.getUser)
+
+	// #1747: user block/unblock endpoints. Each transition cascades
+	// IsActive=false → refresh-token revoke → blacklist bump and
+	// audit-logs reason+forced via the breadcrumb in user_agent.
+	r.Post("/users/{userID}/block", usersAPI.blockUser)
+	r.Post("/users/{userID}/unblock", usersAPI.unblockUser)
+
+	// #1748: cross-tenant groups admin. List + detail bypass RLS at
+	// the registry layer (SET LOCAL row_security = off); DELETE flips
+	// status to pending_deletion (idempotent) and the existing
+	// group_purge_worker finishes the hard-delete. Each handler
+	// audit-logs via params.AuditService.
+	r.Get("/groups", groupsAPI.listGroups)
+	r.Get("/groups/{groupID}", groupsAPI.getGroup)
+	r.Delete("/groups/{groupID}", groupsAPI.deleteGroup)
+
+	// #1749 / #1756: group-membership admin endpoints. add / remove /
+	// role-change route through GroupService so the per-group
+	// invariants (cap, ≥1 owner, ≥1 member) stay single-sourced,
+	// bypassing only the per-group requireGroupAdmin middleware —
+	// the back-office gate above is authorization enough.
+	r.Get("/groups/{groupID}/members", groupMembersAPI.listMembers)
+	r.Post("/groups/{groupID}/members", groupMembersAPI.addMember)
+	r.Delete("/groups/{groupID}/members/{userID}", groupMembersAPI.removeMember)
+	r.Patch("/groups/{groupID}/members/{userID}", groupMembersAPI.updateMemberRole)
+}
+
+// adminImpersonationRoutes registers the #1750 impersonation start /
+// current endpoints. These intentionally stay on the tenant JWT +
+// RequireSystemAdmin gate (rather than RequireBackofficeAuth): the
+// impersonation lifecycle captures and restores the operator's tenant
+// refresh cookie and mints a tenant access token in
+// restoreAdminSession, none of which has a back-office analogue yet.
+// A back-office-native impersonation surface is a follow-up of issue
+// #1785.
+//
+// POST /impersonation/end is registered separately by Admin() because
+// it must remain reachable AFTER the (≤30 min) impersonation access
+// token expires — see Admin() for the full rationale.
+func adminImpersonationRoutes(
+	r chi.Router,
+	requireSystemAdmin func(http.Handler) http.Handler,
+	requireSystemAdminOrImpersonating func(http.Handler) http.Handler,
 	impersonationAPI *adminImpersonationAPI,
 ) {
-	// The bulk of the admin surface is gated by the strict
-	// RequireSystemAdmin middleware in a nested group so every handler
-	// inside it can assume the caller is a genuine system admin. GET
-	// /admin/impersonation/current is registered OUTSIDE this group with
-	// the wider RequireSystemAdminOrImpersonating gate — see below for why.
-	r.Group(func(r chi.Router) {
-		r.Use(requireSystemAdmin)
-		r.Get("/_ping", adminPing)
-
-		// #1746: tenants + users listing endpoints. Each handler
-		// audit-logs via params.AuditService and bypasses RLS at the
-		// registry layer (correlated COUNT subqueries on RLS-enabled
-		// tables run with `SET LOCAL row_security = off` for
-		// defense-in-depth).
-		r.Get("/tenants", tenantsAPI.listTenants)
-		r.Get("/tenants/{tenantID}", tenantsAPI.getTenant)
-		r.Get("/tenants/{tenantID}/users", usersAPI.listTenantUsers)
-		r.Get("/users/{userID}", usersAPI.getUser)
-
-		// #1747: user block/unblock endpoints. Each transition cascades
-		// IsActive=false → refresh-token revoke → blacklist bump and
-		// audit-logs reason+forced via the breadcrumb in user_agent.
-		r.Post("/users/{userID}/block", usersAPI.blockUser)
-		r.Post("/users/{userID}/unblock", usersAPI.unblockUser)
-
-		// #1748: cross-tenant groups admin. List + detail bypass RLS at
-		// the registry layer (SET LOCAL row_security = off); DELETE flips
-		// status to pending_deletion (idempotent) and the existing
-		// group_purge_worker finishes the hard-delete. Each handler
-		// audit-logs via params.AuditService.
-		r.Get("/groups", groupsAPI.listGroups)
-		r.Get("/groups/{groupID}", groupsAPI.getGroup)
-		r.Delete("/groups/{groupID}", groupsAPI.deleteGroup)
-
-		// #1749: group-membership admin endpoints. add / remove /
-		// role-change route through GroupService so the per-group
-		// invariants (cap, ≥1 owner, ≥1 member) stay single-sourced,
-		// bypassing only the per-group requireGroupAdmin middleware —
-		// the RequireSystemAdmin gate above is authorization enough.
-		// #1756: GET /members lists the group's members joined with
-		// each member's identity for the admin membership editor;
-		// cross-tenant via the registry's RLS-bypass path.
-		r.Get("/groups/{groupID}/members", groupMembersAPI.listMembers)
-		r.Post("/groups/{groupID}/members", groupMembersAPI.addMember)
-		r.Delete("/groups/{groupID}/members/{userID}", groupMembersAPI.removeMember)
-		r.Patch("/groups/{groupID}/members/{userID}", groupMembersAPI.updateMemberRole)
-
-		// #1750: starting an impersonation session is a privileged
-		// operation — it stays behind the strict gate. The
-		// nested-impersonation guard in the handler rejects a request
-		// already inside an impersonation session.
-		r.Post("/users/{userID}/impersonate", impersonationAPI.startImpersonation)
-	})
+	// Starting an impersonation session is a privileged operation — it
+	// stays behind the strict gate. The nested-impersonation guard in
+	// the handler rejects a request already inside an impersonation
+	// session.
+	r.With(requireSystemAdmin).Post("/users/{userID}/impersonate", impersonationAPI.startImpersonation)
 
 	// #1750: GET /admin/impersonation/current must be reachable from
 	// INSIDE an impersonation session, whose access token deliberately

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -33,17 +33,19 @@ type AdminPingResponse struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-// adminPing is the placeholder handler behind RequireSystemAdmin.
-// Returns 200 with a simple JSON body so the FE can detect "I have
-// system-admin" without needing a richer endpoint until later
-// admin issues land.
-// @Summary System-admin ping
-// @Description Returns 200 when the caller has system-admin privileges. Probe endpoint for the admin surface (#1745).
+// adminPing is the placeholder handler behind RequireBackofficeAuth.
+// Returns 200 with a simple JSON body so the FE can detect "I am
+// signed in to the back-office plane" without needing a richer
+// endpoint until later admin issues land. Post-#1785 Phase 3 the gate
+// is back-office-only — a tenant JWT with `is_system_admin` no longer
+// reaches this route.
+// @Summary Back-office ping
+// @Description Returns 200 when the caller is authenticated on the back-office plane. Probe endpoint for the admin surface (#1745).
 // @Tags admin
 // @Produce json
 // @Success 200 {object} AdminPingResponse "OK"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Router /admin/_ping [get]
 func adminPing(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")

--- a/go/apiserver/admin_routes_test.go
+++ b/go/apiserver/admin_routes_test.go
@@ -68,6 +68,9 @@ func WithBackofficeAdmin(t *testing.T, params apiserver.Params) (*models.Backoff
 // testJWTSecret. Mirrors the production back-office login mint at the
 // claim level — token_type=access, jti, iat, exp — so the token
 // validates cleanly through RequireBackofficeAuth.
+//
+// Note: omits rti claim — fine for admin CRUD tests; refresh-path tests
+// must set rti explicitly.
 func signBackofficeAccessToken(t *testing.T, adminID, role string) string {
 	t.Helper()
 	now := time.Now()

--- a/go/apiserver/admin_routes_test.go
+++ b/go/apiserver/admin_routes_test.go
@@ -3,50 +3,139 @@ package apiserver_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/go-extras/go-kit/must"
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/denisvmedia/inventario/apiserver"
 	"github.com/denisvmedia/inventario/models"
 )
 
 // promoteToSystemAdmin grants the seeded test user system-admin via
-// the system_admin_grants registry (#1784) so the admin-gate test can
-// compare the gated vs ungated paths without having to wire a second
-// user fixture. Idempotent.
+// the system_admin_grants registry (#1784). After the #1785 Phase 3
+// migration the admin CRUD gate is RequireBackofficeAuth, NOT
+// RequireSystemAdmin — so the grant is only load-bearing for tests
+// that exercise the legacy impersonation routes (which still run under
+// the tenant gate). Cross-tenant CRUD tests use WithBackofficeAdmin
+// instead. Idempotent.
 func promoteToSystemAdmin(c *qt.C, params apiserver.Params, user *models.User) {
 	c.Helper()
 	must.Must(params.FactorySet.SystemAdminGrantRegistry.Grant(context.Background(), user.ID, nil))
 }
 
-func TestAdminPing_DeniesNonAdmin(t *testing.T) {
+// WithBackofficeAdmin seeds an active back-office admin in
+// params.FactorySet.BackofficeUserRegistry and returns the persisted
+// row alongside a signed back-office access token. The token reuses the
+// shared testJWTSecret because production runs the tenant + back-office
+// planes on the same JWT secret — `aud` is the boundary, not the key.
+// Use this helper (together with addBackofficeAuthHeader) wherever a
+// test needs to hit a /api/v1/admin/* CRUD endpoint after the #1785
+// Phase 3 migration.
+func WithBackofficeAdmin(t *testing.T, params apiserver.Params) (*models.BackofficeUser, string) {
+	t.Helper()
+	c := qt.New(t)
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("UnusedTestPassword1!"), bcrypt.DefaultCost)
+	c.Assert(err, qt.IsNil)
+
+	u := models.BackofficeUser{
+		// Email is unique-per-row at the registry layer; suffix with a
+		// monotonic nanosecond so repeated calls inside one test (or
+		// across two tests sharing a registry) never collide.
+		Email:        fmt.Sprintf("ops-%d@example.com", time.Now().UnixNano()),
+		Name:         "Test Operator",
+		PasswordHash: string(hash),
+		Role:         models.BackofficeRolePlatformAdmin,
+		IsActive:     true,
+		MFAEnforced:  false,
+	}
+	created, err := params.FactorySet.BackofficeUserRegistry.Create(context.Background(), u)
+	c.Assert(err, qt.IsNil)
+
+	token := signBackofficeAccessToken(t, created.ID, string(created.Role))
+	return created, token
+}
+
+// signBackofficeAccessToken mints a `aud=backoffice` access token
+// stamped with the supplied admin_id + role and signed with the shared
+// testJWTSecret. Mirrors the production back-office login mint at the
+// claim level — token_type=access, jti, iat, exp — so the token
+// validates cleanly through RequireBackofficeAuth.
+func signBackofficeAccessToken(t *testing.T, adminID, role string) string {
+	t.Helper()
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"jti":        fmt.Sprintf("test-%d", now.UnixNano()),
+		"admin_id":   adminID,
+		"aud":        "backoffice",
+		"role":       role,
+		"token_type": "access",
+		"iat":        now.Unix(),
+		"exp":        now.Add(time.Hour).Unix(),
+	}
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(testJWTSecret)
+	if err != nil {
+		t.Fatalf("signBackofficeAccessToken: %v", err)
+	}
+	return signed
+}
+
+// addBackofficeAuthHeader sets a Bearer back-office access token on the
+// request. Drop-in replacement for addTestUserAuthHeader at every admin
+// CRUD call site after the #1785 Phase 3 migration.
+func addBackofficeAuthHeader(req *http.Request, token string) {
+	req.Header.Set("Authorization", "Bearer "+token)
+}
+
+// backofficeAdminForToken parses the supplied back-office token and
+// loads the matching BackofficeUser row from the params' registry. Used
+// by audit-row assertions that need the actor's persisted ID: a test
+// that built its admin via WithBackofficeAdmin but discarded the user
+// pointer can recover it without re-wiring the helper signature.
+func backofficeAdminForToken(t *testing.T, params apiserver.Params, token string) *models.BackofficeUser {
+	t.Helper()
+	c := qt.New(t)
+	parsed, err := jwt.Parse(token, func(_ *jwt.Token) (any, error) { return testJWTSecret, nil })
+	c.Assert(err, qt.IsNil)
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	c.Assert(ok, qt.IsTrue)
+	adminID, _ := claims["admin_id"].(string)
+	c.Assert(adminID, qt.Not(qt.Equals), "")
+	admin, err := params.FactorySet.BackofficeUserRegistry.Get(context.Background(), adminID)
+	c.Assert(err, qt.IsNil)
+	return admin
+}
+
+func TestAdminPing_DeniesTenantUser(t *testing.T) {
 	c := qt.New(t)
 	params, user, _ := newParams()
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/_ping", nil)
+	// Tenant JWT — RequireBackofficeAuth rejects it (audience mismatch /
+	// missing admin_id), regardless of the user's IsSystemAdmin flag.
 	addTestUserAuthHeader(req, user.ID)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
-	// JSON:API envelope carries the wire code so the FE can branch.
-	c.Assert(rr.Body.String(), qt.Contains, "admin.forbidden")
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }
 
-func TestAdminPing_AllowsSystemAdmin(t *testing.T) {
+func TestAdminPing_AllowsBackofficeAdmin(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := newParams()
-	promoteToSystemAdmin(c, params, user)
-
+	params, _, _ := newParams()
+	_, token := WithBackofficeAdmin(t, params)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/_ping", nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, token)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 

--- a/go/apiserver/admin_tenants.go
+++ b/go/apiserver/admin_tenants.go
@@ -43,8 +43,8 @@ type adminTenantsAPI struct {
 // @Param sort query string false "Sort field: name|slug|created_at|status (prefix with - for desc)"
 // @Param order query string false "Sort direction override: asc|desc (wins over `-` prefix)"
 // @Success 200 {object} jsonapi.AdminTenantsResponse "OK"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Router /admin/tenants [get]
 func (api *adminTenantsAPI) listTenants(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
@@ -88,8 +88,8 @@ func (api *adminTenantsAPI) listTenants(w http.ResponseWriter, r *http.Request) 
 // @Produce json-api
 // @Param tenantID path string true "Tenant ID"
 // @Success 200 {object} jsonapi.AdminTenantResponse "OK"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Failure 404 {object} jsonapi.Errors "Tenant not found"
 // @Router /admin/tenants/{tenantID} [get]
 func (api *adminTenantsAPI) getTenant(w http.ResponseWriter, r *http.Request) {
@@ -166,6 +166,12 @@ func (api *adminTenantsAPI) auditGet(r *http.Request, tenantID string, opErr err
 // a wiring bug, not a data-loss path. The legacy impersonation routes
 // still run under the tenant gate; their handlers do not call this
 // helper, they read the tenant user directly (see admin_impersonation.go).
+//
+// Mutating handlers in admin_groups.go and admin_group_members.go
+// short-circuit on a nil actor with a 401 (mirroring blockUser/unblockUser
+// in admin_users.go) before reaching this helper — read paths intentionally
+// fall through to a NULL ActorID audit row so a wiring-bug deploy is at
+// least observable in the audit trail.
 func actorIDFromRequest(r *http.Request) *string {
 	actor := appctx.AdminActorFromContext(r.Context())
 	if actor == nil || actor.ID == "" {

--- a/go/apiserver/admin_tenants.go
+++ b/go/apiserver/admin_tenants.go
@@ -159,17 +159,19 @@ func (api *adminTenantsAPI) auditGet(r *http.Request, tenantID string, opErr err
 	api.auditService.LogAdmin(r.Context(), ev)
 }
 
-// actorIDFromRequest pulls the authenticated user ID off the context
-// for use as the AdminEvent.ActorID field. Returns nil if the user is
-// missing — RequireSystemAdmin should have rejected the request before
-// reaching the handler, so a missing user here is a wiring bug, not a
-// data-loss path.
+// actorIDFromRequest pulls the back-office admin actor ID off the
+// context for use as the AdminEvent.ActorID field. Returns nil when no
+// admin actor is attached — RequireBackofficeAuth should have rejected
+// the request before reaching the handler, so a missing actor here is
+// a wiring bug, not a data-loss path. The legacy impersonation routes
+// still run under the tenant gate; their handlers do not call this
+// helper, they read the tenant user directly (see admin_impersonation.go).
 func actorIDFromRequest(r *http.Request) *string {
-	user := appctx.UserFromContext(r.Context())
-	if user == nil || user.ID == "" {
+	actor := appctx.AdminActorFromContext(r.Context())
+	if actor == nil || actor.ID == "" {
 		return nil
 	}
-	id := user.ID
+	id := actor.ID
 	return &id
 }
 

--- a/go/apiserver/admin_tenants_test.go
+++ b/go/apiserver/admin_tenants_test.go
@@ -17,18 +17,17 @@ import (
 )
 
 // adminTenantFixture creates a deterministic fixture used by the
-// /admin/tenants endpoint tests. Returns the params with the seeded
-// admin user already promoted to system admin and the slugs of the
-// three additional tenants so each test can assert on shape rather
-// than fragile string equality with auto-generated IDs.
-func adminTenantFixture(c *qt.C) (apiserver.Params, *models.User, []string) {
+// /admin/tenants endpoint tests. After the #1785 Phase 3 migration the
+// admin gate is RequireBackofficeAuth, so the fixture returns a
+// back-office bearer token alongside the seed tenant user (still
+// useful for tenant ID assertions). The three additional tenants give
+// the paging/filter/sort assertions real data beyond the singleton
+// "Test Organization" from newParams.
+func adminTenantFixture(t *testing.T, c *qt.C) (apiserver.Params, *models.User, string, []string) {
 	c.Helper()
 	params, user, _ := newParams()
-	promoteToSystemAdmin(c, params, user)
+	_, adminToken := WithBackofficeAdmin(t, params)
 
-	// Seed three additional tenants so paging/filter/sort assertions
-	// have something to work with beyond the singleton "Test
-	// Organization" from newParams.
 	ctx := context.Background()
 	seeds := []models.Tenant{
 		{Name: "Acme Corp", Slug: "acme", Status: models.TenantStatusActive, PlanID: models.PlanUnlimited.ID},
@@ -40,16 +39,16 @@ func adminTenantFixture(c *qt.C) (apiserver.Params, *models.User, []string) {
 		created := must.Must(params.FactorySet.TenantRegistry.Create(ctx, t))
 		slugs = append(slugs, created.Slug)
 	}
-	return params, user, slugs
+	return params, user, adminToken, slugs
 }
 
-func TestAdminListTenants_AllowsSystemAdmin(t *testing.T) {
+func TestAdminListTenants_AllowsBackofficeAdmin(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := adminTenantFixture(c)
+	params, _, adminToken, _ := adminTenantFixture(t, c)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/tenants", nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -64,7 +63,7 @@ func TestAdminListTenants_AllowsSystemAdmin(t *testing.T) {
 	c.Assert(rr.Header().Get("X-Total"), qt.Equals, "4")
 }
 
-func TestAdminListTenants_DeniesNonAdmin(t *testing.T) {
+func TestAdminListTenants_DeniesTenantUser(t *testing.T) {
 	c := qt.New(t)
 	params, user, _ := newParams()
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
@@ -74,8 +73,8 @@ func TestAdminListTenants_DeniesNonAdmin(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
-	c.Assert(rr.Body.String(), qt.Contains, "admin.forbidden")
+	// RequireBackofficeAuth rejects the tenant JWT at the audience guard.
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }
 
 func TestAdminListTenants_DeniesUnauthenticated(t *testing.T) {
@@ -92,7 +91,7 @@ func TestAdminListTenants_DeniesUnauthenticated(t *testing.T) {
 
 func TestAdminListTenants_FiltersAndPaginatesAndSorts(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := adminTenantFixture(c)
+	params, _, adminToken, _ := adminTenantFixture(t, c)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	tests := []struct {
@@ -134,7 +133,7 @@ func TestAdminListTenants_FiltersAndPaginatesAndSorts(t *testing.T) {
 	for _, tc := range tests {
 		c.Run(tc.name, func(c *qt.C) {
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/tenants"+tc.query, nil)
-			addTestUserAuthHeader(req, user.ID)
+			addBackofficeAuthHeader(req, adminToken)
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)
 
@@ -152,11 +151,11 @@ func TestAdminListTenants_FiltersAndPaginatesAndSorts(t *testing.T) {
 
 func TestAdminGetTenant_ReturnsRowWithCounts(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := adminTenantFixture(c)
+	params, user, adminToken, _ := adminTenantFixture(t, c)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/tenants/%s", user.TenantID), nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -171,18 +170,18 @@ func TestAdminGetTenant_ReturnsRowWithCounts(t *testing.T) {
 
 func TestAdminGetTenant_404OnMissingID(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := adminTenantFixture(c)
+	params, _, adminToken, _ := adminTenantFixture(t, c)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/tenants/does-not-exist", nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
 }
 
-func TestAdminGetTenant_DeniesNonAdmin(t *testing.T) {
+func TestAdminGetTenant_DeniesTenantUser(t *testing.T) {
 	c := qt.New(t)
 	params, user, _ := newParams()
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
@@ -192,16 +191,17 @@ func TestAdminGetTenant_DeniesNonAdmin(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }
 
 func TestAdminListTenants_WritesAuditLog(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := adminTenantFixture(c)
+	params, _, adminToken, _ := adminTenantFixture(t, c)
+	admin := backofficeAdminForToken(t, params, adminToken)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/tenants", nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
@@ -210,16 +210,16 @@ func TestAdminListTenants_WritesAuditLog(t *testing.T) {
 	c.Assert(entries, qt.HasLen, 1)
 	c.Assert(entries[0].Success, qt.IsTrue)
 	c.Assert(entries[0].UserID, qt.IsNotNil)
-	c.Assert(*entries[0].UserID, qt.Equals, user.ID)
+	c.Assert(*entries[0].UserID, qt.Equals, admin.ID)
 }
 
 func TestAdminGetTenant_AuditLog_Success(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := adminTenantFixture(c)
+	params, user, adminToken, _ := adminTenantFixture(t, c)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/admin/tenants/%s", user.TenantID), nil)
-	addTestUserAuthHeader(req, user.ID)
+	addBackofficeAuthHeader(req, adminToken)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)

--- a/go/apiserver/admin_users.go
+++ b/go/apiserver/admin_users.go
@@ -159,8 +159,8 @@ type adminUsersAPI struct {
 // @Param sort query string false "Sort field: email|name|created_at|last_login_at|is_active (prefix with - for desc)"
 // @Param order query string false "Sort direction override: asc|desc (wins over `-` prefix)"
 // @Success 200 {object} jsonapi.AdminUsersResponse "OK"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Failure 404 {object} jsonapi.Errors "Tenant not found"
 // @Router /admin/tenants/{tenantID}/users [get]
 func (api *adminUsersAPI) listTenantUsers(w http.ResponseWriter, r *http.Request) {
@@ -224,8 +224,8 @@ func (api *adminUsersAPI) listTenantUsers(w http.ResponseWriter, r *http.Request
 // @Produce json-api
 // @Param userID path string true "User ID"
 // @Success 200 {object} jsonapi.AdminUserResponse "OK"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Failure 404 {object} jsonapi.Errors "User not found"
 // @Router /admin/users/{userID} [get]
 func (api *adminUsersAPI) getUser(w http.ResponseWriter, r *http.Request) {
@@ -348,8 +348,8 @@ func (api *adminUsersAPI) getUser(w http.ResponseWriter, r *http.Request) {
 // @Param data body AdminBlockRequest true "Block request"
 // @Success 200 {object} AdminUserEnvelope "OK"
 // @Failure 400 {object} jsonapi.Errors "Bad Request - invalid body"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Failure 404 {object} jsonapi.Errors "Not Found - unknown user"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - self-block or admin-on-admin without force"
 // @Router /admin/users/{userID}/block [post]
@@ -482,8 +482,8 @@ func (api *adminUsersAPI) blockUser(w http.ResponseWriter, r *http.Request) {
 // @Param data body AdminUnblockRequest true "Unblock request"
 // @Success 200 {object} AdminUserEnvelope "OK"
 // @Failure 400 {object} jsonapi.Errors "Bad Request - invalid body"
-// @Failure 401 {object} jsonapi.Errors "Unauthorized"
-// @Failure 403 {object} jsonapi.Errors "Forbidden - system-admin required"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
 // @Failure 404 {object} jsonapi.Errors "Not Found - unknown user"
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - invalid reason"
 // @Router /admin/users/{userID}/unblock [post]

--- a/go/apiserver/admin_users.go
+++ b/go/apiserver/admin_users.go
@@ -354,11 +354,11 @@ func (api *adminUsersAPI) getUser(w http.ResponseWriter, r *http.Request) {
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - self-block or admin-on-admin without force"
 // @Router /admin/users/{userID}/block [post]
 func (api *adminUsersAPI) blockUser(w http.ResponseWriter, r *http.Request) {
-	actor := appctx.UserFromContext(r.Context())
+	actor := appctx.AdminActorFromContext(r.Context())
 	if actor == nil {
-		// Defence-in-depth: RequireSystemAdmin should have caught this
-		// already. Reaching here means the middleware chain is wired
-		// wrong; render the same shape RequireSystemAdmin would.
+		// Defence-in-depth: RequireBackofficeAuth should have caught
+		// this already. Reaching here means the middleware chain is
+		// wired wrong; render the standard 401 envelope.
 		_ = unauthorizedError(w, r, ErrMissingUserContext)
 		return
 	}
@@ -377,26 +377,24 @@ func (api *adminUsersAPI) blockUser(w http.ResponseWriter, r *http.Request) {
 	target, err := api.factorySet.UserRegistry.Get(r.Context(), userID)
 	if err != nil {
 		if errors.Is(err, registry.ErrNotFound) {
-			api.logBlockOutcome(r, actor, userID, "", req, false, err.Error(), false)
+			api.logBlockOutcome(r, actor.ID, userID, "", req, false, err.Error(), false)
 			_ = renderEntityError(w, r, err)
 			return
 		}
 		slog.Error("admin block: failed to load user", "user_id", userID, "error", err)
-		api.logBlockOutcome(r, actor, userID, "", req, false, err.Error(), false)
+		api.logBlockOutcome(r, actor.ID, userID, "", req, false, err.Error(), false)
 		_ = internalServerError(w, r, err)
 		return
 	}
 
-	// Self-block guard. Under an impersonation session (#1750) the
-	// JWT's user_id is the impersonated user; the operator-of-record
-	// lives in the `impersonated_by` claim. Resolve the real operator
-	// via services.ImpersonatorIDFromContext so an operator can't
-	// self-block by acting through an impersonated identity. The guard
-	// runs above the idempotency check so an operator who tries to
-	// block themselves always sees the typed error, even if their
-	// account is already inactive.
-	if target.ID == operatorIDFromContext(r.Context(), actor) {
-		api.logBlockOutcome(r, actor, target.ID, target.TenantID, req, false, ErrAdminCannotBlockSelf.Error(), false)
+	// Self-block guard. Under the back-office admin gate the target is
+	// a tenant user and the actor is a back-office identity — their IDs
+	// are namespaced separately so an operator literally cannot
+	// self-block via /admin/users/.../block. The guard is preserved
+	// for defence-in-depth in case the back-office id happens to
+	// collide with a tenant user id (extremely unlikely, but cheap).
+	if target.ID == actor.ID {
+		api.logBlockOutcome(r, actor.ID, target.ID, target.TenantID, req, false, ErrAdminCannotBlockSelf.Error(), false)
 		_ = renderEntityError(w, r, ErrAdminCannotBlockSelf)
 		return
 	}
@@ -415,7 +413,7 @@ func (api *adminUsersAPI) blockUser(w http.ResponseWriter, r *http.Request) {
 		// admin-without-force guard so re-blocking an already-blocked
 		// peer admin is a 200 no-op rather than a surprising 422.
 		cascadeErrMsg := api.applyBlockCascade(r, target.ID)
-		api.logBlockOutcome(r, actor, target.ID, target.TenantID, req, cascadeErrMsg == "", cascadeErrMsg, false)
+		api.logBlockOutcome(r, actor.ID, target.ID, target.TenantID, req, cascadeErrMsg == "", cascadeErrMsg, false)
 		api.writeUserEnvelope(w, r, http.StatusOK, target)
 		return
 	}
@@ -426,12 +424,12 @@ func (api *adminUsersAPI) blockUser(w http.ResponseWriter, r *http.Request) {
 	targetIsAdmin, grantErr := api.factorySet.SystemAdminGrantRegistry.Exists(r.Context(), target.ID)
 	if grantErr != nil {
 		slog.Error("admin block: grant lookup failed", "user_id", target.ID, "error", grantErr)
-		api.logBlockOutcome(r, actor, target.ID, target.TenantID, req, false, grantErr.Error(), false)
+		api.logBlockOutcome(r, actor.ID, target.ID, target.TenantID, req, false, grantErr.Error(), false)
 		_ = internalServerError(w, r, grantErr)
 		return
 	}
 	if targetIsAdmin && !req.Force {
-		api.logBlockOutcome(r, actor, target.ID, target.TenantID, req, false, ErrAdminCannotBlockAdminWithoutForce.Error(), false)
+		api.logBlockOutcome(r, actor.ID, target.ID, target.TenantID, req, false, ErrAdminCannotBlockAdminWithoutForce.Error(), false)
 		_ = renderEntityError(w, r, ErrAdminCannotBlockAdminWithoutForce)
 		return
 	}
@@ -448,7 +446,7 @@ func (api *adminUsersAPI) blockUser(w http.ResponseWriter, r *http.Request) {
 	saved, err := api.factorySet.UserRegistry.Update(r.Context(), updated)
 	if err != nil {
 		slog.Error("admin block: failed to deactivate user", "user_id", target.ID, "error", err)
-		api.logBlockOutcome(r, actor, target.ID, target.TenantID, req, false, err.Error(), forced)
+		api.logBlockOutcome(r, actor.ID, target.ID, target.TenantID, req, false, err.Error(), forced)
 		_ = internalServerError(w, r, err)
 		return
 	}
@@ -461,25 +459,12 @@ func (api *adminUsersAPI) blockUser(w http.ResponseWriter, r *http.Request) {
 	// awareness and the audit row records ErrMsg if either step
 	// blipped.
 	cascadeErrMsg := api.applyBlockCascade(r, target.ID)
-	api.logBlockOutcome(r, actor, target.ID, target.TenantID, req, cascadeErrMsg == "", cascadeErrMsg, forced)
+	api.logBlockOutcome(r, actor.ID, target.ID, target.TenantID, req, cascadeErrMsg == "", cascadeErrMsg, forced)
 	// Reuse the targetIsAdmin lookup the --force guard already did
 	// instead of doing a second SystemAdminGrantRegistry.Exists call
 	// from inside writeUserEnvelope — a successful block has just
 	// committed, so the admin flag cannot have flipped in between.
 	api.writeUserEnvelopeKnownAdmin(w, r, http.StatusOK, saved, targetIsAdmin)
-}
-
-// operatorIDFromContext returns the ID of the user who actually
-// initiated the request: the impersonator if an impersonation session
-// is active (#1750 — `imp` true with non-empty `impersonated_by`),
-// otherwise actor.ID. Used by the self-block guard so an operator
-// cannot deactivate their own account by routing the block through an
-// impersonated identity.
-func operatorIDFromContext(ctx context.Context, actor *models.User) string {
-	if imp := services.ImpersonatorIDFromContext(ctx); imp != nil && *imp != "" {
-		return *imp
-	}
-	return actor.ID
 }
 
 // unblockUser flips IsActive back to true. Does NOT re-issue tokens —
@@ -503,7 +488,7 @@ func operatorIDFromContext(ctx context.Context, actor *models.User) string {
 // @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - invalid reason"
 // @Router /admin/users/{userID}/unblock [post]
 func (api *adminUsersAPI) unblockUser(w http.ResponseWriter, r *http.Request) {
-	actor := appctx.UserFromContext(r.Context())
+	actor := appctx.AdminActorFromContext(r.Context())
 	if actor == nil {
 		_ = unauthorizedError(w, r, ErrMissingUserContext)
 		return
@@ -523,12 +508,12 @@ func (api *adminUsersAPI) unblockUser(w http.ResponseWriter, r *http.Request) {
 	target, err := api.factorySet.UserRegistry.Get(r.Context(), userID)
 	if err != nil {
 		if errors.Is(err, registry.ErrNotFound) {
-			api.logUnblockOutcome(r, actor, userID, "", req, false, err.Error())
+			api.logUnblockOutcome(r, actor.ID, userID, "", req, false, err.Error())
 			_ = renderEntityError(w, r, err)
 			return
 		}
 		slog.Error("admin unblock: failed to load user", "user_id", userID, "error", err)
-		api.logUnblockOutcome(r, actor, userID, "", req, false, err.Error())
+		api.logUnblockOutcome(r, actor.ID, userID, "", req, false, err.Error())
 		_ = internalServerError(w, r, err)
 		return
 	}
@@ -537,7 +522,7 @@ func (api *adminUsersAPI) unblockUser(w http.ResponseWriter, r *http.Request) {
 		// Idempotent: the user is already active. Audit and return
 		// 200 — the alternative would be a 422 that the FE doesn't
 		// actually need to branch on.
-		api.logUnblockOutcome(r, actor, target.ID, target.TenantID, req, true, "")
+		api.logUnblockOutcome(r, actor.ID, target.ID, target.TenantID, req, true, "")
 		api.writeUserEnvelope(w, r, http.StatusOK, target)
 		return
 	}
@@ -547,12 +532,12 @@ func (api *adminUsersAPI) unblockUser(w http.ResponseWriter, r *http.Request) {
 	saved, err := api.factorySet.UserRegistry.Update(r.Context(), updated)
 	if err != nil {
 		slog.Error("admin unblock: failed to reactivate user", "user_id", target.ID, "error", err)
-		api.logUnblockOutcome(r, actor, target.ID, target.TenantID, req, false, err.Error())
+		api.logUnblockOutcome(r, actor.ID, target.ID, target.TenantID, req, false, err.Error())
 		_ = internalServerError(w, r, err)
 		return
 	}
 
-	api.logUnblockOutcome(r, actor, target.ID, target.TenantID, req, true, "")
+	api.logUnblockOutcome(r, actor.ID, target.ID, target.TenantID, req, true, "")
 	api.writeUserEnvelope(w, r, http.StatusOK, saved)
 }
 
@@ -685,7 +670,7 @@ func (api *adminUsersAPI) applyBlockCascade(r *http.Request, userID string) stri
 //revive:disable-next-line:flag-parameter
 func (api *adminUsersAPI) logBlockOutcome(
 	r *http.Request,
-	actor *models.User,
+	actorID string,
 	subjectID, subjectTenantID string,
 	req AdminBlockRequest,
 	success bool,
@@ -701,7 +686,7 @@ func (api *adminUsersAPI) logBlockOutcome(
 	}
 	ev := services.AdminEvent{
 		Action:      action,
-		ActorID:     new(actor.ID),
+		ActorID:     nullableString(actorID),
 		TenantID:    nullableString(subjectTenantID),
 		SubjectType: stringPtr("user"),
 		SubjectID:   nullableString(subjectID),
@@ -720,7 +705,7 @@ func (api *adminUsersAPI) logBlockOutcome(
 // logBlockOutcome but with no force variant — unblock is symmetric.
 func (api *adminUsersAPI) logUnblockOutcome(
 	r *http.Request,
-	actor *models.User,
+	actorID string,
 	subjectID, subjectTenantID string,
 	req AdminUnblockRequest,
 	success bool,
@@ -731,7 +716,7 @@ func (api *adminUsersAPI) logUnblockOutcome(
 	}
 	ev := services.AdminEvent{
 		Action:      AuditActionAdminUserUnblock,
-		ActorID:     new(actor.ID),
+		ActorID:     nullableString(actorID),
 		TenantID:    nullableString(subjectTenantID),
 		SubjectType: stringPtr("user"),
 		SubjectID:   nullableString(subjectID),

--- a/go/apiserver/admin_users_test.go
+++ b/go/apiserver/admin_users_test.go
@@ -21,35 +21,45 @@ import (
 )
 
 // Block + unblock handler tests (#1747). Every AC in the issue spec
-// maps to one (or more) of the subtests below. Tests live alongside
-// admin_routes_test.go and reuse its `promoteToSystemAdmin` helper to
-// flip the IsSystemAdmin flag on a fixture user without standing up a
-// second tenant.
+// maps to one (or more) of the subtests below. After the #1785 Phase 3
+// migration the admin CRUD surface is gated by RequireBackofficeAuth,
+// so the actor is a back-office user (not a tenant system admin). Each
+// test reaches the endpoint with a back-office bearer token issued via
+// the WithBackofficeAdmin helper (see admin_routes_test.go).
 
 // adminTestEnv bundles the moving parts every block/unblock test needs
 // so the per-test setup stays one line. Standing this up via a helper
 // keeps the table-driven cases focused on inputs + expectations rather
 // than ceremony.
+//
+// `admin` is the back-office actor whose ID appears in audit rows.
+// `adminToken` is the Bearer back-office JWT — pass it to
+// doAdminJSONRequest. `tenantID` is the tenant the test's target users
+// live in (the singleton tenant created by newParams) — back-office
+// users have no tenant, so the tenant id needs to flow in explicitly.
 type adminTestEnv struct {
-	params  apiserver.Params
-	handler http.Handler
-	admin   *models.User
+	params     apiserver.Params
+	handler    http.Handler
+	admin      *models.BackofficeUser
+	adminToken string
+	tenantID   string
 }
 
-// newAdminEnv returns a Params with a single system-admin fixture user
-// (the test's "actor") and the assembled HTTP handler. The admin user
-// returned is the one whose auth header should be attached to admin
-// requests — promote a separate fixture (via createSecondUser) when
-// the test needs a distinct subject.
+// newAdminEnv returns a Params with a seeded back-office admin and the
+// assembled HTTP handler. Use env.adminToken as the Bearer for admin
+// CRUD requests; env.admin.ID matches the actor recorded on audit rows;
+// env.tenantID identifies the tenant target users should be created in.
 func newAdminEnv(c *qt.C) adminTestEnv {
 	c.Helper()
-	params, user, _ := newParams()
-	promoteToSystemAdmin(c, params, user)
+	params, tenantUser, _ := newParams()
+	admin, token := WithBackofficeAdmin(c.TB.(*testing.T), params)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 	return adminTestEnv{
-		params:  params,
-		handler: handler,
-		admin:   user,
+		params:     params,
+		handler:    handler,
+		admin:      admin,
+		adminToken: token,
+		tenantID:   tenantUser.TenantID,
 	}
 }
 
@@ -101,13 +111,18 @@ func unblockBody(reason string) map[string]any {
 // variant in doJSONAPIRequest would still work but the explicit JSON
 // content type matches what the FE sends and keeps the test honest.
 //
+// `bearerToken` is set verbatim as the Bearer Authorization header.
+// After the #1785 Phase 3 migration this is a back-office access token
+// (mint via WithBackofficeAdmin or signBackofficeAccessToken); the
+// admin CRUD gate REJECTS tenant tokens. Pass "" to skip the header.
+//
 // `body` is encoded by switching on its concrete type:
 //   - nil → no body
 //   - []byte / json.RawMessage / string → passed through verbatim
 //     (lets tests send malformed JSON or trailing-token payloads that
 //     `json.Marshal` would otherwise sanitise into valid JSON)
 //   - anything else → `json.Marshal`
-func doAdminJSONRequest(t *testing.T, handler http.Handler, method, path, userID string, body any) *httptest.ResponseRecorder {
+func doAdminJSONRequest(t *testing.T, handler http.Handler, method, path, bearerToken string, body any) *httptest.ResponseRecorder {
 	t.Helper()
 	var raw []byte
 	switch v := body.(type) {
@@ -131,8 +146,8 @@ func doAdminJSONRequest(t *testing.T, handler http.Handler, method, path, userID
 		t.Fatalf("new request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if userID != "" {
-		addTestUserAuthHeader(req, userID)
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
 	}
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -142,11 +157,11 @@ func doAdminJSONRequest(t *testing.T, handler http.Handler, method, path, userID
 func TestAdminBlockUser_HappyPath(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", true, false)
+	target := createTestUserDirect(c, env.params, env.tenantID, "ordinary@example.com", true, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/block",
-		env.admin.ID, blockBody("policy violation", false))
+		env.adminToken, blockBody("policy violation", false))
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.id"), target.ID)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.type"), "users")
@@ -160,34 +175,41 @@ func TestAdminBlockUser_HappyPath(t *testing.T) {
 func TestAdminBlockUser_Idempotent(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", false, false)
+	target := createTestUserDirect(c, env.params, env.tenantID, "ordinary@example.com", false, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/block",
-		env.admin.ID, blockBody("policy violation", false))
+		env.adminToken, blockBody("policy violation", false))
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.is_active"), false)
 }
 
-func TestAdminBlockUser_SelfBlockRejected(t *testing.T) {
+// TestAdminBlockUser_SelfBlockStructurallyImpossible documents the
+// post-#1785 Phase 3 invariant: a back-office operator can never
+// target their own ID via /admin/users/{userID}/block because the
+// operator's identity is a backoffice_users row whose ID never appears
+// in the tenant users table. The handler's `target.ID == actor.ID`
+// guard remains as defence-in-depth, but the registry-level lookup
+// short-circuits to 404 first — there is no tenant user with the
+// back-office admin's id to load.
+func TestAdminBlockUser_SelfBlockStructurallyImpossible(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/"+env.admin.ID+"/block",
-		env.admin.ID, blockBody("trying to lock myself out", false))
-	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
-	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminBlockSelfBlockedCode)
+		env.adminToken, blockBody("trying to lock myself out", false))
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
 }
 
 func TestAdminBlockUser_AdminWithoutForceRejected(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	peer := createTestUserDirect(c, env.params, env.admin.TenantID, "peer-admin@example.com", true, true)
+	peer := createTestUserDirect(c, env.params, env.tenantID, "peer-admin@example.com", true, true)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/"+peer.ID+"/block",
-		env.admin.ID, blockBody("peer review", false))
+		env.adminToken, blockBody("peer review", false))
 	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
 	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminBlockAdminRequiresForceCode)
 
@@ -200,11 +222,11 @@ func TestAdminBlockUser_AdminWithoutForceRejected(t *testing.T) {
 func TestAdminBlockUser_AdminWithForceAllowedAndAudited(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	peer := createTestUserDirect(c, env.params, env.admin.TenantID, "peer-admin@example.com", true, true)
+	peer := createTestUserDirect(c, env.params, env.tenantID, "peer-admin@example.com", true, true)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/"+peer.ID+"/block",
-		env.admin.ID, blockBody("compromise drill", true))
+		env.adminToken, blockBody("compromise drill", true))
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.is_active"), false)
 
@@ -228,11 +250,11 @@ func TestAdminBlockUser_AdminWithForceAllowedAndAudited(t *testing.T) {
 func TestAdminBlockUser_AuditRowCarriesReason(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", true, false)
+	target := createTestUserDirect(c, env.params, env.tenantID, "ordinary@example.com", true, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/block",
-		env.admin.ID, blockBody("policy violation: rule 7", false))
+		env.adminToken, blockBody("policy violation: rule 7", false))
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 
 	rows := must.Must(env.params.FactorySet.AuditLogRegistry.List(context.Background()))
@@ -262,7 +284,7 @@ func TestAdminBlockUser_UnknownUserReturns404(t *testing.T) {
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/does-not-exist/block",
-		env.admin.ID, blockBody("policy violation", false))
+		env.adminToken, blockBody("policy violation", false))
 	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
 }
 
@@ -290,33 +312,35 @@ func TestAdminBlockUser_BadBodyVariants(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := qt.New(t)
 			env := newAdminEnv(c)
-			target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", true, false)
+			target := createTestUserDirect(c, env.params, env.tenantID, "ordinary@example.com", true, false)
 
 			rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 				"/api/v1/admin/users/"+target.ID+"/block",
-				env.admin.ID, tc.body)
+				env.adminToken, tc.body)
 			c.Assert(rr.Code, qt.Equals, tc.wantCode)
 		})
 	}
 }
 
-func TestAdminBlockUser_NonAdminForbidden(t *testing.T) {
+func TestAdminBlockUser_TenantTokenRejected(t *testing.T) {
 	c := qt.New(t)
-	params, user, _ := newParams() // not promoted
+	params, user, _ := newParams()
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 	target := createTestUserDirect(c, params, user.TenantID, "ordinary@example.com", true, false)
 
+	// A tenant access token (createTestJWTToken) — RequireBackofficeAuth
+	// rejects at the audience guard with 401, regardless of the user's
+	// IsSystemAdmin flag.
 	rr := doAdminJSONRequest(t, handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/block",
-		user.ID, blockBody("policy violation", false))
-	c.Assert(rr.Code, qt.Equals, http.StatusForbidden)
-	c.Assert(rr.Body.String(), qt.Contains, "admin.forbidden")
+		createTestJWTToken(user.ID), blockBody("policy violation", false))
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
 }
 
 func TestAdminBlockUser_UnauthenticatedRejected(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", true, false)
+	target := createTestUserDirect(c, env.params, env.tenantID, "ordinary@example.com", true, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/block",
@@ -327,11 +351,11 @@ func TestAdminBlockUser_UnauthenticatedRejected(t *testing.T) {
 func TestAdminUnblockUser_HappyPath(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", false, false)
+	target := createTestUserDirect(c, env.params, env.tenantID, "ordinary@example.com", false, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/unblock",
-		env.admin.ID, unblockBody("appeal accepted"))
+		env.adminToken, unblockBody("appeal accepted"))
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.is_active"), true)
 
@@ -342,11 +366,11 @@ func TestAdminUnblockUser_HappyPath(t *testing.T) {
 func TestAdminUnblockUser_Idempotent(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", true, false)
+	target := createTestUserDirect(c, env.params, env.tenantID, "ordinary@example.com", true, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/unblock",
-		env.admin.ID, unblockBody("nothing to do"))
+		env.adminToken, unblockBody("nothing to do"))
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.is_active"), true)
 }
@@ -357,18 +381,18 @@ func TestAdminUnblockUser_UnknownUserReturns404(t *testing.T) {
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/does-not-exist/unblock",
-		env.admin.ID, unblockBody("test"))
+		env.adminToken, unblockBody("test"))
 	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
 }
 
 func TestAdminUnblockUser_AuditRowCarriesReason(t *testing.T) {
 	c := qt.New(t)
 	env := newAdminEnv(c)
-	target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", false, false)
+	target := createTestUserDirect(c, env.params, env.tenantID, "ordinary@example.com", false, false)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/unblock",
-		env.admin.ID, unblockBody("appeal accepted: ticket 1234"))
+		env.adminToken, unblockBody("appeal accepted: ticket 1234"))
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 
 	rows := must.Must(env.params.FactorySet.AuditLogRegistry.List(context.Background()))
@@ -404,11 +428,11 @@ func TestAdminUnblockUser_BadBodyVariants(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := qt.New(t)
 			env := newAdminEnv(c)
-			target := createTestUserDirect(c, env.params, env.admin.TenantID, "ordinary@example.com", false, false)
+			target := createTestUserDirect(c, env.params, env.tenantID, "ordinary@example.com", false, false)
 
 			rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 				"/api/v1/admin/users/"+target.ID+"/unblock",
-				env.admin.ID, tc.body)
+				env.adminToken, tc.body)
 			c.Assert(rr.Code, qt.Equals, tc.wantCode)
 		})
 	}
@@ -449,7 +473,7 @@ func TestAdminBlockUser_AccessTokenIssuedBeforeBlockFails(t *testing.T) {
 	// Build params with a real in-memory blacklister so the BlacklistUserTokens
 	// call inside the block cascade is observable by subsequent /system requests.
 	params, admin, _ := newParams()
-	promoteToSystemAdmin(c, params, admin)
+	_, adminToken := WithBackofficeAdmin(t, params)
 	bl := services.NewInMemoryTokenBlacklister()
 	params.TokenBlacklister = bl
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
@@ -482,7 +506,7 @@ func TestAdminBlockUser_AccessTokenIssuedBeforeBlockFails(t *testing.T) {
 	// Execute the block as the admin actor.
 	blockRR := doAdminJSONRequest(t, handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/block",
-		admin.ID, blockBody("integration test", false))
+		adminToken, blockBody("integration test", false))
 	c.Assert(blockRR.Code, qt.Equals, http.StatusOK,
 		qt.Commentf("block must succeed; body=%s", blockRR.Body.String()))
 
@@ -499,7 +523,7 @@ func TestAdminBlockUser_AccessTokenIssuedBeforeBlockFails(t *testing.T) {
 func TestAdminBlockUser_RefreshTokenRevokedByCascade(t *testing.T) {
 	c := qt.New(t)
 	params, admin, _ := newParams()
-	promoteToSystemAdmin(c, params, admin)
+	_, adminToken := WithBackofficeAdmin(t, params)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	target := createTestUserDirect(c, params, admin.TenantID, "ordinary@example.com", true, false)
@@ -523,7 +547,7 @@ func TestAdminBlockUser_RefreshTokenRevokedByCascade(t *testing.T) {
 
 	blockRR := doAdminJSONRequest(t, handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/block",
-		admin.ID, blockBody("integration test", false))
+		adminToken, blockBody("integration test", false))
 	c.Assert(blockRR.Code, qt.Equals, http.StatusOK)
 
 	postActive := must.Must(params.FactorySet.RefreshTokenRegistry.ListActiveByUserID(context.Background(), target.ID))
@@ -539,7 +563,7 @@ func TestAdminBlockUser_RefreshTokenRevokedByCascade(t *testing.T) {
 func TestAdminBlockUser_IdempotentBlockReRunsCascade(t *testing.T) {
 	c := qt.New(t)
 	params, admin, _ := newParams()
-	promoteToSystemAdmin(c, params, admin)
+	_, adminToken := WithBackofficeAdmin(t, params)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	// Seed an already-inactive user — simulates the "previously
@@ -567,7 +591,7 @@ func TestAdminBlockUser_IdempotentBlockReRunsCascade(t *testing.T) {
 	// must fire.
 	rr := doAdminJSONRequest(t, handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/block",
-		admin.ID, blockBody("re-block to scrub stale tokens", false))
+		adminToken, blockBody("re-block to scrub stale tokens", false))
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 
 	postActive := must.Must(params.FactorySet.RefreshTokenRegistry.ListActiveByUserID(context.Background(), target.ID))
@@ -575,75 +599,14 @@ func TestAdminBlockUser_IdempotentBlockReRunsCascade(t *testing.T) {
 		qt.Commentf("idempotent re-block must run the cascade and revoke the planted token"))
 }
 
-// createTestJWTTokenWithClaims signs an arbitrary MapClaims for the
-// given user. Used by the impersonation self-block test so it can
-// stamp `imp` / `impersonated_by` onto the access token the same way
-// the (forthcoming) impersonation primitive will. Mirrors the shape of
-// createTestJWTToken but stays test-local so the production helper
-// doesn't grow a knob it never uses.
-func createTestJWTTokenWithClaims(t *testing.T, claims jwt.MapClaims) string {
-	t.Helper()
-	if _, ok := claims["exp"]; !ok {
-		claims["exp"] = time.Now().Add(24 * time.Hour).Unix()
-	}
-	// Default to an access token so the forged token clears the
-	// token-type enforcement in validateJWTToken (#1778). Callers can
-	// override token_type explicitly to test the rejection path.
-	if _, ok := claims["token_type"]; !ok {
-		claims["token_type"] = "access"
-	}
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signed, err := token.SignedString(testJWTSecret)
-	if err != nil {
-		t.Fatalf("sign token: %v", err)
-	}
-	return signed
-}
-
-// TestAdminBlockUser_SelfBlockViaImpersonationRejected pins the B2
-// fix: the self-block guard must compare against the operator-of-
-// record (the `impersonated_by` claim), not the impersonated user's
-// JWT user_id. Without this, an operator could route a block-self
-// request through an impersonated peer-admin session and bypass the
-// guard.
-//
-// Scenario: env.admin is the operator and impersonates `peer` (also
-// a system admin so the impersonated session clears the admin gate).
-// The bearer token's user_id is `peer.ID` with `imp=true` and
-// `impersonated_by=env.admin.ID`. The operator then issues a block
-// against env.admin.ID — without the operator-aware guard the
-// handler would compare target.ID (env.admin.ID) to actor.ID
-// (peer.ID) and let it through.
-func TestAdminBlockUser_SelfBlockViaImpersonationRejected(t *testing.T) {
-	c := qt.New(t)
-	env := newAdminEnv(c)
-	peer := createTestUserDirect(c, env.params, env.admin.TenantID, "peer-admin@example.com", true, true)
-
-	token := createTestJWTTokenWithClaims(t, jwt.MapClaims{
-		"user_id":         peer.ID,
-		"imp":             true,
-		"impersonated_by": env.admin.ID,
-	})
-
-	body, err := json.Marshal(blockBody("self-block via impersonation", true))
-	c.Assert(err, qt.IsNil)
-	req, err := http.NewRequest(http.MethodPost,
-		"/api/v1/admin/users/"+env.admin.ID+"/block", bytes.NewReader(body))
-	c.Assert(err, qt.IsNil)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
-	rr := httptest.NewRecorder()
-	env.handler.ServeHTTP(rr, req)
-
-	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity,
-		qt.Commentf("self-block via impersonated session must be 422; body=%s", rr.Body.String()))
-	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminBlockSelfBlockedCode)
-
-	// And the operator's own account stays active — the guard fired
-	// before any registry write.
-	reloaded := must.Must(env.params.FactorySet.UserRegistry.Get(context.Background(), env.admin.ID))
-	c.Assert(reloaded.IsActive, qt.IsTrue)
-}
+// The legacy TestAdminBlockUser_SelfBlockViaImpersonationRejected
+// covered an attack where an operator routed a block-self through an
+// impersonated peer-admin session. After the #1785 Phase 3 migration
+// /api/v1/admin/users/.../block is gated by RequireBackofficeAuth,
+// which rejects every tenant token (impersonation tokens included) at
+// the audience guard — so the attack vector is closed structurally at
+// the middleware, not in the handler. The cross-plane regression test
+// in admin_middleware_test.go pins that boundary.
 
 // TestAdminBlockUser_IdempotentOnPeerAdminWithoutForce pins the S4
 // fix: re-blocking an already-inactive peer system admin must be a
@@ -656,11 +619,11 @@ func TestAdminBlockUser_IdempotentOnPeerAdminWithoutForce(t *testing.T) {
 	// Peer is a system admin AND already inactive — the
 	// admin-without-force guard would normally reject without force,
 	// but the idempotent path must short-circuit it.
-	peer := createTestUserDirect(c, env.params, env.admin.TenantID, "peer-admin@example.com", false, true)
+	peer := createTestUserDirect(c, env.params, env.tenantID, "peer-admin@example.com", false, true)
 
 	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
 		"/api/v1/admin/users/"+peer.ID+"/block",
-		env.admin.ID, blockBody("idempotent peer-admin no-op", false))
+		env.adminToken, blockBody("idempotent peer-admin no-op", false))
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.is_active"), false)
 
@@ -690,7 +653,7 @@ func TestAdminBlockUser_IdempotentOnPeerAdminWithoutForce(t *testing.T) {
 func TestAdminUnblockUser_LeavesStalenessRingIntact(t *testing.T) {
 	c := qt.New(t)
 	params, admin, _ := newParams()
-	promoteToSystemAdmin(c, params, admin)
+	_, adminToken := WithBackofficeAdmin(t, params)
 	bl := services.NewInMemoryTokenBlacklister()
 	params.TokenBlacklister = bl
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
@@ -700,7 +663,7 @@ func TestAdminUnblockUser_LeavesStalenessRingIntact(t *testing.T) {
 	// Block — installs an entry in the staleness ring.
 	blockRR := doAdminJSONRequest(t, handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/block",
-		admin.ID, blockBody("policy violation", false))
+		adminToken, blockBody("policy violation", false))
 	c.Assert(blockRR.Code, qt.Equals, http.StatusOK)
 
 	since, blacklisted, err := bl.UserBlacklistedSince(context.Background(), target.ID)
@@ -711,7 +674,7 @@ func TestAdminUnblockUser_LeavesStalenessRingIntact(t *testing.T) {
 	// Unblock — must leave the ring untouched.
 	unblockRR := doAdminJSONRequest(t, handler, http.MethodPost,
 		"/api/v1/admin/users/"+target.ID+"/unblock",
-		admin.ID, unblockBody("appeal accepted"))
+		adminToken, unblockBody("appeal accepted"))
 	c.Assert(unblockRR.Code, qt.Equals, http.StatusOK)
 
 	sinceAfter, blacklistedAfter, err := bl.UserBlacklistedSince(context.Background(), target.ID)

--- a/go/apiserver/admin_users_test.go
+++ b/go/apiserver/admin_users_test.go
@@ -472,13 +472,15 @@ func TestAdminBlockUser_AccessTokenIssuedBeforeBlockFails(t *testing.T) {
 
 	// Build params with a real in-memory blacklister so the BlacklistUserTokens
 	// call inside the block cascade is observable by subsequent /system requests.
-	params, admin, _ := newParams()
+	// newParams returns the seeded tenant user — used only as a TenantID carrier;
+	// the actual back-office admin actor comes from WithBackofficeAdmin.
+	params, tenantUser, _ := newParams()
 	_, adminToken := WithBackofficeAdmin(t, params)
 	bl := services.NewInMemoryTokenBlacklister()
 	params.TokenBlacklister = bl
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
-	target := createTestUserDirect(c, params, admin.TenantID, "ordinary@example.com", true, false)
+	target := createTestUserDirect(c, params, tenantUser.TenantID, "ordinary@example.com", true, false)
 	// Mint an access token for the TARGET with iat=now-1s. After block
 	// the blacklister stamps "since" at the block's wall-clock time, so
 	// this token is "before" the blacklist threshold and must be rejected.
@@ -522,11 +524,13 @@ func TestAdminBlockUser_AccessTokenIssuedBeforeBlockFails(t *testing.T) {
 
 func TestAdminBlockUser_RefreshTokenRevokedByCascade(t *testing.T) {
 	c := qt.New(t)
-	params, admin, _ := newParams()
+	// newParams returns the seeded tenant user — used only as a TenantID
+	// carrier; the actual back-office admin actor comes from WithBackofficeAdmin.
+	params, tenantUser, _ := newParams()
 	_, adminToken := WithBackofficeAdmin(t, params)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
-	target := createTestUserDirect(c, params, admin.TenantID, "ordinary@example.com", true, false)
+	target := createTestUserDirect(c, params, tenantUser.TenantID, "ordinary@example.com", true, false)
 
 	// Seed a refresh token for the target. After block, ListActiveByUserID
 	// must return zero rows — the cascade calls RevokeByUserID and the
@@ -562,13 +566,15 @@ func TestAdminBlockUser_RefreshTokenRevokedByCascade(t *testing.T) {
 // idempotent path and a stale refresh token survives the second block.
 func TestAdminBlockUser_IdempotentBlockReRunsCascade(t *testing.T) {
 	c := qt.New(t)
-	params, admin, _ := newParams()
+	// newParams returns the seeded tenant user — used only as a TenantID
+	// carrier; the actual back-office admin actor comes from WithBackofficeAdmin.
+	params, tenantUser, _ := newParams()
 	_, adminToken := WithBackofficeAdmin(t, params)
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
 	// Seed an already-inactive user — simulates the "previously
 	// blocked" state where the cascade ran once long ago.
-	target := createTestUserDirect(c, params, admin.TenantID, "ordinary@example.com", false, false)
+	target := createTestUserDirect(c, params, tenantUser.TenantID, "ordinary@example.com", false, false)
 
 	// Plant a fresh refresh token AFTER the user was already inactive.
 	// Represents a token that should never have existed (post-block
@@ -652,13 +658,15 @@ func TestAdminBlockUser_IdempotentOnPeerAdminWithoutForce(t *testing.T) {
 // access tokens minted before the block stay rejected after unblock.
 func TestAdminUnblockUser_LeavesStalenessRingIntact(t *testing.T) {
 	c := qt.New(t)
-	params, admin, _ := newParams()
+	// newParams returns the seeded tenant user — used only as a TenantID
+	// carrier; the actual back-office admin actor comes from WithBackofficeAdmin.
+	params, tenantUser, _ := newParams()
 	_, adminToken := WithBackofficeAdmin(t, params)
 	bl := services.NewInMemoryTokenBlacklister()
 	params.TokenBlacklister = bl
 	handler := apiserver.APIServer(params, &mockRestoreWorker{})
 
-	target := createTestUserDirect(c, params, admin.TenantID, "ordinary@example.com", true, false)
+	target := createTestUserDirect(c, params, tenantUser.TenantID, "ordinary@example.com", true, false)
 
 	// Block — installs an entry in the staleness ring.
 	blockRR := doAdminJSONRequest(t, handler, http.MethodPost,

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -443,19 +443,22 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 		r.With(userMiddlewares...).Route("/system", System(params.DebugInfo, params.StartTime))
 		r.With(userMiddlewares...).Route("/debug", Debug(params))
 		// Platform-administrative subtree (#1745 foundation; #1744 umbrella).
-		// userMiddlewares populates the JWT user; the RequireSystemAdmin gate
-		// inside Admin() rejects non-admins before any handler runs. Mounting
-		// at the same level as /system keeps the surface tenant-agnostic —
-		// system admins are not scoped to a tenant.
+		// The cross-tenant CRUD endpoints are gated by RequireBackofficeAuth
+		// (#1785 Phase 3) which validates a back-office JWT and rejects any
+		// tenant token. The legacy impersonation routes still rely on the
+		// tenant userMiddlewares + RequireSystemAdmin gate — see Admin()
+		// for the rationale. Mounting at the same level as /system keeps
+		// the surface tenant-agnostic.
 		r.Route("/admin", Admin(AdminParams{
-			FactorySet:       params.FactorySet,
-			Blacklist:        blacklist,
-			AuditService:     auditSvc,
-			GroupService:     groupService,
-			JWTSecret:        params.JWTSecret,
-			RateLimiter:      rateLimiter,
-			CSRFService:      csrfSvc,
-			ImpersonationTTL: params.ImpersonationTTL,
+			FactorySet:             params.FactorySet,
+			BackofficeUserRegistry: params.FactorySet.BackofficeUserRegistry,
+			Blacklist:              blacklist,
+			AuditService:           auditSvc,
+			GroupService:           groupService,
+			JWTSecret:              params.JWTSecret,
+			RateLimiter:            rateLimiter,
+			CSRFService:            csrfSvc,
+			ImpersonationTTL:       params.ImpersonationTTL,
 			// ImpersonationStore is the SAME instance /auth/logout
 			// receives, so logout can revoke the operator's genuine
 			// refresh token when an impersonation session is ended via

--- a/go/appctx/admin_actor.go
+++ b/go/appctx/admin_actor.go
@@ -1,0 +1,54 @@
+package appctx
+
+import (
+	"context"
+)
+
+// AdminActor is the identity-only projection of the operator behind an
+// admin/back-office request. It deliberately decouples the audit / op
+// surface in apiserver from the concrete *models.BackofficeUser type:
+// admin handlers only ever need the ID + Email + Name to fill audit-row
+// columns and log lines, so this thin adapter keeps the handler call
+// sites readable and the appctx → apiserver dependency direction clean.
+//
+// Issue #1785, Phase 3 — introduced together with the swap from the
+// tenant-side `RequireSystemAdmin` middleware to the back-office
+// `RequireBackofficeAuth`. A future phase that adds a second admin
+// identity shape (e.g. a federated SSO platform operator) can populate
+// the same struct without forcing a second pass over every handler.
+type AdminActor struct {
+	// ID is backoffice_users.id when the request was admitted via
+	// RequireBackofficeAuth. Empty AdminActor (or a nil pointer from
+	// AdminActorFromContext) signals "no admin actor on this request" —
+	// callers MUST guard against that, exactly as they would for
+	// UserFromContext.
+	ID string
+	// Email is the operator's email, populated for log lines and audit
+	// breadcrumbs. Not used for authorization.
+	Email string
+	// Name is the operator's display name. Same use as Email.
+	Name string
+}
+
+// AdminActorFromContext returns the admin actor attached to the request
+// context by RequireBackofficeAuth (via WithBackofficeUser). Returns nil
+// when the context carries no back-office identity — either the
+// middleware chain is misconfigured, or the call site is running
+// outside the admin subtree. Callers MUST handle nil; do not deref
+// blindly.
+//
+// Deliberately uses the back-office context slot (NOT the tenant
+// userCtxKey) so a tenant-user request cannot accidentally satisfy the
+// admin-actor read — keeping the two universes on separate keys is the
+// same invariant that drives BackofficeUserFromContext.
+func AdminActorFromContext(ctx context.Context) *AdminActor {
+	user := BackofficeUserFromContext(ctx)
+	if user == nil {
+		return nil
+	}
+	return &AdminActor{
+		ID:    user.ID,
+		Email: user.Email,
+		Name:  user.Name,
+	}
+}

--- a/go/appctx/admin_actor.go
+++ b/go/appctx/admin_actor.go
@@ -4,7 +4,7 @@ import (
 	"context"
 )
 
-// AdminActor is the identity-only projection of the operator behind an
+// AdminActor is the plane-agnostic actor abstraction behind an
 // admin/back-office request. It deliberately decouples the audit / op
 // surface in apiserver from the concrete *models.BackofficeUser type:
 // admin handlers only ever need the ID + Email + Name to fill audit-row
@@ -13,9 +13,7 @@ import (
 //
 // Issue #1785, Phase 3 — introduced together with the swap from the
 // tenant-side `RequireSystemAdmin` middleware to the back-office
-// `RequireBackofficeAuth`. A future phase that adds a second admin
-// identity shape (e.g. a federated SSO platform operator) can populate
-// the same struct without forcing a second pass over every handler.
+// `RequireBackofficeAuth`.
 type AdminActor struct {
 	// ID is backoffice_users.id when the request was admitted via
 	// RequireBackofficeAuth. Empty AdminActor (or a nil pointer from

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -24,14 +24,14 @@ const docTemplate = `{
     "paths": {
         "/admin/_ping": {
             "get": {
-                "description": "Returns 200 when the caller has system-admin privileges. Probe endpoint for the admin surface (#1745).",
+                "description": "Returns 200 when the caller is authenticated on the back-office plane. Probe endpoint for the admin surface (#1745).",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "admin"
                 ],
-                "summary": "System-admin ping",
+                "summary": "Back-office ping",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -40,13 +40,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -124,13 +124,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -165,13 +165,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -210,13 +210,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -257,13 +257,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -320,13 +320,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -377,13 +377,13 @@ const docTemplate = `{
                         "description": "No Content"
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -453,13 +453,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -599,13 +599,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -640,13 +640,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -723,13 +723,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -770,13 +770,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -835,13 +835,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -982,13 +982,13 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -117,13 +117,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -158,13 +158,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -203,13 +203,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -250,13 +250,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -313,13 +313,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -370,13 +370,13 @@
                         "description": "No Content"
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -446,13 +446,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -592,13 +592,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -633,13 +633,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -716,13 +716,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -763,13 +763,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -828,13 +828,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -975,13 +975,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -17,14 +17,14 @@
     "paths": {
         "/admin/_ping": {
             "get": {
-                "description": "Returns 200 when the caller has system-admin privileges. Probe endpoint for the admin surface (#1745).",
+                "description": "Returns 200 when the caller is authenticated on the back-office plane. Probe endpoint for the admin surface (#1745).",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "admin"
                 ],
-                "summary": "System-admin ping",
+                "summary": "Back-office ping",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -33,13 +33,13 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized",
+                        "description": "Unauthorized - back-office authentication required",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
                     },
                     "403": {
-                        "description": "Forbidden - system-admin required",
+                        "description": "Account disabled",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -4361,11 +4361,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.AdminGroupsResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: List groups (admin)
@@ -4390,11 +4390,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.AdminGroupResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "404":
@@ -4421,11 +4421,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.AdminGroupResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "404":
@@ -4454,11 +4454,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.AdminGroupMembersResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "404":
@@ -4498,11 +4498,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "404":
@@ -4539,11 +4539,11 @@ paths:
         "204":
           description: No Content
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "404":
@@ -4592,11 +4592,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "404":
@@ -4707,11 +4707,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.AdminTenantsResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: List tenants (admin)
@@ -4736,11 +4736,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.AdminTenantResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "404":
@@ -4795,11 +4795,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.AdminUsersResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "404":
@@ -4828,11 +4828,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.AdminUserResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "404":
@@ -4874,11 +4874,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "404":
@@ -4985,11 +4985,11 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "404":

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -4293,8 +4293,8 @@ info:
 paths:
   /admin/_ping:
     get:
-      description: Returns 200 when the caller has system-admin privileges. Probe
-        endpoint for the admin surface (#1745).
+      description: Returns 200 when the caller is authenticated on the back-office
+        plane. Probe endpoint for the admin surface (#1745).
       produces:
       - application/json
       responses:
@@ -4303,14 +4303,14 @@ paths:
           schema:
             $ref: '#/definitions/apiserver.AdminPingResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized - back-office authentication required
           schema:
             $ref: '#/definitions/jsonapi.Errors'
         "403":
-          description: Forbidden - system-admin required
+          description: Account disabled
           schema:
             $ref: '#/definitions/jsonapi.Errors'
-      summary: System-admin ping
+      summary: Back-office ping
       tags:
       - admin
   /admin/groups:

--- a/go/models/audit_log.go
+++ b/go/models/audit_log.go
@@ -17,7 +17,10 @@ type AuditLog struct {
 	//migrator:schema:field name="timestamp" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
 	Timestamp time.Time `json:"timestamp" db:"timestamp"`
 
-	// UserID is the ID of the user who performed the action (nullable for unauthenticated events).
+	// UserID is the actor id. The column is polymorphic since #1785/Phase 3:
+	//   - For tenant-plane actions (register, login, user-CRUD via tenant JWT), it's a users.id.
+	//   - For back-office-plane admin CRUD (Phase 3 onward), it's a backoffice_users.id.
+	// No FK because of the polymorphism. A future schema change (#1785 follow-up) will add actor_type.
 	//migrator:schema:field name="user_id" type="TEXT"
 	UserID *string `json:"user_id,omitempty" db:"user_id"`
 


### PR DESCRIPTION
Phase 3 of issue #1785. Stacked on PR #1836 (Phase 2 auth plane) — base will auto-rebase to `master` after #1836 lands. Review only the Phase-3 diff.

## What this does

Plugs the new back-office auth plane (introduced in #1836) into the existing admin surface. The CRUD endpoints under `/api/v1/admin/*` STOP accepting tenant JWTs (with `is_system_admin=true`) and now ONLY accept back-office JWTs (with `aud=="backoffice"` + `admin_id`).

- **`go/apiserver/admin_routes.go`** — admin subtree split:
  - `adminBackofficeRoutes` (CRUD: tenants/users/groups/group-members) → gated by `RequireBackofficeAuth`.
  - `adminImpersonationRoutes` (impersonate/end/current) → still gated by `RequireSystemAdmin` (deliberate, see below).
- **`go/appctx/admin_actor.go`** (new) — `AdminActor{ID,Email,Name}` + `AdminActorFromContext(ctx)`. A plane-agnostic abstraction so admin handlers' audit log + actor-id reads don't care which plane the actor came from.
- **Admin CRUD handlers** — `admin_tenants.go`, `admin_users.go` (block/unblock) — switched from `appctx.UserFromContext` to `appctx.AdminActorFromContext`. `logBlockOutcome`/`logUnblockOutcome` now take `actorID string`.
- **`apiserver.go`** — wires `BackofficeUserRegistry` into `AdminParams`.

## Cross-plane regression tests (load-bearing)

In `go/apiserver/admin_middleware_test.go` (new):
- `TestAdmin_RejectsTenantJWTAfterMigration` — a tenant JWT with `is_system_admin=true` is now **rejected with 401** at `/admin/_ping` (privilege no longer flows through the tenant plane).
- `TestAdmin_AcceptsBackofficeJWT` — a back-office JWT successfully reaches `/admin/_ping`.

Both pass locally. Plus full admin handler test suite migrated to use `WithBackofficeAdmin` test helper + `signBackofficeAccessToken` + `addBackofficeAuthHeader`.

## Deliberate scope decision: impersonation NOT migrated

The 3 impersonation routes (`POST /admin/users/{id}/impersonate`, `GET /admin/impersonation/current`, `POST /admin/impersonation/end`) **KEEP `RequireSystemAdmin`** in this PR. A "mechanical swap" would either blow the scope budget or leave the routes functionally broken:

- `restoreAdminSession` captures + restores the operator's TENANT `refresh_token` cookie.
- `signAdminAccessToken(*models.User, rti)` expects a tenant `*models.User`, no back-office analogue.
- The marker refresh cookie binds the `end` action to the operator's browser — assumes tenant cookie path/name.

Migrating impersonation to a back-office actor needs a redesign (separate `/admin/backoffice-impersonation/*` surface, or back-office-native impersonation tokens). That's Phase 5 (cross-plane impersonation) per the epic plan. Documented in `Admin()` + `adminImpersonationRoutes` godoc.

## What this is NOT

- ❌ NO data migration of `users.is_system_admin=true` rows into `backoffice_users` (hand-written SQL needs explicit approval; tracked as follow-up).
- ❌ NO `RequirePlatformAdmin` role gating (`support_agent` vs `platform_admin`) — separate PR.
- ❌ NO `audit_logs` schema change.
- ❌ NO CLI deprecation notices on `inventario admin grant-system-admin`.
- ❌ NO `devdocs/` updates.
- ❌ NO changes to `users.is_system_admin` column or `RequireSystemAdmin` middleware (still live for impersonation + CLI path).
- ❌ NO frontend — Phase 6.

## Follow-ups

1. Back-office-native impersonation (Phase 5) — drops the last `RequireSystemAdmin` usage and the `promoteToSystemAdmin` test helper.
2. `RequirePlatformAdmin` role gating on destructive routes (block/unblock/delete/membership-edit) — follow-up PR.
3. Swagger annotation text on admin handlers still says `"system-admin required"` — descriptive, not contract.
4. Data migration of existing `users.is_system_admin=true` into `backoffice_users` rows — needs explicit operator approval for the hand-written SQL.

## Test plan

- [ ] CI green (stacked on Phase 2, so depends on #1836 landing first)
- [ ] `go test ./apiserver/... -run 'TestAdmin_(RejectsTenantJWT|AcceptsBackofficeJWT)'` passes
- [ ] Existing admin handler test suite passes against the back-office gate

Tracking: #1785 (Phase 3 of 6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized admin API authentication to require back-office JWT tokens instead of system-admin credentials.
  * Added explicit authorization gates across admin endpoints for enhanced security.

* **Documentation**
  * Updated API error descriptions to clarify back-office authentication requirements.
  * Refined 401/403 response messages across admin operations for better clarity.

* **Tests**
  * Expanded test coverage for JWT audience validation and cross-plane authentication boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->