### PR TITLE
[#1943] infra: stable JWT + file-signing + OAuth-state keys from the sops bundle (master + longevity)

### DIFF
--- a/infra/SECRETS.md
+++ b/infra/SECRETS.md
@@ -16,7 +16,10 @@ encrypted bundle is committed to the repo. `bootstrap.sh` decrypts it locally
 on the laptop, ships the plaintext to the VM tmpfs, and `apply-secrets.sh`
 turns the JSON into the admin / repo-creds / OAuth Kubernetes Secrets
 (`inv-vcl01-master` + `inv-vcl01-longevity` `inventario-admin`,
-`argocd/github-app-creds`, `tailscale/operator-oauth`). When the `velero.*`
+`argocd/github-app-creds`, `tailscale/operator-oauth`). The `inventario-admin`
+Secret carries the admin seed password and, when `jwt.secret` is set, a stable
+`INVENTARIO_RUN_JWT_SECRET` so sessions and back-office MFA survive restarts
+(see §4b). When the `velero.*`
 keys are filled, `vm-install.sh` additionally materializes
 `velero/cloud-credentials` (R2 API token) and `velero/velero-repo-credentials`
 (the kopia repo password) at install time — see "Velero / Cloudflare R2" below.
@@ -223,6 +226,37 @@ openssl rand -base64 24
 
 Stash both for "Filling the bundle".
 
+### 4b. Generate the stable JWT secret (recommended for master + longevity)
+
+The `jwt.secret` field pins the apiserver's token-signing key on the two
+persistent envs. `apply-secrets.sh` writes it into the same
+`inventario-admin` Secret under key `INVENTARIO_RUN_JWT_SECRET`, and the chart
+loads the whole Secret via `envFrom`, so the apiserver signs tokens with it.
+
+Why it matters: when `jwt.secret` is empty, each apiserver pod generates a
+fresh **random** secret at startup (`getJWTSecret()` in
+`go/cmd/inventario/run/bootstrap/crypto.go`). On a long-lived env that means
+**every redeploy logs everyone out**, and — because the back-office (super-admin)
+auth plane encrypts each operator's TOTP secret with an HKDF subkey of this
+value — **a back-office MFA enrollment becomes undecryptable after the next
+restart**, so an operator can never complete a durable enrollment and is locked
+out of `/backoffice/login`.
+
+It is optional (an absent value just keeps the ephemeral fallback, and
+`apply-secrets.sh` warns rather than fails), but set it for master/longevity:
+
+```bash
+# 64 hex chars — accepted as-is; set once, never rotate casually
+openssl rand -hex 32
+```
+
+Rotating it later is a deliberate act: it logs every session out and
+invalidates existing back-office MFA enrollments (re-run
+`inventario backoffice mfa setup` afterwards). Per-PR previews are not covered
+— they stay on the ephemeral per-pod secret by design.
+
+Stash it for "Filling the bundle".
+
 ### 5. Optional: Tailscale auth-key (for `make recover` on a fresh VM)
 
 vcluster-dev is already authenticated to your tailnet, so `make bootstrap`
@@ -294,7 +328,8 @@ cd <repo-root>
 cp infra/vm/secrets/secrets.example.yaml infra/vm/secrets/secrets.local.yaml
 chmod 600 infra/vm/secrets/secrets.local.yaml
 
-# 2. Fill in real values — admin.{email,password},
+# 2. Fill in real values — admin.{email,password}, jwt.secret (step 4b;
+#    recommended for master + longevity, optional),
 #    tailscale.{auth_key, oauth_client_id, oauth_client_secret, tailnet_name},
 #    github.{app_id, app_installation_id, app_private_key, url}.
 #    Fill the velero.* block (step 6 above) ONLY if you want the daily R2

--- a/infra/SECRETS.md
+++ b/infra/SECRETS.md
@@ -17,10 +17,10 @@ on the laptop, ships the plaintext to the VM tmpfs, and `apply-secrets.sh`
 turns the JSON into the admin / repo-creds / OAuth Kubernetes Secrets
 (`inv-vcl01-master` + `inv-vcl01-longevity` `inventario-admin`,
 `argocd/github-app-creds`, `tailscale/operator-oauth`). The `inventario-admin`
-Secret carries the admin seed password and, when `jwt.secret` / `file_signing.key`
-are set, stable `INVENTARIO_RUN_JWT_SECRET` / `INVENTARIO_RUN_FILE_SIGNING_KEY`
-so sessions, back-office MFA, and signed file URLs survive restarts (see §4b).
-When the `velero.*`
+Secret carries the admin seed password and, when the optional `jwt.secret` /
+`file_signing.key` / `oauth_state.key` fields are set, the matching stable
+signing keys so sessions, back-office MFA, signed file URLs, and in-flight
+OAuth sign-ins survive restarts (see §4b). When the `velero.*`
 keys are filled, `vm-install.sh` additionally materializes
 `velero/cloud-credentials` (R2 API token) and `velero/velero-repo-credentials`
 (the kopia repo password) at install time — see "Velero / Cloudflare R2" below.
