### PR TITLE
fix(infra): bootstrap exits 5 when the sops bundle omits an optional section (e.g. velero)

### DIFF
--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -35,10 +35,16 @@ warn() { printf '\n[!] %s\n' "$*" >&2; }
 lookup() {
     local key="$1"
     jq -r --arg k "$key" '
+        # Only descend into objects. A missing intermediate key makes the
+        # parent resolve to null/"" — indexing that with the next segment is a
+        # jq RUNTIME ERROR ("Cannot index string", exit 5) that, under this
+        # script`s `set -Eeuo pipefail`, aborts the whole run. Guarding on
+        # object type returns empty for any missing segment, matching the
+        # "empty string if any segment is missing" contract above.
         def lookup($parts; $v):
           if ($parts | length) == 0 then $v
-          else lookup($parts[1:]; $v[$parts[0]] // "")
-          end;
+          elif ($v | type) == "object" then lookup($parts[1:]; $v[$parts[0]])
+          else "" end;
         lookup($k | split("."); .) // empty
     ' <<<"$SECRETS_JSON" 2>/dev/null
 }

--- a/infra/vm/vm-install.sh
+++ b/infra/vm/vm-install.sh
@@ -38,10 +38,18 @@ sops_get() {
     local key="$1"
     [ -f "$SECRETS_FILE" ] || return 0
     jq -r --arg k "$key" '
+        # Walk the dotted path, but only descend when the current value is an
+        # object. A missing intermediate key (e.g. the whole `velero` section
+        # absent on a bundle that never configured backups) makes the parent
+        # resolve to null/"" — indexing that with the next segment is a jq
+        # RUNTIME ERROR ("Cannot index string", exit 5), which under the
+        # caller`s `set -e` aborts the whole bootstrap. Guarding on object
+        # type returns empty for any missing segment instead, matching this
+        # helper`s documented "empty if absent" contract.
         def lookup($parts; $v):
           if ($parts | length) == 0 then $v
-          else lookup($parts[1:]; $v[$parts[0]] // "")
-          end;
+          elif ($v | type) == "object" then lookup($parts[1:]; $v[$parts[0]])
+          else "" end;
         lookup($k | split("."); .) // empty
     ' "$SECRETS_FILE" 2>/dev/null
 }


### PR DESCRIPTION
## Symptom

`make -C infra bootstrap VM=…` dies with **`make: *** [bootstrap] Error 5`** right after the ArgoCD install step — **before** secrets and the ApplicationSets are applied. Net effect: master/longevity never register in ArgoCD, and `inv-vcl01-master/inventario-admin` is never created, even though those steps are themselves correct.

## Root cause

`sops_get` (vm-install.sh) and the identical `lookup` (apply-secrets.sh) resolve a dotted key with:

```jq
def lookup($parts; $v):
  if ($parts | length) == 0 then $v
  else lookup($parts[1:]; $v[$parts[0]] // "")
  end;
```

When an **intermediate** section is absent — e.g. a bundle that never configured Velero/R2 has no top-level `velero` key — the parent resolves to `""`, and the next segment indexes a **string**, which is a jq **runtime error** (`Cannot index string with "s3_bucket"`, **exit 5**), not a graceful empty. Both helpers run under `set -e`, so that exit 5 aborts the whole bootstrap.

The first post-ArgoCD line in vm-install.sh is `VELERO_S3_BUCKET=$(sops_get "velero.s3_bucket")`, which is exactly where it dies. Reproduction:

```
$ echo '{"tailscale":{"oauth_client_secret":"x"}}' | jq -r '<lookup> velero.s3_bucket'
jq: error: Cannot index string with string "s3_bucket"     # exit 5
```

It only bites bundles missing an optional section, which is why it surfaced now (a bundle without `velero.*`).

## Fix

Descend only when the current value is an object; return `""` for any missing segment — matching both helpers' documented *"empty if absent"* contract:

```jq
def lookup($parts; $v):
  if ($parts | length) == 0 then $v
  elif ($v | type) == "object" then lookup($parts[1:]; $v[$parts[0]])
  else "" end;
```

Now a bundle can legitimately omit optional sections (`velero`, `jwt`, `file_signing`, `oauth_state`, …) without aborting bootstrap.

## Validation

- jq: present keys still resolve; missing-parent keys (`velero.s3_bucket`, `jwt.secret`) return empty with **exit 0**; present-but-empty leaves return empty.
- `bash -n` passes on both scripts.

`bootstrap.sh` uploads the local `vm-install.sh`/`apply-secrets.sh`, so re-running `make bootstrap` from this branch already gets past the failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed script failures caused by JSON path lookups encountering non-object intermediate values. Enhanced error handling to gracefully manage missing or unexpected value types, preventing script aborts while preserving expected behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/denisvmedia/inventario/pull/1960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->