### PR TITLE
[#1264] design-system "start": FieldError, shadcn Select on forms, ServerErrorBanner

### DIFF
--- a/devdocs/frontend/design-deviations.md
+++ b/devdocs/frontend/design-deviations.md
@@ -248,7 +248,23 @@ Do not edit prior entries except to fix factual errors (typos, wrong issue numbe
 
 ### Forms & Validation
 
-_None yet._
+#### 2026-05-29 — Design-system "start": blessed FieldError + dropdown policy with annotated native-`<select>` exceptions
+
+- **Issue/PR**: #1264 / PR (this branch)
+- **Mock**: The mock renders field errors as inline `<p className="text-xs text-destructive">` per field and uses the shadcn `<Select>` (`design-mocks/src/views/SettingsView.tsx`) — plus a vendored `components/ui/native-select.tsx` primitive — for dropdowns. It has no single shared field-error component.
+- **Reality**: A shared `<FieldError>` (`components/FieldError.tsx`) replaces the ad-hoc `<p>` across the migrated forms (EditProfile, CreateGroup, AreaForm, SetPassword), baking in the `field-error` class + i18n resolution. Form & settings dropdowns use the shadcn `<Select>`; an ESLint `no-restricted-syntax` guard bans raw native `<select>`. Six **utility** native `<select>`s (bulk-move bars on Files/Commodities lists, the mobile category-tile collapse in `CategoryTiles`, the Tags list sort, the file-edit + per-file-upload category pickers) are kept native — they have `selectOption`-based test coverage and native semantics are intentional there — each annotated with an inline `eslint-disable-next-line` + reason. We did **not** port the mock's `native-select.tsx` primitive (those raw selects stay ad-hoc pending a later pass).
+- **Why**: #1264 is largely satisfied by the React rewrite (#1397); this is the roadmap's "#1264 start" slice (per #1651). Extracting `<FieldError>` is invisible visually but removes n copies of the same markup. The dropdown guard makes every remaining native `<select>` a conscious, documented choice ("pick one and stick with it") without a risky sweep of tested utility selectors. Converting those six is a deferred follow-up.
+- **Approved by**: user (explicit) — chose scope "Roadmap «start»" + approach "primitives-direct + FieldError" when offered the options.
+- **Reversion plan**: Permanent for `<FieldError>` + the lint guard. The six annotated native selectors are the explicit backlog: migrate them to `<Select>` (or a ported `native-select` primitive) and drop the disable comments in the post-launch design-system "finish" pass.
+
+#### 2026-05-29 — Two intentional IconPicker components (popover vs. inline grid) kept separate
+
+- **Issue/PR**: #1264 / PR (this branch)
+- **Mock**: Location/area dialogs (`design-mocks/src/components/LocationDialog.tsx`, `AreaDialog.tsx`) render an inline emoji grid. The group surface is a different composition.
+- **Reality**: Two components share the name `IconPicker` — `components/groups/IconPicker.tsx` (Popover + category tabs, sourced from `features/group/icons.ts`) and `components/locations/IconPicker.tsx` (inline grid, palette via prop). They are **not** merged: the audit for #1264 flagged a "name collision", but the two are genuinely distinct UX with different data sources and a11y trade-offs. Resolved by documenting (cross-ref comments in both files + a forms.md table) which to use, rather than collapsing them into one `mode`-switching component.
+- **Why**: Merging would either bloat one component with a popover/inline `mode` switch (poor cohesion) or break mock fidelity (the dialogs want the inline grid; the group form wants the space-saving popover). The folder paths already disambiguate the imports.
+- **Approved by**: agent-suggested — judgment call within the #1264 "dedup IconPicker" scope item; surfaced to the user as "not duplicates → document, don't merge".
+- **Reversion plan**: Permanent unless the upstream mock unifies the two surfaces.
 
 ### Auth & Profile
 

--- a/devdocs/frontend/forms.md
+++ b/devdocs/frontend/forms.md
@@ -158,31 +158,51 @@ Backends emit three error envelopes:
 "Email already taken"
 ```
 
-`parseServerError(err, fallback)` collapses all three into a single string,
-falling back to the supplied default for 5xx HTML responses or unknown
-shapes:
+Two layered helpers in `@/lib/server-error` normalise these:
 
-```ts
-import { parseServerError } from "@/lib/server-error"
+- `parseServerError(err, fallback)` collapses all three envelopes into a
+  single string, falling back to the supplied default for 5xx HTML
+  responses or unknown shapes. The low-level primitive.
+- `classifyServerError(err, fallback)` returns `{ kind, message }` where
+  `kind` is `network | validation | conflict | unknown` — a hint that
+  drives the banner's headline + whether a Retry affordance shows.
+
+The **blessed form-level surface is `<ServerErrorBanner>`**
+(`@/components/ServerErrorBanner`): one visual contract (icon + typed
+title + message + conditional Retry) so users learn the affordances once.
+Feed it a `classifyServerError` result; it renders nothing for `null`:
+
+```tsx
+import { ServerErrorBanner } from "@/components/ServerErrorBanner"
+import { classifyServerError, type ClassifiedServerError } from "@/lib/server-error"
+
+const [serverError, setServerError] = useState<ClassifiedServerError | null>(null)
 
 try {
   await mutation.mutateAsync(values)
 } catch (err) {
-  setServerError(parseServerError(err, t("auth:login.errorGeneric")))
+  setServerError(classifyServerError(err, t("auth:login.errorGeneric")))
 }
+
+// …in the form:
+<ServerErrorBanner error={serverError} testId="…-server-error" />
 ```
+
+For a bespoke message on a known status (e.g. a 422 "current password is
+incorrect"), construct the classified value directly:
+`setServerError({ kind: "validation", message: t("…") })` — see
+`EditProfilePage`.
 
 Rules:
 
-- **Always pass a fallback** — never `parseServerError(err, "")`. The
+- **Always pass a fallback** — never `classifyServerError(err, "")`. The
   fallback is what a 500 with an HTML body or a network error becomes.
   Use a translated string (`t("...")`).
-- **Don't assume the field map.** The current backend doesn't return
-  per-field errors for the auth surface, so we render server errors as
-  one banner above the form. If a future endpoint returns
-  `{ errors: [{ source: { pointer: "/data/attributes/email" }, … }] }`,
-  extend `parseServerError` first; don't sprinkle ad-hoc parsing in the
-  page.
+- **Prefer `<ServerErrorBanner>`** for form-level server errors. The bare
+  `<Alert variant="destructive">` + `parseServerError` string in some
+  older auth pages (LoginPage) predates the typed banner; new forms use
+  the banner. Field-level zod errors stay on `<FieldError>`, not the
+  banner.
 - **Reset on edit.** Watch the form via `form.watch()` and clear the
   banner when the user edits — see the LoginPage example.
 
@@ -208,15 +228,33 @@ fire and let the schema render the errors.
 ## Field components
 
 Use the shadcn primitives directly — `Input`, `Label`, `Checkbox`,
-`Select`, `Textarea`. The standard field shape is:
+`Select`, `Textarea`. One blessed piece is **not** a raw element: the
+field-level error. Render it with `<FieldError>` (`@/components/FieldError`),
+never an ad-hoc `<p className="text-xs text-destructive">`. The standard
+field shape is:
 
 ```tsx
+import { FieldError } from "@/components/FieldError"
+
+const err = form.formState.errors.fieldId
+
 <div className="space-y-1.5">
   <Label htmlFor="field-id">Label</Label>
-  <Input id="field-id" {...form.register("field-id")} aria-invalid={!!error} />
-  {error && <p className="text-xs text-destructive">{t(error.message ?? "")}</p>}
+  <Input
+    id="field-id"
+    aria-invalid={!!err}
+    aria-describedby={err ? "field-id-error" : undefined}
+    {...form.register("fieldId")}
+  />
+  <FieldError id="field-id-error" testId="field-id-error" message={err?.message} />
 </div>
 ```
+
+`<FieldError>` resolves the message through `t()` itself (the message is an
+i18n key from the zod schema — see [Schema](#schema)), renders nothing when
+the message is empty, and bakes in the `field-error` class the e2e suite
+selects on. Wire `aria-describedby` on the input to the `FieldError` `id`
+so screen readers announce the message when RHF focuses the invalid field.
 
 For complex controls (combobox, date picker), wrap with `Controller`:
 
@@ -229,12 +267,75 @@ import { Controller } from "react-hook-form"
   render={({ field, fieldState }) => (
     <CurrencyCombobox
       value={field.value}
-      onValueChange={field.onChange}
-      aria-invalid={fieldState.invalid}
+      onChange={field.onChange}
+      ariaInvalid={fieldState.invalid}
     />
   )}
 />
 ```
+
+### Dropdowns
+
+There is **one blessed dropdown for form & settings fields: the shadcn
+`<Select>`** (`@/components/ui/select`, Radix under the hood). Wrap it in a
+`Controller` for RHF forms; pass `field.ref` to the `SelectTrigger` so
+focus-on-error still lands on the control:
+
+```tsx
+<Controller
+  control={form.control}
+  name="locationId"
+  render={({ field }) => (
+    <Select value={field.value || undefined} onValueChange={field.onChange}>
+      <SelectTrigger id="location" ref={field.ref} className="w-full">
+        <SelectValue placeholder={t("…")} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((o) => (
+          <SelectItem key={o.id} value={o.id}>{o.name}</SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )}
+/>
+```
+
+Gotcha: Radix forbids an **empty-string** `SelectItem` value. For an
+"auto / none" option use a sentinel (`"auto"`) and map it back to `""` in
+`value` / `onValueChange` (see `SettingsPage`'s Region & formatting field).
+
+A raw native `<select>` is banned by the ESLint rule `no-restricted-syntax`
+(see `eslint.config.js`). It stays permissible only for **utility /
+compact / mobile** selectors — bulk-move bars, the mobile category-tile
+collapse, list sort pickers — where native semantics are intentional and
+already covered by `selectOption`-based tests. Those few sites carry an
+explicit `// eslint-disable-next-line no-restricted-syntax -- <reason>`.
+Don't add a new bare `<select>` to a form; reach for `<Select>`.
+
+In tests, drive a `<Select>` with `pickRadixSelect(user, triggerLabel,
+{ optionLabel })` from `@/test/radix` — `user.selectOptions()` no-ops on
+the Radix trigger (it's a `role="combobox"` button, not an
+`HTMLSelectElement`).
+
+### Icon pickers
+
+There are **two intentional icon pickers** — keep them separate, they are
+not duplicates:
+
+| Component | Use for | Shape |
+| --- | --- | --- |
+| `components/groups/IconPicker` | Group create / settings | Popover + category tabs + grid (many curated glyphs, space-constrained form) |
+| `components/locations/IconPicker` | Location / area dialogs | Inline grid (small curated palette, mirrors the mock dialogs) |
+
+They differ in UX, data source (`features/group/icons.ts` vs. a palette
+prop), and a11y trade-offs by design. Pick by surface; don't merge them.
+
+### Reference screen
+
+`pages/EditProfilePage.tsx` is the canonical reference for these patterns
+(#1264): RHF + zod, `<FieldError>` on every field, `<Select>` for the
+default-group dropdown, and `<ServerErrorBanner>` for the profile +
+password server errors. Copy its shape when building a new form.
 
 ## Multi-step forms
 

--- a/e2e/tests/settings-default-group.spec.ts
+++ b/e2e/tests/settings-default-group.spec.ts
@@ -69,12 +69,15 @@ authTest.describe('Settings — default group, authenticated user (#1592)', () =
     const select = page.locator('[data-testid="settings-default-group-select"]');
     await expect(select).toBeVisible({ timeout: 10000 });
 
-    // The selector must default to a real group (the user's preference under
-    // the #1592 invariant; backfill ensured admin has one). An empty value
-    // would mean the front-end is showing "no default" copy that no longer
-    // exists.
-    const value = await select.inputValue();
-    expect(value).not.toBe('');
+    // The default-group control is a shadcn/Radix <Select> (#1264), i.e. a
+    // role="combobox" button rather than a native <select>, so read the
+    // rendered label instead of inputValue(). The trigger must show a real
+    // group name (the user's preference under the #1592 invariant; backfill
+    // ensured admin has one) — an empty label would mean the front-end is
+    // showing "no default" copy that no longer exists.
+    await expect(select).toHaveAttribute('role', 'combobox');
+    const label = ((await select.textContent()) ?? '').trim();
+    expect(label.length).toBeGreaterThan(0);
 
     // The empty-state CTA must NOT be rendered when the user has memberships.
     await expect(page.locator('[data-testid="settings-no-groups-cta"]')).toHaveCount(0);

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -44,6 +44,22 @@ export default [
       "react/prop-types": "off",
       "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
       "@typescript-eslint/no-explicit-any": "warn",
+      // Design-system guard (#1264): the blessed dropdown for form &
+      // settings fields is the shadcn <Select> primitive
+      // (@/components/ui/select). A raw native <select> drifts from the
+      // single visual contract. It stays permissible for utility / compact
+      // / mobile selectors (bulk-move bars, mobile category collapse, list
+      // sort) — annotate those deliberately with
+      // `eslint-disable-next-line no-restricted-syntax -- <reason>`. See
+      // devdocs/frontend/forms.md → "Dropdowns".
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "JSXOpeningElement[name.name='select']",
+          message:
+            "Use the shadcn <Select> primitive (@/components/ui/select) for form & settings dropdowns. Native <select> is allowed only for utility/compact/mobile selectors — annotate with `// eslint-disable-next-line no-restricted-syntax -- <reason>`. See devdocs/frontend/forms.md.",
+        },
+      ],
       // eslint-plugin-react-hooks 5.x added a React-Compiler ruleset that
       // flags `form.watch(cb)` from React Hook Form because the callback
       // form returns a non-memoizable subscription. RHF's watch() is the

--- a/frontend/src/components/FieldError.tsx
+++ b/frontend/src/components/FieldError.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from "react-i18next"
+
+import { cn } from "@/lib/utils"
+
+interface FieldErrorProps {
+  // Field error message. By convention this is an i18n key produced by a
+  // zod schema (e.g. "auth:validation.emailRequired") — FieldError resolves
+  // it through `t()` so call sites don't repeat the translation. Renders
+  // nothing when undefined / null / empty, so you can pass
+  // `errors.<field>?.message` straight through.
+  message?: string | null
+  // Element id so the matching input can wire `aria-describedby={id}` and
+  // assistive tech announces this message when the field gets focus. RHF's
+  // default `shouldFocusError` moves focus to the first invalid field on
+  // submit, so the described-by text is read out without a `role="alert"`
+  // (which would otherwise double-announce on mount).
+  id?: string
+  // Stable test hook (e.g. "profile-name-error"). Pair it with the input's
+  // `aria-describedby` for a11y and with e2e selectors that prefer ids over
+  // copy matching.
+  testId?: string
+  className?: string
+}
+
+// FieldError — the single blessed rendering for an inline form-field
+// validation error. Replaces the ad-hoc
+// `<p className="text-xs text-destructive">{t(error.message)}</p>` repeated
+// across every form so the color token, sizing, and the `.field-error`
+// hook stay identical app-wide. The `field-error` class is intentionally
+// part of the base: the e2e suite (`e2e/tests/profile.spec.ts`) locates
+// field errors by that class, so baking it in gives every adopting form
+// the same selector for free. See `devdocs/frontend/forms.md` for the
+// field shape this slots into.
+export function FieldError({ message, id, testId, className }: FieldErrorProps) {
+  const { t } = useTranslation()
+  if (!message) return null
+  return (
+    <p
+      id={id}
+      data-testid={testId}
+      className={cn("field-error text-xs text-destructive", className)}
+    >
+      {t(message)}
+    </p>
+  )
+}

--- a/frontend/src/components/__tests__/FieldError.test.tsx
+++ b/frontend/src/components/__tests__/FieldError.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { axe } from "jest-axe"
+
+import { FieldError } from "@/components/FieldError"
+import { i18next } from "@/i18n"
+
+describe("<FieldError />", () => {
+  it("renders nothing when there is no message", () => {
+    const { container } = render(<FieldError message={undefined} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders nothing for an empty-string message", () => {
+    const { container } = render(<FieldError message="" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("resolves the i18n key and carries the field-error hook + id + testId", () => {
+    render(
+      <FieldError message="auth:validation.emailRequired" id="email-error" testId="email-error" />
+    )
+    const el = screen.getByTestId("email-error")
+    // Baked-in class is the e2e selector hook (e2e/tests/profile.spec.ts).
+    expect(el).toHaveClass("field-error")
+    expect(el).toHaveClass("text-destructive")
+    expect(el).toHaveAttribute("id", "email-error")
+    // The component owns the translation — the key resolves to real copy.
+    expect(el).toHaveTextContent(i18next.t("auth:validation.emailRequired"))
+    expect(el.textContent).toBe("Email is required")
+  })
+
+  it("merges a caller className with the base classes", () => {
+    render(<FieldError message="auth:validation.emailRequired" testId="e" className="mt-2" />)
+    const el = screen.getByTestId("e")
+    expect(el).toHaveClass("mt-2")
+    expect(el).toHaveClass("field-error")
+  })
+
+  it("has no axe violations", async () => {
+    const { container } = render(<FieldError message="auth:validation.emailRequired" />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/components/__tests__/FieldError.test.tsx
+++ b/frontend/src/components/__tests__/FieldError.test.tsx
@@ -1,25 +1,28 @@
 import { describe, expect, it } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
 import { axe } from "jest-axe"
 
 import { FieldError } from "@/components/FieldError"
 import { i18next } from "@/i18n"
+import { renderWithProviders } from "@/test/render"
 
 describe("<FieldError />", () => {
   it("renders nothing when there is no message", () => {
-    const { container } = render(<FieldError message={undefined} />)
-    expect(container).toBeEmptyDOMElement()
+    renderWithProviders({ children: <FieldError message={undefined} testId="fe" /> })
+    expect(screen.queryByTestId("fe")).not.toBeInTheDocument()
   })
 
   it("renders nothing for an empty-string message", () => {
-    const { container } = render(<FieldError message="" />)
-    expect(container).toBeEmptyDOMElement()
+    renderWithProviders({ children: <FieldError message="" testId="fe" /> })
+    expect(screen.queryByTestId("fe")).not.toBeInTheDocument()
   })
 
   it("resolves the i18n key and carries the field-error hook + id + testId", () => {
-    render(
-      <FieldError message="auth:validation.emailRequired" id="email-error" testId="email-error" />
-    )
+    renderWithProviders({
+      children: (
+        <FieldError message="auth:validation.emailRequired" id="email-error" testId="email-error" />
+      ),
+    })
     const el = screen.getByTestId("email-error")
     // Baked-in class is the e2e selector hook (e2e/tests/profile.spec.ts).
     expect(el).toHaveClass("field-error")
@@ -31,14 +34,18 @@ describe("<FieldError />", () => {
   })
 
   it("merges a caller className with the base classes", () => {
-    render(<FieldError message="auth:validation.emailRequired" testId="e" className="mt-2" />)
+    renderWithProviders({
+      children: <FieldError message="auth:validation.emailRequired" testId="e" className="mt-2" />,
+    })
     const el = screen.getByTestId("e")
     expect(el).toHaveClass("mt-2")
     expect(el).toHaveClass("field-error")
   })
 
   it("has no axe violations", async () => {
-    const { container } = render(<FieldError message="auth:validation.emailRequired" />)
+    const { container } = renderWithProviders({
+      children: <FieldError message="auth:validation.emailRequired" />,
+    })
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/frontend/src/components/auth/SetPasswordForm.tsx
+++ b/frontend/src/components/auth/SetPasswordForm.tsx
@@ -7,13 +7,15 @@ import { CheckCircle2, KeyRound } from "lucide-react"
 
 import { PasswordInput } from "@/components/auth/PasswordInput"
 import { PasswordStrengthMeter } from "@/components/auth/PasswordStrengthMeter"
+import { FieldError } from "@/components/FieldError"
+import { ServerErrorBanner } from "@/components/ServerErrorBanner"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { useAuth } from "@/features/auth/AuthContext"
 import { useChangePassword, useLogout } from "@/features/auth/hooks"
 import { setPasswordSchema, type SetPasswordInput } from "@/features/auth/schemas"
-import { parseServerError } from "@/lib/server-error"
+import { classifyServerError, type ClassifiedServerError } from "@/lib/server-error"
 
 // SetPasswordForm — surface for OAuth-only users to set their first
 // password (#1394). Same look as the password card on EditProfilePage,
@@ -30,7 +32,7 @@ export function SetPasswordForm() {
   const changePasswordMutation = useChangePassword()
   const logoutMutation = useLogout()
 
-  const [serverError, setServerError] = useState<string | null>(null)
+  const [serverError, setServerError] = useState<ClassifiedServerError | null>(null)
   const [success, setSuccess] = useState(false)
 
   const form = useForm<SetPasswordInput>({
@@ -75,7 +77,7 @@ export function SetPasswordForm() {
         })()
       }, 1500)
     } catch (err) {
-      setServerError(parseServerError(err, t("auth:setPassword.errorGeneric")))
+      setServerError(classifyServerError(err, t("auth:setPassword.errorGeneric")))
     }
   }
 
@@ -115,6 +117,9 @@ export function SetPasswordForm() {
               hideLockIcon
               disabled={changePasswordMutation.isPending}
               aria-invalid={!!form.formState.errors.newPassword}
+              aria-describedby={
+                form.formState.errors.newPassword ? "set-new-password-error" : undefined
+              }
               data-testid="set-new-password"
               {...form.register("newPassword")}
             />
@@ -123,14 +128,11 @@ export function SetPasswordForm() {
               userInputs={strengthInputs}
               testId="set-password-strength"
             />
-            {form.formState.errors.newPassword ? (
-              <p
-                className="field-error text-xs text-destructive"
-                data-testid="set-new-password-error"
-              >
-                {t(form.formState.errors.newPassword.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError
+              id="set-new-password-error"
+              testId="set-new-password-error"
+              message={form.formState.errors.newPassword?.message}
+            />
           </div>
 
           <div className="space-y-1.5">
@@ -141,28 +143,24 @@ export function SetPasswordForm() {
               hideLockIcon
               disabled={changePasswordMutation.isPending}
               aria-invalid={!!form.formState.errors.confirmPassword}
+              aria-describedby={
+                form.formState.errors.confirmPassword ? "set-confirm-password-error" : undefined
+              }
               data-testid="set-confirm-password"
               {...form.register("confirmPassword")}
             />
-            {form.formState.errors.confirmPassword ? (
-              <p
-                className="field-error text-xs text-destructive"
-                data-testid="set-confirm-password-error"
-              >
-                {t(form.formState.errors.confirmPassword.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError
+              id="set-confirm-password-error"
+              testId="set-confirm-password-error"
+              message={form.formState.errors.confirmPassword?.message}
+            />
           </div>
 
-          {serverError ? (
-            <Alert
-              variant="destructive"
-              className="error-banner"
-              data-testid="set-password-server-error"
-            >
-              <AlertDescription>{serverError}</AlertDescription>
-            </Alert>
-          ) : null}
+          <ServerErrorBanner
+            error={serverError}
+            className="error-banner"
+            testId="set-password-server-error"
+          />
 
           <div className="flex justify-end pt-2">
             <Button

--- a/frontend/src/components/files/CategoryTiles.tsx
+++ b/frontend/src/components/files/CategoryTiles.tsx
@@ -31,6 +31,7 @@ export function CategoryTiles({ active, counts, loading, onSelect }: CategoryTil
         <span className="sr-only">
           {t("files:categoryMobileLabel", { defaultValue: "Category" })}
         </span>
+        {/* eslint-disable-next-line no-restricted-syntax -- mobile-only: the category tiles collapse to a compact native <select> to save screen real-estate (mock-driven). Not a form field */}
         <select
           data-testid="files-category-select"
           value={active}

--- a/frontend/src/components/files/UploadFilesDialog.tsx
+++ b/frontend/src/components/files/UploadFilesDialog.tsx
@@ -561,6 +561,7 @@ function MetadataStep({
                 <Label htmlFor={`meta-category-${it.id}`} className="text-xs text-muted-foreground">
                   {t("files:edit.fields.category")}
                 </Label>
+                {/* eslint-disable-next-line no-restricted-syntax -- compact per-file category picker; native <select> retained (covered by upload e2e + unit). shadcn migration tracked as a forms follow-up — see devdocs/frontend/forms.md */}
                 <select
                   id={`meta-category-${it.id}`}
                   value={it.category}

--- a/frontend/src/components/groups/IconPicker.tsx
+++ b/frontend/src/components/groups/IconPicker.tsx
@@ -23,6 +23,15 @@ interface IconPickerProps {
 // emoji (or a placeholder); clicking opens a panel with category tabs + an
 // emoji grid + a close button. The picker mirrors the curated list from
 // features/group/icons.ts.
+//
+// NOTE — there are two intentional icon pickers (see
+// devdocs/frontend/forms.md → "Icon pickers"): this Popover variant for
+// groups (many categorised glyphs, space-constrained create/settings
+// form) and the inline-grid `IconPicker` in
+// `components/locations/IconPicker.tsx` for location/area dialogs (small
+// curated palette, mock renders it inline). They are NOT duplicates —
+// different UX + data source — so they are kept separate rather than
+// merged. Use this one for the group surface.
 export function IconPicker({ value, onChange, testId = "icon-picker", disabled }: IconPickerProps) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)

--- a/frontend/src/components/locations/AreaFormDialog.tsx
+++ b/frontend/src/components/locations/AreaFormDialog.tsx
@@ -3,7 +3,6 @@ import { Controller, useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useTranslation } from "react-i18next"
 
-import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -15,11 +14,20 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { FieldError } from "@/components/FieldError"
+import { ServerErrorBanner } from "@/components/ServerErrorBanner"
 import { AREA_ICONS, IconPicker } from "@/components/locations/IconPicker"
 import type { Area } from "@/features/areas/api"
 import { areaSchema, type AreaFormInput } from "@/features/areas/schemas"
 import type { Location } from "@/features/locations/api"
-import { parseServerError } from "@/lib/server-error"
+import { classifyServerError, type ClassifiedServerError } from "@/lib/server-error"
 
 interface AreaFormDialogProps {
   open: boolean
@@ -48,7 +56,7 @@ export function AreaFormDialog({
   isPending = false,
 }: AreaFormDialogProps) {
   const { t } = useTranslation()
-  const [serverError, setServerError] = useState<string | null>(null)
+  const [serverError, setServerError] = useState<ClassifiedServerError | null>(null)
   const isEdit = !!area
 
   const form = useForm<AreaFormInput>({
@@ -105,7 +113,7 @@ export function AreaFormDialog({
       await onSubmit(values)
       onOpenChange(false)
     } catch (err) {
-      setServerError(parseServerError(err, t("locations:areaDialog.errorGeneric")))
+      setServerError(classifyServerError(err, t("locations:areaDialog.errorGeneric")))
     }
   }
 
@@ -149,11 +157,7 @@ export function AreaFormDialog({
                 />
               )}
             />
-            {form.formState.errors.icon ? (
-              <p className="text-xs text-destructive" data-testid="area-icon-error">
-                {t(form.formState.errors.icon.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError testId="area-icon-error" message={form.formState.errors.icon?.message} />
           </div>
 
           <div className="space-y-1.5">
@@ -168,14 +172,15 @@ export function AreaFormDialog({
               maxLength={200}
               disabled={isPending}
               aria-invalid={!!form.formState.errors.name}
+              aria-describedby={form.formState.errors.name ? "area-name-error" : undefined}
               data-testid="area-name-input"
               {...form.register("name")}
             />
-            {form.formState.errors.name ? (
-              <p className="text-xs text-destructive" data-testid="area-name-error">
-                {t(form.formState.errors.name.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError
+              id="area-name-error"
+              testId="area-name-error"
+              message={form.formState.errors.name?.message}
+            />
           </div>
 
           {showLocationPicker ? (
@@ -185,39 +190,45 @@ export function AreaFormDialog({
                 control={form.control}
                 name="location_id"
                 render={({ field }) => (
-                  // Spread `field` so name / ref / onBlur land on the
-                  // <select> too — without ref the form's focus-on-error
-                  // logic targets nothing, and without onBlur RHF's
-                  // touched/dirty tracking goes stale on this control.
-                  <select
-                    {...field}
-                    id="area-location"
-                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                  // Radix Select is the blessed form dropdown. `field.ref`
+                  // lands on the trigger so RHF's focus-on-error still
+                  // targets this control; onValueChange feeds the form.
+                  <Select
+                    value={field.value || undefined}
+                    onValueChange={field.onChange}
                     disabled={isPending}
-                    aria-invalid={!!form.formState.errors.location_id}
-                    data-testid="area-location-select"
                   >
-                    {locations.map((l) => (
-                      <option key={l.id} value={l.id}>
-                        {l.name}
-                      </option>
-                    ))}
-                  </select>
+                    <SelectTrigger
+                      id="area-location"
+                      ref={field.ref}
+                      className="w-full"
+                      aria-invalid={!!form.formState.errors.location_id}
+                      aria-describedby={
+                        form.formState.errors.location_id ? "area-location-error" : undefined
+                      }
+                      data-testid="area-location-select"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {locations.map((l) => (
+                        <SelectItem key={l.id} value={l.id ?? ""}>
+                          {l.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 )}
               />
-              {form.formState.errors.location_id ? (
-                <p className="text-xs text-destructive" data-testid="area-location-error">
-                  {t(form.formState.errors.location_id.message ?? "")}
-                </p>
-              ) : null}
+              <FieldError
+                id="area-location-error"
+                testId="area-location-error"
+                message={form.formState.errors.location_id?.message}
+              />
             </div>
           ) : null}
 
-          {serverError ? (
-            <Alert variant="destructive" data-testid="area-form-server-error">
-              <AlertDescription>{serverError}</AlertDescription>
-            </Alert>
-          ) : null}
+          <ServerErrorBanner error={serverError} testId="area-form-server-error" />
 
           {/* DialogFooter must stay INSIDE the form. See the matching note in
               LocationFormDialog: webkit-macos drops the form-submission event

--- a/frontend/src/components/locations/IconPicker.tsx
+++ b/frontend/src/components/locations/IconPicker.tsx
@@ -21,6 +21,15 @@ interface IconPickerProps {
   disabled?: boolean
 }
 
+// NOTE — there are two intentional icon pickers (see
+// devdocs/frontend/forms.md → "Icon pickers"): this inline-grid variant
+// for location/area dialogs (small curated palette, the mock renders it
+// inline) and the Popover variant in `components/groups/IconPicker.tsx`
+// for the group create/settings surface (many categorised glyphs in a
+// space-constrained form). They are NOT duplicates — different UX + data
+// source — so they are kept separate rather than merged. Use this one for
+// the location/area dialogs.
+//
 // IconPicker mirrors the mock dialogs' inline icon grid (see
 // `design-mocks/src/components/LocationDialog.tsx` L102-L122 and
 // `AreaDialog.tsx` L62-L82): a `flex-wrap` row of `size-9` `rounded-lg`

--- a/frontend/src/components/locations/LocationFormDialog.tsx
+++ b/frontend/src/components/locations/LocationFormDialog.tsx
@@ -3,7 +3,6 @@ import { Controller, useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useTranslation } from "react-i18next"
 
-import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -16,10 +15,12 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { FieldError } from "@/components/FieldError"
+import { ServerErrorBanner } from "@/components/ServerErrorBanner"
 import { IconPicker, LOCATION_ICONS } from "@/components/locations/IconPicker"
 import type { Location } from "@/features/locations/api"
 import { locationSchema, type LocationFormInput } from "@/features/locations/schemas"
-import { parseServerError } from "@/lib/server-error"
+import { classifyServerError, type ClassifiedServerError } from "@/lib/server-error"
 
 interface LocationFormDialogProps {
   // True opens the dialog. Closing fires `onOpenChange(false)`.
@@ -50,7 +51,7 @@ export function LocationFormDialog({
   isPending = false,
 }: LocationFormDialogProps) {
   const { t } = useTranslation()
-  const [serverError, setServerError] = useState<string | null>(null)
+  const [serverError, setServerError] = useState<ClassifiedServerError | null>(null)
   const isEdit = !!location
 
   const form = useForm<LocationFormInput>({
@@ -100,7 +101,7 @@ export function LocationFormDialog({
       await onSubmit(values)
       onOpenChange(false)
     } catch (err) {
-      setServerError(parseServerError(err, t("locations:dialog.errorGeneric")))
+      setServerError(classifyServerError(err, t("locations:dialog.errorGeneric")))
     }
   }
 
@@ -139,11 +140,10 @@ export function LocationFormDialog({
                 />
               )}
             />
-            {form.formState.errors.icon ? (
-              <p className="text-xs text-destructive" data-testid="location-icon-error">
-                {t(form.formState.errors.icon.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError
+              testId="location-icon-error"
+              message={form.formState.errors.icon?.message}
+            />
           </div>
 
           <div className="space-y-1.5">
@@ -158,14 +158,15 @@ export function LocationFormDialog({
               maxLength={200}
               disabled={isPending}
               aria-invalid={!!form.formState.errors.name}
+              aria-describedby={form.formState.errors.name ? "location-name-error" : undefined}
               data-testid="location-name-input"
               {...form.register("name")}
             />
-            {form.formState.errors.name ? (
-              <p className="text-xs text-destructive" data-testid="location-name-error">
-                {t(form.formState.errors.name.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError
+              id="location-name-error"
+              testId="location-name-error"
+              message={form.formState.errors.name?.message}
+            />
           </div>
 
           <div className="space-y-1.5">
@@ -178,15 +179,18 @@ export function LocationFormDialog({
               rows={2}
               disabled={isPending}
               aria-invalid={!!form.formState.errors.description}
+              aria-describedby={
+                form.formState.errors.description ? "location-description-error" : undefined
+              }
               data-testid="location-description-input"
               className="resize-none"
               {...form.register("description")}
             />
-            {form.formState.errors.description ? (
-              <p className="text-xs text-destructive" data-testid="location-description-error">
-                {t(form.formState.errors.description.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError
+              id="location-description-error"
+              testId="location-description-error"
+              message={form.formState.errors.description?.message}
+            />
             <p className="text-[11px] text-muted-foreground">
               {t("locations:dialog.descriptionHelp")}
             </p>
@@ -201,22 +205,21 @@ export function LocationFormDialog({
               maxLength={2000}
               disabled={isPending}
               aria-invalid={!!form.formState.errors.address}
+              aria-describedby={
+                form.formState.errors.address ? "location-address-error" : undefined
+              }
               data-testid="location-address-input"
               {...form.register("address")}
             />
-            {form.formState.errors.address ? (
-              <p className="text-xs text-destructive" data-testid="location-address-error">
-                {t(form.formState.errors.address.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError
+              id="location-address-error"
+              testId="location-address-error"
+              message={form.formState.errors.address?.message}
+            />
             <p className="text-[11px] text-muted-foreground">{t("locations:dialog.addressHelp")}</p>
           </div>
 
-          {serverError ? (
-            <Alert variant="destructive" data-testid="location-form-server-error">
-              <AlertDescription>{serverError}</AlertDescription>
-            </Alert>
-          ) : null}
+          <ServerErrorBanner error={serverError} testId="location-form-server-error" />
 
           {/* DialogFooter is rendered INSIDE the form. The submit button used
               to live outside the form and bind via `form="location-form"`, but

--- a/frontend/src/pages/EditProfilePage.tsx
+++ b/frontend/src/pages/EditProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { useForm } from "react-hook-form"
+import { useForm, Controller } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useTranslation } from "react-i18next"
 import { Link, useNavigate } from "react-router-dom"
@@ -9,11 +9,20 @@ import { ComingSoonBanner } from "@/components/coming-soon"
 import { PasswordInput } from "@/components/auth/PasswordInput"
 import { PasswordStrengthMeter } from "@/components/auth/PasswordStrengthMeter"
 import { SetPasswordForm } from "@/components/auth/SetPasswordForm"
+import { FieldError } from "@/components/FieldError"
+import { ServerErrorBanner } from "@/components/ServerErrorBanner"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Page, PageHeader } from "@/components/ui/page"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { useAuth } from "@/features/auth/AuthContext"
 import {
   useChangePassword,
@@ -32,7 +41,7 @@ import {
 } from "@/features/auth/schemas"
 import { useAppToast } from "@/hooks/useAppToast"
 import { HttpError } from "@/lib/http"
-import { parseServerError } from "@/lib/server-error"
+import { classifyServerError, type ClassifiedServerError } from "@/lib/server-error"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 
 // /profile/edit — two side-by-side forms in one page: profile fields
@@ -54,9 +63,9 @@ export function EditProfilePage() {
   // never see the wrong shape.
   const hasPassword = useHasPassword()
 
-  const [profileError, setProfileError] = useState<string | null>(null)
+  const [profileError, setProfileError] = useState<ClassifiedServerError | null>(null)
   const [profileSaved, setProfileSaved] = useState(false)
-  const [passwordError, setPasswordError] = useState<string | null>(null)
+  const [passwordError, setPasswordError] = useState<ClassifiedServerError | null>(null)
   const [passwordSuccess, setPasswordSuccess] = useState(false)
   // Password change form is collapsed by default — most page visits are for
   // the name/group fields above. The toggle expands it; e2e specs use the
@@ -137,7 +146,7 @@ export function EditProfilePage() {
       // save and see a "Profile updated" banner.
       setProfileSaved(true)
     } catch (err) {
-      setProfileError(parseServerError(err, t("settings:profile.edit.errorGeneric")))
+      setProfileError(classifyServerError(err, t("settings:profile.edit.errorGeneric")))
     }
   }
 
@@ -170,12 +179,16 @@ export function EditProfilePage() {
     } catch (err) {
       // 422 from the BE means "current password incorrect" — surface a
       // dedicated message for that path; everything else falls back to
-      // the parsed server message.
+      // the classified server error. The 422 is a user-fix case, so it's
+      // a `validation` kind (no Retry affordance).
       if (err instanceof HttpError && err.status === 422) {
-        setPasswordError(t("settings:profile.password.incorrectCurrent"))
+        setPasswordError({
+          kind: "validation",
+          message: t("settings:profile.password.incorrectCurrent"),
+        })
         return
       }
-      setPasswordError(parseServerError(err, t("settings:profile.password.errorGeneric")))
+      setPasswordError(classifyServerError(err, t("settings:profile.password.errorGeneric")))
     }
   }
 
@@ -219,15 +232,18 @@ export function EditProfilePage() {
                 className="pl-9"
                 disabled={updateMutation.isPending}
                 aria-invalid={!!profileForm.formState.errors.name}
+                aria-describedby={
+                  profileForm.formState.errors.name ? "profile-name-error" : undefined
+                }
                 data-testid="profile-name-input"
                 {...profileForm.register("name")}
               />
             </div>
-            {profileForm.formState.errors.name ? (
-              <p className="field-error text-xs text-destructive" data-testid="profile-name-error">
-                {t(profileForm.formState.errors.name.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError
+              id="profile-name-error"
+              testId="profile-name-error"
+              message={profileForm.formState.errors.name?.message}
+            />
           </div>
 
           <div className="space-y-1.5">
@@ -254,34 +270,47 @@ export function EditProfilePage() {
           {(groups?.length ?? 0) > 0 ? (
             <div className="space-y-1.5">
               <Label htmlFor="profile-default-group">{t("settings:profile.defaultGroup")}</Label>
-              <select
-                id="profile-default-group"
-                disabled={updateMutation.isPending}
-                data-testid="profile-default-group-select"
-                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
-                {...profileForm.register("defaultGroupId")}
-              >
-                {groups?.map((g) => (
-                  <option key={g.id} value={g.id}>
-                    {g.name}
-                  </option>
-                ))}
-              </select>
+              <Controller
+                control={profileForm.control}
+                name="defaultGroupId"
+                render={({ field }) => (
+                  // Radix Select is the blessed form dropdown (mirrors the
+                  // mock's SettingsView). Empty value → placeholder; the
+                  // submit handler still treats "" as "no change".
+                  <Select
+                    value={field.value || undefined}
+                    onValueChange={field.onChange}
+                    disabled={updateMutation.isPending}
+                  >
+                    <SelectTrigger
+                      id="profile-default-group"
+                      ref={field.ref}
+                      className="w-full"
+                      data-testid="profile-default-group-select"
+                    >
+                      <SelectValue placeholder={t("settings:profile.defaultGroup")} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {groups?.map((g) => (
+                        <SelectItem key={g.id} value={g.id ?? ""}>
+                          {g.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
               <p className="text-[11px] text-muted-foreground">
                 {t("settings:profile.defaultGroupHelp")}
               </p>
             </div>
           ) : null}
 
-          {profileError ? (
-            <Alert
-              variant="destructive"
-              className="error-banner"
-              data-testid="profile-server-error"
-            >
-              <AlertDescription>{profileError}</AlertDescription>
-            </Alert>
-          ) : null}
+          <ServerErrorBanner
+            error={profileError}
+            className="error-banner"
+            testId="profile-server-error"
+          />
 
           {profileSaved ? (
             <Alert className="success-banner" data-testid="profile-save-success">
@@ -370,17 +399,19 @@ export function EditProfilePage() {
                     hideLockIcon
                     disabled={changePasswordMutation.isPending}
                     aria-invalid={!!passwordForm.formState.errors.currentPassword}
+                    aria-describedby={
+                      passwordForm.formState.errors.currentPassword
+                        ? "current-password-error"
+                        : undefined
+                    }
                     data-testid="current-password"
                     {...passwordForm.register("currentPassword")}
                   />
-                  {passwordForm.formState.errors.currentPassword ? (
-                    <p
-                      className="field-error text-xs text-destructive"
-                      data-testid="current-password-error"
-                    >
-                      {t(passwordForm.formState.errors.currentPassword.message ?? "")}
-                    </p>
-                  ) : null}
+                  <FieldError
+                    id="current-password-error"
+                    testId="current-password-error"
+                    message={passwordForm.formState.errors.currentPassword?.message}
+                  />
                 </div>
 
                 <div className="space-y-1.5">
@@ -391,6 +422,9 @@ export function EditProfilePage() {
                     hideLockIcon
                     disabled={changePasswordMutation.isPending}
                     aria-invalid={!!passwordForm.formState.errors.newPassword}
+                    aria-describedby={
+                      passwordForm.formState.errors.newPassword ? "new-password-error" : undefined
+                    }
                     data-testid="new-password"
                     {...passwordForm.register("newPassword")}
                   />
@@ -399,14 +433,11 @@ export function EditProfilePage() {
                     userInputs={strengthInputs}
                     testId="change-password-strength"
                   />
-                  {passwordForm.formState.errors.newPassword ? (
-                    <p
-                      className="field-error text-xs text-destructive"
-                      data-testid="new-password-error"
-                    >
-                      {t(passwordForm.formState.errors.newPassword.message ?? "")}
-                    </p>
-                  ) : null}
+                  <FieldError
+                    id="new-password-error"
+                    testId="new-password-error"
+                    message={passwordForm.formState.errors.newPassword?.message}
+                  />
                 </div>
 
                 <div className="space-y-1.5">
@@ -419,28 +450,26 @@ export function EditProfilePage() {
                     hideLockIcon
                     disabled={changePasswordMutation.isPending}
                     aria-invalid={!!passwordForm.formState.errors.confirmPassword}
+                    aria-describedby={
+                      passwordForm.formState.errors.confirmPassword
+                        ? "confirm-password-error"
+                        : undefined
+                    }
                     data-testid="confirm-password"
                     {...passwordForm.register("confirmPassword")}
                   />
-                  {passwordForm.formState.errors.confirmPassword ? (
-                    <p
-                      className="field-error text-xs text-destructive"
-                      data-testid="confirm-password-error"
-                    >
-                      {t(passwordForm.formState.errors.confirmPassword.message ?? "")}
-                    </p>
-                  ) : null}
+                  <FieldError
+                    id="confirm-password-error"
+                    testId="confirm-password-error"
+                    message={passwordForm.formState.errors.confirmPassword?.message}
+                  />
                 </div>
 
-                {passwordError ? (
-                  <Alert
-                    variant="destructive"
-                    className="error-banner"
-                    data-testid="password-server-error"
-                  >
-                    <AlertDescription>{passwordError}</AlertDescription>
-                  </Alert>
-                ) : null}
+                <ServerErrorBanner
+                  error={passwordError}
+                  className="error-banner"
+                  testId="password-server-error"
+                />
 
                 <div className="flex justify-end pt-2">
                   <Button

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -27,6 +27,13 @@ import { CurrencyCombobox } from "@/components/CurrencyCombobox"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Page, PageHeader } from "@/components/ui/page"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
 import { useAuth } from "@/features/auth/AuthContext"
@@ -337,8 +344,7 @@ function DefaultGroupSelectorRow() {
       ? currentDefault
       : (groups?.[0]?.id ?? "")
 
-  async function handleChange(event: React.ChangeEvent<HTMLSelectElement>) {
-    const next = event.target.value
+  async function handleValueChange(next: string) {
     if (!next || next === currentDefault || !userId) return
     setError(null)
     try {
@@ -358,20 +364,27 @@ function DefaultGroupSelectorRow() {
       description={t("settings:profile.defaultGroupHelp")}
     >
       <div className="flex flex-col items-end gap-1">
-        <select
-          value={value}
-          onChange={handleChange}
+        <Select
+          value={value || undefined}
+          onValueChange={handleValueChange}
           disabled={updateMutation.isPending}
-          aria-label={t("settings:profile.defaultGroup")}
-          data-testid="settings-default-group-select"
-          className="h-8 rounded-md border border-input bg-background px-2.5 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {groups?.map((g) => (
-            <option key={g.id} value={g.id}>
-              {g.name}
-            </option>
-          ))}
-        </select>
+          <SelectTrigger
+            size="sm"
+            className="w-44"
+            aria-label={t("settings:profile.defaultGroup")}
+            data-testid="settings-default-group-select"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {groups?.map((g) => (
+              <SelectItem key={g.id} value={g.id ?? ""}>
+                {g.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
         {error ? (
           <p className="text-[11px] text-destructive" data-testid="settings-default-group-error">
             {error}
@@ -501,61 +514,82 @@ function AppearanceSection() {
           label={t("settings:appearance.densityLabel")}
           description={t("settings:appearance.densityHelp")}
         >
-          <select
-            value={density}
-            onChange={(e) => setDensity(e.target.value as Density)}
-            data-testid="density-select"
-            aria-label={t("settings:appearance.densityLabel")}
-            className="h-8 rounded-md border border-input bg-background px-2.5 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-          >
-            {DENSITIES.map((d) => (
-              <option key={d} value={d}>
-                {t(`common:shell.density${d.charAt(0).toUpperCase()}${d.slice(1)}`)}
-              </option>
-            ))}
-          </select>
+          <Select value={density} onValueChange={(v) => setDensity(v as Density)}>
+            <SelectTrigger
+              size="sm"
+              className="w-44"
+              data-testid="density-select"
+              aria-label={t("settings:appearance.densityLabel")}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {DENSITIES.map((d) => (
+                <SelectItem key={d} value={d}>
+                  {t(`common:shell.density${d.charAt(0).toUpperCase()}${d.slice(1)}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </SettingRow>
 
         <SettingRow
           label={t("settings:appearance.localeLabel")}
           description={t("settings:appearance.localeHelp")}
         >
-          <select
+          <Select
             value={currentLanguage}
-            onChange={(e) => {
-              const next = e.target.value as SupportedLanguage
+            onValueChange={(next) => {
               // i18next-browser-languagedetector caches to localStorage at
               // key "inventario-language" — calling changeLanguage triggers
               // that cache write, so reload picks the new locale up.
-              void i18next.changeLanguage(next)
+              void i18next.changeLanguage(next as SupportedLanguage)
             }}
-            data-testid="locale-select"
-            aria-label={t("settings:appearance.localeLabel")}
-            className="h-8 rounded-md border border-input bg-background px-2.5 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
           >
-            {SUPPORTED_LANGUAGES.map((lng) => (
-              <option key={lng} value={lng}>
-                {t(`settings:appearance.localeOptions.${lng}`)}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger
+              size="sm"
+              className="w-44"
+              data-testid="locale-select"
+              aria-label={t("settings:appearance.localeLabel")}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SUPPORTED_LANGUAGES.map((lng) => (
+                <SelectItem key={lng} value={lng}>
+                  {t(`settings:appearance.localeOptions.${lng}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </SettingRow>
 
         <SettingRow
           label={t("settings:appearance.defaultViewLabel")}
           description={t("settings:appearance.defaultViewHelp")}
         >
-          <select
+          <Select
             value={defaultItemsView}
-            onChange={(e) => onChangeRemote(SETTING_APPEARANCE_DEFAULT_ITEMS_VIEW, e.target.value)}
+            onValueChange={(v) => onChangeRemote(SETTING_APPEARANCE_DEFAULT_ITEMS_VIEW, v)}
             disabled={!settings}
-            data-testid="default-view-select"
-            aria-label={t("settings:appearance.defaultViewLabel")}
-            className="h-8 rounded-md border border-input bg-background px-2.5 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
           >
-            <option value="grid">{t("settings:appearance.defaultViewOptions.grid")}</option>
-            <option value="list">{t("settings:appearance.defaultViewOptions.list")}</option>
-          </select>
+            <SelectTrigger
+              size="sm"
+              className="w-44"
+              data-testid="default-view-select"
+              aria-label={t("settings:appearance.defaultViewLabel")}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="grid">
+                {t("settings:appearance.defaultViewOptions.grid")}
+              </SelectItem>
+              <SelectItem value="list">
+                {t("settings:appearance.defaultViewOptions.list")}
+              </SelectItem>
+            </SelectContent>
+          </Select>
         </SettingRow>
 
         <SettingRow
@@ -578,23 +612,35 @@ function AppearanceSection() {
           label={t("settings:appearance.numberFormatLocaleLabel")}
           description={t("settings:appearance.numberFormatLocaleHelp")}
         >
-          <select
-            value={numberFormatLocale}
-            onChange={(e) =>
-              onChangeRemote(SETTING_APPEARANCE_NUMBER_FORMAT_LOCALE, e.target.value)
+          {/* Radix Select forbids an empty-string item value, so the
+              auto-detect option uses an "auto" sentinel mapped back to ""
+              (the persisted empty value) on change and from "" on read. */}
+          <Select
+            value={numberFormatLocale || "auto"}
+            onValueChange={(v) =>
+              onChangeRemote(SETTING_APPEARANCE_NUMBER_FORMAT_LOCALE, v === "auto" ? "" : v)
             }
             disabled={!settings}
-            data-testid="number-format-locale-select"
-            aria-label={t("settings:appearance.numberFormatLocaleLabel")}
-            className="h-8 rounded-md border border-input bg-background px-2.5 text-sm shadow-xs focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
           >
-            <option value="">{t("settings:appearance.numberFormatLocaleOptions.auto")}</option>
-            {NUMBER_FORMAT_LOCALE_OPTIONS.map((tag) => (
-              <option key={tag} value={tag}>
-                {t(`settings:appearance.numberFormatLocaleOptions.${tag}`)}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger
+              size="sm"
+              className="w-52"
+              data-testid="number-format-locale-select"
+              aria-label={t("settings:appearance.numberFormatLocaleLabel")}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="auto">
+                {t("settings:appearance.numberFormatLocaleOptions.auto")}
+              </SelectItem>
+              {NUMBER_FORMAT_LOCALE_OPTIONS.map((tag) => (
+                <SelectItem key={tag} value={tag}>
+                  {t(`settings:appearance.numberFormatLocaleOptions.${tag}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </SettingRow>
       </div>
     </div>

--- a/frontend/src/pages/__tests__/EditProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/EditProfilePage.test.tsx
@@ -5,6 +5,7 @@ import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import { EditProfilePage } from "@/pages/EditProfilePage"
+import { pickRadixSelect } from "@/test/radix"
 import { AuthProvider } from "@/features/auth/AuthContext"
 import { GroupProvider } from "@/features/group/GroupContext"
 import { ConfirmProvider } from "@/hooks/useConfirm"
@@ -101,6 +102,49 @@ describe("<EditProfilePage />", () => {
     // saved value — the seeded user has no default_group_id and the form's
     // select stays empty, so this submit only carries `name`.
     expect(captured).toEqual({ name: "Alex 2" })
+  })
+
+  it("default-group is a shadcn Select; picking a group submits default_group_id", async () => {
+    // Reference-screen check (#1264): the default-group control is the
+    // blessed Radix <Select>, not a native <select>. Drive it via the
+    // listbox and confirm the picked id round-trips on submit.
+    let captured: { name: string; default_group_id?: string } | null = null
+    server.use(
+      msw.get(api("/auth/me"), () =>
+        HttpResponse.json({
+          id: "u1",
+          email: "alex@example.com",
+          name: "Alex",
+          default_group_id: "g2",
+        })
+      ),
+      msw.get(api("/groups"), () =>
+        HttpResponse.json({
+          data: [
+            { id: "g1", type: "groups", attributes: { id: "g1", slug: "one", name: "Group One" } },
+            { id: "g2", type: "groups", attributes: { id: "g2", slug: "two", name: "Group Two" } },
+          ],
+        })
+      ),
+      msw.put(api("/auth/me"), async ({ request }) => {
+        captured = (await request.json()) as typeof captured
+        return HttpResponse.json({
+          id: "u1",
+          email: "alex@example.com",
+          name: captured?.name,
+          default_group_id: captured?.default_group_id,
+        })
+      })
+    )
+    const user = userEvent.setup()
+    renderEdit()
+    const trigger = await screen.findByTestId("profile-default-group-select")
+    // It's the blessed Radix combobox, not a native <select>.
+    expect(trigger).toHaveAttribute("role", "combobox")
+    await pickRadixSelect(user, /default group/i, { optionLabel: /^Group One$/i })
+    await user.click(screen.getByTestId("profile-save"))
+    await waitFor(() => expect(screen.getByTestId("profile-save-success")).toBeInTheDocument())
+    expect(captured).toEqual({ name: "Alex", default_group_id: "g1" })
   })
 
   it("password form rejects mismatched confirmation", async () => {

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { http as msw, HttpResponse } from "msw"
 import { Route, useLocation } from "react-router-dom"
-import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { axe } from "jest-axe"
 
 import { SettingsPage } from "@/pages/SettingsPage"
+import { pickRadixSelect } from "@/test/radix"
 import { AuthProvider } from "@/features/auth/AuthContext"
 import { GroupProvider } from "@/features/group/GroupContext"
 import { KeyboardShortcutsProvider } from "@/features/shortcuts"
@@ -164,8 +165,10 @@ describe("<SettingsPage />", () => {
     const user = userEvent.setup()
     renderSettings()
     await user.click(await screen.findByTestId("settings-nav-appearance"))
-    const select = await screen.findByTestId("density-select")
-    await user.selectOptions(select, "compact")
+    await screen.findByTestId("density-select")
+    // Density is now a shadcn/Radix Select (blessed form dropdown), so drive
+    // it via the listbox rather than the native-select-only selectOptions.
+    await pickRadixSelect(user, /^Density$/i, { optionLabel: /^Compact$/i })
     await waitFor(() => expect(localStorage.getItem("density-test-1414")).toBe("compact"))
   })
 
@@ -257,13 +260,17 @@ describe("<SettingsPage />", () => {
     renderSettings("/settings?g=household")
     await user.click(await screen.findByTestId("settings-nav-appearance"))
     expect(await screen.findByTestId("section-appearance")).toBeInTheDocument()
-    const select = await screen.findByTestId("number-format-locale-select")
-    expect(select).toBeInTheDocument()
-    // The first option is the auto-detect fallback (empty string value).
-    const auto = select.querySelector("option[value='']")
-    expect(auto).not.toBeNull()
-    // Spot-check one explicit BCP-47 locale shipping in the option list.
-    expect(select.querySelector("option[value='cs-CZ']")).not.toBeNull()
+    const trigger = await screen.findByTestId("number-format-locale-select")
+    expect(trigger).toBeInTheDocument()
+    // The Region & formatting control is now a shadcn/Radix Select; its
+    // options live in a portalled listbox that only mounts on open.
+    await waitFor(() => expect(trigger).not.toBeDisabled())
+    await user.click(trigger)
+    const listbox = await screen.findByRole("listbox")
+    // Auto-detect (the "" sentinel, surfaced as "auto") + one explicit
+    // BCP-47 locale both render.
+    expect(within(listbox).getByRole("option", { name: /auto-detect/i })).toBeInTheDocument()
+    expect(within(listbox).getByRole("option", { name: /czech \(czechia\)/i })).toBeInTheDocument()
   })
 
   it("changing Region & formatting fires PATCH /settings/{field} (#1683)", async () => {
@@ -280,23 +287,16 @@ describe("<SettingsPage />", () => {
     renderSettings("/settings?g=household")
     await screen.findByTestId("settings-page")
     await user.click(await screen.findByTestId("settings-nav-appearance"))
-    const select = (await screen.findByTestId("number-format-locale-select", undefined, {
+    const trigger = await screen.findByTestId("number-format-locale-select", undefined, {
       timeout: 4000,
-    })) as HTMLSelectElement
-    // The select is disabled while the GET /settings response is in
-    // flight (settings === undefined). Wait until it's interactive so
-    // the change event isn't dropped — same pattern as the notification
-    // row toggle test above.
-    await waitFor(() => expect(select.disabled).toBe(false), { timeout: 4000 })
-    // Drive the change at the option level so jsdom flips the selected
-    // option *and* React's onChange sees the new value before reconciling
-    // the controlled `value` prop back. selectOptions / fireEvent.change
-    // race the controlled-select snap-back when settings haven't fully
-    // populated yet, so we replicate the DOM flow explicitly.
-    const target = select.querySelector("option[value='cs-CZ']") as HTMLOptionElement | null
-    expect(target).not.toBeNull()
-    target!.selected = true
-    fireEvent.change(select, { target: { value: "cs-CZ" } })
+    })
+    // The trigger is disabled while the GET /settings response is in
+    // flight (settings === undefined). Wait until it's interactive so the
+    // pick isn't a no-op — same pattern as the notification row toggle.
+    await waitFor(() => expect(trigger).not.toBeDisabled(), { timeout: 4000 })
+    await pickRadixSelect(user, /^Region & formatting$/i, {
+      optionLabel: /czech \(czechia\)/i,
+    })
     await waitFor(
       () => {
         expect(lastPatch).not.toBeNull()

--- a/frontend/src/pages/commodities/CommoditiesListPage.tsx
+++ b/frontend/src/pages/commodities/CommoditiesListPage.tsx
@@ -625,6 +625,7 @@ export function CommoditiesListPage() {
           </DialogHeader>
           <div className="flex flex-col gap-2">
             <Label htmlFor="bulk-move-area">{t("commodities:bulk.moveTargetLabel")}</Label>
+            {/* eslint-disable-next-line no-restricted-syntax -- bulk move-to-area utility selector; native <select> retained, covered by native-select e2e (commodity-bulk-and-filter.spec.ts) */}
             <select
               id="bulk-move-area"
               value={moveTargetArea}

--- a/frontend/src/pages/files/FileEditPage.tsx
+++ b/frontend/src/pages/files/FileEditPage.tsx
@@ -145,6 +145,7 @@ export function FileEditPage() {
                   control={form.control}
                   name="category"
                   render={({ field }) => (
+                    // eslint-disable-next-line no-restricted-syntax -- file-edit category field; native <select> retained (has native-select coverage). shadcn migration tracked as a forms follow-up — see devdocs/frontend/forms.md
                     <select
                       id="file-category"
                       data-testid="file-edit-category"

--- a/frontend/src/pages/files/FilesListPage.tsx
+++ b/frontend/src/pages/files/FilesListPage.tsx
@@ -439,6 +439,7 @@ export function FilesListPage() {
             <Label htmlFor="files-bulk-move" className="sr-only">
               {t("files:bulk.move")}
             </Label>
+            {/* eslint-disable-next-line no-restricted-syntax -- bulk "move to category" utility selector (context-mode bulk bar); native <select> retained, covered by native-select unit/e2e */}
             <select
               id="files-bulk-move"
               data-testid="files-bulk-move"

--- a/frontend/src/pages/groups/CreateGroupPage.tsx
+++ b/frontend/src/pages/groups/CreateGroupPage.tsx
@@ -5,17 +5,18 @@ import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { ArrowLeft, ArrowRight, Building2 } from "lucide-react"
 
-import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Page, PageHeader } from "@/components/ui/page"
 import { CurrencyCombobox } from "@/components/CurrencyCombobox"
+import { FieldError } from "@/components/FieldError"
+import { ServerErrorBanner } from "@/components/ServerErrorBanner"
 import { IconPicker } from "@/components/groups/IconPicker"
 import { useCreateGroup } from "@/features/group/hooks"
 import { createGroupSchema, type CreateGroupInput } from "@/features/group/schemas"
 import { useAppToast } from "@/hooks/useAppToast"
-import { parseServerError } from "@/lib/server-error"
+import { classifyServerError, type ClassifiedServerError } from "@/lib/server-error"
 import { RouteTitle } from "@/components/routing/RouteTitle"
 
 // /groups/new — create-group form. Renders a single panel (name + icon
@@ -27,7 +28,7 @@ export function CreateGroupPage() {
   const navigate = useNavigate()
   const mutation = useCreateGroup()
   const toast = useAppToast()
-  const [serverError, setServerError] = useState<string | null>(null)
+  const [serverError, setServerError] = useState<ClassifiedServerError | null>(null)
 
   const form = useForm<CreateGroupInput>({
     resolver: zodResolver(createGroupSchema),
@@ -61,13 +62,13 @@ export function CreateGroupPage() {
         // exists; a retry would duplicate it) — they need to reload so
         // RootRedirect can resolve the freshly-created group via the
         // invalidated /groups cache.
-        setServerError(t("groups:create.errorMissingSlug"))
+        setServerError({ kind: "unknown", message: t("groups:create.errorMissingSlug") })
         return
       }
       toast.success(t("groups:create.successToast"))
       navigate(`/g/${encodeURIComponent(created.slug)}`)
     } catch (err) {
-      setServerError(parseServerError(err, t("groups:create.errorGeneric")))
+      setServerError(classifyServerError(err, t("groups:create.errorGeneric")))
     }
   }
 
@@ -118,14 +119,15 @@ export function CreateGroupPage() {
               maxLength={100}
               disabled={mutation.isPending}
               aria-invalid={!!form.formState.errors.name}
+              aria-describedby={form.formState.errors.name ? "group-name-error" : undefined}
               data-testid="group-name-input"
               {...form.register("name")}
             />
-            {form.formState.errors.name ? (
-              <p className="text-xs text-destructive" data-testid="group-name-error">
-                {t(form.formState.errors.name.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError
+              id="group-name-error"
+              testId="group-name-error"
+              message={form.formState.errors.name?.message}
+            />
           </div>
 
           <div className="space-y-1.5">
@@ -143,11 +145,7 @@ export function CreateGroupPage() {
                 />
               )}
             />
-            {form.formState.errors.icon ? (
-              <p className="text-xs text-destructive" data-testid="group-icon-error">
-                {t(form.formState.errors.icon.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError testId="group-icon-error" message={form.formState.errors.icon?.message} />
           </div>
 
           <div className="space-y-1.5">
@@ -166,18 +164,13 @@ export function CreateGroupPage() {
               )}
             />
             <p className="text-[11px] text-muted-foreground">{t("groups:create.currencyHelp")}</p>
-            {form.formState.errors.group_currency ? (
-              <p className="text-xs text-destructive" data-testid="group-currency-error">
-                {t(form.formState.errors.group_currency.message ?? "")}
-              </p>
-            ) : null}
+            <FieldError
+              testId="group-currency-error"
+              message={form.formState.errors.group_currency?.message}
+            />
           </div>
 
-          {serverError ? (
-            <Alert variant="destructive" data-testid="create-group-server-error">
-              <AlertDescription>{serverError}</AlertDescription>
-            </Alert>
-          ) : null}
+          <ServerErrorBanner error={serverError} testId="create-group-server-error" />
 
           <div className="flex justify-end gap-2 pt-2">
             <Button

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -389,6 +389,7 @@ export function TagsListPage() {
           >
             {t("tags:sort.label")}
           </Label>
+          {/* eslint-disable-next-line no-restricted-syntax -- list sort utility selector; native <select> retained, covered by native-select unit (TagsListPage.test) */}
           <select
             id="tags-sort-select"
             data-testid="tags-sort"


### PR DESCRIPTION
## Context — audit first

Closes part of #1264.

**#1264 is mostly outdated.** It was filed 2026-04-19 against the **Vue/PrimeVue** frontend, then folded into the React rewrite epic **#1397** (created 2026-04-28, completed 2026-05-06 — its body literally says *"feature gaps catalogued in #1264"*). The app is now React 19 + Tailwind v4 + shadcn/ui (0 `.vue` files), so most of #1264's acceptance criteria are already satisfied by the rewrite:

| #1264 acceptance criterion | Status |
| --- | --- |
| Design token inventory | ✅ Tailwind v4 `@theme` OKLCH (`styles-and-tokens.md`) |
| Shared component library | ✅ `components/ui/` (shadcn) |
| One screen migrated as reference | ✅ whole app rewritten |
| Documented style guide | ✅ `devdocs/frontend/*` |
| e2e behavioral coverage | ✅ Playwright suite |

The live target is the roadmap (#1651) **"#1264 *start*"** slice: blessed form primitives + one reference screen + lint/test guard. Scope/approach chosen by the maintainer: **Roadmap "start"**, **primitives-direct + `FieldError`** (no parallel `FormField` wrapper layer — that would fight the established `forms.md` convention).

## What this PR does

- **`FieldError` (new)** — one blessed rendering for field-level validation errors, replacing the ad-hoc `<p className="text-xs text-destructive">` repeated across forms. Bakes in the `field-error` class the e2e suite selects on, resolves the i18n key itself, and is wired with `aria-describedby` on the input. Adopted in EditProfile, CreateGroup, AreaForm, SetPassword. + unit test.
- **Native `<select>` → shadcn `<Select>`** on form/settings surfaces — mock-fidelity (`design-mocks/SettingsView` uses shadcn `Select`):
  - `SettingsPage` ×5 (default-group, density, locale, default-view, number-format)
  - `EditProfilePage` ×1 (default-group)
  - `AreaFormDialog` ×1 (parent location, `field.ref` kept on the trigger for focus-on-error)
  - Radix gotcha handled: `SelectItem value=""` is forbidden → `"auto"` sentinel for the number-format field.
- **Server errors unified** through `ServerErrorBanner` + `classifyServerError` (EditProfile, CreateGroup, AreaForm, SetPassword) instead of bespoke `<Alert>`s.
- **`EditProfilePage` = the documented reference screen** (RHF+zod, `FieldError`, `Select`, `ServerErrorBanner`).
- **Lint guard** — ESLint `no-restricted-syntax` bans raw native `<select>`. Six **utility** selectors (bulk-move bars on Files/Commodities, mobile `CategoryTiles` collapse, Tags sort, file-edit + per-file-upload category) stay native with an inline `eslint-disable` + reason — they have `selectOption`-based test coverage and native semantics are intentional. Migrating them is a logged follow-up.
- **IconPicker** — the audit flagged a "name collision", but `groups/IconPicker` (popover + categories) and `locations/IconPicker` (inline grid) are **not duplicates**: different UX, data source, and a11y trade-offs. Merging would break mock fidelity, so the two-variant policy is **documented** (forms.md table + cross-ref comments) rather than collapsed.
- **Docs** — `forms.md` (FieldError, Dropdowns policy, Icon pickers, reference screen) and `design-deviations.md` (Forms & Validation entries).

## Verification

Local gates (in the worktree), all green:

- `tsc -b --noEmit` ✅
- `eslint .` ✅ (0 warnings; verified the new rule fires on a raw `<select>` probe and the annotations suppress)
- `prettier --check` ✅
- `vitest run` ✅ **1162/1162** (156 files)
- `i18n:check` ✅ catalogs in sync

⚠️ **e2e not run locally** (needs the full docker stack + seed). Contracts the existing specs depend on were preserved deliberately: `profile.spec.ts`'s `.field-error` / `.error-banner` / `.success-banner` / `.password-form` / `.password-toggle` selectors are intact, and the default-group select it doesn't drive. `e2e/tests/settings-default-group.spec.ts` was ported off `inputValue()` (the shadcn trigger is a `role="combobox"` button) to read the trigger label. CI should confirm the e2e.

## Not in scope (deferred to the post-launch "finish")

- Migrating the six annotated utility `<select>`s (and/or porting the mock's `native-select` primitive).
- A `FormField`/`FormInput` wrapper layer (explicitly declined — keeps the `forms.md` primitives-direct convention).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable FieldError component for consistent field-level validation messaging

* **Improvements**
  * Standardized dropdowns and selectors across forms/settings using the app Select control
  * Switched server-error handling to a typed flow surfaced via ServerErrorBanner
  * Accessibility: consistent ARIA wiring so screen readers announce field errors
  * ESLint now flags raw native selects, with documented exceptions and targeted suppressions

* **Tests**
  * Updated and added tests to exercise Radix/Select interactions and FieldError behavior

* **Documentation**
  * Revised form guidelines and added design-deviation notes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->