### PR TITLE
[#1005] Make email verification atomic via MarkVerified claim

### DIFF
--- a/go/apiserver/registration.go
+++ b/go/apiserver/registration.go
@@ -364,6 +364,12 @@ func (api *RegistrationAPI) handleVerifyEmail(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Activate the account before claiming the token. IsActive is a monotonic
+	// flip to true, so a concurrent verify applying it twice is harmless, and
+	// ordering it first means a crash between the two writes leaves the benign
+	// "active user, still-unverified token" (self-heals on retry) instead of
+	// the harmful inverse — a verified token guarding a user that can never be
+	// activated.
 	user.IsActive = true
 	if _, err := api.userRegistry.Update(r.Context(), *user); err != nil {
 		slog.Error("Failed to activate user", "user_id", user.ID, "error", err)
@@ -371,10 +377,22 @@ func (api *RegistrationAPI) handleVerifyEmail(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	now := time.Now()
-	ev.VerifiedAt = &now
-	if _, err := api.verificationRegistry.Update(r.Context(), *ev); err != nil {
+	// Atomically claim the token. The IsVerified() check above is a non-locking
+	// fast path; this is the authoritative gate. Exactly one of N concurrent
+	// requests with the same token wins the claim (claimed == true) and runs
+	// the one-time first-verification side effects; the losers fall through to
+	// the idempotent "already verified" response without duplicating them
+	// (#1005). On a registry error we surface 500 so the client can retry — the
+	// account is already active, so the retry re-claims cleanly.
+	claimed, err := api.verificationRegistry.MarkVerified(r.Context(), token)
+	if err != nil {
 		slog.Error("Failed to mark verification as used", "id", ev.ID, "error", err)
+		http.Error(w, "Failed to verify email", http.StatusInternalServerError)
+		return
+	}
+	if !claimed {
+		writeJSON(w, http.StatusOK, map[string]string{"message": "Email already verified. You can log in now."})
+		return
 	}
 
 	api.logAuth(r, "email_verified", &user.ID, true, "")

--- a/go/apiserver/registration_test.go
+++ b/go/apiserver/registration_test.go
@@ -404,6 +404,124 @@ func TestHandleVerifyEmail_HappyPathActivatesUserAndSendsWelcome(t *testing.T) {
 	}
 }
 
+// claimLosingVerificationRegistry simulates the #1005 race loser: GetByToken
+// (and everything else) behaves like the embedded real registry, but the
+// atomic MarkVerified claim always reports false — i.e. a concurrent request
+// already won the token. The handler must then take the idempotent
+// "already verified" path and skip the one-time side effects.
+type claimLosingVerificationRegistry struct {
+	registry.EmailVerificationRegistry
+}
+
+func (*claimLosingVerificationRegistry) MarkVerified(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+// TestHandleVerifyEmail_ConcurrentLoserIsIdempotentAndSkipsWelcome pins the
+// #1005 fix at the handler level: a request that loses the atomic claim still
+// returns a 200 "already verified" but must NOT dispatch a second welcome
+// email or otherwise re-run first-verification side effects.
+func TestHandleVerifyEmail_ConcurrentLoserIsIdempotentAndSkipsWelcome(t *testing.T) {
+	c := qt.New(t)
+
+	user := &models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "race-loser"},
+			TenantID: testTenantID,
+		},
+		Email: "loser@example.com",
+		Name:  "Race Loser",
+	}
+	mem := memory.NewEmailVerificationRegistry()
+	ev, err := mem.Create(context.Background(), models.EmailVerification{
+		UserID:    user.ID,
+		TenantID:  testTenantID,
+		Email:     user.Email,
+		Token:     "loser-token",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	c.Assert(err, qt.IsNil)
+
+	verReg := &claimLosingVerificationRegistry{EmailVerificationRegistry: mem}
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{user.ID: user}}
+	emailSvc := &blockingEmailService{welcome: make(chan struct{}, 1)}
+	r := newRegistrationRouter(apiserver.RegistrationParams{
+		UserRegistry:         userReg,
+		VerificationRegistry: verReg,
+		EmailService:         emailSvc,
+		RateLimiter:          services.NewInMemoryAuthRateLimiter(),
+	}, models.RegistrationModeOpen)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, newVerifyRequest(ev.Token))
+	c.Assert(w.Code, qt.Equals, http.StatusOK)
+	c.Assert(w.Body.String(), qt.Contains, "already verified")
+
+	select {
+	case <-emailSvc.welcome:
+		t.Fatal("a request that lost the verification claim must not send a welcome email")
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+// TestHandleVerifyEmail_SecondVerifyIsIdempotent drives the real memory
+// registry end-to-end: after a successful verify marks the token, a second
+// request with the same token takes the IsVerified() fast path, returns 200,
+// and dispatches no further welcome email.
+func TestHandleVerifyEmail_SecondVerifyIsIdempotent(t *testing.T) {
+	c := qt.New(t)
+
+	user := &models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{
+			EntityID: models.EntityID{ID: "verify-twice"},
+			TenantID: testTenantID,
+		},
+		Email: "twice@example.com",
+		Name:  "Verify Twice",
+	}
+	verReg := memory.NewEmailVerificationRegistry()
+	ev, err := verReg.Create(context.Background(), models.EmailVerification{
+		UserID:    user.ID,
+		TenantID:  testTenantID,
+		Email:     user.Email,
+		Token:     "twice-token",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	c.Assert(err, qt.IsNil)
+
+	userReg := &mockUserRegistryForAuth{users: map[string]*models.User{user.ID: user}}
+	// Buffer 2 so a (buggy) second welcome would land instead of deadlocking.
+	emailSvc := &blockingEmailService{welcome: make(chan struct{}, 2)}
+	r := newRegistrationRouter(apiserver.RegistrationParams{
+		UserRegistry:         userReg,
+		VerificationRegistry: verReg,
+		EmailService:         emailSvc,
+		RateLimiter:          services.NewInMemoryAuthRateLimiter(),
+	}, models.RegistrationModeOpen)
+
+	// First verify: succeeds and sends exactly one welcome.
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, newVerifyRequest(ev.Token))
+	c.Assert(w1.Code, qt.Equals, http.StatusOK)
+	c.Assert(w1.Body.String(), qt.Contains, "Email verified")
+	select {
+	case <-emailSvc.welcome:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first verification should dispatch a welcome email")
+	}
+
+	// Second verify with the same token: idempotent, no new welcome.
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, newVerifyRequest(ev.Token))
+	c.Assert(w2.Code, qt.Equals, http.StatusOK)
+	c.Assert(w2.Body.String(), qt.Contains, "already verified")
+	select {
+	case <-emailSvc.welcome:
+		t.Fatal("a repeat verification must not dispatch a second welcome email")
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
 // ---- handleResendVerification ---------------------------------------------
 
 func TestHandleResendVerification_InvalidJSONReturns400(t *testing.T) {

--- a/go/registry/memory/email_verifications.go
+++ b/go/registry/memory/email_verifications.go
@@ -88,6 +88,37 @@ func (r *EmailVerificationRegistry) GetByUserID(ctx context.Context, userID stri
 	return result, nil
 }
 
+// MarkVerified atomically claims the verification token: under the registry's
+// write lock it sets VerifiedAt only if it is still nil, returning whether this
+// call performed the flip. The lock is the in-process equivalent of the
+// postgres `verified_at IS NULL` filter — two goroutines verifying the same
+// token serialize, so exactly one observes the nil and returns true while the
+// loser (and an already-verified or unknown token) returns false. See #1005.
+func (r *EmailVerificationRegistry) MarkVerified(_ context.Context, token string) (bool, error) {
+	if token == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Token"))
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for pair := r.items.Oldest(); pair != nil; pair = pair.Next() {
+		ev := pair.Value
+		if ev.Token != token {
+			continue
+		}
+		if ev.VerifiedAt != nil {
+			// Already verified — another caller won, or it was verified earlier.
+			return false, nil
+		}
+		now := time.Now()
+		ev.VerifiedAt = &now
+		return true, nil
+	}
+	// Token not found.
+	return false, nil
+}
+
 // DeleteExpired removes all records whose ExpiresAt timestamp is in the past.
 func (r *EmailVerificationRegistry) DeleteExpired(ctx context.Context) error {
 	all, err := r.List(ctx)

--- a/go/registry/memory/email_verifications_test.go
+++ b/go/registry/memory/email_verifications_test.go
@@ -3,6 +3,8 @@ package memory_test
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -228,4 +230,95 @@ func TestEmailVerificationRegistry_Count(t *testing.T) {
 	count, err = r.Count(ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(count, qt.Equals, 2)
+}
+
+func TestEmailVerificationRegistry_MarkVerified_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	created, err := r.Create(ctx, newTestEmailVerification("token-mark-happy"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.VerifiedAt, qt.IsNil)
+
+	claimed, err := r.MarkVerified(ctx, "token-mark-happy")
+	c.Assert(err, qt.IsNil)
+	c.Assert(claimed, qt.IsTrue, qt.Commentf("first claim of an unverified token must win"))
+
+	reloaded, err := r.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(reloaded.IsVerified(), qt.IsTrue)
+}
+
+// TestEmailVerificationRegistry_MarkVerified_AlreadyVerified pins the
+// idempotency contract: a second claim of the same token returns
+// (false, nil) so the caller knows the side effects already ran.
+func TestEmailVerificationRegistry_MarkVerified_AlreadyVerified(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	_, err := r.Create(ctx, newTestEmailVerification("token-mark-twice"))
+	c.Assert(err, qt.IsNil)
+
+	first, err := r.MarkVerified(ctx, "token-mark-twice")
+	c.Assert(err, qt.IsNil)
+	c.Assert(first, qt.IsTrue)
+
+	second, err := r.MarkVerified(ctx, "token-mark-twice")
+	c.Assert(err, qt.IsNil)
+	c.Assert(second, qt.IsFalse, qt.Commentf("re-claiming an already-verified token must not win"))
+}
+
+func TestEmailVerificationRegistry_MarkVerified_TokenNotFound(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	claimed, err := r.MarkVerified(ctx, "no-such-token")
+	c.Assert(err, qt.IsNil)
+	c.Assert(claimed, qt.IsFalse)
+}
+
+func TestEmailVerificationRegistry_MarkVerified_EmptyToken(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	claimed, err := r.MarkVerified(ctx, "")
+	c.Assert(errors.Is(err, registry.ErrFieldRequired), qt.IsTrue)
+	c.Assert(claimed, qt.IsFalse)
+}
+
+// TestEmailVerificationRegistry_MarkVerified_ConcurrentExactlyOnce is the core
+// #1005 regression: many goroutines racing to verify the same token must
+// produce exactly one winner, so the one-time side effects run once.
+func TestEmailVerificationRegistry_MarkVerified_ConcurrentExactlyOnce(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	r := memory.NewEmailVerificationRegistry()
+
+	_, err := r.Create(ctx, newTestEmailVerification("token-race"))
+	c.Assert(err, qt.IsNil)
+
+	const goroutines = 64
+	var winners atomic.Int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			<-start // line everyone up so the calls actually contend
+			claimed, markErr := r.MarkVerified(ctx, "token-race")
+			c.Check(markErr, qt.IsNil)
+			if claimed {
+				winners.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	c.Assert(int(winners.Load()), qt.Equals, 1, qt.Commentf("exactly one concurrent claim may win"))
 }

--- a/go/registry/postgres/email_verifications.go
+++ b/go/registry/postgres/email_verifications.go
@@ -143,6 +143,39 @@ func (r *EmailVerificationRegistry) GetByUserID(ctx context.Context, userID stri
 	return result, nil
 }
 
+// MarkVerified atomically flips verified_at from NULL to the current time for
+// the row matching token, returning whether this call won the claim. The
+// `verified_at IS NULL` filter makes the write idempotent across concurrent
+// requests: exactly one of them changes a row (rows-affected == 1 → true) and
+// the rest — plus a non-existent or already-verified token — observe zero
+// rows-affected → false. See the interface doc and #1005.
+func (r *EmailVerificationRegistry) MarkVerified(ctx context.Context, token string) (bool, error) {
+	if token == "" {
+		return false, errxtrace.Classify(registry.ErrFieldRequired, errx.Attrs("field_name", "Token"))
+	}
+	var claimed bool
+	err := r.newRepo().Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		query := fmt.Sprintf(
+			`UPDATE %s SET verified_at = $1 WHERE token = $2 AND verified_at IS NULL`,
+			r.tableNames.EmailVerifications(),
+		)
+		res, err := tx.ExecContext(ctx, query, time.Now(), token)
+		if err != nil {
+			return errxtrace.Wrap("failed to mark email verification as verified", err)
+		}
+		rows, err := res.RowsAffected()
+		if err != nil {
+			return errxtrace.Wrap("failed to read rows affected", err)
+		}
+		claimed = rows > 0
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return claimed, nil
+}
+
 // DeleteExpired removes all records whose ExpiresAt timestamp is in the past.
 func (r *EmailVerificationRegistry) DeleteExpired(ctx context.Context) error {
 	return r.newRepo().Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {

--- a/go/registry/postgres/email_verifications_test.go
+++ b/go/registry/postgres/email_verifications_test.go
@@ -247,6 +247,49 @@ func TestEmailVerificationRegistry_DeleteExpired(t *testing.T) {
 	c.Assert(all[0].ID, qt.Equals, futureCreated.ID)
 }
 
+// TestEmailVerificationRegistry_MarkVerified pins the atomic claim: the first
+// call flips verified_at and reports true; a second call on the same token
+// reports false (idempotent), and the row stays verified. See #1005.
+func TestEmailVerificationRegistry_MarkVerified(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	user := getTestUser(c, registrySet)
+
+	created, err := registrySet.EmailVerificationRegistry.Create(ctx, newTestEmailVerification(user, "token-mark"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created.VerifiedAt, qt.IsNil)
+
+	claimed, err := registrySet.EmailVerificationRegistry.MarkVerified(ctx, "token-mark")
+	c.Assert(err, qt.IsNil)
+	c.Assert(claimed, qt.IsTrue, qt.Commentf("first claim of an unverified token must win"))
+
+	reloaded, err := registrySet.EmailVerificationRegistry.Get(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(reloaded.IsVerified(), qt.IsTrue)
+
+	again, err := registrySet.EmailVerificationRegistry.MarkVerified(ctx, "token-mark")
+	c.Assert(err, qt.IsNil)
+	c.Assert(again, qt.IsFalse, qt.Commentf("re-claiming an already-verified token must not win"))
+}
+
+// TestEmailVerificationRegistry_MarkVerified_TokenNotFound pins that an unknown
+// token yields (false, nil) rather than an error — the zero-row UPDATE is a
+// non-event for the claim primitive.
+func TestEmailVerificationRegistry_MarkVerified_TokenNotFound(t *testing.T) {
+	registrySet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	claimed, err := registrySet.EmailVerificationRegistry.MarkVerified(ctx, "no-such-token")
+	c.Assert(err, qt.IsNil)
+	c.Assert(claimed, qt.IsFalse)
+}
+
 func TestEmailVerificationRegistry_Count(t *testing.T) {
 	registrySet, cleanup := setupTestRegistrySet(t)
 	defer cleanup()

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -1291,6 +1291,19 @@ type EmailVerificationRegistry interface {
 	// GetByUserID returns all email verification records for a user.
 	GetByUserID(ctx context.Context, userID string) ([]*models.EmailVerification, error)
 
+	// MarkVerified atomically claims the verification token by setting
+	// verified_at from NULL to the current time. The UPDATE filter includes
+	// `verified_at IS NULL`, so exactly one of N concurrent requests carrying
+	// the same token wins the row: it returns (true, nil) and is the caller
+	// responsible for the one-time first-verification side effects (welcome
+	// email, audit log, ...). Every other caller — whether it lost the race
+	// or the token was already verified earlier — gets (false, nil) and must
+	// treat the verification as already done. A token that does not exist
+	// also yields (false, nil). This closes the check-then-act race between
+	// the IsVerified() read and the write that previously let two requests
+	// both run the first-verification side effects (#1005).
+	MarkVerified(ctx context.Context, token string) (bool, error)
+
 	// DeleteExpired removes all records whose expiry time has passed.
 	DeleteExpired(ctx context.Context) error
 }


### PR DESCRIPTION
## What & why

Closes #1005.

`handleVerifyEmail` performed a non-atomic check-then-act:

```
GetByToken → ev.IsVerified() check → Update(user) → Update(verification)
```

Two concurrent requests carrying the same token could both pass the `IsVerified()` gate before either wrote `verified_at`, and both run the **one-time first-verification side effects**. When #1005 was filed this was theoretical (double-activation is idempotent), but the handler now calls `api.sendWelcome(user)` (welcome email, added with the registration/email-verification work), so the race is a real **double welcome-email send** — exactly the failure mode the issue called out.

## Approach

Add an atomic *claim* primitive to `EmailVerificationRegistry`, mirroring the existing `CommodityLoanRegistry.MarkReminderSent` idiom:

```go
MarkVerified(ctx, token) (bool, error)
```

- **postgres** — `UPDATE email_verifications SET verified_at = $now WHERE token = $token AND verified_at IS NULL`, returning `rows-affected > 0`. The `verified_at IS NULL` filter is the exclusion: exactly one concurrent UPDATE changes the row.
- **memory** — check-and-set of `VerifiedAt` under the registry write lock (the in-process equivalent of the conditional `WHERE`).

Exactly one of N concurrent callers wins the claim (`true`); the losers, an already-verified token, and an unknown token all get `false`.

`handleVerifyEmail` is rewired to:

1. **Activate the user first.** `IsActive` is a monotonic, idempotent flip, so a concurrent verify applying it twice is harmless. Ordering it *before* the claim means a crash between the two writes leaves the benign "active user, still-unverified token" (self-heals on retry) instead of the harmful inverse — a verified token guarding a user that can never be activated.
2. **Claim the token** via `MarkVerified`. The earlier `IsVerified()` check is kept as a non-locking fast path (the common "user clicks the link twice" case); the claim is the authoritative gate.
3. Only the **winner** runs the welcome email + audit log; losers fall through to the idempotent `200 "already verified"` without duplicating side effects.

A registry error from `MarkVerified` now surfaces `500` (previously the `Update` error was swallowed). The account is already active at that point, so a client retry re-claims cleanly and still sends the welcome exactly once.

## Tests

- **memory registry**: `MarkVerified` happy / already-verified / token-not-found / empty-token, plus a **64-goroutine exactly-one-winner** race (passes under `-race`).
- **postgres registry** (integration, CI-gated on `POSTGRES_TEST_DSN`): `MarkVerified` happy + idempotent re-claim, and token-not-found.
- **handler**: a claim-*loser* request returns the idempotent `200` and dispatches **no** welcome email; a sequential second verify takes the fast path and does not re-send.

Local: `go build ./...`, `go vet`, `golangci-lint run --fix` (0 issues), and `go test -race` on `./registry/memory/` + `./apiserver/` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email verification now safely handles concurrent and repeated verification requests, preventing unintended duplicate side effects such as multiple welcome emails.

* **Tests**
  * Added comprehensive test coverage for concurrent verification scenarios and idempotency behavior across all implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1907?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->