### PR TITLE
Add Copilot Go instructions, document new(expr) for Go 1.26

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,11 +59,24 @@ Do **not** flag the following as compile errors or "doesn't compile in Go" — t
   `func(yield func(K, V) bool)` (i.e. `iter.Seq` / `iter.Seq2`) is valid since **Go 1.23**.
 - **Builtins** `min`, `max`, `clear` are available since Go 1.21.
 - **Generic type aliases** (`type Foo[T any] = Bar[T]`) are valid since Go 1.24.
+- **`sync.WaitGroup.Go`** — `wg.Go(task)` (auto `Add`/`Done`) is valid since **Go 1.25**.
+  The classic `Add`/`Done` pattern is also fine; don't push contributors to one form
+  over the other.
+- **`new` takes an expression, not just a type** — since **Go 1.26**, `new(x)` where
+  `x` has type `T` allocates a `*T` initialized to the value of `x`. Examples in this
+  repo: `new(true)` (→ `*bool`), `new(value)` (→ `*int`), `m.users[user.ID] = new(user)`
+  (→ `*models.User` initialized from `user`). This is **not** the legacy `new(T)`
+  zero-value form — do **not** "fix" it to `&x`, do **not** claim "the argument is not
+  a type", and do **not** propose `ptrTo` / `toPtr` helpers (the project bans those).
+  Reference: <https://tip.golang.org/doc/go1.26>.
 
 **Before claiming Go code "does not compile":** the project's `go-test*.yml` workflows
 build and run the full test suite on every PR. If those are green and you're flagging a
 compile error, you're wrong — your knowledge of Go syntax is outdated. Defer to the
-build, not to memory.
+build, not to memory. **The Go language version in `go/go.mod` is authoritative; read
+it before commenting on syntax.**
+
+For deeper Go-specific review guidance see [`.github/instructions/go.instructions.md`](instructions/go.instructions.md).
 
 ### Frontend Development
 - Use React 19 with TypeScript

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,7 +74,8 @@ Do **not** flag the following as compile errors or "doesn't compile in Go" — t
 build and run the full test suite on every PR. If those are green and you're flagging a
 compile error, you're wrong — your knowledge of Go syntax is outdated. Defer to the
 build, not to memory. **The Go language version in `go/go.mod` is authoritative; read
