### PR TITLE
[#1887] scope Plan & Notifications to dedicated GroupSettings sub-sections

### DIFF
--- a/frontend/src/components/groups/PlanCard.tsx
+++ b/frontend/src/components/groups/PlanCard.tsx
@@ -61,11 +61,14 @@ export function PlanCard({ groupSlug, ownerName, className }: PlanCardProps) {
           </div>
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2">
-              <h2 className="text-base font-semibold truncate" data-testid="plan-card-name">
+              {/* h3 not h2: the enclosing Info section already renders the
+                  section-level h2 (#1887). PlanCard's card title is the
+                  next level down. */}
+              <h3 className="text-base font-semibold truncate" data-testid="plan-card-name">
                 {t("groups:settings.plan.title", {
                   name: plan.name ?? "—",
                 })}
-              </h2>
+              </h3>
               <Badge variant="secondary" className="text-xs">
                 {t("groups:settings.plan.activeBadge")}
               </Badge>

--- a/frontend/src/i18n/locales/en/groups.json
+++ b/frontend/src/i18n/locales/en/groups.json
@@ -143,7 +143,8 @@
       "data": "Data & storage",
       "info": "Info",
       "management": "Management",
-      "members": "Members"
+      "members": "Members",
+      "notifications": "Notifications"
     },
     "slugHelp": "Slugs are randomly generated at creation and immutable.",
     "slugLabel": "URL slug",

--- a/frontend/src/pages/groups/GroupSettingsPage.tsx
+++ b/frontend/src/pages/groups/GroupSettingsPage.tsx
@@ -4,7 +4,6 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useTranslation } from "react-i18next"
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom"
 import {
-  ArrowLeft,
   ArrowRight,
   ArrowRightLeft,
   Bell,
@@ -106,7 +105,6 @@ export function GroupSettingsPage() {
 
 function GroupSettingsBody({ groupId }: { groupId: string }) {
   const { t } = useTranslation()
-  const navigate = useNavigate()
   const { user } = useAuth()
   const groupQuery = useGroup(groupId)
   const membersQuery = useMembers(groupId)
@@ -175,23 +173,6 @@ function GroupSettingsBody({ groupId }: { groupId: string }) {
             </>
           }
           subtitle={t("groups:settings.subtitle")}
-          /*
-            Back returns to the previous location rather than hard-coding
-            /profile or /no-group: this page is reachable from the
-            GroupSelector dropdown, the members page, and onboarding;
-            any single destination would be wrong for some of them.
-          */
-          backLink={
-            <button
-              type="button"
-              onClick={() => navigate(-1)}
-              data-testid="group-settings-back"
-              className="inline-flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <ArrowLeft className="size-4" aria-hidden="true" />
-              {t("common:actions.back")}
-            </button>
-          }
         />
 
         <div className="flex flex-col gap-6 md:flex-row">

--- a/frontend/src/pages/groups/GroupSettingsPage.tsx
+++ b/frontend/src/pages/groups/GroupSettingsPage.tsx
@@ -7,6 +7,7 @@ import {
   ArrowLeft,
   ArrowRight,
   ArrowRightLeft,
+  Bell,
   ChevronRight,
   Database,
   Download,
@@ -66,7 +67,7 @@ import { getServerErrorCode, parseServerError } from "@/lib/server-error"
 import { cn } from "@/lib/utils"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 
-type SectionId = "info" | "members" | "data" | "management"
+type SectionId = "info" | "members" | "notifications" | "data" | "management"
 
 interface SectionMeta {
   id: SectionId
@@ -76,6 +77,7 @@ interface SectionMeta {
 const SECTIONS: SectionMeta[] = [
   { id: "info", icon: Info },
   { id: "members", icon: Users },
+  { id: "notifications", icon: Bell },
   { id: "data", icon: Database },
   { id: "management", icon: ShieldAlert },
 ]
@@ -187,22 +189,17 @@ function GroupSettingsBody({ groupId }: { groupId: string }) {
           }
         />
 
-        {/* Plan & quota card — mock-parity surface fed by GET
-            /g/<slug>/plan (#1389). Sits above the section split so it
-            stays visible regardless of which section the user opens —
-            it's a tenant-wide identity, not section-specific. */}
-        <PlanCard groupSlug={group.slug ?? null} ownerName={ownerName} />
-
-        {/* Per-group notification preferences (#1648). Sits next to the
-            Plan card above the section split because it's another
-            tenant/user-wide identity-shaped surface, not section
-            specific — same reasoning as PlanCard's placement. */}
-        <NotificationsCard groupSlug={group.slug ?? null} />
-
         <div className="flex flex-col gap-6 md:flex-row">
           <GroupSettingsNav active={active} onSelect={setActive} />
           <div className="min-w-0 flex-1">
-            {active === "info" ? <InfoSection groupId={groupId} isAdmin={isAdmin} /> : null}
+            {active === "info" ? (
+              <InfoSection
+                groupId={groupId}
+                groupSlug={group.slug ?? null}
+                isAdmin={isAdmin}
+                ownerName={ownerName}
+              />
+            ) : null}
             {active === "members" ? (
               <MembersSection
                 groupId={groupId}
@@ -210,6 +207,9 @@ function GroupSettingsBody({ groupId }: { groupId: string }) {
                 isLastOwner={isLastOwner}
                 membersLoading={membersQuery.isLoading}
               />
+            ) : null}
+            {active === "notifications" ? (
+              <NotificationsSection groupSlug={group.slug ?? null} />
             ) : null}
             {active === "data" ? <DataSection groupSlug={group.slug ?? null} /> : null}
             {active === "management" ? (
@@ -266,11 +266,25 @@ function SectionTitle({ children }: { children: ReactNode }) {
 }
 
 // InfoSection — identity (name, icon, slug, currency) + currency
-// migration controls. Admin-only; non-admins see a read-only summary.
+// migration controls. Admin-only edit form; non-admins see a read-only
+// notice. The Plan & quota card (#1389) lives here too — moved out of the
+// per-page header (#1887) so it no longer renders on every settings
+// sub-page. PlanCard is read-only identity, so it renders for non-admins
+// as well.
 // TODO(#1647): description field (Textarea) once BE lands `description` on
 // LocationGroup. Belongs below the icon picker (mock parity with Location +
 // Area description fields).
-function InfoSection({ groupId, isAdmin }: { groupId: string; isAdmin: boolean }) {
+function InfoSection({
+  groupId,
+  groupSlug,
+  isAdmin,
+  ownerName,
+}: {
+  groupId: string
+  groupSlug: string | null
+  isAdmin: boolean
+  ownerName: string | null
+}) {
   const { t } = useTranslation()
   const groupQuery = useGroup(groupId)
   const updateMutation = useUpdateGroup()
@@ -289,9 +303,8 @@ function InfoSection({ groupId, isAdmin }: { groupId: string; isAdmin: boolean }
   // settings has no :groupSlug URL param, so the http rewrite slot is
   // empty here — the API takes the slug explicitly and builds
   // /g/${slug}/currency-migrations itself.
-  const groupSlug = groupQuery.data?.slug ?? ""
-  const migrationsQuery = useCurrencyMigrations(groupSlug, {
-    enabled: !!groupQuery.data && currencyMigrationEnabled,
+  const migrationsQuery = useCurrencyMigrations(groupSlug ?? "", {
+    enabled: !!groupQuery.data && currencyMigrationEnabled && !!groupSlug,
   })
   const migrations = migrationsQuery.data?.migrations ?? []
   const migrationInFlightId = groupQuery.data?.currency_migration_id
@@ -351,6 +364,9 @@ function InfoSection({ groupId, isAdmin }: { groupId: string; isAdmin: boolean }
     return (
       <div className="space-y-6" data-testid="group-section-info">
         <SectionTitle>{t("groups:settings.sections.info")}</SectionTitle>
+        {/* Plan & quota lives in Info (#1887). It's read-only identity,
+            not an admin-gated action, so non-admins see it too. */}
+        <PlanCard groupSlug={groupSlug} ownerName={ownerName} />
         <div className="rounded-xl border border-border bg-muted/30 p-5 text-sm text-muted-foreground">
           {t("members:adminOnlyHelp")}
         </div>
@@ -361,6 +377,10 @@ function InfoSection({ groupId, isAdmin }: { groupId: string; isAdmin: boolean }
   return (
     <div className="space-y-6" data-testid="group-section-info">
       <SectionTitle>{t("groups:settings.sections.info")}</SectionTitle>
+
+      {/* Plan & quota (#1389). Lives at the top of Info (#1887) so it
+          no longer renders on every settings sub-page. */}
+      <PlanCard groupSlug={groupSlug} ownerName={ownerName} />
 
       <form
         className="space-y-4 rounded-xl border border-border bg-card p-5"
@@ -633,6 +653,19 @@ function MembersSection({
           {t("groups:settings.leaveCta")}
         </Button>
       </div>
+    </div>
+  )
+}
+
+// NotificationsSection — per-group notification preferences (#1648),
+// pulled out of the per-page header (#1887) so users only see the
+// toggles when they navigate here. The card already carries its own
+// title + subtitle, so we drop the SectionTitle to avoid double
+// headings.
+function NotificationsSection({ groupSlug }: { groupSlug: string | null }) {
+  return (
+    <div className="space-y-6" data-testid="group-section-notifications">
+      <NotificationsCard groupSlug={groupSlug} />
     </div>
   )
 }

--- a/frontend/src/pages/groups/GroupSettingsPage.tsx
+++ b/frontend/src/pages/groups/GroupSettingsPage.tsx
@@ -82,13 +82,18 @@ const SECTIONS: SectionMeta[] = [
   { id: "management", icon: ShieldAlert },
 ]
 
-// /groups/:groupId/settings — group admin panel split across four
+// /groups/:groupId/settings — group admin panel split across five
 // sub-sections behind a left rail (mirrors the user Preferences pattern
 // at /settings):
-//   - Info        identity (name, icon, slug, currency + migrate)
-//   - Members     members link + leave-group panel
-//   - Data        per-group storage usage + exports shortcut
-//   - Management  destructive actions (delete group)
+//   - Info           identity (name, icon, slug, currency + migrate)
+//                    + Plan & quota card (#1887: moved out of the
+//                    page header so it no longer renders everywhere)
+//   - Members        members link + leave-group panel
+//   - Notifications  per-group notification preference toggles
+//                    (#1887: pulled out of the page header into its
+//                    own sub-section)
+//   - Data           per-group storage usage + exports shortcut
+//   - Management     destructive actions (delete group)
 //
 // Group `id` (UUID) is the path key here, not the slug — slugs are
 // random and not in URLs that admin tools reach for. Sub-pages that

--- a/frontend/src/pages/groups/__tests__/GroupSettingsPage.test.tsx
+++ b/frontend/src/pages/groups/__tests__/GroupSettingsPage.test.tsx
@@ -89,10 +89,11 @@ const baseHandlers = [
       },
     })
   ),
-  // The PlanCard mounts unconditionally on top of the page (#1389); stub
-  // it once at the base level so every test that renders GroupSettings
-  // can resolve the plan query cleanly. Per-test overrides (e.g. an
-  // error response) can call `server.use(...)` to replace this handler.
+  // The PlanCard mounts on the Info sub-section (#1887; was page-wide
+  // before). Stub the plan endpoint at the base level so every test
+  // that opens Info — which is the default sub-section — can resolve
+  // the plan query cleanly. Per-test overrides (e.g. an error response)
+  // call `server.use(...)` to replace this handler.
   msw.get(api("/g/household/plan"), () =>
     HttpResponse.json({
       plan: {
@@ -107,10 +108,11 @@ const baseHandlers = [
       usage: { items: 7, locations: 2, storage_bytes: 12_582_912 },
     })
   ),
-  // NotificationsCard also mounts unconditionally (#1648). Default
-  // both toggles on so the existing tests don't fail on an empty
-  // response shape; per-test overrides can replace with the values
-  // they need.
+  // NotificationsCard now lives in its own Notifications sub-section
+  // (#1887). The stub is kept at the base level so tests that navigate
+  // there don't need to redeclare it; the query only fires after the
+  // user clicks the nav, so this is dead weight in tests that stay on
+  // Info — fine to keep for consistency. Per-test overrides can replace.
   msw.get(api("/g/household/notifications"), () =>
     HttpResponse.json({ warranty_expiring_alerts: true, weekly_digest: false })
   ),
@@ -371,7 +373,12 @@ describe("<GroupSettingsPage />", () => {
       ...baseHandlers,
       adminMembership
     )
+    const user = userEvent.setup()
     renderSettings()
+    // Notifications moved into its own sub-section (#1887); we have to
+    // navigate there before the card mounts.
+    await waitFor(() => expect(screen.getByTestId("group-settings-page")).toBeInTheDocument())
+    await user.click(screen.getByTestId("group-settings-nav-notifications"))
     expect(await screen.findByTestId("notifications-card")).toBeInTheDocument()
     expect(screen.getByTestId("notifications-toggle-warranty")).toHaveAttribute(
       "aria-checked",
@@ -398,6 +405,8 @@ describe("<GroupSettingsPage />", () => {
     )
     const user = userEvent.setup()
     renderSettings()
+    await waitFor(() => expect(screen.getByTestId("group-settings-page")).toBeInTheDocument())
+    await user.click(screen.getByTestId("group-settings-nav-notifications"))
     const warranty = await screen.findByTestId("notifications-toggle-warranty")
     // baseHandlers default → warranty=on; flipping should send false.
     await user.click(warranty)
@@ -413,10 +422,39 @@ describe("<GroupSettingsPage />", () => {
       ...baseHandlers,
       adminMembership
     )
+    const user = userEvent.setup()
     renderSettings()
+    await waitFor(() => expect(screen.getByTestId("group-settings-page")).toBeInTheDocument())
+    await user.click(screen.getByTestId("group-settings-nav-notifications"))
     expect(await screen.findByTestId("notifications-card-error")).toBeInTheDocument()
     expect(screen.queryByTestId("notifications-card-skeleton")).not.toBeInTheDocument()
     expect(screen.queryByTestId("notifications-card")).not.toBeInTheDocument()
+  })
+
+  // #1887 — the Plan & quota card and Notifications card used to render
+  // on every settings sub-page header. They now live only in their
+  // respective sub-sections (Info / Notifications), so navigating to
+  // another sub-section must not surface either of them. The Members
+  // pane is a representative sibling — if it stays clean, the others
+  // will too.
+  it("scopes Plan and Notifications to their own sub-sections (#1887)", async () => {
+    server.use(...baseHandlers, adminMembership)
+    const user = userEvent.setup()
+    renderSettings()
+    // Info is the default → Plan card mounts; Notifications does not.
+    expect(await screen.findByTestId("plan-card")).toBeInTheDocument()
+    expect(screen.queryByTestId("notifications-card")).not.toBeInTheDocument()
+
+    // Members pane → neither card should be present.
+    await user.click(screen.getByTestId("group-settings-nav-members"))
+    await screen.findByTestId("group-section-members")
+    expect(screen.queryByTestId("plan-card")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("notifications-card")).not.toBeInTheDocument()
+
+    // Notifications pane → Notifications mounts; Plan does not.
+    await user.click(screen.getByTestId("group-settings-nav-notifications"))
+    expect(await screen.findByTestId("notifications-card")).toBeInTheDocument()
+    expect(screen.queryByTestId("plan-card")).not.toBeInTheDocument()
   })
 
   // #1616 — the Migrate Currency CTA must be hidden when the backend


### PR DESCRIPTION
Closes #1897.

## Summary

Group settings used to render both the Plan / quota card and the Notifications panel in the page header — above the sub-section switcher — so every sub-page (Members, Data, Management) carried two unrelated panels above its own content. This PR pulls each into the sub-section it belongs in.

- **Plan & quota** → top of the **Info** sub-section. It's identity-shaped (owner, plan, usage), not action-shaped, so it renders for non-admins too. Existing PlanCard component is unchanged.
- **Notifications** → its own new **Notifications** sub-section, sibling of Info / Members / Data / Management. A new `Bell`-iconed sidebar entry mounts the existing `NotificationsCard` lazily (the GET only fires when the user navigates there).

Members / Data / Management sub-pages now render with just their own header → content. No backend changes; per-group notification override semantics (`/g/<slug>/notifications` PATCH) are untouched.

### Drive-by during review

- **Heading hierarchy fix** (per Copilot review): `PlanCard` now renders an `h3` instead of an `h2`. The enclosing Info section's `SectionTitle` is the only `h2`, so the card's title is one level deeper. `NotificationsCard` keeps its `h2` because its sub-section has no `SectionTitle` — the card's title doubles as the section heading.
- **Back link removed from the GroupSettings header** (per direct review feedback). This page is reachable from the sidebar (always visible) and the GroupSelector dropdown; the explicit "← Back" button in the PageHeader was redundant. Dropped the now-unused `ArrowLeft` import and the top-level `useNavigate()` reference. No e2e selectors referenced `group-settings-back`.

## Files

- `frontend/src/pages/groups/GroupSettingsPage.tsx` — drop the always-on `PlanCard` + `NotificationsCard` from above the section split; add `notifications` to `SectionId` / `SECTIONS`; thread `groupSlug` + `ownerName` into `InfoSection`; add a small `NotificationsSection` wrapper; drop the PageHeader back link.
- `frontend/src/components/groups/PlanCard.tsx` — title element `h2` → `h3` (visual styling unchanged).
- `frontend/src/i18n/locales/en/groups.json` — add `settings.sections.notifications: "Notifications"` (i18n:check ✓).
- `frontend/src/pages/groups/__tests__/GroupSettingsPage.test.tsx` — notification-card assertions now navigate to the Notifications tab first; new regression test (`scopes Plan and Notifications to their own sub-sections (#1887)`) asserts that neither card surfaces on Members and that Plan stays out of Notifications.

## Acceptance check

- [x] Sub-pages no longer carry the plan/quota card at the top — only Info does.
- [x] Sub-pages no longer carry the Notifications panel at the bottom — only the new Notifications sub-page does.
- [x] Sidebar / tab navigation surfaces both Info and Notifications as distinct sub-sections.
- [x] Each remaining sub-page renders with just its own header → content.
- [x] No regressions to per-group notification override semantics.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run i18n:check`
- [x] `npx vitest run` — 155 files / 1155 tests pass
- [x] Full CI green on `56731881` (Docker image, Kind Smoke, E2E all passing after a transient GHCR 502 on the previous SHA).
- [ ] Visual spot-check on PR preview deploy: open Info → see Plan + form; open Notifications → see toggles; open Members / Data / Management → no Plan, no Notifications, no back link.