### PR TITLE
[#1972] Show build commit short-hash as a faint bottom-right badge

### DIFF
--- a/frontend/src/app/Shell.tsx
+++ b/frontend/src/app/Shell.tsx
@@ -3,6 +3,7 @@ import { Outlet } from "react-router-dom"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { AppSidebar } from "@/components/AppSidebar"
 import { CommandPalette } from "@/components/CommandPalette"
+import { CommitBadge } from "@/components/CommitBadge"
 import { CurrencyMigrationBanner } from "@/components/CurrencyMigrationBanner"
 import { ImpersonationBanner } from "@/components/ImpersonationBanner"
 import { InviteBanner } from "@/components/InviteBanner"
@@ -74,6 +75,9 @@ export function Shell() {
               </SidebarInset>
               <CommandPalette />
               <Toaster />
+              {/* Faint build-commit watermark, bottom-right, hidden on
+                  mobile; renders nothing in dev/tests (#1972). */}
+              <CommitBadge />
               {tour.isOpen ? (
                 <OnboardingTour
                   step={tour.step}

--- a/frontend/src/components/CommitBadge.tsx
+++ b/frontend/src/components/CommitBadge.tsx
@@ -1,0 +1,32 @@
+import { useSystemInfo } from "@/features/system/hooks"
+
+// A faint, non-interactive watermark pinned to the bottom-right corner that
+// shows the build commit short-hash (#1972). The backend is the source of
+// truth: the hash is injected into the binary at build time and surfaced via
+// `GET /api/v1/system`; this component only renders it.
+//
+// Mounted inside the authenticated Shell, so it's auth-gated for free and
+// never appears on /login or other public pages. Hidden on mobile.
+//
+// goreleaser injects the full 40-char SHA while `make` injects the 7-char
+// short hash — we truncate to 7 for display and keep the full SHA (plus the
+// version) in the tooltip, which works for either build path. In dev / tests
+// the binary reports "unknown", so we render nothing.
+export function CommitBadge() {
+  const { data } = useSystemInfo()
+  const commit = data?.commit
+  if (!commit || commit === "unknown") {
+    return null
+  }
+
+  const short = commit.slice(0, 7)
+  return (
+    <div
+      aria-hidden="true"
+      title={data?.version ? `${data.version} · ${commit}` : commit}
+      className="pointer-events-none fixed right-2 bottom-1.5 z-40 hidden font-mono text-[10px] leading-none text-muted-foreground/50 select-none sm:block"
+    >
+      {short}
+    </div>
+  )
+}

--- a/frontend/src/components/__tests__/CommitBadge.test.tsx
+++ b/frontend/src/components/__tests__/CommitBadge.test.tsx
@@ -12,7 +12,7 @@ const mockUseSystemInfo = vi.mocked(useSystemInfo)
 
 // Only `data` is read by the component; cast a minimal shape.
 function withData(data: unknown) {
-  mockUseSystemInfo.mockReturnValue({ data } as ReturnType<typeof useSystemInfo>)
+  mockUseSystemInfo.mockReturnValue({ data } as unknown as ReturnType<typeof useSystemInfo>)
 }
 
 describe("CommitBadge", () => {
@@ -22,6 +22,16 @@ describe("CommitBadge", () => {
     const badge = screen.getByText("e814328")
     expect(badge).toBeInTheDocument()
     expect(badge).toHaveAttribute("title", "1.2.3 · e8143282abcdef0123456789abcdef0123456789")
+  })
+
+  it("stays a hidden-on-mobile, click-through watermark (acceptance criteria)", () => {
+    withData({ commit: "e814328", version: "1.2.3" })
+    render(<CommitBadge />)
+    const badge = screen.getByText("e814328")
+    // hidden by default, only shown from the `sm` breakpoint up
+    expect(badge).toHaveClass("hidden", "sm:block")
+    // never intercepts clicks on the content beneath it
+    expect(badge).toHaveClass("pointer-events-none")
   })
 
   it("renders an already-short hash unchanged (local make build)", () => {

--- a/frontend/src/components/__tests__/CommitBadge.test.tsx
+++ b/frontend/src/components/__tests__/CommitBadge.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+import { CommitBadge } from "@/components/CommitBadge"
+import { useSystemInfo } from "@/features/system/hooks"
+
+vi.mock("@/features/system/hooks", () => ({
+  useSystemInfo: vi.fn(),
+}))
+
+const mockUseSystemInfo = vi.mocked(useSystemInfo)
+
+// Only `data` is read by the component; cast a minimal shape.
+function withData(data: unknown) {
+  mockUseSystemInfo.mockReturnValue({ data } as ReturnType<typeof useSystemInfo>)
+}
+
+describe("CommitBadge", () => {
+  it("renders the 7-char short hash from a full SHA, full SHA + version in the tooltip", () => {
+    withData({ commit: "e8143282abcdef0123456789abcdef0123456789", version: "1.2.3" })
+    render(<CommitBadge />)
+    const badge = screen.getByText("e814328")
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveAttribute("title", "1.2.3 · e8143282abcdef0123456789abcdef0123456789")
+  })
+
+  it("renders an already-short hash unchanged (local make build)", () => {
+    withData({ commit: "e814328", version: "dev" })
+    render(<CommitBadge />)
+    expect(screen.getByText("e814328")).toBeInTheDocument()
+  })
+
+  it("renders nothing when the commit is unknown (dev/tests)", () => {
+    withData({ commit: "unknown", version: "dev" })
+    const { container } = render(<CommitBadge />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders nothing before the /system response lands", () => {
+    withData(undefined)
+    const { container } = render(<CommitBadge />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/features/system/api.ts
+++ b/frontend/src/features/system/api.ts
@@ -1,0 +1,13 @@
+import { http } from "@/lib/http"
+import type { Schema } from "@/types"
+
+// System/build info served by `GET /api/v1/system`. The `version`, `commit`
+// and `build_date` fields are injected into the Go binary at build time via
+// ldflags (see .goreleaser.yaml / Makefile); everything else is runtime.
+export type SystemInfo = Schema<"apiserver.SystemInfo">
+
+// `/system` is not group-scoped, so the http helper sends it verbatim under
+// /api/v1 with no /g/{slug} rewrite.
+export function getSystemInfo(signal?: AbortSignal): Promise<SystemInfo> {
+  return http.get<SystemInfo>("/system", { signal })
+}

--- a/frontend/src/features/system/hooks.ts
+++ b/frontend/src/features/system/hooks.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { getSystemInfo } from "./api"
+
+export const systemKeys = {
+  all: ["system"] as const,
+  info: () => [...systemKeys.all, "info"] as const,
+}
+
+// Build/system info is immutable for the lifetime of a deploy, so we fetch it
+// once and never revalidate — no focus refetch, no retry churn. Currently
+// only the CommitBadge consumes it (#1972).
+export function useSystemInfo() {
+  return useQuery({
+    queryKey: systemKeys.info(),
+    queryFn: ({ signal }) => getSystemInfo(signal),
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    retry: false,
+  })
+}


### PR DESCRIPTION
Closes #1972.

## What

A faint, non-interactive watermark pinned to the bottom-right corner showing the running build's commit short-hash, for logged-in users only.

![bottom-right corner, ~10px muted monospace]

## Approach (backend already does the heavy lifting)

The backend is the source of truth — no backend or release changes were needed:

- `.goreleaser.yaml` already injects `version.Version/Commit/Date` via ldflags (and `Makefile` does the same for local `make` builds).
- `GET /api/v1/system` (`apiserver.SystemInfo`) already returns `commit`, mounted under plain user middleware → any authenticated user can read it.

So this is **frontend-only**: read `/system` and render `commit`.

## Changes

- **`features/system/`** — `getSystemInfo()` + `useSystemInfo()` (React Query, `staleTime: Infinity`, no focus refetch / retry, since build info is immutable per deploy → one fetch per session).
- **`CommitBadge`** — mounted once in the authenticated `Shell` (wrapped by `ProtectedRoute`), so it's **auth-gated** for free and never appears on `/login` or other public pages.
  - `hidden sm:block` → not rendered on mobile.
  - `pointer-events-none` → never intercepts clicks.
  - faint `text-muted-foreground/50`, `text-[10px]`, monospace.
  - Truncates to a **7-char short hash** (goreleaser injects the full 40-char SHA; `make` injects the short one) and keeps the full SHA + version in the `title` tooltip.
  - Renders **nothing** when the commit is `"unknown"` (dev / tests) or before the response lands.

## Notes / decisions

- We deliberately **do not** switch goreleaser to `{{.ShortCommit}}` — FE-side truncation keeps the full SHA available for the tooltip and works for both build paths.
- Reuses the existing `/system` endpoint (which also returns settings + runtime metrics) rather than splitting a lighter `/version`; fine for a once-per-session, aggressively-cached fetch.

## Verification

- New `CommitBadge.test.tsx` (4 cases: full-SHA truncation + tooltip, already-short hash, `"unknown"` → nothing, pre-load → nothing) ✅
- Full vitest suite: **1187 passed** ✅
- `npm run lint` ✅ · `npm run format:check` ✅ · `npm run build` ✅

**Visual caveat:** in dev (`go run`) `version.Commit == "unknown"`, so the badge is intentionally hidden — to eyeball it, run a `make build` binary (which injects the short hash) and load the embedded UI.