### PR TITLE
[#1974 follow-up] Combined-Job deadline budget + paginated GHCR cleanup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -442,18 +442,20 @@ jobs:
             package_api="/users/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
           fi
 
-          # For each package version, delete it if ANY of its tags is one of
-          # ours. The multi-arch manifest list carries both pr-<N> and its
+          # Pass 1 — collect the version ids to delete. We must NOT delete
+          # inside the `gh api --paginate` stream: removing a version from an
+          # earlier page shifts the remaining pages, so later matches would be
+          # skipped and survive cleanup. Drain the full listing first, then
+          # delete in pass 2. A version is ours if ANY of its tags is one of
+          # ours — the multi-arch manifest list carries both pr-<N> and its
           # sha-<7>; intermediate per-commit versions carry only sha-<7>.
-          deleted=0
+          versions_to_delete=()
           while IFS=$'\t' read -r version_id tags_csv; do
             [ -z "$version_id" ] && continue
             IFS=',' read -ra tags <<< "${tags_csv}"
             for t in "${tags[@]}"; do
               if [ -n "${pr_tags[$t]:-}" ]; then
-                gh api --method DELETE "${package_api}/${version_id}"
-                echo "Deleted package version ${version_id} (tags: ${tags_csv:-<none>})"
-                deleted=$((deleted + 1))
+                versions_to_delete+=("${version_id}"$'\t'"${tags_csv}")
                 break
               fi
             done
@@ -461,5 +463,16 @@ jobs:
             gh api "${package_api}?per_page=100" --paginate \
               --jq '.[] | [(.id|tostring), ((.metadata.container.tags // []) | join(","))] | @tsv'
           )
+
+          # Pass 2 — delete the collected versions.
+          deleted=0
+          if [ "${#versions_to_delete[@]}" -gt 0 ]; then
+            for row in "${versions_to_delete[@]}"; do
+              IFS=$'\t' read -r version_id tags_csv <<< "${row}"
+              gh api --method DELETE "${package_api}/${version_id}"
+              echo "Deleted package version ${version_id} (tags: ${tags_csv:-<none>})"
+              deleted=$((deleted + 1))
+            done
+          fi
 
           echo "Deleted ${deleted} package version(s) for PR #${PR_NUMBER}."

--- a/helm/inventario/templates/job-setup.yaml
+++ b/helm/inventario/templates/job-setup.yaml
@@ -40,14 +40,31 @@ metadata:
     {{- end }}
 spec:
   backoffLimit: 3
-  {{- with .Values.setupJob.activeDeadlineSeconds }}
-  # Cap the Job's wall-clock so an unpullable image (e.g. a PR preview pinned
-  # to a sha- tag CI hasn't published yet / has GC'd) FAILS instead of sitting
-  # in ImagePullBackOff forever. A failed Job fails the sync op rather than
-  # leaving it Running, which is what otherwise deadlocks the
-  # resources-finalizer cascade and makes the Application undeletable. See
-  # values.yaml setupJob.activeDeadlineSeconds for the full rationale.
-  activeDeadlineSeconds: {{ . }}
+  {{- /*
+    Cap the Job's wall-clock so an unpullable image (e.g. a PR preview pinned
+    to a sha- tag CI hasn't published yet / has GC'd) FAILS instead of sitting
+    in ImagePullBackOff forever. A failed Job fails the sync op rather than
+    leaving it Running, which is what otherwise deadlocks the
+    resources-finalizer cascade and makes the Application undeletable. See
+    values.yaml setupJob.activeDeadlineSeconds for the full rationale.
+
+    Budget depends on what this Job actually does:
+      - argocdMode  → bootstrap-only (migrate + init-data/seed run in the
+        Deployment's migrate init container and the separate wave +5
+        init-data Job), so the setup budget is just setupJob.activeDeadlineSeconds.
+      - non-argocd  → this ONE Job runs bootstrap + migrate + init-data +
+        (optional) seed sequentially, so its budget must cover BOTH phases.
+        Hence the SUM (not the max): the phases run back-to-back, so the seed
+        budget (setupJob.initData.activeDeadlineSeconds) is added on top of
+        the bootstrap budget rather than competing with it.
+    0 on both knobs leaves the cap unset (unbounded, old behavior).
+  */}}
+  {{- $deadline := int .Values.setupJob.activeDeadlineSeconds }}
+  {{- if not .Values.setupJob.argocdMode }}
+  {{- $deadline = add $deadline (int .Values.setupJob.initData.activeDeadlineSeconds) }}
+  {{- end }}
+  {{- if gt $deadline 0 }}
+  activeDeadlineSeconds: {{ $deadline }}
   {{- end }}
   {{- if not .Values.setupJob.argocdMode }}
   # Auto-delete the Job 24h after it completes — keeps `kubectl get jobs`


### PR DESCRIPTION
Addresses the two CodeRabbit review findings on #1974 that were merged without being applied.

## 1. `job-setup.yaml` — combined non-argocd Job was under-budgeted (Major)

In the default **non-`argocdMode`** path the setup Job runs **bootstrap + migrate + init-data + (optional) seed in one pod**, but it only carried `setupJob.activeDeadlineSeconds` (900s). That capped the whole combined flow at 900s — so seeding, which the `argocdMode` path grants **1800s** via the separate wave +5 init-data Job, could time out, and `setupJob.initData.activeDeadlineSeconds` was effectively ignored for Helm-hook installs.

Now the cap is computed per mode:
- **argocdMode** → `setupJob.activeDeadlineSeconds` (900) — bootstrap-only; migrate runs in the Deployment's `migrate` init container and seed in the wave +5 init-data Job.
- **non-argocd** → **sum** of both phase budgets (`900 + 1800 = 2700`), because the phases run back-to-back in the one Job.

I chose **sum over CodeRabbit's `max`**: the seed budget must be *added on top of* the bootstrap budget, not compete with it (`max(900, 1800)=1800` would under-budget when bootstrap+migrate is non-trivial). Setting both knobs to `0` still leaves the cap unset.

## 2. `docker.yml` — delete-during-pagination could skip images (Minor)

The PR-close cleanup deleted package versions **inline while iterating the `gh api --paginate` stream**. Deleting a version from an earlier page shifts the remaining pages, so some matching PR images could be skipped and survive cleanup. Split into two passes — **collect all matching version ids first (drain the full listing), then delete** — with an empty-array guard.

## Validation
- `helm template`:
  - non-argocd setup Job → `activeDeadlineSeconds: 2700`
  - argocdMode setup Job → `900`, init-data Job → `1800`
  - both knobs `0` → field omitted
  - argocdMode with `setupJob.activeDeadlineSeconds=0` → setup omitted, init-data still `1800`
- `docker.yml` YAML-parses; collect-then-delete two-pass confirmed (no inline delete during pagination, empty-array guarded); `bash -n` clean.