### PR TITLE
[#1866] opt-in ResourceQuota + LimitRange per preview namespace

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -387,6 +387,105 @@ jobs:
             exit 1
           fi
 
+      - name: Render chart with quota.enabled=false (default — no quota emitted)
+        run: |
+          set -euo pipefail
+
+          # #1866: quota.yaml is opt-in. Default render must not emit
+          # ResourceQuota or LimitRange (operators using `helm install`
+          # against a production namespace don't expect chart-managed
+          # quotas to land silently).
+          helm template inventario helm/inventario \
+            --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
+            --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+            --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+            --set setupJob.initData.adminPassword=test \
+            > /tmp/inventario-quota-off-render.yaml
+
+          if grep -Eq '^kind: (ResourceQuota|LimitRange)$' /tmp/inventario-quota-off-render.yaml; then
+            echo "Default render must not include ResourceQuota or LimitRange (quota.enabled=false)." >&2
+            exit 1
+          fi
+          if grep -Eq '^# Source: inventario/templates/quota\.yaml' /tmp/inventario-quota-off-render.yaml; then
+            echo "Default render must not include templates/quota.yaml output." >&2
+            exit 1
+          fi
+
+      - name: Render chart with quota.enabled=true (ResourceQuota + LimitRange)
+        run: |
+          set -euo pipefail
+
+          # #1866: opt-in render emits both a ResourceQuota carrying the
+          # full hard-cap surface and a LimitRange with container defaults
+          # so ad-hoc pods inherit limits and don't get rejected by the
+          # ResourceQuota's `limits.*` admission check.
+          helm template inventario helm/inventario \
+            --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
+            --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+            --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+            --set setupJob.initData.adminPassword=test \
+            --set quota.enabled=true \
+            > /tmp/inventario-quota-on-render.yaml
+
+          quota_block="$(awk '
+            /^# Source: inventario\/templates\/quota.yaml/ { in_block=1 }
+            in_block { print }
+            in_block && /^# Source: / && !/quota\.yaml/ { exit }
+          ' /tmp/inventario-quota-on-render.yaml)"
+
+          test -n "$quota_block" \
+            || { echo "quota.enabled=true render is missing templates/quota.yaml output" >&2; exit 1; }
+
+          echo "$quota_block" | grep -Eq '^kind: ResourceQuota$' \
+            || { echo "quota render missing ResourceQuota" >&2; echo "$quota_block" >&2; exit 1; }
+          echo "$quota_block" | grep -Eq '^kind: LimitRange$' \
+            || { echo "quota render missing LimitRange" >&2; echo "$quota_block" >&2; exit 1; }
+
+          # Sync-wave -10 (before bootstrap Job at -5) so the quota is in
+          # effect before any chart-rendered pod schedules.
+          wave_count="$(echo "$quota_block" | grep -c '"argocd.argoproj.io/sync-wave": "-10"')"
+          [ "$wave_count" -eq 2 ] \
+            || { echo "Expected sync-wave -10 on both quota resources, got ${wave_count}" >&2; exit 1; }
+
+          # Every default hard-cap key from values.yaml must round-trip.
+          for key in requests.cpu requests.memory limits.cpu limits.memory requests.storage persistentvolumeclaims pods; do
+            echo "$quota_block" | grep -Eq "^[[:space:]]+${key}: " \
+              || { echo "quota.hard.${key} missing from ResourceQuota render" >&2; echo "$quota_block" >&2; exit 1; }
+          done
+
+          # LimitRange must declare per-Container defaults so unconfigured
+          # ad-hoc pods inherit cpu/memory and aren't rejected by quota.
+          echo "$quota_block" | grep -Eq '^[[:space:]]+- type: Container$' \
+            || { echo "LimitRange missing Container type" >&2; exit 1; }
+          echo "$quota_block" | grep -Eq '^[[:space:]]+defaultRequest:$' \
+            || { echo "LimitRange missing defaultRequest" >&2; exit 1; }
+          echo "$quota_block" | grep -Eq '^[[:space:]]+default:$' \
+            || { echo "LimitRange missing default" >&2; exit 1; }
+          echo "$quota_block" | grep -Eq '^[[:space:]]+max:$' \
+            || { echo "LimitRange missing max" >&2; exit 1; }
+
+      - name: Render chart with quota.enabled=true but limitRange.enabled=false
+        run: |
+          set -euo pipefail
+
+          # Operators with a cluster-level LimitRange already in place can
+          # turn off the chart's LimitRange while keeping the ResourceQuota.
+          helm template inventario helm/inventario \
+            --set-string secrets.dbDsn='postgres://user:pass@pg-host:5432/inventario?sslmode=require' \
+            --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+            --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+            --set setupJob.initData.adminPassword=test \
+            --set quota.enabled=true \
+            --set quota.limitRange.enabled=false \
+            > /tmp/inventario-quota-no-limitrange-render.yaml
+
+          grep -Eq '^kind: ResourceQuota$' /tmp/inventario-quota-no-limitrange-render.yaml \
+            || { echo "ResourceQuota must still render when limitRange.enabled=false" >&2; exit 1; }
+          if grep -Eq '^kind: LimitRange$' /tmp/inventario-quota-no-limitrange-render.yaml; then
+            echo "LimitRange must NOT render when quota.limitRange.enabled=false" >&2
+            exit 1
+          fi
+
       - name: Render chart with setupJob.argocdMode=false (regression check)
         run: |
           set -euo pipefail

--- a/helm/inventario/README.md
+++ b/helm/inventario/README.md
@@ -209,6 +209,27 @@ The shared preview overlay `infra/helm-overlays/preview-base.values.yaml` alread
 
 For direct `helm install` / `helm upgrade --install` workflows, keep `setupJob.argocdMode=false` (the default). The existing setup Job runs as a Helm hook in the usual way — bootstrap → migrate → init-data sequentially in a single pod — which is the simpler story when Helm is the deployment engine.
 
+## Namespace quotas (opt-in)
+
+Set `quota.enabled=true` to render a namespace-scoped `ResourceQuota` plus an opt-out `LimitRange` (#1866). The pair is off by default because direct `helm install` against a production namespace usually shouldn't drop chart-managed quotas in silently; turn it on for installs that share a namespace boundary with other tenants — the canonical case is the per-PR preview namespaces driven by `infra/argocd/applicationset-pr.yaml`.
+
+When enabled, the chart emits:
+
+- a `ResourceQuota` covering `requests.cpu`, `requests.memory`, `limits.cpu`, `limits.memory`, `requests.storage`, `persistentvolumeclaims`, and a hard `pods` ceiling, with values straight from `quota.hard.*`;
+- a `LimitRange` of type `Container` carrying `defaultRequest` / `default` / `max`, so an ad-hoc pod (`kubectl debug`, an operator-applied tool) that omits resources still inherits a request/limit pair and isn't rejected by the `ResourceQuota`'s `limits.*` admission check. Disable with `quota.limitRange.enabled=false` if your cluster already has an equivalent LimitRange in place.
+
+Both resources land at ArgoCD `sync-wave: "-10"`, before the bootstrap Job at wave `-5`, so the quota is enforced from the first scheduled pod. Helm's built-in kind-sort apply order places `ResourceQuota` / `LimitRange` before workloads, so the same template works for `helm install` without an explicit hook.
+
+Chart defaults are sized for a single combined-mode install (apiserver pod only) with external Postgres/Redis/object-storage — `1500m / 2Gi` requests, `3 / 3Gi` limits, `10Gi` storage. Installs that enable `demo.*` sidecars or split mode should raise the caps. The shared overlay `infra/helm-overlays/preview-base.values.yaml` already overrides `quota.hard.*` to fit the preview demo bundle (postgres + redis + minio + apiserver + transient setup / init-data Jobs).
+
+Operational notes:
+
+- A pod that would push the namespace over a hard cap fails admission with a `Forbidden: exceeded quota` event — the failure is fast and the message names the offending dimension, satisfying the "fails fast with a clear message" acceptance criterion from #1866.
+- The `pods` ceiling counts only pods in a non-terminal state (Pending / Running). Succeeded and Failed Job pods do not consume the quota — they are pruned in the background by `kube-controller-manager`'s PodGC once `terminated-pod-gc-threshold` is exceeded. The ceiling therefore caps *in-flight* pods (active workloads + transient Job pods overlapping a sync), not the historical record. See [kubernetes/kubernetes#51150](https://github.com/kubernetes/kubernetes/issues/51150) for the upstream design discussion. To defensively cap accumulated Job objects too, add an explicit `count/jobs.batch` line to `quota.hard`.
+- When `persistence.enabled=true` and `persistence.size` ≥ `quota.hard.requests.storage`, the single uploads PVC consumes the entire storage quota and any additional PVC will be rejected. Raise `quota.hard.requests.storage` (or trim `persistence.size`) for installs that need both.
+- Overriding `quota.hard.*` via `--set` requires escaping the dots: `--set 'quota.hard.requests\.cpu=2'`. Without the escape, Helm parses the path as a nested map (`{requests: {cpu: 2}}`) and the ResourceQuota renders an unrecognized resource that kubectl rejects. Prefer `--values` (or a values file) for non-trivial overrides.
+- The pivot away from a queue bot (per the [2026-05-24 issue update](https://github.com/denisvmedia/inventario/issues/1866#issuecomment-4528708945)) makes the per-namespace quota itself the concurrency cap for PR previews: when the cluster runs out of capacity, the next ArgoCD `Application` stays `Pending` until an older preview is `/destroy`-ed.
+
 ## Important values reference
 
 For the complete default surface, see `helm/inventario/values.yaml`.
@@ -250,6 +271,9 @@ For the complete default surface, see `helm/inventario/values.yaml`.
 | `demo.postgresql.enabled` | `false` | Turn on in-cluster demo PostgreSQL. |
 | `demo.redis.enabled` | `false` | Turn on in-cluster demo Redis. |
 | `demo.minio.enabled` | `false` | Turn on in-cluster demo MinIO and S3-style uploads. |
+| `quota.enabled` | `false` | Render a namespace-scoped `ResourceQuota` + `LimitRange` (#1866). Enable on multi-tenant namespaces such as PR previews; raise `quota.hard.*` when enabling `demo.*` or split mode. See [Namespace quotas](#namespace-quotas-opt-in). |
+| `quota.hard` | see `values.yaml` | Map passed straight into `ResourceQuota.spec.hard`. |
+| `quota.limitRange.enabled` | `true` | Set to `false` to skip the chart's `LimitRange` (e.g. when a cluster-wide LimitRange is already in place). |
 
 ## Upgrade notes
 

--- a/helm/inventario/templates/quota.yaml
+++ b/helm/inventario/templates/quota.yaml
@@ -1,0 +1,65 @@
+{{/*
+Namespace-scoped ResourceQuota + LimitRange (#1866). Renders only when
+quota.enabled=true. Defaults in values.yaml are sized for a single
+combined-mode install with external services; the shared preview overlay
+(infra/helm-overlays/preview-base.values.yaml) overrides quota.hard.* to
+fit the demo bundle.
+
+Apply ordering:
+  - helm install / upgrade: ResourceQuota / LimitRange share helm's built-
+    in apply order (kind-sorted; quotas land before workloads), so no
+    explicit hook annotation is needed.
+  - ArgoCD (argocdMode or otherwise): use sync-wave -10 so the quota is
+    in effect before the bootstrap Job at wave -5 ever schedules a pod.
+    Outside argocdMode the wave is harmless — ArgoCD treats unset waves
+    as 0, and setting -10 on a non-ArgoCD-managed cluster is a no-op
+    annotation.
+*/}}
+{{- if .Values.quota.enabled -}}
+{{- $fullName := include "inventario.fullname" . -}}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: {{ $fullName }}-quota
+  labels:
+    {{- include "inventario.labels" . | nindent 4 }}
+    app.kubernetes.io/component: quota
+  annotations:
+    "argocd.argoproj.io/sync-wave": "-10"
+spec:
+  hard:
+    {{- range $k, $v := .Values.quota.hard }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+{{- if .Values.quota.limitRange.enabled }}
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: {{ $fullName }}-limits
+  labels:
+    {{- include "inventario.labels" . | nindent 4 }}
+    app.kubernetes.io/component: quota
+  annotations:
+    "argocd.argoproj.io/sync-wave": "-10"
+spec:
+  limits:
+    - type: Container
+      {{- with .Values.quota.limitRange.container.defaultRequest }}
+      defaultRequest:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.quota.limitRange.container.default }}
+      default:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.quota.limitRange.container.max }}
+      max:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.quota.limitRange.container.min }}
+      min:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -599,6 +599,79 @@ setupJob:
     seedDatabase: false
 
 # ============================================================
