### PR TITLE
[#1853] fix: make -C infra paths + kubeconfig TLS server name

### DIFF
--- a/infra/Makefile
+++ b/infra/Makefile
@@ -12,6 +12,12 @@
 
 SHELL := /bin/bash
 
+# Resolve script paths relative to this Makefile, not the caller's cwd, so
+# `make -C infra bootstrap` (as the README documents) and `make -f infra/Makefile`
+# both work. Without this the recipes' literal `infra/vm/...` paths would only
+# work when invoked from the repo root and would 404 under `-C infra`.
+THIS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 VM ?=
 SVC ?= vcluster.service
 
@@ -48,7 +54,7 @@ preflight:
 
 bootstrap: preflight
 	$(REQUIRE_VM)
-	bash infra/vm/bootstrap.sh "$(VM)"
+	bash "$(THIS_DIR)vm/bootstrap.sh" "$(VM)"
 
 upgrade: bootstrap
 
@@ -56,7 +62,7 @@ recover: bootstrap
 
 destroy:
 	$(REQUIRE_VM)
-	bash infra/vm/destroy.sh "$(VM)"
+	bash "$(THIS_DIR)vm/destroy.sh" "$(VM)"
 
 status:
 	$(REQUIRE_VM)

--- a/infra/vm/bootstrap.sh
+++ b/infra/vm/bootstrap.sh
@@ -92,7 +92,18 @@ if [ -n "$TS_IP" ]; then
     # macOS sed and GNU sed differ; perl is portable.
     perl -pi -e "s|https://127\.0\.0\.1:|https://${TS_IP}:|g; s|https://localhost:|https://${TS_IP}:|g" \
         "$LAPTOP_KUBECONFIG"
-    note "kubeconfig server rewritten to https://${TS_IP}:<port> (tailnet IP)"
+
+    # The vcluster kube-apiserver TLS cert is signed for 127.0.0.1, 10.96.0.1,
+    # and the in-cluster API IP — NOT for the tailnet IP. Without tls-server-name,
+    # kubectl from the laptop would fail with "certificate is valid for 127.0.0.1
+    # ..., not <tailnet IP>". Tell kubectl to verify against 127.0.0.1 (a SAN
+    # that IS in the cert) while still dialling the tailnet IP. Idempotent.
+    if ! grep -q '^    tls-server-name:' "$LAPTOP_KUBECONFIG"; then
+        perl -i -pe '$_ .= "    tls-server-name: 127.0.0.1\n" if /^    server: https:/;' \
+            "$LAPTOP_KUBECONFIG"
+    fi
+
+    note "kubeconfig server rewritten to https://${TS_IP}:<port> (tls-server-name: 127.0.0.1)"
 else
     warn "Couldn't fetch tailnet IP. kubeconfig still points at 127.0.0.1 —"
     warn "either ssh-tunnel port 443/6443 or edit the server: field manually."


### PR DESCRIPTION
Two real-run bugs in #1870 / #1853 caught by following the `infra/README.md` quick-start verbatim against a fresh VM.

## Bug 1 — `make -C infra bootstrap` 404s its own script

```text
$ make -C infra bootstrap VM=buster@vcluster-dev
Laptop prereqs OK
bash infra/vm/bootstrap.sh "buster@vcluster-dev"
bash: infra/vm/bootstrap.sh: No such file or directory
make: *** [bootstrap] Error 127
```

The recipes used literal `infra/vm/...` paths that only resolve from the repo root, but the README documents `make -C infra bootstrap VM=...`. Under `-C infra` the cwd is already `infra/`, so the path becomes `infra/infra/vm/bootstrap.sh` → ENOENT.

**Fix**: resolve scripts relative to the Makefile via `THIS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))`. Both `make -C infra ...` and `make -f infra/Makefile ...` now work.

## Bug 2 — kubeconfig TLS verify fails from the laptop

After `bootstrap.sh` rewrites `server: https://127.0.0.1:8443` to the tailnet IP, kubectl from the laptop fails:

```text
Unable to connect to the server: tls: failed to verify certificate:
x509: certificate is valid for 127.0.0.1, 10.96.0.1, 172.16.0.11,
not 100.x.x.x
```

The vcluster kube-apiserver TLS cert SAN does not include the tailnet IP — only `127.0.0.1`, `10.96.0.1`, and the in-cluster API IP.

**Fix**: also append `tls-server-name: 127.0.0.1` to the rewritten cluster entry. kubectl now dials the tailnet IP but presents `127.0.0.1` as SNI and verifies the cert against `127.0.0.1` (which IS in the SAN). Idempotent.

## Verified end-to-end

On a clean Ubuntu 26.04 VM (snapshot-protected) with no sops bundle yet:

```text
$ make -C infra bootstrap VM=buster@vcluster-dev
...
==> vm-install.sh finished
NAME           STATUS   ROLES                  AGE   VERSION
vcluster-dev   Ready    control-plane,master   56s   v1.34.0
NAMESPACE        NAME                                                READY   STATUS      RESTARTS
argocd           argocd-application-controller-0                     1/1     Running     0
argocd           argocd-applicationset-controller-6889bd899b-5f26p   1/1     Running     0
argocd           argocd-dex-server-66bbbc9f4d-65jhh                  1/1     Running     0
argocd           argocd-notifications-controller-6b965bb6d4-ntlqn    1/1     Running     0
argocd           argocd-redis-6c6699d6c4-n8mm6                       1/1     Running     0
argocd           argocd-repo-server-857f589457-trlhj                 1/1     Running     0
argocd           argocd-server-78d55f5bdd-txbkl                      1/1     Running     0
[...kube-system, kube-flannel, local-path-storage all Running...]
==> kubeconfig server rewritten to https://<tailnet-ip>:<port> (tls-server-name: 127.0.0.1)
==> Bootstrap complete.

$ KUBECONFIG=~/.kube/inv-vcl01.config kubectl get nodes
NAME           STATUS   ROLES                  AGE   VERSION
vcluster-dev   Ready    control-plane,master   3m    v1.34.0

$ KUBECONFIG=~/.kube/inv-vcl01.config kubectl run testpod --image=nginx:alpine --restart=Never
pod/testpod created
$ KUBECONFIG=~/.kube/inv-vcl01.config kubectl get pod testpod
NAME      READY   STATUS    RESTARTS   AGE
testpod   1/1     Running   0          7s
```

Tailscale-operator install was skipped as expected (no OAuth creds in sops bundle — that lands in #1854/#1855).

## Test plan

- [x] `make -C infra bootstrap` no longer 404s
- [x] `make -f infra/Makefile bootstrap` still works
- [x] `make -C infra destroy` resolves the same way (same `THIS_DIR` pattern)
- [x] kubectl from laptop works through tailnet IP after bootstrap
- [x] Re-running bootstrap is idempotent — `tls-server-name` not duplicated
- [ ] Repeat with sops bundle (#1854) — out of scope here, will land with #1855/#1858

Refs #1852 epic, follow-up to #1870.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed infrastructure script execution paths to resolve correctly when invoked from any directory, ensuring reliable operation of setup and infrastructure management commands throughout your environment
* Improved TLS verification handling for connections to vcluster environments on VMs, with enhanced certificate validation and configuration settings for more secure and stable connections during deployment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->