@@ -229,17 +229,20 @@ Stash both for "Filling the bundle".
 
 ### 4b. Generate the stable signing keys (recommended for master + longevity)
 
-Two runtime keys pin the apiserver's signing material on the persistent envs.
+Three runtime keys pin the apiserver's signing material on the persistent envs.
 `apply-secrets.sh` writes each into the same `inventario-admin` Secret, and the
 chart loads the whole Secret via `envFrom`:
 
 - **`jwt.secret`** → `INVENTARIO_RUN_JWT_SECRET` — signs auth tokens.
 - **`file_signing.key`** → `INVENTARIO_RUN_FILE_SIGNING_KEY` — signs time-limited
   file-download URLs.
+- **`oauth_state.key`** → `INVENTARIO_RUN_OAUTH_STATE_KEY` — signs the OAuth
+  `state` parameter during social sign-in.
 
 Why they matter: when a field is empty, each apiserver pod generates a fresh
-**random** value at startup (`getJWTSecret()` / `getFileSigningKey()` in
-`go/cmd/inventario/run/bootstrap/crypto.go`). On a long-lived env:
+**random** value at startup (`getJWTSecret()` / `getFileSigningKey()` /
+`getOAuthStateKey()` in `go/cmd/inventario/run/bootstrap/crypto.go`). On a
+long-lived env:
 
 - An ephemeral **JWT secret** logs **everyone out on every redeploy**, and —
   because the back-office (super-admin) plane encrypts each operator's TOTP
@@ -249,8 +252,11 @@ Why they matter: when a field is empty, each apiserver pod generates a fresh
 - An ephemeral **file-signing key** invalidates previously-issued signed
   file-download URLs on every restart (the SPA re-fetches them, so it mostly
   self-heals, but bookmarked / in-flight links break).
+- An ephemeral **OAuth state key** fails state validation for any OAuth
+  sign-in that began before a restart/redeploy or lands on a different replica
+  after the provider redirect (only relevant when OAuth sign-in is enabled).
 