+# Namespace ResourceQuota + LimitRange (#1866)
+# ------------------------------------------------------------
+# Off by default. Turn on when the chart is installed into a
+# namespace that needs defensive guard-rails against a single
+# runaway pod / PVC starving other workloads — the canonical
+# case is PR-preview namespaces sharing one VM (the shared
+# overlay infra/helm-overlays/preview-base.values.yaml turns
+# this on and sizes the caps for the demo-bundle pod-set).
+#
+# When enabled, the chart renders:
+#   - a ResourceQuota covering compute (requests + limits),
+#     storage (requests + PVC count), and a pod-count ceiling;
+#   - an optional LimitRange that supplies per-container
+#     defaults + a per-container max so an ad-hoc pod
+#     (kubectl debug, an operator-applied tool) can't bypass
+#     the quota by omitting resources entirely.
+#
+# Chart-owned pods (apiserver / workers / demo / setup Jobs)
+# all set explicit requests + limits; the LimitRange defaults
+# only kick in for pods that don't, but having both pieces in
+# the same template keeps the safety contract complete.
+# ============================================================
+quota:
+  enabled: false
+
+  # ResourceQuota.spec.hard — every key here passes straight
+  # into spec.hard. Values use the standard k8s resource format
+  # (CPU as cores or m, memory/storage with Ki/Mi/Gi/Ti).
+  # Sized for a single combined-mode Deployment with external
+  # Postgres/Redis/S3 (no demo sidecars). Override per overlay
+  # for installs that enable demo.* or split mode.
+  #
+  # Operator note: keys here use dotted names (`requests.cpu`)
+  # to match k8s ResourceQuota.spec.hard verbatim. Overriding
+  # via `--set` requires escaping the dot, or Helm will create
+  # a nested map and emit an unrecognized quota resource:
+  #   --set 'quota.hard.requests\.cpu=2'      ✓ correct
+  #   --set quota.hard.requests.cpu=2          ✗ silent footgun
+  # Prefer `--values` (or a values file) for any non-trivial
+  # override.
+  hard:
+    requests.cpu: "1500m"
+    requests.memory: "2Gi"
+    limits.cpu: "3"
+    limits.memory: "3Gi"
+    requests.storage: "10Gi"
+    persistentvolumeclaims: "5"
+    pods: "20"
+
+  limitRange:
+    # Set to false to skip the LimitRange while keeping the
+    # ResourceQuota. Practical only when the operator has a
+    # cluster-level LimitRange already in place.
+    enabled: true
+
+    # Per-container defaults applied to any container missing
+    # requests/limits. Kept generous so chart-owned containers
+    # are never reshaped — only ad-hoc pods get filled in.
+    container:
+      defaultRequest:
+        cpu: "50m"
+        memory: "64Mi"
+      default:
+        cpu: "500m"
+        memory: "512Mi"
+      # Hard per-container ceiling. Keep at least as large as
+      # the biggest run.workers.<group>.resources.limits in
+      # the install (run.workers.media defaults to 1000m/1Gi).
+      max:
+        cpu: "2"
+        memory: "2Gi"
+
+# ============================================================
 # Persistent Volume for /app/uploads (local file storage)
 # Only relevant when app.uploadLocation starts with "file://"
 # and demo.minio.enabled=false.

