### PR TITLE
[#1971] Fix undeletable PR previews: bound setup Jobs, retry syncs, finalizer-prune, stop GHCR sha churn

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -306,36 +306,20 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Delete currently tagged PR image versions before re-publishing
-        # PR-only. Delete-before-push keeps PR-tagged versions discoverable
-        # for the close-time cleanup instead of overwriting tags onto older
-        # GHCR versions.
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          PACKAGE_NAME: inventario
-          PR_TAG: pr-${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          owner_type="$(gh api "/users/${OWNER}" --jq '.type')"
-          if [ "${owner_type}" = "Organization" ]; then
-            package_api="/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
-          else
-            package_api="/users/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
-          fi
-          mapfile -t version_ids < <(
-            gh api "${package_api}?per_page=100" --paginate \
-              --jq '.[] | select(any((.metadata.container.tags // [])[]; . == env.PR_TAG)) | .id'
-          )
-          if [ "${#version_ids[@]}" -eq 0 ]; then
-            echo "No currently tagged GHCR package versions found for ${PR_TAG}"
-            exit 0
-          fi
-          for version_id in "${version_ids[@]}"; do
-            gh api --method DELETE "${package_api}/${version_id}"
-            echo "Deleted currently tagged package version ${version_id} for ${PR_TAG} before re-publish"
-          done
+      # NB: there is deliberately NO "delete the previous PR version before
+      # re-publishing" step here anymore. That step used to delete the GHCR
+      # version tagged pr-<N> on every push — but that version also carried
+      # the previous commit's sha-<7> tag, so it destroyed an image a running
+      # preview env could still be pulling (it pins image.tag to that exact
+      # sha until the ApplicationSet re-renders to the new head). That was the
+      # root trigger of the #1971 "stuck, undeletable preview" deadlock and it
+      # broke the in-code promise that sha-<7> is immutable per commit.
+      #
+      # Now every commit's image simply persists for the life of the PR
+      # (imagetools below just moves the mutable pr-<N> tag onto the new
+      # version; the prior version keeps its sha-<7> tag). All of a PR's
+      # images — pr-<N> and every per-commit sha-<7> — are reclaimed in one
+      # shot by the `cleanup` job when the PR closes.
 
       - name: Create multi-arch manifest list
         # Registry-side stitching: imagetools reads the per-arch manifests by
@@ -410,21 +394,46 @@ jobs:
           echo "Pinned inv-vcl01-master image to sha-${SHORT_SHA}"
 
   cleanup:
-    name: Cleanup PR image
+    name: Cleanup PR images
     if: |
       github.event_name == 'pull_request' &&
       github.event.action == 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # Needed to list the PR's commits so we know which sha-<7> tags belong
+      # to this PR (and only this PR).
+      pull-requests: read
     steps:
-      - name: Delete PR image
+      - name: Delete all GHCR image versions published by this PR
+        # Reclaim every image this PR ever published — the final pr-<N>
+        # version AND each per-commit sha-<7> version (we stopped deleting
+        # those on push; see the merge job). We enumerate the PR's commits to
+        # derive exactly which sha-<7> tags are ours, so we never touch
+        # master/edge/tag images or another PR's images.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}
           PACKAGE_NAME: inventario
-          PR_TAG: pr-${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+
+          # Tags this PR may have published: pr-<N> + sha-<7> for every commit
+          # on the PR (paginated, so long PRs are fully covered). Commits that
+          # were rebased/force-pushed away aren't in this list; any image they
+          # left behind is swept later by time-based GHCR retention, not here.
+          declare -A pr_tags=( ["pr-${PR_NUMBER}"]=1 )
+          while IFS= read -r full_sha; do
+            [ -z "$full_sha" ] && continue
+            pr_tags["sha-${full_sha:0:7}"]=1
+          done < <(
+            gh api "/repos/${REPO}/pulls/${PR_NUMBER}/commits?per_page=100" --paginate \
+              --jq '.[].sha'
+          )
 
           owner_type="$(gh api "/users/${OWNER}" --jq '.type')"
           if [ "${owner_type}" = "Organization" ]; then
@@ -433,17 +442,24 @@ jobs:
             package_api="/users/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
           fi
 
-          mapfile -t version_ids < <(
+          # For each package version, delete it if ANY of its tags is one of
+          # ours. The multi-arch manifest list carries both pr-<N> and its
+          # sha-<7>; intermediate per-commit versions carry only sha-<7>.
+          deleted=0
+          while IFS=$'\t' read -r version_id tags_csv; do
+            [ -z "$version_id" ] && continue
+            IFS=',' read -ra tags <<< "${tags_csv}"
+            for t in "${tags[@]}"; do
+              if [ -n "${pr_tags[$t]:-}" ]; then
+                gh api --method DELETE "${package_api}/${version_id}"
+                echo "Deleted package version ${version_id} (tags: ${tags_csv:-<none>})"
+                deleted=$((deleted + 1))
+                break
+              fi
+            done
+          done < <(
             gh api "${package_api}?per_page=100" --paginate \
-              --jq '.[] | select(any((.metadata.container.tags // [])[]; . == env.PR_TAG)) | .id'
+              --jq '.[] | [(.id|tostring), ((.metadata.container.tags // []) | join(","))] | @tsv'
           )
 
-          if [ "${#version_ids[@]}" -eq 0 ]; then
-            echo "No GHCR package versions found for ${PR_TAG}"
-            exit 0
-          fi
-
-          for version_id in "${version_ids[@]}"; do
-            gh api --method DELETE "${package_api}/${version_id}"
-            echo "Deleted package version ${version_id} for ${PR_TAG}"
-          done
+          echo "Deleted ${deleted} package version(s) for PR #${PR_NUMBER}."

--- a/helm/inventario/templates/job-init-data.yaml
+++ b/helm/inventario/templates/job-init-data.yaml
@@ -38,6 +38,12 @@ metadata:
     "argocd.argoproj.io/sync-options": "Force=true,Replace=true"
 spec:
   backoffLimit: 3
+  {{- with .Values.setupJob.initData.activeDeadlineSeconds }}
+  # Cap the Job's wall-clock so an unpullable image fails the Job (and the
+  # sync op) instead of hanging it indefinitely. See values.yaml
+  # setupJob.initData.activeDeadlineSeconds.
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/helm/inventario/templates/job-setup.yaml
+++ b/helm/inventario/templates/job-setup.yaml
@@ -40,6 +40,15 @@ metadata:
     {{- end }}
 spec:
   backoffLimit: 3
+  {{- with .Values.setupJob.activeDeadlineSeconds }}
+  # Cap the Job's wall-clock so an unpullable image (e.g. a PR preview pinned
+  # to a sha- tag CI hasn't published yet / has GC'd) FAILS instead of sitting
+  # in ImagePullBackOff forever. A failed Job fails the sync op rather than
+  # leaving it Running, which is what otherwise deadlocks the
+  # resources-finalizer cascade and makes the Application undeletable. See
+  # values.yaml setupJob.activeDeadlineSeconds for the full rationale.
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
   {{- if not .Values.setupJob.argocdMode }}
   # Auto-delete the Job 24h after it completes — keeps `kubectl get jobs`
   # clean for `helm install` consumers where the Job is a one-shot hook.

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -577,6 +577,27 @@ setupJob:
   # See helm/inventario/README.md → "ArgoCD-managed migrations".
   argocdMode: false
 
+  # Hard wall-clock cap on the bootstrap/setup Job (templates/job-setup.yaml).
+  #
+  # WHY this exists: a setup Job pinned to an image tag that isn't in the
+  # registry — e.g. a PR preview pinned to sha-<commit> while CI is still
+  # building it, or after that tag was deleted — sits in ImagePullBackOff
+  # forever. ImagePullBackOff never starts the container, so `backoffLimit`
+  # is never consumed and the Job runs unbounded. In argocdMode (wave -5)
+  # that wedges the sync operation ("waiting for healthy state of …-setup"),
+  # and a perpetually-Running operation BLOCKS ArgoCD's resources-finalizer
+  # cascade — making the whole Application undeletable (#1971 post-mortem).
+  #
+  # A deadline turns "hang forever" into "fail after N seconds": the sync op
+  # fails instead of running, deletion is unblocked, and syncPolicy.retry on
+  # the ApplicationSets re-attempts until the image lands so the env
+  # self-heals. Set GENEROUSLY (> a cold CI build): while the pod sits in
+  # ImagePullBackOff the kubelet keeps retrying the pull, so an image that is
+  # merely still-building is picked up by the SAME Job attempt with zero
+  # failures; the deadline only trips on a genuinely-missing image.
+  # 0 disables the cap (restores the old unbounded behavior).
+  activeDeadlineSeconds: 900
+
   bootstrap:
     # Whether to run the DB bootstrap step (creates migrator DB user).
     # Set to false if you manage DB users externally.
@@ -597,6 +618,14 @@ setupJob:
     usernameForMigrations: "inventario_migrator"
 
   initData:
+    # Wall-clock cap on the init-data Job (templates/job-init-data.yaml,
+    # sync-wave +5). Same rationale as setupJob.activeDeadlineSeconds above
+    # (a missing image must fail the Job instead of hanging the sync op and
+    # blocking deletion), but larger because seeding — seedDatabase /
+    # seedBlobUploads — legitimately takes longer (it starts a temporary
+    # server in-pod and writes fixture blobs). 0 disables the cap.
+    activeDeadlineSeconds: 1800
+
     # Default tenant display name
     # Env: INVENTARIO_MIGRATE_DATA_DEFAULT_TENANT_NAME
     defaultTenantName: "Default Organization"

--- a/infra/argocd/applicationset-longevity.yaml
+++ b/infra/argocd/applicationset-longevity.yaml
@@ -106,6 +106,16 @@ spec:
         automated:
           prune: true
           selfHeal: true
+        # Re-attempt a failed sync with backoff so a master push self-heals
+        # across the build/deploy race (see applicationset-master.yaml). The
+        # setup Job fails fast on a not-yet-pullable image
+        # (activeDeadlineSeconds) and retry re-syncs until it's published.
+        retry:
+          limit: 10
+          backoff:
+            duration: 15s
+            factor: 2
+            maxDuration: 3m
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true

--- a/infra/argocd/applicationset-master.yaml
+++ b/infra/argocd/applicationset-master.yaml
@@ -144,6 +144,18 @@ spec:
         automated:
           prune: true
           selfHeal: true
+        # Re-attempt a failed sync with backoff so a master push self-heals
+        # across the same build/deploy race the PR previews hit: the pin file
+        # flips to the new sha-<7> as soon as the image publish job force-
+        # pushes it, but if a sync fires against an image that isn't fully
+        # propagated yet the setup Job fails fast (activeDeadlineSeconds) and
+        # retry re-syncs until it's pullable. Mirrors applicationset-pr.yaml.
+        retry:
+          limit: 10
+          backoff:
+            duration: 15s
+            factor: 2
+            maxDuration: 3m
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true

--- a/infra/argocd/applicationset-pr.yaml
+++ b/infra/argocd/applicationset-pr.yaml
@@ -40,6 +40,16 @@ spec:
   template:
     metadata:
       name: 'inv-vcl01-pr{{.number}}'
+      # Cascade-prune the Application's resources when the PR is unlabeled or
+      # closed and the generator drops it. Without this finalizer the
+      # ApplicationSet deletes only the Application object and leaves the
+      # whole namespace's workloads (Deployments, demo Postgres/MinIO/Redis,
+      # the Tailscale Ingress) orphaned — which is why stale inv-vcl01-pr*
+      # namespaces used to pile up. Safe to enable now that
+      # setupJob.activeDeadlineSeconds (helm) stops a stuck image pull from
+      # wedging the sync op and thereby deadlocking this very finalizer.
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
       labels:
         inventario-preview: "true"
         inventario-pr: '{{.number}}'
@@ -95,6 +105,21 @@ spec:
         automated:
           prune: true
           selfHeal: true
+        # Re-attempt a failed sync with backoff. This is what makes the
+        # build/deploy race self-heal: the generator pins image.tag to the PR
+        # head's sha-<7> the instant the commit lands, but CI publishes that
+        # image a few minutes later. If the setup Job hits its
+        # activeDeadlineSeconds before the image exists, the sync fails;
+        # retry keeps re-syncing (and requeueAfterSeconds re-renders to the
+        # newest head SHA) until the image is published — so the preview
+        # converges on its own instead of going stuck-red or, worse,
+        # undeletable.
+        retry:
+          limit: 10
+          backoff:
+            duration: 15s
+            factor: 2
+            maxDuration: 3m
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true


### PR DESCRIPTION
## Problem

A PR-preview Application (`inv-vcl01-pr<N>`) got wedged in `Terminating` for hours and could not be deleted. Investigating it on the cluster (`~/.kube/inv-vcl01.config`) revealed a **two-part deadlock**:

1. **CI destroyed the in-flight image.** `.github/workflows/docker.yml`'s *"Delete currently tagged PR image versions before re-publishing"* step deleted the GHCR version tagged `pr-<N>` on **every** push — but that multi-arch version co-carried **both** `pr-<N>` **and** `sha-<7>`. So it destroyed the previous commit's immutable `sha-<7>` image while a live preview was still pinned to it (the PR ApplicationSet pins `image.tag: sha-{{.head_short_sha_7}}`). This broke the in-code promise that `sha-<7>` is immutable per commit.

2. **The setup Job hung forever and blocked deletion.** `templates/job-setup.yaml` (sync-wave `-5`) had no `activeDeadlineSeconds`. An `ImagePullBackOff` never starts the container, so `backoffLimit` is never consumed and the Job runs **unbounded** → the ArgoCD sync operation stays `Running` (`waiting for healthy state of …-setup`). A perpetually-Running operation **blocks the `resources-finalizer` cascade**, so the Application can never finish deleting.

Observed on the cluster: `deletionTimestamp` set ~2h, `resources-finalizer.argocd.argoproj.io` present, op `Running` on the setup Job, whose init container was stuck pulling `ghcr.io/denisvmedia/inventario:sha-5c774f4` → `NotFound`. The ApplicationSet meanwhile logged `generated 0 applications` + repeated `Deleted application` (the `preview` label was already removed, so the generator no longer wanted it).

A related side effect: the PR ApplicationSet template had **no finalizer**, so a normal unlabel/close deleted only the Application object and left the namespace's workloads orphaned (the stale `inv-vcl01-pr*` namespaces that pile up).

## Fix (defense in depth)

| # | Change | Effect |
|---|--------|--------|
| 1 | `setupJob.activeDeadlineSeconds: 900` + `setupJob.initData.activeDeadlineSeconds: 1800` (helm), rendered via `{{- with }}` so `0` disables | A missing / not-yet-built image **fails the Job fast** instead of hanging the sync op → deletion is never blocked. Set generously (> a cold CI build) so the kubelet's pull-retries pick up a still-building image within the **same** Job attempt — zero failures in the normal build-lag case. |
| 1 | `syncPolicy.retry` (limit 10, `15s ×2 → 3m`) on the `pr` / `master` / `longevity` ApplicationSets | A failed sync **self-heals** once CI publishes the image (`requeueAfterSeconds: 60` re-renders to the newest head SHA in the meantime). |
| 2 | Drop `delete-before-push` in `docker.yml`; rework PR-close cleanup | `sha-<7>` is immutable again; every commit's image persists for the PR's life and is reclaimed in **one shot at close** — the cleanup enumerates the PR's commits to delete exactly `pr-<N>` + each `sha-<7>` (never master/edge/tag or other PRs' images). |
| 3 | `resources-finalizer.argocd.argoproj.io` on the PR ApplicationSet template | Unlabel/close now **cascade-prunes** the namespace's resources instead of orphaning them. Safe now that the Job deadline keeps a stuck sync op from wedging this very finalizer. |

### Why fail-fast doesn't hurt the "image not built yet" race
The deadline is deliberately **larger than a cold CI build**. While the pod sits in `ImagePullBackOff` the kubelet keeps retrying the pull, so an image that is merely still-building is picked up by the same Job attempt with **no failure**. The deadline only trips on a genuinely-missing image — and then the op **fails** (instead of running forever) → deletion is unblocked and `retry` re-syncs until CI publishes it. Net: never wedges, never undeletable, self-heals.

## Files
- `helm/inventario/values.yaml` — two `activeDeadlineSeconds` knobs + rationale
- `helm/inventario/templates/job-setup.yaml`, `job-init-data.yaml` — render the caps (guarded; `0` omits)
- `infra/argocd/applicationset-pr.yaml` — `retry` + `resources-finalizer`
- `infra/argocd/applicationset-master.yaml`, `applicationset-longevity.yaml` — `retry`
- `.github/workflows/docker.yml` — remove `delete-before-push`; rework PR-close image cleanup

## Validation
- `helm template` in **default**, **argocdMode**, and **preview-overlay** modes: setup Job (wave `-5`) → `activeDeadlineSeconds: 900`, init-data (wave `+5`) → `1800`; with `=0` the field is omitted.
- YAML-parsed all three ApplicationSets (`retry` present everywhere, finalizer only on PR) and `docker.yml` (delete-before-push gone, cleanup enumerates PR commits, `pull-requests: read` set).

## Follow-ups (not in this PR)
- Images from rebased/force-pushed-away commits aren't in the PR's final commit list, so close-cleanup misses them → add a time-based GHCR retention sweep.
- With `CreateNamespace=true`, ArgoCD prunes the chart's resources but not the namespace object itself — an empty `inv-vcl01-pr*` ns may remain. Add an in-chart `Namespace` resource or a periodic sweep if zero-residue is desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout limits for setup job execution phases to prevent indefinite hangs
  * Added automatic retry mechanism with exponential backoff for failed deployment synchronizations

* **Improvements**
  * Enhanced cleanup of container images when pull requests close, now removing all related image versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->