### PR TITLE
[#1928] Split tags into separate Item-tags and File-tags entities

### DIFF
--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -83,7 +83,9 @@ async function attachTagToCommodity(
 test.describe('Tags page', () => {
   test('renders the page shell with stats + create CTA', async ({ page }) => {
     await gotoTags(page)
-    await expect(page.getByTestId('tags-stats-tags-total')).toBeVisible()
+    // Default view is the commodity (item-tags) view, so the stats bar
+    // shows the per-kind item tiles (no combined "all tags" total).
+    await expect(page.getByTestId('tags-stats-commodity-tags-total')).toBeVisible()
     await expect(page.getByTestId('tags-stats-items-tagged')).toBeVisible()
     await expect(page.getByTestId('tags-stats-items-untagged')).toBeVisible()
     await expect(page.getByTestId('tags-create-button')).toBeVisible()

--- a/frontend/src/components/files/TagsInput.tsx
+++ b/frontend/src/components/files/TagsInput.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/badge"
 import { Label } from "@/components/ui/label"
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
-import type { TagScope } from "@/features/tags/api"
+import type { TagKind } from "@/features/tags/api"
 import { useTagAutocomplete } from "@/features/tags/hooks"
 
 // Lightweight tag chip input — type, hit Enter / comma to commit;
@@ -33,12 +33,11 @@ export interface TagsInputProps {
   // row of CommodityFormDialog where the input sits below filename
   // metadata and the default size feels too tall.
   compact?: boolean
-  // Restrict autocomplete suggestions to tags actually used on the
-  // given entity type (#1628). The commodity-tags input on the Extras
-  // step passes "commodity"; the per-file row inside the Files step
-  // passes "file". Standalone callers that pre-date scope awareness
-  // can omit it for the legacy combined ranking.
-  scope?: TagScope
+  // Which entity's tags to suggest. Item-tags and file-tags are separate
+  // entities: the commodity-tags input passes "commodity"; file inputs
+  // pass "file". Required when `autocomplete` is set — without it the
+  // suggestion query stays disabled.
+  kind?: TagKind
 }
 
 export function TagsInput({
@@ -50,7 +49,7 @@ export function TagsInput({
   suggestions,
   autocomplete,
   compact,
-  scope,
+  kind,
 }: TagsInputProps) {
   const [draft, setDraft] = useState("")
   // Remote suggestions live in local state and are populated via the
@@ -276,7 +275,7 @@ export function TagsInput({
         inputAndChips
       )}
       {autocomplete ? (
-        <AutocompleteSink draft={draft} scope={scope} onChange={setRemoteSuggestions} />
+        <AutocompleteSink draft={draft} kind={kind} onChange={setRemoteSuggestions} />
       ) : null}
     </div>
   )
@@ -294,14 +293,14 @@ export function TagsInput({
 // usage-ranked default list when `q` is empty.
 function AutocompleteSink({
   draft,
-  scope,
+  kind,
   onChange,
 }: {
   draft: string
-  scope?: TagScope
+  kind?: TagKind
   onChange: (slugs: string[]) => void
 }) {
-  const remote = useTagAutocomplete(draft, 8, { enabled: true, scope })
+  const remote = useTagAutocomplete(draft, 8, { enabled: true, kind })
   const data = remote.data
   useEffect(() => {
     onChange(data ? data.map((t) => t.slug) : [])

--- a/frontend/src/components/files/UploadFilesDialog.tsx
+++ b/frontend/src/components/files/UploadFilesDialog.tsx
@@ -604,7 +604,7 @@ function MetadataStep({
               })}
               testId={`files-upload-meta-tags-${it.id}`}
               autocomplete
-              scope="file"
+              kind="file"
               compact
             />
           </li>

--- a/frontend/src/components/items/CommodityFormDialog.tsx
+++ b/frontend/src/components/items/CommodityFormDialog.tsx
@@ -1671,7 +1671,7 @@ function ExtrasStep(props: any) {
           placeholder={t("commodities:fields.tagsPlaceholder")}
           testId="commodity-tags"
           autocomplete
-          scope="commodity"
+          kind="commodity"
         />
         <p className="text-xs text-muted-foreground">{t("commodities:fields.tagsHelp")}</p>
         <TagsSuggestionChips
@@ -1936,7 +1936,7 @@ function PendingFileRow({ entry, onRemove, onTagsChange }: PendingFileRowProps) 
         testId={`commodity-files-tags-${entry.id}`}
         autocomplete
         compact
-        scope="file"
+        kind="file"
       />
     </li>
   )
@@ -1970,10 +1970,9 @@ function TagsSuggestionChips({
   onPick: (slug: string) => void
   testId?: string
 }) {
-  // Commodity-scoped — chips on the Extras step are a nudge for tagging
-  // the commodity itself, so the candidate pool excludes file-only tags
-  // (#1628).
-  const remote = useTagAutocomplete("", 8, { enabled: true, scope: "commodity" })
+  // Commodity-kind — chips on the Extras step are a nudge for tagging
+  // the commodity itself, so the candidate pool is item-tags only.
+  const remote = useTagAutocomplete("", 8, { enabled: true, kind: "commodity" })
   // Hide once the user has selected any tag — the chips' job was the
   // first-tag nudge.
   if (selected.length > 0) return null

--- a/frontend/src/components/tags/TagsStatsBar.tsx
+++ b/frontend/src/components/tags/TagsStatsBar.tsx
@@ -3,45 +3,46 @@ import { useTranslation } from "react-i18next"
 
 import { cn } from "@/lib/utils"
 
-import type { TagStats } from "@/features/tags/api"
+import type { TagKind, TagStats } from "@/features/tags/api"
 
 export interface TagsStatsBarProps {
   stats?: TagStats
+  kind: TagKind
   loading?: boolean
   testId?: string
 }
 
 // Visual contract: matches the stats row in
-// `design-mocks/src/views/TagsView.tsx` — icon-tile + label + value
-// laid out horizontally inside a `rounded-xl border bg-card` shell. Mock
-// shows three tiles (Total / Tagged / Untagged items); we keep the
-// extra two file tiles so the page also surfaces file-tag adoption
-// (the Files page mirrors this number elsewhere but the Tags page is
-// the canonical "how are tags being used?" surface). Logged as a
-// deviation in devdocs/frontend/design-deviations.md.
+// `design-mocks/src/views/TagsView.tsx` — icon-tile + label + value laid
+// out horizontally inside a `rounded-xl border bg-card` shell. Item-tags
+// and file-tags are separate entities, so the bar shows only the three
+// tiles relevant to the active view (tag count + tagged/untagged for that
+// entity), never a combined total.
 interface TileSpec {
   key: keyof TagStats
   labelKey: string
   icon: typeof Tag
 }
 
-const TILES: TileSpec[] = [
-  { key: "tags_total", labelKey: "tags:stats.tagsTotal", icon: Tag },
+const COMMODITY_TILES: TileSpec[] = [
+  { key: "commodity_tags_total", labelKey: "tags:stats.commodityTagsTotal", icon: Tag },
   { key: "items_tagged", labelKey: "tags:stats.itemsTagged", icon: Package },
   { key: "items_untagged", labelKey: "tags:stats.itemsUntagged", icon: Hash },
+]
+
+const FILE_TILES: TileSpec[] = [
+  { key: "file_tags_total", labelKey: "tags:stats.fileTagsTotal", icon: Tag },
   { key: "files_tagged", labelKey: "tags:stats.filesTagged", icon: File },
   { key: "files_untagged", labelKey: "tags:stats.filesUntagged", icon: FileX },
 ]
 
-export function TagsStatsBar({ stats, loading, testId }: TagsStatsBarProps) {
+export function TagsStatsBar({ stats, kind, loading, testId }: TagsStatsBarProps) {
   const { t } = useTranslation(["tags"])
   const showPlaceholder = loading && stats === undefined
+  const tiles = kind === "file" ? FILE_TILES : COMMODITY_TILES
   return (
-    <div
-      className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5"
-      data-testid={testId ?? "tags-stats"}
-    >
-      {TILES.map(({ key, labelKey, icon: Icon }) => {
+    <div className="grid grid-cols-3 gap-3" data-testid={testId ?? "tags-stats"}>
+      {tiles.map(({ key, labelKey, icon: Icon }) => {
         const value = stats?.[key]
         return (
           <div

--- a/frontend/src/components/tags/__tests__/TagsStatsBar.test.tsx
+++ b/frontend/src/components/tags/__tests__/TagsStatsBar.test.tsx
@@ -5,47 +5,45 @@ import { beforeAll, describe, expect, it } from "vitest"
 import { TagsStatsBar } from "@/components/tags/TagsStatsBar"
 import { initI18n } from "@/i18n"
 
+const STATS = {
+  tags_total: 12,
+  commodity_tags_total: 8,
+  file_tags_total: 4,
+  items_tagged: 50,
+  items_untagged: 7,
+  files_tagged: 30,
+  files_untagged: 5,
+}
+
 beforeAll(async () => {
   await initI18n({ lng: "en" })
 })
 
 describe("<TagsStatsBar />", () => {
-  it("renders five tiles with the supplied counts", () => {
-    render(
-      <TagsStatsBar
-        stats={{
-          tags_total: 12,
-          items_tagged: 50,
-          items_untagged: 7,
-          files_tagged: 30,
-          files_untagged: 5,
-        }}
-      />
-    )
-    expect(screen.getByTestId("tags-stats-tags-total")).toHaveTextContent("12")
+  it("renders the commodity tiles for the item-tags view", () => {
+    render(<TagsStatsBar kind="commodity" stats={STATS} />)
+    expect(screen.getByTestId("tags-stats-commodity-tags-total")).toHaveTextContent("8")
     expect(screen.getByTestId("tags-stats-items-tagged")).toHaveTextContent("50")
     expect(screen.getByTestId("tags-stats-items-untagged")).toHaveTextContent("7")
+    // File tiles must not appear in the commodity view.
+    expect(screen.queryByTestId("tags-stats-files-tagged")).not.toBeInTheDocument()
+  })
+
+  it("renders the file tiles for the file-tags view", () => {
+    render(<TagsStatsBar kind="file" stats={STATS} />)
+    expect(screen.getByTestId("tags-stats-file-tags-total")).toHaveTextContent("4")
     expect(screen.getByTestId("tags-stats-files-tagged")).toHaveTextContent("30")
     expect(screen.getByTestId("tags-stats-files-untagged")).toHaveTextContent("5")
+    expect(screen.queryByTestId("tags-stats-items-tagged")).not.toBeInTheDocument()
   })
 
   it("falls back to em-dashes while loading without data", () => {
-    render(<TagsStatsBar loading />)
-    expect(screen.getByTestId("tags-stats-tags-total")).toHaveTextContent("—")
+    render(<TagsStatsBar kind="commodity" loading />)
+    expect(screen.getByTestId("tags-stats-commodity-tags-total")).toHaveTextContent("—")
   })
 
   it("is axe-clean with stats present", async () => {
-    const { container } = render(
-      <TagsStatsBar
-        stats={{
-          tags_total: 1,
-          items_tagged: 0,
-          items_untagged: 0,
-          files_tagged: 0,
-          files_untagged: 0,
-        }}
-      />
-    )
+    const { container } = render(<TagsStatsBar kind="commodity" stats={STATS} />)
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })

--- a/frontend/src/features/tags/__tests__/api.test.ts
+++ b/frontend/src/features/tags/__tests__/api.test.ts
@@ -52,7 +52,7 @@ describe("features/tags/api", () => {
       )
     )
 
-    const result = await listTags({ includeUsage: true })
+    const result = await listTags({ kind: "commodity", includeUsage: true })
     expect(result.total).toBe(2)
     expect(result.tags).toHaveLength(2)
     expect(result.tags[0].tag.slug).toBe("kitchen")
@@ -69,8 +69,9 @@ describe("features/tags/api", () => {
         return HttpResponse.json({ data: [], meta: { tags: 0, total: 0 } })
       })
     )
-    await listTags({ search: "k", sort: "usage", order: "desc", includeUsage: true })
+    await listTags({ kind: "file", search: "k", sort: "usage", order: "desc", includeUsage: true })
     expect(captured).not.toBeNull()
+    expect(captured!.searchParams.get("kind")).toBe("file")
     expect(captured!.searchParams.get("q")).toBe("k")
     expect(captured!.searchParams.get("sort")).toBe("usage")
     expect(captured!.searchParams.get("order")).toBe("desc")
@@ -127,7 +128,12 @@ describe("features/tags/api", () => {
         )
       )
     )
-    const created = await createTag({ slug: "kitchen", label: "Kitchen", color: "amber" })
+    const created = await createTag({
+      kind: "commodity",
+      slug: "kitchen",
+      label: "Kitchen",
+      color: "amber",
+    })
     expect(created.id).toBe("new")
     expect(created.slug).toBe("kitchen")
   })
@@ -182,7 +188,7 @@ describe("features/tags/api", () => {
         })
       )
     )
-    const result = await autocompleteTags("ki")
+    const result = await autocompleteTags("ki", 10, { kind: "commodity" })
     expect(result).toHaveLength(2)
     expect(result[0].slug).toBe("kitchen")
   })

--- a/frontend/src/features/tags/__tests__/hooks.test.tsx
+++ b/frontend/src/features/tags/__tests__/hooks.test.tsx
@@ -74,14 +74,16 @@ describe("features/tags/hooks", () => {
       ])
     )
     const client = newClient()
-    const { result } = renderHook(() => useTags({ includeUsage: true }), {
+    const { result } = renderHook(() => useTags({ kind: "commodity", includeUsage: true }), {
       wrapper: makeWrapper(client),
     })
     await waitFor(() => expect(result.current.data?.tags.length).toBe(1))
     expect(result.current.data?.tags[0].usage?.commodities).toBe(2)
     // Cache is keyed under `tagKeys.list(slug, opts)`. Reading directly
     // proves the slug propagated through GroupProvider into the hook.
-    const cached = client.getQueryData(tagKeys.list(SLUG, { includeUsage: true }))
+    const cached = client.getQueryData(
+      tagKeys.list(SLUG, { kind: "commodity", includeUsage: true })
+    )
     expect(cached).toBeDefined()
   })
 
@@ -127,12 +129,16 @@ describe("features/tags/hooks", () => {
       })
     )
     const client = newClient()
-    const { result } = renderHook(() => ({ list: useTags(), create: useCreateTag() }), {
-      wrapper: makeWrapper(client),
-    })
+    const { result } = renderHook(
+      () => ({ list: useTags({ kind: "commodity" }), create: useCreateTag() }),
+      {
+        wrapper: makeWrapper(client),
+      }
+    )
     await waitFor(() => expect(result.current.list.data).toBeDefined())
     const initialCalls = listCalls
     const created = await result.current.create.mutateAsync({
+      kind: "commodity",
       slug: "kitchen",
       label: "Kitchen",
       color: "amber",
@@ -188,7 +194,7 @@ describe("features/tags/hooks", () => {
       )
     )
     const client = newClient()
-    const { result } = renderHook(() => useTagAutocomplete("ki"), {
+    const { result } = renderHook(() => useTagAutocomplete("ki", 10, { kind: "commodity" }), {
       wrapper: makeWrapper(client),
     })
     await waitFor(() => expect(result.current.data?.length).toBe(1))

--- a/frontend/src/features/tags/api.ts
+++ b/frontend/src/features/tags/api.ts
@@ -27,11 +27,10 @@ export const TAG_COLORS = [
 export type TagSortField = "label" | "created_at" | "usage"
 export type TagSortOrder = "asc" | "desc"
 
-// TagScope narrows tag listing / autocomplete to tags actually used on a
-// specific entity type. Wire contract: bare "commodity" / "file" tokens
-// (singular) match the BE; "all" is the in-FE label for "no filter" and
-// is omitted from the request URL by the data layer.
-export type TagScope = "commodity" | "file"
+// TagKind is the entity a tag belongs to. Item-tags (commodity) and
+// file-tags (file) are *separate* entities — there is no combined "all"
+// view. Mirrors the BE's models.TagKind; the wire param is `?kind=`.
+export type TagKind = Schema<"models.TagKind">
 
 export interface ListTagsOptions {
   page?: number
@@ -40,7 +39,8 @@ export interface ListTagsOptions {
   sort?: TagSortField
   order?: TagSortOrder
   includeUsage?: boolean
-  scope?: TagScope
+  // kind is required — the BE 422s a list/autocomplete request without it.
+  kind: TagKind
   signal?: AbortSignal
 }
 
@@ -74,7 +74,7 @@ interface TagStatsEnvelope {
 }
 
 export async function listTags(
-  options: ListTagsOptions = {}
+  options: ListTagsOptions
 ): Promise<{ tags: ListedTag[]; total: number }> {
   const params = new URLSearchParams()
   if (options.page !== undefined) params.set("page", String(options.page))
@@ -83,7 +83,7 @@ export async function listTags(
   if (options.sort) params.set("sort", options.sort)
   if (options.order) params.set("order", options.order)
   if (options.includeUsage) params.set("include", "usage")
-  if (options.scope) params.set("scope", options.scope)
+  params.set("kind", options.kind)
   const qs = params.toString()
   const path = qs ? `/tags?${qs}` : "/tags"
   const body = await http.get<TagsListEnvelope>(path, { signal: options.signal })
@@ -113,6 +113,9 @@ export async function getTag(
 }
 
 export interface CreateTagRequest {
+  // kind is immutable after creation — item-tags and file-tags are
+  // separate entities.
+  kind: TagKind
   slug: string
   label: string
   color: TagColor
@@ -173,12 +176,12 @@ interface TagAutocompleteEnvelope {
 export async function autocompleteTags(
   q: string,
   limit = 10,
-  options: { scope?: TagScope; signal?: AbortSignal } = {}
+  options: { kind: TagKind; signal?: AbortSignal }
 ): Promise<TagAutocompleteEntry[]> {
   const params = new URLSearchParams()
   if (q.trim()) params.set("q", q.trim())
   params.set("limit", String(limit))
-  if (options.scope) params.set("scope", options.scope)
+  params.set("kind", options.kind)
   const body = await http.get<TagAutocompleteEnvelope>(`/tags/autocomplete?${params.toString()}`, {
     signal: options.signal,
   })

--- a/frontend/src/features/tags/hooks.ts
+++ b/frontend/src/features/tags/hooks.ts
@@ -131,7 +131,12 @@ export function useTagAutocomplete(q: string, limit = 10, opts: AutocompleteOpti
   const kind = opts.kind
   return useQuery<TagAutocompleteEntry[]>({
     queryKey: tagKeys.autocomplete(slug, q, limit, kind),
-    queryFn: ({ signal }) => autocompleteTags(q, limit, { kind: kind as TagKind, signal }),
+    queryFn: ({ signal }) => {
+      // Defensive: `enabled` already gates on kind, but a manual refetch()
+      // bypasses it — never issue a malformed `kind=undefined` request.
+      if (!kind) return Promise.resolve([])
+      return autocompleteTags(q, limit, { kind, signal })
+    },
     enabled: enabled && slug.length > 0 && kind !== undefined,
     // Keep the previous result visible while the next query (next
     // keystroke / different prefix) is in flight. Without this, `data`

--- a/frontend/src/features/tags/hooks.ts
+++ b/frontend/src/features/tags/hooks.ts
@@ -15,7 +15,7 @@ import {
   type ListedTag,
   type TagAutocompleteEntry,
   type TagEntity,
-  type TagScope,
+  type TagKind,
   type TagStats,
   type TagUsage,
   type UpdateTagRequest,
@@ -26,7 +26,7 @@ interface QueryOptions {
   enabled?: boolean
 }
 
-export function useTags(opts: ListTagsOptions = {}, query: QueryOptions = {}) {
+export function useTags(opts: ListTagsOptions, query: QueryOptions = {}) {
   const { currentGroup } = useCurrentGroup()
   const slug = currentGroup?.slug ?? ""
   const enabled = query.enabled ?? true
@@ -117,22 +117,22 @@ export function useDeleteTag() {
 // When the slug is unknown we just don't enable the query — there's
 // no group to scope autocomplete results to anyway.
 //
-// scope (#1628) narrows results to tags actually used on the named
-// entity type. Omit (or pass undefined) for the legacy combined ranking
-// — the standalone files-edit-page input that pre-dates per-scope
-// awareness still calls it that way during the rollout.
+// kind selects which entity's tags to suggest (item-tags vs file-tags) —
+// required, since the two are separate entities and the BE 422s without it.
+// When kind is absent the query stays disabled (no request fired).
 interface AutocompleteOptions extends QueryOptions {
-  scope?: TagScope
+  kind?: TagKind
 }
 
 export function useTagAutocomplete(q: string, limit = 10, opts: AutocompleteOptions = {}) {
   const ctx = useOptionalCurrentGroup()
   const slug = ctx?.currentGroup?.slug ?? ""
   const enabled = opts.enabled ?? true
+  const kind = opts.kind
   return useQuery<TagAutocompleteEntry[]>({
-    queryKey: tagKeys.autocomplete(slug, q, limit, opts.scope),
-    queryFn: ({ signal }) => autocompleteTags(q, limit, { scope: opts.scope, signal }),
-    enabled: enabled && slug.length > 0,
+    queryKey: tagKeys.autocomplete(slug, q, limit, kind),
+    queryFn: ({ signal }) => autocompleteTags(q, limit, { kind: kind as TagKind, signal }),
+    enabled: enabled && slug.length > 0 && kind !== undefined,
     // Keep the previous result visible while the next query (next
     // keystroke / different prefix) is in flight. Without this, `data`
     // briefly returns `undefined` between queries, the consumer's

--- a/frontend/src/features/tags/keys.ts
+++ b/frontend/src/features/tags/keys.ts
@@ -1,4 +1,4 @@
-import type { ListTagsOptions, TagScope } from "./api"
+import type { ListTagsOptions, TagKind } from "./api"
 
 function listKeySuffix(opts: ListTagsOptions | undefined): string {
   if (!opts) return ""
@@ -9,7 +9,7 @@ function listKeySuffix(opts: ListTagsOptions | undefined): string {
   if (opts.sort) params.set("sort", opts.sort)
   if (opts.order) params.set("order", opts.order)
   if (opts.includeUsage) params.set("include", "usage")
-  if (opts.scope) params.set("scope", opts.scope)
+  if (opts.kind) params.set("kind", opts.kind)
   return params.toString()
 }
 
@@ -23,9 +23,9 @@ export const tagKeys = {
     [...tagKeys.group(slug), "list", listKeySuffix(opts)] as const,
   stats: (slug: string) => [...tagKeys.group(slug), "stats"] as const,
   detail: (slug: string, id: string) => [...tagKeys.group(slug), "detail", id] as const,
-  // autocomplete key includes scope so the per-input cache buckets a
-  // commodity-scoped query separately from a file-scoped one even
-  // when q + limit happen to be identical.
-  autocomplete: (slug: string, q: string, limit: number, scope: TagScope | undefined) =>
-    [...tagKeys.group(slug), "autocomplete", q, limit, scope ?? "all"] as const,
+  // autocomplete key includes kind so the per-input cache buckets a
+  // commodity-tag query separately from a file-tag one even when q +
+  // limit happen to be identical.
+  autocomplete: (slug: string, q: string, limit: number, kind: TagKind | undefined) =>
+    [...tagKeys.group(slug), "autocomplete", q, limit, kind ?? "none"] as const,
 }

--- a/frontend/src/i18n/locales/en/tags.json
+++ b/frontend/src/i18n/locales/en/tags.json
@@ -40,7 +40,6 @@
   "list": {
     "delete": "Delete tag",
     "edit": "Edit tag",
-    "empty": "No tags yet — create your first one below.",
     "emptyFiltered": "No tags match \"{{query}}\".",
     "emptyScopeCommodity": "No tags used on items yet — apply one from the Add Item dialog's Extras step to seed this list.",
     "emptyScopeFile": "No tags used on files yet — apply one from a file's tag input to seed this list.",
@@ -54,9 +53,6 @@
     "usageItems_one": "{{count}} item",
     "usageItems_other": "{{count}} items",
     "usageNone": "Not used yet"
-  },
-  "preview": {
-    "heading": "Preview"
   },
   "removal": {
     "confirmAction": "Delete",
@@ -82,16 +78,13 @@
     "newest": "Newest"
   },
   "stats": {
+    "commodityTagsTotal": "Item tags",
     "filesTagged": "Tagged files",
     "filesUntagged": "Untagged files",
+    "fileTagsTotal": "File tags",
     "itemsTagged": "Tagged items",
     "itemsUntagged": "Untagged items",
     "tagsTotal": "Tags"
-  },
-  "tabs": {
-    "all": "All",
-    "commodity": "Item tags",
-    "file": "File tags"
   },
   "title": "Tags",
   "usage": {
@@ -108,5 +101,10 @@
     "slugInvalid": "Slug must be lowercase, kebab-cased.",
     "slugRequired": "Slug is required.",
     "slugTooLong": "Slug must be 64 characters or fewer."
+  },
+  "views": {
+    "commodity": "Item tags",
+    "file": "File tags",
+    "label": "Tag type"
   }
 }

--- a/frontend/src/pages/files/FileEditPage.tsx
+++ b/frontend/src/pages/files/FileEditPage.tsx
@@ -176,6 +176,8 @@ export function FileEditPage() {
                     values={field.value ?? []}
                     onChange={field.onChange}
                     testId="file-edit-tags"
+                    autocomplete
+                    kind="file"
                   />
                 )}
               />

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -1,9 +1,8 @@
-import { Plus, Search, Tag as TagIcon, X } from "lucide-react"
+import { Boxes, FileText, Plus, Search, Tag as TagIcon, X } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useSearchParams } from "react-router-dom"
 
-import { TagBadge } from "@/components/tags/TagBadge"
 import { TagFormDialog } from "@/components/tags/TagFormDialog"
 import { TagInlineCreate } from "@/components/tags/TagInlineCreate"
 import { TagRow, type TagRowPreviewItem } from "@/components/tags/TagRow"
@@ -14,13 +13,12 @@ import { Label } from "@/components/ui/label"
 import { Page, PageHeader } from "@/components/ui/page"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useCommodities } from "@/features/commodities/hooks"
 import {
   type CreateTagRequest,
   type TagColor,
   type TagEntity,
-  type TagScope,
+  type TagKind,
   type TagSortField,
   type TagSortOrder,
   type UpdateTagRequest,
@@ -66,12 +64,14 @@ const VALID_SORT_ORDERS = ["asc", "desc"] as const satisfies readonly TagSortOrd
 const PREVIEW_COMMODITIES_LIMIT = 100
 const PREVIEW_ITEMS_PER_TAG = 2
 
-// Cap on the unfiltered-tag companion query. 100 matches the BE's
-// per_page ceiling; realistic per-group tag counts (typically < 30)
-// sit comfortably below this. Groups with more than 100 tags will see
-// the Preview footer / inline duplicate-slug check truncate at the
-// hundredth — acceptable for v1; revisit if real groups exceed this.
+// Cap on the same-kind companion query that backs the inline-create
+// duplicate-slug check. 100 matches the BE's per_page ceiling; realistic
+// per-group/per-kind tag counts (typically < 30) sit comfortably below it.
 const ALL_TAGS_FETCH_LIMIT = 100
+
+// localStorage key for the last-used view kind, mirroring Files'
+// `files:viewMode`. Lets the page reopen on the kind the user left on.
+const VIEW_KIND_KEY = "tags:viewKind"
 
 function parseSort(raw: string | null): TagSortField {
   return (VALID_SORT_FIELDS as readonly string[]).includes(raw ?? "")
@@ -85,18 +85,13 @@ function parseOrder(raw: string | null): TagSortOrder {
     : "asc"
 }
 
-// Local tab id — "all" stays in the URL as the explicit no-filter
-// sentinel; the data layer turns it into "no scope param" before the
-// request. "commodity" / "file" mirror the BE's wire contract.
-type TabId = "all" | TagScope
-const VALID_TABS = ["all", "commodity", "file"] as const satisfies readonly TabId[]
+// The view kind drives the whole page: item-tags and file-tags are
+// separate entities switched via the Files-style toggle, never merged.
+// "commodity" is the default landing view.
+const VALID_KINDS = ["commodity", "file"] as const satisfies readonly TagKind[]
 
-function parseTab(raw: string | null): TabId {
-  return (VALID_TABS as readonly string[]).includes(raw ?? "") ? (raw as TabId) : "all"
-}
-
-function scopeForTab(tab: TabId): TagScope | undefined {
-  return tab === "all" ? undefined : tab
+function parseKind(raw: string | null): TagKind | null {
+  return (VALID_KINDS as readonly string[]).includes(raw ?? "") ? (raw as TagKind) : null
 }
 
 interface DialogState {
@@ -114,7 +109,17 @@ export function TagsListPage() {
   const urlQuery = searchParams.get("q") ?? ""
   const urlSort = parseSort(searchParams.get("sort"))
   const urlOrder = parseOrder(searchParams.get("order"))
-  const urlTab = parseTab(searchParams.get("tab"))
+
+  // View kind: URL (?kind=) wins so refreshes / shared links survive,
+  // then localStorage (per-device), then the "commodity" default —
+  // exactly the resolution order FilesListPage uses for its view mode.
+  const urlKind = parseKind(searchParams.get("kind"))
+  const [storedKind, setStoredKind] = useState<TagKind>(() => {
+    if (typeof window === "undefined") return "commodity"
+    const raw = window.localStorage.getItem(VIEW_KIND_KEY)
+    return raw === "commodity" || raw === "file" ? raw : "commodity"
+  })
+  const viewKind: TagKind = urlKind ?? storedKind
 
   const [pendingSearch, setPendingSearch] = useState(urlQuery)
   // Re-seed the input when the URL query changes via back/forward — this
@@ -151,25 +156,24 @@ export function TagsListPage() {
       // small/medium groups render in one page. Paging arrives in a
       // follow-up if real groups exceed 100 tags.
       perPage: 100,
-      scope: scopeForTab(urlTab),
+      kind: viewKind,
     }),
-    [urlQuery, urlSort, urlOrder, urlTab]
+    [urlQuery, urlSort, urlOrder, viewKind]
   )
   const tagsQuery = useTags(listOpts)
-  // Unfiltered companion query — backs the duplicate-slug check inside
-  // the inline-create row and the Preview footer pill grid. Without it,
-  // both consumers see only the search-filtered (and paginated) slice
-  // and would (a) miss collisions for tags outside the current view
-  // and (b) shrink the pill grid down to the search results, which
-  // defeats the whole "all-tags palette" purpose of the footer.
+  // Same-kind companion query — backs the duplicate-slug check inside the
+  // inline-create row. Scoped to the current kind because uniqueness is
+  // per (group, kind, slug): a slug that exists as a file tag must not
+  // block creating the same slug as an item tag.
   const allTagsQuery = useTags(
     useMemo(
       () => ({
         sort: "label" as TagSortField,
         order: "asc" as TagSortOrder,
         perPage: ALL_TAGS_FETCH_LIMIT,
+        kind: viewKind,
       }),
-      []
+      [viewKind]
     )
   )
   const statsQuery = useTagStats()
@@ -233,20 +237,19 @@ export function TagsListPage() {
     setSearchParams(next, { replace: true })
   }
 
-  function patchTab(next: string) {
-    const tab = parseTab(next)
-    const params = new URLSearchParams(searchParams)
-    if (tab === "all") {
-      params.delete("tab")
-    } else {
-      params.set("tab", tab)
+  function setViewKind(kind: TagKind) {
+    setStoredKind(kind)
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(VIEW_KIND_KEY, kind)
     }
+    const params = new URLSearchParams(searchParams)
+    params.set("kind", kind)
     setSearchParams(params, { replace: true })
   }
 
   async function onInlineCreate(values: { label: string; slug: string; color: TagColor }) {
     try {
-      await createMutation.mutateAsync(values)
+      await createMutation.mutateAsync({ ...values, kind: viewKind })
       toast.success(t("tags:form.createSuccess"))
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -255,9 +258,9 @@ export function TagsListPage() {
     }
   }
 
-  async function onCreateSubmit(values: CreateTagRequest) {
+  async function onCreateSubmit(values: Omit<CreateTagRequest, "kind">) {
     try {
-      await createMutation.mutateAsync(values)
+      await createMutation.mutateAsync({ ...values, kind: viewKind })
       toast.success(t("tags:form.createSuccess"))
       setDialog({ open: false, mode: "create" })
     } catch (err) {
@@ -325,12 +328,9 @@ export function TagsListPage() {
     }
   }
 
-  // Both the count line and the Preview footer must reflect the
-  // server-reported total (not `items.length`, which is capped by
-  // perPage) and the unfiltered tag set (not the search/scope-filtered
-  // view).
+  // The count line reflects the server-reported total (not `items.length`,
+  // which is capped by perPage).
   const filteredCount = totalMatches
-  const allTagsForPreview = allTags
 
   // emptyMessage picks the right key for the empty list — scope-aware
   // when no search query is set so users on the commodity/file tab see
@@ -338,15 +338,12 @@ export function TagsListPage() {
   // generic empty state.
   function emptyMessage(): string {
     if (urlQuery) return t("tags:list.emptyFiltered", { query: urlQuery })
-    if (urlTab === "commodity") return t("tags:list.emptyScopeCommodity")
-    if (urlTab === "file") return t("tags:list.emptyScopeFile")
-    return t("tags:list.empty")
+    return viewKind === "file" ? t("tags:list.emptyScopeFile") : t("tags:list.emptyScopeCommodity")
   }
 
-  // tabBody is the toolbar + list payload mounted inside the active
-  // TabsContent. Defined once and referenced from all three tab panels
-  // so each TabsTrigger has a real aria-controls target (Radix mounts
-  // only the active panel's children, so there is no triple-render).
+  // tabBody is the toolbar + list payload rendered under the kind
+  // switcher. The list query is keyed by viewKind, so switching kinds
+  // re-fetches the right slice.
   const tabBody = (
     <div className="flex flex-col gap-4 pt-3">
       <div className="flex flex-wrap items-end gap-3">
@@ -452,7 +449,9 @@ export function TagsListPage() {
                   <TagRow
                     tag={tag}
                     usage={usage}
-                    previewItems={previewByTag.get(tag.slug ?? "") ?? []}
+                    previewItems={
+                      viewKind === "commodity" ? (previewByTag.get(tag.slug ?? "") ?? []) : []
+                    }
                     onEdit={() =>
                       setDialog({
                         open: true,
@@ -497,61 +496,42 @@ export function TagsListPage() {
         }
       />
 
-      <TagsStatsBar stats={statsQuery.data} loading={statsQuery.isLoading} />
+      <TagsStatsBar stats={statsQuery.data} kind={viewKind} loading={statsQuery.isLoading} />
 
-      <Tabs value={urlTab} onValueChange={patchTab} className="gap-3">
-        <TabsList data-testid="tags-tabs">
-          <TabsTrigger value="all" data-testid="tags-tab-all">
-            {t("tags:tabs.all")}
-          </TabsTrigger>
-          <TabsTrigger value="commodity" data-testid="tags-tab-commodity">
-            {t("tags:tabs.commodity")}
-          </TabsTrigger>
-          <TabsTrigger value="file" data-testid="tags-tab-file">
-            {t("tags:tabs.file")}
-          </TabsTrigger>
-        </TabsList>
-        {/* One TabsContent per trigger value so each TabsTrigger's
-            aria-controls resolves to a real tabpanel element (Radix
-            otherwise skips inactive panels entirely, leaving the
-            triggers' aria-controls dangling and tripping axe). Only
-            the active panel mounts its children — `tabBody` is the
-            same JSX in each slot but React + Radix mount it exactly
-            once per active value, so there is no triple-render cost.
-            Scoping happens via `urlTab → listOpts.scope`, which is
-            evaluated outside the Tabs subtree, so the actual data
-            query also runs only once per tab. */}
-        <TabsContent value="all" className="m-0" data-testid="tags-tab-all-content">
-          {tabBody}
-        </TabsContent>
-        <TabsContent value="commodity" className="m-0" data-testid="tags-tab-commodity-content">
-          {tabBody}
-        </TabsContent>
-        <TabsContent value="file" className="m-0" data-testid="tags-tab-file-content">
-          {tabBody}
-        </TabsContent>
-      </Tabs>
-
-      {allTagsForPreview.length > 0 ? (
-        <div
-          className="rounded-xl border border-border bg-card px-4 py-4 space-y-3"
-          data-testid="tags-preview"
+      {/* Item-tags and file-tags are separate entities, switched with a
+          Files-style icon+label toggle (active = secondary, inactive =
+          ghost). There is no combined "All" view. */}
+      <div
+        className="flex items-center gap-1"
+        role="group"
+        aria-label={t("tags:views.label")}
+        data-testid="tags-view-switcher"
+      >
+        <Button
+          type="button"
+          variant={viewKind === "commodity" ? "secondary" : "ghost"}
+          size="sm"
+          onClick={() => setViewKind("commodity")}
+          aria-pressed={viewKind === "commodity"}
+          data-testid="tags-view-commodity"
         >
-          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-            {t("tags:preview.heading")}
-          </p>
-          <div className="flex flex-wrap gap-1.5">
-            {allTagsForPreview.map((tag) => (
-              <TagBadge
-                key={tag.id}
-                label={tag.label ?? tag.slug ?? ""}
-                color={(tag.color ?? "muted") as TagColor}
-                testId={`tags-preview-${tag.slug}`}
-              />
-            ))}
-          </div>
-        </div>
-      ) : null}
+          <Boxes className="mr-1.5 size-4" aria-hidden="true" />
+          {t("tags:views.commodity")}
+        </Button>
+        <Button
+          type="button"
+          variant={viewKind === "file" ? "secondary" : "ghost"}
+          size="sm"
+          onClick={() => setViewKind("file")}
+          aria-pressed={viewKind === "file"}
+          data-testid="tags-view-file"
+        >
+          <FileText className="mr-1.5 size-4" aria-hidden="true" />
+          {t("tags:views.file")}
+        </Button>
+      </div>
+
+      {tabBody}
 
       <TagFormDialog
         open={dialog.open}

--- a/frontend/src/pages/tags/__tests__/TagsListPage.test.tsx
+++ b/frontend/src/pages/tags/__tests__/TagsListPage.test.tsx
@@ -74,7 +74,9 @@ function seed() {
     ...groupHandlers.list(groupFixture),
     ...commodityHandlers.list(SLUG, commodityFixture),
     ...tagHandlers.stats(SLUG, {
-      tags_total: 2,
+      tags_total: 3,
+      commodity_tags_total: 2,
+      file_tags_total: 1,
       items_tagged: 5,
       items_untagged: 1,
       files_tagged: 3,
@@ -100,12 +102,16 @@ function seed() {
 }
 
 describe("<TagsListPage />", () => {
-  it("renders the stats bar with values from /tags/stats", async () => {
+  it("renders the commodity stats bar (default view) with values from /tags/stats", async () => {
     seed()
     renderPage()
-    await waitFor(() => expect(screen.getByTestId("tags-stats-tags-total")).toHaveTextContent("2"))
+    await waitFor(() =>
+      expect(screen.getByTestId("tags-stats-commodity-tags-total")).toHaveTextContent("2")
+    )
     expect(screen.getByTestId("tags-stats-items-tagged")).toHaveTextContent("5")
-    expect(screen.getByTestId("tags-stats-files-untagged")).toHaveTextContent("2")
+    expect(screen.getByTestId("tags-stats-items-untagged")).toHaveTextContent("1")
+    // File tiles belong to the file-tags view only.
+    expect(screen.queryByTestId("tags-stats-files-tagged")).not.toBeInTheDocument()
   })
 
   it("renders one row per tag with the inline usage block", async () => {
@@ -116,12 +122,18 @@ describe("<TagsListPage />", () => {
     expect(screen.getByTestId("tag-row-garden-usage")).toHaveTextContent(/Not used yet/i)
   })
 
-  it("renders a tag preview footer card with all tag pills", async () => {
+  it("switches to the file-tags view via the kind toggle", async () => {
     seed()
+    const user = userEvent.setup()
     renderPage()
-    expect(await screen.findByTestId("tags-preview")).toBeVisible()
-    expect(screen.getByTestId("tags-preview-kitchen")).toBeInTheDocument()
-    expect(screen.getByTestId("tags-preview-garden")).toBeInTheDocument()
+    await screen.findByTestId("tag-row-kitchen")
+    // Default view is the commodity (item-tags) view.
+    expect(screen.getByTestId("tags-view-commodity")).toHaveAttribute("aria-pressed", "true")
+    await user.click(screen.getByTestId("tags-view-file"))
+    // File view swaps the stats tiles to the file-tag set.
+    expect(await screen.findByTestId("tags-stats-file-tags-total")).toBeVisible()
+    expect(screen.queryByTestId("tags-stats-items-tagged")).not.toBeInTheDocument()
+    expect(screen.getByTestId("tags-view-file")).toHaveAttribute("aria-pressed", "true")
   })
 
   it("renders item-preview chips for tags with usage", async () => {
@@ -165,9 +177,8 @@ describe("<TagsListPage />", () => {
     const clear = await screen.findByTestId("tags-search-clear")
     await user.click(clear)
     // Re-query the input after the click — the URL-debounce effect can
-    // cause the Tabs subtree to re-render, which can detach the
-    // pre-click element reference even though the visible DOM still
-    // shows the new state.
+    // re-render the page subtree, which can detach the pre-click element
+    // reference even though the visible DOM still shows the new state.
     await waitFor(() => {
       const fresh = screen.getByTestId("tags-search-input") as HTMLInputElement
       expect(fresh.value).toBe("")

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -6958,11 +6958,13 @@ export type paths = {
         };
         /**
          * List tags
-         * @description get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block. Pass scope=commodity|file to restrict to tags actually used on that entity type.
+         * @description get tags of the given kind. Pass include=usage to attach a per-row meta.usage block. kind=commodity|file is required — item-tags and file-tags are separate entities.
          */
         get: {
             parameters: {
-                query?: {
+                query: {
+                    /** @description Tag kind (commodity = item-tags, file = file-tags) */
+                    kind: "commodity" | "file";
                     /** @description Search by label or slug */
                     q?: string;
                     /** @description Sort field (label, created_at, usage) */
@@ -6975,8 +6977,6 @@ export type paths = {
                     per_page?: number;
                     /** @description Comma-separated extras. 'usage' attaches per-row meta.usage. */
                     include?: "usage";
-                    /** @description Restrict to tags used on commodities or files. Empty = no filter. */
-                    scope?: "commodity" | "file";
                 };
                 header?: never;
                 path: {
@@ -6996,7 +6996,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.TagsResponse"];
                     };
                 };
-                /** @description Invalid scope value */
+                /** @description Missing or invalid kind value */
                 422: {
                     headers: {
                         [name: string]: unknown;
@@ -7064,17 +7064,17 @@ export type paths = {
         };
         /**
          * Autocomplete tag suggestions
-         * @description Top-N tags matching the query, ranked by scope-aware usage desc + created_at desc.
+         * @description Top-N tags of the given kind matching the query, ranked by usage desc + created_at desc.
          */
         get: {
             parameters: {
-                query?: {
+                query: {
+                    /** @description Tag kind (commodity = item-tags, file = file-tags) */
+                    kind: "commodity" | "file";
                     /** @description Substring match against label and slug */
                     q?: string;
                     /** @description Maximum suggestions returned */
                     limit?: number;
-                    /** @description Restrict to tags used on commodities or files. Empty = no filter. */
-                    scope?: "commodity" | "file";
                 };
                 header?: never;
                 path: {
@@ -7094,7 +7094,7 @@ export type paths = {
                         "application/vnd.api+json": components["schemas"]["jsonapi.TagAutocompleteResponse"];
                     };
                 };
-                /** @description Invalid scope value */
+                /** @description Missing or invalid kind value */
                 422: {
                     headers: {
                         [name: string]: unknown;
@@ -10912,12 +10912,19 @@ export type components = {
             color?: components["schemas"]["models.TagColor"];
             created_at?: string;
             id?: string;
+            /**
+             * @description Kind separates item-tags (commodity) from file-tags (file). Two tags
+             *     with the same slug but different kind are distinct entities. Existing
+             *     rows default to "commodity" on migration; new rows always carry an
+             *     explicit kind from the write path.
+             */
+            kind?: components["schemas"]["models.TagKind"];
             /** @description Label is the human-readable display name. */
             label?: string;
             meta?: components["schemas"]["jsonapi.TagMeta"];
             /**
              * @description Slug is the kebab-cased identifier referenced from
-             *     commodities.tags / files.tags JSONB arrays. Unique per group.
+             *     commodities.tags / files.tags JSONB arrays. Unique per (group, kind).
              */
             slug?: string;
             updated_at?: string;
@@ -10935,6 +10942,11 @@ export type components = {
              * @enum {unknown}
              */
             color?: "amber" | "green" | "blue" | "orange" | "red" | "muted";
+            /**
+             * @example commodity
+             * @enum {unknown}
+             */
+            kind?: "commodity" | "file";
             label?: string;
             slug?: string;
         };
@@ -11778,11 +11790,18 @@ export type components = {
             color?: components["schemas"]["models.TagColor"];
             created_at?: string;
             id?: string;
+            /**
+             * @description Kind separates item-tags (commodity) from file-tags (file). Two tags
+             *     with the same slug but different kind are distinct entities. Existing
+             *     rows default to "commodity" on migration; new rows always carry an
+             *     explicit kind from the write path.
+             */
+            kind?: components["schemas"]["models.TagKind"];
             /** @description Label is the human-readable display name. */
             label?: string;
             /**
              * @description Slug is the kebab-cased identifier referenced from
-             *     commodities.tags / files.tags JSONB arrays. Unique per group.
+             *     commodities.tags / files.tags JSONB arrays. Unique per (group, kind).
              */
             slug?: string;
             updated_at?: string;
@@ -11790,6 +11809,8 @@ export type components = {
         };
         /** @enum {string} */
         "models.TagColor": "amber" | "green" | "blue" | "orange" | "red" | "muted";
+        /** @enum {string} */
+        "models.TagKind": "" | "commodity" | "file";
         /** @enum {string} */
         "models.TenantStatus": "active" | "suspended" | "inactive";
         "models.User": {
@@ -11844,6 +11865,8 @@ export type components = {
             other?: number;
         };
         "registry.TagStats": {
+            commodity_tags_total?: number;
+            file_tags_total?: number;
             files_tagged?: number;
             files_untagged?: number;
             items_tagged?: number;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -11810,7 +11810,7 @@ export type components = {
         /** @enum {string} */
         "models.TagColor": "amber" | "green" | "blue" | "orange" | "red" | "muted";
         /** @enum {string} */
-        "models.TagKind": "" | "commodity" | "file";
+        "models.TagKind": "commodity" | "file";
         /** @enum {string} */
         "models.TenantStatus": "active" | "suspended" | "inactive";
         "models.User": {

--- a/go/apiserver/commodities.go
+++ b/go/apiserver/commodities.go
@@ -336,7 +336,7 @@ func (api *commoditiesAPI) createCommodity(w http.ResponseWriter, r *http.Reques
 	// Auto-create any tags the user typed but that don't yet exist as
 	// first-class rows; replace the JSONB list with the canonical slugs.
 	if len(commodity.Tags) > 0 {
-		slugs, terr := api.tagService.NormalizeAndEnsureSlugs(r.Context(), []string(commodity.Tags))
+		slugs, terr := api.tagService.NormalizeAndEnsureSlugs(r.Context(), models.TagKindCommodity, []string(commodity.Tags))
 		if terr != nil {
 			renderEntityError(w, r, terr)
 			return
@@ -489,7 +489,7 @@ func (api *commoditiesAPI) updateCommodity(w http.ResponseWriter, r *http.Reques
 	}
 
 	if len(updateData.Tags) > 0 {
-		slugs, terr := api.tagService.NormalizeAndEnsureSlugs(r.Context(), []string(updateData.Tags))
+		slugs, terr := api.tagService.NormalizeAndEnsureSlugs(r.Context(), models.TagKindCommodity, []string(updateData.Tags))
 		if terr != nil {
 			renderEntityError(w, r, terr)
 			return

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -303,7 +303,7 @@ func (api *filesAPI) createFile(w http.ResponseWriter, r *http.Request) {
 		input.Data.Attributes.LinkedEntityType,
 		input.Data.Attributes.LinkedEntityMeta,
 	)
-	tagSlugs, terr := api.tagService.NormalizeAndEnsureSlugs(r.Context(), mergedTags)
+	tagSlugs, terr := api.tagService.NormalizeAndEnsureSlugs(r.Context(), models.TagKindFile, mergedTags)
 	if terr != nil {
 		renderEntityError(w, r, terr)
 		return
@@ -461,7 +461,7 @@ func (api *filesAPI) updateFile(w http.ResponseWriter, r *http.Request) {
 		input.Data.Attributes.LinkedEntityType,
 		input.Data.Attributes.LinkedEntityMeta,
 	)
-	tagSlugs, terr := api.tagService.NormalizeAndEnsureSlugs(r.Context(), mergedTags)
+	tagSlugs, terr := api.tagService.NormalizeAndEnsureSlugs(r.Context(), models.TagKindFile, mergedTags)
 	if terr != nil {
 		renderEntityError(w, r, terr)
 		return

--- a/go/apiserver/tags.go
+++ b/go/apiserver/tags.go
@@ -54,20 +54,20 @@ type tagsAPI struct {
 
 // listTags lists tags with pagination, optional q-search, and sort.
 // @Summary List tags
-// @Description get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block. Pass scope=commodity|file to restrict to tags actually used on that entity type.
+// @Description get tags of the given kind. Pass include=usage to attach a per-row meta.usage block. kind=commodity|file is required — item-tags and file-tags are separate entities.
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
 // @Param groupSlug path string true "Group slug"
+// @Param kind query string true "Tag kind (commodity = item-tags, file = file-tags)" Enums(commodity,file)
 // @Param q query string false "Search by label or slug"
 // @Param sort query string false "Sort field (label, created_at, usage)" Enums(label,created_at,usage)
 // @Param order query string false "Sort direction (asc, desc)" default(asc)
 // @Param page query int false "Page number (1-based)" default(1)
 // @Param per_page query int false "Items per page" default(50)
 // @Param include query string false "Comma-separated extras. 'usage' attaches per-row meta.usage." Enums(usage)
-// @Param scope query string false "Restrict to tags used on commodities or files. Empty = no filter." Enums(commodity,file)
 // @Success 200 {object} jsonapi.TagsResponse "OK"
-// @Failure 422 {object} jsonapi.Errors "Invalid scope value"
+// @Failure 422 {object} jsonapi.Errors "Missing or invalid kind value"
 // @Router /g/{groupSlug}/tags [get].
 func (api *tagsAPI) listTags(w http.ResponseWriter, r *http.Request) {
 	regSet := RegistrySetFromContext(r.Context())
@@ -80,9 +80,9 @@ func (api *tagsAPI) listTags(w http.ResponseWriter, r *http.Request) {
 	page, perPage := parsePagination(q.Get("page"), q.Get("per_page"))
 	offset := (page - 1) * perPage
 
-	scope, ok := parseTagScope(q.Get("scope"))
+	kind, ok := parseTagKind(q.Get("kind"))
 	if !ok {
-		unprocessableEntityError(w, r, fmt.Errorf("invalid scope: %q (must be one of: commodity, file)", q.Get("scope")))
+		unprocessableEntityError(w, r, fmt.Errorf("invalid kind: %q (must be one of: commodity, file)", q.Get("kind")))
 		return
 	}
 
@@ -90,7 +90,7 @@ func (api *tagsAPI) listTags(w http.ResponseWriter, r *http.Request) {
 		Search:    q.Get("q"),
 		SortField: registry.TagSortField(q.Get("sort")),
 		SortDesc:  q.Get("order") == "desc",
-		Scope:     scope,
+		Kind:      kind,
 	}
 
 	tags, total, err := regSet.TagRegistry.ListPaginated(r.Context(), offset, perPage, opts)
@@ -105,7 +105,7 @@ func (api *tagsAPI) listTags(w http.ResponseWriter, r *http.Request) {
 		for _, t := range tags {
 			slugs = append(slugs, t.Slug)
 		}
-		usageBySlug, err = regSet.TagRegistry.GetUsageBatch(r.Context(), slugs)
+		usageBySlug, err = regSet.TagRegistry.GetUsageBatch(r.Context(), kind, slugs)
 		if err != nil {
 			renderEntityError(w, r, err)
 			return
@@ -165,16 +165,16 @@ func includeHasToken(raw, token string) bool {
 
 // autocompleteTags returns the top-N matching tags ranked by usage and recency.
 // @Summary Autocomplete tag suggestions
-// @Description Top-N tags matching the query, ranked by scope-aware usage desc + created_at desc.
+// @Description Top-N tags of the given kind matching the query, ranked by usage desc + created_at desc.
 // @Tags tags
 // @Accept json-api
 // @Produce json-api
 // @Param groupSlug path string true "Group slug"
+// @Param kind query string true "Tag kind (commodity = item-tags, file = file-tags)" Enums(commodity,file)
 // @Param q query string false "Substring match against label and slug"
 // @Param limit query int false "Maximum suggestions returned" default(10)
-// @Param scope query string false "Restrict to tags used on commodities or files. Empty = no filter." Enums(commodity,file)
 // @Success 200 {object} jsonapi.TagAutocompleteResponse "OK"
-// @Failure 422 {object} jsonapi.Errors "Invalid scope value"
+// @Failure 422 {object} jsonapi.Errors "Missing or invalid kind value"
 // @Router /g/{groupSlug}/tags/autocomplete [get].
 func (api *tagsAPI) autocompleteTags(w http.ResponseWriter, r *http.Request) {
 	regSet := RegistrySetFromContext(r.Context())
@@ -190,13 +190,13 @@ func (api *tagsAPI) autocompleteTags(w http.ResponseWriter, r *http.Request) {
 			limit = parsed
 		}
 	}
-	scope, ok := parseTagScope(r.URL.Query().Get("scope"))
+	kind, ok := parseTagKind(r.URL.Query().Get("kind"))
 	if !ok {
-		unprocessableEntityError(w, r, fmt.Errorf("invalid scope: %q (must be one of: commodity, file)", r.URL.Query().Get("scope")))
+		unprocessableEntityError(w, r, fmt.Errorf("invalid kind: %q (must be one of: commodity, file)", r.URL.Query().Get("kind")))
 		return
 	}
 
-	tags, err := regSet.TagRegistry.Search(r.Context(), q, limit, scope)
+	tags, err := regSet.TagRegistry.Search(r.Context(), q, limit, kind)
 	if err != nil {
 		renderEntityError(w, r, err)
 		return
@@ -206,14 +206,14 @@ func (api *tagsAPI) autocompleteTags(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// parseTagScope validates and returns the requested tag scope from the
-// raw ?scope= query value. Returns (TagScopeAny, true) for the empty
-// string (treated as no filter). Returns (_, false) for any other value
-// the registry doesn't understand — handler converts to 422.
-func parseTagScope(raw string) (registry.TagScope, bool) {
-	candidate := registry.TagScope(strings.TrimSpace(raw))
+// parseTagKind validates and returns the required tag kind from the raw
+// ?kind= query value. Item-tags and file-tags are separate entities, so
+// kind is mandatory — there is no "all". Returns (_, false) for an empty
+// or unknown value; the handler converts that to 422.
+func parseTagKind(raw string) (models.TagKind, bool) {
+	candidate := models.TagKind(strings.TrimSpace(raw))
 	if !candidate.IsValid() {
-		return registry.TagScopeAny, false
+		return models.TagKindAny, false
 	}
 	return candidate, true
 }
@@ -242,7 +242,7 @@ func (api *tagsAPI) getTag(w http.ResponseWriter, r *http.Request) { //revive:di
 		return
 	}
 
-	usage, err := regSet.TagRegistry.GetUsage(r.Context(), tag.Slug)
+	usage, err := regSet.TagRegistry.GetUsage(r.Context(), tag.Kind, tag.Slug)
 	if err != nil {
 		renderEntityError(w, r, err)
 		return
@@ -278,6 +278,7 @@ func (api *tagsAPI) createTag(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tag := models.Tag{
+		Kind:  input.Data.Attributes.Kind,
 		Slug:  input.Data.Attributes.Slug,
 		Label: input.Data.Attributes.Label,
 		Color: input.Data.Attributes.Color,

--- a/go/apiserver/tags_test.go
+++ b/go/apiserver/tags_test.go
@@ -5,51 +5,52 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/models"
 )
 
-// parseTagScope is unexported, so this test lives in the apiserver
-// package itself. Pins the wire contract for ?scope= introduced in #1628:
-// empty / commodity / file are accepted; anything else 422s.
-func TestParseTagScope(t *testing.T) {
-	t.Run("empty string returns TagScopeAny + ok", func(t *testing.T) {
+// parseTagKind is unexported, so this test lives in the apiserver package
+// itself. Pins the wire contract for the required ?kind= param: commodity /
+// file are accepted; empty or anything else 422s (item-tags and file-tags
+// are separate entities, so there is no "all").
+func TestParseTagKind(t *testing.T) {
+	t.Run("empty string rejected — kind is required", func(t *testing.T) {
 		c := qt.New(t)
-		got, ok := parseTagScope("")
-		c.Assert(ok, qt.IsTrue)
-		c.Assert(got, qt.Equals, registry.TagScopeAny)
+		got, ok := parseTagKind("")
+		c.Assert(ok, qt.IsFalse)
+		c.Assert(got, qt.Equals, models.TagKindAny)
 	})
 
 	t.Run("commodity parses", func(t *testing.T) {
 		c := qt.New(t)
-		got, ok := parseTagScope("commodity")
+		got, ok := parseTagKind("commodity")
 		c.Assert(ok, qt.IsTrue)
-		c.Assert(got, qt.Equals, registry.TagScopeCommodity)
+		c.Assert(got, qt.Equals, models.TagKindCommodity)
 	})
 
 	t.Run("file parses", func(t *testing.T) {
 		c := qt.New(t)
-		got, ok := parseTagScope("file")
+		got, ok := parseTagKind("file")
 		c.Assert(ok, qt.IsTrue)
-		c.Assert(got, qt.Equals, registry.TagScopeFile)
+		c.Assert(got, qt.Equals, models.TagKindFile)
 	})
 
 	t.Run("whitespace is trimmed", func(t *testing.T) {
 		c := qt.New(t)
-		got, ok := parseTagScope("  commodity  ")
+		got, ok := parseTagKind("  commodity  ")
 		c.Assert(ok, qt.IsTrue)
-		c.Assert(got, qt.Equals, registry.TagScopeCommodity)
+		c.Assert(got, qt.Equals, models.TagKindCommodity)
 	})
 
 	t.Run("unknown value rejected", func(t *testing.T) {
 		c := qt.New(t)
-		got, ok := parseTagScope("bogus")
+		got, ok := parseTagKind("bogus")
 		c.Assert(ok, qt.IsFalse)
-		c.Assert(got, qt.Equals, registry.TagScopeAny)
+		c.Assert(got, qt.Equals, models.TagKindAny)
 	})
 
 	t.Run("commodities plural rejected — wire contract is singular", func(t *testing.T) {
 		c := qt.New(t)
-		_, ok := parseTagScope("commodities")
+		_, ok := parseTagKind("commodities")
 		c.Assert(ok, qt.IsFalse)
 	})
 }

--- a/go/backup/restore/processor/processor.go
+++ b/go/backup/restore/processor/processor.go
@@ -1428,7 +1428,7 @@ func (l *RestoreOperationProcessor) ensureCommodityTags(ctx context.Context, com
 	if len(commodity.Tags) == 0 {
 		return nil
 	}
-	slugs, err := l.tagService.NormalizeAndEnsureSlugs(ctx, []string(commodity.Tags))
+	slugs, err := l.tagService.NormalizeAndEnsureSlugs(ctx, models.TagKindCommodity, []string(commodity.Tags))
 	if err != nil {
 		return errxtrace.Wrap("failed to ensure tags for restored commodity", err, errx.Attrs("original_commodity_id", originalXMLID))
 	}

--- a/go/backup/restore/restore_tags_test.go
+++ b/go/backup/restore/restore_tags_test.go
@@ -141,9 +141,12 @@ func TestRestore_AutoCreatesTagsForNewSlugs(t *testing.T) {
 	// (color or label) caused by the restore path mistakenly re-creating
 	// them via Update.
 	tagReg := must.Must(factorySet.TagRegistryFactory.CreateUserRegistry(ctx))
+	// Pre-seed as commodity-kind tags — that's the kind the commodity
+	// restore path looks up by, so these rows are reused rather than
+	// duplicated.
 	preExisting := []models.Tag{
-		{Slug: "electronics", Label: "Electronics (curated)", Color: models.TagColorBlue},
-		{Slug: "entertainment", Label: "Entertainment (curated)", Color: models.TagColorGreen},
+		{Kind: models.TagKindCommodity, Slug: "electronics", Label: "Electronics (curated)", Color: models.TagColorBlue},
+		{Kind: models.TagKindCommodity, Slug: "entertainment", Label: "Entertainment (curated)", Color: models.TagColorGreen},
 	}
 	for _, t := range preExisting {
 		must.Must(tagReg.Create(ctx, t))

--- a/go/debug/seeddata/seeddata_tags.go
+++ b/go/debug/seeddata/seeddata_tags.go
@@ -57,7 +57,9 @@ var seedTagCatalogue = []seedTagSpec{
 func seedTags(ctx context.Context, set *registry.Set, user *models.User, group *models.LocationGroup) error {
 	now := time.Now()
 	for _, spec := range seedTagCatalogue {
-		existing, err := set.TagRegistry.GetBySlug(ctx, spec.Slug)
+		// The curated catalogue is item-oriented; file tags auto-provision
+		// on file write. Seed everything as commodity-kind.
+		existing, err := set.TagRegistry.GetBySlug(ctx, models.TagKindCommodity, spec.Slug)
 		switch {
 		case err == nil && existing != nil:
 			// Tag row already exists in this group; leave the
@@ -76,6 +78,7 @@ func seedTags(ctx context.Context, set *registry.Set, user *models.User, group *
 				GroupID:         group.ID,
 				CreatedByUserID: user.ID,
 			},
+			Kind:      models.TagKindCommodity,
 			Slug:      spec.Slug,
 			Label:     spec.Label,
 			Color:     spec.Color,

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -6121,7 +6121,7 @@ const docTemplate = `{
         },
         "/g/{groupSlug}/tags": {
             "get": {
-                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block. Pass scope=commodity|file to restrict to tags actually used on that entity type.",
+                "description": "get tags of the given kind. Pass include=usage to attach a per-row meta.usage block. kind=commodity|file is required — item-tags and file-tags are separate entities.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -6138,6 +6138,17 @@ const docTemplate = `{
                         "description": "Group slug",
                         "name": "groupSlug",
                         "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "commodity",
+                            "file"
+                        ],
+                        "type": "string",
+                        "description": "Tag kind (commodity = item-tags, file = file-tags)",
+                        "name": "kind",
+                        "in": "query",
                         "required": true
                     },
                     {
@@ -6186,16 +6197,6 @@ const docTemplate = `{
                         "description": "Comma-separated extras. 'usage' attaches per-row meta.usage.",
                         "name": "include",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "commodity",
-                            "file"
-                        ],
-                        "type": "string",
-                        "description": "Restrict to tags used on commodities or files. Empty = no filter.",
-                        "name": "scope",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -6206,7 +6207,7 @@ const docTemplate = `{
                         }
                     },
                     "422": {
-                        "description": "Invalid scope value",
+                        "description": "Missing or invalid kind value",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -6261,7 +6262,7 @@ const docTemplate = `{
         },
         "/g/{groupSlug}/tags/autocomplete": {
             "get": {
-                "description": "Top-N tags matching the query, ranked by scope-aware usage desc + created_at desc.",
+                "description": "Top-N tags of the given kind matching the query, ranked by usage desc + created_at desc.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -6281,6 +6282,17 @@ const docTemplate = `{
                         "required": true
                     },
                     {
+                        "enum": [
+                            "commodity",
+                            "file"
+                        ],
+                        "type": "string",
+                        "description": "Tag kind (commodity = item-tags, file = file-tags)",
+                        "name": "kind",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
                         "type": "string",
                         "description": "Substring match against label and slug",
                         "name": "q",
@@ -6292,16 +6304,6 @@ const docTemplate = `{
                         "description": "Maximum suggestions returned",
                         "name": "limit",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "commodity",
-                            "file"
-                        ],
-                        "type": "string",
-                        "description": "Restrict to tags used on commodities or files. Empty = no filter.",
-                        "name": "scope",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -6312,7 +6314,7 @@ const docTemplate = `{
                         }
                     },
                     "422": {
-                        "description": "Invalid scope value",
+                        "description": "Missing or invalid kind value",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -11848,6 +11850,14 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "kind": {
+                    "description": "Kind separates item-tags (commodity) from file-tags (file). Two tags\nwith the same slug but different kind are distinct entities. Existing\nrows default to \"commodity\" on migration; new rows always carry an\nexplicit kind from the write path.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.TagKind"
+                        }
+                    ]
+                },
                 "label": {
                     "description": "Label is the human-readable display name.",
                     "type": "string"
@@ -11856,7 +11866,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/jsonapi.TagMeta"
                 },
                 "slug": {
-                    "description": "Slug is the kebab-cased identifier referenced from\ncommodities.tags / files.tags JSONB arrays. Unique per group.",
+                    "description": "Slug is the kebab-cased identifier referenced from\ncommodities.tags / files.tags JSONB arrays. Unique per (group, kind).",
                     "type": "string"
                 },
                 "updated_at": {
@@ -11901,6 +11911,18 @@ const docTemplate = `{
                         }
                     ],
                     "example": "muted"
+                },
+                "kind": {
+                    "enum": [
+                        "commodity",
+                        "file"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.TagKind"
+                        }
+                    ],
+                    "example": "commodity"
                 },
                 "label": {
                     "type": "string"
@@ -13448,12 +13470,20 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "kind": {
+                    "description": "Kind separates item-tags (commodity) from file-tags (file). Two tags\nwith the same slug but different kind are distinct entities. Existing\nrows default to \"commodity\" on migration; new rows always carry an\nexplicit kind from the write path.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.TagKind"
+                        }
+                    ]
+                },
                 "label": {
                     "description": "Label is the human-readable display name.",
                     "type": "string"
                 },
                 "slug": {
-                    "description": "Slug is the kebab-cased identifier referenced from\ncommodities.tags / files.tags JSONB arrays. Unique per group.",
+                    "description": "Slug is the kebab-cased identifier referenced from\ncommodities.tags / files.tags JSONB arrays. Unique per (group, kind).",
                     "type": "string"
                 },
                 "updated_at": {
@@ -13481,6 +13511,19 @@ const docTemplate = `{
                 "TagColorOrange",
                 "TagColorRed",
                 "TagColorMuted"
+            ]
+        },
+        "models.TagKind": {
+            "type": "string",
+            "enum": [
+                "",
+                "commodity",
+                "file"
+            ],
+            "x-enum-varnames": [
+                "TagKindAny",
+                "TagKindCommodity",
+                "TagKindFile"
             ]
         },
         "models.TenantStatus": {
@@ -13557,6 +13600,12 @@ const docTemplate = `{
         "registry.TagStats": {
             "type": "object",
             "properties": {
+                "commodity_tags_total": {
+                    "type": "integer"
+                },
+                "file_tags_total": {
+                    "type": "integer"
+                },
                 "files_tagged": {
                     "type": "integer"
                 },

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -13516,12 +13516,10 @@ const docTemplate = `{
         "models.TagKind": {
             "type": "string",
             "enum": [
-                "",
                 "commodity",
                 "file"
             ],
             "x-enum-varnames": [
-                "TagKindAny",
                 "TagKindCommodity",
                 "TagKindFile"
             ]

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -6114,7 +6114,7 @@
         },
         "/g/{groupSlug}/tags": {
             "get": {
-                "description": "get tags with optional filtering. Pass include=usage to attach a per-row meta.usage block. Pass scope=commodity|file to restrict to tags actually used on that entity type.",
+                "description": "get tags of the given kind. Pass include=usage to attach a per-row meta.usage block. kind=commodity|file is required — item-tags and file-tags are separate entities.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -6131,6 +6131,17 @@
                         "description": "Group slug",
                         "name": "groupSlug",
                         "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "commodity",
+                            "file"
+                        ],
+                        "type": "string",
+                        "description": "Tag kind (commodity = item-tags, file = file-tags)",
+                        "name": "kind",
+                        "in": "query",
                         "required": true
                     },
                     {
@@ -6179,16 +6190,6 @@
                         "description": "Comma-separated extras. 'usage' attaches per-row meta.usage.",
                         "name": "include",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "commodity",
-                            "file"
-                        ],
-                        "type": "string",
-                        "description": "Restrict to tags used on commodities or files. Empty = no filter.",
-                        "name": "scope",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -6199,7 +6200,7 @@
                         }
                     },
                     "422": {
-                        "description": "Invalid scope value",
+                        "description": "Missing or invalid kind value",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -6254,7 +6255,7 @@
         },
         "/g/{groupSlug}/tags/autocomplete": {
             "get": {
-                "description": "Top-N tags matching the query, ranked by scope-aware usage desc + created_at desc.",
+                "description": "Top-N tags of the given kind matching the query, ranked by usage desc + created_at desc.",
                 "consumes": [
                     "application/vnd.api+json"
                 ],
@@ -6274,6 +6275,17 @@
                         "required": true
                     },
                     {
+                        "enum": [
+                            "commodity",
+                            "file"
+                        ],
+                        "type": "string",
+                        "description": "Tag kind (commodity = item-tags, file = file-tags)",
+                        "name": "kind",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
                         "type": "string",
                         "description": "Substring match against label and slug",
                         "name": "q",
@@ -6285,16 +6297,6 @@
                         "description": "Maximum suggestions returned",
                         "name": "limit",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "commodity",
-                            "file"
-                        ],
-                        "type": "string",
-                        "description": "Restrict to tags used on commodities or files. Empty = no filter.",
-                        "name": "scope",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -6305,7 +6307,7 @@
                         }
                     },
                     "422": {
-                        "description": "Invalid scope value",
+                        "description": "Missing or invalid kind value",
                         "schema": {
                             "$ref": "#/definitions/jsonapi.Errors"
                         }
@@ -11841,6 +11843,14 @@
                 "id": {
                     "type": "string"
                 },
+                "kind": {
+                    "description": "Kind separates item-tags (commodity) from file-tags (file). Two tags\nwith the same slug but different kind are distinct entities. Existing\nrows default to \"commodity\" on migration; new rows always carry an\nexplicit kind from the write path.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.TagKind"
+                        }
+                    ]
+                },
                 "label": {
                     "description": "Label is the human-readable display name.",
                     "type": "string"
@@ -11849,7 +11859,7 @@
                     "$ref": "#/definitions/jsonapi.TagMeta"
                 },
                 "slug": {
-                    "description": "Slug is the kebab-cased identifier referenced from\ncommodities.tags / files.tags JSONB arrays. Unique per group.",
+                    "description": "Slug is the kebab-cased identifier referenced from\ncommodities.tags / files.tags JSONB arrays. Unique per (group, kind).",
                     "type": "string"
                 },
                 "updated_at": {
@@ -11894,6 +11904,18 @@
                         }
                     ],
                     "example": "muted"
+                },
+                "kind": {
+                    "enum": [
+                        "commodity",
+                        "file"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.TagKind"
+                        }
+                    ],
+                    "example": "commodity"
                 },
                 "label": {
                     "type": "string"
@@ -13441,12 +13463,20 @@
                 "id": {
                     "type": "string"
                 },
+                "kind": {
+                    "description": "Kind separates item-tags (commodity) from file-tags (file). Two tags\nwith the same slug but different kind are distinct entities. Existing\nrows default to \"commodity\" on migration; new rows always carry an\nexplicit kind from the write path.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.TagKind"
+                        }
+                    ]
+                },
                 "label": {
                     "description": "Label is the human-readable display name.",
                     "type": "string"
                 },
                 "slug": {
-                    "description": "Slug is the kebab-cased identifier referenced from\ncommodities.tags / files.tags JSONB arrays. Unique per group.",
+                    "description": "Slug is the kebab-cased identifier referenced from\ncommodities.tags / files.tags JSONB arrays. Unique per (group, kind).",
                     "type": "string"
                 },
                 "updated_at": {
@@ -13474,6 +13504,19 @@
                 "TagColorOrange",
                 "TagColorRed",
                 "TagColorMuted"
+            ]
+        },
+        "models.TagKind": {
+            "type": "string",
+            "enum": [
+                "",
+                "commodity",
+                "file"
+            ],
+            "x-enum-varnames": [
+                "TagKindAny",
+                "TagKindCommodity",
+                "TagKindFile"
             ]
         },
         "models.TenantStatus": {
@@ -13550,6 +13593,12 @@
         "registry.TagStats": {
             "type": "object",
             "properties": {
+                "commodity_tags_total": {
+                    "type": "integer"
+                },
+                "file_tags_total": {
+                    "type": "integer"
+                },
                 "files_tagged": {
                     "type": "integer"
                 },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -13509,12 +13509,10 @@
         "models.TagKind": {
             "type": "string",
             "enum": [
-                "",
                 "commodity",
                 "file"
             ],
             "x-enum-varnames": [
-                "TagKindAny",
                 "TagKindCommodity",
                 "TagKindFile"
             ]

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -4288,12 +4288,10 @@ definitions:
     - TagColorMuted
   models.TagKind:
     enum:
-    - ""
     - commodity
     - file
     type: string
     x-enum-varnames:
-    - TagKindAny
     - TagKindCommodity
     - TagKindFile
   models.TenantStatus:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -2863,6 +2863,14 @@ definitions:
         type: string
       id:
         type: string
+      kind:
+        allOf:
+        - $ref: '#/definitions/models.TagKind'
+        description: |-
+          Kind separates item-tags (commodity) from file-tags (file). Two tags
+          with the same slug but different kind are distinct entities. Existing
+          rows default to "commodity" on migration; new rows always carry an
+          explicit kind from the write path.
       label:
         description: Label is the human-readable display name.
         type: string
@@ -2871,7 +2879,7 @@ definitions:
       slug:
         description: |-
           Slug is the kebab-cased identifier referenced from
-          commodities.tags / files.tags JSONB arrays. Unique per group.
+          commodities.tags / files.tags JSONB arrays. Unique per (group, kind).
         type: string
       updated_at:
         type: string
@@ -2901,6 +2909,13 @@ definitions:
         - red
         - muted
         example: muted
+      kind:
+        allOf:
+        - $ref: '#/definitions/models.TagKind'
+        enum:
+        - commodity
+        - file
+        example: commodity
       label:
         type: string
       slug:
@@ -4234,13 +4249,21 @@ definitions:
         type: string
       id:
         type: string
+      kind:
+        allOf:
+        - $ref: '#/definitions/models.TagKind'
+        description: |-
+          Kind separates item-tags (commodity) from file-tags (file). Two tags
+          with the same slug but different kind are distinct entities. Existing
+          rows default to "commodity" on migration; new rows always carry an
+          explicit kind from the write path.
       label:
         description: Label is the human-readable display name.
         type: string
       slug:
         description: |-
           Slug is the kebab-cased identifier referenced from
-          commodities.tags / files.tags JSONB arrays. Unique per group.
+          commodities.tags / files.tags JSONB arrays. Unique per (group, kind).
         type: string
       updated_at:
         type: string
@@ -4263,6 +4286,16 @@ definitions:
     - TagColorOrange
     - TagColorRed
     - TagColorMuted
+  models.TagKind:
+    enum:
+    - ""
+    - commodity
+    - file
+    type: string
+    x-enum-varnames:
+    - TagKindAny
+    - TagKindCommodity
+    - TagKindFile
   models.TenantStatus:
     enum:
     - active
@@ -4340,6 +4373,10 @@ definitions:
     type: object
   registry.TagStats:
     properties:
+      commodity_tags_total:
+        type: integer
+      file_tags_total:
+        type: integer
       files_tagged:
         type: integer
       files_untagged:
@@ -8596,13 +8633,21 @@ paths:
     get:
       consumes:
       - application/vnd.api+json
-      description: get tags with optional filtering. Pass include=usage to attach
-        a per-row meta.usage block. Pass scope=commodity|file to restrict to tags
-        actually used on that entity type.
+      description: get tags of the given kind. Pass include=usage to attach a per-row
+        meta.usage block. kind=commodity|file is required — item-tags and file-tags
+        are separate entities.
       parameters:
       - description: Group slug
         in: path
         name: groupSlug
+        required: true
+        type: string
+      - description: Tag kind (commodity = item-tags, file = file-tags)
+        enum:
+        - commodity
+        - file
+        in: query
+        name: kind
         required: true
         type: string
       - description: Search by label or slug
@@ -8638,13 +8683,6 @@ paths:
         in: query
         name: include
         type: string
-      - description: Restrict to tags used on commodities or files. Empty = no filter.
-        enum:
-        - commodity
-        - file
-        in: query
-        name: scope
-        type: string
       produces:
       - application/vnd.api+json
       responses:
@@ -8653,7 +8691,7 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.TagsResponse'
         "422":
-          description: Invalid scope value
+          description: Missing or invalid kind value
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: List tags
@@ -8802,12 +8840,20 @@ paths:
     get:
       consumes:
       - application/vnd.api+json
-      description: Top-N tags matching the query, ranked by scope-aware usage desc
-        + created_at desc.
+      description: Top-N tags of the given kind matching the query, ranked by usage
+        desc + created_at desc.
       parameters:
       - description: Group slug
         in: path
         name: groupSlug
+        required: true
+        type: string
+      - description: Tag kind (commodity = item-tags, file = file-tags)
+        enum:
+        - commodity
+        - file
+        in: query
+        name: kind
         required: true
         type: string
       - description: Substring match against label and slug
@@ -8819,13 +8865,6 @@ paths:
         in: query
         name: limit
         type: integer
-      - description: Restrict to tags used on commodities or files. Empty = no filter.
-        enum:
-        - commodity
-        - file
-        in: query
-        name: scope
-        type: string
       produces:
       - application/vnd.api+json
       responses:
@@ -8834,7 +8873,7 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.TagAutocompleteResponse'
         "422":
-          description: Invalid scope value
+          description: Missing or invalid kind value
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: Autocomplete tag suggestions

--- a/go/jsonapi/tags.go
+++ b/go/jsonapi/tags.go
@@ -174,8 +174,11 @@ type TagRequestDataWrapper struct {
 	Attributes TagRequestData `json:"attributes"`
 }
 
-// TagRequestData carries the user-supplied fields on create.
+// TagRequestData carries the user-supplied fields on create. Kind is
+// required and immutable — item-tags and file-tags are separate entities,
+// so a tag's kind is fixed at creation (PATCH cannot change it).
 type TagRequestData struct {
+	Kind  models.TagKind  `json:"kind" example:"commodity" enums:"commodity,file"`
 	Slug  string          `json:"slug"`
 	Label string          `json:"label"`
 	Color models.TagColor `json:"color" example:"muted" enums:"amber,green,blue,orange,red,muted"`
@@ -188,6 +191,13 @@ func (trd *TagRequestData) Validate() error {
 func (trd *TagRequestData) ValidateWithContext(ctx context.Context) error {
 	fields := make([]*validation.FieldRules, 0)
 	fields = append(fields,
+		validation.Field(&trd.Kind, validation.Required, validation.By(func(value any) error {
+			k, ok := value.(models.TagKind)
+			if !ok || !k.IsValid() {
+				return validation.NewError("invalid_tag_kind", "kind must be one of: commodity, file")
+			}
+			return nil
+		})),
 		validation.Field(&trd.Slug, validation.Required, validation.By(func(value any) error {
 			s, _ := value.(string)
 			if !models.IsValidTagSlug(s) {

--- a/go/models/tag.go
+++ b/go/models/tag.go
@@ -91,15 +91,22 @@ func (c TagColor) Validate() error {
 type TagKind string
 
 const (
-	// TagKindAny is the empty-string filter sentinel meaning "no kind
-	// filter". Never a valid *stored* value — IsValid rejects it; the
-	// model validator requires a concrete kind.
-	TagKindAny TagKind = ""
 	// TagKindCommodity is the kind for tags attached to commodities (items).
 	TagKindCommodity TagKind = "commodity"
 	// TagKindFile is the kind for tags attached to files.
 	TagKindFile TagKind = "file"
 )
+
+// TagKindAny is the empty-string filter sentinel meaning "no kind filter".
+// Declared as a `var` (not a `const` in the enum block) so swag does NOT
+// fold "" into the public models.TagKind OpenAPI enum — the exported
+// contract / generated client types are commodity|file only. Same technique
+// as DefaultTagColor above. Never a valid *stored* value: IsValid rejects it
+// and the model validator requires a concrete kind; it exists purely as an
+// internal "no filter" sentinel.
+//
+//nolint:gochecknoglobals // intentional: keep "" out of the swag enum; see comment above.
+var TagKindAny TagKind = ""
 
 // IsValid reports whether k is a valid *stored* kind (commodity or file).
 // The empty string (TagKindAny) is a filter-only sentinel and is NOT valid

--- a/go/models/tag.go
+++ b/go/models/tag.go
@@ -81,6 +81,46 @@ func (c TagColor) Validate() error {
 	return nil
 }
 
+// TagKind is the entity type a tag belongs to. Item-tags (commodity) and
+// file-tags (file) are *separate* entities that merely share the tags table:
+// the same slug can exist once as a commodity tag and once as a file tag
+// (uniqueness is per (group, kind, slug)). The kind is stored on the row —
+// it is no longer derived from usage.
+//
+// Names are part of the public API surface (FE sends them as ?kind=).
+type TagKind string
+
+const (
+	// TagKindAny is the empty-string filter sentinel meaning "no kind
+	// filter". Never a valid *stored* value — IsValid rejects it; the
+	// model validator requires a concrete kind.
+	TagKindAny TagKind = ""
+	// TagKindCommodity is the kind for tags attached to commodities (items).
+	TagKindCommodity TagKind = "commodity"
+	// TagKindFile is the kind for tags attached to files.
+	TagKindFile TagKind = "file"
+)
+
+// IsValid reports whether k is a valid *stored* kind (commodity or file).
+// The empty string (TagKindAny) is a filter-only sentinel and is NOT valid
+// here — mirrors TagColor.IsValid rejecting "".
+func (k TagKind) IsValid() bool {
+	switch k {
+	case TagKindCommodity, TagKindFile:
+		return true
+	}
+	return false
+}
+
+// Validate makes TagKind a validation.Validatable so it can be referenced
+// directly by validation.Field rules (mirrors TagColor.Validate).
+func (k TagKind) Validate() error {
+	if !k.IsValid() {
+		return validation.NewError("invalid_tag_kind", "invalid tag kind")
+	}
+	return nil
+}
+
 // NormalizeTagSlug coerces a free-form user-typed string into the canonical
 // slug shape accepted by IsValidTagSlug:
 //
@@ -145,8 +185,15 @@ type Tag struct {
 	//migrator:embedded mode="inline"
 	TenantGroupAwareEntityID
 
+	// Kind separates item-tags (commodity) from file-tags (file). Two tags
+	// with the same slug but different kind are distinct entities. Existing
+	// rows default to "commodity" on migration; new rows always carry an
+	// explicit kind from the write path.
+	//migrator:schema:field name="kind" type="TEXT" not_null="true" default="commodity"
+	Kind TagKind `json:"kind" db:"kind"`
+
 	// Slug is the kebab-cased identifier referenced from
-	// commodities.tags / files.tags JSONB arrays. Unique per group.
+	// commodities.tags / files.tags JSONB arrays. Unique per (group, kind).
 	//migrator:schema:field name="slug" type="TEXT" not_null="true"
 	Slug string `json:"slug" db:"slug"`
 
@@ -179,9 +226,11 @@ type TagIndexes struct {
 	//migrator:schema:index name="idx_tags_tenant_group" fields="tenant_id,group_id" table="tags"
 	_ int
 
-	// Per-group slug uniqueness — backs the autocomplete lookup and
-	// prevents duplicate "kitchen" / "Kitchen" tags within the same group.
-	//migrator:schema:index name="idx_tags_group_slug" fields="group_id,slug" unique="true" table="tags"
+	// Per-group, per-kind slug uniqueness — backs the autocomplete lookup
+	// and prevents duplicate "kitchen" / "Kitchen" tags within the same
+	// group AND kind, while allowing the same slug to exist once as a
+	// commodity tag and once as a file tag.
+	//migrator:schema:index name="idx_tags_group_kind_slug" fields="group_id,kind,slug" unique="true" table="tags"
 	_ int
 
 	// Trigram similarity for label search (autocomplete / ?q=).
@@ -195,6 +244,7 @@ func (*Tag) Validate() error {
 
 func (t *Tag) ValidateWithContext(ctx context.Context) error {
 	return validation.ValidateStructWithContext(ctx, t,
+		validation.Field(&t.Kind, validation.Required),
 		validation.Field(&t.Slug, rules.NotEmpty, validation.By(func(value any) error {
 			s, _ := value.(string)
 			if !IsValidTagSlug(s) {

--- a/go/models/tag_test.go
+++ b/go/models/tag_test.go
@@ -90,6 +90,7 @@ func TestTag_ValidateWithContext(t *testing.T) {
 		{
 			name: "valid tag",
 			tag: models.Tag{
+				Kind:  models.TagKindCommodity,
 				Slug:  "kitchen",
 				Label: "Kitchen",
 				Color: models.TagColorAmber,
@@ -97,8 +98,38 @@ func TestTag_ValidateWithContext(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid file tag",
+			tag: models.Tag{
+				Kind:  models.TagKindFile,
+				Slug:  "invoice",
+				Label: "Invoice",
+				Color: models.TagColorBlue,
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing kind",
+			tag: models.Tag{
+				Slug:  "kitchen",
+				Label: "Kitchen",
+				Color: models.TagColorAmber,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid kind",
+			tag: models.Tag{
+				Kind:  models.TagKind("widget"),
+				Slug:  "kitchen",
+				Label: "Kitchen",
+				Color: models.TagColorAmber,
+			},
+			wantErr: true,
+		},
+		{
 			name: "missing slug",
 			tag: models.Tag{
+				Kind:  models.TagKindCommodity,
 				Label: "Kitchen",
 				Color: models.TagColorAmber,
 			},
@@ -107,6 +138,7 @@ func TestTag_ValidateWithContext(t *testing.T) {
 		{
 			name: "invalid slug shape",
 			tag: models.Tag{
+				Kind:  models.TagKindCommodity,
 				Slug:  "Kitchen Office",
 				Label: "Kitchen Office",
 				Color: models.TagColorAmber,
@@ -116,6 +148,7 @@ func TestTag_ValidateWithContext(t *testing.T) {
 		{
 			name: "missing label",
 			tag: models.Tag{
+				Kind:  models.TagKindCommodity,
 				Slug:  "kitchen",
 				Color: models.TagColorAmber,
 			},
@@ -124,6 +157,7 @@ func TestTag_ValidateWithContext(t *testing.T) {
 		{
 			name: "label too long",
 			tag: models.Tag{
+				Kind:  models.TagKindCommodity,
 				Slug:  "kitchen",
 				Label: stringOfLen(65),
 				Color: models.TagColorAmber,
@@ -133,6 +167,7 @@ func TestTag_ValidateWithContext(t *testing.T) {
 		{
 			name: "missing color",
 			tag: models.Tag{
+				Kind:  models.TagKindCommodity,
 				Slug:  "kitchen",
 				Label: "Kitchen",
 			},
@@ -141,6 +176,7 @@ func TestTag_ValidateWithContext(t *testing.T) {
 		{
 			name: "invalid color",
 			tag: models.Tag{
+				Kind:  models.TagKindCommodity,
 				Slug:  "kitchen",
 				Label: "Kitchen",
 				Color: models.TagColor("rainbow"),

--- a/go/registry/memory/tags.go
+++ b/go/registry/memory/tags.go
@@ -143,13 +143,13 @@ func (r *TagRegistry) Update(ctx context.Context, tag models.Tag) (*models.Tag, 
 	return updated, nil
 }
 
-func (r *TagRegistry) GetBySlug(ctx context.Context, slug string) (*models.Tag, error) {
+func (r *TagRegistry) GetBySlug(ctx context.Context, kind models.TagKind, slug string) (*models.Tag, error) {
 	tags, err := r.List(ctx)
 	if err != nil {
 		return nil, err
 	}
 	for _, t := range tags {
-		if t.Slug == slug {
+		if t.Kind == kind && t.Slug == slug {
 			return t, nil
 		}
 	}
@@ -163,21 +163,17 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 	}
 
 	all = filterTagsBySearch(all, opts.Search)
+	all = filterTagsByKind(all, opts.Kind)
 
-	// usagePerScope is computed when either (a) usage sort is selected or
-	// (b) a scope filter is in effect — both need per-tag-per-scope counts.
-	needUsage := opts.SortField == registry.TagSortUsage ||
-		opts.Scope == registry.TagScopeCommodity ||
-		opts.Scope == registry.TagScopeFile
+	// usagePerScope is computed only when usage sort is selected — the kind
+	// filter is now intrinsic (the Kind field), not usage-derived.
 	var usagePerScope map[string]registry.TagUsage
-	if needUsage {
+	if opts.SortField == registry.TagSortUsage {
 		usagePerScope, err = r.computePerScopeUsageMap(ctx)
 		if err != nil {
 			return nil, 0, err
 		}
 	}
-
-	all = filterTagsByScope(all, opts.Scope, usagePerScope)
 
 	sortField := opts.SortField
 	if !sortField.IsValid() {
@@ -189,8 +185,8 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 		case registry.TagSortCreatedAt:
 			less = all[i].CreatedAt.Before(all[j].CreatedAt)
 		case registry.TagSortUsage:
-			ui := scopedUsage(usagePerScope[all[i].Slug], opts.Scope)
-			uj := scopedUsage(usagePerScope[all[j].Slug], opts.Scope)
+			ui := scopedUsage(usagePerScope[all[i].Slug], opts.Kind)
+			uj := scopedUsage(usagePerScope[all[j].Slug], opts.Kind)
 			if ui == uj {
 				less = strings.ToLower(all[i].Label) < strings.ToLower(all[j].Label)
 			} else {
@@ -217,7 +213,7 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 	return all[start:end], total, nil
 }
 
-func (r *TagRegistry) Search(ctx context.Context, q string, limit int, scope registry.TagScope) ([]*models.Tag, error) {
+func (r *TagRegistry) Search(ctx context.Context, q string, limit int, kind models.TagKind) ([]*models.Tag, error) {
 	all, err := r.List(ctx)
 	if err != nil {
 		return nil, err
@@ -227,19 +223,19 @@ func (r *TagRegistry) Search(ctx context.Context, q string, limit int, scope reg
 	// no-op pass-through, so the "match everything" case stays cheap.
 	matched := filterTagsBySearch(all, q)
 
+	// Intrinsic kind filter — a commodity input only ever sees commodity
+	// tags, a file input only file tags.
+	matched = filterTagsByKind(matched, kind)
+
 	usagePerScope, err := r.computePerScopeUsageMap(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Strict scope filter — drop tags with zero usage in the requested
-	// bucket. Mirrors the postgres `>0` predicate.
-	matched = filterTagsByScope(matched, scope, usagePerScope)
-
-	// Rank: per-scope usage desc, then created_at desc (recent wins ties).
+	// Rank: kind usage desc, then created_at desc (recent wins ties).
 	sort.SliceStable(matched, func(i, j int) bool {
-		ui := scopedUsage(usagePerScope[matched[i].Slug], scope)
-		uj := scopedUsage(usagePerScope[matched[j].Slug], scope)
+		ui := scopedUsage(usagePerScope[matched[i].Slug], kind)
+		uj := scopedUsage(usagePerScope[matched[j].Slug], kind)
 		if ui != uj {
 			return ui > uj
 		}
@@ -252,14 +248,14 @@ func (r *TagRegistry) Search(ctx context.Context, q string, limit int, scope reg
 	return matched, nil
 }
 
-// scopedUsage returns the slice of TagUsage relevant to the requested
-// scope. TagScopeAny sums commodities + files; explicit scopes return
-// just that bucket.
-func scopedUsage(u registry.TagUsage, scope registry.TagScope) int {
-	switch scope {
-	case registry.TagScopeCommodity:
+// scopedUsage returns the part of TagUsage relevant to the given kind.
+// Empty kind sums commodities + files; explicit kinds return just that
+// bucket.
+func scopedUsage(u registry.TagUsage, kind models.TagKind) int {
+	switch kind {
+	case models.TagKindCommodity:
 		return u.Commodities
-	case registry.TagScopeFile:
+	case models.TagKindFile:
 		return u.Files
 	default:
 		return u.Commodities + u.Files
@@ -283,25 +279,22 @@ func filterTagsBySearch(in []*models.Tag, search string) []*models.Tag {
 	return filtered
 }
 
-// filterTagsByScope drops tags with zero usage in the requested scope.
-// TagScopeAny is a no-op pass-through. Mirrors the postgres `>0`
-// predicate on scopedUsageExpr.
-func filterTagsByScope(in []*models.Tag, scope registry.TagScope, usagePerScope map[string]registry.TagUsage) []*models.Tag {
-	if scope != registry.TagScopeCommodity && scope != registry.TagScopeFile {
+// filterTagsByKind keeps only tags whose stored Kind matches. Empty kind
+// (TagKindAny) is a no-op pass-through (list across all kinds).
+func filterTagsByKind(in []*models.Tag, kind models.TagKind) []*models.Tag {
+	if kind != models.TagKindCommodity && kind != models.TagKindFile {
 		return in
 	}
 	filtered := in[:0:0]
 	for _, t := range in {
-		u := usagePerScope[t.Slug]
-		if (scope == registry.TagScopeCommodity && u.Commodities > 0) ||
-			(scope == registry.TagScopeFile && u.Files > 0) {
+		if t.Kind == kind {
 			filtered = append(filtered, t)
 		}
 	}
 	return filtered
 }
 
-func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[string]registry.TagUsage, error) {
+func (r *TagRegistry) GetUsageBatch(ctx context.Context, kind models.TagKind, slugs []string) (map[string]registry.TagUsage, error) {
 	out := make(map[string]registry.TagUsage, len(slugs))
 	for _, s := range slugs {
 		out[s] = registry.TagUsage{}
@@ -310,9 +303,30 @@ func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[st
 		return out, nil
 	}
 
-	// Per-row seen-set so a commodity / file with a duplicated slug in
-	// its JSONB tags array is counted at most once — matches the
-	// postgres @> containment semantics and GetUsage's per-entity count.
+	// Count only the kind's own table — commodity tags count commodity
+	// rows, file tags count file rows. Per-row seen-set so a row with a
+	// duplicated slug in its JSONB tags array is counted at most once.
+	if kind == models.TagKindFile {
+		files, err := r.fileRegistry.List(ctx)
+		if err != nil {
+			return nil, errxtrace.Wrap("failed to list files", err)
+		}
+		for _, f := range files {
+			seen := map[string]struct{}{}
+			for _, slug := range f.Tags {
+				if _, dup := seen[slug]; dup {
+					continue
+				}
+				seen[slug] = struct{}{}
+				if u, ok := out[slug]; ok {
+					u.Files++
+					out[slug] = u
+				}
+			}
+		}
+		return out, nil
+	}
+
 	commodities, err := r.commodityRegistry.List(ctx)
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to list commodities", err)
@@ -330,24 +344,6 @@ func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[st
 			}
 		}
 	}
-
-	files, err := r.fileRegistry.List(ctx)
-	if err != nil {
-		return nil, errxtrace.Wrap("failed to list files", err)
-	}
-	for _, f := range files {
-		seen := map[string]struct{}{}
-		for _, slug := range f.Tags {
-			if _, dup := seen[slug]; dup {
-				continue
-			}
-			seen[slug] = struct{}{}
-			if u, ok := out[slug]; ok {
-				u.Files++
-				out[slug] = u
-			}
-		}
-	}
 	return out, nil
 }
 
@@ -355,6 +351,15 @@ func (r *TagRegistry) GetStats(ctx context.Context) (registry.TagStats, error) {
 	tags, err := r.List(ctx)
 	if err != nil {
 		return registry.TagStats{}, errxtrace.Wrap("failed to list tags", err)
+	}
+	commodityTagsTotal, fileTagsTotal := 0, 0
+	for _, t := range tags {
+		switch t.Kind {
+		case models.TagKindCommodity:
+			commodityTagsTotal++
+		case models.TagKindFile:
+			fileTagsTotal++
+		}
 	}
 
 	commodities, err := r.commodityRegistry.List(ctx)
@@ -380,15 +385,31 @@ func (r *TagRegistry) GetStats(ctx context.Context) (registry.TagStats, error) {
 	}
 
 	return registry.TagStats{
-		TagsTotal:     len(tags),
-		ItemsTagged:   itemsTagged,
-		ItemsUntagged: len(commodities) - itemsTagged,
-		FilesTagged:   filesTagged,
-		FilesUntagged: len(files) - filesTagged,
+		TagsTotal:          len(tags),
+		CommodityTagsTotal: commodityTagsTotal,
+		FileTagsTotal:      fileTagsTotal,
+		ItemsTagged:        itemsTagged,
+		ItemsUntagged:      len(commodities) - itemsTagged,
+		FilesTagged:        filesTagged,
+		FilesUntagged:      len(files) - filesTagged,
 	}, nil
 }
 
-func (r *TagRegistry) GetUsage(ctx context.Context, slug string) (registry.TagUsage, error) {
+func (r *TagRegistry) GetUsage(ctx context.Context, kind models.TagKind, slug string) (registry.TagUsage, error) {
+	if kind == models.TagKindFile {
+		files, err := r.fileRegistry.List(ctx)
+		if err != nil {
+			return registry.TagUsage{}, errxtrace.Wrap("failed to list files", err)
+		}
+		fileCount := 0
+		for _, f := range files {
+			if slices.Contains([]string(f.Tags), slug) {
+				fileCount++
+			}
+		}
+		return registry.TagUsage{Files: fileCount}, nil
+	}
+
 	commodities, err := r.commodityRegistry.List(ctx)
 	if err != nil {
 		return registry.TagUsage{}, errxtrace.Wrap("failed to list commodities", err)
@@ -399,19 +420,7 @@ func (r *TagRegistry) GetUsage(ctx context.Context, slug string) (registry.TagUs
 			commodityCount++
 		}
 	}
-
-	files, err := r.fileRegistry.List(ctx)
-	if err != nil {
-		return registry.TagUsage{}, errxtrace.Wrap("failed to list files", err)
-	}
-	fileCount := 0
-	for _, f := range files {
-		if slices.Contains([]string(f.Tags), slug) {
-			fileCount++
-		}
-	}
-
-	return registry.TagUsage{Commodities: commodityCount, Files: fileCount}, nil
+	return registry.TagUsage{Commodities: commodityCount}, nil
 }
 
 // computePerScopeUsageMap walks commodities + files once each and returns
@@ -458,9 +467,29 @@ func (r *TagRegistry) computePerScopeUsageMap(ctx context.Context) (map[string]r
 	return usage, nil
 }
 
-func (r *TagRegistry) RewriteSlugReferences(ctx context.Context, oldSlug, newSlug string) (commodityRows, fileRows int, err error) {
+func (r *TagRegistry) RewriteSlugReferences(ctx context.Context, kind models.TagKind, oldSlug, newSlug string) (commodityRows, fileRows int, err error) {
 	if oldSlug == newSlug {
 		return 0, 0, nil
+	}
+
+	if kind == models.TagKindFile {
+		files, err := r.fileRegistry.List(ctx)
+		if err != nil {
+			return 0, 0, errxtrace.Wrap("failed to list files", err)
+		}
+		fileCount := 0
+		for _, f := range files {
+			changed, newTags := replaceTagSlugString(f.Tags, oldSlug, newSlug)
+			if !changed {
+				continue
+			}
+			f.Tags = newTags
+			if _, err := r.fileRegistry.Update(ctx, *f); err != nil {
+				return 0, fileCount, errxtrace.Wrap("failed to rewrite file tag", err)
+			}
+			fileCount++
+		}
+		return 0, fileCount, nil
 	}
 
 	commodities, err := r.commodityRegistry.List(ctx)
@@ -479,28 +508,30 @@ func (r *TagRegistry) RewriteSlugReferences(ctx context.Context, oldSlug, newSlu
 		}
 		commodityCount++
 	}
-
-	files, err := r.fileRegistry.List(ctx)
-	if err != nil {
-		return commodityCount, 0, errxtrace.Wrap("failed to list files", err)
-	}
-	fileCount := 0
-	for _, f := range files {
-		changed, newTags := replaceTagSlugString(f.Tags, oldSlug, newSlug)
-		if !changed {
-			continue
-		}
-		f.Tags = newTags
-		if _, err := r.fileRegistry.Update(ctx, *f); err != nil {
-			return commodityCount, fileCount, errxtrace.Wrap("failed to rewrite file tag", err)
-		}
-		fileCount++
-	}
-
-	return commodityCount, fileCount, nil
+	return commodityCount, 0, nil
 }
 
-func (r *TagRegistry) StripSlugReferences(ctx context.Context, slug string) (commodityRows, fileRows int, err error) {
+func (r *TagRegistry) StripSlugReferences(ctx context.Context, kind models.TagKind, slug string) (commodityRows, fileRows int, err error) {
+	if kind == models.TagKindFile {
+		files, err := r.fileRegistry.List(ctx)
+		if err != nil {
+			return 0, 0, errxtrace.Wrap("failed to list files", err)
+		}
+		fileCount := 0
+		for _, f := range files {
+			changed, newTags := stripTagSlugString(f.Tags, slug)
+			if !changed {
+				continue
+			}
+			f.Tags = newTags
+			if _, err := r.fileRegistry.Update(ctx, *f); err != nil {
+				return 0, fileCount, errxtrace.Wrap("failed to strip file tag", err)
+			}
+			fileCount++
+		}
+		return 0, fileCount, nil
+	}
+
 	commodities, err := r.commodityRegistry.List(ctx)
 	if err != nil {
 		return 0, 0, errxtrace.Wrap("failed to list commodities", err)
@@ -517,24 +548,7 @@ func (r *TagRegistry) StripSlugReferences(ctx context.Context, slug string) (com
 		}
 		commodityCount++
 	}
-
-	files, err := r.fileRegistry.List(ctx)
-	if err != nil {
-		return commodityCount, 0, errxtrace.Wrap("failed to list files", err)
-	}
-	fileCount := 0
-	for _, f := range files {
-		changed, newTags := stripTagSlugString(f.Tags, slug)
-		if !changed {
-			continue
-		}
-		f.Tags = newTags
-		if _, err := r.fileRegistry.Update(ctx, *f); err != nil {
-			return commodityCount, fileCount, errxtrace.Wrap("failed to strip file tag", err)
-		}
-		fileCount++
-	}
-	return commodityCount, fileCount, nil
+	return commodityCount, 0, nil
 }
 
 // RenameAtomic mirrors the postgres semantics: re-read the tag, run the
@@ -562,7 +576,9 @@ func (r *TagRegistry) RenameAtomic(ctx context.Context, id, newLabel, newSlug st
 	slugChanged := newSlug != "" && newSlug != current.Slug
 	if slugChanged {
 		updated.Slug = newSlug
-		clash, clashErr := r.GetBySlug(ctx, newSlug)
+		// Clash + rewrite are scoped to the tag's own kind: the same slug
+		// may legitimately exist under the other kind.
+		clash, clashErr := r.GetBySlug(ctx, current.Kind, newSlug)
 		if clashErr != nil && !errors.Is(clashErr, registry.ErrNotFound) {
 			return nil, errxtrace.Wrap("failed to check slug availability", clashErr)
 		}
@@ -570,7 +586,7 @@ func (r *TagRegistry) RenameAtomic(ctx context.Context, id, newLabel, newSlug st
 			return nil, errxtrace.Wrap("target slug is already used by another tag",
 				registry.ErrAlreadyExists, errx.Attrs("slug", newSlug))
 		}
-		if _, _, err := r.RewriteSlugReferences(ctx, current.Slug, newSlug); err != nil {
+		if _, _, err := r.RewriteSlugReferences(ctx, current.Kind, current.Slug, newSlug); err != nil {
 			return nil, errxtrace.Wrap("failed to rewrite slug references", err)
 		}
 	}
@@ -595,7 +611,7 @@ func (r *TagRegistry) DeleteAtomic(ctx context.Context, id string, force bool) (
 		return registry.TagUsage{}, errxtrace.Wrap("failed to look up tag", err)
 	}
 
-	usage, err := r.GetUsage(ctx, current.Slug)
+	usage, err := r.GetUsage(ctx, current.Kind, current.Slug)
 	if err != nil {
 		return registry.TagUsage{}, errxtrace.Wrap("failed to compute tag usage", err)
 	}
@@ -604,7 +620,7 @@ func (r *TagRegistry) DeleteAtomic(ctx context.Context, id string, force bool) (
 		return usage, registry.ErrTagInUse
 	}
 	if usage.Commodities+usage.Files > 0 {
-		if _, _, err := r.StripSlugReferences(ctx, current.Slug); err != nil {
+		if _, _, err := r.StripSlugReferences(ctx, current.Kind, current.Slug); err != nil {
 			return usage, errxtrace.Wrap("failed to strip slug references", err)
 		}
 	}

--- a/go/registry/memory/tags_test.go
+++ b/go/registry/memory/tags_test.go
@@ -58,6 +58,7 @@ func TestTagRegistry_Memory_CreateAndGetBySlug(t *testing.T) {
 	fx := newTagFixture(c, "group-1")
 
 	created, err := fx.tagReg.Create(fx.ctx, models.Tag{
+		Kind:  models.TagKindCommodity,
 		Slug:  "kitchen",
 		Label: "Kitchen",
 		Color: models.TagColorAmber,
@@ -66,13 +67,42 @@ func TestTagRegistry_Memory_CreateAndGetBySlug(t *testing.T) {
 	c.Assert(created.ID, qt.Not(qt.Equals), "")
 	c.Assert(created.Slug, qt.Equals, "kitchen")
 
-	got, err := fx.tagReg.GetBySlug(fx.ctx, "kitchen")
+	got, err := fx.tagReg.GetBySlug(fx.ctx, models.TagKindCommodity, "kitchen")
 	c.Assert(err, qt.IsNil)
 	c.Assert(got.ID, qt.Equals, created.ID)
 	c.Assert(got.Color, qt.Equals, models.TagColorAmber)
 
-	_, err = fx.tagReg.GetBySlug(fx.ctx, "missing")
+	// Same slug under the other kind is a *different* entity → not found.
+	_, err = fx.tagReg.GetBySlug(fx.ctx, models.TagKindFile, "kitchen")
 	c.Assert(err, qt.IsNotNil)
+
+	_, err = fx.tagReg.GetBySlug(fx.ctx, models.TagKindCommodity, "missing")
+	c.Assert(err, qt.IsNotNil)
+}
+
+// TestTagRegistry_Memory_SameSlugDifferentKinds pins the core split
+// invariant: the same slug can exist once as a commodity tag and once as a
+// file tag, and the two are distinct rows.
+func TestTagRegistry_Memory_SameSlugDifferentKinds(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagFixture(c, "group-1")
+
+	commTag, err := fx.tagReg.Create(fx.ctx, models.Tag{
+		Kind: models.TagKindCommodity, Slug: "warranty", Label: "Warranty", Color: models.TagColorRed,
+	})
+	c.Assert(err, qt.IsNil)
+	fileTag, err := fx.tagReg.Create(fx.ctx, models.Tag{
+		Kind: models.TagKindFile, Slug: "warranty", Label: "Warranty", Color: models.TagColorBlue,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(commTag.ID, qt.Not(qt.Equals), fileTag.ID)
+
+	gotComm, err := fx.tagReg.GetBySlug(fx.ctx, models.TagKindCommodity, "warranty")
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotComm.ID, qt.Equals, commTag.ID)
+	gotFile, err := fx.tagReg.GetBySlug(fx.ctx, models.TagKindFile, "warranty")
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotFile.ID, qt.Equals, fileTag.ID)
 }
 
 func TestTagRegistry_Memory_ListPaginatedSortByLabel(t *testing.T) {
@@ -81,6 +111,7 @@ func TestTagRegistry_Memory_ListPaginatedSortByLabel(t *testing.T) {
 
 	for _, slug := range []string{"banana", "apple", "cherry"} {
 		_, err := fx.tagReg.Create(fx.ctx, models.Tag{
+			Kind:  models.TagKindCommodity,
 			Slug:  slug,
 			Label: slug,
 			Color: models.TagColorMuted,
@@ -88,7 +119,9 @@ func TestTagRegistry_Memory_ListPaginatedSortByLabel(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 	}
 
-	got, total, err := fx.tagReg.ListPaginated(fx.ctx, 0, 10, registry.TagListOptions{})
+	got, total, err := fx.tagReg.ListPaginated(fx.ctx, 0, 10, registry.TagListOptions{
+		Kind: models.TagKindCommodity,
+	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(total, qt.Equals, 3)
 	c.Assert(got, qt.HasLen, 3)
@@ -97,6 +130,7 @@ func TestTagRegistry_Memory_ListPaginatedSortByLabel(t *testing.T) {
 	c.Assert(got[2].Slug, qt.Equals, "cherry")
 
 	desc, _, err := fx.tagReg.ListPaginated(fx.ctx, 0, 10, registry.TagListOptions{
+		Kind:     models.TagKindCommodity,
 		SortDesc: true,
 	})
 	c.Assert(err, qt.IsNil)
@@ -108,7 +142,7 @@ func TestTagRegistry_Memory_GetUsage(t *testing.T) {
 	fx := newTagFixture(c, "group-1")
 
 	_, err := fx.tagReg.Create(fx.ctx, models.Tag{
-		Slug: "kitchen", Label: "Kitchen", Color: models.TagColorAmber,
+		Kind: models.TagKindCommodity, Slug: "kitchen", Label: "Kitchen", Color: models.TagColorAmber,
 	})
 	c.Assert(err, qt.IsNil)
 
@@ -134,7 +168,7 @@ func TestTagRegistry_Memory_GetUsage(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	// One file references 'kitchen'.
+	// One file references 'kitchen' — a separate file-tag namespace.
 	_, err = fx.fileReg.Create(fx.ctx, models.FileEntity{
 		Title:    "fridge-photo",
 		Type:     models.FileTypeImage,
@@ -146,12 +180,19 @@ func TestTagRegistry_Memory_GetUsage(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	usage, err := fx.tagReg.GetUsage(fx.ctx, "kitchen")
+	// Commodity-kind usage counts commodities only.
+	usage, err := fx.tagReg.GetUsage(fx.ctx, models.TagKindCommodity, "kitchen")
 	c.Assert(err, qt.IsNil)
 	c.Assert(usage.Commodities, qt.Equals, 2)
-	c.Assert(usage.Files, qt.Equals, 1)
+	c.Assert(usage.Files, qt.Equals, 0)
 
-	usage, err = fx.tagReg.GetUsage(fx.ctx, "appliance")
+	// File-kind usage of the same slug counts files only.
+	fileUsage, err := fx.tagReg.GetUsage(fx.ctx, models.TagKindFile, "kitchen")
+	c.Assert(err, qt.IsNil)
+	c.Assert(fileUsage.Commodities, qt.Equals, 0)
+	c.Assert(fileUsage.Files, qt.Equals, 1)
+
+	usage, err = fx.tagReg.GetUsage(fx.ctx, models.TagKindCommodity, "appliance")
 	c.Assert(err, qt.IsNil)
 	c.Assert(usage.Commodities, qt.Equals, 1)
 	c.Assert(usage.Files, qt.Equals, 0)
@@ -161,10 +202,6 @@ func TestTagRegistry_Memory_RewriteSlugReferences(t *testing.T) {
 	c := qt.New(t)
 	fx := newTagFixture(c, "group-1")
 
-	_, err := fx.tagReg.Create(fx.ctx, models.Tag{
-		Slug: "kitchen", Label: "Kitchen", Color: models.TagColorAmber,
-	})
-	c.Assert(err, qt.IsNil)
 	cmd1, err := fx.commodityReg.Create(fx.ctx, models.Commodity{
 		Name:   "fridge",
 		Status: models.CommodityStatusInUse,
@@ -179,16 +216,27 @@ func TestTagRegistry_Memory_RewriteSlugReferences(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	commCount, fileCount, err := fx.tagReg.RewriteSlugReferences(fx.ctx, "kitchen", "kitchen-area")
+	// Commodity-kind rewrite touches ONLY commodities — the file's
+	// "kitchen" slug belongs to a separate file tag and is left alone.
+	commCount, fileCount, err := fx.tagReg.RewriteSlugReferences(fx.ctx, models.TagKindCommodity, "kitchen", "kitchen-area")
 	c.Assert(err, qt.IsNil)
 	c.Assert(commCount, qt.Equals, 1)
-	c.Assert(fileCount, qt.Equals, 1)
+	c.Assert(fileCount, qt.Equals, 0)
 
 	got, err := fx.commodityReg.Get(fx.ctx, cmd1.ID)
 	c.Assert(err, qt.IsNil)
 	c.Assert([]string(got.Tags), qt.DeepEquals, []string{"kitchen-area", "appliance"})
 
 	gotFile, err := fx.fileReg.Get(fx.ctx, file1.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotFile.Tags), qt.DeepEquals, []string{"kitchen"})
+
+	// File-kind rewrite touches ONLY files.
+	commCount, fileCount, err = fx.tagReg.RewriteSlugReferences(fx.ctx, models.TagKindFile, "kitchen", "kitchen-area")
+	c.Assert(err, qt.IsNil)
+	c.Assert(commCount, qt.Equals, 0)
+	c.Assert(fileCount, qt.Equals, 1)
+	gotFile, err = fx.fileReg.Get(fx.ctx, file1.ID)
 	c.Assert(err, qt.IsNil)
 	c.Assert([]string(gotFile.Tags), qt.DeepEquals, []string{"kitchen-area"})
 }
@@ -204,29 +252,41 @@ func TestTagRegistry_Memory_StripSlugReferences(t *testing.T) {
 		Tags:   models.ValuerSlice[string]{"kitchen", "appliance"},
 	})
 	c.Assert(err, qt.IsNil)
+	file1, err := fx.fileReg.Create(fx.ctx, models.FileEntity{
+		Title: "photo", Type: models.FileTypeImage, Category: models.FileCategoryImages,
+		Tags: models.StringSlice{"kitchen"},
+		File: &models.File{Path: "p", OriginalPath: "p.jpg", Ext: ".jpg", MIMEType: "image/jpeg"},
+	})
+	c.Assert(err, qt.IsNil)
 
-	commCount, _, err := fx.tagReg.StripSlugReferences(fx.ctx, "kitchen")
+	commCount, fileCount, err := fx.tagReg.StripSlugReferences(fx.ctx, models.TagKindCommodity, "kitchen")
 	c.Assert(err, qt.IsNil)
 	c.Assert(commCount, qt.Equals, 1)
+	c.Assert(fileCount, qt.Equals, 0)
 
 	got, err := fx.commodityReg.Get(fx.ctx, cmd1.ID)
 	c.Assert(err, qt.IsNil)
 	c.Assert([]string(got.Tags), qt.DeepEquals, []string{"appliance"})
+
+	// The file's "kitchen" (a file tag) is untouched by the commodity strip.
+	gotFile, err := fx.fileReg.Get(fx.ctx, file1.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(gotFile.Tags), qt.DeepEquals, []string{"kitchen"})
 }
 
 func TestTagRegistry_Memory_SearchRanksByUsage(t *testing.T) {
 	c := qt.New(t)
 	fx := newTagFixture(c, "group-1")
 
-	_, err := fx.tagReg.Create(fx.ctx, models.Tag{Slug: "alpha", Label: "Alpha", Color: models.TagColorMuted})
-	c.Assert(err, qt.IsNil)
-	_, err = fx.tagReg.Create(fx.ctx, models.Tag{Slug: "beta", Label: "Beta", Color: models.TagColorMuted})
-	c.Assert(err, qt.IsNil)
-	_, err = fx.tagReg.Create(fx.ctx, models.Tag{Slug: "gamma", Label: "Gamma", Color: models.TagColorMuted})
-	c.Assert(err, qt.IsNil)
+	for _, slug := range []string{"alpha", "beta", "gamma"} {
+		_, err := fx.tagReg.Create(fx.ctx, models.Tag{
+			Kind: models.TagKindCommodity, Slug: slug, Label: slug, Color: models.TagColorMuted,
+		})
+		c.Assert(err, qt.IsNil)
+	}
 
 	// gamma has 2 commodity uses, alpha has 1, beta has 0.
-	_, err = fx.commodityReg.Create(fx.ctx, models.Commodity{
+	_, err := fx.commodityReg.Create(fx.ctx, models.Commodity{
 		Name: "x", Status: models.CommodityStatusInUse, Type: models.CommodityTypeOther,
 		Tags: models.ValuerSlice[string]{"gamma"},
 	})
@@ -237,7 +297,9 @@ func TestTagRegistry_Memory_SearchRanksByUsage(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	got, err := fx.tagReg.Search(fx.ctx, "", 10, registry.TagScopeAny)
+	// All three are commodity-kind, so all appear (zero-usage included),
+	// ranked by usage desc then recency.
+	got, err := fx.tagReg.Search(fx.ctx, "", 10, models.TagKindCommodity)
 	c.Assert(err, qt.IsNil)
 	c.Assert(got, qt.HasLen, 3)
 	c.Assert(got[0].Slug, qt.Equals, "gamma")
@@ -245,111 +307,81 @@ func TestTagRegistry_Memory_SearchRanksByUsage(t *testing.T) {
 	c.Assert(got[2].Slug, qt.Equals, "beta")
 }
 
-// TestTagRegistry_Memory_SearchScoped exercises the per-scope filter +
-// ranking added for #1628: scope=commodity strictly excludes file-only
-// tags (and vice versa), and a tag used on both scopes appears in both
-// scoped result sets.
-func TestTagRegistry_Memory_SearchScoped(t *testing.T) {
+// TestTagRegistry_Memory_SearchByKind exercises the intrinsic kind filter:
+// Search(commodity) returns only commodity tags (including zero-usage ones)
+// and never file tags, and the same slug can appear under both kinds as two
+// distinct rows.
+func TestTagRegistry_Memory_SearchByKind(t *testing.T) {
 	c := qt.New(t)
 	fx := newTagFixture(c, "group-1")
 
-	for _, slug := range []string{"kitchen", "invoice", "warranty", "unused"} {
+	mk := func(kind models.TagKind, slug string) {
 		_, err := fx.tagReg.Create(fx.ctx, models.Tag{
-			Slug: slug, Label: slug, Color: models.TagColorMuted,
+			Kind: kind, Slug: slug, Label: slug, Color: models.TagColorMuted,
 		})
 		c.Assert(err, qt.IsNil)
 	}
+	mk(models.TagKindCommodity, "kitchen")
+	mk(models.TagKindCommodity, "warranty")
+	mk(models.TagKindCommodity, "unused") // zero usage, still a commodity tag
+	mk(models.TagKindFile, "invoice")
+	mk(models.TagKindFile, "warranty") // same slug, different kind
 
-	// kitchen → commodity only; invoice → file only; warranty → both.
-	_, err := fx.commodityReg.Create(fx.ctx, models.Commodity{
-		Name: "fridge", Status: models.CommodityStatusInUse, Type: models.CommodityTypeWhiteGoods,
-		Tags: models.ValuerSlice[string]{"kitchen", "warranty"},
-	})
-	c.Assert(err, qt.IsNil)
-	_, err = fx.fileReg.Create(fx.ctx, models.FileEntity{
-		Title: "f", Type: models.FileTypeDocument, Category: models.FileCategoryDocuments,
-		Tags: models.StringSlice{"invoice", "warranty"},
-		File: &models.File{Path: "f", OriginalPath: "f.pdf", Ext: ".pdf", MIMEType: "application/pdf"},
-	})
-	c.Assert(err, qt.IsNil)
+	commoditySlugs := slugsOf(c, fx, models.TagKindCommodity)
+	c.Assert(commoditySlugs, qt.Contains, "kitchen")
+	c.Assert(commoditySlugs, qt.Contains, "warranty")
+	c.Assert(commoditySlugs, qt.Contains, "unused") // kind filter includes unused
+	c.Assert(commoditySlugs, qt.Not(qt.Contains), "invoice")
+	c.Assert(commoditySlugs, qt.HasLen, 3)
 
-	commodityScope, err := fx.tagReg.Search(fx.ctx, "", 10, registry.TagScopeCommodity)
-	c.Assert(err, qt.IsNil)
-	commodityScopeSlugs := make([]string, 0, len(commodityScope))
-	for _, t := range commodityScope {
-		commodityScopeSlugs = append(commodityScopeSlugs, t.Slug)
-	}
-	c.Assert(commodityScopeSlugs, qt.Contains, "kitchen")
-	c.Assert(commodityScopeSlugs, qt.Contains, "warranty")
-	c.Assert(commodityScopeSlugs, qt.Not(qt.Contains), "invoice") // file-only excluded
-	c.Assert(commodityScopeSlugs, qt.Not(qt.Contains), "unused")  // zero usage excluded
-
-	fileScope, err := fx.tagReg.Search(fx.ctx, "", 10, registry.TagScopeFile)
-	c.Assert(err, qt.IsNil)
-	fileScopeSlugs := make([]string, 0, len(fileScope))
-	for _, t := range fileScope {
-		fileScopeSlugs = append(fileScopeSlugs, t.Slug)
-	}
-	c.Assert(fileScopeSlugs, qt.Contains, "invoice")
-	c.Assert(fileScopeSlugs, qt.Contains, "warranty")
-	c.Assert(fileScopeSlugs, qt.Not(qt.Contains), "kitchen")
-	c.Assert(fileScopeSlugs, qt.Not(qt.Contains), "unused")
-
-	// TagScopeAny includes every tag even with zero usage — preserves
-	// the legacy pre-#1628 behaviour for the merged "All tags" tab.
-	all, err := fx.tagReg.Search(fx.ctx, "", 10, registry.TagScopeAny)
-	c.Assert(err, qt.IsNil)
-	c.Assert(all, qt.HasLen, 4)
+	fileSlugs := slugsOf(c, fx, models.TagKindFile)
+	c.Assert(fileSlugs, qt.Contains, "invoice")
+	c.Assert(fileSlugs, qt.Contains, "warranty")
+	c.Assert(fileSlugs, qt.Not(qt.Contains), "kitchen")
+	c.Assert(fileSlugs, qt.HasLen, 2)
 }
 
-// TestTagRegistry_Memory_ListPaginatedScoped mirrors SearchScoped for the
-// list endpoint: scope filter + correct totals.
-func TestTagRegistry_Memory_ListPaginatedScoped(t *testing.T) {
+func slugsOf(c *qt.C, fx tagFixture, kind models.TagKind) []string {
+	c.Helper()
+	tags, err := fx.tagReg.Search(fx.ctx, "", 50, kind)
+	c.Assert(err, qt.IsNil)
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		out = append(out, t.Slug)
+	}
+	return out
+}
+
+// TestTagRegistry_Memory_ListPaginatedByKind mirrors SearchByKind for the
+// list endpoint: kind filter + correct totals.
+func TestTagRegistry_Memory_ListPaginatedByKind(t *testing.T) {
 	c := qt.New(t)
 	fx := newTagFixture(c, "group-1")
 
-	for _, slug := range []string{"kitchen", "invoice", "warranty", "unused"} {
+	mk := func(kind models.TagKind, slug string) {
 		_, err := fx.tagReg.Create(fx.ctx, models.Tag{
-			Slug: slug, Label: slug, Color: models.TagColorMuted,
+			Kind: kind, Slug: slug, Label: slug, Color: models.TagColorMuted,
 		})
 		c.Assert(err, qt.IsNil)
 	}
-	_, err := fx.commodityReg.Create(fx.ctx, models.Commodity{
-		Name: "fridge", Status: models.CommodityStatusInUse, Type: models.CommodityTypeWhiteGoods,
-		Tags: models.ValuerSlice[string]{"kitchen", "warranty"},
-	})
-	c.Assert(err, qt.IsNil)
-	_, err = fx.fileReg.Create(fx.ctx, models.FileEntity{
-		Title: "f", Type: models.FileTypeDocument, Category: models.FileCategoryDocuments,
-		Tags: models.StringSlice{"invoice", "warranty"},
-		File: &models.File{Path: "f", OriginalPath: "f.pdf", Ext: ".pdf", MIMEType: "application/pdf"},
-	})
-	c.Assert(err, qt.IsNil)
+	mk(models.TagKindCommodity, "kitchen")
+	mk(models.TagKindCommodity, "warranty")
+	mk(models.TagKindFile, "invoice")
+	mk(models.TagKindFile, "warranty")
 
-	gotComm, totalComm, err := fx.tagReg.ListPaginated(fx.ctx, 0, 10, registry.TagListOptions{
-		Scope: registry.TagScopeCommodity,
+	_, totalComm, err := fx.tagReg.ListPaginated(fx.ctx, 0, 10, registry.TagListOptions{
+		Kind: models.TagKindCommodity,
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(totalComm, qt.Equals, 2)
-	slugsComm := make([]string, 0, len(gotComm))
-	for _, t := range gotComm {
-		slugsComm = append(slugsComm, t.Slug)
-	}
-	c.Assert(slugsComm, qt.Contains, "kitchen")
-	c.Assert(slugsComm, qt.Contains, "warranty")
 
-	gotFile, totalFile, err := fx.tagReg.ListPaginated(fx.ctx, 0, 10, registry.TagListOptions{
-		Scope: registry.TagScopeFile,
+	_, totalFile, err := fx.tagReg.ListPaginated(fx.ctx, 0, 10, registry.TagListOptions{
+		Kind: models.TagKindFile,
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(totalFile, qt.Equals, 2)
-	slugsFile := make([]string, 0, len(gotFile))
-	for _, t := range gotFile {
-		slugsFile = append(slugsFile, t.Slug)
-	}
-	c.Assert(slugsFile, qt.Contains, "invoice")
-	c.Assert(slugsFile, qt.Contains, "warranty")
 
+	// Zero-value kind returns every tag regardless of kind (internal only).
 	gotAny, totalAny, err := fx.tagReg.ListPaginated(fx.ctx, 0, 10, registry.TagListOptions{})
 	c.Assert(err, qt.IsNil)
 	c.Assert(totalAny, qt.Equals, 4)
@@ -359,13 +391,6 @@ func TestTagRegistry_Memory_ListPaginatedScoped(t *testing.T) {
 func TestTagRegistry_Memory_GetUsageBatch(t *testing.T) {
 	c := qt.New(t)
 	fx := newTagFixture(c, "group-1")
-
-	for _, slug := range []string{"kitchen", "appliance", "garden"} {
-		_, err := fx.tagReg.Create(fx.ctx, models.Tag{
-			Slug: slug, Label: slug, Color: models.TagColorMuted,
-		})
-		c.Assert(err, qt.IsNil)
-	}
 
 	_, err := fx.commodityReg.Create(fx.ctx, models.Commodity{
 		Name: "fridge", Status: models.CommodityStatusInUse, Type: models.CommodityTypeWhiteGoods,
@@ -384,17 +409,24 @@ func TestTagRegistry_Memory_GetUsageBatch(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
-	usage, err := fx.tagReg.GetUsageBatch(fx.ctx, []string{"kitchen", "appliance", "garden"})
+	// Commodity-kind batch counts commodities only.
+	commUsage, err := fx.tagReg.GetUsageBatch(fx.ctx, models.TagKindCommodity, []string{"kitchen", "appliance", "garden"})
 	c.Assert(err, qt.IsNil)
-	c.Assert(usage["kitchen"].Commodities, qt.Equals, 2)
-	c.Assert(usage["kitchen"].Files, qt.Equals, 0)
-	c.Assert(usage["appliance"].Commodities, qt.Equals, 1)
-	c.Assert(usage["appliance"].Files, qt.Equals, 1)
-	c.Assert(usage["garden"].Commodities, qt.Equals, 0)
-	c.Assert(usage["garden"].Files, qt.Equals, 0)
+	c.Assert(commUsage["kitchen"].Commodities, qt.Equals, 2)
+	c.Assert(commUsage["kitchen"].Files, qt.Equals, 0)
+	c.Assert(commUsage["appliance"].Commodities, qt.Equals, 1)
+	c.Assert(commUsage["appliance"].Files, qt.Equals, 0)
+	c.Assert(commUsage["garden"].Commodities, qt.Equals, 0)
+
+	// File-kind batch counts files only.
+	fileUsage, err := fx.tagReg.GetUsageBatch(fx.ctx, models.TagKindFile, []string{"appliance", "kitchen"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(fileUsage["appliance"].Files, qt.Equals, 1)
+	c.Assert(fileUsage["appliance"].Commodities, qt.Equals, 0)
+	c.Assert(fileUsage["kitchen"].Files, qt.Equals, 0)
 
 	// Empty input returns empty map without touching the registries.
-	empty, err := fx.tagReg.GetUsageBatch(fx.ctx, nil)
+	empty, err := fx.tagReg.GetUsageBatch(fx.ctx, models.TagKindCommodity, nil)
 	c.Assert(err, qt.IsNil)
 	c.Assert(empty, qt.HasLen, 0)
 }
@@ -403,15 +435,20 @@ func TestTagRegistry_Memory_GetStats(t *testing.T) {
 	c := qt.New(t)
 	fx := newTagFixture(c, "group-1")
 
-	for _, slug := range []string{"a", "b", "c"} {
+	// 2 commodity tags, 1 file tag.
+	for _, slug := range []string{"a", "b"} {
 		_, err := fx.tagReg.Create(fx.ctx, models.Tag{
-			Slug: slug, Label: slug, Color: models.TagColorMuted,
+			Kind: models.TagKindCommodity, Slug: slug, Label: slug, Color: models.TagColorMuted,
 		})
 		c.Assert(err, qt.IsNil)
 	}
+	_, err := fx.tagReg.Create(fx.ctx, models.Tag{
+		Kind: models.TagKindFile, Slug: "c", Label: "c", Color: models.TagColorMuted,
+	})
+	c.Assert(err, qt.IsNil)
 
 	// 2 tagged commodities + 1 untagged.
-	_, err := fx.commodityReg.Create(fx.ctx, models.Commodity{
+	_, err = fx.commodityReg.Create(fx.ctx, models.Commodity{
 		Name: "x1", Status: models.CommodityStatusInUse, Type: models.CommodityTypeOther,
 		Tags: models.ValuerSlice[string]{"a"},
 	})
@@ -447,6 +484,8 @@ func TestTagRegistry_Memory_GetStats(t *testing.T) {
 	stats, err := fx.tagReg.GetStats(fx.ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(stats.TagsTotal, qt.Equals, 3)
+	c.Assert(stats.CommodityTagsTotal, qt.Equals, 2)
+	c.Assert(stats.FileTagsTotal, qt.Equals, 1)
 	c.Assert(stats.ItemsTagged, qt.Equals, 2)
 	c.Assert(stats.ItemsUntagged, qt.Equals, 1)
 	c.Assert(stats.FilesTagged, qt.Equals, 1)
@@ -460,10 +499,12 @@ func TestTagRegistry_Memory_CrossGroupIsolation(t *testing.T) {
 	g1 := newTagFixture(c, "group-1")
 	g2 := newTagFixture(c, "group-2")
 
-	_, err := g1.tagReg.Create(g1.ctx, models.Tag{Slug: "g1-only", Label: "G1", Color: models.TagColorMuted})
+	_, err := g1.tagReg.Create(g1.ctx, models.Tag{
+		Kind: models.TagKindCommodity, Slug: "g1-only", Label: "G1", Color: models.TagColorMuted,
+	})
 	c.Assert(err, qt.IsNil)
 
 	// Tag created in g1 must not be visible in g2.
-	_, err = g2.tagReg.GetBySlug(g2.ctx, "g1-only")
+	_, err = g2.tagReg.GetBySlug(g2.ctx, models.TagKindCommodity, "g1-only")
 	c.Assert(err, qt.IsNotNil)
 }

--- a/go/registry/postgres/commodities.go
+++ b/go/registry/postgres/commodities.go
@@ -111,7 +111,7 @@ func (r *CommodityRegistry) Create(ctx context.Context, commodity models.Commodi
 		// so a concurrent DeleteTag(force=true) on one of these slugs
 		// can't leave us with an orphan JSONB reference at commit. See
 		// ensureTagRowsInTx in tags.go for the full lock invariant.
-		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, []string(commodity.Tags))
+		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, models.TagKindCommodity, []string(commodity.Tags))
 	})
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to create commodity", err)
@@ -535,7 +535,7 @@ func (r *CommodityRegistry) Update(ctx context.Context, commodity models.Commodi
 		// tag slugs needs to grab the per-(group, slug) lock + upsert the
 		// tag row before the JSONB column is rewritten by the surrounding
 		// Update query.
-		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, []string(commodity.Tags))
+		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, models.TagKindCommodity, []string(commodity.Tags))
 	})
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to update commodity", err)

--- a/go/registry/postgres/files.go
+++ b/go/registry/postgres/files.go
@@ -116,7 +116,7 @@ func (r *FileRegistry) Create(ctx context.Context, file models.FileEntity) (*mod
 	createdFile, err := reg.Create(ctx, file, func(ctx context.Context, tx *sqlx.Tx) error {
 		// Same orphan-prevention as in CommodityRegistry.Create — see
 		// ensureTagRowsInTx in tags.go for the cross-tx invariant.
-		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, []string(file.Tags))
+		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, models.TagKindFile, []string(file.Tags))
 	})
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to create file", err)
@@ -129,7 +129,7 @@ func (r *FileRegistry) Update(ctx context.Context, file models.FileEntity) (*mod
 	reg := r.newSQLRegistry()
 
 	err := reg.Update(ctx, file, func(ctx context.Context, tx *sqlx.Tx, dbFile models.FileEntity) error {
-		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, []string(file.Tags))
+		return ensureTagRowsInTx(ctx, tx, r.tableNames, r.tenantID, r.groupID, r.createdByUserID, models.TagKindFile, []string(file.Tags))
 	})
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to update file", err)

--- a/go/registry/postgres/tags.go
+++ b/go/registry/postgres/tags.go
@@ -94,13 +94,38 @@ func (r *TagRegistry) Get(ctx context.Context, id string) (*models.Tag, error) {
 	return &tag, nil
 }
 
-func (r *TagRegistry) GetBySlug(ctx context.Context, slug string) (*models.Tag, error) {
+func (r *TagRegistry) GetBySlug(ctx context.Context, kind models.TagKind, slug string) (*models.Tag, error) {
 	var tag models.Tag
-	err := r.newSQLRegistry().ScanOneByField(ctx, store.Pair("slug", slug), &tag)
+	reg := r.newSQLRegistry()
+	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		// RLS scopes the query to the current tenant+group; (kind, slug)
+		// disambiguates the per-(group, kind) unique tuple.
+		err := tx.QueryRowxContext(ctx,
+			fmt.Sprintf(`SELECT * FROM %s WHERE kind = $1 AND slug = $2 LIMIT 1`, r.tableNames.Tags()),
+			kind, slug).StructScan(&tag)
+		if errors.Is(err, sql.ErrNoRows) {
+			return registry.ErrNotFound
+		}
+		return err
+	})
 	if err != nil {
+		if errors.Is(err, registry.ErrNotFound) {
+			return nil, err
+		}
 		return nil, errxtrace.Wrap("failed to get tag by slug", err)
 	}
 	return &tag, nil
+}
+
+// tableForKind returns the JSONB-bearing table whose `tags` column holds
+// references for the given tag kind: commodities for commodity tags, files
+// for file tags. Unknown/empty kind falls back to commodities (defence in
+// depth — the write paths always pass a concrete kind).
+func (r *TagRegistry) tableForKind(kind models.TagKind) store.TableName {
+	if kind == models.TagKindFile {
+		return r.tableNames.Files()
+	}
+	return r.tableNames.Commodities()
 }
 
 func (r *TagRegistry) List(ctx context.Context) ([]*models.Tag, error) {
@@ -142,28 +167,27 @@ func (r *TagRegistry) Delete(ctx context.Context, id string) error {
 	return r.newSQLRegistry().Delete(ctx, id, nil)
 }
 
-// scopedUsageExpr returns the per-tag reference-count SQL expression for
-// a single scope: commodity-only, file-only, or commodities + files
-// combined (TagScopeAny). The expression is evaluated against the outer
-// `t` alias (the tags row), so callers must reference the tags table as
-// `t`. The two `tags @>` operands use the JSONB containment operator
-// backed by the existing GIN indexes (commodities_tags_gin_idx,
-// files_tags_gin_idx).
+// kindUsageExpr returns the per-tag reference-count SQL expression for the
+// given kind: commodity tags count commodity rows, file tags count file
+// rows. The expression is evaluated against the outer `t` alias (the tags
+// row), so callers must reference the tags table as `t`. The `tags @>`
+// operand uses the JSONB containment operator backed by the existing GIN
+// indexes (commodities_tags_gin_idx, files_tags_gin_idx).
 //
-// Unknown scope values fall back to the combined (TagScopeAny) expression
-// — the handler validates the wire value before it reaches the registry,
-// so this is a defence-in-depth fallback rather than a routine code path.
-func (r *TagRegistry) scopedUsageExpr(scope registry.TagScope) string {
+// Empty/unknown kind falls back to the combined expression — only reached
+// when listing across all kinds (the public handlers always pass a concrete
+// kind).
+func (r *TagRegistry) kindUsageExpr(kind models.TagKind) string {
 	commodityExpr := fmt.Sprintf(
 		`(SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array(t.slug))`,
 		r.tableNames.Commodities())
 	fileExpr := fmt.Sprintf(
 		`(SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array(t.slug))`,
 		r.tableNames.Files())
-	switch scope {
-	case registry.TagScopeCommodity:
+	switch kind {
+	case models.TagKindCommodity:
 		return commodityExpr
-	case registry.TagScopeFile:
+	case models.TagKindFile:
 		return fileExpr
 	default:
 		return "(" + commodityExpr + " + " + fileExpr + ")"
@@ -178,17 +202,20 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
 		var conditions []string
 		var args []any
+		argIdx := 1
 		if opts.Search != "" {
-			conditions = append(conditions, "(t.label ILIKE $1 OR t.slug ILIKE $2)")
+			conditions = append(conditions, fmt.Sprintf("(t.label ILIKE $%d OR t.slug ILIKE $%d)", argIdx, argIdx+1))
 			pattern := "%" + opts.Search + "%"
 			args = append(args, pattern, pattern)
+			argIdx += 2
 		}
-		// Scope filter: usage-derived. A tag passes ?scope=commodity if it
-		// has at least one commodity referencing it; same for ?scope=file.
-		// TagScopeAny adds no condition.
-		scopeFilterExpr := r.scopedUsageExpr(opts.Scope)
-		if opts.Scope == registry.TagScopeCommodity || opts.Scope == registry.TagScopeFile {
-			conditions = append(conditions, scopeFilterExpr+" > 0")
+		// Kind filter: intrinsic. A tag passes ?kind=commodity iff its
+		// stored kind is "commodity"; same for file. Zero kind adds no
+		// condition (list across all kinds — internal callers only).
+		if opts.Kind == models.TagKindCommodity || opts.Kind == models.TagKindFile {
+			conditions = append(conditions, fmt.Sprintf("t.kind = $%d", argIdx))
+			args = append(args, opts.Kind)
+			argIdx++
 		}
 		whereClause := ""
 		if len(conditions) > 0 {
@@ -213,10 +240,10 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 		case registry.TagSortCreatedAt:
 			orderBy = fmt.Sprintf("ORDER BY t.created_at %s, t.label ASC", dir)
 		case registry.TagSortUsage:
-			// Usage sort uses the SAME scoped expression as the filter so
-			// the "Sort by usage" toggle on a scoped tab reflects per-scope
-			// usage rather than combined usage.
-			orderBy = fmt.Sprintf("ORDER BY %s %s, t.label ASC", scopeFilterExpr, dir)
+			// Usage sort counts only the kind's own table (commodity tags →
+			// commodities, file tags → files), so "Sort by usage" reflects
+			// the tag's relevant usage.
+			orderBy = fmt.Sprintf("ORDER BY %s %s, t.label ASC", r.kindUsageExpr(opts.Kind), dir)
 		default:
 			orderBy = fmt.Sprintf("ORDER BY LOWER(t.label) %s, t.id ASC", dir)
 		}
@@ -225,7 +252,7 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 		dataArgs = append(dataArgs, limit, offset)
 		dataQuery := fmt.Sprintf(
 			`SELECT t.* FROM %s t %s %s LIMIT $%d OFFSET $%d`,
-			r.tableNames.Tags(), whereClause, orderBy, len(args)+1, len(args)+2,
+			r.tableNames.Tags(), whereClause, orderBy, argIdx, argIdx+1,
 		)
 		rows, err := tx.QueryxContext(ctx, dataQuery, dataArgs...)
 		if err != nil {
@@ -248,7 +275,7 @@ func (r *TagRegistry) ListPaginated(ctx context.Context, offset, limit int, opts
 	return tags, total, nil
 }
 
-func (r *TagRegistry) Search(ctx context.Context, q string, limit int, scope registry.TagScope) ([]*models.Tag, error) {
+func (r *TagRegistry) Search(ctx context.Context, q string, limit int, kind models.TagKind) ([]*models.Tag, error) {
 	var tags []*models.Tag
 
 	reg := r.newSQLRegistry()
@@ -262,25 +289,26 @@ func (r *TagRegistry) Search(ctx context.Context, q string, limit int, scope reg
 			args = append(args, pattern, pattern)
 			argIdx += 2
 		}
-		// Scope filter mirrors ListPaginated: strict exclusion of tags
-		// with zero usage in the requested scope, so the autocomplete
-		// dropdown on a commodity input never offers a file-only tag.
-		scopeUsageExpr := r.scopedUsageExpr(scope)
-		if scope == registry.TagScopeCommodity || scope == registry.TagScopeFile {
-			conditions = append(conditions, scopeUsageExpr+" > 0")
+		// Kind filter (intrinsic): the autocomplete dropdown on a commodity
+		// input only ever offers commodity tags, and a file input only file
+		// tags — they are separate entities.
+		if kind == models.TagKindCommodity || kind == models.TagKindFile {
+			conditions = append(conditions, fmt.Sprintf("t.kind = $%d", argIdx))
+			args = append(args, kind)
+			argIdx++
 		}
 		whereClause := ""
 		if len(conditions) > 0 {
 			whereClause = "WHERE " + strings.Join(conditions, " AND ")
 		}
 
-		// Rank by per-scope usage desc, then created_at desc
-		// (recency tiebreaker). For TagScopeAny this is combined usage,
-		// matching the legacy pre-#1628 ranking.
+		// Rank by the kind's own usage desc, then created_at desc
+		// (recency tiebreaker).
+		kindUsageExpr := r.kindUsageExpr(kind)
 		args = append(args, limit)
 		query := fmt.Sprintf(
 			`SELECT t.* FROM %s t %s ORDER BY %s DESC, t.created_at DESC LIMIT $%d`,
-			r.tableNames.Tags(), whereClause, scopeUsageExpr, argIdx,
+			r.tableNames.Tags(), whereClause, kindUsageExpr, argIdx,
 		)
 
 		rows, err := tx.QueryxContext(ctx, query, args...)
@@ -304,7 +332,7 @@ func (r *TagRegistry) Search(ctx context.Context, q string, limit int, scope reg
 	return tags, nil
 }
 
-func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[string]registry.TagUsage, error) {
+func (r *TagRegistry) GetUsageBatch(ctx context.Context, kind models.TagKind, slugs []string) (map[string]registry.TagUsage, error) {
 	out := make(map[string]registry.TagUsage, len(slugs))
 	for _, s := range slugs {
 		out[s] = registry.TagUsage{}
@@ -315,39 +343,25 @@ func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[st
 
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		// Single-pass query: scan commodities + files at most once each
-		// (filtered by `tags ?| input` so the GIN index on the JSONB tags
-		// column drives the lookup), unnest the JSONB arrays once per row,
-		// COUNT(DISTINCT id) per slug to match the @> containment semantics
-		// (a row with duplicate slugs in its tags array still counts as 1),
-		// then LEFT JOIN back to the requested input list so missing slugs
-		// land as 0/0 instead of being dropped.
-		//
-		// Compared to the per-slug correlated-subquery approach, this is
-		// O(rows scanned once per table) vs O(slugs × rows) — important
-		// for the upcoming Tags page which fetches usage for the whole
-		// page (default per_page=50).
+		// Single-pass query over the kind's own table only (commodity tags
+		// count commodity rows, file tags count file rows): filtered by
+		// `tags ?| input` so the GIN index drives the lookup, unnest the
+		// JSONB arrays once per row, COUNT(DISTINCT id) per slug to match
+		// the @> containment semantics (a row with duplicate slugs still
+		// counts as 1), then LEFT JOIN back to the requested input list so
+		// missing slugs land as 0 instead of being dropped.
 		query := fmt.Sprintf(`
 			WITH input(slug) AS (SELECT unnest($1::text[])),
-			commodity_counts AS (
-				SELECT t.value AS slug, COUNT(DISTINCT id)::int AS cnt
-				FROM %s, jsonb_array_elements_text(tags) AS t(value)
-				WHERE tags ?| $1::text[]
-				GROUP BY t.value
-			),
-			file_counts AS (
+			counts AS (
 				SELECT t.value AS slug, COUNT(DISTINCT id)::int AS cnt
 				FROM %s, jsonb_array_elements_text(tags) AS t(value)
 				WHERE tags ?| $1::text[]
 				GROUP BY t.value
 			)
-			SELECT input.slug,
-				COALESCE(c.cnt, 0) AS commodities,
-				COALESCE(f.cnt, 0) AS files
+			SELECT input.slug, COALESCE(c.cnt, 0) AS cnt
 			FROM input
-			LEFT JOIN commodity_counts c ON c.slug = input.slug
-			LEFT JOIN file_counts f ON f.slug = input.slug
-		`, r.tableNames.Commodities(), r.tableNames.Files())
+			LEFT JOIN counts c ON c.slug = input.slug
+		`, r.tableForKind(kind))
 
 		rows, err := tx.QueryxContext(ctx, query, slugs)
 		if err != nil {
@@ -356,11 +370,11 @@ func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[st
 		defer rows.Close()
 		for rows.Next() {
 			var slug string
-			var u registry.TagUsage
-			if err := rows.Scan(&slug, &u.Commodities, &u.Files); err != nil {
+			var cnt int
+			if err := rows.Scan(&slug, &cnt); err != nil {
 				return errxtrace.Wrap("failed to scan tag usage", err)
 			}
-			out[slug] = u
+			out[slug] = usageForKind(kind, cnt)
 		}
 		return rows.Err()
 	})
@@ -368,6 +382,15 @@ func (r *TagRegistry) GetUsageBatch(ctx context.Context, slugs []string) (map[st
 		return nil, errxtrace.Wrap("failed to compute tag usage batch", err)
 	}
 	return out, nil
+}
+
+// usageForKind packs a single per-kind reference count into the relevant
+// side of TagUsage (the other side stays zero).
+func usageForKind(kind models.TagKind, cnt int) registry.TagUsage {
+	if kind == models.TagKindFile {
+		return registry.TagUsage{Files: cnt}
+	}
+	return registry.TagUsage{Commodities: cnt}
 }
 
 func (r *TagRegistry) GetStats(ctx context.Context) (registry.TagStats, error) {
@@ -381,17 +404,21 @@ func (r *TagRegistry) GetStats(ctx context.Context) (registry.TagStats, error) {
 		query := fmt.Sprintf(`
 			SELECT
 				(SELECT COUNT(*) FROM %s) AS tags_total,
+				(SELECT COUNT(*) FROM %s WHERE kind = 'commodity') AS commodity_tags_total,
+				(SELECT COUNT(*) FROM %s WHERE kind = 'file') AS file_tags_total,
 				(SELECT COUNT(*) FROM %s WHERE jsonb_array_length(COALESCE(tags, '[]'::jsonb)) > 0) AS items_tagged,
 				(SELECT COUNT(*) FROM %s WHERE jsonb_array_length(COALESCE(tags, '[]'::jsonb)) = 0) AS items_untagged,
 				(SELECT COUNT(*) FROM %s WHERE jsonb_array_length(COALESCE(tags, '[]'::jsonb)) > 0) AS files_tagged,
 				(SELECT COUNT(*) FROM %s WHERE jsonb_array_length(COALESCE(tags, '[]'::jsonb)) = 0) AS files_untagged
 		`,
 			r.tableNames.Tags(),
+			r.tableNames.Tags(), r.tableNames.Tags(),
 			r.tableNames.Commodities(), r.tableNames.Commodities(),
 			r.tableNames.Files(), r.tableNames.Files(),
 		)
 		return tx.QueryRowxContext(ctx, query).Scan(
 			&stats.TagsTotal,
+			&stats.CommodityTagsTotal, &stats.FileTagsTotal,
 			&stats.ItemsTagged, &stats.ItemsUntagged,
 			&stats.FilesTagged, &stats.FilesUntagged,
 		)
@@ -402,23 +429,21 @@ func (r *TagRegistry) GetStats(ctx context.Context) (registry.TagStats, error) {
 	return stats, nil
 }
 
-func (r *TagRegistry) GetUsage(ctx context.Context, slug string) (registry.TagUsage, error) {
-	var usage registry.TagUsage
+func (r *TagRegistry) GetUsage(ctx context.Context, kind models.TagKind, slug string) (registry.TagUsage, error) {
+	var cnt int
 
 	reg := r.newSQLRegistry()
 	err := reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
 		query := fmt.Sprintf(
-			`SELECT
-				(SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array($1::text)),
-				(SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array($1::text))`,
-			r.tableNames.Commodities(), r.tableNames.Files(),
+			`SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array($1::text)`,
+			r.tableForKind(kind),
 		)
-		return tx.QueryRowxContext(ctx, query, slug).Scan(&usage.Commodities, &usage.Files)
+		return tx.QueryRowxContext(ctx, query, slug).Scan(&cnt)
 	})
 	if err != nil {
 		return registry.TagUsage{}, errxtrace.Wrap("failed to compute tag usage", err)
 	}
-	return usage, nil
+	return usageForKind(kind, cnt), nil
 }
 
 // jsonbReplaceSlugExpr emits the SQL expression that returns the rewritten
@@ -447,47 +472,42 @@ func jsonbStripSlugExpr(slugParam int) string {
 	)
 }
 
-func (r *TagRegistry) RewriteSlugReferences(ctx context.Context, oldSlug, newSlug string) (commodityRows, fileRows int, err error) {
+func (r *TagRegistry) RewriteSlugReferences(ctx context.Context, kind models.TagKind, oldSlug, newSlug string) (commodityRows, fileRows int, err error) {
 	if oldSlug == newSlug {
 		return 0, 0, nil
 	}
 
-	var commodityCount, fileCount int
+	var affected int
 	reg := r.newSQLRegistry()
 	err = reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		commQuery := fmt.Sprintf(
+		query := fmt.Sprintf(
 			`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
-			r.tableNames.Commodities(), jsonbReplaceSlugExpr(1, 2),
+			r.tableForKind(kind), jsonbReplaceSlugExpr(1, 2),
 		)
-		commRes, execErr := tx.ExecContext(ctx, commQuery, oldSlug, newSlug)
+		res, execErr := tx.ExecContext(ctx, query, oldSlug, newSlug)
 		if execErr != nil {
-			return errxtrace.Wrap("failed to rewrite commodity tags", execErr)
+			return errxtrace.Wrap("failed to rewrite tag references", execErr)
 		}
-		commAffected, raErr := commRes.RowsAffected()
+		n, raErr := res.RowsAffected()
 		if raErr != nil {
-			return errxtrace.Wrap("failed to read commodity rows affected", raErr)
+			return errxtrace.Wrap("failed to read rows affected", raErr)
 		}
-		commodityCount = int(commAffected)
-
-		fileQuery := fmt.Sprintf(
-			`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
-			r.tableNames.Files(), jsonbReplaceSlugExpr(1, 2),
-		)
-		fileRes, execErr := tx.ExecContext(ctx, fileQuery, oldSlug, newSlug)
-		if execErr != nil {
-			return errxtrace.Wrap("failed to rewrite file tags", execErr)
-		}
-		fileAffected, raErr := fileRes.RowsAffected()
-		if raErr != nil {
-			return errxtrace.Wrap("failed to read file rows affected", raErr)
-		}
-		fileCount = int(fileAffected)
+		affected = int(n)
 		return nil
 	})
 	if err != nil {
 		return 0, 0, errxtrace.Wrap("failed to rewrite slug references", err)
 	}
-	return commodityCount, fileCount, nil
+	return rowsForKind(kind, affected)
+}
+
+// rowsForKind splits a single affected-row count into the
+// (commodityRows, fileRows) return tuple used by Rewrite/StripSlugReferences.
+func rowsForKind(kind models.TagKind, affected int) (commodityRows, fileRows int, err error) {
+	if kind == models.TagKindFile {
+		return 0, affected, nil
+	}
+	return affected, 0, nil
 }
 
 // acquireTagAdvisoryLock takes a transaction-scoped postgres advisory lock
@@ -536,7 +556,7 @@ func defaultTagLabelFromSlug(slug string) string {
 // Slugs are deduplicated and sorted before locking so the lock
 // acquisition order is deterministic across writers — eliminates
 // deadlock potential when two writers reference overlapping slug sets.
-func ensureTagRowsInTx(ctx context.Context, tx *sqlx.Tx, tableNames store.TableNames, tenantID, groupID, userID string, slugs []string) error {
+func ensureTagRowsInTx(ctx context.Context, tx *sqlx.Tx, tableNames store.TableNames, tenantID, groupID, userID string, kind models.TagKind, slugs []string) error {
 	if len(slugs) == 0 || groupID == "" {
 		return nil
 	}
@@ -558,14 +578,17 @@ func ensureTagRowsInTx(ctx context.Context, tx *sqlx.Tx, tableNames store.TableN
 	sort.Strings(cleaned)
 
 	selectForUpdate := fmt.Sprintf(
-		`SELECT 1 FROM %s WHERE group_id = $1 AND slug = $2 FOR UPDATE`, tableNames.Tags())
+		`SELECT 1 FROM %s WHERE group_id = $1 AND kind = $2 AND slug = $3 FOR UPDATE`, tableNames.Tags())
 	insertQuery := fmt.Sprintf(`
-		INSERT INTO %s (id, tenant_id, group_id, slug, label, color, created_by_user_id)
-		VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6)
-		ON CONFLICT (group_id, slug) DO NOTHING`, tableNames.Tags())
+		INSERT INTO %s (id, tenant_id, group_id, kind, slug, label, color, created_by_user_id)
+		VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (group_id, kind, slug) DO NOTHING`, tableNames.Tags())
 
 	for _, slug := range cleaned {
-		if err := acquireTagAdvisoryLock(ctx, tx, groupID, "slug:"+slug); err != nil {
+		// Lock key is namespaced by kind so a commodity-tag insert and a
+		// file-tag insert of the same slug don't serialize against each
+		// other (they are separate rows).
+		if err := acquireTagAdvisoryLock(ctx, tx, groupID, tagSlugLockKey(kind, slug)); err != nil {
 			return err
 		}
 		// SELECT FOR UPDATE — if the row exists, take a row-level lock so
@@ -575,14 +598,14 @@ func ensureTagRowsInTx(ctx context.Context, tx *sqlx.Tx, tableNames store.TableN
 		// the existing row, so a concurrent delete that committed
 		// before us would still leave us with an orphan reference.
 		var dummy int
-		err := tx.QueryRowContext(ctx, selectForUpdate, groupID, slug).Scan(&dummy)
+		err := tx.QueryRowContext(ctx, selectForUpdate, groupID, kind, slug).Scan(&dummy)
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 			// Row gone (or never existed) — INSERT a fresh one. ON
 			// CONFLICT DO NOTHING is the safety net for two concurrent
-			// inserters racing on the same brand-new slug.
+			// inserters racing on the same brand-new (kind, slug).
 			if _, err := tx.ExecContext(ctx, insertQuery,
-				tenantID, groupID, slug, defaultTagLabelFromSlug(slug), models.DefaultTagColor, userID); err != nil {
+				tenantID, groupID, kind, slug, defaultTagLabelFromSlug(slug), models.DefaultTagColor, userID); err != nil {
 				return errxtrace.Wrap("failed to insert tag row", err, errx.Attrs("slug", slug))
 			}
 		case err != nil:
@@ -590,6 +613,13 @@ func ensureTagRowsInTx(ctx context.Context, tx *sqlx.Tx, tableNames store.TableN
 		}
 	}
 	return nil
+}
+
+// tagSlugLockKey builds the per-(kind, slug) advisory-lock key. The inserter
+// (ensureTagRowsInTx) and the rename/delete paths (acquireSlugLocks) must
+// agree on this key so they serialize on the same (kind, slug) tuple.
+func tagSlugLockKey(kind models.TagKind, slug string) string {
+	return "slug:" + string(kind) + ":" + slug
 }
 
 // peekTagSlug reads the tag's current slug WITHOUT taking a row lock.
@@ -604,18 +634,17 @@ func ensureTagRowsInTx(ctx context.Context, tx *sqlx.Tx, tableNames store.TableN
 // lock, otherwise a concurrent inserter holding (slug-lock + waiting
 // for row-lock) deadlocks against a deleter holding (row-lock +
 // waiting for slug-lock).
-func (r *TagRegistry) peekTagSlug(ctx context.Context, tx *sqlx.Tx, id string) (string, error) {
-	var slug string
-	err := tx.QueryRowContext(ctx,
-		fmt.Sprintf(`SELECT slug FROM %s WHERE id = $1`, r.tableNames.Tags()),
-		id).Scan(&slug)
+func (r *TagRegistry) peekTagSlug(ctx context.Context, tx *sqlx.Tx, id string) (slug string, kind models.TagKind, err error) {
+	err = tx.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT slug, kind FROM %s WHERE id = $1`, r.tableNames.Tags()),
+		id).Scan(&slug, &kind)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", errxtrace.Wrap("failed to look up tag", registry.ErrNotFound, errx.Attrs("id", id))
+		return "", "", errxtrace.Wrap("failed to look up tag", registry.ErrNotFound, errx.Attrs("id", id))
 	}
 	if err != nil {
-		return "", errxtrace.Wrap("failed to look up tag", err)
+		return "", "", errxtrace.Wrap("failed to look up tag", err)
 	}
-	return slug, nil
+	return slug, kind, nil
 }
 
 // renameRewriteSlug runs the JSONB-rewrite half of RenameAtomic — slug
@@ -624,15 +653,17 @@ func (r *TagRegistry) peekTagSlug(ctx context.Context, tx *sqlx.Tx, id string) (
 // before the tag-row FOR UPDATE so the lock acquisition order matches
 // ensureTagRowsInTx). Lifted out of RenameAtomic so the orchestrator
 // stays under gocognit's threshold without losing the rewrite step.
-func (r *TagRegistry) renameRewriteSlug(ctx context.Context, tx *sqlx.Tx, id, oldSlug, newSlug string) error {
-	// Pre-emptive slug-clash check, inside the lock — relying on
-	// the unique index alone would still work, but yields a worse
-	// error message (Postgres-level uniqueness violation vs. our
-	// domain ErrAlreadyExists).
+func (r *TagRegistry) renameRewriteSlug(ctx context.Context, tx *sqlx.Tx, id string, kind models.TagKind, oldSlug, newSlug string) error {
+	// Pre-emptive slug-clash check, inside the lock — scoped to the same
+	// kind, because (group, kind, slug) is the uniqueness tuple: the same
+	// slug may legitimately exist under the other kind. Relying on the
+	// unique index alone would still work, but yields a worse error
+	// message (Postgres-level uniqueness violation vs. our domain
+	// ErrAlreadyExists).
 	var clashID string
 	clashErr := tx.QueryRowContext(ctx,
-		fmt.Sprintf(`SELECT id FROM %s WHERE slug = $1 AND id != $2 LIMIT 1`, r.tableNames.Tags()),
-		newSlug, id).Scan(&clashID)
+		fmt.Sprintf(`SELECT id FROM %s WHERE kind = $1 AND slug = $2 AND id != $3 LIMIT 1`, r.tableNames.Tags()),
+		kind, newSlug, id).Scan(&clashID)
 	switch {
 	case errors.Is(clashErr, sql.ErrNoRows):
 		// no clash — proceed
@@ -643,17 +674,13 @@ func (r *TagRegistry) renameRewriteSlug(ctx context.Context, tx *sqlx.Tx, id, ol
 			registry.ErrAlreadyExists, errx.Attrs("slug", newSlug))
 	}
 
-	rewriteCommQuery := fmt.Sprintf(
+	// Rewrite references only on the kind's own table — a commodity-tag
+	// rename must not touch files (those slugs belong to file tags).
+	rewriteQuery := fmt.Sprintf(
 		`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
-		r.tableNames.Commodities(), jsonbReplaceSlugExpr(1, 2))
-	if _, err := tx.ExecContext(ctx, rewriteCommQuery, oldSlug, newSlug); err != nil {
-		return errxtrace.Wrap("failed to rewrite commodity tags", err)
-	}
-	rewriteFileQuery := fmt.Sprintf(
-		`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
-		r.tableNames.Files(), jsonbReplaceSlugExpr(1, 2))
-	if _, err := tx.ExecContext(ctx, rewriteFileQuery, oldSlug, newSlug); err != nil {
-		return errxtrace.Wrap("failed to rewrite file tags", err)
+		r.tableForKind(kind), jsonbReplaceSlugExpr(1, 2))
+	if _, err := tx.ExecContext(ctx, rewriteQuery, oldSlug, newSlug); err != nil {
+		return errxtrace.Wrap("failed to rewrite tag references", err)
 	}
 	return nil
 }
@@ -665,7 +692,7 @@ func (r *TagRegistry) renameRewriteSlug(ctx context.Context, tx *sqlx.Tx, id, ol
 // reverse, because the reverse interleaves with the inserter's order
 // and deadlocks under concurrency (real failure mode seen in CI on
 // PR #1491; see follow-up #1492).
-func (r *TagRegistry) acquireSlugLocks(ctx context.Context, tx *sqlx.Tx, slugs ...string) error {
+func (r *TagRegistry) acquireSlugLocks(ctx context.Context, tx *sqlx.Tx, kind models.TagKind, slugs ...string) error {
 	keys := slices.Clone(slugs)
 	sort.Strings(keys)
 	keys = slices.Compact(keys)
@@ -673,7 +700,7 @@ func (r *TagRegistry) acquireSlugLocks(ctx context.Context, tx *sqlx.Tx, slugs .
 		if s == "" {
 			continue
 		}
-		if err := acquireTagAdvisoryLock(ctx, tx, r.groupID, "slug:"+s); err != nil {
+		if err := acquireTagAdvisoryLock(ctx, tx, r.groupID, tagSlugLockKey(kind, s)); err != nil {
 			return err
 		}
 	}
@@ -698,13 +725,14 @@ func (r *TagRegistry) RenameAtomic(ctx context.Context, id, newLabel, newSlug st
 			return err
 		}
 
-		// Peek the slug without locking the row, so we can take the
-		// slug-advisory lock(s) BEFORE the row lock.
-		oldSlug, err := r.peekTagSlug(ctx, tx, id)
+		// Peek the slug + kind without locking the row, so we can take the
+		// slug-advisory lock(s) BEFORE the row lock. Kind is needed both to
+		// namespace the locks and to scope the rewrite to the right table.
+		oldSlug, kind, err := r.peekTagSlug(ctx, tx, id)
 		if err != nil {
 			return err
 		}
-		if err := r.acquireSlugLocks(ctx, tx, oldSlug, newSlug); err != nil {
+		if err := r.acquireSlugLocks(ctx, tx, kind, oldSlug, newSlug); err != nil {
 			return err
 		}
 
@@ -731,7 +759,7 @@ func (r *TagRegistry) RenameAtomic(ctx context.Context, id, newLabel, newSlug st
 
 		if newSlug != "" && newSlug != current.Slug {
 			updated.Slug = newSlug
-			if err := r.renameRewriteSlug(ctx, tx, id, current.Slug, newSlug); err != nil {
+			if err := r.renameRewriteSlug(ctx, tx, id, kind, current.Slug, newSlug); err != nil {
 				return err
 			}
 		}
@@ -779,13 +807,13 @@ func (r *TagRegistry) DeleteAtomic(ctx context.Context, id string, force bool) (
 			return err
 		}
 
-		// Peek the slug without locking the row, so we can take the
+		// Peek the slug + kind without locking the row, so we can take the
 		// slug-advisory lock BEFORE the row lock.
-		slug, err := r.peekTagSlug(ctx, tx, id)
+		slug, kind, err := r.peekTagSlug(ctx, tx, id)
 		if err != nil {
 			return err
 		}
-		if err := r.acquireSlugLocks(ctx, tx, slug); err != nil {
+		if err := r.acquireSlugLocks(ctx, tx, kind, slug); err != nil {
 			return err
 		}
 
@@ -800,29 +828,26 @@ func (r *TagRegistry) DeleteAtomic(ctx context.Context, id string, force bool) (
 			return errxtrace.Wrap("failed to look up tag", err)
 		}
 
+		// Usage counts only the tag's own kind table — a commodity tag's
+		// usage is its commodities, never files that happen to share the slug.
+		var refCount int
 		usageQuery := fmt.Sprintf(
-			`SELECT (SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array($1::text)),
-			        (SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array($1::text))`,
-			r.tableNames.Commodities(), r.tableNames.Files())
-		if err := tx.QueryRowxContext(ctx, usageQuery, current.Slug).Scan(&usage.Commodities, &usage.Files); err != nil {
+			`SELECT COUNT(*) FROM %s WHERE tags @> jsonb_build_array($1::text)`,
+			r.tableForKind(current.Kind))
+		if err := tx.QueryRowxContext(ctx, usageQuery, current.Slug).Scan(&refCount); err != nil {
 			return errxtrace.Wrap("failed to compute tag usage", err)
 		}
+		usage = usageForKind(current.Kind, refCount)
 
-		if usage.Commodities+usage.Files > 0 && !force {
+		if refCount > 0 && !force {
 			return registry.ErrTagInUse
 		}
-		if usage.Commodities+usage.Files > 0 {
-			stripCommQuery := fmt.Sprintf(
+		if refCount > 0 {
+			stripQuery := fmt.Sprintf(
 				`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
-				r.tableNames.Commodities(), jsonbStripSlugExpr(1))
-			if _, err := tx.ExecContext(ctx, stripCommQuery, current.Slug); err != nil {
-				return errxtrace.Wrap("failed to strip commodity tags", err)
-			}
-			stripFileQuery := fmt.Sprintf(
-				`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
-				r.tableNames.Files(), jsonbStripSlugExpr(1))
-			if _, err := tx.ExecContext(ctx, stripFileQuery, current.Slug); err != nil {
-				return errxtrace.Wrap("failed to strip file tags", err)
+				r.tableForKind(current.Kind), jsonbStripSlugExpr(1))
+			if _, err := tx.ExecContext(ctx, stripQuery, current.Slug); err != nil {
+				return errxtrace.Wrap("failed to strip tag references", err)
 			}
 		}
 
@@ -838,41 +863,27 @@ func (r *TagRegistry) DeleteAtomic(ctx context.Context, id string, force bool) (
 	return usage, nil
 }
 
-func (r *TagRegistry) StripSlugReferences(ctx context.Context, slug string) (commodityRows, fileRows int, err error) {
-	var commodityCount, fileCount int
+func (r *TagRegistry) StripSlugReferences(ctx context.Context, kind models.TagKind, slug string) (commodityRows, fileRows int, err error) {
+	var affected int
 	reg := r.newSQLRegistry()
 	err = reg.Do(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
-		commQuery := fmt.Sprintf(
+		query := fmt.Sprintf(
 			`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
-			r.tableNames.Commodities(), jsonbStripSlugExpr(1),
+			r.tableForKind(kind), jsonbStripSlugExpr(1),
 		)
-		commRes, execErr := tx.ExecContext(ctx, commQuery, slug)
+		res, execErr := tx.ExecContext(ctx, query, slug)
 		if execErr != nil {
-			return errxtrace.Wrap("failed to strip commodity tags", execErr)
+			return errxtrace.Wrap("failed to strip tag references", execErr)
 		}
-		commAffected, raErr := commRes.RowsAffected()
+		n, raErr := res.RowsAffected()
 		if raErr != nil {
-			return errxtrace.Wrap("failed to read commodity rows affected", raErr)
+			return errxtrace.Wrap("failed to read rows affected", raErr)
 		}
-		commodityCount = int(commAffected)
-
-		fileQuery := fmt.Sprintf(
-			`UPDATE %s SET tags = %s WHERE tags @> jsonb_build_array($1::text)`,
-			r.tableNames.Files(), jsonbStripSlugExpr(1),
-		)
-		fileRes, execErr := tx.ExecContext(ctx, fileQuery, slug)
-		if execErr != nil {
-			return errxtrace.Wrap("failed to strip file tags", execErr)
-		}
-		fileAffected, raErr := fileRes.RowsAffected()
-		if raErr != nil {
-			return errxtrace.Wrap("failed to read file rows affected", raErr)
-		}
-		fileCount = int(fileAffected)
+		affected = int(n)
 		return nil
 	})
 	if err != nil {
 		return 0, 0, errxtrace.Wrap("failed to strip slug references", err)
 	}
-	return commodityCount, fileCount, nil
+	return rowsForKind(kind, affected)
 }

--- a/go/registry/postgres/tags_test.go
+++ b/go/registry/postgres/tags_test.go
@@ -167,9 +167,10 @@ func seedTagFile(c *qt.C, set *registry.Set, ctx context.Context, name string, t
 	return file.GetID()
 }
 
-func mustCreateTag(c *qt.C, reg registry.TagRegistry, ctx context.Context, slug string) *models.Tag {
+func mustCreateTag(c *qt.C, reg registry.TagRegistry, ctx context.Context, kind models.TagKind, slug string) *models.Tag {
 	c.Helper()
 	tag, err := reg.Create(ctx, models.Tag{
+		Kind:  kind,
 		Slug:  slug,
 		Label: slug,
 		Color: models.DefaultTagColor,
@@ -193,6 +194,25 @@ func rawCommodityTagsText(c *qt.C, dbx *sqlx.DB, id string) string {
 	return *raw
 }
 
+// TestTagRegistry_Postgres_SameSlugDifferentKinds pins the core split
+// invariant at the DB level: the (group_id, kind, slug) unique index lets
+// the same slug exist once per kind as two distinct rows.
+func TestTagRegistry_Postgres_SameSlugDifferentKinds(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	commTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "warranty")
+	fileTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindFile, "warranty")
+	c.Assert(commTag.ID, qt.Not(qt.Equals), fileTag.ID)
+
+	gotComm, err := fx.groupASet.TagRegistry.GetBySlug(fx.ctxA, models.TagKindCommodity, "warranty")
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotComm.ID, qt.Equals, commTag.ID)
+	gotFile, err := fx.groupASet.TagRegistry.GetBySlug(fx.ctxA, models.TagKindFile, "warranty")
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotFile.ID, qt.Equals, fileTag.ID)
+}
+
 func TestTagRegistry_Postgres_RewriteSlugReferences(t *testing.T) {
 	c := qt.New(t)
 	fx := newTagPGFixture(t)
@@ -200,10 +220,12 @@ func TestTagRegistry_Postgres_RewriteSlugReferences(t *testing.T) {
 	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen", "appliance")
 	fileID := seedTagFile(c, fx.groupASet, fx.ctxA, "fridge-photo", "kitchen")
 
-	commCount, fileCount, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, "kitchen", "kitchen-area")
+	// Commodity-kind rewrite touches ONLY commodities — the file's "kitchen"
+	// belongs to a separate file tag and must be left alone.
+	commCount, fileCount, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, models.TagKindCommodity, "kitchen", "kitchen-area")
 	c.Assert(err, qt.IsNil)
 	c.Assert(commCount, qt.Equals, 1)
-	c.Assert(fileCount, qt.Equals, 1)
+	c.Assert(fileCount, qt.Equals, 0)
 
 	cmd, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdID)
 	c.Assert(err, qt.IsNil)
@@ -213,6 +235,15 @@ func TestTagRegistry_Postgres_RewriteSlugReferences(t *testing.T) {
 	c.Assert([]string(cmd.Tags), qt.Not(qt.Contains), "kitchen")
 
 	file, err := fx.groupASet.FileRegistry.Get(fx.ctxA, fileID)
+	c.Assert(err, qt.IsNil)
+	c.Assert([]string(file.Tags), qt.DeepEquals, []string{"kitchen"})
+
+	// File-kind rewrite touches ONLY files.
+	commCount, fileCount, err = fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, models.TagKindFile, "kitchen", "kitchen-area")
+	c.Assert(err, qt.IsNil)
+	c.Assert(commCount, qt.Equals, 0)
+	c.Assert(fileCount, qt.Equals, 1)
+	file, err = fx.groupASet.FileRegistry.Get(fx.ctxA, fileID)
 	c.Assert(err, qt.IsNil)
 	c.Assert([]string(file.Tags), qt.DeepEquals, []string{"kitchen-area"})
 }
@@ -225,7 +256,7 @@ func TestTagRegistry_Postgres_RewriteSlugReferences_DedupOnRenameOntoExisting(t 
 	// must collapse them to a single occurrence post-rewrite.
 	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen", "kitchen-area", "appliance")
 
-	commCount, _, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, "kitchen", "kitchen-area")
+	commCount, _, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, models.TagKindCommodity, "kitchen", "kitchen-area")
 	c.Assert(err, qt.IsNil)
 	c.Assert(commCount, qt.Equals, 1)
 
@@ -245,7 +276,7 @@ func TestTagRegistry_Postgres_RewriteSlugReferences_CrossGroupIsolation(t *testi
 	fileB := seedTagFile(c, fx.groupBSet, fx.ctxB, "in-B-photo", "kitchen")
 
 	// Rewrite scoped to group A only.
-	commCount, fileCount, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, "kitchen", "kitchen-area")
+	commCount, fileCount, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, models.TagKindCommodity, "kitchen", "kitchen-area")
 	c.Assert(err, qt.IsNil)
 	c.Assert(commCount, qt.Equals, 1)
 	c.Assert(fileCount, qt.Equals, 0)
@@ -272,7 +303,7 @@ func TestTagRegistry_Postgres_RewriteSlugReferences_LeavesUnrelatedRowsAlone(t *
 	otherID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "other", "appliance")
 	taggedID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen")
 
-	commCount, _, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, "kitchen", "kitchen-area")
+	commCount, _, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, models.TagKindCommodity, "kitchen", "kitchen-area")
 	c.Assert(err, qt.IsNil)
 	c.Assert(commCount, qt.Equals, 1, qt.Commentf("only the row containing the old slug is touched"))
 
@@ -295,7 +326,7 @@ func TestTagRegistry_Postgres_RewriteSlugReferences_NoOpWhenSlugUnchanged(t *tes
 
 	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen")
 
-	commCount, fileCount, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, "kitchen", "kitchen")
+	commCount, fileCount, err := fx.groupASet.TagRegistry.RewriteSlugReferences(fx.ctxA, models.TagKindCommodity, "kitchen", "kitchen")
 	c.Assert(err, qt.IsNil)
 	c.Assert(commCount, qt.Equals, 0)
 	c.Assert(fileCount, qt.Equals, 0)
@@ -312,10 +343,12 @@ func TestTagRegistry_Postgres_StripSlugReferences(t *testing.T) {
 	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen", "appliance")
 	fileID := seedTagFile(c, fx.groupASet, fx.ctxA, "fridge-photo", "kitchen")
 
-	commCount, fileCount, err := fx.groupASet.TagRegistry.StripSlugReferences(fx.ctxA, "kitchen")
+	// Commodity-kind strip touches ONLY commodities; the file's "kitchen"
+	// (a file tag) is left intact.
+	commCount, fileCount, err := fx.groupASet.TagRegistry.StripSlugReferences(fx.ctxA, models.TagKindCommodity, "kitchen")
 	c.Assert(err, qt.IsNil)
 	c.Assert(commCount, qt.Equals, 1)
-	c.Assert(fileCount, qt.Equals, 1)
+	c.Assert(fileCount, qt.Equals, 0)
 
 	cmd, err := fx.groupASet.CommodityRegistry.Get(fx.ctxA, cmdID)
 	c.Assert(err, qt.IsNil)
@@ -323,7 +356,7 @@ func TestTagRegistry_Postgres_StripSlugReferences(t *testing.T) {
 
 	file, err := fx.groupASet.FileRegistry.Get(fx.ctxA, fileID)
 	c.Assert(err, qt.IsNil)
-	c.Assert([]string(file.Tags), qt.HasLen, 0)
+	c.Assert([]string(file.Tags), qt.DeepEquals, []string{"kitchen"})
 }
 
 func TestTagRegistry_Postgres_StripSlugReferences_EmptyArrayNotNull(t *testing.T) {
@@ -335,7 +368,7 @@ func TestTagRegistry_Postgres_StripSlugReferences_EmptyArrayNotNull(t *testing.T
 	// jsonb_array_length on the column.
 	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen")
 
-	_, _, err := fx.groupASet.TagRegistry.StripSlugReferences(fx.ctxA, "kitchen")
+	_, _, err := fx.groupASet.TagRegistry.StripSlugReferences(fx.ctxA, models.TagKindCommodity, "kitchen")
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(rawCommodityTagsText(c, fx.dbx, cmdID), qt.Equals, "[]")
@@ -348,7 +381,7 @@ func TestTagRegistry_Postgres_StripSlugReferences_CrossGroupIsolation(t *testing
 	cmdA := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "in-A", "kitchen", "appliance")
 	cmdB := seedTagCommodity(c, fx.groupBSet, fx.ctxB, fx.areaBID, "in-B", "kitchen")
 
-	commCount, _, err := fx.groupASet.TagRegistry.StripSlugReferences(fx.ctxA, "kitchen")
+	commCount, _, err := fx.groupASet.TagRegistry.StripSlugReferences(fx.ctxA, models.TagKindCommodity, "kitchen")
 	c.Assert(err, qt.IsNil)
 	c.Assert(commCount, qt.Equals, 1)
 
@@ -368,8 +401,8 @@ func TestTagService_Postgres_RenameTag_RefusesPreemptivelyOnSlugClash(t *testing
 	c := qt.New(t)
 	fx := newTagPGFixture(t)
 
-	srcTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen")
-	_ = mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen-area")
+	srcTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "kitchen")
+	_ = mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "kitchen-area")
 	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen")
 
 	svc := services.NewTagService(fx.factorySet)
@@ -384,6 +417,23 @@ func TestTagService_Postgres_RenameTag_RefusesPreemptivelyOnSlugClash(t *testing
 		qt.Commentf("JSONB must be untouched when rename is refused — no partial rewrite"))
 }
 
+// TestTagService_Postgres_RenameTag_SameSlugDifferentKindNoClash asserts a
+// commodity-tag rename onto a slug that exists only as a *file* tag succeeds
+// — uniqueness is per (group, kind, slug), so the kinds don't collide.
+func TestTagService_Postgres_RenameTag_SameSlugDifferentKindNoClash(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	srcTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "kitchen")
+	_ = mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindFile, "kitchen-area")
+
+	svc := services.NewTagService(fx.factorySet)
+	updated, err := svc.RenameTag(fx.ctxA, srcTag.ID, "", "kitchen-area", "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(updated.Slug, qt.Equals, "kitchen-area")
+	c.Assert(updated.Kind, qt.Equals, models.TagKindCommodity)
+}
+
 // TestTagService_Postgres_RenameTag_ParallelDifferentSourceSlugs covers two
 // renames operating on distinct tags in the same group: they share no
 // row-level state, so both must succeed and both rewrites must land.
@@ -391,8 +441,8 @@ func TestTagService_Postgres_RenameTag_ParallelDifferentSourceSlugs(t *testing.T
 	c := qt.New(t)
 	fx := newTagPGFixture(t)
 
-	tagA := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "alpha")
-	tagB := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "beta")
+	tagA := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "alpha")
+	tagB := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "beta")
 	cmdA := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "with-alpha", "alpha")
 	cmdB := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "with-beta", "beta")
 
@@ -444,7 +494,7 @@ func TestTagService_Postgres_RenameTag_ParallelSameSourceSlug(t *testing.T) {
 	c := qt.New(t)
 	fx := newTagPGFixture(t)
 
-	srcTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen")
+	srcTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "kitchen")
 	cmdID := seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen")
 
 	svc := services.NewTagService(fx.factorySet)
@@ -494,7 +544,7 @@ func TestTagService_Postgres_DeleteTag_ForceUnderConcurrentInsert(t *testing.T) 
 	c := qt.New(t)
 	fx := newTagPGFixture(t)
 
-	srcTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen")
+	srcTag := mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "kitchen")
 	_ = seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "existing", "kitchen")
 
 	svc := services.NewTagService(fx.factorySet)
@@ -514,7 +564,7 @@ func TestTagService_Postgres_DeleteTag_ForceUnderConcurrentInsert(t *testing.T) 
 		// Mirrors the apiserver write path: normalize-and-ensure runs first
 		// (will auto-recreate if the tag was already deleted), then the
 		// commodity row is persisted with the resolved slug list.
-		slugs, ensErr := svc.NormalizeAndEnsureSlugs(fx.ctxA, []string{"kitchen"})
+		slugs, ensErr := svc.NormalizeAndEnsureSlugs(fx.ctxA, models.TagKindCommodity, []string{"kitchen"})
 		if ensErr != nil {
 			errIns = ensErr
 			return
@@ -529,7 +579,7 @@ func TestTagService_Postgres_DeleteTag_ForceUnderConcurrentInsert(t *testing.T) 
 	c.Assert(err, qt.IsNil)
 	for _, cmd := range allCmds {
 		for _, slug := range cmd.Tags {
-			_, lookupErr := fx.groupASet.TagRegistry.GetBySlug(fx.ctxA, slug)
+			_, lookupErr := fx.groupASet.TagRegistry.GetBySlug(fx.ctxA, models.TagKindCommodity, slug)
 			c.Assert(lookupErr, qt.IsNil,
 				qt.Commentf("orphan reference: commodity %s -> tag slug %q with no matching row (errDel=%v errIns=%v)",
 					cmd.ID, slug, errDel, errIns))
@@ -537,90 +587,104 @@ func TestTagService_Postgres_DeleteTag_ForceUnderConcurrentInsert(t *testing.T) 
 	}
 }
 
-// TestTagRegistry_Postgres_SearchScoped verifies the per-scope strict
-// filter on the autocomplete (Search) endpoint added for #1628. The
-// scoped expression must match what GetUsage returns for the same slug.
-func TestTagRegistry_Postgres_SearchScoped(t *testing.T) {
+// TestTagRegistry_Postgres_SearchByKind verifies the intrinsic kind filter on
+// the autocomplete (Search) endpoint: a commodity input only ever sees
+// commodity tags (including zero-usage ones), a file input only file tags,
+// and the same slug appears under both kinds as two distinct rows.
+func TestTagRegistry_Postgres_SearchByKind(t *testing.T) {
 	c := qt.New(t)
 	fx := newTagPGFixture(t)
 
-	// Seed four tags, vary usage by scope.
-	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen")
-	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "invoice")
-	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "warranty")
-	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "unused")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "kitchen")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "warranty")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "unused")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindFile, "invoice")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindFile, "warranty")
 
 	seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen", "warranty")
 	seedTagFile(c, fx.groupASet, fx.ctxA, "fridge-receipt", "invoice", "warranty")
 
-	gotCommodity, err := fx.groupASet.TagRegistry.Search(fx.ctxA, "", 10, registry.TagScopeCommodity)
-	c.Assert(err, qt.IsNil)
-	gotCommoditySlugs := make([]string, 0, len(gotCommodity))
-	for _, t := range gotCommodity {
-		gotCommoditySlugs = append(gotCommoditySlugs, t.Slug)
-	}
+	gotCommoditySlugs := searchSlugs(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity)
 	c.Assert(gotCommoditySlugs, qt.Contains, "kitchen")
 	c.Assert(gotCommoditySlugs, qt.Contains, "warranty")
+	c.Assert(gotCommoditySlugs, qt.Contains, "unused") // kind filter includes unused
 	c.Assert(gotCommoditySlugs, qt.Not(qt.Contains), "invoice")
-	c.Assert(gotCommoditySlugs, qt.Not(qt.Contains), "unused")
 
-	gotFile, err := fx.groupASet.TagRegistry.Search(fx.ctxA, "", 10, registry.TagScopeFile)
-	c.Assert(err, qt.IsNil)
-	gotFileSlugs := make([]string, 0, len(gotFile))
-	for _, t := range gotFile {
-		gotFileSlugs = append(gotFileSlugs, t.Slug)
-	}
+	gotFileSlugs := searchSlugs(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindFile)
 	c.Assert(gotFileSlugs, qt.Contains, "invoice")
 	c.Assert(gotFileSlugs, qt.Contains, "warranty")
 	c.Assert(gotFileSlugs, qt.Not(qt.Contains), "kitchen")
 	c.Assert(gotFileSlugs, qt.Not(qt.Contains), "unused")
-
-	// TagScopeAny includes every tag, including the unused one.
-	gotAny, err := fx.groupASet.TagRegistry.Search(fx.ctxA, "", 10, registry.TagScopeAny)
-	c.Assert(err, qt.IsNil)
-	c.Assert(gotAny, qt.HasLen, 4)
 }
 
-// TestTagRegistry_Postgres_ListPaginatedScoped mirrors SearchScoped for
-// the paginated listing endpoint. Asserts both filter + total count.
-func TestTagRegistry_Postgres_ListPaginatedScoped(t *testing.T) {
+func searchSlugs(c *qt.C, reg registry.TagRegistry, ctx context.Context, kind models.TagKind) []string {
+	c.Helper()
+	tags, err := reg.Search(ctx, "", 50, kind)
+	c.Assert(err, qt.IsNil)
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		out = append(out, t.Slug)
+	}
+	return out
+}
+
+// TestTagRegistry_Postgres_ListPaginatedByKind mirrors SearchByKind for the
+// paginated listing endpoint. Asserts both filter + total count.
+func TestTagRegistry_Postgres_ListPaginatedByKind(t *testing.T) {
 	c := qt.New(t)
 	fx := newTagPGFixture(t)
 
-	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "kitchen")
-	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "invoice")
-	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "warranty")
-	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, "unused")
-
-	seedTagCommodity(c, fx.groupASet, fx.ctxA, fx.areaAID, "fridge", "kitchen", "warranty")
-	seedTagFile(c, fx.groupASet, fx.ctxA, "fridge-receipt", "invoice", "warranty")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "kitchen")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "warranty")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindFile, "invoice")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindFile, "warranty")
 
 	got, total, err := fx.groupASet.TagRegistry.ListPaginated(fx.ctxA, 0, 50, registry.TagListOptions{
-		Scope: registry.TagScopeCommodity,
+		Kind: models.TagKindCommodity,
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(total, qt.Equals, 2)
 	slugs := make([]string, 0, len(got))
 	for _, t := range got {
+		c.Assert(t.Kind, qt.Equals, models.TagKindCommodity)
 		slugs = append(slugs, t.Slug)
 	}
 	c.Assert(slugs, qt.Contains, "kitchen")
 	c.Assert(slugs, qt.Contains, "warranty")
 
 	got, total, err = fx.groupASet.TagRegistry.ListPaginated(fx.ctxA, 0, 50, registry.TagListOptions{
-		Scope: registry.TagScopeFile,
+		Kind: models.TagKindFile,
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(total, qt.Equals, 2)
 	slugs = slugs[:0]
 	for _, t := range got {
+		c.Assert(t.Kind, qt.Equals, models.TagKindFile)
 		slugs = append(slugs, t.Slug)
 	}
 	c.Assert(slugs, qt.Contains, "invoice")
 	c.Assert(slugs, qt.Contains, "warranty")
 
+	// Zero-value kind returns every tag regardless of kind (internal only).
 	got, total, err = fx.groupASet.TagRegistry.ListPaginated(fx.ctxA, 0, 50, registry.TagListOptions{})
 	c.Assert(err, qt.IsNil)
 	c.Assert(total, qt.Equals, 4)
 	c.Assert(got, qt.HasLen, 4)
+}
+
+// TestTagRegistry_Postgres_GetStats_PerKindTotals asserts the per-kind tag
+// totals added for the split-view stats bar.
+func TestTagRegistry_Postgres_GetStats_PerKindTotals(t *testing.T) {
+	c := qt.New(t)
+	fx := newTagPGFixture(t)
+
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "kitchen")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindCommodity, "warranty")
+	mustCreateTag(c, fx.groupASet.TagRegistry, fx.ctxA, models.TagKindFile, "invoice")
+
+	stats, err := fx.groupASet.TagRegistry.GetStats(fx.ctxA)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stats.TagsTotal, qt.Equals, 3)
+	c.Assert(stats.CommodityTagsTotal, qt.Equals, 2)
+	c.Assert(stats.FileTagsTotal, qt.Equals, 1)
 }

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -414,39 +414,6 @@ func (s TagSortField) IsValid() bool {
 	return false
 }
 
-// TagScope narrows tag listing / autocomplete to tags that are actually used
-// on a specific entity type. Scope is *usage-derived* — there is no scope
-// column on the tags row itself; a tag's scope is whichever entity types
-// have at least one row referencing the tag via their JSONB tags array.
-//
-// A tag used on both commodities and files is multi-scope and shows up
-// under both TagScopeCommodity and TagScopeFile filters. A brand-new tag
-// with zero usage shows up only under TagScopeAny.
-//
-// Names are part of the public API surface (FE sends them as ?scope=).
-type TagScope string
-
-const (
-	// TagScopeAny matches every tag regardless of where it is used.
-	// Default when ?scope= is missing.
-	TagScopeAny TagScope = ""
-	// TagScopeCommodity matches tags referenced by at least one commodity.
-	TagScopeCommodity TagScope = "commodity"
-	// TagScopeFile matches tags referenced by at least one file.
-	TagScopeFile TagScope = "file"
-)
-
-// IsValid reports whether s is a known tag scope. Empty string is treated
-// as TagScopeAny by callers; this returns true for the empty string so the
-// handler can validate the raw query value uniformly.
-func (s TagScope) IsValid() bool {
-	switch s {
-	case TagScopeAny, TagScopeCommodity, TagScopeFile:
-		return true
-	}
-	return false
-}
-
 // TagListOptions narrows the result of TagRegistry.ListPaginated.
 type TagListOptions struct {
 	// Search runs case-insensitive substring match on label and slug.
@@ -455,9 +422,10 @@ type TagListOptions struct {
 	SortField TagSortField
 	// SortDesc reverses the natural order of the chosen field.
 	SortDesc bool
-	// Scope filters to tags actually used on the named entity type.
-	// TagScopeAny (or zero value) returns every tag.
-	Scope TagScope
+	// Kind filters to tags of the given kind (item-tags vs file-tags).
+	// models.TagKindAny (the zero value) returns every tag regardless of
+	// kind; the public list/autocomplete handlers require a concrete kind.
+	Kind models.TagKind
 }
 
 // TagUsage is the per-tag breakdown of how many commodity / file rows
@@ -471,12 +439,16 @@ type TagUsage struct {
 // TagStats is the group-wide tag adoption summary that backs the Tags page
 // stats bar. Tagged/untagged counts are derived from the JSONB tags array
 // on commodities + files (presence vs. emptiness, not per-tag breakdown).
+// CommodityTagsTotal / FilesTagsTotal are the per-kind tag counts so each
+// scoped view can show its own total.
 type TagStats struct {
-	TagsTotal     int `json:"tags_total"`
-	ItemsTagged   int `json:"items_tagged"`
-	ItemsUntagged int `json:"items_untagged"`
-	FilesTagged   int `json:"files_tagged"`
-	FilesUntagged int `json:"files_untagged"`
+	TagsTotal          int `json:"tags_total"`
+	CommodityTagsTotal int `json:"commodity_tags_total"`
+	FileTagsTotal      int `json:"file_tags_total"`
+	ItemsTagged        int `json:"items_tagged"`
+	ItemsUntagged      int `json:"items_untagged"`
+	FilesTagged        int `json:"files_tagged"`
+	FilesUntagged      int `json:"files_untagged"`
 }
 
 // TagRegistry is the group-scoped catalogue of tags. The tag-string
@@ -485,53 +457,49 @@ type TagStats struct {
 type TagRegistry interface {
 	Registry[models.Tag]
 
-	// GetBySlug returns a tag by its slug within the current group.
-	// Returns ErrNotFound if no tag with that slug exists.
-	GetBySlug(ctx context.Context, slug string) (*models.Tag, error)
+	// GetBySlug returns a tag by its (kind, slug) within the current group.
+	// Returns ErrNotFound if no tag with that kind+slug exists. The same
+	// slug can exist under two kinds, so kind is required to disambiguate.
+	GetBySlug(ctx context.Context, kind models.TagKind, slug string) (*models.Tag, error)
 
 	// ListPaginated returns paginated tags with optional q-search and
-	// sorting. Pass a zero TagListOptions for "all rows, label asc".
+	// sorting. opts.Kind filters by kind (zero value = all kinds).
 	ListPaginated(ctx context.Context, offset, limit int, opts TagListOptions) ([]*models.Tag, int, error)
 
-	// Search returns tags whose label or slug matches q (case-insensitive
-	// substring), capped at limit. Used by the autocomplete endpoint and
-	// ranked by scope-aware usage desc + recency. Empty q returns the
-	// most-used tags within the requested scope, also capped at limit.
-	//
-	// When scope is TagScopeCommodity or TagScopeFile the result strictly
-	// excludes tags with zero usage in that scope (multi-scope tags that
-	// also have commodity OR file usage in the requested bucket are
-	// included). TagScopeAny ranks by combined commodity+file usage and
-	// includes every tag regardless of whether it has any usage yet.
-	Search(ctx context.Context, q string, limit int, scope TagScope) ([]*models.Tag, error)
+	// Search returns tags of the given kind whose label or slug matches q
+	// (case-insensitive substring), capped at limit. Used by the
+	// autocomplete endpoint and ranked by usage desc + recency. Empty q
+	// returns the most-used tags of that kind, also capped at limit.
+	Search(ctx context.Context, q string, limit int, kind models.TagKind) ([]*models.Tag, error)
 
-	// GetUsage returns the per-entity reference counts for a tag slug
-	// within the current group (commodities + files JSONB arrays
-	// containing this slug).
-	GetUsage(ctx context.Context, slug string) (TagUsage, error)
+	// GetUsage returns the reference count for a tag of the given kind
+	// within the current group (commodities for commodity tags, files for
+	// file tags). The irrelevant side of TagUsage is zero.
+	GetUsage(ctx context.Context, kind models.TagKind, slug string) (TagUsage, error)
 
-	// GetUsageBatch returns per-slug usage for the given slugs in a single
-	// round-trip. Used by the GET /tags?include=usage list endpoint to
-	// avoid N+1 queries when the FE wants per-row usage for the whole
-	// page. Returned map is keyed by slug; missing slugs map to a zero
-	// TagUsage so callers can read it unconditionally.
-	GetUsageBatch(ctx context.Context, slugs []string) (map[string]TagUsage, error)
+	// GetUsageBatch returns per-slug usage for the given slugs of the given
+	// kind in a single round-trip. Used by the GET /tags?include=usage list
+	// endpoint to avoid N+1 queries. Returned map is keyed by slug; missing
+	// slugs map to a zero TagUsage so callers can read it unconditionally.
+	GetUsageBatch(ctx context.Context, kind models.TagKind, slugs []string) (map[string]TagUsage, error)
 
 	// GetStats returns the group-wide adoption summary for the Tags page
-	// stats bar: total tags, plus tagged/untagged counts on commodities
-	// and files. "Tagged" = jsonb_array_length(tags) > 0.
+	// stats bar: total tags (overall + per kind), plus tagged/untagged
+	// counts on commodities and files. "Tagged" = jsonb_array_length(tags) > 0.
 	GetStats(ctx context.Context) (TagStats, error)
 
-	// RewriteSlugReferences atomically rewrites every commodities.tags +
-	// files.tags JSONB array entry from oldSlug to newSlug for the
-	// current group, in the same logical operation as the slug change on
-	// the tags row itself. Returns (commodityRows, fileRows) touched.
-	RewriteSlugReferences(ctx context.Context, oldSlug, newSlug string) (int, int, error)
+	// RewriteSlugReferences atomically rewrites the JSONB array entries from
+	// oldSlug to newSlug for the current group on the table matching kind
+	// (commodities for commodity tags, files for file tags), in the same
+	// logical operation as the slug change on the tags row itself. Returns
+	// (commodityRows, fileRows) touched — only the kind's side is non-zero.
+	RewriteSlugReferences(ctx context.Context, kind models.TagKind, oldSlug, newSlug string) (int, int, error)
 
-	// StripSlugReferences atomically removes every occurrence of slug
-	// from commodities.tags + files.tags JSONB arrays for the current
-	// group. Used by force-delete. Returns (commodityRows, fileRows).
-	StripSlugReferences(ctx context.Context, slug string) (int, int, error)
+	// StripSlugReferences atomically removes every occurrence of slug from
+	// the JSONB array on the table matching kind for the current group.
+	// Used by force-delete. Returns (commodityRows, fileRows) — only the
+	// kind's side is non-zero.
+	StripSlugReferences(ctx context.Context, kind models.TagKind, slug string) (int, int, error)
 
 	// RenameAtomic re-reads the tag, validates the new slug isn't already
 	// owned by another tag, rewrites every JSONB reference, and writes

--- a/go/schema/migrations/_sqldata/1780069224_add_tag_kind.down.sql
+++ b/go/schema/migrations/_sqldata/1780069224_add_tag_kind.down.sql
@@ -1,0 +1,10 @@
+-- Migration rollback
+-- Generated on: 2026-05-29T15:40:24Z
+-- Direction: DOWN
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_group_slug ON tags (group_id, slug);
+DROP INDEX IF EXISTS idx_tags_group_kind_slug;
+-- Remove columns from table: tags --
+-- ALTER statements: --
+ALTER TABLE tags DROP COLUMN kind CASCADE;
+-- WARNING: Dropping column tags.kind with CASCADE - This will delete data and dependent objects! --;

--- a/go/schema/migrations/_sqldata/1780069224_add_tag_kind.up.sql
+++ b/go/schema/migrations/_sqldata/1780069224_add_tag_kind.up.sql
@@ -1,0 +1,9 @@
+-- Migration generated from schema differences
+-- Generated on: 2026-05-29T15:40:24Z
+-- Direction: UP
+
+-- Add/modify columns for table: tags --
+-- ALTER statements: --
+ALTER TABLE tags ADD COLUMN kind TEXT NOT NULL DEFAULT 'commodity';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_group_kind_slug ON tags (group_id, kind, slug);
+DROP INDEX IF EXISTS idx_tags_group_slug;

--- a/go/services/tag_service.go
+++ b/go/services/tag_service.go
@@ -51,7 +51,7 @@ func NewTagService(factorySet *registry.FactorySet) *TagService {
 // the error rather than retrying — the autocomplete UI prevents most
 // realistic races, and the issue body permits this (concurrency target is
 // rename, not auto-create).
-func (s *TagService) EnsureTagsExist(ctx context.Context, slugs []string) (map[string]*models.Tag, error) {
+func (s *TagService) EnsureTagsExist(ctx context.Context, kind models.TagKind, slugs []string) (map[string]*models.Tag, error) {
 	tagReg, err := s.factorySet.TagRegistryFactory.CreateUserRegistry(ctx)
 	if err != nil {
 		return nil, errxtrace.Wrap("failed to create tag registry", err)
@@ -70,7 +70,7 @@ func (s *TagService) EnsureTagsExist(ctx context.Context, slugs []string) (map[s
 		}
 		seen[slug] = struct{}{}
 
-		existing, err := tagReg.GetBySlug(ctx, slug)
+		existing, err := tagReg.GetBySlug(ctx, kind, slug)
 		if err == nil && existing != nil {
 			out[slug] = existing
 			continue
@@ -87,6 +87,7 @@ func (s *TagService) EnsureTagsExist(ctx context.Context, slugs []string) (map[s
 		// what the DEFAULT would have produced.
 		now := time.Now()
 		tag := models.Tag{
+			Kind:      kind,
 			Slug:      slug,
 			Label:     defaultLabelFromSlug(slug),
 			Color:     models.DefaultTagColor,
@@ -115,11 +116,11 @@ func (s *TagService) EnsureTagsExist(ctx context.Context, slugs []string) (map[s
 //
 // Returns an empty slice (never nil) when nothing usable remains, so
 // callers persist `[]` instead of `null` on the JSONB column.
-func (s *TagService) NormalizeAndEnsureSlugs(ctx context.Context, raw []string) ([]string, error) {
+func (s *TagService) NormalizeAndEnsureSlugs(ctx context.Context, kind models.TagKind, raw []string) ([]string, error) {
 	if len(raw) == 0 {
 		return []string{}, nil
 	}
-	tags, err := s.EnsureTagsExist(ctx, raw)
+	tags, err := s.EnsureTagsExist(ctx, kind, raw)
 	if err != nil {
 		return nil, err
 	}

--- a/go/services/tag_service_test.go
+++ b/go/services/tag_service_test.go
@@ -38,7 +38,7 @@ func TestTagService_EnsureTagsExist_AutoCreates(t *testing.T) {
 	ctx, fs := newTagServiceFixture(c)
 	svc := services.NewTagService(fs)
 
-	tags, err := svc.EnsureTagsExist(ctx, []string{"Kitchen", "front office", "kitchen"})
+	tags, err := svc.EnsureTagsExist(ctx, models.TagKindCommodity, []string{"Kitchen", "front office", "kitchen"})
 	c.Assert(err, qt.IsNil)
 	c.Assert(tags, qt.HasLen, 2) // duplicate Kitchen / kitchen folds in
 	c.Assert(tags["kitchen"].Color, qt.Equals, models.DefaultTagColor)
@@ -47,7 +47,7 @@ func TestTagService_EnsureTagsExist_AutoCreates(t *testing.T) {
 	c.Assert(tags["front-office"].Label, qt.Equals, "Front Office")
 
 	// Idempotent — second call returns the same rows.
-	tags2, err := svc.EnsureTagsExist(ctx, []string{"kitchen", "front-office"})
+	tags2, err := svc.EnsureTagsExist(ctx, models.TagKindCommodity, []string{"kitchen", "front-office"})
 	c.Assert(err, qt.IsNil)
 	c.Assert(tags2["kitchen"].ID, qt.Equals, tags["kitchen"].ID)
 	c.Assert(tags2["front-office"].ID, qt.Equals, tags["front-office"].ID)
@@ -58,7 +58,7 @@ func TestTagService_EnsureTagsExist_FiltersEmpty(t *testing.T) {
 	ctx, fs := newTagServiceFixture(c)
 	svc := services.NewTagService(fs)
 
-	tags, err := svc.EnsureTagsExist(ctx, []string{"   ", "###", ""})
+	tags, err := svc.EnsureTagsExist(ctx, models.TagKindCommodity, []string{"   ", "###", ""})
 	c.Assert(err, qt.IsNil)
 	c.Assert(tags, qt.HasLen, 0)
 }
@@ -68,7 +68,7 @@ func TestTagService_NormalizeAndEnsureSlugs(t *testing.T) {
 	ctx, fs := newTagServiceFixture(c)
 	svc := services.NewTagService(fs)
 
-	slugs, err := svc.NormalizeAndEnsureSlugs(ctx, []string{"Kitchen", "Kitchen", "front office"})
+	slugs, err := svc.NormalizeAndEnsureSlugs(ctx, models.TagKindCommodity, []string{"Kitchen", "Kitchen", "front office"})
 	c.Assert(err, qt.IsNil)
 	c.Assert(slugs, qt.HasLen, 2)
 	c.Assert(slugs, qt.Contains, "kitchen")
@@ -80,7 +80,7 @@ func TestTagService_RenameTag_RewritesReferences(t *testing.T) {
 	ctx, fs := newTagServiceFixture(c)
 	svc := services.NewTagService(fs)
 
-	tags, err := svc.EnsureTagsExist(ctx, []string{"kitchen"})
+	tags, err := svc.EnsureTagsExist(ctx, models.TagKindCommodity, []string{"kitchen"})
 	c.Assert(err, qt.IsNil)
 
 	// Seed a commodity referencing the slug.
@@ -112,7 +112,7 @@ func TestTagService_RenameTag_ConflictsWithExistingSlug(t *testing.T) {
 	ctx, fs := newTagServiceFixture(c)
 	svc := services.NewTagService(fs)
 
-	tags, err := svc.EnsureTagsExist(ctx, []string{"kitchen", "bedroom"})
+	tags, err := svc.EnsureTagsExist(ctx, models.TagKindCommodity, []string{"kitchen", "bedroom"})
 	c.Assert(err, qt.IsNil)
 
 	_, err = svc.RenameTag(ctx, tags["kitchen"].ID, "", "bedroom", "")
@@ -125,7 +125,7 @@ func TestTagService_DeleteTag_RefusesWhenInUse(t *testing.T) {
 	ctx, fs := newTagServiceFixture(c)
 	svc := services.NewTagService(fs)
 
-	tags, err := svc.EnsureTagsExist(ctx, []string{"kitchen"})
+	tags, err := svc.EnsureTagsExist(ctx, models.TagKindCommodity, []string{"kitchen"})
 	c.Assert(err, qt.IsNil)
 
 	commodityReg, err := fs.CommodityRegistryFactory.CreateUserRegistry(ctx)
@@ -144,7 +144,7 @@ func TestTagService_DeleteTag_RefusesWhenInUse(t *testing.T) {
 	c.Assert(usage.Files, qt.Equals, 0)
 
 	// Tag still exists.
-	_, err = fs.TagRegistryFactory.MustCreateUserRegistry(ctx).GetBySlug(ctx, "kitchen")
+	_, err = fs.TagRegistryFactory.MustCreateUserRegistry(ctx).GetBySlug(ctx, models.TagKindCommodity, "kitchen")
 	c.Assert(err, qt.IsNil)
 }
 
@@ -153,7 +153,7 @@ func TestTagService_DeleteTag_ForceStripsAndDeletes(t *testing.T) {
 	ctx, fs := newTagServiceFixture(c)
 	svc := services.NewTagService(fs)
 
-	tags, err := svc.EnsureTagsExist(ctx, []string{"kitchen"})
+	tags, err := svc.EnsureTagsExist(ctx, models.TagKindCommodity, []string{"kitchen"})
 	c.Assert(err, qt.IsNil)
 
 	commodityReg, err := fs.CommodityRegistryFactory.CreateUserRegistry(ctx)
@@ -171,7 +171,7 @@ func TestTagService_DeleteTag_ForceStripsAndDeletes(t *testing.T) {
 	c.Assert(usage.Commodities, qt.Equals, 1)
 
 	// Tag is gone.
-	_, err = fs.TagRegistryFactory.MustCreateUserRegistry(ctx).GetBySlug(ctx, "kitchen")
+	_, err = fs.TagRegistryFactory.MustCreateUserRegistry(ctx).GetBySlug(ctx, models.TagKindCommodity, "kitchen")
 	c.Assert(err, qt.IsNotNil)
 
 	// Commodity reference is stripped, other tags preserved.
@@ -185,7 +185,7 @@ func TestTagService_DeleteTag_NoUsage(t *testing.T) {
 	ctx, fs := newTagServiceFixture(c)
 	svc := services.NewTagService(fs)
 
-	tags, err := svc.EnsureTagsExist(ctx, []string{"kitchen"})
+	tags, err := svc.EnsureTagsExist(ctx, models.TagKindCommodity, []string{"kitchen"})
 	c.Assert(err, qt.IsNil)
 
 	usage, err := svc.DeleteTag(ctx, tags["kitchen"].ID, false)


### PR DESCRIPTION
## Summary

- Tags were a single shared catalogue where "item vs file" was only a *usage-derived* scope. They are now **genuinely separate entities** via an intrinsic `kind` column (`commodity` | `file`) on the `tags` table — the same slug can exist once as an item-tag and once as a file-tag.
- The Tags page drops the combined **All** view and switches between **Item tags** / **File tags** with a Files-style icon toggle.

Closes #1928.

## Backend

- **Model** (`go/models/tag.go`): `TagKind` discriminator + `Kind` field; unique index changes from `(group_id, slug)` → `(group_id, kind, slug)`; `Kind` is required + validated.
- **Registry** (`registry.go`, `postgres/tags.go`, `memory/tags.go`): filtering is now intrinsic (`WHERE kind = …`) instead of usage-derived. Usage, rename-cascade, force-delete-strip, auto-create, and advisory-lock keys are all **kind-scoped** (a commodity-tag rename never touches files). `TagStats` gains per-kind totals.
- **Service / attach paths**: `EnsureTagsExist` / `NormalizeAndEnsureSlugs` take a kind; commodity writes pass `commodity`, file writes pass `file` (incl. restore + seed).
- **API** (`apiserver/tags.go`): `?scope=` becomes a **required** `?kind=commodity|file` on list + autocomplete (422 without); create requires `kind`; update is kind-immutable; stats expose per-kind totals. Swagger annotations updated.
- **Migration** (generated): `ALTER TABLE tags ADD COLUMN kind TEXT NOT NULL DEFAULT 'commodity'` + swap the unique index. Existing rows default to `commodity`; file-tags repopulate naturally as files are saved (no backfill — display/stats are unaffected because file tags render from `files.tags` JSONB).

## Frontend

- **Tags page** (`TagsListPage.tsx`): two-button icon switcher (Item tags / File tags) persisted via `?kind=` + `localStorage` (mirrors `FilesListPage`); the combined all-tags preview footer is removed; stats bar shows only the active kind's tiles; create + dup-slug check are kind-scoped.
- `scope` → `kind` across the tags feature (`features/tags/*`, `TagsInput`, commodity/file pickers); the file-edit page gains the previously-missing tag autocomplete (`kind="file"`).

## Verification

- `golangci-lint run --fix` → 0 issues; full Go suite green incl. the **full Postgres registry package run against a real DB** (new `SameSlugDifferentKinds`, kind-scoped cascade, per-kind stats, same-slug-cross-kind rename); migration drift-check (`generate --check`) reports **schema in sync**.
- Frontend: `typecheck`, `eslint`, `prettier --check`, `codegen:check` clean; **1157** vitest tests pass.
- e2e tags spec (create → rename → assign → force-delete) unchanged — default commodity view covers it.

## Out of scope

No backfill CLI; no commodity-list tag filtering; no colored-badge upgrade on commodity detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tags are now kind-scoped (commodity vs file); identical slugs can exist separately per kind.
  * Tags list adds a kind view toggle (commodity vs file).

* **Improvements**
  * Tag stats now show separate commodity and file totals.
  * Autocomplete, search, inline-create and tag inputs respect the active kind.
  * File/item flows and previews are wired to the appropriate kind.

* **Documentation**
  * Localization and API docs updated with kind-related labels and messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->