### PR TITLE
[#1976] Enable AI-vision photo-scan in deployed environments (sops → Helm → env)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,19 @@ SMTP_HOST=mailpit
 SMTP_PORT=1025
 SMTP_USE_TLS=false
 
+# AI Vision photo-scan (Add Item -> "Scan with AI"). Optional; off by default.
+# Provider: none | mock | anthropic | openai
+#   none   - feature disabled (the scan endpoint returns 503)
+#   mock   - deterministic canned result; no network call, no API key
+#   anthropic / openai - real extraction; needs the matching API key below
+AI_VISION_PROVIDER=none
+# Anthropic (Claude). Get a key at https://console.anthropic.com/
+# AI_VISION_ANTHROPIC_API_KEY=sk-ant-...
+# AI_VISION_ANTHROPIC_MODEL=claude-sonnet-4-6
+# OpenAI (GPT-4o)
+# AI_VISION_OPENAI_API_KEY=sk-...
+# AI_VISION_OPENAI_MODEL=gpt-4o
+
 # System Configuration
 TZ=UTC
 

--- a/devdocs/ai-vision-photo-scan.md
+++ b/devdocs/ai-vision-photo-scan.md
@@ -79,22 +79,33 @@ network call, so it does not depend on a real provider.
 Two halves — both required to actually serve scans:
 
 1. **Provider selector** (non-secret, ConfigMap). Set `aivision.provider` in the
-   chart values. The persistent envs already pin it in their ApplicationSets:
-   `anthropic` for `inv-vcl01-master` + `inv-vcl01-longevity`
-   (`infra/argocd/applicationset-{master,longevity}.yaml`), `mock` for PR
+   chart values. Every preview-stack env pins `anthropic` in its ApplicationSet:
+   `inv-vcl01-master` + `inv-vcl01-longevity`
+   (`infra/argocd/applicationset-{master,longevity}.yaml`) and the per-PR
    previews (`applicationset-pr.yaml`). Generic `helm install` defaults to
    `none`.
 2. **API key** (secret). Add `anthropic.api_key` to the sops bundle
    (`infra/vm/secrets/secrets.example.yaml` is the schema; see
-   `infra/SECRETS.md` step 7). `apply-secrets.sh` materializes it into the
-   `inventario-admin` Secret as `INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY`,
-   and the chart loads the whole Secret via `envFrom`. For a chart-managed
-   secret (no `existingSecret`), set `secrets.aiVisionAnthropicApiKey` instead.
+   `infra/SECRETS.md` step 7). `apply-secrets.sh` delivers it two ways:
+   - **master + longevity** (static namespaces): materialized into the
+     `inventario-admin` Secret as `INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY`,
+     loaded via `envFrom`.
+   - **per-PR previews** (dynamic namespaces, #1976): put into a separate
+     `inventario-ai-vision` Secret in `inventario-shared`, which
+     **emberstack/reflector** (installed by `vm-install.sh`) auto-copies into
+     each `inv-vcl01-pr{N}` namespace; the PR chart's `extraEnvFrom` loads it.
 
-> ⚠️ **Ordering.** Because master/longevity pin `provider: anthropic`, the key
-> must be in place **before** that config syncs, or those apiservers CrashLoop
-> (fail-loud above). Fill `anthropic.api_key` + run `apply-secrets.sh` first, or
-> flip the ApplicationSet's `aivision.provider` to `none`/`mock` to defer.
+   For a chart-managed secret (no `existingSecret`), set
+   `secrets.aiVisionAnthropicApiKey` instead.
+
+> ⚠️ **Ordering / dependency.** Because all three preview envs pin
+> `provider: anthropic`, the key must be in place **before** that config syncs,
+> or those apiservers CrashLoop (fail-loud above) — including **every** PR
+> preview. A fresh PR preview may CrashLoop briefly until reflector copies the
+> Secret into its new namespace — the kubelet then restarts the pod, which
+> re-reads the now-present Secret. Fill
+> `anthropic.api_key` + run `apply-secrets.sh` first, or flip the
+> ApplicationSet's `aivision.provider` to `none`/`mock` to defer.
 
 ### Verify
 
@@ -106,6 +117,9 @@ kubectl -n inv-vcl01-master get secret inventario-admin \
 # a successful scan lands an audit row:
 #   SELECT status, provider, model FROM commodity_scan_audits ORDER BY created_at DESC LIMIT 1;
 #   -> ok | anthropic | claude-sonnet-4-6
+
+# in a PR preview, confirm reflector copied the key into the per-PR namespace:
+kubectl -n inv-vcl01-pr<N> get secret inventario-ai-vision
 ```
 
 ## Operability
@@ -115,7 +129,16 @@ kubectl -n inv-vcl01-master get secret inventario-admin \
   `disabled`). The per-user hourly limiter counts only rows that actually
   reached the provider. The table is RLS-isolated per tenant.
 - **Cost control**: keep `AI_VISION_RATE_LIMIT_PER_HOUR` and
-  `AI_VISION_MAX_PHOTOS`/`AI_VISION_MAX_PHOTO_BYTES` set in production.
+  `AI_VISION_MAX_PHOTOS`/`AI_VISION_MAX_PHOTO_BYTES` set in production. PR
+  previews run the real provider too, so each preview scan bills the vendor —
+  they're tailnet-gated and rate-limited, but flip `applicationset-pr.yaml`'s
+  `aivision.provider` to `mock` if you'd rather previews not spend.
+- **Preview key delivery (#1976)**: per-PR namespaces are dynamic, so the key
+  reaches them via emberstack/reflector copying the `inventario-ai-vision`
+  Secret (AI keys only — never the admin/JWT material) into each
+  `inv-vcl01-pr{N}` namespace. The reflector is a hard dependency for preview
+  scans: if it's down, new previews CrashLoop until the Secret is present.
 - **Security**: the providers never log the API key or the auth header. The key
-  lives only in the sops bundle and the materialized Secret — never in git, the
-  ConfigMap, or logs.
+  lives only in the sops bundle and the cluster Secrets it's materialized into
+  (`inventario-admin` + the reflected `inventario-ai-vision`) — never in git,
+  the ConfigMap, or logs.

--- a/devdocs/ai-vision-photo-scan.md
+++ b/devdocs/ai-vision-photo-scan.md
@@ -1,0 +1,121 @@
+# AI vision photo-scan
+
+The Add-Item dialog can prefill the form from one or more product photos: the
+user uploads photos, the backend asks a vision model to extract structured
+fields (name, type, price, currency, serial number, URLs, purchase date,
+comments), and the user reviews/accepts per-field before saving.
+
+Tracked under #1720 (feature) and #1976 (deploy/config wiring).
+
+This doc is the operator + developer guide for **turning the feature on**. The
+application code (backend + frontend) already ships; only configuration selects
+a provider and supplies a key.
+
+## How it works (code map)
+
+- Provider abstraction: `go/internal/aivision/` — `Provider` interface +
+  `ScanRequest`/`ScanResult` types, a name→constructor registry
+  (`registry.go`), and three implementations: `anthropic/` (Claude, tool-use
+  forcing), `openai/` (GPT-4o, structured output), and `mock/` (deterministic
+  canned result, no network).
+- Service: `go/services/commodity_scan_service.go` — validation (photo count,
+  per-photo bytes, MIME allowlist), per-user hourly rate limit, and an audit
+  row on **every** outcome (`commodity_scan_audits` table).
+- HTTP: `POST /g/{groupSlug}/commodities/scan` in
+  `go/apiserver/commodity_scan.go` — multipart `photos` (+ optional `hint`),
+  behind JWT + RLS + CSRF + group-role gate, with body/part size caps.
+- Config: parsed in `go/cmd/inventario/run/bootstrap/config.go`, wired in
+  `server_params.go` (`wireCommodityScan`).
+- Frontend: `frontend/src/components/items/AiScanStep.tsx` +
+  `frontend/src/features/commodities/scanApi.ts` / `scanHooks.ts`.
+
+When the provider is `none` (the default), the route stays mounted but returns
+`503` and the FE shows an "AI vision is unavailable" banner with a "Fill
+manually" fallback.
+
+## Configuration reference
+
+All settings read from the `run` config section, i.e. the env var name is the
+`INVENTARIO_RUN_` prefix + the name below.
+
+| Env (under `INVENTARIO_RUN_`) | Default | Notes |
+| --- | --- | --- |
+| `AI_VISION_PROVIDER` | `none` | `none` \| `mock` \| `anthropic` \| `openai` |
+| `AI_VISION_ANTHROPIC_API_KEY` | `""` | Required when provider=`anthropic` |
+| `AI_VISION_ANTHROPIC_MODEL` | `claude-sonnet-4-6` | |
+| `AI_VISION_ANTHROPIC_BASE_URL` | `""` | Empty = public `api.anthropic.com` |
+| `AI_VISION_OPENAI_API_KEY` | `""` | Required when provider=`openai` |
+| `AI_VISION_OPENAI_MODEL` | `gpt-4o` | |
+| `AI_VISION_OPENAI_BASE_URL` | `""` | Empty = public `api.openai.com` |
+| `AI_VISION_TIMEOUT` | `20s` | Per-call upstream deadline |
+| `AI_VISION_MAX_PHOTOS` | `5` | Per scan request |
+| `AI_VISION_MAX_PHOTO_BYTES` | `10485760` | 10 MiB per photo |
+| `AI_VISION_RATE_LIMIT_PER_HOUR` | `30` | Per-user; `0` disables |
+
+> ⚠️ **Fail-loud on empty key.** Selecting a real provider (`anthropic` /
+> `openai`) with an empty API key makes the apiserver **fail to boot** — this is
+> intentional (a misconfig should be loud, not a silent downgrade). `none` and
+> `mock` never need a key.
+
+## Local / dev quickstart
+
+`.env` (see `.env.example`) drives `docker-compose.yaml`:
+
+```bash
+# Deterministic, no key, no network — best for UI work:
+AI_VISION_PROVIDER=mock
+
+# Real Claude extraction:
+AI_VISION_PROVIDER=anthropic
+AI_VISION_ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Then `docker compose up -d`. The e2e stack pins `mock` (see
+`docker-compose.e2e.yaml`); the `ai-scan.spec.ts` suite mainly intercepts the
+network call, so it does not depend on a real provider.
+
+## Production enablement (Helm + sops cluster)
+
+Two halves — both required to actually serve scans:
+
+1. **Provider selector** (non-secret, ConfigMap). Set `aivision.provider` in the
+   chart values. The persistent envs already pin it in their ApplicationSets:
+   `anthropic` for `inv-vcl01-master` + `inv-vcl01-longevity`
+   (`infra/argocd/applicationset-{master,longevity}.yaml`), `mock` for PR
+   previews (`applicationset-pr.yaml`). Generic `helm install` defaults to
+   `none`.
+2. **API key** (secret). Add `anthropic.api_key` to the sops bundle
+   (`infra/vm/secrets/secrets.example.yaml` is the schema; see
+   `infra/SECRETS.md` step 7). `apply-secrets.sh` materializes it into the
+   `inventario-admin` Secret as `INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY`,
+   and the chart loads the whole Secret via `envFrom`. For a chart-managed
+   secret (no `existingSecret`), set `secrets.aiVisionAnthropicApiKey` instead.
+
+> ⚠️ **Ordering.** Because master/longevity pin `provider: anthropic`, the key
+> must be in place **before** that config syncs, or those apiservers CrashLoop
+> (fail-loud above). Fill `anthropic.api_key` + run `apply-secrets.sh` first, or
+> flip the ApplicationSet's `aivision.provider` to `none`/`mock` to defer.
+
+### Verify
+
+```bash
+# the materialized Secret carries the key:
+kubectl -n inv-vcl01-master get secret inventario-admin \
+  -o jsonpath='{.data.INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY}' | base64 -d | head -c8
+
+# a successful scan lands an audit row:
+#   SELECT status, provider, model FROM commodity_scan_audits ORDER BY created_at DESC LIMIT 1;
+#   -> ok | anthropic | claude-sonnet-4-6
+```
+
+## Operability
+
+- **Audit / rate limit**: every scan attempt writes a `commodity_scan_audits`
+  row (status `ok` / `error` / `timeout` / `validation` / `rate_limited` /
+  `disabled`). The per-user hourly limiter counts only rows that actually
+  reached the provider. The table is RLS-isolated per tenant.
+- **Cost control**: keep `AI_VISION_RATE_LIMIT_PER_HOUR` and
+  `AI_VISION_MAX_PHOTOS`/`AI_VISION_MAX_PHOTO_BYTES` set in production.
+- **Security**: the providers never log the API key or the auth header. The key
+  lives only in the sops bundle and the materialized Secret — never in git, the
+  ConfigMap, or logs.

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -66,3 +66,10 @@ services:
       # value just satisfies the handler's "configured?" check so the
       # e2e flow can exercise the happy path.
       INVENTARIO_RUN_SUPPORT_EMAIL: "support@e2e.test"
+      # AI-vision photo-scan runs the deterministic mock provider in e2e: the
+      # ai-scan.spec.ts suite mainly intercepts the network call, but the mock
+      # keeps the endpoint functional for any full-stack assertion and needs no
+      # key/spend. Rate limit off, matching the other high-throughput e2e
+      # disables above.
+      INVENTARIO_RUN_AI_VISION_PROVIDER: "mock"
+      INVENTARIO_RUN_AI_VISION_RATE_LIMIT_PER_HOUR: "0"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -211,6 +211,15 @@ services:
       INVENTARIO_RUN_SMTP_PORT: ${SMTP_PORT:-1025}
       INVENTARIO_RUN_SMTP_USE_TLS: ${SMTP_USE_TLS:-false}
 
+      # AI-vision photo-scan (#1720). Defaults OFF. Set AI_VISION_PROVIDER=mock
+      # in .env for a no-key deterministic result, or =anthropic|openai with the
+      # matching API key to hit the real vendor.
+      INVENTARIO_RUN_AI_VISION_PROVIDER: ${AI_VISION_PROVIDER:-none}
+      INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY: ${AI_VISION_ANTHROPIC_API_KEY:-}
+      INVENTARIO_RUN_AI_VISION_ANTHROPIC_MODEL: ${AI_VISION_ANTHROPIC_MODEL:-claude-sonnet-4-6}
+      INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY: ${AI_VISION_OPENAI_API_KEY:-}
+      INVENTARIO_RUN_AI_VISION_OPENAI_MODEL: ${AI_VISION_OPENAI_MODEL:-gpt-4o}
+
       # Feature flags
       # Currency migration is on by default. Set FEATURE_CURRENCY_MIGRATION=false
       # in .env to disable the wizard, lock middleware, and worker.

--- a/go/internal/aivision/anthropic/anthropic.go
+++ b/go/internal/aivision/anthropic/anthropic.go
@@ -62,8 +62,10 @@ type Provider struct {
 	maxTokens  int
 }
 
-// New constructs a Provider from cfg. Returns an error when APIKey is
-// empty so the registry constructor can downgrade to disabled.
+// New constructs a Provider from cfg. Returns ErrProviderAuth when APIKey is
+// empty. This is NOT a silent downgrade to disabled: NewProvider propagates the
+// error and wireCommodityScan treats a selected-but-keyless provider as a fatal
+// boot error (fail-loud). Only the provider name "none"/"" disables the feature.
 func New(cfg Config) (*Provider, error) {
 	if cfg.APIKey == "" {
 		return nil, errxtrace.Classify(aivision.ErrProviderAuth)

--- a/helm/inventario/README.md
+++ b/helm/inventario/README.md
@@ -152,6 +152,7 @@ Expected secret keys when using `secrets.existingSecret`:
 - `SETUP_SUPERUSER_DSN` (optional)
 - `INVENTARIO_RUN_TOKEN_BLACKLIST_REDIS_URL`, `INVENTARIO_RUN_AUTH_RATE_LIMIT_REDIS_URL`, `INVENTARIO_RUN_GLOBAL_RATE_LIMIT_REDIS_URL`, `INVENTARIO_RUN_CSRF_REDIS_URL`, `INVENTARIO_RUN_EMAIL_QUEUE_REDIS_URL` (optional)
 - `INVENTARIO_RUN_SMTP_PASSWORD`, `INVENTARIO_RUN_SENDGRID_API_KEY`, `INVENTARIO_RUN_MANDRILL_API_KEY` (provider-specific)
+- `INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY` (required when `aivision.provider=anthropic`), `INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY` (required when `aivision.provider=openai`)
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (required for `s3://` upload targets)
 
 Example existing Secret install:
@@ -257,6 +258,9 @@ For the complete default surface, see `helm/inventario/values.yaml`.
 | `persistence.size` | `10Gi` | Resize the uploads PVC for local file storage. |
 | `email.provider` | `stub` | Switch to `smtp`, `sendgrid`, `ses`, `mandrill`, or `mailchimp` for real email. |
 | `email.from` | `""` | Required for real email delivery. |
+| `aivision.provider` | `none` | AI photo-scan provider: `none` (off, 503), `mock` (canned), `anthropic`, or `openai`. A real provider **requires** the matching `secrets.aiVision*ApiKey`, or the apiserver fails to boot. |
+| `aivision.anthropicModel` / `aivision.openaiModel` | `claude-sonnet-4-6` / `gpt-4o` | Model id used for the selected provider. |
+| `secrets.aiVisionAnthropicApiKey` / `secrets.aiVisionOpenaiApiKey` | `""` | Provider API key; required for the matching `aivision.provider` unless supplied via `secrets.existingSecret`. |
 | `secrets.existingSecret` | `""` | Use an externally managed Secret instead of chart-managed secret data. |
 | `secrets.dbDsn` | `""` | Required for production-style installs unless `secrets.existingSecret` is used. |
 | `secrets.migratorDbDsn` | `""` | Set when schema migrations need a different DB user than the app runtime. |

--- a/helm/inventario/templates/configmap.yaml
+++ b/helm/inventario/templates/configmap.yaml
@@ -53,4 +53,18 @@ data:
   INVENTARIO_RUN_SENDGRID_BASE_URL: {{ .Values.email.sendgrid.baseUrl | quote }}
   INVENTARIO_RUN_AWS_REGION: {{ .Values.email.aws.region | quote }}
   INVENTARIO_RUN_MANDRILL_BASE_URL: {{ .Values.email.mandrill.baseUrl | quote }}
+  # AI-vision photo-scan (#1720). Non-secret knobs; the per-provider API keys
+  # live in the Secret (templates/secret.yaml). See values.yaml `aivision:`.
+  INVENTARIO_RUN_AI_VISION_PROVIDER: {{ .Values.aivision.provider | quote }}
+  INVENTARIO_RUN_AI_VISION_ANTHROPIC_MODEL: {{ .Values.aivision.anthropicModel | quote }}
+  INVENTARIO_RUN_AI_VISION_ANTHROPIC_BASE_URL: {{ .Values.aivision.anthropicBaseUrl | quote }}
+  INVENTARIO_RUN_AI_VISION_OPENAI_MODEL: {{ .Values.aivision.openaiModel | quote }}
+  INVENTARIO_RUN_AI_VISION_OPENAI_BASE_URL: {{ .Values.aivision.openaiBaseUrl | quote }}
+  INVENTARIO_RUN_AI_VISION_TIMEOUT: {{ .Values.aivision.timeout | quote }}
+  # int64 coercion: Helm loads YAML numbers as float64, and `quote` would render
+  # a large value like 10485760 in scientific notation ("1.048576e+07"), which
+  # the Go int env parser rejects. int64 forces a plain integer string.
+  INVENTARIO_RUN_AI_VISION_MAX_PHOTOS: {{ .Values.aivision.maxPhotos | int64 | quote }}
+  INVENTARIO_RUN_AI_VISION_MAX_PHOTO_BYTES: {{ .Values.aivision.maxPhotoBytes | int64 | quote }}
+  INVENTARIO_RUN_AI_VISION_RATE_LIMIT_PER_HOUR: {{ .Values.aivision.rateLimitPerHour | int64 | quote }}
   TZ: {{ .Values.app.tz | quote }}

--- a/helm/inventario/templates/deployment-apiserver.yaml
+++ b/helm/inventario/templates/deployment-apiserver.yaml
@@ -82,6 +82,9 @@ spec:
                 name: {{ $fullName }}-config
             - secretRef:
                 name: {{ $secretName }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if or .Values.demo.postgresql.enabled .Values.demo.redis.enabled .Values.demo.minio.enabled }}
           env:
             {{- if .Values.demo.postgresql.enabled }}

--- a/helm/inventario/templates/deployment-workers.yaml
+++ b/helm/inventario/templates/deployment-workers.yaml
@@ -92,6 +92,9 @@ spec:
                 name: {{ $fullName }}-config
             - secretRef:
                 name: {{ $secretName }}
+            {{- with $root.Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if or $root.Values.demo.postgresql.enabled $root.Values.demo.redis.enabled $root.Values.demo.minio.enabled }}
           env:
             {{- if $root.Values.demo.postgresql.enabled }}

--- a/helm/inventario/templates/deployment.yaml
+++ b/helm/inventario/templates/deployment.yaml
@@ -86,6 +86,9 @@ spec:
                 name: {{ $fullName }}-config
             - secretRef:
                 name: {{ $secretName }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if or .Values.demo.postgresql.enabled .Values.demo.redis.enabled .Values.demo.minio.enabled }}
           env:
             {{- if .Values.demo.postgresql.enabled }}

--- a/helm/inventario/templates/job-init-data.yaml
+++ b/helm/inventario/templates/job-init-data.yaml
@@ -152,6 +152,17 @@ spec:
             - secretRef:
                 name: {{ $secretName }}
           env:
+            # The seed step boots a throwaway `inventario run` server, which
+            # initializes the AI-vision provider. Seeding never uses it, and this
+            # Job does NOT carry the provider's API key (the reflected
+            # inventario-ai-vision Secret is wired via extraEnvFrom on the
+            # Deployments only). Inheriting provider=anthropic from the ConfigMap
+            # would therefore fail the temporary server's boot (wireCommodityScan
+            # is fail-loud on an empty key) and the seed would never run. Force
+            # the provider off here — an explicit `env` entry overrides the same
+            # key coming from the ConfigMap via envFrom. (#1976)
+            - name: INVENTARIO_RUN_AI_VISION_PROVIDER
+              value: "none"
             - name: APP_DB_DSN
               {{- if .Values.demo.postgresql.enabled }}
               value: {{ include "inventario.dbDsn" . | quote }}

--- a/helm/inventario/templates/job-setup.yaml
+++ b/helm/inventario/templates/job-setup.yaml
@@ -299,6 +299,13 @@ spec:
             - secretRef:
                 name: {{ $secretName }}
           env:
+            # Same as job-init-data.yaml: the seed step boots a throwaway
+            # `inventario run` server, which would inherit provider=anthropic
+            # from the ConfigMap but has no API key here (extraEnvFrom is
+            # Deployment-only), failing the boot (fail-loud). Seeding never uses
+            # AI vision — force it off; explicit env overrides envFrom. (#1976)
+            - name: INVENTARIO_RUN_AI_VISION_PROVIDER
+              value: "none"
             - name: APP_DB_DSN
               {{- if .Values.demo.postgresql.enabled }}
               value: {{ include "inventario.dbDsn" . | quote }}

--- a/helm/inventario/templates/secret.yaml
+++ b/helm/inventario/templates/secret.yaml
@@ -21,6 +21,8 @@ data:
   INVENTARIO_RUN_SMTP_PASSWORD: {{ .Values.secrets.smtpPassword | b64enc | quote }}
   INVENTARIO_RUN_SENDGRID_API_KEY: {{ .Values.secrets.sendgridApiKey | b64enc | quote }}
   INVENTARIO_RUN_MANDRILL_API_KEY: {{ .Values.secrets.mandrillApiKey | b64enc | quote }}
+  INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY: {{ .Values.secrets.aiVisionAnthropicApiKey | b64enc | quote }}
+  INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY: {{ .Values.secrets.aiVisionOpenaiApiKey | b64enc | quote }}
   AWS_ACCESS_KEY_ID: {{ ternary .Values.demo.minio.rootUser .Values.secrets.awsAccessKeyId .Values.demo.minio.enabled | b64enc | quote }}
   AWS_SECRET_ACCESS_KEY: {{ ternary .Values.demo.minio.rootPassword .Values.secrets.awsSecretAccessKey .Values.demo.minio.enabled | b64enc | quote }}
   SETUP_ADMIN_PASSWORD: {{ .Values.setupJob.initData.adminPassword | b64enc | quote }}

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -459,6 +459,54 @@ email:
     baseUrl: ""
 
 # ============================================================
+# AI vision — photo-scan that prefills the Add-Item form (#1720).
+# Non-sensitive knobs live here (ConfigMap); the per-provider API keys are
+# secrets — see secrets.aiVisionAnthropicApiKey / secrets.aiVisionOpenaiApiKey.
+# ============================================================
+aivision:
+  # Provider: none | mock | anthropic | openai
+  #   none      — feature off; POST .../commodities/scan returns 503.
+  #   mock      — deterministic canned result; no network, no API key.
+  #   anthropic — Claude vision; REQUIRES secrets.aiVisionAnthropicApiKey.
+  #   openai    — GPT-4o vision; REQUIRES secrets.aiVisionOpenaiApiKey.
+  # ⚠️ The apiserver fails to boot when a real provider is selected but its key
+  # is empty (fail-loud by design). Keep `none` unless the key is wired.
+  # Env: INVENTARIO_RUN_AI_VISION_PROVIDER
+  provider: "none"
+
+  # Anthropic model id (used when provider=anthropic).
+  # Env: INVENTARIO_RUN_AI_VISION_ANTHROPIC_MODEL
+  anthropicModel: "claude-sonnet-4-6"
+
+  # Anthropic API base URL override (empty = public api.anthropic.com).
+  # Env: INVENTARIO_RUN_AI_VISION_ANTHROPIC_BASE_URL
+  anthropicBaseUrl: ""
+
+  # OpenAI model id (used when provider=openai).
+  # Env: INVENTARIO_RUN_AI_VISION_OPENAI_MODEL
+  openaiModel: "gpt-4o"
+
+  # OpenAI API base URL override (empty = public api.openai.com).
+  # Env: INVENTARIO_RUN_AI_VISION_OPENAI_BASE_URL
+  openaiBaseUrl: ""
+
+  # Per-call upstream timeout (e.g. "20s").
+  # Env: INVENTARIO_RUN_AI_VISION_TIMEOUT
+  timeout: "20s"
+
+  # Max photos accepted per scan request.
+  # Env: INVENTARIO_RUN_AI_VISION_MAX_PHOTOS
+  maxPhotos: 5
+
+  # Max bytes accepted per photo (default 10 MiB).
+  # Env: INVENTARIO_RUN_AI_VISION_MAX_PHOTO_BYTES
+  maxPhotoBytes: 10485760
+
+  # Per-user hourly scan rate limit (0 disables the limit).
+  # Env: INVENTARIO_RUN_AI_VISION_RATE_LIMIT_PER_HOUR
+  rateLimitPerHour: 30
+
+# ============================================================
 # Secrets
 # ============================================================
 secrets:
@@ -478,6 +526,8 @@ secrets:
   #   INVENTARIO_RUN_SMTP_PASSWORD               (required for smtp provider)
   #   INVENTARIO_RUN_SENDGRID_API_KEY            (required for sendgrid provider)
   #   INVENTARIO_RUN_MANDRILL_API_KEY            (required for mandrill/mailchimp provider)
+  #   INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY (required when aivision.provider=anthropic)
+  #   INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY    (required when aivision.provider=openai)
   #   SETUP_ADMIN_PASSWORD                       (required by job-setup if setupJob.enabled)
   #   SETUP_SUPERUSER_DSN                        (optional; used when setupJob.bootstrap.superuserDsn is managed outside the chart)
   #   AWS_ACCESS_KEY_ID                          (required for S3/MinIO upload)
@@ -521,6 +571,11 @@ secrets:
   smtpPassword: ""               # Env: INVENTARIO_RUN_SMTP_PASSWORD
   sendgridApiKey: ""             # Env: INVENTARIO_RUN_SENDGRID_API_KEY
   mandrillApiKey: ""             # Env: INVENTARIO_RUN_MANDRILL_API_KEY
+
+  # AI-vision provider secrets (#1720). Required only for the matching
+  # aivision.provider; empty otherwise. See the `aivision:` block above.
+  aiVisionAnthropicApiKey: ""    # Env: INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY
+  aiVisionOpenaiApiKey: ""       # Env: INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY
 
   # S3/MinIO credentials (required when app.uploadLocation uses s3://)
   # Automatically set from demo.minio.* when demo.minio.enabled=true.

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -507,6 +507,24 @@ aivision:
   rateLimitPerHour: 30
 
 # ============================================================
+# Extra envFrom sources appended verbatim to every app container's
+# `envFrom` (combined, apiserver, and worker Deployments). Each entry is a
+# standard EnvFromSource (secretRef / configMapRef). Use to inject env from
+# Secrets/ConfigMaps this chart does not manage.
+#
+# PR previews (#1976) use this to pull the AI-vision API key: a secret
+# reflector (emberstack/reflector) copies a sops-sourced Secret into each
+# dynamically-created inv-vcl01-pr{N} namespace as `inventario-ai-vision`,
+# and the deployment reads it via this list. `optional: true` keeps the pod
+# schedulable before the reflected copy lands (the app still fails loud on an
+# empty key, so set the key — see infra/argocd/applicationset-pr.yaml).
+# ============================================================
+extraEnvFrom: []
+#  - secretRef:
+#      name: inventario-ai-vision
+#      optional: true
+
+# ============================================================
 # Secrets
 # ============================================================
 secrets:

--- a/infra/SECRETS.md
+++ b/infra/SECRETS.md
@@ -334,6 +334,33 @@ Stash all five values for "Filling the bundle".
 
 ---
 
+### 7. Optional: AI-vision provider API key (#1976)
+
+The AI-vision photo-scan feature (#1720) lets users prefill the Add-Item form
+from product photos. It's wired but defaults OFF; the persistent envs
+(`inv-vcl01-master` + `inv-vcl01-longevity`) pin `aivision.provider: anthropic`,
+so they need an Anthropic key to actually serve scans. Per-PR previews run the
+`mock` provider (no key, no spend).
+
+1. Get a key at <https://console.anthropic.com/> → **API keys** (`sk-ant-...`).
+2. Put it in `anthropic.api_key` in the bundle (OpenAI users: `openai.api_key`
+   instead, and set `aivision.provider: openai` in the ApplicationSet).
+
+`apply-secrets.sh` materializes it into the `inventario-admin` Secret as
+`INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY`; the chart loads the whole Secret
+via `envFrom`.
+
+> ⚠️ **Ordering hazard.** The apiserver **fails to boot** when
+> `aivision.provider=anthropic` but the key env is empty (intentional fail-loud
+> in `wireCommodityScan`). Fill `anthropic.api_key` and run `apply-secrets.sh`
+> **before** the `aivision.provider: anthropic` config syncs to master/longevity
+> — otherwise those apiservers CrashLoop. To stage it the other way round, flip
+> the ApplicationSet's `aivision.provider` back to `none` (or `mock`) until the
+> key is in place. Leaving the key empty is otherwise harmless: every other env
+> ignores `anthropic.*`.
+
+---
+
 ## Filling the bundle
 
 With all the values from steps 1-5 in hand, populate the encrypted bundle:
@@ -350,6 +377,8 @@ chmod 600 infra/vm/secrets/secrets.local.yaml
 #    master + longevity, optional),
 #    tailscale.{auth_key, oauth_client_id, oauth_client_secret, tailnet_name},
 #    github.{app_id, app_installation_id, app_private_key, url}.
+#    Fill anthropic.api_key (step 7 above) ONLY to turn the AI-vision feature
+#    on for master + longevity — and mind the boot-ordering hazard noted there.
 #    Fill the velero.* block (step 6 above) ONLY if you want the daily R2
 #    backup of inv-vcl01-longevity; leave it empty to skip the Velero install.
 #    Don't leave half-filled velero.* keys — vm-install.sh treats the block as
@@ -509,6 +538,22 @@ GH Apps allow multiple active private keys. Painless flow:
 3. `make -C infra upgrade VM=...` → applies new Secret to argocd namespace,
    rolling-restarts `argocd-repo-server` + `argocd-applicationset-controller`.
 4. Wait 24h (sanity buffer) → App settings → delete old key.
+
+### Rotating the AI-vision provider API key (`anthropic.api_key` / `openai.api_key`)
+
+Safe to rotate any time — at worst an in-flight scan request fails and the user
+retries:
+
+1. Provider console → create a new key → keep the old one live for the handoff.
+2. `sops infra/vm/secrets/secrets.enc.yaml` → replace `anthropic.api_key` (or
+   `openai.api_key`).
+3. `make -C infra upgrade VM=...` → re-applies the `inventario-admin` Secret;
+   the apiserver picks up the new key on its next rollout.
+4. Revoke the old key in the provider console.
+
+> Do NOT blank the key while `aivision.provider` is still `anthropic`/`openai` —
+> the apiserver fails to boot on an empty key for a selected real provider. Flip
+> the provider to `none` first if you intend to disable the feature.
 
 ### Rotating the Tailscale OAuth client secret
 

--- a/infra/SECRETS.md
+++ b/infra/SECRETS.md
@@ -337,27 +337,35 @@ Stash all five values for "Filling the bundle".
 ### 7. Optional: AI-vision provider API key (#1976)
 
 The AI-vision photo-scan feature (#1720) lets users prefill the Add-Item form
-from product photos. It's wired but defaults OFF; the persistent envs
-(`inv-vcl01-master` + `inv-vcl01-longevity`) pin `aivision.provider: anthropic`,
-so they need an Anthropic key to actually serve scans. Per-PR previews run the
-`mock` provider (no key, no spend).
+from product photos. It's wired but defaults OFF; all preview-stack envs —
+`inv-vcl01-master`, `inv-vcl01-longevity`, AND the per-PR previews — pin
+`aivision.provider: anthropic`, so they need an Anthropic key to serve scans.
 
 1. Get a key at <https://console.anthropic.com/> → **API keys** (`sk-ant-...`).
 2. Put it in `anthropic.api_key` in the bundle (OpenAI users: `openai.api_key`
    instead, and set `aivision.provider: openai` in the ApplicationSet).
 
-`apply-secrets.sh` materializes it into the `inventario-admin` Secret as
-`INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY`; the chart loads the whole Secret
-via `envFrom`.
+`apply-secrets.sh` delivers it two ways:
 
-> ⚠️ **Ordering hazard.** The apiserver **fails to boot** when
+- **master + longevity**: materialized into the static `inventario-admin` Secret
+  as `INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY`; the chart loads it via
+  `envFrom`.
+- **per-PR previews** (#1976): the namespaces are created on the fly by ArgoCD,
+  so the key goes into a separate `inventario-ai-vision` Secret (AI keys only)
+  in the `inventario-shared` namespace, annotated for **emberstack/reflector**
+  (installed by `vm-install.sh`) to auto-copy into every `inv-vcl01-pr{N}`
+  namespace. The PR chart's `extraEnvFrom` then loads it.
+
+> ⚠️ **Ordering / dependency hazard.** The apiserver **fails to boot** when
 > `aivision.provider=anthropic` but the key env is empty (intentional fail-loud
 > in `wireCommodityScan`). Fill `anthropic.api_key` and run `apply-secrets.sh`
-> **before** the `aivision.provider: anthropic` config syncs to master/longevity
-> — otherwise those apiservers CrashLoop. To stage it the other way round, flip
-> the ApplicationSet's `aivision.provider` back to `none` (or `mock`) until the
-> key is in place. Leaving the key empty is otherwise harmless: every other env
-> ignores `anthropic.*`.
+> **before** the `aivision.provider: anthropic` config syncs — otherwise the
+> master/longevity apiservers, and **every** PR preview, CrashLoop. A freshly
+> created PR preview may also CrashLoop briefly until reflector copies the
+> Secret into its new namespace — the kubelet then restarts the pod, which
+> re-reads the now-present Secret. To stage it the other
+> way round, flip the relevant ApplicationSet's `aivision.provider` back to
+> `none`/`mock` until the key is in place.
 
 ---
 

--- a/infra/argocd/applicationset-longevity.yaml
+++ b/infra/argocd/applicationset-longevity.yaml
@@ -83,6 +83,16 @@ spec:
               # encrypted bundle (the longevity block mirrors the master one).
               secrets:
                 existingSecret: inventario-admin
+              # AI-vision photo-scan (#1976): enable Claude on this persistent
+              # env (mirrors master). The API key comes from the
+              # inventario-admin Secret that apply-secrets.sh materializes from
+              # `anthropic.api_key` in the sops bundle. ⚠️ ORDERING: the
+              # apiserver fails to boot when provider=anthropic but the key env
+              # is empty (fail-loud in wireCommodityScan). Fill anthropic.api_key
+              # and run apply-secrets.sh BEFORE this commit syncs, or this env
+              # CrashLoops. Flip to `none`/`mock` to defer the key.
+              aivision:
+                provider: anthropic
               ingress:
                 annotations:
                   tailscale.com/hostname: inv-vcl01-longevity

--- a/infra/argocd/applicationset-master.yaml
+++ b/infra/argocd/applicationset-master.yaml
@@ -121,6 +121,17 @@ spec:
               # back to a random per-restart value for that key.
               secrets:
                 existingSecret: inventario-admin
+              # AI-vision photo-scan (#1976): enable Claude on this persistent
+              # env. The API key is NOT inlined here — apply-secrets.sh
+              # materializes it into the inventario-admin Secret from
+              # `anthropic.api_key` in the sops bundle, and the chart loads it
+              # via envFrom. ⚠️ ORDERING: the apiserver fails to boot when
+              # provider=anthropic but the key env is empty (intentional
+              # fail-loud in wireCommodityScan). Fill anthropic.api_key in the
+              # bundle and run apply-secrets.sh BEFORE this commit syncs, or
+              # this env CrashLoops. Flip to `none`/`mock` to defer the key.
+              aivision:
+                provider: anthropic
               ingress:
                 annotations:
                   tailscale.com/hostname: inv-vcl01-master

--- a/infra/argocd/applicationset-pr.yaml
+++ b/infra/argocd/applicationset-pr.yaml
@@ -82,6 +82,13 @@ spec:
               setupJob:
                 initData:
                   adminPassword: "PreviewAdmin123"
+              # AI-vision photo-scan (#1976): PR previews run the `mock`
+              # provider — exercises the full Add-Item AI step (offer → scan →
+              # review → prefill) with a deterministic canned result, no API key
+              # and no vendor spend. The `mock` provider needs no secret, so
+              # there's no boot hazard here (unlike master/longevity's anthropic).
+              aivision:
+                provider: mock
               ingress:
                 annotations:
                   tailscale.com/hostname: 'inv-vcl01-pr{{.number}}'

--- a/infra/argocd/applicationset-pr.yaml
+++ b/infra/argocd/applicationset-pr.yaml
@@ -82,13 +82,25 @@ spec:
               setupJob:
                 initData:
                   adminPassword: "PreviewAdmin123"
-              # AI-vision photo-scan (#1976): PR previews run the `mock`
-              # provider — exercises the full Add-Item AI step (offer → scan →
-              # review → prefill) with a deterministic canned result, no API key
-              # and no vendor spend. The `mock` provider needs no secret, so
-              # there's no boot hazard here (unlike master/longevity's anthropic).
+              # AI-vision photo-scan (#1976): PR previews run the REAL Anthropic
+              # provider so reviewers can test extraction on actual uploaded
+              # photos. The key is NOT inlined here (public repo) — emberstack/
+              # reflector (installed by vm-install.sh) copies the sops-sourced
+              # `inventario-ai-vision` Secret into each inv-vcl01-pr{N} namespace
+              # as it is created (see infra/vm/scripts/apply-secrets.sh), and the
+              # chart's extraEnvFrom below loads it. ⚠️ Requires anthropic.api_key
+              # in the sops bundle: with provider=anthropic and the reflected
+              # Secret absent/empty the preview apiserver CrashLoops (fail-loud) —
+              # there can be a brief CrashLoop right after namespace creation
+              # until reflector copies the Secret — the kubelet then restarts the
+              # pod and re-reads it. Flip provider back to `mock` to run keyless
+              # with canned data.
               aivision:
-                provider: mock
+                provider: anthropic
+              extraEnvFrom:
+                - secretRef:
+                    name: inventario-ai-vision
+                    optional: true
               ingress:
                 annotations:
                   tailscale.com/hostname: 'inv-vcl01-pr{{.number}}'

--- a/infra/helm-overlays/preview-base.values.yaml
+++ b/infra/helm-overlays/preview-base.values.yaml
@@ -107,6 +107,12 @@ setupJob:
     # INVENTARIO_SEED_ALLOW_BLOB_UPLOADS on the Job's temporary seed server.
     seedBlobUploads: true
 
+# AI-vision photo-scan provider is intentionally NOT set in this shared overlay
+# — it's pinned per-Application: `mock` for PR previews (applicationset-pr.yaml),
+# `anthropic` for master + longevity (applicationset-{master,longevity}.yaml).
+# Anything that doesn't override it inherits the chart default `none` (feature
+# off), the safe fallback. (#1976)
+
 # Defensive guard-rails per #1866: cap aggregate compute/storage/pod-count
 # in every PR-preview namespace so one runaway pod can't starve other
 # previews sharing the same 16 GiB VM. Sized for the demo bundle below

--- a/infra/helm-overlays/preview-base.values.yaml
+++ b/infra/helm-overlays/preview-base.values.yaml
@@ -108,10 +108,11 @@ setupJob:
     seedBlobUploads: true
 
 # AI-vision photo-scan provider is intentionally NOT set in this shared overlay
-# — it's pinned per-Application: `mock` for PR previews (applicationset-pr.yaml),
-# `anthropic` for master + longevity (applicationset-{master,longevity}.yaml).
-# Anything that doesn't override it inherits the chart default `none` (feature
-# off), the safe fallback. (#1976)
+# — it's pinned per-Application to `anthropic` everywhere: master + longevity
+# (applicationset-{master,longevity}.yaml, key via inventario-admin) AND PR
+# previews (applicationset-pr.yaml, key reflected per-namespace as
+# inventario-ai-vision + extraEnvFrom). Anything that doesn't override it
+# inherits the chart default `none` (feature off), the safe fallback. (#1976)
 
 # Defensive guard-rails per #1866: cap aggregate compute/storage/pod-count
 # in every PR-preview namespace so one runaway pod can't starve other

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -207,6 +207,55 @@ EOF
     done
 fi
 
+# --- inventario-ai-vision (reflected into dynamic PR-preview namespaces, #1976) ---
+# A SEPARATE Secret carrying ONLY the AI-vision keys — never the admin password,
+# JWT, file-signing, or OAuth-state material — so emberstack/reflector can safely
+# fan it out to every per-PR namespace without leaking the load-bearing secrets.
+# Reflector (installed by vm-install.sh) auto-creates a copy named
+# `inventario-ai-vision` in each `inv-vcl01-pr[0-9]+` namespace as ArgoCD spins
+# them up; the chart's extraEnvFrom (set in infra/argocd/applicationset-pr.yaml)
+# loads it so PR previews run the real Anthropic provider. The static
+# master/longevity envs do NOT use this — they get the key via inventario-admin
+# above. Created only when at least one AI key is present.
+if [ -n "$ANTHROPIC_API_KEY" ] || [ -n "$OPENAI_API_KEY" ]; then
+    note "Applying inventario-shared/inventario-ai-vision (reflected to inv-vcl01-pr*)"
+    {
+        cat <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: inventario-shared
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: inventario-ai-vision
+  namespace: inventario-shared
+  annotations:
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "inv-vcl01-pr[0-9]+"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "inv-vcl01-pr[0-9]+"
+type: Opaque
+stringData:
+EOF
+        if [ -n "$ANTHROPIC_API_KEY" ]; then
+            cat <<EOF
+  INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY: |-
+$(printf '%s' "$ANTHROPIC_API_KEY" | sed 's/^/    /')
+EOF
+        fi
+        if [ -n "$OPENAI_API_KEY" ]; then
+            cat <<EOF
+  INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY: |-
+$(printf '%s' "$OPENAI_API_KEY" | sed 's/^/    /')
+EOF
+        fi
+    } | remote_apply
+else
+    warn "anthropic.api_key/openai.api_key both empty; skipping inventario-ai-vision. PR previews pin aivision.provider=anthropic and will CrashLoop until a key is set — fill anthropic.api_key, or flip applicationset-pr.yaml back to mock to defer."
+fi
+
 # --- argocd / github-app-creds (repo-creds + ApplicationSet PR-generator) ---
 GH_APP_ID=$(lookup "github.app_id")
 GH_INSTALL_ID=$(lookup "github.app_installation_id")

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -122,6 +122,23 @@ elif [ "${#OAUTH_STATE_KEY}" -lt 32 ]; then
     warn "oauth_state.key is shorter than 32 chars; the apiserver ignores it and generates a random per-restart key. Treating it as unset — use 'openssl rand -hex 32'."
     OAUTH_STATE_KEY=""
 fi
+# Optional AI-vision provider API keys for the persistent envs (#1976). When
+# present they are injected into the inventario-admin Secret below as
+# INVENTARIO_RUN_AI_VISION_{ANTHROPIC,OPENAI}_API_KEY so the apiserver can reach
+# the vendor; the chart loads the whole Secret via envFrom. No length check —
+# vendor keys are opaque, unlike the >=32-char signing keys above.
+#
+# The master + longevity ApplicationSets pin `aivision.provider: anthropic`, and
+# wireCommodityScan FAILS THE BOOT when a real provider is selected but its key
+# is empty. So a missing anthropic.api_key is a HARD warning here (the apiserver
+# will CrashLoop) — but still best-effort, not fatal, so a Phase-1 bundle without
+# it can bootstrap the rest of the cluster; flip aivision.provider to none/mock
+# in the ApplicationSet if you want to defer the key.
+ANTHROPIC_API_KEY=$(lookup "anthropic.api_key")
+OPENAI_API_KEY=$(lookup "openai.api_key")
+if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$OPENAI_API_KEY" ]; then
+    warn "anthropic.api_key (and openai.api_key) missing in secrets bundle; inv-vcl01-master/longevity pin aivision.provider=anthropic, so their apiservers will CrashLoop until a key is set (AI-vision photo-scan boots fail-loud on an empty key). Fill anthropic.api_key, or flip aivision.provider to none/mock in the ApplicationSet to defer it."
+fi
 ADMIN_MISSING=0
 if [ -z "$ADMIN_PASSWORD" ]; then
     warn "admin.password missing in secrets bundle; required by master + longevity ApplicationSets via secrets.existingSecret"
@@ -168,6 +185,18 @@ EOF
                 cat <<EOF
   INVENTARIO_RUN_OAUTH_STATE_KEY: |-
 $(printf '%s' "$OAUTH_STATE_KEY" | sed 's/^/    /')
+EOF
+            fi
+            if [ -n "$ANTHROPIC_API_KEY" ]; then
+                cat <<EOF
+  INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY: |-
+$(printf '%s' "$ANTHROPIC_API_KEY" | sed 's/^/    /')
+EOF
+            fi
+            if [ -n "$OPENAI_API_KEY" ]; then
+                cat <<EOF
+  INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY: |-
+$(printf '%s' "$OPENAI_API_KEY" | sed 's/^/    /')
 EOF
             fi
         } | remote_apply

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -49,9 +49,20 @@ lookup() {
     ' <<<"$SECRETS_JSON" 2>/dev/null
 }
 
-# Pipe a manifest through `kubectl apply -f -` on the remote VM.
+# Pipe a manifest through server-side `kubectl apply` on the remote VM.
+#
+# Server-side apply (NOT the default client-side) is deliberate for the Secrets
+# this script emits: client-side apply stores the ENTIRE applied manifest —
+# including the plaintext `stringData` API keys / passwords — in the
+# `kubectl.kubernetes.io/last-applied-configuration` annotation, which then
+# leaks via `kubectl get secret -o yaml` / `describe` (and is far easier to
+# expose accidentally than the base64 `.data`). SSA records only field
+# ownership in `.metadata.managedFields` (no values), so the secret value never
+# lands in an annotation. `--force-conflicts` lets SSA take ownership of fields
+# previously written by a client-side apply (one-time migration for the
+# pre-existing inventario-admin / github / tailscale Secrets).
 remote_apply() {
-    ssh "$VM" 'sudo /usr/local/bin/kubectl apply -f -'
+    ssh "$VM" 'sudo /usr/local/bin/kubectl apply --server-side --force-conflicts -f -'
 }
 
 # --- inventario-admin (chart consumes via secrets.existingSecret) ---

--- a/infra/vm/scripts/apply-secrets.sh
+++ b/infra/vm/scripts/apply-secrets.sh
@@ -136,8 +136,12 @@ fi
 # in the ApplicationSet if you want to defer the key.
 ANTHROPIC_API_KEY=$(lookup "anthropic.api_key")
 OPENAI_API_KEY=$(lookup "openai.api_key")
-if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$OPENAI_API_KEY" ]; then
-    warn "anthropic.api_key (and openai.api_key) missing in secrets bundle; inv-vcl01-master/longevity pin aivision.provider=anthropic, so their apiservers will CrashLoop until a key is set (AI-vision photo-scan boots fail-loud on an empty key). Fill anthropic.api_key, or flip aivision.provider to none/mock in the ApplicationSet to defer it."
+# Warn on a missing anthropic.api_key SPECIFICALLY: master + longevity pin
+# aivision.provider=anthropic, so that's the key they actually consume. Filling
+# only openai.api_key does NOT satisfy an anthropic-pinned env — it would still
+# CrashLoop — so the openai key is intentionally not part of this guard.
+if [ -z "$ANTHROPIC_API_KEY" ]; then
+    warn "anthropic.api_key missing in secrets bundle; inv-vcl01-master/longevity pin aivision.provider=anthropic, so their apiservers will CrashLoop until it is set (AI-vision photo-scan boots fail-loud on an empty key — setting only openai.api_key does NOT satisfy an anthropic-pinned env). Fill anthropic.api_key, or flip aivision.provider to none/mock (or openai, with openai.api_key) in the ApplicationSet to defer it."
 fi
 ADMIN_MISSING=0
 if [ -z "$ADMIN_PASSWORD" ]; then

--- a/infra/vm/secrets/secrets.example.yaml
+++ b/infra/vm/secrets/secrets.example.yaml
@@ -83,6 +83,36 @@ oauth_state:
   # Per-PR previews (inv-vcl01-pr{N}) are NOT covered — they are disposable.
   key: ""
 
+anthropic:
+  # Anthropic (Claude) API key for the AI-vision photo-scan feature (#1720 /
+  # #1976) on the PERSISTENT envs (inv-vcl01-master + inv-vcl01-longevity).
+  # Materialized by infra/vm/scripts/apply-secrets.sh into the inventario-admin
+  # Secret under key INVENTARIO_RUN_AI_VISION_ANTHROPIC_API_KEY; the chart loads
+  # that whole Secret via envFrom, so the apiserver reaches Anthropic with it.
+  #
+  # OPTIONAL — leave empty to keep the AI-vision feature dark. NOTE the
+  # ordering hazard: the master + longevity ApplicationSets pin
+  # `aivision.provider: anthropic`, and the apiserver FAILS TO BOOT when a real
+  # provider is selected but its key is empty (intentional fail-loud in
+  # wireCommodityScan). So either fill this BEFORE that config syncs, or flip
+  # the ApplicationSet's `aivision.provider` back to `none`/`mock` until you do.
+  #
+  # Get a key at https://console.anthropic.com/ → API keys. Rotate by pasting a
+  # new value here and re-running `make secrets` / apply-secrets.sh (no app
+  # restart hazard beyond the in-flight scan request).
+  #
+  # Per-PR previews (inv-vcl01-pr{N}) are NOT covered — they run the `mock`
+  # provider (no key, no spend).
+  api_key: ""
+
+openai:
+  # OpenAI (GPT-4o) API key — the alternate AI-vision provider. Same lifecycle
+  # as anthropic.api_key above: materialized into inventario-admin under key
+  # INVENTARIO_RUN_AI_VISION_OPENAI_API_KEY, OPTIONAL, only consulted when an
+  # ApplicationSet sets `aivision.provider: openai`. Left empty by default
+  # because the persistent envs default to the Anthropic provider.
+  api_key: ""
+
 tailscale:
   # One-shot reusable auth key from the Tailscale admin console.
   # Used only on first bootstrap; after that tailscaled is authenticated.

--- a/infra/vm/secrets/secrets.example.yaml
+++ b/infra/vm/secrets/secrets.example.yaml
@@ -91,9 +91,9 @@ anthropic:
   # that whole Secret via envFrom, so the apiserver reaches Anthropic with it.
   #
   # OPTIONAL — leave empty to keep the AI-vision feature dark. NOTE the
-  # ordering hazard: the master + longevity ApplicationSets pin
-  # `aivision.provider: anthropic`, and the apiserver FAILS TO BOOT when a real
-  # provider is selected but its key is empty (intentional fail-loud in
+  # ordering hazard: the master, longevity, AND per-PR-preview ApplicationSets
+  # all pin `aivision.provider: anthropic`, and the apiserver FAILS TO BOOT when
+  # a real provider is selected but its key is empty (intentional fail-loud in
   # wireCommodityScan). So either fill this BEFORE that config syncs, or flip
   # the ApplicationSet's `aivision.provider` back to `none`/`mock` until you do.
   #
@@ -101,8 +101,11 @@ anthropic:
   # new value here and re-running `make secrets` / apply-secrets.sh (no app
   # restart hazard beyond the in-flight scan request).
   #
-  # Per-PR previews (inv-vcl01-pr{N}) are NOT covered — they run the `mock`
-  # provider (no key, no spend).
+  # Per-PR previews (inv-vcl01-pr{N}) ARE covered too (#1976): apply-secrets.sh
+  # puts this key in the `inventario-ai-vision` Secret and emberstack/reflector
+  # copies it into each per-PR namespace, so previews run the real Anthropic
+  # provider on actual uploaded photos. With this empty, previews CrashLoop
+  # (same fail-loud) — flip applicationset-pr.yaml to `mock` to defer.
   api_key: ""
 
 openai:

--- a/infra/vm/vm-install.sh
+++ b/infra/vm/vm-install.sh
@@ -289,6 +289,22 @@ note "Installing/upgrading ArgoCD"
     --set 'applicationSet.enabled=true' \
     --wait --timeout 10m
 
+# --- reflector (#1976 — copy the AI-vision API key into dynamic PR-preview namespaces) ---
+# emberstack/reflector is a tiny controller that mirrors annotated Secrets into
+# other namespaces. apply-secrets.sh creates a single sops-sourced
+# `inventario-ai-vision` Secret (AI keys only) annotated for reflection into
+# `inv-vcl01-pr[0-9]+`; reflector copies it into each per-PR namespace as ArgoCD
+# creates them, so PR previews can run the real Anthropic provider (the static
+# master/longevity envs get the key via apply-secrets.sh directly and don't need
+# this). Installed unconditionally — harmless with no source Secret; the
+# reflection annotations are what actually drive behavior.
+note "Installing/upgrading reflector"
+"$HELM" repo add emberstack https://emberstack.github.io/helm-charts >/dev/null 2>&1 || true
+"$HELM" repo update >/dev/null
+"$HELM" upgrade --install reflector emberstack/reflector \
+    --namespace reflector --create-namespace \
+    --wait --timeout 5m
+
 # --- Velero (#1865 — daily, encrypted, off-VM backup of inv-vcl01-longevity to R2) ---
 # Optional Phase-2 component. Gated on the velero.s3_* keys being present in
 # the sops bundle; a bundle without them simply skips Velero (preview-env core


### PR DESCRIPTION
Closes #1976. Follow-up of #1720; part of epic #1651.

## Summary

The AI-vision photo-scan feature (#1720) was fully built in backend **and**
frontend, but never wired into the deploy/config layers — the provider defaulted
to `none` everywhere and there was no slot for an API key. This PR threads the
provider selector + Anthropic/OpenAI API keys through every layer and turns the
feature on for **all** preview-stack envs (master, longevity, **and** per-PR
previews). **No application behavior changes** (one stale Go doc-comment
corrected; no `go/` logic, no `frontend/`).

## What changed

| Layer | Change |
| --- | --- |
| **sops** | `secrets.example.yaml` gains `anthropic.api_key` / `openai.api_key`; `SECRETS.md` documents step 7 + rotation. The encrypted bundle is operator-filled via `sops` (see below) — not touched here. |
| **apply-secrets.sh** | Materializes the key into `inventario-admin` (master/longevity, mirrors the `JWT_SECRET` block) **and** into a separate `inventario-ai-vision` Secret (AI keys only) in `inventario-shared`, annotated for reflection into per-PR namespaces. |
| **reflector** | `vm-install.sh` installs `emberstack/reflector`, which auto-copies `inventario-ai-vision` into each dynamically-created `inv-vcl01-pr{N}` namespace (the only clean way to get a non-committed key into dynamic namespaces in a public repo). |
| **Helm chart** | `aivision.*` knobs (`values.yaml` + `configmap.yaml`), API-key secrets (`secret.yaml`, mirrors SendGrid), and a generic `extraEnvFrom` list on all app deployments (combined/apiserver/workers). `README.md` documents them. |
| **Per-env** | master + longevity + **PR previews** all pin `aivision.provider=anthropic`; generic `helm install` defaults to `none`. PR previews load the reflected key via `extraEnvFrom`. |
| **Local/dev** | `.env.example` + `docker-compose.yaml` mapping; `docker-compose.e2e.yaml` pins `mock`. |
| **Docs** | New `devdocs/ai-vision-photo-scan.md` operator + dev guide. |

## ⚠️ Operator action required before this reaches master

All three preview envs pin `aivision.provider=anthropic`, and the apiserver
**fails to boot (CrashLoop)** when a real provider is selected but its key env
is empty (intentional fail-loud in `wireCommodityScan`). So **before** this
config syncs:

1. `sops infra/vm/secrets/secrets.enc.yaml` → set `anthropic.api_key`.
2. Run `make -C infra upgrade VM=...` (or `apply-secrets.sh`) so both the
   `inventario-admin` Secret and the reflected `inventario-ai-vision` Secret
   carry the key, and `vm-install.sh` has installed the reflector.

To defer, flip the relevant ApplicationSet's `aivision.provider` to
`none`/`mock`. A freshly created PR preview may CrashLoop briefly until reflector
copies the Secret into its new namespace; the kubelet then restarts the pod and
it boots. Documented in SECRETS.md, the ApplicationSets, the apply-secrets.sh
warning, secrets.example.yaml, and the devdocs guide.

## Testing / verification

- `helm lint` clean; `helm template` rendered in all CI scenarios (default
  `none`, `provider=anthropic` + key, `existingSecret`, demo, split) incl. the
  `helm-lint.yml` commands, plus `extraEnvFrom` set (combined + split) — the
  reflected secretRef appends to `envFrom` with valid YAML; default renders
  nothing. Fixed a real bug where `maxPhotoBytes` rendered as `"1.048576e+07"`
  (scientific notation the Go int parser rejects) via `int64` coercion.
- `bash -n` on `apply-secrets.sh` + `vm-install.sh`; `gofmt`/`go build` on the
  touched Go file; outer + inner (`values: |`) YAML validated for all
  ApplicationSets; `markdownlint-cli2` clean.
- Cross-checked every `INVENTARIO_RUN_AI_VISION_*` env name against the Go
  `env:` tags in `config.go` — zero typos.

## Self-review

Reviewed by dedicated **security** and **functional** subagents across two
passes (base wiring + the preview/reflector delta). Security: **SHIP** (0
findings) both times — it read the reflector source and confirmed the namespace
match is full-length-anchored, so `inv-vcl01-pr[0-9]+` cannot leak the key into
master/longevity/system namespaces, and the reflected Secret carries only the AI
keys. Functional: **approve** both times; the findings it raised (an
`apply-secrets.sh` warning blind spot, an imprecise "ArgoCD self-heals" wording,
and a stale `anthropic.go` comment) are all fixed in follow-up commits.