### PR TITLE
[#1854] sops bundle + GitHub App + Tailscale OAuth credentials

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,23 @@
+# sops creation rules — decides which key encrypts which file.
+# See: https://github.com/getsops/sops#using-sops-yaml-conf-to-select-kms-pgp-and-age-for-new-files
+#
+# To add a teammate's age key as a second recipient (so they can decrypt too):
+#   1. Get their public key (output of `age-keygen -y ~/.config/sops/age/keys.txt` on their laptop)
+#   2. Append it after a `,` in the `age:` field below
+#   3. Re-encrypt existing files: `sops updatekeys infra/vm/secrets/secrets.enc.yaml`
+#   4. Commit both changes in the same PR
+#
+# Rotation procedure: see infra/SECRETS.md → "Key rotation".
+
+creation_rules:
+  # path_regex matches the file path RELATIVE TO THIS .sops.yaml — which lives
+  # at the repo root because sops walks up from $PWD (not from the file path)
+  # to find its config. Scoping each rule to `^infra/vm/secrets/` prevents the
+  # rule from accidentally firing on unrelated `*.local.yaml` / `*.enc.yaml`
+  # elsewhere in the repo. Both rules pin the same age recipient: .local.yaml
+  # lets `sops -e secrets.local.yaml > secrets.enc.yaml` work without --age;
+  # .enc.yaml covers in-place `sops` editor sessions.
+  - path_regex: ^infra/vm/secrets/.*\.enc\.yaml$
+    age: age1dz6m6gzmu9tuqhkvdhz9gnvgmjqry7u6a69w670u22kjht5amsjsdx2re0
+  - path_regex: ^infra/vm/secrets/.*\.local\.yaml$
+    age: age1dz6m6gzmu9tuqhkvdhz9gnvgmjqry7u6a69w670u22kjht5amsjsdx2re0

--- a/infra/README.md
+++ b/infra/README.md
@@ -13,6 +13,8 @@ this skeleton landed in [#1853](https://github.com/denisvmedia/inventario/issues
 ## What this directory ships (#1853)
 
 ```
+.sops.yaml                  ← REPO ROOT: sops creation_rules + age recipients
+                              (sops walks up from $PWD to find this)
 infra/
 ├── Makefile               targets: bootstrap upgrade recover destroy status logs shell
 ├── README.md              this file
@@ -25,7 +27,6 @@ infra/
     │   └── apply-secrets.sh   translate sops bundle into k8s Secrets
     └── secrets/
         ├── .gitignore
-        ├── .sops.yaml             creation_rules → age recipient (added in #1854)
         ├── secrets.example.yaml   schema reference (safe to commit)
         └── secrets.enc.yaml       sops-encrypted bundle (added in #1854)
 ```

--- a/infra/README.md
+++ b/infra/README.md
@@ -16,6 +16,7 @@ this skeleton landed in [#1853](https://github.com/denisvmedia/inventario/issues
 infra/
 ├── Makefile               targets: bootstrap upgrade recover destroy status logs shell
 ├── README.md              this file
+├── SECRETS.md             secrets setup walkthrough (age, GH App, TS OAuth, DR) — #1854
 └── vm/
     ├── bootstrap.sh       laptop orchestrator — ssh, sops, upload, apply
     ├── vm-install.sh      remote installer — tailscale, vcluster, TS-op, ArgoCD
@@ -24,7 +25,9 @@ infra/
     │   └── apply-secrets.sh   translate sops bundle into k8s Secrets
     └── secrets/
         ├── .gitignore
-        └── secrets.example.yaml   schema reference (safe to commit)
+        ├── .sops.yaml             creation_rules → age recipient (added in #1854)
+        ├── secrets.example.yaml   schema reference (safe to commit)
+        └── secrets.enc.yaml       sops-encrypted bundle (added in #1854)
 ```
 
 ## Quick start
@@ -50,7 +53,7 @@ data that orchestration needs to be useful:
 
 | Need | Filled by | Without it |
 |---|---|---|
-| `infra/vm/secrets/secrets.enc.yaml` (sops bundle) | [#1854](https://github.com/denisvmedia/inventario/issues/1854) | `tailscale up` must be run manually on the VM; TS-op and GH App creds unavailable. |
+| `infra/vm/secrets/secrets.enc.yaml` (sops bundle) | [#1854](https://github.com/denisvmedia/inventario/issues/1854) — see [`SECRETS.md`](./SECRETS.md) | `tailscale up` must be run manually on the VM; TS-op and GH App creds unavailable. |
 | Tailscale Operator helm values overlay | [#1855](https://github.com/denisvmedia/inventario/issues/1855) | Default chart values used (works for basic Service/Ingress). |
 | `helm/inventario/` PR-preview overlay | [#1856](https://github.com/denisvmedia/inventario/issues/1856) | ApplicationSet template can't reference it yet. |
 | `infra/argocd/*.yaml` (AppProject, ApplicationSet, master Application) | [#1858](https://github.com/denisvmedia/inventario/issues/1858) | ArgoCD installs but no Applications appear; PR labels do nothing. |

--- a/infra/SECRETS.md
+++ b/infra/SECRETS.md
@@ -1,0 +1,327 @@
+# Secrets setup (#1854)
+
+Operating reference for the sops+age secret bundle that `infra/vm/bootstrap.sh`
+consumes. Covers one-time setup, the GitHub App + Tailscale OAuth flows, and
+the disaster-recovery runbook.
+
+> Full beginner README will live in #1863. This file is the focused secrets
+> walkthrough.
+
+## Architecture in one paragraph
+
+All identity-critical state lives in `infra/vm/secrets/secrets.enc.yaml`
+encrypted with **sops + age**. The only thing that must live **off-VM** is one
+age private key on the laptop (with a copy in your password manager). The
+encrypted bundle is committed to the repo. `bootstrap.sh` decrypts it locally
+on the laptop, ships the plaintext to the VM tmpfs, and `apply-secrets.sh`
+turns the JSON into three Kubernetes Secrets (`inv-system/inventario-admin`,
+`argocd/github-app-creds`, `tailscale/operator-oauth`).
+
+## Files in this layout
+
+```
+infra/vm/secrets/
+├── .gitignore               ← already in repo; ignores *.plain.*, secrets.{yaml,json}
+├── .sops.yaml               ← sops creation_rules (added once you have an age recipient)
+├── secrets.example.yaml     ← schema reference, safe to commit
+└── secrets.enc.yaml         ← THE bundle, sops-encrypted
+```
+
+---
+
+## One-time setup (you do this once, ever)
+
+### 1. Generate the age keypair
+
+On your laptop, **once** in your entire life:
+
+```bash
+mkdir -p ~/.config/sops/age
+age-keygen -o ~/.config/sops/age/keys.txt
+chmod 600 ~/.config/sops/age/keys.txt
+```
+
+This prints a `age1...` **public** key to stdout (and stores both halves in
+`keys.txt`). The public key goes into `.sops.yaml` and into this repo. The
+private key file stays on your laptop and never leaves it via git.
+
+**macOS-specific gotcha**: sops on macOS looks for the age key at
+`~/Library/Application Support/sops/age/keys.txt` (the OS-native
+"Application Support" XDG path), NOT at `~/.config/sops/age/keys.txt`.
+If you keep the key at the latter (cleaner), make a symlink so sops finds it:
+
+```bash
+mkdir -p "$HOME/Library/Application Support/sops/age"
+ln -sf "$HOME/.config/sops/age/keys.txt" \
+       "$HOME/Library/Application Support/sops/age/keys.txt"
+```
+
+Alternative: set `SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt` in your
+shell rc. The symlink is the less invasive option.
+
+**Critical**: back up `~/.config/sops/age/keys.txt` to your password manager
+(1Password / Bitwarden / etc.) right now, before doing anything else. If you
+lose it, the secrets bundle becomes a brick — there's no recovery path. Other
+team members who get added later will get their own age key and become an
+additional recipient on the bundle (`age:` accepts a comma-separated list).
+
+Tell me the public key (`age1...`) and I'll write `.sops.yaml` and the
+encrypted bundle.
+
+### 2. Create the GitHub App
+
+Inventario's bot uses a GitHub App (not a PAT) to read PR state and clone
+the repo. Permissions are read-only — the bot doesn't post comments or
+labels.
+
+1. Open <https://github.com/settings/apps/new>
+2. Fill in:
+   - **GitHub App name**: `inventario-deploy-bot` (must be globally unique on
+     GitHub; suffix with your handle if taken)
+   - **Homepage URL**: `https://github.com/denisvmedia/inventario`
+   - **Webhook** → **Active**: uncheck (we poll, not webhook — see [#1852 pivot](https://github.com/denisvmedia/inventario/issues/1852#issuecomment-4528693792))
+   - **Repository permissions**:
+     - **Contents**: Read-only
+     - **Metadata**: Read-only (always required by GitHub)
+     - **Pull requests**: Read-only
+     - (everything else stays "No access")
+   - **Subscribe to events**: none (we poll)
+   - **Where can this GitHub App be installed?**: **Only on this account**
+3. Click **Create GitHub App**.
+4. On the resulting App page, record the **App ID** (top of page, e.g.
+   `App ID: 123456`).
+5. Click **Generate a private key**. A `.pem` file downloads — keep it
+   somewhere safe for the next step.
+6. In the left sidebar, click **Install App** → next to your username, click
+   **Install** → choose **Only select repositories** → pick
+   `denisvmedia/inventario` → **Install**.
+7. After install, the URL becomes `https://github.com/settings/installations/<NNNNN>`.
+   Record the `NNNNN` — that's the **Installation ID**.
+
+Tell me the **App ID**, **Installation ID**, and paste the **private key PEM**
+(I'll put it in the encrypted bundle, never in clear repo).
+
+### 3. Create the Tailscale OAuth client
+
+For the Tailscale Kubernetes Operator (#1855) to create ephemeral tailnet
+nodes for each Service/Ingress.
+
+1. Open <https://login.tailscale.com/admin/settings/oauth>
+2. Click **Generate OAuth client**.
+3. **Description**: `inventario-vcluster-operator`
+4. **Scopes**: tick `Devices` → `Write` (operator needs to create devices).
+   No other scope.
+5. **Tags**: pick or create a tag the operator will own (e.g. `tag:k8s`).
+   You'll need to make sure that tag is **owned by** the user/group that has
+   permissions to use this OAuth client — see the
+   [Tailscale ACL docs](https://tailscale.com/kb/1018/acls#tag-owners).
+6. Click **Generate Client**.
+7. Copy the **Client ID** (visible from then on in the table) and the
+   **Client Secret** (visible **once**, can't be retrieved later — save it
+   immediately).
+
+Tell me the **Client ID** and **Client Secret**.
+
+#### Tailscale ACL — `tagOwners` (one-time, easy to forget)
+
+After creating the OAuth client, you also need the tags it'll use to be
+**owned** by something in the Tailscale ACL — otherwise the operator
+boots with `creating operator authkey: requested tags [tag:k8s-operator]
+are invalid or not permitted (400)`.
+
+Open <https://login.tailscale.com/admin/acls> and add (or extend) the
+`tagOwners` block — **note the empty owners list on `tag:k8s-operator`,
+this is intentional** (see "Why empty `[]`" below):
+
+```json
+"tagOwners": {
+  "tag:k8s-operator": [],
+  "tag:k8s":          ["tag:k8s-operator"]
+}
+```
+
+What this means:
+
+- **`tag:k8s-operator`** — the operator pod's own tailnet identity
+  (one node, permanent). Empty owners list `[]` means "anyone with
+  `auth_keys:write` scope on this tailnet can mint auth-keys for this
+  tag", which is exactly what the operator needs to bootstrap itself.
+- **`tag:k8s`** — the tag the operator stamps on every ephemeral proxy
+  node it spawns per `Service` / `Ingress`. Owning this with
+  `["tag:k8s-operator"]` is the standard "chain of trust": only a device
+  carrying `tag:k8s-operator` (the operator itself) can issue auth-keys
+  for `tag:k8s` proxy nodes.
+
+#### Why empty `[]` and not `["<your-email>"]`?
+
+Counter-intuitive but correct: Tailscale's OAuth-as-caller permission
+model treats an OAuth client as a **tagged device**, not as the user who
+created it. Listing a user email there would let the user-the-human mint
+auth-keys for `tag:k8s-operator` — but the OAuth client isn't acting as
+that user. The empty list (`[]`) is the canonical operator-bootstrap pattern
+documented at <https://tailscale.com/kb/1236/kubernetes-operator>.
+
+Symptom of getting this wrong: operator crashes with
+`creating operator authkey: requested tags [tag:k8s-operator] are invalid
+or not permitted (400)`. We've been there.
+
+Save in the ACL editor — changes apply instantly. The operator pod
+(if already deployed and CrashLoopBackoff'ing on this) will recover on
+its next restart, or force it with
+`kubectl -n tailscale rollout restart deploy/operator`.
+
+### 4. Pick the admin email + password
+
+The Inventario `inv-system/inventario-admin` Secret holds the super-admin
+login the app uses on first start.
+
+```bash
+# Generate a strong random password (or use your own)
+openssl rand -base64 24
+```
+
+Tell me an **email** + the **password** you want baked in.
+
+### 5. Optional: Tailscale auth-key (for `make recover` on a fresh VM)
+
+vcluster-dev is already authenticated to your tailnet, so `make bootstrap`
+on this VM doesn't need an auth-key. But for the disaster-recovery scenario
+(VM totally gone → spin up new VM → `make recover`), you'll need a reusable
+auth-key so `tailscale up` on the fresh VM can join the tailnet headless.
+
+1. <https://login.tailscale.com/admin/settings/keys>
+2. **Generate auth key** → tick **Reusable** + **Ephemeral: NO** + **Tags**: same as #3.
+3. Set TTL to whatever you're comfortable with (90 days is the max, then it
+   needs rotation).
+
+This one is optional for now — if missing, `vm-install.sh` falls back to
+warning "run `tailscale up` manually". For Phase 1 with just one VM it's
+acceptable to skip.
+
+---
+
+## What I'll do once you give me the values above
+
+1. Write `infra/vm/secrets/.sops.yaml` with your age public key as the recipient.
+2. Build `infra/vm/secrets/secrets.enc.yaml` populated with all 8-ish values
+   (admin / tailscale.{auth_key?, oauth_client_id, oauth_client_secret, tailnet_name} /
+   github.{app_id, app_installation_id, app_private_key, url}).
+3. Verify locally: `sops -d --output-type json infra/vm/secrets/secrets.enc.yaml | jq .` round-trips.
+4. Run `make -C infra bootstrap VM=buster@vcluster-dev` end-to-end on the
+   clean VM to confirm:
+   - Tailscale operator helm install succeeds
+   - `kubectl -n tailscale get pods` shows operator Ready
+   - `kubectl -n argocd get secret github-app-creds` exists with our label
+   - `kubectl -n inv-system get secret inventario-admin` exists
+5. Commit + PR.
+
+---
+
+## Day-to-day: editing the bundle
+
+After initial setup, edit values with the `sops` interactive editor:
+
+```bash
+sops infra/vm/secrets/secrets.enc.yaml
+# Opens $EDITOR with the plaintext. Save and exit → sops re-encrypts in place.
+```
+
+Then re-run `make -C infra bootstrap VM=...` — bootstrap is idempotent and
+will re-apply changed Secret values, then trigger rolling restarts of the
+affected workloads (argocd-repo-server / argocd-applicationset-controller on
+GitHub App cred changes; tailscale-operator on TS OAuth changes).
+
+---
+
+## Disaster recovery — "the VM is gone"
+
+Scenario: h3 is gone, or VM 101 is unrecoverable, or someone `qm destroy`d it.
+
+What you need on-hand:
+- Your laptop with `~/.config/sops/age/keys.txt` intact (or restore from your
+  password manager)
+- This repo checked out (or re-clonable)
+- A fresh Ubuntu 26.04 VM somewhere with ssh access
+
+Recovery:
+
+```bash
+# 1. Restore age key from password manager if needed
+mkdir -p ~/.config/sops/age
+# paste contents into ~/.config/sops/age/keys.txt
+chmod 600 ~/.config/sops/age/keys.txt
+
+# 2. Spin up the new VM (any provider — Hetzner, DigitalOcean, Proxmox...)
+
+# 3. ssh-copy-id so passwordless ssh works
+ssh-copy-id user@new-vm-ip
+
+# 4. Run recover (alias for bootstrap)
+make -C infra recover VM=user@new-vm-ip
+```
+
+`bootstrap.sh` decrypts the bundle locally with your age key, ships it to the
+fresh VM, and re-creates **the same** admin credentials, **the same** tailnet
+hostname (`inv-vcl01`), **the same** GitHub App association, **the same**
+Tailscale operator OAuth. From any tailnet peer, `inv-vcl01.<tailnet>.ts.net`
+resolves to the new VM, certificates auto-renew, ArgoCD picks up the master
+Application again.
+
+You don't need to notify anyone or change any URL. The only off-VM dependency
+is your age private key — protect it accordingly.
+
+---
+
+## Key rotation
+
+### Rotating the age private key (you got phished, or laptop stolen)
+
+1. Generate a new age key: `age-keygen -o ~/.config/sops/age/keys2.txt`
+2. Edit `.sops.yaml` to add the **new** public key alongside the **old** one:
+   ```yaml
+   creation_rules:
+     - path_regex: \.enc\.yaml$
+       age: >-
+         age1old...,
+         age1new...
+   ```
+3. Re-encrypt the bundle with both recipients: `sops updatekeys infra/vm/secrets/secrets.enc.yaml`
+4. Commit + push.
+5. Switch your `~/.config/sops/age/keys.txt` to the new key.
+6. Edit `.sops.yaml` to **remove** the old recipient, run `sops updatekeys` again, commit.
+7. Securely shred `~/.config/sops/age/keys.txt.old` and the password-manager copy.
+
+### Rotating the GitHub App private key (App-side compromise, or just hygiene)
+
+GH Apps allow multiple active private keys. Painless flow:
+
+1. App settings → **Generate a private key** → download new PEM.
+2. `sops infra/vm/secrets/secrets.enc.yaml` → replace `github.app_private_key`
+   with new PEM contents.
+3. `make -C infra upgrade VM=...` → applies new Secret to argocd namespace,
+   rolling-restarts `argocd-repo-server` + `argocd-applicationset-controller`.
+4. Wait 24h (sanity buffer) → App settings → delete old key.
+
+### Rotating the Tailscale OAuth client secret
+
+1. <https://login.tailscale.com/admin/settings/oauth> → **Revoke** old client (or generate new one first then revoke).
+2. Update `tailscale.oauth_client_id` + `tailscale.oauth_client_secret` in
+   the sops bundle.
+3. `make -C infra upgrade VM=...` → rolls the tailscale-operator pod.
+
+---
+
+## Troubleshooting
+
+- **`sops -d` says "Failed to get the data key required to decrypt"**:
+  your age private key doesn't match any recipient in the file. Either
+  you're on the wrong laptop, the key was rotated and you lost the password-
+  manager backup, or `SOPS_AGE_KEY_FILE` env var points at the wrong path.
+- **`bootstrap.sh` warns "secrets.enc.yaml missing"**: file isn't in
+  `infra/vm/secrets/`. You're either on a branch where it hasn't landed yet,
+  or you haven't pulled the latest master.
+- **ArgoCD applicationset-controller crashloops with "github auth failed"**:
+  GH App credentials in `secrets.enc.yaml` are stale or wrong. Re-check the
+  3 fields, re-encrypt, re-bootstrap.
+- **TS operator pod crashloops**: same with `tailscale.oauth_client_{id,secret}`.
+  Check Tailscale admin console hasn't revoked the client.

--- a/infra/SECRETS.md
+++ b/infra/SECRETS.md
@@ -20,11 +20,12 @@ turns the JSON into three Kubernetes Secrets (`inv-system/inventario-admin`,
 ## Files in this layout
 
 ```
+.sops.yaml                       ← repo-root: creation_rules + age recipients
+                                   (sops walks up from $PWD to find this)
 infra/vm/secrets/
-├── .gitignore               ← already in repo; ignores *.plain.*, secrets.{yaml,json}
-├── .sops.yaml               ← sops creation_rules (added once you have an age recipient)
-├── secrets.example.yaml     ← schema reference, safe to commit
-└── secrets.enc.yaml         ← THE bundle, sops-encrypted
+├── .gitignore                   ← ignores *.plain.*, secrets.{yaml,json}
+├── secrets.example.yaml         ← schema reference, safe to commit
+└── secrets.enc.yaml             ← THE bundle, sops-encrypted
 ```
 
 ---
@@ -65,14 +66,18 @@ lose it, the secrets bundle becomes a brick — there's no recovery path. Other
 team members who get added later will get their own age key and become an
 additional recipient on the bundle (`age:` accepts a comma-separated list).
 
-Tell me the public key (`age1...`) and I'll write `.sops.yaml` and the
-encrypted bundle.
+The public key (`age1...`) needs to land in the repo-root `.sops.yaml`. If
+you're the first person setting this up, write it there directly (see
+"Adding teammates" below for the multi-recipient layout). If `.sops.yaml`
+already lists one recipient (the current case in this repo), add yours as
+a second one and re-encrypt — also covered in "Adding teammates".
 
 ### 2. Create the GitHub App
 
-Inventario's bot uses a GitHub App (not a PAT) to read PR state and clone
-the repo. Permissions are read-only — the bot doesn't post comments or
-labels.
+ArgoCD's `repo-server` (for `git clone` of the inventario repo) and the
+ApplicationSet PR generator (for listing PRs and reading labels) consume
+a GitHub App credential — no PAT, no custom bot component. Permissions are
+read-only; ArgoCD never writes to GitHub.
 
 1. Open <https://github.com/settings/apps/new>
 2. Fill in:
@@ -98,29 +103,37 @@ labels.
 7. After install, the URL becomes `https://github.com/settings/installations/<NNNNN>`.
    Record the `NNNNN` — that's the **Installation ID**.
 
-Tell me the **App ID**, **Installation ID**, and paste the **private key PEM**
-(I'll put it in the encrypted bundle, never in clear repo).
+Stash these three values (App ID, Installation ID, private key PEM) for
+the "Filling the bundle" step below.
 
 ### 3. Create the Tailscale OAuth client
 
 For the Tailscale Kubernetes Operator (#1855) to create ephemeral tailnet
-nodes for each Service/Ingress.
+nodes for each Service/Ingress AND to bootstrap its own tailnet identity.
 
 1. Open <https://login.tailscale.com/admin/settings/oauth>
 2. Click **Generate OAuth client**.
 3. **Description**: `inventario-vcluster-operator`
-4. **Scopes**: tick `Devices` → `Write` (operator needs to create devices).
-   No other scope.
-5. **Tags**: pick or create a tag the operator will own (e.g. `tag:k8s`).
-   You'll need to make sure that tag is **owned by** the user/group that has
-   permissions to use this OAuth client — see the
-   [Tailscale ACL docs](https://tailscale.com/kb/1018/acls#tag-owners).
+4. **Scopes** — tick BOTH (one alone is not enough):
+   - **Devices → Core → Write** (Read is implied; operator creates ephemeral
+     proxy devices).
+   - **Keys → Auth Keys → Write** (operator mints one-shot auth-keys per
+     proxy device).
+   Everything else stays unchecked, including `API Access Tokens` which is
+   sometimes pre-ticked — uncheck it (principle of least privilege).
+5. **Tags** — pick BOTH (one alone is not enough):
+   - `tag:k8s-operator` — the operator pod's own tailnet identity.
+   - `tag:k8s` — every proxy node the operator spawns for a Service/Ingress.
+   The `tagOwners` configuration in your Tailscale ACL must match (see
+   "Tailscale ACL — `tagOwners`" sub-section below). Get the ACL right
+   BEFORE generating the client — Tailscale checks tag ownership at
+   client-create time, and a mis-configured ACL forces you to regenerate.
 6. Click **Generate Client**.
 7. Copy the **Client ID** (visible from then on in the table) and the
    **Client Secret** (visible **once**, can't be retrieved later — save it
    immediately).
 
-Tell me the **Client ID** and **Client Secret**.
+Stash these two values for the "Filling the bundle" step below.
 
 #### Tailscale ACL — `tagOwners` (one-time, easy to forget)
 
@@ -180,7 +193,7 @@ login the app uses on first start.
 openssl rand -base64 24
 ```
 
-Tell me an **email** + the **password** you want baked in.
+Stash both for "Filling the bundle".
 
 ### 5. Optional: Tailscale auth-key (for `make recover` on a fresh VM)
 
@@ -200,20 +213,49 @@ acceptable to skip.
 
 ---
 
-## What I'll do once you give me the values above
+## Filling the bundle
 
-1. Write `infra/vm/secrets/.sops.yaml` with your age public key as the recipient.
-2. Build `infra/vm/secrets/secrets.enc.yaml` populated with all 8-ish values
-   (admin / tailscale.{auth_key?, oauth_client_id, oauth_client_secret, tailnet_name} /
-   github.{app_id, app_installation_id, app_private_key, url}).
-3. Verify locally: `sops -d --output-type json infra/vm/secrets/secrets.enc.yaml | jq .` round-trips.
-4. Run `make -C infra bootstrap VM=buster@vcluster-dev` end-to-end on the
-   clean VM to confirm:
-   - Tailscale operator helm install succeeds
-   - `kubectl -n tailscale get pods` shows operator Ready
-   - `kubectl -n argocd get secret github-app-creds` exists with our label
-   - `kubectl -n inv-system get secret inventario-admin` exists
-5. Commit + PR.
+With all the values from steps 1-5 in hand, populate the encrypted bundle:
+
+```bash
+cd <repo-root>
+
+# 1. Start from the schema reference (safe placeholders).
+cp infra/vm/secrets/secrets.example.yaml infra/vm/secrets/secrets.local.yaml
+chmod 600 infra/vm/secrets/secrets.local.yaml
+
+# 2. Fill in real values — admin.{email,password},
+#    tailscale.{auth_key, oauth_client_id, oauth_client_secret, tailnet_name},
+#    github.{app_id, app_installation_id, app_private_key, url}.
+#    Leave the velero block out entirely until #1865 ships — Phase 1 doesn't
+#    need it, and committing empty placeholders into the encrypted bundle
+#    creates a footgun (someone later adds a real key in plaintext).
+$EDITOR infra/vm/secrets/secrets.local.yaml
+
+# 3. Encrypt. The repo-root .sops.yaml picks the right age recipient
+#    automatically because the *.local.yaml path matches a creation_rule.
+sops -e infra/vm/secrets/secrets.local.yaml > infra/vm/secrets/secrets.enc.yaml
+chmod 600 infra/vm/secrets/secrets.enc.yaml
+
+# 4. Verify round-trip BEFORE deleting plaintext. All expected keys should
+#    appear "filled"; velero.* should not appear at all if you followed the
+#    note in step 2.
+sops -d --output-type json infra/vm/secrets/secrets.enc.yaml | jq -r '
+  paths(scalars) as $p |
+  ($p|join(".")) + ": " +
+  (getpath($p) | tostring | if length > 0 then "filled" else "empty" end)
+'
+
+# 5. Shred the plaintext.
+SIZE=$(wc -c < infra/vm/secrets/secrets.local.yaml)
+dd if=/dev/urandom of=infra/vm/secrets/secrets.local.yaml bs=$SIZE count=1 conv=notrunc 2>/dev/null
+rm -f infra/vm/secrets/secrets.local.yaml
+
+# 6. End-to-end test against a real VM.
+make -C infra bootstrap VM=user@vm-host
+
+# 7. Commit secrets.enc.yaml (+ .sops.yaml if first time) and open a PR.
+```
 
 ---
 
@@ -274,22 +316,35 @@ is your age private key — protect it accordingly.
 
 ## Key rotation
 
-### Rotating the age private key (you got phished, or laptop stolen)
+### Adding a teammate (or rotating the age private key — same flow)
 
-1. Generate a new age key: `age-keygen -o ~/.config/sops/age/keys2.txt`
-2. Edit `.sops.yaml` to add the **new** public key alongside the **old** one:
+`.sops.yaml` at the repo root accepts a comma-separated list of age
+recipients; each can decrypt the bundle independently.
+
+1. Generate a new age key (or get the teammate's public key from theirs):
+   `age-keygen -o ~/.config/sops/age/keys2.txt`
+2. Edit repo-root `.sops.yaml` so BOTH rules list the new recipient
+   alongside the existing one (keep the scoping prefix and both file-type
+   regexes — drift here means some files get encrypted with the old key
+   only):
    ```yaml
    creation_rules:
-     - path_regex: \.enc\.yaml$
+     - path_regex: ^infra/vm/secrets/.*\.enc\.yaml$
+       age: >-
+         age1old...,
+         age1new...
+     - path_regex: ^infra/vm/secrets/.*\.local\.yaml$
        age: >-
          age1old...,
          age1new...
    ```
 3. Re-encrypt the bundle with both recipients: `sops updatekeys infra/vm/secrets/secrets.enc.yaml`
 4. Commit + push.
-5. Switch your `~/.config/sops/age/keys.txt` to the new key.
-6. Edit `.sops.yaml` to **remove** the old recipient, run `sops updatekeys` again, commit.
-7. Securely shred `~/.config/sops/age/keys.txt.old` and the password-manager copy.
+5. (Rotation only) Switch your `~/.config/sops/age/keys.txt` to the new key.
+6. (Rotation only) Edit `.sops.yaml` to **remove** the old recipient from
+   BOTH rules, run `sops updatekeys` again, commit.
+7. (Rotation only) Securely shred `~/.config/sops/age/keys.txt.old` and the
+   password-manager copy.
 
 ### Rotating the GitHub App private key (App-side compromise, or just hygiene)
 

--- a/infra/vm/secrets/secrets.enc.yaml
+++ b/infra/vm/secrets/secrets.enc.yaml
@@ -1,0 +1,57 @@
+#ENC[AES256_GCM,data:KlhftFlK5ZxmR5EGdB5h99NMBJjcDXq4XqhxPSbNbwnpgkIZeUo=,iv:mj+/G6y8bAX+cMWLAryU/Yta4YLay/lPPsvwU0SodcI=,tag:iDgNwkNgntkT2KHbv3/8Ag==,type:comment]
+#
+#ENC[AES256_GCM,data:thoTtaUQ1QMnt2K45c3+EDKrt3OyXrF3+WUOViNwysmEtWObgwxloq3j/ixNPlNvsG4sTX1G+QtfphigOvcP1g576pA=,iv:2LCHEL7JPDRqEoLapeUzbYXPtJ3xeNYOZ9TAU4ENt6M=,tag:S7O6UZNmTuRe7Ph6ZbRZ7w==,type:comment]
+#ENC[AES256_GCM,data:tsp9BqePmz34zFF03yI8jvFsOa9BwM+K3couAdy05dFPEGkCNUadw0+WBz9hrmL0eT+hoSW+s4T/QVdwZ4zTlvxTgayzKXcgvD/7YA==,iv:8CHlW6oxDy2lcIQvq1DMGTXfW6Hj+D8w2U8n0nvsIhI=,tag:fUNeMpJRQi7pG4IO3lkKDg==,type:comment]
+#ENC[AES256_GCM,data:xvas6nmLfffIugdbfsUmM4GFwMv6oYOWUrPC3jbok+aGJZxedIXbLIROySnwGQHa3YRiqyk+TbHjyfVmJqm27MXDHfg=,iv:NGxO2ajKz0e3lulHHKBcnyMCz3iO2WodpiJJRmenwv8=,tag:b1KdvkRXyrKPn/tzhXQtzg==,type:comment]
+#ENC[AES256_GCM,data:XfBlAgLsznf/zCbUSO782yrO1mRc1ooKcnJticvgJf5gAW9sI3qcdKaxk3RbA3wJeeuW2SJnMEha7Sc=,iv:W1s14yPRYtTNxdGzL5krb6OY6ngzb9Z5f2kveudYrrQ=,tag:/pkremq2z/nOnwUR/EOpOA==,type:comment]
+#
+#ENC[AES256_GCM,data:isXtWo6vYzxKhFuUSR6Hmze6Q6mlwpp+V6yyzK54jtOEwIiPRrZqcUWpp3Ai7QuNLuCpD8ZJynenRX26E6+Gvybe51g91QED3Q==,iv:m+q1EWqdGs9J9nutIJ5E4g7hWts+Dz/PY3vH53ZKYNg=,tag:K0LDvKaxpgk6jEgcX/Zuag==,type:comment]
+#ENC[AES256_GCM,data:Z3SFouL3nzdMm52m/gcCW0IFWTyKCyra82eGo9ZId3Q6nRWaljVN1U+zQyRczKq5F51d1I0jP+LmCVaj0pLw1XjJlZIpYsdklrf4sBikqk0=,iv:rDUAWc7g/ajeNGLCT4r8Sex3GZvQY4cu7YXeuSUu1sQ=,tag:JMb9AI1rb5/u6N7kKEZfAA==,type:comment]
+#ENC[AES256_GCM,data:EkSGoBhx0mlOs5343zihZUSg5NKHzywzEMqNXTl1PbEvf8+m1w==,iv:rfFa8phtjdSrnRJH/AEBVQGrkHBzAhz/b03MZHYCe6o=,tag:pgEKdrioVaXxr841KuK/sA==,type:comment]
+admin:
+    #ENC[AES256_GCM,data:BU4JgN9a7jw9JGs/+iChWf5zZfT43f/zKTeg1IW+xWEV/Af/Yyu9flWY5BUDjlb50XE23ZqUpXZBXLYst+CS9nCETAALOXJcT/6Bst8KKWA=,iv:4TnaCTs1+HIVGs/0CkmwvI2bzLRM794jhIq4UXKunKE=,tag:dx7gWCyj6V6yQpfX+h5Otg==,type:comment]
+    #ENC[AES256_GCM,data:sjGktNdSAkVduKgV2YPd7VsKwx6K3TiBBs6o1DBKgXIFCjmZlBM1l/lbeo8RfPcYLoUYwmV+hjdqcx1trBrPRZrFsSeHNok=,iv:S3cWSbcc7GFMhxf9avbzPwytg8Yw80ZrO/IELdHSRbY=,tag:TAg9/x0CE+inR1k+JFn5Rw==,type:comment]
+    email: ENC[AES256_GCM,data:XhOhGvIf1nLP4LBsKLMB+kA=,iv:llGmS8Z5OYazukSnXyN8xi87jAubZXcP2yzsMZYVcf0=,tag:yeUpcFL9+IYdjbUUHCqgAA==,type:str]
+    password: ENC[AES256_GCM,data:kK/Ddc/7SK+T4LVyqew0VQ==,iv:F4rO6RX14jt/i0tKK2Xs9uhlmQGJ8k6mxVbzcQbzWQQ=,tag:QBFvmg5VMPOBNWW9qotEPA==,type:str]
+tailscale:
+    #ENC[AES256_GCM,data:9O8TOIhMMdE6qJqkxKg+CEja1O9W7JVqINu3tMQX8QtsAbsKmEh1g69H2idN0kEiz1ijX2qd8p2u9lnLZA==,iv:M0muPGdrAAlCepx7TpRc15HSPQRp7vmhnvs6/bTsPUk=,tag:A8YfEj4YIvhzqNxaty8O6A==,type:comment]
+    #ENC[AES256_GCM,data:whJ06MKfxZKaFF+J0LGzbx38/Z1nGY4rho+I0jJqa0mz0qc+BCkQu3NvKOaYinW31TwBYIr4YT1vPLK2i++kJPERpO53Fw==,iv:qKIhbFyrTL1o7fxyGnu5fEIW2ULIKdZUor7OUcTaaLg=,tag:4fyBFAlkJnc4tG6CA7sg6Q==,type:comment]
+    auth_key: ENC[AES256_GCM,data:V3xH2bpn58JwOTrS/lNJHSo8rSN2nt3gtai2PRzQ1zhrQApAB2WndGe7rJuJnt9iyaiErA2a0pTZ9PrmlA==,iv:wIUUL1fUd3Pb9u+v7RANY2O/tLcN3jqEo8rH4plgW9M=,tag:aTZo9efvRbAiIMyYmxwQnQ==,type:str]
+    #ENC[AES256_GCM,data:c2JKZBZzKHzhu5wtRBNYfwNzdEfhCYwW6sWivd7aVd9q5pThcOY4ElvX3MfiOwK4CsMuWFpvBvP8uGjb7CghiH8UlvwClS/yz8jepmAxBwovKnnuR/H1,iv:pwhwSsY087Y+PBIkBhAbyjbggeT+mTmLGQjhnXTziUk=,tag:YhrtuGtKuND9p6ijKp+HVg==,type:comment]
+    #ENC[AES256_GCM,data:kit7iXunK/2H+ddXPRHT7ycHNjs1G8hC1U6uB4Pf49I2I5v7Wh34ArDnsGpYzKdLCLRtbvprQdhHIL1J2cLm+fg1cMSl7b92bTaZpai/4kngYfNXNKbj,iv:mevGqd0b1TvFOvuiKOrcmRA+8+N+BXUzB59/zLAvSb8=,tag:ZdWZsuCjvjSimS82XpBgxg==,type:comment]
+    oauth_client_id: ENC[AES256_GCM,data:eCzNd2dWXR4P8LX15u4BblA=,iv:xxzr+ybURinbjIDaD/1xcr47i+CNsnefP9ED5TqlZiE=,tag:KhgxSRtbMmqSllEd4ryZrQ==,type:str]
+    oauth_client_secret: ENC[AES256_GCM,data:xjuD4bTjJLIzi7hd0poGHJoZzdgfBYD9MoywKMTQFXhy1UZ8524Bv2wX3h5nFjjsYgIq8lCij6wDMxlliw7Lkw==,iv:angumDD+wvR+QpZwrJbGsvOwYynx6FKBKQCyI+78BEA=,tag:SKuwCQ8VEBuoWFfF8Vr+pw==,type:str]
+    #ENC[AES256_GCM,data:tDeIfI2Z6LVWA9R5A28LSrKEAOIwnpj91Ju9COKXLACQNc8DrY8TkcNU+ZIYTicTf9KzuiqyTfE1ip4XLWl6yBasPhMssiYJKZMI/udxhXYy/g==,iv:6Ip3NU56WRs4YaqjfxZ7WeGbHONoHDYzm/0+rtowpyY=,tag:93fuPPN2BD4mC7dOYYuohQ==,type:comment]
+    tailnet_name: ENC[AES256_GCM,data:/BYs9VbEJxvlIhFJ,iv:h5+XtC6kbfqAy25vc53b55o6Brr8V1y1nqomXIWVCsk=,tag:WrMR06EXA0dlsaGeGq8LSQ==,type:str]
+github:
+    #ENC[AES256_GCM,data:+fHQjDN7/XckwzQaAafNtSZP+eMCYbwCQ8Ypus3j2wz+GCnczt0fi5K40mrh1Hw0AxEg7/0FYOuGN0c7QEQthZF1h9yd6eynBpmZ,iv:qa+XVeEb+kBFhrmeGGS9CdQ050yVye5kCuqeV/zcWBo=,tag:2jWfNlZoGjQ0alLgNGo7SA==,type:comment]
+    #ENC[AES256_GCM,data:Js60967IOu8il6Wb16Bbnc+grgxglnqDy7vY+tvpY4luQfGqOTW/yHgs2wBkyO0GsJJRunVIq2sGtMnQWm8HQ9uLWQ==,iv:0y3bSs19767SWKclMfe5d8Dfx119NTPcBFN74QpHgG0=,tag:CNaezXr81m0cD7V8rBjsxQ==,type:comment]
+    #ENC[AES256_GCM,data:86/sW8AH0D83QQiHuKVz5XJgvtGwURf2XCfnPKi8lKou7eK1zYsvha+IAtELO9QhPtgjR4wfppaj/ItxkFMq,iv:a1FenN1pJIc+yU01xmJndf/902gZxfrG1XCy1MnmaoQ=,tag:QY59yEUQuuom6fXmc9GY1g==,type:comment]
+    #ENC[AES256_GCM,data:pD/t8LTOfatna3jSvJ1swcWzwOw5mnDVeF/nAPiDHOCt0m6iSfk42VXgcFhoIsk7ysCMPzyxrzrXm7Kqa43r4u/y,iv:W7zz1ZMcaSgoS2p+8fjotrY3wvv8fmUcClNqXPkDS3M=,tag:hLghhy7crID+NyQeILj/YQ==,type:comment]
+    app_id: ENC[AES256_GCM,data:rLGfEw9OEw==,iv:8gp6Rc//ywYG0NrI8oFVAS+iP4mqx9nCAnQFBW0TjAU=,tag:n+KIyLB2qCjgvDxnRpI5jQ==,type:str]
+    app_installation_id: ENC[AES256_GCM,data:J2ypLjWgLENR,iv:F/Ej9Ll/HH/Vf+GYIPI9Bm8rQd7zNPMKHVteNveoKCw=,tag:qmRdvZj22LpGSZBwoGL2mQ==,type:str]
+    app_private_key: ENC[AES256_GCM,data:QEKdBmyT0S4il8n+UcALIKp6V+XbbEOhgwUYFiYlHepym6nSjZIiDJGABYefzF1huVB3uq3fXN5bBO/biPpwXz3MFPNi000gM5XCdNtTFlN8c3XwY209H+K2Rs/iiK9E676k3Gjr699sPBnAlvYTTD76w+Ox/fOX5Djf9OKNQyjFQFh9RkKvToS9rNtRdMsy3YzXrjlyfqSxdWLt3jj6OaBldOoEXpxIjbdb8t5e6h5N2gHA6eu4hNlUrWRKE3EgfspKCZbDlS8tC7FHLufwXNVzau9gXu3pmGSL8vt0sfAGzupTs7kM91VSQDaORPK5VK2+XfOZLGEIZbegl9DR8VWZcSUyOfxPafcPS+j40BruDgeAGqiGCitwhpxGiYxRi5MaWDLyJhHIYIk2qCChjwZAKZzbeQOId5m2IsqpyaNPsihZU03a9IzDjc6K9OCi9QPdCVIt2k/9y2+9/hvCvGS9yB56IOeHWtsUop6AlUpm7tufkOUa6TaoiBCllUkSRSMsqT/5PwFyL9RPrxceOL26muU5vZn7Kp6aDWuFYMwAmhum1DTCmT1pRjVy6xeFquTeZ6dQ5IX1kLvwN5hPC+M00vqS7lUgyGX2CGpq3q9GVg0K/xhhWRF6DcfHxjwDrMHFtEEufMLISRZIhdSkX+POb/nIukrcKphH/SxUC0FCjTBXmQtHeSaWdmmyFStjDSwvzEIscfPb2T10ougKhS9rsWEeF85CaOS0AHJwbd0vhVncGwaFEDuKjsPAvDuCWBxnyoGHrq7eja6Ua7XWPcwajwp0IEIq3KcrDd7xV+2AXzNbi/MIn7i3dpD5li+LKHNgZbsPQ/VORFg9DRDQD8iiFyea3hIZ/AeaIMdFYtS8z+4Qp8fEzebArgL8bB+yQi6wSLIfEraUp73VCb3A3FjlyJsPNyrMOScplF1xOU2kU3zevMNvsKLUd4DMbqj+8ti4l84Ls90mrnCfRPtZKl9f5W1rHNWnNu/TJwB7qRdxfKBkKR7Jzm1usLiVsY6dQLtATxbMqg6lThmd2l4xJp+4Avfr/1OMJ65iLQ4u73XdKlhX+IInws6HOQGrdzvnaBgwXrHQC6mYzQHEPmC8+UB4n7RFxGFdslrhH6z5Apyv+F+OWTEHxCM6R1qun/wIP+PZ18i1UFSAA4+SSOudoQXouse0piLIxEU1S7yvIVZlgrONS/Mmlbor5pFgFKSh067WDb8AmjET0JuqvpS6R08XsnJ5PbfXKZNZOxpZLO8JxLXEUbBoQSbY7F7KiVQG23InC3pt3eGK/KJxrWdCkscnZ/wvC0QIam2D3EQk02oY3/4Mp4rmKOmvlX6k1Kj/sMZBHTvnyeclS2Z1WZBGpupD05xsCpRIhY/+mbJ7gkt0bqBGX3ufKBnwfbQUa90leuXjA25Mf/wxeFqFJaKyMKLBlmmQ3HB2XMbHFU0tsVralzdiVL+buQL/RJvoGmGKG0WqYfEC3k2XMTMeidPPCXoNe5wcUT7K+qzJc5HE/hL3E1n38z+BQdWNXRotXaIl5KSXQf1Rf9r3nEr6SG1gjcc4NomPPLrDMJw8zAlMio2ZK/O56bkC1RhqUaPPmJnaELxAd0vE5GNMG4LbuMEc3FEpBkkrXml0/vNJ6HPUeYo2aMMn9yEycjkiTgMc9P26FJ2JM7lfyKC6xz/RcC3XKRy0rNLdT59kq2hxPS8AnWbSb01avQp5PjbCHuFKpWTGVQCxIf1H0WA/dJrBO8JM/hIxM0fBCNYlqFs+kdlaHjDe/TUkmCc6EXIZz3EY900yAB5T2nauv4qTOYSrHxT7PJwNDsFwqSeJm+nU8UwHV6UmI/re5BBZiTzC3HIKBfkvvhKbwGL67R1G2zNyGZjay3I8b6AOfEtAXqUtLXPVylY5liTmmRCGEZSEfYU56ShJqxTRfHk+5K2cSumAUa4n+A1KOASh1aZX9XgOKnYxhC4pfEiDDuJZspvPvrW3jiA4mPShMIq/rjQBsoTGR7Os6FkXZzgjuvc4GHUilZckYMXnPJfMhIxu7dfeA51UXHn5ZMz+SmRblcAibCNaDRQzKXeNpt9IrhG/o0GIkjjoRvnZqliAClEqrg6dV3RIDiXMUHLKWUtM2G7T8BQttz7Cekn/NFtMBUDSLN1gpDWgTwZbwQ+J/+0edem5sFXY6YowWnpPuheK7c2Cu52wEZpPlK3QiaFPNLKfSBZlH5KAdioqxJ2fF5lAyOQCOS+dAAA=,iv:JLCgnjZ8w+lf8n068sIVIK4e4hmRW7AV1nDeXhXlOWc=,tag:j/6BkGAEYaUaXl4OI27edw==,type:str]
+    #ENC[AES256_GCM,data:2SZADCeM2DDiurXOCJNJjSHblP71Cgs3m9TNQp4yQ1+osLwmFN1fG7Wyzw59hoHbpx2C4WRvpiERJh2eH40mWjD9b/x7JAE2xRA/+9EJ,iv:oxQOMVQ2MVqWkRwGxQgdJS2bU2X5+IoI/uWhTgQx4pw=,tag:1Kh8LKrMYej+PVaYyO84+g==,type:comment]
+    url: ENC[AES256_GCM,data:dOrPYA8Ktx6ZP2u8j8XmdE/sLSnqHpQ2ZqzMdMqe,iv:Nx6fwagsxwkyq3fKFOkwoMQwB1R4io5dWjgSAoklEBM=,tag:uYp8vzgNni9y59ItsxLuXA==,type:str]
+#ENC[AES256_GCM,data:VTO+e/1zQ3vqT7ba+b/mqQWeQnfKwfOPcjqduALeq0LbF0oSj/JM+NLQ3dgperF8voIKUoX1sA==,iv:MYzQMVSUY+JONry6gU7/Mn+zAlBXD3OcHdAtSSoCi6o=,tag:f3hpVVD64RM2Kw6LVhVpqg==,type:comment]
+velero:
+    encryption_key: ""
+    s3_bucket: ""
+    s3_endpoint: ""
+    s3_access_key: ""
+    s3_secret_key: ""
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBabzdXN2p1NTJHSGsvSFUv
+            ZnFsc2E2WWM0RGZoMjB3dFRrcHBobHNPNWdjCnZoT28yWGlrVUkyQ3VnOEhqR0RI
+            UEhNaEtRR2VzZElaYVQzblBvNngzVFEKLS0tIEVMcjZMOWFBOUpUUHdma1JWdi9G
+            NCs4SXB5OGlPS1pvdXEybmxZTHo4aWsKKEVznhUxYphDNr3T+R6uPMj5x01gyjNC
+            iPPiIQgzgn0JtERZYYtXYEHeHr757kAiPqGIwIAFl+tteFuZGVYxvQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1dz6m6gzmu9tuqhkvdhz9gnvgmjqry7u6a69w670u22kjht5amsjsdx2re0
+    lastmodified: "2026-05-25T00:06:01Z"
+    mac: ENC[AES256_GCM,data:5ccWNhEx8Xf8VIMXq6QOwTSNxecpqbjrHFd4lkHydmSx7x9n/2aKR5vJcRT9XTazM1wyYmkTlCuVt7wTJ4uMIb/7EvBBmCHFW5NZqC5ETedF1erBZ5CNkKaJy9ZkZovjaAc1jm8jJh3EpC/N+llMHnYxb8wFUEzWtS1zHggrlp4=,iv:FFXjQhOhelwyeTGsvnPKYB0WIOV0QmE+n7JYPOFRQcs=,tag:Xn7L871LdfwyjUbH5ew5MA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.1

--- a/infra/vm/secrets/secrets.enc.yaml
+++ b/infra/vm/secrets/secrets.enc.yaml
@@ -34,12 +34,6 @@ github:
     #ENC[AES256_GCM,data:2SZADCeM2DDiurXOCJNJjSHblP71Cgs3m9TNQp4yQ1+osLwmFN1fG7Wyzw59hoHbpx2C4WRvpiERJh2eH40mWjD9b/x7JAE2xRA/+9EJ,iv:oxQOMVQ2MVqWkRwGxQgdJS2bU2X5+IoI/uWhTgQx4pw=,tag:1Kh8LKrMYej+PVaYyO84+g==,type:comment]
     url: ENC[AES256_GCM,data:dOrPYA8Ktx6ZP2u8j8XmdE/sLSnqHpQ2ZqzMdMqe,iv:Nx6fwagsxwkyq3fKFOkwoMQwB1R4io5dWjgSAoklEBM=,tag:uYp8vzgNni9y59ItsxLuXA==,type:str]
 #ENC[AES256_GCM,data:VTO+e/1zQ3vqT7ba+b/mqQWeQnfKwfOPcjqduALeq0LbF0oSj/JM+NLQ3dgperF8voIKUoX1sA==,iv:MYzQMVSUY+JONry6gU7/Mn+zAlBXD3OcHdAtSSoCi6o=,tag:f3hpVVD64RM2Kw6LVhVpqg==,type:comment]
-velero:
-    encryption_key: ""
-    s3_bucket: ""
-    s3_endpoint: ""
-    s3_access_key: ""
-    s3_secret_key: ""
 sops:
     age:
         - enc: |
@@ -51,7 +45,7 @@ sops:
             iPPiIQgzgn0JtERZYYtXYEHeHr757kAiPqGIwIAFl+tteFuZGVYxvQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1dz6m6gzmu9tuqhkvdhz9gnvgmjqry7u6a69w670u22kjht5amsjsdx2re0
-    lastmodified: "2026-05-25T00:06:01Z"
-    mac: ENC[AES256_GCM,data:5ccWNhEx8Xf8VIMXq6QOwTSNxecpqbjrHFd4lkHydmSx7x9n/2aKR5vJcRT9XTazM1wyYmkTlCuVt7wTJ4uMIb/7EvBBmCHFW5NZqC5ETedF1erBZ5CNkKaJy9ZkZovjaAc1jm8jJh3EpC/N+llMHnYxb8wFUEzWtS1zHggrlp4=,iv:FFXjQhOhelwyeTGsvnPKYB0WIOV0QmE+n7JYPOFRQcs=,tag:Xn7L871LdfwyjUbH5ew5MA==,type:str]
+    lastmodified: "2026-05-25T05:47:33Z"
+    mac: ENC[AES256_GCM,data:mloHEUtBubcqf/WLrDmWO8c+rM1rwDveG2xCYJyLs3wu4PSiZcpJHgKKbfU/QN+Wp97PQkrIMyG22J5i0btytrCy8Je/GIKvp7dcpG2EsaeAK5A93uNe5LkPTCLWJMcR/hXrSDYnAU3pn+3JWxS0x7QLA7+UYuRrlL1Qyhp+90c=,iv:Z6MuolCOj0pkH1ZucvjE4KQABRvM6JhZQ5N5Rd9OZEA=,tag:CvgtP45R1ConPsPsBItINw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1


### PR DESCRIPTION
Closes #1854.

End-to-end secrets layout for the preview-env infra. The encrypted bundle unblocks #1855 (Tailscale Operator install actually authenticates) and #1858 (ArgoCD ApplicationSet repo-server has a GitHub App to clone with).

## What lands

```
.sops.yaml                                ← creation_rules, age recipient pinned at repo root
infra/vm/secrets/secrets.enc.yaml         ← sops-encrypted bundle (~9.3 KB)
infra/SECRETS.md                          ← 250-line operating reference
infra/README.md                           ← cross-references SECRETS.md
```

## What's inside the bundle (schema in `secrets.example.yaml`)

| Key | Used by | Renders into |
|---|---|---|
| `admin.{email,password}` | chart via `existingSecret` | `inv-system/inventario-admin` |
| `github.{app_id, app_installation_id, app_private_key, url}` | ArgoCD repo-server + ApplicationSet PR-generator | `argocd/github-app-creds` (with `argocd.argoproj.io/secret-type: repo-creds` label) |
| `tailscale.{oauth_client_id, oauth_client_secret}` | Tailscale Operator (#1855) | `tailscale/operator-oauth` + helm values |
| `tailscale.{auth_key, tailnet_name}` | `make recover` on a fresh VM, helm overlays (#1856) | direct consumption |
| `velero.*` | #1865 Phase 2 | placeholders, all empty |

## sops layout decisions

- **`.sops.yaml` at repo root, not in `infra/vm/secrets/`** — sops walks up from `$PWD` (not from the file path) to find its config. Nested config gets missed when running `sops -e` from repo root.
- **Two `creation_rules` covering `*.enc.yaml` and `*.local.yaml`** — the .local.yaml rule lets `sops -e secrets.local.yaml > secrets.enc.yaml` work without `--age`, and the .enc.yaml rule covers in-place `sops` editor sessions.
- **macOS XDG-path gotcha** — sops 3.13 on macOS looks for the age key at `~/Library/Application Support/sops/age/keys.txt`, not `~/.config/sops/age/keys.txt`. Documented + suggested symlink fix in `SECRETS.md` → "Generate the age keypair".

## SECRETS.md highlights

Beyond the schema, it documents:

- One-time setup: age keypair, GitHub App creation with exact permissions (Contents/Metadata/Pull requests = Read), Tailscale OAuth client with the right scopes (`devices:core` write, `auth_keys` write) and tags (`tag:k8s-operator`, `tag:k8s`).
- **ACL `tagOwners` config** with the empty `[]` owner pattern for `tag:k8s-operator`. This was the only real grabl during end-to-end testing — Tailscale's OAuth-as-caller model treats the client as a tagged device, not as its creating user, so listing a user email there doesn't grant the operator permission to mint its own auth-keys. Empty list is the canonical bootstrap pattern per <https://tailscale.com/kb/1236/kubernetes-operator>.
- Day-to-day editing (`sops infra/vm/secrets/secrets.enc.yaml`).
- Full disaster-recovery runbook (laptop with age key + this repo → fresh VM `make recover`).
- Key rotation procedures for all three credentials.

## End-to-end verification

On a clean Ubuntu 26.04 VM (snapshot-protected), after applying this PR + #1872 (Makefile path fix in master):

```text
$ make -C infra bootstrap VM=buster@vcluster-dev
... (vm-install: apt prereqs, tailscale up, vcluster v0.34.0, TS operator helm install, ArgoCD helm install)
==> Applying k8s Secrets to argocd/tailscale/inv-system namespaces
==> Applying inv-system/inventario-admin
namespace/inv-system created
secret/inventario-admin created
==> Applying argocd/github-app-creds
secret/github-app-creds created
==> Applying tailscale/operator-oauth
secret/operator-oauth configured
==> Bootstrap complete.

$ KUBECONFIG=~/.kube/inv-vcl01.config kubectl get pods -A | grep -v Running
(no failing pods)

$ KUBECONFIG=~/.kube/inv-vcl01.config kubectl -n tailscale get pods
NAME                        READY   STATUS    RESTARTS   AGE
operator-8474f554f8-l27xz   1/1     Running   0          38s

$ ssh vcluster-dev 'tailscale status | grep operator'
100.x.x.x   tailscale-operator      tagged-devices  linux    -
```

Operator boots clean, registers in the tailnet as `tailscale-operator` carrying `tag:k8s-operator`, and the reconciler controllers (Service, Ingress, ProxyGroup, ProxyGroupPolicy, Tailnet) all start.

## Test plan

- [x] `sops -d --output-type json infra/vm/secrets/secrets.enc.yaml | jq .` round-trips cleanly
- [x] `make -C infra bootstrap VM=...` end-to-end on a clean VM applies all three Secrets
- [x] Tailscale operator boots Ready (no CrashLoopBackoff) and shows up in tailnet
- [x] ArgoCD reads `github-app-creds` (label `repo-creds`) — verified pod can start, end-to-end repo-clone exercised by #1858
- [x] No PII / email leaks in any tracked file (`grep -r '@v-media' infra/ .sops.yaml`)
- [ ] `make destroy && make recover` round-trip — out of scope here, covered by #1863 README walkthrough

Refs #1852 epic, depends on #1872 (Makefile path fix, already in master).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive secrets management guide covering setup, configuration, rotation, disaster recovery, and troubleshooting
  * Updated infra documentation to reference the new secrets guidance and encrypted secrets bundle

* **Chores**
  * Added repository-wide encryption configuration for managing secrets
  * Added an encrypted secrets bundle containing initial credentials and service secrets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->