### PR TITLE
[#843] Prometheus metrics & observability

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -255,6 +255,18 @@ sudo journalctl -u inventario -f
 ./inventario run 2>&1 | tee /var/log/inventario.log
 ```
 
+### Observability
+
+Prometheus metrics are **always on** at `/metrics` — on the API HTTP port (`3333`) and, in split deployments, on each worker's probe port (`3334`). No flag is required to expose them.
+
+```bash
+# Scrape metrics from a running instance
+curl http://localhost:3333/metrics
+```
+
+- **Local / docker-compose:** a ready-to-run Prometheus + Grafana stack lives at [`deploy/monitoring/`](deploy/monitoring/README.md) (`docker compose --profile monitoring up -d`).
+- **Kubernetes:** the Helm chart can emit `prometheus.io/*` pod annotations (operator-less discovery) or a ServiceMonitor (Prometheus Operator). Both default off — see [`helm/inventario/README.md`](helm/inventario/README.md) → "Metrics & scraping".
+
 ## Maintenance
 
 ### Database Backups

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -181,6 +181,16 @@ View health status:
 docker-compose ps
 ```
 
+## Monitoring (optional)
+
+Inventario exposes Prometheus metrics at `/metrics` (API port `3333`). A self-contained Prometheus + Grafana stack for local development ships under [`deploy/monitoring/`](deploy/monitoring/README.md) and is wired into this compose project behind a profile:
+
+```bash
+docker compose --profile monitoring up -d
+```
+
+See [`deploy/monitoring/README.md`](deploy/monitoring/README.md) for the dashboards, scrape config, and access URLs.
+
 ## Production Deployment
 
 For production deployment, consider:

--- a/deploy/monitoring/README.md
+++ b/deploy/monitoring/README.md
@@ -1,0 +1,114 @@
+# Inventario monitoring stack (Prometheus + Grafana)
+
+Opt-in observability stack for local/dev use, added in issue #843. The
+application always exposes Prometheus metrics at `/metrics`; this directory adds
+a Prometheus to scrape them and a Grafana with a pre-provisioned dashboard.
+
+## Quick start
+
+```bash
+docker compose --profile monitoring up -d
+```
+
+| Service    | URL                     | Notes                                   |
+| ---------- | ----------------------- | --------------------------------------- |
+| App        | http://localhost:3333   | `/metrics` is the scrape target         |
+| Prometheus | http://localhost:9090   | Status → Targets shows `inventario` UP  |
+| Grafana    | http://localhost:3000   | dashboard **Inventario / Overview**     |
+
+Grafana default login is `admin` / `admin` (override with `GRAFANA_ADMIN_USER` /
+`GRAFANA_ADMIN_PASSWORD`). Anonymous **Viewer** access is enabled for dev
+convenience — **never enable that on an internet-exposed deployment.**
+
+The stack is gated behind the compose `monitoring` profile, so a plain
+`docker compose up` and the e2e stack do not start it.
+
+## Two clocks: scrape interval vs. business-collector tick
+
+- **Prometheus `scrape_interval` = 15s** (`prometheus/prometheus.yml`): how often
+  Prometheus reads `/metrics`. Counters/histograms (HTTP, DB, auth, email,
+  rate-limit) change in real time, so 15s gives good `rate()` resolution.
+- **Business-collector tick = 60s** (app config
+  `INVENTARIO_RUN_BUSINESS_METRICS_INTERVAL`): how often the app recomputes the
+  installation-wide business gauges (`inventario_users`, `inventario_commodities`,
+  `inventario_file_storage_bytes`, …). They step every 60s and read flat in
+  between — that is expected, not a gap.
+
+## Files
+
+```
+deploy/monitoring/
+├── prometheus/
+│   ├── prometheus.yml            # scrape config (job: inventario → inventario:3333)
+│   └── rules/inventario.rules.yml# recording rules + alerts (5xx ratio, p95, target down)
+└── grafana/
+    ├── provisioning/
+    │   ├── datasources/prometheus.yml   # Prometheus datasource (uid inventario-prometheus)
+    │   └── dashboards/inventario.yml    # provider: read-only file provisioning
+    └── dashboards/
+        └── inventario-overview.json     # the dashboard
+```
+
+## Metric families → dashboard panels
+
+The dashboard PromQL is the contract with the app's metric names. If a metric is
+renamed in `go/internal/metrics`, update the matching panel/rule here.
+
+| Family                                            | Type            | Panel(s)                          |
+| ------------------------------------------------- | --------------- | --------------------------------- |
+| `inventario_http_requests_total`                  | counter         | request rate, 5xx ratio, classes  |
+| `inventario_http_request_duration_seconds`        | histogram       | latency p50/p95/p99               |
+| `inventario_http_requests_in_flight`              | gauge           | in-flight                         |
+| `inventario_db_query_duration_seconds`            | histogram       | DB query latency p95 by op        |
+| `inventario_db_queries_total`                     | counter         | DB queries by op & status         |
+| `inventario_db_pool_connections` / `…_max_connections` | gauge      | DB pool connections               |
+| `inventario_auth_login_attempts_total`            | counter         | login attempts by outcome         |
+| `inventario_auth_tokens_issued_total`             | counter         | tokens issued by type             |
+| `inventario_rate_limit_rejections_total`          | counter         | rate-limit rejections by scope    |
+| `inventario_email_queue_depth`                    | gauge           | email queue depth                 |
+| `inventario_emails_processed_total`               | counter         | emails processed by status        |
+| `inventario_tenants/users/…/commodities/files`    | gauge           | business entity counts            |
+| `inventario_file_storage_bytes`                   | gauge           | file storage by category          |
+| `up{job="inventario"}`                            | synthetic       | scrape target up                  |
+
+## Split deployments (`run apiserver` + `run workers`)
+
+The default compose runs `run all` (one process), so every metric — HTTP, DB,
+auth, email, and the business gauges — is exported on `:3333` and the dashboard
+works out of the box.
+
+In a **split** deployment the producers are split across processes:
+
+- The **apiserver** process exports HTTP / auth / DB metrics on `:3333`.
+- The **workers** process exports the email metrics and the business gauges
+  (`inventario_users`, `inventario_commodities`, `inventario_file_storage_bytes`,
+  `inventario_email_queue_depth`, …) on its probe port `:3334`.
+
+The business/email gauges also exist (at `0`) in the apiserver process because
+they are package-level, so a Prometheus that scrapes **only** the apiserver
+target will show those panels flat at `0`. To get real values, scrape the
+workers target too (uncomment the `inventario-workers` job in `prometheus.yml`,
+or in k8s add the worker PodMonitor — see `helm/inventario/README.md`). When both
+targets are scraped, the dashboard's `sum()`-based panels read correctly.
+
+## Kubernetes
+
+For cluster scraping see the chart's **Metrics & scraping** section in
+`helm/inventario/README.md` (`metrics.podAnnotations` / `metrics.serviceMonitor`).
+The app serves `/metrics` on the API port `3333` and, in split deployments, on
+each worker's probe port `3334`.
+
+## Security: keep `/metrics` off untrusted networks
+
+`/metrics` is unauthenticated (as it was before #843) and now also publishes
+installation-wide aggregate gauges (tenant/user/commodity counts, total storage
+bytes). These are aggregates only — **no per-tenant data and no secrets** — but
+they still reveal rough scale. Expose `/metrics` only to the monitoring network
+(the in-cluster Prometheus via ServiceMonitor / `kubernetes_sd`, or a private
+interface), never to the public internet.
+
+## After editing Prometheus config
+
+```bash
+curl -X POST http://localhost:9090/-/reload   # --web.enable-lifecycle is set
+```

--- a/deploy/monitoring/README.md
+++ b/deploy/monitoring/README.md
@@ -88,8 +88,16 @@ The business/email gauges also exist (at `0`) in the apiserver process because
 they are package-level, so a Prometheus that scrapes **only** the apiserver
 target will show those panels flat at `0`. To get real values, scrape the
 workers target too (uncomment the `inventario-workers` job in `prometheus.yml`,
-or in k8s add the worker PodMonitor — see `helm/inventario/README.md`). When both
-targets are scraped, the dashboard's `sum()`-based panels read correctly.
+or in k8s add the worker PodMonitor — see `helm/inventario/README.md`).
+
+Because these gauges are installation-wide (every producer reports the same
+total), the dashboard collapses them across targets with `max()` rather than
+`sum()` — e.g. `max(inventario_users)`,
+`max by (category) (inventario_file_storage_bytes)`,
+`max(inventario_email_queue_depth)`. `max()` drops the apiserver `0` series and,
+crucially, does not double-count when more than one `run all`/worker replica is
+scraped. (Counter/histogram panels — request rate, latency — correctly keep
+`sum(rate(...))`, since those aggregate per-process activity across the fleet.)
 
 ## Kubernetes
 

--- a/deploy/monitoring/grafana/dashboards/inventario-overview.json
+++ b/deploy/monitoring/grafana/dashboards/inventario-overview.json
@@ -152,7 +152,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
       "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
       "targets": [
-        { "refId": "A", "expr": "inventario_email_queue_depth", "legendFormat": "queue depth" }
+        { "refId": "A", "expr": "max(inventario_email_queue_depth)", "legendFormat": "queue depth" }
       ]
     },
     {
@@ -175,13 +175,13 @@
       "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "fixed", "fixedColor": "blue" } }, "overrides": [] },
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none", "textMode": "value_and_name", "orientation": "horizontal" },
       "targets": [
-        { "refId": "A", "expr": "inventario_tenants", "legendFormat": "tenants" },
-        { "refId": "B", "expr": "inventario_users", "legendFormat": "users" },
-        { "refId": "C", "expr": "inventario_location_groups", "legendFormat": "groups" },
-        { "refId": "D", "expr": "inventario_locations", "legendFormat": "locations" },
-        { "refId": "E", "expr": "inventario_areas", "legendFormat": "areas" },
-        { "refId": "F", "expr": "inventario_commodities", "legendFormat": "commodities" },
-        { "refId": "G", "expr": "inventario_files", "legendFormat": "files" }
+        { "refId": "A", "expr": "max(inventario_tenants)", "legendFormat": "tenants" },
+        { "refId": "B", "expr": "max(inventario_users)", "legendFormat": "users" },
+        { "refId": "C", "expr": "max(inventario_location_groups)", "legendFormat": "groups" },
+        { "refId": "D", "expr": "max(inventario_locations)", "legendFormat": "locations" },
+        { "refId": "E", "expr": "max(inventario_areas)", "legendFormat": "areas" },
+        { "refId": "F", "expr": "max(inventario_commodities)", "legendFormat": "commodities" },
+        { "refId": "G", "expr": "max(inventario_files)", "legendFormat": "files" }
       ]
     },
     {
@@ -192,7 +192,7 @@
       "gridPos": { "h": 8, "w": 8, "x": 16, "y": 48 },
       "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 40, "stacking": { "mode": "normal" } } }, "overrides": [] },
       "targets": [
-        { "refId": "A", "expr": "sum by (category) (inventario_file_storage_bytes)", "legendFormat": "{{category}}" }
+        { "refId": "A", "expr": "max by (category) (inventario_file_storage_bytes)", "legendFormat": "{{category}}" }
       ]
     },
     {

--- a/deploy/monitoring/grafana/dashboards/inventario-overview.json
+++ b/deploy/monitoring/grafana/dashboards/inventario-overview.json
@@ -1,0 +1,220 @@
+{
+  "uid": "inventario-overview",
+  "title": "Inventario / Overview",
+  "tags": ["inventario", "issue-843"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Prometheus", "value": "inventario-prometheus" },
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "HTTP request rate (req/s by route)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (route) (rate(inventario_http_requests_total[$__rate_interval]))", "legendFormat": "{{route}}" }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "HTTP error rate (5xx ratio)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(inventario_http_requests_total{status_class=\"5xx\"}[$__rate_interval])) / clamp_min(sum(rate(inventario_http_requests_total[$__rate_interval])), 1e-9)", "legendFormat": "5xx ratio" }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "HTTP status classes (req/s)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 40, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (status_class) (rate(inventario_http_requests_total[$__rate_interval]))", "legendFormat": "{{status_class}}" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "HTTP latency p50 / p95 / p99",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 10, "x": 8, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 0 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "histogram_quantile(0.50, sum by (le) (rate(inventario_http_request_duration_seconds_bucket[$__rate_interval])))", "legendFormat": "p50" },
+        { "refId": "B", "expr": "histogram_quantile(0.95, sum by (le) (rate(inventario_http_request_duration_seconds_bucket[$__rate_interval])))", "legendFormat": "p95" },
+        { "refId": "C", "expr": "histogram_quantile(0.99, sum by (le) (rate(inventario_http_request_duration_seconds_bucket[$__rate_interval])))", "legendFormat": "p99" }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "HTTP requests in flight",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" } }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" },
+      "targets": [
+        { "refId": "A", "expr": "sum(inventario_http_requests_in_flight)", "legendFormat": "in flight" }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "DB pool connections",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "inventario_db_pool_connections", "legendFormat": "{{state}}" },
+        { "refId": "B", "expr": "inventario_db_pool_max_connections", "legendFormat": "max" }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "DB query latency p95 by operation",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 0 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(inventario_db_query_duration_seconds_bucket[$__rate_interval])))", "legendFormat": "{{operation}}" }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "DB queries (per/s by operation & status)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (operation, status) (rate(inventario_db_queries_total[$__rate_interval]))", "legendFormat": "{{operation}} {{status}}" }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Login attempts by outcome",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 40, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (outcome) (rate(inventario_auth_login_attempts_total[$__rate_interval]))", "legendFormat": "{{outcome}}" }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Tokens issued by type",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (type) (rate(inventario_auth_tokens_issued_total[$__rate_interval]))", "legendFormat": "{{type}}" }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Rate-limit rejections by scope",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (scope) (rate(inventario_rate_limit_rejections_total[$__rate_interval]))", "legendFormat": "{{scope}}" }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Email queue depth",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "inventario_email_queue_depth", "legendFormat": "queue depth" }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Emails processed by status",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (status) (rate(inventario_emails_processed_total[$__rate_interval]))", "legendFormat": "{{status}}" }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "Business entity counts",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 48 },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "fixed", "fixedColor": "blue" } }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none", "textMode": "value_and_name", "orientation": "horizontal" },
+      "targets": [
+        { "refId": "A", "expr": "inventario_tenants", "legendFormat": "tenants" },
+        { "refId": "B", "expr": "inventario_users", "legendFormat": "users" },
+        { "refId": "C", "expr": "inventario_location_groups", "legendFormat": "groups" },
+        { "refId": "D", "expr": "inventario_locations", "legendFormat": "locations" },
+        { "refId": "E", "expr": "inventario_areas", "legendFormat": "areas" },
+        { "refId": "F", "expr": "inventario_commodities", "legendFormat": "commodities" },
+        { "refId": "G", "expr": "inventario_files", "legendFormat": "files" }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "File storage by category",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 48 },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 40, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (category) (inventario_file_storage_bytes)", "legendFormat": "{{category}}" }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "stat",
+      "title": "Scrape target up",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 56 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+          ],
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "orientation": "horizontal" },
+      "targets": [
+        { "refId": "A", "expr": "up{job=\"inventario\"}", "legendFormat": "{{instance}}" }
+      ]
+    }
+  ]
+}

--- a/deploy/monitoring/grafana/provisioning/dashboards/inventario.yml
+++ b/deploy/monitoring/grafana/provisioning/dashboards/inventario.yml
@@ -1,0 +1,14 @@
+# Grafana dashboard provisioning (issue #843). Loads the version-controlled
+# dashboard JSON read-only (no UI edits / deletes), so it stays reproducible.
+apiVersion: 1
+providers:
+  - name: inventario
+    orgId: 1
+    folder: Inventario
+    type: file
+    disableDeletion: true
+    allowUiUpdates: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,14 @@
+# Grafana datasource provisioning (issue #843). Points Grafana at the
+# Prometheus service over the shared inventario-network.
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: inventario-prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      # Match prometheus.yml scrape_interval so $__rate_interval is sane.
+      timeInterval: 15s

--- a/deploy/monitoring/prometheus/prometheus.yml
+++ b/deploy/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,45 @@
+# Prometheus scrape configuration for the Inventario observability stack
+# (issue #843). Used by the docker-compose `monitoring` profile.
+#
+# Two clocks to keep straight:
+#   - scrape_interval (below, 15s): how often Prometheus reads /metrics.
+#     Counters/histograms (HTTP, DB, auth, email) update in real time.
+#   - the app's business-metrics collector tick (60s, configured in the app
+#     via INVENTARIO_RUN_BUSINESS_METRICS_INTERVAL): how often the business
+#     gauges (inventario_users, inventario_commodities, ...) are recomputed.
+#     They therefore step every 60s and look flat in between — expected.
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    monitor: inventario-dev
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+scrape_configs:
+  # Prometheus self-scrape — cheap sanity signal.
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # Inventario. In the default single-container compose the app runs `run all`,
+  # so the API and every worker counter are exported together on :3333.
+  - job_name: inventario
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["inventario:3333"]
+        labels:
+          service: inventario
+          role: all
+
+  # Split-deployment variant: a dedicated workers container exposes its probe
+  # listener (and worker/business metrics) on :3334. Left commented because the
+  # default compose has no separate workers container.
+  # - job_name: inventario-workers
+  #   metrics_path: /metrics
+  #   static_configs:
+  #     - targets: ["inventario-workers:3334"]
+  #       labels:
+  #         service: inventario
+  #         role: workers

--- a/deploy/monitoring/prometheus/rules/inventario.rules.yml
+++ b/deploy/monitoring/prometheus/rules/inventario.rules.yml
@@ -1,0 +1,56 @@
+# Recording + alerting rules for Inventario (issue #843). Minimal but real:
+# the recording rules back the Overview dashboard's hot paths, and the alerts
+# are evaluated/visible in Prometheus' Alerts tab (no Alertmanager is shipped
+# in the dev compose, so they are not routed anywhere — they document intent
+# and surface in the UI).
+groups:
+  - name: inventario-recording
+    interval: 15s
+    rules:
+      # Server-error ratio over 5m, per matched route.
+      - record: inventario:http_5xx_ratio:rate5m
+        expr: |
+          sum by (route) (rate(inventario_http_requests_total{status_class="5xx"}[5m]))
+          /
+          clamp_min(sum by (route) (rate(inventario_http_requests_total[5m])), 1e-9)
+
+      # Global p95 request latency over 5m.
+      - record: inventario:http_request_p95_seconds:5m
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (rate(inventario_http_request_duration_seconds_bucket[5m]))
+          )
+
+  - name: inventario-alerts
+    rules:
+      - alert: InventarioTargetDown
+        expr: up{job="inventario"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Inventario /metrics target is down"
+          description: "Prometheus cannot scrape {{ $labels.instance }} (job inventario) for 2m."
+
+      - alert: InventarioHighErrorRate
+        expr: |
+          sum(rate(inventario_http_requests_total{status_class="5xx"}[5m]))
+          /
+          clamp_min(sum(rate(inventario_http_requests_total[5m])), 1e-9)
+          > 0.05
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Inventario 5xx ratio > 5% (10m)"
+          description: "Global server-error ratio is {{ $value | humanizePercentage }} over the last 5m."
+
+      - alert: InventarioHighLatencyP95
+        expr: inventario:http_request_p95_seconds:5m > 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Inventario p95 latency > 1s (10m)"
+          description: "Global p95 request latency is {{ $value }}s over the last 5m."

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -236,6 +236,71 @@ services:
       retries: 3
       start_period: 60s
 
+  # ---------------------------------------------------------------------------
+  # Observability stack (issue #843) — opt-in, OFF by default.
+  # Start with:  docker compose --profile monitoring up -d
+  # Prometheus scrapes the app's /metrics (default registry) on :3333; Grafana
+  # auto-provisions a Prometheus datasource + the "Inventario / Overview"
+  # dashboard. Kept behind a profile so a plain `docker compose up` and the e2e
+  # stack stay lean and unaffected.
+  # ---------------------------------------------------------------------------
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    profiles: ["monitoring"]
+    restart: unless-stopped
+    depends_on:
+      inventario:
+        condition: service_healthy
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=15d
+      - --web.enable-lifecycle
+    volumes:
+      - ./deploy/monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./deploy/monitoring/prometheus/rules:/etc/prometheus/rules:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    networks:
+      - inventario-network
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:9090/-/healthy"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    profiles: ["monitoring"]
+    restart: unless-stopped
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      # Dev convenience only: anonymous read-only viewer. DO NOT enable on any
+      # internet-exposed deployment.
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
+    volumes:
+      - ./deploy/monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./deploy/monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+    networks:
+      - inventario-network
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:3000/api/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
   # PostgreSQL Test Database
   postgres-test:
     profiles: ["test"]
@@ -461,6 +526,10 @@ volumes:
   inventario-uploads:
   inventario-data:
   redis-data:
+
+  # Observability stack volumes (issue #843, monitoring profile)
+  prometheus-data:
+  grafana-data:
 
   # Test volumes (optional, using tmpfs above)
   postgres-test-data:

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -331,12 +331,14 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 	r.Use(middleware.Timeout(60 * time.Second))
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Logger)
-	r.Use(middleware.Recoverer)
-
-	// RED metrics (#843): installed after Recoverer so a recovered panic is
-	// counted as a 500, and after chi routing middleware so RoutePattern
-	// resolves to the matched template. The middleware self-skips "/metrics".
+	// RED metrics (#843): registered BEFORE Recoverer so it WRAPS it — the
+	// deferred status read then observes the 500 that Recoverer writes for a
+	// recovered panic. Installed inside Recoverer it would run its defer as
+	// the panic unwinds, before the 500 is written, and miscount panics as
+	// 2xx. It still sits inside chi routing, so RoutePattern resolves; it
+	// self-skips "/metrics".
 	r.Use(metrics.HTTPMiddleware)
+	r.Use(middleware.Recoverer)
 
 	// r.Get("/", func(w http.ResponseWriter, _r *http.Request) {
 	//	w.Write([]byte("Welcome to Inventario!"))

--- a/go/apiserver/apiserver.go
+++ b/go/apiserver/apiserver.go
@@ -29,6 +29,7 @@ import (
 	"github.com/denisvmedia/inventario/debug"
 	_ "github.com/denisvmedia/inventario/docs" // register swagger docs
 	_ "github.com/denisvmedia/inventario/internal/fileblob"
+	"github.com/denisvmedia/inventario/internal/metrics"
 	"github.com/denisvmedia/inventario/jsonapi"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
@@ -331,6 +332,11 @@ func APIServer(params Params, restoreStatus RestoreStatusQuerier) http.Handler {
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+
+	// RED metrics (#843): installed after Recoverer so a recovered panic is
+	// counted as a 500, and after chi routing middleware so RoutePattern
+	// resolves to the matched template. The middleware self-skips "/metrics".
+	r.Use(metrics.HTTPMiddleware)
 
 	// r.Get("/", func(w http.ResponseWriter, _r *http.Request) {
 	//	w.Write([]byte("Welcome to Inventario!"))

--- a/go/apiserver/auth.go
+++ b/go/apiserver/auth.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/denisvmedia/inventario/appctx"
 	"github.com/denisvmedia/inventario/csrf"
+	"github.com/denisvmedia/inventario/internal/metrics"
 	"github.com/denisvmedia/inventario/jsonapi"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
@@ -195,6 +196,7 @@ func (api *AuthAPI) login(w http.ResponseWriter, r *http.Request) {
 		} else if locked {
 			retryAfter := max(int(time.Until(resetAt).Seconds()), 0)
 			w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+			metrics.RecordRateLimitRejection(metrics.RateLimitScopeAuth)
 			api.recordLoginEvent(r.Context(), tenantID, req.Email, nil, models.LoginOutcomeAccountLocked, r)
 			http.Error(w, "Too many failed login attempts. Please try again later.", http.StatusTooManyRequests)
 			return
@@ -1268,6 +1270,14 @@ func (api *AuthAPI) recordLoginEvent(ctx context.Context, tenantID, email string
 // we record the attempt against the email the client typed but cannot
 // link it to a row in users.
 func (api *AuthAPI) recordLoginEventWithMethod(ctx context.Context, tenantID, email string, userID *string, outcome models.LoginOutcome, method models.LoginMethod, r *http.Request) {
+	// Login-attempt metric (#843). Recorded here because this is the single
+	// chokepoint every login path funnels through (password flow via
+	// recordLoginEvent, OAuth callback directly), carrying both the resolved
+	// outcome and the credential method. Counted before the registry-nil /
+	// empty-tenant guards below so the attempt is still observed in
+	// test/memory-mode bootstrap where the audit row is intentionally skipped.
+	metrics.RecordLoginAttempt(string(outcome), string(method))
+
 	if api.loginEventRegistry == nil {
 		return
 	}
@@ -1344,7 +1354,13 @@ func (api *AuthAPI) issueAccessToken(ctx context.Context, user *models.User, rti
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	tokenString, err := token.SignedString(api.jwtSecret)
-	return tokenString, expiresAt, err
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	// Token-issuance metric (#843): only fired on a successfully signed
+	// token. Covers both fresh login and refresh-rotation callers (desired).
+	metrics.RecordTokenIssued(metrics.TokenTypeAccess)
+	return tokenString, expiresAt, nil
 }
 
 // persistRefreshToken stores a fresh refresh-token row in the database
@@ -1382,6 +1398,9 @@ func (api *AuthAPI) persistRefreshToken(ctx context.Context, r *http.Request, us
 	if err != nil {
 		return "", "", err
 	}
+	// Token-issuance metric (#843): only fired once the refresh row is
+	// actually persisted. Covers refresh-rotation callers too (desired).
+	metrics.RecordTokenIssued(metrics.TokenTypeRefresh)
 	return created.ID, raw, nil
 }
 

--- a/go/apiserver/rate_limit_middleware.go
+++ b/go/apiserver/rate_limit_middleware.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/internal/metrics"
 	"github.com/denisvmedia/inventario/services"
 )
 
@@ -97,6 +98,7 @@ func GlobalRateLimitMiddleware(limiter services.GlobalRateLimiter, trustedProxyN
 			if !res.Allowed {
 				retryAfter := max(int(time.Until(res.ResetAt).Seconds()), 0)
 				w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+				metrics.RecordRateLimitRejection(metrics.RateLimitScopeGlobal)
 				slog.Warn("Global rate limit exceeded", "ip", ip, "path", r.URL.Path, "method", r.Method, "retry_after_seconds", retryAfter)
 				http.Error(w, "Rate limit exceeded. Please try again later.", http.StatusTooManyRequests)
 				return

--- a/go/cmd/inventario/run/all/all.go
+++ b/go/cmd/inventario/run/all/all.go
@@ -100,6 +100,9 @@ func (c *Command) run() error {
 	stopCurrencyMigration := bootstrap.StartCurrencyMigrationWorker(ctx, rs, c.cfg)
 	defer stopCurrencyMigration()
 
+	stopBusinessMetrics := bootstrap.StartBusinessMetricsWorker(ctx, rs, c.cfg)
+	defer stopBusinessMetrics()
+
 	// One-shot backfill of files.size_bytes for rows that pre-date #1388.
 	// Runs in a goroutine so a slow bucket walk can't delay readiness;
 	// errors are swallowed (logged at debug) so a partial blob outage

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	LoanReminderDueSoonDays       int    `yaml:"loan_reminder_due_soon_days" env:"LOAN_REMINDER_DUE_SOON_DAYS" env-default:"0"`
 	MaintenanceReminderInterval   string `yaml:"maintenance_reminder_interval" env:"MAINTENANCE_REMINDER_INTERVAL" env-default:""`
 	CurrencyMigrationInterval     string `yaml:"currency_migration_interval" env:"CURRENCY_MIGRATION_INTERVAL" env-default:""`
+	BusinessMetricsInterval       string `yaml:"business_metrics_interval" env:"BUSINESS_METRICS_INTERVAL" env-default:""`
 	JWTSecret                     string `yaml:"jwt_secret" env:"JWT_SECRET" env-default:""`
 	FileSigningKey                string `yaml:"file_signing_key" env:"FILE_SIGNING_KEY" env-default:""`
 	FileURLExpiration             string `yaml:"file_url_expiration" env:"FILE_URL_EXPIRATION" env-default:"15m"`
@@ -262,6 +263,9 @@ func (c *Config) setWorkerDefaults() {
 	}
 	if c.CurrencyMigrationInterval == "" {
 		c.CurrencyMigrationInterval = defaults.GetCurrencyMigrationInterval()
+	}
+	if c.BusinessMetricsInterval == "" {
+		c.BusinessMetricsInterval = defaults.GetBusinessMetricsInterval()
 	}
 }
 

--- a/go/cmd/inventario/run/bootstrap/durations.go
+++ b/go/cmd/inventario/run/bootstrap/durations.go
@@ -21,6 +21,7 @@ type WorkerDurations struct {
 	LoanReminderInterval         time.Duration
 	MaintenanceReminderInterval  time.Duration
 	CurrencyMigrationInterval    time.Duration
+	BusinessMetricsInterval      time.Duration
 	ThumbnailPollInterval        time.Duration
 	ThumbnailCleanupInterval     time.Duration
 	ThumbnailJobRetentionPeriod  time.Duration
@@ -62,6 +63,7 @@ func ParseWorkerDurations(cfg *Config) (WorkerDurations, error) {
 		{"loan-reminder-interval", cfg.LoanReminderInterval, &out.LoanReminderInterval},
 		{"maintenance-reminder-interval", cfg.MaintenanceReminderInterval, &out.MaintenanceReminderInterval},
 		{"currency-migration-interval", cfg.CurrencyMigrationInterval, &out.CurrencyMigrationInterval},
+		{"business-metrics-interval", cfg.BusinessMetricsInterval, &out.BusinessMetricsInterval},
 		{"thumbnail-poll-interval", cfg.ThumbnailPollInterval, &out.ThumbnailPollInterval},
 		{"thumbnail-cleanup-interval", cfg.ThumbnailCleanupInterval, &out.ThumbnailCleanupInterval},
 		{"thumbnail-job-retention-period", cfg.ThumbnailJobRetentionPeriod, &out.ThumbnailJobRetentionPeriod},

--- a/go/cmd/inventario/run/bootstrap/durations_test.go
+++ b/go/cmd/inventario/run/bootstrap/durations_test.go
@@ -23,6 +23,7 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 		LoanReminderInterval:         "45m",
 		MaintenanceReminderInterval:  "55m",
 		CurrencyMigrationInterval:    "8s",
+		BusinessMetricsInterval:      "90s",
 		ThumbnailPollInterval:        "7s",
 		ThumbnailCleanupInterval:     "6m",
 		ThumbnailJobRetentionPeriod:  "48h",
@@ -42,6 +43,7 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 	c.Assert(got.LoanReminderInterval, qt.Equals, 45*time.Minute)
 	c.Assert(got.MaintenanceReminderInterval, qt.Equals, 55*time.Minute)
 	c.Assert(got.CurrencyMigrationInterval, qt.Equals, 8*time.Second)
+	c.Assert(got.BusinessMetricsInterval, qt.Equals, 90*time.Second)
 	c.Assert(got.ThumbnailPollInterval, qt.Equals, 7*time.Second)
 	c.Assert(got.ThumbnailCleanupInterval, qt.Equals, 6*time.Minute)
 	c.Assert(got.ThumbnailJobRetentionPeriod, qt.Equals, 48*time.Hour)

--- a/go/cmd/inventario/run/bootstrap/export_test.go
+++ b/go/cmd/inventario/run/bootstrap/export_test.go
@@ -1,0 +1,14 @@
+package bootstrap
+
+import (
+	"github.com/denisvmedia/inventario/internal/metrics"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// SystemStatsToBusinessStats exposes the unexported adapter copy to the
+// black-box bootstrap_test package so the field mapping can be asserted
+// without a database or a running collector. It compiles only under
+// `go test`.
+func SystemStatsToBusinessStats(s registry.SystemStats) metrics.BusinessStats {
+	return systemStatsToBusinessStats(s)
+}

--- a/go/cmd/inventario/run/bootstrap/flags.go
+++ b/go/cmd/inventario/run/bootstrap/flags.go
@@ -33,6 +33,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config, dbConfig *shared.DatabaseCon
 	flags.IntVar(&cfg.LoanReminderDueSoonDays, "loan-reminder-due-soon-days", cfg.LoanReminderDueSoonDays, "Forward-looking window in days for the due-soon loan reminder (default 7)")
 	flags.StringVar(&cfg.MaintenanceReminderInterval, "maintenance-reminder-interval", cfg.MaintenanceReminderInterval, "Interval between maintenance reminder sweeps (14/7/1-day + overdue maintenance emails; e.g., 1h)")
 	flags.StringVar(&cfg.CurrencyMigrationInterval, "currency-migration-interval", cfg.CurrencyMigrationInterval, "Currency migration worker active-poll interval (when pending rows exist; idle cadence is fixed at 1m). Values like 5s, 10s.")
+	flags.StringVar(&cfg.BusinessMetricsInterval, "business-metrics-interval", cfg.BusinessMetricsInterval, "Interval between installation-wide business-metrics collection sweeps (#843; e.g., 60s)")
 	flags.IntVar(&cfg.ThumbnailBatchSize, "thumbnail-batch-size", cfg.ThumbnailBatchSize, "Maximum thumbnail jobs processed per batch")
 	flags.StringVar(&cfg.ThumbnailPollInterval, "thumbnail-poll-interval", cfg.ThumbnailPollInterval, "Thumbnail worker poll interval (e.g., 5s, 10s)")
 	flags.StringVar(&cfg.ThumbnailCleanupInterval, "thumbnail-cleanup-interval", cfg.ThumbnailCleanupInterval, "Interval between thumbnail job cleanup runs (e.g., 5m)")

--- a/go/cmd/inventario/run/bootstrap/metrics_adapter_test.go
+++ b/go/cmd/inventario/run/bootstrap/metrics_adapter_test.go
@@ -1,0 +1,47 @@
+package bootstrap_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/cmd/inventario/run/bootstrap"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// TestSystemStatsToBusinessStats asserts the registry.SystemStats →
+// metrics.BusinessStats adapter copies every field into the matching
+// slot. Distinct values per field guard against a transposed
+// assignment (e.g. swapping StorageImages and StorageDocuments).
+func TestSystemStatsToBusinessStats(t *testing.T) {
+	c := qt.New(t)
+
+	in := registry.SystemStats{
+		Tenants:        1,
+		Users:          2,
+		LocationGroups: 3,
+		Locations:      4,
+		Areas:          5,
+		Commodities:    6,
+		Files:          7,
+
+		StorageImages:    8,
+		StorageDocuments: 9,
+		StorageOther:     10,
+		StorageExports:   11,
+	}
+
+	got := bootstrap.SystemStatsToBusinessStats(in)
+
+	c.Assert(got.Tenants, qt.Equals, int64(1))
+	c.Assert(got.Users, qt.Equals, int64(2))
+	c.Assert(got.LocationGroups, qt.Equals, int64(3))
+	c.Assert(got.Locations, qt.Equals, int64(4))
+	c.Assert(got.Areas, qt.Equals, int64(5))
+	c.Assert(got.Commodities, qt.Equals, int64(6))
+	c.Assert(got.Files, qt.Equals, int64(7))
+	c.Assert(got.StorageImages, qt.Equals, int64(8))
+	c.Assert(got.StorageDocuments, qt.Equals, int64(9))
+	c.Assert(got.StorageOther, qt.Equals, int64(10))
+	c.Assert(got.StorageExports, qt.Equals, int64(11))
+}

--- a/go/cmd/inventario/run/bootstrap/workers.go
+++ b/go/cmd/inventario/run/bootstrap/workers.go
@@ -8,7 +8,9 @@ import (
 	"github.com/denisvmedia/inventario/backup/export"
 	importpkg "github.com/denisvmedia/inventario/backup/import"
 	"github.com/denisvmedia/inventario/backup/restore"
+	"github.com/denisvmedia/inventario/internal/metrics"
 	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
 	"github.com/denisvmedia/inventario/registry/postgres"
 	"github.com/denisvmedia/inventario/services"
 	"github.com/denisvmedia/inventario/services/notifications"
@@ -181,6 +183,64 @@ func StartStorageQuotaReminderWorker(ctx context.Context, rs *RuntimeSetup, cfg 
 	)
 	worker.Start(ctx)
 	return worker.Stop
+}
+
+// StartBusinessMetricsWorker wires and starts the installation-wide
+// business-metrics collector (#843). It mirrors the reminder-worker
+// wiring: pulls the configured interval from rs.WorkerDurations and owns
+// a single goroutine with a graceful stop.
+//
+// The collector reads through rs.FactorySet.SystemStats, which bypasses
+// tenant scoping (the postgres source runs under the background-worker
+// role), so this MUST run in exactly one producer — the housekeeping
+// worker group / `run all` — never the apiserver path, otherwise split
+// deployments would publish duplicate series for the same gauges.
+//
+// Returns a no-op stop when no SystemStats source is configured (e.g. a
+// backend that left the field nil); the collector itself also no-ops on
+// a nil source, but short-circuiting here keeps the log honest.
+func StartBusinessMetricsWorker(ctx context.Context, rs *RuntimeSetup, _ *Config) func() {
+	if rs.FactorySet.SystemStats == nil {
+		slog.Info("Business metrics collector disabled; no SystemStats source configured")
+		return func() {}
+	}
+
+	// Adapt registry.SystemStats → metrics.BusinessStats field-by-field.
+	// The explicit copy (rather than a struct cast) keeps the metrics
+	// package free of any registry import and fails at compile time here
+	// if either struct drifts.
+	source := func(ctx context.Context) (metrics.BusinessStats, error) {
+		s, err := rs.FactorySet.SystemStats(ctx)
+		if err != nil {
+			return metrics.BusinessStats{}, err
+		}
+		return systemStatsToBusinessStats(s), nil
+	}
+
+	coll := metrics.NewBusinessCollector(source, rs.WorkerDurations.BusinessMetricsInterval)
+	coll.Start(ctx)
+	return coll.Stop
+}
+
+// systemStatsToBusinessStats copies the registry-layer SystemStats
+// snapshot into the metrics-layer BusinessStats the collector consumes.
+// Kept as an explicit, separately-testable function so the field mapping
+// is asserted in a unit test without needing a database.
+func systemStatsToBusinessStats(s registry.SystemStats) metrics.BusinessStats {
+	return metrics.BusinessStats{
+		Tenants:        s.Tenants,
+		Users:          s.Users,
+		LocationGroups: s.LocationGroups,
+		Locations:      s.Locations,
+		Areas:          s.Areas,
+		Commodities:    s.Commodities,
+		Files:          s.Files,
+
+		StorageImages:    s.StorageImages,
+		StorageDocuments: s.StorageDocuments,
+		StorageOther:     s.StorageOther,
+		StorageExports:   s.StorageExports,
+	}
 }
 
 // StartMaintenanceReminderWorker wires and starts the maintenance

--- a/go/cmd/inventario/run/workers/workers.go
+++ b/go/cmd/inventario/run/workers/workers.go
@@ -150,6 +150,7 @@ func (c *Command) run() error {
 			bootstrap.StartLoanReminderWorker,
 			bootstrap.StartMaintenanceReminderWorker,
 			bootstrap.StartCurrencyMigrationWorker,
+			bootstrap.StartBusinessMetricsWorker,
 		}},
 	}
 

--- a/go/email/queue/inmemory/queue.go
+++ b/go/email/queue/inmemory/queue.go
@@ -78,6 +78,16 @@ func (q *Queue) ScheduleRetry(ctx context.Context, payload []byte, readyAt time.
 	return nil
 }
 
+// Depth returns the number of payloads currently in the ready queue.
+//
+// It reports only the ready channel buffer (what Enqueue/Dequeue operate
+// on), not the delayed-retry slice. len on a channel is safe to call
+// concurrently and the retry mutex guards only the retries slice, so no
+// lock is taken here.
+func (q *Queue) Depth(_ context.Context) (int, error) {
+	return len(q.ready), nil
+}
+
 // PromoteDueRetries moves due payloads to ready queue.
 func (q *Queue) PromoteDueRetries(ctx context.Context, now time.Time, limit int) (int, error) {
 	if limit <= 0 {

--- a/go/email/queue/inmemory/queue_test.go
+++ b/go/email/queue/inmemory/queue_test.go
@@ -69,6 +69,44 @@ func TestQueue_ScheduleRetryAndPromoteDueRetries(t *testing.T) {
 	c.Assert(string(got), qt.Equals, "future")
 }
 
+func TestQueue_Depth(t *testing.T) {
+	c := qt.New(t)
+
+	q := New(4)
+
+	depth, err := q.Depth(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(depth, qt.Equals, 0)
+
+	c.Assert(q.Enqueue(context.Background(), []byte("a")), qt.IsNil)
+	c.Assert(q.Enqueue(context.Background(), []byte("b")), qt.IsNil)
+
+	depth, err = q.Depth(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(depth, qt.Equals, 2)
+
+	got, err := q.Dequeue(context.Background(), 20*time.Millisecond)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.IsNotNil)
+
+	depth, err = q.Depth(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(depth, qt.Equals, 1)
+}
+
+func TestQueue_Depth_IgnoresScheduledRetries(t *testing.T) {
+	c := qt.New(t)
+
+	q := New(4)
+	now := time.Unix(1700000000, 0)
+
+	c.Assert(q.ScheduleRetry(context.Background(), []byte("retry"), now.Add(time.Hour)), qt.IsNil)
+
+	depth, err := q.Depth(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(depth, qt.Equals, 0)
+}
+
 func TestQueue_PromoteDueRetries_RespectsLimit(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/email/queue/queue.go
+++ b/go/email/queue/queue.go
@@ -23,4 +23,6 @@ type Queue interface {
 	// PromoteDueRetries moves due retry payloads to ready queue.
 	// Returns number of promoted payloads.
 	PromoteDueRetries(ctx context.Context, now time.Time, limit int) (int, error)
+	// Depth returns the number of payloads currently in the ready queue.
+	Depth(ctx context.Context) (int, error)
 }

--- a/go/email/queue/redis/queue.go
+++ b/go/email/queue/redis/queue.go
@@ -113,6 +113,19 @@ func (q *Queue) ScheduleRetry(ctx context.Context, payload []byte, readyAt time.
 	}).Err()
 }
 
+// Depth returns the number of payloads currently in the ready list.
+//
+// It counts only the ready list (the LIST that Enqueue/Dequeue operate
+// on via RPUSH/BLPOP), not the delayed-retry sorted set, so the reported
+// depth matches what workers can consume immediately.
+func (q *Queue) Depth(ctx context.Context) (int, error) {
+	n, err := q.client.LLen(ctx, q.readyKey).Result()
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
 // PromoteDueRetries moves due delayed payloads into ready list.
 func (q *Queue) PromoteDueRetries(ctx context.Context, now time.Time, limit int) (int, error) {
 	moved, err := q.client.Eval(

--- a/go/email/queue/redis/queue_test.go
+++ b/go/email/queue/redis/queue_test.go
@@ -129,6 +129,58 @@ func TestQueue_CustomKeysIsolation(t *testing.T) {
 	c.Assert(string(got), qt.Equals, "only-q1")
 }
 
+func TestQueue_Depth(t *testing.T) {
+	c := qt.New(t)
+
+	mr, err := miniredis.Run()
+	c.Assert(err, qt.IsNil)
+	defer mr.Close()
+
+	q, err := NewFromConfig(Config{
+		RedisURL: fmt.Sprintf("redis://%s/0", mr.Addr()),
+	})
+	c.Assert(err, qt.IsNil)
+
+	depth, err := q.Depth(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(depth, qt.Equals, 0)
+
+	c.Assert(q.Enqueue(context.Background(), []byte("a")), qt.IsNil)
+	c.Assert(q.Enqueue(context.Background(), []byte("b")), qt.IsNil)
+
+	depth, err = q.Depth(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(depth, qt.Equals, 2)
+
+	got, err := q.Dequeue(context.Background(), 20*time.Millisecond)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.IsNotNil)
+
+	depth, err = q.Depth(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(depth, qt.Equals, 1)
+}
+
+func TestQueue_Depth_IgnoresScheduledRetries(t *testing.T) {
+	c := qt.New(t)
+
+	mr, err := miniredis.Run()
+	c.Assert(err, qt.IsNil)
+	defer mr.Close()
+
+	q, err := NewFromConfig(Config{
+		RedisURL: fmt.Sprintf("redis://%s/0", mr.Addr()),
+	})
+	c.Assert(err, qt.IsNil)
+
+	now := time.Unix(1700000000, 0)
+	c.Assert(q.ScheduleRetry(context.Background(), []byte("retry"), now.Add(time.Hour)), qt.IsNil)
+
+	depth, err := q.Depth(context.Background())
+	c.Assert(err, qt.IsNil)
+	c.Assert(depth, qt.Equals, 0)
+}
+
 func TestQueue_PromoteDueRetries_RespectsLimit(t *testing.T) {
 	c := qt.New(t)
 

--- a/go/internal/defaults/defaults.go
+++ b/go/internal/defaults/defaults.go
@@ -36,6 +36,7 @@ type Workers struct {
 	LoanReminderDueSoonDays      int    // Forward-looking window for the loan due-soon reminder (default 7)
 	MaintenanceReminderInterval  string // Maintenance reminder worker interval (e.g., "1h")
 	CurrencyMigrationInterval    string // Currency migration worker active-poll interval (e.g., "5s")
+	BusinessMetricsInterval      string // Business-metrics collector interval (e.g., "60s")
 }
 
 // ThumbnailGeneration contains default values for thumbnail generation configuration
@@ -102,6 +103,7 @@ func New() Config {
 			LoanReminderDueSoonDays:      7,
 			MaintenanceReminderInterval:  "1h",
 			CurrencyMigrationInterval:    "5s",
+			BusinessMetricsInterval:      "60s",
 		},
 		ThumbnailGeneration: ThumbnailGeneration{
 			MaxConcurrentPerUser: 5,     // Maximum 5 simultaneous thumbnail generation jobs per user
@@ -233,6 +235,14 @@ func GetMaintenanceReminderInterval() string {
 // knob the operator tunes.
 func GetCurrencyMigrationInterval() string {
 	return defaultConfig.Workers.CurrencyMigrationInterval
+}
+
+// GetBusinessMetricsInterval returns the default interval between
+// business-metrics collection sweeps (#843). 60s is frequent enough for
+// installation-wide gauges (tenants/users/storage move slowly) without
+// adding meaningful aggregate-query load.
+func GetBusinessMetricsInterval() string {
+	return defaultConfig.Workers.BusinessMetricsInterval
 }
 
 // GetThumbnailBatchSize returns the default thumbnail worker batch size

--- a/go/internal/metrics/business.go
+++ b/go/internal/metrics/business.go
@@ -1,0 +1,139 @@
+package metrics
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// BusinessStats is a point-in-time snapshot of installation-wide
+// entity counts and storage usage. It is produced by a
+// BusinessStatsFunc and fed into the business gauges by
+// BusinessCollector.
+type BusinessStats struct {
+	Tenants        int64
+	Users          int64
+	LocationGroups int64
+	Locations      int64
+	Areas          int64
+	Commodities    int64
+	Files          int64
+
+	StorageImages    int64
+	StorageDocuments int64
+	StorageOther     int64
+	StorageExports   int64
+}
+
+// BusinessStatsFunc returns a fresh BusinessStats snapshot. It is the
+// only seam through which this leaf package reaches the database, so
+// the registry/service code that knows how to count rows stays out of
+// the metrics package's import graph.
+type BusinessStatsFunc func(ctx context.Context) (BusinessStats, error)
+
+// defaultBusinessCollectInterval is a sane fallback cadence; the
+// caller normally passes an explicit interval.
+const defaultBusinessCollectInterval = time.Minute
+
+// BusinessCollector periodically calls a BusinessStatsFunc and pushes
+// the result into the business gauges. It owns a single goroutine,
+// mirroring the lifecycle of the storage-quota reminder worker:
+// run-once-immediately, then tick, with a best-effort graceful stop.
+type BusinessCollector struct {
+	source   BusinessStatsFunc
+	interval time.Duration
+	logger   *slog.Logger
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+// NewBusinessCollector constructs a BusinessCollector. A non-positive
+// interval falls back to defaultBusinessCollectInterval.
+func NewBusinessCollector(source BusinessStatsFunc, interval time.Duration) *BusinessCollector {
+	if interval <= 0 {
+		interval = defaultBusinessCollectInterval
+	}
+	return &BusinessCollector{
+		source:   source,
+		interval: interval,
+		logger:   slog.Default(),
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start launches the collection goroutine. It collects once
+// immediately so the gauges are populated right after a deploy rather
+// than after the first full interval, then ticks every interval. The
+// goroutine exits on ctx cancellation or Stop. No-op if no source is
+// configured.
+func (c *BusinessCollector) Start(ctx context.Context) {
+	if c.source == nil {
+		c.logger.Warn("BusinessCollector: no source configured, skipping startup")
+		return
+	}
+	c.wg.Go(func() {
+		c.run(ctx)
+	})
+	c.logger.Info("Business metrics collector started", "interval", c.interval)
+}
+
+// Stop signals the goroutine and waits for it to exit. Safe to call
+// multiple times.
+func (c *BusinessCollector) Stop() {
+	c.stopOnce.Do(func() {
+		close(c.stopCh)
+	})
+	c.wg.Wait()
+	c.logger.Info("Business metrics collector stopped")
+}
+
+func (c *BusinessCollector) run(ctx context.Context) {
+	// Collect once at startup; same rationale as the reminder workers.
+	c.collectOnce(ctx)
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			c.collectOnce(ctx)
+		}
+	}
+}
+
+// collectOnce runs a single collection sweep. On error it records the
+// failure and returns WITHOUT touching the gauges, so a transient DB
+// blip leaves the last good values in place rather than zeroing them.
+func (c *BusinessCollector) collectOnce(ctx context.Context) {
+	start := time.Now()
+	defer func() {
+		businessCollectDuration.Observe(time.Since(start).Seconds())
+	}()
+
+	stats, err := c.source(ctx)
+	if err != nil {
+		businessCollectErrorsTotal.Inc()
+		c.logger.Warn("Business metrics collection failed", "error", err)
+		return
+	}
+
+	businessTenants.Set(float64(stats.Tenants))
+	businessUsers.Set(float64(stats.Users))
+	businessLocationGroups.Set(float64(stats.LocationGroups))
+	businessLocations.Set(float64(stats.Locations))
+	businessAreas.Set(float64(stats.Areas))
+	businessCommodities.Set(float64(stats.Commodities))
+	businessFiles.Set(float64(stats.Files))
+
+	businessFileStorageBytes.WithLabelValues(storageCategoryImages).Set(float64(stats.StorageImages))
+	businessFileStorageBytes.WithLabelValues(storageCategoryDocuments).Set(float64(stats.StorageDocuments))
+	businessFileStorageBytes.WithLabelValues(storageCategoryOther).Set(float64(stats.StorageOther))
+	businessFileStorageBytes.WithLabelValues(storageCategoryExports).Set(float64(stats.StorageExports))
+}

--- a/go/internal/metrics/business_test.go
+++ b/go/internal/metrics/business_test.go
@@ -1,0 +1,104 @@
+package metrics_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/denisvmedia/inventario/internal/metrics"
+)
+
+func TestBusinessCollector_CollectOnceSetsGauges(t *testing.T) {
+	c := qt.New(t)
+
+	stats := metrics.BusinessStats{
+		Tenants:        3,
+		Users:          12,
+		LocationGroups: 4,
+		Locations:      9,
+		Areas:          25,
+		Commodities:    140,
+		Files:          77,
+
+		StorageImages:    1000,
+		StorageDocuments: 2000,
+		StorageOther:     3000,
+		StorageExports:   4000,
+	}
+
+	collector := metrics.NewBusinessCollector(func(context.Context) (metrics.BusinessStats, error) {
+		return stats, nil
+	}, time.Hour)
+
+	collector.CollectOnceForTest(context.Background())
+
+	c.Assert(testutil.ToFloat64(metrics.BusinessTenants), qt.Equals, float64(3))
+	c.Assert(testutil.ToFloat64(metrics.BusinessUsers), qt.Equals, float64(12))
+	c.Assert(testutil.ToFloat64(metrics.BusinessLocationGroups), qt.Equals, float64(4))
+	c.Assert(testutil.ToFloat64(metrics.BusinessLocations), qt.Equals, float64(9))
+	c.Assert(testutil.ToFloat64(metrics.BusinessAreas), qt.Equals, float64(25))
+	c.Assert(testutil.ToFloat64(metrics.BusinessCommodities), qt.Equals, float64(140))
+	c.Assert(testutil.ToFloat64(metrics.BusinessFiles), qt.Equals, float64(77))
+
+	c.Assert(testutil.ToFloat64(
+		metrics.BusinessFileStorageBytes.WithLabelValues(metrics.StorageCategoryImages)),
+		qt.Equals, float64(1000))
+	c.Assert(testutil.ToFloat64(
+		metrics.BusinessFileStorageBytes.WithLabelValues(metrics.StorageCategoryDocuments)),
+		qt.Equals, float64(2000))
+	c.Assert(testutil.ToFloat64(
+		metrics.BusinessFileStorageBytes.WithLabelValues(metrics.StorageCategoryOther)),
+		qt.Equals, float64(3000))
+	c.Assert(testutil.ToFloat64(
+		metrics.BusinessFileStorageBytes.WithLabelValues(metrics.StorageCategoryExports)),
+		qt.Equals, float64(4000))
+}
+
+func TestBusinessCollector_ErrorLeavesGaugesUntouched(t *testing.T) {
+	c := qt.New(t)
+
+	// Seed a known good value first.
+	good := metrics.NewBusinessCollector(func(context.Context) (metrics.BusinessStats, error) {
+		return metrics.BusinessStats{Tenants: 42}, nil
+	}, time.Hour)
+	good.CollectOnceForTest(context.Background())
+	c.Assert(testutil.ToFloat64(metrics.BusinessTenants), qt.Equals, float64(42))
+
+	errBefore := testutil.ToFloat64(metrics.BusinessCollectErrorsTotal)
+
+	failing := metrics.NewBusinessCollector(func(context.Context) (metrics.BusinessStats, error) {
+		return metrics.BusinessStats{Tenants: 999}, errors.New("db down")
+	}, time.Hour)
+	failing.CollectOnceForTest(context.Background())
+
+	// Error counter incremented...
+	c.Assert(testutil.ToFloat64(metrics.BusinessCollectErrorsTotal)-errBefore, qt.Equals, float64(1))
+	// ...and the gauge kept its last good value rather than 999.
+	c.Assert(testutil.ToFloat64(metrics.BusinessTenants), qt.Equals, float64(42))
+}
+
+func TestBusinessCollector_StartStopDoesNotDeadlock(t *testing.T) {
+	c := qt.New(t)
+
+	collector := metrics.NewBusinessCollector(func(context.Context) (metrics.BusinessStats, error) {
+		return metrics.BusinessStats{}, nil
+	}, time.Hour)
+
+	collector.Start(t.Context())
+
+	done := make(chan struct{})
+	go func() {
+		collector.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		c.Fatal("BusinessCollector.Stop deadlocked")
+	}
+}

--- a/go/internal/metrics/dbtracer.go
+++ b/go/internal/metrics/dbtracer.go
@@ -1,0 +1,62 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// queryTraceKey is the unexported context key under which the query
+// start time and parsed verb are stashed between TraceQueryStart and
+// TraceQueryEnd. A dedicated unexported type guarantees no collision
+// with other context values.
+type queryTraceKey struct{}
+
+// queryTraceData carries per-query state across the trace lifecycle.
+type queryTraceData struct {
+	start time.Time
+	verb  string
+}
+
+// QueryTracer implements pgx.QueryTracer to record per-query latency
+// and counts into the Prometheus default registry. The SQL operation
+// (select/insert/update/...) is the only label, keeping cardinality
+// bounded — see parseSQLVerb.
+type QueryTracer struct{}
+
+// compile-time assertion that QueryTracer satisfies pgx.QueryTracer.
+var _ pgx.QueryTracer = (*QueryTracer)(nil)
+
+// NewQueryTracer constructs a QueryTracer ready to be attached to a
+// pgx (pool) config via the QueryTracer field.
+func NewQueryTracer() *QueryTracer {
+	return &QueryTracer{}
+}
+
+// TraceQueryStart stashes the start time and parsed SQL verb in the
+// returned context for retrieval in TraceQueryEnd.
+func (*QueryTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	return context.WithValue(ctx, queryTraceKey{}, queryTraceData{
+		start: time.Now(),
+		verb:  parseSQLVerb(data.SQL),
+	})
+}
+
+// TraceQueryEnd observes the elapsed duration and increments the query
+// counter, partitioned by operation and outcome. If the start context
+// value is missing (which should not happen), it no-ops safely.
+func (*QueryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
+	td, ok := ctx.Value(queryTraceKey{}).(queryTraceData)
+	if !ok {
+		return
+	}
+
+	status := "ok"
+	if data.Err != nil {
+		status = "error"
+	}
+
+	dbQueryDuration.WithLabelValues(td.verb).Observe(time.Since(td.start).Seconds())
+	dbQueriesTotal.WithLabelValues(td.verb, status).Inc()
+}

--- a/go/internal/metrics/dbtracer_test.go
+++ b/go/internal/metrics/dbtracer_test.go
@@ -1,0 +1,68 @@
+package metrics_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/denisvmedia/inventario/internal/metrics"
+)
+
+func TestQueryTracer_RecordsSuccess(t *testing.T) {
+	c := qt.New(t)
+
+	tracer := metrics.NewQueryTracer()
+
+	countBefore := testutil.ToFloat64(metrics.DBQueriesTotal.WithLabelValues("select", "ok"))
+	durBefore := histogramCount(c, "select")
+
+	ctx := tracer.TraceQueryStart(context.Background(), nil, pgx.TraceQueryStartData{
+		SQL: "SELECT * FROM commodities",
+	})
+	tracer.TraceQueryEnd(ctx, nil, pgx.TraceQueryEndData{Err: nil})
+
+	countAfter := testutil.ToFloat64(metrics.DBQueriesTotal.WithLabelValues("select", "ok"))
+	c.Assert(countAfter-countBefore, qt.Equals, float64(1))
+	c.Assert(histogramCount(c, "select")-durBefore, qt.Equals, uint64(1))
+}
+
+func TestQueryTracer_RecordsError(t *testing.T) {
+	c := qt.New(t)
+
+	tracer := metrics.NewQueryTracer()
+
+	countBefore := testutil.ToFloat64(metrics.DBQueriesTotal.WithLabelValues("update", "error"))
+
+	ctx := tracer.TraceQueryStart(context.Background(), nil, pgx.TraceQueryStartData{
+		SQL: "UPDATE files SET path = $1",
+	})
+	tracer.TraceQueryEnd(ctx, nil, pgx.TraceQueryEndData{Err: errors.New("boom")})
+
+	countAfter := testutil.ToFloat64(metrics.DBQueriesTotal.WithLabelValues("update", "error"))
+	c.Assert(countAfter-countBefore, qt.Equals, float64(1))
+}
+
+func TestQueryTracer_MissingStartContextNoOps(t *testing.T) {
+	c := qt.New(t)
+
+	tracer := metrics.NewQueryTracer()
+	// Call End without a corresponding Start context: must not panic.
+	c.Assert(func() {
+		tracer.TraceQueryEnd(context.Background(), nil, pgx.TraceQueryEndData{})
+	}, qt.Not(qt.PanicMatches), ".*")
+}
+
+// histogramCount returns the cumulative sample count of the
+// db_query_duration histogram series for the given operation.
+func histogramCount(c *qt.C, operation string) uint64 {
+	obs, err := metrics.DBQueryDuration.GetMetricWithLabelValues(operation)
+	c.Assert(err, qt.IsNil)
+	coll, ok := obs.(prometheus.Collector)
+	c.Assert(ok, qt.IsTrue)
+	return metrics.HistogramSampleCount(coll)
+}

--- a/go/internal/metrics/export_test.go
+++ b/go/internal/metrics/export_test.go
@@ -47,6 +47,11 @@ func StatusClass(code int) string {
 	return statusClass(code)
 }
 
+// NormalizeMethod exposes normalizeMethod for tests.
+func NormalizeMethod(m string) string {
+	return normalizeMethod(m)
+}
+
 // CollectOnceForTest drives a single business collection sweep
 // synchronously, bypassing the goroutine, so tests can assert on the
 // gauge side effects deterministically.

--- a/go/internal/metrics/export_test.go
+++ b/go/internal/metrics/export_test.go
@@ -1,0 +1,85 @@
+package metrics
+
+// This file exposes selected unexported metric vars and helpers to the
+// black-box metrics_test package so tests can assert on them without
+// widening the public API. It compiles only under `go test`.
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// HTTP metrics.
+var (
+	HTTPRequestsTotal    = httpRequestsTotal
+	HTTPRequestDuration  = httpRequestDuration
+	HTTPRequestsInFlight = httpRequestsInFlight
+)
+
+// DB query metrics.
+var (
+	DBQueryDuration = dbQueryDuration
+	DBQueriesTotal  = dbQueriesTotal
+)
+
+// Business gauges.
+var (
+	BusinessTenants            = businessTenants
+	BusinessUsers              = businessUsers
+	BusinessLocationGroups     = businessLocationGroups
+	BusinessLocations          = businessLocations
+	BusinessAreas              = businessAreas
+	BusinessCommodities        = businessCommodities
+	BusinessFiles              = businessFiles
+	BusinessFileStorageBytes   = businessFileStorageBytes
+	BusinessCollectErrorsTotal = businessCollectErrorsTotal
+)
+
+// ParseSQLVerb exposes parseSQLVerb for table tests.
+func ParseSQLVerb(sql string) string {
+	return parseSQLVerb(sql)
+}
+
+// StatusClass exposes statusClass for tests.
+func StatusClass(code int) string {
+	return statusClass(code)
+}
+
+// CollectOnceForTest drives a single business collection sweep
+// synchronously, bypassing the goroutine, so tests can assert on the
+// gauge side effects deterministically.
+func (c *BusinessCollector) CollectOnceForTest(ctx context.Context) {
+	c.collectOnce(ctx)
+}
+
+// Storage category label values, re-exported for assertion convenience.
+const (
+	StorageCategoryImages    = storageCategoryImages
+	StorageCategoryDocuments = storageCategoryDocuments
+	StorageCategoryOther     = storageCategoryOther
+	StorageCategoryExports   = storageCategoryExports
+)
+
+// HistogramSampleCount returns the cumulative sample count of a
+// single-series histogram (or a HistogramVec series) by collecting it
+// directly, without a registry. Tests use it to assert that an
+// observation landed.
+func HistogramSampleCount(c prometheus.Collector) uint64 {
+	ch := make(chan prometheus.Metric, 8)
+	c.Collect(ch)
+	close(ch)
+
+	var total uint64
+	for m := range ch {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			continue
+		}
+		if pb.Histogram != nil {
+			total += pb.Histogram.GetSampleCount()
+		}
+	}
+	return total
+}

--- a/go/internal/metrics/http.go
+++ b/go/internal/metrics/http.go
@@ -1,0 +1,72 @@
+package metrics
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+)
+
+// metricsRoute is the path we never self-instrument: counting the
+// scrape itself would pollute latency and rate dashboards.
+const metricsRoute = "/metrics"
+
+// HTTPMiddleware is a chi-aware RED (Rate, Errors, Duration)
+// middleware. It must be installed after chi has had a chance to fill
+// the route pattern, i.e. as router middleware (r.Use), so that
+// chi.RouteContext(...).RoutePattern() resolves to the matched
+// template (e.g. "/x/{id}") rather than the concrete path.
+//
+// Unmatched requests (404) keep the empty route pattern chi returns;
+// we deliberately do NOT fall back to r.URL.Path, which would be
+// unbounded and blow up label cardinality.
+func HTTPMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		httpRequestsInFlight.Inc()
+		defer httpRequestsInFlight.Dec()
+
+		ww := chimiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+		defer func() {
+			// chi fills the route pattern during ServeHTTP, so it is
+			// only reliable here, after next has returned.
+			route := chi.RouteContext(r.Context()).RoutePattern()
+			if route == metricsRoute {
+				// Skip self-instrumentation of the scrape endpoint.
+				return
+			}
+
+			elapsed := time.Since(start)
+			class := statusClass(ww.Status())
+
+			httpRequestsTotal.WithLabelValues(r.Method, route, class).Inc()
+			httpRequestDuration.WithLabelValues(r.Method, route).Observe(elapsed.Seconds())
+		}()
+
+		next.ServeHTTP(ww, r)
+	})
+}
+
+// statusClass maps an HTTP status code to its class label ("1xx" ..
+// "5xx"). A zero code means the handler never wrote a header, which
+// the wrapped writer reports as the default 200, so we treat 0 as
+// "2xx" defensively.
+func statusClass(code int) string {
+	switch code / 100 {
+	case 1:
+		return "1xx"
+	case 2:
+		return "2xx"
+	case 3:
+		return "3xx"
+	case 4:
+		return "4xx"
+	case 5:
+		return "5xx"
+	default:
+		return "2xx"
+	}
+}

--- a/go/internal/metrics/http.go
+++ b/go/internal/metrics/http.go
@@ -13,16 +13,27 @@ import (
 const metricsRoute = "/metrics"
 
 // HTTPMiddleware is a chi-aware RED (Rate, Errors, Duration)
-// middleware. It must be installed after chi has had a chance to fill
-// the route pattern, i.e. as router middleware (r.Use), so that
-// chi.RouteContext(...).RoutePattern() resolves to the matched
-// template (e.g. "/x/{id}") rather than the concrete path.
+// middleware. It must be installed as router middleware (r.Use) so that
+// chi.RouteContext(...).RoutePattern() resolves to the matched template
+// (e.g. "/x/{id}") rather than the concrete path. It should also wrap
+// chi's Recoverer (be registered BEFORE it) so the deferred status read
+// observes the 500 Recoverer writes for a recovered panic.
 //
 // Unmatched requests (404) keep the empty route pattern chi returns;
 // we deliberately do NOT fall back to r.URL.Path, which would be
 // unbounded and blow up label cardinality.
 func HTTPMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Skip the scrape endpoint entirely — including the in-flight
+		// gauge — so an otherwise idle instance does not report an
+		// in-flight request on every scrape. The raw path is reliable
+		// here because /metrics is mounted at a fixed path; this runs
+		// before any routing, so RoutePattern is not yet available.
+		if r.URL.Path == metricsRoute {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		start := time.Now()
 
 		httpRequestsInFlight.Inc()
@@ -34,20 +45,31 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 			// chi fills the route pattern during ServeHTTP, so it is
 			// only reliable here, after next has returned.
 			route := chi.RouteContext(r.Context()).RoutePattern()
-			if route == metricsRoute {
-				// Skip self-instrumentation of the scrape endpoint.
-				return
-			}
-
 			elapsed := time.Since(start)
 			class := statusClass(ww.Status())
+			method := normalizeMethod(r.Method)
 
-			httpRequestsTotal.WithLabelValues(r.Method, route, class).Inc()
-			httpRequestDuration.WithLabelValues(r.Method, route).Observe(elapsed.Seconds())
+			httpRequestsTotal.WithLabelValues(method, route, class).Inc()
+			httpRequestDuration.WithLabelValues(method, route).Observe(elapsed.Seconds())
 		}()
 
 		next.ServeHTTP(ww, r)
 	})
+}
+
+// normalizeMethod maps an HTTP method to a bounded label value. r.Method
+// is client-controlled — an arbitrary token (e.g. on an unmatched route)
+// would otherwise create an unbounded `method` label — so anything
+// outside the standard set collapses to "OTHER".
+func normalizeMethod(m string) string {
+	switch m {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace:
+		return m
+	default:
+		return "OTHER"
+	}
 }
 
 // statusClass maps an HTTP status code to its class label ("1xx" ..

--- a/go/internal/metrics/http_test.go
+++ b/go/internal/metrics/http_test.go
@@ -71,6 +71,25 @@ func TestHTTPMiddleware_SkipsMetricsRoute(t *testing.T) {
 	c.Assert(after-before, qt.Equals, float64(0))
 }
 
+func TestNormalizeMethod(t *testing.T) {
+	c := qt.New(t)
+
+	// Standard methods pass through unchanged.
+	for _, m := range []string{
+		http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace,
+	} {
+		c.Assert(metrics.NormalizeMethod(m), qt.Equals, m)
+	}
+
+	// Anything client-controlled outside the set collapses to OTHER, so an
+	// attacker cannot blow up the `method` label cardinality.
+	for _, m := range []string{"FOOBAR", "get", "", "PROPFIND", "x\x00y"} {
+		c.Assert(metrics.NormalizeMethod(m), qt.Equals, "OTHER")
+	}
+}
+
 func TestStatusClass(t *testing.T) {
 	tests := []struct {
 		code int

--- a/go/internal/metrics/http_test.go
+++ b/go/internal/metrics/http_test.go
@@ -1,0 +1,92 @@
+package metrics_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/denisvmedia/inventario/internal/metrics"
+)
+
+func TestHTTPMiddleware_RecordsRoutePatternNotConcretePath(t *testing.T) {
+	c := qt.New(t)
+
+	r := chi.NewRouter()
+	r.Use(metrics.HTTPMiddleware)
+	r.Get("/x/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	before := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(http.MethodGet, "/x/{id}", "2xx"))
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x/123", nil))
+
+	c.Assert(rec.Code, qt.Equals, http.StatusOK)
+
+	after := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(http.MethodGet, "/x/{id}", "2xx"))
+	c.Assert(after-before, qt.Equals, float64(1))
+
+	// The concrete path must NOT have produced its own series.
+	concrete := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(http.MethodGet, "/x/123", "2xx"))
+	c.Assert(concrete, qt.Equals, float64(0))
+}
+
+func TestHTTPMiddleware_InFlightReturnsToZero(t *testing.T) {
+	c := qt.New(t)
+
+	r := chi.NewRouter()
+	r.Use(metrics.HTTPMiddleware)
+	r.Get("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ping", nil))
+
+	c.Assert(testutil.ToFloat64(metrics.HTTPRequestsInFlight), qt.Equals, float64(0))
+}
+
+func TestHTTPMiddleware_SkipsMetricsRoute(t *testing.T) {
+	c := qt.New(t)
+
+	r := chi.NewRouter()
+	r.Use(metrics.HTTPMiddleware)
+	r.Get("/metrics", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	before := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(http.MethodGet, "/metrics", "2xx"))
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	c.Assert(rec.Code, qt.Equals, http.StatusOK)
+
+	after := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(http.MethodGet, "/metrics", "2xx"))
+	c.Assert(after-before, qt.Equals, float64(0))
+}
+
+func TestStatusClass(t *testing.T) {
+	tests := []struct {
+		code int
+		want string
+	}{
+		{0, "2xx"},
+		{100, "1xx"},
+		{200, "2xx"},
+		{301, "3xx"},
+		{404, "4xx"},
+		{503, "5xx"},
+	}
+	for _, tc := range tests {
+		t.Run(http.StatusText(tc.code), func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(metrics.StatusClass(tc.code), qt.Equals, tc.want)
+		})
+	}
+}

--- a/go/internal/metrics/metrics.go
+++ b/go/internal/metrics/metrics.go
@@ -1,0 +1,240 @@
+// Package metrics is the central Prometheus metric registry for
+// Inventario's cross-cutting instrumentation (HTTP, database, auth,
+// email, rate-limiting, and system-wide business counts).
+//
+// Every metric is registered with promauto against the default
+// registry, which is the same registry promhttp.Handler() exposes on
+// /metrics. This package is deliberately a leaf: it imports only the
+// Prometheus client, pgx/v5 (+pgxpool), chi/v5, and the standard
+// library. It MUST NOT import apiserver, services, registry, or
+// models — wiring code in those packages calls the thin recording
+// helpers exported here instead of touching the metric vars directly.
+//
+// Naming follows Prometheus best practice: every metric carries the
+// inventario_ prefix; counters end in _total; durations are
+// _seconds histograms; sizes are _bytes; gauges never carry _total.
+//
+// See issue #843 for the original instrumentation plan.
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// HTTP request/response (RED) metrics. See HTTPMiddleware.
+var (
+	httpRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_http_requests_total",
+		Help: "Total number of HTTP requests handled, partitioned by method, chi route pattern, and status class.",
+	}, []string{"method", "route", "status_class"})
+
+	httpRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "inventario_http_request_duration_seconds",
+		Help:    "HTTP request latency in seconds, partitioned by method and chi route pattern.",
+		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+	}, []string{"method", "route"})
+
+	httpRequestsInFlight = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "inventario_http_requests_in_flight",
+		Help: "Number of HTTP requests currently being served.",
+	})
+)
+
+// Database query metrics. See QueryTracer.
+var (
+	dbQueryDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "inventario_db_query_duration_seconds",
+		Help:    "Database query latency in seconds, partitioned by SQL operation.",
+		Buckets: []float64{0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+	}, []string{"operation"})
+
+	dbQueriesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_db_queries_total",
+		Help: "Total number of database queries executed, partitioned by SQL operation and outcome.",
+	}, []string{"operation", "status"})
+)
+
+// Authentication metrics.
+var (
+	authLoginAttemptsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_auth_login_attempts_total",
+		Help: "Total number of tenant-plane login attempts, partitioned by outcome and authentication method (the back-office auth plane is not counted here).",
+	}, []string{"outcome", "method"})
+
+	authTokensIssuedTotal = newTokensIssuedTotal()
+)
+
+// Email processing metrics.
+var (
+	emailsProcessedTotal = newEmailsProcessedTotal()
+
+	emailSendDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "inventario_email_send_duration_seconds",
+		Help:    "Latency in seconds of a single email send attempt to the upstream provider.",
+		Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+	})
+
+	emailQueueDepth = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "inventario_email_queue_depth",
+		Help: "Number of emails currently waiting in the outbound queue.",
+	})
+)
+
+// Rate-limiting metrics.
+var rateLimitRejectionsTotal = newRateLimitRejectionsTotal()
+
+// System-wide business gauges. Populated by BusinessCollector. These
+// are deliberately unlabelled by tenant: they describe the whole
+// installation, not a single tenant, so a high-cardinality tenant
+// label would be both expensive and misleading.
+var (
+	businessTenants = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "inventario_tenants",
+		Help: "Current number of tenants.",
+	})
+	businessUsers = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "inventario_users",
+		Help: "Current number of users.",
+	})
+	businessLocationGroups = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "inventario_location_groups",
+		Help: "Current number of location groups.",
+	})
+	businessLocations = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "inventario_locations",
+		Help: "Current number of locations.",
+	})
+	businessAreas = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "inventario_areas",
+		Help: "Current number of areas.",
+	})
+	businessCommodities = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "inventario_commodities",
+		Help: "Current number of commodities.",
+	})
+	businessFiles = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "inventario_files",
+		Help: "Current number of files.",
+	})
+
+	businessFileStorageBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "inventario_file_storage_bytes",
+		Help: "Current total file storage in bytes, partitioned by category.",
+	}, []string{"category"})
+
+	businessCollectDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "inventario_business_collect_duration_seconds",
+		Help: "Latency in seconds of a single business-stats collection sweep.",
+	})
+
+	businessCollectErrorsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "inventario_business_collect_errors_total",
+		Help: "Total number of business-stats collection sweeps that failed.",
+	})
+)
+
+// Token type label values for RecordTokenIssued.
+const (
+	TokenTypeAccess  = "access"
+	TokenTypeRefresh = "refresh"
+)
+
+// Rate-limit scope label values for RecordRateLimitRejection.
+const (
+	RateLimitScopeGlobal = "global"
+	RateLimitScopeAuth   = "auth"
+)
+
+// Email status label values for RecordEmailProcessed.
+const (
+	EmailStatusSent    = "sent"
+	EmailStatusFailed  = "failed"
+	EmailStatusRetried = "retried"
+)
+
+// File storage category label values for the file_storage_bytes gauge.
+const (
+	storageCategoryImages    = "images"
+	storageCategoryDocuments = "documents"
+	storageCategoryOther     = "other"
+	storageCategoryExports   = "exports"
+)
+
+// The constructors below build a CounterVec and pre-initialise its
+// bounded label series to 0, so the metric exports a zero-valued
+// series before the first real event. That gives rate() a baseline
+// and dashboards a non-empty series on a fresh deploy. They are
+// var-initializer functions rather than an init() so the package
+// keeps `gochecknoinits` happy (mirrors models/user.go).
+//
+// Counters whose label set depends on an enum this leaf package does
+// not import (login outcomes/methods) are left lazy on purpose.
+
+func newTokensIssuedTotal() *prometheus.CounterVec {
+	cv := promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_auth_tokens_issued_total",
+		Help: "Total number of tenant-plane authentication tokens issued, partitioned by token type (the back-office auth plane is not counted here).",
+	}, []string{"type"})
+	cv.WithLabelValues(TokenTypeAccess).Add(0)
+	cv.WithLabelValues(TokenTypeRefresh).Add(0)
+	return cv
+}
+
+func newRateLimitRejectionsTotal() *prometheus.CounterVec {
+	cv := promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_rate_limit_rejections_total",
+		Help: "Total number of requests rejected by a rate limiter, partitioned by scope.",
+	}, []string{"scope"})
+	cv.WithLabelValues(RateLimitScopeGlobal).Add(0)
+	cv.WithLabelValues(RateLimitScopeAuth).Add(0)
+	return cv
+}
+
+func newEmailsProcessedTotal() *prometheus.CounterVec {
+	cv := promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "inventario_emails_processed_total",
+		Help: "Total number of email send outcomes, partitioned by status. 'sent' and 'failed' are terminal; 'retried' counts each requeue, so a message may contribute several 'retried' before one terminal outcome.",
+	}, []string{"status"})
+	cv.WithLabelValues(EmailStatusSent).Add(0)
+	cv.WithLabelValues(EmailStatusFailed).Add(0)
+	cv.WithLabelValues(EmailStatusRetried).Add(0)
+	return cv
+}
+
+// RecordLoginAttempt increments the login-attempt counter for the
+// given outcome (e.g. "success", "failure") and authentication method
+// (e.g. "password", "mfa"). The caller owns the label vocabulary.
+func RecordLoginAttempt(outcome, method string) {
+	authLoginAttemptsTotal.WithLabelValues(outcome, method).Inc()
+}
+
+// RecordTokenIssued increments the issued-token counter for the given
+// token type. Use the TokenType* constants.
+func RecordTokenIssued(tokenType string) {
+	authTokensIssuedTotal.WithLabelValues(tokenType).Inc()
+}
+
+// RecordRateLimitRejection increments the rate-limit rejection counter
+// for the given scope. Use the RateLimitScope* constants.
+func RecordRateLimitRejection(scope string) {
+	rateLimitRejectionsTotal.WithLabelValues(scope).Inc()
+}
+
+// RecordEmailProcessed increments the processed-email counter for the
+// given terminal status. Use the EmailStatus* constants.
+func RecordEmailProcessed(status string) {
+	emailsProcessedTotal.WithLabelValues(status).Inc()
+}
+
+// ObserveEmailSend records the duration of a single email send attempt.
+func ObserveEmailSend(d time.Duration) {
+	emailSendDuration.Observe(d.Seconds())
+}
+
+// SetEmailQueueDepth sets the current outbound email queue depth.
+func SetEmailQueueDepth(n int) {
+	emailQueueDepth.Set(float64(n))
+}

--- a/go/internal/metrics/poolcollector.go
+++ b/go/internal/metrics/poolcollector.go
@@ -1,0 +1,135 @@
+package metrics
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// PoolStatProvider is the slice of *pgxpool.Pool the PoolCollector
+// needs: a way to snapshot pool statistics on demand.
+type PoolStatProvider interface {
+	Stat() *pgxpool.Stat
+}
+
+// compile-time assertion that *pgxpool.Pool satisfies PoolStatProvider.
+var _ PoolStatProvider = (*pgxpool.Pool)(nil)
+
+// Descriptors for the const metrics the PoolCollector emits. Defined
+// as package vars so every collector instance shares one set.
+var (
+	poolConnectionsDesc = prometheus.NewDesc(
+		"inventario_db_pool_connections",
+		"Current number of pool connections, partitioned by state.",
+		[]string{"state"}, nil,
+	)
+	poolMaxConnectionsDesc = prometheus.NewDesc(
+		"inventario_db_pool_max_connections",
+		"Maximum number of connections the pool is configured to allow.",
+		nil, nil,
+	)
+	poolAcquireTotalDesc = prometheus.NewDesc(
+		"inventario_db_pool_acquire_total",
+		"Cumulative number of successful connection acquisitions.",
+		nil, nil,
+	)
+	poolEmptyAcquireTotalDesc = prometheus.NewDesc(
+		"inventario_db_pool_empty_acquire_total",
+		"Cumulative number of acquisitions that had to wait for a connection because the pool was empty.",
+		nil, nil,
+	)
+	poolCanceledAcquireTotalDesc = prometheus.NewDesc(
+		"inventario_db_pool_canceled_acquire_total",
+		"Cumulative number of acquisitions canceled by context before completing.",
+		nil, nil,
+	)
+)
+
+// PoolCollector is a prometheus.Collector that snapshots a pgx pool's
+// statistics on each scrape and emits them as const metrics. Using
+// const metrics (rather than promauto gauges) keeps the snapshot
+// consistent and avoids a background sampling goroutine.
+type PoolCollector struct {
+	provider PoolStatProvider
+}
+
+// compile-time assertion that *PoolCollector satisfies the Collector
+// interface.
+var _ prometheus.Collector = (*PoolCollector)(nil)
+
+// NewPoolCollector constructs a PoolCollector backed by the given
+// stat provider (typically a *pgxpool.Pool).
+func NewPoolCollector(p PoolStatProvider) *PoolCollector {
+	return &PoolCollector{provider: p}
+}
+
+// Describe sends the descriptors of all metrics the collector may emit.
+func (*PoolCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- poolConnectionsDesc
+	ch <- poolMaxConnectionsDesc
+	ch <- poolAcquireTotalDesc
+	ch <- poolEmptyAcquireTotalDesc
+	ch <- poolCanceledAcquireTotalDesc
+}
+
+// Collect snapshots the pool once and emits the const metrics.
+func (c *PoolCollector) Collect(ch chan<- prometheus.Metric) {
+	stat := c.provider.Stat()
+
+	ch <- prometheus.MustNewConstMetric(poolConnectionsDesc, prometheus.GaugeValue,
+		float64(stat.AcquiredConns()), "acquired")
+	ch <- prometheus.MustNewConstMetric(poolConnectionsDesc, prometheus.GaugeValue,
+		float64(stat.IdleConns()), "idle")
+	ch <- prometheus.MustNewConstMetric(poolConnectionsDesc, prometheus.GaugeValue,
+		float64(stat.ConstructingConns()), "constructing")
+
+	ch <- prometheus.MustNewConstMetric(poolMaxConnectionsDesc, prometheus.GaugeValue,
+		float64(stat.MaxConns()))
+
+	ch <- prometheus.MustNewConstMetric(poolAcquireTotalDesc, prometheus.CounterValue,
+		float64(stat.AcquireCount()))
+	ch <- prometheus.MustNewConstMetric(poolEmptyAcquireTotalDesc, prometheus.CounterValue,
+		float64(stat.EmptyAcquireCount()))
+	ch <- prometheus.MustNewConstMetric(poolCanceledAcquireTotalDesc, prometheus.CounterValue,
+		float64(stat.CanceledAcquireCount()))
+}
+
+// RegisterPoolCollector registers a PoolCollector for p against the
+// default registerer and returns a function that unregisters it.
+//
+// An AlreadyRegisteredError (an identical collector is already
+// registered, e.g. by a previous pool or a parallel test) is tolerated
+// and yields a no-op unregister, so callers in postgres.go can blindly
+// register on pool creation and unregister on cleanup without ever
+// panicking.
+//
+// LIMITATION: all PoolCollectors share one set of descriptors, so the
+// registry derives the same collector identity for every pool. Only the
+// FIRST live pool's stats are exported; a SECOND concurrently-live pool
+// (e.g. a future read-replica or a second registry set) collides and is
+// dropped. That is correct for the single-pool deployment today, and the
+// collision is logged (below) rather than swallowed silently so the gap
+// is visible if it ever arises. Supporting multiple pools would require a
+// distinguishing const label on the descriptors.
+func RegisterPoolCollector(p PoolStatProvider) (unregister func()) {
+	coll := NewPoolCollector(p)
+	if err := prometheus.DefaultRegisterer.Register(coll); err != nil {
+		var already prometheus.AlreadyRegisteredError
+		if errors.As(err, &already) {
+			// Identical collector already present — its stats, not this
+			// pool's, will be exported. Surface it; see the LIMITATION note.
+			slog.Warn("db pool metrics collector already registered; " +
+				"this pool's stats will not be exported (multiple pools are not supported)")
+			return func() {}
+		}
+		// Any other registration error is non-fatal for the caller's
+		// happy path, but should not pass unnoticed.
+		slog.Warn("failed to register db pool metrics collector", "error", err)
+		return func() {}
+	}
+	return func() {
+		prometheus.DefaultRegisterer.Unregister(coll)
+	}
+}

--- a/go/internal/metrics/poolcollector_test.go
+++ b/go/internal/metrics/poolcollector_test.go
@@ -1,0 +1,59 @@
+package metrics_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/denisvmedia/inventario/internal/metrics"
+)
+
+// stubProvider satisfies PoolStatProvider.
+//
+// NOTE on the test limitation: pgxpool.Stat has only unexported
+// fields, no public constructor, and wraps a *puddle.Stat that is nil
+// in a zero-value Stat. Calling any accessor (e.g. AcquiredConns) on a
+// fabricated &pgxpool.Stat{} panics with a nil-pointer dereference, so
+// a unit test cannot exercise PoolCollector.Collect at all. We
+// therefore cover Describe (descriptor count), the registration
+// duplicate-tolerance contract, and a compile-time interface
+// assertion; the Collect path that reads real numbers is left to
+// integration tests running against an actual *pgxpool.Pool.
+type stubProvider struct{}
+
+func (stubProvider) Stat() *pgxpool.Stat { return &pgxpool.Stat{} }
+
+func TestPoolCollector_Describe(t *testing.T) {
+	c := qt.New(t)
+
+	coll := metrics.NewPoolCollector(stubProvider{})
+
+	ch := make(chan *prometheus.Desc, 16)
+	coll.Describe(ch)
+	close(ch)
+
+	var descs []*prometheus.Desc
+	for d := range ch {
+		descs = append(descs, d)
+	}
+
+	// connections, max_connections, acquire_total, empty_acquire_total,
+	// canceled_acquire_total = 5 distinct descriptors.
+	c.Assert(descs, qt.HasLen, 5)
+}
+
+func TestRegisterPoolCollector_ToleratesDuplicate(t *testing.T) {
+	c := qt.New(t)
+
+	unregister1 := metrics.RegisterPoolCollector(stubProvider{})
+	c.Assert(unregister1, qt.IsNotNil)
+	defer unregister1()
+
+	// A second identical collector must not panic; it returns a
+	// no-op unregister.
+	unregister2 := metrics.RegisterPoolCollector(stubProvider{})
+	c.Assert(unregister2, qt.IsNotNil)
+	defer unregister2()
+}

--- a/go/internal/metrics/sqlverb.go
+++ b/go/internal/metrics/sqlverb.go
@@ -1,0 +1,113 @@
+package metrics
+
+// parseSQLVerb extracts a bounded, lowercase operation label from the
+// first keyword of a SQL statement. The returned value is always one
+// of a fixed set, so it is safe to use as a Prometheus label without
+// risking cardinality blow-up:
+//
+//	select, insert, update, delete, begin, commit, rollback, with, other
+//
+// Leading whitespace, SQL line comments ("-- ..."), and leading "("
+// are skipped. Only the first token is lowercased (not the whole
+// string) to keep the hot path allocation-light. Anything outside the
+// known set maps to "other" (e.g. "SET LOCAL ROLE ...").
+func parseSQLVerb(sql string) string {
+	i := skipLeading(sql)
+
+	// Capture the first token: a run of ASCII letters.
+	start := i
+	for i < len(sql) && isASCIILetter(sql[i]) {
+		i++
+	}
+	if i == start {
+		return verbOther
+	}
+
+	// Match the token case-insensitively against the known verbs
+	// without lowercasing the whole string. lowerToken allocates at
+	// most the small first word.
+	switch lowerToken(sql[start:i]) {
+	case verbSelect:
+		return verbSelect
+	case verbInsert:
+		return verbInsert
+	case verbUpdate:
+		return verbUpdate
+	case verbDelete:
+		return verbDelete
+	case verbBegin:
+		return verbBegin
+	case verbCommit:
+		return verbCommit
+	case verbRollback:
+		return verbRollback
+	case verbWith:
+		return verbWith
+	default:
+		return verbOther
+	}
+}
+
+const (
+	verbSelect   = "select"
+	verbInsert   = "insert"
+	verbUpdate   = "update"
+	verbDelete   = "delete"
+	verbBegin    = "begin"
+	verbCommit   = "commit"
+	verbRollback = "rollback"
+	verbWith     = "with"
+	verbOther    = "other"
+)
+
+// skipLeading returns the index of the first byte of the first SQL
+// keyword, skipping whitespace, "-- ..." line comments, and "(".
+func skipLeading(sql string) int {
+	i := 0
+	for i < len(sql) {
+		c := sql[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			i++
+		case c == '(':
+			i++
+		case c == '-' && i+1 < len(sql) && sql[i+1] == '-':
+			// Line comment: skip to end of line.
+			i += 2
+			for i < len(sql) && sql[i] != '\n' {
+				i++
+			}
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+func isASCIILetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// lowerToken returns the ASCII-lowercased form of a short token. It
+// avoids allocating when the token is already lowercase.
+func lowerToken(tok string) string {
+	needsLower := false
+	for i := 0; i < len(tok); i++ {
+		if tok[i] >= 'A' && tok[i] <= 'Z' {
+			needsLower = true
+			break
+		}
+	}
+	if !needsLower {
+		return tok
+	}
+	b := make([]byte, len(tok))
+	for i := 0; i < len(tok); i++ {
+		c := tok[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		b[i] = c
+	}
+	return string(b)
+}

--- a/go/internal/metrics/sqlverb_test.go
+++ b/go/internal/metrics/sqlverb_test.go
@@ -1,0 +1,41 @@
+package metrics_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/internal/metrics"
+)
+
+func TestParseSQLVerb(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{"select", "SELECT * FROM commodities", "select"},
+		{"insert", "INSERT INTO areas (id) VALUES ($1)", "insert"},
+		{"update", "UPDATE files SET path = $1", "update"},
+		{"delete", "DELETE FROM tenants WHERE id = $1", "delete"},
+		{"begin", "BEGIN", "begin"},
+		{"commit", "COMMIT", "commit"},
+		{"rollback", "ROLLBACK", "rollback"},
+		{"with cte", "WITH t AS (SELECT 1) SELECT * FROM t", "with"},
+		{"leading whitespace", "   \n\t SELECT 1", "select"},
+		{"leading line comment", "-- a comment\nSELECT 1", "select"},
+		{"leading paren", "(SELECT 1)", "select"},
+		{"lowercase normalization", "sElEcT 1", "select"},
+		{"set local role is other", "SET LOCAL ROLE app_user", "other"},
+		{"empty is other", "", "other"},
+		{"whitespace only is other", "   \n  ", "other"},
+		{"comment only is other", "-- nothing here", "other"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(metrics.ParseSQLVerb(tc.sql), qt.Equals, tc.want)
+		})
+	}
+}

--- a/go/registry/factories.go
+++ b/go/registry/factories.go
@@ -130,6 +130,35 @@ type OperationSlotRegistryFactory interface {
 	ServiceRegistryFactory[models.OperationSlot, OperationSlotRegistry]
 }
 
+// SystemStats is a point-in-time snapshot of installation-wide entity
+// counts and storage usage. It is the registry-layer mirror of
+// metrics.BusinessStats: defining it here keeps the registry package
+// free of any dependency on internal/metrics (which must stay a leaf —
+// it must NOT import registry). The backend constructor populates the
+// SystemStatsFunc; the bootstrap layer adapts SystemStats →
+// metrics.BusinessStats field-by-field when wiring the collector.
+type SystemStats struct {
+	Tenants        int64
+	Users          int64
+	LocationGroups int64
+	Locations      int64
+	Areas          int64
+	Commodities    int64
+	Files          int64
+
+	StorageImages    int64
+	StorageDocuments int64
+	StorageOther     int64
+	StorageExports   int64
+}
+
+// SystemStatsFunc returns a fresh installation-wide SystemStats
+// snapshot. Implementations bypass tenant scoping (postgres runs the
+// reads under the background-worker role) to report totals across every
+// tenant and group — it is NOT user-aware and must never be invoked
+// from an HTTP request path.
+type SystemStatsFunc func(ctx context.Context) (SystemStats, error)
+
 // FactorySet contains all registry factories - these create safe, context-aware registries
 type FactorySet struct {
 	LocationRegistryFactory               LocationRegistryFactory
@@ -201,6 +230,16 @@ type FactorySet struct {
 	// external OAuth provider accounts (#1394). Service-mode only — the
 	// OAuth callback resolves identities before any user session exists.
 	OAuthIdentityRegistry OAuthIdentityRegistry
+
+	// SystemStats reports installation-wide entity counts and storage
+	// usage for the business-metrics collector (#843). It deliberately
+	// bypasses tenant scoping — the totals cover every tenant and group,
+	// so it must NOT be called from any user-facing request path. It is
+	// populated by the backend constructor (postgres runs the aggregate
+	// reads under the background-worker role; the memory backend reports
+	// zeros). Nil-able: a nil func means "no business gauges", and the
+	// collector no-ops on a nil source.
+	SystemStats SystemStatsFunc
 }
 
 // Ping checks readiness of the backing registry dependency (e.g. database).

--- a/go/registry/memory/memory.go
+++ b/go/registry/memory/memory.go
@@ -121,6 +121,18 @@ func NewFactorySet() *registry.FactorySet {
 		fs.MaintenanceReminderRegistry,
 		fs.GroupMembershipRegistry,
 	)
+	// SystemStats (#843): the memory backend is dev/test only and its
+	// data registries are tenant/group-scoped behind the per-request
+	// context, with no cheap installation-wide roll-up. Rather than range
+	// every registry's internal maps (which would couple this constructor
+	// to each registry's storage shape), report zeros for the business
+	// gauges. A non-nil zero-returning closure is preferred over leaving
+	// the field nil so the collector's behaviour is predictable in dev:
+	// the gauges publish at 0 instead of being skipped entirely. The
+	// postgres backend is the real producer of business metrics.
+	fs.SystemStats = func(context.Context) (registry.SystemStats, error) {
+		return registry.SystemStats{}, nil
+	}
 	fs.PingFn = func(context.Context) error { return nil }
 
 	return fs

--- a/go/registry/postgres/metrics_stats.go
+++ b/go/registry/postgres/metrics_stats.go
@@ -1,0 +1,90 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+// newSystemStatsFunc returns the installation-wide stats source wired
+// onto FactorySet.SystemStats for the business-metrics collector
+// (#843). Every read runs under the inventario_background_worker role
+// (via store.DoAsBackgroundWorker), which is NOT bound by the per-tenant
+// RLS policies — so the counts and storage totals span every tenant and
+// group, exactly what an installation-wide gauge needs. This is the same
+// RLS-bypass posture the housekeeping sweeps use; it must never be
+// reachable from a user-facing request path.
+//
+// All reads share a single transaction so the snapshot is internally
+// consistent and pays one round of role setup rather than one per query.
+func newSystemStatsFunc(dbx *sqlx.DB) registry.SystemStatsFunc {
+	// Table names are resolved once from the defaults, matching the
+	// constructor that builds every other registry with
+	// store.DefaultTableNames.
+	tableNames := store.DefaultTableNames
+
+	return func(ctx context.Context) (registry.SystemStats, error) {
+		var stats registry.SystemStats
+
+		err := store.DoAsBackgroundWorker(ctx, dbx, func(ctx context.Context, tx *sqlx.Tx) error {
+			// Entity counts. Each is a plain installation-wide
+			// COUNT(*) — the background-worker role sees rows in every
+			// tenant, so no tenant/group filter is applied.
+			counts := []struct {
+				table store.TableName
+				dst   *int64
+			}{
+				{tableNames.Tenants(), &stats.Tenants},
+				{tableNames.Users(), &stats.Users},
+				{tableNames.LocationGroups(), &stats.LocationGroups},
+				{tableNames.Locations(), &stats.Locations},
+				{tableNames.Areas(), &stats.Areas},
+				{tableNames.Commodities(), &stats.Commodities},
+				{tableNames.Files(), &stats.Files},
+			}
+			for _, c := range counts {
+				query := fmt.Sprintf("SELECT count(*) FROM %s", c.table)
+				if err := tx.QueryRowxContext(ctx, query).Scan(c.dst); err != nil {
+					return errxtrace.Wrap("failed to count rows", err)
+				}
+			}
+
+			// Storage breakdown. Same CASE/SUM logic as
+			// FileRegistry.SumSizeBreakdown, but installation-wide (no
+			// tenant/group WHERE clause): export bundles
+			// (linked_entity_type='export') are split out of the
+			// category buckets so "exports" is a distinct series and the
+			// other buckets don't double-count it. COALESCE keeps an
+			// empty table from returning NULL.
+			storageQuery := fmt.Sprintf(`
+				SELECT
+					COALESCE(SUM(CASE WHEN linked_entity_type = 'export' THEN size_bytes ELSE 0 END), 0) AS exports,
+					COALESCE(SUM(CASE WHEN linked_entity_type IS DISTINCT FROM 'export' AND category = 'images' THEN size_bytes ELSE 0 END), 0) AS images,
+					COALESCE(SUM(CASE WHEN linked_entity_type IS DISTINCT FROM 'export' AND category = 'documents' THEN size_bytes ELSE 0 END), 0) AS documents,
+					COALESCE(SUM(CASE WHEN linked_entity_type IS DISTINCT FROM 'export' AND category = 'other' THEN size_bytes ELSE 0 END), 0) AS other
+				FROM %s`, tableNames.Files())
+
+			row := tx.QueryRowxContext(ctx, storageQuery)
+			if err := row.Scan(
+				&stats.StorageExports,
+				&stats.StorageImages,
+				&stats.StorageDocuments,
+				&stats.StorageOther,
+			); err != nil {
+				return errxtrace.Wrap("failed to scan storage breakdown", err)
+			}
+
+			return nil
+		})
+		if err != nil {
+			return registry.SystemStats{}, errxtrace.Wrap("failed to collect system stats", err)
+		}
+
+		return stats, nil
+	}
+}

--- a/go/registry/postgres/metrics_stats_test.go
+++ b/go/registry/postgres/metrics_stats_test.go
@@ -1,0 +1,147 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres"
+)
+
+// TestSystemStats_CrossTenantTotals is the security-relevant regression
+// test for the business-metrics source (#843). It seeds entities in TWO
+// tenants and asserts that FactorySet.SystemStats reports the COMBINED
+// totals — proving the source runs under the RLS-bypassing
+// background-worker role and sees every tenant's rows, not just the
+// caller's. If a future change accidentally scoped SystemStats to a
+// single tenant (e.g. by routing through inventario_app), the
+// cross-tenant counts would drop and this test would fail.
+//
+// Self-skips when POSTGRES_TEST_DSN is unset (via skipIfNoPostgreSQL),
+// so it is inert under the default `make test-go`.
+func TestSystemStats_CrossTenantTotals(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	// Tenant A: setupTestRegistrySet bootstraps the schema and returns a
+	// user+group-aware set already scoped to tenant A's seeded user/group.
+	tenantASet, cleanup := setupTestRegistrySet(t)
+	defer cleanup()
+
+	const imageSize = int64(1024)
+
+	// Seed tenant A: location → area → commodity, plus one image file.
+	locA := createTestLocation(c, tenantASet)
+	areaA := createTestArea(c, tenantASet, locA.ID)
+	createTestCommodity(c, tenantASet, areaA.ID)
+	seedImageFile(c, tenantASet, imageSize)
+
+	// Tenant B: a second, fully independent tenant + user + group seeded
+	// via the service (RLS-bypass) registry set, then a user+group-aware
+	// set built for it so the per-entity registries pass their tenant /
+	// group context checks.
+	serviceSet := postgres.NewFactorySet(newSystemStatsDBX(c, dsn)).CreateServiceRegistrySet()
+
+	tenantB, err := serviceSet.TenantRegistry.Create(ctx, models.Tenant{
+		Name:   "Metrics Tenant B",
+		Slug:   "metrics-tenant-b",
+		Status: models.TenantStatusActive,
+	})
+	c.Assert(err, qt.IsNil)
+
+	userB, err := serviceSet.UserRegistry.Create(ctx, models.User{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantB.ID},
+		Email:               "owner@metrics-tenant-b.com",
+		Name:                "Metrics Owner B",
+		IsActive:            true,
+	})
+	c.Assert(err, qt.IsNil)
+
+	groupBSlug, err := models.GenerateGroupSlug()
+	c.Assert(err, qt.IsNil)
+	groupB, err := serviceSet.LocationGroupRegistry.Create(ctx, models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantB.ID},
+		Name:                "Metrics Group B",
+		Slug:                groupBSlug,
+		Status:              models.LocationGroupStatusActive,
+		CreatedBy:           userB.ID,
+		GroupCurrency:       models.Currency("USD"),
+	})
+	c.Assert(err, qt.IsNil)
+
+	tenantBSet := postgres.NewRegistrySetWithUserAndGroupID(
+		newSystemStatsDBX(c, dsn), userB.ID, tenantB.ID, groupB.ID,
+	)
+
+	locB := createTestLocation(c, tenantBSet)
+	areaB := createTestArea(c, tenantBSet, locB.ID)
+	createTestCommodity(c, tenantBSet, areaB.ID)
+	seedImageFile(c, tenantBSet, imageSize)
+
+	// Collect installation-wide stats through the wired SystemStats source.
+	statsFn := postgres.NewFactorySet(newSystemStatsDBX(c, dsn)).SystemStats
+	c.Assert(statsFn, qt.IsNotNil)
+
+	stats, err := statsFn(ctx)
+	c.Assert(err, qt.IsNil)
+
+	// Both tenants contributed: setupTestRegistrySet seeds tenant A
+	// (1 tenant, 1 user, 1 group) and we added tenant B (1/1/1), plus one
+	// location/area/commodity/image-file in each. The DB is shared across
+	// tests in a run, so assert lower bounds (>=) rather than exact counts
+	// — the point is that BOTH tenants are visible, not that the table is
+	// pristine.
+	c.Assert(stats.Tenants >= 2, qt.IsTrue, qt.Commentf("tenants=%d", stats.Tenants))
+	c.Assert(stats.Users >= 2, qt.IsTrue, qt.Commentf("users=%d", stats.Users))
+	c.Assert(stats.LocationGroups >= 2, qt.IsTrue, qt.Commentf("groups=%d", stats.LocationGroups))
+	c.Assert(stats.Locations >= 2, qt.IsTrue, qt.Commentf("locations=%d", stats.Locations))
+	c.Assert(stats.Areas >= 2, qt.IsTrue, qt.Commentf("areas=%d", stats.Areas))
+	c.Assert(stats.Commodities >= 2, qt.IsTrue, qt.Commentf("commodities=%d", stats.Commodities))
+	c.Assert(stats.Files >= 2, qt.IsTrue, qt.Commentf("files=%d", stats.Files))
+
+	// Storage breakdown is summed across tenants too: two image files of
+	// imageSize each land in the images bucket regardless of tenant.
+	c.Assert(stats.StorageImages >= 2*imageSize, qt.IsTrue,
+		qt.Commentf("storage_images=%d", stats.StorageImages))
+}
+
+// newSystemStatsDBX opens a fresh *sqlx.DB over the shared test pool. A
+// distinct *sql.DB handle per FactorySet keeps the test from sharing
+// transaction state across the several factory sets it builds.
+func newSystemStatsDBX(c *qt.C, dsn string) *sqlx.DB {
+	c.Helper()
+	pool, err := getOrCreatePool(dsn)
+	c.Assert(err, qt.IsNil)
+	sqlDB := stdlib.OpenDBFromPool(pool)
+	c.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlx.NewDb(sqlDB, "pgx")
+}
+
+// seedImageFile creates one image FileEntity with an explicit byte size
+// so the storage-breakdown SUM is non-zero and provably cross-tenant.
+func seedImageFile(c *qt.C, set *registry.Set, size int64) {
+	c.Helper()
+	now := time.Now()
+	_, err := set.FileRegistry.Create(c.Context(), models.FileEntity{
+		Title:     "metrics-photo",
+		Type:      models.FileTypeFromMIME("image/jpeg"),
+		Category:  models.FileCategoryImages,
+		CreatedAt: now,
+		UpdatedAt: now,
+		File: &models.File{
+			Path:         "metrics-photo",
+			OriginalPath: "metrics-photo.jpg",
+			Ext:          ".jpg",
+			MIMEType:     "image/jpeg",
+			SizeBytes:    size,
+		},
+	})
+	c.Assert(err, qt.IsNil)
+}

--- a/go/registry/postgres/postgres.go
+++ b/go/registry/postgres/postgres.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/internal/metrics"
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 )
@@ -85,6 +86,12 @@ func NewFactorySet(dbx *sqlx.DB) *registry.FactorySet {
 	// back-office user; the operator CLI mints, regenerates, and wipes
 	// rows. Same no-RLS rationale as the rest of the back-office tables.
 	fs.BackofficeUserMFASecretRegistry = NewBackofficeUserMFASecretRegistry(dbx)
+	// Installation-wide business-metrics source (#843). Runs its aggregate
+	// reads under the background-worker role, so the counts and storage
+	// totals span every tenant; the bootstrap layer adapts this into the
+	// metrics.BusinessStats gauges. Service-mode only — never reachable
+	// from a request path.
+	fs.SystemStats = newSystemStatsFunc(dbx)
 	fs.PingFn = dbx.PingContext
 
 	return fs
@@ -146,6 +153,11 @@ func NewPostgresRegistrySet() (registrySetFunc func(c registry.Config) (factoryS
 			return nil, errxtrace.Wrap("failed to parse PostgreSQL connection string", err)
 		}
 
+		// DB query metrics (#843): attach the pgx QueryTracer so every
+		// query is timed and counted by SQL verb. Set before the pool is
+		// built so it applies to all connections in the pool.
+		poolConfig.ConnConfig.Tracer = metrics.NewQueryTracer()
+
 		// Set some reasonable defaults if not specified
 		// Use smaller connection pools for testing to prevent exhaustion
 		if poolConfig.MaxConns == 0 {
@@ -177,6 +189,12 @@ func NewPostgresRegistrySet() (registrySetFunc func(c registry.Config) (factoryS
 			return nil, errxtrace.Wrap("failed to initialize database schema", err)
 		}
 
+		// Pool-stats collector (#843): exposes pgxpool acquire/idle/total
+		// gauges. *pgxpool.Pool satisfies metrics.PoolStatProvider via its
+		// Stat() method. Unregistered on cleanup so per-test pools don't
+		// leak collectors.
+		unregisterPoolCollector := metrics.RegisterPoolCollector(pool)
+
 		// Create sqlx DB wrapper from pgxpool
 		sqlDB := stdlib.OpenDBFromPool(pool)
 		sqlxDB := sqlx.NewDb(sqlDB, "pgx")
@@ -185,6 +203,7 @@ func NewPostgresRegistrySet() (registrySetFunc func(c registry.Config) (factoryS
 		factorySet = NewFactorySet(sqlxDB)
 
 		doCleanup = func() error {
+			unregisterPoolCollector()
 			err := sqlxDB.Close()
 			pool.Close()
 			return err

--- a/go/services/email_async_service.go
+++ b/go/services/email_async_service.go
@@ -14,6 +14,7 @@ import (
 
 	emailqueue "github.com/denisvmedia/inventario/email/queue"
 	mailsender "github.com/denisvmedia/inventario/email/sender"
+	"github.com/denisvmedia/inventario/internal/metrics"
 )
 
 // AsyncEmailService is the orchestration layer between business flows and provider
@@ -354,6 +355,7 @@ func (s *AsyncEmailService) processJob(ctx context.Context, job emailJob, worker
 		}
 	}
 
+	sendStart := time.Now()
 	err = s.sender.Send(sendCtx, mailsender.Message{
 		To:      job.To,
 		From:    s.from,
@@ -362,7 +364,10 @@ func (s *AsyncEmailService) processJob(ctx context.Context, job emailJob, worker
 		HTML:    rendered.HTML,
 		Text:    rendered.Text,
 	})
+	// Send-attempt latency is recorded regardless of outcome.
+	metrics.ObserveEmailSend(time.Since(sendStart))
 	if err == nil {
+		metrics.RecordEmailProcessed(metrics.EmailStatusSent)
 		slog.Debug("Email sent",
 			"worker_id", workerID,
 			"job_id", job.ID,
@@ -374,6 +379,7 @@ func (s *AsyncEmailService) processJob(ctx context.Context, job emailJob, worker
 
 	nextAttempt := job.Attempt + 1
 	if nextAttempt > s.maxRetries {
+		metrics.RecordEmailProcessed(metrics.EmailStatusFailed)
 		slog.Error("Email delivery failed after retries; dropping job",
 			"worker_id", workerID,
 			"job_id", job.ID,
@@ -390,6 +396,7 @@ func (s *AsyncEmailService) processJob(ctx context.Context, job emailJob, worker
 	readyAt := time.Now().Add(delay)
 	retryPayload, marshalErr := json.Marshal(job)
 	if marshalErr != nil {
+		metrics.RecordEmailProcessed(metrics.EmailStatusFailed)
 		slog.Error("Failed to encode email retry payload; dropping job",
 			"worker_id", workerID,
 			"job_id", job.ID,
@@ -403,6 +410,7 @@ func (s *AsyncEmailService) processJob(ctx context.Context, job emailJob, worker
 	}
 
 	if retryErr := s.queue.ScheduleRetry(ctx, retryPayload, readyAt); retryErr != nil {
+		metrics.RecordEmailProcessed(metrics.EmailStatusFailed)
 		slog.Error("Failed to schedule email retry; dropping job",
 			"worker_id", workerID,
 			"job_id", job.ID,
@@ -415,6 +423,7 @@ func (s *AsyncEmailService) processJob(ctx context.Context, job emailJob, worker
 		return
 	}
 
+	metrics.RecordEmailProcessed(metrics.EmailStatusRetried)
 	slog.Warn("Email delivery failed; retry scheduled",
 		"worker_id", workerID,
 		"job_id", job.ID,
@@ -462,6 +471,18 @@ func (s *AsyncEmailService) runRetryPromoter(ctx context.Context) {
 			}
 			if moved > 0 {
 				slog.Debug("Promoted due retry emails", "count", moved)
+			}
+
+			// Reuse the existing ticker to refresh the queue-depth
+			// gauge. A Depth error must not crash the promoter loop, so
+			// we log at debug and leave the gauge at its previous value.
+			if depth, depthErr := s.queue.Depth(ctx); depthErr != nil {
+				if isContextShutdownError(depthErr) {
+					return
+				}
+				slog.Debug("Failed to read email queue depth", "error", depthErr)
+			} else {
+				metrics.SetEmailQueueDepth(depth)
 			}
 		}
 	}

--- a/go/services/email_async_service.go
+++ b/go/services/email_async_service.go
@@ -331,6 +331,10 @@ func isContextShutdownError(err error) bool {
 func (s *AsyncEmailService) processJob(ctx context.Context, job emailJob, workerID int) {
 	rendered, err := s.renderer.render(job)
 	if err != nil {
+		// Terminal drop: an un-renderable job is never delivered, so count
+		// it as failed like the other drop paths below (retries exhausted,
+		// marshal error, ScheduleRetry error) — otherwise it undercounts.
+		metrics.RecordEmailProcessed(metrics.EmailStatusFailed)
 		slog.Error("Email template rendering failed; dropping job",
 			"worker_id", workerID,
 			"job_id", job.ID,

--- a/go/services/email_async_service_test.go
+++ b/go/services/email_async_service_test.go
@@ -55,6 +55,10 @@ func (q *erroringQueue) PromoteDueRetries(context.Context, time.Time, int) (int,
 	return 0, q.promoteErr
 }
 
+func (q *erroringQueue) Depth(context.Context) (int, error) {
+	return 0, nil
+}
+
 func (q *erroringQueue) DequeueCalls() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -342,6 +346,12 @@ func (q *captureQueue) ScheduleRetry(_ context.Context, payload []byte, readyAt 
 
 func (q *captureQueue) PromoteDueRetries(context.Context, time.Time, int) (int, error) {
 	return 0, nil
+}
+
+func (q *captureQueue) Depth(context.Context) (int, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.dequeueItems), nil
 }
 
 func (q *captureQueue) EnqueuedPayloads() [][]byte {

--- a/helm/inventario/README.md
+++ b/helm/inventario/README.md
@@ -333,6 +333,40 @@ A typical upgrade looks like:
 
 Run `helm template ... --debug | grep -E 'replicas|resources|nodeSelector|tolerations|affinity'` after rewriting your values to confirm the new render still reflects your overrides.
 
+## Metrics & scraping
+
+Inventario always serves Prometheus metrics at `/metrics` — on the API HTTP port (`:3333`, served by `run.all` and `run.apiserver`) and on each worker's probe port (`:3334`, alongside `/healthz` and `/readyz`). The endpoint is unconditional; the `metrics.*` values only control how an external Prometheus *discovers* the pods. Everything below is **OFF by default** and does not change rendered output unless explicitly enabled.
+
+| Value | Default | Effect |
+| ----- | ------- | ------ |
+| `metrics.podAnnotations.enabled` | `false` | Adds `prometheus.io/scrape`, `prometheus.io/port`, and `prometheus.io/path=/metrics` annotations to the API and worker pods. Use this for a vanilla, **operator-less** Prometheus running a `kubernetes_sd_configs` (role: pod) discovery job. The port is role-aware: `3333` on API/combined pods, the worker's probe port (`3334`) on worker pods. |
+| `metrics.serviceMonitor.enabled` | `false` | Renders a `monitoring.coreos.com/v1` ServiceMonitor selecting the API Service's `http` port at `/metrics`. **Requires the Prometheus Operator** — the template is additionally guarded by a CRD-capability check (`.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"`), so enabling it on a cluster without the operator is a no-op rather than a render error. Tune `interval`, `scrapeTimeout`, and `labels` (e.g. `release: kube-prometheus-stack` so the operator selects it). |
+
+```bash
+# Operator-less discovery: annotate API + worker pods.
+helm template inventario helm/inventario/ \
+  --set-string secrets.dbDsn='postgres://u:p@h:5432/inv?sslmode=require' \
+  --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+  --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+  --set setupJob.initData.adminPassword=test \
+  --set metrics.podAnnotations.enabled=true
+
+# Prometheus Operator: render a ServiceMonitor (no-op without the CRD).
+helm template inventario helm/inventario/ \
+  --set-string secrets.dbDsn='postgres://u:p@h:5432/inv?sslmode=require' \
+  --set-string secrets.jwtSecret='testtesttesttesttesttesttesttest' \
+  --set-string secrets.fileSigningKey='testtesttesttesttesttesttesttest' \
+  --set setupJob.initData.adminPassword=test \
+  --set metrics.serviceMonitor.enabled=true \
+  --set metrics.serviceMonitor.labels.release=kube-prometheus-stack
+```
+
+The ServiceMonitor only covers the API Service. In split mode each worker group runs a **headless** Service (`clusterIP: None`, port name `probe`), which a ServiceMonitor cannot reliably target per-pod; scrape workers with `metrics.podAnnotations.enabled=true` (pod discovery) or add a PodMonitor (a commented example ships in `templates/servicemonitor.yaml`).
+
+Horizontal Pod Autoscaling on one of these custom metrics (e.g. `inventario_email_queue_depth`) is **not** wired up by enabling scraping: HPA reads custom/external metrics through the metrics API, which needs a metrics adapter such as [prometheus-adapter](https://github.com/kubernetes-sigs/prometheus-adapter). This chart does not install one — see the commented `run.*.autoscaling.metrics` example in `values.yaml`.
+
+A ready-to-run developer monitoring stack (Prometheus + Grafana via docker-compose) lives at [`deploy/monitoring/`](../../deploy/monitoring/README.md).
+
 ## Validation
 
 The chart is covered by the `helm-lint.yml` CI workflow across combined, split, demo, and misconfiguration scenarios. The commands below reproduce those scenarios locally:

--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -132,6 +132,26 @@ Usage: include "inventario.workerName" (dict "root" . "role" "media")
 {{- end -}}
 
 {{/*
+Prometheus scrape annotations for a pod, emitted ONLY when
+.Values.metrics.podAnnotations.enabled is true. The app always serves
+/metrics; these annotations just let an operator-less Prometheus
+(kubernetes_sd_configs role: pod) discover the pod. The port differs by
+role — the API pods pass "3333", workers pass their probe port — so it is
+taken as an argument rather than hard-coded.
+Usage (drop under spec.template.metadata.annotations):
+  {{- include "inventario.metricsPodAnnotations" (dict "root" . "port" "3333") | nindent 8 }}
+Renders nothing when disabled, so callers must still guard the parent
+`annotations:` key so it is never emitted empty.
+*/}}
+{{- define "inventario.metricsPodAnnotations" -}}
+{{- if .root.Values.metrics.podAnnotations.enabled -}}
+prometheus.io/scrape: "true"
+prometheus.io/port: {{ .port | quote }}
+prometheus.io/path: "/metrics"
+{{- end -}}
+{{- end -}}
+
+{{/*
 Component selector labels for the combined (run.all) Deployment.
 Alias of appSelectorLabels kept for explicitness.
 */}}