--- a/infra/helm-overlays/preview-base.values.yaml
+++ b/infra/helm-overlays/preview-base.values.yaml
@@ -81,6 +81,41 @@ setupJob:
     # we always seed). Negligible extra Job time (~15s).
     seedDatabase: true
 
+# Defensive guard-rails per #1866: cap aggregate compute/storage/pod-count
+# in every PR-preview namespace so one runaway pod can't starve other
+# previews sharing the same 16 GiB VM. Sized for the demo bundle below
+# (run all + postgres + redis + minio + transient setup / init-data /
+# mc-bucket Jobs):
+#   - Sum of always-on `limits.cpu` = 500m (inventario run all) + 500m
+#     (demo.postgres) + 200m (demo.redis) + 500m (demo.minio) = 1700m;
+#     `limits.cpu: "4"` leaves ~2300m headroom, enough for one rolling-
+#     update surge replica (+500m) and up to three transient Job pods
+#     defaulted by the chart's LimitRange (~500m each).
+#   - Sum of always-on `limits.memory` = 512+512+128+512 = 1664Mi;
+#     `limits.memory: "4Gi"` leaves ~2.4Gi headroom. WARNING: the
+#     worst-case overlap (steady + surge + three Job pods getting the
+#     LimitRange-default 512Mi each) lands around 3712Mi, ~384Mi shy of
+#     the cap. Bump `limits.memory` (and `requests.memory`) here in
+#     lockstep with any new chart-owned container that doesn't override
+#     the LimitRange default.
+#   - `requests.storage` covers the chart's single 10Gi uploads PVC with
+#     room for an operator-applied debug PVC. demo.* PVCs are disabled in
+#     this overlay (Postgres/MinIO use emptyDir), so 20Gi is generous.
+# The LimitRange defaults from the chart (50m / 64Mi request, 500m /
+# 512Mi limit, max 2 CPU / 2Gi) stay intact — they only kick in for ad-
+# hoc kubectl-debug pods and the un-resourced init / sidecar containers
+# in the chart's argocdMode Jobs.
+quota:
+  enabled: true
+  hard:
+    requests.cpu: "2"
+    requests.memory: "2Gi"
+    limits.cpu: "4"
+    limits.memory: "4Gi"
+    requests.storage: "20Gi"
+    persistentvolumeclaims: "5"
+    pods: "30"
+
 # Expose via Tailscale Ingress, NOT LoadBalancer. The TS operator (#1855)
 # provisions a tailnet proxy node from the Ingress + `className: tailscale`
 # and handles cert termination outside the chart.


