### PR TITLE
[#1883] source master admin password from sops bundle

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -255,16 +255,26 @@ section — see [SECRETS.md §3 "Tailscale ACL — tagOwners"](./SECRETS.md#tail
 
 ### 3.4 Pick the admin email + password
 
-The `admin.email` / `admin.password` fields in the sops bundle are reserved
-for a future production overlay — they are NOT what PR-preview environments
-log in with today. The preview overlay
-[`infra/helm-overlays/preview-base.values.yaml`](./helm-overlays/preview-base.values.yaml)
-hard-codes `admin@example.com` / `PreviewAdmin123` for the seeded admin user,
-and that's what you use to sign into a preview URL. Reading the sops bundle
-for prod-style admin credentials is tracked under
-[#1883](https://github.com/denisvmedia/inventario/issues/1883); for Phase 1
-you can put any non-empty placeholder values in `admin.email` /
-`admin.password` and they'll simply be ignored by the chart.
+The `admin.password` field in the sops bundle becomes the **master**
+super-admin seed password (#1883). `apply-secrets.sh` materializes it
+as `inv-vcl01-master/inventario-admin` (key `SETUP_ADMIN_PASSWORD`),
+and the master ArgoCD Application points the chart at it via
+`secrets.existingSecret`. The chart's setup Job consumes the value on
+first install of the master deployment — after that, rotate the admin
+password from the app UI.
+
+`admin.email` is informational: the chart uses its own
+`setupJob.initData.adminEmail` value (default `admin@example.com`), not
+the bundle field. Fill it in anyway so the bundle stays the single
+source of truth for "who is the admin" in the docs.
+
+PR previews keep the well-known dev password `PreviewAdmin123` inlined
+in [`infra/argocd/applicationset-pr.yaml`](./argocd/applicationset-pr.yaml).
+Their namespaces (`inv-vcl01-pr{N}`) are created dynamically by the
+ApplicationSet, so there's nowhere for `apply-secrets.sh` to write a
+per-PR Secret pre-emptively — and the tailnet-gated URL doesn't need a
+real secret anyway. Sign in to any preview URL with
+`admin@example.com` / `PreviewAdmin123`.
 
 Walkthrough: [SECRETS.md §4 "Pick the admin email + password"](./SECRETS.md#4-pick-the-admin-email--password).
 

--- a/infra/SECRETS.md
+++ b/infra/SECRETS.md
@@ -14,8 +14,9 @@ encrypted with **sops + age**. The only thing that must live **off-VM** is one
 age private key on the laptop (with a copy in your password manager). The
 encrypted bundle is committed to the repo. `bootstrap.sh` decrypts it locally
 on the laptop, ships the plaintext to the VM tmpfs, and `apply-secrets.sh`
-turns the JSON into three Kubernetes Secrets (`inv-system/inventario-admin`,
-`argocd/github-app-creds`, `tailscale/operator-oauth`).
+turns the JSON into three Kubernetes Secrets
+(`inv-vcl01-master/inventario-admin`, `argocd/github-app-creds`,
+`tailscale/operator-oauth`).
 
 ## Files in this layout
 
@@ -185,8 +186,26 @@ its next restart, or force it with
 
 ### 4. Pick the admin email + password
 
-The Inventario `inv-system/inventario-admin` Secret holds the super-admin
-login the app uses on first start.
+The Inventario `admin.password` field in the sops bundle becomes the
+**master** super-admin login the app seeds on first start (#1883).
+`apply-secrets.sh` materializes it as `inv-vcl01-master/inventario-admin`
+with key `SETUP_ADMIN_PASSWORD`; the master ArgoCD Application points
+`secrets.existingSecret` at this Secret and the chart's setup Job reads
+the password from it.
+
+The `admin.email` field is informational — the chart sources the admin
+email from its values (`setupJob.initData.adminEmail`, default
+`admin@example.com`), not from the sops bundle. Filling `admin.email`
+in the bundle keeps the docs honest about "who is the admin" but does
+not affect what gets seeded.
+
+PR previews are deliberately NOT covered by this Secret: their
+namespaces (`inv-vcl01-pr{N}`) are created dynamically by the
+ApplicationSet, so there's nowhere for `apply-secrets.sh` to write the
+Secret pre-emptively. Per-PR previews use the well-known dev password
+`PreviewAdmin123` inlined in `infra/argocd/applicationset-pr.yaml` —
+acceptable because the URL sits behind a Tailscale ACL and the
+environment is tearable.
 
 ```bash
 # Generate a strong random password (or use your own)
@@ -345,6 +364,32 @@ recipients; each can decrypt the bundle independently.
    BOTH rules, run `sops updatekeys` again, commit.
 7. (Rotation only) Securely shred `~/.config/sops/age/keys.txt.old` and the
    password-manager copy.
+
+### Rotating the master admin seed password
+
+`admin.password` is the **seed** value the chart's setup Job uses to create
+the super-admin on first install of the master Application. After first
+install the password lives in the app's own user table; rotating
+`admin.password` in the sops bundle does NOT change the running app's
+admin login — for that, sign in to the master deployment and rotate from
+the app UI.
+
+The bundle field still matters for two reasons:
+1. Fresh deploys / disaster recovery seed from this value (see "Disaster
+   recovery — the VM is gone" below).
+2. The `inv-vcl01-master/inventario-admin` Secret is created from this
+   field on every `bootstrap`/`upgrade`. If you ever delete the master
+   namespace and re-sync, the chart re-seeds from the current Secret —
+   so keep `admin.password` aligned with what's actually in the app's
+   user table, or document the divergence.
+
+To update the seed value:
+
+1. `sops infra/vm/secrets/secrets.enc.yaml` → replace `admin.password`.
+2. `make -C infra upgrade VM=...` → re-applies the Secret. The setup Job
+   reruns under `argocdMode: Force=true,Replace=true` but is idempotent
+   in `migrate-data`: it skips re-creating an existing admin user, so
+   the new value only takes effect on a clean re-install.
 
 ### Rotating the GitHub App private key (App-side compromise, or just hygiene)
 

--- a/infra/argocd/applicationset-master.yaml
+++ b/infra/argocd/applicationset-master.yaml
@@ -93,6 +93,18 @@ spec:
             values: |
               image:
                 tag: 'sha-{{ slice .sha 0 7 }}'
+              # Source the admin seed password from the sops bundle (#1883).
+              # `inventario-admin` is materialized in this namespace by
+              # infra/vm/scripts/apply-secrets.sh from admin.password in
+              # the encrypted bundle. The chart's setup Job reads
+              # SETUP_ADMIN_PASSWORD from it; runtime workloads slurp the
+              # rest of envFrom unchanged (the demo.* stack provides DSNs
+              # inline via the deployment's env: block, and JWT/file-signing
+              # keys are intentionally ephemeral on master — same behavior
+              # as the pre-#1883 chart-generated Secret, where these values
+              # were empty strings).
+              secrets:
+                existingSecret: inventario-admin
               ingress:
                 annotations:
                   tailscale.com/hostname: inv-vcl01-master

--- a/infra/argocd/applicationset-pr.yaml
+++ b/infra/argocd/applicationset-pr.yaml
@@ -62,6 +62,16 @@ spec:
             values: |
               image:
                 tag: 'sha-{{ .head_short_sha_7 }}'
+              # Well-known dev login for tailnet-gated PR previews. Per-PR
+              # namespaces are created dynamically by this ApplicationSet,
+              # so we can't pre-materialize a per-namespace Secret from the
+              # sops bundle the way master does (see
+              # infra/argocd/applicationset-master.yaml). #1883 explicitly
+              # accepts a shared plaintext for tearable previews — rotation
+              # is rare and the URL sits behind a Tailscale ACL.
+              setupJob:
+                initData:
+                  adminPassword: "PreviewAdmin123"
               ingress:
                 annotations:
                   tailscale.com/hostname: 'inv-vcl01-pr{{.number}}'

--- a/infra/helm-overlays/preview-base.values.yaml
+++ b/infra/helm-overlays/preview-base.values.yaml
@@ -1,6 +1,6 @@
 # Shared overlay used by BOTH:
 #   - infra/argocd/applicationset-pr.yaml (per-PR previews)
-#   - infra/argocd/application-master.yaml (static master)
+#   - infra/argocd/applicationset-master.yaml (master)
 #
 # Both Applications layer this file via ArgoCD's helm.valueFiles (referencing
 # a second `ref: values` source so the file is pulled from the repo alongside
@@ -58,15 +58,20 @@ demo:
 # `ttlSecondsAfterFinished` on the Job (template-level) so ArgoCD selfHeal
 # doesn't see drift and re-trigger migrations every 24h.
 #
-# initData.adminPassword: must be set explicitly — the chart's `env-default`
-# of "admin123" fails the binary's password complexity check
-# (≥8 chars + uppercase). For tailnet-gated previews this isn't a secret;
-# it's the well-known dev login. Real production overlays should source it
-# from a sops bundle via secrets.existingSecret.
+# initData.adminPassword: NOT set here. The chart's `env-default` of
+# "admin123" fails the binary's password complexity check (≥8 chars +
+# uppercase), so each consuming Application must wire a real password:
+#   - infra/argocd/applicationset-master.yaml sets
+#     `secrets.existingSecret: inventario-admin` so the chart reads
+#     SETUP_ADMIN_PASSWORD from the sops-sourced Secret materialized in
+#     inv-vcl01-master by infra/vm/scripts/apply-secrets.sh.
+#   - infra/argocd/applicationset-pr.yaml inlines the well-known dev
+#     password — tailnet-gated PR previews don't merit a per-PR Secret
+#     (their namespaces are dynamic; #1883 explicitly accepts a shared
+#     plaintext for tearable previews).
 setupJob:
   argocdMode: true
   initData:
-    adminPassword: "PreviewAdmin123"
     # Populate the demo with example locations, areas, commodities, etc. so
     # the preview is interesting to browse. The chart's setup Job (after
     # migrations + admin user) spins up a temporary `inventario run` server

--- a/infra/vm/bootstrap.sh
+++ b/infra/vm/bootstrap.sh
@@ -66,7 +66,7 @@ ssh "$VM" "sudo bash $REMOTE_TMP/vm-install.sh $REMOTE_TMP"
 # --- Apply k8s Secrets generated from the sops bundle (#1854) ---
 if [ -n "$SECRETS_JSON" ]; then
     if [ -x "$APPLY_SECRETS" ]; then
-        note "Applying k8s Secrets to argocd/tailscale/inv-system namespaces"
+        note "Applying k8s Secrets to argocd/tailscale/inv-vcl01-master namespaces"
         SECRETS_JSON="$SECRETS_JSON" bash "$APPLY_SECRETS" "$VM"
     else
         warn "$APPLY_SECRETS not executable; skipping k8s Secret apply step."

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -10,8 +10,16 @@
 # Schema lives in infra/vm/secrets/secrets.example.yaml; the real encrypted bundle
 # at infra/vm/secrets/secrets.enc.yaml is owned by #1854.
 #
-# This script is best-effort: if a section is missing from the bundle (e.g. GitHub
-# App not yet configured), the corresponding Secret apply is skipped with a warning.
+# Two posture bands:
+#   - inv-vcl01-master/inventario-admin (admin.password) — HARD REQUIREMENT,
+#     because the master ApplicationSet pins `secrets.existingSecret` to this
+#     name and a missing Secret silently breaks master. A missing
+#     admin.password makes the script exit non-zero (deferred to the end so
+#     the optional sections still get applied — supports iterative bootstrap
+#     with a partially-filled bundle).
+#   - argocd/github-app-creds and tailscale/operator-oauth — best-effort:
+#     a missing/empty section is skipped with a warning so a Phase-1 bundle
+#     without those credentials can still bootstrap.
 #
 # Usage: SECRETS_JSON='{...}' bash apply-secrets.sh user@host
 
@@ -53,23 +61,23 @@ remote_apply() {
 # ArgoCD and so are NOT covered here; their ApplicationSet template
 # (infra/argocd/applicationset-pr.yaml) sets a well-known dev password
 # inline. See infra/SECRETS.md §4 for the master/PR split.
+# admin.password is a hard requirement (see header) but we defer the exit so
+# the optional GH App / Tailscale sections below can still apply on a
+# partially-filled bundle; the final exit-non-zero at the bottom of the
+# script ensures the missing field is surfaced loudly to bootstrap.sh
+# (which runs under `set -e` and will halt the whole bootstrap).
 ADMIN_PASSWORD=$(lookup "admin.password")
-# Unlike the GH App / Tailscale sections below (which legitimately tolerate a
-# Phase-1 bundle without those credentials), admin.password is a hard
-# requirement: the master ApplicationSet hard-codes
-# `secrets.existingSecret: inventario-admin`, so a missing field here
-# silently breaks the master sync — the setup Job fails with
-# "secret not found" and master never reaches Healthy. Fail fast instead of
-# leaving the operator to debug it from kubectl logs.
+ADMIN_MISSING=0
 if [ -z "$ADMIN_PASSWORD" ]; then
     warn "admin.password missing in secrets bundle; required by master ApplicationSet via secrets.existingSecret"
-    exit 1
-fi
-note "Applying inv-vcl01-master/inventario-admin"
-# Emit value as a YAML block scalar so passwords with special chars
-# (':', '{', '#', newlines) don't break manifest parsing or open an
-# injection path. Same pattern as the github private key block below.
-cat <<EOF | remote_apply
+    warn "Continuing with optional sections; will exit non-zero at the end so the issue can't be missed."
+    ADMIN_MISSING=1
+else
+    note "Applying inv-vcl01-master/inventario-admin"
+    # Emit value as a YAML block scalar so passwords with special chars
+    # (':', '{', '#', newlines) don't break manifest parsing or open an
+    # injection path. Same pattern as the github private key block below.
+    cat <<EOF | remote_apply
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -85,6 +93,7 @@ stringData:
   SETUP_ADMIN_PASSWORD: |-
 $(printf '%s' "$ADMIN_PASSWORD" | sed 's/^/    /')
 EOF
+fi
 
 # --- argocd / github-app-creds (repo-creds + ApplicationSet PR-generator) ---
 GH_APP_ID=$(lookup "github.app_id")
@@ -125,7 +134,7 @@ TS_ID=$(lookup "tailscale.oauth_client_id")
 TS_SECRET=$(lookup "tailscale.oauth_client_secret")
 if [ -n "$TS_ID" ] && [ -n "$TS_SECRET" ]; then
     note "Applying tailscale/operator-oauth"
-    # Block scalars for the same reason as inv-system/inventario-admin above.
+    # Block scalars for the same reason as inv-vcl01-master/inventario-admin above.
     cat <<EOF | remote_apply
 apiVersion: v1
 kind: Secret
@@ -141,4 +150,15 @@ $(printf '%s' "$TS_SECRET" | sed 's/^/    /')
 EOF
 else
     warn "tailscale.oauth_client_{id,secret} missing; skipping tailscale/operator-oauth"
+fi
+
+# --- deferred fatal: admin.password ---
+# See the admin block above for rationale (master ApplicationSet pins
+# secrets.existingSecret = inventario-admin; a missing Secret silently breaks
+# master). Optional sections above ran first so iterative bootstrap with a
+# partially-filled bundle still applies what it can. bootstrap.sh runs under
+# `set -e`, so the non-zero exit halts the rest of the run.
+if [ "$ADMIN_MISSING" = 1 ]; then
+    warn "Bootstrap incomplete: admin.password is required (see warning above). Fill the field in the sops bundle and re-run."
+    exit 1
 fi

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -54,12 +54,22 @@ remote_apply() {
 # (infra/argocd/applicationset-pr.yaml) sets a well-known dev password
 # inline. See infra/SECRETS.md §4 for the master/PR split.
 ADMIN_PASSWORD=$(lookup "admin.password")
-if [ -n "$ADMIN_PASSWORD" ]; then
-    note "Applying inv-vcl01-master/inventario-admin"
-    # Emit value as a YAML block scalar so passwords with special chars
-    # (':', '{', '#', newlines) don't break manifest parsing or open an
-    # injection path. Same pattern as the github private key block below.
-    cat <<EOF | remote_apply
+# Unlike the GH App / Tailscale sections below (which legitimately tolerate a
+# Phase-1 bundle without those credentials), admin.password is a hard
+# requirement: the master ApplicationSet hard-codes
+# `secrets.existingSecret: inventario-admin`, so a missing field here
+# silently breaks the master sync — the setup Job fails with
+# "secret not found" and master never reaches Healthy. Fail fast instead of
+# leaving the operator to debug it from kubectl logs.
+if [ -z "$ADMIN_PASSWORD" ]; then
+    warn "admin.password missing in secrets bundle; required by master ApplicationSet via secrets.existingSecret"
+    exit 1
+fi
+note "Applying inv-vcl01-master/inventario-admin"
+# Emit value as a YAML block scalar so passwords with special chars
+# (':', '{', '#', newlines) don't break manifest parsing or open an
+# injection path. Same pattern as the github private key block below.
+cat <<EOF | remote_apply
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -75,9 +85,6 @@ stringData:
   SETUP_ADMIN_PASSWORD: |-
 $(printf '%s' "$ADMIN_PASSWORD" | sed 's/^/    /')
 EOF
-else
-    warn "admin.password missing in secrets; skipping inv-vcl01-master/inventario-admin"
-fi
 
 # --- argocd / github-app-creds (repo-creds + ApplicationSet PR-generator) ---
 GH_APP_ID=$(lookup "github.app_id")

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -40,34 +40,43 @@ remote_apply() {
     ssh "$VM" 'sudo /usr/local/bin/kubectl apply -f -'
 }
 
-# --- inv-system / inventario-admin (chart consumes via existingSecret) ---
-ADMIN_EMAIL=$(lookup "admin.email")
+# --- inv-vcl01-master / inventario-admin (chart consumes via secrets.existingSecret) ---
+# Materialized in the static master namespace so the master ArgoCD
+# ApplicationSet (infra/argocd/applicationset-master.yaml; #1885 replaced the
+# previous static Application with a single-template ApplicationSet of the
+# same name) can reference it via
+# `secrets.existingSecret: inventario-admin`. The chart's setup Job reads
+# `SETUP_ADMIN_PASSWORD` from this Secret on first install (idempotent
+# thereafter — the password is the seed value, not a runtime credential).
+#
+# Per-PR preview namespaces (`inv-vcl01-pr{N}`) are created dynamically by
+# ArgoCD and so are NOT covered here; their ApplicationSet template
+# (infra/argocd/applicationset-pr.yaml) sets a well-known dev password
+# inline. See infra/SECRETS.md §4 for the master/PR split.
 ADMIN_PASSWORD=$(lookup "admin.password")
-if [ -n "$ADMIN_EMAIL" ] && [ -n "$ADMIN_PASSWORD" ]; then
-    note "Applying inv-system/inventario-admin"
-    # Emit values as YAML block scalars so passwords with special chars (':', '{', '#', newlines)
-    # don't break manifest parsing or open an injection path. Same pattern as
-    # the github private key block below.
+if [ -n "$ADMIN_PASSWORD" ]; then
+    note "Applying inv-vcl01-master/inventario-admin"
+    # Emit value as a YAML block scalar so passwords with special chars
+    # (':', '{', '#', newlines) don't break manifest parsing or open an
+    # injection path. Same pattern as the github private key block below.
     cat <<EOF | remote_apply
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: inv-system
+  name: inv-vcl01-master
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: inventario-admin
-  namespace: inv-system
+  namespace: inv-vcl01-master
 type: Opaque
 stringData:
-  email: |-
-$(printf '%s' "$ADMIN_EMAIL" | sed 's/^/    /')
-  password: |-
+  SETUP_ADMIN_PASSWORD: |-
 $(printf '%s' "$ADMIN_PASSWORD" | sed 's/^/    /')
 EOF
 else
-    warn "admin.{email,password} missing in secrets; skipping inv-system/inventario-admin"
+    warn "admin.password missing in secrets; skipping inv-vcl01-master/inventario-admin"
 fi
 
 # --- argocd / github-app-creds (repo-creds + ApplicationSet PR-generator) ---

--- a/infra/vm/secrets/secrets.example.yaml
+++ b/infra/vm/secrets/secrets.example.yaml
@@ -10,8 +10,17 @@
 # simple (no anchors / merges / tags).
 
 admin:
-  # Inventario super-admin. Generated once on first bootstrap if password is empty,
-  # then immutable. Surfaces in Kubernetes as inv-system/inventario-admin.
+  # Inventario super-admin password used by the chart's setup Job on first
+  # install to seed the admin user (idempotent thereafter — the user owns
+  # rotation from the app UI). Materialized by
+  # infra/vm/scripts/apply-secrets.sh into inv-vcl01-master/inventario-admin
+  # under key SETUP_ADMIN_PASSWORD; the master ArgoCD Application points
+  # `secrets.existingSecret` at it (#1883). Per-PR previews use a shared
+  # well-known dev password inlined in the PR ApplicationSet template.
+  #
+  # `email` is informational — the chart sources the admin email from
+  # values, not from the sops bundle. Keep this field so the bundle stays
+  # the single source of truth for "who is the admin" in the docs.
   email: admin@example.invalid
   password: ""
 


### PR DESCRIPTION
## Summary

- The shared `preview-base.values.yaml` overlay had the admin seed password as a literal (`PreviewAdmin123`), and the master ArgoCD Application read the same file — so master had a public-knowledge admin password checked into git.
- Wire the master path through the existing sops bundle. `apply-secrets.sh` now materializes `inv-vcl01-master/inventario-admin` (key `SETUP_ADMIN_PASSWORD`) from `admin.password`; `application-master.yaml` points the chart at that Secret via `secrets.existingSecret`. No chart change needed — `secrets.existingSecret` already exists.
- PR previews keep the inline well-known dev password, just relocated from the shared overlay into `applicationset-pr.yaml` so master no longer inherits it. Per-PR namespaces are dynamic, so we can't pre-create a per-PR Secret; #1883 explicitly accepts a shared plaintext for tearable, tailnet-gated previews.

## Mechanics (why this needed no chart change)

- The chart's `secrets.existingSecret` is all-or-nothing: setting it skips the chart-generated main Secret and `envFrom`s the named Secret wholesale.
- For master, that's a no-op: demo `INVENTARIO_DB_DSN` / Redis URLs / MinIO creds are set inline in the deployment `env:` block (overriding `envFrom`) when `demo.*.enabled`; `INVENTARIO_RUN_JWT_SECRET` and `INVENTARIO_RUN_FILE_SIGNING_KEY` were empty strings before, which the Go app treats identically to unset (random per-pod ephemeral key, same behavior).
- Render check with `helm template` confirms `SETUP_ADMIN_PASSWORD` for master comes from `inventario-admin`, PR previews still bake it into the chart-generated Secret from inline values.

## Acceptance (against #1883)

- [x] `infra/helm-overlays/preview-base.values.yaml` no longer contains a literal admin password.
- [x] `infra/vm/secrets/secrets.enc.yaml` schema includes the admin password (kept the existing `admin.password` path; the issue's `inventario.admin_password` was a proposal — keeping the established field avoids re-encrypting the bundle).
- [x] `infra/vm/scripts/apply-secrets.sh` materializes a Kubernetes Secret consumable by the chart (`inv-vcl01-master/inventario-admin`, key `SETUP_ADMIN_PASSWORD`).
- [x] Fresh-deploy path: chart's setup Job sources the password from the sops-derived Secret (verified by `helm template` on the master overlay).
- [x] `infra/SECRETS.md` documents the field consumption (§4) and adds a rotation section explaining the seed-vs-runtime split (`migrate-data` is idempotent on existing user — touches tenant_id only, not password, so post-install rotation lives in the app UI).
- [x] `infra/README.md` §3.4 flipped from "reserved for future overlay" to "consumed by master".

## Test plan

- [x] `helm lint helm/inventario -f infra/helm-overlays/preview-base.values.yaml` clean.
- [x] `helm template` of master overlay: setup Job env `INVENTARIO_MIGRATE_DATA_ADMIN_PASSWORD` sources from `inventario-admin/SETUP_ADMIN_PASSWORD`; runtime `envFrom` references `inventario-admin`; demo DSNs come inline in the deployment `env:` block.
- [x] `helm template` of PR overlay: chart-generated `inv-vcl01-pr123-inventario-secret` has `SETUP_ADMIN_PASSWORD=PreviewAdmin123`; setup Job reads from it.
- [x] `apply-secrets.sh` dry-run with special-char password (colon, newline, `$`) round-trips via YAML block scalar — confirms the existing pattern carries.
- [ ] End-to-end on a real preview VM: re-run `make -C infra bootstrap VM=...`, confirm `inv-vcl01-master/inventario-admin` Secret lands, sync master app, log in with the sops-sourced password (owner-side smoke test before merge).

Refs: PR #1881 (introduced the literal), parent epic #1852.
Closes #1883.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how the master admin password is seeded on first install, how to rotate it afterward, and that admin email is informational only
  * Corrected references and updated bootstrap/apply guidance for the target secret/namespace

* **Configuration**
  * Master deployments now read the seeded admin secret for initial setup
  * PR preview environments use a fixed dev password (PreviewAdmin123) for sign-in/testing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->