--- a/helm/inventario/templates/deployment-apiserver.yaml
+++ b/helm/inventario/templates/deployment-apiserver.yaml
@@ -32,9 +32,15 @@ spec:
         {{- with $cfg.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $cfg.podAnnotations }}
+      {{- $metricsAnnotations := include "inventario.metricsPodAnnotations" (dict "root" $ "port" "3333") }}
+      {{- if or $cfg.podAnnotations (trim $metricsAnnotations) }}
       annotations:
+        {{- with $cfg.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with trim $metricsAnnotations }}
+        {{- . | nindent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       {{- with .Values.image.pullSecrets }}

--- a/helm/inventario/templates/deployment-workers.yaml
+++ b/helm/inventario/templates/deployment-workers.yaml
@@ -39,9 +39,15 @@ spec:
         {{- with $cfg.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $cfg.podAnnotations }}
+      {{- $metricsAnnotations := include "inventario.metricsPodAnnotations" (dict "root" $root "port" (toString $probePort)) }}
+      {{- if or $cfg.podAnnotations (trim $metricsAnnotations) }}
       annotations:
+        {{- with $cfg.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with trim $metricsAnnotations }}
+        {{- . | nindent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       {{- with $root.Values.image.pullSecrets }}

--- a/helm/inventario/templates/deployment.yaml
+++ b/helm/inventario/templates/deployment.yaml
@@ -32,9 +32,15 @@ spec:
         {{- with $cfg.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $cfg.podAnnotations }}
+      {{- $metricsAnnotations := include "inventario.metricsPodAnnotations" (dict "root" $ "port" "3333") }}
+      {{- if or $cfg.podAnnotations (trim $metricsAnnotations) }}
       annotations:
+        {{- with $cfg.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with trim $metricsAnnotations }}
+        {{- . | nindent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       {{- with .Values.image.pullSecrets }}

--- a/helm/inventario/templates/servicemonitor.yaml
+++ b/helm/inventario/templates/servicemonitor.yaml
@@ -1,0 +1,63 @@
+{{- /*
+Prometheus Operator ServiceMonitor for the API Service (#843).
+
+Double-gated so it is inert by default AND safe to enable on a cluster
+without the Prometheus Operator:
+  1. .Values.metrics.serviceMonitor.enabled must be true, AND
+  2. the monitoring.coreos.com/v1 CRD must be installed
+     (.Capabilities.APIVersions.Has). Without (2), enabling the toggle is a
+     no-op rather than a render error — `helm template` / `helm install`
+     never fail when the operator is absent.
+
+This scrapes the apiserver Service `http` port (:3333) at /metrics. The app
+also exposes /metrics on each worker's probe port (:3334), but in split mode
+the worker Service is headless (clusterIP: None) with port name `probe`; a
+ServiceMonitor cannot reliably target a headless Service's per-pod endpoints,
+so worker scraping needs a PodMonitor (see the commented stanza at the bottom)
+or a kubernetes_sd pod job (metrics.podAnnotations.enabled=true).
+*/ -}}
+{{- if and .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if eq (include "inventario.apiserverRendered" .) "true" }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "inventario.fullname" . }}
+  labels:
+    {{- include "inventario.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "inventario.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}
+{{- end }}
+{{- /*
+Worker (:3334) scraping in split mode needs a separate PodMonitor (or a
+kubernetes_sd pod job via metrics.podAnnotations.enabled=true) because the
+worker Service is headless with port name `probe`. Example PodMonitor — left
+COMMENTED on purpose; this chart does NOT render it:
+
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "inventario.fullname" . }}-workers
+  labels:
+    {{- include "inventario.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{ include "inventario.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: probe
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+*/ -}}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -88,13 +88,17 @@ run:
       targetMemoryUtilizationPercentage: null
       # Additional metrics entries (autoscaling/v2 MetricSpec), for
       # example an external metric exposed by the app's /metrics
-      # endpoint via a metrics adapter. Inventario does not ship
-      # custom metrics yet; this list stays empty by default.
+      # endpoint. Inventario DOES now ship Prometheus metrics on
+      # /metrics (API :3333, each worker :3334) — see the top-level
+      # `metrics:` block below. However, HPA on a custom metric still
+      # requires a metrics adapter (e.g. prometheus-adapter) to surface
+      # those series to the external.metrics.k8s.io API; this chart does
+      # not install one, so the list below stays empty by default.
       # metrics:
       #   - type: External
       #     external:
       #       metric:
-      #         name: inventario_jobs_pending
+      #         name: inventario_email_queue_depth
       #         selector:
       #           matchLabels:
       #             worker: media
@@ -248,6 +252,28 @@ run:
         limits:
           cpu: 1000m
           memory: 1Gi
+
+# ============================================================
+# Metrics / scraping (#843)
+# ============================================================
+# Prometheus metrics / scraping (#843). The app always serves /metrics on the
+# API port (3333) and each worker's probe port (3334); these toggles only
+# control how an external Prometheus discovers the pods. Both default OFF.
+metrics:
+  # Add prometheus.io/* scrape annotations to API + worker pods so a vanilla
+  # (operator-less) Prometheus kubernetes_sd job can discover them.
+  podAnnotations:
+    enabled: false
+  # ServiceMonitor for the Prometheus Operator. OFF by default and additionally
+  # guarded by a CRD-capability check, so enabling it without the operator is a
+  # no-op rather than a render error.
+  serviceMonitor:
+    enabled: false
+    interval: 15s
+    scrapeTimeout: 10s
+    # Extra labels for the ServiceMonitor (e.g. release: kube-prometheus-stack
+    # so the operator selects it).
+    labels: {}
 
 # ============================================================
 # Service (targets the apiserver endpoint — run.all or run.apiserver).


### PR DESCRIPTION
## What & why

Closes #843 (MVP Phase 4.1: Prometheus Metrics & Observability).

**Starting point:** the Prometheus client was already a dependency and `/metrics` was already mounted (API `:3333` via `promhttp.Handler()`, workers probe `:3334`) with a handful of worker counters. This PR fills the instrumentation gaps and ships an opt-in dev monitoring stack — no new endpoint plumbing was needed; the new metrics register on the same default registry.

All metric naming follows [Prometheus best practice](https://prometheus.io/docs/practices/): `inventario_` prefix, `_total` only on counters, `_seconds`/`_bytes` base units, histograms with sane buckets, and **bounded labels only** (no user id / email / raw path / SQL text / tenant id).

## Backend — new `go/internal/metrics` leaf package

Imports only prometheus/pgx/chi/stdlib (no `apiserver`/`services`/`registry` deps); cross-cutting code calls thin recording helpers.

| Area | Metrics | Wiring |
| --- | --- | --- |
| HTTP (RED) | `inventario_http_requests_total{method,route,status_class}`, `…_request_duration_seconds`, `…_requests_in_flight` | chi middleware after `Recoverer`; `route` = matched `RoutePattern` (`""` for 404, never raw path); self-skips `/metrics` |
| DB | `inventario_db_query_duration_seconds{operation}`, `…_db_queries_total{operation,status}`, `…_db_pool_*` | pgx `QueryTracer` + `pgxpool.Stat()` collector in `registry/postgres/postgres.go` |
| Auth | `inventario_auth_login_attempts_total{outcome,method}`, `…_tokens_issued_total{type}` | counted at the `recordLoginEventWithMethod` chokepoint + `issueAccessToken`/`persistRefreshToken` (tenant plane) |
| Rate limit | `inventario_rate_limit_rejections_total{scope}` | global middleware + auth lockout |
| Email | `inventario_emails_processed_total{status}`, `…_email_send_duration_seconds`, `…_email_queue_depth` | async service; new `Queue.Depth()` (Redis `LLEN` / in-memory `len`) |
| Business | `inventario_tenants/users/location_groups/locations/areas/commodities/files`, `…_file_storage_bytes{category}` | 60s ticker collector; RLS-bypass **read-only** aggregate `SELECT`s via `DoAsBackgroundWorker`; runs in `workers`/`all` only (single producer) |

## Ops

- **docker-compose** `monitoring` profile (off by default): Prometheus + Grafana with a provisioned read-only **"Inventario / Overview"** dashboard, recording rules (5xx ratio, p95) and alerts (target down, high error rate, high latency). Start with `docker compose --profile monitoring up -d` → Grafana `:3000`, Prometheus `:9090`.
- **Helm**: gated-off `metrics.podAnnotations` (operator-less pod discovery, 3333/3334) + CRD-guarded `metrics.serviceMonitor` (inert without the Prometheus Operator). Default render is unchanged; stale "no custom metrics yet" comment fixed.
- Docs: `deploy/monitoring/README.md`, `helm/inventario/README.md` (Metrics & scraping), `DOCKER.md`/`DEPLOYMENT.md` cross-refs.

## Verification

- `go build ./...`, `go vet`, `golangci-lint run` → 0 issues across all 12 changed packages; full `go test ./...` green (postgres integration test for cross-tenant `SystemStats` self-skips without a DB, runs in CI).
- `promtool check config`/`check rules` ✅, dashboard JSON + provisioning YAML valid, `docker compose --profile monitoring config` ✅, `helm lint` + render matrix ✅.

## Reviews

Built with focused sub-agents, then reviewed by a project-aware code reviewer (**fix-then-ship**, no blockers) and a security reviewer (**ship**, no HIGH/MEDIUM). Addressed: pool-collector multi-pool collision now logged (not silent), metric help text clarified (tenant-plane auth; `retried` is per-attempt), and the split-mode / `/metrics`-exposure caveats documented.

## Known limitations / possible follow-ups

- **Split deployments**: business/email gauges are produced only by the workers process (`:3334`); the apiserver process exports them at `0`. Default `run all` is unaffected. Documented in `deploy/monitoring/README.md`; scrape the workers target (or PodMonitor) in split mode.
- **Single DB pool** assumed by the pool collector (shared descriptors); a second concurrent pool would be dropped — now logged rather than silent.
- `/metrics` remains **unauthenticated** (pre-existing posture) and now also exposes installation-wide aggregate counts (no per-tenant data, no secrets). Docs recommend keeping it on the monitoring network only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now exposes Prometheus metrics at /metrics (API and worker ports). Metrics include HTTP, DB, auth/token, email processing & queue depth, connection pool, and installation-wide business gauges; alerting rules added.
  * New Grafana dashboard with panels for requests, errors, latency, DB, auth, emails, queues, files and business counts.

* **Documentation**
  * Deployment, Docker Compose and Helm docs updated with monitoring guidance and an opt-in Prometheus+Grafana stack and optional scraping via pod annotations or ServiceMonitor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->