### PR TITLE
[#1961] Fade images/thumbnails in instead of popping

### DIFF
--- a/frontend/src/components/files/CommodityFilesTab.tsx
+++ b/frontend/src/components/files/CommodityFilesTab.tsx
@@ -16,6 +16,7 @@ import { FilePreviewDialog } from "@/components/files/FilePreviewDialog"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { FadeInImage } from "@/components/ui/fade-in-image"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useDeleteFile, useFiles } from "@/features/files/hooks"
 import type { FileCategory, ListedFile } from "@/features/files/api"
@@ -432,7 +433,7 @@ function PhotoGrid({
               data-testid={`commodity-files-photo-${file.id}`}
             >
               {thumbUrl ? (
-                <img
+                <FadeInImage
                   src={thumbUrl}
                   alt={title}
                   loading="lazy"

--- a/frontend/src/components/files/FileCard.tsx
+++ b/frontend/src/components/files/FileCard.tsx
@@ -4,6 +4,7 @@ import { Star } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
+import { FadeInImage } from "@/components/ui/fade-in-image"
 import type { FileEntity, URLData } from "@/features/files/api"
 import {
   FILE_CATEGORY_TILES,
@@ -171,9 +172,9 @@ export function FileCard({
         data-testid={`file-card-open-${file.id}`}
         className="flex flex-1 flex-col text-left focus-visible:outline-none"
       >
-        <div className="relative aspect-[4/3] w-full overflow-hidden">
+        <div className="relative aspect-[4/3] w-full overflow-hidden bg-muted">
           {renderImage ? (
-            <img
+            <FadeInImage
               src={thumbUrl ?? signedUrl?.url}
               alt={title}
               loading="lazy"

--- a/frontend/src/components/files/FileDetailSheet.tsx
+++ b/frontend/src/components/files/FileDetailSheet.tsx
@@ -26,6 +26,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
+import { FadeInImage } from "@/components/ui/fade-in-image"
 import { useDeleteFile, useFile } from "@/features/files/hooks"
 import { isImageMime, isPdfMime } from "@/features/files/constants"
 import { useAppToast } from "@/hooks/useAppToast"
@@ -389,7 +390,7 @@ function FilePreview({ mime, url, alt, onExpandImage, onExpandPdf }: PreviewProp
         className="group relative -mx-5 w-[calc(100%+2.5rem)] overflow-hidden bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
         data-testid="file-preview-image-trigger"
       >
-        <img
+        <FadeInImage
           src={url}
           alt={alt}
           className="max-h-[60vh] w-full object-contain"

--- a/frontend/src/components/files/FileDetailSheet.tsx
+++ b/frontend/src/components/files/FileDetailSheet.tsx
@@ -386,8 +386,10 @@ function FilePreview({ mime, url, alt, onExpandImage, onExpandPdf }: PreviewProp
         onClick={onExpandImage}
         // Full-bleed banner: breaks out of the body's px-5 inset (#1962)
         // so the image spans the panel edge-to-edge while the metadata
-        // below stays inset.
-        className="group relative -mx-5 w-[calc(100%+2.5rem)] overflow-hidden bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+        // below stays inset. `min-h` reserves a box for the fade-in
+        // shimmer (#1961) and centers a short `object-contain` image so
+        // the panel doesn't grow from a zero-height placeholder.
+        className="group relative -mx-5 flex min-h-[12rem] w-[calc(100%+2.5rem)] items-center justify-center overflow-hidden bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
         data-testid="file-preview-image-trigger"
       >
         <FadeInImage

--- a/frontend/src/components/files/ImageViewer.tsx
+++ b/frontend/src/components/files/ImageViewer.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import {
   ChevronLeft,
   ChevronRight,
+  Loader2,
   Maximize2,
   Minus,
   Plus,
@@ -19,6 +20,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { useImageFadeIn } from "@/components/ui/fade-in-image"
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion"
 
 const MIN_SCALE = 0.5
 const MAX_SCALE = 6
@@ -89,6 +92,19 @@ export function ImageViewer(props: ImageViewerProps) {
   const [offset, setOffset] = useState({ x: 0, y: 0 })
   const draggingRef = useRef<{ x: number; y: number } | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  // Fade the image in once it decodes instead of letting it snap onto
+  // the black backdrop (#1961). `useImageFadeIn` resets on `url`, so
+  // gallery navigation re-runs the fade. The opacity transition lives in
+  // the inline style next to the transform transition, so reduced-motion
+  // can't be a CSS variant here — gate it in JS instead.
+  const {
+    ref: imgRef,
+    status: imgStatus,
+    onLoad: onImgLoad,
+    onError: onImgError,
+  } = useImageFadeIn(url)
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const imgSettled = imgStatus !== "loading"
 
   const reset = useCallback(() => {
     setScale(1)
@@ -269,7 +285,7 @@ export function ImageViewer(props: ImageViewerProps) {
         {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
         <div
           ref={containerRef}
-          className="flex flex-1 cursor-grab items-center justify-center overflow-hidden active:cursor-grabbing"
+          className="relative flex flex-1 cursor-grab items-center justify-center overflow-hidden active:cursor-grabbing"
           onWheel={(e) => {
             e.preventDefault()
             setScale((s) => clamp(s - e.deltaY * WHEEL_COEFFICIENT * s))
@@ -291,17 +307,37 @@ export function ImageViewer(props: ImageViewerProps) {
             draggingRef.current = null
           }}
         >
+          {imgStatus === "loading" ? (
+            <div
+              className="pointer-events-none absolute inset-0 flex items-center justify-center"
+              aria-hidden="true"
+              data-testid="image-viewer-loading"
+            >
+              <Loader2 className="size-8 animate-spin text-white/70" />
+            </div>
+          ) : null}
           <img
+            ref={imgRef}
             src={url}
             alt={alt}
             draggable={false}
+            decoding="async"
+            onLoad={onImgLoad}
+            onError={onImgError}
             data-testid="image-viewer-img"
             className="max-h-none max-w-none select-none"
             style={{
               transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
               transformOrigin: "center center",
+              // Skip the opacity fade entirely under reduced motion; the
+              // image just appears once decoded.
+              opacity: prefersReducedMotion || imgSettled ? 1 : 0,
               // eslint-disable-next-line react-hooks/refs -- read during render is intentional: this only toggles a CSS transition string, not behaviour. Using state would cause an extra re-render per dragstart/dragend.
-              transition: draggingRef.current ? "none" : "transform 80ms ease-out",
+              transition: draggingRef.current
+                ? "none"
+                : prefersReducedMotion
+                  ? "transform 80ms ease-out"
+                  : "transform 80ms ease-out, opacity 200ms ease-out",
             }}
           />
         </div>

--- a/frontend/src/components/files/__tests__/ImageViewer.test.tsx
+++ b/frontend/src/components/files/__tests__/ImageViewer.test.tsx
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import { ImageViewer } from "@/components/files/ImageViewer"
@@ -99,6 +99,19 @@ describe("<ImageViewer />", () => {
     render(<ImageViewer open onOpenChange={onOpenChange} url="https://example/a.png" alt="A" />)
     await user.keyboard("{Escape}")
     expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("shows a loading spinner until the image decodes, then fades it in (#1961)", () => {
+    render(<ImageViewer open onOpenChange={vi.fn()} url="https://example/a.png" alt="A" />)
+    const img = screen.getByTestId("image-viewer-img") as HTMLImageElement
+    // While loading: spinner up, image transparent (fade not yet started).
+    expect(screen.getByTestId("image-viewer-loading")).toBeInTheDocument()
+    expect(img.style.opacity).toBe("0")
+
+    fireEvent.load(img)
+    // After decode: spinner gone, image fully faded in.
+    expect(screen.queryByTestId("image-viewer-loading")).not.toBeInTheDocument()
+    expect(img.style.opacity).toBe("1")
   })
 
   it("clamps the displayed zoom level to the configured min/max", async () => {

--- a/frontend/src/components/ui/__tests__/fade-in-image.test.tsx
+++ b/frontend/src/components/ui/__tests__/fade-in-image.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+
+import { FadeInImage } from "@/components/ui/fade-in-image"
+
+const SRC = "https://example.test/photo.jpg"
+
+describe("<FadeInImage />", () => {
+  it("starts hidden behind a shimmer placeholder, then fades in on load", () => {
+    render(<FadeInImage src={SRC} alt="Photo" data-testid="img" />)
+    const img = screen.getByTestId("img")
+    // Placeholder visible while loading; image is transparent + async-decoded.
+    expect(screen.getByTestId("img").className).toContain("opacity-0")
+    expect(document.querySelector('[data-slot="fade-in-image-placeholder"]')).not.toBeNull()
+    expect(img).toHaveAttribute("decoding", "async")
+
+    fireEvent.load(img)
+    // After load: image opaque, placeholder gone.
+    expect(img.className).toContain("opacity-100")
+    expect(document.querySelector('[data-slot="fade-in-image-placeholder"]')).toBeNull()
+  })
+
+  it("reveals the (broken) image and drops the placeholder on error", () => {
+    const onError = vi.fn()
+    render(<FadeInImage src={SRC} alt="Photo" data-testid="img" onError={onError} />)
+    const img = screen.getByTestId("img")
+    fireEvent.error(img)
+    // A failed image must not stay stuck invisible — the surface decides
+    // its own fallback (e.g. CommodityThumb swaps to an icon).
+    expect(img.className).toContain("opacity-100")
+    expect(document.querySelector('[data-slot="fade-in-image-placeholder"]')).toBeNull()
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-runs the fade when src changes (recycled <img>)", () => {
+    const { rerender } = render(<FadeInImage src={SRC} alt="Photo" data-testid="img" />)
+    const img = screen.getByTestId("img")
+    fireEvent.load(img)
+    expect(img.className).toContain("opacity-100")
+
+    rerender(<FadeInImage src="https://example.test/other.jpg" alt="Photo" data-testid="img" />)
+    // New src resets to loading: transparent again + shimmer back.
+    expect(screen.getByTestId("img").className).toContain("opacity-0")
+    expect(document.querySelector('[data-slot="fade-in-image-placeholder"]')).not.toBeNull()
+  })
+
+  it("forwards image attributes and merges the caller className", () => {
+    render(
+      <FadeInImage
+        src={SRC}
+        alt="Photo"
+        loading="lazy"
+        width={120}
+        height={120}
+        className="size-full object-cover"
+        data-testid="img"
+      />
+    )
+    const img = screen.getByTestId("img") as HTMLImageElement
+    expect(img).toHaveAttribute("loading", "lazy")
+    expect(img).toHaveAttribute("width", "120")
+    expect(img.className).toContain("object-cover")
+    expect(img.className).toContain("transition-opacity")
+  })
+
+  it("renders a caller-supplied placeholder only while loading", () => {
+    render(
+      <FadeInImage
+        src={SRC}
+        alt="Photo"
+        data-testid="img"
+        placeholder={<span data-testid="custom-ph" />}
+      />
+    )
+    expect(screen.getByTestId("custom-ph")).toBeInTheDocument()
+    // The default muted shimmer is not rendered when overridden.
+    expect(document.querySelector('[data-slot="fade-in-image-placeholder"]')).toBeNull()
+
+    fireEvent.load(screen.getByTestId("img"))
+    expect(screen.queryByTestId("custom-ph")).not.toBeInTheDocument()
+  })
+
+  it("treats an already-complete (cached) image as loaded without waiting for onLoad", () => {
+    // A cache hit can fire `load` before React wires onLoad; the hook
+    // reconciles `<img>.complete` after mount so the image never stays
+    // stranded at opacity-0. jsdom never decodes, so fake the getters.
+    const proto = HTMLImageElement.prototype
+    const completeDesc = Object.getOwnPropertyDescriptor(proto, "complete")
+    const widthDesc = Object.getOwnPropertyDescriptor(proto, "naturalWidth")
+    Object.defineProperty(proto, "complete", { configurable: true, get: () => true })
+    Object.defineProperty(proto, "naturalWidth", { configurable: true, get: () => 42 })
+    try {
+      render(<FadeInImage src={SRC} alt="Photo" data-testid="img" />)
+      expect(screen.getByTestId("img").className).toContain("opacity-100")
+      expect(document.querySelector('[data-slot="fade-in-image-placeholder"]')).toBeNull()
+    } finally {
+      if (completeDesc) Object.defineProperty(proto, "complete", completeDesc)
+      if (widthDesc) Object.defineProperty(proto, "naturalWidth", widthDesc)
+    }
+  })
+
+  it("renders no placeholder when placeholder is null", () => {
+    render(<FadeInImage src={SRC} alt="Photo" data-testid="img" placeholder={null} />)
+    expect(document.querySelector('[data-slot="fade-in-image-placeholder"]')).toBeNull()
+    expect(screen.getByTestId("img").className).toContain("opacity-0")
+  })
+})

--- a/frontend/src/components/ui/fade-in-image.tsx
+++ b/frontend/src/components/ui/fade-in-image.tsx
@@ -34,13 +34,32 @@ export function useImageFadeIn(src: string | undefined) {
   const ref = useRef<HTMLImageElement>(null)
   const [status, setStatus] = useState<FadeStatus>("loading")
 
+  // Reset to `loading` the instant `src` changes, during render, so the
+  // new image's very first painted frame is already opacity-0 and the
+  // fade reliably plays — on gallery navigation and on the
+  // generating-placeholder → real-thumbnail swap alike. Doing this in an
+  // effect would leave one stale `loaded` frame at opacity-1 first, which
+  // the browser can coalesce into skipping the transition. This is
+  // React's endorsed "adjust state when a prop changes" pattern — a state
+  // mirror of the previous src, set during render (no extra commit; React
+  // restarts the render with the new state).
+  const [trackedSrc, setTrackedSrc] = useState(src)
+  if (trackedSrc !== src) {
+    setTrackedSrc(src)
+    setStatus("loading")
+  }
+
   useEffect(() => {
+    // Reconcile a cache hit: an image already in cache can fire `load`
+    // before React wired `onLoad`, so promote a `complete` element to
+    // `loaded` here (reading the external <img>.complete via the ref is
+    // the sanctioned way to sync it in). Promote-only — the render-phase
+    // reset above owns going back to `loading`. `naturalWidth > 0` also
+    // rejects a broken cached image (complete, but zero-sized).
     const img = ref.current
-    // Reconcile a cache hit (the load event may have fired before this
-    // handler was wired) and otherwise reset to `loading` for the new
-    // src. Reading the external DOM property (<img>.complete) via the ref
-    // is the sanctioned way to sync it into state.
-    setStatus(img?.complete && img.naturalWidth > 0 ? "loaded" : "loading")
+    if (img?.complete && img.naturalWidth > 0) {
+      setStatus("loaded")
+    }
   }, [src])
 
   const onLoad = useCallback(() => setStatus("loaded"), [])
@@ -54,9 +73,11 @@ export interface FadeInImageProps extends ComponentProps<"img"> {
   // when `placeholder` is supplied.
   placeholderClassName?: string
   // Overrides the default placeholder, rendered only while the image is
-  // still loading. Pass `null` to render no placeholder at all — the
-  // caller owns the backdrop then (e.g. a dark fullscreen surface where
-  // a muted box reads wrong).
+  // still loading. A custom node owns its own positioning (the default
+  // placeholder is `absolute inset-0`; a replacement is rendered as a
+  // bare sibling of the <img>). Pass `null` to render no placeholder at
+  // all — the caller owns the backdrop then (e.g. a dark fullscreen
+  // surface where a muted box reads wrong).
   placeholder?: ReactNode
 }
 

--- a/frontend/src/components/ui/fade-in-image.tsx
+++ b/frontend/src/components/ui/fade-in-image.tsx
@@ -1,0 +1,135 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from "react"
+
+import { cn } from "@/lib/utils"
+
+// Load state of the underlying <img>. `loading` until the browser
+// reports the first load/error for the current `src`; `error` lets the
+// caller distinguish a broken image from a decoded one.
+type FadeStatus = "loading" | "loaded" | "error"
+
+// useImageFadeIn tracks the load state of a single <img> and resets it
+// whenever `src` changes, so a recycled element — gallery navigation, or
+// a cover that swaps to its real thumbnail once generation finishes
+// (#1961) — re-runs the fade instead of staying stuck on the previous
+// image's "loaded" state.
+//
+// It also reconciles the browser cache: an image already in cache can
+// fire its `load` event before React attaches the `onLoad` handler, so
+// the post-paint effect promotes a `complete` element to `loaded`. That
+// keeps a cache hit from being stranded at opacity-0 (load fired, nobody
+// listened) while still painting one frame at opacity-0 first so the
+// fade actually plays.
+//
+// The hook is the shared core behind <FadeInImage>; the fullscreen
+// viewer consumes it directly because its <img> carries an inline
+// transform-transition that a className-based fade can't compose with.
+export function useImageFadeIn(src: string | undefined) {
+  const ref = useRef<HTMLImageElement>(null)
+  const [status, setStatus] = useState<FadeStatus>("loading")
+
+  useEffect(() => {
+    const img = ref.current
+    // Reconcile a cache hit (the load event may have fired before this
+    // handler was wired) and otherwise reset to `loading` for the new
+    // src. Reading the external DOM property (<img>.complete) via the ref
+    // is the sanctioned way to sync it into state.
+    setStatus(img?.complete && img.naturalWidth > 0 ? "loaded" : "loading")
+  }, [src])
+
+  const onLoad = useCallback(() => setStatus("loaded"), [])
+  const onError = useCallback(() => setStatus("error"), [])
+
+  return { ref, status, onLoad, onError }
+}
+
+export interface FadeInImageProps extends ComponentProps<"img"> {
+  // Extra classes for the default muted-shimmer placeholder. Ignored
+  // when `placeholder` is supplied.
+  placeholderClassName?: string
+  // Overrides the default placeholder, rendered only while the image is
+  // still loading. Pass `null` to render no placeholder at all — the
+  // caller owns the backdrop then (e.g. a dark fullscreen surface where
+  // a muted box reads wrong).
+  placeholder?: ReactNode
+}
+
+// FadeInImage eases an image in once it decodes instead of letting it
+// snap into place (issue #1961). A neutral shimmer fills the box until
+// the image is ready, then the <img> fades from opacity-0 to
+// opacity-100. The fade is pure CSS and is skipped under
+// `prefers-reduced-motion` via the `motion-reduce` variant; the shimmer
+// likewise only animates under `motion-safe`. `decoding="async"` keeps
+// the decode off the paint path.
+//
+// Layout contract: the placeholder fills the nearest positioned ancestor
+// (`absolute inset-0`), so the wrapping element must establish a
+// positioning context (`relative`) and reserve space (aspect-ratio or a
+// fixed size) to keep CLS at zero. Give that wrapper a muted background
+// (`bg-muted`) so the brief gap between the shimmer unmounting and the
+// fade completing reads as the same neutral tone rather than a flash.
+// The placeholder is phrasing content (a <span>), so it stays valid
+// inside the <button> wrappers these grids use.
+export function FadeInImage({
+  className,
+  placeholderClassName,
+  placeholder,
+  src,
+  alt,
+  onLoad,
+  onError,
+  ...rest
+}: FadeInImageProps) {
+  const { ref, status, onLoad: markLoaded, onError: markError } = useImageFadeIn(src)
+  const isLoading = status === "loading"
+
+  // While loading: the default muted shimmer, a caller override, or
+  // nothing (placeholder === null). Once settled the placeholder is
+  // dropped and the muted wrapper background covers the fade.
+  const placeholderNode = isLoading ? (
+    placeholder === undefined ? (
+      <span
+        aria-hidden="true"
+        data-slot="fade-in-image-placeholder"
+        className={cn(
+          "pointer-events-none absolute inset-0 bg-muted motion-safe:animate-pulse",
+          placeholderClassName
+        )}
+      />
+    ) : (
+      placeholder
+    )
+  ) : null
+
+  return (
+    <>
+      {placeholderNode}
+      <img
+        {...rest}
+        ref={ref}
+        src={src}
+        alt={alt}
+        decoding="async"
+        onLoad={(e) => {
+          markLoaded()
+          onLoad?.(e)
+        }}
+        onError={(e) => {
+          markError()
+          onError?.(e)
+        }}
+        className={cn(
+          "transition-opacity duration-200 ease-out motion-reduce:transition-none",
+          isLoading ? "opacity-0" : "opacity-100",
+          className
+        )}
+      />
+    </>
+  )
+}

--- a/frontend/src/features/commodities/CommodityThumb.tsx
+++ b/frontend/src/features/commodities/CommodityThumb.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 
+import { FadeInImage } from "@/components/ui/fade-in-image"
 import { cn } from "@/lib/utils"
 import {
   COMMODITY_TYPE_FALLBACK_ICON,
@@ -102,7 +103,7 @@ export function CommodityThumb({
   return (
     <div
       className={cn(
-        "flex shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted",
+        "relative flex shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted",
         className
       )}
       style={{ width: dim, height: dim }}
@@ -111,7 +112,7 @@ export function CommodityThumb({
       data-commodity-type={type ?? "unknown"}
     >
       {showImage ? (
-        <img
+        <FadeInImage
           src={url}
           alt={name ?? "Commodity photo"}
           loading="lazy"

--- a/frontend/src/hooks/__tests__/usePrefersReducedMotion.test.tsx
+++ b/frontend/src/hooks/__tests__/usePrefersReducedMotion.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion"
+
+interface MqlMock {
+  matches: boolean
+  listeners: Array<(event: { matches: boolean }) => void>
+  fire(matches: boolean): void
+}
+
+let mql: MqlMock
+let originalMatchMedia: typeof window.matchMedia
+
+beforeEach(() => {
+  mql = {
+    matches: false,
+    listeners: [],
+    fire(matches: boolean) {
+      this.matches = matches
+      this.listeners.forEach((cb) => cb({ matches }))
+    },
+  }
+  originalMatchMedia = window.matchMedia
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    media: query,
+    get matches() {
+      return mql.matches
+    },
+    addEventListener: (_type: string, cb: (event: { matches: boolean }) => void) => {
+      mql.listeners.push(cb)
+    },
+    removeEventListener: (_type: string, cb: (event: { matches: boolean }) => void) => {
+      mql.listeners = mql.listeners.filter((l) => l !== cb)
+    },
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+  })) as unknown as typeof window.matchMedia
+})
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia
+})
+
+describe("usePrefersReducedMotion", () => {
+  it("reads the initial value synchronously from matchMedia", () => {
+    mql.matches = true
+    const { result } = renderHook(() => usePrefersReducedMotion())
+    expect(result.current).toBe(true)
+  })
+
+  it("flips when the preference changes", () => {
+    mql.matches = false
+    const { result } = renderHook(() => usePrefersReducedMotion())
+    expect(result.current).toBe(false)
+    act(() => mql.fire(true))
+    expect(result.current).toBe(true)
+    act(() => mql.fire(false))
+    expect(result.current).toBe(false)
+  })
+})

--- a/frontend/src/hooks/usePrefersReducedMotion.ts
+++ b/frontend/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react"
+
+const QUERY = "(prefers-reduced-motion: reduce)"
+
+// Read the preference synchronously on first render so the very first
+// paint already reflects it — no desktop→reduced flash. SSR-safe and
+// degrades to "motion allowed" when matchMedia is unavailable (older
+// jsdom in unit tests stubs a static `matches: false`).
+function getInitialPrefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false
+  return window.matchMedia(QUERY).matches
+}
+
+// usePrefersReducedMotion reports whether the user asked the OS to
+// minimise non-essential motion. Class-based fades honour this directly
+// through Tailwind's `motion-reduce` variant; this hook exists for the
+// cases that must decide in JS — e.g. the fullscreen image viewer, whose
+// opacity transition is set via inline style (composed with a transform
+// transition) and so can't be gated by a CSS media query.
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(getInitialPrefersReducedMotion)
+
+  useEffect(() => {
+    if (!window.matchMedia) return
+    const mql = window.matchMedia(QUERY)
+    const onChange = () => setReduced(mql.matches)
+    // Sync once on mount in case the preference flipped between the
+    // synchronous init read and the effect running.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- subscribing to an external API (matchMedia)
+    setReduced(mql.matches)
+    mql.addEventListener("change", onChange)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return reduced
+}


### PR DESCRIPTION
## Summary

- Images/thumbnails across the file & commodity surfaces used to **snap** into place (empty → hard-cut → image). This adds a smooth shimmer-then-fade so they ease in instead.
- New shared **`FadeInImage`** primitive (`components/ui/fade-in-image.tsx`) + the **`useImageFadeIn`** hook it's built on: a neutral muted shimmer holds the box until the image decodes, then the `<img>` fades `opacity-0 → opacity-100` with `decoding="async"`. It resets on `src` change (recycled `<img>` for gallery nav / cover swap) and reconciles **cache hits** (the `load` event can fire before React wires `onLoad`) so a cached image never stalls invisible at opacity-0.
- The fade is **pure CSS** and is skipped under `prefers-reduced-motion` (`motion-reduce:transition-none`); the shimmer only animates under `motion-safe`. The one surface that can't use a CSS variant — the fullscreen viewer, whose `<img>` carries an inline transform-transition — gates its inline-style fade with a small new **`usePrefersReducedMotion`** hook.

### Surfaces wired (the ones the issue calls out)

| Surface | Notes |
| --- | --- |
| `FileCard` grid thumbnail | added `bg-muted` to the `aspect-[4/3]` box so the fade has a neutral backdrop |
| `CommodityThumb` cover | keeps its existing `failed` → type-icon fallback |
| `CommodityFilesTab` 3-col photo grid | |
| `FileDetailSheet` inline preview banner | already `bg-muted`/`object-contain` |
| `ImageViewer` fullscreen preview | consumes `useImageFadeIn` directly; inline-style fade + centred spinner placeholder; resets per gallery image |

Aspect-ratio / fixed-size boxes are untouched, so **CLS stays at zero**.

### Deliberately excluded

- `AiScanStep` — local `object-URL` upload preview, decodes instantly; not a network thumbnail surface.
- insurance-report `PhotoSection` — it's a **print/report** view; fading via `opacity-0` would risk blank images if the page is printed mid-fade.

> Note on the "generating-placeholder → real-thumbnail" crossfade (an optional nice-to-have in the issue): swapping `src` re-runs the fade (shimmer → new image), rather than a true two-layer crossfade. Kept simple per the "CSS-driven, no heavy JS / new deps" guidance.

## Related issues

Closes #1961. Polish layer on top of the thumbnail variant/blur work in #1955.

## Test plan

- New `fade-in-image.test.tsx` (load/error/reset/passthrough/custom-placeholder/null-placeholder/**cache-hit reconcile**) and `usePrefersReducedMotion.test.tsx`; viewer fade test added to `ImageViewer.test.tsx`.
- [x] `npm run lint` (eslint) — clean
- [x] `npm run format:check` (prettier) — clean
- [x] `npm run typecheck` (`tsc -b`) — clean
- [x] `npm run build` (`vite build`) — clean
- [x] `npm run test` (vitest) — **1214 passed**
- [ ] `make test-e2e` — relies on preserved `data-testid`s; Playwright `toBeVisible()` ignores opacity, so the fade is selector-safe (CI)