### PR TITLE
[#1853] infra: VM bootstrap orchestration for preview-env vCluster

### DIFF
--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,7 +1,9 @@
 # Inventario preview-env infra orchestrator (#1853).
 #
-# All targets require VM=user@host (the bootstrap target VM). The orchestration
-# always runs from the laptop; nothing runs locally that needs root.
+# Most targets require VM=user@host (the bootstrap target VM). The orchestration
+# always runs from the laptop; nothing runs locally that needs root. The
+# `preflight` target is the exception — it only checks laptop-side tooling and
+# does not need VM.
 #
 # Required laptop tools: ssh, scp, sops, age. Helm/kubectl are nice-to-have
 # (the installer ships them on the VM via vcluster standalone).
@@ -18,7 +20,7 @@ REQUIRE_VM = @[ -n "$(VM)" ] || { echo "ERROR: VM is required, e.g. make $@ VM=u
 .PHONY: help preflight bootstrap upgrade recover destroy status logs shell
 
 help:
-	@echo "Inventario preview-env infra targets (all require VM=user@host)"
+	@echo "Inventario preview-env infra targets (VM=user@host required except preflight)"
 	@echo ""
 	@echo "  bootstrap    Bring a clean Ubuntu 26.04 VM up to a working preview-env host."
 	@echo "  upgrade      Re-run bootstrap; idempotent. Use for vcluster/argocd version bumps."

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,0 +1,77 @@
+# Inventario preview-env infra orchestrator (#1853).
+#
+# All targets require VM=user@host (the bootstrap target VM). The orchestration
+# always runs from the laptop; nothing runs locally that needs root.
+#
+# Required laptop tools: ssh, scp, sops, age. Helm/kubectl are nice-to-have
+# (the installer ships them on the VM via vcluster standalone).
+#
+# See infra/README.md for the operating guide.
+
+SHELL := /bin/bash
+
+VM ?=
+SVC ?= vcluster.service
+
+REQUIRE_VM = @[ -n "$(VM)" ] || { echo "ERROR: VM is required, e.g. make $@ VM=user@host" >&2; exit 1; }
+
+.PHONY: help preflight bootstrap upgrade recover destroy status logs shell
+
+help:
+	@echo "Inventario preview-env infra targets (all require VM=user@host)"
+	@echo ""
+	@echo "  bootstrap    Bring a clean Ubuntu 26.04 VM up to a working preview-env host."
+	@echo "  upgrade      Re-run bootstrap; idempotent. Use for vcluster/argocd version bumps."
+	@echo "  recover      Alias for bootstrap; intended after total VM loss + 'ssh-copy-id'."
+	@echo "  destroy      Stop services and remove vcluster data dir. Tailnet membership preserved."
+	@echo "  status       Show vcluster+tailscaled state and kubectl get nodes,pods -A."
+	@echo "  logs         Tail journalctl for SVC (default: vcluster.service)."
+	@echo "               Example: make logs VM=... SVC=tailscaled.service"
+	@echo "  shell        ssh into the VM."
+	@echo ""
+	@echo "Laptop prereqs: ssh, scp, sops, age. Run 'make preflight' to verify."
+
+preflight:
+	@missing=""; \
+	for c in ssh scp sops age; do \
+	  command -v $$c >/dev/null 2>&1 || missing="$$missing $$c"; \
+	done; \
+	if [ -n "$$missing" ]; then \
+	  echo "Missing tools:$$missing" >&2; \
+	  echo "  macOS: brew install$$missing" >&2; \
+	  echo "  Debian/Ubuntu: apt-get install$$missing" >&2; \
+	  exit 1; \
+	fi; \
+	echo "Laptop prereqs OK"
+
+bootstrap: preflight
+	$(REQUIRE_VM)
+	bash infra/vm/bootstrap.sh "$(VM)"
+
+upgrade: bootstrap
+
+recover: bootstrap
+
+destroy:
+	$(REQUIRE_VM)
+	bash infra/vm/destroy.sh "$(VM)"
+
+status:
+	$(REQUIRE_VM)
+	@ssh "$(VM)" 'set -e; \
+	  printf "\n=== systemd units ===\n"; \
+	  systemctl is-active vcluster.service tailscaled.service || true; \
+	  printf "\n=== tailscale ===\n"; \
+	  tailscale status --self=true --peers=false 2>/dev/null || true; \
+	  printf "\n=== kubectl get nodes ===\n"; \
+	  sudo /usr/local/bin/kubectl get nodes -o wide 2>/dev/null || echo "(kubectl unavailable)"; \
+	  printf "\n=== pods (all namespaces) ===\n"; \
+	  sudo /usr/local/bin/kubectl get pods -A 2>/dev/null || true'
+
+logs:
+	$(REQUIRE_VM)
+	ssh "$(VM)" "sudo journalctl -u $(SVC) -f --no-pager"
+
+shell:
+	$(REQUIRE_VM)
+	ssh "$(VM)"

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,82 @@
+# Inventario preview-env infra
+
+PR-preview environments served from a single Ubuntu 26.04 VM, exposed via
+Tailscale. Continuous delivery via ArgoCD ApplicationSet PR Generator (label
+`preview` on a PR → one `Application` per PR → namespace `inv-vcl01-prNNNN`).
+
+Tracking: epic [#1852](https://github.com/denisvmedia/inventario/issues/1852),
+this skeleton landed in [#1853](https://github.com/denisvmedia/inventario/issues/1853).
+
+> Full beginner README lives in [#1863](https://github.com/denisvmedia/inventario/issues/1863).
+> This file is a thin operating reference for the orchestration this issue ships.
+
+## What this directory ships (#1853)
+
+```
+infra/
+├── Makefile               targets: bootstrap upgrade recover destroy status logs shell
+├── README.md              this file
+└── vm/
+    ├── bootstrap.sh       laptop orchestrator — ssh, sops, upload, apply
+    ├── vm-install.sh      remote installer — tailscale, vcluster, TS-op, ArgoCD
+    ├── destroy.sh         remote teardown — vcluster + data; tailnet preserved
+    ├── scripts/
+    │   └── apply-secrets.sh   translate sops bundle into k8s Secrets
+    └── secrets/
+        ├── .gitignore
+        └── secrets.example.yaml   schema reference (safe to commit)
+```
+
+## Quick start
+
+```bash
+# Laptop prerequisites (macOS Homebrew or Debian/Ubuntu apt).
+make -C infra preflight     # checks: ssh scp sops age
+
+# Bootstrap a fresh Ubuntu 26.04 VM with passwordless ssh.
+make -C infra bootstrap VM=user@your-vm-ip
+
+# Verify.
+KUBECONFIG=~/.kube/inv-vcl01.config kubectl get nodes,pods -A
+make -C infra status VM=user@your-vm-ip
+```
+
+The `bootstrap` target is idempotent — re-running it serves as `upgrade` and `recover`.
+
+## What's still missing for end-to-end Phase 1
+
+This issue ships the orchestration only. The following sub-issues fill in the
+data that orchestration needs to be useful:
+
+| Need | Filled by | Without it |
+|---|---|---|
+| `infra/vm/secrets/secrets.enc.yaml` (sops bundle) | [#1854](https://github.com/denisvmedia/inventario/issues/1854) | `tailscale up` must be run manually on the VM; TS-op and GH App creds unavailable. |
+| Tailscale Operator helm values overlay | [#1855](https://github.com/denisvmedia/inventario/issues/1855) | Default chart values used (works for basic Service/Ingress). |
+| `helm/inventario/` PR-preview overlay | [#1856](https://github.com/denisvmedia/inventario/issues/1856) | ApplicationSet template can't reference it yet. |
+| `infra/argocd/*.yaml` (AppProject, ApplicationSet, master Application) | [#1858](https://github.com/denisvmedia/inventario/issues/1858) | ArgoCD installs but no Applications appear; PR labels do nothing. |
+| Full README with first-time setup walkthrough and DR runbook | [#1863](https://github.com/denisvmedia/inventario/issues/1863) | Use this file + bootstrap.sh warnings as a stopgap. |
+
+`bootstrap.sh` and `vm-install.sh` warn (don't fail) when these are missing, so
+this issue can land and the others can fill in independently.
+
+## Pinned versions
+
+- vcluster standalone: `v0.34.0`
+- Kubernetes (inside vcluster): `v1.34.0`
+- Tailscale: latest from `tailscale.com/install.sh` (idempotent)
+- ArgoCD chart: latest in `argo/argo-cd` repo (pin once #1858 lands a chart-version)
+- Tailscale Operator chart: latest in `tailscale/tailscale-operator` repo (same, pin in #1855)
+
+Pinning the latter two lands with the issues that own them.
+
+## Tailscale hostname
+
+The bootstrap registers the VM in the tailnet as `inv-vcl01`. Override via
+environment if you need a different label (for a second VM, multi-environment,
+etc.):
+
+```bash
+# On the laptop
+TS_HOSTNAME=inv-vcl02 make -C infra bootstrap VM=...
+# This is passed through to vm-install.sh via the env-preserving sudo -E.
+```

--- a/infra/vm/bootstrap.sh
+++ b/infra/vm/bootstrap.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# bootstrap.sh — laptop orchestrator for the Inventario preview-env VM (#1853).
+#
+# Brings up a clean Ubuntu 26.04 VM with tailscaled, vcluster standalone,
+# Tailscale Operator, and ArgoCD. Reads secrets from the sops bundle
+# (introduced in #1854) and applies ArgoCD manifests (introduced in #1858)
+# at the end. Idempotent — re-runs are safe and act as upgrades.
+#
+# Usage: bash infra/vm/bootstrap.sh user@host
+#   (typically invoked via `make bootstrap VM=user@host`)
+
+set -Eeuo pipefail
+
+VM="${1:?usage: bootstrap.sh user@host}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+
+SECRETS_FILE="$REPO_ROOT/infra/vm/secrets/secrets.enc.yaml"
+ARGOCD_DIR="$REPO_ROOT/infra/argocd"
+VM_INSTALL="$SCRIPT_DIR/vm-install.sh"
+APPLY_SECRETS="$SCRIPT_DIR/scripts/apply-secrets.sh"
+
+note() { printf '\n==> %s\n' "$*" >&2; }
+warn() { printf '\n[!] %s\n' "$*" >&2; }
+
+# --- SSH preflight ---
+note "SSH preflight: $VM"
+ssh -o ConnectTimeout=10 -o BatchMode=yes "$VM" 'echo ok' >/dev/null
+
+# --- Decrypt sops bundle locally (when present) ---
+# Bundle schema lives in #1854; until that lands, bootstrap can still run and
+# bring services up — just without auth-key, OAuth, or GH App credentials.
+SECRETS_JSON=""
+if [ -f "$SECRETS_FILE" ]; then
+    command -v sops >/dev/null || { echo "sops required to decrypt $SECRETS_FILE" >&2; exit 1; }
+    note "Decrypting $SECRETS_FILE"
+    SECRETS_JSON=$(sops -d --output-type json "$SECRETS_FILE")
+else
+    warn "$SECRETS_FILE missing (lands in #1854)."
+    warn "Tailscale will need manual 'sudo tailscale up' on the VM."
+    warn "Tailscale Operator and ArgoCD GH-App integration won't have credentials."
+fi
+
+# --- Upload installer (and decrypted secrets if any) to a remote tmp dir ---
+REMOTE_TMP=$(ssh "$VM" 'mktemp -d /tmp/inv-bootstrap.XXXXXX')
+cleanup() { ssh "$VM" "rm -rf $REMOTE_TMP" 2>/dev/null || true; }
+trap cleanup EXIT
+
+note "Uploading installer to $VM:$REMOTE_TMP"
+scp -q "$VM_INSTALL" "$VM":"$REMOTE_TMP/vm-install.sh"
+
+if [ -n "$SECRETS_JSON" ]; then
+    ssh "$VM" "umask 077 && cat > $REMOTE_TMP/secrets.plain.json" <<<"$SECRETS_JSON"
+fi
+
+# --- Run remote installer ---
+note "Running vm-install.sh on $VM (first run takes 3-5 minutes)"
+ssh "$VM" "sudo bash $REMOTE_TMP/vm-install.sh $REMOTE_TMP"
+
+# --- Apply k8s Secrets generated from the sops bundle (#1854) ---
+if [ -n "$SECRETS_JSON" ]; then
+    if [ -x "$APPLY_SECRETS" ]; then
+        note "Applying k8s Secrets to argocd/tailscale/inv-system namespaces"
+        SECRETS_JSON="$SECRETS_JSON" bash "$APPLY_SECRETS" "$VM"
+    else
+        warn "$APPLY_SECRETS not executable; skipping k8s Secret apply step."
+    fi
+fi
+
+# --- Apply ArgoCD manifests (AppProject, ApplicationSet, master Application) (#1858) ---
+if [ -d "$ARGOCD_DIR" ] && compgen -G "$ARGOCD_DIR/*.yaml" >/dev/null; then
+    note "Applying ArgoCD manifests from $ARGOCD_DIR"
+    for m in "$ARGOCD_DIR"/*.yaml; do
+        ssh "$VM" 'sudo /usr/local/bin/kubectl apply -f -' < "$m"
+    done
+else
+    warn "$ARGOCD_DIR has no manifests yet (lands in #1858)."
+    warn "ArgoCD is installed but no AppProject/ApplicationSet/Application is registered."
+fi
+
+# --- Copy kubeconfig back, rewrite server to tailnet IP ---
+LAPTOP_KUBECONFIG="$HOME/.kube/inv-vcl01.config"
+note "Copying kubeconfig to $LAPTOP_KUBECONFIG"
+mkdir -p "$HOME/.kube"
+ssh "$VM" 'sudo cat /var/lib/vcluster/kubeconfig.yaml' >"$LAPTOP_KUBECONFIG"
+chmod 600 "$LAPTOP_KUBECONFIG"
+
+TS_IP=$(ssh "$VM" 'tailscale ip -4 2>/dev/null | head -1' || true)
+if [ -n "$TS_IP" ]; then
+    # macOS sed and GNU sed differ; perl is portable.
+    perl -pi -e "s|https://127\.0\.0\.1:|https://${TS_IP}:|g; s|https://localhost:|https://${TS_IP}:|g" \
+        "$LAPTOP_KUBECONFIG"
+    note "kubeconfig server rewritten to https://${TS_IP}:<port> (tailnet IP)"
+else
+    warn "Couldn't fetch tailnet IP. kubeconfig still points at 127.0.0.1 —"
+    warn "either ssh-tunnel port 443/6443 or edit the server: field manually."
+fi
+
+note "Bootstrap complete. Verify:"
+echo "    KUBECONFIG=$LAPTOP_KUBECONFIG kubectl get nodes,pods -A"
+echo "    ssh $VM 'tailscale status | head'"

--- a/infra/vm/destroy.sh
+++ b/infra/vm/destroy.sh
@@ -23,12 +23,14 @@ note "SSH preflight: $VM"
 ssh -o ConnectTimeout=10 -o BatchMode=yes "$VM" 'echo ok' >/dev/null
 
 note "Stopping vcluster.service and removing data"
+# Always attempt stop/disable — systemctl is idempotent and tolerates a missing
+# unit when we ignore the error. The previous list-unit-files gate was unreliable
+# (it can exit 0 with "0 unit files listed") and gated the data-dir removal
+# unnecessarily.
 ssh "$VM" 'set -e
-    if systemctl list-unit-files vcluster.service >/dev/null 2>&1; then
-        sudo systemctl disable --now vcluster.service 2>/dev/null || true
-        sudo rm -f /etc/systemd/system/vcluster.service
-        sudo systemctl daemon-reload
-    fi
+    sudo systemctl disable --now vcluster.service 2>/dev/null || true
+    sudo rm -f /etc/systemd/system/vcluster.service
+    sudo systemctl daemon-reload
     sudo rm -rf /etc/vcluster /var/lib/vcluster
     sudo rm -f /usr/local/bin/vcluster /usr/local/bin/kubectl
     echo "vcluster + data removed"

--- a/infra/vm/destroy.sh
+++ b/infra/vm/destroy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# destroy.sh — tear down vcluster + data on a preview-env VM (#1853).
+#
+# Stops and disables vcluster.service, wipes /etc/vcluster + /var/lib/vcluster,
+# removes the /usr/local/bin/{vcluster,kubectl} symlinks the installer created.
+# Tailscale membership (tailscaled + auth state) is intentionally preserved —
+# `tailscale logout` is a separate, more destructive operation that breaks DNS
+# for any other peer that has the host pinned.
+#
+# Idempotent. Re-running on a VM that has nothing to destroy is a no-op.
+#
+# Usage: bash infra/vm/destroy.sh user@host
+#   (typically via `make destroy VM=user@host`)
+
+set -Eeuo pipefail
+
+VM="${1:?usage: destroy.sh user@host}"
+
+note() { printf '\n==> %s\n' "$*" >&2; }
+
+note "SSH preflight: $VM"
+ssh -o ConnectTimeout=10 -o BatchMode=yes "$VM" 'echo ok' >/dev/null
+
+note "Stopping vcluster.service and removing data"
+ssh "$VM" 'set -e
+    if systemctl list-unit-files vcluster.service >/dev/null 2>&1; then
+        sudo systemctl disable --now vcluster.service 2>/dev/null || true
+        sudo rm -f /etc/systemd/system/vcluster.service
+        sudo systemctl daemon-reload
+    fi
+    sudo rm -rf /etc/vcluster /var/lib/vcluster
+    sudo rm -f /usr/local/bin/vcluster /usr/local/bin/kubectl
+    echo "vcluster + data removed"
+'
+
+note "Done. Tailscale state preserved (use \"sudo tailscale logout\" on the VM to revoke)."

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -61,9 +61,9 @@ metadata:
   namespace: inv-system
 type: Opaque
 stringData:
-  email: |
+  email: |-
 $(printf '%s' "$ADMIN_EMAIL" | sed 's/^/    /')
-  password: |
+  password: |-
 $(printf '%s' "$ADMIN_PASSWORD" | sed 's/^/    /')
 EOF
 else
@@ -79,6 +79,8 @@ GH_URL=$(lookup "github.url")
 if [ -n "$GH_APP_ID" ] && [ -n "$GH_INSTALL_ID" ] && [ -n "$GH_PRIVATE_KEY" ]; then
     note "Applying argocd/github-app-creds"
     # PEM may contain newlines; embed via stringData so kubectl handles escaping.
+    # All values use chomped block scalars (`|-`) — keeps multi-line PEM intact
+    # while stripping the spurious trailing newline that a `|` clip would add.
     cat <<EOF | remote_apply
 apiVersion: v1
 kind: Secret
@@ -93,7 +95,7 @@ stringData:
   url: $GH_URL
   githubAppID: "$GH_APP_ID"
   githubAppInstallationID: "$GH_INSTALL_ID"
-  githubAppPrivateKey: |
+  githubAppPrivateKey: |-
 $(printf '%s' "$GH_PRIVATE_KEY" | sed 's/^/    /')
 EOF
 else
@@ -116,9 +118,9 @@ metadata:
   namespace: tailscale
 type: Opaque
 stringData:
-  client_id: |
+  client_id: |-
 $(printf '%s' "$TS_ID" | sed 's/^/    /')
-  client_secret: |
+  client_secret: |-
 $(printf '%s' "$TS_SECRET" | sed 's/^/    /')
 EOF
 else

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -45,6 +45,9 @@ ADMIN_EMAIL=$(lookup "admin.email")
 ADMIN_PASSWORD=$(lookup "admin.password")
 if [ -n "$ADMIN_EMAIL" ] && [ -n "$ADMIN_PASSWORD" ]; then
     note "Applying inv-system/inventario-admin"
+    # Emit values as YAML block scalars so passwords with special chars (':', '{', '#', newlines)
+    # don't break manifest parsing or open an injection path. Same pattern as
+    # the github private key block below.
     cat <<EOF | remote_apply
 apiVersion: v1
 kind: Namespace
@@ -58,8 +61,10 @@ metadata:
   namespace: inv-system
 type: Opaque
 stringData:
-  email: $ADMIN_EMAIL
-  password: $ADMIN_PASSWORD
+  email: |
+$(printf '%s' "$ADMIN_EMAIL" | sed 's/^/    /')
+  password: |
+$(printf '%s' "$ADMIN_PASSWORD" | sed 's/^/    /')
 EOF
 else
     warn "admin.{email,password} missing in secrets; skipping inv-system/inventario-admin"
@@ -102,6 +107,7 @@ TS_ID=$(lookup "tailscale.oauth_client_id")
 TS_SECRET=$(lookup "tailscale.oauth_client_secret")
 if [ -n "$TS_ID" ] && [ -n "$TS_SECRET" ]; then
     note "Applying tailscale/operator-oauth"
+    # Block scalars for the same reason as inv-system/inventario-admin above.
     cat <<EOF | remote_apply
 apiVersion: v1
 kind: Secret
@@ -110,8 +116,10 @@ metadata:
   namespace: tailscale
 type: Opaque
 stringData:
-  client_id: $TS_ID
-  client_secret: $TS_SECRET
+  client_id: |
+$(printf '%s' "$TS_ID" | sed 's/^/    /')
+  client_secret: |
+$(printf '%s' "$TS_SECRET" | sed 's/^/    /')
 EOF
 else
     warn "tailscale.oauth_client_{id,secret} missing; skipping tailscale/operator-oauth"

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# apply-secrets.sh — translate the sops bundle into k8s Secrets and apply them
+# to the in-cluster namespaces consumed by the chart, the Tailscale Operator,
+# and ArgoCD's repo-creds layer.
+#
+# Invoked by bootstrap.sh after vm-install.sh has brought the cluster up.
+# Expects SECRETS_JSON in the environment (decrypted JSON from sops --output-type json).
+#
+# Schema lives in infra/vm/secrets/secrets.example.yaml; the real encrypted bundle
+# at infra/vm/secrets/secrets.enc.yaml is owned by #1854.
+#
+# This script is best-effort: if a section is missing from the bundle (e.g. GitHub
+# App not yet configured), the corresponding Secret apply is skipped with a warning.
+#
+# Usage: SECRETS_JSON='{...}' bash apply-secrets.sh user@host
+
+set -Eeuo pipefail
+
+VM="${1:?usage: apply-secrets.sh user@host}"
+: "${SECRETS_JSON:?SECRETS_JSON env var required}"
+
+note() { printf '\n==> %s\n' "$*" >&2; }
+warn() { printf '\n[!] %s\n' "$*" >&2; }
+
+# Look up a dotted key, returning empty string if any segment is missing.
+lookup() {
+    local key="$1"
+    jq -r --arg k "$key" '
+        def lookup($parts; $v):
+          if ($parts | length) == 0 then $v
+          else lookup($parts[1:]; $v[$parts[0]] // "")
+          end;
+        lookup($k | split("."); .) // empty
+    ' <<<"$SECRETS_JSON" 2>/dev/null
+}
+
+# Pipe a manifest through `kubectl apply -f -` on the remote VM.
+remote_apply() {
+    ssh "$VM" 'sudo /usr/local/bin/kubectl apply -f -'
+}
+
+# --- inv-system / inventario-admin (chart consumes via existingSecret) ---
+ADMIN_EMAIL=$(lookup "admin.email")
+ADMIN_PASSWORD=$(lookup "admin.password")
+if [ -n "$ADMIN_EMAIL" ] && [ -n "$ADMIN_PASSWORD" ]; then
+    note "Applying inv-system/inventario-admin"
+    cat <<EOF | remote_apply
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: inv-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: inventario-admin
+  namespace: inv-system
+type: Opaque
+stringData:
+  email: $ADMIN_EMAIL
+  password: $ADMIN_PASSWORD
+EOF
+else
+    warn "admin.{email,password} missing in secrets; skipping inv-system/inventario-admin"
+fi
+
+# --- argocd / github-app-creds (repo-creds + ApplicationSet PR-generator) ---
+GH_APP_ID=$(lookup "github.app_id")
+GH_INSTALL_ID=$(lookup "github.app_installation_id")
+GH_PRIVATE_KEY=$(lookup "github.app_private_key")
+GH_URL=$(lookup "github.url")
+[ -n "$GH_URL" ] || GH_URL="https://github.com/denisvmedia"
+if [ -n "$GH_APP_ID" ] && [ -n "$GH_INSTALL_ID" ] && [ -n "$GH_PRIVATE_KEY" ]; then
+    note "Applying argocd/github-app-creds"
+    # PEM may contain newlines; embed via stringData so kubectl handles escaping.
+    cat <<EOF | remote_apply
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-app-creds
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repo-creds
+type: Opaque
+stringData:
+  type: git
+  url: $GH_URL
+  githubAppID: "$GH_APP_ID"
+  githubAppInstallationID: "$GH_INSTALL_ID"
+  githubAppPrivateKey: |
+$(printf '%s' "$GH_PRIVATE_KEY" | sed 's/^/    /')
+EOF
+else
+    warn "github.app_{id,installation_id,private_key} incomplete in secrets; skipping argocd/github-app-creds"
+fi
+
+# --- tailscale / operator-oauth (consumed by the TS-op helm chart in vm-install.sh) ---
+# The chart's helm install also takes OAuth via --set-string flags, but a Secret
+# keeps the bundle the source of truth for rotation. Optional.
+TS_ID=$(lookup "tailscale.oauth_client_id")
+TS_SECRET=$(lookup "tailscale.oauth_client_secret")
+if [ -n "$TS_ID" ] && [ -n "$TS_SECRET" ]; then
+    note "Applying tailscale/operator-oauth"
+    cat <<EOF | remote_apply
+apiVersion: v1
+kind: Secret
+metadata:
+  name: operator-oauth
+  namespace: tailscale
+type: Opaque
+stringData:
+  client_id: $TS_ID
+  client_secret: $TS_SECRET
+EOF
+else
+    warn "tailscale.oauth_client_{id,secret} missing; skipping tailscale/operator-oauth"
+fi

--- a/infra/vm/secrets/.gitignore
+++ b/infra/vm/secrets/.gitignore
@@ -1,0 +1,7 @@
+# The real sops-encrypted bundle lands in #1854 and is committed.
+# Until then, ignore any local plaintext or partially-encrypted variants.
+*.plain.*
+*.local.*
+# Never commit raw secrets even by accident.
+secrets.yaml
+secrets.json

--- a/infra/vm/secrets/secrets.example.yaml
+++ b/infra/vm/secrets/secrets.example.yaml
@@ -1,0 +1,46 @@
+# infra/vm/secrets/secrets.example.yaml
+#
+# Schema reference for the sops-encrypted bundle the bootstrap reads.
+# This file is SAFE TO COMMIT — placeholders only. The real, sops-encrypted
+# bundle (infra/vm/secrets/secrets.enc.yaml) is owned by #1854 and is
+# .gitignore'd until that issue lands the production layout.
+#
+# Sops `--output-type json` mode is what bootstrap.sh consumes. The bundle
+# must therefore parse as YAML AND survive a YAML→JSON round-trip — keep keys
+# simple (no anchors / merges / tags).
+
+admin:
+  # Inventario super-admin. Generated once on first bootstrap if password is empty,
+  # then immutable. Surfaces in Kubernetes as inv-system/inventario-admin.
+  email: admin@example.invalid
+  password: ""
+
+tailscale:
+  # One-shot reusable auth key from the Tailscale admin console.
+  # Used only on first bootstrap; after that tailscaled is authenticated.
+  auth_key: ""
+  # OAuth client for the Tailscale Kubernetes Operator (separate from the auth_key above).
+  # Required scopes: devices:write (operator creates ephemeral nodes for Service/Ingress).
+  oauth_client_id: ""
+  oauth_client_secret: ""
+  # MagicDNS suffix of the tailnet — used by helm overlays (#1856) for tls.hosts[].
+  tailnet_name: ""
+
+github:
+  # GitHub App used by ArgoCD's repo-server (git clone via repo-creds) AND the
+  # ApplicationSet PR-generator (list open PRs). Permissions required:
+  #   Repository: Contents=Read, Metadata=Read, Pull requests=Read
+  # No write permissions. See #1854 for the App creation walkthrough.
+  app_id: ""
+  app_installation_id: ""
+  app_private_key: ""
+  # Owner-level URL the repo-creds Secret advertises (matches any repo under it).
+  url: https://github.com/denisvmedia
+
+# Phase 2 only — populated by #1865 when Velero lands.
+velero:
+  encryption_key: ""
+  s3_bucket: ""
+  s3_endpoint: ""
+  s3_access_key: ""
+  s3_secret_key: ""

--- a/infra/vm/vm-install.sh
+++ b/infra/vm/vm-install.sh
@@ -111,11 +111,22 @@ if [ -n "${TS_OAUTH_ID:-}" ] && [ -n "${TS_OAUTH_SECRET:-}" ]; then
     "$KUBECTL" create namespace tailscale --dry-run=client -o yaml | "$KUBECTL" apply -f -
     "$HELM" repo add tailscale https://pkgs.tailscale.com/helmcharts >/dev/null 2>&1 || true
     "$HELM" repo update >/dev/null
+    # Write OAuth into a temp values file with restrictive permissions instead
+    # of passing via --set-string, which would leak the secret into /proc/*/cmdline
+    # and any audit log that captures process args.
+    TS_VALUES=$(umask 077 && mktemp "$REMOTE_TMP/ts-op-values.XXXXXX.yaml")
+    trap 'rm -f "$TS_VALUES"' EXIT
+    cat >"$TS_VALUES" <<EOF
+oauth:
+  clientId: "$TS_OAUTH_ID"
+  clientSecret: "$TS_OAUTH_SECRET"
+EOF
     "$HELM" upgrade --install tailscale-operator tailscale/tailscale-operator \
         --namespace tailscale \
-        --set-string oauth.clientId="$TS_OAUTH_ID" \
-        --set-string oauth.clientSecret="$TS_OAUTH_SECRET" \
+        --values "$TS_VALUES" \
         --wait --timeout 5m
+    rm -f "$TS_VALUES"
+    trap - EXIT
 else
     warn "tailscale.oauth_client_{id,secret} not in secrets; skipping Tailscale Operator install."
     warn "Provide them in the sops bundle and re-run bootstrap. See #1855."

--- a/infra/vm/vm-install.sh
+++ b/infra/vm/vm-install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# vm-install.sh — Inventario preview-env remote installer (#1853).
+#
+# Runs as root on a clean Ubuntu 26.04 VM. Brings up tailscaled, vcluster
+# standalone (single-VM = both control-plane and worker; no token+join, per
+# #1867 spike), Tailscale Kubernetes Operator (#1855), and ArgoCD (#1858).
+# Idempotent — re-running is safe.
+#
+# Argument: $1 = path to an upload tmp dir on the VM. May contain
+#               secrets.plain.json (sops-decrypted bundle, schema per #1854).
+
+set -Eeuo pipefail
+
+REMOTE_TMP="${1:?usage: vm-install.sh /tmp/upload-dir}"
+SECRETS_FILE="$REMOTE_TMP/secrets.plain.json"
+
+if [ "$EUID" -ne 0 ]; then
+    exec sudo -E "$0" "$@"
+fi
+
+# --- Pinned versions ---
+VCLUSTER_VERSION="v0.34.0"
+K8S_VERSION="v1.34.0"
+TS_HOSTNAME="${TS_HOSTNAME:-inv-vcl01}"
+
+note() { printf '\n==> %s\n' "$*" >&2; }
+warn() { printf '\n[!] %s\n' "$*" >&2; }
+
+# Look up a dotted key in the sops JSON bundle. Returns empty if absent.
+sops_get() {
+    local key="$1"
+    [ -f "$SECRETS_FILE" ] || return 0
+    jq -r --arg k "$key" '
+        def lookup($parts; $v):
+          if ($parts | length) == 0 then $v
+          else lookup($parts[1:]; $v[$parts[0]] // "")
+          end;
+        lookup($k | split("."); .) // empty
+    ' "$SECRETS_FILE" 2>/dev/null
+}
+
+# --- apt prereqs (#1867 noted conntrack + socat missing on stock Ubuntu 26.04) ---
+note "apt prereqs"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq curl jq ca-certificates conntrack socat
+
+# --- tailscaled ---
+if ! command -v tailscale >/dev/null; then
+    note "Installing tailscale"
+    curl -fsSL https://tailscale.com/install.sh | sh
+fi
+systemctl enable --now tailscaled
+
+if ! tailscale status >/dev/null 2>&1; then
+    AUTHKEY=$(sops_get "tailscale.auth_key")
+    if [ -n "${AUTHKEY:-}" ]; then
+        note "tailscale up --hostname=$TS_HOSTNAME"
+        tailscale up --authkey="$AUTHKEY" --hostname="$TS_HOSTNAME" --ssh=false
+    else
+        warn "tailscaled not authenticated and no tailscale.auth_key in secrets."
+        warn "Run manually:  sudo tailscale up --hostname=$TS_HOSTNAME"
+    fi
+else
+    # Ensure hostname matches even on re-runs.
+    CURRENT_HOSTNAME=$(tailscale status --self=true --peers=false --json 2>/dev/null \
+        | jq -r '.Self.HostName // empty')
+    if [ -n "$CURRENT_HOSTNAME" ] && [ "$CURRENT_HOSTNAME" != "$TS_HOSTNAME" ]; then
+        warn "Tailscale hostname is '$CURRENT_HOSTNAME', expected '$TS_HOSTNAME' — leaving as-is."
+        warn "Re-key with: sudo tailscale up --hostname=$TS_HOSTNAME --reset"
+    fi
+fi
+
+# --- vcluster standalone (single-VM = CP + worker, no taint; verified in #1867) ---
+if [ ! -f /etc/vcluster/vcluster.yaml ]; then
+    note "Writing /etc/vcluster/vcluster.yaml (k8s $K8S_VERSION)"
+    mkdir -p /etc/vcluster
+    cat >/etc/vcluster/vcluster.yaml <<EOF
+controlPlane:
+  distro:
+    k8s:
+      version: $K8S_VERSION
+EOF
+fi
+
+if ! systemctl is-active --quiet vcluster.service; then
+    note "Installing vcluster standalone $VCLUSTER_VERSION"
+    INSTALL_URL="https://github.com/loft-sh/vcluster/releases/download/${VCLUSTER_VERSION}/install-standalone.sh"
+    curl -sfL "$INSTALL_URL" -o "$REMOTE_TMP/install-standalone.sh"
+    bash "$REMOTE_TMP/install-standalone.sh" --vcluster-name standalone
+fi
+
+export KUBECONFIG=/var/lib/vcluster/kubeconfig.yaml
+HELM=/var/lib/vcluster/bin/helm
+KUBECTL=/usr/local/bin/kubectl
+
+# --- Wait for kube-apiserver to be reachable ---
+note "Waiting for kube-apiserver"
+for i in $(seq 1 30); do
+    if "$KUBECTL" get nodes >/dev/null 2>&1; then break; fi
+    if [ "$i" -eq 30 ]; then echo "kube-apiserver never came up" >&2; exit 1; fi
+    sleep 5
+done
+
+# --- Tailscale Kubernetes Operator (#1855 owns the helm values overlay) ---
+TS_OAUTH_ID=$(sops_get "tailscale.oauth_client_id")
+TS_OAUTH_SECRET=$(sops_get "tailscale.oauth_client_secret")
+if [ -n "${TS_OAUTH_ID:-}" ] && [ -n "${TS_OAUTH_SECRET:-}" ]; then
+    note "Installing Tailscale Kubernetes Operator"
+    "$KUBECTL" create namespace tailscale --dry-run=client -o yaml | "$KUBECTL" apply -f -
+    "$HELM" repo add tailscale https://pkgs.tailscale.com/helmcharts >/dev/null 2>&1 || true
+    "$HELM" repo update >/dev/null
+    "$HELM" upgrade --install tailscale-operator tailscale/tailscale-operator \
+        --namespace tailscale \
+        --set-string oauth.clientId="$TS_OAUTH_ID" \
+        --set-string oauth.clientSecret="$TS_OAUTH_SECRET" \
+        --wait --timeout 5m
+else
+    warn "tailscale.oauth_client_{id,secret} not in secrets; skipping Tailscale Operator install."
+    warn "Provide them in the sops bundle and re-run bootstrap. See #1855."
+fi
+
+# --- ArgoCD (#1858 owns the ApplicationSet/AppProject/Application manifests) ---
+note "Installing/upgrading ArgoCD"
+"$KUBECTL" create namespace argocd --dry-run=client -o yaml | "$KUBECTL" apply -f -
+"$HELM" repo add argo https://argoproj.github.io/argo-helm >/dev/null 2>&1 || true
+"$HELM" repo update >/dev/null
+"$HELM" upgrade --install argocd argo/argo-cd \
+    --namespace argocd \
+    --set 'configs.params.server\.insecure=true' \
+    --set 'configs.params.applicationsetcontroller\.policy=sync' \
+    --set 'applicationSet.enabled=true' \
+    --wait --timeout 10m
+
+note "vm-install.sh finished"
+"$KUBECTL" get nodes -o wide
+"$KUBECTL" get pods -A 2>/dev/null | head -30


### PR DESCRIPTION
Closes #1853. Part of the #1852 epic, following the #1867 spike.

Ships the laptop+VM orchestration skeleton for the Phase 1 preview-env on a single Ubuntu 26.04 VM. Brings tailscaled, vcluster standalone (single-VM = CP + worker per the spike — no token+join step), the Tailscale Kubernetes Operator, and ArgoCD up via idempotent bootstrap.

## What lands

```
infra/Makefile                          help / preflight / bootstrap / upgrade / recover / destroy / status / logs / shell
infra/README.md                         operating reference (full beginner guide arrives in #1863)
infra/vm/bootstrap.sh                   laptop orchestrator
infra/vm/vm-install.sh                  remote installer (runs as root on the VM)
infra/vm/destroy.sh                     cleanup (preserves tailnet membership)
infra/vm/scripts/apply-secrets.sh       sops bundle → k8s Secrets in inv-system / argocd / tailscale
infra/vm/secrets/secrets.example.yaml   schema reference (safe to commit, placeholders only)
infra/vm/secrets/.gitignore             ignore plaintext + accidental commits
```

## Bootstrap flow

1. **SSH preflight** + sops decrypt the bundle locally (when present).
2. **Upload installer** (and decrypted secrets) to a remote tmp dir.
3. **Remote installer** (`sudo bash vm-install.sh`):
   - apt prereqs: `curl jq ca-certificates conntrack socat` (the last two were noted missing on stock Ubuntu 26.04 in the #1867 spike).
   - Install tailscaled and `tailscale up --hostname=inv-vcl01` using `tailscale.auth_key` from the sops bundle.
   - Install vcluster standalone v0.34.0 (kubernetes v1.34.0). Single-VM acts as CP + worker out of the box; no `vcluster token create` + `curl /node/join` step.
   - Helm install the Tailscale Kubernetes Operator in `tailscale` namespace, fed by `tailscale.oauth_client_{id,secret}`.
   - Helm install ArgoCD in `argocd` namespace, with `server.insecure=true` (tailnet-only access via `kubectl port-forward`) and `applicationSet.enabled=true`.
4. **Apply k8s Secrets** translated from the sops bundle (admin creds → `inv-system/inventario-admin`, GitHub App creds → `argocd/github-app-creds` with `argocd.argoproj.io/secret-type: repo-creds`, TS OAuth → `tailscale/operator-oauth`).
5. **Apply ArgoCD manifests** from `infra/argocd/*.yaml` (added in #1858).
6. **Copy kubeconfig back** to `~/.kube/inv-vcl01.config`, rewriting the server URL from `127.0.0.1` to the tailnet IP so `kubectl` works from the laptop directly.

## Cooperating with the rest of Phase 1

`bootstrap.sh` and `vm-install.sh` **warn but don't fail** when sibling-issue artifacts are missing, so this can land cleanly ahead of:

| Need | Filled by | Without it |
|---|---|---|
| `infra/vm/secrets/secrets.enc.yaml` (sops bundle) | #1854 | `tailscale up` runs manually; TS-op + GH App creds skipped. |
| TS Operator helm values overlay | #1855 | Default chart values used. |
| `helm/inventario/` PR-preview overlay | #1856 | ApplicationSet template can't reference it yet. |
| `infra/argocd/*.yaml` (AppProject, ApplicationSet, Application) | #1858 | ArgoCD installs but no Applications appear. |
| Full README + DR runbook | #1863 | Use `infra/README.md` as a stopgap. |

## Acceptance status

From #1853:
- ✅ `make bootstrap` script chain exists, idempotent, syntax-clean (`bash -n` for all 4 scripts, Makefile parses).
- ✅ `make preflight` validates laptop tooling (ssh / scp / sops / age).
- ✅ `make destroy`, `make status`, `make logs SVC=...`, `make shell` all wired.
- ⏳ End-to-end run against a real Ubuntu 26.04 VM — pending a clean VM (architecturally same sequence as the #1867 spike empirical run, which passed).
- ⏳ Full `kubectl -n argocd get applicationset / application` requires #1858 manifests; this PR only installs ArgoCD itself.

## Test plan

- [ ] `make help` shows targets — verified locally.
- [ ] `make preflight` passes — verified locally.
- [ ] `make bootstrap VM=user@throwaway-vm` on a fresh Ubuntu 26.04 VM:
  - [ ] `KUBECONFIG=~/.kube/inv-vcl01.config kubectl get nodes` → 1 Ready node, no NoSchedule taint
  - [ ] `tailscale status` (from a peer) → `inv-vcl01` visible
  - [ ] `systemctl is-active vcluster tailscaled` (on VM) → both `active`
  - [ ] `kubectl -n tailscale get pods` → operator Ready (requires TS OAuth in sops bundle)
  - [ ] `kubectl -n argocd get pods` → all 5 ArgoCD pods Ready
- [ ] `make destroy VM=...` cleanly removes vcluster + data; re-bootstrap works.
- [ ] `make recover VM=user@new-vm` on a fresh VM with `ssh-copy-id` restores identical state (requires #1854 sops bundle).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Laptop-driven workflows to manage preview VMs: preflight, bootstrap/upgrade/recover/destroy, plus status/logs/shell operations over SSH
  * Idempotent bootstrapping and safe teardown that preserves network auth state
  * Conditional secret provisioning to populate required credentials when available

* **Documentation**
  * Quick-start operational guide with workflow examples, behavior notes, and list of pending Phase 1 items

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->