### PR TITLE
Bound the MinIO bucket-create Job (deadline + capped wait + pinned mc image)

### DIFF
--- a/helm/inventario/templates/demo/minio-job.yaml
+++ b/helm/inventario/templates/demo/minio-job.yaml
@@ -21,6 +21,14 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     {{- end }}
 spec:
+  {{- with .Values.demo.minio.bucketJob.activeDeadlineSeconds }}
+  # Wall-clock cap so a stuck image pull or a never-ready MinIO FAILS the Job
+  # instead of hanging forever. In argocdMode this Job is a blocking sync-wave
+  # (-6) resource, so a hang would stall the sync op and wedge namespace
+  # deletion (#1974/#1971); under plain Helm it bounds the post-install hook.
+  # See values.yaml demo.minio.bucketJob.activeDeadlineSeconds.
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
   backoffLimit: 6
   template:
     metadata:
@@ -34,7 +42,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mc
-          image: quay.io/minio/mc:latest
+          image: {{ .Values.demo.minio.mcImage | quote }}
           imagePullPolicy: IfNotPresent
           env:
             - name: MC_CONFIG_DIR
@@ -54,7 +62,13 @@ spec:
             - -c
             - |
               set -e
+              i=0
               until mc alias set demo {{ include "inventario.minioEndpointUrl" . }} "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                i=$((i+1))
+                if [ "$i" -ge 60 ]; then
+                  echo "MinIO not ready after 120s; giving up" >&2
+                  exit 1
+                fi
                 echo "Waiting for MinIO to become ready..."
                 sleep 2
               done

--- a/helm/inventario/values.yaml
+++ b/helm/inventario/values.yaml
@@ -836,6 +836,13 @@ demo:
 
     image: minio/minio:RELEASE.2025-01-20T14-49-07Z
 
+    # Image for the `mc` client run by the one-shot bucket-create Job.
+    # Pinned to an immutable RELEASE tag (NOT :latest): in argocdMode that Job
+    # sits on an early sync-wave on the critical path, so a floating-tag drift
+    # or a transient registry hiccup must not be able to wedge the sync. Bump
+    # deliberately alongside `image` above.
+    mcImage: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+
     rootUser: minioadmin
     rootPassword: minioadmin123
 
@@ -856,6 +863,16 @@ demo:
       limits:
         cpu: 500m
         memory: 512Mi
+
+    # One-shot Job that creates the bucket. In argocdMode it runs at an early
+    # sync-wave (-6) on the critical path, so an unpullable mc image or a MinIO
+    # that never becomes ready must FAIL the Job (and surface a fast sync error)
+    # instead of hanging forever — a hung Job stalls the ArgoCD sync op and
+    # blocks namespace deletion (the undeletable-preview class fixed in
+    # #1974/#1971). Same rationale as setupJob.activeDeadlineSeconds; creating a
+    # bucket is near-instant once MinIO is up, so 300s is generous. 0 disables.
+    bucketJob:
+      activeDeadlineSeconds: 300
 
   mailpit:
     # Enable an in-cluster Mailpit mail-trap (SMTP catch-all + web UI) for


### PR DESCRIPTION
## Why

Follow-up to #1978 (merged as `16808c7c`). A self-review of that PR surfaced a **HIGH** regression that landed *after* #1978 was merged, so it is **not yet in master** — this PR carries it.

#1978 moved the demo MinIO **bucket-create** Job from a Helm `post-install` hook onto an ArgoCD `sync-wave: "-6"`. That correctly fixes the empty-seed-files bug — but it also puts the Job's health on the **critical path**: as a Sync-phase resource (no longer a PostSync hook), ArgoCD now blocks waves `-5/0/+5` until it goes Healthy. The Job still had:

- **no `activeDeadlineSeconds`**,
- an **unbounded** `until mc alias set … ; sleep 2` readiness loop, and
- a floating **`quay.io/minio/mc:latest`** tag (`IfNotPresent`).

So a never-ready MinIO or an unpullable `mc` image hangs the Job forever → stalls the sync op → wedges namespace deletion. That is exactly the **undeletable-preview** class #1974/#1971 just fixed for the `setup` (-5) and `init-data` (+5) Jobs. (`backoffLimit` doesn't help — a *running* pod is never counted as a failure; and the ApplicationSet `retry.limit` only re-runs *failed* syncs, not hung ones.)

## Fix

- **`demo.minio.bucketJob.activeDeadlineSeconds`** (default `300`), rendered via `{{- with }}` on the Job — same pattern/rationale as `setupJob.activeDeadlineSeconds`.
- **Capped the readiness loop** at 60×2s → `exit 1`, so an unready MinIO fails fast and visibly instead of spinning to the deadline.
- **Pinned the `mc` image**: new `demo.minio.mcImage` = immutable `quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z` (no more `:latest`), removing the most realistic unbounded-pull trigger.

Applies in both `argocdMode` and plain Helm; the plain-Helm `post-install` hook path is otherwise unchanged.

## Verification (all green on the committed tree)

- **Preview (`argocdMode`)**: bucket Job renders `sync-wave: "-6"` + `Force=true,Replace=true`, `activeDeadlineSeconds: 300`, pinned `mc` image, the `if [ "$i" -ge 60 ]` guard, and `mc mb --ignore-existing` — no `helm.sh/hook`.
- **Plain Helm (`argocdMode=false`)**: bucket Job keeps `helm.sh/hook: post-install,post-upgrade` + `hook-delete-policy`, and also gains the deadline/cap/pin (harmless, intended).
- `helm lint`: `0 chart(s) failed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MinIO setup job now terminates after a configurable timeout instead of hanging indefinitely when MinIO is unavailable or the client image cannot be pulled.

* **Configuration**
  * Added `activeDeadlineSeconds` setting to cap bucket-creation job runtime (set to `0` to disable the cap).
  * Added pinned MinIO client image version for deployment stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->