### PR TITLE
[#1652] MembersPage typed error toasts (ErrLastOwner / ErrLastMember)

### DIFF
--- a/e2e/tests/groups.spec.ts
+++ b/e2e/tests/groups.spec.ts
@@ -495,6 +495,156 @@ test.describe('Remove Member — last admin protection (#1257)', () => {
     }
   });
 
+  // #1652 (FE half of Invariant B): the row-level dropdown disables the
+  // remove button on the last-owner row, but a stale members snapshot or
+  // role-data drift can let a click through. When that happens, MembersPage
+  // must render a typed toast ("…delete the group instead") so the user has
+  // an actionable remediation instead of the generic "Couldn't load" copy.
+  // We force the typed 422 response via page.route() rather than corrupting
+  // real DB state; the BE-side enforcement of Invariant B is already
+  // covered at the registry layer (postgres/group_memberships_test.go) and
+  // the service layer (services/group_service_test.go) with race tests.
+  test('MembersPage toast surfaces the lastMember typed copy on a 422 (#1652)', async ({ page, request }) => {
+    const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
+    const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    const groupName = `LastMember Toast UI ${Date.now()}`;
+    const createResp = await request.post('/api/v1/groups', {
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json',
+        'Authorization': `Bearer ${authToken}`,
+        'X-CSRF-Token': csrfToken,
+      },
+      data: { data: { type: 'groups', attributes: { name: groupName, icon: '🧪' } } },
+    });
+    expect(createResp.status(), await createResp.text()).toBe(201);
+    const createdBody = await createResp.json();
+    const groupId = createdBody.data.id as string;
+    const groupSlug = createdBody.data.attributes.slug as string;
+
+    try {
+      // Discover the owner's real member_user_id from the live roster
+      // before installing the route mock — the mocked GET below has to
+      // claim the same id for the self row, or the page renders the user
+      // as a non-self member and the gate that hides actions on `isMe`
+      // wouldn't fire / would fire on the wrong row.
+      const membersResp = await request.get(`/api/v1/groups/${groupId}/members`, {
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+        },
+      });
+      expect(membersResp.status()).toBe(200);
+      const realMembers = await membersResp.json();
+      const ownerUserId = realMembers.data[0].attributes.member_user_id as string;
+
+      const fakeOtherUserId = 'u2-other-toast-1652';
+      const fakeOtherShort = fakeOtherUserId.slice(0, 8);
+      const fakeRoster = {
+        data: [
+          {
+            id: 'm1-real-owner',
+            type: 'memberships',
+            attributes: {
+              group_id: groupId,
+              member_user_id: ownerUserId,
+              role: 'owner',
+              joined_at: '2026-04-01T00:00:00Z',
+              user: { id: ownerUserId, name: 'Owner', email: 'owner@example.com' },
+            },
+          },
+          {
+            id: 'm2-fake-user',
+            type: 'memberships',
+            attributes: {
+              group_id: groupId,
+              member_user_id: fakeOtherUserId,
+              role: 'user',
+              joined_at: '2026-04-02T00:00:00Z',
+              user: { id: fakeOtherUserId, name: 'Bea Smith', email: 'bea@example.com' },
+            },
+          },
+        ],
+      };
+
+      // Mock the roster GET to surface a second non-self row whose
+      // actions menu the test can drive. The route is scoped to this
+      // group only so neighbouring tests are unaffected. Auth + CSRF
+      // headers are not asserted — the goal is the FE handler wiring,
+      // not re-testing the request shape.
+      await page.route(`**/api/v1/groups/${groupId}/members`, async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/vnd.api+json',
+            body: JSON.stringify(fakeRoster),
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      // Mock the DELETE on the fake non-self row to return the typed
+      // 422 envelope the BE would emit when Invariant B trips. Hitting
+      // this from a normal-state stack is impossible (Invariant A wins
+      // the owner-first ordering), so the route mock is the only way to
+      // exercise the FE branch in a real browser.
+      await page.route(
+        `**/api/v1/groups/${groupId}/members/${fakeOtherUserId}`,
+        async (route) => {
+          if (route.request().method() === 'DELETE') {
+            await route.fulfill({
+              status: 422,
+              contentType: 'application/vnd.api+json',
+              body: JSON.stringify({
+                errors: [{ code: 'group.last_member', detail: 'last member' }],
+              }),
+            });
+            return;
+          }
+          await route.continue();
+        },
+      );
+
+      await page.goto(`/g/${encodeURIComponent(groupSlug)}/members`);
+      await page.waitForSelector('[data-testid="members-list"]', { timeout: 10000 });
+
+      await page.click(`[data-testid="member-actions-${fakeOtherShort}"]`);
+      await page.click(`[data-testid="remove-member-btn-${fakeOtherUserId}"]`);
+      // The confirm dialog is the shared useConfirm primitive; the accept
+      // button carries the `confirm-accept` testid the project uses.
+      await page.click('[data-testid="confirm-accept"]');
+
+      // Sonner renders into a portal as a role=status region; locate the
+      // toast by its localized copy. Matching "delete the group instead"
+      // pins the typed branch (members:errors.lastMember) vs. the generic
+      // parseServerError fallback ("Couldn't load…").
+      await expect(page.getByText(/delete the group instead/i)).toBeVisible({
+        timeout: 5000,
+      });
+    } finally {
+      // Even though we mocked the DELETE response, the cleanup below
+      // hits the real BE — that's what actually removes the test group.
+      await page.unroute(`**/api/v1/groups/${groupId}/members`);
+      await page.unroute(`**/api/v1/groups/${groupId}/members/${'u2-other-toast-1652'}`);
+      const deleteResp = await request.delete(`/api/v1/groups/${groupId}`, {
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          'Accept': 'application/vnd.api+json',
+          'Authorization': `Bearer ${authToken}`,
+          'X-CSRF-Token': csrfToken,
+        },
+        data: { confirm_word: groupName, password: 'TestPassword123' },
+      });
+      expect(deleteResp.status()).toBe(204);
+    }
+  });
+
   test('Remove button on the sole admin is disabled with tooltip', async ({ page, request }) => {
     const authToken = await page.evaluate(() => localStorage.getItem('inventario_token') || '');
     const csrfToken = await page.evaluate(() => sessionStorage.getItem('inventario_csrf_token') || '');

--- a/frontend/src/i18n/locales/en/members.json
+++ b/frontend/src/i18n/locales/en/members.json
@@ -7,6 +7,10 @@
   },
   "adminOnlyHelp": "Only admins and owners can change roles, remove members, or manage invites.",
   "empty": "This group has no members yet.",
+  "errors": {
+    "lastMember": "Couldn't remove. That would leave the group empty — delete the group instead.",
+    "lastOwner": "Couldn't remove. They're the last owner — promote another member to owner first."
+  },
   "invite": {
     "actions": {
       "resend": "Resend invite",

--- a/frontend/src/pages/groups/MembersPage.tsx
+++ b/frontend/src/pages/groups/MembersPage.tsx
@@ -57,7 +57,7 @@ import type { GroupRole, MemberRow } from "@/features/group/api"
 import { useAppToast } from "@/hooks/useAppToast"
 import { useConfirm } from "@/hooks/useConfirm"
 import { formatDate } from "@/lib/intl"
-import { parseServerError } from "@/lib/server-error"
+import { getServerErrorCode, parseServerError } from "@/lib/server-error"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 import { cn } from "@/lib/utils"
 
@@ -87,6 +87,18 @@ const ROLE_BADGE_CLASS: Record<GroupRole, string> = {
 // owner is a transfer-of-ownership action, not an invite role. The BE
 // rejects role=owner on POST /invites with 422; the UI mirrors that.
 const INVITE_ROLE_OPTIONS: GroupRole[] = ["viewer", "user", "admin"]
+
+// Typed 422 codes the membership endpoints surface for the ≥1-owner /
+// ≥1-member invariants (#1652). The row-level dropdown gates these
+// pre-emptively (disabled when `isLastOwner`), so we only land here on
+// a race or role-data drift — but the toast still needs to point at
+// the actionable remediation rather than dumping "the last owner"
+// straight from the server. Mirrors admin/MembershipEditor.tsx's
+// MEMBER_ERROR_KEY pattern so the two surfaces stay coherent.
+const REMOVE_ERROR_CODE: Record<string, string> = {
+  "group.last_owner": "members:errors.lastOwner",
+  "group.last_member": "members:errors.lastMember",
+}
 
 function inviteUrl(token: string | undefined): string {
   if (!token) return ""
@@ -427,6 +439,15 @@ function MemberRowView({
         role: next as GroupRole,
       })
     } catch (err) {
+      // #1652: a demote that would drop the group below ≥1 owner trips
+      // ErrLastOwner; the row gate disables the dropdown but a stale
+      // membership snapshot (loading flicker, optimistic UI) can let a
+      // click through, so we still need the typed copy here.
+      const codeKey = REMOVE_ERROR_CODE[getServerErrorCode(err) ?? ""]
+      if (codeKey) {
+        toast.error(t(codeKey))
+        return
+      }
       toast.error(parseServerError(err, t("members:loadError")))
     }
   }
@@ -444,6 +465,16 @@ function MemberRowView({
     try {
       await removeMutation.mutateAsync({ groupId, memberUserId })
     } catch (err) {
+      // #1652: defense-in-depth toast for the two invariants — ErrLastOwner
+      // ("transfer ownership first") vs. ErrLastMember ("delete the group
+      // instead"). The row-level gate (isLastOwner → disableMutation)
+      // covers the common path; this catches races and role-data drift
+      // where Invariant B is the only thing keeping a group non-empty.
+      const codeKey = REMOVE_ERROR_CODE[getServerErrorCode(err) ?? ""]
+      if (codeKey) {
+        toast.error(t(codeKey))
+        return
+      }
       toast.error(parseServerError(err, t("members:loadError")))
     }
   }

--- a/frontend/src/pages/groups/__tests__/MembersPage.errors.test.tsx
+++ b/frontend/src/pages/groups/__tests__/MembersPage.errors.test.tsx
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { http as msw, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+// Local sonner mock per-file: the global setup turns `toast.error` into a
+// no-op (test/setup.ts) so the tree never portals an actual <Toaster /> —
+// fine for everything else, but here we need to assert the wrapper picked
+// the typed-code copy instead of the generic fallback. `vi.mock` hoists
+// per-file, so this override wins inside this file only.
+vi.mock("sonner", () => {
+  const toastError = vi.fn(() => "stub-toast-id")
+  const noop = vi.fn(() => "stub-toast-id")
+  return {
+    Toaster: () => null,
+    toast: Object.assign(noop, {
+      success: noop,
+      error: toastError,
+      info: noop,
+      warning: noop,
+      message: noop,
+      promise: noop,
+      dismiss: vi.fn(),
+      loading: noop,
+      custom: noop,
+    }),
+  }
+})
+
+import { toast } from "sonner"
+
+import { MembersPage } from "@/pages/groups/MembersPage"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { ConfirmProvider } from "@/hooks/useConfirm"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+
+const api = (path: string) => `${window.location.origin}/api/v1${path}`
+
+const groupsHandler = msw.get(api("/groups"), () =>
+  HttpResponse.json({
+    data: [
+      {
+        id: "g1",
+        type: "groups",
+        attributes: { id: "g1", slug: "household", name: "Household" },
+      },
+    ],
+  })
+)
+
+const userMeHandler = msw.get(api("/auth/me"), () =>
+  HttpResponse.json({ id: "u1", email: "alex@example.com", name: "Alex" })
+)
+
+// Two-row roster: the current user is the owner, plus a second non-self
+// member whose row exposes the actions dropdown (self-row is gated out
+// by the page). The remove button on the non-self row is the surface we
+// drive in these tests.
+const twoMemberRoster = msw.get(api("/groups/g1/members"), () =>
+  HttpResponse.json({
+    data: [
+      {
+        id: "m1",
+        type: "memberships",
+        attributes: {
+          group_id: "g1",
+          member_user_id: "u1",
+          role: "owner",
+          joined_at: "2026-04-01T00:00:00Z",
+          user: { id: "u1", name: "Alex Doe", email: "alex@example.com" },
+        },
+      },
+      {
+        id: "m2",
+        type: "memberships",
+        attributes: {
+          group_id: "g1",
+          member_user_id: "u2-other",
+          role: "user",
+          joined_at: "2026-04-02T00:00:00Z",
+          user: { id: "u2-other", name: "Bea Smith", email: "bea@example.com" },
+        },
+      },
+    ],
+  })
+)
+
+const invitesEmpty = msw.get(api("/groups/g1/invites"), () => HttpResponse.json({ data: [] }))
+
+function renderMembers() {
+  setAccessToken("good-token")
+  return renderWithProviders({
+    initialPath: "/g/household/members",
+    routes: (
+      <Route
+        path="/g/:groupSlug/members"
+        element={
+          <AuthProvider>
+            <GroupProvider>
+              <ConfirmProvider>
+                <MembersPage />
+              </ConfirmProvider>
+            </GroupProvider>
+          </AuthProvider>
+        }
+      />
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+  ;(toast.error as ReturnType<typeof vi.fn>).mockClear()
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  })
+})
+
+// #1652: the row-level dropdown disables the remove button when
+// isLastOwner, but a stale membership snapshot (loading flicker, role
+// drift, or a sysadmin-side change committed mid-render) can let a
+// click through. Both invariants ship distinct toast copy so the user
+// gets an actionable remediation rather than a generic "Couldn't load"
+// message that buries the actual cause.
+
+describe("<MembersPage /> typed error toasts (#1652)", () => {
+  it("surfaces the lastOwner copy when DELETE returns group.last_owner", async () => {
+    server.use(
+      groupsHandler,
+      userMeHandler,
+      twoMemberRoster,
+      invitesEmpty,
+      msw.delete(api("/groups/g1/members/u2-other"), () =>
+        HttpResponse.json(
+          { errors: [{ code: "group.last_owner", detail: "sole owner" }] },
+          { status: 422 }
+        )
+      )
+    )
+    const user = userEvent.setup()
+    renderMembers()
+    await waitFor(() => expect(screen.getByTestId("members-list")).toBeInTheDocument())
+    await user.click(screen.getByTestId("member-actions-u2-other"))
+    await user.click(await screen.findByTestId("remove-member-btn-u2-other"))
+    await user.click(await screen.findByTestId("confirm-accept"))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1))
+    // The toast carries the localized "last owner" copy (i18n
+    // members:errors.lastOwner), not the generic fallback. We match on
+    // the leading words so harmless copy tweaks don't force a test
+    // update — the assertion's point is that we landed on the typed
+    // branch and not on `parseServerError`'s "Couldn't load".
+    expect((toast.error as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatch(/last owner/i)
+  })
+
+  it("surfaces the lastMember copy when DELETE returns group.last_member", async () => {
+    server.use(
+      groupsHandler,
+      userMeHandler,
+      twoMemberRoster,
+      invitesEmpty,
+      msw.delete(api("/groups/g1/members/u2-other"), () =>
+        HttpResponse.json(
+          { errors: [{ code: "group.last_member", detail: "leaves zero members" }] },
+          { status: 422 }
+        )
+      )
+    )
+    const user = userEvent.setup()
+    renderMembers()
+    await waitFor(() => expect(screen.getByTestId("members-list")).toBeInTheDocument())
+    await user.click(screen.getByTestId("member-actions-u2-other"))
+    await user.click(await screen.findByTestId("remove-member-btn-u2-other"))
+    await user.click(await screen.findByTestId("confirm-accept"))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1))
+    // members:errors.lastMember — "delete the group instead" is the
+    // actionable hint the user actually needs.
+    expect((toast.error as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatch(
+      /delete the group instead/i
+    )
+  })
+
+  it("falls back to the generic parseServerError copy for an unrelated 422", async () => {
+    server.use(
+      groupsHandler,
+      userMeHandler,
+      twoMemberRoster,
+      invitesEmpty,
+      msw.delete(api("/groups/g1/members/u2-other"), () =>
+        HttpResponse.json(
+          { errors: [{ code: "validation_error", detail: "something else" }] },
+          { status: 422 }
+        )
+      )
+    )
+    const user = userEvent.setup()
+    renderMembers()
+    await waitFor(() => expect(screen.getByTestId("members-list")).toBeInTheDocument())
+    await user.click(screen.getByTestId("member-actions-u2-other"))
+    await user.click(await screen.findByTestId("remove-member-btn-u2-other"))
+    await user.click(await screen.findByTestId("confirm-accept"))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1))
+    // The typed-code map didn't match → parseServerError won. Assert
+    // we didn't accidentally render either typed copy (otherwise the
+    // map fallthrough is broken).
+    const msg = (toast.error as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+    expect(msg).not.toMatch(/last owner/i)
+    expect(msg).not.toMatch(/delete the group instead/i)
+  })
+})

--- a/frontend/src/pages/groups/__tests__/MembersPage.errors.test.tsx
+++ b/frontend/src/pages/groups/__tests__/MembersPage.errors.test.tsx
@@ -218,4 +218,36 @@ describe("<MembersPage /> typed error toasts (#1652)", () => {
     expect(msg).not.toMatch(/last owner/i)
     expect(msg).not.toMatch(/delete the group instead/i)
   })
+
+  it("surfaces the lastOwner copy when PATCH role-change returns group.last_owner", async () => {
+    // handleRoleChange shares the same typed-code map as handleRemove, so a
+    // failed demotion that trips ErrLastOwner (e.g. the owner picks "User"
+    // from another owner's role dropdown via a stale snapshot) must also
+    // surface the actionable copy. Reuse the same two-row roster; drive the
+    // second row's inline role select rather than the remove menu item.
+    server.use(
+      groupsHandler,
+      userMeHandler,
+      twoMemberRoster,
+      invitesEmpty,
+      msw.patch(api("/groups/g1/members/u2-other"), () =>
+        HttpResponse.json(
+          { errors: [{ code: "group.last_owner", detail: "sole owner" }] },
+          { status: 422 }
+        )
+      )
+    )
+    const user = userEvent.setup()
+    renderMembers()
+    await waitFor(() => expect(screen.getByTestId("members-list")).toBeInTheDocument())
+    // The role-change controls live inside the same actions dropdown the
+    // remove tests open; the dropdown also lists the role tier menu items.
+    await user.click(screen.getByTestId("member-actions-u2-other"))
+    // Bea is currently "user"; clicking the "admin" item submits the PATCH
+    // (any role other than the current one would do — admin is unambiguous).
+    await user.click(await screen.findByTestId("member-role-u2-other-admin"))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1))
+    expect((toast.error as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatch(/last owner/i)
+  })
 })


### PR DESCRIPTION
## Summary

PR #1666 already closed most of #1652 (Invariants A+B in registry/service/handler with race tests, GroupSettingsPage's `group.last_member` toast, seed-as-owner, the API-level Playwright spec for ErrLastOwner). The one surface that still fell back to the generic `parseServerError` copy was **MembersPage.tsx** — both per-row remove and inline role change.

The row-level dropdown disables the remove button on the last-owner row, but a stale members snapshot (loading flicker, role-data drift, admin-side change committed mid-render) can let a click through. When that happens the generic "Couldn't load the member list." toast buries the actual cause and leaves the user without the actionable remediation.

This PR closes the gap:

- `handleRemove` and `handleRoleChange` consult `getServerErrorCode` first and pick `members:errors.lastOwner` / `members:errors.lastMember` for the two typed 422 codes; everything else falls through to `parseServerError` as before. The map mirrors `admin/MembershipEditor.tsx`'s `MEMBER_ERROR_KEY` pattern so the per-group and admin surfaces stay coherent.
- New i18n keys in `members.json` (en — `cs`/`ru` translations of this file are empty placeholders so no parity update needed).
- Vitest coverage for all three branches (typed `group.last_owner`, typed `group.last_member`, generic fallback) using a per-file `vi.mock("sonner", ...)` so `toast.error` is spy-able without breaking the global no-op stub.
- A Playwright spec under the existing "Remove Member — last admin protection (#1257)" describe-block that drives the FE handler end-to-end via `page.route()` mocks of `GET /members` (to surface a non-self row whose actions menu can be opened) and the `DELETE`'s 422 response. Invariant B is not reachable from a normal-state stack (Invariant A wins the owner-first ordering), so the route mock is the only way to exercise the FE branch in a real browser — BE enforcement of Invariant B stays unit-tested at the registry layer (`postgres/group_memberships_test.go`) plus the service-layer race tests (`services/group_service_test.go`).

Closes #1652.

## Test plan

- [ ] CI green (Go test, frontend test, frontend lint + format:check, e2e suite)
- [ ] Vitest: `MembersPage.errors.test.tsx` — 3 cases, all green locally
- [ ] Playwright: `tests/groups.spec.ts:507` (`MembersPage toast surfaces the lastMember typed copy on a 422 (#1652)`) — listed across chromium + firefox projects
- [ ] Manual: open `/g/<slug>/members`, intercept the DELETE on a non-self row to return `{ errors: [{ code: "group.last_member" }] }` → toast reads "Couldn't remove. That would leave the group empty — delete the group instead."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Members page now shows specific, localized error messages when removal or role changes are blocked (e.g., cannot remove last admin or leave a group empty), with guidance on next steps.

* **Bug Fixes**
  * Improved UI error handling so the correct localized toast is shown for these server-side invariant errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->