### PR TITLE
[#1888] Personal Preferences lands on Account, not Appearance

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -267,6 +267,15 @@ _None yet._
 
 ### Settings & Preferences
 
+#### 2026-05-26 — Personal Preferences lands on Account, not Appearance
+
+- **Issue/PR**: #1888 / PR (pending)
+- **Mock**: [`design-mocks/src/views/SettingsView.tsx`](../../design-mocks/src/views/SettingsView.tsx) L41 initialises `useState<SettingsSection>("appearance")` — opening the Preferences view lands on the Appearance tab.
+- **Reality**: `frontend/src/pages/SettingsPage.tsx` initialises `useState<SectionId>("account")` so `/settings` lands on Account. All other sub-tabs (Appearance, Notifications, Privacy, Help) remain siblings reachable via the nav rail.
+- **Why**: User-driven UX correction. Appearance is a low-traffic settings area (theme / density / locale). The high-traffic surfaces under Preferences — email, password, MFA, default group, profile — all live in Account, which is what most users open Preferences to find or change.
+- **Approved by**: user (explicit) — issue #1888 ("Personal Preferences: default landing tab should be Account, not Appearance").
+- **Reversion plan**: Permanent unless the upstream mock flips its own default. The change is a single-line `useState` initialiser — trivial to reconcile if the mock catches up.
+
 #### 2026-05-08 — "Migrate currency…" CTA + 4-step wizard dialog
 
 - **Issue/PR**: #1553 / PR #1604

--- a/e2e/tests/settings-default-group.spec.ts
+++ b/e2e/tests/settings-default-group.spec.ts
@@ -39,9 +39,8 @@ test.describe('Settings — default group (#1592)', () => {
   test('zero-group user sees the create-first-group call-to-action', async ({ page }) => {
     await loginAsOrphan(page);
     await page.goto('/settings');
-    // The settings page renders the Appearance section by default; flip to
-    // Account so the default-group surface is mounted.
-    await page.locator('[data-testid="settings-nav-account"]').click();
+    // Account is the default landing tab (#1888), so the default-group
+    // surface mounts without a nav click.
 
     const cta = page.locator('[data-testid="settings-no-groups-cta"]');
     await expect(cta).toBeVisible({ timeout: 10000 });
@@ -64,7 +63,8 @@ test.describe('Settings — default group (#1592)', () => {
 authTest.describe('Settings — default group, authenticated user (#1592)', () => {
   authTest('admin sees the default-group selector populated with their memberships', async ({ page }) => {
     await page.goto('/settings');
-    await page.locator('[data-testid="settings-nav-account"]').click();
+    // Account is the default landing tab (#1888), so the default-group
+    // selector mounts without a nav click.
 
     const select = page.locator('[data-testid="settings-default-group-select"]');
     await expect(select).toBeVisible({ timeout: 10000 });

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -90,7 +90,10 @@ const SECTIONS: SectionMeta[] = [
 // (e.g. whether to send a warranty reminder email) round-trip.
 export function SettingsPage() {
   const { t } = useTranslation()
-  const [active, setActive] = useState<SectionId>("appearance")
+  // #1888 — landing tab is Account, not Appearance: most users open
+  // Preferences for email/password/MFA/profile (Account), not for theme
+  // and density (Appearance). Appearance remains a sibling tab.
+  const [active, setActive] = useState<SectionId>("account")
 
   return (
     <>

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -128,9 +128,20 @@ describe("<SettingsPage />", () => {
     expect(screen.queryByTestId("settings-nav-data")).not.toBeInTheDocument()
   })
 
-  it("appearance section is the default and shows theme/density/locale controls", async () => {
+  // #1888 — Account is the landing tab (was Appearance). Most users open
+  // Preferences for email/password/MFA/profile, not theme/density.
+  it("account section is the default landing (#1888)", async () => {
     server.use(...baseHandlers)
     renderSettings()
+    expect(await screen.findByTestId("section-account")).toBeInTheDocument()
+    expect(screen.queryByTestId("section-appearance")).not.toBeInTheDocument()
+  })
+
+  it("appearance section shows theme/density/locale controls", async () => {
+    server.use(...baseHandlers)
+    const user = userEvent.setup()
+    renderSettings()
+    await user.click(await screen.findByTestId("settings-nav-appearance"))
     expect(await screen.findByTestId("section-appearance")).toBeInTheDocument()
     expect(screen.getByTestId("theme-system")).toBeInTheDocument()
     expect(screen.getByTestId("theme-light")).toBeInTheDocument()
@@ -143,6 +154,7 @@ describe("<SettingsPage />", () => {
     server.use(...baseHandlers)
     const user = userEvent.setup()
     renderSettings()
+    await user.click(await screen.findByTestId("settings-nav-appearance"))
     await user.click(await screen.findByTestId("theme-dark"))
     await waitFor(() => expect(localStorage.getItem("theme-test-1414")).toBe("dark"))
   })
@@ -151,6 +163,7 @@ describe("<SettingsPage />", () => {
     server.use(...baseHandlers)
     const user = userEvent.setup()
     renderSettings()
+    await user.click(await screen.findByTestId("settings-nav-appearance"))
     const select = await screen.findByTestId("density-select")
     await user.selectOptions(select, "compact")
     await waitFor(() => expect(localStorage.getItem("density-test-1414")).toBe("compact"))
@@ -218,14 +231,18 @@ describe("<SettingsPage />", () => {
 
   it("has no axe violations on the appearance section", async () => {
     server.use(...baseHandlers)
+    const user = userEvent.setup()
     const { container } = renderSettings()
+    await user.click(await screen.findByTestId("settings-nav-appearance"))
     await waitFor(() => expect(screen.getByTestId("section-appearance")).toBeInTheDocument())
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it("appearance section adds Default view + preferred currency rows", async () => {
     server.use(...baseHandlers)
+    const user = userEvent.setup()
     renderSettings()
+    await user.click(await screen.findByTestId("settings-nav-appearance"))
     expect(await screen.findByTestId("section-appearance")).toBeInTheDocument()
     expect(screen.getByTestId("default-view-select")).toBeInTheDocument()
     expect(screen.getByTestId("preferred-currency-row")).toBeInTheDocument()
@@ -236,7 +253,9 @@ describe("<SettingsPage />", () => {
   // and follows the same autosave path (PATCH /settings/{field}).
   it("appearance section adds a Region & formatting dropdown (#1683)", async () => {
     server.use(...withGroupHandlers({}))
+    const user = userEvent.setup()
     renderSettings("/settings?g=household")
+    await user.click(await screen.findByTestId("settings-nav-appearance"))
     expect(await screen.findByTestId("section-appearance")).toBeInTheDocument()
     const select = await screen.findByTestId("number-format-locale-select")
     expect(select).toBeInTheDocument()
@@ -257,8 +276,10 @@ describe("<SettingsPage />", () => {
         return HttpResponse.json({ appearanceNumberFormatLocale: body })
       })
     )
+    const user = userEvent.setup()
     renderSettings("/settings?g=household")
     await screen.findByTestId("settings-page")
+    await user.click(await screen.findByTestId("settings-nav-appearance"))
     const select = (await screen.findByTestId("number-format-locale-select", undefined, {
       timeout: 4000,
     })) as HTMLSelectElement


### PR DESCRIPTION
Closes #1888.

## Summary

Personal Preferences (`/settings`) used to open on the **Appearance** sub-tab — a low-traffic surface (theme / density / locale / number format). Most users come to Preferences to find or change something in the **Account** surface (email, password, MFA, default group, profile). Flip the landing tab to Account; Appearance stays a sibling, reachable from the nav rail.

## What changed

- **`frontend/src/pages/SettingsPage.tsx`** — `useState<SectionId>("appearance")` → `useState<SectionId>("account")` (one line + a comment explaining the rationale).
- **`frontend/src/pages/__tests__/SettingsPage.test.tsx`** — the `"appearance section is the default"` test becomes `"account section is the default landing (#1888)"`, asserting `section-account` is visible and `section-appearance` is not. Four other appearance tests (theme card, density select, default-view / preferred-currency, region-and-formatting + its PATCH probe) now click `settings-nav-appearance` first since it is no longer the landing surface. All 16 cases pass.
- **`e2e/tests/settings-default-group.spec.ts`** — two cases (orphan + admin) drop their now-redundant `settings-nav-account` clicks; comments updated to point at #1888 as the source of the new default.
- **`devdocs/frontend/design-deviations.md`** — logged under **Settings & Preferences** as an intentional deviation from the upstream mock, which still ships `useState<SettingsSection>("appearance")` in `SettingsView.tsx`.

## Notes for reviewers

- The issue body speculated that Preferences uses nested-router child routes / `<Navigate replace>` and worried about deep-link preservation. In reality the section is plain React `useState` — no URL-based sub-tab routing exists, so there is no deep-link surface to preserve. Manual nav-button clicks still take the user to any sibling section as before.
- The Account section's danger-zone test (`account danger zone's delete button opens a confirm dialog...`) keeps its explicit `settings-nav-account` click for defensive intentional-navigation, even though that click is now a no-op (Account is already active). The test exercises the dialog, not the navigation.

## Test plan

- [x] `npx vitest run src/pages/__tests__/SettingsPage.test.tsx` — 16/16 passing
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [ ] CI e2e: `settings-default-group.spec.ts` should still pass with the nav-click removed (the surface mounts on landing now).
- [ ] Manual: open `/settings` → land on Account (avatar card, default-group selector, change-password row, danger-zone visible by default).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Settings**
  * The Settings page now defaults to the Account tab when first opened, instead of Appearance. All preference tabs remain accessible via navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->