-Both are optional (an absent value keeps the ephemeral fallback, and
+All three are optional (an absent value keeps the ephemeral fallback, and
 `apply-secrets.sh` warns rather than fails). Generate each once and keep it
 stable:
 
@@ -258,6 +264,7 @@ stable:
 # one value per field — 64 hex chars each; set once, don't rotate casually
 openssl rand -hex 32   # -> jwt.secret
 openssl rand -hex 32   # -> file_signing.key
+openssl rand -hex 32   # -> oauth_state.key
 ```
 
 Rotating `jwt.secret` later is a deliberate act: it logs every session out and
@@ -265,7 +272,7 @@ invalidates existing back-office MFA enrollments (re-run
 `inventario backoffice mfa setup` afterwards). Per-PR previews are not covered —
 they stay on the ephemeral per-pod values by design.
 
-Stash both for "Filling the bundle".
+Stash all three for "Filling the bundle".
 
 ### 5. Optional: Tailscale auth-key (for `make recover` on a fresh VM)
 
@@ -339,7 +346,8 @@ cp infra/vm/secrets/secrets.example.yaml infra/vm/secrets/secrets.local.yaml
 chmod 600 infra/vm/secrets/secrets.local.yaml
 
 # 2. Fill in real values — admin.{email,password}, jwt.secret +
-#    file_signing.key (step 4b; recommended for master + longevity, optional),
+#    file_signing.key + oauth_state.key (step 4b; recommended for
+#    master + longevity, optional),
 #    tailscale.{auth_key, oauth_client_id, oauth_client_secret, tailnet_name},
 #    github.{app_id, app_installation_id, app_private_key, url}.
 #    Fill the velero.* block (step 6 above) ONLY if you want the daily R2

--- a/infra/SECRETS.md
+++ b/infra/SECRETS.md
@@ -17,9 +17,10 @@ on the laptop, ships the plaintext to the VM tmpfs, and `apply-secrets.sh`
 turns the JSON into the admin / repo-creds / OAuth Kubernetes Secrets
 (`inv-vcl01-master` + `inv-vcl01-longevity` `inventario-admin`,
 `argocd/github-app-creds`, `tailscale/operator-oauth`). The `inventario-admin`
-Secret carries the admin seed password and, when `jwt.secret` is set, a stable
-`INVENTARIO_RUN_JWT_SECRET` so sessions and back-office MFA survive restarts
-(see §4b). When the `velero.*`
+Secret carries the admin seed password and, when `jwt.secret` / `file_signing.key`
+are set, stable `INVENTARIO_RUN_JWT_SECRET` / `INVENTARIO_RUN_FILE_SIGNING_KEY`
+so sessions, back-office MFA, and signed file URLs survive restarts (see §4b).
+When the `velero.*`
 keys are filled, `vm-install.sh` additionally materializes
 `velero/cloud-credentials` (R2 API token) and `velero/velero-repo-credentials`
 (the kopia repo password) at install time — see "Velero / Cloudflare R2" below.
@@ -226,36 +227,45 @@ openssl rand -base64 24
 
 Stash both for "Filling the bundle".
 
-### 4b. Generate the stable JWT secret (recommended for master + longevity)
+### 4b. Generate the stable signing keys (recommended for master + longevity)
 
-The `jwt.secret` field pins the apiserver's token-signing key on the two
-persistent envs. `apply-secrets.sh` writes it into the same
-`inventario-admin` Secret under key `INVENTARIO_RUN_JWT_SECRET`, and the chart
-loads the whole Secret via `envFrom`, so the apiserver signs tokens with it.
+Two runtime keys pin the apiserver's signing material on the persistent envs.
+`apply-secrets.sh` writes each into the same `inventario-admin` Secret, and the
+chart loads the whole Secret via `envFrom`:
 
-Why it matters: when `jwt.secret` is empty, each apiserver pod generates a
-fresh **random** secret at startup (`getJWTSecret()` in
-`go/cmd/inventario/run/bootstrap/crypto.go`). On a long-lived env that means
-**every redeploy logs everyone out**, and — because the back-office (super-admin)
-auth plane encrypts each operator's TOTP secret with an HKDF subkey of this
-value — **a back-office MFA enrollment becomes undecryptable after the next
-restart**, so an operator can never complete a durable enrollment and is locked
-out of `/backoffice/login`.
+- **`jwt.secret`** → `INVENTARIO_RUN_JWT_SECRET` — signs auth tokens.
+- **`file_signing.key`** → `INVENTARIO_RUN_FILE_SIGNING_KEY` — signs time-limited
+  file-download URLs.
 
-It is optional (an absent value just keeps the ephemeral fallback, and
-`apply-secrets.sh` warns rather than fails), but set it for master/longevity:
+Why they matter: when a field is empty, each apiserver pod generates a fresh
+**random** value at startup (`getJWTSecret()` / `getFileSigningKey()` in
+`go/cmd/inventario/run/bootstrap/crypto.go`). On a long-lived env:
+
+- An ephemeral **JWT secret** logs **everyone out on every redeploy**, and —
+  because the back-office (super-admin) plane encrypts each operator's TOTP
+  secret with an HKDF subkey of it — makes a back-office MFA enrollment
+  **undecryptable after the next restart**, locking operators out of
+  `/backoffice/login`.
+- An ephemeral **file-signing key** invalidates previously-issued signed
+  file-download URLs on every restart (the SPA re-fetches them, so it mostly
+  self-heals, but bookmarked / in-flight links break).
+
+Both are optional (an absent value keeps the ephemeral fallback, and
+`apply-secrets.sh` warns rather than fails). Generate each once and keep it
+stable:
 
 ```bash
-# 64 hex chars — accepted as-is; set once, never rotate casually
-openssl rand -hex 32
+# one value per field — 64 hex chars each; set once, don't rotate casually
+openssl rand -hex 32   # -> jwt.secret
+openssl rand -hex 32   # -> file_signing.key
 ```
 
-Rotating it later is a deliberate act: it logs every session out and
+Rotating `jwt.secret` later is a deliberate act: it logs every session out and
 invalidates existing back-office MFA enrollments (re-run
-`inventario backoffice mfa setup` afterwards). Per-PR previews are not covered
-— they stay on the ephemeral per-pod secret by design.
+`inventario backoffice mfa setup` afterwards). Per-PR previews are not covered —
+they stay on the ephemeral per-pod values by design.
 
-Stash it for "Filling the bundle".
+Stash both for "Filling the bundle".
 
 ### 5. Optional: Tailscale auth-key (for `make recover` on a fresh VM)
 
@@ -328,8 +338,8 @@ cd <repo-root>
 cp infra/vm/secrets/secrets.example.yaml infra/vm/secrets/secrets.local.yaml
 chmod 600 infra/vm/secrets/secrets.local.yaml
 
-# 2. Fill in real values — admin.{email,password}, jwt.secret (step 4b;
-#    recommended for master + longevity, optional),
+# 2. Fill in real values — admin.{email,password}, jwt.secret +
+#    file_signing.key (step 4b; recommended for master + longevity, optional),
 #    tailscale.{auth_key, oauth_client_id, oauth_client_secret, tailnet_name},
 #    github.{app_id, app_installation_id, app_private_key, url}.
 #    Fill the velero.* block (step 6 above) ONLY if you want the daily R2

--- a/infra/argocd/applicationset-master.yaml
+++ b/infra/argocd/applicationset-master.yaml
@@ -100,12 +100,13 @@ spec:
               # SETUP_ADMIN_PASSWORD from it; runtime workloads slurp the
               # rest of envFrom unchanged (the demo.* stack provides DSNs
               # inline via the deployment's env: block). When the bundle
-              # provides jwt.secret / file_signing.key, the same Secret also
-              # carries INVENTARIO_RUN_JWT_SECRET / INVENTARIO_RUN_FILE_SIGNING_KEY
-              # so the apiserver's token-signing key (durable sessions +
-              # back-office MFA enrollment) and file-URL signing key are stable
-              # across restarts (#1943); absent either, the apiserver falls back
-              # to a random per-restart value for that key.
+              # provides jwt.secret / file_signing.key / oauth_state.key, the
+              # same Secret also carries the matching INVENTARIO_RUN_JWT_SECRET /
+              # INVENTARIO_RUN_FILE_SIGNING_KEY / INVENTARIO_RUN_OAUTH_STATE_KEY
+              # so the apiserver's signing material (durable sessions +
+              # back-office MFA, signed file URLs, in-flight OAuth state) is
+              # stable across restarts (#1943); absent any, the apiserver falls
+              # back to a random per-restart value for that key.
               secrets:
                 existingSecret: inventario-admin
               ingress:

--- a/infra/argocd/applicationset-master.yaml
+++ b/infra/argocd/applicationset-master.yaml
@@ -100,13 +100,12 @@ spec:
               # SETUP_ADMIN_PASSWORD from it; runtime workloads slurp the
               # rest of envFrom unchanged (the demo.* stack provides DSNs
               # inline via the deployment's env: block). When the bundle
-              # provides jwt.secret, the same Secret also carries
-              # INVENTARIO_RUN_JWT_SECRET so the apiserver's token-signing key
-              # is stable across restarts — required for durable sessions and
-              # back-office MFA enrollment (#1943); absent it, the apiserver
-              # falls back to a random per-restart secret. The file-signing key
-              # stays ephemeral (only affects signed file-download URLs, which
-              # the SPA re-fetches).
+              # provides jwt.secret / file_signing.key, the same Secret also
+              # carries INVENTARIO_RUN_JWT_SECRET / INVENTARIO_RUN_FILE_SIGNING_KEY
+              # so the apiserver's token-signing key (durable sessions +
+              # back-office MFA enrollment) and file-URL signing key are stable
+              # across restarts (#1943); absent either, the apiserver falls back
+              # to a random per-restart value for that key.
               secrets:
                 existingSecret: inventario-admin
               ingress:

--- a/infra/argocd/applicationset-master.yaml
+++ b/infra/argocd/applicationset-master.yaml
@@ -99,10 +99,14 @@ spec:
               # the encrypted bundle. The chart's setup Job reads
               # SETUP_ADMIN_PASSWORD from it; runtime workloads slurp the
               # rest of envFrom unchanged (the demo.* stack provides DSNs
-              # inline via the deployment's env: block, and JWT/file-signing
-              # keys are intentionally ephemeral on master — same behavior
-              # as the pre-#1883 chart-generated Secret, where these values
-              # were empty strings).
+              # inline via the deployment's env: block). When the bundle
+              # provides jwt.secret, the same Secret also carries
+              # INVENTARIO_RUN_JWT_SECRET so the apiserver's token-signing key
+              # is stable across restarts — required for durable sessions and
+              # back-office MFA enrollment (#1943); absent it, the apiserver
+              # falls back to a random per-restart secret. The file-signing key
+              # stays ephemeral (only affects signed file-download URLs, which
+              # the SPA re-fetches).
               secrets:
                 existingSecret: inventario-admin
               ingress:

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -88,6 +88,13 @@ ADMIN_PASSWORD=$(lookup "admin.password")
 JWT_SECRET=$(lookup "jwt.secret")
 if [ -z "$JWT_SECRET" ]; then
     warn "jwt.secret missing in secrets bundle; inv-vcl01-master/longevity will use an EPHEMERAL per-restart JWT secret (every redeploy logs users out and back-office MFA enrollment won't survive a restart). Set jwt.secret to make it stable."
+elif [ "${#JWT_SECRET}" -lt 32 ]; then
+    # getJWTSecret() only accepts >=32 chars (plaintext) or >=64 hex chars;
+    # anything shorter is silently ignored and a random per-restart secret is
+    # generated. Drop it so we fall through to the ephemeral fallback loudly
+    # rather than injecting a value the apiserver will discard.
+    warn "jwt.secret is shorter than 32 chars; the apiserver ignores it and generates a random per-restart secret. Treating it as unset — use 'openssl rand -hex 32'."
+    JWT_SECRET=""
 fi
 # Optional file-URL signing key for the persistent envs, same scheme as
 # jwt.secret above. Absent it, signed file-download URLs break after a restart
@@ -95,6 +102,9 @@ fi
 FILE_SIGNING_KEY=$(lookup "file_signing.key")
 if [ -z "$FILE_SIGNING_KEY" ]; then
     warn "file_signing.key missing in secrets bundle; inv-vcl01-master/longevity will use an EPHEMERAL per-restart file-signing key (previously-issued signed file-download URLs stop validating after a redeploy). Set file_signing.key to make it stable."
+elif [ "${#FILE_SIGNING_KEY}" -lt 32 ]; then
+    warn "file_signing.key is shorter than 32 chars; the apiserver ignores it and generates a random per-restart key. Treating it as unset — use 'openssl rand -hex 32'."
+    FILE_SIGNING_KEY=""
 fi
 # Optional OAuth state-signing key for the persistent envs, same scheme. Only
 # matters when OAuth sign-in is enabled; absent it, an in-flight OAuth flow that
@@ -102,6 +112,9 @@ fi
 OAUTH_STATE_KEY=$(lookup "oauth_state.key")
 if [ -z "$OAUTH_STATE_KEY" ]; then
     warn "oauth_state.key missing in secrets bundle; inv-vcl01-master/longevity will use an EPHEMERAL per-restart OAuth state key (an OAuth sign-in spanning a redeploy/replica fails state validation). Set oauth_state.key to make it stable."
+elif [ "${#OAUTH_STATE_KEY}" -lt 32 ]; then
+    warn "oauth_state.key is shorter than 32 chars; the apiserver ignores it and generates a random per-restart key. Treating it as unset — use 'openssl rand -hex 32'."
+    OAUTH_STATE_KEY=""
 fi
 ADMIN_MISSING=0
 if [ -z "$ADMIN_PASSWORD" ]; then

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -59,15 +59,16 @@ remote_apply() {
 # install (idempotent thereafter — the password is the seed value, not a
 # runtime credential).
 #
-# When the bundle also provides `jwt.secret` and/or `file_signing.key`, this
-# same Secret additionally carries `INVENTARIO_RUN_JWT_SECRET` and
-# `INVENTARIO_RUN_FILE_SIGNING_KEY`, pinning the apiserver's token-signing key
-# (sessions + back-office MFA) and file-URL signing key across restarts (#1943).
-# The chart loads the whole Secret via `envFrom`, so the keys reach the
-# apiserver as-is — no chart change needed. Both are OPTIONAL: an absent value
-# leaves the apiserver on its random per-restart fallback (JWT: every redeploy
-# logs users out and back-office MFA enrollment becomes undecryptable;
-# file-signing: previously-issued signed file-download URLs stop validating).
+# When the bundle provides any of `jwt.secret`, `file_signing.key`, or
+# `oauth_state.key`, this same Secret additionally carries the matching
+# `INVENTARIO_RUN_JWT_SECRET` / `INVENTARIO_RUN_FILE_SIGNING_KEY` /
+# `INVENTARIO_RUN_OAUTH_STATE_KEY`, pinning the apiserver's signing material
+# across restarts (#1943). The chart loads the whole Secret via `envFrom`, so
+# the keys reach the apiserver as-is — no chart change needed. All are OPTIONAL;
+# an absent value leaves that key on the apiserver's random per-restart fallback
+# (JWT: every redeploy logs users out and back-office MFA enrollment becomes
+# undecryptable; file-signing: previously-issued signed file-download URLs stop
+# validating; oauth-state: an in-flight OAuth sign-in fails state validation).
 #
 # Per-PR preview namespaces (`inv-vcl01-pr{N}`) are created dynamically by
 # ArgoCD and so are NOT covered here; their ApplicationSet template
@@ -94,6 +95,13 @@ fi
 FILE_SIGNING_KEY=$(lookup "file_signing.key")
 if [ -z "$FILE_SIGNING_KEY" ]; then
     warn "file_signing.key missing in secrets bundle; inv-vcl01-master/longevity will use an EPHEMERAL per-restart file-signing key (previously-issued signed file-download URLs stop validating after a redeploy). Set file_signing.key to make it stable."
+fi
+# Optional OAuth state-signing key for the persistent envs, same scheme. Only
+# matters when OAuth sign-in is enabled; absent it, an in-flight OAuth flow that
+# crosses a restart/replica fails state validation. Warn, don't fail.
+OAUTH_STATE_KEY=$(lookup "oauth_state.key")
+if [ -z "$OAUTH_STATE_KEY" ]; then
+    warn "oauth_state.key missing in secrets bundle; inv-vcl01-master/longevity will use an EPHEMERAL per-restart OAuth state key (an OAuth sign-in spanning a redeploy/replica fails state validation). Set oauth_state.key to make it stable."
 fi
 ADMIN_MISSING=0
 if [ -z "$ADMIN_PASSWORD" ]; then
@@ -135,6 +143,12 @@ EOF
                 cat <<EOF
   INVENTARIO_RUN_FILE_SIGNING_KEY: |-
 $(printf '%s' "$FILE_SIGNING_KEY" | sed 's/^/    /')
+EOF
+            fi
+            if [ -n "$OAUTH_STATE_KEY" ]; then
+                cat <<EOF
+  INVENTARIO_RUN_OAUTH_STATE_KEY: |-
+$(printf '%s' "$OAUTH_STATE_KEY" | sed 's/^/    /')
 EOF
             fi
         } | remote_apply

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -59,6 +59,15 @@ remote_apply() {
 # install (idempotent thereafter — the password is the seed value, not a
 # runtime credential).
 #
+# When the bundle also provides `jwt.secret`, this same Secret additionally
+# carries `INVENTARIO_RUN_JWT_SECRET`, pinning the apiserver's token-signing
+# key so sessions and back-office MFA enrollments survive restarts (#1943).
+# The chart loads the whole Secret via `envFrom`, so the key reaches the
+# apiserver as-is — no chart change needed. It is OPTIONAL: an absent
+# jwt.secret leaves the apiserver on its random per-restart fallback (every
+# redeploy logs users out and any back-office MFA enrollment becomes
+# undecryptable).
+#
 # Per-PR preview namespaces (`inv-vcl01-pr{N}`) are created dynamically by
 # ArgoCD and so are NOT covered here; their ApplicationSet template
 # (infra/argocd/applicationset-pr.yaml) sets a well-known dev password
@@ -69,6 +78,15 @@ remote_apply() {
 # script ensures the missing field is surfaced loudly to bootstrap.sh
 # (which runs under `set -e` and will halt the whole bootstrap).
 ADMIN_PASSWORD=$(lookup "admin.password")
+# Optional runtime JWT signing key for the persistent envs (master + longevity).
+# When present it is injected into the inventario-admin Secret below as
+# INVENTARIO_RUN_JWT_SECRET so the apiserver stops minting a fresh random secret
+# on every restart. Absent it, warn (don't fail) — master ran disposably without
+# a stable secret for a long time, so this stays best-effort.
+JWT_SECRET=$(lookup "jwt.secret")
+if [ -z "$JWT_SECRET" ]; then
+    warn "jwt.secret missing in secrets bundle; inv-vcl01-master/longevity will use an EPHEMERAL per-restart JWT secret (every redeploy logs users out and back-office MFA enrollment won't survive a restart). Set jwt.secret to make it stable."
+fi
 ADMIN_MISSING=0
 if [ -z "$ADMIN_PASSWORD" ]; then
     warn "admin.password missing in secrets bundle; required by master + longevity ApplicationSets via secrets.existingSecret"
@@ -77,10 +95,13 @@ if [ -z "$ADMIN_PASSWORD" ]; then
 else
     for ns in inv-vcl01-master inv-vcl01-longevity; do
         note "Applying $ns/inventario-admin"
-        # Emit value as a YAML block scalar so passwords with special chars
+        # Emit values as YAML block scalars so secrets with special chars
         # (':', '{', '#', newlines) don't break manifest parsing or open an
         # injection path. Same pattern as the github private key block below.
-        cat <<EOF | remote_apply
+        # Grouped so the optional INVENTARIO_RUN_JWT_SECRET key can be appended
+        # to the same stringData map before a single apply.
+        {
+            cat <<EOF
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -96,6 +117,13 @@ stringData:
   SETUP_ADMIN_PASSWORD: |-
 $(printf '%s' "$ADMIN_PASSWORD" | sed 's/^/    /')
 EOF
+            if [ -n "$JWT_SECRET" ]; then
+                cat <<EOF
+  INVENTARIO_RUN_JWT_SECRET: |-
+$(printf '%s' "$JWT_SECRET" | sed 's/^/    /')
+EOF
+            fi
+        } | remote_apply
     done
 fi
 

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -59,14 +59,15 @@ remote_apply() {
 # install (idempotent thereafter — the password is the seed value, not a
 # runtime credential).
 #
-# When the bundle also provides `jwt.secret`, this same Secret additionally
-# carries `INVENTARIO_RUN_JWT_SECRET`, pinning the apiserver's token-signing
-# key so sessions and back-office MFA enrollments survive restarts (#1943).
-# The chart loads the whole Secret via `envFrom`, so the key reaches the
-# apiserver as-is — no chart change needed. It is OPTIONAL: an absent
-# jwt.secret leaves the apiserver on its random per-restart fallback (every
-# redeploy logs users out and any back-office MFA enrollment becomes
-# undecryptable).
+# When the bundle also provides `jwt.secret` and/or `file_signing.key`, this
+# same Secret additionally carries `INVENTARIO_RUN_JWT_SECRET` and
+# `INVENTARIO_RUN_FILE_SIGNING_KEY`, pinning the apiserver's token-signing key
+# (sessions + back-office MFA) and file-URL signing key across restarts (#1943).
+# The chart loads the whole Secret via `envFrom`, so the keys reach the
+# apiserver as-is — no chart change needed. Both are OPTIONAL: an absent value
+# leaves the apiserver on its random per-restart fallback (JWT: every redeploy
+# logs users out and back-office MFA enrollment becomes undecryptable;
+# file-signing: previously-issued signed file-download URLs stop validating).
 #
 # Per-PR preview namespaces (`inv-vcl01-pr{N}`) are created dynamically by
 # ArgoCD and so are NOT covered here; their ApplicationSet template
@@ -86,6 +87,13 @@ ADMIN_PASSWORD=$(lookup "admin.password")
 JWT_SECRET=$(lookup "jwt.secret")
 if [ -z "$JWT_SECRET" ]; then
     warn "jwt.secret missing in secrets bundle; inv-vcl01-master/longevity will use an EPHEMERAL per-restart JWT secret (every redeploy logs users out and back-office MFA enrollment won't survive a restart). Set jwt.secret to make it stable."
+fi
+# Optional file-URL signing key for the persistent envs, same scheme as
+# jwt.secret above. Absent it, signed file-download URLs break after a restart
+# (the SPA re-fetches them, so it mostly self-heals); warn, don't fail.
+FILE_SIGNING_KEY=$(lookup "file_signing.key")
+if [ -z "$FILE_SIGNING_KEY" ]; then
+    warn "file_signing.key missing in secrets bundle; inv-vcl01-master/longevity will use an EPHEMERAL per-restart file-signing key (previously-issued signed file-download URLs stop validating after a redeploy). Set file_signing.key to make it stable."
 fi
 ADMIN_MISSING=0
 if [ -z "$ADMIN_PASSWORD" ]; then
@@ -121,6 +129,12 @@ EOF
                 cat <<EOF
   INVENTARIO_RUN_JWT_SECRET: |-
 $(printf '%s' "$JWT_SECRET" | sed 's/^/    /')
+EOF
+            fi
+            if [ -n "$FILE_SIGNING_KEY" ]; then
+                cat <<EOF
+  INVENTARIO_RUN_FILE_SIGNING_KEY: |-
+$(printf '%s' "$FILE_SIGNING_KEY" | sed 's/^/    /')
 EOF
             fi
         } | remote_apply

--- a/infra/vm/secrets/secrets.example.yaml
+++ b/infra/vm/secrets/secrets.example.yaml
@@ -24,6 +24,27 @@ admin:
   email: admin@example.invalid
   password: ""
 
+jwt:
+  # Runtime JWT signing key for the Inventario app on the PERSISTENT envs
+  # (inv-vcl01-master + inv-vcl01-longevity). Materialized by
+  # infra/vm/scripts/apply-secrets.sh into the inventario-admin Secret under
+  # key INVENTARIO_RUN_JWT_SECRET; the chart loads that whole Secret via
+  # envFrom, so the apiserver signs tokens with this value.
+  #
+  # OPTIONAL but strongly recommended for these long-lived envs. When empty,
+  # each apiserver pod generates a fresh RANDOM secret at startup, so every
+  # redeploy/restart invalidates all sessions AND makes any back-office MFA
+  # enrollment undecryptable (the TOTP secret is encrypted with an HKDF subkey
+  # of this value). Set it ONCE and keep it stable — rotating it logs everyone
+  # out and invalidates existing back-office MFA enrollments.
+  #
+  # Accepts a 32+ byte plaintext string or 64+ hex chars. Generate with:
+  #   openssl rand -hex 32
+  #
+  # Per-PR previews (inv-vcl01-pr{N}) are NOT covered — they are disposable and
+  # keep the ephemeral per-pod secret.
+  secret: ""
+
 tailscale:
   # One-shot reusable auth key from the Tailscale admin console.
   # Used only on first bootstrap; after that tailscaled is authenticated.

--- a/infra/vm/secrets/secrets.example.yaml
+++ b/infra/vm/secrets/secrets.example.yaml
@@ -45,6 +45,25 @@ jwt:
   # keep the ephemeral per-pod secret.
   secret: ""
 
+file_signing:
+  # HMAC key the app uses to sign + verify time-limited file-download URLs, on
+  # the same PERSISTENT envs. Materialized by
+  # infra/vm/scripts/apply-secrets.sh into the inventario-admin Secret under
+  # key INVENTARIO_RUN_FILE_SIGNING_KEY; loaded by the chart via the same
+  # envFrom.
+  #
+  # OPTIONAL. When empty, each apiserver pod generates a fresh RANDOM key at
+  # startup, so previously-issued signed URLs stop validating after a
+  # redeploy/restart. The SPA re-requests signed URLs on load so it mostly
+  # self-heals, but any in-flight or bookmarked link breaks on every restart.
+  # Set it ONCE and keep it stable.
+  #
+  # Accepts a 32+ byte plaintext string or 64+ hex chars. Generate with:
+  #   openssl rand -hex 32
+  #
+  # Per-PR previews (inv-vcl01-pr{N}) are NOT covered — they are disposable.
+  key: ""
+
 tailscale:
   # One-shot reusable auth key from the Tailscale admin console.
   # Used only on first bootstrap; after that tailscaled is authenticated.

--- a/infra/vm/secrets/secrets.example.yaml
+++ b/infra/vm/secrets/secrets.example.yaml
@@ -64,6 +64,25 @@ file_signing:
   # Per-PR previews (inv-vcl01-pr{N}) are NOT covered — they are disposable.
   key: ""
 
+oauth_state:
+  # HMAC key the app uses to sign + verify the OAuth `state` parameter during
+  # social sign-in, on the same PERSISTENT envs. Materialized by
+  # infra/vm/scripts/apply-secrets.sh into the inventario-admin Secret under
+  # key INVENTARIO_RUN_OAUTH_STATE_KEY; loaded by the chart via the same
+  # envFrom.
+  #
+  # OPTIONAL, and only matters when OAuth sign-in is enabled on the env. When
+  # empty, each apiserver pod generates a fresh RANDOM key at startup, so an
+  # OAuth flow that began before a restart/redeploy — or that lands on a
+  # different replica after the provider redirect — fails state validation.
+  # Set it ONCE and keep it stable.
+  #
+  # Accepts a 32+ byte plaintext string or 64+ hex chars. Generate with:
+  #   openssl rand -hex 32
+  #
+  # Per-PR previews (inv-vcl01-pr{N}) are NOT covered — they are disposable.
+  key: ""
+
 tailscale:
   # One-shot reusable auth key from the Tailscale admin console.
   # Used only on first bootstrap; after that tailscaled is authenticated.


### PR DESCRIPTION
Closes #1943.

## Problem

The persistent envs `inv-vcl01-master` and `inv-vcl01-longevity` pin `secrets.existingSecret: inventario-admin`, and `apply-secrets.sh` materialized that Secret with **only** `SETUP_ADMIN_PASSWORD`. Because `existingSecret` is set, the chart skips rendering its own `secret.yaml` (the only place these signing keys would otherwise come from), so the apiserver booted with **empty** signing keys.

With an empty value, `getJWTSecret()` / `getFileSigningKey()` / `getOAuthStateKey()` (`go/cmd/inventario/run/bootstrap/crypto.go`) generate a fresh **random** key in memory on every pod start. On these long-lived envs:

- **JWT secret** ephemeral → every redeploy/restart invalidates all sessions (everyone logged out); and because the back-office (super-admin) plane encrypts each operator's TOTP secret with an HKDF subkey of the JWT secret, a back-office MFA enrollment is **undecryptable after the next restart** — an operator can never complete a durable enrollment and is locked out of `/backoffice/login`.
- **File-signing key** ephemeral → previously-issued signed file-download URLs stop validating after a restart (the SPA re-fetches them so it mostly self-heals, but bookmarked / in-flight links break).
- **OAuth state key** ephemeral → an OAuth sign-in that spans a restart/redeploy, or lands on a different replica after the provider redirect, fails state validation (only relevant when OAuth sign-in is enabled on the env).

Found while trying to sign a platform operator into `inv-vcl01-master`: the env had no `inventario-admin` Secret at all and the in-pod `INVENTARIO_RUN_JWT_SECRET` resolved empty, confirming the ephemeral-per-boot path.

## Fix

Source all three signing keys from the sops bundle the same way `admin.password` is:

- **`secrets.example.yaml`** — new **optional** `jwt.secret`, `file_signing.key`, and `oauth_state.key` fields with schema docs.
- **`apply-secrets.sh`** — `lookup` each; when present, inject into the `inventario-admin` Secret as `INVENTARIO_RUN_JWT_SECRET` / `INVENTARIO_RUN_FILE_SIGNING_KEY` / `INVENTARIO_RUN_OAUTH_STATE_KEY` for both persistent namespaces. When absent each **warns but does not fail**, so existing bundles keep bootstrapping.
- **`SECRETS.md`** — §4b (now "stable signing keys") plus architecture / filling-the-bundle updates.
- **`applicationset-master.yaml`** — correct the now-stale "JWT/file-signing keys are intentionally ephemeral" comment.

### No chart change needed

The combined Deployment already loads the whole `inventario-admin` Secret via `envFrom: secretRef`, and `inventario.secretName` resolves to `existingSecret` (= `inventario-admin`). New keys in that Secret flow straight into the pod env, which the run config reads (`env:"JWT_SECRET"` / `"FILE_SIGNING_KEY"` / `"OAUTH_STATE_KEY"`, prefix `INVENTARIO_RUN_`).

## Testing

- `bash -n apply-secrets.sh` — clean.
- Simulated manifest generation with a special-char password + hex JWT/file-signing/OAuth-state keys: output parses as valid YAML, all four `stringData` keys present and round-trip exactly; with a field empty its key is omitted.
- `secrets.example.yaml` parses as YAML with the three new fields empty.
- `markdownlint-cli2` on `SECRETS.md` with the repo config — 0 errors.

## Rollout (operator, after merge)

1. Add to the sops bundle (`sops infra/vm/secrets/secrets.enc.yaml`):
   ```yaml
   jwt:
     secret: <openssl rand -hex 32>
   file_signing:
     key: <openssl rand -hex 32>
   oauth_state:
     key: <openssl rand -hex 32>
   ```
2. Re-run the bootstrap (or just `apply-secrets.sh`) so `inventario-admin` is (re)created with the keys, then restart the deployment.
3. Enroll back-office MFA — it now survives restarts. (The immediate `mfa_enforced=false` DB workaround used to get in today is independent and can stay or be reverted.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Support optional stable runtime signing keys (JWT, file-signing, OAuth state) so sessions, back-office MFA, and signed download URLs persist across restarts; deployment tooling injects these when present and warns when missing.
* **Documentation**
  * Added guidance to generate, stash, and rotate stable keys; clarified that leaving them empty yields ephemeral per-start keys with consequences (logout on redeploy, MFA re-enrollment loss, invalidated signed URLs) and updated checklist for persistent environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->