### PR DESCRIPTION
Closes #1866.

## Scope

Per the [2026-05-24 issue update](https://github.com/denisvmedia/inventario/issues/1866#issuecomment-4528708945) the still-relevant slice of #1866 after the ArgoCD pivot is the chart-side templating of `ResourceQuota` + `LimitRange`. The "bot-level concurrent cap" and `make status` bullets are out of scope (no bot after the pivot; the per-namespace quota is itself the implicit concurrency cap — extra previews stay `Pending` when the cluster runs out of capacity).

## What changed

- **`helm/inventario/templates/quota.yaml` (new)** — opt-in `ResourceQuota` + opt-out `LimitRange`. Both annotated with `argocd.argoproj.io/sync-wave: "-10"` so the cap lands before the bootstrap Job at wave `-5`. Helm's built-in kind-sort places both kinds ahead of workloads for direct `helm install` consumers, so no hook annotation is needed there. Off by default — `quota.enabled=false` in chart values.
- **`helm/inventario/values.yaml`** — new top-level `quota:` block. Chart defaults sized for a combined-mode install with external services (requests `1500m / 2Gi`, limits `3 / 3Gi`, storage `10Gi`, 5 PVCs, 20 pods). `LimitRange.container` defaults are generous (`50m / 64Mi` request, `500m / 512Mi` limit, max `2 / 2Gi`) so chart-owned containers are never reshaped — only un-resourced ad-hoc pods inherit them.
- **`infra/helm-overlays/preview-base.values.yaml`** — flip `quota.enabled=true` and raise `hard.*` to fit the demo bundle (requests `2 / 2Gi`, limits `4 / 4Gi`, storage `20Gi`, 5 PVCs, 30 pods). Header comment walks the budget math and flags that worst-case overlap (steady + rolling-update surge + 3 transient Jobs) lands ~384 MiB shy of the memory cap — bump in lockstep with any new chart-owned container that doesn't override the LimitRange default.
- **`.github/workflows/helm-lint.yml`** — three new render checks pin the shape: `quota.enabled=false` emits nothing under `templates/quota.yaml`; `quota.enabled=true` emits both kinds with `sync-wave: -10` and every `hard.*` key by name; `quota.limitRange.enabled=false` keeps the `ResourceQuota` and drops only the `LimitRange`.
- **`helm/inventario/README.md`** — new "Namespace quotas (opt-in)" section plus values-reference rows. Documents the `pods`-quota semantics correctly (non-terminal pods only, per [kubernetes/kubernetes#51150](https://github.com/kubernetes/kubernetes/issues/51150)), the PVC/storage interaction with `persistence.size`, and the `--set` dotted-key escaping foot-gun.

## Acceptance (issue #1866)

- ✅ "A preview hitting the quota fails fast with a clear message" — Kubernetes' admission controller rejects with `Forbidden: exceeded quota` naming the offending dimension; called out in the README.
- ❌ "6th `/deploy` with cap=5 queues correctly" — explicitly out of scope per the issue update. New `Applications` past capacity stay `Pending` in ArgoCD (implicit cap via cluster resource pressure), which is the documented replacement for the bot-level cap.

## Verification

Local checks (all green):

- `helm lint` on chart defaults + on `preview-base` overlay.
- All 12 existing `helm-lint.yml` render scenarios still pass (production / demo / split / existingSecret / argocdMode permutations / 3 negative guards / long-release name-collision check).
- 3 new quota-specific assertions (off / on / on-without-LimitRange) pass with full key-by-key shape pinning.
- Preview overlay render emits `ResourceQuota` + `LimitRange` with the expected `4 CPU / 4Gi limits`, `2 / 2Gi requests`, `20Gi storage`, `30 pods`, `5 PVCs`, and chart-default container defaults.
- Resource math against preview caps: steady-state requests ~`350m / 832Mi` (vs `2 / 2Gi` cap); steady-state limits ~`1700m / 1664Mi` (vs `4 / 4Gi` cap); worst-case overlap (surge replica + 3 LimitRange-defaulted Job pods) ~`3700m / 3712Mi` with ~`300m / 384Mi` headroom.

Skipped: `helm-kind-smoke` variant with `quota.enabled=true`. The existing smoke continues to exercise the no-quota path; adding a quota-on variant would lock the "chart admits its own pods under its own quota" guarantee at apply-time. Tracked as a follow-up — not blocking this PR since the math fits with margin and the lint render already pins the shape.

## Self-review

Ran `inventario-code-reviewer` against the branch before pushing. Zero blockers; addressed 1 MEDIUM (README factual fix on `pods` quota terminal-state semantics), 1 LOW (budget headroom warning in preview-base), 2 NITs (preview-base comment math, `--set` dotted-key warning). The reviewer's NIT about annotation key quoting was a misread — the chart's existing convention IS to quote ArgoCD annotation keys (see `templates/job-setup.yaml:32-33`, `templates/job-init-data.yaml:37-38`), which this PR matches.

## Test plan

- [ ] Helm Lint CI: green (new render assertions wired in)
- [ ] Helm Kind Smoke CI: green (no-op path; quota stays off in the smoke values)
- [ ] Manual: once merged, the next PR labeled `preview` should render a `ResourceQuota` + `LimitRange` in `inv-vcl01-pr<N>`; `kubectl describe quota -n inv-vcl01-pr<N>` should show usage stays under the caps after the initial sync stabilizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional namespace resource quota and limit enforcement capabilities. Users can now enable per-namespace hard limits for CPU, memory, storage, and pod counts. An optional per-container limit range feature is also available to enforce default requests and maximum resource ceilings.

* **Documentation**
  * Added comprehensive documentation on configuring and managing namespace quotas, including configuration options and operational considerations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->