### PR TITLE
[#1038] Frontend auth follow-ups: auth-flow doc + tenancy decisions + test gaps

### DIFF
--- a/devdocs/frontend/README.md
+++ b/devdocs/frontend/README.md
@@ -20,6 +20,7 @@ codebase uses.
 | [accessibility.md](accessibility.md) | Focus rings, label/htmlFor, modal a11y, contrast, reduced motion. |
 | [data.md](data.md) | TanStack Query keys, mutations, optimistic updates, cache invalidation. |
 | [routing.md](routing.md) | Adding a route, group context, route guards. |
+| [auth.md](auth.md) | Auth state model, token/session storage, the 401-refresh interceptor, host-based tenancy, route-guard redirects. |
 | [i18n.md](i18n.md) | Adding a translatable string, namespaces, locale fallback, `preservePatterns`. |
 | [imports-and-bans.md](imports-and-bans.md) | Why a dependency is on the no-fly list (next-themes, @base-ui/react, FontAwesome, Bolt artifacts). |
 | [testing.md](testing.md) | Vitest harness, MSW handler factories, jest-axe, coverage thresholds. |

--- a/devdocs/frontend/auth.md
+++ b/devdocs/frontend/auth.md
@@ -1,0 +1,197 @@
+# Authentication
+
+How the React frontend authenticates, stores credentials, refreshes
+sessions, and decides who is signed in. This is the **frontend** view —
+the wire protocol and server-side token lifecycle live in
+[`../REFRESH_TOKEN_SYSTEM.md`](../REFRESH_TOKEN_SYSTEM.md) and
+[`../CSRF_PROTECTION.md`](../CSRF_PROTECTION.md); route-guard placement is in
+[routing.md](routing.md). This doc does not repeat them — it explains how the
+frontend implements its half of the contract.
+
+Source of truth in code:
+
+| Concern | File |
+| --- | --- |
+| Auth state (one source of truth for "who is signed in") | `src/features/auth/AuthContext.tsx` |
+| Credential storage | `src/lib/auth-storage.ts` |
+| Boot-time speculative refresh | `src/features/auth/bootRefresh.ts` |
+| HTTP client (Bearer, CSRF, 401-retry, plane routing) | `src/lib/http.ts` |
+| Auth API calls (login/logout/register/MFA/…) | `src/features/auth/api.ts` |
+| TanStack Query wrappers + keys | `src/features/auth/hooks.ts`, `keys.ts` |
+| Route guards + redirects | `src/components/routing/`, see [routing.md](routing.md) |
+| Login page + error surfacing | `src/pages/auth/LoginPage.tsx` |
+
+## Auth state model
+
+`AuthContext` exposes one source of truth via `useAuth()`. The `user` field is
+**tri-state** — and the third state is the one that matters:
+
+| `user` | Meaning | Guard behavior |
+| --- | --- | --- |
+| `CurrentUser` (object) | Signed in. Only branch where `isAuthenticated` is `true`. | Render the page. |
+| `null` | Definitively signed out — no token, or `/auth/me` returned **401**. | Redirect to `/login`. |
+| `undefined` | **Unknown** — the boot probe hasn't settled, or it errored with a non-401 status (transient 5xx / network blip). | Hold the boot fallback; do **not** bounce to `/login`. |
+
+`isInitialized` is `true` once there is a definitive answer (the probe settled,
+or there was no token to probe with). It stays `false` while the boot refresh is
+in flight and on transient backend errors, so the boot fallback renders instead
+of the login page.
+
+Read these through `useAuth()` (or `useOptionalAuth()` for chrome that mounts in
+both authenticated and bare-boot states). **Never** branch on `useAuth().user`
+inside a page to gate access — wrap the page in `<ProtectedRoute>` so the
+redirect, the `?redirect=` param, and the loading state stay uniform
+([routing.md](routing.md)).
+
+## Token & session handling
+
+Three credentials, three homes:
+
+| Credential | Storage | Accessor | Notes |
+| --- | --- | --- | --- |
+| Access token (short-lived JWT) | `localStorage["inventario_token"]` | `getAccessToken` / `setAccessToken` | Sent as `Authorization: Bearer …`. |
+| CSRF token | `sessionStorage["inventario_csrf_token"]` (+ in-memory cache) | `getCsrfToken` / `setCsrfToken` | Sent as `X-CSRF-Token` on mutating requests. |
+| Refresh token (long-lived) | **httpOnly cookie** (never JS-readable) | — (browser-attached) | Rooted at `/api/v1` (tenant) and `/api/v1/backoffice` (back-office). |
+
+`src/lib/auth-storage.ts` is the only module that touches storage; all access
+goes through it (it also degrades gracefully when storage is unavailable, e.g.
+SSR or a locked-down browser).
+
+### Boot sequence
+
+On startup `AuthProvider` resolves who is signed in:
+
+1. **Token present at mount?** → skip the speculative refresh; go straight to the
+   `/auth/me` probe.
+2. **No token?** → call `tryBootRefresh()` once. This speculatively POSTs
+   `/auth/refresh`; the browser attaches the httpOnly refresh cookie if it
+   exists. This closes the OAuth-callback gap (#1394): the provider 302s the
+   browser back with **no** access token in `localStorage`, only the cookie the
+   backend just minted — without this step the guard would see "no token" and
+   undo the sign-in.
+   - **Success** (200 + `access_token`) → store the token + CSRF, invalidate the
+     `currentUser` query so the `/auth/me` probe fires with the new Bearer token.
+   - **Failure** (401, network error, no cookie) → leave storage empty; the guard
+     bounces to `/login` as normal.
+3. **`/auth/me` probe** (`useCurrentUser`, enabled only when a token is present)
+   resolves the `CurrentUser`. Its outcome drives the tri-state above.
+
+`tryBootRefresh()` is a **one-shot** (module-level `attempted` guard + a
+memoized in-flight promise) so a React StrictMode double-mount doesn't fire two
+refreshes. It never throws — a cold tab with no cookie is a normal "no session
+yet" outcome, not an error.
+
+## HTTP client (`src/lib/http.ts`)
+
+A tiny `fetch` wrapper every feature slice uses through TanStack Query. Per
+request it:
+
+- **Sets `Accept: application/vnd.api+json`** and, for non-GET JSON bodies,
+  `Content-Type: application/vnd.api+json` (FormData uploads keep the browser's
+  multipart boundary).
+- **Attaches the Bearer token** for the request's plane (see below).
+- **Attaches `X-CSRF-Token`** on mutating verbs (`POST`/`PUT`/`PATCH`/`DELETE`).
+  CSRF rides the **header only — never the body**.
+- **Rewrites group-scoped paths**: `/commodities` → `/g/{slug}/commodities` when
+  a group is active (see [routing.md](routing.md) for the group-context slot).
+- **Handles 401 with single-flight refresh-and-retry**: on a 401 it calls the
+  plane's refresh endpoint once (concurrent 401s await the same in-flight
+  promise, so the backend sees one `/auth/refresh`, not N), then retries the
+  original request with the new token. If the refresh fails, it clears auth and
+  redirects to the login surface via `navigateToLogin` (an SPA navigation
+  installed by `AuthProvider`, not a full-page reload).
+- **Surfaces non-2xx as `HttpError`** (`status`, `url`, `data`) so React Query
+  and pages can react. See "Surfacing auth errors" below.
+
+### Non-refreshable auth paths
+
+A 401 on `/auth/login`, `/auth/register`, or `/auth/refresh` (and the
+back-office equivalents) is an **application-level error** — bad credentials or
+an invalid refresh token — not session expiry. The wrapper lists these in
+`NON_REFRESHABLE_AUTH_PATHS` and surfaces the real error body instead of firing
+a doomed refresh loop. This is why a wrong-password login shows an inline error
+rather than silently retrying.
+
+### Plane awareness (tenant vs back-office)
+
+The tenant plane and the back-office plane (`/admin/*`, `/backoffice/*`, gated
+by `RequireBackofficeAuth` since #1785 Phase 6) are **separately credentialed** —
+different access tokens, CSRF tokens, and httpOnly refresh cookies.
+`isBackofficePath()` routes each request to the right plane's credentials and
+refresh endpoint, with an independent single-flight slot per plane, so a 401 on
+`/admin/*` refreshes via `/backoffice/auth/refresh` and never deduplicates
+against a tenant refresh.
+
+### Surfacing auth errors
+
+Pages map an `HttpError` to copy with `parseServerError(err, fallback)`
+(`src/lib/server-error.ts`). `LoginPage` funnels every login failure — 401, 422,
+429, 5xx — through it into the destructive `server-error` Alert; the page stays
+on `/login` and the banner clears as soon as the user edits a field. See
+[forms.md](forms.md) for the broader server-error pattern.
+
+## Route guards & unauthorized redirects
+
+Full guard placement is in [routing.md](routing.md); the auth-relevant summary:
+
+- `<ProtectedRoute>` bounces a signed-out user to
+  `/login?redirect=<path>&reason=auth_required`. It branches on the tri-state
+  `user` (render fallback while `undefined`, redirect while `null`, render
+  children for a `CurrentUser`).
+- The login page reads `?redirect=` and returns the user there after sign-in.
+  `sanitizeRedirectPath()` (`src/lib/safe-redirect.ts`) rejects absolute /
+  protocol-relative targets so a crafted query can't open-redirect off the app.
+- `reason` keys live under `auth:session.*` (`session_expired`, `auth_required`)
+  and render the banner at the top of the login page.
+- A failed refresh from the http client redirects with
+  `reason=session_expired`; a guard redirect uses `reason=auth_required`.
+
+## Login input model — host-based tenancy
+
+**The login request body is `{ email, password }` only. There is no
+`tenantSlug`.** Tenancy is resolved **server-side** from the request host:
+`HostTenantResolver` (`../../go/apiserver/tenant_context.go`) maps the subdomain
+to a tenant (e.g. `acme.inventario.app` → tenant `acme`) before the login
+handler runs, via `PublicTenantMiddleware`. In single-tenant mode (empty base
+domain) the middleware selects the one tenant. The frontend never sends, asks
+for, or displays a tenant identifier at login.
+
+The issue that tracked this (#1038) noted an **optional** per-deployment "tenant
+field on the login form" for installs that don't use subdomains. That field is
+**intentionally not implemented** — the host-based model covers the supported
+deployments, and adding a field would also require backend support to accept it.
+Revisit only if a non-subdomain deployment needs it.
+
+## Tenant UX — intentionally not surfaced
+
+The tenant / organization name is **deliberately not shown** in the regular UI
+(header, user menu, sidebar). This matches the canonical
+[`design-mocks/`](../../design-mocks/), which carry no tenant branding, and the
+host-based model where the subdomain already identifies the org. Tenant identity
+is visible only to system admins on the `/admin/*` pages.
+
+`CurrentUser` (the `/auth/me` payload, `Schema<"models.User">`) carries **no
+tenant-name field**, so surfacing the tenant in the shell would require
+extending that endpoint on the backend **and** a logged deviation in
+[design-deviations.md](design-deviations.md). Neither is in scope today; this is
+a recorded decision, not an oversight.
+
+## MFA (two-step login)
+
+When a user has TOTP enabled, `POST /auth/login` returns **200** with
+`mfa_required: true` + a short-lived `mfa_token` instead of issuing tokens
+(credentials were correct — only the *step* is incomplete). `login()` returns a
+discriminated `LoginOutcome` (`"ok"` | `"mfa_required"`); `LoginPage` swaps the
+password form for `<MFAChallenge>`, which exchanges the `mfa_token` + a TOTP or
+backup code at `POST /auth/login/mfa` for a session. Cancelling drops the
+challenge (the `mfa_token` expires server-side anyway).
+
+## See also
+
+- [`../REFRESH_TOKEN_SYSTEM.md`](../REFRESH_TOKEN_SYSTEM.md) — dual-token model,
+  refresh/revocation/blacklisting, impersonation sessions (backend).
+- [`../CSRF_PROTECTION.md`](../CSRF_PROTECTION.md) — CSRF token issuance and
+  validation (backend).
+- [routing.md](routing.md) — guards, the group-context slot, `?redirect=`.
+- [forms.md](forms.md) — `parseServerError` and server-error surfacing.
+- [testing.md](testing.md) — the MSW auth handlers and `renderWithProviders`.

--- a/devdocs/frontend/auth.md
+++ b/devdocs/frontend/auth.md
@@ -153,7 +153,7 @@ Full guard placement is in [routing.md](routing.md); the auth-relevant summary:
 `HostTenantResolver` (`../../go/apiserver/tenant_context.go`) maps the subdomain
 to a tenant (e.g. `acme.inventario.app` → tenant `acme`) before the login
 handler runs, via `PublicTenantMiddleware`. In single-tenant mode (empty base
-domain) the middleware selects the one tenant. The frontend never sends, asks
+domain) the middleware selects the default tenant. The frontend never sends, asks
 for, or displays a tenant identifier at login.
 
 The issue that tracked this (#1038) noted an **optional** per-deployment "tenant

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Login unhappy-path journey (#1038).
+ *
+ * The happy path + most edge cases are covered by the vitest suite
+ * (frontend/src/pages/auth/__tests__/LoginPage.test.tsx). This e2e asserts
+ * the one journey that's only meaningful against the real backend: a 401 on
+ * POST /api/v1/auth/login surfaces the inline error banner and leaves the
+ * user on /login (no navigation, no token).
+ *
+ * Uses a NON-EXISTENT email on purpose — a wrong password against the seeded
+ * admin could trip the account-lock / rate-limit guard and flake the many
+ * other specs that log in as admin@test-org.com. An unknown email still
+ * returns 401 (the handler records a bad-password login event and rejects)
+ * without touching any real account.
+ */
+
+test.describe('Login — unhappy paths', () => {
+  test('bad credentials show an inline error and keep the user on /login', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByTestId('email').fill('nobody-1038@test-org.com');
+    await page.getByTestId('password').fill('definitely-the-wrong-password');
+
+    const loginResponse = page.waitForResponse(
+      (response) => response.url().includes('/api/v1/auth/login'),
+      { timeout: 20_000 },
+    );
+    await page.getByTestId('login-button').click();
+    expect((await loginResponse).status()).toBe(401);
+
+    // Inline destructive banner appears and we are NOT redirected.
+    await expect(page.getByTestId('server-error')).toBeVisible();
+    await expect(page).toHaveURL(/\/login(\?.*)?$/);
+    expect(await page.evaluate(() => localStorage.getItem('inventario_token'))).toBeNull();
+
+    // Editing a field clears the stale banner (LoginPage resets serverError
+    // on form.watch) — the form is usable again for a retry.
+    await page.getByTestId('password').fill('another-attempt');
+    await expect(page.getByTestId('server-error')).toBeHidden();
+  });
+});

--- a/frontend/src/features/auth/__tests__/AuthContext.test.tsx
+++ b/frontend/src/features/auth/__tests__/AuthContext.test.tsx
@@ -6,6 +6,7 @@ import { screen, waitFor, act } from "@testing-library/react"
 import { server } from "@/test/server"
 import { renderWithProviders } from "@/test/render"
 import { AuthProvider, useAuth } from "@/features/auth/AuthContext"
+import { ProtectedRoute } from "@/components/routing/ProtectedRoute"
 import { __resetBootRefreshForTests } from "@/features/auth/bootRefresh"
 import { __resetGroupContextForTests } from "@/lib/group-context"
 import { __resetHttpForTests } from "@/lib/http"
@@ -145,5 +146,65 @@ describe("useAuth", () => {
     const params = new URLSearchParams(search)
     expect(params.get("reason")).toBe("session_expired")
     expect(params.get("redirect")).toBe("/")
+  })
+
+  // #1038 — a non-401 probe failure (transient 5xx / network blip) is NOT a
+  // logout. AuthContext must hold the boot fallback: user stays `undefined`,
+  // isInitialized stays false, and the user is NOT bounced to /login. (Uses
+  // 500, not 503 — a 503 bounces the whole shell to /maintenance.)
+  it("holds the boot fallback on a transient /auth/me error instead of logging out", async () => {
+    let meCalls = 0
+    setAccessToken("good-token")
+    server.use(
+      msw.get(api("/auth/me"), () => {
+        meCalls++
+        return HttpResponse.json({ error: "boom" }, { status: 500 })
+      })
+    )
+    renderWithProviders({ initialPath: "/", routes })
+    await waitFor(() => expect(meCalls).toBeGreaterThan(0))
+    await waitFor(() => {
+      const probe = screen.getByTestId("probe")
+      expect(probe.getAttribute("data-initialized")).toBe("false")
+      expect(probe.getAttribute("data-authenticated")).toBe("false")
+    })
+    // Transient error must not redirect — the probe is still mounted.
+    expect(screen.queryByTestId("login-stub")).not.toBeInTheDocument()
+  })
+
+  // #1038 — logging out clears stored credentials and, on a guarded route,
+  // drops the user to `null` so ProtectedRoute redirects to /login.
+  it("clears credentials and redirects a guarded route to /login on logout", async () => {
+    setAccessToken("good-token")
+    server.use(
+      msw.get(api("/auth/me"), () =>
+        HttpResponse.json({ id: "u1", email: "denis@example.com", name: "Denis" })
+      ),
+      msw.post(api("/auth/logout"), () => new HttpResponse(null, { status: 204 }))
+    )
+    const guardedRoutes = (
+      <>
+        <Route
+          path="/"
+          element={
+            <AuthProvider>
+              <ProtectedRoute fallback={<div data-testid="boot" />}>
+                <Probe />
+              </ProtectedRoute>
+            </AuthProvider>
+          }
+        />
+        <Route path="/login" element={<LoginEcho />} />
+      </>
+    )
+    renderWithProviders({ initialPath: "/", routes: guardedRoutes })
+    await waitFor(() =>
+      expect(screen.getByTestId("probe").getAttribute("data-authenticated")).toBe("true")
+    )
+    await act(async () => {
+      screen.getByRole("button", { name: /sign out/i }).click()
+    })
+    await waitFor(() => expect(screen.getByTestId("login-stub")).toBeInTheDocument())
+    expect(getAccessToken()).toBeNull()
   })
 })

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -61,6 +61,12 @@ interface LoginMFAChallengeBody {
 // login persists the access + CSRF tokens before resolving so the very next
 // /auth/me probe sees them.
 //
+// Tenancy is HOST-BASED: the request body carries only { email, password } —
+// no tenantSlug. The backend's HostTenantResolver derives the tenant from the
+// request host (subdomain) before this handler runs, so the frontend never
+// sends or asks for a tenant identifier. See devdocs/frontend/auth.md
+// ("Login input model — host-based tenancy") and go/apiserver/tenant_context.go.
+//
 // When MFA is enabled the backend returns 200 with `mfa_required: true`
 // instead of issuing tokens. We disambiguate via the field rather than
 // HTTP status because credentials were correct — it's the *step* that

--- a/frontend/src/pages/auth/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/auth/__tests__/LoginPage.test.tsx
@@ -104,6 +104,64 @@ describe("<LoginPage />", () => {
     expect(await screen.findByTestId("server-error")).toHaveTextContent(/invalid credentials/i)
   })
 
+  // Unhappy paths beyond 401 (#1038). Every login failure funnels through
+  // parseServerError into the same destructive banner and the page stays on
+  // /login — none of these trigger a refresh-and-retry (/auth/login is a
+  // NON_REFRESHABLE_AUTH_PATH) or a navigation.
+  it("surfaces a 422 validation error from the JSON:API envelope", async () => {
+    server.use(
+      msw.post(api("/auth/login"), () =>
+        HttpResponse.json(
+          { errors: [{ detail: "Email and password are required" }] },
+          { status: 422 }
+        )
+      )
+    )
+    const user = userEvent.setup()
+    renderLogin()
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.type(screen.getByTestId("password"), "secret-pw")
+    await user.click(screen.getByTestId("login-button"))
+    expect(await screen.findByTestId("server-error")).toHaveTextContent(
+      /email and password are required/i
+    )
+    // Still on the login page — no token stored, no navigation away.
+    expect(screen.getByTestId("login-page")).toBeInTheDocument()
+    expect(getAccessToken()).toBeNull()
+  })
+
+  it("surfaces a 429 rate-limit error inline", async () => {
+    server.use(
+      msw.post(api("/auth/login"), () =>
+        HttpResponse.json(
+          { error: "Too many attempts. Please wait and try again." },
+          { status: 429 }
+        )
+      )
+    )
+    const user = userEvent.setup()
+    renderLogin()
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.type(screen.getByTestId("password"), "secret-pw")
+    await user.click(screen.getByTestId("login-button"))
+    expect(await screen.findByTestId("server-error")).toHaveTextContent(/too many attempts/i)
+    expect(screen.getByTestId("login-page")).toBeInTheDocument()
+  })
+
+  it("falls back to generic copy when a 5xx returns an opaque body", async () => {
+    // 500 (not 503 — a 503 bounces the shell to /maintenance) with no useful
+    // body: parseServerError can extract nothing, so the page shows the
+    // generic auth:login.errorGeneric copy rather than an empty banner.
+    server.use(msw.post(api("/auth/login"), () => new HttpResponse(null, { status: 500 })))
+    const user = userEvent.setup()
+    renderLogin()
+    await user.type(screen.getByTestId("email"), "alex@example.com")
+    await user.type(screen.getByTestId("password"), "secret-pw")
+    await user.click(screen.getByTestId("login-button"))
+    expect(await screen.findByTestId("server-error")).toHaveTextContent(/sign-in failed/i)
+    expect(screen.getByTestId("login-page")).toBeInTheDocument()
+  })
+
   it("auto-accepts a pending invite after successful login", async () => {
     savePendingInvite({ token: "inv-tok", groupName: "Household" })
     let acceptCalls = 0

--- a/frontend/src/pages/auth/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/auth/__tests__/LoginPage.test.tsx
@@ -107,7 +107,7 @@ describe("<LoginPage />", () => {
   // Unhappy paths beyond 401 (#1038). Every login failure funnels through
   // parseServerError into the same destructive banner and the page stays on
   // /login — none of these trigger a refresh-and-retry (/auth/login is a
-  // NON_REFRESHABLE_AUTH_PATH) or a navigation.
+  // NON_REFRESHABLE_AUTH_PATHS entry) or a navigation.
   it("surfaces a 422 validation error from the JSON:API envelope", async () => {
     server.use(
       msw.post(api("/auth/login"), () =>


### PR DESCRIPTION
Closes #1038.

## Context

#1038 aggregates the leftover Phase-5 follow-ups from #433 (multi-tenant frontend auth). The issue was written for the old **Vue/Pinia** frontend (`stores/authStore.ts`), but the frontend has since been rewritten to **React 19 + Tailwind v4 + shadcn/ui** (#1397). The core auth flow — store/context, login/logout, session restore, router guards, HTTP token/refresh/CSRF wiring — is **already implemented** in React. So the remaining work is to **record the open decisions in docs** and **fill targeted test gaps**, not to build new features.

Settled decisions (per discussion):

1. **Tenant UX** — *document, don't display.* Tenant/org name is intentionally not surfaced in the regular UI: it matches the canonical `design-mocks/`, the host-based model already identifies the org via subdomain, and `/auth/me` (`models.User`) carries no tenant-name field. No backend change, no design-deviation entry.
2. **Login input model** — *document host-based resolution only.* The login body is `{ email, password }`; tenancy is resolved server-side from the request host by `HostTenantResolver`. The optional per-deployment "tenant field" is intentionally **not** built.
3. **Test coverage** — fill the high-value gaps (existing auth coverage was already substantial).

## Changes

| File | What |
|---|---|
| `devdocs/frontend/auth.md` *(new)* | Frontend auth-flow doc: tri-state auth model, token/session storage (access→localStorage, CSRF→sessionStorage, refresh→httpOnly cookie), boot-refresh, the 401 single-flight refresh interceptor, plane awareness, route-guard redirects, **host-based tenancy** and the **tenant-UX decision**. Cross-references `REFRESH_TOKEN_SYSTEM.md` / `CSRF_PROTECTION.md` / `routing.md` rather than duplicating them. |
| `devdocs/frontend/README.md` | Added the `auth.md` row to the doc index. |
| `frontend/src/features/auth/api.ts` | Comment at `login()` documenting host-based tenant resolution (no `tenantSlug`). |
| `frontend/src/pages/auth/__tests__/LoginPage.test.tsx` | +3 unhappy-path tests: server **422** (JSON:API detail), **429** (rate-limit), **5xx** → generic fallback. Each asserts the inline `server-error` banner and that the page stays on `/login`. |
| `frontend/src/features/auth/__tests__/AuthContext.test.tsx` | +2 tests: a transient **500** on `/auth/me` holds the boot fallback (`user` stays `undefined`, no redirect); a guarded **logout** clears credentials and redirects to `/login`. |
| `e2e/tests/login.spec.ts` *(new)* | Bad-credentials Playwright journey: 401 → inline error, stays on `/login`, no token, banner clears on edit. Uses a non-existent email so it never locks the seeded admin. |

## Verification

- **Prettier** `--check` ✓ · **ESLint** ✓ · **tsc** (frontend + e2e) ✓
- **Vitest**: full suite **1109 passed**; the 5 new tests included. (4 `pdfjs-dist` suites initially failed to *load* under a `node_modules`-symlink fs-allowlist artifact during local setup; reconfirmed green after a real install.)
- **E2E `login.spec.ts`**: type-checked and pattern-consistent; not executed against the live docker-compose stack locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive frontend authentication guide covering auth state, token/CSRF handling, refresh behavior, error mapping, route-guard redirects, tenancy notes, MFA, and cross-references.
  * Updated docs index to reference the new authentication guide.

* **Tests**
  * Added e2e and unit tests for login failure and logout scenarios, covering 401/422/429/500 responses, inline error banners, no token storage, and redirect behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->