### PR TITLE
[#1370] Remove orphaned insurance stub-title key

### DIFF
--- a/frontend/src/i18n/locales/en/stubs.json
+++ b/frontend/src/i18n/locales/en/stubs.json
@@ -20,7 +20,6 @@
   "groupCreate": "Create group",
   "groupSettings": "Group settings",
   "helpCenter": "Help center",
-  "insurance": "Insurance",
   "inviteAccept": "Accept invite",
   "locationDetail": "Location",
   "locationEdit": "Edit location",


### PR DESCRIPTION
## What

Removes the orphaned `"insurance": "Insurance"` flat key from `frontend/src/i18n/locales/en/stubs.json`.

## Why

Since #1370 (PR #1950) the insurance route renders the real `InsuranceReportPage`, not a placeholder. The flat `stubs:insurance` title key — only ever consumed by the now-unmounted `PlaceholderPage` via `t(\`stubs:${titleKey}\`)` — is the last residue of the old stub and is referenced nowhere in code. (`ru`/`cs` never had it.)

This explains a report that the per-item *"Insurance report — Print-ready snapshot… Tracked by #1370"* stub was still visible: that text only exists in builds predating PR #1950. `master` already serves the real report; this PR just deletes the leftover dictionary entry.

## Verification

- `npm run i18n:check` → `catalogs in sync ✓` (the `i18next-cli extract --ci` pass reports *"No files were updated"* — the extractor does not want the key back).
- `npm run typecheck` → clean (`StubKey = keyof typeof enStubs` simply narrows; nothing references the removed key).
- `vitest src/pages/Placeholder.test.tsx src/i18n/__tests__/i18n.test.ts` → 8/8 pass.

## Follow-up

The broader dead-code cleanup — deleting `PlaceholderPage` entirely and pruning the rest of the now-orphaned flat `stubs.json` route-title keys + narrowing `preservePatterns` — is tracked separately in #1956.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated English localization strings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->