### PR TITLE
Add Mailpit mail-trap to demo deploys, exposed via Tailscale

### DIFF
--- a/helm/inventario/Chart.yaml
+++ b/helm/inventario/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inventario
 description: Personal inventory management system
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "latest" # overridden by CI with the actual image tag
 keywords:
   - inventory

--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -333,6 +333,13 @@ explicit app.publicUrl; in demo-mailpit mode it falls back to
 https://<first ingress host> so verification / invite / reset links resolve to
 the same tailnet node the demo is served on, again without per-environment
 wiring. Outside demo-mailpit mode the historical empty default is preserved.
+
+NOTE: the fallback derives from the APP's ingress host, not the Mailpit one —
+the public URL is where the app (and its email links) live. If demo.mailpit is
+on with an explicit demo.mailpit.ingress.host but an EMPTY ingress.hosts (the
+app has no ingress host to derive from), set app.publicUrl explicitly; an empty
+public URL is rejected at boot for the smtp provider (ValidateEmailPublicURLConfig),
+so this fails loudly rather than silently shipping broken links.
 */}}
 {{- define "inventario.publicUrl" -}}
 {{- $explicit := .Values.app.publicUrl | default "" | trim -}}

--- a/helm/inventario/templates/_helpers.tpl
+++ b/helm/inventario/templates/_helpers.tpl
@@ -291,6 +291,58 @@ whichever Deployment (all or apiserver) is currently enabled.
 {{- printf "%s-create-bucket" (include "inventario.demoMinioName" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "inventario.demoMailpitName" -}}
+{{- printf "%s-demo-mailpit" (include "inventario.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+mailpitIngressHost — full FQDN the Mailpit web UI is published at.
+
+Defaults to "mail-"-prefixing the app's first ingress host so each demo
+environment gets a sibling tailnet node (mail-<app-host>) with zero
+per-environment wiring — the app ingress host is already layered per-Application
+in infra/argocd/applicationset-*.yaml, so master/PR/longevity all derive
+correctly. Override with demo.mailpit.ingress.host for non-derivable setups.
+*/}}
+{{- define "inventario.mailpitIngressHost" -}}
+{{- $explicit := .Values.demo.mailpit.ingress.host | default "" | trim -}}
+{{- if $explicit -}}
+{{- $explicit -}}
+{{- else if .Values.ingress.hosts -}}
+{{- printf "mail-%s" (index .Values.ingress.hosts 0).host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+mailpitTsHostname — the tailscale.com/hostname (first DNS label, no tailnet
+suffix; the TS operator appends the suffix from MagicDNS) for the Mailpit
+Ingress. Derived from the resolved Mailpit ingress host unless overridden.
+*/}}
+{{- define "inventario.mailpitTsHostname" -}}
+{{- $explicit := .Values.demo.mailpit.ingress.tsHostname | default "" | trim -}}
+{{- if $explicit -}}
+{{- $explicit -}}
+{{- else -}}
+{{- include "inventario.mailpitIngressHost" . | splitList "." | first -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+publicUrl — external base URL used in transactional email links. Prefers an
+explicit app.publicUrl; in demo-mailpit mode it falls back to
+https://<first ingress host> so verification / invite / reset links resolve to
+the same tailnet node the demo is served on, again without per-environment
+wiring. Outside demo-mailpit mode the historical empty default is preserved.
+*/}}
+{{- define "inventario.publicUrl" -}}
+{{- $explicit := .Values.app.publicUrl | default "" | trim -}}
+{{- if $explicit -}}
+{{- $explicit -}}
+{{- else if and .Values.demo.mailpit.enabled .Values.ingress.hosts -}}
+{{- printf "https://%s" (index .Values.ingress.hosts 0).host -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "inventario.dbDsn" -}}
 {{- if .Values.demo.postgresql.enabled -}}
 {{- printf "postgres://%s:%s@%s:5432/%s?sslmode=disable" .Values.demo.postgresql.username .Values.demo.postgresql.password (include "inventario.demoPostgresName" .) .Values.demo.postgresql.database -}}

--- a/helm/inventario/templates/configmap.yaml
+++ b/helm/inventario/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
   INVENTARIO_RUN_THUMBNAIL_MAX_CONCURRENT_PER_USER: {{ .Values.app.thumbnailMaxConcurrentPerUser | quote }}
   INVENTARIO_RUN_THUMBNAIL_RATE_LIMIT_PER_MINUTE: {{ .Values.app.thumbnailRateLimitPerMinute | quote }}
   INVENTARIO_RUN_THUMBNAIL_SLOT_DURATION: {{ .Values.app.thumbnailSlotDuration | quote }}
-  INVENTARIO_RUN_PUBLIC_URL: {{ .Values.app.publicUrl | quote }}
+  INVENTARIO_RUN_PUBLIC_URL: {{ include "inventario.publicUrl" . | quote }}
   INVENTARIO_RUN_ALLOWED_ORIGINS: {{ .Values.app.allowedOrigins | quote }}
   INVENTARIO_RUN_GLOBAL_RATE_LIMIT: {{ .Values.app.globalRateLimit | quote }}
   INVENTARIO_RUN_GLOBAL_RATE_WINDOW: {{ .Values.app.globalRateWindow | quote }}
@@ -25,16 +25,31 @@ data:
   # cmd/inventario/run/bootstrap/config.go resolves at runtime to
   # INVENTARIO_RUN_FEATURE_*. See values.yaml `features:` block.
   INVENTARIO_RUN_FEATURE_CURRENCY_MIGRATION: {{ .Values.features.currencyMigration | quote }}
+  {{- if .Values.demo.mailpit.enabled }}
+  # Demo mail-trap (templates/demo/mailpit-*.yaml): route ALL transactional
+  # email to the in-cluster Mailpit sidecar — unauthenticated SMTP on :1025,
+  # no TLS — so verification / invite / reset messages are captured and
+  # viewable in its web UI instead of being black-holed by the stub provider.
+  # Enabling demo.mailpit deliberately forces the provider here so "turn on the
+  # mail-trap" also means "email actually flows to it"; email.provider /
+  # email.smtp.* below are ignored in this mode.
+  INVENTARIO_RUN_EMAIL_PROVIDER: "smtp"
+  INVENTARIO_RUN_SMTP_HOST: {{ include "inventario.demoMailpitName" . | quote }}
+  INVENTARIO_RUN_SMTP_PORT: "1025"
+  INVENTARIO_RUN_SMTP_USERNAME: ""
+  INVENTARIO_RUN_SMTP_USE_TLS: "false"
+  {{- else }}
   INVENTARIO_RUN_EMAIL_PROVIDER: {{ .Values.email.provider | quote }}
+  INVENTARIO_RUN_SMTP_HOST: {{ .Values.email.smtp.host | quote }}
+  INVENTARIO_RUN_SMTP_PORT: {{ .Values.email.smtp.port | quote }}
+  INVENTARIO_RUN_SMTP_USERNAME: {{ .Values.email.smtp.username | quote }}
+  INVENTARIO_RUN_SMTP_USE_TLS: {{ .Values.email.smtp.useTls | quote }}
+  {{- end }}
   INVENTARIO_RUN_EMAIL_FROM: {{ .Values.email.from | quote }}
   INVENTARIO_RUN_EMAIL_REPLY_TO: {{ .Values.email.replyTo | quote }}
   INVENTARIO_RUN_EMAIL_QUEUE_WORKERS: {{ .Values.email.queueWorkers | quote }}
   INVENTARIO_RUN_EMAIL_QUEUE_MAX_RETRIES: {{ .Values.email.queueMaxRetries | quote }}
   INVENTARIO_RUN_LOG_EMAIL_URLS: {{ .Values.email.logUrls | quote }}
-  INVENTARIO_RUN_SMTP_HOST: {{ .Values.email.smtp.host | quote }}
-  INVENTARIO_RUN_SMTP_PORT: {{ .Values.email.smtp.port | quote }}
-  INVENTARIO_RUN_SMTP_USERNAME: {{ .Values.email.smtp.username | quote }}
-  INVENTARIO_RUN_SMTP_USE_TLS: {{ .Values.email.smtp.useTls | quote }}
   INVENTARIO_RUN_SENDGRID_BASE_URL: {{ .Values.email.sendgrid.baseUrl | quote }}
   INVENTARIO_RUN_AWS_REGION: {{ .Values.email.aws.region | quote }}
   INVENTARIO_RUN_MANDRILL_BASE_URL: {{ .Values.email.mandrill.baseUrl | quote }}

--- a/helm/inventario/templates/demo/mailpit-deployment.yaml
+++ b/helm/inventario/templates/demo/mailpit-deployment.yaml
@@ -8,6 +8,11 @@ metadata:
     app.kubernetes.io/component: demo-mailpit
 spec:
   replicas: 1
+  # Recreate, not RollingUpdate: the message store is an in-memory ring buffer,
+  # so there's nothing to drain — and it keeps the preview-base quota's surge
+  # math airtight (no transient 2nd Mailpit pod on an image bump).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "inventario.selectorLabels" . | nindent 6 }}
@@ -29,8 +34,19 @@ spec:
             # In-memory ring buffer (no MP_DATABASE → nothing written to disk).
             - name: MP_MAX_MESSAGES
               value: {{ .Values.demo.mailpit.maxMessages | quote }}
+            # readOnlyRootFilesystem below makes / read-only; point any scratch
+            # writes at the mounted emptyDir.
+            - name: TMPDIR
+              value: /tmp
           securityContext:
+            # Hardened beyond the redis sidecar baseline to match the
+            # postgres/minio demo sidecars: unprivileged UID (both ports are
+            # >1024) + read-only rootfs (in-memory store needs no writable FS,
+            # only /tmp scratch, mounted below).
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           ports:
@@ -58,4 +74,10 @@ spec:
             failureThreshold: 3
           resources:
             {{- toYaml .Values.demo.mailpit.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
 {{- end }}

--- a/helm/inventario/templates/demo/mailpit-deployment.yaml
+++ b/helm/inventario/templates/demo/mailpit-deployment.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.demo.mailpit.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "inventario.demoMailpitName" . }}
+  labels:
+    {{- include "inventario.labels" . | nindent 4 }}
+    app.kubernetes.io/component: demo-mailpit
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "inventario.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: demo-mailpit
+  template:
+    metadata:
+      labels:
+        {{- include "inventario.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: demo-mailpit
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mailpit
+          image: {{ .Values.demo.mailpit.image | quote }}
+          imagePullPolicy: IfNotPresent
+          env:
+            # In-memory ring buffer (no MP_DATABASE → nothing written to disk).
+            - name: MP_MAX_MESSAGES
+              value: {{ .Values.demo.mailpit.maxMessages | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: smtp
+              containerPort: 1025
+              protocol: TCP
+            - name: http
+              containerPort: 8025
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/v1/info
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /api/v1/info
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.demo.mailpit.resources | nindent 12 }}
+{{- end }}

--- a/helm/inventario/templates/demo/mailpit-ingress.yaml
+++ b/helm/inventario/templates/demo/mailpit-ingress.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.demo.mailpit.enabled .Values.demo.mailpit.ingress.enabled }}
+{{- $host := include "inventario.mailpitIngressHost" . -}}
+{{- if not $host }}
+{{- fail "demo.mailpit.ingress.enabled=true but no host could be derived — set demo.mailpit.ingress.host, or ingress.hosts[0].host so it can derive mail-<app host>" }}
+{{- end }}
+# Tailscale Ingress exposing the Mailpit web UI as its own tailnet node, a
+# sibling to the app's ingress. Host + tailscale.com/hostname default to
+# "mail-"<app ingress host> (see the inventario.mailpitIngressHost /
+# mailpitTsHostname helpers), so master/PR/longevity each get
+# mail-inv-vcl01-<env>.<tailnet>.ts.net with no per-environment values.
+#
+# Same plaintext-to-cluster + TLS-at-the-TS-proxy split as the app ingress and
+# infra/vm/cluster-extras/argocd-ts-ingress.yaml: tls lists the host but no
+# secretName — the TS operator issues and manages the cert internally.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "inventario.demoMailpitName" . }}
+  labels:
+    {{- include "inventario.labels" . | nindent 4 }}
+    app.kubernetes.io/component: demo-mailpit
+  annotations:
+    tailscale.com/hostname: {{ include "inventario.mailpitTsHostname" . | quote }}
+    {{- with .Values.demo.mailpit.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.demo.mailpit.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  tls:
+    - hosts:
+        - {{ $host | quote }}
+  rules:
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "inventario.demoMailpitName" . }}
+                port:
+                  number: 8025
+{{- end }}

--- a/helm/inventario/templates/demo/mailpit-ingress.yaml
+++ b/helm/inventario/templates/demo/mailpit-ingress.yaml
@@ -10,8 +10,9 @@
 # mail-inv-vcl01-<env>.<tailnet>.ts.net with no per-environment values.
 #
 # Same plaintext-to-cluster + TLS-at-the-TS-proxy split as the app ingress and
-# infra/vm/cluster-extras/argocd-ts-ingress.yaml: tls lists the host but no
-# secretName — the TS operator issues and manages the cert internally.
+# infra/vm/cluster-extras/argocd-ts-ingress.yaml: tls lists the host with no
+# managed secret (the app ingress omits secretName; argocd sets it to "" — both
+# equivalent), so the TS operator issues and manages the cert internally.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/helm/inventario/templates/demo/mailpit-service.yaml
+++ b/helm/inventario/templates/demo/mailpit-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.demo.mailpit.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "inventario.demoMailpitName" . }}
+  labels:
+    {{- include "inventario.labels" . | nindent 4 }}
+    app.kubernetes.io/component: demo-mailpit
+spec:
+  selector:
+    {{- include "inventario.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: demo-mailpit
+  ports:
+    # SMTP intake — the app's email queue worker connects here (see
+    # INVENTARIO_RUN_SMTP_HOST in templates/configmap.yaml).
+    - name: smtp
+      port: 1025
+      targetPort: smtp
+    # Web UI — backend for the Tailscale Ingress in mailpit-ingress.yaml.
+    - name: http
+      port: 8025
+      targetPort: http
+{{- end }}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -856,3 +856,48 @@ demo:
       limits:
         cpu: 500m
         memory: 512Mi
+
+  mailpit:
+    # Enable an in-cluster Mailpit mail-trap (SMTP catch-all + web UI) for
+    # demo / preview environments. When enabled:
+    #   - the app's email provider is FORCED to smtp pointed at this sidecar
+    #     (:1025, no auth, no TLS) in templates/configmap.yaml, so
+    #     verification / invite / reset emails are captured instead of being
+    #     black-holed by the stub provider;
+    #   - app.publicUrl falls back to https://<first ingress host> (see the
+    #     inventario.publicUrl helper) so the links inside those emails resolve;
+    #   - set email.from to a non-empty bare address (the async email service
+    #     rejects an empty FROM for non-stub providers).
+    # Messages live in an in-memory ring buffer (emptyDir) — never persisted,
+    # never backed up, even in the longevity environment.
+    enabled: false
+
+    image: axllent/mailpit:v1.21
+
+    # Max retained messages (ring buffer); mirrors docker-compose's
+    # MP_MAX_MESSAGES. Env: MP_MAX_MESSAGES on the Mailpit container.
+    maxMessages: 500
+
+    resources:
+      requests:
+        cpu: 25m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+
+    ingress:
+      # Publish the Mailpit web UI (:8025) as its OWN Tailscale node, sibling to
+      # the app's ingress. Host + tailscale.com/hostname are derived as
+      # "mail-"<app ingress host> by the inventario.mailpitIngressHost /
+      # mailpitTsHostname helpers, so no per-environment values are required.
+      enabled: false
+      className: tailscale
+      # Explicit overrides (leave empty to derive from the app ingress host):
+      #   host:       full FQDN, e.g. mail-inv-vcl01-master.<tailnet>.ts.net
+      #   tsHostname: tailscale.com/hostname (first DNS label, no suffix)
+      host: ""
+      tsHostname: ""
+      # Extra annotations merged onto the derived tailscale.com/hostname.
+      annotations:
+        tailscale.com/http-redirect: "true"

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -896,6 +896,8 @@ demo:
       # Explicit overrides (leave empty to derive from the app ingress host):
       #   host:       full FQDN, e.g. mail-inv-vcl01-master.<tailnet>.ts.net
       #   tsHostname: tailscale.com/hostname (first DNS label, no suffix)
+      # If you set `host` here but leave the app's ingress.hosts empty, also set
+      # app.publicUrl explicitly — it derives from the app host, not this one.
       host: ""
       tsHostname: ""
       # Extra annotations merged onto the derived tailscale.com/hostname.

--- a/infra/helm-overlays/preview-base.values.yaml
+++ b/infra/helm-overlays/preview-base.values.yaml
@@ -42,6 +42,25 @@ demo:
     enabled: true
   minio:
     enabled: true
+  # Mailpit mail-trap so the demo's transactional email actually works:
+  # enabling it FORCES the app's email provider to smtp → this Mailpit (see
+  # templates/configmap.yaml), and exposes Mailpit's web UI as its own
+  # Tailscale node at mail-<app host> (the chart derives host +
+  # tailscale.com/hostname from the per-Application app ingress host, so
+  # master / PR / longevity all work with no per-environment wiring).
+  mailpit:
+    enabled: true
+    ingress:
+      enabled: true
+
+# email.from MUST be a non-empty BARE address (no "Display Name <...>" form —
+# it is used verbatim as the SMTP envelope MAIL FROM): the async email service
+# rejects an empty FROM for non-stub providers, and demo.mailpit forces smtp.
+# Everything else (provider, smtp host/port/tls) is wired by the chart in
+# demo.mailpit mode; app.publicUrl is derived from the app ingress host so the
+# links in these emails resolve to the same tailnet node.
+email:
+  from: "noreply@inventario.example"
 
 # Bootstrap + migrate runs via the chart's setup Job (templates/job-setup.yaml).
 # Idempotent — re-applies safely.
@@ -91,20 +110,22 @@ setupJob:
 # Defensive guard-rails per #1866: cap aggregate compute/storage/pod-count
 # in every PR-preview namespace so one runaway pod can't starve other
 # previews sharing the same 16 GiB VM. Sized for the demo bundle below
-# (run all + postgres + redis + minio + transient setup / init-data /
-# mc-bucket Jobs):
+# (run all + postgres + redis + minio + mailpit + transient setup /
+# init-data / mc-bucket Jobs):
 #   - Sum of always-on `limits.cpu` = 500m (inventario run all) + 500m
-#     (demo.postgres) + 200m (demo.redis) + 500m (demo.minio) = 1700m;
-#     `limits.cpu: "4"` leaves ~2300m headroom, enough for one rolling-
-#     update surge replica (+500m) and up to three transient Job pods
-#     defaulted by the chart's LimitRange (~500m each).
-#   - Sum of always-on `limits.memory` = 512+512+128+512 = 1664Mi;
-#     `limits.memory: "4Gi"` leaves ~2.4Gi headroom. WARNING: the
+#     (demo.postgres) + 200m (demo.redis) + 500m (demo.minio) + 100m
+#     (demo.mailpit) = 1800m; `limits.cpu: "4"` leaves ~2200m headroom,
+#     enough for one rolling-update surge replica (+500m) and up to three
+#     transient Job pods defaulted by the chart's LimitRange (~500m each).
+#   - Sum of always-on `limits.memory` = 512+512+128+512+64 = 1728Mi;
+#     `limits.memory: "4Gi"` leaves ~2.3Gi headroom. WARNING: the
 #     worst-case overlap (steady + surge + three Job pods getting the
-#     LimitRange-default 512Mi each) lands around 3712Mi, ~384Mi shy of
+#     LimitRange-default 512Mi each) lands around 3776Mi, ~320Mi shy of
 #     the cap. Bump `limits.memory` (and `requests.memory`) here in
 #     lockstep with any new chart-owned container that doesn't override
-#     the LimitRange default.
+#     the LimitRange default. demo.mailpit DOES set explicit resources
+#     (100m/64Mi limit), so only that 64Mi — not a LimitRange default —
+#     counts toward the steady-state sum above.
 #   - `requests.storage` covers the chart's single 10Gi uploads PVC with
 #     room for an operator-applied debug PVC. demo.* PVCs are disabled in
 #     this overlay (Postgres/MinIO use emptyDir), so 20Gi is generous.


### PR DESCRIPTION
## Problem

Demo/preview deployments (master, PR previews, longevity) ran the **stub** email provider — `email.provider` defaulted to `stub` in the chart and no overlay overrode it, with `logUrls: false`. So verification / invite / password-reset / back-office-MFA emails were black-holed, and there was **no mail-trap reachable over the tailnet**. The email-dependent flows simply couldn't be exercised on the demos.

Mailpit existed only in `docker-compose.yaml` (local/e2e); the Helm chart's `demo/` sidecars were Postgres/Redis/MinIO only.

## Change

Add an in-cluster **Mailpit** sidecar (SMTP `:1025` + web UI `:8025`, in-memory ring buffer) gated on `demo.mailpit.enabled`. When enabled, the chart:

1. **Forces** the email provider to `smtp` pointed at the Mailpit service (no auth, no TLS) — so "turn on the mail-trap" also means "email actually flows to it".
2. **Derives** the Mailpit Tailscale Ingress hostname and `app.publicUrl` from the per-Application app ingress host, as `mail-<app-host>`:

| Env | App | Mailpit UI |
|---|---|---|
| master | `inv-vcl01-master.<tailnet>.ts.net` | `mail-inv-vcl01-master.…` |
| PR #N | `inv-vcl01-prN.…` | `mail-inv-vcl01-prN.…` |
| longevity | `inv-vcl01-longevity.…` | `mail-inv-vcl01-longevity.…` |

Because the per-environment bits are derived in the chart, the whole feature ships via the **normal ArgoCD git-sync** — **no `applicationset-*.yaml` edits and no `bootstrap.sh` re-run** (those manifests are applied by `bootstrap.sh`, not ArgoCD, so touching them would be a footgun).

### Files
- **chart** — `templates/demo/mailpit-{deployment,service,ingress}.yaml`; `demoMailpitName` + `mailpitIngressHost` / `mailpitTsHostname` / `publicUrl` helpers; demo-mailpit-aware `configmap.yaml` email block; `demo.mailpit` values block; `Chart.yaml` `0.3.0 → 0.4.0`.
- **overlay** — `preview-base.values.yaml`: enable `demo.mailpit` (+ ingress), `email.from` (a **bare** address — the async sender rejects an empty FROM for non-stub providers and uses it verbatim as the SMTP envelope), updated quota comment math (+100m / 64Mi for the mailpit container).

## Validation
- `helm lint` clean.
- `helm template` rendered for master / PR / longevity sims + a mailpit-disabled regression + the full multi-doc YAML parse — all green.
- Provider → `smtp`, `SMTP_HOST` → templated Mailpit service, `PUBLIC_URL` + `mail-` ingress host derive correctly per env; email queue rides the demo Redis; longevity Mailpit has **no PVC** (in-memory), so Velero/R2 backup and the `persistentvolumeclaims: 5` quota are untouched; mailpit-disabled installs render zero mailpit resources and keep `stub` / empty publicUrl.

## Notes / trade-offs
- **Rollout:** master/longevity pick this up after merge (the `master-pin` advances → ArgoCD re-syncs). PR previews get it once their branch contains the chart change (i.e. post-merge).
- **Security:** the Mailpit UI is **unauthenticated** but tailnet-gated — same trust boundary as ArgoCD-insecure and the shared preview admin password (#1883). `MP_UI_AUTH` basic-auth can be added later if we want a second gate.
- `email.from` is the placeholder `noreply@inventario.example` (Mailpit doesn't validate); swap for a real domain if preferred.