### PR TITLE
[seed + fe + e2e] Family default-promotion fix + back-office plane fallout

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -64,13 +64,5 @@ jobs:
         working-directory: go
 
       - name: Run tests
-        # -timeout=20m bumps the per-package test timeout from the 10-minute
-        # default. The `apiserver` package crosses 10m on the ubuntu-latest
-        # runner under -race after the backoffice plane landed (#1785 Phase
-        # 1-6 added ~1.5k LOC of admin/backoffice handler tests). Master
-        # itself was hitting `panic: test timed out after 10m0s` on the
-        # alarm goroutine, blaming whichever subtest happened to be running
-        # — flake symptom, structural cause. 20m leaves enough headroom for
-        # the next round of additions before this needs revisiting.
-        run: go test -v -race -timeout=20m ./...
+        run: go test -v -race ./...
         working-directory: go

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -64,5 +64,13 @@ jobs:
         working-directory: go
 
       - name: Run tests
-        run: go test -v -race ./...
+        # -timeout=20m bumps the per-package test timeout from the 10-minute
+        # default. The `apiserver` package crosses 10m on the ubuntu-latest
+        # runner under -race after the backoffice plane landed (#1785 Phase
+        # 1-6 added ~1.5k LOC of admin/backoffice handler tests). Master
+        # itself was hitting `panic: test timed out after 10m0s` on the
+        # alarm goroutine, blaming whichever subtest happened to be running
+        # — flake symptom, structural cause. 20m leaves enough headroom for
+        # the next round of additions before this needs revisiting.
+        run: go test -v -race -timeout=20m ./...
         working-directory: go

--- a/e2e/tests/ai-scan.spec.ts
+++ b/e2e/tests/ai-scan.spec.ts
@@ -18,7 +18,7 @@ import { test } from '../fixtures/app-fixture.js';
 import { expect } from '@playwright/test';
 import { createLocation, deleteLocation } from './includes/locations.js';
 import { createArea, deleteArea } from './includes/areas.js';
-import { navigateTo, TO_LOCATIONS } from './includes/navigate.js';
+import { navigateTo, TO_COMMODITIES, TO_LOCATIONS } from './includes/navigate.js';
 
 // PRE-EXISTING MASTER REGRESSION — the spec landed in PR #1835 without
 // picking up the (page, recorder, ...) contract that createLocation /
@@ -70,6 +70,13 @@ test.describe.skip('AI vision scan flow [BLOCKED: helper-signature + nav drift, 
         }),
       })
     );
+
+    // Navigate to the commodities list so `commodities-add-button` is
+    // in the DOM. createArea lands on the area-detail page, which has
+    // its own "Add commodity" testid but not the top-level one this
+    // spec targets — without this step the click below waits 30s and
+    // the whole test times out.
+    await navigateTo(page, recorder, TO_COMMODITIES);
 
     // Open the Add item dialog from the commodities list.
     await page.locator('[data-testid="commodities-add-button"]').first().click();
@@ -134,6 +141,11 @@ test.describe.skip('AI vision scan flow [BLOCKED: helper-signature + nav drift, 
         }),
       })
     );
+
+    // Same /commodities navigation as the happy-path test —
+    // `commodities-add-button` lives on the commodities list page,
+    // not on the area-detail page createArea lands on.
+    await navigateTo(page, recorder, TO_COMMODITIES);
 
     await page.locator('[data-testid="commodities-add-button"]').first().click();
     await page.locator('[data-testid="commodity-form-ai-step"]').waitFor();

--- a/e2e/tests/ai-scan.spec.ts
+++ b/e2e/tests/ai-scan.spec.ts
@@ -20,15 +20,6 @@ import { createLocation, deleteLocation } from './includes/locations.js';
 import { createArea, deleteArea } from './includes/areas.js';
 import { navigateTo, TO_COMMODITIES, TO_LOCATIONS } from './includes/navigate.js';
 
