### PR TITLE
seed: real files & images in demo/preview deploys

### DIFF
--- a/go/apiserver/seed.go
+++ b/go/apiserver/seed.go
@@ -29,6 +29,17 @@ const envSeedSystemAdminFixture = "INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE"
 // cross-tenant OAuth fixture.
 const envSeedAllowCreateTenant = "INVENTARIO_SEED_ALLOW_CREATE_TENANT"
 
+// envSeedAllowBlobUploads is the opt-in env var that lets the seed write
+// the bundled fixture *bytes* (photos, invoices, manuals) into the
+// configured blob bucket for a non-`test-org` tenant — not just the
+// metadata rows. It is OFF by default for the same reason
+// envSeedAllowCreateTenant is: /api/v1/seed is unauthenticated, so
+// writing real bytes for an arbitrary tenant_slug would let any caller
+// spam the configured bucket. The Helm chart sets it (only on the
+// init-data Job's temporary server) for the demo overlay so the
+// evaluation deployment looks lived-in.
+const envSeedAllowBlobUploads = "INVENTARIO_SEED_ALLOW_BLOB_UPLOADS"
+
 type seedAPI struct {
 	factorySet     *registry.FactorySet
 	uploadLocation string
@@ -95,6 +106,11 @@ func (api *seedAPI) seedDatabase(w http.ResponseWriter, r *http.Request) {
 		// body so a misconfigured production deployment can't be
 		// coaxed into minting tenants from the public seed surface.
 		CreateTenantIfMissing: os.Getenv(envSeedAllowCreateTenant) == "true",
+		// Opt-in only — see envSeedAllowBlobUploads. Same env-gated
+		// pattern: lets the demo overlay publish bundled fixture bytes
+		// for its `default` tenant without opening the public seed
+		// surface to bucket-spam from arbitrary tenant_slug values.
+		AllowBlobUploads: os.Getenv(envSeedAllowBlobUploads) == "true",
 	}
 
 	alreadySeeded, err := seeddata.SeedData(api.factorySet, opts)

--- a/go/debug/seeddata/seeddata.go
+++ b/go/debug/seeddata/seeddata.go
@@ -88,6 +88,20 @@ type SeedOptions struct {
 	// — never sourced from the request body). Has effect only when
 	// TenantSlug is non-empty.
 	CreateTenantIfMissing bool
+
+	// AllowBlobUploads opts a non-`test-org` tenant into having the
+	// bundled fixture *bytes* (photos, invoices, manuals) written to the
+	// configured UploadLocation, not just the metadata rows. Without it,
+	// blob writes are restricted to the well-known `test-org` tenant
+	// because /api/v1/seed is unauthenticated and writing real bytes for
+	// an arbitrary tenant_slug is an abuse vector (see the gate in
+	// SeedData). OFF by default; the seed handler reads
+	// INVENTARIO_SEED_ALLOW_BLOB_UPLOADS to flip it on — same env-var-
+	// gated pattern as SeedSystemAdmin / CreateTenantIfMissing, never
+	// sourced from the request body. The Helm chart sets it for the demo
+	// overlay so the evaluation deployment looks lived-in. Has effect
+	// only when UploadLocation is non-empty.
+	AllowBlobUploads bool
 }
 
 // SeedData seeds the database with example data. Returns alreadySeeded=true
@@ -184,8 +198,14 @@ func SeedData(factorySet *registry.FactorySet, opts SeedOptions) (alreadySeeded 
 	// well-known test tenant keeps the demo-fidelity story for
 	// test-org while making the public endpoint cost-bounded for
 	// every other tenant.
+	//
+	// AllowBlobUploads is the explicit, env-gated opt-out of that
+	// restriction (INVENTARIO_SEED_ALLOW_BLOB_UPLOADS, set server-side
+	// only — see the seed handler). The Helm chart flips it on for the
+	// demo overlay so the evaluation deployment's `default` tenant gets
+	// real cover photos and documents like test-org does.
 	uploadLocation := opts.UploadLocation
-	if tenant.Slug != "test-org" {
+	if tenant.Slug != "test-org" && !opts.AllowBlobUploads {
 		uploadLocation = ""
 	}
 	uploader, err := newBlobUploader(ctx, uploadLocation)

--- a/go/debug/seeddata/seeddata_test.go
+++ b/go/debug/seeddata/seeddata_test.go
@@ -2,11 +2,14 @@ package seeddata_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	_ "gocloud.dev/blob/fileblob" // register the file:// blob driver for the upload-location tests
 
 	"github.com/denisvmedia/inventario/debug/seeddata"
 	"github.com/denisvmedia/inventario/models"
@@ -512,3 +515,97 @@ func TestSeedDataMissingTenantSlug_CreatesWhenOptIn(t *testing.T) {
 // commodity seeded with WarrantyDaysFromNow=5 lands in the "expiring"
 // bucket when computed at test time.
 func referenceNow() time.Time { return time.Now() }
+
+// TestSeedDataBlobUploads_OffByDefault pins the security default: even
+// with a real UploadLocation configured, a non-`test-org` tenant must
+// NOT get fixture bytes written when AllowBlobUploads is off. The seed
+// still creates the cover-photo file *rows* (so the UI surfaces them),
+// but the no-op uploader leaves SizeBytes at 0. This is the
+// public-/api/v1/seed cost-bound: an arbitrary tenant_slug can't be
+// coaxed into spamming the configured bucket.
+func TestSeedDataBlobUploads_OffByDefault(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	factorySet := memory.NewFactorySet()
+	_, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{
+		TenantSlug:            "acme",
+		CreateTenantIfMissing: true,
+		UploadLocation:        "file://" + t.TempDir() + "?create_dir=1",
+		// AllowBlobUploads left at zero (false).
+	})
+	c.Assert(err, qt.IsNil)
+
+	images, withBytes := seededImageStats(c, factorySet, ctx)
+	c.Assert(images > 0, qt.IsTrue, qt.Commentf("seed still creates cover-photo rows"))
+	c.Assert(withBytes, qt.Equals, 0,
+		qt.Commentf("no fixture bytes for a non-test-org tenant without the opt-in"))
+}
+
+// TestSeedDataBlobUploads_WhenOptIn covers the AllowBlobUploads path:
+// the seed handler binds it from INVENTARIO_SEED_ALLOW_BLOB_UPLOADS,
+// which the Helm chart sets for the demo overlay so the evaluation
+// deployment's `default` tenant gets real cover photos and documents.
+// With the opt-in on, every bundled cover photo is written to the
+// configured bucket and its row carries the real byte count.
+func TestSeedDataBlobUploads_WhenOptIn(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tempDir := t.TempDir()
+
+	factorySet := memory.NewFactorySet()
+	_, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{
+		TenantSlug:            "acme",
+		CreateTenantIfMissing: true,
+		UploadLocation:        "file://" + tempDir + "?create_dir=1",
+		AllowBlobUploads:      true,
+	})
+	c.Assert(err, qt.IsNil)
+
+	images, withBytes := seededImageStats(c, factorySet, ctx)
+	c.Assert(images > 0, qt.IsTrue)
+	c.Assert(withBytes, qt.Equals, images,
+		qt.Commentf("every cover photo gets real bytes when the opt-in is on"))
+
+	// The fixture bytes physically landed in the bucket.
+	c.Assert(countRegularFiles(c, tempDir) > 0, qt.IsTrue,
+		qt.Commentf("seed fixtures written to the configured bucket"))
+}
+
+// seededImageStats returns (number of image-category file rows, number
+// of those carrying non-zero SizeBytes). Image-category rows only ever
+// come from the bundled fixture upload path, so they cleanly isolate the
+// blob-upload gate from unrelated file rows (e.g. export documents).
+func seededImageStats(c *qt.C, factorySet *registry.FactorySet, ctx context.Context) (images, withBytes int) {
+	files, err := factorySet.CreateServiceRegistrySet().FileRegistry.List(ctx)
+	c.Assert(err, qt.IsNil)
+	for _, f := range files {
+		if f.Category != models.FileCategoryImages {
+			continue
+		}
+		images++
+		if f.File != nil && f.File.SizeBytes > 0 {
+			withBytes++
+		}
+	}
+	return images, withBytes
+}
+
+// countRegularFiles walks dir and returns the number of regular files
+// found — used to assert whether the seed wrote fixture bytes to the
+// configured file:// bucket.
+func countRegularFiles(c *qt.C, dir string) int {
+	n := 0
+	err := filepath.WalkDir(dir, func(_ string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.Type().IsRegular() {
+			n++
+		}
+		return nil
+	})
+	c.Assert(err, qt.IsNil)
+	return n
+}

--- a/helm/inventario/templates/job-init-data.yaml
+++ b/helm/inventario/templates/job-init-data.yaml
@@ -191,6 +191,13 @@ spec:
             # /api/v1/seed handler).
             - name: SETUP_SKIP_SEED_ON_UPGRADE
               value: "false"
+            # Opt the seed into writing the bundled fixture bytes (cover
+            # photos / invoices / manuals) for whatever tenant we seed —
+            # not just the well-known `test-org`. Set only here on the
+            # Job's temporary seed server, never on the main Deployment,
+            # so the public /api/v1/seed surface stays cost-bounded.
+            - name: INVENTARIO_SEED_ALLOW_BLOB_UPLOADS
+              value: {{ ternary "true" "false" .Values.setupJob.initData.seedBlobUploads | quote }}
             - name: INVENTARIO_SEED_DB_DSN
               {{- if .Values.demo.postgresql.enabled }}
               value: {{ include "inventario.dbDsn" . | quote }}
@@ -200,8 +207,13 @@ spec:
                   name: {{ $secretName }}
                   key: INVENTARIO_DB_DSN
               {{- end }}
+            # Point the temporary seed server at the SAME bucket the app
+            # reads from (MinIO s3:// when demo.minio.enabled, the file://
+            # uploads PVC otherwise). Hardcoding file:///app/uploads here
+            # would strand seed blobs in the Job pod's emptyDir under the
+            # MinIO demo, where the app can never read them.
             - name: INVENTARIO_RUN_UPLOAD_LOCATION
-              value: file:///app/uploads?create_dir=1
+              value: {{ include "inventario.uploadLocation" . | quote }}
             {{- if .Values.demo.redis.enabled }}
             - name: INVENTARIO_RUN_TOKEN_BLACKLIST_REDIS_URL
               value: {{ $redisUrl | quote }}

--- a/helm/inventario/templates/job-setup.yaml
+++ b/helm/inventario/templates/job-setup.yaml
@@ -307,6 +307,11 @@ spec:
               value: {{ .Values.setupJob.initData.adminName | quote }}
             - name: SEED_DATABASE
               value: {{ ternary "true" "false" .Values.setupJob.initData.seedDatabase | quote }}
+            # See job-init-data.yaml — opt the seed into writing bundled
+            # fixture bytes for the seeded tenant. Default off; demo/eval
+            # overlays flip it on.
+            - name: INVENTARIO_SEED_ALLOW_BLOB_UPLOADS
+              value: {{ ternary "true" "false" .Values.setupJob.initData.seedBlobUploads | quote }}
             - name: SETUP_SKIP_SEED_ON_UPGRADE
               value: {{ ternary "true" "false" .Release.IsUpgrade | quote }}
             - name: INVENTARIO_SEED_DB_DSN
@@ -318,8 +323,10 @@ spec:
                   name: {{ $secretName }}
                   key: INVENTARIO_DB_DSN
               {{- end }}
+            # Match the app's bucket so seed blobs land where the app reads
+            # them (MinIO s3:// under the demo bundle, file:// PVC otherwise).
             - name: INVENTARIO_RUN_UPLOAD_LOCATION
-              value: file:///app/uploads?create_dir=1
+              value: {{ include "inventario.uploadLocation" . | quote }}
             {{- if .Values.demo.redis.enabled }}
             - name: INVENTARIO_RUN_TOKEN_BLACKLIST_REDIS_URL
               value: {{ $redisUrl | quote }}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -598,6 +598,17 @@ setupJob:
     # Env: SEED_DATABASE
     seedDatabase: false
 
+    # Write the bundled fixture *bytes* (cover photos, invoices, manuals) into
+    # the upload bucket during seeding, so items and the Files page look
+    # lived-in instead of carrying empty/broken file rows. Only has effect
+    # when seedDatabase=true.
+    # Keep false in production: /api/v1/seed is unauthenticated, so enabling
+    # blob writes for the default tenant widens the surface for bucket-spam.
+    # Enable only for demo / evaluation installs (the in-cluster MinIO/file
+    # bucket is the seed target). Maps to the server-side opt-in env var.
+    # Env: INVENTARIO_SEED_ALLOW_BLOB_UPLOADS
+    seedBlobUploads: false
+
 # ============================================================
 # Namespace ResourceQuota + LimitRange (#1866)
 # ------------------------------------------------------------

--- a/infra/helm-overlays/preview-base.values.yaml
+++ b/infra/helm-overlays/preview-base.values.yaml
@@ -80,6 +80,13 @@ setupJob:
     # SETUP_SKIP_SEED_ON_UPGRADE, but each PR preview is a fresh install so
     # we always seed). Negligible extra Job time (~15s).
     seedDatabase: true
+    # Also publish the bundled fixture bytes (cover photos, invoices,
+    # manuals) into the in-cluster MinIO bucket so items and the Files page
+    # look lived-in instead of carrying empty file rows. Safe here: these
+    # are tailnet-gated demo/preview namespaces, the embed bundle is ~130 KB,
+    # and each install seeds exactly once. Maps to
+    # INVENTARIO_SEED_ALLOW_BLOB_UPLOADS on the Job's temporary seed server.
+    seedBlobUploads: true
 
 # Defensive guard-rails per #1866: cap aggregate compute/storage/pod-count
 # in every PR-preview namespace so one runaway pod can't starve other


### PR DESCRIPTION
## Context

The demo deployment (`inv-vcl01-master`) and PR previews seed a rich dataset — locations, areas, ~35 commodities, loans, services — but **no files or images** appeared on items or the Files page. The seed already bundles curated assets in `go/debug/seeddata/_files/` (6 Pexels room photos + `invoice.pdf` + `manual.pdf`, embedded via `go:embed`) and already attaches them as cover photos / invoices / manuals — they just never became visible in the demo.

Related: preview-environment epic #1852.

## Root cause — two independent bugs

1. **The `test-org` gate.** `SeedData` forced `uploadLocation = ""` for any tenant whose slug isn't `test-org`, so the demo's `default` tenant got the **no-op uploader**: `FileEntity` rows were created but **no bytes were ever written**. The gate exists for a good reason — `/api/v1/seed` is public and unauthenticated, so writing real bytes for an arbitrary `tenant_slug` is a bucket-spam vector.
2. **The init-data Job pointed the seed at the wrong bucket.** `job-init-data.yaml` hardcoded `INVENTARIO_RUN_UPLOAD_LOCATION=file:///app/uploads`, while the demo app reads from **MinIO (`s3://`)**. Seed bytes would have landed in the Job pod's `emptyDir` and vanished — broken regardless of the gate.

## Fix

Adds a third opt-in following the existing env-gated pattern (`INVENTARIO_SEED_SYSTEM_ADMIN_FIXTURE`, `INVENTARIO_SEED_ALLOW_CREATE_TENANT`) — read server-side, never from the request body, default-off so the public seed surface stays cost-bounded:

- **`go/debug/seeddata/seeddata.go`** — `SeedOptions.AllowBlobUploads`; gate relaxed to `slug != "test-org" && !opts.AllowBlobUploads`.
- **`go/apiserver/seed.go`** — new const `INVENTARIO_SEED_ALLOW_BLOB_UPLOADS`, bound via `os.Getenv`.
- **Helm** — new value `setupJob.initData.seedBlobUploads` (default `false`). `job-init-data.yaml` + `job-setup.yaml` now (a) set the env from it and (b) use the `inventario.uploadLocation` helper so the seed server writes to the **same bucket the app reads** (MinIO `s3://` under the demo bundle, the `file://` PVC otherwise). The env is set **only on the Job's temporary seed server**, never on the main Deployment.
- **`infra/helm-overlays/preview-base.values.yaml`** — `seedBlobUploads: true` (lights up the master demo **and** every PR preview; ~130 KB embed bundle, each install seeds once).

Assets are the **existing bundled fixtures** (no new imagery). Missing thumbnails self-heal: `downloadThumbnail` serves a placeholder and enqueues a generation job which the demo's combined pod's workers fulfill — so `default` ends up identical to the already-working `test-org` demo-fidelity path.

## Verification

- `go test ./debug/seeddata/...` ✅ — new tests `TestSeedDataBlobUploads_OffByDefault` (rows exist, `SizeBytes==0`) and `TestSeedDataBlobUploads_WhenOptIn` (every cover photo carries real bytes + blobs physically written).
- `golangci-lint run --fix` → 0 issues; `go build` ✅.
- `helm template` with the demo overlay → init-data Job shows `INVENTARIO_SEED_ALLOW_BLOB_UPLOADS: "true"` and `INVENTARIO_RUN_UPLOAD_LOCATION: s3://…minio…`.
- `helm template` with defaults → `"false"` + `file://` (production surface untouched).
- `helm lint` ✅.

## ⚠️ Rollout note (operator step)

The seed is idempotent (`locCount > 0` short-circuits) and the demo's Postgres/MinIO use `emptyDir`. To populate the **already-running** master demo: after this merges and the image rolls, **delete the `demo-postgresql` pod** in `inv-vcl01-master` → fresh DB → the next init-data Job seeds with files. PR previews need nothing (fresh install each time).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Seed operations now support optional upload of bundled fixture files (photos, invoices, manuals) to configured storage, disabled by default.

* **Tests**
  * Added regression tests verifying fixture files are disabled by default and enabled when explicitly configured.

* **Configuration**
  * Added configuration option to control whether fixture files are written during seeding.
  * Preview environments now enable fixture file uploads by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->