### PR TITLE
[#1308] Add runtime soft-pause for background workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,31 @@ See the [System Admin Operations Runbook](devdocs/admin-runbook.md) for
 bootstrapping the first admin, audit-log inspection, lockout recovery, and
 the [admin threat model](devdocs/security/admin-threat-model.md).
 
+#### Background Worker Control (#1308)
+
+Soft-pause / resume Inventario's polling background workers without a
+restart. Pausing keeps a worker's run loop ticking but stops it claiming
+new work; in-flight jobs finish, the state persists in the database, and
+every replica is coordinated via the shared `worker_control` table.
+
+```bash
+# Pause a worker (optionally record a reason)
+./inventario workers pause --type export --reason "maintenance window"
+
+# Resume it
+./inventario workers resume --type export
+
+# Show the pause state of every worker
+./inventario workers status
+```
+
+These commands require a PostgreSQL DSN (the pause state must persist in
+a database shared with the worker process; `memory://` is rejected). This
+is distinct from `run workers`, which *starts* the worker process. See the
+[System Admin Operations Runbook §7](devdocs/admin-runbook.md) for the
+canonical worker types, the equivalent admin REST API, and the
+`inventario_worker_paused` metric.
+
 #### Command Options
 
 **Tenant Commands:**

--- a/devdocs/admin-runbook.md
+++ b/devdocs/admin-runbook.md
@@ -311,8 +311,10 @@ claim phase** while paused:
 - **Resuming is immediate** — it takes effect on the worker's next tick
   (≤ ~10s, the controller poll interval) with **no process restart**.
 - **State persists across restarts** and is stored in the
-  `worker_control` table (one row per paused worker; an absent row means
-  the worker runs normally).
+  `worker_control` table. A row with `paused=true` is paused; `paused=false`
+  — or no row at all — means the worker runs normally. Resuming flips the
+  flag to `false` (the row is kept, not deleted), so a paused-then-resumed
+  worker leaves a `paused=false` row behind.
 - **The whole fleet is coordinated via the shared database** — every
   replica's pause controller polls the same table, so a single
   pause/resume applies everywhere.

--- a/devdocs/admin-runbook.md
+++ b/devdocs/admin-runbook.md
@@ -144,6 +144,8 @@ Admin actions use the `admin.` action prefix:
 | `admin.list_groups` / `…get_group` / `…delete_group` | group endpoints |
 | `admin.group_member_add` / `…remove` / `…role_change` | membership endpoints |
 | `admin.impersonate_start` / `admin.impersonate_end` | impersonation endpoints |
+| `admin.worker_pause` | `POST /api/v1/admin/workers/{type}/pause` (actor = back-office operator) or `inventario workers pause` (`paused_by="cli"`); subject = worker type (#1308) |
+| `admin.worker_resume` | `POST /api/v1/admin/workers/{type}/resume` (actor = back-office operator) or `inventario workers resume`; subject = worker type (#1308) |
 
 Useful queries:
 

--- a/devdocs/admin-runbook.md
+++ b/devdocs/admin-runbook.md
@@ -295,6 +295,113 @@ schema migrations.
 
 ---
 
+## 7. Pausing / resuming background workers (#1308)
+
+Inventario's polling background workers can be **soft-paused** by a
+platform operator
+([#1308](https://github.com/denisvmedia/inventario/issues/1308)).
+Soft-pause keeps each worker's run loop ticking but makes it **skip its
+claim phase** while paused:
+
+- **In-flight jobs finish** — a pause does not interrupt work already
+  running; it only stops *new* work from being claimed.
+- **No new jobs are claimed** while paused.
+- **Resuming is immediate** — it takes effect on the worker's next tick
+  (≤ ~10s, the controller poll interval) with **no process restart**.
+- **State persists across restarts** and is stored in the
+  `worker_control` table (one row per paused worker; an absent row means
+  the worker runs normally).
+- **The whole fleet is coordinated via the shared database** — every
+  replica's pause controller polls the same table, so a single
+  pause/resume applies everywhere.
+
+The `worker_control` table is **not tenant-scoped and has no RLS** —
+worker pause is a platform-operator control orthogonal to tenants (same
+posture as `system_admin_grants` and `audit_logs`).
+
+> **Split deployments (`run workers --workers-only=<group>`):** pause
+> state is fleet-wide, but a paused row only has an effect on replicas
+> that actually run that worker. The pause controller still polls and
+> exposes all canonical types regardless of `--workers-only`, so in a
+> process that doesn't schedule a given worker the
+> `inventario_worker_paused{type=...}` gauge and `workers status` line
+> for it are informational — the worker is paused wherever it *is*
+> scheduled (e.g. another group's Deployment).
+
+### Canonical worker types
+
+The pausable worker types (stable identifiers used by the CLI, the API,
+and the `worker_control.worker_type` column):
+
+`export`, `import`, `restore`, `thumbnail`, `refresh-token-cleanup`,
+`login-event-retention`, `group-purge`, `warranty-reminder`,
+`storage-quota-reminder`, `loan-reminder`, `maintenance-reminder`,
+`currency-migration`.
+
+> Email delivery is intentionally **not** in this set — it is a Redis
+> subscriber rather than a polling worker, with a separate pause story.
+
+### CLI
+
+The `inventario workers` command group mutates pause state directly in
+the database (PostgreSQL only — `memory://` is rejected, since the state
+must persist in a database shared with the worker process):
+
+```bash
+# Pause a worker (optionally with a reason)
+inventario workers pause --type export --reason "maintenance window" \
+  --db-dsn postgres://user:pass@localhost:5432/inventario
+
+# Resume it
+inventario workers resume --type export --db-dsn postgres://...
+
+# Show the pause state of every worker (no row => running)
+inventario workers status --db-dsn postgres://...
+```
+
+> This is **not** the same as `inventario run workers`, which *starts*
+> the worker process. The `workers` group mutates the pause state of an
+> already-running deployment.
+
+A CLI pause records `paused_by = "cli"` (the CLI has no authenticated
+operator session). Each operation writes an audit row
+(`admin.worker_pause` / `admin.worker_resume`, see §4) with the worker
+type as the subject.
+
+### Admin REST API
+
+The same control is exposed under the back-office-gated admin subtree
+(requires a back-office session, `RequireBackofficeAuth`):
+
+| Method & path | Effect |
+| ------------- | ------ |
+| `GET /api/v1/admin/workers` | List every canonical worker type with its pause state (`type: "worker_control"`, `id`: the worker type). |
+| `POST /api/v1/admin/workers/{workerType}/pause` | Soft-pause the worker. Optional `{"reason": "..."}` body (≤ 500 chars; empty body allowed). |
+| `POST /api/v1/admin/workers/{workerType}/resume` | Resume the worker (no body). |
+
+- An unknown `{workerType}` returns **404** with code
+  `admin.worker.unknown_type`; a reason over 500 characters returns
+  **422** with `admin.worker.reason_too_long`.
+- A pause via the API records `paused_by = <backoffice_users.id>` (the
+  operator of record) rather than the CLI's `"cli"` marker.
+
+### Observability
+
+- **Metric:** `inventario_worker_paused{type="<worker>"}` is a gauge —
+  `1` while the named worker is soft-paused, `0` otherwise. The series
+  exists for every canonical type (initialised to `0` at startup) so
+  dashboards and alerts always have the full label set.
+- **Log lines (once per transition):** `worker paused`
+  (`type`, and `reason` / `paused_by` when present) and
+  `worker resumed` (`type`). These are emitted by the pause controller
+  on the paused↔running flip, not on every poll.
+- **Fail-safe:** if the controller's poll of `worker_control` fails, the
+  last-known state is **retained** (a DB blip cannot silently un-pause a
+  worker an operator deliberately stopped); the failure is logged once
+  on the error transition.
+
+---
+
 ## See also
 
 - [`devdocs/security/admin-threat-model.md`](security/admin-threat-model.md)

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1264,6 +1264,226 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/admin/workers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List background workers and their pause state (admin)
+         * @description Returns one resource per canonical worker type with its soft-pause state (#1308). A worker with no control row renders as paused=false. Resource `type` is "worker_control"; `id` is the worker-type string.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["apiserver.WorkerControlListEnvelope"];
+                    };
+                };
+                /** @description Unauthorized - back-office authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Account disabled */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/workers/{workerType}/pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Soft-pause a background worker (admin)
+         * @description Soft-pauses the worker named by {workerType} (#1308): its run loop keeps ticking but skips claiming new work until resumed; in-flight jobs finish. Idempotent.
+         *     The optional `reason` body field is recorded on the control row and the audit breadcrumb. An empty body is accepted.
+         *     Unknown worker types return 404 with `admin.worker.unknown_type`; a reason over 500 characters returns 422 with `admin.worker.reason_too_long`.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Worker type (e.g. export, import, thumbnail) */
+                    workerType: string;
+                };
+                cookie?: never;
+            };
+            /** @description Optional pause request (reason) */
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["apiserver.WorkerPauseRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["apiserver.WorkerControlEnvelope"];
+                    };
+                };
+                /** @description Bad Request - invalid body */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unauthorized - back-office authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Account disabled */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Not Found - unknown worker type */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Unprocessable Entity - reason too long */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/workers/{workerType}/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resume a soft-paused background worker (admin)
+         * @description Clears the soft-pause on the worker named by {workerType} (#1308) so it resumes claiming work on its next tick. Idempotent. Unknown worker types return 404 with `admin.worker.unknown_type`.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Worker type (e.g. export, import, thumbnail) */
+                    workerType: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["apiserver.WorkerControlEnvelope"];
+                    };
+                };
+                /** @description Unauthorized - back-office authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Account disabled */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+                /** @description Not Found - unknown worker type */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/vnd.api+json": components["schemas"]["jsonapi.Errors"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/change-password": {
         parameters: {
             query?: never;
@@ -9320,6 +9540,32 @@ export type components = {
             uptime?: string;
             /** @description Version information */
             version?: string;
+        };
+        "apiserver.WorkerControlEnvelope": {
+            data?: components["schemas"]["apiserver.WorkerControlResource"];
+        };
+        "apiserver.WorkerControlListEnvelope": {
+            data?: components["schemas"]["apiserver.WorkerControlResource"][];
+        };
+        "apiserver.WorkerControlResource": {
+            attributes?: components["schemas"]["apiserver.WorkerControlView"];
+            id?: string;
+            type?: string;
+        };
+        "apiserver.WorkerControlView": {
+            paused?: boolean;
+            paused_at?: string;
+            paused_by?: string;
+            reason?: string;
+            updated_at?: string;
+            worker_type?: string;
+        };
+        "apiserver.WorkerPauseRequest": {
+            /**
+             * @description Reason is the optional operator-supplied note for the pause (max 500
+             *     chars). Persisted into worker_control.reason and the audit breadcrumb.
+             */
+            reason?: string;
         };
         "apiserver.linkedIdentitiesResponse": {
             identities?: components["schemas"]["apiserver.linkedIdentityEntry"][];

--- a/go/apiserver/admin_routes.go
+++ b/go/apiserver/admin_routes.go
@@ -194,6 +194,12 @@ func Admin(params AdminParams) func(r chi.Router) {
 		jwtSecret:    params.JWTSecret,
 		ttl:          params.ImpersonationTTL,
 	}
+	// #1308: background-worker soft-pause control plane. FactorySet +
+	// AuditService are guaranteed non-nil by the fail-fast block above.
+	workersAPI := &adminWorkersAPI{
+		factorySet:   params.FactorySet,
+		auditService: params.AuditService,
+	}
 	// #1785 Phase 5 removed the legacy `RequireSystemAdmin` gate from
 	// every admin route: the CRUD subtree is gated by RequireBackofficeAuth
 	// (Phase 3), impersonation/start is gated by RequirePlatformAdmin
@@ -257,7 +263,7 @@ func Admin(params AdminParams) func(r chi.Router) {
 		// tokens (and vice versa).
 		r.Group(func(r chi.Router) {
 			r.Use(backofficeAuth)
-			adminBackofficeRoutes(r, tenantsAPI, usersAPI, groupsAPI, groupMembersAPI, impersonationAPI)
+			adminBackofficeRoutes(r, tenantsAPI, usersAPI, groupsAPI, groupMembersAPI, impersonationAPI, workersAPI)
 		})
 	}
 }
@@ -282,6 +288,7 @@ func adminBackofficeRoutes(
 	groupsAPI *adminGroupsAPI,
 	groupMembersAPI *adminGroupMembersAPI,
 	impersonationAPI *adminImpersonationAPI,
+	workersAPI *adminWorkersAPI,
 ) {
 	r.Get("/_ping", adminPing)
 
@@ -319,6 +326,15 @@ func adminBackofficeRoutes(
 	r.Post("/groups/{groupID}/members", groupMembersAPI.addMember)
 	r.Delete("/groups/{groupID}/members/{userID}", groupMembersAPI.removeMember)
 	r.Patch("/groups/{groupID}/members/{userID}", groupMembersAPI.updateMemberRole)
+
+	// #1308: background-worker soft-pause control plane. List the
+	// canonical worker types with their pause state; pause / resume by
+	// worker type. No tenant scope — worker_control is a platform control
+	// orthogonal to tenants. Each handler audit-logs via the shared
+	// AuditService.
+	r.Get("/workers", workersAPI.listWorkers)
+	r.Post("/workers/{workerType}/pause", workersAPI.pauseWorker)
+	r.Post("/workers/{workerType}/resume", workersAPI.resumeWorker)
 
 	// #1785 Phase 5: impersonation-start is gated on platform_admin —
 	// support_agent (the read-mostly persona) cannot borrow a tenant

--- a/go/apiserver/admin_workers.go
+++ b/go/apiserver/admin_workers.go
@@ -1,0 +1,340 @@
+package apiserver
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// Worker soft-pause action names (#1308). Kept as constants so the audit
+// trail uses the same literals as the CLI service path
+// (services/admin emits the identical strings) and the swagger tags.
+// Mirrors the "admin.<noun>_<verb>" pattern.
+const (
+	// AuditActionAdminWorkerPause is the audit-row Action emitted on a
+	// successful (or attempted) soft-pause of a background worker.
+	AuditActionAdminWorkerPause = "admin.worker_pause"
+	// AuditActionAdminWorkerResume is the audit-row Action emitted on a
+	// successful (or attempted) resume of a soft-paused worker.
+	AuditActionAdminWorkerResume = "admin.worker_resume"
+)
+
+// JSON:API error codes returned by the worker pause/resume endpoints.
+// Kept as constants so the swagger annotations, the FE branch table, and
+// the tests reference the same literals.
+const (
+	// AdminWorkerUnknownTypeCode signals "the {workerType} path segment is
+	// not one of the known worker types". Maps to a 404.
+	AdminWorkerUnknownTypeCode = "admin.worker.unknown_type"
+	// AdminWorkerReasonTooLongCode signals "the supplied reason exceeds the
+	// 500-char cap". Maps to a 422.
+	AdminWorkerReasonTooLongCode = "admin.worker.reason_too_long"
+)
+
+// adminWorkerReasonMaxLen caps the pause reason at 500 characters, matching
+// the block/unblock reason cap so the audit breadcrumb stays bounded.
+const adminWorkerReasonMaxLen = 500
+
+// WorkerPauseRequest is the request body for
+// POST /admin/workers/{workerType}/pause. `reason` is OPTIONAL (the
+// worker_control.reason column is nullable); an empty body is accepted
+// and records no reason.
+type WorkerPauseRequest struct {
+	// Reason is the optional operator-supplied note for the pause (max 500
+	// chars). Persisted into worker_control.reason and the audit breadcrumb.
+	Reason string `json:"reason,omitempty"`
+}
+
+// WorkerControlView is the JSON:API attributes block returned by the
+// worker endpoints. Mirrors the operator-facing fields of
+// models.WorkerControl plus the worker_type (also carried as the
+// resource id).
+type WorkerControlView struct {
+	WorkerType string     `json:"worker_type"`
+	Paused     bool       `json:"paused"`
+	PausedBy   *string    `json:"paused_by,omitempty"`
+	PausedAt   *time.Time `json:"paused_at,omitempty"`
+	Reason     *string    `json:"reason,omitempty"`
+	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
+}
+
+// WorkerControlResource is the JSON:API resource block. `type` is
+// "worker_control" and `id` is the worker-type string (the natural key).
+type WorkerControlResource struct {
+	Type       string            `json:"type"`
+	ID         string            `json:"id"`
+	Attributes WorkerControlView `json:"attributes"`
+}
+
+// WorkerControlEnvelope is the single-resource JSON:API envelope returned
+// by pause / resume.
+type WorkerControlEnvelope struct {
+	Data WorkerControlResource `json:"data"`
+}
+
+// WorkerControlListEnvelope is the list JSON:API envelope returned by
+// GET /admin/workers — one resource per models.AllWorkerTypes().
+type WorkerControlListEnvelope struct {
+	Data []WorkerControlResource `json:"data"`
+}
+
+// adminWorkersAPI backs the /admin/workers/* routes (#1308). Holds the
+// FactorySet directly (not the per-request user-aware Set) for the same
+// reason the other admin APIs do — the worker_control table is a
+// platform-operator control with no tenant scope. AuditService is shared
+// with the rest of the apiserver so the worker audit trail lands in the
+// same audit_logs table.
+type adminWorkersAPI struct {
+	factorySet   *registry.FactorySet
+	auditService services.AuditLogger
+}
+
+// listWorkers returns every canonical worker type with its current pause
+// state. Worker types with no control row render as not-paused
+// (paused=false) — "no row" is the running default.
+//
+// @Summary List background workers and their pause state (admin)
+// @Description Returns one resource per canonical worker type with its soft-pause state (#1308). A worker with no control row renders as paused=false. Resource `type` is "worker_control"; `id` is the worker-type string.
+// @Tags admin
+// @Produce json-api
+// @Success 200 {object} WorkerControlListEnvelope "OK"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
+// @Router /admin/workers [get]
+func (api *adminWorkersAPI) listWorkers(w http.ResponseWriter, r *http.Request) {
+	rows, err := api.factorySet.WorkerControlRegistry.List(r.Context())
+	if err != nil {
+		slog.Error("admin listWorkers: failed to list worker controls", "error", err)
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	// Index the rows by worker type so the canonical-order merge below is
+	// O(1) per type. Absent => the worker is running.
+	byType := make(map[models.WorkerType]*models.WorkerControl, len(rows))
+	for _, row := range rows {
+		if row != nil {
+			byType[row.WorkerType] = row
+		}
+	}
+
+	resources := make([]WorkerControlResource, 0, len(models.AllWorkerTypes()))
+	for _, wt := range models.AllWorkerTypes() {
+		resources = append(resources, workerControlResource(wt, byType[wt]))
+	}
+
+	api.writeEnvelope(w, r, http.StatusOK, WorkerControlListEnvelope{Data: resources})
+}
+
+// pauseWorker soft-pauses the worker named in the {workerType} path
+// segment. The reason body field is optional. Idempotent — re-pausing an
+// already-paused worker updates the reason but preserves the original
+// paused_at.
+//
+// @Summary Soft-pause a background worker (admin)
+// @Description Soft-pauses the worker named by {workerType} (#1308): its run loop keeps ticking but skips claiming new work until resumed; in-flight jobs finish. Idempotent.
+// @Description The optional `reason` body field is recorded on the control row and the audit breadcrumb. An empty body is accepted.
+// @Description Unknown worker types return 404 with `admin.worker.unknown_type`; a reason over 500 characters returns 422 with `admin.worker.reason_too_long`.
+// @Tags admin
+// @Accept json
+// @Produce json-api
+// @Param workerType path string true "Worker type (e.g. export, import, thumbnail)"
+// @Param data body WorkerPauseRequest false "Optional pause request (reason)"
+// @Success 200 {object} WorkerControlEnvelope "OK"
+// @Failure 400 {object} jsonapi.Errors "Bad Request - invalid body"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
+// @Failure 404 {object} jsonapi.Errors "Not Found - unknown worker type"
+// @Failure 422 {object} jsonapi.Errors "Unprocessable Entity - reason too long"
+// @Router /admin/workers/{workerType}/pause [post]
+func (api *adminWorkersAPI) pauseWorker(w http.ResponseWriter, r *http.Request) {
+	actor := appctx.AdminActorFromContext(r.Context())
+	if actor == nil {
+		// Defence-in-depth: RequireBackofficeAuth should have populated this.
+		_ = unauthorizedError(w, r, ErrMissingUserContext)
+		return
+	}
+
+	wt, ok := api.resolveWorkerType(w, r)
+	if !ok {
+		return
+	}
+
+	req, ok := api.decodePauseRequest(w, r)
+	if !ok {
+		return
+	}
+
+	// Record the operator's id as paused_by so the control row attributes
+	// the pause to a back-office identity (the CLI path records "cli"
+	// instead). Email would be more human-readable, but the id is the
+	// stable key and matches the actor recorded on the audit row.
+	control, err := api.factorySet.WorkerControlRegistry.Pause(r.Context(), string(wt), actor.ID, req.Reason)
+	if err != nil {
+		slog.Error("admin pauseWorker: failed to pause worker", "worker_type", string(wt), "error", err)
+		api.logWorkerOutcome(r, AuditActionAdminWorkerPause, actor.ID, string(wt), req.Reason, false, err.Error())
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	api.writeEnvelope(w, r, http.StatusOK, WorkerControlEnvelope{Data: workerControlResource(wt, control)})
+	// Audit AFTER render so a writer failure lands as Success=false.
+	api.logWorkerOutcome(r, AuditActionAdminWorkerPause, actor.ID, string(wt), req.Reason, true, "")
+}
+
+// resumeWorker clears the soft-pause on the worker named in the
+// {workerType} path segment. No body is required. Idempotent — resuming
+// a worker that is not paused is a no-op returning the not-paused state.
+//
+// @Summary Resume a soft-paused background worker (admin)
+// @Description Clears the soft-pause on the worker named by {workerType} (#1308) so it resumes claiming work on its next tick. Idempotent. Unknown worker types return 404 with `admin.worker.unknown_type`.
+// @Tags admin
+// @Produce json-api
+// @Param workerType path string true "Worker type (e.g. export, import, thumbnail)"
+// @Success 200 {object} WorkerControlEnvelope "OK"
+// @Failure 401 {object} jsonapi.Errors "Unauthorized - back-office authentication required"
+// @Failure 403 {object} jsonapi.Errors "Account disabled"
+// @Failure 404 {object} jsonapi.Errors "Not Found - unknown worker type"
+// @Router /admin/workers/{workerType}/resume [post]
+func (api *adminWorkersAPI) resumeWorker(w http.ResponseWriter, r *http.Request) {
+	actor := appctx.AdminActorFromContext(r.Context())
+	if actor == nil {
+		_ = unauthorizedError(w, r, ErrMissingUserContext)
+		return
+	}
+
+	wt, ok := api.resolveWorkerType(w, r)
+	if !ok {
+		return
+	}
+
+	control, err := api.factorySet.WorkerControlRegistry.Resume(r.Context(), string(wt))
+	if err != nil {
+		slog.Error("admin resumeWorker: failed to resume worker", "worker_type", string(wt), "error", err)
+		api.logWorkerOutcome(r, AuditActionAdminWorkerResume, actor.ID, string(wt), "", false, err.Error())
+		_ = internalServerError(w, r, err)
+		return
+	}
+
+	api.writeEnvelope(w, r, http.StatusOK, WorkerControlEnvelope{Data: workerControlResource(wt, control)})
+	api.logWorkerOutcome(r, AuditActionAdminWorkerResume, actor.ID, string(wt), "", true, "")
+}
+
+// resolveWorkerType reads + validates the {workerType} path segment.
+// Writes a coded 404 and returns ok=false when the type is unknown so
+// the caller can early-return.
+func (api *adminWorkersAPI) resolveWorkerType(w http.ResponseWriter, r *http.Request) (models.WorkerType, bool) {
+	raw := strings.TrimSpace(chi.URLParam(r, "workerType"))
+	wt, ok := models.ParseWorkerType(raw)
+	if !ok {
+		_ = codedNotFoundError(w, r, errors.New("unknown worker type"), AdminWorkerUnknownTypeCode)
+		return "", false
+	}
+	return wt, true
+}
+
+// decodePauseRequest parses + validates the POST /pause body. An empty
+// body is allowed (no reason). Writes the right error response and
+// returns ok=false on failure so the caller can early-return.
+func (api *adminWorkersAPI) decodePauseRequest(w http.ResponseWriter, r *http.Request) (WorkerPauseRequest, bool) {
+	var req WorkerPauseRequest
+	if r.Body == nil {
+		// No body at all is fine — reason is optional.
+		return req, true
+	}
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		// An empty body decodes to io.EOF — treat it as "no reason"
+		// rather than a 400, since the reason is optional.
+		if errors.Is(err, io.EOF) {
+			return WorkerPauseRequest{}, true
+		}
+		_ = badRequest(w, r, err)
+		return req, false
+	}
+	if !decoderAtEOF(dec) {
+		_ = badRequest(w, r, errors.New("invalid JSON body — trailing tokens"))
+		return req, false
+	}
+	req.Reason = strings.TrimSpace(req.Reason)
+	if utf8.RuneCountInString(req.Reason) > adminWorkerReasonMaxLen {
+		_ = codedUnprocessableEntityError(w, r, errors.New("reason is too long"), AdminWorkerReasonTooLongCode)
+		return req, false
+	}
+	return req, true
+}
+
+// writeEnvelope encodes v as a JSON:API response on w. Centralised so the
+// content-type + encode-error handling is identical across list / single
+// responses.
+func (api *adminWorkersAPI) writeEnvelope(w http.ResponseWriter, _ *http.Request, status int, v any) {
+	w.Header().Set("Content-Type", "application/vnd.api+json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		// Headers (and status) already flushed — cannot recover, but log
+		// so the operator-side trail is honest.
+		slog.Error("admin workers: failed to encode response", "error", err)
+	}
+}
+
+// logWorkerOutcome writes the admin.worker_pause / admin.worker_resume
+// audit row. Best-effort: nil-safe when AuditService was not wired in.
+func (api *adminWorkersAPI) logWorkerOutcome(
+	r *http.Request,
+	action, actorID, workerType, reason string,
+	success bool,
+	errMsg string,
+) {
+	if api.auditService == nil {
+		return
+	}
+	ev := services.AdminEvent{
+		Action:      action,
+		ActorID:     nullableString(actorID),
+		SubjectType: stringPtr("worker"),
+		SubjectID:   nullableString(workerType),
+		Success:     success,
+		Request:     r,
+		Reason:      reason,
+	}
+	if errMsg != "" {
+		ev.ErrMsg = new(errMsg)
+	}
+	api.auditService.LogAdmin(r.Context(), ev)
+}
+
+// workerControlResource builds the JSON:API resource for worker type wt.
+// A nil control row (no row in the table) renders as the not-paused
+// default — "no row" means the worker is running.
+func workerControlResource(wt models.WorkerType, control *models.WorkerControl) WorkerControlResource {
+	view := WorkerControlView{
+		WorkerType: string(wt),
+		Paused:     false,
+	}
+	if control != nil {
+		view.Paused = control.Paused
+		view.PausedBy = control.PausedBy
+		view.PausedAt = control.PausedAt
+		view.Reason = control.Reason
+		updatedAt := control.UpdatedAt
+		view.UpdatedAt = &updatedAt
+	}
+	return WorkerControlResource{
+		Type:       "worker_control",
+		ID:         string(wt),
+		Attributes: view,
+	}
+}

--- a/go/apiserver/admin_workers.go
+++ b/go/apiserver/admin_workers.go
@@ -54,7 +54,7 @@ const adminWorkerReasonMaxLen = 500
 type WorkerPauseRequest struct {
 	// Reason is the optional operator-supplied note for the pause (max 500
 	// chars). Persisted into worker_control.reason and the audit breadcrumb.
-	Reason string `json:"reason,omitempty"`
+	Reason string `json:"reason,omitempty" maxLength:"500"`
 }
 
 // WorkerControlView is the JSON:API attributes block returned by the
@@ -329,8 +329,13 @@ func workerControlResource(wt models.WorkerType, control *models.WorkerControl) 
 		view.PausedBy = control.PausedBy
 		view.PausedAt = control.PausedAt
 		view.Reason = control.Reason
-		updatedAt := control.UpdatedAt
-		view.UpdatedAt = &updatedAt
+		// The synthetic not-paused row Resume returns for an absent worker
+		// carries a zero UpdatedAt; only surface a real timestamp so the
+		// response matches the list endpoint (which omits it too).
+		if !control.UpdatedAt.IsZero() {
+			updatedAt := control.UpdatedAt
+			view.UpdatedAt = &updatedAt
+		}
 	}
 	return WorkerControlResource{
 		Type:       "worker_control",

--- a/go/apiserver/admin_workers_test.go
+++ b/go/apiserver/admin_workers_test.go
@@ -1,0 +1,180 @@
+package apiserver_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-extras/go-kit/must"
+
+	"github.com/denisvmedia/inventario/apiserver"
+	"github.com/denisvmedia/inventario/internal/checkers"
+	"github.com/denisvmedia/inventario/models"
+)
+
+// Worker soft-pause admin endpoint tests (#1308). The /admin/workers/*
+// surface is gated by RequireBackofficeAuth (same as the rest of the
+// admin CRUD subtree), so the actor is a back-office user minted via
+// WithBackofficeAdmin. See admin_users_test.go for the shared harness
+// (newAdminEnv / doAdminJSONRequest).
+
+func TestAdminPauseWorker_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/workers/"+string(models.WorkerTypeExport)+"/pause",
+		env.adminToken, map[string]any{"reason": "maintenance window"})
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.type"), "worker_control")
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.id"), string(models.WorkerTypeExport))
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.paused"), true)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.reason"), "maintenance window")
+
+	// Persisted on the registry row, attributed to the back-office actor.
+	rows := must.Must(env.params.FactorySet.WorkerControlRegistry.List(context.Background()))
+	var row *models.WorkerControl
+	for i := range rows {
+		if rows[i].WorkerType == models.WorkerTypeExport {
+			row = rows[i]
+			break
+		}
+	}
+	c.Assert(row, qt.IsNotNil)
+	c.Assert(row.Paused, qt.IsTrue)
+	c.Assert(row.PausedBy, qt.IsNotNil)
+	c.Assert(*row.PausedBy, qt.Equals, env.admin.ID)
+}
+
+func TestAdminPauseWorker_EmptyBodyAllowed(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+
+	// Reason is optional — an empty body must still pause.
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/workers/"+string(models.WorkerTypeImport)+"/pause",
+		env.adminToken, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.paused"), true)
+}
+
+func TestAdminListWorkers_ReflectsPauseState(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+
+	// Pause one worker, then assert the listing reflects every canonical
+	// type with the paused one flagged.
+	pause := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/workers/"+string(models.WorkerTypeThumbnail)+"/pause",
+		env.adminToken, map[string]any{"reason": "gpu maintenance"})
+	c.Assert(pause.Code, qt.Equals, http.StatusOK)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodGet,
+		"/api/v1/admin/workers", env.adminToken, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusOK)
+	// Every canonical worker type is listed.
+	c.Assert(rr.Body.Bytes(), checkers.JSONPathMatches("$.data", qt.HasLen), len(models.AllWorkerTypes()))
+}
+
+func TestAdminResumeWorker_ClearsPause(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+
+	// Pause, then resume; assert the round-trip flips paused back to false.
+	pause := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/workers/"+string(models.WorkerTypeExport)+"/pause",
+		env.adminToken, map[string]any{"reason": "x"})
+	c.Assert(pause.Code, qt.Equals, http.StatusOK)
+	c.Assert(pause.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.paused"), true)
+
+	resume := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/workers/"+string(models.WorkerTypeExport)+"/resume",
+		env.adminToken, nil)
+	c.Assert(resume.Code, qt.Equals, http.StatusOK)
+	c.Assert(resume.Body.Bytes(), checkers.JSONPathEquals("$.data.attributes.paused"), false)
+
+	// Registry row is cleared too.
+	rows := must.Must(env.params.FactorySet.WorkerControlRegistry.List(context.Background()))
+	for i := range rows {
+		if rows[i].WorkerType == models.WorkerTypeExport {
+			c.Assert(rows[i].Paused, qt.IsFalse)
+		}
+	}
+}
+
+func TestAdminPauseWorker_UnknownTypeNotFound(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/workers/not-a-real-worker/pause",
+		env.adminToken, map[string]any{"reason": "x"})
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminWorkerUnknownTypeCode)
+}
+
+func TestAdminResumeWorker_UnknownTypeNotFound(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/workers/not-a-real-worker/resume",
+		env.adminToken, nil)
+	c.Assert(rr.Code, qt.Equals, http.StatusNotFound)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminWorkerUnknownTypeCode)
+}
+
+func TestAdminPauseWorker_ReasonTooLong(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/workers/"+string(models.WorkerTypeExport)+"/pause",
+		env.adminToken, map[string]any{"reason": strings.Repeat("x", 501)})
+	c.Assert(rr.Code, qt.Equals, http.StatusUnprocessableEntity)
+	assertErrorCode(t, c, rr.Body.Bytes(), apiserver.AdminWorkerReasonTooLongCode)
+}
+
+func TestAdminPauseWorker_UnknownJSONFieldRejected(t *testing.T) {
+	c := qt.New(t)
+	env := newAdminEnv(c)
+
+	// DisallowUnknownFields rejects extra keys with a 400, mirroring the
+	// block/unblock decode guard.
+	rr := doAdminJSONRequest(t, env.handler, http.MethodPost,
+		"/api/v1/admin/workers/"+string(models.WorkerTypeExport)+"/pause",
+		env.adminToken, []byte(`{"reason":"x","bogus":true}`))
+	c.Assert(rr.Code, qt.Equals, http.StatusBadRequest)
+}
+
+func TestAdminPauseWorker_DeniesTenantUser(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := newParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	// Tenant JWT — RequireBackofficeAuth rejects at the audience guard,
+	// regardless of the user's IsSystemAdmin flag.
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/admin/workers/"+string(models.WorkerTypeExport)+"/pause", nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
+}
+
+func TestAdminListWorkers_DeniesTenantUser(t *testing.T) {
+	c := qt.New(t)
+	params, user, _ := newParams()
+	handler := apiserver.APIServer(params, &mockRestoreWorker{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/workers", nil)
+	addTestUserAuthHeader(req, user.ID)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	c.Assert(rr.Code, qt.Equals, http.StatusUnauthorized)
+}

--- a/go/apiserver/admin_workers_test.go
+++ b/go/apiserver/admin_workers_test.go
@@ -2,6 +2,7 @@ package apiserver_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -77,6 +78,20 @@ func TestAdminListWorkers_ReflectsPauseState(t *testing.T) {
 	c.Assert(rr.Code, qt.Equals, http.StatusOK)
 	// Every canonical worker type is listed.
 	c.Assert(rr.Body.Bytes(), checkers.JSONPathMatches("$.data", qt.HasLen), len(models.AllWorkerTypes()))
+
+	// And the one we paused is flagged paused=true — assert the entry, not
+	// just cardinality, so the test fails if the listing ignores pause state.
+	var listed apiserver.WorkerControlListEnvelope
+	c.Assert(json.Unmarshal(rr.Body.Bytes(), &listed), qt.IsNil)
+	var thumb *apiserver.WorkerControlResource
+	for i := range listed.Data {
+		if listed.Data[i].ID == string(models.WorkerTypeThumbnail) {
+			thumb = &listed.Data[i]
+			break
+		}
+	}
+	c.Assert(thumb, qt.IsNotNil, qt.Commentf("thumbnail must be present in the listing"))
+	c.Assert(thumb.Attributes.Paused, qt.IsTrue)
 }
 
 func TestAdminResumeWorker_ClearsPause(t *testing.T) {

--- a/go/backup/export/worker.go
+++ b/go/backup/export/worker.go
@@ -17,11 +17,20 @@ const (
 	// Note: Cleanup interval removed - exports now use immediate hard delete with file entities
 )
 
+// PauseChecker reports whether a worker type is currently soft-paused
+// (#1308). Declared locally so this package depends only on models, not
+// on the workerpause controller — avoiding an import cycle while still
+// being satisfied by *workerpause.Controller.
+type PauseChecker interface {
+	IsPaused(models.WorkerType) bool
+}
+
 // ExportWorker processes export requests in the background
 type ExportWorker struct {
 	exportService *ExportService
 	factorySet    *registry.FactorySet
 	pollInterval  time.Duration
+	pause         PauseChecker
 	stopCh        chan struct{}
 	wg            sync.WaitGroup
 	isRunning     bool
@@ -35,6 +44,7 @@ type WorkerOption func(*exportWorkerOptions)
 
 type exportWorkerOptions struct {
 	pollInterval time.Duration
+	pause        PauseChecker
 }
 
 // WithPollInterval overrides the default interval between export queue polls.
@@ -43,6 +53,17 @@ func WithPollInterval(d time.Duration) WorkerOption {
 	return func(o *exportWorkerOptions) {
 		if d > 0 {
 			o.pollInterval = d
+		}
+	}
+}
+
+// WithPauseController wires the soft-pause controller so the worker skips
+// its claim phase while the export worker type is paused (#1308). A nil
+// checker leaves the worker unpaused.
+func WithPauseController(pc PauseChecker) WorkerOption {
+	return func(o *exportWorkerOptions) {
+		if pc != nil {
+			o.pause = pc
 		}
 	}
 }
@@ -59,6 +80,7 @@ func NewExportWorker(exportService *ExportService, factorySet *registry.FactoryS
 		exportService: exportService,
 		factorySet:    factorySet,
 		pollInterval:  options.pollInterval,
+		pause:         options.pause,
 		stopCh:        make(chan struct{}),
 		semaphore:     semaphore.NewWeighted(int64(maxConcurrentExports)),
 	}
@@ -132,6 +154,13 @@ func (w *ExportWorker) run(ctx context.Context) {
 
 // processPendingExports finds and processes pending export requests
 func (w *ExportWorker) processPendingExports(ctx context.Context) {
+	// Soft-pause (#1308): skip the claim phase while paused. The ticker
+	// keeps running so resuming takes effect on the next tick without a
+	// restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeExport) {
+		return
+	}
+
 	reg := w.factorySet.ExportRegistryFactory.CreateServiceRegistry()
 	exports, err := reg.List(ctx)
 	if err != nil {

--- a/go/backup/export/worker_pause_test.go
+++ b/go/backup/export/worker_pause_test.go
@@ -1,0 +1,125 @@
+package export
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	_ "github.com/denisvmedia/inventario/internal/fileblob" // register fileblob driver
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/services/workerpause"
+)
+
+// TestExportWorkerSoftPause is the #1308 acceptance test: a paused export
+// worker does NOT claim a pending export, and resuming it does. It drives
+// the controller's RefreshOnce + the worker's processPendingExports
+// directly (no ticker) so the pause/resume transition is deterministic.
+//
+// "Not picked up while paused" is proved by the export's status staying
+// ExportStatusPending after processPendingExports runs under a pause —
+// contrast the baseline / resumed cases where the status leaves pending
+// (the worker claimed it and the service ran to completed/failed).
+func TestExportWorkerSoftPause(t *testing.T) {
+	c := qt.New(t)
+	factorySet := newTestFactorySet()
+	registrySet := factorySet.CreateServiceRegistrySet()
+
+	tempDir := c.TempDir()
+	var uploadLocation string
+	if runtime.GOOS == "windows" {
+		uploadLocation = "file:///" + tempDir + "?create_dir=1"
+	} else {
+		uploadLocation = "file://" + tempDir + "?create_dir=1"
+	}
+
+	exportService := NewExportService(factorySet, uploadLocation)
+
+	// The controller polls the WorkerControlRegistry; the worker consults
+	// the controller's lock-free IsPaused on its claim phase.
+	ctrl := workerpause.NewController(factorySet.WorkerControlRegistry)
+	worker := NewExportWorker(exportService, factorySet, 3, WithPauseController(ctrl))
+
+	ctx := newTestContext()
+
+	newPendingExport := func() string {
+		c.Helper()
+		export := models.Export{
+			TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+				CreatedByUserID: testUserID,
+				TenantID:        "test-tenant",
+				GroupID:         testGroupID,
+			},
+			Type:            models.ExportTypeCommodities,
+			Status:          models.ExportStatusPending,
+			IncludeFileData: false,
+		}
+		created, err := registrySet.ExportRegistry.Create(ctx, export)
+		c.Assert(err, qt.IsNil)
+		return created.ID
+	}
+
+	statusOf := func(id string) models.ExportStatus {
+		c.Helper()
+		got, err := registrySet.ExportRegistry.Get(ctx, id)
+		c.Assert(err, qt.IsNil)
+		return got.Status
+	}
+
+	// (1) BASELINE — no pause row. RefreshOnce sees nothing paused, the
+	// worker claims the pending export, and its status leaves pending.
+	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
+	c.Assert(ctrl.IsPaused(models.WorkerTypeExport), qt.IsFalse)
+
+	baselineID := newPendingExport()
+	worker.processPendingExports(ctx)
+	c.Assert(waitForStatusLeavesPending(ctx, registrySet, baselineID), qt.IsTrue,
+		qt.Commentf("baseline: unpaused worker should claim the pending export"))
+
+	// (2) PAUSED — write a pause row, refresh, and confirm the worker
+	// leaves a fresh pending export untouched.
+	_, err := factorySet.WorkerControlRegistry.Pause(ctx, string(models.WorkerTypeExport), "tester", "maint")
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
+	c.Assert(ctrl.IsPaused(models.WorkerTypeExport), qt.IsTrue)
+
+	pausedID := newPendingExport()
+	worker.processPendingExports(ctx)
+	// Give any (erroneously spawned) async processing a chance to run so
+	// the assertion is not racing a goroutine that should never exist.
+	time.Sleep(100 * time.Millisecond)
+	c.Assert(statusOf(pausedID), qt.Equals, models.ExportStatusPending,
+		qt.Commentf("paused worker must NOT claim the pending export"))
+
+	// (3) RESUMED — clear the pause, refresh, and confirm the once-blocked
+	// export is now claimed.
+	_, err = factorySet.WorkerControlRegistry.Resume(ctx, string(models.WorkerTypeExport))
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
+	c.Assert(ctrl.IsPaused(models.WorkerTypeExport), qt.IsFalse)
+
+	worker.processPendingExports(ctx)
+	c.Assert(waitForStatusLeavesPending(ctx, registrySet, pausedID), qt.IsTrue,
+		qt.Commentf("resumed worker should now claim the previously-paused export"))
+}
+
+// waitForStatusLeavesPending polls the export row until its status is no
+// longer ExportStatusPending (the worker claimed + processed it) or a
+// short timeout elapses. Returns true on the leave-pending transition,
+// false on timeout. The export worker processes claimed exports in a
+// goroutine, so the assertion must give that goroutine a bounded chance
+// to run rather than reading the status synchronously.
+func waitForStatusLeavesPending(ctx context.Context, registrySet *registry.Set, exportID string) bool {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := registrySet.ExportRegistry.Get(ctx, exportID)
+		if err == nil && got.Status != models.ExportStatusPending {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}

--- a/go/backup/export/worker_pause_test.go
+++ b/go/backup/export/worker_pause_test.go
@@ -62,13 +62,6 @@ func TestExportWorkerSoftPause(t *testing.T) {
 		return created.ID
 	}
 
-	statusOf := func(id string) models.ExportStatus {
-		c.Helper()
-		got, err := registrySet.ExportRegistry.Get(ctx, id)
-		c.Assert(err, qt.IsNil)
-		return got.Status
-	}
-
 	// (1) BASELINE — no pause row. RefreshOnce sees nothing paused, the
 	// worker claims the pending export, and its status leaves pending.
 	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
@@ -88,10 +81,11 @@ func TestExportWorkerSoftPause(t *testing.T) {
 
 	pausedID := newPendingExport()
 	worker.processPendingExports(ctx)
-	// Give any (erroneously spawned) async processing a chance to run so
-	// the assertion is not racing a goroutine that should never exist.
-	time.Sleep(100 * time.Millisecond)
-	c.Assert(statusOf(pausedID), qt.Equals, models.ExportStatusPending,
+	// A single sleep+check could let a late async claim slip through after
+	// the assertion ran. Instead, poll over a window and require the export
+	// to stay pending for the whole interval — any non-pending observation
+	// means the paused worker wrongly claimed it.
+	c.Assert(staysPending(ctx, registrySet, pausedID), qt.IsTrue,
 		qt.Commentf("paused worker must NOT claim the pending export"))
 
 	// (3) RESUMED — clear the pause, refresh, and confirm the once-blocked
@@ -122,4 +116,21 @@ func waitForStatusLeavesPending(ctx context.Context, registrySet *registry.Set, 
 		time.Sleep(20 * time.Millisecond)
 	}
 	return false
+}
+
+// staysPending polls the export status every ~20ms over a ~400ms window
+// and returns true only if the status remains ExportStatusPending for the
+// whole window. It returns false on the first non-pending observation, so
+// a late async claim by a worker that should be paused cannot slip past a
+// single point-in-time check.
+func staysPending(ctx context.Context, registrySet *registry.Set, exportID string) bool {
+	deadline := time.Now().Add(400 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		got, err := registrySet.ExportRegistry.Get(ctx, exportID)
+		if err == nil && got.Status != models.ExportStatusPending {
+			return false
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return true
 }

--- a/go/backup/export/worker_pause_test.go
+++ b/go/backup/export/worker_pause_test.go
@@ -1,3 +1,5 @@
+package export
+
 // White-box (package export, not export_test) on purpose: this test drives
 // the unexported processPendingExports directly so the pause/resume claim
 // transition is deterministic — exercising it through Start()/the ticker
@@ -6,7 +8,6 @@
 // export); qtlint passes on white-box tests here, so the external-test-package
 // guideline is not lint-enforced for this directory. Converting to
 // export_test would need an artificial exported seam for no behavioral gain.
-package export
 
 import (
 	"context"

--- a/go/backup/export/worker_pause_test.go
+++ b/go/backup/export/worker_pause_test.go
@@ -1,3 +1,11 @@
+// White-box (package export, not export_test) on purpose: this test drives
+// the unexported processPendingExports directly so the pause/resume claim
+// transition is deterministic — exercising it through Start()/the ticker
+// would be flaky. It follows the existing precedent in this package
+// (worker_test.go, service_test.go, streaming_test.go are all package
+// export); qtlint passes on white-box tests here, so the external-test-package
+// guideline is not lint-enforced for this directory. Converting to
+// export_test would need an artificial exported seam for no behavioral gain.
 package export
 
 import (

--- a/go/backup/import/worker.go
+++ b/go/backup/import/worker.go
@@ -16,11 +16,20 @@ const (
 	defaultPollInterval = 10 * time.Second
 )
 
+// PauseChecker reports whether a worker type is currently soft-paused
+// (#1308). Declared locally so this package depends only on models, not
+// on the workerpause controller — avoiding an import cycle while still
+// being satisfied by *workerpause.Controller.
+type PauseChecker interface {
+	IsPaused(models.WorkerType) bool
+}
+
 // ImportWorker processes import requests in the background
 type ImportWorker struct {
 	importService *ImportService
 	factorySet    *registry.FactorySet
 	pollInterval  time.Duration
+	pause         PauseChecker
 	stopCh        chan struct{}
 	wg            sync.WaitGroup
 	isRunning     bool
@@ -34,6 +43,7 @@ type WorkerOption func(*importWorkerOptions)
 
 type importWorkerOptions struct {
 	pollInterval time.Duration
+	pause        PauseChecker
 }
 
 // WithPollInterval overrides the default interval between import queue polls.
@@ -42,6 +52,17 @@ func WithPollInterval(d time.Duration) WorkerOption {
 	return func(o *importWorkerOptions) {
 		if d > 0 {
 			o.pollInterval = d
+		}
+	}
+}
+
+// WithPauseController wires the soft-pause controller so the worker skips
+// its claim phase while the import worker type is paused (#1308). A nil
+// checker leaves the worker unpaused.
+func WithPauseController(pc PauseChecker) WorkerOption {
+	return func(o *importWorkerOptions) {
+		if pc != nil {
+			o.pause = pc
 		}
 	}
 }
@@ -58,6 +79,7 @@ func NewImportWorker(importService *ImportService, factorySet *registry.FactoryS
 		importService: importService,
 		factorySet:    factorySet,
 		pollInterval:  options.pollInterval,
+		pause:         options.pause,
 		stopCh:        make(chan struct{}),
 		semaphore:     semaphore.NewWeighted(int64(maxConcurrentImports)),
 	}
@@ -131,6 +153,13 @@ func (w *ImportWorker) run(ctx context.Context) {
 
 // processPendingImports finds and processes pending import requests
 func (w *ImportWorker) processPendingImports(ctx context.Context) {
+	// Soft-pause (#1308): skip the claim phase while paused. The ticker
+	// keeps running so resuming takes effect on the next tick without a
+	// restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeImport) {
+		return
+	}
+
 	expReg := w.factorySet.ExportRegistryFactory.CreateServiceRegistry()
 	exports, err := expReg.List(ctx)
 	if err != nil {

--- a/go/backup/restore/worker.go
+++ b/go/backup/restore/worker.go
@@ -17,12 +17,21 @@ const (
 	defaultMaxConcurrentRestores = 1
 )
 
+// PauseChecker reports whether a worker type is currently soft-paused
+// (#1308). Declared locally so this package depends only on models, not
+// on the workerpause controller — avoiding an import cycle while still
+// being satisfied by *workerpause.Controller.
+type PauseChecker interface {
+	IsPaused(models.WorkerType) bool
+}
+
 // RestoreWorker processes restore requests in the background
 type RestoreWorker struct {
 	restoreService *RestoreService
 	registrySet    *registry.Set
 	uploadLocation string
 	pollInterval   time.Duration
+	pause          PauseChecker
 	stopCh         chan struct{}
 	wg             sync.WaitGroup
 	isRunning      bool
@@ -37,6 +46,7 @@ type WorkerOption func(*restoreWorkerOptions)
 type restoreWorkerOptions struct {
 	pollInterval  time.Duration
 	maxConcurrent int
+	pause         PauseChecker
 }
 
 // WithPollInterval overrides the default interval between restore queue polls.
@@ -59,6 +69,17 @@ func WithMaxConcurrent(n int) WorkerOption {
 	}
 }
 
+// WithPauseController wires the soft-pause controller so the worker skips
+// its claim phase while the restore worker type is paused (#1308). A nil
+// checker leaves the worker unpaused.
+func WithPauseController(pc PauseChecker) WorkerOption {
+	return func(o *restoreWorkerOptions) {
+		if pc != nil {
+			o.pause = pc
+		}
+	}
+}
+
 // NewRestoreWorker creates a new restore worker
 func NewRestoreWorker(restoreService *RestoreService, registrySet *registry.Set, uploadLocation string, opts ...WorkerOption) *RestoreWorker {
 	options := restoreWorkerOptions{
@@ -73,6 +94,7 @@ func NewRestoreWorker(restoreService *RestoreService, registrySet *registry.Set,
 		registrySet:    registrySet,
 		uploadLocation: uploadLocation,
 		pollInterval:   options.pollInterval,
+		pause:          options.pause,
 		stopCh:         make(chan struct{}),
 		semaphore:      semaphore.NewWeighted(int64(options.maxConcurrent)),
 	}
@@ -146,6 +168,13 @@ func (w *RestoreWorker) run(ctx context.Context) {
 
 // processPendingRestores finds and processes pending restore requests
 func (w *RestoreWorker) processPendingRestores(ctx context.Context) {
+	// Soft-pause (#1308): skip the claim phase while paused. The ticker
+	// keeps running so resuming takes effect on the next tick without a
+	// restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeRestore) {
+		return
+	}
+
 	restoreOperations, err := w.registrySet.RestoreOperationRegistry.List(ctx)
 	if err != nil {
 		slog.Error("Failed to get restore operations", "error", err)

--- a/go/cmd/inventario/inventario.go
+++ b/go/cmd/inventario/inventario.go
@@ -16,6 +16,7 @@ import (
 	"github.com/denisvmedia/inventario/cmd/inventario/shared"
 	"github.com/denisvmedia/inventario/cmd/inventario/tenants"
 	"github.com/denisvmedia/inventario/cmd/inventario/users"
+	"github.com/denisvmedia/inventario/cmd/inventario/workers"
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -61,6 +62,11 @@ Use "inventario [command] --help" for detailed information about each command.`,
 	rootCmd.AddCommand(tenants.New(&dbConfig))
 	rootCmd.AddCommand(users.New(&dbConfig))
 	rootCmd.AddCommand(admin.New(&dbConfig))
+	// Top-level `workers` group (#1308) — soft-pause/resume/status of the
+	// background workers. Distinct from `run workers` (which starts the
+	// worker process): this group MUTATES the shared pause state of an
+	// already-running deployment.
+	rootCmd.AddCommand(workers.New(&dbConfig))
 	rootCmd.AddCommand(backfill.New(&dbConfig))
 	rootCmd.AddCommand(backoffice.New(&dbConfig))
 	rootCmd.AddCommand(version.New())

--- a/go/cmd/inventario/run/all/all.go
+++ b/go/cmd/inventario/run/all/all.go
@@ -62,6 +62,12 @@ func (c *Command) run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Start the soft-pause controller (#1308) before any worker so the
+	// first worker tick observes the correct pause state, and defer its
+	// stop FIRST so it shuts down LAST (after every worker has stopped).
+	stopPause := bootstrap.StartPauseController(ctx, rs)
+	defer stopPause()
+
 	stopEmail := bootstrap.StartEmailLifecycle(ctx, rs, c.cfg)
 	defer stopEmail()
 

--- a/go/cmd/inventario/run/bootstrap/bootstrap.go
+++ b/go/cmd/inventario/run/bootstrap/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 	"github.com/denisvmedia/inventario/schema/migrations/migrator"
+	"github.com/denisvmedia/inventario/services/workerpause"
 )
 
 // Mode identifies which `run` subcommand is driving the bootstrap. It selects
@@ -46,6 +47,12 @@ type RuntimeSetup struct {
 	EmailLifecycle            EmailServiceLifecycle
 	WorkerDurations           WorkerDurations
 	CloseReadinessRedisPinger func()
+
+	// PauseController polls the worker_control rows and exposes the
+	// soft-pause check the workers consult each tick (#1308). It is built
+	// only in worker-bearing modes (ModeAll / ModeWorkers); it stays nil in
+	// ModeAPIServer, where no worker run loop exists to gate.
+	PauseController *workerpause.Controller
 }
 
 // Build performs the non-goroutine preamble of `inventario run`: it logs the
@@ -102,14 +109,26 @@ func Build(cfg *Config, dbConfig *shared.DatabaseConfig, mode Mode) (*RuntimeSet
 		return nil, err
 	}
 
-	return &RuntimeSetup{
+	rs := &RuntimeSetup{
 		DSN:                       dsn,
 		FactorySet:                factorySet,
 		Params:                    serverSetup.params,
 		EmailLifecycle:            serverSetup.emailLifecycle,
 		WorkerDurations:           durations,
 		CloseReadinessRedisPinger: serverSetup.closeReadinessRedisPinger,
-	}, nil
+	}
+
+	// Build the soft-pause controller only in worker-bearing modes (#1308).
+	// ModeAPIServer has no worker run loops to gate, so it stays nil there
+	// and the workers' nil-safe pause field keeps them running.
+	if mode == ModeAll || mode == ModeWorkers {
+		rs.PauseController = workerpause.NewController(
+			factorySet.WorkerControlRegistry,
+			workerpause.WithRefreshInterval(durations.WorkerControlRefreshInterval),
+		)
+	}
+
+	return rs, nil
 }
 
 // logInventarioEnv emits every INVENTARIO_-prefixed environment variable name

--- a/go/cmd/inventario/run/bootstrap/config.go
+++ b/go/cmd/inventario/run/bootstrap/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	MaintenanceReminderInterval   string `yaml:"maintenance_reminder_interval" env:"MAINTENANCE_REMINDER_INTERVAL" env-default:""`
 	CurrencyMigrationInterval     string `yaml:"currency_migration_interval" env:"CURRENCY_MIGRATION_INTERVAL" env-default:""`
 	BusinessMetricsInterval       string `yaml:"business_metrics_interval" env:"BUSINESS_METRICS_INTERVAL" env-default:""`
+	WorkerControlRefreshInterval  string `yaml:"worker_control_refresh_interval" env:"WORKER_CONTROL_REFRESH_INTERVAL" env-default:""`
 	JWTSecret                     string `yaml:"jwt_secret" env:"JWT_SECRET" env-default:""`
 	FileSigningKey                string `yaml:"file_signing_key" env:"FILE_SIGNING_KEY" env-default:""`
 	FileURLExpiration             string `yaml:"file_url_expiration" env:"FILE_URL_EXPIRATION" env-default:"15m"`
@@ -266,6 +267,9 @@ func (c *Config) setWorkerDefaults() {
 	}
 	if c.BusinessMetricsInterval == "" {
 		c.BusinessMetricsInterval = defaults.GetBusinessMetricsInterval()
+	}
+	if c.WorkerControlRefreshInterval == "" {
+		c.WorkerControlRefreshInterval = defaults.GetWorkerControlRefreshInterval()
 	}
 }
 

--- a/go/cmd/inventario/run/bootstrap/durations.go
+++ b/go/cmd/inventario/run/bootstrap/durations.go
@@ -102,6 +102,13 @@ const defaultWorkerControlRefreshInterval = 10 * time.Second
 func parseWorkerDurationOrDefault(value string, fallback time.Duration) time.Duration {
 	d, err := time.ParseDuration(value)
 	if err != nil || d <= 0 {
+		// An unset value is a silent, always-safe default; but a non-empty
+		// value that we couldn't honour is operator intent we're ignoring,
+		// so surface it before falling back.
+		if value != "" {
+			slog.Warn("Ignoring invalid worker-control refresh interval; using default",
+				"value", value, "default", fallback)
+		}
 		return fallback
 	}
 	return d

--- a/go/cmd/inventario/run/bootstrap/durations.go
+++ b/go/cmd/inventario/run/bootstrap/durations.go
@@ -22,6 +22,7 @@ type WorkerDurations struct {
 	MaintenanceReminderInterval  time.Duration
 	CurrencyMigrationInterval    time.Duration
 	BusinessMetricsInterval      time.Duration
+	WorkerControlRefreshInterval time.Duration
 	ThumbnailPollInterval        time.Duration
 	ThumbnailCleanupInterval     time.Duration
 	ThumbnailJobRetentionPeriod  time.Duration
@@ -78,5 +79,30 @@ func ParseWorkerDurations(cfg *Config) (WorkerDurations, error) {
 		}
 		*spec.dst = d
 	}
+
+	// The soft-pause refresh interval (#1308) is parsed tolerantly rather
+	// than fail-fast: an unset or non-positive value falls back to the 10s
+	// default instead of aborting startup. The controller would clamp it
+	// anyway, and this keeps callers that build a bare Config (tests) from
+	// having to populate a knob whose default is always safe.
+	out.WorkerControlRefreshInterval = parseWorkerDurationOrDefault(cfg.WorkerControlRefreshInterval, defaultWorkerControlRefreshInterval)
+
 	return out, nil
+}
+
+// defaultWorkerControlRefreshInterval mirrors the controller's own
+// fallback and the defaults package value so a missing/invalid config
+// resolves to the same 10s cadence everywhere.
+const defaultWorkerControlRefreshInterval = 10 * time.Second
+
+// parseWorkerDurationOrDefault parses value, returning fallback when value
+// is empty, malformed, or non-positive. Used for the soft-pause refresh
+// interval where an always-safe default is preferable to a hard startup
+// failure.
+func parseWorkerDurationOrDefault(value string, fallback time.Duration) time.Duration {
+	d, err := time.ParseDuration(value)
+	if err != nil || d <= 0 {
+		return fallback
+	}
+	return d
 }

--- a/go/cmd/inventario/run/bootstrap/durations_test.go
+++ b/go/cmd/inventario/run/bootstrap/durations_test.go
@@ -33,6 +33,9 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 
 	got, err := bootstrap.ParseWorkerDurations(cfg)
 	c.Assert(err, qt.IsNil)
+	// Unset soft-pause refresh interval (#1308) falls back to 10s rather
+	// than failing the parse, unlike the fail-fast worker intervals above.
+	c.Assert(got.WorkerControlRefreshInterval, qt.Equals, 10*time.Second)
 	c.Assert(got.ExportPollInterval, qt.Equals, 11*time.Second)
 	c.Assert(got.ImportPollInterval, qt.Equals, 12*time.Second)
 	c.Assert(got.RestorePollInterval, qt.Equals, 13*time.Second)
@@ -49,6 +52,32 @@ func TestParseWorkerDurations_Valid(t *testing.T) {
 	c.Assert(got.ThumbnailJobRetentionPeriod, qt.Equals, 48*time.Hour)
 	c.Assert(got.ThumbnailJobBatchTimeout, qt.Equals, 45*time.Second)
 	c.Assert(got.DetachedThumbnailJobTimeout, qt.Equals, 3*time.Minute)
+}
+
+func TestParseWorkerDurations_WorkerControlRefreshOverride(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := &bootstrap.Config{}
+	cfg.SetDefaults()
+	cfg.WorkerControlRefreshInterval = "3s"
+
+	got, err := bootstrap.ParseWorkerDurations(cfg)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.WorkerControlRefreshInterval, qt.Equals, 3*time.Second)
+}
+
+func TestParseWorkerDurations_WorkerControlRefreshInvalidFallsBack(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := &bootstrap.Config{}
+	cfg.SetDefaults()
+	// A malformed / non-positive value falls back to 10s rather than
+	// aborting startup — unlike the fail-fast worker intervals.
+	cfg.WorkerControlRefreshInterval = "-5s"
+
+	got, err := bootstrap.ParseWorkerDurations(cfg)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.WorkerControlRefreshInterval, qt.Equals, 10*time.Second)
 }
 
 func TestParseWorkerDurations_FailsOnInvalidFlag(t *testing.T) {

--- a/go/cmd/inventario/run/bootstrap/workers.go
+++ b/go/cmd/inventario/run/bootstrap/workers.go
@@ -20,6 +20,19 @@ import (
 // the adapter signatures below stay readable.
 type currencyMigrationOp = models.CurrencyMigration
 
+// StartPauseController starts the background-worker soft-pause controller
+// (#1308) and returns its stop function. When rs.PauseController is nil
+// (ModeAPIServer, where no worker run loop exists to gate) it is a no-op.
+// It must be started BEFORE the workers so the first worker tick observes
+// the correct pause state, and stopped AFTER them.
+func StartPauseController(ctx context.Context, rs *RuntimeSetup) func() {
+	if rs.PauseController == nil {
+		return func() {}
+	}
+	rs.PauseController.Start(ctx)
+	return rs.PauseController.Stop
+}
+
 // StartEmailLifecycle starts the configured email service (if any) and returns
 // the matching stop function. cfg is accepted (and ignored) so the signature
 // matches the other Start* helpers and lets them be stored in a uniform slice.
@@ -32,10 +45,13 @@ func StartEmailLifecycle(ctx context.Context, rs *RuntimeSetup, _ *Config) func(
 // function.
 func StartExportWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) func() {
 	service := export.NewExportService(rs.FactorySet, rs.Params.UploadLocation)
-	worker := export.NewExportWorker(
-		service, rs.FactorySet, cfg.MaxConcurrentExports,
+	opts := []export.WorkerOption{
 		export.WithPollInterval(rs.WorkerDurations.ExportPollInterval),
-	)
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, export.WithPauseController(rs.PauseController))
+	}
+	worker := export.NewExportWorker(service, rs.FactorySet, cfg.MaxConcurrentExports, opts...)
 	worker.Start(ctx)
 	return worker.Stop
 }
@@ -44,10 +60,13 @@ func StartExportWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) func(
 // function.
 func StartImportWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) func() {
 	service := importpkg.NewImportService(rs.FactorySet, rs.Params.UploadLocation)
-	worker := importpkg.NewImportWorker(
-		service, rs.FactorySet, cfg.MaxConcurrentImports,
+	opts := []importpkg.WorkerOption{
 		importpkg.WithPollInterval(rs.WorkerDurations.ImportPollInterval),
-	)
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, importpkg.WithPauseController(rs.PauseController))
+	}
+	worker := importpkg.NewImportWorker(service, rs.FactorySet, cfg.MaxConcurrentImports, opts...)
 	worker.Start(ctx)
 	return worker.Stop
 }
@@ -57,10 +76,15 @@ func StartImportWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) func(
 // interface) and its stop function.
 func StartRestoreWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) (*restore.RestoreWorker, func()) {
 	service := restore.NewRestoreService(rs.FactorySet, rs.Params.EntityService, rs.Params.UploadLocation)
-	worker := restore.NewRestoreWorker(
-		service, rs.FactorySet.CreateServiceRegistrySet(), rs.Params.UploadLocation,
+	opts := []restore.WorkerOption{
 		restore.WithPollInterval(rs.WorkerDurations.RestorePollInterval),
 		restore.WithMaxConcurrent(cfg.MaxConcurrentRestores),
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, restore.WithPauseController(rs.PauseController))
+	}
+	worker := restore.NewRestoreWorker(
+		service, rs.FactorySet.CreateServiceRegistrySet(), rs.Params.UploadLocation, opts...,
 	)
 	worker.Start(ctx)
 	return worker, worker.Stop
@@ -69,14 +93,19 @@ func StartRestoreWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) (*re
 // StartThumbnailWorker wires and starts the thumbnail generation worker and
 // returns its stop function.
 func StartThumbnailWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) func() {
-	worker := services.NewThumbnailGenerationWorker(
-		rs.FactorySet, rs.Params.UploadLocation, rs.Params.ThumbnailConfig,
+	opts := []services.ThumbnailWorkerOption{
 		services.WithThumbnailPollInterval(rs.WorkerDurations.ThumbnailPollInterval),
 		services.WithThumbnailBatchSize(cfg.ThumbnailBatchSize),
 		services.WithThumbnailCleanupInterval(rs.WorkerDurations.ThumbnailCleanupInterval),
 		services.WithThumbnailJobRetentionPeriod(rs.WorkerDurations.ThumbnailJobRetentionPeriod),
 		services.WithThumbnailJobBatchTimeout(rs.WorkerDurations.ThumbnailJobBatchTimeout),
 		services.WithDetachedThumbnailJobTimeout(rs.WorkerDurations.DetachedThumbnailJobTimeout),
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, services.WithThumbnailPauseController(rs.PauseController))
+	}
+	worker := services.NewThumbnailGenerationWorker(
+		rs.FactorySet, rs.Params.UploadLocation, rs.Params.ThumbnailConfig, opts...,
 	)
 	worker.Start(ctx)
 	return worker.Stop
@@ -86,10 +115,13 @@ func StartThumbnailWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) fu
 // worker (which deletes expired tokens on the configured interval) and returns
 // its stop function.
 func StartRefreshTokenCleanupWorker(ctx context.Context, rs *RuntimeSetup, _ *Config) func() {
-	worker := services.NewRefreshTokenCleanupWorker(
-		rs.FactorySet.RefreshTokenRegistry,
+	opts := []services.RefreshTokenCleanupOption{
 		services.WithRefreshTokenCleanupInterval(rs.WorkerDurations.RefreshTokenCleanupInterval),
-	)
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, services.WithRefreshTokenCleanupPauseController(rs.PauseController))
+	}
+	worker := services.NewRefreshTokenCleanupWorker(rs.FactorySet.RefreshTokenRegistry, opts...)
 	worker.Start(ctx)
 	return worker.Stop
 }
@@ -100,7 +132,11 @@ func StartRefreshTokenCleanupWorker(ctx context.Context, rs *RuntimeSetup, _ *Co
 // 24h sweep) match the design doc and are conservative enough that
 // adding a knob is YAGNI for the v1 surface.
 func StartLoginEventRetentionWorker(ctx context.Context, rs *RuntimeSetup, _ *Config) func() {
-	worker := services.NewLoginEventRetentionWorker(rs.FactorySet.LoginEventRegistry)
+	var opts []services.LoginEventRetentionOption
+	if rs.PauseController != nil {
+		opts = append(opts, services.WithLoginEventRetentionPauseController(rs.PauseController))
+	}
+	worker := services.NewLoginEventRetentionWorker(rs.FactorySet.LoginEventRegistry, opts...)
 	worker.Start(ctx)
 	return worker.Stop
 }
@@ -111,10 +147,13 @@ func StartLoginEventRetentionWorker(ctx context.Context, rs *RuntimeSetup, _ *Co
 func StartGroupPurgeWorker(ctx context.Context, rs *RuntimeSetup, _ *Config) func() {
 	fileService := services.NewFileService(rs.FactorySet, rs.Params.UploadLocation)
 	service := services.NewGroupPurgeService(rs.FactorySet, fileService)
-	worker := services.NewGroupPurgeWorker(
-		service,
+	opts := []services.GroupPurgeOption{
 		services.WithGroupPurgeInterval(rs.WorkerDurations.GroupPurgeInterval),
-	)
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, services.WithGroupPurgePauseController(rs.PauseController))
+	}
+	worker := services.NewGroupPurgeWorker(service, opts...)
 	worker.Start(ctx)
 	return worker.Stop
 }
@@ -137,10 +176,13 @@ func StartWarrantyReminderWorker(ctx context.Context, rs *RuntimeSetup, cfg *Con
 	prefs := notifications.NewService(rs.FactorySet.SettingsRegistryFactory)
 	prefs.SetGroupPrefs(rs.FactorySet.GroupNotificationPrefRegistry)
 	service := services.NewWarrantyReminderService(rs.FactorySet, rs.EmailLifecycle.Service, urlBuilder).WithPreferences(prefs)
-	worker := services.NewWarrantyReminderWorker(
-		service,
+	opts := []services.WarrantyReminderOption{
 		services.WithWarrantyReminderInterval(rs.WorkerDurations.WarrantyReminderInterval),
-	)
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, services.WithWarrantyReminderPauseController(rs.PauseController))
+	}
+	worker := services.NewWarrantyReminderWorker(service, opts...)
 	worker.Start(ctx)
 	return worker.Stop
 }
@@ -160,10 +202,13 @@ func StartLoanReminderWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config)
 	service := services.NewLoanReminderService(rs.FactorySet, rs.EmailLifecycle.Service, urlBuilder).
 		WithPreferences(prefs).
 		WithDueSoonDays(cfg.LoanReminderDueSoonDays)
-	worker := services.NewLoanReminderWorker(
-		service,
+	opts := []services.LoanReminderOption{
 		services.WithLoanReminderInterval(rs.WorkerDurations.LoanReminderInterval),
-	)
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, services.WithLoanReminderPauseController(rs.PauseController))
+	}
+	worker := services.NewLoanReminderWorker(service, opts...)
 	worker.Start(ctx)
 	return worker.Stop
 }
@@ -177,10 +222,13 @@ func StartLoanReminderWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config)
 func StartStorageQuotaReminderWorker(ctx context.Context, rs *RuntimeSetup, cfg *Config) func() {
 	filesURL, settingsURL := buildStorageQuotaURLBuilders(cfg.PublicURL)
 	service := services.NewStorageQuotaReminderService(rs.FactorySet, rs.EmailLifecycle.Service, filesURL, settingsURL)
-	worker := services.NewStorageQuotaReminderWorker(
-		service,
+	opts := []services.StorageQuotaReminderOption{
 		services.WithStorageQuotaReminderInterval(rs.WorkerDurations.StorageQuotaReminderInterval),
-	)
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, services.WithStorageQuotaReminderPauseController(rs.PauseController))
+	}
+	worker := services.NewStorageQuotaReminderWorker(service, opts...)
 	worker.Start(ctx)
 	return worker.Stop
 }
@@ -252,10 +300,13 @@ func StartMaintenanceReminderWorker(ctx context.Context, rs *RuntimeSetup, cfg *
 	prefs := notifications.NewService(rs.FactorySet.SettingsRegistryFactory)
 	prefs.SetGroupPrefs(rs.FactorySet.GroupNotificationPrefRegistry)
 	service := services.NewMaintenanceReminderService(rs.FactorySet, rs.EmailLifecycle.Service, urlBuilder).WithPreferences(prefs)
-	worker := services.NewMaintenanceReminderWorker(
-		service,
+	opts := []services.MaintenanceReminderOption{
 		services.WithMaintenanceReminderInterval(rs.WorkerDurations.MaintenanceReminderInterval),
-	)
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, services.WithMaintenanceReminderPauseController(rs.PauseController))
+	}
+	worker := services.NewMaintenanceReminderWorker(service, opts...)
 	worker.Start(ctx)
 	return worker.Stop
 }
@@ -285,10 +336,16 @@ func StartCurrencyMigrationWorker(ctx context.Context, rs *RuntimeSetup, cfg *Co
 
 	processor := pgFactory.NewProcessor()
 	adapter := &currencyMigrationProcessorAdapter{inner: processor}
+	opts := []services.CurrencyMigrationWorkerOption{
+		services.WithCurrencyMigrationActiveInterval(rs.WorkerDurations.CurrencyMigrationInterval),
+	}
+	if rs.PauseController != nil {
+		opts = append(opts, services.WithCurrencyMigrationPauseController(rs.PauseController))
+	}
 	worker := services.NewCurrencyMigrationWorker(
 		rs.FactorySet.CurrencyMigrationRegistryFactory.CreateServiceRegistry(),
 		adapter,
-		services.WithCurrencyMigrationActiveInterval(rs.WorkerDurations.CurrencyMigrationInterval),
+		opts...,
 	)
 	worker.Start(ctx)
 	return worker.Stop

--- a/go/cmd/inventario/run/workers/workers.go
+++ b/go/cmd/inventario/run/workers/workers.go
@@ -128,6 +128,13 @@ func (c *Command) run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Start the soft-pause controller (#1308) before any worker group so
+	// the first worker tick observes the correct pause state. It is not
+	// part of any --workers-only/--workers-exclude group — pause state is
+	// orthogonal to worker selection, so it always runs. Its stop is the
+	// first entry pushed onto the LIFO stack below, so it shuts down last.
+	stopPause := bootstrap.StartPauseController(ctx, rs)
+
 	// Group and starter order matches the historical `run all` / `run workers`
 	// sequence so LIFO shutdown is unchanged for the default (all-groups) case.
 	groups := []group{
@@ -155,6 +162,9 @@ func (c *Command) run() error {
 	}
 
 	stops := make([]func(), 0, 8)
+	// Pushed first so the LIFO unwind below stops it last — after every
+	// worker group — mirroring the defer ordering in `run all`.
+	stops = append(stops, stopPause)
 	defer func() {
 		// LIFO shutdown to mirror the deferred-stop ordering of `run all`.
 		for _, stop := range slices.Backward(stops) {

--- a/go/cmd/inventario/workers/pause/pause.go
+++ b/go/cmd/inventario/workers/pause/pause.go
@@ -73,14 +73,17 @@ func (c *Command) registerFlags() {
 func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
 	out := c.Cmd().OutOrStdout()
 
-	if err := dbConfig.Validate(); err != nil {
-		return errxtrace.Wrap("database configuration error", err)
-	}
+	// Reject memory:// BEFORE the generic Validate(): Validate() already
+	// rejects non-postgres DSNs, so the worker-specific message would be
+	// unreachable for the default memory DSN if checked afterwards.
 	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
 		// The pause state must live in a persistent database shared with
 		// the worker process; an in-memory store is per-process and would
 		// never be seen by the workers.
 		return errors.New("worker pause commands are not supported for memory databases: the pause state must persist in a database shared with the worker process; use PostgreSQL")
+	}
+	if err := dbConfig.Validate(); err != nil {
+		return errxtrace.Wrap("database configuration error", err)
 	}
 	workerType := strings.TrimSpace(cfg.Type)
 	if workerType == "" {

--- a/go/cmd/inventario/workers/pause/pause.go
+++ b/go/cmd/inventario/workers/pause/pause.go
@@ -1,0 +1,129 @@
+// Package pause implements `inventario workers pause`.
+package pause
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/spf13/cobra"
+
+	"github.com/denisvmedia/inventario/cmd/internal/command"
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/services/admin"
+)
+
+// Config carries the pause command's flags.
+type Config struct {
+	Type   string `yaml:"type" env:"TYPE"`
+	Reason string `yaml:"reason" env:"REASON"`
+}
+
+// Command is the `workers pause` cobra wrapper.
+type Command struct {
+	command.Base
+
+	config Config
+}
+
+// New constructs the command with the supplied database config.
+func New(dbConfig *shared.DatabaseConfig) *Command {
+	c := &Command{}
+
+	shared.TryReadSection("workers.pause", &c.config)
+
+	c.Base = command.NewBase(&cobra.Command{
+		Use:   "pause",
+		Short: "Soft-pause a background worker",
+		Long: `Soft-pause the background worker named by --type.
+
+Soft-pause keeps the worker's run loop ticking but skips its unit of
+work: in-flight jobs finish, no new jobs are claimed, and the state
+persists across restarts. Resuming takes effect on the next tick.
+
+The operation is idempotent: re-pausing an already-paused worker
+updates the reason but preserves the original pause time.
+
+Known worker types: ` + knownWorkerTypes() + `
+
+Examples:
+  inventario workers pause --type export
+  inventario workers pause --type thumbnail --reason "GPU maintenance"`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.run(&c.config, dbConfig)
+		},
+	})
+
+	c.registerFlags()
+
+	return c
+}
+
+func (c *Command) registerFlags() {
+	// `--type` is "required" but enforced inside run() (with a friendlier
+	// error than cobra's default) so the same shape is reached whether the
+	// command is invoked through the root binary or directly from tests.
+	c.Cmd().Flags().StringVar(&c.config.Type, "type", c.config.Type, "Worker type to pause (required)")
+	c.Cmd().Flags().StringVar(&c.config.Reason, "reason", c.config.Reason, "Optional reason recorded with the pause")
+}
+
+func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
+	out := c.Cmd().OutOrStdout()
+
+	if err := dbConfig.Validate(); err != nil {
+		return errxtrace.Wrap("database configuration error", err)
+	}
+	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
+		// The pause state must live in a persistent database shared with
+		// the worker process; an in-memory store is per-process and would
+		// never be seen by the workers.
+		return errors.New("worker pause commands are not supported for memory databases: the pause state must persist in a database shared with the worker process; use PostgreSQL")
+	}
+	workerType := strings.TrimSpace(cfg.Type)
+	if workerType == "" {
+		return errors.New("--type is required")
+	}
+	if _, ok := models.ParseWorkerType(workerType); !ok {
+		return fmt.Errorf("unknown worker type %q; known types: %s", workerType, knownWorkerTypes())
+	}
+	reason := strings.TrimSpace(cfg.Reason)
+
+	adminService, err := admin.NewService(dbConfig)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := adminService.Close(); closeErr != nil {
+			fmt.Fprintf(out, "Warning: failed to close admin service: %v\n", closeErr)
+		}
+	}()
+
+	control, err := adminService.PauseWorker(c.Cmd().Context(), workerType, reason)
+	if err != nil {
+		return errxtrace.Wrap("failed to pause worker", err)
+	}
+
+	pausedAt := "unknown"
+	if control.PausedAt != nil {
+		pausedAt = control.PausedAt.Format("2006-01-02 15:04:05 MST")
+	}
+	fmt.Fprintf(out, "⏸️  Paused worker %q (paused_at: %s).\n", control.WorkerType, pausedAt)
+	if reason != "" {
+		fmt.Fprintf(out, "   reason: %s\n", reason)
+	}
+	return nil
+}
+
+// knownWorkerTypes renders the canonical worker-type set as a
+// comma-separated list for help text and error messages.
+func knownWorkerTypes() string {
+	all := models.AllWorkerTypes()
+	names := make([]string, len(all))
+	for i, t := range all {
+		names[i] = string(t)
+	}
+	return strings.Join(names, ", ")
+}

--- a/go/cmd/inventario/workers/resume/resume.go
+++ b/go/cmd/inventario/workers/resume/resume.go
@@ -1,0 +1,109 @@
+// Package resume implements `inventario workers resume`.
+package resume
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/spf13/cobra"
+
+	"github.com/denisvmedia/inventario/cmd/internal/command"
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/services/admin"
+)
+
+// Config carries the resume command's flags.
+type Config struct {
+	Type string `yaml:"type" env:"TYPE"`
+}
+
+// Command is the `workers resume` cobra wrapper.
+type Command struct {
+	command.Base
+
+	config Config
+}
+
+// New constructs the command with the supplied database config.
+func New(dbConfig *shared.DatabaseConfig) *Command {
+	c := &Command{}
+
+	shared.TryReadSection("workers.resume", &c.config)
+
+	c.Base = command.NewBase(&cobra.Command{
+		Use:   "resume",
+		Short: "Resume a soft-paused background worker",
+		Long: `Resume the background worker named by --type.
+
+Clears the soft-pause so the worker starts claiming jobs again on its
+next tick. The operation is idempotent: resuming a worker that is not
+paused is a no-op.
+
+Known worker types: ` + knownWorkerTypes() + `
+
+Examples:
+  inventario workers resume --type export`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.run(&c.config, dbConfig)
+		},
+	})
+
+	c.registerFlags()
+
+	return c
+}
+
+func (c *Command) registerFlags() {
+	c.Cmd().Flags().StringVar(&c.config.Type, "type", c.config.Type, "Worker type to resume (required)")
+}
+
+func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
+	out := c.Cmd().OutOrStdout()
+
+	if err := dbConfig.Validate(); err != nil {
+		return errxtrace.Wrap("database configuration error", err)
+	}
+	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
+		return errors.New("worker pause commands are not supported for memory databases: the pause state must persist in a database shared with the worker process; use PostgreSQL")
+	}
+	workerType := strings.TrimSpace(cfg.Type)
+	if workerType == "" {
+		return errors.New("--type is required")
+	}
+	if _, ok := models.ParseWorkerType(workerType); !ok {
+		return fmt.Errorf("unknown worker type %q; known types: %s", workerType, knownWorkerTypes())
+	}
+
+	adminService, err := admin.NewService(dbConfig)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := adminService.Close(); closeErr != nil {
+			fmt.Fprintf(out, "Warning: failed to close admin service: %v\n", closeErr)
+		}
+	}()
+
+	control, err := adminService.ResumeWorker(c.Cmd().Context(), workerType)
+	if err != nil {
+		return errxtrace.Wrap("failed to resume worker", err)
+	}
+
+	fmt.Fprintf(out, "▶️  Resumed worker %q.\n", control.WorkerType)
+	return nil
+}
+
+// knownWorkerTypes renders the canonical worker-type set as a
+// comma-separated list for help text and error messages.
+func knownWorkerTypes() string {
+	all := models.AllWorkerTypes()
+	names := make([]string, len(all))
+	for i, t := range all {
+		names[i] = string(t)
+	}
+	return strings.Join(names, ", ")
+}

--- a/go/cmd/inventario/workers/resume/resume.go
+++ b/go/cmd/inventario/workers/resume/resume.go
@@ -64,11 +64,14 @@ func (c *Command) registerFlags() {
 func (c *Command) run(cfg *Config, dbConfig *shared.DatabaseConfig) error {
 	out := c.Cmd().OutOrStdout()
 
-	if err := dbConfig.Validate(); err != nil {
-		return errxtrace.Wrap("database configuration error", err)
-	}
+	// Reject memory:// BEFORE the generic Validate(): Validate() already
+	// rejects non-postgres DSNs, so the worker-specific message would be
+	// unreachable for the default memory DSN if checked afterwards.
 	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
 		return errors.New("worker pause commands are not supported for memory databases: the pause state must persist in a database shared with the worker process; use PostgreSQL")
+	}
+	if err := dbConfig.Validate(); err != nil {
+		return errxtrace.Wrap("database configuration error", err)
 	}
 	workerType := strings.TrimSpace(cfg.Type)
 	if workerType == "" {

--- a/go/cmd/inventario/workers/status/status.go
+++ b/go/cmd/inventario/workers/status/status.go
@@ -1,0 +1,107 @@
+// Package status implements `inventario workers status`.
+package status
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/spf13/cobra"
+
+	"github.com/denisvmedia/inventario/cmd/internal/command"
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/services/admin"
+)
+
+// Command is the `workers status` cobra wrapper. It carries no flags —
+// status renders every worker type unconditionally.
+type Command struct {
+	command.Base
+}
+
+// New constructs the command with the supplied database config.
+func New(dbConfig *shared.DatabaseConfig) *Command {
+	c := &Command{}
+
+	c.Base = command.NewBase(&cobra.Command{
+		Use:   "status",
+		Short: "Show the pause state of every background worker",
+		Long: `Show the soft-pause state of every background worker.
+
+Every canonical worker type is listed. A worker with no control row is
+rendered as "running"; a paused worker shows who paused it, when, and
+the optional reason.
+
+Examples:
+  inventario workers status`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.run(dbConfig)
+		},
+	})
+
+	return c
+}
+
+func (c *Command) run(dbConfig *shared.DatabaseConfig) error {
+	out := c.Cmd().OutOrStdout()
+
+	if err := dbConfig.Validate(); err != nil {
+		return errxtrace.Wrap("database configuration error", err)
+	}
+	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
+		return errors.New("worker pause commands are not supported for memory databases: the pause state must persist in a database shared with the worker process; use PostgreSQL")
+	}
+
+	adminService, err := admin.NewService(dbConfig)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := adminService.Close(); closeErr != nil {
+			fmt.Fprintf(out, "Warning: failed to close admin service: %v\n", closeErr)
+		}
+	}()
+
+	controls, err := adminService.ListWorkerControls(c.Cmd().Context())
+	if err != nil {
+		return errxtrace.Wrap("failed to list worker controls", err)
+	}
+
+	// Index the control rows by worker type so the canonical-order walk
+	// below can look up state in O(1). Absent => the worker is running.
+	byType := make(map[models.WorkerType]*models.WorkerControl, len(controls))
+	for _, ctrl := range controls {
+		if ctrl != nil {
+			byType[ctrl.WorkerType] = ctrl
+		}
+	}
+
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+
+	fmt.Fprintln(w, "WORKER\tSTATE\tPAUSED_BY\tPAUSED_AT\tREASON")
+	for _, wt := range models.AllWorkerTypes() {
+		state := "running"
+		pausedBy := "-"
+		pausedAt := "-"
+		reason := "-"
+		if ctrl, ok := byType[wt]; ok && ctrl.Paused {
+			state = "paused"
+			if ctrl.PausedBy != nil && *ctrl.PausedBy != "" {
+				pausedBy = *ctrl.PausedBy
+			}
+			if ctrl.PausedAt != nil {
+				pausedAt = ctrl.PausedAt.Format("2006-01-02 15:04:05")
+			}
+			if ctrl.Reason != nil && *ctrl.Reason != "" {
+				reason = *ctrl.Reason
+			}
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", wt, state, pausedBy, pausedAt, reason)
+	}
+	return nil
+}

--- a/go/cmd/inventario/workers/status/status.go
+++ b/go/cmd/inventario/workers/status/status.go
@@ -49,11 +49,14 @@ Examples:
 func (c *Command) run(dbConfig *shared.DatabaseConfig) error {
 	out := c.Cmd().OutOrStdout()
 
-	if err := dbConfig.Validate(); err != nil {
-		return errxtrace.Wrap("database configuration error", err)
-	}
+	// Reject memory:// BEFORE the generic Validate(): Validate() already
+	// rejects non-postgres DSNs, so the worker-specific message would be
+	// unreachable for the default memory DSN if checked afterwards.
 	if strings.HasPrefix(dbConfig.DBDSN, "memory://") {
 		return errors.New("worker pause commands are not supported for memory databases: the pause state must persist in a database shared with the worker process; use PostgreSQL")
+	}
+	if err := dbConfig.Validate(); err != nil {
+		return errxtrace.Wrap("database configuration error", err)
 	}
 
 	adminService, err := admin.NewService(dbConfig)

--- a/go/cmd/inventario/workers/workers.go
+++ b/go/cmd/inventario/workers/workers.go
@@ -1,0 +1,74 @@
+// Package workers is the CLI command group for the background-worker
+// soft-pause control plane (#1308): pausing, resuming, and inspecting
+// the pause state of the polling background workers (export, import,
+// thumbnails, reminders, etc.).
+//
+// Soft-pause means the worker's run loop keeps ticking but skips its
+// unit of work while paused, so in-flight jobs finish, no new jobs are
+// claimed, and resuming is immediate without a process restart. The
+// state is persisted in the worker_control table and shared across every
+// replica via the database, so a single `inventario workers pause`
+// coordinates the whole fleet.
+//
+// NOTE: this is a SEPARATE top-level command from `inventario run
+// workers` (which STARTS the worker process). This group MUTATES pause
+// state in the shared database and is intended for ops use against a
+// running deployment.
+//
+// All operations require a PostgreSQL DSN — the in-memory backend has no
+// persistence and is not shared with the worker process, so a pause
+// against memory:// would be lost and never seen by the workers.
+package workers
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/denisvmedia/inventario/cmd/inventario/shared"
+	"github.com/denisvmedia/inventario/cmd/inventario/workers/pause"
+	"github.com/denisvmedia/inventario/cmd/inventario/workers/resume"
+	"github.com/denisvmedia/inventario/cmd/inventario/workers/status"
+)
+
+// New creates the parent `workers` command and registers its
+// subcommands. Mounted from cmd/inventario/inventario.go alongside
+// `admin`, `users`, `tenants`, etc. — the dbConfig flagset is supplied
+// by the root command.
+func New(dbConfig *shared.DatabaseConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workers",
+		Short: "Soft-pause / resume background workers (#1308)",
+		Long: `Soft-pause, resume, and inspect Inventario's background workers.
+
+Soft-pause keeps each worker's run loop ticking but skips its unit of
+work while paused: in-flight jobs finish, no new jobs are claimed, and
+resuming takes effect on the next tick without a process restart. The
+pause state is stored in the database and shared across every replica,
+so one command coordinates the whole fleet.
+
+This is NOT the same as "inventario run workers", which STARTS the
+worker process. These commands MUTATE the shared pause state of an
+already-running deployment.
+
+IMPORTANT: These commands ONLY support PostgreSQL databases. The
+in-memory backend has no persistence and is not shared with the worker
+process, so a pause against memory:// would never be seen.
+
+USAGE EXAMPLES:
+
+  Pause the export worker with a reason:
+    inventario workers pause --type export --reason "maintenance window"
+
+  Resume the export worker:
+    inventario workers resume --type export
+
+  Show the pause state of every worker:
+    inventario workers status`,
+		Args: cobra.NoArgs,
+	}
+
+	cmd.AddCommand(pause.New(dbConfig).Cmd())
+	cmd.AddCommand(resume.New(dbConfig).Cmd())
+	cmd.AddCommand(status.New(dbConfig).Cmd())
+
+	return cmd
+}

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -1002,6 +1002,155 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/workers": {
+            "get": {
+                "description": "Returns one resource per canonical worker type with its soft-pause state (#1308). A worker with no control row renders as paused=false. Resource ` + "`" + `type` + "`" + ` is \"worker_control\"; ` + "`" + `id` + "`" + ` is the worker-type string.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "List background workers and their pause state (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.WorkerControlListEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - back-office authentication required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Account disabled",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/workers/{workerType}/pause": {
+            "post": {
+                "description": "Soft-pauses the worker named by {workerType} (#1308): its run loop keeps ticking but skips claiming new work until resumed; in-flight jobs finish. Idempotent.\nThe optional ` + "`" + `reason` + "`" + ` body field is recorded on the control row and the audit breadcrumb. An empty body is accepted.\nUnknown worker types return 404 with ` + "`" + `admin.worker.unknown_type` + "`" + `; a reason over 500 characters returns 422 with ` + "`" + `admin.worker.reason_too_long` + "`" + `.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Soft-pause a background worker (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker type (e.g. export, import, thumbnail)",
+                        "name": "workerType",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Optional pause request (reason)",
+                        "name": "data",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.WorkerPauseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.WorkerControlEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - back-office authentication required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Account disabled",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown worker type",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - reason too long",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/workers/{workerType}/resume": {
+            "post": {
+                "description": "Clears the soft-pause on the worker named by {workerType} (#1308) so it resumes claiming work on its next tick. Idempotent. Unknown worker types return 404 with ` + "`" + `admin.worker.unknown_type` + "`" + `.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Resume a soft-paused background worker (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker type (e.g. export, import, thumbnail)",
+                        "name": "workerType",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.WorkerControlEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - back-office authentication required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Account disabled",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown worker type",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/change-password": {
             "post": {
                 "description": "Change the authenticated user's password. All existing sessions are invalidated on success.",
@@ -8582,6 +8731,71 @@ const docTemplate = `{
                 },
                 "version": {
                     "description": "Version information",
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.WorkerControlEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/apiserver.WorkerControlResource"
+                }
+            }
+        },
+        "apiserver.WorkerControlListEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/apiserver.WorkerControlResource"
+                    }
+                }
+            }
+        },
+        "apiserver.WorkerControlResource": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/apiserver.WorkerControlView"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.WorkerControlView": {
+            "type": "object",
+            "properties": {
+                "paused": {
+                    "type": "boolean"
+                },
+                "paused_at": {
+                    "type": "string"
+                },
+                "paused_by": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "worker_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.WorkerPauseRequest": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "description": "Reason is the optional operator-supplied note for the pause (max 500\nchars). Persisted into worker_control.reason and the audit breadcrumb.",
                     "type": "string"
                 }
             }

--- a/go/docs/docs.go
+++ b/go/docs/docs.go
@@ -8796,7 +8796,8 @@ const docTemplate = `{
             "properties": {
                 "reason": {
                     "description": "Reason is the optional operator-supplied note for the pause (max 500\nchars). Persisted into worker_control.reason and the audit breadcrumb.",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 500
                 }
             }
         },

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -995,6 +995,155 @@
                 }
             }
         },
+        "/admin/workers": {
+            "get": {
+                "description": "Returns one resource per canonical worker type with its soft-pause state (#1308). A worker with no control row renders as paused=false. Resource `type` is \"worker_control\"; `id` is the worker-type string.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "List background workers and their pause state (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.WorkerControlListEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - back-office authentication required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Account disabled",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/workers/{workerType}/pause": {
+            "post": {
+                "description": "Soft-pauses the worker named by {workerType} (#1308): its run loop keeps ticking but skips claiming new work until resumed; in-flight jobs finish. Idempotent.\nThe optional `reason` body field is recorded on the control row and the audit breadcrumb. An empty body is accepted.\nUnknown worker types return 404 with `admin.worker.unknown_type`; a reason over 500 characters returns 422 with `admin.worker.reason_too_long`.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Soft-pause a background worker (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker type (e.g. export, import, thumbnail)",
+                        "name": "workerType",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Optional pause request (reason)",
+                        "name": "data",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.WorkerPauseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.WorkerControlEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - invalid body",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - back-office authentication required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Account disabled",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown worker type",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - reason too long",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/workers/{workerType}/resume": {
+            "post": {
+                "description": "Clears the soft-pause on the worker named by {workerType} (#1308) so it resumes claiming work on its next tick. Idempotent. Unknown worker types return 404 with `admin.worker.unknown_type`.",
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Resume a soft-paused background worker (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker type (e.g. export, import, thumbnail)",
+                        "name": "workerType",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/apiserver.WorkerControlEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - back-office authentication required",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "403": {
+                        "description": "Account disabled",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - unknown worker type",
+                        "schema": {
+                            "$ref": "#/definitions/jsonapi.Errors"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/change-password": {
             "post": {
                 "description": "Change the authenticated user's password. All existing sessions are invalidated on success.",
@@ -8575,6 +8724,71 @@
                 },
                 "version": {
                     "description": "Version information",
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.WorkerControlEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/apiserver.WorkerControlResource"
+                }
+            }
+        },
+        "apiserver.WorkerControlListEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/apiserver.WorkerControlResource"
+                    }
+                }
+            }
+        },
+        "apiserver.WorkerControlResource": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/apiserver.WorkerControlView"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.WorkerControlView": {
+            "type": "object",
+            "properties": {
+                "paused": {
+                    "type": "boolean"
+                },
+                "paused_at": {
+                    "type": "string"
+                },
+                "paused_by": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "worker_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "apiserver.WorkerPauseRequest": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "description": "Reason is the optional operator-supplied note for the pause (max 500\nchars). Persisted into worker_control.reason and the audit breadcrumb.",
                     "type": "string"
                 }
             }

--- a/go/docs/swagger.json
+++ b/go/docs/swagger.json
@@ -8789,7 +8789,8 @@
             "properties": {
                 "reason": {
                     "description": "Reason is the optional operator-supplied note for the pause (max 500\nchars). Persisted into worker_control.reason and the audit breadcrumb.",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 500
                 }
             }
         },

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -561,6 +561,50 @@ definitions:
         description: Version information
         type: string
     type: object
+  apiserver.WorkerControlEnvelope:
+    properties:
+      data:
+        $ref: '#/definitions/apiserver.WorkerControlResource'
+    type: object
+  apiserver.WorkerControlListEnvelope:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/apiserver.WorkerControlResource'
+        type: array
+    type: object
+  apiserver.WorkerControlResource:
+    properties:
+      attributes:
+        $ref: '#/definitions/apiserver.WorkerControlView'
+      id:
+        type: string
+      type:
+        type: string
+    type: object
+  apiserver.WorkerControlView:
+    properties:
+      paused:
+        type: boolean
+      paused_at:
+        type: string
+      paused_by:
+        type: string
+      reason:
+        type: string
+      updated_at:
+        type: string
+      worker_type:
+        type: string
+    type: object
+  apiserver.WorkerPauseRequest:
+    properties:
+      reason:
+        description: |-
+          Reason is the optional operator-supplied note for the pause (max 500
+          chars). Persisted into worker_control.reason and the audit breadcrumb.
+        type: string
+    type: object
   apiserver.linkedIdentitiesResponse:
     properties:
       identities:
@@ -5116,6 +5160,111 @@ paths:
           schema:
             $ref: '#/definitions/jsonapi.Errors'
       summary: Unblock (reactivate) a user account
+      tags:
+      - admin
+  /admin/workers:
+    get:
+      description: Returns one resource per canonical worker type with its soft-pause
+        state (#1308). A worker with no control row renders as paused=false. Resource
+        `type` is "worker_control"; `id` is the worker-type string.
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.WorkerControlListEnvelope'
+        "401":
+          description: Unauthorized - back-office authentication required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Account disabled
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: List background workers and their pause state (admin)
+      tags:
+      - admin
+  /admin/workers/{workerType}/pause:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Soft-pauses the worker named by {workerType} (#1308): its run loop keeps ticking but skips claiming new work until resumed; in-flight jobs finish. Idempotent.
+        The optional `reason` body field is recorded on the control row and the audit breadcrumb. An empty body is accepted.
+        Unknown worker types return 404 with `admin.worker.unknown_type`; a reason over 500 characters returns 422 with `admin.worker.reason_too_long`.
+      parameters:
+      - description: Worker type (e.g. export, import, thumbnail)
+        in: path
+        name: workerType
+        required: true
+        type: string
+      - description: Optional pause request (reason)
+        in: body
+        name: data
+        schema:
+          $ref: '#/definitions/apiserver.WorkerPauseRequest'
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.WorkerControlEnvelope'
+        "400":
+          description: Bad Request - invalid body
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "401":
+          description: Unauthorized - back-office authentication required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Account disabled
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Not Found - unknown worker type
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "422":
+          description: Unprocessable Entity - reason too long
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Soft-pause a background worker (admin)
+      tags:
+      - admin
+  /admin/workers/{workerType}/resume:
+    post:
+      description: Clears the soft-pause on the worker named by {workerType} (#1308)
+        so it resumes claiming work on its next tick. Idempotent. Unknown worker types
+        return 404 with `admin.worker.unknown_type`.
+      parameters:
+      - description: Worker type (e.g. export, import, thumbnail)
+        in: path
+        name: workerType
+        required: true
+        type: string
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/apiserver.WorkerControlEnvelope'
+        "401":
+          description: Unauthorized - back-office authentication required
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "403":
+          description: Account disabled
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+        "404":
+          description: Not Found - unknown worker type
+          schema:
+            $ref: '#/definitions/jsonapi.Errors'
+      summary: Resume a soft-paused background worker (admin)
       tags:
       - admin
   /auth/change-password:

--- a/go/docs/swagger.yaml
+++ b/go/docs/swagger.yaml
@@ -603,6 +603,7 @@ definitions:
         description: |-
           Reason is the optional operator-supplied note for the pause (max 500
           chars). Persisted into worker_control.reason and the audit breadcrumb.
+        maxLength: 500
         type: string
     type: object
   apiserver.linkedIdentitiesResponse:

--- a/go/internal/defaults/defaults.go
+++ b/go/internal/defaults/defaults.go
@@ -37,6 +37,7 @@ type Workers struct {
 	MaintenanceReminderInterval  string // Maintenance reminder worker interval (e.g., "1h")
 	CurrencyMigrationInterval    string // Currency migration worker active-poll interval (e.g., "5s")
 	BusinessMetricsInterval      string // Business-metrics collector interval (e.g., "60s")
+	WorkerControlRefreshInterval string // Worker soft-pause control poll interval (e.g., "10s")
 }
 
 // ThumbnailGeneration contains default values for thumbnail generation configuration
@@ -104,6 +105,7 @@ func New() Config {
 			MaintenanceReminderInterval:  "1h",
 			CurrencyMigrationInterval:    "5s",
 			BusinessMetricsInterval:      "60s",
+			WorkerControlRefreshInterval: "10s",
 		},
 		ThumbnailGeneration: ThumbnailGeneration{
 			MaxConcurrentPerUser: 5,     // Maximum 5 simultaneous thumbnail generation jobs per user
@@ -243,6 +245,14 @@ func GetCurrencyMigrationInterval() string {
 // adding meaningful aggregate-query load.
 func GetBusinessMetricsInterval() string {
 	return defaultConfig.Workers.BusinessMetricsInterval
+}
+
+// GetWorkerControlRefreshInterval returns the default poll interval for
+// the background-worker soft-pause controller (#1308). 10s keeps a
+// pause/resume flip visible within a few seconds while adding negligible
+// DB load (one indexed List per interval).
+func GetWorkerControlRefreshInterval() string {
+	return defaultConfig.Workers.WorkerControlRefreshInterval
 }
 
 // GetThumbnailBatchSize returns the default thumbnail worker batch size

--- a/go/internal/defaults/defaults_test.go
+++ b/go/internal/defaults/defaults_test.go
@@ -33,6 +33,7 @@ func TestDefaults(t *testing.T) {
 	c.Assert(cfg.Workers.RefreshTokenCleanupInterval, qt.Equals, "1h")
 	c.Assert(cfg.Workers.GroupPurgeInterval, qt.Equals, "5m")
 	c.Assert(cfg.Workers.CurrencyMigrationInterval, qt.Equals, "5s")
+	c.Assert(cfg.Workers.WorkerControlRefreshInterval, qt.Equals, "10s")
 
 	// Test thumbnail generation defaults
 	c.Assert(cfg.ThumbnailGeneration.MaxConcurrentPerUser, qt.Equals, 5)
@@ -61,6 +62,7 @@ func TestDefaultGetters(t *testing.T) {
 	c.Assert(defaults.GetRefreshTokenCleanupInterval(), qt.Equals, "1h")
 	c.Assert(defaults.GetGroupPurgeInterval(), qt.Equals, "5m")
 	c.Assert(defaults.GetCurrencyMigrationInterval(), qt.Equals, "5s")
+	c.Assert(defaults.GetWorkerControlRefreshInterval(), qt.Equals, "10s")
 	c.Assert(defaults.GetThumbnailBatchSize(), qt.Equals, 10)
 	c.Assert(defaults.GetThumbnailPollInterval(), qt.Equals, "5s")
 	c.Assert(defaults.GetThumbnailCleanupInterval(), qt.Equals, "5m")

--- a/go/models/worker_control.go
+++ b/go/models/worker_control.go
@@ -128,10 +128,12 @@ type WorkerControl struct {
 	//migrator:schema:field name="paused" type="BOOLEAN" not_null="true" default="false"
 	Paused bool `json:"paused" db:"paused"`
 
-	// PausedBy records the operator id/email who paused the worker. NULL
-	// when paused via the CLI (no authenticated operator session). Not an
-	// FK — this control plane is intentionally decoupled from the users
-	// table (and a CLI/back-office operator may not be a tenant user row).
+	// PausedBy records who paused the worker: the back-office operator id
+	// for an API pause, or the literal "cli" for a CLI pause (the CLI has
+	// no authenticated operator session). NULL only when no actor was
+	// recorded. Not an FK — this control plane is intentionally decoupled
+	// from the users table (and a CLI/back-office operator may not be a
+	// tenant user row).
 	//migrator:schema:field name="paused_by" type="TEXT"
 	PausedBy *string `json:"paused_by,omitempty" db:"paused_by"`
 

--- a/go/models/worker_control.go
+++ b/go/models/worker_control.go
@@ -1,0 +1,168 @@
+package models
+
+import "time"
+
+// WorkerType is the typed natural key identifying a background worker
+// whose run loop can be soft-paused (#1308). The string values are the
+// stable, operator-facing identifiers used in the CLI (`inventario
+// workers pause <type>`), the admin REST surface, and the
+// worker_control.worker_type column — keep them stable across releases
+// and add new variants conservatively.
+//
+// `email` is intentionally NOT in this set: email delivery is a Redis
+// subscriber rather than a polling worker, and its pause/resume story is
+// handled separately.
+type WorkerType string
+
+const (
+	// WorkerTypeExport pauses the export generation worker.
+	WorkerTypeExport WorkerType = "export"
+	// WorkerTypeImport pauses the import processing worker.
+	WorkerTypeImport WorkerType = "import"
+	// WorkerTypeRestore pauses the restore processing worker.
+	WorkerTypeRestore WorkerType = "restore"
+	// WorkerTypeThumbnail pauses the thumbnail generation worker.
+	WorkerTypeThumbnail WorkerType = "thumbnail"
+	// WorkerTypeRefreshTokenCleanup pauses the refresh-token cleanup worker.
+	WorkerTypeRefreshTokenCleanup WorkerType = "refresh-token-cleanup"
+	// WorkerTypeLoginEventRetention pauses the login-event retention worker.
+	WorkerTypeLoginEventRetention WorkerType = "login-event-retention"
+	// WorkerTypeGroupPurge pauses the group purge worker.
+	WorkerTypeGroupPurge WorkerType = "group-purge"
+	// WorkerTypeWarrantyReminder pauses the warranty reminder worker.
+	WorkerTypeWarrantyReminder WorkerType = "warranty-reminder"
+	// WorkerTypeStorageQuotaReminder pauses the storage-quota reminder worker.
+	WorkerTypeStorageQuotaReminder WorkerType = "storage-quota-reminder"
+	// WorkerTypeLoanReminder pauses the loan reminder worker.
+	WorkerTypeLoanReminder WorkerType = "loan-reminder"
+	// WorkerTypeMaintenanceReminder pauses the maintenance reminder worker.
+	WorkerTypeMaintenanceReminder WorkerType = "maintenance-reminder"
+	// WorkerTypeCurrencyMigration pauses the currency migration worker.
+	WorkerTypeCurrencyMigration WorkerType = "currency-migration"
+)
+
+// allWorkerTypes is the canonical ordered set of pausable worker types.
+// Ordering is intentional (lifecycle workers first, then periodic
+// maintenance jobs) and backs AllWorkerTypes() so the CLI/admin listing
+// renders deterministically. Keep in sync with the const block above.
+var allWorkerTypes = []WorkerType{
+	WorkerTypeExport,
+	WorkerTypeImport,
+	WorkerTypeRestore,
+	WorkerTypeThumbnail,
+	WorkerTypeRefreshTokenCleanup,
+	WorkerTypeLoginEventRetention,
+	WorkerTypeGroupPurge,
+	WorkerTypeWarrantyReminder,
+	WorkerTypeStorageQuotaReminder,
+	WorkerTypeLoanReminder,
+	WorkerTypeMaintenanceReminder,
+	WorkerTypeCurrencyMigration,
+}
+
+// AllWorkerTypes returns a copy of the canonical ordered worker-type set.
+// Callers (CLI listing, admin endpoint enumeration) get a fresh slice so
+// they can sort/filter without mutating the package-level source of truth.
+func AllWorkerTypes() []WorkerType {
+	out := make([]WorkerType, len(allWorkerTypes))
+	copy(out, allWorkerTypes)
+	return out
+}
+
+// IsValid reports whether w is one of the known pausable worker types.
+// The empty string is not valid — callers must pass a concrete type.
+func (w WorkerType) IsValid() bool {
+	switch w {
+	case WorkerTypeExport,
+		WorkerTypeImport,
+		WorkerTypeRestore,
+		WorkerTypeThumbnail,
+		WorkerTypeRefreshTokenCleanup,
+		WorkerTypeLoginEventRetention,
+		WorkerTypeGroupPurge,
+		WorkerTypeWarrantyReminder,
+		WorkerTypeStorageQuotaReminder,
+		WorkerTypeLoanReminder,
+		WorkerTypeMaintenanceReminder,
+		WorkerTypeCurrencyMigration:
+		return true
+	}
+	return false
+}
+
+// ParseWorkerType validates s and returns the typed worker type. The
+// second return reports whether s named a known worker — callers (CLI
+// arg parsing, admin request validation) branch on it to reject unknown
+// types with a clear error rather than silently creating a control row
+// for a worker that doesn't exist.
+func ParseWorkerType(s string) (WorkerType, bool) {
+	w := WorkerType(s)
+	if !w.IsValid() {
+		return "", false
+	}
+	return w, true
+}
+
+// WorkerControl is the global control row for a single background worker
+// type (#1308). A present row with paused=true soft-pauses that worker;
+// an absent row means the worker runs normally. Soft-pause means the
+// worker's run loop keeps ticking but skips its unit of work while
+// paused, so resuming is immediate and needs no process restart.
+//
+// The table is NOT tenant-scoped and has NO RLS policy: worker pause
+// state is a platform-operator control orthogonal to tenants (same
+// posture as system_admin_grants / audit_logs). It is stored directly on
+// FactorySet rather than behind a per-request Factory.
+//
+//migrator:schema:table name="worker_control"
+type WorkerControl struct {
+	//migrator:embedded mode="inline"
+	EntityID
+
+	// WorkerType is the natural key — one control row per worker type.
+	// Backed by a unique index so Pause can use ON CONFLICT (worker_type).
+	//migrator:schema:field name="worker_type" type="TEXT" not_null="true"
+	WorkerType WorkerType `json:"worker_type" db:"worker_type"`
+
+	// Paused is the soft-pause flag the worker run loop checks each tick.
+	//migrator:schema:field name="paused" type="BOOLEAN" not_null="true" default="false"
+	Paused bool `json:"paused" db:"paused"`
+
+	// PausedBy records the operator id/email who paused the worker. NULL
+	// when paused via the CLI (no authenticated operator session). Not an
+	// FK — this control plane is intentionally decoupled from the users
+	// table (and a CLI/back-office operator may not be a tenant user row).
+	//migrator:schema:field name="paused_by" type="TEXT"
+	PausedBy *string `json:"paused_by,omitempty" db:"paused_by"`
+
+	// PausedAt is when the worker was first paused. Preserved across
+	// re-pauses (updating by/reason does not reset the original pause
+	// time), and cleared to NULL on resume.
+	//migrator:schema:field name="paused_at" type="TIMESTAMP"
+	PausedAt *time.Time `json:"paused_at,omitempty" db:"paused_at"`
+
+	// Reason is the optional operator-supplied note for the pause. NULL
+	// when none was given; cleared on resume.
+	//migrator:schema:field name="reason" type="TEXT"
+	Reason *string `json:"reason,omitempty" db:"reason"`
+
+	// UpdatedAt is the wall-clock time of the last state change (pause,
+	// re-pause, or resume).
+	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
+}
+
+// WorkerControlIndexes defines the PostgreSQL indexes for the
+// worker_control table.
+type WorkerControlIndexes struct {
+	// Unique index for the immutable UUID (the dedup key every entity
+	// carries for import/restore — mirrors the convention used elsewhere).
+	//migrator:schema:index name="idx_worker_control_uuid" fields="uuid" unique="true" table="worker_control"
+	_ int
+
+	// Unique index on worker_type: at most one control row per worker.
+	// Backs the Pause INSERT ... ON CONFLICT (worker_type) upsert and the
+	// hot-path lookup the worker run loop runs each tick.
+	//migrator:schema:index name="worker_control_worker_type_idx" fields="worker_type" unique="true" table="worker_control"
+	_ int
+}

--- a/go/registry/factories.go
+++ b/go/registry/factories.go
@@ -240,6 +240,12 @@ type FactorySet struct {
 	// zeros). Nil-able: a nil func means "no business gauges", and the
 	// collector no-ops on a nil source.
 	SystemStats SystemStatsFunc
+
+	// WorkerControlRegistry holds the global background-worker soft-pause
+	// control rows (issue #1308). Lives on FactorySet only — not
+	// tenant-scoped, not user-aware, no RLS (same posture as
+	// SystemAdminGrantRegistry / AuditLogRegistry).
+	WorkerControlRegistry WorkerControlRegistry
 }
 
 // Ping checks readiness of the backing registry dependency (e.g. database).
@@ -382,6 +388,7 @@ func (fs *FactorySet) CreateUserRegistrySet(ctx context.Context) (*Set, error) {
 		CommodityScanAuditRegistry:     fs.CommodityScanAuditRegistry,
 		SystemAdminGrantRegistry:       fs.SystemAdminGrantRegistry,
 		OAuthIdentityRegistry:          fs.OAuthIdentityRegistry,
+		WorkerControlRegistry:          fs.WorkerControlRegistry,
 	}, nil
 }
 
@@ -426,5 +433,6 @@ func (fs *FactorySet) CreateServiceRegistrySet() *Set {
 		CommodityScanAuditRegistry:     fs.CommodityScanAuditRegistry,
 		SystemAdminGrantRegistry:       fs.SystemAdminGrantRegistry,
 		OAuthIdentityRegistry:          fs.OAuthIdentityRegistry,
+		WorkerControlRegistry:          fs.WorkerControlRegistry,
 	}
 }

--- a/go/registry/memory/memory.go
+++ b/go/registry/memory/memory.go
@@ -81,6 +81,9 @@ func NewFactorySet() *registry.FactorySet {
 	// tenant users* hold platform-wide admin privilege; it has no
 	// tenant scope (mirrors AuditLogRegistry).
 	fs.SystemAdminGrantRegistry = NewSystemAdminGrantRegistry()
+	// Background-worker soft-pause control (issue #1308). Global control
+	// plane — no tenant scope, no RLS (mirrors SystemAdminGrantRegistry).
+	fs.WorkerControlRegistry = NewWorkerControlRegistry()
 	// Back-office MFA secrets (issue #1785, Phase 4). One row per
 	// back-office user; the operator CLI mints, regenerates, and wipes
 	// rows. No RLS / tenant scoping — same reasoning as the rest of the

--- a/go/registry/memory/worker_control.go
+++ b/go/registry/memory/worker_control.go
@@ -1,0 +1,173 @@
+package memory
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/google/uuid"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+var _ registry.WorkerControlRegistry = (*WorkerControlRegistry)(nil)
+
+// WorkerControlRegistry is the in-memory implementation of the
+// background-worker soft-pause control store (#1308). All operations are
+// guarded by a single per-registry mutex: the postgres impl serialises
+// the pause/resume upsert via the unique (worker_type) index, so the
+// in-memory equivalent must serialise too to keep the idempotency
+// contract race-free. nowFn/uuidFn are injectable so tests get
+// deterministic timestamps and IDs.
+type WorkerControlRegistry struct {
+	lock sync.Mutex
+	// items is keyed by worker_type (the natural key), mirroring the SQL
+	// unique index — at most one control row per worker type.
+	items  map[string]*models.WorkerControl
+	nowFn  func() time.Time
+	uuidFn func() string
+}
+
+// NewWorkerControlRegistry creates a new in-memory WorkerControlRegistry.
+func NewWorkerControlRegistry() *WorkerControlRegistry {
+	return &WorkerControlRegistry{
+		items:  make(map[string]*models.WorkerControl),
+		nowFn:  func() time.Time { return time.Now().UTC() },
+		uuidFn: func() string { return uuid.New().String() },
+	}
+}
+
+// NewWorkerControlRegistryForTesting builds a registry with injected
+// clock and id generators so tests get deterministic paused_at /
+// updated_at timestamps and stable ids. Production code must use
+// NewWorkerControlRegistry.
+func NewWorkerControlRegistryForTesting(nowFn func() time.Time, uuidFn func() string) *WorkerControlRegistry {
+	return &WorkerControlRegistry{
+		items:  make(map[string]*models.WorkerControl),
+		nowFn:  nowFn,
+		uuidFn: uuidFn,
+	}
+}
+
+// List returns every worker_control row ordered by worker_type. Returns
+// defensive copies so a caller mutating the slice can't corrupt registry
+// state.
+func (r *WorkerControlRegistry) List(_ context.Context) ([]*models.WorkerControl, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	out := make([]*models.WorkerControl, 0, len(r.items))
+	for _, wc := range r.items {
+		out = append(out, cloneWorkerControl(wc))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].WorkerType < out[j].WorkerType
+	})
+	return out, nil
+}
+
+// Pause idempotently marks workerType paused. pausedBy/reason are stored
+// as NULL when empty. Re-pausing an already-paused type updates
+// paused_by/reason but PRESERVES the original paused_at — same semantics
+// as the postgres CASE expression.
+func (r *WorkerControlRegistry) Pause(_ context.Context, workerType, pausedBy, reason string) (*models.WorkerControl, error) {
+	if workerType == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired)
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	now := r.nowFn()
+
+	existing, ok := r.items[workerType]
+	if ok && existing.Paused {
+		// Already paused: update by/reason, preserve the original
+		// paused_at, bump updated_at.
+		existing.PausedBy = optionalString(pausedBy)
+		existing.Reason = optionalString(reason)
+		existing.UpdatedAt = now
+		return cloneWorkerControl(existing), nil
+	}
+
+	pausedAt := now
+	wc := &models.WorkerControl{
+		EntityID: models.EntityID{
+			ID:   r.uuidFn(),
+			UUID: r.uuidFn(),
+		},
+		WorkerType: models.WorkerType(workerType),
+		Paused:     true,
+		PausedBy:   optionalString(pausedBy),
+		PausedAt:   &pausedAt,
+		Reason:     optionalString(reason),
+		UpdatedAt:  now,
+	}
+	if ok {
+		// A row existed but was not paused — reuse its identity so the
+		// id/uuid stay stable across pause/resume cycles, mirroring the
+		// postgres upsert which keeps the same row.
+		wc.EntityID = existing.EntityID
+	}
+	r.items[workerType] = wc
+	return cloneWorkerControl(wc), nil
+}
+
+// Resume idempotently marks workerType not paused, clearing
+// paused_at/paused_by/reason. When no row exists it is a no-op and
+// returns a synthetic not-paused WorkerControl (no row created).
+func (r *WorkerControlRegistry) Resume(_ context.Context, workerType string) (*models.WorkerControl, error) {
+	if workerType == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired)
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	existing, ok := r.items[workerType]
+	if !ok {
+		// Already running — synthesize a not-paused state without
+		// creating a row (matches the postgres no-op behaviour).
+		return &models.WorkerControl{WorkerType: models.WorkerType(workerType)}, nil
+	}
+
+	existing.Paused = false
+	existing.PausedBy = nil
+	existing.PausedAt = nil
+	existing.Reason = nil
+	existing.UpdatedAt = r.nowFn()
+	return cloneWorkerControl(existing), nil
+}
+
+// optionalString maps an empty string to a nil *string (stored as NULL)
+// and a non-empty value to a fresh pointer the caller can't alias.
+func optionalString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	cp := s
+	return &cp
+}
+
+// cloneWorkerControl deep-copies a control row, duplicating the nullable
+// pointer fields so a caller writing through the returned pointer can't
+// reach the stored row.
+func cloneWorkerControl(wc *models.WorkerControl) *models.WorkerControl {
+	cp := *wc
+	if wc.PausedBy != nil {
+		v := *wc.PausedBy
+		cp.PausedBy = &v
+	}
+	if wc.PausedAt != nil {
+		v := *wc.PausedAt
+		cp.PausedAt = &v
+	}
+	if wc.Reason != nil {
+		v := *wc.Reason
+		cp.Reason = &v
+	}
+	return &cp
+}

--- a/go/registry/memory/worker_control.go
+++ b/go/registry/memory/worker_control.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"github.com/google/uuid"
 
@@ -77,6 +78,12 @@ func (r *WorkerControlRegistry) Pause(_ context.Context, workerType, pausedBy, r
 	if workerType == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired)
 	}
+	// Defence-in-depth: the handler/CLI already reject unknown types, but
+	// the registry is the storage authority — never write a control row
+	// for a worker that doesn't exist.
+	if !models.WorkerType(workerType).IsValid() {
+		return nil, errxtrace.Classify(registry.ErrInvalidInput, errx.Attrs("worker_type", workerType))
+	}
 
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -122,6 +129,9 @@ func (r *WorkerControlRegistry) Pause(_ context.Context, workerType, pausedBy, r
 func (r *WorkerControlRegistry) Resume(_ context.Context, workerType string) (*models.WorkerControl, error) {
 	if workerType == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired)
+	}
+	if !models.WorkerType(workerType).IsValid() {
+		return nil, errxtrace.Classify(registry.ErrInvalidInput, errx.Attrs("worker_type", workerType))
 	}
 
 	r.lock.Lock()

--- a/go/registry/memory/worker_control_test.go
+++ b/go/registry/memory/worker_control_test.go
@@ -1,0 +1,191 @@
+package memory_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry/memory"
+)
+
+// newWorkerControlRegistryForTest builds a registry with deterministic
+// nowFn/uuidFn so timestamp- and id-sensitive assertions are stable.
+// nowFn advances by one second per call so re-pause vs original pause
+// times are distinguishable; uuidFn hands out predictable ids.
+func newWorkerControlRegistryForTest(t *testing.T) (*memory.WorkerControlRegistry, *time.Time) {
+	t.Helper()
+
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	clock := base
+	var idSeq int
+	r := memory.NewWorkerControlRegistryForTesting(
+		func() time.Time {
+			cur := clock
+			clock = clock.Add(time.Second)
+			return cur
+		},
+		func() string {
+			idSeq++
+			return "id-" + strconv.Itoa(idSeq)
+		},
+	)
+	return r, &base
+}
+
+// TestWorkerControlRegistry_List_Empty verifies a fresh registry reports
+// no control rows — the caller treats this as "every worker running".
+func TestWorkerControlRegistry_List_Empty(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	r := memory.NewWorkerControlRegistry()
+
+	controls, err := r.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controls, qt.HasLen, 0)
+}
+
+// TestWorkerControlRegistry_Pause_Creates verifies the first Pause writes
+// a paused row carrying the operator, reason, and a pause timestamp.
+func TestWorkerControlRegistry_Pause_Creates(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	r, base := newWorkerControlRegistryForTest(t)
+
+	wc, err := r.Pause(ctx, string(models.WorkerTypeExport), "operator@example.com", "maintenance window")
+	c.Assert(err, qt.IsNil)
+	c.Assert(wc.WorkerType, qt.Equals, models.WorkerTypeExport)
+	c.Assert(wc.Paused, qt.IsTrue)
+	c.Assert(wc.PausedBy, qt.IsNotNil)
+	c.Assert(*wc.PausedBy, qt.Equals, "operator@example.com")
+	c.Assert(wc.Reason, qt.IsNotNil)
+	c.Assert(*wc.Reason, qt.Equals, "maintenance window")
+	c.Assert(wc.PausedAt, qt.IsNotNil)
+	c.Assert(wc.PausedAt.Equal(*base), qt.IsTrue)
+
+	controls, err := r.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controls, qt.HasLen, 1)
+}
+
+// TestWorkerControlRegistry_Pause_EmptyByAndReasonStoredAsNull verifies
+// that the CLI pause path (no operator session, no reason) lands NULLs
+// rather than empty-string sentinels.
+func TestWorkerControlRegistry_Pause_EmptyByAndReasonStoredAsNull(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	r, _ := newWorkerControlRegistryForTest(t)
+
+	wc, err := r.Pause(ctx, string(models.WorkerTypeImport), "", "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(wc.Paused, qt.IsTrue)
+	c.Assert(wc.PausedBy, qt.IsNil)
+	c.Assert(wc.Reason, qt.IsNil)
+}
+
+// TestWorkerControlRegistry_Pause_IdempotentPreservesPausedAt verifies a
+// second Pause updates paused_by/reason but keeps the ORIGINAL paused_at,
+// so the timestamp reflects when the worker first stopped.
+func TestWorkerControlRegistry_Pause_IdempotentPreservesPausedAt(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	r, base := newWorkerControlRegistryForTest(t)
+
+	first, err := r.Pause(ctx, string(models.WorkerTypeThumbnail), "alice", "first reason")
+	c.Assert(err, qt.IsNil)
+	originalPausedAt := *first.PausedAt
+	c.Assert(originalPausedAt.Equal(*base), qt.IsTrue)
+
+	second, err := r.Pause(ctx, string(models.WorkerTypeThumbnail), "bob", "second reason")
+	c.Assert(err, qt.IsNil)
+	c.Assert(second.Paused, qt.IsTrue)
+	// paused_at unchanged...
+	c.Assert(second.PausedAt, qt.IsNotNil)
+	c.Assert(second.PausedAt.Equal(originalPausedAt), qt.IsTrue)
+	// ...but by/reason updated...
+	c.Assert(*second.PausedBy, qt.Equals, "bob")
+	c.Assert(*second.Reason, qt.Equals, "second reason")
+	// ...and updated_at advanced past the original pause time.
+	c.Assert(second.UpdatedAt.After(originalPausedAt), qt.IsTrue)
+
+	// Still a single row.
+	controls, err := r.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controls, qt.HasLen, 1)
+}
+
+// TestWorkerControlRegistry_Resume_Clears verifies resume flips paused to
+// false and clears paused_at/paused_by/reason.
+func TestWorkerControlRegistry_Resume_Clears(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	r, _ := newWorkerControlRegistryForTest(t)
+
+	_, err := r.Pause(ctx, string(models.WorkerTypeGroupPurge), "alice", "cleanup")
+	c.Assert(err, qt.IsNil)
+
+	resumed, err := r.Resume(ctx, string(models.WorkerTypeGroupPurge))
+	c.Assert(err, qt.IsNil)
+	c.Assert(resumed.WorkerType, qt.Equals, models.WorkerTypeGroupPurge)
+	c.Assert(resumed.Paused, qt.IsFalse)
+	c.Assert(resumed.PausedBy, qt.IsNil)
+	c.Assert(resumed.PausedAt, qt.IsNil)
+	c.Assert(resumed.Reason, qt.IsNil)
+}
+
+// TestWorkerControlRegistry_Resume_Absent verifies resuming a worker that
+// was never paused is a no-op returning a synthetic not-paused state and
+// does NOT create a row.
+func TestWorkerControlRegistry_Resume_Absent(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	r := memory.NewWorkerControlRegistry()
+
+	resumed, err := r.Resume(ctx, string(models.WorkerTypeLoanReminder))
+	c.Assert(err, qt.IsNil)
+	c.Assert(resumed.WorkerType, qt.Equals, models.WorkerTypeLoanReminder)
+	c.Assert(resumed.Paused, qt.IsFalse)
+
+	controls, err := r.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controls, qt.HasLen, 0)
+}
+
+// TestWorkerControlRegistry_List_OrderedByWorkerType verifies List comes
+// back sorted by worker_type so the CLI/admin render is deterministic.
+func TestWorkerControlRegistry_List_OrderedByWorkerType(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	r, _ := newWorkerControlRegistryForTest(t)
+
+	_, err := r.Pause(ctx, string(models.WorkerTypeThumbnail), "", "")
+	c.Assert(err, qt.IsNil)
+	_, err = r.Pause(ctx, string(models.WorkerTypeExport), "", "")
+	c.Assert(err, qt.IsNil)
+	_, err = r.Pause(ctx, string(models.WorkerTypeImport), "", "")
+	c.Assert(err, qt.IsNil)
+
+	controls, err := r.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controls, qt.HasLen, 3)
+
+	types := make([]models.WorkerType, len(controls))
+	for i, wc := range controls {
+		types[i] = wc.WorkerType
+	}
+	c.Assert(types, qt.DeepEquals, []models.WorkerType{
+		models.WorkerTypeExport,
+		models.WorkerTypeImport,
+		models.WorkerTypeThumbnail,
+	})
+}

--- a/go/registry/memory/worker_control_test.go
+++ b/go/registry/memory/worker_control_test.go
@@ -9,6 +9,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
 	"github.com/denisvmedia/inventario/registry/memory"
 )
 
@@ -154,6 +155,26 @@ func TestWorkerControlRegistry_Resume_Absent(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(resumed.WorkerType, qt.Equals, models.WorkerTypeLoanReminder)
 	c.Assert(resumed.Paused, qt.IsFalse)
+
+	controls, err := r.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controls, qt.HasLen, 0)
+}
+
+// TestWorkerControlRegistry_RejectsUnknownType verifies the registry-level
+// defence-in-depth validation (#1308 review fix): Pause and Resume reject
+// a worker type that is not in the canonical set, mirroring postgres.
+func TestWorkerControlRegistry_RejectsUnknownType(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	r := memory.NewWorkerControlRegistry()
+
+	_, err := r.Pause(ctx, "not-a-worker", "alice", "x")
+	c.Assert(err, qt.ErrorIs, registry.ErrInvalidInput)
+
+	_, err = r.Resume(ctx, "not-a-worker")
+	c.Assert(err, qt.ErrorIs, registry.ErrInvalidInput)
 
 	controls, err := r.List(ctx)
 	c.Assert(err, qt.IsNil)

--- a/go/registry/postgres/postgres.go
+++ b/go/registry/postgres/postgres.go
@@ -50,6 +50,9 @@ func NewFactorySet(dbx *sqlx.DB) *registry.FactorySet {
 	fs.UserMFASecretRegistry = NewUserMFASecretRegistry(dbx)
 	fs.AuditLogRegistry = NewAuditLogRegistry(dbx)
 	fs.SystemAdminGrantRegistry = NewSystemAdminGrantRegistry(dbx)
+	// Background-worker soft-pause control (issue #1308). Global control
+	// plane — not tenant-scoped, no RLS (same posture as system_admin_grants).
+	fs.WorkerControlRegistry = NewWorkerControlRegistry(dbx)
 	fs.EmailVerificationRegistry = NewEmailVerificationRegistry(dbx)
 	fs.PasswordResetRegistry = NewPasswordResetRegistry(dbx)
 	// OAuth identities (#1394) — service-mode lookup keyed by

--- a/go/registry/postgres/store/tablenames.go
+++ b/go/registry/postgres/store/tablenames.go
@@ -44,6 +44,7 @@ type TableNames struct {
 	SystemAdminGrants        func() TableName
 	BackofficeUserMFASecrets func() TableName
 	UserOAuthIdentities      func() TableName
+	WorkerControl            func() TableName
 }
 
 var DefaultTableNames = TableNames{
@@ -88,6 +89,7 @@ var DefaultTableNames = TableNames{
 	SystemAdminGrants:        func() TableName { return "system_admin_grants" },
 	BackofficeUserMFASecrets: func() TableName { return "backoffice_user_mfa_secrets" },
 	UserOAuthIdentities:      func() TableName { return "user_oauth_identities" },
+	WorkerControl:            func() TableName { return "worker_control" },
 }
 
 // NewTableNames returns the default table names

--- a/go/registry/postgres/worker_control.go
+++ b/go/registry/postgres/worker_control.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/go-extras/errx"
 	errxtrace "github.com/go-extras/errx/stacktrace"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
@@ -84,6 +85,12 @@ func (r *WorkerControlRegistry) Pause(ctx context.Context, workerType, pausedBy,
 	if workerType == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired)
 	}
+	// Defence-in-depth: the handler/CLI already reject unknown types, but
+	// the registry is the storage authority — never write a control row
+	// for a worker that doesn't exist.
+	if !models.WorkerType(workerType).IsValid() {
+		return nil, errxtrace.Classify(registry.ErrInvalidInput, errx.Attrs("worker_type", workerType))
+	}
 
 	// Empty strings map to NULL columns so a paused-without-reason row
 	// reads as reason IS NULL rather than an empty-string sentinel.
@@ -126,6 +133,9 @@ func (r *WorkerControlRegistry) Pause(ctx context.Context, workerType, pausedBy,
 func (r *WorkerControlRegistry) Resume(ctx context.Context, workerType string) (*models.WorkerControl, error) {
 	if workerType == "" {
 		return nil, errxtrace.Classify(registry.ErrFieldRequired)
+	}
+	if !models.WorkerType(workerType).IsValid() {
+		return nil, errxtrace.Classify(registry.ErrInvalidInput, errx.Attrs("worker_type", workerType))
 	}
 
 	query := fmt.Sprintf(

--- a/go/registry/postgres/worker_control.go
+++ b/go/registry/postgres/worker_control.go
@@ -1,0 +1,154 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	errxtrace "github.com/go-extras/errx/stacktrace"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+	"github.com/denisvmedia/inventario/registry/postgres/store"
+)
+
+var _ registry.WorkerControlRegistry = (*WorkerControlRegistry)(nil)
+
+// WorkerControlRegistry is the postgres-backed background-worker
+// soft-pause control store (#1308). The table is NOT RLS-enabled —
+// worker pause state is a platform-operator control orthogonal to
+// tenants (same posture as system_admin_grants / audit_logs). All
+// operations run against r.dbx directly: Pause is a single ON CONFLICT
+// upsert and Resume is a single UPDATE, so neither needs a multi-
+// statement transaction. The unique index on worker_type guarantees at
+// most one control row per worker and backs the upsert's ON CONFLICT
+// target.
+type WorkerControlRegistry struct {
+	dbx        *sqlx.DB
+	tableNames store.TableNames
+}
+
+// NewWorkerControlRegistry creates a new WorkerControlRegistry.
+func NewWorkerControlRegistry(dbx *sqlx.DB) *WorkerControlRegistry {
+	return NewWorkerControlRegistryWithTableNames(dbx, store.DefaultTableNames)
+}
+
+// NewWorkerControlRegistryWithTableNames is the test-friendly constructor
+// that lets a caller override the table-name mapping.
+func NewWorkerControlRegistryWithTableNames(dbx *sqlx.DB, tableNames store.TableNames) *WorkerControlRegistry {
+	return &WorkerControlRegistry{
+		dbx:        dbx,
+		tableNames: tableNames,
+	}
+}
+
+// List returns every worker_control row ordered by worker_type. An
+// absent worker type means that worker is running — the caller treats
+// "no row" as not-paused.
+func (r *WorkerControlRegistry) List(ctx context.Context) ([]*models.WorkerControl, error) {
+	query := fmt.Sprintf(
+		`SELECT * FROM %s ORDER BY worker_type`,
+		r.tableNames.WorkerControl(),
+	)
+	rows, err := r.dbx.QueryxContext(ctx, query)
+	if err != nil {
+		return nil, errxtrace.Wrap("failed to list worker_control", err)
+	}
+	defer rows.Close()
+
+	var controls []*models.WorkerControl
+	for rows.Next() {
+		var wc models.WorkerControl
+		if scanErr := rows.StructScan(&wc); scanErr != nil {
+			return nil, errxtrace.Wrap("failed to scan worker_control row", scanErr)
+		}
+		controls = append(controls, &wc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errxtrace.Wrap("failed during worker_control iteration", err)
+	}
+	return controls, nil
+}
+
+// Pause idempotently marks workerType paused. pausedBy and reason are
+// stored as NULL when empty. Re-pausing an already-paused type updates
+// paused_by/reason but PRESERVES the original paused_at via the CASE
+// expression below — the pause timestamp must reflect when the worker
+// first stopped, not the most recent operator note edit. The unique
+// index on worker_type backs the ON CONFLICT upsert so concurrent pause
+// calls collapse onto a single row.
+func (r *WorkerControlRegistry) Pause(ctx context.Context, workerType, pausedBy, reason string) (*models.WorkerControl, error) {
+	if workerType == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired)
+	}
+
+	// Empty strings map to NULL columns so a paused-without-reason row
+	// reads as reason IS NULL rather than an empty-string sentinel.
+	var pausedByArg, reasonArg any
+	if pausedBy != "" {
+		pausedByArg = pausedBy
+	}
+	if reason != "" {
+		reasonArg = reason
+	}
+
+	query := fmt.Sprintf(
+		`INSERT INTO %s (id, uuid, worker_type, paused, paused_by, paused_at, reason, updated_at)
+		 VALUES ($1, $2, $3, true, $4, now(), $5, now())
+		 ON CONFLICT (worker_type) DO UPDATE SET
+		   paused = true,
+		   paused_by = excluded.paused_by,
+		   reason = excluded.reason,
+		   paused_at = CASE WHEN %s.paused THEN %s.paused_at ELSE now() END,
+		   updated_at = now()
+		 RETURNING *`,
+		r.tableNames.WorkerControl(),
+		r.tableNames.WorkerControl(),
+		r.tableNames.WorkerControl(),
+	)
+
+	var wc models.WorkerControl
+	if err := r.dbx.QueryRowxContext(ctx, query,
+		uuid.New().String(), uuid.New().String(), workerType, pausedByArg, reasonArg,
+	).StructScan(&wc); err != nil {
+		return nil, errxtrace.Wrap("failed to pause worker", err)
+	}
+	return &wc, nil
+}
+
+// Resume idempotently marks workerType not paused, clearing
+// paused_at/paused_by/reason. When no row exists it is a no-op and
+// returns a synthetic not-paused WorkerControl (no INSERT) — the worker
+// was already running, so there is nothing to persist.
+func (r *WorkerControlRegistry) Resume(ctx context.Context, workerType string) (*models.WorkerControl, error) {
+	if workerType == "" {
+		return nil, errxtrace.Classify(registry.ErrFieldRequired)
+	}
+
+	query := fmt.Sprintf(
+		`UPDATE %s SET
+		   paused = false,
+		   paused_by = NULL,
+		   paused_at = NULL,
+		   reason = NULL,
+		   updated_at = now()
+		 WHERE worker_type = $1
+		 RETURNING *`,
+		r.tableNames.WorkerControl(),
+	)
+
+	var wc models.WorkerControl
+	switch err := r.dbx.QueryRowxContext(ctx, query, workerType).StructScan(&wc); {
+	case err == nil:
+		return &wc, nil
+	case errors.Is(err, sql.ErrNoRows):
+		// No control row — the worker is already running. Return a
+		// synthetic not-paused state without inserting a row.
+		return &models.WorkerControl{WorkerType: models.WorkerType(workerType)}, nil
+	default:
+		return nil, errxtrace.Wrap("failed to resume worker", err)
+	}
+}

--- a/go/registry/postgres/worker_control_test.go
+++ b/go/registry/postgres/worker_control_test.go
@@ -1,0 +1,184 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// TestWorkerControlRegistry_Pause_Creates_Postgres verifies the first
+// Pause writes a paused row carrying the operator, reason, and a pause
+// timestamp. worker_control is NOT tenant-scoped, so no seeded
+// tenant/user/group fixtures are required — a clean factory set suffices.
+func TestWorkerControlRegistry_Pause_Creates_Postgres(t *testing.T) {
+	fs := setupCleanPostgresFactorySet(t)
+
+	c := qt.New(t)
+	ctx := context.Background()
+	reg := fs.WorkerControlRegistry
+
+	wc, err := reg.Pause(ctx, string(models.WorkerTypeExport), "operator@example.com", "maintenance window")
+	c.Assert(err, qt.IsNil)
+	c.Assert(wc.WorkerType, qt.Equals, models.WorkerTypeExport)
+	c.Assert(wc.Paused, qt.IsTrue)
+	c.Assert(wc.PausedBy, qt.IsNotNil)
+	c.Assert(*wc.PausedBy, qt.Equals, "operator@example.com")
+	c.Assert(wc.Reason, qt.IsNotNil)
+	c.Assert(*wc.Reason, qt.Equals, "maintenance window")
+	c.Assert(wc.PausedAt, qt.IsNotNil)
+	c.Assert(wc.PausedAt.IsZero(), qt.IsFalse)
+	c.Assert(wc.UpdatedAt.IsZero(), qt.IsFalse)
+
+	controls, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controls, qt.HasLen, 1)
+}
+
+// TestWorkerControlRegistry_Pause_IdempotentPreservesPausedAt_Postgres
+// verifies a second Pause updates paused_by/reason but PRESERVES the
+// original paused_at via the CASE expression — the pause time must
+// reflect when the worker first stopped, not the latest note edit.
+func TestWorkerControlRegistry_Pause_IdempotentPreservesPausedAt_Postgres(t *testing.T) {
+	fs := setupCleanPostgresFactorySet(t)
+
+	c := qt.New(t)
+	ctx := context.Background()
+	reg := fs.WorkerControlRegistry
+
+	first, err := reg.Pause(ctx, string(models.WorkerTypeThumbnail), "alice", "first reason")
+	c.Assert(err, qt.IsNil)
+	c.Assert(first.PausedAt, qt.IsNotNil)
+	originalPausedAt := *first.PausedAt
+
+	second, err := reg.Pause(ctx, string(models.WorkerTypeThumbnail), "bob", "second reason")
+	c.Assert(err, qt.IsNil)
+	c.Assert(second.Paused, qt.IsTrue)
+	// paused_at preserved...
+	c.Assert(second.PausedAt, qt.IsNotNil)
+	c.Assert(second.PausedAt.Equal(originalPausedAt), qt.IsTrue)
+	// ...but by/reason updated.
+	c.Assert(*second.PausedBy, qt.Equals, "bob")
+	c.Assert(*second.Reason, qt.Equals, "second reason")
+
+	// Still a single row (ON CONFLICT collapsed onto it).
+	controls, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controls, qt.HasLen, 1)
+}
+
+// TestWorkerControlRegistry_Pause_EmptyByAndReasonStoredAsNull_Postgres
+// verifies the CLI pause path (no operator session, no reason) lands NULL
+// columns rather than empty-string sentinels.
+func TestWorkerControlRegistry_Pause_EmptyByAndReasonStoredAsNull_Postgres(t *testing.T) {
+	fs := setupCleanPostgresFactorySet(t)
+
+	c := qt.New(t)
+	ctx := context.Background()
+	reg := fs.WorkerControlRegistry
+
+	wc, err := reg.Pause(ctx, string(models.WorkerTypeImport), "", "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(wc.Paused, qt.IsTrue)
+	c.Assert(wc.PausedBy, qt.IsNil)
+	c.Assert(wc.Reason, qt.IsNil)
+}
+
+// TestWorkerControlRegistry_Resume_Clears_Postgres verifies Resume flips
+// paused to false and clears paused_at/paused_by/reason.
+func TestWorkerControlRegistry_Resume_Clears_Postgres(t *testing.T) {
+	fs := setupCleanPostgresFactorySet(t)
+
+	c := qt.New(t)
+	ctx := context.Background()
+	reg := fs.WorkerControlRegistry
+
+	_, err := reg.Pause(ctx, string(models.WorkerTypeGroupPurge), "alice", "cleanup")
+	c.Assert(err, qt.IsNil)
+
+	resumed, err := reg.Resume(ctx, string(models.WorkerTypeGroupPurge))
+	c.Assert(err, qt.IsNil)
+	c.Assert(resumed.WorkerType, qt.Equals, models.WorkerTypeGroupPurge)
+	c.Assert(resumed.Paused, qt.IsFalse)
+	c.Assert(resumed.PausedBy, qt.IsNil)
+	c.Assert(resumed.PausedAt, qt.IsNil)
+	c.Assert(resumed.Reason, qt.IsNil)
+}
+
+// TestWorkerControlRegistry_Resume_Absent_Postgres verifies resuming a
+// worker that was never paused is a no-op: it returns a synthetic
+// not-paused state and does NOT insert a row.
+func TestWorkerControlRegistry_Resume_Absent_Postgres(t *testing.T) {
+	fs := setupCleanPostgresFactorySet(t)
+
+	c := qt.New(t)
+	ctx := context.Background()
+	reg := fs.WorkerControlRegistry
+
+	resumed, err := reg.Resume(ctx, string(models.WorkerTypeLoanReminder))
+	c.Assert(err, qt.IsNil)
+	c.Assert(resumed.WorkerType, qt.Equals, models.WorkerTypeLoanReminder)
+	c.Assert(resumed.Paused, qt.IsFalse)
+
+	controls, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controls, qt.HasLen, 0)
+}
+
+// TestWorkerControlRegistry_List_OrderedByWorkerType_Postgres verifies
+// List comes back sorted by worker_type so the CLI/admin render is
+// deterministic.
+func TestWorkerControlRegistry_List_OrderedByWorkerType_Postgres(t *testing.T) {
+	fs := setupCleanPostgresFactorySet(t)
+
+	c := qt.New(t)
+	ctx := context.Background()
+	reg := fs.WorkerControlRegistry
+
+	_, err := reg.Pause(ctx, string(models.WorkerTypeThumbnail), "", "")
+	c.Assert(err, qt.IsNil)
+	_, err = reg.Pause(ctx, string(models.WorkerTypeExport), "", "")
+	c.Assert(err, qt.IsNil)
+	_, err = reg.Pause(ctx, string(models.WorkerTypeImport), "", "")
+	c.Assert(err, qt.IsNil)
+
+	controls, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controls, qt.HasLen, 3)
+
+	types := make([]models.WorkerType, len(controls))
+	for i, wc := range controls {
+		types[i] = wc.WorkerType
+	}
+	c.Assert(types, qt.DeepEquals, []models.WorkerType{
+		models.WorkerTypeExport,
+		models.WorkerTypeImport,
+		models.WorkerTypeThumbnail,
+	})
+}
+
+// TestWorkerControlRegistry_RejectsUnknownType_Postgres verifies the
+// registry-level defence-in-depth validation (#1308 review fix): Pause
+// and Resume reject a worker type that is not in the canonical set,
+// before touching the table.
+func TestWorkerControlRegistry_RejectsUnknownType_Postgres(t *testing.T) {
+	fs := setupCleanPostgresFactorySet(t)
+
+	c := qt.New(t)
+	ctx := context.Background()
+	reg := fs.WorkerControlRegistry
+
+	_, err := reg.Pause(ctx, "not-a-worker", "alice", "x")
+	c.Assert(err, qt.ErrorIs, registry.ErrInvalidInput)
+
+	_, err = reg.Resume(ctx, "not-a-worker")
+	c.Assert(err, qt.ErrorIs, registry.ErrInvalidInput)
+
+	// No row was written for the rejected type.
+	controls, err := reg.List(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(controls, qt.HasLen, 0)
+}

--- a/go/registry/registry.go
+++ b/go/registry/registry.go
@@ -1746,6 +1746,34 @@ type SystemAdminGrantRegistry interface {
 	List(ctx context.Context) ([]*models.SystemAdminGrant, error)
 }
 
+// WorkerControlRegistry stores the global soft-pause control rows for
+// background workers (#1308). One row per worker type; an absent row
+// means the worker runs normally, a present row with paused=true means
+// the worker's run loop skips its work each tick until resumed.
+//
+// The registry is NOT tenant-scoped and has NO RLS — worker pause state
+// is a platform-operator control orthogonal to tenants (same posture as
+// SystemAdminGrantRegistry / AuditLogRegistry). It lives directly on
+// FactorySet and is identical in user-mode and service-mode sets.
+type WorkerControlRegistry interface {
+	// List returns every worker_control row. An absent worker type means
+	// that worker is running (the caller treats "no row" as not-paused).
+	List(ctx context.Context) ([]*models.WorkerControl, error)
+
+	// Pause idempotently marks workerType paused. pausedBy and reason may
+	// be "" (stored as NULL). Re-pausing an already-paused type updates
+	// paused_by/reason but PRESERVES the original paused_at so the pause
+	// timestamp reflects when the worker first stopped. Returns the
+	// resulting row.
+	Pause(ctx context.Context, workerType, pausedBy, reason string) (*models.WorkerControl, error)
+
+	// Resume idempotently marks workerType not paused, clearing
+	// paused_at/paused_by/reason. When no row exists it is a no-op and
+	// returns a synthetic not-paused WorkerControl{WorkerType: workerType}
+	// without inserting a row. Returns the resulting state.
+	Resume(ctx context.Context, workerType string) (*models.WorkerControl, error)
+}
+
 // AdminUserSortField names the columns the admin user listing endpoint
 // understands for sorting. Names are part of the public API surface; the
 // FE codegen treats them as opaque strings sent in `?sort`.
@@ -2046,6 +2074,7 @@ type Set struct {
 	CommodityScanAuditRegistry     CommodityScanAuditRegistry    // CommodityScanAuditRegistry records every AI vision scan request (#1720); also backs the per-user rate limiter
 	SystemAdminGrantRegistry       SystemAdminGrantRegistry      // Platform-admin grant rows (#1784); no tenant scope, no HTTP write surface
 	OAuthIdentityRegistry          OAuthIdentityRegistry         // OAuth provider link rows (#1394); service-mode (looked up before user session exists in callback)
+	WorkerControlRegistry          WorkerControlRegistry         // Background-worker soft-pause control rows (#1308); no tenant scope, no RLS
 }
 
 // Search-related types and functions
@@ -2117,6 +2146,7 @@ func (s *Set) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&s.CommodityScanAuditRegistry, validation.Required),
 		validation.Field(&s.SystemAdminGrantRegistry, validation.Required),
 		validation.Field(&s.OAuthIdentityRegistry, validation.Required),
+		validation.Field(&s.WorkerControlRegistry, validation.Required),
 	)
 
 	return validation.ValidateStructWithContext(ctx, s, fields...)

--- a/go/schema/migrations/_sqldata/1780128395_add_worker_control.down.sql
+++ b/go/schema/migrations/_sqldata/1780128395_add_worker_control.down.sql
@@ -1,0 +1,8 @@
+-- Migration rollback
+-- Generated on: 2026-05-30T08:06:35Z
+-- Direction: DOWN
+
+DROP INDEX IF EXISTS idx_worker_control_uuid;
+DROP INDEX IF EXISTS worker_control_worker_type_idx;
+-- WARNING: This will delete all data!
+DROP TABLE IF EXISTS worker_control CASCADE;

--- a/go/schema/migrations/_sqldata/1780128395_add_worker_control.up.sql
+++ b/go/schema/migrations/_sqldata/1780128395_add_worker_control.up.sql
@@ -1,0 +1,17 @@
+-- Migration generated from schema differences
+-- Generated on: 2026-05-30T08:06:35Z
+-- Direction: UP
+
+-- POSTGRES TABLE: worker_control --
+CREATE TABLE worker_control (
+  worker_type TEXT NOT NULL,
+  paused BOOLEAN NOT NULL DEFAULT 'false',
+  paused_by TEXT,
+  paused_at TIMESTAMP,
+  reason TEXT,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  id TEXT PRIMARY KEY NOT NULL,
+  uuid TEXT NOT NULL DEFAULT (gen_random_uuid())::text
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_worker_control_uuid ON worker_control (uuid);
+CREATE UNIQUE INDEX IF NOT EXISTS worker_control_worker_type_idx ON worker_control (worker_type);

--- a/go/services/admin/service.go
+++ b/go/services/admin/service.go
@@ -630,6 +630,156 @@ func (s *Service) ListSystemAdmins(ctx context.Context) ([]*SystemAdminListing, 
 	return out, nil
 }
 
+// Worker soft-pause action names (#1308). Kept as constants so the CLI
+// audit rows use the same literals as the admin REST surface
+// (admin.worker_pause / admin.worker_resume), mirroring the
+// "admin.<noun>_<verb>" pattern set by #1745.
+const (
+	// auditActionWorkerPause is the audit-row Action emitted when an
+	// operator soft-pauses a background worker via the CLI.
+	auditActionWorkerPause = "admin.worker_pause"
+	// auditActionWorkerResume is the audit-row Action emitted when an
+	// operator resumes a soft-paused background worker via the CLI.
+	auditActionWorkerResume = "admin.worker_resume"
+	// auditActionListWorkerControls is the audit-row Action emitted on a
+	// read of the worker-control listing, so operator-side reads land in
+	// the trail alongside the writes (mirrors admin.list_system_admins).
+	auditActionListWorkerControls = "admin.list_worker_controls"
+)
+
+// ErrUnknownWorkerType is returned by PauseWorker/ResumeWorker when the
+// supplied worker type is not one of models.AllWorkerTypes(). Surfaced
+// to the CLI so a typo (`--type expot`) fails with a clear message
+// rather than silently creating a control row for a non-existent worker.
+var ErrUnknownWorkerType = errx.NewSentinel("unknown worker type")
+
+// PauseWorker soft-pauses the named background worker (#1308). The
+// workerType is validated against models.AllWorkerTypes() up front so a
+// typo fails clearly rather than writing a control row for a worker that
+// doesn't exist. Idempotent at the registry layer: re-pausing an
+// already-paused worker updates by/reason but preserves the original
+// paused_at. Writes an `admin.worker_pause` audit row regardless of
+// outcome so the trail records the attempt.
+//
+// The CLI runs out-of-band with no authenticated operator session, so
+// the control row's paused_by is recorded as "cli" — a coarse marker
+// distinguishing CLI pauses from the admin-REST pauses (which record the
+// back-office operator's id/email). The audit row's actor (UserID) stays
+// nil for the same reason GrantSystemAdmin's does: CLI "operator"
+// identity is the OS/host boundary, not a row in this database.
+func (s *Service) PauseWorker(ctx context.Context, workerType, reason string) (*models.WorkerControl, error) {
+	wt, ok := models.ParseWorkerType(workerType)
+	if !ok {
+		err := errxtrace.Classify(ErrUnknownWorkerType, errx.Attrs("worker_type", workerType))
+		s.logWorkerAction(ctx, auditActionWorkerPause, workerType, err)
+		return nil, err
+	}
+
+	if s.factorySet.WorkerControlRegistry == nil {
+		configErr := errxtrace.Classify(registry.ErrInvalidConfig, errx.Attrs("missing", "WorkerControlRegistry"))
+		s.logWorkerAction(ctx, auditActionWorkerPause, string(wt), configErr)
+		return nil, configErr
+	}
+
+	control, err := s.factorySet.WorkerControlRegistry.Pause(ctx, string(wt), workerPausedByCLI, reason)
+	if err != nil {
+		s.logWorkerAction(ctx, auditActionWorkerPause, string(wt), err)
+		return nil, errxtrace.Wrap("failed to pause worker", err)
+	}
+
+	s.logWorkerAction(ctx, auditActionWorkerPause, string(wt), nil)
+	return control, nil
+}
+
+// ResumeWorker clears the soft-pause on the named worker (#1308).
+// Idempotent: resuming a worker that is not paused (no control row) is a
+// no-op that returns a synthetic not-paused row. Validates workerType up
+// front and writes an `admin.worker_resume` audit row.
+func (s *Service) ResumeWorker(ctx context.Context, workerType string) (*models.WorkerControl, error) {
+	wt, ok := models.ParseWorkerType(workerType)
+	if !ok {
+		err := errxtrace.Classify(ErrUnknownWorkerType, errx.Attrs("worker_type", workerType))
+		s.logWorkerAction(ctx, auditActionWorkerResume, workerType, err)
+		return nil, err
+	}
+
+	if s.factorySet.WorkerControlRegistry == nil {
+		configErr := errxtrace.Classify(registry.ErrInvalidConfig, errx.Attrs("missing", "WorkerControlRegistry"))
+		s.logWorkerAction(ctx, auditActionWorkerResume, string(wt), configErr)
+		return nil, configErr
+	}
+
+	control, err := s.factorySet.WorkerControlRegistry.Resume(ctx, string(wt))
+	if err != nil {
+		s.logWorkerAction(ctx, auditActionWorkerResume, string(wt), err)
+		return nil, errxtrace.Wrap("failed to resume worker", err)
+	}
+
+	s.logWorkerAction(ctx, auditActionWorkerResume, string(wt), nil)
+	return control, nil
+}
+
+// ListWorkerControls returns every worker_control row (#1308). The CLI
+// `workers status` command merges these against models.AllWorkerTypes()
+// so a worker with no row renders as "running". Logs an
+// `admin.list_worker_controls` audit row regardless of result count so
+// operator-side reads are visible in the trail too.
+func (s *Service) ListWorkerControls(ctx context.Context) ([]*models.WorkerControl, error) {
+	if s.factorySet.WorkerControlRegistry == nil {
+		err := errxtrace.Classify(registry.ErrInvalidConfig, errx.Attrs("missing", "WorkerControlRegistry"))
+		s.logWorkerAction(ctx, auditActionListWorkerControls, "", err)
+		return nil, err
+	}
+
+	controls, err := s.factorySet.WorkerControlRegistry.List(ctx)
+	if err != nil {
+		s.logWorkerAction(ctx, auditActionListWorkerControls, "", err)
+		return nil, errxtrace.Wrap("failed to list worker controls", err)
+	}
+
+	s.logWorkerAction(ctx, auditActionListWorkerControls, "", nil)
+	return controls, nil
+}
+
+// workerPausedByCLI is the paused_by marker recorded for CLI-driven
+// pauses (#1308). The CLI has no authenticated operator session, so a
+// coarse "cli" marker distinguishes a CLI pause from an admin-REST pause
+// (which records the back-office operator's id/email) without pretending
+// a specific person did it.
+const workerPausedByCLI = "cli"
+
+// logWorkerAction writes a worker-control admin audit row. Mirrors
+// logAdminAction but stores the worker type as the subject (EntityType
+// "worker" / EntityID the worker-type string) rather than a user id.
+// Best-effort: a missing audit row is recoverable and surfaced via slog.
+// Actor (UserID) is nil for the same reason logAdminAction's is — CLI
+// invocations have no authenticated operator row in this database.
+func (s *Service) logWorkerAction(ctx context.Context, action, workerType string, opErr error) {
+	if s.factorySet == nil || s.factorySet.AuditLogRegistry == nil {
+		return
+	}
+
+	entry := models.AuditLog{
+		Action:  action,
+		UserID:  nil, // CLI invocations have no authenticated actor — see logAdminAction doc.
+		Success: opErr == nil,
+	}
+	if workerType != "" {
+		subjectType := "worker"
+		entry.EntityType = &subjectType
+		entry.EntityID = &workerType
+	}
+	if opErr != nil {
+		msg := opErr.Error()
+		entry.ErrorMessage = &msg
+	}
+
+	if _, createErr := s.factorySet.AuditLogRegistry.Create(ctx, entry); createErr != nil {
+		slog.Error("Failed to write worker-control audit log entry",
+			"action", action, "worker_type", workerType, "error", createErr)
+	}
+}
+
 // logAdminAction writes an admin audit row via the AuditLogRegistry on
 // the factory set. Best-effort: write failures are tolerated because the
 // CLI surfaces them via slog; the operator-visible result is still the

--- a/go/services/currency_migration_worker.go
+++ b/go/services/currency_migration_worker.go
@@ -137,6 +137,7 @@ type currencyMigrationWorkerOptions struct {
 	activeInterval time.Duration
 	idleInterval   time.Duration
 	clock          func() time.Time
+	pause          PauseChecker
 }
 
 // WithCurrencyMigrationActiveInterval overrides the cadence used after
@@ -175,6 +176,19 @@ func WithCurrencyMigrationClock(now func() time.Time) CurrencyMigrationWorkerOpt
 	}
 }
 
+// WithCurrencyMigrationPauseController wires the soft-pause controller so
+// the worker skips claiming new migrations while the currency-migration
+// worker type is paused (#1308). The recovery sweep still runs while
+// paused — only the new claim is gated. A nil checker leaves the worker
+// unpaused.
+func WithCurrencyMigrationPauseController(pc PauseChecker) CurrencyMigrationWorkerOption {
+	return func(o *currencyMigrationWorkerOptions) {
+		if pc != nil {
+			o.pause = pc
+		}
+	}
+}
+
 // CurrencyMigrationWorker periodically sweeps stuck running rows,
 // claims one pending migration per tick, and hands the row to the
 // CurrencyMigrationProcessor for TX2.
@@ -205,6 +219,7 @@ type CurrencyMigrationWorker struct {
 	activeInterval time.Duration
 	idleInterval   time.Duration
 	clock          func() time.Time
+	pause          PauseChecker
 
 	stopCh   chan struct{}
 	stopOnce sync.Once
@@ -232,6 +247,7 @@ func NewCurrencyMigrationWorker(reg registry.CurrencyMigrationRegistry, processo
 		activeInterval: options.activeInterval,
 		idleInterval:   options.idleInterval,
 		clock:          options.clock,
+		pause:          options.pause,
 		stopCh:         make(chan struct{}),
 	}
 }
@@ -334,6 +350,14 @@ func (w *CurrencyMigrationWorker) run(ctx context.Context) {
 // run loop uses this signal to switch to active cadence.
 func (w *CurrencyMigrationWorker) tick(ctx context.Context) bool {
 	w.runSweep(ctx)
+
+	// Soft-pause (#1308): the recovery sweep above MUST still run while
+	// paused (it recovers crashed-worker stuck rows), but claiming a new
+	// migration is gated. Returning false keeps the worker on its idle
+	// cadence so a paused worker doesn't spin at the active interval.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeCurrencyMigration) {
+		return false
+	}
 
 	op, err := w.registry.ClaimNextPending(ctx)
 	switch {

--- a/go/services/group_purge_worker.go
+++ b/go/services/group_purge_worker.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/denisvmedia/inventario/models"
 )
 
 const defaultGroupPurgeInterval = 5 * time.Minute
@@ -37,6 +39,7 @@ var (
 type GroupPurgeWorker struct {
 	service       *GroupPurgeService
 	purgeInterval time.Duration
+	pause         PauseChecker
 	stopCh        chan struct{}
 	stopOnce      sync.Once
 	wg            sync.WaitGroup
@@ -48,6 +51,7 @@ type GroupPurgeOption func(*groupPurgeOptions)
 
 type groupPurgeOptions struct {
 	purgeInterval time.Duration
+	pause         PauseChecker
 }
 
 // WithGroupPurgeInterval overrides the default purge interval. Non-positive
@@ -56,6 +60,17 @@ func WithGroupPurgeInterval(d time.Duration) GroupPurgeOption {
 	return func(o *groupPurgeOptions) {
 		if d > 0 {
 			o.purgeInterval = d
+		}
+	}
+}
+
+// WithGroupPurgePauseController wires the soft-pause controller so the
+// worker skips its sweep while the group-purge worker type is paused
+// (#1308). A nil checker leaves the worker unpaused.
+func WithGroupPurgePauseController(pc PauseChecker) GroupPurgeOption {
+	return func(o *groupPurgeOptions) {
+		if pc != nil {
+			o.pause = pc
 		}
 	}
 }
@@ -72,6 +87,7 @@ func NewGroupPurgeWorker(service *GroupPurgeService, opts ...GroupPurgeOption) *
 	return &GroupPurgeWorker{
 		service:       service,
 		purgeInterval: options.purgeInterval,
+		pause:         options.pause,
 		stopCh:        make(chan struct{}),
 	}
 }
@@ -118,6 +134,12 @@ func (w *GroupPurgeWorker) run(ctx context.Context) {
 // the worker — a transient failure is expected to be retried on the next
 // tick.
 func (w *GroupPurgeWorker) tick(ctx context.Context) {
+	// Soft-pause (#1308): skip the sweep while paused. The ticker keeps
+	// running so resuming takes effect on the next tick without a restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeGroupPurge) {
+		return
+	}
+
 	if purged, failed, err := w.service.PurgeOnce(ctx); err != nil {
 		slog.Error("Group purge sweep failed", "error", err)
 	} else {

--- a/go/services/loan_reminder_worker.go
+++ b/go/services/loan_reminder_worker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 )
 
@@ -38,6 +39,7 @@ type LoanReminderWorker struct {
 	service  *LoanReminderService
 	interval time.Duration
 	clock    func() time.Time
+	pause    PauseChecker
 	stopCh   chan struct{}
 	stopOnce sync.Once
 	wg       sync.WaitGroup
@@ -49,6 +51,7 @@ type LoanReminderOption func(*loanReminderOptions)
 type loanReminderOptions struct {
 	interval time.Duration
 	clock    func() time.Time
+	pause    PauseChecker
 }
 
 // WithLoanReminderInterval overrides the default tick cadence. Non-
@@ -72,6 +75,17 @@ func WithLoanReminderClock(now func() time.Time) LoanReminderOption {
 	}
 }
 
+// WithLoanReminderPauseController wires the soft-pause controller so the
+// worker skips its sweep while the loan-reminder worker type is paused
+// (#1308). A nil checker leaves the worker unpaused.
+func WithLoanReminderPauseController(pc PauseChecker) LoanReminderOption {
+	return func(o *loanReminderOptions) {
+		if pc != nil {
+			o.pause = pc
+		}
+	}
+}
+
 // NewLoanReminderWorker constructs the worker. Default cadence: one
 // hour — same reasoning as warranty / storage-quota workers: cadence
 // is hours-scale, not minutes, so a longer interval wastes ticks and a
@@ -88,6 +102,7 @@ func NewLoanReminderWorker(service *LoanReminderService, opts ...LoanReminderOpt
 		service:  service,
 		interval: options.interval,
 		clock:    options.clock,
+		pause:    options.pause,
 		stopCh:   make(chan struct{}),
 	}
 }
@@ -135,6 +150,12 @@ func (w *LoanReminderWorker) run(ctx context.Context) {
 // a per-kind breakdown so the worker emits one Prometheus series per
 // kind label.
 func (w *LoanReminderWorker) tick(ctx context.Context) {
+	// Soft-pause (#1308): skip the sweep while paused. The ticker keeps
+	// running so resuming takes effect on the next tick without a restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeLoanReminder) {
+		return
+	}
+
 	stats, err := w.service.RemindOnce(ctx, w.clock())
 	if err != nil {
 		slog.Error("Loan reminder sweep failed", "error", err)

--- a/go/services/login_event_retention_worker.go
+++ b/go/services/login_event_retention_worker.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 )
 
@@ -29,6 +30,7 @@ type LoginEventRetentionWorker struct {
 	registry      registry.LoginEventRegistry
 	retention     time.Duration
 	sweepInterval time.Duration
+	pause         PauseChecker
 	stopCh        chan struct{}
 	stopOnce      sync.Once
 	wg            sync.WaitGroup
@@ -42,6 +44,7 @@ type loginEventRetentionOptions struct {
 	retention     time.Duration
 	sweepInterval time.Duration
 	clock         func() time.Time
+	pause         PauseChecker
 }
 
 // WithLoginEventRetention overrides the retention window. Non-positive
@@ -76,6 +79,17 @@ func WithLoginEventRetentionClock(fn func() time.Time) LoginEventRetentionOption
 	}
 }
 
+// WithLoginEventRetentionPauseController wires the soft-pause controller
+// so the worker skips its sweep while the login-event-retention worker
+// type is paused (#1308). A nil checker leaves the worker unpaused.
+func WithLoginEventRetentionPauseController(pc PauseChecker) LoginEventRetentionOption {
+	return func(o *loginEventRetentionOptions) {
+		if pc != nil {
+			o.pause = pc
+		}
+	}
+}
+
 // NewLoginEventRetentionWorker constructs the worker. A nil registry
 // produces an instance whose Start is a no-op; callers can wire the
 // worker unconditionally and let the registry presence decide whether
@@ -92,6 +106,7 @@ func NewLoginEventRetentionWorker(r registry.LoginEventRegistry, opts ...LoginEv
 		registry:      r,
 		retention:     options.retention,
 		sweepInterval: options.sweepInterval,
+		pause:         options.pause,
 		stopCh:        make(chan struct{}),
 		clock:         options.clock,
 	}
@@ -138,6 +153,12 @@ func (w *LoginEventRetentionWorker) run(ctx context.Context) {
 }
 
 func (w *LoginEventRetentionWorker) sweep(ctx context.Context) {
+	// Soft-pause (#1308): skip the sweep while paused. The ticker keeps
+	// running so resuming takes effect on the next tick without a restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeLoginEventRetention) {
+		return
+	}
+
 	now := time.Now
 	if w.clock != nil {
 		now = w.clock

--- a/go/services/maintenance_reminder_worker.go
+++ b/go/services/maintenance_reminder_worker.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/denisvmedia/inventario/models"
 )
 
 const defaultMaintenanceReminderInterval = 1 * time.Hour
@@ -43,6 +45,7 @@ type MaintenanceReminderWorker struct {
 	service  *MaintenanceReminderService
 	interval time.Duration
 	clock    func() time.Time
+	pause    PauseChecker
 	stopCh   chan struct{}
 	stopOnce sync.Once
 	wg       sync.WaitGroup
@@ -54,6 +57,7 @@ type MaintenanceReminderOption func(*maintenanceReminderOptions)
 type maintenanceReminderOptions struct {
 	interval time.Duration
 	clock    func() time.Time
+	pause    PauseChecker
 }
 
 // WithMaintenanceReminderInterval overrides the default tick cadence.
@@ -75,6 +79,17 @@ func WithMaintenanceReminderClock(now func() time.Time) MaintenanceReminderOptio
 	}
 }
 
+// WithMaintenanceReminderPauseController wires the soft-pause controller
+// so the worker skips its sweep while the maintenance-reminder worker
+// type is paused (#1308). A nil checker leaves the worker unpaused.
+func WithMaintenanceReminderPauseController(pc PauseChecker) MaintenanceReminderOption {
+	return func(o *maintenanceReminderOptions) {
+		if pc != nil {
+			o.pause = pc
+		}
+	}
+}
+
 func NewMaintenanceReminderWorker(service *MaintenanceReminderService, opts ...MaintenanceReminderOption) *MaintenanceReminderWorker {
 	options := maintenanceReminderOptions{
 		interval: defaultMaintenanceReminderInterval,
@@ -87,6 +102,7 @@ func NewMaintenanceReminderWorker(service *MaintenanceReminderService, opts ...M
 		service:  service,
 		interval: options.interval,
 		clock:    options.clock,
+		pause:    options.pause,
 		stopCh:   make(chan struct{}),
 	}
 }
@@ -130,6 +146,12 @@ func (w *MaintenanceReminderWorker) run(ctx context.Context) {
 }
 
 func (w *MaintenanceReminderWorker) tick(ctx context.Context) {
+	// Soft-pause (#1308): skip the sweep while paused. The ticker keeps
+	// running so resuming takes effect on the next tick without a restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeMaintenanceReminder) {
+		return
+	}
+
 	stats, err := w.service.RemindOnce(ctx, w.clock())
 	if err != nil {
 		slog.Error("Maintenance reminder sweep failed", "error", err)

--- a/go/services/refresh_token_cleanup_worker.go
+++ b/go/services/refresh_token_cleanup_worker.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 )
 
@@ -17,6 +18,7 @@ const defaultRefreshTokenCleanupInterval = 1 * time.Hour
 type RefreshTokenCleanupWorker struct {
 	registry        registry.RefreshTokenRegistry
 	cleanupInterval time.Duration
+	pause           PauseChecker
 	stopCh          chan struct{}
 	stopOnce        sync.Once
 	wg              sync.WaitGroup
@@ -27,6 +29,7 @@ type RefreshTokenCleanupOption func(*refreshTokenCleanupOptions)
 
 type refreshTokenCleanupOptions struct {
 	cleanupInterval time.Duration
+	pause           PauseChecker
 }
 
 // WithRefreshTokenCleanupInterval overrides the default cleanup interval.
@@ -35,6 +38,17 @@ func WithRefreshTokenCleanupInterval(d time.Duration) RefreshTokenCleanupOption 
 	return func(o *refreshTokenCleanupOptions) {
 		if d > 0 {
 			o.cleanupInterval = d
+		}
+	}
+}
+
+// WithRefreshTokenCleanupPauseController wires the soft-pause controller
+// so the worker skips its cleanup while the refresh-token-cleanup worker
+// type is paused (#1308). A nil checker leaves the worker unpaused.
+func WithRefreshTokenCleanupPauseController(pc PauseChecker) RefreshTokenCleanupOption {
+	return func(o *refreshTokenCleanupOptions) {
+		if pc != nil {
+			o.pause = pc
 		}
 	}
 }
@@ -51,6 +65,7 @@ func NewRefreshTokenCleanupWorker(r registry.RefreshTokenRegistry, opts ...Refre
 	return &RefreshTokenCleanupWorker{
 		registry:        r,
 		cleanupInterval: options.cleanupInterval,
+		pause:           options.pause,
 		stopCh:          make(chan struct{}),
 	}
 }
@@ -87,11 +102,22 @@ func (w *RefreshTokenCleanupWorker) runCleanup(ctx context.Context) {
 		case <-w.stopCh:
 			return
 		case <-ticker.C:
-			if err := w.registry.DeleteExpired(ctx); err != nil {
-				slog.Error("Failed to delete expired refresh tokens", "error", err)
-			} else {
-				slog.Debug("Expired refresh tokens cleaned up")
-			}
+			w.cleanupOnce(ctx)
 		}
+	}
+}
+
+// cleanupOnce runs a single expired-token sweep.
+func (w *RefreshTokenCleanupWorker) cleanupOnce(ctx context.Context) {
+	// Soft-pause (#1308): skip the cleanup while paused. The ticker keeps
+	// running so resuming takes effect on the next tick without a restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeRefreshTokenCleanup) {
+		return
+	}
+
+	if err := w.registry.DeleteExpired(ctx); err != nil {
+		slog.Error("Failed to delete expired refresh tokens", "error", err)
+	} else {
+		slog.Debug("Expired refresh tokens cleaned up")
 	}
 }

--- a/go/services/storage_quota_reminder_worker.go
+++ b/go/services/storage_quota_reminder_worker.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/denisvmedia/inventario/models"
 )
 
 const defaultStorageQuotaReminderInterval = 1 * time.Hour
@@ -46,6 +48,7 @@ type StorageQuotaReminderWorker struct {
 	service  *StorageQuotaReminderService
 	interval time.Duration
 	clock    func() time.Time
+	pause    PauseChecker
 	stopCh   chan struct{}
 	stopOnce sync.Once
 	wg       sync.WaitGroup
@@ -57,6 +60,7 @@ type StorageQuotaReminderOption func(*storageQuotaReminderOptions)
 type storageQuotaReminderOptions struct {
 	interval time.Duration
 	clock    func() time.Time
+	pause    PauseChecker
 }
 
 // WithStorageQuotaReminderInterval overrides the default tick
@@ -81,6 +85,17 @@ func WithStorageQuotaReminderClock(now func() time.Time) StorageQuotaReminderOpt
 	}
 }
 
+// WithStorageQuotaReminderPauseController wires the soft-pause controller
+// so the worker skips its sweep while the storage-quota-reminder worker
+// type is paused (#1308). A nil checker leaves the worker unpaused.
+func WithStorageQuotaReminderPauseController(pc PauseChecker) StorageQuotaReminderOption {
+	return func(o *storageQuotaReminderOptions) {
+		if pc != nil {
+			o.pause = pc
+		}
+	}
+}
+
 // NewStorageQuotaReminderWorker constructs the worker. The default
 // cadence is one hour — quota usage rarely changes faster than that
 // and a shorter cadence risks repeated SUM(size_bytes) queries
@@ -97,6 +112,7 @@ func NewStorageQuotaReminderWorker(service *StorageQuotaReminderService, opts ..
 		service:  service,
 		interval: options.interval,
 		clock:    options.clock,
+		pause:    options.pause,
 		stopCh:   make(chan struct{}),
 	}
 }
@@ -145,6 +161,12 @@ func (w *StorageQuotaReminderWorker) run(ctx context.Context) {
 // tick runs a single sweep. The service returns per-threshold stats
 // so the worker can emit one Prometheus series per threshold value.
 func (w *StorageQuotaReminderWorker) tick(ctx context.Context) {
+	// Soft-pause (#1308): skip the sweep while paused. The ticker keeps
+	// running so resuming takes effect on the next tick without a restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeStorageQuotaReminder) {
+		return
+	}
+
 	stats, err := w.service.RemindOnce(ctx, w.clock())
 	if err != nil {
 		slog.Error("Storage quota reminder sweep failed", "error", err)

--- a/go/services/thumbnail_generation_worker.go
+++ b/go/services/thumbnail_generation_worker.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/denisvmedia/inventario/models"
 	"github.com/denisvmedia/inventario/registry"
 )
 
@@ -18,6 +19,15 @@ const (
 	defaultDetachedThumbnailTimeout = 2 * time.Minute  // Bound each detached thumbnail job
 )
 
+// PauseChecker reports whether a worker type is currently soft-paused
+// (#1308). Declared locally in the services package so the workers depend
+// only on models, not on the workerpause controller — avoiding an import
+// cycle while still being satisfied by *workerpause.Controller. Shared by
+// every go/services background worker.
+type PauseChecker interface {
+	IsPaused(models.WorkerType) bool
+}
+
 // ThumbnailGenerationWorker processes thumbnail generation requests in the background
 type ThumbnailGenerationWorker struct {
 	thumbnailService   *ThumbnailGenerationService
@@ -28,6 +38,7 @@ type ThumbnailGenerationWorker struct {
 	retentionPeriod    time.Duration
 	jobBatchTimeout    time.Duration
 	detachedJobTimeout time.Duration
+	pause              PauseChecker
 	stopCh             chan struct{}
 	wg                 sync.WaitGroup
 	isRunning          bool
@@ -45,6 +56,7 @@ type thumbnailWorkerOptions struct {
 	retentionPeriod    time.Duration
 	jobBatchTimeout    time.Duration
 	detachedJobTimeout time.Duration
+	pause              PauseChecker
 }
 
 // WithThumbnailPollInterval overrides the default interval between job queue polls.
@@ -107,6 +119,17 @@ func WithDetachedThumbnailJobTimeout(d time.Duration) ThumbnailWorkerOption {
 	}
 }
 
+// WithThumbnailPauseController wires the soft-pause controller so the
+// worker skips its claim phase while the thumbnail worker type is paused
+// (#1308). A nil checker leaves the worker unpaused.
+func WithThumbnailPauseController(pc PauseChecker) ThumbnailWorkerOption {
+	return func(o *thumbnailWorkerOptions) {
+		if pc != nil {
+			o.pause = pc
+		}
+	}
+}
+
 // NewThumbnailGenerationWorker creates a new thumbnail generation worker
 func NewThumbnailGenerationWorker(factorySet *registry.FactorySet, uploadLocation string, config ThumbnailGenerationConfig, opts ...ThumbnailWorkerOption) *ThumbnailGenerationWorker {
 	thumbnailService := NewThumbnailGenerationService(factorySet, uploadLocation, config)
@@ -132,6 +155,7 @@ func NewThumbnailGenerationWorker(factorySet *registry.FactorySet, uploadLocatio
 		retentionPeriod:    options.retentionPeriod,
 		jobBatchTimeout:    options.jobBatchTimeout,
 		detachedJobTimeout: options.detachedJobTimeout,
+		pause:              options.pause,
 		stopCh:             make(chan struct{}),
 	}
 }
@@ -230,6 +254,13 @@ func (w *ThumbnailGenerationWorker) runCleanup(ctx context.Context) {
 
 // processPendingJobs finds and processes pending thumbnail generation jobs
 func (w *ThumbnailGenerationWorker) processPendingJobs(ctx context.Context) {
+	// Soft-pause (#1308): skip the claim phase while paused. The ticker
+	// keeps running so resuming takes effect on the next tick without a
+	// restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeThumbnail) {
+		return
+	}
+
 	jobs, err := w.thumbnailService.GetPendingJobs(ctx, w.jobBatchSize)
 	if err != nil {
 		slog.Error("Failed to get pending thumbnail jobs", "error", err)

--- a/go/services/warranty_reminder_worker.go
+++ b/go/services/warranty_reminder_worker.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/denisvmedia/inventario/models"
 )
 
 const defaultWarrantyReminderInterval = 1 * time.Hour
@@ -48,6 +50,7 @@ type WarrantyReminderWorker struct {
 	service  *WarrantyReminderService
 	interval time.Duration
 	clock    func() time.Time
+	pause    PauseChecker
 	stopCh   chan struct{}
 	stopOnce sync.Once
 	wg       sync.WaitGroup
@@ -59,6 +62,7 @@ type WarrantyReminderOption func(*warrantyReminderOptions)
 type warrantyReminderOptions struct {
 	interval time.Duration
 	clock    func() time.Time
+	pause    PauseChecker
 }
 
 // WithWarrantyReminderInterval overrides the default tick cadence.
@@ -82,6 +86,17 @@ func WithWarrantyReminderClock(now func() time.Time) WarrantyReminderOption {
 	}
 }
 
+// WithWarrantyReminderPauseController wires the soft-pause controller so
+// the worker skips its sweep while the warranty-reminder worker type is
+// paused (#1308). A nil checker leaves the worker unpaused.
+func WithWarrantyReminderPauseController(pc PauseChecker) WarrantyReminderOption {
+	return func(o *warrantyReminderOptions) {
+		if pc != nil {
+			o.pause = pc
+		}
+	}
+}
+
 // NewWarrantyReminderWorker constructs the worker. The default cadence
 // is one hour — the threshold windows are days, not minutes, so a
 // longer cadence wastes ticks; a shorter one risks flapping at
@@ -98,6 +113,7 @@ func NewWarrantyReminderWorker(service *WarrantyReminderService, opts ...Warrant
 		service:  service,
 		interval: options.interval,
 		clock:    options.clock,
+		pause:    options.pause,
 		stopCh:   make(chan struct{}),
 	}
 }
@@ -148,6 +164,12 @@ func (w *WarrantyReminderWorker) run(ctx context.Context) {
 // worker can emit one Prometheus series per threshold value
 // (matching the documented label set: 60 / 30 / 7).
 func (w *WarrantyReminderWorker) tick(ctx context.Context) {
+	// Soft-pause (#1308): skip the sweep while paused. The ticker keeps
+	// running so resuming takes effect on the next tick without a restart.
+	if w.pause != nil && w.pause.IsPaused(models.WorkerTypeWarrantyReminder) {
+		return
+	}
+
 	stats, err := w.service.RemindOnce(ctx, w.clock())
 	if err != nil {
 		slog.Error("Warranty reminder sweep failed", "error", err)

--- a/go/services/workerpause/controller.go
+++ b/go/services/workerpause/controller.go
@@ -1,0 +1,288 @@
+// Package workerpause hosts the runtime side of the background-worker
+// soft-pause control plane (#1308). The data layer (models.WorkerControl
+// + registry.WorkerControlRegistry) records which worker types an
+// operator has paused; this package turns those rows into a lock-free,
+// hot-path-cheap IsPaused check that every worker's claim phase consults
+// each tick.
+//
+// The design splits the slow path (a DB List poll, once per
+// refreshInterval) from the fast path (a single atomic.Bool read per
+// worker tick) so a paused/running flip costs the workers nothing at
+// steady state and resuming is near-instant without a process restart.
+package workerpause
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/denisvmedia/inventario/models"
+)
+
+// defaultRefreshInterval is how often the controller re-polls the
+// WorkerControlRegistry. 10s keeps a paused/resumed flip visible to the
+// workers within a few seconds while adding negligible DB load (one
+// indexed List per interval). Overridable via WithRefreshInterval.
+const defaultRefreshInterval = 10 * time.Second
+
+// workerPausedGauge exposes the live pause state per worker type on
+// /metrics. Initialised to 0 for every canonical type at the first
+// refresh so the series always exist for dashboards/alerts, then driven
+// to 1/0 as operators pause/resume. Package-level + promauto so it
+// registers against the default registry exactly like the per-worker
+// metrics do.
+var workerPausedGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "inventario_worker_paused",
+	Help: "1 when the named background worker type is soft-paused (#1308), else 0.",
+}, []string{"type"})
+
+// PausedGaugeFor returns the live inventario_worker_paused gauge series
+// for worker type t. Exposed for tests (the external _test package can't
+// reach the unexported workerPausedGauge directly) so they can assert the
+// metric tracks the pause state; not part of the runtime API.
+func PausedGaugeFor(t models.WorkerType) prometheus.Gauge {
+	return workerPausedGauge.WithLabelValues(string(t))
+}
+
+// pauseRegistry is the minimal slice of registry.WorkerControlRegistry
+// the controller needs. Declared locally (rather than importing the full
+// registry interface) so the polling side depends only on List — the
+// Pause/Resume writers live behind the CLI/admin surface, not here.
+type pauseRegistry interface {
+	List(ctx context.Context) ([]*models.WorkerControl, error)
+}
+
+// Controller polls the WorkerControlRegistry on an interval and exposes a
+// lock-free IsPaused check the workers consult on their hot path. The
+// pause state for each canonical worker type is held in an atomic.Bool so
+// reads never contend with the refresh goroutine.
+type Controller struct {
+	reg             pauseRegistry
+	refreshInterval time.Duration
+
+	// states is pre-populated for every models.AllWorkerTypes() at
+	// construction and never has keys added/removed afterwards, so it is
+	// safe to read concurrently without a lock — only the atomic values
+	// mutate. IsPaused for an unknown type returns false.
+	states map[models.WorkerType]*atomic.Bool
+
+	// lastLogged tracks the most recently logged paused state per type so
+	// transitions are logged exactly once (not on every poll). Guarded by
+	// mu because RefreshOnce may be called from both Start's synchronous
+	// preflight and the ticker goroutine.
+	mu         sync.Mutex
+	lastLogged map[models.WorkerType]bool
+	// listErrored records whether the previous poll failed, so the
+	// fail-safe warning is logged once on the error transition rather than
+	// on every failing poll.
+	listErrored bool
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+// Option customises a Controller.
+type Option func(*Controller)
+
+// WithRefreshInterval overrides the registry poll cadence. Non-positive
+// values are ignored — the 10s default is kept.
+func WithRefreshInterval(d time.Duration) Option {
+	return func(c *Controller) {
+		if d > 0 {
+			c.refreshInterval = d
+		}
+	}
+}
+
+// NewController constructs a Controller over reg. Every canonical worker
+// type is pre-registered as not-paused so IsPaused is a pure atomic read
+// (no map mutation) on the hot path and unknown types simply return false.
+func NewController(reg pauseRegistry, opts ...Option) *Controller {
+	c := &Controller{
+		reg:             reg,
+		refreshInterval: defaultRefreshInterval,
+		states:          make(map[models.WorkerType]*atomic.Bool),
+		lastLogged:      make(map[models.WorkerType]bool),
+		stopCh:          make(chan struct{}),
+	}
+	for _, t := range models.AllWorkerTypes() {
+		c.states[t] = &atomic.Bool{}
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// IsPaused reports whether worker type t is currently soft-paused. It is
+// a single lock-free atomic read and returns false for any type not in
+// the canonical set (so a worker that passes an unknown type fails open
+// and keeps running).
+func (c *Controller) IsPaused(t models.WorkerType) bool {
+	if c == nil {
+		return false
+	}
+	state, ok := c.states[t]
+	if !ok {
+		return false
+	}
+	return state.Load()
+}
+
+// Start performs one synchronous RefreshOnce so the pause state is
+// correct before any worker ticks, then launches a goroutine that
+// re-polls every refreshInterval until Stop or ctx cancellation. The
+// initial refresh error (if any) is logged but does not block startup —
+// the workers fail open (run) until the first successful poll.
+func (c *Controller) Start(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	if err := c.RefreshOnce(ctx); err != nil {
+		slog.Warn("Worker pause controller: initial refresh failed; workers run until first successful poll", "error", err)
+	}
+	c.wg.Go(func() {
+		c.run(ctx)
+	})
+	slog.Info("Worker pause controller started", "refresh_interval", c.refreshInterval)
+}
+
+// Stop signals the poll goroutine and waits for it to exit. Idempotent.
+func (c *Controller) Stop() {
+	if c == nil {
+		return
+	}
+	c.stopOnce.Do(func() {
+		close(c.stopCh)
+	})
+	c.wg.Wait()
+	slog.Info("Worker pause controller stopped")
+}
+
+func (c *Controller) run(ctx context.Context) {
+	ticker := time.NewTicker(c.refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			// Errors are swallowed here (already logged inside
+			// RefreshOnce) — a transient List failure must not kill the
+			// poll loop, and the last-known state is retained meanwhile.
+			_ = c.RefreshOnce(ctx)
+		}
+	}
+}
+
+// RefreshOnce reads the current control rows and reconciles the atomic
+// pause flags + the Prometheus gauge.
+//
+// Fail-safe: on a List error the last-known state is RETAINED (atomics are
+// not flipped to false) so a DB blip can't silently un-pause a worker an
+// operator deliberately stopped. The error is logged once on the
+// error transition and returned to the caller.
+//
+// On success the controller marks every canonical type 1/0 based on rows
+// where paused==true AND the type IsValid (unknown/legacy rows are
+// ignored), logs each paused/resumed transition exactly once, and
+// initialises every canonical gauge series so /metrics always carries the
+// full label set.
+func (c *Controller) RefreshOnce(ctx context.Context) error {
+	rows, err := c.reg.List(ctx)
+	if err != nil {
+		c.mu.Lock()
+		if !c.listErrored {
+			c.listErrored = true
+			slog.Warn("Worker pause controller: failed to refresh pause state; retaining last-known state", "error", err)
+		}
+		c.mu.Unlock()
+		return err
+	}
+
+	paused := make(map[models.WorkerType]bool, len(rows))
+	for _, row := range rows {
+		if row == nil || !row.Paused {
+			continue
+		}
+		if !row.WorkerType.IsValid() {
+			continue
+		}
+		paused[row.WorkerType] = true
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.listErrored = false
+
+	for t, state := range c.states {
+		isPaused := paused[t]
+		state.Store(isPaused)
+		gaugeValue := 0.0
+		if isPaused {
+			gaugeValue = 1
+		}
+		workerPausedGauge.WithLabelValues(string(t)).Set(gaugeValue)
+
+		if isPaused {
+			c.logPausedTransition(t, rowFor(rows, t))
+		} else {
+			c.logResumedTransition(t)
+		}
+	}
+
+	return nil
+}
+
+// logPausedTransition logs "worker paused" exactly once when t flips from
+// running (or unknown) to paused versus the last logged value. Called
+// with c.mu held.
+func (c *Controller) logPausedTransition(t models.WorkerType, row *models.WorkerControl) {
+	if prev, seen := c.lastLogged[t]; seen && prev {
+		return // already logged as paused
+	}
+	c.lastLogged[t] = true
+
+	attrs := []any{"type", string(t)}
+	if row != nil {
+		if row.Reason != nil {
+			attrs = append(attrs, "reason", *row.Reason)
+		}
+		if row.PausedBy != nil {
+			attrs = append(attrs, "paused_by", *row.PausedBy)
+		}
+	}
+	slog.Info("worker paused", attrs...)
+}
+
+// logResumedTransition logs "worker resumed" exactly once when t flips
+// from paused back to running. The initial "everything is running"
+// baseline is intentionally silent — only a paused→running flip is
+// noteworthy. Called with c.mu held.
+func (c *Controller) logResumedTransition(t models.WorkerType) {
+	if prev, seen := c.lastLogged[t]; !seen || !prev {
+		c.lastLogged[t] = false
+		return // never logged as paused → nothing to announce
+	}
+	c.lastLogged[t] = false
+	slog.Info("worker resumed", "type", string(t))
+}
+
+// rowFor returns the control row for type t, or nil when none is present.
+func rowFor(rows []*models.WorkerControl, t models.WorkerType) *models.WorkerControl {
+	for _, row := range rows {
+		if row != nil && row.WorkerType == t {
+			return row
+		}
+	}
+	return nil
+}

--- a/go/services/workerpause/controller_test.go
+++ b/go/services/workerpause/controller_test.go
@@ -1,0 +1,175 @@
+package workerpause_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services/workerpause"
+)
+
+func TestControllerRefreshOnce_NoRows_AllRunning(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	reg := memory.NewWorkerControlRegistry()
+	ctrl := workerpause.NewController(reg)
+
+	err := ctrl.RefreshOnce(ctx)
+	c.Assert(err, qt.IsNil)
+
+	for _, wt := range models.AllWorkerTypes() {
+		c.Assert(ctrl.IsPaused(wt), qt.IsFalse)
+	}
+}
+
+func TestControllerRefreshOnce_PauseMarksOnlyThatType(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	reg := memory.NewWorkerControlRegistry()
+	_, err := reg.Pause(ctx, string(models.WorkerTypeExport), "operator@example.com", "maintenance window")
+	c.Assert(err, qt.IsNil)
+
+	ctrl := workerpause.NewController(reg)
+	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
+
+	c.Assert(ctrl.IsPaused(models.WorkerTypeExport), qt.IsTrue)
+	for _, wt := range models.AllWorkerTypes() {
+		if wt == models.WorkerTypeExport {
+			continue
+		}
+		c.Assert(ctrl.IsPaused(wt), qt.IsFalse)
+	}
+}
+
+func TestControllerRefreshOnce_ResumeClearsPause(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	reg := memory.NewWorkerControlRegistry()
+	ctrl := workerpause.NewController(reg)
+
+	_, err := reg.Pause(ctx, string(models.WorkerTypeImport), "", "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
+	c.Assert(ctrl.IsPaused(models.WorkerTypeImport), qt.IsTrue)
+
+	_, err = reg.Resume(ctx, string(models.WorkerTypeImport))
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
+	c.Assert(ctrl.IsPaused(models.WorkerTypeImport), qt.IsFalse)
+}
+
+func TestControllerRefreshOnce_FailSafeRetainsLastKnownState(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	fake := &flakyRegistry{
+		rows: []*models.WorkerControl{
+			{WorkerType: models.WorkerTypeThumbnail, Paused: true},
+		},
+	}
+	ctrl := workerpause.NewController(fake)
+
+	// First poll succeeds and records the paused state.
+	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
+	c.Assert(ctrl.IsPaused(models.WorkerTypeThumbnail), qt.IsTrue)
+
+	// Next poll errors: the controller must return the error AND keep the
+	// last-known paused state rather than flipping the worker back on.
+	fake.err = errors.New("db unavailable")
+	err := ctrl.RefreshOnce(ctx)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(ctrl.IsPaused(models.WorkerTypeThumbnail), qt.IsTrue)
+}
+
+func TestControllerIsPaused_UnknownTypeIsFalse(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	reg := memory.NewWorkerControlRegistry()
+	ctrl := workerpause.NewController(reg)
+	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
+
+	c.Assert(ctrl.IsPaused(models.WorkerType("not-a-real-worker")), qt.IsFalse)
+}
+
+func TestControllerRefreshOnce_IgnoresInvalidWorkerTypeRows(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	fake := &flakyRegistry{
+		rows: []*models.WorkerControl{
+			{WorkerType: models.WorkerType("legacy-removed-worker"), Paused: true},
+			{WorkerType: models.WorkerTypeLoanReminder, Paused: true},
+		},
+	}
+	ctrl := workerpause.NewController(fake)
+	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
+
+	c.Assert(ctrl.IsPaused(models.WorkerTypeLoanReminder), qt.IsTrue)
+	c.Assert(ctrl.IsPaused(models.WorkerType("legacy-removed-worker")), qt.IsFalse)
+}
+
+func TestControllerGaugeReflectsPauseState(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	reg := memory.NewWorkerControlRegistry()
+	ctrl := workerpause.NewController(reg)
+
+	_, err := reg.Pause(ctx, string(models.WorkerTypeGroupPurge), "", "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
+
+	c.Assert(testutil.ToFloat64(workerpause.PausedGaugeFor(models.WorkerTypeGroupPurge)), qt.Equals, 1.0)
+	c.Assert(testutil.ToFloat64(workerpause.PausedGaugeFor(models.WorkerTypeExport)), qt.Equals, 0.0)
+
+	_, err = reg.Resume(ctx, string(models.WorkerTypeGroupPurge))
+	c.Assert(err, qt.IsNil)
+	c.Assert(ctrl.RefreshOnce(ctx), qt.IsNil)
+	c.Assert(testutil.ToFloat64(workerpause.PausedGaugeFor(models.WorkerTypeGroupPurge)), qt.Equals, 0.0)
+}
+
+func TestControllerStartStop(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	reg := memory.NewWorkerControlRegistry()
+	_, err := reg.Pause(ctx, string(models.WorkerTypeRestore), "", "")
+	c.Assert(err, qt.IsNil)
+
+	ctrl := workerpause.NewController(reg, workerpause.WithRefreshInterval(10*time.Millisecond))
+	ctrl.Start(ctx)
+	defer ctrl.Stop()
+
+	// Start performs a synchronous RefreshOnce, so the paused state is
+	// correct immediately without waiting for the ticker.
+	c.Assert(ctrl.IsPaused(models.WorkerTypeRestore), qt.IsTrue)
+
+	// Stop is idempotent.
+	ctrl.Stop()
+	ctrl.Stop()
+}
+
+// flakyRegistry is a tiny pauseRegistry stand-in whose List can be made to
+// fail on demand, so the fail-safe and invalid-type paths can be exercised
+// without a real backend.
+type flakyRegistry struct {
+	rows []*models.WorkerControl
+	err  error
+}
+
+func (f *flakyRegistry) List(_ context.Context) ([]*models.WorkerControl, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.rows, nil
+}


### PR DESCRIPTION
## Summary

Implements the soft-pause follow-up from #1308. Background workers can now be **paused at runtime without restarting the process**: the run loop keeps ticking (probes green, `/metrics` exposed) but skips its claim phase, so **in-flight jobs finish** while **no new work is claimed**. Resuming is immediate, symmetric, and idempotent.

Of the three options the issue floated, this takes the **DB-backed** route — the only one that persists across restarts (real "drain before deploy") and coordinates every worker pod/replica under the #1214 split-deployment model, and the most idiomatic for this registry-driven codebase. Granularity is **per worker family**; control is exposed via **CLI + an authenticated admin API**.

## How it works

- **Data layer** — a new global, non-tenant, **non-RLS** `worker_control` table (generated migration `1780128395`, same posture as `system_admin_grants`/`audit_logs`) fronted by `WorkerControlRegistry` (postgres + memory). `Pause`/`Resume` are idempotent; re-pausing preserves the original `paused_at`.
- **Runtime controller** (`services/workerpause`) — polls the registry on an interval, caches per-type state in `atomic.Bool` for a **lock-free `IsPaused` hot path**, drives the `inventario_worker_paused{type=...}` gauge, logs each transition **once**, and **fails safe** (retains last-known state on a DB read error, so a blip can't silently un-pause a deliberately-stopped worker). Built only in `run all` / `run workers`; **nil in `run apiserver`**, so the HTTP API keeps serving while the worker side is paused.
- **Workers** — all 12 pausable families gained a claim-phase guard. The currency-migration worker still runs its **stuck-row sweep** while paused and only gates new claims.
- **Control surfaces**
  - CLI `inventario workers pause|resume|status` (rejects `memory://`, audit-logged, `paused_by="cli"`).
  - Back-office-gated REST: `GET /api/v1/admin/workers`, `POST /api/v1/admin/workers/{workerType}/pause|resume` (optional `reason` ≤500 chars, strict decode, audited via `AuditService`, actor = back-office operator).

Pausable types: `export, import, restore, thumbnail, refresh-token-cleanup, login-event-retention, group-purge, warranty-reminder, storage-quota-reminder, loan-reminder, maintenance-reminder, currency-migration`. (Email delivery is a Redis subscriber, intentionally out of scope.)

## Acceptance criteria (#1308)

- ✅ Worker types can be paused/resumed at runtime without restart (all 12).
- ✅ Paused state observable via metric (`inventario_worker_paused{type}`) and one-time transition logs.
- ✅ In `run all`, pause affects only the worker side; the HTTP API keeps serving.
- ✅ Tests covering pause → job arrives → not picked up → resume → picked up (export acceptance test).

## Testing

- `golangci-lint run ./...` → 0 issues; `go test ./...` green; `go test -race ./services/workerpause/...` clean.
- Swagger regenerated (`make swagger`); `TestSwaggerRouteCoverage` passes.
- New tests: registry idempotency/`paused_at` preservation (postgres+memory parity), controller fail-safe + transition logging, admin handlers (tenant-JWT→401, unknown type→404, oversize reason→422, unknown field→400), and the export pause→resume acceptance test.
- Docs: admin runbook §7 + README.

## Review notes

Reviewed by a code-correctness pass (APPROVE — no Critical/High) and a security pass (SHIP — no High/Medium): auth boundary (`RequireBackofficeAuth`, unreachable by tenant/impersonation tokens), allowlist-validated `{workerType}` + fully parameterized SQL, complete audit trail, and fail-safe pause retention all verified.

Closes #1308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Soft-pause/resume/status for background workers via CLI and admin REST API; pause state persists in PostgreSQL (memory:// rejected) and is coordinated across replicas; Prometheus gauge exported.

* **Documentation**
  * README and admin runbook updated with commands, examples, canonical worker types, audit behavior, observability and fail‑safe notes.

* **Config / Migration**
  * New worker-control refresh interval default (10s) and a DB migration to store worker pause state.

* **Tests**
  * Expanded tests covering controller, registries, CLI, API, and worker pause/resume behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->