### PR TITLE
fix: demo/seed files & thumbnails not rendering

### DIFF
--- a/frontend/src/components/files/CommodityFilesTab.tsx
+++ b/frontend/src/components/files/CommodityFilesTab.tsx
@@ -400,9 +400,12 @@ function PhotoGrid({
     <ul className="grid grid-cols-3 gap-1.5" data-testid="commodity-files-photo-grid">
       {photos.map(({ file, signedUrl }) => {
         const title = file.title?.trim() || file.path?.trim() || file.id
+        // Photo grid cells are `aspect-square w-full` in a 3-column grid
+        // (~200–300px wide), so the 150px `small` variant would upscale
+        // and blur — prefer `medium` (300px), then fall back.
         const thumbUrl =
-          signedUrl?.thumbnails?.small ??
           signedUrl?.thumbnails?.medium ??
+          signedUrl?.thumbnails?.small ??
           signedUrl?.thumbnails?.large ??
           signedUrl?.url
         const isExplicit = onSetCover && coverState?.current === file.id

--- a/frontend/src/components/files/FileCard.tsx
+++ b/frontend/src/components/files/FileCard.tsx
@@ -75,12 +75,13 @@ export function FileCard({
   const visual = getFileVisualMeta(file)
   const FallbackIcon = visual.icon
   // Thumbnail keys come from services/file_signing_service.go — the BE
-  // emits `small` / `medium` / `large`. Falling back through the sizes
-  // means we always pick the smallest available (best for the
-  // grid-card cell), and finally drop to the full-resolution signed
-  // URL if no thumbnails were generated yet.
+  // emits `small` (150px) / `medium` (300px) / `large`. The grid card
+  // renders the cover in a full-width `aspect-[4/3]` box (~250–300px wide
+  // on a typical layout), so `small` gets upscaled ~2× and looks blurry —
+  // prefer `medium`, then fall back to `small`/`large`, and finally to
+  // the full-resolution signed URL if no thumbnails were generated yet.
   const thumbUrl =
-    signedUrl?.thumbnails?.small ?? signedUrl?.thumbnails?.medium ?? signedUrl?.thumbnails?.large
+    signedUrl?.thumbnails?.medium ?? signedUrl?.thumbnails?.small ?? signedUrl?.thumbnails?.large
   const renderImage = isImageMime(file.mime_type) && (thumbUrl || signedUrl?.url)
   const tags = file.tags ?? []
   const tile = FILE_CATEGORY_TILES.find((c) => c.key === file.category) ?? FILE_CATEGORY_TILES[0]

--- a/go/apiserver/files.go
+++ b/go/apiserver/files.go
@@ -814,8 +814,17 @@ func (api *filesAPI) servePlaceholderThumbnail(w http.ResponseWriter, r *http.Re
 	// Check if there's a thumbnail generation job for this file
 	thumbnailService := services.NewThumbnailGenerationService(api.factorySet, api.uploadLocation, api.thumbnailConfig)
 
+	// "No job yet" is the common first-view case — match the registry's
+	// own sentinel, not apiserver.ErrNotFound. The registry wraps
+	// registry.ErrNotFound (see ThumbnailGenerationJobRegistry.GetJobByFileID),
+	// and apiserver.ErrNotFound is a *separate* sentinel that wraps
+	// registry.ErrNotFound rather than being wrapped by it — so
+	// errors.Is(err, ErrNotFound) is false here and the handler used to
+	// 500 instead of falling through to enqueue generation. That meant
+	// on-demand thumbnails never generated for any file without a
+	// pre-existing job (e.g. every seeded fixture image).
 	job, err := thumbnailService.GetJobByFileID(r.Context(), fileID)
-	if err != nil && !errors.Is(err, ErrNotFound) {
+	if err != nil && !errors.Is(err, registry.ErrNotFound) {
 		internalServerError(w, r, errxtrace.Wrap("failed to check thumbnail generation status", err))
 		return
 	}

--- a/go/apiserver/thumbnail_placeholder_test.go
+++ b/go/apiserver/thumbnail_placeholder_test.go
@@ -1,0 +1,92 @@
+package apiserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/denisvmedia/inventario/appctx"
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry/memory"
+	"github.com/denisvmedia/inventario/services"
+)
+
+// TestServePlaceholderThumbnail_NoJobEnqueuesAndServesPlaceholder pins the
+// fix for the thumbnail download 500: when a file has no thumbnail and no
+// generation job yet (the first-view case, and always true for seeded
+// fixtures), the handler must serve the placeholder (HTTP 200) and enqueue
+// a generation job — NOT 500.
+//
+// The regression it guards: GetJobByFileID returns registry.ErrNotFound
+// wrapped, but the handler used to match apiserver.ErrNotFound. errors.Is
+// doesn't match in that direction (apiserver.ErrNotFound *wraps*
+// registry.ErrNotFound, not the reverse), so the not-found landed in the
+// 500 branch and on-demand generation never fired.
+func TestServePlaceholderThumbnail_NoJobEnqueuesAndServesPlaceholder(t *testing.T) {
+	c := qt.New(t)
+	fs := memory.NewFactorySet()
+
+	const tenantID = "t1"
+	const userID = "u1"
+	const groupID = "g1"
+
+	user := &models.User{TenantAwareEntityID: models.TenantAwareEntityID{
+		TenantID: tenantID,
+		EntityID: models.EntityID{ID: userID},
+	}}
+	group := &models.LocationGroup{
+		TenantAwareEntityID: models.TenantAwareEntityID{TenantID: tenantID, EntityID: models.EntityID{ID: groupID}},
+		GroupCurrency:       models.Currency("USD"),
+	}
+	ctx := appctx.WithGroup(appctx.WithUser(context.Background(), user), group)
+
+	// An image file row with no thumbnail and no generation job — exactly
+	// the state a freshly seeded fixture image is in.
+	created, err := fs.FileRegistryFactory.CreateServiceRegistry().Create(ctx, models.FileEntity{
+		TenantGroupAwareEntityID: models.TenantGroupAwareEntityID{
+			TenantID:        tenantID,
+			GroupID:         groupID,
+			CreatedByUserID: userID,
+		},
+		Title:    "Cover",
+		Type:     models.FileTypeImage,
+		Category: models.FileCategoryImages,
+		File: &models.File{
+			Path:         "photo-livingroom",
+			OriginalPath: "t/t1/seed-abc.jpg",
+			Ext:          ".jpg",
+			MIMEType:     "image/jpeg",
+			SizeBytes:    1,
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	api := &filesAPI{
+		factorySet:     fs,
+		uploadLocation: "", // no bucket needed: we exercise the placeholder + enqueue path only
+		thumbnailConfig: services.ThumbnailGenerationConfig{
+			MaxConcurrentPerUser: 10,
+			RateLimitPerMinute:   60,
+			SlotDuration:         time.Minute,
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/files/download/thumbnails/"+created.ID+"/small", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	api.servePlaceholderThumbnail(w, req, created.ID, "small")
+
+	c.Assert(w.Code, qt.Equals, http.StatusOK)
+	c.Assert(w.Header().Get("Content-Type"), qt.Equals, "image/gif")
+
+	// The placeholder response must come with an enqueued pending job so a
+	// worker actually generates the thumbnail.
+	job, err := fs.ThumbnailGenerationJobRegistryFactory.CreateServiceRegistry().GetJobByFileID(ctx, created.ID)
+	c.Assert(err, qt.IsNil)
+	c.Assert(job, qt.IsNotNil)
+	c.Assert(job.Status, qt.Equals, models.ThumbnailStatusPending)
+}

--- a/go/debug/seeddata/seeddata.go
+++ b/go/debug/seeddata/seeddata.go
@@ -178,6 +178,18 @@ func SeedData(factorySet *registry.FactorySet, opts SeedOptions) (alreadySeeded 
 			"user", user1.Email,
 			"location_count", locCount,
 		)
+		// The data tables are populated, but the bundled fixture BLOBS
+		// live in a separate store with an independent lifecycle. A DB
+		// seeded metadata-only (before blob uploads were enabled for its
+		// tenant, #1931) or a bucket wiped independently of the DB leaves
+		// fixture file rows pointing at objects that don't exist — the
+		// Files page then shows entries whose download/thumbnail 404s.
+		// Reconcile so the bucket converges back to the rows on the next
+		// seed call instead of staying permanently diverged. Best-effort
+		// and conservative — see reconcileSeedBlobs.
+		if err := reconcileSeedBlobs(userCtx, userRegistrySet, tenant, opts); err != nil {
+			return true, fmt.Errorf("reconcile seed blobs: %w", err)
+		}
 		return true, nil
 	}
 

--- a/go/debug/seeddata/seeddata_fixtures.go
+++ b/go/debug/seeddata/seeddata_fixtures.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 	"gocloud.dev/blob"
@@ -66,6 +67,27 @@ var fixtureMetadata = map[fixtureKind]fixtureMeta{
 	fixtureManual:          {Ext: ".pdf", MIMEType: "application/pdf"},
 }
 
+// seedBasenamePrefix is the fixed prefix every seed blob basename
+// carries (the full basename is `seed-<uuid><ext>`). It is the single
+// source of truth shared by the uploaders that MINT keys (upload) and
+// the reconciler that RECOGNISES already-seeded keys
+// (reconcileSeedBlobs / seedFixtureForRow).
+const seedBasenamePrefix = "seed-"
+
+// fixtureByPathBasename reverse-maps the Path stored on a seeded file
+// row back to the fixture it was created from. attachFile stores
+// Path = <fixture-basename> (e.g. "photo-livingroom", "invoice",
+// "manual"), so an untouched seed row round-trips cleanly here; a file a
+// user has since renamed won't match and the reconciler leaves it alone.
+var fixtureByPathBasename = func() map[string]fixtureKind {
+	m := make(map[string]fixtureKind, len(fixtureMetadata))
+	for fx := range fixtureMetadata {
+		base := strings.TrimSuffix(strings.TrimPrefix(string(fx), "_files/"), fixtureExt(fx))
+		m[base] = fx
+	}
+	return m
+}()
+
 // blobUploader writes seed fixture bytes into the configured upload
 // bucket. Implementations differ between "real backend" (open the bucket
 // via gocloud, copy bytes through) and "no backend" (no-op — the seed
@@ -78,6 +100,17 @@ var fixtureMetadata = map[fixtureKind]fixtureMeta{
 // namespace as user-uploaded files (#1793).
 type blobUploader interface {
 	upload(ctx context.Context, fixture fixtureKind, tenantID string) (storagePath string, sizeBytes int64, err error)
+	// ensure idempotently guarantees the fixture bytes exist at an
+	// ALREADY-KNOWN blob key (the OriginalPath recorded on an existing
+	// seed file row), returning the blob's authoritative size. Where
+	// upload mints a fresh key for a brand-new row, ensure repairs a row
+	// whose key predates its bytes — e.g. a database seeded metadata-only
+	// before blob uploads were enabled for its tenant (#1931), or a
+	// bucket that lost its contents independently of the DB. wrote
+	// reports whether bytes were actually written this call (false when
+	// the blob already existed, or for the no-op uploader). See
+	// reconcileSeedBlobs.
+	ensure(ctx context.Context, blobKey string, fixture fixtureKind) (sizeBytes int64, wrote bool, err error)
 	close()
 }
 
@@ -109,8 +142,15 @@ func (*noopUploader) upload(_ context.Context, fixture fixtureKind, tenantID str
 	// these rows obvious if anyone debugs the table. The full key is
 	// tenant-prefixed (#1793) for consistency with real uploads, even
 	// though no bucket actually receives the bytes.
-	basename := fmt.Sprintf("seed-%s%s", uuid.NewString(), filepath.Ext(string(fixture)))
+	basename := fmt.Sprintf("%s%s%s", seedBasenamePrefix, uuid.NewString(), filepath.Ext(string(fixture)))
 	return blobkeys.BuildSeedKey(tenantID, basename), 0, nil
+}
+
+// ensure is a no-op for the no-op uploader: with no bucket attached there
+// is nothing to write and nothing to repair. Returns wrote=false so the
+// reconciler doesn't touch the row's recorded size.
+func (*noopUploader) ensure(context.Context, string, fixtureKind) (int64, bool, error) {
+	return 0, false, nil
 }
 
 func (*noopUploader) close() {}
@@ -124,20 +164,55 @@ func (u *bucketUploader) upload(ctx context.Context, fixture fixtureKind, tenant
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to read fixture %s: %w", fixture, err)
 	}
-	basename := fmt.Sprintf("seed-%s%s", uuid.NewString(), filepath.Ext(string(fixture)))
+	basename := fmt.Sprintf("%s%s%s", seedBasenamePrefix, uuid.NewString(), filepath.Ext(string(fixture)))
 	storagePath := blobkeys.BuildSeedKey(tenantID, basename)
-	w, err := u.bucket.NewWriter(ctx, storagePath, nil)
+	if err := u.writeFixture(ctx, storagePath, data); err != nil {
+		return "", 0, err
+	}
+	return storagePath, int64(len(data)), nil
+}
+
+// ensure writes the fixture bytes at the given pre-existing key only when
+// the object is missing from the bucket, so it is safe to call on every
+// re-seed. When the blob is already present it returns its current size
+// without rewriting. See the blobUploader interface doc.
+func (u *bucketUploader) ensure(ctx context.Context, blobKey string, fixture fixtureKind) (int64, bool, error) {
+	exists, err := u.bucket.Exists(ctx, blobKey)
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to open bucket writer for %s: %w", storagePath, err)
+		return 0, false, fmt.Errorf("failed to check existence of %s: %w", blobKey, err)
+	}
+	if exists {
+		attrs, aerr := u.bucket.Attributes(ctx, blobKey)
+		if aerr != nil {
+			return 0, false, fmt.Errorf("failed to read attributes of %s: %w", blobKey, aerr)
+		}
+		return attrs.Size, false, nil
+	}
+	data, err := fixturesFS.ReadFile(string(fixture))
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to read fixture %s: %w", fixture, err)
+	}
+	if err := u.writeFixture(ctx, blobKey, data); err != nil {
+		return 0, false, err
+	}
+	return int64(len(data)), true, nil
+}
+
+// writeFixture streams data into the bucket at key, wrapping the
+// open/write/close trio shared by upload and ensure.
+func (u *bucketUploader) writeFixture(ctx context.Context, key string, data []byte) error {
+	w, err := u.bucket.NewWriter(ctx, key, nil)
+	if err != nil {
+		return fmt.Errorf("failed to open bucket writer for %s: %w", key, err)
 	}
 	if _, werr := w.Write(data); werr != nil {
 		_ = w.Close()
-		return "", 0, fmt.Errorf("failed to write seed fixture %s: %w", storagePath, werr)
+		return fmt.Errorf("failed to write seed fixture %s: %w", key, werr)
 	}
 	if cerr := w.Close(); cerr != nil {
-		return "", 0, fmt.Errorf("failed to close writer for %s: %w", storagePath, cerr)
+		return fmt.Errorf("failed to close writer for %s: %w", key, cerr)
 	}
-	return storagePath, int64(len(data)), nil
+	return nil
 }
 
 func (u *bucketUploader) close() {

--- a/go/debug/seeddata/seeddata_reconcile.go
+++ b/go/debug/seeddata/seeddata_reconcile.go
@@ -1,0 +1,137 @@
+package seeddata
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path"
+	"strings"
+
+	"github.com/denisvmedia/inventario/models"
+	"github.com/denisvmedia/inventario/registry"
+)
+
+// reconcileSeedBlobs repairs the blob bytes for bundled fixture file rows
+// whose row exists in the database but whose object is missing from the
+// upload bucket.
+//
+// Why this exists: SeedData is idempotent via a location-count gate that
+// short-circuits the WHOLE seed once data tables are populated — including
+// the blob-upload step. That gate keys solely on database state, but the
+// fixture bytes live in a separate store (e.g. the demo MinIO bucket)
+// with an independent lifecycle. Two situations leave the DB carrying
+// fixture file rows that point at blobs which do not exist:
+//
+//   - A database seeded metadata-only BEFORE blob uploads were enabled
+//     for its tenant. Blob writes for non-`test-org` tenants only became
+//     possible with the AllowBlobUploads opt-in (#1931); any demo/preview
+//     env first seeded before that shipped has rows with no bytes and a
+//     SizeBytes of 0, and the location-count gate means a later re-seed
+//     never backfills them.
+//   - A bucket that lost its contents independently of the DB (the demo
+//     MinIO runs on an emptyDir, so a MinIO-only pod replacement wipes the
+//     objects while Postgres keeps the rows).
+//
+// Both leave the Files page showing entries whose download/thumbnail
+// 404s. reconcileSeedBlobs converges the bucket back to the rows: it runs
+// on every seed call (including the already-seeded fast path), so the
+// next sync self-heals instead of carrying permanently-dangling rows.
+//
+// It is deliberately conservative — it only ever WRITES fixture bytes at
+// keys that already belong to recognised seed rows, never deletes, and
+// never touches a row a user has renamed. It honours the same tenant gate
+// as the fresh-seed upload path so it cannot be used to spam an arbitrary
+// tenant's bucket through the public /api/v1/seed surface.
+func reconcileSeedBlobs(ctx context.Context, set *registry.Set, tenant *models.Tenant, opts SeedOptions) error {
+	// Same gate as the fresh-seed upload step in SeedData: fixture bytes
+	// are only written for the well-known `test-org` tenant or when a
+	// caller explicitly opts in (env-gated, server-side only). For any
+	// other tenant there is intentionally nothing to reconcile.
+	if tenant.Slug != "test-org" && !opts.AllowBlobUploads {
+		return nil
+	}
+	if opts.UploadLocation == "" {
+		// No bucket attached (in-memory unit tests, or a deployment that
+		// deliberately keeps metadata-only rows). Nothing to repair.
+		return nil
+	}
+	if err := ensureFixturesPresent(); err != nil {
+		return err
+	}
+
+	uploader, err := newBlobUploader(ctx, opts.UploadLocation)
+	if err != nil {
+		return err
+	}
+	defer uploader.close()
+
+	files, err := set.FileRegistry.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list files for blob reconcile: %w", err)
+	}
+
+	var repaired, resized int
+	for _, f := range files {
+		fixture, ok := seedFixtureForRow(f)
+		if !ok {
+			continue
+		}
+		size, wrote, eerr := uploader.ensure(ctx, f.OriginalPath, fixture)
+		if eerr != nil {
+			return fmt.Errorf("reconcile blob for file %s (%s): %w", f.ID, f.OriginalPath, eerr)
+		}
+		if wrote {
+			repaired++
+		}
+		// Heal a drifted SizeBytes whether we just wrote the blob (the
+		// metadata-only row recorded 0) or the row simply disagreed with
+		// the blob already in the bucket. The per-group storage-usage
+		// aggregation (#1388) reads SizeBytes, so leaving it at 0 would
+		// undercount even after the bytes are restored.
+		if f.File != nil && f.SizeBytes != size {
+			f.SizeBytes = size
+			if _, uerr := set.FileRegistry.Update(ctx, *f); uerr != nil {
+				return fmt.Errorf("update size for reconciled file %s: %w", f.ID, uerr)
+			}
+			resized++
+		}
+	}
+	if repaired > 0 || resized > 0 {
+		slog.Info("Reconciled seed blobs",
+			"tenant", tenant.Slug,
+			"bytes_rewritten", repaired,
+			"sizes_healed", resized,
+		)
+	}
+	return nil
+}
+
+// seedFixtureForRow returns the bundled fixture a seeded file row was
+// created from, or ok=false when the row is not a reconcilable seed
+// fixture. Identification requires BOTH:
+//
+//   - the OriginalPath basename carries the seed prefix
+//     (`seed-<uuid><ext>`), so user-uploaded files are never matched even
+//     if a user happened to name one "invoice"; and
+//   - the row's Path still maps to a known fixture basename, so a seed
+//     file a user has since renamed is left untouched.
+//
+// The fixture's extension is checked against the row's so a row can never
+// be repaired with bytes of the wrong type (e.g. PDF bytes onto an image
+// row).
+func seedFixtureForRow(f *models.FileEntity) (fixtureKind, bool) {
+	if f == nil || f.File == nil {
+		return "", false
+	}
+	if !strings.HasPrefix(path.Base(f.OriginalPath), seedBasenamePrefix) {
+		return "", false
+	}
+	fixture, ok := fixtureByPathBasename[f.Path]
+	if !ok {
+		return "", false
+	}
+	if fixtureExt(fixture) != f.Ext {
+		return "", false
+	}
+	return fixture, true
+}

--- a/go/debug/seeddata/seeddata_test.go
+++ b/go/debug/seeddata/seeddata_test.go
@@ -573,6 +573,105 @@ func TestSeedDataBlobUploads_WhenOptIn(t *testing.T) {
 		qt.Commentf("seed fixtures written to the configured bucket"))
 }
 
+// TestSeedDataReconcilesMissingBlobsOnReseed reproduces the production
+// failure mode behind inv-vcl01-master's empty Files page: a database
+// first seeded metadata-only (blob uploads disabled for its tenant, the
+// pre-#1931 default) carries fixture file rows with SizeBytes 0 and no
+// objects in the bucket. The location-count idempotency gate means a
+// later re-seed short-circuits the whole seed — so before the reconcile
+// step, the bytes were never backfilled and the rows stayed dangling
+// forever. A second seed with the bucket + opt-in now configured must
+// repair them.
+func TestSeedDataReconcilesMissingBlobsOnReseed(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	factorySet := memory.NewFactorySet()
+
+	// First seed: no UploadLocation → no-op uploader → metadata-only rows.
+	// This is the state any demo/preview env seeded before #1931 is in.
+	_, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{
+		TenantSlug:            "acme",
+		CreateTenantIfMissing: true,
+		// UploadLocation empty: metadata-only, mirrors the pre-opt-in seed.
+	})
+	c.Assert(err, qt.IsNil)
+
+	images, withBytes := seededImageStats(c, factorySet, ctx)
+	c.Assert(images > 0, qt.IsTrue)
+	c.Assert(withBytes, qt.Equals, 0,
+		qt.Commentf("first seed wrote no bytes — rows are metadata-only"))
+
+	// Second seed: bucket + opt-in now wired (the post-#1931 config). The
+	// location-count gate makes this an "already seeded" no-op for the
+	// data tables, but reconcileSeedBlobs must still backfill the bytes.
+	tempDir := t.TempDir()
+	alreadySeeded, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{
+		TenantSlug:       "acme",
+		UploadLocation:   "file://" + tempDir + "?create_dir=1",
+		AllowBlobUploads: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(alreadySeeded, qt.IsTrue,
+		qt.Commentf("data tables already populated — this is the reconcile path"))
+
+	imagesAfter, withBytesAfter := seededImageStats(c, factorySet, ctx)
+	c.Assert(imagesAfter, qt.Equals, images,
+		qt.Commentf("reconcile must not create or drop rows"))
+	c.Assert(withBytesAfter, qt.Equals, imagesAfter,
+		qt.Commentf("every fixture row now carries the real byte count"))
+
+	// The fixture bytes physically landed in the bucket at the rows'
+	// pre-existing keys.
+	c.Assert(countRegularFiles(c, tempDir) > 0, qt.IsTrue,
+		qt.Commentf("reconcile wrote the missing blobs to the bucket"))
+
+	// Idempotent: a third identical seed finds every blob present and is a
+	// clean no-op (no error, nothing rewritten).
+	alreadySeeded, err = seeddata.SeedData(factorySet, seeddata.SeedOptions{
+		TenantSlug:       "acme",
+		UploadLocation:   "file://" + tempDir + "?create_dir=1",
+		AllowBlobUploads: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(alreadySeeded, qt.IsTrue)
+	_, withBytesFinal := seededImageStats(c, factorySet, ctx)
+	c.Assert(withBytesFinal, qt.Equals, imagesAfter)
+}
+
+// TestSeedDataReconcileRespectsBlobGate pins that the reconcile path
+// honours the same tenant gate as the fresh-seed upload path: a re-seed
+// of a non-`test-org` tenant WITHOUT the opt-in must not write bytes,
+// even with a real UploadLocation configured. Otherwise the reconcile
+// step would be a back door around the public-/api/v1/seed cost bound.
+func TestSeedDataReconcileRespectsBlobGate(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	factorySet := memory.NewFactorySet()
+
+	_, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{
+		TenantSlug:            "acme",
+		CreateTenantIfMissing: true,
+	})
+	c.Assert(err, qt.IsNil)
+
+	tempDir := t.TempDir()
+	alreadySeeded, err := seeddata.SeedData(factorySet, seeddata.SeedOptions{
+		TenantSlug:     "acme",
+		UploadLocation: "file://" + tempDir + "?create_dir=1",
+		// AllowBlobUploads left false — no opt-in.
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(alreadySeeded, qt.IsTrue)
+
+	_, withBytes := seededImageStats(c, factorySet, ctx)
+	c.Assert(withBytes, qt.Equals, 0,
+		qt.Commentf("reconcile must not write bytes without the opt-in"))
+	c.Assert(countRegularFiles(c, tempDir), qt.Equals, 0,
+		qt.Commentf("no objects written to the bucket without the opt-in"))
+}
+
 // seededImageStats returns (number of image-category file rows, number
 // of those carrying non-zero SizeBytes). Image-category rows only ever
 // come from the bundled fixture upload path, so they cleanly isolate the


### PR DESCRIPTION
Fixes three related defects discovered investigating why the Files page on the `inv-vcl01-master` preview showed broken images.

## 1. Seed: fixture blobs never uploaded for already-seeded DBs (root cause)

The seed creates a `FileEntity` row **and** uploads the fixture bytes in one pass, but `SeedData`'s idempotency gate short-circuits the **whole** seed once the data tables are populated — *before* the blob-upload step:

```go
if locCount > 0 { /* ... */ return true, nil }   // <- before blob upload
```

That gate keys only on **database** state, while the bytes live in a separate store (the demo MinIO bucket) with an independent lifecycle. So any DB seeded *metadata-only* keeps fixture rows pointing at objects that never get written, and no later re-seed repairs them:

- **Seeded before blob uploads were enabled for the tenant.** Blob writes for non-`test-org` tenants only became possible with the `AllowBlobUploads` opt-in (#1931). Anything first seeded before that has rows with `size_bytes = 0` and an empty bucket.
- **Bucket wiped independently of Postgres** (demo MinIO is an `emptyDir`).

`inv-vcl01-master` was first seeded **before #1931**, so its 55 fixture rows had `size_bytes = 0` against an empty bucket, and every subsequent master sync re-ran the seed as a ~6s "already seeded" no-op that never backfilled the bytes.

**Fix:** `reconcileSeedBlobs` runs on every seed call (incl. the already-seeded fast path), re-uploads any recognised seed fixture whose blob is missing, and heals a drifted `SizeBytes`. New idempotent `blobUploader.ensure(key, fixture)` writes only when the object is missing. Honours the same tenant gate as the fresh-seed upload path; only touches rows whose `OriginalPath` carries the seed prefix and whose `Path` still maps to a known fixture (never user data). Because master re-runs the seed on every push, affected envs self-heal on the next sync.

## 2. Thumbnails: 500 instead of placeholder when no job exists

`servePlaceholderThumbnail` matched `errors.Is(err, ErrNotFound)` with the **apiserver** sentinel, but `GetJobByFileID` wraps `registry.ErrNotFound`. `apiserver.ErrNotFound` *wraps* `registry.ErrNotFound` rather than the reverse, so `errors.Is` doesn't match in that direction — the "no job yet" case 500'd **before** enqueuing generation. On-demand thumbnails therefore never generated for any file without a pre-existing job (always true for seeded images; normal uploads hide it via eager generation). Now matches `registry.ErrNotFound` → enqueues + serves the placeholder. Regression test included.

## 3. Frontend: grid cards used the 150px thumbnail → blur

`FileCard` (full-width `aspect-[4/3]` cell) and the `CommodityFilesTab` photo grid (`aspect-square` cells, 3-col) preferred the `small` (150px) variant, which the browser upscaled ~2× into a ~250–300px card (intrinsic 150px rendered at ~295px → blurry). Now prefer `medium` (300px). Pure variant-selection change — layout/markup unchanged.

## Tests

- `go`: `TestSeedDataReconcilesMissingBlobsOnReseed`, `TestSeedDataReconcileRespectsBlobGate`, `TestServePlaceholderThumbnail_NoJobEnqueuesAndServesPlaceholder`; full `seeddata` + `apiserver` packages, `go vet`, `golangci-lint` green.
- `frontend`: `tsc -b` typecheck, `eslint`, and the files/commodity vitest suites (96 tests) green.

## Live env

`inv-vcl01-master` was repaired out-of-band so it's correct now: 55 fixture objects restored to the bucket + `size_bytes` healed, and 37 thumbnail-generation jobs enqueued (the running worker generated all of them). This PR makes it stay that way and prevents recurrence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Seed data reseed now reconciles and restores missing file content and corrects stored sizes when metadata exists but blob bytes are missing.
  * Placeholder thumbnail handler now enqueues generation when no job exists (avoids 500 error).

* **New Features**
  * Thumbnail selection now prefers medium thumbnails to reduce upscaling/blur.

* **Tests**
  * Added tests covering blob reconciliation on reseed and placeholder-thumbnail enqueue behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->