### PR TITLE
[#1264] SettingsPage: unify dropdown trigger widths to w-52

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -371,7 +371,7 @@ function DefaultGroupSelectorRow() {
         >
           <SelectTrigger
             size="sm"
-            className="w-44"
+            className="w-52"
             aria-label={t("settings:profile.defaultGroup")}
             data-testid="settings-default-group-select"
           >
@@ -517,7 +517,7 @@ function AppearanceSection() {
           <Select value={density} onValueChange={(v) => setDensity(v as Density)}>
             <SelectTrigger
               size="sm"
-              className="w-44"
+              className="w-52"
               data-testid="density-select"
               aria-label={t("settings:appearance.densityLabel")}
             >
@@ -548,7 +548,7 @@ function AppearanceSection() {
           >
             <SelectTrigger
               size="sm"
-              className="w-44"
+              className="w-52"
               data-testid="locale-select"
               aria-label={t("settings:appearance.localeLabel")}
             >
@@ -575,7 +575,7 @@ function AppearanceSection() {
           >
             <SelectTrigger
               size="sm"
-              className="w-44"
+              className="w-52"
               data-testid="default-view-select"
               aria-label={t("settings:appearance.defaultViewLabel")}
             >


### PR DESCRIPTION
Tiny follow-up to #1930 (merged). That PR migrated the settings dropdowns to shadcn `<Select>` but shipped them with **two different trigger widths** — `w-44` for default-group / density / language / default-view, and `w-52` for the longer "Region & formatting". This standardises all five on `w-52`.

- Fits the longest option label ("Auto-detect (browser)") without truncation.
- Removes the self-introduced width inconsistency in the very surface this epic is about (dropdown consistency).
- Pure Tailwind-class change (`w-44` → `w-52` ×4); no behavioural or test impact.

Branched off fresh `master` (#1930 was squash-merged, so the original branch would produce a duplicate diff).

**Verification:** identical change already passed `tsc` / `eslint` / `prettier` / `vitest` locally on the #1930 branch, and was **visually confirmed** via the screenshot pass posted on #1264 (all Appearance + Account dropdowns now share one width). CI re-runs the FE gates here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the width of dropdown selectors in the Settings page for improved visibility and usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1942?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->