-it before commenting on syntax.**
+it before commenting on syntax. Treat any Go-version references in these instructions
+as feature minimums only, not as the exact project patch version.**
 
 For deeper Go-specific review guidance see [`.github/instructions/go.instructions.md`](instructions/go.instructions.md).
 

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,206 @@
+---
+description: Go review/edit guidance for GitHub Copilot in the Inventario repository. Tells Copilot to trust go.mod over its training data and not re-flag known false positives.
+applyTo: "go/**/*.go,go/go.mod,go/go.sum"
+---
+
+# Go instructions for Copilot
+
+These instructions are **for GitHub Copilot only** (PR review bot + Copilot in IDE).
+For human/agent contributors the source of truth is [`AGENTS.md`](../../AGENTS.md) at
+the repo root and [`.claude/agents/inventario-backend.md`](../../.claude/agents/inventario-backend.md).
+This file does not duplicate either of those — read them for the architectural
+contract, multi-tenancy, migrations, registry pattern, error model, etc.
+
+## Where the Go code lives
+
+The Go module lives in **`go/`** (`./go/...` from the repository root).
+This module is not at the repo root; the React frontend lives next to it under
+`frontend/`. When you reason about imports, build flags, or `go vet`/`go test`
+invocations, the working directory is `go/`, not the repo root.
+
+## Trust `go.mod`, not your training data
+
+Before you flag any line of Go as a "compile error", "won't build", "invalid
+syntax", or "use the C-style form instead", **read `go/go.mod`** and use the
+declared `go` directive as the language version baseline. Today that's
+`go 1.26.x`; CI runs the matching toolchain. The full test suite runs on every
+PR (`go-test*.yml`). If the suite is green and your knowledge of Go syntax says
+the code shouldn't compile, **your knowledge is out of date — defer to the
+build**. Do not suggest a rewrite.
+
+The following are valid in this codebase and **must not be flagged**:
+
+### `new(expr)` — Go 1.26 expression form
+
+Since **Go 1.26** the `new` builtin's operand is an **expression**, not a type.
+`new(x)` where `x` has type `T` allocates a `*T` and initializes the pointee to
+the value of `x`. Examples that appear throughout this repo and are *not* bugs:
+
+```go
+newField.defaultValue = new(true)        // *bool pointing to true
+newField.defaultValue = new(value)       // *int pointing to value
+newField.minValue     = new(0)           // *int pointing to 0
+m.users[user.ID]      = new(user)        // *models.User initialized from user
+return new(yearsSince(born))             // *int initialized from the call result
+```
+
+This is **not** the old `new(T)` form returning a zero-valued pointer. Do not
+"correct" it to `&x`, do not claim it "doesn't compile because the argument is
+not a type", and do not propose `ptrTo(x)` helpers. The repo bans manufacturing
+helpers like `ptrTo` / `toPtr` — the direct `new(expr)` form is the project
+convention.
+
+Reference: [Go 1.26 release notes — `new`](https://tip.golang.org/doc/go1.26).
+
+### Range over integers — Go 1.22
+
+`for i := range n { ... }` where `n` is an `int` is valid since **Go 1.22**
+(Feb 2024). It's equivalent to `for i := 0; i < n; i++`. Do not propose a
+C-style rewrite.
+
+### Range over functions — Go 1.23
+
+`for k, v := range iterFunc { ... }` where `iterFunc` is a
+`func(yield func(K, V) bool)` (i.e. `iter.Seq` / `iter.Seq2`) is valid since
+**Go 1.23**.
+
+### Generic type aliases — Go 1.24
+
+`type Foo[T any] = Bar[T]` is valid since **Go 1.24**.
+
+### Builtins `min`, `max`, `clear` — Go 1.21
+
+Available everywhere. Do not suggest hand-rolled equivalents.
+
+### `sync.WaitGroup.Go` — Go 1.25
+
+`wg.Go(task)` (auto `Add`/`Done`) is valid since **Go 1.25**. The classic
+`Add`/`Done`/`defer Done` pattern is also fine. Don't push contributors to
+"the other form" just because you only know one.
+
+If you spot a Go feature you don't recognize, **assume the toolchain knows
+better than your training data**. Look it up in the Go release notes for the
+version declared in `go.mod` before commenting.
+
+## Repo-specific style — short version
+
+These follow from `.golangci.yml`. They override anything in generic Go style
+guides you may have been trained on.
+
+- **Tests use `package <pkg>_test`** (external/black-box). `qtlint` enforces
+  this. Do **not** suggest moving tests into the same package as the code
+  under test — that contradicts the project rule.
+- **Test framework is `github.com/frankban/quicktest`**, imported as `qt`
+  (enforced by `importas`). Do **not** suggest `testify`, `assert`, or
+  `require`.
+- **Error stacktraces use `github.com/go-extras/errx/stacktrace`** imported as
+  `errxtrace` (enforced by `importas`). Sentinels via `errx.NewSentinel(...)`.
+  See `go/registry/errors.go` and `go/apiserver/errors.go` for the canonical
+  pattern. The plain `errors` package is fine for `errors.Is` / `errors.As`.
+- **Import groups via `gci`** in three sections: standard, default (third
+  party), then `prefix(github.com/denisvmedia/inventario)`. Do not suggest
+  `goimports`-flavored single-group layouts.
+- **Banned imports:** `io/ioutil` (use `io` / `os`). Enforced by `depguard`.
+- **`any`, not `interface{}`** — `revive use-any` is on. Don't suggest the
+  reverse.
+- **Comma-ok type assertions** required outside test code
+  (`revive unchecked-type-assertion`).
+- **Filename format** `^[_a-z][_a-z0-9]*\.go$` — no camelCase, no dashes
+  (except generated migration files under `registry/postgres/migrations/`
+  which are exempt).
+- **Function limits** (`funlen`): 240 lines / 160 statements. Cognitive
+  complexity ≤ 30 (`gocognit`). Cyclomatic ≤ 20 (`gocyclo`). Nested-if depth
+  ≤ 6 (`nestif`). Line length ≤ 240 (`lll`). Test files are exempt from these.
+- **`function-result-limit: 3`** — more than 3 return values? Wrap them in a
+  struct.
+- **Naked return** allowed only in functions ≤ 2 lines (`nakedret`).
+- **`//nolint:` directives** must carry an explanation unless the lint is
+  `errcheck` or `lll` (`nolintlint`). Don't suggest `//nolint:` without a
+  reason comment.
+- **Error strings:** `revive error-strings` is **disabled** in this repo —
+  do **not** flag error messages for starting with uppercase or ending in a
+  period. That's a deliberate project choice.
+- **`gochecknoinits`** is enabled but **disabled for `cmd/...`**. Don't flag
+  `init()` in CLI entry points.
+- **`gosec`** suppressions: `G117` (false positive on struct field names
+  containing "Secret"/"Token") and `G706` (structured `slog` logging is not
+  log-injection-vulnerable) are project-wide exclusions. Don't re-raise them.
+- **Structured logging** uses `log/slog` with key/value pairs:
+  `slog.Error("Security violation", "user_id", user.ID, ...)`. The repo's
+  internal `github.com/denisvmedia/inventario/internal/log` wrapper is also
+  fine. Never the std `log` package.
+- **Standard layout differs:** the module lives in `go/`, not at repo root.
+  Sub-packages: `apiserver/` (HTTP handlers), `registry/` (data layer
+  interface + memory/postgres implementations), `services/` (business
+  logic), `models/` (domain models with `//migrator:schema:*` annotations),
+  `internal/` (shared infra). There's no `pkg/` directory and no `cmd/` at
+  the *root* — CLI commands live under `go/cmd/`. Don't suggest the
+  standard `pkg/`/`cmd/`/`internal/` layout reorg.
+
+## Multi-tenancy is load-bearing
+
+This is a multi-tenant SaaS. **Never suggest reading `tenant_id` from request
+bodies, query parameters, or headers**. It comes only from the authenticated
+user's context (`appctx.UserFromContext(ctx).TenantID`), and the
+`TenantMiddleware` validates that the user's tenant matches the resolved
+tenant. Suggesting otherwise is a security regression. See
+`apiserver/tenant_context.go` and `apiserver/jwt_middleware.go`.
+
+Registries come in two flavors:
+
+- **User registry** (`FactorySet.CreateUserRegistrySet(ctx)`) — RLS-scoped to
+  the authenticated user. HTTP handlers use this.
+- **Service registry** (`FactorySet.CreateServiceRegistrySet()`) — bypasses
+  RLS. Background workers only. Never in an HTTP handler.
+
+Don't propose switching one for the other without naming the security impact.
+
+## Migrations are generated, not hand-written
+
+Schema migrations under `go/schema/migrations/_sqldata/` are **generated** from
+Go model annotations (`//migrator:schema:...`) by `./scripts/generate-migration.sh`.
+CI's schema-drift check regenerates and fails on any mismatch. **Do not
+suggest editing `.up.sql` / `.down.sql` files directly** — the correct fix is
+to change the model annotations and regenerate. Hand-written SQL is allowed
+only for cases annotations can't express (data backfills, multi-step ALTERs)
+and that requires explicit human approval; Copilot should never recommend
+hand-writing migration SQL as a normal workflow.
+
+## Swagger / OpenAPI is paired with frontend codegen
+
+Handler annotations live as `swag` comment blocks. Regeneration is
+`make swagger` from the repo root (it runs both `swagger-backend` *and*
+`codegen-frontend`). Don't suggest running just `swag init` directly — the
+frontend types in `frontend/src/types/api.d.ts` need to stay in sync, and the
+codegen CI gate will fail otherwise.
+
+## Things Copilot has historically gotten wrong here
+
+If you find yourself about to write any of these, **stop**:
+
+- "This should use `goimports` ordering" — no, the project uses `gci` with
+  three sections.
+- "Move the test into the same package" — no, the project enforces external
+  `_test` packages.
+- "Replace `new(...)` with `&...`" — no, `new(expr)` is the project's
+  preferred form on Go 1.26+.
+- "Use `for i := 0; i < n; i++`" — no, range-over-int has been valid since
+  Go 1.22.
+- "Use `interface{}` instead of `any`" — no, the project mandates `any`.
+- "Use `testify`/`assert`/`require`" — no, the project uses `quicktest` with
+  the `qt` alias.
+- "Read tenant from the request body/query" — no, that's a security bug; it
+  comes from the auth context.
+- "Edit the generated migration SQL" — no, edit the model annotation and
+  regenerate.
+- "Add a `ptrTo` / `toPtr` helper" — no, use `new(expr)` directly.
+- "Lowercase the error message" — no, `revive error-strings` is disabled
+  here.
+
+## When in doubt
+
+1. Read [`AGENTS.md`](../../AGENTS.md) for the project contract.
+2. Read [`.claude/agents/inventario-backend.md`](../../.claude/agents/inventario-backend.md)
+   for the operational playbook (lint chain, error mapping, registry
+   contract, testing conventions).
+3. Trust the CI build over your prior assumptions about Go syntax.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,6 +1,9 @@
 ---
 description: Go review/edit guidance for GitHub Copilot in the Inventario repository. Tells Copilot to trust go.mod over its training data and not re-flag known false positives.
-applyTo: "go/**/*.go,go/go.mod,go/go.sum"
+applyTo:
+  - "go/**/*.go"
+  - "go/go.mod"
+  - "go/go.sum"
 ---
 
 # Go instructions for Copilot
@@ -144,7 +147,7 @@ bodies, query parameters, or headers**. It comes only from the authenticated
 user's context (`appctx.UserFromContext(ctx).TenantID`), and the
 `TenantMiddleware` validates that the user's tenant matches the resolved
 tenant. Suggesting otherwise is a security regression. See
-`apiserver/tenant_context.go` and `apiserver/jwt_middleware.go`.
+`go/apiserver/tenant_context.go` and `go/apiserver/jwt_middleware.go`.
 
 Registries come in two flavors:
 


### PR DESCRIPTION
## Summary

- Add `.github/instructions/go.instructions.md` — a path-scoped GitHub Copilot
  instructions file (`applyTo: "go/**/*.go,go/go.mod,go/go.sum"`) so the
  reviewer bot and Copilot in IDE stop re-flagging modern Go syntax and
  proposing rewrites that contradict project conventions. Defers to
  `AGENTS.md` and `.claude/agents/inventario-backend.md` for everything
  architectural rather than duplicating it.
- Extend the existing global `.github/copilot-instructions.md`
  "Go version and modern syntax" section with **`sync.WaitGroup.Go`** (Go 1.25)
  and **`new(expr)`** (Go 1.26), strengthen "defer to the build" to require
  reading `go/go.mod`, and link to the new path-scoped file.

## Why

Primary motivation is the **Go 1.26 `new` change**: `new(x)` where `x` is an
expression of type `T` allocates a `*T` initialized to the value of `x` (not
the legacy zero-value form). The repo already uses this in
`go/cmd/internal/input/*.go` (`new(true)`, `new(value)`, `new(0)`, …) and
`AGENTS.md` documents it with examples, but Copilot's training data predates
the change and the reviewer bot is at risk of "fixing" it to `&x` or
proposing banned `ptrTo` / `toPtr` helpers. Same shape as the earlier
range-over-int (Go 1.22) false positives that needed an explicit
instructions section to suppress.

## What the new file covers

- **Trust `go.mod`, not training data.** Explicit list of features Copilot
  routinely flags incorrectly: `new(expr)` (1.26), `WaitGroup.Go` (1.25),
  generic type aliases (1.24), range-over-func (1.23), range-over-int (1.22),
  `min`/`max`/`clear` (1.21).
- **Project overrides** that contradict generic Go style guides — written to
  match `.golangci.yml`:
  - External `_test` packages (qtlint-enforced)
  - `quicktest` with the `qt` alias, **not** testify
  - `errx` + `errxtrace` for stack traces
  - `gci` with three import sections (standard / default /
    `prefix(github.com/denisvmedia/inventario)`), **not** goimports
  - `any` not `interface{}`
  - Banned `io/ioutil`, comma-ok type assertions, filename-format
    `^[_a-z][_a-z0-9]*\.go$`, `funlen` 240/160, `gocognit` ≤ 30,
    `gocyclo` ≤ 20, `nestif` ≤ 6, `lll` ≤ 240,
    `function-result-limit: 3`, `nakedret` ≤ 2 lines
  - `nolintlint` requires explanation (except `errcheck` / `lll`)
  - **`error-strings` is disabled** — uppercase first letter / trailing
    period on error messages are intentional here, don't flag
  - `gochecknoinits` exempt for `cmd/`
  - `gosec` G117 / G706 project-wide exclusions
  - Structured `log/slog` logging
- **Load-bearing invariants:** `tenant_id` never from request body / query /
  headers; user vs service registry split; migrations are generated, not
  hand-written; `make swagger` pairs backend + frontend codegen.
- **"Things Copilot has historically gotten wrong here"** explicit
  do-not-suggest list (don't propose goimports, don't move tests into the
  same package, don't replace `new(...)` with `&...`, don't suggest
  `interface{}`, etc.).

## Why a separate path-scoped file (not just one big global one)

- The global `.github/copilot-instructions.md` is loaded for **all** Copilot
  contexts (frontend reviews, PR summaries, etc.). Bloating it with Go-only
  rules dilutes signal for non-Go review.
- VS Code / Copilot-in-IDE supports `.github/instructions/*.instructions.md`
  with an `applyTo` glob, which scopes the guidance to files that match —
  cleaner separation.
- The most-likely-to-be-flagged false positives (`new(expr)`, `WaitGroup.Go`)
  are still surfaced in the global file so PR-summary contexts see them too.

## Non-goals

- **No `.golangci.yml` changes.** The new file describes what's already
  enforced; it doesn't change enforcement.
- **No human-targeted doc duplication.** Architecture, multi-tenancy,
  registry pattern, error model, migration workflow, swagger workflow are
  already in `AGENTS.md` and `.claude/agents/inventario-backend.md` — the
  new file links there rather than restating.
- **Awesome-copilot Go file was not copied 1-to-1.** Several of its
  defaults conflict with this repo (testify, white-box tests in same
  package, lowercase error messages, standard `pkg/cmd/internal/` layout —
  this module lives in `go/` with `apiserver/`, `registry/`, `services/`,
  `models/`, `internal/` subpackages).

## Test plan

- [x] `.github/instructions/go.instructions.md` exists with valid YAML
      frontmatter and `applyTo` glob pointing at the Go module
- [x] Relative links from the new file resolve
      (`../../AGENTS.md`, `../../.claude/agents/inventario-backend.md`)
- [x] Existing global `copilot-instructions.md` still parses (added items in
      the same bulleted list, no structural changes)
- [ ] Watch the next few Copilot PR reviews — `new(expr)` should stop being
      flagged on `go/cmd/internal/input/*.go`. If it recurs, escalate by
      adding a concrete code example to the global file's modern-syntax
      section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded AI/Copilot guidance to cover Go 1.25/1.26+ syntax allowances and reviewer guidance to treat go.mod and CI results as authoritative.
  * Added a comprehensive Go instructions doc detailing allowed language features by version, linting/formatting conventions, security and migration workflows, and OpenAPI/codegen notes.
  * Clarified review-time expectations to improve consistency for Go contributions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->