-// PRE-EXISTING MASTER REGRESSION — the spec landed in PR #1835 without
-// picking up the (page, recorder, ...) contract that createLocation /
-// createArea / navigateTo grew in PR #1666. Wiring `recorder` through
-// is mechanical, but the post-create navigation to /commodities (where
-// `commodities-add-button` lives) also drifted somewhere between #1531
-// (area detail page redesign) and now and needs reworking. Masked on
-// master by the fast-fail gate until PR #1849 fixed it. Skipped here
-// as scope-control for #1849; tracked as a follow-up to #1720/#1835.
-
 function makeTestData() {
   const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   return {
@@ -42,7 +33,15 @@ function makeTestData() {
 // helper); use a wildcard glob.
 const SCAN_URL_GLOB = '**/api/v1/g/*/commodities/scan';
 
-test.describe.skip('AI vision scan flow [BLOCKED: helper-signature + nav drift, follow-up to #1720]', () => {
+// The two specs in this describe block share the admin@test-org.com
+// fixture (login, default group, etc.). Running them in parallel
+// against the same backend lets ensureAuthenticated / login race —
+// the second test's session-establish step can race the first test's
+// in-flight CSRF rotation and bounce to a guarded route before the
+// login form renders, producing a "input[type='email'] not visible"
+// timeout. `serial` opts both into the same worker; cleanup of the
+// first runs before the setup of the second.
+test.describe.serial('AI vision scan flow', () => {
   test('happy path: scan → review → use values prefills Basics', async ({ page, recorder }) => {
     const { location, area } = makeTestData();
     await navigateTo(page, recorder, TO_LOCATIONS);
@@ -110,7 +109,11 @@ test.describe.skip('AI vision scan flow [BLOCKED: helper-signature + nav drift, 
     await page.locator('[data-testid="commodity-form-ai-use-values"]').click();
     await expect(page.locator('input#commodity-name')).toHaveValue('Stub Item');
 
-    // Cleanup.
+    // Cleanup. deleteArea looks up the area tile on the location-detail
+    // page, but we're currently on /commodities (the Add Item dialog
+    // routed us here via use-values). Navigate back to /locations first
+    // — the helper drills into the parent location card from there.
+    await navigateTo(page, recorder, TO_LOCATIONS);
     await deleteArea(page, recorder, area.name, location.name);
     await deleteLocation(page, recorder, location.name);
   });
@@ -165,9 +168,12 @@ test.describe.skip('AI vision scan flow [BLOCKED: helper-signature + nav drift, 
     await page.locator('[data-testid="commodity-form-ai-fill-manually"]').click();
     await expect(page.locator('input#commodity-name')).toBeVisible();
 
-    // Cleanup.
-    await page.keyboard.press('Escape');
-    await page.locator('[data-testid="commodity-form-close-confirm-discard"]').click();
+    // Cleanup. After Fill-manually the dialog sits on the empty Basics
+    // step — Escape would only fire the discard-confirm dialog if the
+    // user had typed something, which we haven't. Navigating away does
+    // the same job (route change unmounts the dialog) and lands us on
+    // /locations where deleteArea expects to be.
+    await navigateTo(page, recorder, TO_LOCATIONS);
     await deleteArea(page, recorder, area.name, location.name);
     await deleteLocation(page, recorder, location.name);
   });

--- a/e2e/tests/includes/auth.ts
+++ b/e2e/tests/includes/auth.ts
@@ -138,8 +138,11 @@ export async function login(
 ): Promise<string | null> {
   log(recorder, `🔐 Performing login as ${credentials.email}...`);
 
-  // Wait for login form to be visible
-  await page.waitForSelector('input[type="email"]', { timeout: 10000 });
+  // Wait for login form to be visible. Generous timeout because the
+  // login route lazy-loads under heavy parallel load — when many
+  // workers hit the same vite dev server simultaneously the bundle
+  // fetch + initial render can take 15-20s on a busy laptop.
+  await page.waitForSelector('input[type="email"]', { timeout: 30000 });
 
   // Fill in credentials
   await page.fill('input[type="email"]', credentials.email);

--- a/e2e/tests/includes/auth.ts
+++ b/e2e/tests/includes/auth.ts
@@ -79,9 +79,15 @@ export const BLOCK_TARGET_TEST_CREDENTIALS = {
  */
 export async function isLoginPage(page: Page): Promise<boolean> {
   try {
-    // Check URL first
-    const currentUrl = page.url();
-    if (currentUrl.includes('/login')) {
+    // Match the tenant /login route exactly. Substring matching used to be
+    // enough, but #1844 added a sibling /backoffice/login surface — also
+    // containing the literal "/login" — for the platform-operator plane,
+    // and falsely treating that as the tenant login bounces the helper into
+    // filling the back-office form (whose POST goes to
+    // /api/v1/backoffice/auth/login, not /api/v1/auth/login, so the
+    // waitForResponse predicate in login() times out).
+    const pathname = new URL(page.url()).pathname;
+    if (pathname === '/login' || pathname.startsWith('/login/')) {
       return true;
     }
 
@@ -205,10 +211,15 @@ export async function login(
     await recoverFromNoGroupRace(page, recorder);
   }
 
-  // If we're still on login page but the page has rendered, manually
-  // navigate to home (defensive — should not happen given the
+  // If we're still on the tenant login page but the page has rendered,
+  // manually navigate to home (defensive — should not happen given the
   // waitForFunction above, but keeps parity with prior behaviour).
-  if (page.url().includes('/login')) {
+  // Exact-path match so the sibling /backoffice/login surface (#1844)
+  // doesn't trip this branch — landing on /backoffice/login means an
+  // unrelated back-office redirect won the race; goto('/') would just
+  // bounce right back via RootRedirect → guard chain, so let the caller
+  // deal with that state instead of hiding it.
+  if (new URL(page.url()).pathname === '/login') {
     log(recorder, '🔄 Still on /login after auth completed, navigating home...');
     await page.goto('/');
   }

--- a/frontend/src/lib/__tests__/http.test.ts
+++ b/frontend/src/lib/__tests__/http.test.ts
@@ -337,6 +337,53 @@ describe("error handling", () => {
     })
   })
 
+  it("503 carrying a typed JSON:API product error (#1720/#1835) does NOT bounce to /maintenance", async () => {
+    // Some endpoints use 503 to surface a typed product-level error rather
+    // than an infra outage — `commodity_scan.provider_disabled` is the
+    // canonical one (#1720, AI vision provider off by config). The feature
+    // handler maps the typed code to an inline banner, so the global
+    // 503 → /maintenance bounce must skip it; otherwise the shell unmounts
+    // before the banner ever paints.
+    server.use(
+      msw.get(api("/groups"), () =>
+        HttpResponse.json(
+          {
+            errors: [
+              {
+                code: "commodity_scan.provider_disabled",
+                status: "503",
+                title: "provider disabled",
+              },
+            ],
+          },
+          { status: 503 }
+        )
+      )
+    )
+    const navigate = vi.fn()
+    setNavigateToMaintenance(navigate)
+    await expect(http.get("/groups")).rejects.toBeInstanceOf(HttpError)
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it("503 with an UNTYPED errors[] code (no dot) still bounces — guards against widening", async () => {
+    // The typed-error detection keys off `code` containing a dot
+    // (`<feature>.<reason>`). A plain string code without a dot is the
+    // legacy/untyped shape and SHOULD still trigger the maintenance bounce.
+    server.use(
+      msw.get(api("/groups"), () =>
+        HttpResponse.json(
+          { errors: [{ code: "service_unavailable", status: "503" }] },
+          { status: 503 }
+        )
+      )
+    )
+    const navigate = vi.fn()
+    setNavigateToMaintenance(navigate)
+    await expect(http.get("/groups")).rejects.toBeInstanceOf(HttpError)
+    expect(navigate).toHaveBeenCalledOnce()
+  })
+
   it("503 does NOT re-bounce when the user is already on /maintenance (#1542 — avoids reload loop)", async () => {
     server.use(msw.get(api("/groups"), () => HttpResponse.json(null, { status: 503 })))
     const navigate = vi.fn()

--- a/frontend/src/lib/__tests__/http.test.ts
+++ b/frontend/src/lib/__tests__/http.test.ts
@@ -9,7 +9,11 @@ import {
   setCsrfToken,
   setImpersonationReturn,
 } from "@/lib/auth-storage"
-import { clearBackofficeAuth, getBackofficeAccessToken } from "@/features/backoffice/auth/storage"
+import {
+  clearBackofficeAuth,
+  getBackofficeAccessToken,
+  setBackofficeAccessToken,
+} from "@/features/backoffice/auth/storage"
 import { __resetGroupContextForTests, setCurrentGroupSlug } from "@/lib/group-context"
 import {
   __resetNavigationForTests,
@@ -432,6 +436,57 @@ describe("401 flow", () => {
     expect(getCsrfToken()).toBeNull()
     expect(navigate).toHaveBeenCalledOnce()
     expect(navigate.mock.calls[0][1]).toBe("session_expired")
+  })
+
+  it("backoffice 401 + no back-office session: does NOT navigate to /backoffice/login", async () => {
+    // Regression: <ImpersonationProvider> in the tenant Shell probes
+    // /admin/impersonation/current for every authenticated tenant user
+    // (the banner consumer is on the tenant plane). After #1838 hardened
+    // /admin/* on the back-office plane, the probe 401s for any user
+    // without a back-office session. Before this guard, the http client
+    // dutifully tried `/backoffice/auth/refresh` (404, no cookie), then
+    // bounced the user to /backoffice/login on every tenant page render.
+    // Verify the 401 surfaces to the caller's onError without any
+    // navigation when there was no back-office session to "expire" in the
+    // first place.
+    setAccessToken("tenant-good")
+    const navigate = vi.fn()
+    setNavigateToLogin(navigate)
+    server.use(
+      msw.get(api("/admin/impersonation/current"), () =>
+        HttpResponse.json({ error: "no operator session" }, { status: 401 })
+      ),
+      msw.post(api("/backoffice/auth/refresh"), () =>
+        HttpResponse.json({ error: "no cookie" }, { status: 404 })
+      )
+    )
+    await expect(http.get("/admin/impersonation/current")).rejects.toBeInstanceOf(HttpError)
+    expect(navigate).not.toHaveBeenCalled()
+    // Tenant session must survive — the back-office 401 is unrelated.
+    expect(getAccessToken()).toBe("tenant-good")
+  })
+
+  it("backoffice 401 + had back-office session: DOES navigate to /backoffice/login", async () => {
+    // Companion to the no-session case above: when a back-office operator
+    // genuinely loses their session (refresh cookie expired or revoked),
+    // the bounce to /backoffice/login is correct — there *was* something
+    // to expire. Guard regressions where the guard becomes "never bounce."
+    setBackofficeAccessToken("operator-stale")
+    const navigate = vi.fn()
+    setNavigateToLogin(navigate)
+    server.use(
+      msw.get(api("/admin/impersonation/current"), () =>
+        HttpResponse.json({ error: "expired" }, { status: 401 })
+      ),
+      msw.post(api("/backoffice/auth/refresh"), () =>
+        HttpResponse.json({ error: "refresh-bad" }, { status: 401 })
+      )
+    )
+    await expect(http.get("/admin/impersonation/current")).rejects.toBeInstanceOf(HttpError)
+    expect(getBackofficeAccessToken()).toBeNull()
+    expect(navigate).toHaveBeenCalledOnce()
+    expect(navigate.mock.calls[0][1]).toBe("session_expired")
+    expect(navigate.mock.calls[0][2]).toBe("backoffice")
   })
 
   it("background /auth/me 401: does NOT clear auth or navigate", async () => {

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -247,6 +247,28 @@ async function parseBody(response: Response): Promise<unknown> {
   return await response.text()
 }
 
+// hasTypedProductError checks the response body for a JSON:API errors[]
+// entry carrying a typed feature-namespaced code (e.g. `commodity_scan.
+// provider_disabled`). Those are product-level errors riding on 503 by
+// BE convention (#1720), distinct from "the whole API is down" — the
+// feature handler maps them to an inline banner, so the global
+// 503 → /maintenance bounce in performRequest must skip them.
+//
+// A code is considered "typed" when it contains a dot — every typed BE
+// error code is `<feature>.<reason>`. Untyped server errors (plain
+// "internal server error" string bodies, JSON:API "Service Unavailable"
+// titles) keep the maintenance bounce.
+function hasTypedProductError(body: unknown): boolean {
+  if (body === null || typeof body !== "object") return false
+  const errors = (body as { errors?: unknown }).errors
+  if (!Array.isArray(errors)) return false
+  return errors.some((e) => {
+    if (e === null || typeof e !== "object") return false
+    const code = (e as { code?: unknown }).code
+    return typeof code === "string" && code.includes(".")
+  })
+}
+
 async function refreshAccessToken(): Promise<string> {
   if (refreshInFlight) return refreshInFlight
   refreshInFlight = (async () => {
@@ -570,20 +592,32 @@ async function performRequest<T = unknown>(
   if (response.status === 401) {
     return (await handle401(url, path, init, response)) as HttpResponse<T>
   }
+  const data = (await parseBody(response)) as T
   if (response.status === 503) {
     // BE convention (#1542): a 503 means the API is in scheduled maintenance
     // or otherwise unreachable. Bounce the user to /maintenance with the
     // Retry-After + X-Maintenance-Status headers carried as URL params so a
     // refresh keeps showing the page. The actual HttpError still propagates
     // so any onError that wanted to react (e.g. revalidation queries) can.
-    if (typeof window !== "undefined" && !window.location.pathname.startsWith("/maintenance")) {
+    //
+    // Exception (#1720 / #1835): some endpoints use 503 to carry a typed
+    // product-level error (e.g. `commodity_scan.provider_disabled` when the
+    // AI vision provider is intentionally turned off — a per-feature error,
+    // not an infra outage). Those responses carry a JSON:API errors[].code
+    // that the feature handler already maps to an inline banner; bouncing
+    // the whole shell to /maintenance hides that banner. Skip the global
+    // bounce when the response body looks like a typed product error.
+    if (
+      typeof window !== "undefined" &&
+      !window.location.pathname.startsWith("/maintenance") &&
+      !hasTypedProductError(data)
+    ) {
       navigateToMaintenance({
         retryAfter: response.headers.get("Retry-After"),
         componentStatus: response.headers.get("X-Maintenance-Status"),
       })
     }
   }
-  const data = (await parseBody(response)) as T
   if (!response.ok) {
     throw new HttpError(
       `Request to ${url} failed with ${response.status}`,

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -248,11 +248,12 @@ async function parseBody(response: Response): Promise<unknown> {
 }
 
 // hasTypedProductError checks the response body for a JSON:API errors[]
-// entry carrying a typed feature-namespaced code (e.g. `commodity_scan.
-// provider_disabled`). Those are product-level errors riding on 503 by
-// BE convention (#1720), distinct from "the whole API is down" — the
-// feature handler maps them to an inline banner, so the global
-// 503 → /maintenance bounce in performRequest must skip them.
+// entry carrying a typed feature-namespaced code
+// (e.g. `commodity_scan.provider_disabled`). Those are product-level
+// errors riding on 503 by BE convention (#1720), distinct from "the
+// whole API is down" — the feature handler maps them to an inline
+// banner, so the global 503 → /maintenance bounce in performRequest
+// must skip them.
 //
 // A code is considered "typed" when it contains a dot — every typed BE
 // error code is `<feature>.<reason>`. Untyped server errors (plain

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -520,6 +520,19 @@ async function handle401(
     return recoverFromImpersonationExpiry(url)
   }
   const backoffice = isBackofficePath(originalPath)
+  // Capture whether the plane that just 401'd actually had a session BEFORE
+  // attempting refresh — the refresh failure path below clears the tokens,
+  // so checking after would always be false.
+  //
+  // The bounce to the plane's login screen is only correct when there *was*
+  // a session that expired. A tenant-only user touching a back-office-gated
+  // path (e.g. `<ImpersonationProvider>` in the tenant Shell probing
+  // /admin/impersonation/current after #1838 hardened /admin/* on the
+  // back-office plane) has no back-office tokens at all — bouncing them to
+  // /backoffice/login on every page render is a regression. Let those
+  // callers' onError handle the 401 quietly instead.
+  const hadBackofficeSession = !!getBackofficeAccessToken()
+  const hadTenantSession = !!getAccessToken()
   try {
     if (backoffice) {
       await refreshBackofficeAccessToken()
@@ -529,12 +542,12 @@ async function handle401(
   } catch (refreshErr) {
     if (backoffice) {
       clearBackofficeAuth()
-      if (shouldRedirectFromCurrentPath()) {
+      if (hadBackofficeSession && shouldRedirectFromCurrentPath()) {
         navigateToLogin(currentReturnTo(), "session_expired", "backoffice")
       }
     } else {
       clearAuth()
-      if (shouldRedirectFromCurrentPath()) {
+      if (hadTenantSession && shouldRedirectFromCurrentPath()) {
         navigateToLogin(currentReturnTo(), "session_expired")
       }
     }

--- a/go/debug/seeddata/seeddata_members.go
+++ b/go/debug/seeddata/seeddata_members.go
@@ -101,26 +101,14 @@ func seedGroupMembers(ctx context.Context, set *registry.Set, tenant *models.Ten
 		return fmt.Errorf("create family owner membership: %w", err)
 	}
 
-	// admin's Family-group membership intentionally JoinedAt LATER than
-	// every group admin owns. `pickDefaultMembership` (the tiebreaker
-	// `GroupService.EnsureUserDefaultGroup` uses when `GroupPurgeService.
-	// repromoteDefaultGroupForUsers` re-elects a default after admin's
-	// then-current default is purged) sorts by `joined_at ASC` and picks
-	// the oldest. Backdating Family the same way the owner row is
-	// backdated would let Family win that tiebreaker — re-promoting
-	// admin onto Family where they only carry GroupRoleUser. Every
-	// subsequent admin write (POST /locations, /commodities, /files…)
-	// then 403s with "Group admin access required" from
-	// `structuralWriteGate(requireGroupRoleForWrite(GroupRoleAdmin))`
-	// and the e2e suite collapses (storage-usage, warranties,
-	// user-isolation, files, mail — 14 tests in sequence). The
-	// macOS-webkit lane is where this lands deterministically; the
-	// docker linux lanes happen to never trip the purge → re-promote
-	// chain inside a single workflow attempt. Pinning Family strictly
-	// later than admin's own primary-group owner stamp (set at request
-	// time inside SeedData) keeps Family visible in the switcher (which
-	// only requires the membership row to exist) while taking it out
-	// of the default-promotion lottery entirely.
+	// Invariant: admin's Family membership must JoinedAt strictly LATER
+	// than admin's own owner memberships. The default-group re-election
+	// tiebreaker (`pickDefaultMembership` in services/group_service.go)
+	// sorts by joined_at ASC and picks the oldest — and admin only carries
+	// GroupRoleUser on Family. Letting Family win that tiebreaker
+	// re-promotes admin onto a group where they cannot write, breaking the
+	// rest of the e2e suite the next time `GroupPurgeService` re-elects a
+	// default (#1841).
 	if _, err := set.GroupMembershipRegistry.Create(ctx, models.GroupMembership{
 		TenantAwareEntityID: models.TenantAwareEntityID{
 			TenantID: tenant.ID,

--- a/go/debug/seeddata/seeddata_members.go
+++ b/go/debug/seeddata/seeddata_members.go
@@ -101,6 +101,26 @@ func seedGroupMembers(ctx context.Context, set *registry.Set, tenant *models.Ten
 		return fmt.Errorf("create family owner membership: %w", err)
 	}
 
+	// admin's Family-group membership intentionally JoinedAt LATER than
+	// every group admin owns. `pickDefaultMembership` (the tiebreaker
+	// `GroupService.EnsureUserDefaultGroup` uses when `GroupPurgeService.
+	// repromoteDefaultGroupForUsers` re-elects a default after admin's
+	// then-current default is purged) sorts by `joined_at ASC` and picks
+	// the oldest. Backdating Family the same way the owner row is
+	// backdated would let Family win that tiebreaker — re-promoting
+	// admin onto Family where they only carry GroupRoleUser. Every
+	// subsequent admin write (POST /locations, /commodities, /files…)
+	// then 403s with "Group admin access required" from
+	// `structuralWriteGate(requireGroupRoleForWrite(GroupRoleAdmin))`
+	// and the e2e suite collapses (storage-usage, warranties,
+	// user-isolation, files, mail — 14 tests in sequence). The
+	// macOS-webkit lane is where this lands deterministically; the
+	// docker linux lanes happen to never trip the purge → re-promote
+	// chain inside a single workflow attempt. Pinning Family strictly
+	// later than admin's own primary-group owner stamp (set at request
+	// time inside SeedData) keeps Family visible in the switcher (which
+	// only requires the membership row to exist) while taking it out
+	// of the default-promotion lottery entirely.
 	if _, err := set.GroupMembershipRegistry.Create(ctx, models.GroupMembership{
 		TenantAwareEntityID: models.TenantAwareEntityID{
 			TenantID: tenant.ID,
@@ -108,7 +128,7 @@ func seedGroupMembers(ctx context.Context, set *registry.Set, tenant *models.Ten
 		GroupID:      family.ID,
 		MemberUserID: user1.ID,
 		Role:         models.GroupRoleUser,
-		JoinedAt:     now.AddDate(0, 0, -60),
+		JoinedAt:     now.AddDate(0, 0, 1),
 	}); err != nil {
 		return fmt.Errorf("add user1 to family group: %w", err)
 	}

--- a/go/debug/seeddata/seeddata_members.go
+++ b/go/debug/seeddata/seeddata_members.go
@@ -101,7 +101,7 @@ func seedGroupMembers(ctx context.Context, set *registry.Set, tenant *models.Ten
 		return fmt.Errorf("create family owner membership: %w", err)
 	}
 
-	// Invariant: admin's Family membership must JoinedAt strictly LATER
+	// Invariant: admin's Family membership must be JoinedAt strictly LATER
 	// than admin's own owner memberships. The default-group re-election
 	// tiebreaker (`pickDefaultMembership` in services/group_service.go)
 	// sorts by joined_at ASC and picks the oldest — and admin only carries


### PR DESCRIPTION
## Scope

This PR started as a one-line seed-fixture fix for the macOS-webkit e2e race, but grew while triaging local-suite stability against the rebased master tip (the back-office plane #1785 Phase 1-6 landed in parallel). What ships:

1. **`go/debug/seeddata/seeddata_members.go`** — the original fix. Admin's `Family` group membership `JoinedAt` moves from `now-60d` to `now+1d` so the default-group re-promotion tiebreaker can't pick it.
2. **`e2e/tests/ai-scan.spec.ts`** — `test.describe.serial` + helper-signature corrections (`createLocation` / `createArea` / `deleteArea` / `deleteLocation` all take `recorder`) + navigate to `/commodities` before opening the Add Item dialog.
3. **`e2e/tests/includes/auth.ts`** — `isLoginPage` no longer false-matches `/backoffice/login` (substring → exact-path); the `"Still on /login..."` defensive bounce also uses exact path. Login-form wait bumped 10s → 30s for vite cold-start under load.
4. **`frontend/src/lib/http.ts`** — TWO functional changes:
   - **Typed-503 skip** (#1720 / #1835). New `hasTypedProductError(body)` inspects JSON:API `errors[].code` for a feature-namespaced code (`<feature>.<reason>`, contains a dot). When present, the global 503 → `/maintenance` bounce is skipped so the feature handler's inline banner can render.
   - **Tenant-no-bounce on back-office 401** (master regression from #1838). `handle401` no longer navigates to `/backoffice/login` when the user never had a back-office session in the first place. `ImpersonationProvider` in the tenant Shell probes `/admin/impersonation/current` for every authenticated tenant user; once #1838 hardened `/admin/*` on the back-office plane, that probe 401s and (before this fix) bounced every tenant user to `/backoffice/login`.
5. **`frontend/src/lib/__tests__/http.test.ts`** — 4 new regression tests:
   - Typed-503 → does NOT bounce to `/maintenance`.
   - Untyped-503 → still bounces (guards against the dot rule being widened by accident).
   - Backoffice 401 + no back-office session → does NOT navigate.
   - Backoffice 401 + had back-office session → DOES navigate to `/backoffice/login` (kept).

`http.test.ts`: **48 passed** (was 44 pre-PR).

## Root cause — the original seed fix

`GroupPurgeService.repromoteDefaultGroupForUsers` hands every affected user's default re-promotion to `GroupService.EnsureUserDefaultGroup` → `pickDefaultMembership` (`go/services/group_service.go:1041-1065`), which **sorts by `joined_at ASC` and picks the oldest membership**.

The Family fixture seeded admin's membership with `JoinedAt = now-60d` — older than admin's own primary-group owner stamp (set at request time inside `SeedData`), so any purge-driven re-promotion picked **Family**. Family only carries `GroupRoleUser` for admin (by design — Family is the multi-group multi-member demo, owned by `family@test-org.com`).

The moment any earlier e2e test deleted admin's then-current default group, `GroupPurgeService` re-promoted admin onto Family. Every subsequent admin write (`POST /locations`, `/commodities`, `/files`, …) then 403'd from `structuralWriteGate(requireGroupRoleForWrite(GroupRoleAdmin))` (`go/apiserver/apiserver.go:471-474`) with `"Group admin access required"`.

### Where it landed
The macOS-webkit lane in CI landed on this race every workflow attempt — 14 tests collapsing in sequence on the same attempt (storage-usage, warranties, user-isolation, files, mail). The linux-docker lanes (chromium / firefox) happened to never trip the purge → re-promote chain inside a single workflow attempt because their cadence missed the window. A workflow rerun of the exact same SHA passed — confirming the state-dependent race.

This was the root cause of the webkit failures on PR #1834's last few attempts; diagnosis detailed in [PR #1834's audit trail](https://github.com/denisvmedia/inventario/pull/1834). Latent bug, present since the seeded Family fixture was introduced.

### Smoking gun (from PR #1834's failed-webkit trace)
- `POST /api/v1/g/{slug}/locations` response body: `"Group admin access required\n"` — 28 bytes — from `forbiddenMessageForRole(GroupRoleAdmin)` at `go/apiserver/groups.go:271-284`.
- `/auth/me` after the flip returns `default_group_id` pointing at the Family group, where admin has `user` role.
- Server log ~22s before the failure: a flurry of `"group purged"` lines from `GroupPurgeService.PurgeOnce` (`go/services/group_purge_service.go`).

### The seed-fix diff
```diff
 if _, err := set.GroupMembershipRegistry.Create(ctx, models.GroupMembership{
     ...
     GroupID:      family.ID,
     MemberUserID: user1.ID,
     Role:         models.GroupRoleUser,
-    JoinedAt:     now.AddDate(0, 0, -60),
+    JoinedAt:     now.AddDate(0, 0, 1),
 })
```

Family stays visible in the group switcher (visibility comes from the membership row existing, not `JoinedAt`). The user-isolation specs don't depend on Family's order in the switcher. Strictly newer than the admin's own primary-group owner stamp takes Family out of the `pickDefaultMembership` lottery entirely.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./debug/seeddata/...` green
- [x] `npm run test -- --run src/lib/__tests__/http.test.ts` — 48/48 green
- [x] `npx playwright test --project=chromium -g "fast-fail debug"` — passes on rebased branch (was 20s timeout before the http.ts handle401 fix)
- [ ] CI E2E (chromium + firefox + webkit) green on this branch

## References

- Discovered while triaging the webkit failures on #1834.
- The detailed investigation (with trace artifacts cited) lives in #1834's review thread.
- The tenant → `/backoffice/login` regression was introduced by #1838 (gate `/admin/*` on `RequireBackofficeAuth`) and surfaces on every tenant page render after the back-office plane landed.