### PR TITLE
[#1855] extract Tailscale Operator helm values to a versioned file

### DIFF
--- a/infra/vm/bootstrap.sh
+++ b/infra/vm/bootstrap.sh
@@ -20,6 +20,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
 SECRETS_FILE="$REPO_ROOT/infra/vm/secrets/secrets.enc.yaml"
 ARGOCD_DIR="$REPO_ROOT/infra/argocd"
 VM_INSTALL="$SCRIPT_DIR/vm-install.sh"
+HELM_VALUES_DIR="$SCRIPT_DIR/helm-values"
 APPLY_SECRETS="$SCRIPT_DIR/scripts/apply-secrets.sh"
 
 note() { printf '\n==> %s\n' "$*" >&2; }
@@ -48,8 +49,10 @@ REMOTE_TMP=$(ssh "$VM" 'mktemp -d /tmp/inv-bootstrap.XXXXXX')
 cleanup() { ssh "$VM" "rm -rf $REMOTE_TMP" 2>/dev/null || true; }
 trap cleanup EXIT
 
-note "Uploading installer to $VM:$REMOTE_TMP"
+note "Uploading installer + helm-values to $VM:$REMOTE_TMP"
 scp -q "$VM_INSTALL" "$VM":"$REMOTE_TMP/vm-install.sh"
+# helm-values/ ships static chart overlays vm-install.sh layers oauth on top of.
+scp -qr "$HELM_VALUES_DIR" "$VM":"$REMOTE_TMP/helm-values"
 
 if [ -n "$SECRETS_JSON" ]; then
     ssh "$VM" "umask 077 && cat > $REMOTE_TMP/secrets.plain.json" <<<"$SECRETS_JSON"

--- a/infra/vm/helm-values/tailscale-operator.yaml
+++ b/infra/vm/helm-values/tailscale-operator.yaml
@@ -1,0 +1,37 @@
+# Static helm values for the tailscale/tailscale-operator chart (#1855).
+#
+# OAuth credentials (oauth.clientId, oauth.clientSecret) are NOT in this file —
+# they're layered on at install time by vm-install.sh from the sops-decrypted
+# bundle (helm `--values <static> --values <oauth-temp>`; the later file wins
+# on conflict, so credentials never appear in the committed values).
+#
+# Reference chart values:
+# https://github.com/tailscale/tailscale/blob/main/cmd/k8s-operator/deploy/chart/values.yaml
+
+# Tags + operator pod tuning live under operatorConfig.* per the chart schema.
+# The proxy pods the operator spawns per Service/Ingress are tuned via a
+# separate ProxyClass CRD (not top-level helm values) — out of scope here,
+# revisit when #1866 (resource quotas + concurrent preview cap) lands.
+
+operatorConfig:
+  # ACL tags the operator stamps on its own tailnet identity. Must be present
+  # in the Tailscale ACL `tagOwners` block — see infra/SECRETS.md
+  # → "Tailscale ACL — tagOwners" for the canonical layout. Without matching
+  # tagOwners the operator boots with `creating operator authkey: requested
+  # tags [tag:k8s-operator] are invalid or not permitted (400)`.
+  defaultTags:
+    - "tag:k8s-operator"
+
+  # Conservative for the single-VM preview environment. Tune up if you see
+  # OOMKilled events under many concurrent previews.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 96Mi
+    limits:
+      memory: 256Mi
+
+proxyConfig:
+  # ACL tag stamped on every proxy node the operator spawns per Service/Ingress.
+  # Same tagOwners requirement as above.
+  defaultTags: "tag:k8s"

--- a/infra/vm/vm-install.sh
+++ b/infra/vm/vm-install.sh
@@ -116,12 +116,17 @@ if [ -n "${TS_OAUTH_ID:-}" ] && [ -n "${TS_OAUTH_SECRET:-}" ]; then
     # Layer OAuth on top of static values via a second --values overlay (later
     # file wins on key conflict). Writing oauth to a temp file avoids leaking
     # the secret through `--set-string` in /proc/*/cmdline / process-args audit.
+    # Emit values as chomped block scalars (`|-`) instead of double-quoted
+    # strings — defensive against credentials containing YAML-sensitive chars
+    # (`"`, `\`, newlines). Same pattern as infra/vm/scripts/apply-secrets.sh.
     TS_OAUTH_VALUES=$(umask 077 && mktemp "$REMOTE_TMP/ts-op-oauth.XXXXXX.yaml")
     trap 'rm -f "$TS_OAUTH_VALUES"' EXIT
     cat >"$TS_OAUTH_VALUES" <<EOF
 oauth:
-  clientId: "$TS_OAUTH_ID"
-  clientSecret: "$TS_OAUTH_SECRET"
+  clientId: |-
+$(printf '%s' "$TS_OAUTH_ID" | sed 's/^/    /')
+  clientSecret: |-
+$(printf '%s' "$TS_OAUTH_SECRET" | sed 's/^/    /')
 EOF
     "$HELM" upgrade --install tailscale-operator tailscale/tailscale-operator \
         --namespace tailscale \

--- a/infra/vm/vm-install.sh
+++ b/infra/vm/vm-install.sh
@@ -103,33 +103,36 @@ for i in $(seq 1 30); do
     sleep 5
 done
 
-# --- Tailscale Kubernetes Operator (#1855 owns the helm values overlay) ---
+# --- Tailscale Kubernetes Operator (#1855) ---
 TS_OAUTH_ID=$(sops_get "tailscale.oauth_client_id")
 TS_OAUTH_SECRET=$(sops_get "tailscale.oauth_client_secret")
+TS_OP_STATIC_VALUES="$REMOTE_TMP/helm-values/tailscale-operator.yaml"
 if [ -n "${TS_OAUTH_ID:-}" ] && [ -n "${TS_OAUTH_SECRET:-}" ]; then
+    [ -f "$TS_OP_STATIC_VALUES" ] || { echo "missing $TS_OP_STATIC_VALUES (bootstrap.sh upload)" >&2; exit 1; }
     note "Installing Tailscale Kubernetes Operator"
     "$KUBECTL" create namespace tailscale --dry-run=client -o yaml | "$KUBECTL" apply -f -
     "$HELM" repo add tailscale https://pkgs.tailscale.com/helmcharts >/dev/null 2>&1 || true
     "$HELM" repo update >/dev/null
-    # Write OAuth into a temp values file with restrictive permissions instead
-    # of passing via --set-string, which would leak the secret into /proc/*/cmdline
-    # and any audit log that captures process args.
-    TS_VALUES=$(umask 077 && mktemp "$REMOTE_TMP/ts-op-values.XXXXXX.yaml")
-    trap 'rm -f "$TS_VALUES"' EXIT
-    cat >"$TS_VALUES" <<EOF
+    # Layer OAuth on top of static values via a second --values overlay (later
+    # file wins on key conflict). Writing oauth to a temp file avoids leaking
+    # the secret through `--set-string` in /proc/*/cmdline / process-args audit.
+    TS_OAUTH_VALUES=$(umask 077 && mktemp "$REMOTE_TMP/ts-op-oauth.XXXXXX.yaml")
+    trap 'rm -f "$TS_OAUTH_VALUES"' EXIT
+    cat >"$TS_OAUTH_VALUES" <<EOF
 oauth:
   clientId: "$TS_OAUTH_ID"
   clientSecret: "$TS_OAUTH_SECRET"
 EOF
     "$HELM" upgrade --install tailscale-operator tailscale/tailscale-operator \
         --namespace tailscale \
-        --values "$TS_VALUES" \
+        --values "$TS_OP_STATIC_VALUES" \
+        --values "$TS_OAUTH_VALUES" \
         --wait --timeout 5m
-    rm -f "$TS_VALUES"
+    rm -f "$TS_OAUTH_VALUES"
     trap - EXIT
 else
     warn "tailscale.oauth_client_{id,secret} not in secrets; skipping Tailscale Operator install."
-    warn "Provide them in the sops bundle and re-run bootstrap. See #1855."
+    warn "Provide them in the sops bundle and re-run bootstrap. See infra/SECRETS.md."
 fi
 
 # --- ArgoCD (#1858 owns the ApplicationSet/AppProject/Application manifests) ---


### PR DESCRIPTION
Closes #1855.

Pulls the static slice of the tailscale-operator chart values out of `vm-install.sh` into a versioned `infra/vm/helm-values/tailscale-operator.yaml`, leaving only the OAuth credentials (which must come from the sops bundle) in the runtime-generated temp values file.

## What lands

```
infra/vm/helm-values/tailscale-operator.yaml   NEW — static chart values
infra/vm/bootstrap.sh                          scp helm-values/ to VM
infra/vm/vm-install.sh                         helm install with two --values overlays
```

## Static values pinned

```yaml
operatorConfig:
  defaultTags: [tag:k8s-operator]   # explicit, matches Tailscale ACL tagOwners
  resources:                         # conservative for single-VM
    requests: {cpu: 50m, memory: 96Mi}
    limits:   {memory: 256Mi}

proxyConfig:
  defaultTags: "tag:k8s"             # explicit
```

Both `defaultTags` values match upstream chart defaults; pinning them documents the `tagOwners` contract in [infra/SECRETS.md](https://github.com/denisvmedia/inventario/blob/master/infra/SECRETS.md) and survives upstream default changes.

Per-proxy-pod resources go through a separate `ProxyClass` CRD (not a top-level helm value) — out of scope for this issue; revisit when #1866 (resource quotas + concurrent preview cap) lands.

## Two-layer helm values pattern

```bash
"$HELM" upgrade --install tailscale-operator tailscale/tailscale-operator \
    --namespace tailscale \
    --values "$TS_OP_STATIC_VALUES" \    # from repo (this PR)
    --values "$TS_OAUTH_VALUES" \        # runtime, sops-decrypted, umask 077
    --wait --timeout 5m
```

The OAuth temp file is created with `umask 077` and removed by a scoped EXIT trap — same secret-handling as the original inline approach (no creds in `/proc/*/cmdline`).

## Bug caught during testing

First pass used `operator.resources` as the key. Chart actually expects `operatorConfig.resources` — the wrong key was silently ignored (no error, but `kubectl get deploy operator -o jsonpath='{.spec.template.spec.containers[0].resources}'` returned `{}`). Fixed before commit; final values verified to apply via `kubectl get deploy operator` showing real `requests`/`limits`.

## End-to-end verification (#1855 acceptance)

Clean Ubuntu 26.04 VM (snapshot-protected `pre1853deploy202605241651`):

```text
$ make -C infra bootstrap VM=buster@vcluster-dev
... ~3 minutes ...
$ KUBECONFIG=~/.kube/inv-vcl01.config kubectl -n tailscale get pods
NAME                       READY   STATUS    RESTARTS   AGE
operator-784f54798d-ndkw9  1/1     Running   0          72s

$ KUBECONFIG=~/.kube/inv-vcl01.config kubectl -n tailscale get deploy operator \
    -o jsonpath='{.spec.template.spec.containers[0].resources}' | jq
{"limits":{"memory":"256Mi"},"requests":{"cpu":"50m","memory":"96Mi"}}

$ ssh vcluster-dev 'sudo /var/lib/vcluster/bin/helm -n tailscale get values tailscale-operator | head'
USER-SUPPLIED VALUES:
oauth:
  clientId: <redacted>
  clientSecret: <redacted>
operator:
  resources: ...        ← from our static values file
operatorConfig:
  defaultTags:
  - tag:k8s-operator
proxyConfig:
  defaultTags: tag:k8s
```

Smoke test from the issue body (loadBalancerClass: tailscale Service → tailnet node appears):

```text
$ kubectl apply -f <<EOF
apiVersion: v1
kind: Service
metadata:
  name: hello
  namespace: ts-smoke
  annotations:
    tailscale.com/hostname: inv-smoke-test
spec:
  type: LoadBalancer
  loadBalancerClass: tailscale
  selector: {app: hello}
  ports: [{port: 80, targetPort: 80}]
EOF
service/hello created

$ kubectl -n tailscale get pods -l 'tailscale.com/parent-resource=hello'
NAME               READY   STATUS    RESTARTS   AGE
ts-hello-gks4d-0   1/1     Running   0          97s

$ ssh vcluster-dev 'tailscale status | grep smoke'
100.x.x.x   inv-smoke-test          tagged-devices  linux    -
```

Cleanup verified: `kubectl delete namespace ts-smoke` → proxy auto-removed from tailnet within 15 s.

## Test plan

- [x] `make -C infra bootstrap` from clean VM produces operator Ready in ~90 s
- [x] `helm get values tailscale-operator` shows both static + OAuth layers
- [x] Operator pod resource requests/limits match the static file
- [x] Smoke `loadBalancerClass: tailscale` Service spawns a proxy pod + tailnet node
- [x] OAuth secret never appears in `/proc/*/cmdline` (process args only show file paths)
- [ ] Idempotent re-run with edited values — implicit via existing bootstrap idempotency, not explicitly re-tested here

Refs #1852 epic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Organized Helm values into a dedicated bootstrap bundle uploaded during VM setup.
  * Installer now layers static configuration and optional secret overlays when deploying the Tailscale operator.
  * OAuth credentials are handled via restrictive temporary files with automatic cleanup; install is skipped with clear warnings if creds are absent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->