### PR TITLE
[#1884] support in-place ArgoCD upgrades with new migrations

### DIFF
--- a/.github/workflows/helm-kind-smoke-test.yml
+++ b/.github/workflows/helm-kind-smoke-test.yml
@@ -1,0 +1,278 @@
+name: Helm Kind Smoke Test
+
+# Chart-level smoke for the argocdMode upgrade path (#1884). Helm-direct
+# install (no ArgoCD): the chart's sync-wave annotations are ignored, but
+# the retry logic in the bootstrap Job / migrate init container / init-data
+# Job tolerates the unordered apply. The smoke validates:
+#   - the bootstrap Job (wave -5 in argocdMode) successfully creates the
+#     migrator DB user against demo postgres,
+#   - the app Deployment's `migrate` init container (#1884) runs
+#     `inventario db migrate up` against the demo schema and the main
+#     container then comes Ready,
+#   - the init-data Job (wave +5 in argocdMode) creates the default tenant
+#     + admin and (with seedDatabase=true) seeds demo data,
+#   - a second `helm upgrade --install` (no-op re-sync) re-runs the Jobs
+#     idempotently and the Deployment stays Ready.
+#
+# A real ArgoCD-managed e2e (Application targeting the chart at HEAD,
+# verifying actual sync-wave ordering across an image bump) is a separate
+# follow-up — it needs a tailnet-resolved Application destination that CI
+# doesn't have.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'Dockerfile'
+      - 'go/**'
+      - 'helm/**'
+      - '.github/workflows/helm-kind-smoke-test.yml'
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'go/**'
+      - 'helm/**'
+      - '.github/workflows/helm-kind-smoke-test.yml'
+
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve-build:
+    name: Resolve build artifacts
+    uses: ./.github/workflows/_wait-for-docker-image.yml
+
+  helm-kind-smoke-test:
+    name: Helm chart kind smoke (argocdMode)
+    runs-on: ubuntu-latest
+    needs: resolve-build
+    timeout-minutes: 30
+
+    env:
+      KIND_CLUSTER_NAME: inventario-helm-ci
+      K8S_NAMESPACE: inventario-helm
+      RELEASE_NAME: inv
+      INVENTARIO_IMAGE: ${{ needs.resolve-build.outputs.image }}
+      ADMIN_PASSWORD: SmokeAdmin123
+      ARTIFACTS_DIR: artifacts
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v5
+
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+
+      - name: Install kind
+        run: |
+          set -euo pipefail
+          tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
+          curl -fsSL -o "$tmpdir/kind-linux-amd64" https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64
+          curl -fsSL -o "$tmpdir/kind.sha256sum" https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64.sha256sum
+          (cd "$tmpdir" && sha256sum --check kind.sha256sum)
+          sudo install -m 0755 "$tmpdir/kind-linux-amd64" /usr/local/bin/kind
+          kind version
+
+      - name: Prepare artifacts directory
+        run: mkdir -p "$ARTIFACTS_DIR"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image
+        run: docker pull "$INVENTARIO_IMAGE"
+
+      - name: Create kind cluster
+        run: |
+          set -euo pipefail
+          kind create cluster --name "$KIND_CLUSTER_NAME" --wait 120s
+          kubectl cluster-info
+
+      - name: Load image into kind
+        run: kind load docker-image "$INVENTARIO_IMAGE" --name "$KIND_CLUSTER_NAME"
+
+      - name: Resolve image tag
+        id: image-tag
+        run: |
+          # The chart values take repo + tag separately. Split the fully
+          # qualified reference we just loaded so image.tag matches the
+          # sha-<7> that the loaded image actually carries.
+          tag="${INVENTARIO_IMAGE##*:}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Install chart (argocdMode + demo)
+        run: |
+          set -euo pipefail
+          helm upgrade --install "$RELEASE_NAME" helm/inventario \
+            --namespace "$K8S_NAMESPACE" \
+            --create-namespace \
+            --set-string image.tag="${{ steps.image-tag.outputs.tag }}" \
+            --set demo.postgresql.enabled=true \
+            --set demo.redis.enabled=true \
+            --set demo.minio.enabled=true \
+            --set setupJob.argocdMode=true \
+            --set setupJob.initData.seedDatabase=true \
+            --set-string setupJob.initData.adminPassword="$ADMIN_PASSWORD" \
+            --wait --wait-for-jobs --timeout 8m
+
+      - name: Verify resource shape (argocdMode)
+        run: |
+          set -euo pipefail
+
+          # Bootstrap-only setup Job — only the bootstrap init container.
+          setup_init="$(kubectl get job "${RELEASE_NAME}-inventario-setup" \
+            -n "$K8S_NAMESPACE" \
+            -o jsonpath='{range .spec.template.spec.initContainers[*]}{.name}{"\n"}{end}')"
+          echo "setup Job init containers:"
+          echo "$setup_init"
+          [ "$setup_init" = "bootstrap" ] || {
+            echo "Setup Job init containers must be exactly [bootstrap] in argocdMode" >&2
+            exit 1
+          }
+
+          # Init-data Job is a separate resource in argocdMode.
+          init_data_init="$(kubectl get job "${RELEASE_NAME}-inventario-init-data" \
+            -n "$K8S_NAMESPACE" \
+            -o jsonpath='{range .spec.template.spec.initContainers[*]}{.name}{"\n"}{end}')"
+          echo "init-data Job init containers:"
+          echo "$init_data_init"
+          [ "$init_data_init" = "init-data" ] || {
+            echo "init-data Job init containers must be exactly [init-data]" >&2
+            exit 1
+          }
+
+          # App Deployment must carry the migrate init container.
+          app_init="$(kubectl get deployment "${RELEASE_NAME}-inventario" \
+            -n "$K8S_NAMESPACE" \
+            -o jsonpath='{range .spec.template.spec.initContainers[*]}{.name}{"\n"}{end}')"
+          echo "app Deployment init containers:"
+          echo "$app_init"
+          [ "$app_init" = "migrate" ] || {
+            echo "App Deployment must have exactly the [migrate] init container in argocdMode" >&2
+            exit 1
+          }
+
+      - name: Verify migration applied
+        run: |
+          set -euo pipefail
+
+          # Confirm the demo schema was actually migrated by the
+          # Deployment's migrate init container. schema_migrations is
+          # ptah's bookkeeping table — its row count proves migrate-up ran.
+          pg_pod="$(kubectl get pod -n "$K8S_NAMESPACE" \
+            -l app.kubernetes.io/component=demo-postgresql \
+            -o jsonpath='{.items[0].metadata.name}')"
+
+          count="$(kubectl exec -n "$K8S_NAMESPACE" "$pg_pod" -- \
+            psql -U inventario -d inventario -At \
+            -c "SELECT count(*) FROM schema_migrations")"
+          echo "schema_migrations row count: $count"
+          [ "$count" -gt 0 ] || {
+            echo "schema_migrations is empty — migrate-up did not run" >&2
+            exit 1
+          }
+
+          # Confirm init-data ran (default tenant exists, admin user
+          # exists).
+          tenants="$(kubectl exec -n "$K8S_NAMESPACE" "$pg_pod" -- \
+            psql -U inventario -d inventario -At \
+            -c "SELECT count(*) FROM tenants")"
+          echo "tenants row count: $tenants"
+          [ "$tenants" -gt 0 ] || {
+            echo "tenants table is empty — init-data did not run" >&2
+            exit 1
+          }
+
+          users="$(kubectl exec -n "$K8S_NAMESPACE" "$pg_pod" -- \
+            psql -U inventario -d inventario -At \
+            -c "SELECT count(*) FROM users WHERE email = 'admin@example.com'")"
+          echo "admin user count: $users"
+          [ "$users" -eq 1 ] || {
+            echo "admin user not created by init-data" >&2
+            exit 1
+          }
+
+      - name: Smoke API
+        run: |
+          set -euo pipefail
+          # Port-forward in the background and curl /readyz.
+          kubectl port-forward -n "$K8S_NAMESPACE" \
+            "svc/${RELEASE_NAME}-inventario" 3333:3333 \
+            > "$ARTIFACTS_DIR/port-forward.log" 2>&1 &
+          PF_PID=$!
+          trap 'kill "$PF_PID" 2>/dev/null || true' EXIT
+
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:3333/readyz > /dev/null; then
+              echo "Inventario is ready"
+              break
+            fi
+            if ! kill -0 "$PF_PID" 2>/dev/null; then
+              echo "port-forward exited unexpectedly" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+
+          curl -fsS http://127.0.0.1:3333/readyz | tee "$ARTIFACTS_DIR/readyz.json"
+          curl -fsS http://127.0.0.1:3333/healthz | tee "$ARTIFACTS_DIR/healthz.json"
+
+      - name: Re-sync (no-op helm upgrade)
+        run: |
+          set -euo pipefail
+          # Second `helm upgrade --install` with identical values simulates
+          # an ArgoCD re-sync against the same image. Helm's --wait makes
+          # the test fail if the new Job pods or the rolled Deployment
+          # don't reach Ready.
+          helm upgrade --install "$RELEASE_NAME" helm/inventario \
+            --namespace "$K8S_NAMESPACE" \
+            --set-string image.tag="${{ steps.image-tag.outputs.tag }}" \
+            --set demo.postgresql.enabled=true \
+            --set demo.redis.enabled=true \
+            --set demo.minio.enabled=true \
+            --set setupJob.argocdMode=true \
+            --set setupJob.initData.seedDatabase=true \
+            --set-string setupJob.initData.adminPassword="$ADMIN_PASSWORD" \
+            --wait --wait-for-jobs --timeout 8m
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          set -euo pipefail
+          mkdir -p "$ARTIFACTS_DIR"
+
+          kubectl get all,jobs,pvc,svc,endpoints -n "$K8S_NAMESPACE" -o wide > "$ARTIFACTS_DIR/kubectl-get.txt" 2>&1 || true
+          kubectl get events -n "$K8S_NAMESPACE" --sort-by=.metadata.creationTimestamp > "$ARTIFACTS_DIR/events.txt" 2>&1 || true
+          kubectl describe pods,jobs,deployments -n "$K8S_NAMESPACE" > "$ARTIFACTS_DIR/describe.txt" 2>&1 || true
+
+          for pod in $(kubectl get pods -n "$K8S_NAMESPACE" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'); do
+            kubectl logs "$pod" -n "$K8S_NAMESPACE" --all-containers=true --prefix > "$ARTIFACTS_DIR/${pod}.log" 2>&1 || true
+          done
+
+          kind export logs --name "$KIND_CLUSTER_NAME" "$ARTIFACTS_DIR/kind-logs" > "$ARTIFACTS_DIR/kind-export.log" 2>&1 || true
+
+      - name: Upload diagnostics artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: helm-kind-smoke-diagnostics
+          path: artifacts/
+          retention-days: 14
+
+      - name: Tear down
+        if: always()
+        run: kind delete cluster --name "$KIND_CLUSTER_NAME" || true

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -314,13 +314,17 @@ jobs:
             || { echo "setup Job missing sync-wave -5" >&2; echo "$setup_job_block" >&2; exit 1; }
           echo "$setup_job_block" | grep -Eq '"argocd.argoproj.io/sync-options": "Force=true,Replace=true"' \
             || { echo "setup Job missing Force=true,Replace=true" >&2; exit 1; }
-          echo "$setup_job_block" | grep -Eq '- name: bootstrap' \
+          # `--` separates options from the pattern so the leading `-`
+          # in `- name: ...` isn't probed as a flag (matters for BSD grep
+          # / ugrep; GNU grep on ubuntu-latest tolerates it but the
+          # portability win is free).
+          echo "$setup_job_block" | grep -Eq -- '- name: bootstrap' \
             || { echo "setup Job missing bootstrap init container" >&2; exit 1; }
-          if echo "$setup_job_block" | grep -Eq '- name: migrate'; then
+          if echo "$setup_job_block" | grep -Eq -- '- name: migrate'; then
             echo "setup Job must not contain a migrate init container in argocdMode" >&2
             exit 1
           fi
-          if echo "$setup_job_block" | grep -Eq '- name: init-data'; then
+          if echo "$setup_job_block" | grep -Eq -- '- name: init-data'; then
             echo "setup Job must not contain an init-data init container in argocdMode" >&2
             exit 1
           fi
@@ -334,7 +338,7 @@ jobs:
 
           echo "$deployment_block" | grep -Eq '^      initContainers:' \
             || { echo "combined Deployment missing initContainers block" >&2; exit 1; }
-          echo "$deployment_block" | grep -Eq '- name: migrate' \
+          echo "$deployment_block" | grep -Eq -- '- name: migrate' \
             || { echo "combined Deployment missing migrate init container" >&2; exit 1; }
           echo "$deployment_block" | grep -Eq 'inventario db migrate up' \
             || { echo "combined Deployment migrate container missing migrate-up command" >&2; exit 1; }
@@ -350,7 +354,7 @@ jobs:
             || { echo "argocdMode render is missing the init-data Job" >&2; exit 1; }
           echo "$init_data_block" | grep -Eq '"argocd.argoproj.io/sync-wave": "5"' \
             || { echo "init-data Job missing sync-wave 5" >&2; exit 1; }
-          echo "$init_data_block" | grep -Eq '- name: init-data' \
+          echo "$init_data_block" | grep -Eq -- '- name: init-data' \
             || { echo "init-data Job missing init-data init container" >&2; exit 1; }
 
       - name: Render chart with setupJob.argocdMode (split + external services)
@@ -412,7 +416,7 @@ jobs:
             in_block && /^# Source: / && !/templates\/deployment\.yaml/ { exit }
           ' /tmp/inventario-non-argocd-render.yaml)"
 
-          if echo "$deployment_block" | grep -Eq '- name: migrate'; then
+          if echo "$deployment_block" | grep -Eq -- '- name: migrate'; then
             echo "Non-argocdMode Deployment must not carry a migrate init container." >&2
             exit 1
           fi
@@ -425,6 +429,6 @@ jobs:
           ' /tmp/inventario-non-argocd-render.yaml)"
 
           for step in bootstrap migrate init-data; do
-            echo "$setup_job_block" | grep -Eq "- name: ${step}" \
+            echo "$setup_job_block" | grep -Eq -- "- name: ${step}" \
               || { echo "Non-argocdMode setup Job missing ${step} init container" >&2; exit 1; }
           done

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -279,3 +279,152 @@ jobs:
           --set run.all.autoscaling.metrics[0].external.target.type=AverageValue
           --set-string run.all.autoscaling.metrics[0].external.target.averageValue=5
           > /tmp/inventario-hpa-external-render.yaml
+
+      - name: Render chart with setupJob.argocdMode (combined + demo)
+        run: |
+          set -euo pipefail
+
+          # argocdMode rearranges the setup work into three coordinated
+          # resources (#1884 approach A): a bootstrap-only Job at sync-wave
+          # -5, app Deployment(s) with a `migrate` init container at wave 0,
+          # and a post-Deployment init-data Job at sync-wave +5. The render
+          # checks below pin every required annotation, init-container name,
+          # and Job-step move so a future refactor can't silently break the
+          # ordering that the in-place ArgoCD upgrade story depends on.
+          helm template inventario helm/inventario \
+            --set demo.postgresql.enabled=true \
+            --set demo.redis.enabled=true \
+            --set demo.minio.enabled=true \
+            --set setupJob.argocdMode=true \
+            --set setupJob.initData.seedDatabase=true \
+            --set setupJob.initData.adminPassword=demo-secret \
+            > /tmp/inventario-argocd-combined-render.yaml
+
+          # Setup Job:
+          # - declares sync-wave "-5" (runs before the app Deployment)
+          # - keeps the bootstrap init container
+          # - drops the migrate + init-data steps (they live elsewhere now)
+          setup_job_block="$(awk '
+            /^# Source: inventario\/templates\/job-setup.yaml/ { in_block=1 }
+            in_block { print }
+            in_block && /^# Source: / && !/job-setup\.yaml/ { exit }
+          ' /tmp/inventario-argocd-combined-render.yaml)"
+
+          echo "$setup_job_block" | grep -Eq '"argocd.argoproj.io/sync-wave": "-5"' \
+            || { echo "setup Job missing sync-wave -5" >&2; echo "$setup_job_block" >&2; exit 1; }
+          echo "$setup_job_block" | grep -Eq '"argocd.argoproj.io/sync-options": "Force=true,Replace=true"' \
+            || { echo "setup Job missing Force=true,Replace=true" >&2; exit 1; }
+          echo "$setup_job_block" | grep -Eq '- name: bootstrap' \
+            || { echo "setup Job missing bootstrap init container" >&2; exit 1; }
+          if echo "$setup_job_block" | grep -Eq '- name: migrate'; then
+            echo "setup Job must not contain a migrate init container in argocdMode" >&2
+            exit 1
+          fi
+          if echo "$setup_job_block" | grep -Eq '- name: init-data'; then
+            echo "setup Job must not contain an init-data init container in argocdMode" >&2
+            exit 1
+          fi
+
+          # App Deployment: must carry the `migrate` init container.
+          deployment_block="$(awk '
+            /^# Source: inventario\/templates\/deployment.yaml/ { in_block=1 }
+            in_block { print }
+            in_block && /^# Source: / && !/templates\/deployment\.yaml/ { exit }
+          ' /tmp/inventario-argocd-combined-render.yaml)"
+
+          echo "$deployment_block" | grep -Eq '^      initContainers:' \
+            || { echo "combined Deployment missing initContainers block" >&2; exit 1; }
+          echo "$deployment_block" | grep -Eq '- name: migrate' \
+            || { echo "combined Deployment missing migrate init container" >&2; exit 1; }
+          echo "$deployment_block" | grep -Eq 'inventario db migrate up' \
+            || { echo "combined Deployment migrate container missing migrate-up command" >&2; exit 1; }
+
+          # init-data Job: separate template, sync-wave +5, hosts init-data.
+          init_data_block="$(awk '
+            /^# Source: inventario\/templates\/job-init-data.yaml/ { in_block=1 }
+            in_block { print }
+            in_block && /^# Source: / && !/job-init-data\.yaml/ { exit }
+          ' /tmp/inventario-argocd-combined-render.yaml)"
+
+          test -n "$init_data_block" \
+            || { echo "argocdMode render is missing the init-data Job" >&2; exit 1; }
+          echo "$init_data_block" | grep -Eq '"argocd.argoproj.io/sync-wave": "5"' \
+            || { echo "init-data Job missing sync-wave 5" >&2; exit 1; }
+          echo "$init_data_block" | grep -Eq '- name: init-data' \
+            || { echo "init-data Job missing init-data init container" >&2; exit 1; }
+
+      - name: Render chart with setupJob.argocdMode (split + external services)
+        run: |
+          set -euo pipefail
+
+          # Split-mode parity: every Deployment (apiserver + each worker
+          # group) must include the migrate init container in argocdMode,
+          # since they all go through verifySchemaMatchesBinary at startup.
+          helm template inventario helm/inventario \
+            --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
+            --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+            --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+            --set setupJob.argocdMode=true \
+            --set setupJob.initData.adminPassword=test \
+            --set run.all.enabled=false \
+            --set run.apiserver.enabled=true \
+            --set run.workers.archive.enabled=true \
+            --set run.workers.emails.enabled=true \
+            --set run.workers.housekeeping.enabled=true \
+            --set run.workers.media.enabled=true \
+            > /tmp/inventario-argocd-split-render.yaml
+
+          # Every Deployment must contain a migrate init container.
+          deployment_count="$(grep -c '^kind: Deployment$' /tmp/inventario-argocd-split-render.yaml)"
+          migrate_count="$(grep -c '^        - name: migrate$' /tmp/inventario-argocd-split-render.yaml)"
+          if [ "$deployment_count" -ne "$migrate_count" ]; then
+            echo "Expected migrate init container in every Deployment: ${deployment_count} Deployments, ${migrate_count} migrate containers." >&2
+            grep -nE '^kind: Deployment|^        - name: migrate' /tmp/inventario-argocd-split-render.yaml >&2 || true
+            exit 1
+          fi
+
+      - name: Render chart with setupJob.argocdMode=false (regression check)
+        run: |
+          set -euo pipefail
+
+          # Non-argocdMode must keep the legacy behavior: single setup Job
+          # with bootstrap + migrate + init-data, no migrate init container
+          # on the Deployment, no separate init-data Job.
+          helm template inventario helm/inventario \
+            --set demo.postgresql.enabled=true \
+            --set demo.redis.enabled=true \
+            --set demo.minio.enabled=true \
+            --set setupJob.initData.adminPassword=demo-secret \
+            > /tmp/inventario-non-argocd-render.yaml
+
+          if grep -q 'templates/job-init-data.yaml' /tmp/inventario-non-argocd-render.yaml; then
+            echo "Non-argocdMode must not render the init-data Job." >&2
+            exit 1
+          fi
+
+          # The combined Deployment must NOT have a migrate init container
+          # outside argocdMode (it would re-run migrate on every pod restart
+          # for `helm install` consumers that already get it via the Helm
+          # hook).
+          deployment_block="$(awk '
+            /^# Source: inventario\/templates\/deployment.yaml/ { in_block=1 }
+            in_block { print }
+            in_block && /^# Source: / && !/templates\/deployment\.yaml/ { exit }
+          ' /tmp/inventario-non-argocd-render.yaml)"
+
+          if echo "$deployment_block" | grep -Eq '- name: migrate'; then
+            echo "Non-argocdMode Deployment must not carry a migrate init container." >&2
+            exit 1
+          fi
+
+          # The setup Job in non-argocdMode keeps the legacy three-step shape.
+          setup_job_block="$(awk '
+            /^# Source: inventario\/templates\/job-setup.yaml/ { in_block=1 }
+            in_block { print }
+            in_block && /^# Source: / && !/job-setup\.yaml/ { exit }
+          ' /tmp/inventario-non-argocd-render.yaml)"
+
+          for step in bootstrap migrate init-data; do
+            echo "$setup_job_block" | grep -Eq "- name: ${step}" \
+              || { echo "Non-argocdMode setup Job missing ${step} init container" >&2; exit 1; }
+          done

--- a/helm/inventario/README.md
+++ b/helm/inventario/README.md
@@ -168,6 +168,47 @@ helm upgrade --install inventario ./helm/inventario \
   --set-string secrets.existingSecret='inventario-runtime'
 ```
 
+## ArgoCD-managed migrations
+
+When the chart is deployed via ArgoCD (rather than `helm install` directly), Helm hooks don't map cleanly to ArgoCD's PreSync / Sync / PostSync phases — a `pre-install` hook fires before the Postgres demo Deployment exists, and a `post-install` hook fires only after the main app Deployment is Healthy (which can't happen if the schema isn't migrated yet). Setting `setupJob.argocdMode=true` switches the chart to an ArgoCD-native layout that supports in-place upgrades across new migrations.
+
+### Sync-wave layout
+
+| Wave | Resource | Step |
+| --- | --- | --- |
+| `-5` | `<release>-setup` Job | Bootstrap only — creates the `inventario_migrator` DB role. Carries `argocd.argoproj.io/sync-options: Force=true,Replace=true` so each sync delete-then-creates the immutable Job pod. |
+| `0` (default) | App `Deployment` (combined and/or apiserver + workers) | Adds a `migrate` init container that runs `inventario db migrate up` against `MIGRATOR_DB_DSN`. Migrations are pinned to the same image revision that runs the new pod. |
+| `+5` | `<release>-init-data` Job | Runs `inventario db migrate data` (idempotent default-tenant + admin) and, when `setupJob.initData.seedDatabase=true`, seeds demo data via a temporary in-Job `inventario run` server. |
+
+This is approach **A** from #1884: schema upgrades are coupled to the Deployment revision, so an in-place ArgoCD sync never leaves old-image pods talking to a newer schema for longer than the rolling-update window.
+
+### What this fixes
+
+- **No standalone migration window.** In the previous argocdMode (single Job at wave 0 alongside everything else), a re-sync with new migrations would re-create the Job with the new image and apply the migration while old-image app pods were still serving. Now the migration runs as part of starting a new-image pod; the surge replica brings up the new schema, then the rolling-update terminates one old pod at a time.
+- **No `Replace=true` label collisions for the migrate step.** ArgoCD's `Replace=true` performs a `kubectl replace` on the Job, which delete-then-creates the resource. Moving migrations off the Job removes the label-collision flake observed during local testing — the bootstrap Job that remains at wave -5 only ever runs short, idempotent role-creation.
+- **Cleaner failure mode.** A bad migration now fails the new pod's init container, the surge replica never becomes Ready, the Deployment rollout stalls at `progressDeadlineSeconds`, and the old pods keep serving. ArgoCD reports `Degraded`; the operator can roll the image tag back without manual schema intervention.
+
+### Caveats
+
+- **Migrations must be backward-compatible.** During the rolling update there is a window where old-image pods serve traffic against the newly migrated schema. This is the same expand-contract rule every rolling-update operator follows; the chart cannot enforce it. Plan multi-step renames / column drops over multiple releases.
+- **Idempotent per-pod cost.** Every new app pod re-runs `inventario db migrate up`. The ptah migrator returns immediately when `schema_migrations.version` already equals the embedded max, so the steady-state cost is a single round-trip to Postgres per pod start.
+- **External Postgres still requires bootstrap.** With `demo.postgresql.enabled=false`, the bootstrap Job at wave -5 connects to the external Postgres using `setupJob.bootstrap.superuserDsn` (or the `SETUP_SUPERUSER_DSN` key in `secrets.existingSecret`). If your platform creates DB roles out-of-band, set `setupJob.bootstrap.enabled=false` — the chart will skip the bootstrap container; the operator is responsible for ensuring `inventario_migrator` exists before the Deployment starts.
+
+### Enabling
+
+```yaml
+setupJob:
+  argocdMode: true
+  initData:
+    adminPassword: "<set-via-overlay-or-existingSecret>"
+```
+
+The shared preview overlay `infra/helm-overlays/preview-base.values.yaml` already sets `setupJob.argocdMode=true` for both the per-PR preview Applications and the static master Application.
+
+### When to leave it off
+
+For direct `helm install` / `helm upgrade --install` workflows, keep `setupJob.argocdMode=false` (the default). The existing setup Job runs as a Helm hook in the usual way — bootstrap → migrate → init-data sequentially in a single pod — which is the simpler story when Helm is the deployment engine.
+
 ## Important values reference
 
 For the complete default surface, see `helm/inventario/values.yaml`.
@@ -200,6 +241,7 @@ For the complete default surface, see `helm/inventario/values.yaml`.
 | `secrets.migratorDbDsn` | `""` | Set when schema migrations need a different DB user than the app runtime. |
 | `secrets.jwtSecret` | `""` | Required unless supplied through `secrets.existingSecret`. |
 | `secrets.fileSigningKey` | `""` | Required unless supplied through `secrets.existingSecret`. |
+| `setupJob.argocdMode` | `false` | Enable for ArgoCD-managed installs to use the sync-wave layout that supports in-place upgrades with new migrations. See [ArgoCD-managed migrations](#argocd-managed-migrations). |
 | `setupJob.bootstrap.enabled` | `true` | Disable if DB bootstrap/role management is handled outside Helm. |
 | `setupJob.bootstrap.superuserDsn` | `""` | Provide when bootstrap needs elevated DB privileges. |
 | `setupJob.initData.adminEmail` | `admin@example.com` | Set the initial admin login name. |

--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -305,6 +305,74 @@ whichever Deployment (all or apiserver) is currently enabled.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Migration init container, used by the app Deployment(s) in argocdMode so the
+schema is brought up to date by the same pod revision that runs the new image
+(approach A from #1884). Runs `inventario db migrate up` with MIGRATOR_DB_DSN
+(falling back to INVENTARIO_DB_DSN); identical retry-loop semantics to the
+setup Job's migrate step. Idempotent — re-runs on every pod start, no-ops
+when schema is already at the embedded max version.
+
+The container's name is hard-coded `migrate` so callers don't pick the wrong
+name; rolling-update / advisory-lock semantics make concurrent runs safe
+across replicas.
+
+Usage:
+  {{ include "inventario.migrateInitContainer" . | nindent 8 }}
+The caller is expected to render this list item under `initContainers:`.
+*/}}
+{{- define "inventario.migrateInitContainer" -}}
+{{- $secretName := include "inventario.secretName" . -}}
+{{- $imageTag := default .Chart.AppVersion .Values.image.tag -}}
+- name: migrate
+  image: {{ printf "%s:%s" .Values.image.repository $imageTag | quote }}
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  command: ["sh", "-c"]
+  args:
+    - |
+      set -eu
+      export INVENTARIO_DB_DSN="${MIGRATOR_DB_DSN:-$APP_DB_DSN}"
+      i=1
+      while [ "$i" -le 15 ]; do
+        if inventario db migrate up; then
+          echo "Schema migrations completed successfully"
+          exit 0
+        fi
+        echo "Migration attempt $i failed, retrying in 2 seconds..."
+        i=$((i + 1))
+        sleep 2
+      done
+      echo "Schema migrations failed after 15 attempts"
+      exit 1
+  env:
+    - name: APP_DB_DSN
+      {{- if .Values.demo.postgresql.enabled }}
+      value: {{ include "inventario.dbDsn" . | quote }}
+      {{- else }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ $secretName }}
+          key: INVENTARIO_DB_DSN
+      {{- end }}
+    - name: MIGRATOR_DB_DSN
+      {{- if .Values.demo.postgresql.enabled }}
+      value: {{ include "inventario.migratorDsn" . | quote }}
+      {{- else }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ $secretName }}
+          key: MIGRATOR_DB_DSN
+          optional: true
+      {{- end }}
+  {{- with .Values.containerSecurityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  volumeMounts:
+    - name: tmp
+      mountPath: /tmp
+{{- end -}}
+
 {{- define "inventario.uploadLocation" -}}
 {{- if .Values.demo.minio.enabled -}}
 {{- printf "s3://%s?prefix=%s&region=us-east-1&endpoint=%s&s3ForcePathStyle=true" .Values.demo.minio.bucket .Values.demo.minio.prefix (include "inventario.minioEndpointUrl" .) -}}

--- a/helm/inventario/templates/deployment-apiserver.yaml
+++ b/helm/inventario/templates/deployment-apiserver.yaml
@@ -50,6 +50,13 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.setupJob.argocdMode }}
+      # Migrate init container — argocdMode only (#1884). See deployment.yaml
+      # for the full rationale; same approach A semantics apply to the split
+      # apiserver Deployment.
+      initContainers:
+        {{- include "inventario.migrateInitContainer" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: inventario
           image: {{ printf "%s:%s" .Values.image.repository $imageTag | quote }}

--- a/helm/inventario/templates/deployment-workers.yaml
+++ b/helm/inventario/templates/deployment-workers.yaml
@@ -57,6 +57,14 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if $root.Values.setupJob.argocdMode }}
+      # Migrate init container — argocdMode only (#1884). Workers go through
+      # the same verifySchemaMatchesBinary preflight as the apiserver, so they
+      # need the same image-coupled migrate-up. Concurrent runs across
+      # worker-group Deployments are safe via ptah's advisory lock.
+      initContainers:
+        {{- include "inventario.migrateInitContainer" $root | nindent 8 }}
+      {{- end }}
       containers:
         - name: inventario
           image: {{ printf "%s:%s" $root.Values.image.repository $imageTag | quote }}

--- a/helm/inventario/templates/deployment.yaml
+++ b/helm/inventario/templates/deployment.yaml
@@ -50,6 +50,17 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.setupJob.argocdMode }}
+      # Migrate init container — argocdMode only (#1884). Couples the schema
+      # upgrade to the same pod revision that runs the new image so an
+      # in-place ArgoCD sync doesn't leave old-image pods talking to a
+      # newer schema. The setup Job in argocdMode is bootstrap-only and
+      # runs at sync-wave -5, so the migrator DB user already exists when
+      # this container's `inventario db migrate up` runs. Idempotent — the
+      # advisory lock inside ptah serializes concurrent runs across pods.
+      initContainers:
+        {{- include "inventario.migrateInitContainer" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: inventario
           image: {{ printf "%s:%s" .Values.image.repository $imageTag | quote }}

--- a/helm/inventario/templates/job-init-data.yaml
+++ b/helm/inventario/templates/job-init-data.yaml
@@ -1,64 +1,48 @@
-{{- if .Values.setupJob.enabled }}
+{{- /*
+Separate init-data Job for argocdMode (#1884). Runs at sync-wave +5, i.e.
+AFTER the app Deployment is Healthy and the schema has been migrated by
+the Deployment's `migrate` init container. Creates the default tenant /
+admin user (idempotent) and optionally seeds demo data via a temporary
+`inventario run` server.
+
+This intentionally lives in a separate template from job-setup.yaml so the
+two argocdMode Jobs (bootstrap-only at wave -5, init-data at wave +5)
+stay readable. The non-argocdMode path keeps everything in the existing
+setup Job (templates/job-setup.yaml) — see that file for the Helm-hook
+ordering it relies on.
+*/}}
+{{- if and .Values.setupJob.enabled .Values.setupJob.argocdMode }}
 {{- $fullName := include "inventario.fullname" . -}}
 {{- $secretName := include "inventario.secretName" . -}}
 {{- $imageTag := default .Chart.AppVersion .Values.image.tag -}}
 {{- $redisUrl := include "inventario.redisUrl" . -}}
-{{- $setupHook := .Values.setupJob.hookOverride | default (ternary "post-install,pre-upgrade" "pre-install,pre-upgrade" .Values.demo.postgresql.enabled) -}}
 {{- $usePersistentUploads := and .Values.persistence.enabled (hasPrefix "file://" (include "inventario.uploadLocation" .)) -}}
+{{- $jobName := printf "%s-init-data" $fullName | trunc 63 | trimSuffix "-" -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $fullName }}-setup
+  name: {{ $jobName }}
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
-    app.kubernetes.io/component: setup
+    app.kubernetes.io/component: init-data
   annotations:
-    {{- if .Values.setupJob.argocdMode }}
-    # ArgoCD-native ordering for in-place upgrades (#1884). Approach A:
-    # this Job is now BOOTSTRAP-ONLY and runs at sync-wave -5 so the
-    # migrator DB user exists before the app Deployment's `migrate` init
-    # container needs it at wave 0. Schema migrations AND data migrations
-    # both moved out of this Job:
-    #   - schema migrations → app Deployment(s)' `migrate` init container
-    #     (templates/_helpers.tpl: inventario.migrateInitContainer). Pin
-    #     migrations to the same image revision that runs the new pod,
-    #     eliminating the old-image / new-schema window.
-    #   - data migrations + optional seed → separate init-data Job at
-    #     sync-wave +5 (templates/job-init-data.yaml), runs after the
-    #     Deployment is Healthy and the schema is up to date.
-    # Force=true,Replace=true is still required because Jobs are immutable
-    # in K8s and need delete-then-create on each sync (new image revision
-    # produces a new Job pod that re-runs idempotent bootstrap).
-    "argocd.argoproj.io/sync-wave": "-5"
+    # ArgoCD post-Deployment Job (#1884). Runs after the app Deployment is
+    # Healthy (which only happens once its `migrate` init container brings
+    # the schema up to date). This Job then calls `inventario db migrate
+    # data` to ensure the default tenant / admin row exists, and on a fresh
+    # install also seeds demo data via a temporary in-Job `inventario run`
+    # server. Idempotent — admin/tenant rows are created with IF NOT
+    # EXISTS semantics and the seed step honors SETUP_SKIP_SEED_ON_UPGRADE.
+    # Replace=true delete-then-creates the immutable Job on each sync.
+    "argocd.argoproj.io/sync-wave": "5"
     "argocd.argoproj.io/sync-options": "Force=true,Replace=true"
-    {{- else }}
-    # Default: helm install / upgrade hooks. Behaves as before for non-
-    # ArgoCD consumers (the operator runs `helm` directly).
-    "helm.sh/hook": {{ $setupHook | quote }}
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-failed
-    {{- end }}
 spec:
   backoffLimit: 3
-  {{- if not .Values.setupJob.argocdMode }}
-  # Auto-delete the Job 24h after it completes — keeps `kubectl get jobs`
-  # clean for `helm install` consumers where the Job is a one-shot hook.
-  #
-  # Intentionally OMITTED in argocdMode: when ArgoCD's selfHeal=true sees
-  # the Job missing (after TTL GC) but present in git, it recreates the
-  # resource and migrations re-run every ~24h. Migrations are idempotent
-  # so this is harmless but noisy. Keeping the Completed Job in place
-  # means selfHeal sees no drift and only re-applies when an actual sync
-  # is triggered (new commit, manual sync). Old Jobs are pruned naturally
-  # whenever a new commit lands and ArgoCD's Replace=true delete-then-
-  # creates them.
-  ttlSecondsAfterFinished: 86400
-  {{- end }}
   template:
     metadata:
       labels:
         {{- include "inventario.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: setup
+        app.kubernetes.io/component: init-data
     spec:
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -70,118 +54,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- /* Don't emit `initContainers:` with no entries — happens when
-             argocdMode=true AND bootstrap.enabled=false. An empty key is
-             rejected by the k8s API. */}}
-      {{- if or .Values.setupJob.bootstrap.enabled (not .Values.setupJob.argocdMode) }}
       initContainers:
-        {{- if .Values.setupJob.bootstrap.enabled }}
-        - name: bootstrap
-          image: {{ printf "%s:%s" .Values.image.repository $imageTag | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["sh", "-c"]
-          args:
-            - |
-              set -eu
-              if [ -n "${SETUP_SUPERUSER_DSN:-}" ]; then
-                export INVENTARIO_DB_DSN="$SETUP_SUPERUSER_DSN"
-              fi
-              i=1
-              while [ "$i" -le 30 ]; do
-                if inventario db bootstrap apply \
-                  --username="$INVENTARIO_BOOTSTRAP_USERNAME" \
-                  --username-for-migrations="$INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS"; then
-                  echo "Bootstrap migrations completed successfully"
-                  exit 0
-                fi
-                echo "Bootstrap attempt $i failed, retrying in 3 seconds..."
-                i=$((i + 1))
-                sleep 3
-              done
-              echo "Bootstrap failed after 30 attempts"
-              exit 1
-          env:
-            - name: INVENTARIO_DB_DSN
-              {{- if .Values.demo.postgresql.enabled }}
-              value: {{ include "inventario.dbDsn" . | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: INVENTARIO_DB_DSN
-              {{- end }}
-            - name: SETUP_SUPERUSER_DSN
-              {{- if .Values.demo.postgresql.enabled }}
-              value: {{ include "inventario.superuserDsn" . | quote }}
-              {{- else if .Values.setupJob.bootstrap.superuserDsn }}
-              value: {{ .Values.setupJob.bootstrap.superuserDsn | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: SETUP_SUPERUSER_DSN
-                  optional: true
-              {{- end }}
-            - name: INVENTARIO_BOOTSTRAP_USERNAME
-              value: {{ .Values.setupJob.bootstrap.username | quote }}
-            - name: INVENTARIO_BOOTSTRAP_USERNAME_FOR_MIGRATIONS
-              value: {{ .Values.setupJob.bootstrap.usernameForMigrations | quote }}
-          {{- with .Values.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
-        {{- end }}
-        {{- if not .Values.setupJob.argocdMode }}
-        - name: migrate
-          image: {{ printf "%s:%s" .Values.image.repository $imageTag | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["sh", "-c"]
-          args:
-            - |
-              set -eu
-              export INVENTARIO_DB_DSN="${MIGRATOR_DB_DSN:-$APP_DB_DSN}"
-              i=1
-              while [ "$i" -le 15 ]; do
-                if inventario db migrate up; then
-                  echo "Schema migrations completed successfully"
-                  exit 0
-                fi
-                echo "Migration attempt $i failed, retrying in 2 seconds..."
-                i=$((i + 1))
-                sleep 2
-              done
-              echo "Schema migrations failed after 15 attempts"
-              exit 1
-          env:
-            - name: APP_DB_DSN
-              {{- if .Values.demo.postgresql.enabled }}
-              value: {{ include "inventario.dbDsn" . | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: INVENTARIO_DB_DSN
-              {{- end }}
-            - name: MIGRATOR_DB_DSN
-              {{- if .Values.demo.postgresql.enabled }}
-              value: {{ include "inventario.migratorDsn" . | quote }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: MIGRATOR_DB_DSN
-                  optional: true
-              {{- end }}
-          {{- with .Values.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
         - name: init-data
           image: {{ printf "%s:%s" .Values.image.repository $imageTag | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -215,7 +88,7 @@ spec:
               fi
 
               if [ "${SETUP_SKIP_SEED_ON_UPGRADE:-false}" = "true" ]; then
-                echo "Skipping database seeding during Helm upgrade to avoid duplicate demo data"
+                echo "Skipping database seeding during upgrade to avoid duplicate demo data"
                 exit 0
               fi
 
@@ -307,8 +180,17 @@ spec:
               value: {{ .Values.setupJob.initData.adminName | quote }}
             - name: SEED_DATABASE
               value: {{ ternary "true" "false" .Values.setupJob.initData.seedDatabase | quote }}
+            # SETUP_SKIP_SEED_ON_UPGRADE: in non-argocdMode this was driven by
+            # .Release.IsUpgrade. ArgoCD doesn't expose Helm's upgrade flag in
+            # the same way — and the Job is delete-then-created on every sync
+            # under Replace=true regardless. The seed step here is gated by
+            # `seedDatabase` alone; operators who don't want re-seeding on
+            # subsequent syncs should leave seedDatabase=false in production
+            # overlays (the seed itself is also a one-shot via /api/v1/seed
+            # which the server only allows for the first install — see
+            # /api/v1/seed handler).
             - name: SETUP_SKIP_SEED_ON_UPGRADE
-              value: {{ ternary "true" "false" .Release.IsUpgrade | quote }}
+              value: "false"
             - name: INVENTARIO_SEED_DB_DSN
               {{- if .Values.demo.postgresql.enabled }}
               value: {{ include "inventario.dbDsn" . | quote }}
@@ -347,13 +229,11 @@ spec:
               mountPath: /app/uploads
             - name: tmp
               mountPath: /tmp
-        {{- end }}
-      {{- end }}
       containers:
         - name: complete
           image: "busybox:1.36"
           imagePullPolicy: IfNotPresent
-          command: ["sh", "-c", "echo \"Setup complete\" && exit 0"]
+          command: ["sh", "-c", "echo \"Init-data complete\" && exit 0"]
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -523,20 +523,32 @@ setupJob:
   # require Healthy main resources, deadlocking with schema-dependent apps).
   hookOverride: ""
 
-  # ArgoCD-native mode for the setup Job. When true:
-  #   - the `helm.sh/hook` annotation is dropped entirely (Job is no longer
-  #     a Helm hook, just a regular Sync-phase resource);
-  #   - `argocd.argoproj.io/sync-options: Force=true,Replace=true` is added
-  #     so ArgoCD replaces (delete-then-create) the immutable Job on each
-  #     sync rather than failing the apply.
-  # The Job runs in the default sync-wave alongside ServiceAccount/Secret/
-  # ConfigMap/Postgres/Deployment. Its own pg_isready loop in the bootstrap
-  # init container handles waiting for Postgres; the main Deployment pod
-  # CrashLoops on the schema-version guard until the Job has migrated.
+  # ArgoCD-native mode (#1884 approach A — in-place upgrades safe across
+  # new migrations). When true:
+  #   - the `helm.sh/hook` annotation is dropped (Job is a regular
+  #     Sync-phase resource);
+  #   - the setup Job (templates/job-setup.yaml) becomes BOOTSTRAP-ONLY
+  #     and runs at sync-wave -5, before the app Deployment;
+  #   - schema migrations run from a `migrate` init container injected
+  #     into every app Deployment (combined / apiserver / workers) at
+  #     wave 0, coupling the schema upgrade to the same image revision
+  #     the new pods are running — no old-image-vs-new-schema window;
+  #   - data migrations + optional seed move to a separate init-data
+  #     Job (templates/job-init-data.yaml) at sync-wave +5, which only
+  #     runs after the Deployment is Healthy;
+  #   - all Jobs carry `argocd.argoproj.io/sync-options:
+  #     Force=true,Replace=true` so ArgoCD delete-then-creates the
+  #     immutable Job objects on each sync.
+  #
+  # Migrations must remain backward-compatible with the previously
+  # deployed image — during the rolling update there is a brief window
+  # where old pods serve traffic against the newly migrated schema
+  # (typical expand-contract requirement; not unique to this chart).
   #
   # This is the right setting for any ArgoCD-managed install; the only
   # reason it's not the default is to keep the chart drop-in compatible
   # with non-ArgoCD `helm install` flows that expect post-install hooks.
+  # See helm/inventario/README.md → "ArgoCD-managed migrations".
   argocdMode: false
 
   bootstrap:


### PR DESCRIPTION
## Summary

Approach **A** from #1884: move `inventario db migrate up` out of the setup Job and into an init container on every app Deployment, so the schema upgrade is coupled to the same image revision that runs the new pod. Eliminates the old-image / new-schema window that the previous single-Job-at-wave-0 `argocdMode` left open during in-place ArgoCD syncs.

## Chart layout when `setupJob.argocdMode=true`

| Wave | Resource | Step |
| --- | --- | --- |
| `-5` | `<release>-setup` Job | bootstrap only (creates `inventario_migrator` DB role). `Force=true,Replace=true`. |
| `0` | App `Deployment` (combined / apiserver / workers) | new `migrate` init container (`inventario.migrateInitContainer` helper) runs `inventario db migrate up`. |
| `+5` | `<release>-init-data` Job (new template) | `inventario db migrate data` + optional seed. `Force=true,Replace=true`. |

Non-`argocdMode` is unchanged: the existing setup Job still runs `bootstrap` → `migrate` → `init-data` sequentially as a Helm hook.

Backward-compat notes:
- Migrations must remain forward/backward compatible (expand-contract). During the rolling update there is a brief window where old pods serve traffic against the newly migrated schema. Documented in the new README section.
- Migrate is idempotent — re-runs on every pod restart are cheap (ptah's advisory lock + `schema_migrations.version` short-circuit).
- `setupJob.bootstrap.enabled=false` + `argocdMode=true` renders an empty setup Job (no `initContainers:` key emitted, just the no-op `complete` container). Operator-managed DB roles still work.

## Tests

- `helm-lint.yml` gains three render checks:
  - `setupJob.argocdMode=true` combined + demo — pins sync-wave `-5` on the setup Job, sync-wave `+5` on the init-data Job, `migrate` init container on the Deployment, and the absence of `migrate`/`init-data` steps in the setup Job.
  - `setupJob.argocdMode=true` split + external services — verifies `migrate` init container is present on every Deployment (apiserver + 4 worker groups) by counting `kind: Deployment` against `- name: migrate`.
  - `setupJob.argocdMode=false` regression — asserts the legacy layout (single setup Job with 3 init containers, no `migrate` init container on the Deployment, no init-data Job).
- `helm-kind-smoke-test.yml` (new): boots KIND, pulls the sha-`<7>` image, `helm install`s the chart in demo + `argocdMode`, validates resource shape (bootstrap-only setup Job / migrate init container / init-data Job), asserts `schema_migrations` is populated and the default tenant + admin row exist, port-forwards to hit `/readyz`, then runs a second `helm upgrade --install` to validate the re-sync path is idempotent.

## What's deferred

A real ArgoCD-on-KIND e2e covering sync-wave ordering across an actual image bump (issue's "push a commit with a new migration to a `preview`-labeled PR" criterion) is intentionally deferred — it needs an ArgoCD Application target at the chart at HEAD/SHA and image availability in GHCR that CI's PR-flow doesn't currently coordinate. Worth a follow-up if the preview infra stabilizes a tailnet-reachable Application destination for CI.

## Test plan

- [ ] `helm-lint.yml` (existing + 3 new steps) — green
- [ ] `helm-kind-smoke-test.yml` — green on this PR's image
- [ ] Manually sync an existing preview Application after this lands, push a no-op commit with a new migration, confirm preview returns Healthy

Closes #1884.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ArgoCD-native migrations mode: migrator runs as pod init containers and a separate init-data job to support in-place upgrades and safe seeding.

* **Documentation**
  * Helm chart docs updated with guidance, sync-wave layout, and operational caveats for the ArgoCD mode.

* **Tests**
  * Added CI smoke and rendering assertions to validate ArgoCD-mode behavior and ensure chart readiness across upgrade/resync scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->