### PR TITLE
Fix preview/demo seed: order MinIO bucket-create before the seed (sync-wave)

### DIFF
--- a/helm/inventario/templates/demo/minio-deployment.yaml
+++ b/helm/inventario/templates/demo/minio-deployment.yaml
@@ -6,6 +6,14 @@ metadata:
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo-minio
+  annotations:
+    # Bring the demo MinIO up BEFORE the wave--6 bucket-create Job and the
+    # wave--5 bootstrap setup Job. The same #1884 ordering gap that the
+    # demo-postgres infra fixed at -7 (see postgresql-deployment.yaml): every
+    # demo-minio resource shares -7 so the Secret/PVC exist when the
+    # Deployment starts and MinIO is reachable when the bucket Job runs at -6.
+    # Inert under plain `helm install`.
+    argocd.argoproj.io/sync-wave: "-7"
 spec:
   replicas: 1
   strategy:

--- a/helm/inventario/templates/demo/minio-job.yaml
+++ b/helm/inventario/templates/demo/minio-job.yaml
@@ -7,8 +7,19 @@ metadata:
     {{- include "inventario.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo-minio
   annotations:
+    {{- if .Values.setupJob.argocdMode }}
+    # ArgoCD: a Helm post-install hook becomes a PostSync hook that runs AFTER
+    # the Sync-phase init-data seed Job (sync-wave +5) — so the bucket wouldn't
+    # exist when the seed writes blob bytes, leaving size_bytes=0 file rows.
+    # Create the bucket as an early Sync-wave resource instead: after the MinIO
+    # Deployment (-7), before setup/migrations (-5) and the init-data seed (+5).
+    # The mc container's `until mc alias set … sleep 2` loop waits for MinIO.
+    argocd.argoproj.io/sync-wave: "-6"
+    argocd.argoproj.io/sync-options: "Force=true,Replace=true"
+    {{- else }}
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    {{- end }}
 spec:
   backoffLimit: 6
   template:

--- a/helm/inventario/templates/demo/minio-pvc.yaml
+++ b/helm/inventario/templates/demo/minio-pvc.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo-minio
+  annotations:
+    # Same early wave as the demo-minio Deployment that binds it —
+    # see minio-deployment.yaml (#1884).
+    argocd.argoproj.io/sync-wave: "-7"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/helm/inventario/templates/demo/minio-secret.yaml
+++ b/helm/inventario/templates/demo/minio-secret.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo-minio
+  annotations:
+    # Same early wave as the demo-minio Deployment / bucket Job that mount it —
+    # see minio-deployment.yaml (#1884).
+    argocd.argoproj.io/sync-wave: "-7"
 type: Opaque
 stringData:
   MINIO_ROOT_USER: {{ .Values.demo.minio.rootUser | quote }}

--- a/helm/inventario/templates/demo/minio-service.yaml
+++ b/helm/inventario/templates/demo/minio-service.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "inventario.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo-minio
+  annotations:
+    # Same early wave as the demo-minio Deployment so the bucket-create Job
+    # (-6) can resolve this service — see minio-deployment.yaml (#1884).
+    argocd.argoproj.io/sync-wave: "-7"
 spec:
   selector:
     {{- include "inventario.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## Problem

Per-PR preview (and master) deployments seed rich demo data, but the file/image attachments came out empty — `FileEntity` rows with `size_bytes=0` and broken thumbnails.

Root cause: the in-cluster MinIO **bucket-create** Job was the only ordering-sensitive chart resource still using a Helm hook instead of an ArgoCD sync-wave.

`helm/inventario/templates/demo/minio-job.yaml` used:

```yaml
annotations:
  helm.sh/hook: post-install,post-upgrade
  helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
```

Under ArgoCD, a `helm.sh/hook: post-install` becomes a **PostSync** hook — it runs AFTER all Sync-phase resources are Healthy, including the init-data seed Job at `argocd.argoproj.io/sync-wave: "5"` (`helm/inventario/templates/job-init-data.yaml`). So when the seed wrote blobs to the MinIO bucket, the bucket did not exist yet. gocloud's s3 `OpenBucket` is lazy and fails late, so blob writes failed silently → a metadata-only seed.

Other ordering-sensitive resources were migrated to sync-waves in #1884 (postgres infra at `-7`, setup Job at `-5`, init-data seed Job at `+5`). The MinIO bucket Job and MinIO infra were missed.

## Fix

Target wave layout:

- **MinIO infra** (deployment, service, secret, pvc) → `argocd.argoproj.io/sync-wave: "-7"`, same as the demo-postgres infra. Emitted unconditionally (the annotation is inert under plain `helm install`).
- **MinIO bucket-create Job** → in `argocdMode` use `sync-wave: "-6"` + `sync-options: "Force=true,Replace=true"` (Jobs are immutable; matches `job-init-data.yaml`). In non-`argocdMode` the existing Helm hook annotations are kept unchanged (conditional on `.Values.setupJob.argocdMode`).

Resulting order:

```
postgres + minio infra (-7) -> bucket-create (-6) -> setup/migrations (-5) -> app + defaults (0) -> init-data seed (+5)
```

By the time the seed runs (+5), the bucket created at -6 already exists. No deadlock: ArgoCD brings MinIO (-7) Healthy before the bucket Job (-6) starts, and the Job's existing `until mc alias set … sleep 2` retry loop is belt-and-suspenders.

Plain `helm install/upgrade` behavior is unchanged — the bucket Job keeps its `post-install,post-upgrade` Helm hook, so the helm-kind-smoke-test CI stays green.

## Verification

All three checks green locally.

**1. Preview render (`argocdMode=true`)** — `helm template` against `infra/helm-overlays/preview-base.values.yaml` (the overlay leaves ingress host/tls for CI to fill, so they were supplied via a small extra values file):

```
[Job]        minio-job.yaml         name=inv-inventario-demo-minio-create-bucket
        argocd.argoproj.io/sync-wave: "-6"
        argocd.argoproj.io/sync-options: "Force=true,Replace=true"   (NO helm.sh/hook)
[Service]    minio-service.yaml     argocd.argoproj.io/sync-wave: "-7"
[Secret]     minio-secret.yaml      argocd.argoproj.io/sync-wave: "-7"
[Deployment] minio-deployment.yaml  argocd.argoproj.io/sync-wave: "-7"
[PVC]        minio-pvc.yaml         argocd.argoproj.io/sync-wave: "-7"   (persistence enabled)
[Job]        job-setup.yaml         "argocd.argoproj.io/sync-wave": "-5"   (unchanged)
[Job]        job-init-data.yaml     "argocd.argoproj.io/sync-wave": "5"    (unchanged)
```

**2. Plain-Helm render (`argocdMode=false`, default)** — `helm template inv helm/inventario --set demo.minio.enabled=true`:

```
[Job] minio-job.yaml name=inv-inventario-demo-minio-create-bucket
        helm.sh/hook: post-install,post-upgrade
        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
```

The bucket Job keeps the Helm hook and emits no argocd annotations — non-ArgoCD behavior is unchanged. (MinIO infra still carries the inert `sync-wave: "-7"`, exactly like the demo-postgres infra under plain Helm.)

**3. `helm lint helm/inventario`** — `1 chart(s) linted, 0 chart(s) failed` (only the cosmetic `[INFO] Chart.yaml: icon is recommended`).