### PR TITLE
fix(helm): fresh argocdMode deploys deadlock — SA + demo Postgres wave ordering

### DIFF
--- a/helm/inventario/templates/demo/postgresql-configmap.yaml
+++ b/helm/inventario/templates/demo/postgresql-configmap.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo-postgresql
+  annotations:
+    # Same early wave as the demo-postgres Deployment that mounts it —
+    # see postgresql-deployment.yaml (#1884).
+    argocd.argoproj.io/sync-wave: "-7"
 data:
   01-create-users.sh: |
     #!/bin/sh

--- a/helm/inventario/templates/demo/postgresql-deployment.yaml
+++ b/helm/inventario/templates/demo/postgresql-deployment.yaml
@@ -6,6 +6,18 @@ metadata:
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo-postgresql
+  annotations:
+    # Bring the demo Postgres up BEFORE the wave--5 bootstrap setup Job,
+    # which connects to it on a fresh argocdMode install. Without this the
+    # Job's bootstrap can't resolve the demo-postgres service ("no such
+    # host"), never goes healthy, and ArgoCD never reaches wave 0 to create
+    # Postgres — a deadlock that only bites FRESH installs (existing envs
+    # keep a running Postgres across re-syncs). Same #1884 ordering gap as
+    # the ServiceAccount (see templates/serviceaccount.yaml). -7 is before
+    # the SA (-6) and the Job (-5); every demo-postgres resource shares it
+    # so the Secret/ConfigMap/PVC exist when the Deployment starts. Inert
+    # under plain `helm install`.
+    argocd.argoproj.io/sync-wave: "-7"
 spec:
   replicas: 1
   strategy:

--- a/helm/inventario/templates/demo/postgresql-pvc.yaml
+++ b/helm/inventario/templates/demo/postgresql-pvc.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo-postgresql
+  annotations:
+    # Same early wave as the demo-postgres Deployment that binds it —
+    # see postgresql-deployment.yaml (#1884).
+    argocd.argoproj.io/sync-wave: "-7"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/helm/inventario/templates/demo/postgresql-secret.yaml
+++ b/helm/inventario/templates/demo/postgresql-secret.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo-postgresql
+  annotations:
+    # Same early wave as the demo-postgres Deployment that mounts it —
+    # see postgresql-deployment.yaml (#1884).
+    argocd.argoproj.io/sync-wave: "-7"
 type: Opaque
 stringData:
   POSTGRES_DB: {{ .Values.demo.postgresql.database | quote }}

--- a/helm/inventario/templates/demo/postgresql-service.yaml
+++ b/helm/inventario/templates/demo/postgresql-service.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo-postgresql
+  annotations:
+    # Same early wave as the demo-postgres Deployment so the bootstrap can
+    # resolve this service — see postgresql-deployment.yaml (#1884).
+    argocd.argoproj.io/sync-wave: "-7"
 spec:
   selector:
     {{- include "inventario.selectorLabels" . | nindent 4 }}

--- a/helm/inventario/templates/serviceaccount.yaml
+++ b/helm/inventario/templates/serviceaccount.yaml
@@ -6,8 +6,20 @@ metadata:
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
     app.kubernetes.io/component: serviceaccount
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+    # Create the ServiceAccount BEFORE the bootstrap setup Job. In
+    # argocdMode that Job runs at sync-wave -5 (templates/job-setup.yaml)
+    # and references this SA by name; with the SA left at the default
+    # wave 0, ArgoCD applies the wave--5 Job first and waits for it to go
+    # healthy before creating wave-0 resources — but the Job can never
+    # schedule a pod ("serviceaccount ... not found"), so the whole sync
+    # deadlocks. This regressed when #1884 moved the Job to -5 without
+    # moving the SA it depends on. -6 is strictly before the Job (-5) and
+    # after the namespace ResourceQuota (-10). The annotation is inert
+    # under plain `helm install`, where the SA is created in normal
+    # manifest order.
+    argocd.argoproj.io/sync-wave: "-6"
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
## Symptom

A **freshly-created** PR preview (and any fresh argocdMode deploy: master, longevity) hangs forever. The ArgoCD Application sits `OutOfSync / Progressing`, the namespace has **zero pods**, and the setup Job is stuck `Running 0/1`:

```
Running: waiting for healthy state of batch/Job/<ns>-inventario-setup
```

## Root cause — two wave-ordering deadlocks, both regressions from #1884

#1884 moved the bootstrap setup Job to **sync-wave -5** but left two things it depends on at the default **wave 0**. In argocdMode ArgoCD applies wave -5 and **waits for that Job to be healthy before creating any wave-0 resource** — so anything the Job needs at wave 0 can never be created → deadlock.

**1. ServiceAccount.** `templates/serviceaccount.yaml` had no sync-wave:
```
FailedCreate: pods "<ns>-inventario-setup-" is forbidden:
  serviceaccount "<ns>-inventario" not found
```

**2. Demo Postgres.** Once the SA exists and the pod schedules, the bootstrap initContainer can't reach the DB (Deployment/Service/Secret/ConfigMap also at wave 0):
```
hostname resolving error: lookup <ns>-inventario-demo-postgres ... no such host
Bootstrap failed after 30 attempts
```

Both only bite **fresh installs**: an already-deployed env keeps its SA and a running Postgres across re-syncs, so the wave--5 bootstrap finds them. That's why existing envs (created before #1884 merged 2026-05-28) stayed green while a brand-new preview deadlocks. Confirmed live: `inv-vcl01-pr1897` (pre-#1884) is healthy; a new preview hit both errors above in sequence.

## Fix

Pull the setup Job's prerequisites into earlier waves:

| Resource | wave |
|---|---|
| `ResourceQuota` | -10 (unchanged) |
| demo Postgres (Deployment/Service/Secret/ConfigMap/PVC) | **-7** (new) |
| `ServiceAccount` | **-6** (new) |
| bootstrap setup Job | -5 (unchanged) |
| app Deployment, demo Redis/MinIO, ingress, … | 0 |
| init-data (migrate + seed) Job | +5 |

Redis/MinIO stay at wave 0 — only the init-data Job (+5) needs them. No `Role`/`RoleBinding` templates exist, so the SA is the only RBAC prerequisite. All annotations are **inert under plain `helm install`** (resources apply in normal manifest order).

## Validation

- `helm template … -f preview-base.values.yaml` → renders `postgres -7 → SA -6 → setup Job -5 → … → init-data +5`.
- `helm lint` clean on both the preview overlay and the longevity (PVC-persistence) overlay.
- Live: manually creating the missing SA let the job-controller schedule the setup pod (`SuccessfulCreate`); the bootstrap then surfaced the Postgres-resolution failure above — exactly the two-step deadlock this PR removes.

> [!NOTE]
> Existing previews that deploy a branch *without* this fix (e.g. an open PR's own preview) won't self-heal until the fix reaches that branch — they need the chart fix in their head commit. New deploys on a fixed `master` come up clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a deployment sync deadlock by ensuring service account creation occurs in the correct order.
  * Added Argo CD sync-ordering annotations so demo PostgreSQL resources (deployment, config, PVC, secret, service) are provisioned before bootstrap jobs, preventing startup timing issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->