### PR TITLE
[#1886] Hide empty Inventory/Group sidebar sections + harden create-group fallbacks

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -275,11 +275,20 @@ export function AppSidebar({ onRestartTour }: AppSidebarProps = {}) {
   const { isMobile, setOpenMobile, state } = useSidebar()
   const { user, logout } = useAuth()
   const isSystemAdmin = useIsSystemAdmin()
-  const { currentGroup } = useCurrentGroup()
+  const { groups, currentGroup } = useCurrentGroup()
   const migrationLock = useGroupMigrationLock()
   const navigate = useNavigate()
   const location = useLocation()
   const { t } = useTranslation()
+
+  // Inventory + Group(Manage) entries all require an active group to resolve
+  // (`/g/<slug>/...`), so rendering empty section headers when the user
+  // belongs to zero groups leaves two label-only orphans in the sidebar
+  // (#1886). `groups === undefined` means the list is still loading — we
+  // keep the sections mounted in that case so first paint doesn't flash
+  // "no sections → sections" once the cache settles. Personal stays
+  // always-on (its entries are path-clean and resolve without a group).
+  const showGroupSections = groups === undefined || groups.length > 0
 
   function closeMobileSidebar() {
     if (isMobile) setOpenMobile(false)
@@ -371,37 +380,41 @@ export function AppSidebar({ onRestartTour }: AppSidebarProps = {}) {
       </SidebarHeader>
 
       <SidebarContent className="pt-2 group-data-[collapsible=icon]:!overflow-y-auto">
-        <SidebarGroup>
-          <SidebarGroupLabel>{t("common:nav.groupInventory")}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {INVENTORY.map((e) => (
-                <NavRow
-                  key={e.labelKey}
-                  entry={e}
-                  group={currentGroup}
-                  onNavigate={closeMobileSidebar}
-                />
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+        {showGroupSections ? (
+          <SidebarGroup data-testid="sidebar-inventory-group">
+            <SidebarGroupLabel>{t("common:nav.groupInventory")}</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {INVENTORY.map((e) => (
+                  <NavRow
+                    key={e.labelKey}
+                    entry={e}
+                    group={currentGroup}
+                    onNavigate={closeMobileSidebar}
+                  />
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ) : null}
 
-        <SidebarGroup>
-          <SidebarGroupLabel>{t("common:nav.groupManage")}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {MANAGE.map((e) => (
-                <NavRow
-                  key={e.labelKey}
-                  entry={e}
-                  group={currentGroup}
-                  onNavigate={closeMobileSidebar}
-                />
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+        {showGroupSections ? (
+          <SidebarGroup data-testid="sidebar-manage-group">
+            <SidebarGroupLabel>{t("common:nav.groupManage")}</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {MANAGE.map((e) => (
+                  <NavRow
+                    key={e.labelKey}
+                    entry={e}
+                    group={currentGroup}
+                    onNavigate={closeMobileSidebar}
+                  />
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ) : null}
 
         <SidebarGroup>
           <SidebarGroupLabel>{t("common:nav.groupPersonal")}</SidebarGroupLabel>

--- a/frontend/src/components/__tests__/AppSidebar.test.tsx
+++ b/frontend/src/components/__tests__/AppSidebar.test.tsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { http, HttpResponse } from "msw"
+import { Route } from "react-router-dom"
+import { screen, waitFor } from "@testing-library/react"
+
+import { AppSidebar } from "@/components/AppSidebar"
+import { SidebarProvider } from "@/components/ui/sidebar"
+import { AuthProvider } from "@/features/auth/AuthContext"
+import { GroupProvider } from "@/features/group/GroupContext"
+import { apiUrl, authHandlers, groupHandlers } from "@/test/handlers"
+import { renderWithProviders } from "@/test/render"
+import { server } from "@/test/server"
+import { clearAuth, setAccessToken } from "@/lib/auth-storage"
+import { __resetGroupContextForTests } from "@/lib/group-context"
+import { __resetHttpForTests } from "@/lib/http"
+
+// Mount AppSidebar inside the same provider chain Shell uses at runtime
+// (AuthProvider -> GroupProvider -> SidebarProvider) so the test sees the
+// same currentGroup / groups wiring the production sidebar does.
+function renderSidebar(initialPath = "/no-group") {
+  setAccessToken("good-token")
+  // The current cases only need the root /g/:slug shape — if a future
+  // test passes /g/<slug>/<sub>, this mount will still resolve only
+  // /g/:slug, won't match, and AppSidebar won't render. Widen the
+  // pattern then (e.g. /g/:groupSlug/*).
+  const routePath = initialPath.startsWith("/g/") ? "/g/:groupSlug" : initialPath
+  return renderWithProviders({
+    initialPath,
+    routes: (
+      <Route
+        path={routePath}
+        element={
+          <AuthProvider>
+            <GroupProvider>
+              <SidebarProvider>
+                <AppSidebar />
+              </SidebarProvider>
+            </GroupProvider>
+          </AuthProvider>
+        }
+      />
+    ),
+  })
+}
+
+beforeEach(() => {
+  clearAuth()
+  __resetGroupContextForTests()
+  __resetHttpForTests()
+})
+
+describe("<AppSidebar /> — group-section gating (#1886)", () => {
+  it("hides Inventory + Group sections when the user belongs to no groups", async () => {
+    server.use(...authHandlers.signedIn(), ...groupHandlers.empty())
+    renderSidebar("/no-group")
+    // Personal always renders unconditionally. The Inventory + Group
+    // sections render during the in-flight window (groups === undefined)
+    // and only retract once /groups resolves []. Wait for the retract
+    // explicitly so the test isn't reading the loading-state snapshot.
+    await waitFor(() =>
+      expect(screen.queryByTestId("sidebar-inventory-group")).not.toBeInTheDocument()
+    )
+    expect(screen.queryByTestId("sidebar-manage-group")).not.toBeInTheDocument()
+    expect(screen.getByText("Personal")).toBeInTheDocument()
+  })
+
+  it("renders all three sections when the user has at least one group", async () => {
+    server.use(...authHandlers.signedIn(), ...groupHandlers.list())
+    renderSidebar("/g/household")
+    await waitFor(() => expect(screen.getByTestId("sidebar-inventory-group")).toBeInTheDocument())
+    expect(screen.getByTestId("sidebar-manage-group")).toBeInTheDocument()
+    expect(screen.getByText("Personal")).toBeInTheDocument()
+  })
+
+  it("keeps the group sections rendered while /groups is still loading", async () => {
+    // Hang the /groups response so we observe the in-flight state and
+    // verify we don't flash the sections off and back on. A never-
+    // resolving handler keeps `groups === undefined` for the entirety
+    // of the test, which is exactly the loading branch the gate covers.
+    server.use(
+      ...authHandlers.signedIn(),
+      http.get(apiUrl("/groups"), () => new Promise<HttpResponse>(() => {}))
+    )
+    renderSidebar("/no-group")
+    // Personal renders unconditionally — using it as the readiness probe
+    // so the assertion isn't racing the first render.
+    await waitFor(() => expect(screen.getByText("Personal")).toBeInTheDocument())
+    // groups hasn't resolved, so the section headers must still be in
+    // the DOM. If they weren't, the user would see "no sections" briefly
+    // and then "sections appear" once /groups lands.
+    expect(screen.getByTestId("sidebar-inventory-group")).toBeInTheDocument()
+    expect(screen.getByTestId("sidebar-manage-group")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/i18n/locales/en/groups.json
+++ b/frontend/src/i18n/locales/en/groups.json
@@ -8,6 +8,7 @@
     "currencyPlaceholder": "Pick a currency",
     "currencySearchPlaceholder": "Search ISO 4217 code…",
     "errorGeneric": "Couldn't create the group. Please try again.",
+    "errorMissingSlug": "The group was created but its URL is missing. Reload the page to continue.",
     "iconChange": "Change",
     "iconHelp": "Optional — pick something to make the group easier to recognize in the sidebar.",
     "iconLabel": "Icon",

--- a/frontend/src/pages/NoGroupPage.tsx
+++ b/frontend/src/pages/NoGroupPage.tsx
@@ -47,16 +47,24 @@ export function NoGroupPage() {
     setServerError(null)
     try {
       const created = await createMutation.mutateAsync({ name: trimmed })
-      toast.success(t("groups:create.successToast"))
       // Created group has a slug 22+ chars per the BE invariant, but the
       // generated LocationGroup type marks it optional — guard so we
-      // never construct "/g/" and drop into the 404. Fallback to "/"
-      // mirrors the pre-fix behaviour and lets RootRedirect resolve.
-      if (created.slug) {
-        navigate(`/g/${encodeURIComponent(created.slug)}`)
-      } else {
-        navigate("/")
+      // never construct "/g/" and drop into the 404. Treat the missing
+      // slug as an error path (#1886) so the user keeps the form open
+      // with feedback rather than seeing a toast + a stuck page; the
+      // earlier `navigate("/")` fallback hid the real symptom because
+      // RootRedirect would race the invalidated cache and sometimes
+      // leave the user back on /no-group.
+      if (!created.slug) {
+        // Dedicated key so the user isn't told to "try again" (the group
+        // exists; a retry would duplicate it) — they need to reload so
+        // RootRedirect can resolve the freshly-created group via the
+        // invalidated /groups cache.
+        setServerError(t("groups:create.errorMissingSlug"))
+        return
       }
+      toast.success(t("groups:create.successToast"))
+      navigate(`/g/${encodeURIComponent(created.slug)}`)
     } catch (err) {
       setServerError(parseServerError(err, t("groups:create.errorGeneric")))
     }

--- a/frontend/src/pages/__tests__/NoGroupPage.test.tsx
+++ b/frontend/src/pages/__tests__/NoGroupPage.test.tsx
@@ -149,6 +149,44 @@ describe("<NoGroupPage />", () => {
     expect(await screen.findByTestId("no-group-server-error")).toBeInTheDocument()
   })
 
+  it("treats a slug-less 201 as an error and keeps the inline form mounted (#1886)", async () => {
+    // BE invariant: every persisted group has a slug. A 201 without one
+    // is treated as an error path so the user keeps the form open with
+    // feedback instead of seeing a success toast + a stuck page; the
+    // earlier `navigate("/")` fallback hid the real symptom via the
+    // RootRedirect race.
+    server.use(
+      ...baseHandlers,
+      msw.post(api("/groups"), () =>
+        HttpResponse.json(
+          {
+            data: {
+              id: "g-new",
+              type: "groups",
+              attributes: {
+                id: "g-new",
+                name: "Household",
+                group_currency: "USD",
+                icon: "",
+              },
+            },
+          },
+          { status: 201 }
+        )
+      )
+    )
+    const user = userEvent.setup()
+    renderNoGroup()
+    await user.click(await screen.findByTestId("no-group-create-button"))
+    await user.type(await screen.findByTestId("no-group-name-input"), "Household")
+    await user.click(screen.getByTestId("no-group-submit"))
+    expect(await screen.findByTestId("no-group-server-error")).toBeInTheDocument()
+    // The page must not have navigated. <LocationProbe> only renders
+    // when the wildcard route catches a different pathname; it being
+    // absent is the assertion that we stayed at /no-group.
+    expect(screen.queryByTestId("loc")).not.toBeInTheDocument()
+  })
+
   it("the cancel button collapses the form back to the CTA", async () => {
     server.use(...baseHandlers)
     const user = userEvent.setup()

--- a/frontend/src/pages/groups/CreateGroupPage.tsx
+++ b/frontend/src/pages/groups/CreateGroupPage.tsx
@@ -49,15 +49,23 @@ export function CreateGroupPage() {
         icon: values.icon || undefined,
         group_currency: values.group_currency.toUpperCase(),
       })
-      toast.success(t("groups:create.successToast"))
-      // Server-generated slug is the canonical address. If the response
-      // is missing one (defensive), fall back to /no-group rather than
-      // build a broken URL.
-      if (created.slug) {
-        navigate(`/g/${encodeURIComponent(created.slug)}`)
-      } else {
-        navigate("/no-group")
+      // The BE invariant is that every persisted group carries a slug
+      // (assigned at create-time inside the transaction). A response
+      // without one means something is off — surface it as an error
+      // and stay on the form rather than silently navigating to
+      // /no-group, which would *also* drop the user's active group
+      // context when they came from GroupSelector → "Create new
+      // group" (the previous fallback). #1886.
+      if (!created.slug) {
+        // Dedicated key so the user isn't told to "try again" (the group
+        // exists; a retry would duplicate it) — they need to reload so
+        // RootRedirect can resolve the freshly-created group via the
+        // invalidated /groups cache.
+        setServerError(t("groups:create.errorMissingSlug"))
+        return
       }
+      toast.success(t("groups:create.successToast"))
+      navigate(`/g/${encodeURIComponent(created.slug)}`)
     } catch (err) {
       setServerError(parseServerError(err, t("groups:create.errorGeneric")))
     }

--- a/frontend/src/pages/groups/__tests__/CreateGroupPage.test.tsx
+++ b/frontend/src/pages/groups/__tests__/CreateGroupPage.test.tsx
@@ -113,6 +113,43 @@ describe("<CreateGroupPage />", () => {
     expect(await screen.findByTestId("create-group-server-error")).toHaveTextContent(/iso code/i)
   })
 
+  it("treats a slug-less success response as an error and keeps the form mounted (#1886)", async () => {
+    // The BE invariant is that every persisted group carries a slug,
+    // so a 201 without one is a contract violation. We surface that as
+    // an inline server error rather than silently navigating to
+    // /no-group — which would also drop the user's active-group
+    // context when they reached the form via GroupSelector.
+    server.use(
+      msw.post(api("/groups"), () =>
+        HttpResponse.json(
+          {
+            data: {
+              id: "g1",
+              type: "groups",
+              attributes: {
+                id: "g1",
+                name: "Household",
+                group_currency: "USD",
+                icon: "",
+              },
+            },
+          },
+          { status: 201 }
+        )
+      )
+    )
+    const user = userEvent.setup()
+    renderCreate()
+    await user.type(screen.getByTestId("group-name-input"), "Household")
+    await user.click(screen.getByTestId("create-group-submit"))
+    expect(await screen.findByTestId("create-group-server-error")).toBeInTheDocument()
+    // The form must still be present — the user can retry without
+    // losing context. A navigation away would unmount CreateGroupPage
+    // and `*` would catch the new pathname via <LocationProbe />.
+    expect(screen.getByTestId("create-group-page")).toBeInTheDocument()
+    expect(screen.queryByTestId("loc")).not.toBeInTheDocument()
+  })
+
   it("has no axe violations on the form", async () => {
     const { container } = renderCreate()
     expect(await axe(container)).toHaveNoViolations()


### PR DESCRIPTION
Closes #1886 (partially — see notes below).

## Bug 2 — empty Inventory/Group sidebar sections (REPRODUCED + FIXED)

Reproduced locally with a memory-backed backend (`INVENTARIO_RUN_MEMORY_TENANT_SLUG=test-org`) + `/api/v1/seed?tenant_slug=test-org` + login as `orphan@test-org.com` (zero memberships). The sidebar showed `Inventory` and `Group` section labels over empty bodies — every `NavRow` short-circuits without a slug, but the `SidebarGroup` wrappers themselves stayed mounted.

**Fix:** gate both sections on `groups === undefined || groups.length > 0` so:
- During the in-flight `/groups` window (`groups === undefined`), the sections stay mounted — no flash of "no sections → sections appear" once the response lands.
- Once `/groups` resolves with `[]`, both sections collapse out entirely.
- `Personal` stays always-on (its entries are path-clean and resolve without a group).

| Before | After |
| --- | --- |
| Two label-only orphans in the sidebar | Only `Personal` until the user has ≥1 group |

## Bug 1 — "Create-group dialog stays open after submit" (NOT REPRODUCED on master)

I drove both create-group surfaces end-to-end against a fresh memory-backed BE:
- `NoGroupPage` inline form (`/no-group`)
- `CreateGroupPage` dedicated page (`/groups/new`)

Both correctly navigate to `/g/<new-slug>` after a successful submit. There is no Radix Dialog component for group creation in the React frontend; the issue's "dialog" terminology likely came from the design-mock vocabulary or from a preview deploy of [`feat/1856-1858-helm-argocd` (#1881)](https://github.com/denisvmedia/inventario/pull/1881), which is where the issue was originally observed.

**Prophylactic hardening landed anyway:** the BE invariant is that every persisted group carries a slug (assigned at create-time inside the transaction). The previous code silently fell back to `navigate("/no-group")` / `navigate("/")` when `created.slug` was missing — that path:
- Hid a contract violation from the user.
- Dropped the active-group context when a user reached `/groups/new` from `GroupSelector → "Create new group"`.
- Could leave the user on an unexpected page with no feedback.

Both pages now treat a slug-less 201 as an error: set the inline `serverError` banner, suppress the success toast, keep the form mounted. The user can retry without losing context.

## Tests

- New `frontend/src/components/__tests__/AppSidebar.test.tsx` covers all three sidebar-gate states (zero groups → sections hidden, ≥1 group → sections rendered, loading → sections rendered to avoid flash).
- `NoGroupPage.test.tsx` + `CreateGroupPage.test.tsx` pick up the slug-less-201 regression guard.
- Full vitest suite: 1146 passed.
- `npm run lint` + `npm run format:check` + `npm run typecheck` green.

## Test plan

- [x] Reproduce Bug 2 locally with `orphan@test-org.com` (zero groups) and confirm the empty `Inventory`/`Group` labels appear before the fix.
- [x] Apply the fix and confirm the sections are gone for zero-group users while `Personal` still renders.
- [x] Create the first group from the inline `NoGroupPage` form; confirm navigation lands on `/g/<new-slug>` and the sidebar then shows `Inventory` + `Group` + `Personal`.
- [x] Vitest + lint + format + typecheck.
- [ ] Manual reproduction of the original Bug 1 on the PR-preview deploy of #1881 — out of scope for this PR; if the dialog reappears there, file a follow-up against that branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar now keeps Inventory/Manage visible while group data is loading and hides them when the user has no groups, avoiding flicker.
  * Group creation now treats a missing URL slug as a server error: the form stays open, shows an error, and prevents navigation.

* **Localization**
  * Added a user-facing message advising to reload if a created group’s URL slug is missing.

* **Tests**
  * Added tests covering sidebar visibility states and group-creation missing-slug error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->