### PR TITLE
[#1892] expose ArgoCD UI + vcluster API as tailnet services

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -17,7 +17,8 @@ For the credentials walkthrough alone see [`SECRETS.md`](./SECRETS.md).
 > [#1855](https://github.com/denisvmedia/inventario/issues/1855),
 > [#1856](https://github.com/denisvmedia/inventario/issues/1856),
 > [#1858](https://github.com/denisvmedia/inventario/issues/1858),
-> [#1863](https://github.com/denisvmedia/inventario/issues/1863).
+> [#1863](https://github.com/denisvmedia/inventario/issues/1863),
+> [#1892](https://github.com/denisvmedia/inventario/issues/1892).
 
 ---
 
@@ -98,7 +99,7 @@ You need these tools on your laptop:
 | `sops` | Decrypts the secrets bundle locally. |
 | `age` | Asymmetric crypto sops uses for our recipients. |
 | `make` | Orchestrator entry point. |
-| `kubectl` | Optional — bootstrap installs it on the VM, but you'll want it locally to inspect Applications + port-forward ArgoCD. |
+| `kubectl` | Optional — bootstrap installs it on the VM, but you'll want it locally to inspect Applications. |
 | `helm` | Optional — same. |
 | `tailscale` | The tailnet client. You need to be a member of the same tailnet the VM joins, or you can't reach the previews. |
 
@@ -335,10 +336,15 @@ Expected timing on a fresh VM: 3-5 minutes. The script:
 6. Installs the Tailscale Kubernetes Operator via helm (OAuth from sops bundle).
 7. Installs ArgoCD via helm.
 8. Materializes Kubernetes Secrets from the sops bundle.
-9. Applies the `ts-orphan-cleanup` CronJob to the `tailscale` namespace.
+9. Applies the cluster-extras manifests (`ts-orphan-cleanup` CronJob, plus
+   the tailnet Ingress that exposes the ArgoCD UI at
+   `argocd-inv-vcl01.<tailnet>.ts.net`).
 10. Applies the ArgoCD `AppProject`, `Application` (master), and
     `ApplicationSet` (PR previews).
-11. Copies the kubeconfig back to `~/.kube/inv-vcl01.config` on your laptop.
+11. Copies the kubeconfig back to `~/.kube/inv-vcl01.config` on your laptop,
+    with the server set to the stable tailnet FQDN
+    (`inv-vcl01.<tailnet>.ts.net:8443`) so the kubeconfig survives VM
+    redeploys without an IP rewrite.
 
 The script is **idempotent** — re-running it is the upgrade path. The
 `make upgrade` and `make recover` targets are aliases for `make bootstrap`.
@@ -369,9 +375,9 @@ KUBECONFIG=~/.kube/inv-vcl01.config kubectl -n argocd get application inv-vcl01-
 #         sha-master image build to finish on GHCR)
 
 # 6. The ArgoCD UI loads.
-KUBECONFIG=~/.kube/inv-vcl01.config kubectl -n argocd port-forward svc/argocd-server 8080:80 &
-open http://localhost:8080         # macOS; on Linux: xdg-open
-# Admin password:
+#    Open https://argocd-inv-vcl01.<your-tailnet-name>.ts.net/ from any
+#    tailnet member with the right ACL — no port-forward, no kubeconfig.
+#    Admin password (initial bootstrap):
 KUBECONFIG=~/.kube/inv-vcl01.config kubectl -n argocd get secret argocd-initial-admin-secret \
   -o jsonpath='{.data.password}' | base64 -d
 ```
@@ -421,21 +427,25 @@ about an hour OR delete the device manually in the
 
 ### Inspect a running preview
 
-There is no direct ArgoCD-UI exposure on the tailnet today (planned in
-[#1892](https://github.com/denisvmedia/inventario/issues/1892)). Until then,
-port-forward from your laptop:
+The ArgoCD UI is exposed as a tailnet service (#1892). Any tailnet member
+with the right ACL can open it directly — no `kubectl port-forward`, no
+kubeconfig, no `localhost:8080` URL:
+
+```
+https://argocd-inv-vcl01.<your-tailnet-name>.ts.net/
+```
+
+Login is `admin` + the initial bootstrap password (read once via
+`kubectl`, then rotate per [section 5 "ArgoCD UI returns 401 after
+rotating the admin secret"](#argocd-ui-returns-401-after-rotating-the-admin-secret)):
 
 ```bash
-KUBECONFIG=~/.kube/inv-vcl01.config kubectl -n argocd \
-  port-forward svc/argocd-server 8080:80
-# open http://localhost:8080
-
-# Admin password (only needed first time; you can rotate after):
 KUBECONFIG=~/.kube/inv-vcl01.config kubectl -n argocd \
   get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d
 ```
 
-For raw kubectl access:
+For raw kubectl access (the kubeconfig server is the stable tailnet FQDN —
+`inv-vcl01.<tailnet>.ts.net:8443` — so it keeps working after a VM redeploy):
 
 ```bash
 KUBECONFIG=~/.kube/inv-vcl01.config kubectl -n inv-vcl01-pr<N> get pods
@@ -664,6 +674,31 @@ KUBECONFIG=~/.kube/inv-vcl01.config kubectl -n tailscale \
 Manual cleanup via the [admin Machines view](https://login.tailscale.com/admin/machines)
 is always an option — filter by `tag:k8s`, remove offline rows.
 
+### kubectl fails with "certificate is valid for 127.0.0.1, ..., not <FQDN>"
+
+You're on a cluster bootstrapped before #1892 landed. The vcluster apiserver
+TLS cert was generated WITHOUT the tailnet FQDN in its SAN list, but the
+new bootstrap.sh writes a kubeconfig that points at the FQDN. The
+post-#1892 `/etc/vcluster/vcluster.yaml` carries the correct
+`controlPlane.proxy.extraSANs`, but vcluster only consults it during
+initial cert generation — restarting the service against an existing
+PKI dir won't pick up the new SAN.
+
+Fastest fix: redo the bootstrap from scratch (loses any in-cluster state
+that isn't ArgoCD-managed, which for a Phase 1 preview-env is normally
+nothing important — per-PR namespaces re-sync from the ApplicationSet in
+~5 min):
+
+```bash
+make -C infra destroy VM=user@host
+make -C infra bootstrap VM=user@host
+```
+
+Surgical alternative: stop vcluster, delete the apiserver cert + key files
+under `/var/lib/vcluster/pki/`, restart vcluster. The exact filenames vary
+across vcluster patch versions, so the `make destroy` + `make bootstrap`
+path is generally less error-prone.
+
 ### bootstrap fails on `apt-get update` with "Release file ... is not valid yet"
 
 VM clock skew. The bootstrap NTP resync didn't converge in 30 s — check VM
@@ -771,11 +806,6 @@ issue:
   quotas per preview namespace.** Today each preview can consume up to the
   VM's total budget; under load this would degrade other previews. Quotas
   cap per-PR CPU/memory/storage.
-- **[#1892](https://github.com/denisvmedia/inventario/issues/1892) Expose
-  ArgoCD UI + vcluster API as Tailscale services.** Today both reach via
-  `kubectl port-forward` from a laptop with the kubeconfig; the issue
-  surfaces them as proper tailnet hostnames (`argocd-inv-vcl01.<tailnet>.ts.net`,
-  `k8s-inv-vcl01.<tailnet>.ts.net`) so any tailnet member can bookmark.
 
 Other open follow-ups touch the chart or workflow rather than the runtime:
 [#1882](https://github.com/denisvmedia/inventario/issues/1882) (TLS
@@ -807,6 +837,7 @@ infra/
     ├── destroy.sh            remote teardown (vcluster + data; tailnet preserved)
     ├── helm-values/          static chart overlays vm-install.sh layers OAuth on top of
     ├── cluster-extras/
+    │   ├── argocd-ts-ingress.yaml  tailnet Ingress for the ArgoCD UI (#1892)
     │   └── ts-orphan-cleanup.yaml  hourly TS device GC CronJob
     ├── scripts/
     │   └── apply-secrets.sh  translate sops bundle into k8s Secrets

--- a/infra/vm/bootstrap.sh
+++ b/infra/vm/bootstrap.sh
@@ -73,25 +73,51 @@ if [ -n "$SECRETS_JSON" ]; then
     fi
 fi
 
-# --- Apply cluster-extras manifests (#1858 — hourly TS device cleanup) ---
+# --- Resolve tailnet name from the sops bundle (shared by cluster-extras + ArgoCD) ---
+# `<TAILNET>` in committed manifests is substituted to the tailnet MagicDNS
+# suffix at apply time. Read once so both cluster-extras (TS Ingress for the
+# ArgoCD UI from #1892) and the ArgoCD manifests (per-PR Ingress hosts) see
+# the same value. Empty string is treated as "missing" downstream.
+TAILNET_NAME=""
+if [ -n "$SECRETS_JSON" ]; then
+    TAILNET_NAME=$(jq -r '.tailscale.tailnet_name // ""' <<<"$SECRETS_JSON")
+fi
+
+# --- Apply cluster-extras manifests (#1858 — hourly TS device cleanup; #1892 — ArgoCD TS Ingress) ---
 # In-cluster resources that aren't ArgoCD-managed but need to live in the
-# cluster for the long term. Currently: a CronJob in the `tailscale`
-# namespace that reuses the operator's OAuth credentials (`operator-oauth`
-# Secret applied above) to delete stale Tailscale device records for
-# closed PR previews. See the header comment in
-# infra/vm/cluster-extras/ts-orphan-cleanup.yaml for the full rationale.
+# cluster for the long term:
+#   - CronJob in the `tailscale` namespace reusing the operator's OAuth
+#     credentials to delete stale Tailscale device records (#1858);
+#   - Tailscale Ingress in the `argocd` namespace exposing the ArgoCD UI
+#     directly to the tailnet (#1892).
+# See the per-file header comments under infra/vm/cluster-extras/ for the
+# full rationale.
 #
 # Gated on the `tailscale` namespace existing: vm-install.sh creates it
 # only when tailscale.oauth_client_{id,secret} are present in the sops
 # bundle, so a bootstrap-without-secrets path leaves the namespace
-# absent and `kubectl apply` of a CronJob into it would hard-fail under
-# `set -e`. Skip with a warning in that case — preserves the
+# absent — without the TS Operator, neither cluster-extras manifest does
+# anything useful (the Ingress would Pending forever; the CronJob would
+# 401). Skip with a warning in that case — preserves the
 # "bootstrap can still run without secrets" property.
+#
+# `<TAILNET>` substitution mirrors the ArgoCD apply block below: pure-bash
+# literal substitution (no sed) so a tailnet name containing `&` or `\`
+# cannot corrupt the manifest. Existing cluster-extras files without the
+# placeholder are passed through unchanged by the same operator.
 if [ -d "$CLUSTER_EXTRAS_DIR" ] && compgen -G "$CLUSTER_EXTRAS_DIR/*.yaml" >/dev/null; then
     if ssh "$VM" 'sudo /usr/local/bin/kubectl get namespace tailscale' >/dev/null 2>&1; then
-        note "Applying cluster-extras manifests from $CLUSTER_EXTRAS_DIR"
+        ce_tailnet="$TAILNET_NAME"
+        if [ -z "$ce_tailnet" ]; then
+            warn "$CLUSTER_EXTRAS_DIR present but tailscale.tailnet_name missing from sops bundle."
+            warn "Applying with literal <TAILNET> placeholder — TS Ingress will route to broken hosts."
+            ce_tailnet="<TAILNET>"
+        fi
+        note "Applying cluster-extras manifests from $CLUSTER_EXTRAS_DIR (tailnet: $ce_tailnet)"
         for m in "$CLUSTER_EXTRAS_DIR"/*.yaml; do
-            ssh "$VM" 'sudo /usr/local/bin/kubectl apply -f -' < "$m"
+            content=$(cat "$m")
+            printf '%s' "${content//<TAILNET>/$ce_tailnet}" | \
+                ssh "$VM" 'sudo /usr/local/bin/kubectl apply -f -'
         done
     else
         warn "$CLUSTER_EXTRAS_DIR present but namespace 'tailscale' missing (TS Operator was skipped)."
@@ -100,14 +126,7 @@ if [ -d "$CLUSTER_EXTRAS_DIR" ] && compgen -G "$CLUSTER_EXTRAS_DIR/*.yaml" >/dev
 fi
 
 # --- Apply ArgoCD manifests (AppProject, ApplicationSet, master Application) (#1858) ---
-# `<TAILNET>` in the manifests is substituted to the tailnet MagicDNS suffix
-# from the sops bundle so the rendered Ingress hosts end up at the
-# tailnet-correct FQDN.
 if [ -d "$ARGOCD_DIR" ] && compgen -G "$ARGOCD_DIR/*.yaml" >/dev/null; then
-    TAILNET_NAME=""
-    if [ -n "$SECRETS_JSON" ]; then
-        TAILNET_NAME=$(jq -r '.tailscale.tailnet_name // ""' <<<"$SECRETS_JSON")
-    fi
     if [ -z "$TAILNET_NAME" ]; then
         warn "$ARGOCD_DIR present but tailscale.tailnet_name missing from sops bundle."
         warn "Applying with literal <TAILNET> placeholder — Applications will Ingress to broken hosts."
@@ -147,32 +166,55 @@ else
     warn "ArgoCD is installed but no AppProject/ApplicationSet/Application is registered."
 fi
 
-# --- Copy kubeconfig back, rewrite server to tailnet IP ---
+# --- Copy kubeconfig back, rewrite server to tailnet FQDN (#1892) ---
+# Prefer the stable tailnet FQDN (`<host>.<tailnet>.ts.net`) over the host's
+# current tailnet IP: the FQDN survives VM redeploys (Tailscale preserves
+# the hostname via the reusable auth-key in the sops bundle), so the
+# kubeconfig keeps working without re-bootstrap. The FQDN path requires the
+# vcluster apiserver cert to include the FQDN in its SAN list — added via
+# `controlPlane.proxy.extraSANs` in /etc/vcluster/vcluster.yaml by
+# vm-install.sh. Without the SAN we fall back to the legacy IP-rewrite +
+# `tls-server-name: 127.0.0.1` override so the existing path still works
+# until cert regen (manual `make destroy` + `make bootstrap`).
 LAPTOP_KUBECONFIG="$HOME/.kube/inv-vcl01.config"
 note "Copying kubeconfig to $LAPTOP_KUBECONFIG"
 mkdir -p "$HOME/.kube"
 ssh "$VM" 'sudo cat /var/lib/vcluster/kubeconfig.yaml' >"$LAPTOP_KUBECONFIG"
 chmod 600 "$LAPTOP_KUBECONFIG"
 
+# Pull the actual TS hostname from the live tailscaled (not the default in
+# vm-install.sh) so the kubeconfig reflects whatever the VM is currently
+# registered as. `tailscale status --json` is stable across CLI versions.
+TS_HOSTNAME_REMOTE=$(ssh "$VM" 'tailscale status --self=true --peers=false --json 2>/dev/null \
+    | jq -r ".Self.HostName // \"\""' || true)
 TS_IP=$(ssh "$VM" 'tailscale ip -4 2>/dev/null | head -1' || true)
-if [ -n "$TS_IP" ]; then
+
+if [ -n "$TS_HOSTNAME_REMOTE" ] && [ -n "$TAILNET_NAME" ] && [ "$TAILNET_NAME" != "<TAILNET>" ]; then
+    TS_FQDN="${TS_HOSTNAME_REMOTE}.${TAILNET_NAME}.ts.net"
     # macOS sed and GNU sed differ; perl is portable.
+    perl -pi -e "s|https://127\.0\.0\.1:|https://${TS_FQDN}:|g; s|https://localhost:|https://${TS_FQDN}:|g" \
+        "$LAPTOP_KUBECONFIG"
+    # Strip any legacy `tls-server-name: 127.0.0.1` line left by a pre-#1892
+    # bootstrap run. The FQDN-based server matches the cert SAN directly
+    # (assuming extraSANs is in place — vm-install.sh writes it), so no
+    # server-name override is needed.
+    perl -i -ne 'print unless /^\s*tls-server-name:\s*127\.0\.0\.1\s*$/' \
+        "$LAPTOP_KUBECONFIG"
+    note "kubeconfig server rewritten to https://${TS_FQDN}:<port>"
+elif [ -n "$TS_IP" ]; then
+    # Fallback: tailnet_name missing from sops OR hostname unreadable — use
+    # the legacy IP rewrite + tls-server-name override. Same kludge as
+    # pre-#1892 bootstrap.sh; works against any vcluster cert.
+    warn "Falling back to legacy IP-based kubeconfig (no tailnet FQDN available)."
     perl -pi -e "s|https://127\.0\.0\.1:|https://${TS_IP}:|g; s|https://localhost:|https://${TS_IP}:|g" \
         "$LAPTOP_KUBECONFIG"
-
-    # The vcluster kube-apiserver TLS cert is signed for 127.0.0.1, 10.96.0.1,
-    # and the in-cluster API IP — NOT for the tailnet IP. Without tls-server-name,
-    # kubectl from the laptop would fail with "certificate is valid for 127.0.0.1
-    # ..., not <tailnet IP>". Tell kubectl to verify against 127.0.0.1 (a SAN
-    # that IS in the cert) while still dialling the tailnet IP. Idempotent.
     if ! grep -q '^    tls-server-name:' "$LAPTOP_KUBECONFIG"; then
         perl -i -pe '$_ .= "    tls-server-name: 127.0.0.1\n" if /^    server: https:/;' \
             "$LAPTOP_KUBECONFIG"
     fi
-
     note "kubeconfig server rewritten to https://${TS_IP}:<port> (tls-server-name: 127.0.0.1)"
 else
-    warn "Couldn't fetch tailnet IP. kubeconfig still points at 127.0.0.1 —"
+    warn "Couldn't fetch tailnet hostname OR IP. kubeconfig still points at 127.0.0.1 —"
     warn "either ssh-tunnel port 443/6443 or edit the server: field manually."
 fi
 

--- a/infra/vm/bootstrap.sh
+++ b/infra/vm/bootstrap.sh
@@ -103,20 +103,26 @@ fi
 #
 # `<TAILNET>` substitution mirrors the ArgoCD apply block below: pure-bash
 # literal substitution (no sed) so a tailnet name containing `&` or `\`
-# cannot corrupt the manifest. Existing cluster-extras files without the
-# placeholder are passed through unchanged by the same operator.
+# cannot corrupt the manifest. Manifests that contain `<TAILNET>` are
+# SKIPPED (with a warning) when tailnet_name is absent — applying with a
+# literal `<TAILNET>` placeholder produces an invalid DNS host that
+# Kubernetes rejects, aborting bootstrap under `set -e`. Untemplated
+# manifests pass through unchanged regardless of tailnet_name presence,
+# preserving the "bootstrap can still run without secrets" property.
 if [ -d "$CLUSTER_EXTRAS_DIR" ] && compgen -G "$CLUSTER_EXTRAS_DIR/*.yaml" >/dev/null; then
     if ssh "$VM" 'sudo /usr/local/bin/kubectl get namespace tailscale' >/dev/null 2>&1; then
-        ce_tailnet="$TAILNET_NAME"
-        if [ -z "$ce_tailnet" ]; then
+        if [ -z "$TAILNET_NAME" ]; then
             warn "$CLUSTER_EXTRAS_DIR present but tailscale.tailnet_name missing from sops bundle."
-            warn "Applying with literal <TAILNET> placeholder — TS Ingress will route to broken hosts."
-            ce_tailnet="<TAILNET>"
+            warn "Manifests that reference <TAILNET> will be skipped; untemplated manifests still apply."
         fi
-        note "Applying cluster-extras manifests from $CLUSTER_EXTRAS_DIR (tailnet: $ce_tailnet)"
+        note "Applying cluster-extras manifests from $CLUSTER_EXTRAS_DIR (tailnet: ${TAILNET_NAME:-<missing>})"
         for m in "$CLUSTER_EXTRAS_DIR"/*.yaml; do
             content=$(cat "$m")
-            printf '%s' "${content//<TAILNET>/$ce_tailnet}" | \
+            if [[ "$content" == *"<TAILNET>"* ]] && [ -z "$TAILNET_NAME" ]; then
+                warn "  skipping $(basename "$m") — unresolved <TAILNET> placeholder"
+                continue
+            fi
+            printf '%s' "${content//<TAILNET>/$TAILNET_NAME}" | \
                 ssh "$VM" 'sudo /usr/local/bin/kubectl apply -f -'
         done
     else
@@ -129,10 +135,9 @@ fi
 if [ -d "$ARGOCD_DIR" ] && compgen -G "$ARGOCD_DIR/*.yaml" >/dev/null; then
     if [ -z "$TAILNET_NAME" ]; then
         warn "$ARGOCD_DIR present but tailscale.tailnet_name missing from sops bundle."
-        warn "Applying with literal <TAILNET> placeholder — Applications will Ingress to broken hosts."
-        TAILNET_NAME="<TAILNET>"
+        warn "Manifests that reference <TAILNET> will be skipped; untemplated manifests still apply."
     fi
-    note "Applying ArgoCD manifests from $ARGOCD_DIR (tailnet: $TAILNET_NAME)"
+    note "Applying ArgoCD manifests from $ARGOCD_DIR (tailnet: ${TAILNET_NAME:-<missing>})"
     # Three explicit globs in dependency order:
     #   - appproject*.yaml: AppProject must land BEFORE Application/
     #     ApplicationSet that reference it via .spec.project.
@@ -154,6 +159,10 @@ if [ -d "$ARGOCD_DIR" ] && compgen -G "$ARGOCD_DIR/*.yaml" >/dev/null; then
         for m in "$ARGOCD_DIR"/$pattern; do
             [ -f "$m" ] || continue
             content=$(cat "$m")
+            if [[ "$content" == *"<TAILNET>"* ]] && [ -z "$TAILNET_NAME" ]; then
+                warn "  skipping $(basename "$m") — unresolved <TAILNET> placeholder"
+                continue
+            fi
             printf '%s' "${content//<TAILNET>/$TAILNET_NAME}" | \
                 ssh "$VM" 'sudo /usr/local/bin/kubectl apply -f -'
         done
@@ -189,7 +198,7 @@ TS_HOSTNAME_REMOTE=$(ssh "$VM" 'tailscale status --self=true --peers=false --jso
     | jq -r ".Self.HostName // \"\""' || true)
 TS_IP=$(ssh "$VM" 'tailscale ip -4 2>/dev/null | head -1' || true)
 
-if [ -n "$TS_HOSTNAME_REMOTE" ] && [ -n "$TAILNET_NAME" ] && [ "$TAILNET_NAME" != "<TAILNET>" ]; then
+if [ -n "$TS_HOSTNAME_REMOTE" ] && [ -n "$TAILNET_NAME" ]; then
     TS_FQDN="${TS_HOSTNAME_REMOTE}.${TAILNET_NAME}.ts.net"
     # macOS sed and GNU sed differ; perl is portable.
     perl -pi -e "s|https://127\.0\.0\.1:|https://${TS_FQDN}:|g; s|https://localhost:|https://${TS_FQDN}:|g" \

--- a/infra/vm/cluster-extras/argocd-ts-ingress.yaml
+++ b/infra/vm/cluster-extras/argocd-ts-ingress.yaml
@@ -1,0 +1,57 @@
+# Tailscale Ingress that exposes the ArgoCD UI as a tailnet service (#1892).
+#
+# Why this exists:
+#   Before this, the only way to reach the ArgoCD UI from a tailnet member
+#   was `kubectl port-forward svc/argocd-server -n argocd 8080:80`, which
+#   requires the kubeconfig (and a chain of TLS overrides — see #1892's
+#   "vcluster kubeconfig" history). This Ingress hands the Tailscale Operator
+#   a hostname (`argocd-inv-vcl01`) to provision a tailnet device for, with a
+#   TS-issued Let's Encrypt cert; tailnet members can then bookmark
+#   `https://argocd-inv-vcl01.<tailnet>.ts.net/` without going through kubectl.
+#
+# Why an Ingress and not a Service-of-type-LoadBalancer:
+#   Same pattern as the per-PR preview Ingresses (helm/inventario chart).
+#   `argocd-server` runs as plain HTTP on :80 internally (we install with
+#   `configs.params.server.insecure=true` in vm-install.sh — ArgoCD's self-cert
+#   would be a second TLS hop the TS proxy would have to insecure-skip);
+#   plaintext-to-the-cluster + TLS-at-the-proxy is the cleanest split.
+#
+# `<TAILNET>` placeholder:
+#   Substituted by bootstrap.sh from tailscale.tailnet_name in the sops bundle
+#   before kubectl apply, identical to how infra/argocd/*.yaml are templated.
+#   The `tailscale.com/hostname` annotation does NOT need the suffix (the TS
+#   operator appends it from its own MagicDNS discovery), but the Ingress
+#   `host:` + `tls.hosts[]` MUST be the full FQDN for routing / cert SAN.
+#
+# Not ArgoCD-managed (intentional):
+#   Putting this Ingress in an Application would have ArgoCD potentially
+#   delete/recreate its own Ingress during a sync — recursive trouble. Static
+#   apply via bootstrap.sh keeps it stable across ArgoCD restarts.
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-server
+  namespace: argocd
+  annotations:
+    tailscale.com/hostname: argocd-inv-vcl01
+spec:
+  ingressClassName: tailscale
+  # `secretName: ""` is the documented pattern for TS Operator Ingresses —
+  # the operator issues + manages the cert internally rather than reading
+  # from a kube Secret. Matches the per-PR Ingress pattern in the chart.
+  tls:
+    - hosts:
+        - argocd-inv-vcl01.<TAILNET>.ts.net
+      secretName: ""
+  rules:
+    - host: argocd-inv-vcl01.<TAILNET>.ts.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: argocd-server
+                port:
+                  number: 80

--- a/infra/vm/vm-install.sh
+++ b/infra/vm/vm-install.sh
@@ -154,16 +154,44 @@ else
 fi
 
 # --- vcluster standalone (single-VM = CP + worker, no taint; verified in #1867) ---
-if [ ! -f /etc/vcluster/vcluster.yaml ]; then
-    note "Writing /etc/vcluster/vcluster.yaml (k8s $K8S_VERSION)"
-    mkdir -p /etc/vcluster
-    cat >/etc/vcluster/vcluster.yaml <<EOF
+# Always write the canonical vcluster.yaml so config drift (e.g. adding the
+# tailnet FQDN extraSAN from #1892) lands on every bootstrap, not just the
+# first one. The file is small and deterministic; on re-runs against a
+# running vcluster.service, a content change is fine — the binary re-reads
+# the config on next restart. SANs are baked into the apiserver TLS cert on
+# first generation, so a fresh extraSAN added against an EXISTING cluster
+# does NOT propagate to the live cert until certs are regenerated (manual
+# `make destroy` + `make bootstrap`, or selective cert wipe in
+# /var/lib/vcluster/pki/). For first-time bootstraps (the common path) this
+# is a no-op — the config is written before vcluster ever starts, so the
+# initial cert includes the SAN.
+note "Writing /etc/vcluster/vcluster.yaml (k8s $K8S_VERSION)"
+mkdir -p /etc/vcluster
+
+# proxy.extraSANs adds the host's tailnet FQDN to the apiserver cert SAN
+# list so a kubeconfig with server=https://<host>.<tailnet>.ts.net:8443
+# verifies cleanly — no tls-server-name override, no insecure-skip-tls.
+# Schema: https://github.com/loft-sh/vcluster v0.34 controlPlane.proxy.extraSANs.
+# Without tailscale.tailnet_name in the sops bundle we skip the SAN and
+# fall back to the legacy IP-rewrite path in bootstrap.sh.
+EXTRA_SANS_BLOCK=""
+TAILNET_NAME=$(sops_get "tailscale.tailnet_name")
+if [ -n "${TAILNET_NAME:-}" ]; then
+    EXTRA_SANS_BLOCK="
+  proxy:
+    extraSANs:
+      - ${TS_HOSTNAME}.${TAILNET_NAME}.ts.net"
+else
+    warn "tailscale.tailnet_name missing from sops bundle — apiserver cert won't include tailnet FQDN SAN."
+    warn "bootstrap.sh will fall back to IP-based kubeconfig with tls-server-name override."
+fi
+
+cat >/etc/vcluster/vcluster.yaml <<EOF
 controlPlane:
   distro:
     k8s:
-      version: $K8S_VERSION
+      version: $K8S_VERSION${EXTRA_SANS_BLOCK}
 EOF
-fi
 
 if ! systemctl is-active --quiet vcluster.service; then
     note "Installing vcluster standalone $VCLUSTER_VERSION"

--- a/infra/vm/vm-install.sh
+++ b/infra/vm/vm-install.sh
@@ -174,13 +174,27 @@ mkdir -p /etc/vcluster
 # Schema: https://github.com/loft-sh/vcluster v0.34 controlPlane.proxy.extraSANs.
 # Without tailscale.tailnet_name in the sops bundle we skip the SAN and
 # fall back to the legacy IP-rewrite path in bootstrap.sh.
+#
+# Source the hostname from the live tailscaled (not the configured
+# `TS_HOSTNAME` default) so the cert SAN tracks whatever the VM is
+# currently registered as — important when the operator has manually
+# re-keyed under a different hostname on an already-authenticated VM,
+# where vm-install.sh only warns about the mismatch rather than forcing
+# a reset. Falls back to `TS_HOSTNAME` (the install-time default) when
+# tailscaled isn't authenticated yet (e.g. bootstrap-without-secrets).
+# bootstrap.sh queries the SAME `.Self.HostName` source for the
+# kubeconfig server, so both ends use the same identity.
 EXTRA_SANS_BLOCK=""
 TAILNET_NAME=$(sops_get "tailscale.tailnet_name")
+LIVE_TS_HOSTNAME=$(tailscale status --self=true --peers=false --json 2>/dev/null \
+    | jq -r '.Self.HostName // empty')
+SAN_HOSTNAME="${LIVE_TS_HOSTNAME:-$TS_HOSTNAME}"
 if [ -n "${TAILNET_NAME:-}" ]; then
     EXTRA_SANS_BLOCK="
   proxy:
     extraSANs:
-      - ${TS_HOSTNAME}.${TAILNET_NAME}.ts.net"
+      - ${SAN_HOSTNAME}.${TAILNET_NAME}.ts.net"
+    note "vcluster apiserver cert will include SAN: ${SAN_HOSTNAME}.${TAILNET_NAME}.ts.net"
 else
     warn "tailscale.tailnet_name missing from sops bundle — apiserver cert won't include tailnet FQDN SAN."
     warn "bootstrap.sh will fall back to IP-based kubeconfig with tls-server-name override."


### PR DESCRIPTION
Closes #1892.

## Summary

Replaces the kubectl-port-forward + IP-rewrite kludge for the two preview-env control-plane endpoints with proper tailnet services:

- **ArgoCD UI** — new static Tailscale Ingress (`infra/vm/cluster-extras/argocd-ts-ingress.yaml`) applied by `bootstrap.sh` alongside the existing `ts-orphan-cleanup` CronJob. Tailnet members open `https://argocd-inv-vcl01.<tailnet>.ts.net/` directly — no kubeconfig, no port-forward, valid TS-issued Let's Encrypt cert.
- **vcluster kube-apiserver** — `controlPlane.proxy.extraSANs` in `/etc/vcluster/vcluster.yaml` (written by `vm-install.sh` from `tailscale.tailnet_name` in the sops bundle) bakes the host's tailnet FQDN into the apiserver TLS cert on first generation. `bootstrap.sh` rewrites the laptop kubeconfig server to `https://<host>.<tailnet>.ts.net:8443/`, strips any legacy `tls-server-name: 127.0.0.1` override, and falls back to the pre-existing IP-rewrite path when the tailnet name is missing.

The kubeconfig is now keyed off a stable tailnet hostname — survives VM redeploys (Tailscale preserves identity via the reusable auth-key in sops). MagicDNS resolves the FQDN to the host's current tailnet IP automatically; no in-cluster proxy needed for the apiserver since vcluster's `proxy` listens on `0.0.0.0:8443` by default.

## Files changed

- `infra/vm/cluster-extras/argocd-ts-ingress.yaml` — new TS Ingress for `argocd-server:80`, includes the `<TAILNET>` placeholder pattern.
- `infra/vm/bootstrap.sh` — lifted `TAILNET_NAME` resolution above both cluster-extras and ArgoCD apply blocks; extended cluster-extras apply to substitute `<TAILNET>`; rewrote kubeconfig logic to prefer FQDN with IP-rewrite as fallback; pulls the live TS hostname via `tailscale status --json` so re-keys are reflected.
- `infra/vm/vm-install.sh` — always writes `vcluster.yaml` (no longer gated on file absence); reads `tailscale.tailnet_name` via `sops_get` and injects `controlPlane.proxy.extraSANs` when present.
- `infra/README.md` — "Inspect a running preview" drops port-forward + links to the FQDN; verify step 6 swaps port-forward for the FQDN URL; new troubleshooting entry for the upgrade-from-pre-#1892 case (existing apiserver cert lacks the SAN until `make destroy` + `make bootstrap`); #1892 removed from Phase 2, added to the top-of-file issue list.

## Out of scope (per issue)

- Tailscale Funnel / public exposure.
- Multi-tenant ArgoCD UI / SSO.

The issue acceptance suggested a separate `k8s-inv-vcl01` hostname for the apiserver via a B1 LoadBalancer Service; in vcluster standalone the apiserver runs on the host (not as a pod in the cluster), so the cleanest path is the VM's own tailnet FQDN — explicitly allowed by the "(or similar stable FQDN)" caveat in the acceptance criteria.

## Test plan

- [ ] Fresh-VM `make bootstrap VM=user@host` brings the cluster up; `kubectl get nodes` works from the laptop against `https://inv-vcl01.<tailnet>.ts.net:8443/` with no `tls-server-name` override.
- [ ] `https://argocd-inv-vcl01.<tailnet>.ts.net/` loads the ArgoCD UI from any tailnet member with the right ACL.
- [ ] Cert validation succeeds (Let's Encrypt via Tailscale, no `--insecure`).
- [ ] Kubeconfig has no `tls-server-name: 127.0.0.1` line and no `insecure-skip-tls-verify`.
- [ ] `make bootstrap` against an EXISTING pre-#1892 VM: kubeconfig rewrite fails with cert mismatch (expected — documented in the new troubleshooting entry). `make destroy` + `make bootstrap` then succeeds.
- [ ] `make bootstrap` with `tailscale.tailnet_name` absent from sops: warns and falls back to IP-based kubeconfig + `tls-server-name: 127.0.0.1` (legacy path preserved).
- [ ] VM redeploy: same tailnet hostname re-registers, kubeconfig keeps working without re-bootstrap.
- [ ] `ts-orphan-cleanup` regex still ignores the new `argocd-inv-vcl01` hostname so it's not GC'd when offline >1h.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated preview environment guide with expanded references, prerequisites, revised bootstrap/verify steps, and a new troubleshooting section for certificate/SAN issues

* **New Features**
  * ArgoCD accessible directly via the Tailscale interface (no port-forwarding)
  * Added Tailscale-based ingress exposure for ArgoCD
  * Kubeconfig handling improved to prefer stable tailnet hostnames and surface warnings when tailnet info is missing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->